### PR TITLE
Added support for Get/SetColour in wxFontPickerCtrl

### DIFF
--- a/include/wx/fontpicker.h
+++ b/include/wx/fontpicker.h
@@ -2,7 +2,7 @@
 // Name:        wx/fontpicker.h
 // Purpose:     wxFontPickerCtrl base header
 // Author:      Francesco Montorsi
-// Modified by:
+// Modified by: Pana Alexandru
 // Created:     14/4/2006
 // Copyright:   (c) Francesco Montorsi
 // Licence:     wxWindows Licence
@@ -41,6 +41,9 @@ public:
     virtual void SetSelectedFont(const wxFont &f)
         { m_selectedFont = f; UpdateFont(); }
 
+    virtual wxColour GetSelectedColour() const = 0;
+    virtual void SetSelectedColour(const wxColour &colour) = 0;
+
 protected:
 
     virtual void UpdateFont() = 0;
@@ -59,7 +62,7 @@ protected:
 // E.g. choosing "Times New Roman bold, italic with size 10" from the fontdialog,
 //      updates the wxFontButtonGeneric's label (overwriting any previous label)
 //      with the "Times New Roman, 10" text (only fontface + fontsize is displayed
-//      to avoid extralong labels).
+//      to avoid extra long labels).
 #define wxFNTP_FONTDESC_AS_LABEL      0x0008
 
 // uses the currently selected font to draw the label of the button
@@ -91,7 +94,7 @@ protected:
 
 // ----------------------------------------------------------------------------
 // wxFontPickerCtrl: platform-independent class which embeds the
-// platform-dependent wxFontPickerWidget andm if wxFNTP_USE_TEXTCTRL style is
+// platform-dependent wxFontPickerWidget and if wxFNTP_USE_TEXTCTRL style is
 // used, a textctrl next to it.
 // ----------------------------------------------------------------------------
 
@@ -128,17 +131,24 @@ public:
                 const wxValidator& validator = wxDefaultValidator,
                 const wxString& name = wxFontPickerCtrlNameStr);
 
-
 public:         // public API
 
     // get the font chosen
     wxFont GetSelectedFont() const
-        { return ((wxFontPickerWidget *)m_picker)->GetSelectedFont(); }
+        { return getPickerWidget()->GetSelectedFont(); }
 
     // sets currently displayed font
     void SetSelectedFont(const wxFont& f);
 
-    // set/get the max pointsize
+	// returns the selected color
+	wxColour GetSelectedColour() const
+		{ return getPickerWidget()->GetSelectedColour(); }
+
+	// sets the currently selected color
+	void SetSelectedColour(const wxColour& colour)
+		{ getPickerWidget()->SetSelectedColour(colour); }
+
+	// set/get the max point size
     void SetMaxPointSize(unsigned int max)
         { m_nMaxPointSize=max; }
     unsigned int GetMaxPointSize() const
@@ -166,6 +176,9 @@ protected:
     unsigned int m_nMaxPointSize;
 
 private:
+	wxFontPickerWidget* getPickerWidget() const
+		{ return static_cast<wxFontPickerWidget*>(m_picker); }
+
     DECLARE_DYNAMIC_CLASS(wxFontPickerCtrl)
 };
 
@@ -217,5 +230,4 @@ typedef void (wxEvtHandler::*wxFontPickerEventFunction)(wxFontPickerEvent&);
 
 #endif // wxUSE_FONTPICKERCTRL
 
-#endif
-    // _WX_FONTPICKER_H_BASE_
+#endif // _WX_FONTPICKER_H_BASE_

--- a/include/wx/generic/fontpickerg.h
+++ b/include/wx/generic/fontpickerg.h
@@ -2,7 +2,7 @@
 // Name:        wx/generic/fontpickerg.h
 // Purpose:     wxGenericFontButton header
 // Author:      Francesco Montorsi
-// Modified by:
+// Modified by: Pana Alexandru
 // Created:     14/4/2006
 // Copyright:   (c) Francesco Montorsi
 // Licence:     wxWindows Licence
@@ -34,6 +34,12 @@ public:
     {
         Create(parent, id, initial, pos, size, style, validator, name);
     }
+
+	virtual wxColour GetSelectedColour() const 
+		{ return m_data.GetColour(); }
+
+	virtual void SetSelectedColour(const wxColour &colour)
+		{ m_data.SetColour(colour); UpdateFont(); }
 
     virtual ~wxGenericFontButton() {}
 

--- a/include/wx/gtk/fontpicker.h
+++ b/include/wx/gtk/fontpicker.h
@@ -2,7 +2,7 @@
 // Name:        wx/gtk/fontpicker.h
 // Purpose:     wxFontButton header
 // Author:      Francesco Montorsi
-// Modified by:
+// Modified by: Pana Alexandru
 // Created:     14/4/2006
 // Copyright:   (c) Francesco Montorsi
 // Licence:     wxWindows Licence
@@ -43,6 +43,12 @@ public:
                 const wxValidator& validator = wxDefaultValidator,
                 const wxString& name = wxFontPickerWidgetNameStr);
 
+    virtual wxColour GetSelectedColour() const
+        { return m_selectedColour; }
+
+    void SetSelectedColour(const wxColour &colour)
+        { m_selectedColour = colour; }
+
     virtual ~wxFontButton();
 
 protected:
@@ -55,6 +61,11 @@ public:     // used by the GTK callback only
         { m_selectedFont.SetNativeFontInfo(wxString::FromAscii(gtkdescription)); }
 
 private:
+
+    // This can't be changed by the user, but is provided to
+    // satisfy the wxFontPickerWidgetBase interface.
+    wxColour m_selectedColour;
+
     DECLARE_DYNAMIC_CLASS(wxFontButton)
 };
 

--- a/src/common/fontpickercmn.cpp
+++ b/src/common/fontpickercmn.cpp
@@ -2,7 +2,7 @@
 // Name:        src/common/fontpickercmn.cpp
 // Purpose:     wxFontPickerCtrl class implementation
 // Author:      Francesco Montorsi
-// Modified by:
+// Modified by: Pana Alexandru
 // Created:     15/04/2006
 // Copyright:   (c) Francesco Montorsi
 // Licence:     wxWindows licence
@@ -48,8 +48,6 @@ IMPLEMENT_DYNAMIC_CLASS(wxFontPickerEvent, wxCommandEvent)
 // ----------------------------------------------------------------------------
 // wxFontPickerCtrl
 // ----------------------------------------------------------------------------
-
-#define M_PICKER     ((wxFontPickerWidget*)m_picker)
 
 bool wxFontPickerCtrl::Create( wxWindow *parent, wxWindowID id,
                         const wxFont &initial,
@@ -116,7 +114,7 @@ wxFont wxFontPickerCtrl::String2Font(const wxString &s)
 
 void wxFontPickerCtrl::SetSelectedFont(const wxFont &f)
 {
-    M_PICKER->SetSelectedFont(f);
+    getPickerWidget()->SetSelectedFont(f);
     UpdateTextCtrlFromPicker();
 }
 
@@ -132,9 +130,9 @@ void wxFontPickerCtrl::UpdatePickerFromTextCtrl()
     if (!f.IsOk())
         return;     // invalid user input
 
-    if (M_PICKER->GetSelectedFont() != f)
+    if (getPickerWidget()->GetSelectedFont() != f)
     {
-        M_PICKER->SetSelectedFont(f);
+        getPickerWidget()->SetSelectedFont(f);
 
         // fire an event
         wxFontPickerEvent event(this, GetId(), f);
@@ -149,7 +147,7 @@ void wxFontPickerCtrl::UpdateTextCtrlFromPicker()
 
     // Take care to use ChangeValue() here and not SetValue() to avoid
     // infinite recursion.
-    m_text->ChangeValue(Font2String(M_PICKER->GetSelectedFont()));
+    m_text->ChangeValue(Font2String(getPickerWidget()->GetSelectedFont()));
 }
 
 

--- a/src/generic/fontpickerg.cpp
+++ b/src/generic/fontpickerg.cpp
@@ -2,7 +2,7 @@
 // Name:        src/generic/fontpickerg.cpp
 // Purpose:     wxGenericFontButton class implementation
 // Author:      Francesco Montorsi
-// Modified by:
+// Modified by: Pana Alexandru
 // Created:     15/04/2006
 // Copyright:   (c) Francesco Montorsi
 // Licence:     wxWindows licence
@@ -62,9 +62,10 @@ bool wxGenericFontButton::Create( wxWindow *parent, wxWindowID id,
             wxCommandEventHandler(wxGenericFontButton::OnButtonClick),
             NULL, this);
 
+    InitFontData();
+
     m_selectedFont = initial.IsOk() ? initial : *wxNORMAL_FONT;
     UpdateFont();
-    InitFontData();
 
     return true;
 }

--- a/tests/controls/pickertest.cpp
+++ b/tests/controls/pickertest.cpp
@@ -2,6 +2,7 @@
 // Name:        tests/controls/pickertest.cpp
 // Purpose:     Tests for various wxPickerBase based classes
 // Author:      Steven Lamerton
+// Modified By: Pana Alexandru
 // Created:     2010-08-07
 // Copyright:   (c) 2010 Steven Lamerton
 ///////////////////////////////////////////////////////////////////////////////
@@ -172,7 +173,10 @@ private:
 
     CPPUNIT_TEST_SUITE( FontPickerCtrlTestCase );
         wxPICKER_BASE_TESTS();
+        CPPUNIT_TEST( ColourSelection );
     CPPUNIT_TEST_SUITE_END();
+
+    void ColourSelection();
 
     wxFontPickerCtrl *m_font;
 
@@ -198,4 +202,17 @@ void FontPickerCtrlTestCase::tearDown()
     wxDELETE(m_font);
 }
 
+void FontPickerCtrlTestCase::ColourSelection()
+{
+    wxUint32 colourRGB = 0xFF4269;
+    wxColour selectedColour(colourRGB);
+
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Default font picker color must be black",
+        m_font->GetSelectedColour().GetRGB(), wxColour(*wxBLACK).GetRGB());
+
+    m_font->SetSelectedColour(selectedColour);
+
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Font picker did not react to color selection",
+        m_font->GetSelectedColour().GetRGB(), colourRGB);
+}
 #endif //wxUSE_FONTPICKERCTRL


### PR DESCRIPTION
Pull request for http://trac.wxwidgets.org/ticket/11614

I've also taken the liberty of replacing a define with a private member function and replacing an old style C cast with a static_cast.

I've added two virtual methods to wxFontPickerWidgetBase which is used to represent the control that displays the font dialog. They allow the setting and getting of the font colour.

For wxMSW these are implemented through the wxFontData available.
For wxGTK2 these are implemented by using a data member.

A simple tests case is also included.
