### PR TITLE
Silenced gcc warnings for tests.

### DIFF
--- a/tests/cmdline/cmdlinetest.cpp
+++ b/tests/cmdline/cmdlinetest.cpp
@@ -286,20 +286,20 @@ void CmdLineTestCase::Usage()
     // details, its format can change in the future)
     static const wxCmdLineEntryDesc desc[] =
     {
-        { wxCMD_LINE_USAGE_TEXT, NULL, NULL, "Verbosity options" },
-        { wxCMD_LINE_SWITCH, "v", "verbose", "be verbose" },
-        { wxCMD_LINE_SWITCH, "q", "quiet",   "be quiet" },
+        { wxCMD_LINE_USAGE_TEXT, NULL, NULL, "Verbosity options", wxCMD_LINE_VAL_NONE, 0x0 },
+        { wxCMD_LINE_SWITCH, "v", "verbose", "be verbose", wxCMD_LINE_VAL_NONE, 0x0 },
+        { wxCMD_LINE_SWITCH, "q", "quiet",   "be quiet", wxCMD_LINE_VAL_NONE, 0x0 },
 
-        { wxCMD_LINE_USAGE_TEXT, NULL, NULL, "Output options" },
-        { wxCMD_LINE_OPTION, "o", "output",  "output file" },
-        { wxCMD_LINE_OPTION, "s", "size",    "output block size", wxCMD_LINE_VAL_NUMBER },
-        { wxCMD_LINE_OPTION, "d", "date",    "output file date", wxCMD_LINE_VAL_DATE },
-        { wxCMD_LINE_OPTION, "f", "double",  "output double", wxCMD_LINE_VAL_DOUBLE },
+        { wxCMD_LINE_USAGE_TEXT, NULL, NULL, "Output options", wxCMD_LINE_VAL_NONE, 0x0 },
+        { wxCMD_LINE_OPTION, "o", "output",  "output file", wxCMD_LINE_VAL_NONE, 0x0 },
+        { wxCMD_LINE_OPTION, "s", "size",    "output block size", wxCMD_LINE_VAL_NUMBER, 0x0 },
+        { wxCMD_LINE_OPTION, "d", "date",    "output file date", wxCMD_LINE_VAL_DATE, 0x0 },
+        { wxCMD_LINE_OPTION, "f", "double",  "output double", wxCMD_LINE_VAL_DOUBLE, 0x0 },
 
-        { wxCMD_LINE_PARAM,  NULL, NULL, "input file", },
+        { wxCMD_LINE_PARAM,  NULL, NULL, "input file", wxCMD_LINE_VAL_NONE, 0x0 },
 
-        { wxCMD_LINE_USAGE_TEXT, NULL, NULL, "\nEven more usage text" },
-        { wxCMD_LINE_NONE }
+        { wxCMD_LINE_USAGE_TEXT, NULL, NULL, "\nEven more usage text", wxCMD_LINE_VAL_NONE, 0x0 },
+        wxCMD_LINE_DESC_END
     };
 
     wxCmdLineParser p(desc);
@@ -333,13 +333,13 @@ void CmdLineTestCase::Found()
 {
     static const wxCmdLineEntryDesc desc[] =
     {
-        { wxCMD_LINE_SWITCH, "v", "verbose", "be verbose" },
-        { wxCMD_LINE_OPTION, "o", "output",  "output file" },
-        { wxCMD_LINE_OPTION, "s", "size",    "output block size", wxCMD_LINE_VAL_NUMBER },
-        { wxCMD_LINE_OPTION, "d", "date",    "output file date", wxCMD_LINE_VAL_DATE },
-        { wxCMD_LINE_OPTION, "f", "double",  "output double", wxCMD_LINE_VAL_DOUBLE },
-        { wxCMD_LINE_PARAM,  NULL, NULL, "input file", },
-        { wxCMD_LINE_NONE }
+        { wxCMD_LINE_SWITCH, "v", "verbose", "be verbose", wxCMD_LINE_VAL_NONE, 0x0 },
+        { wxCMD_LINE_OPTION, "o", "output",  "output file", wxCMD_LINE_VAL_NONE, 0x0 },
+        { wxCMD_LINE_OPTION, "s", "size",    "output block size", wxCMD_LINE_VAL_NUMBER, 0x0 },
+        { wxCMD_LINE_OPTION, "d", "date",    "output file date", wxCMD_LINE_VAL_DATE, 0x0 },
+        { wxCMD_LINE_OPTION, "f", "double",  "output double", wxCMD_LINE_VAL_DOUBLE, 0x0 },
+        { wxCMD_LINE_PARAM,  NULL, NULL, "input file", wxCMD_LINE_VAL_NONE, 0x0 },
+        wxCMD_LINE_DESC_END
     };
 
     wxCmdLineParser p(desc);

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -689,19 +689,19 @@ void DateTimeTestCase::TestTimeFormat()
 
     static const Date formatTestDates[] =
     {
-        { 29, wxDateTime::May, 1976, 18, 30, 00, 0.0, wxDateTime::Inv_WeekDay },
-        { 31, wxDateTime::Dec, 1999, 23, 30, 00, 0.0, wxDateTime::Inv_WeekDay },
-        {  6, wxDateTime::Feb, 1937, 23, 30, 00, 0.0, wxDateTime::Inv_WeekDay },
-        {  6, wxDateTime::Feb, 1856, 23, 30, 00, 0.0, wxDateTime::Inv_WeekDay },
-        {  6, wxDateTime::Feb, 1857, 23, 30, 00, 0.0, wxDateTime::Inv_WeekDay },
-        { 29, wxDateTime::May, 2076, 18, 30, 00, 0.0, wxDateTime::Inv_WeekDay },
+        { 29, wxDateTime::May, 1976, 18, 30, 00, 0.0, wxDateTime::Inv_WeekDay, -1 },
+        { 31, wxDateTime::Dec, 1999, 23, 30, 00, 0.0, wxDateTime::Inv_WeekDay, -1 },
+        {  6, wxDateTime::Feb, 1937, 23, 30, 00, 0.0, wxDateTime::Inv_WeekDay, -1 },
+        {  6, wxDateTime::Feb, 1856, 23, 30, 00, 0.0, wxDateTime::Inv_WeekDay, -1 },
+        {  6, wxDateTime::Feb, 1857, 23, 30, 00, 0.0, wxDateTime::Inv_WeekDay, -1 },
+        { 29, wxDateTime::May, 2076, 18, 30, 00, 0.0, wxDateTime::Inv_WeekDay, -1 },
 
         // FIXME: the test with 02:15:25 time doesn't pass because of DST
         //        computation problems, we get back 03:15:25
-        { 29, wxDateTime::Feb, 2400, 04, 15, 25, 0.0, wxDateTime::Inv_WeekDay },
+        { 29, wxDateTime::Feb, 2400, 04, 15, 25, 0.0, wxDateTime::Inv_WeekDay, -1 },
 #if 0
         // Need to add support for BCE dates.
-        { 01, wxDateTime::Jan,  -52, 03, 16, 47, 0.0, wxDateTime::Inv_WeekDay },
+        { 01, wxDateTime::Jan,  -52, 03, 16, 47, 0.0, wxDateTime::Inv_WeekDay, -1 },
 #endif
     };
 
@@ -957,37 +957,37 @@ void DateTimeTestCase::TestParceRFC822()
     {
         {
             "Sat, 18 Dec 1999 00:46:40 +0100",
-            { 17, wxDateTime::Dec, 1999, 23, 46, 40 },
+            { 17, wxDateTime::Dec, 1999, 23, 46, 40, 0.0, wxDateTime::Inv_WeekDay, -1 },
             true
         },
         {
             "Wed, 1 Dec 1999 05:17:20 +0300",
-            {  1, wxDateTime::Dec, 1999, 2, 17, 20 },
+            {  1, wxDateTime::Dec, 1999, 2, 17, 20, 0.0, wxDateTime::Inv_WeekDay, -1 },
             true
         },
         {
             "Sun, 28 Aug 2005 03:31:30 +0200",
-            { 28, wxDateTime::Aug, 2005, 1, 31, 30 },
+            { 28, wxDateTime::Aug, 2005, 1, 31, 30, 0.0, wxDateTime::Inv_WeekDay, -1 },
             true
         },
 
         {
             "Sat, 18 Dec 1999 10:48:30 -0500",
-            { 18, wxDateTime::Dec, 1999, 15, 48, 30 },
+            { 18, wxDateTime::Dec, 1999, 15, 48, 30, 0.0, wxDateTime::Inv_WeekDay, -1 },
             true
         },
 
         // seconds are optional according to the RFC
         {
             "Sun, 01 Jun 2008 16:30 +0200",
-            {  1, wxDateTime::Jun, 2008, 14, 30, 00 },
+            {  1, wxDateTime::Jun, 2008, 14, 30, 00, 0.0, wxDateTime::Inv_WeekDay, -1 },
             true
         },
 
         // try some bogus ones too
         {
             "Sun, 01 Jun 2008 16:30: +0200",
-            { 0 },
+            { 0, wxDateTime::Inv_Month, 00, 00, 00, 00, 0.0, wxDateTime::Inv_WeekDay, -1 },
             false
         },
     };
@@ -1027,17 +1027,17 @@ void DateTimeTestCase::TestDateParse()
         bool good;
     } parseTestDates[] =
     {
-        { "21 Mar 2006", { 21, wxDateTime::Mar, 2006 }, true },
-        { "29 Feb 1976", { 29, wxDateTime::Feb, 1976 }, true },
-        { "Feb 29 1976", { 29, wxDateTime::Feb, 1976 }, true },
-        { "31/03/06",    { 31, wxDateTime::Mar,    6 }, true },
-        { "31/03/2006",  { 31, wxDateTime::Mar, 2006 }, true },
+        { "21 Mar 2006", { 21, wxDateTime::Mar, 2006, 00, 00, 00, 0.0, wxDateTime::Inv_WeekDay, -1 }, true },
+        { "29 Feb 1976", { 29, wxDateTime::Feb, 1976, 00, 00, 00, 0.0, wxDateTime::Inv_WeekDay, -1 }, true },
+        { "Feb 29 1976", { 29, wxDateTime::Feb, 1976, 00, 00, 00, 0.0, wxDateTime::Inv_WeekDay, -1 }, true },
+        { "31/03/06",    { 31, wxDateTime::Mar,    6, 00, 00, 00, 0.0, wxDateTime::Inv_WeekDay, -1 }, true },
+        { "31/03/2006",  { 31, wxDateTime::Mar, 2006, 00, 00, 00, 0.0, wxDateTime::Inv_WeekDay, -1 }, true },
 
         // some invalid ones too
-        { "29 Feb 2006" },
-        { "31/04/06" },
-        { "bloordyblop" },
-        { "2 .  .    " },
+        { "29 Feb 2006", { 0, wxDateTime::Inv_Month, 00, 00, 00, 00, 0.0, wxDateTime::Inv_WeekDay, -1 }, true },
+        { "31/04/06", { 0, wxDateTime::Inv_Month, 00, 00, 00, 00, 0.0, wxDateTime::Inv_WeekDay, -1 }, true },
+        { "bloordyblop", { 0, wxDateTime::Inv_Month, 00, 00, 00, 00, 0.0, wxDateTime::Inv_WeekDay, -1 }, true },
+        { "2 .  .    ", { 0, wxDateTime::Inv_Month, 00, 00, 00, 00, 0.0, wxDateTime::Inv_WeekDay, -1 }, true },
     };
 
     // special cases
@@ -1082,15 +1082,15 @@ void DateTimeTestCase::TestDateParseISO()
         bool good;
     } parseTestDates[] =
     {
-        { "2006-03-21", { 21, wxDateTime::Mar, 2006 }, true },
-        { "1976-02-29", { 29, wxDateTime::Feb, 1976 }, true },
-        { "0006-03-31", { 31, wxDateTime::Mar,    6 }, true },
+        { "2006-03-21", { 21, wxDateTime::Mar, 2006, 00, 00, 00, 0.0, wxDateTime::Inv_WeekDay, -1 }, true },
+        { "1976-02-29", { 29, wxDateTime::Feb, 1976, 00, 00, 00, 0.0, wxDateTime::Inv_WeekDay, -1 }, true },
+        { "0006-03-31", { 31, wxDateTime::Mar,    6, 00, 00, 00, 0.0, wxDateTime::Inv_WeekDay, -1 }, true },
 
         // some invalid ones too
-        { "2006:03:31" },
-        { "31/04/06" },
-        { "bloordyblop" },
-        { "" },
+        { "2006:03:31", { 0, wxDateTime::Inv_Month, 00, 00, 00, 00, 0.0, wxDateTime::Inv_WeekDay, -1 }, true },
+        { "31/04/06", { 0, wxDateTime::Inv_Month, 00, 00, 00, 00, 0.0, wxDateTime::Inv_WeekDay, -1 }, true },
+        { "bloordyblop", { 0, wxDateTime::Inv_Month, 00, 00, 00, 00, 0.0, wxDateTime::Inv_WeekDay, -1 }, true },
+        { "", { 0, wxDateTime::Inv_Month, 00, 00, 00, 00, 0.0, wxDateTime::Inv_WeekDay, -1 }, true },
     };
 
     static const struct
@@ -1104,10 +1104,10 @@ void DateTimeTestCase::TestDateParseISO()
         { "02:17:01",  2, 17,  1, true },
 
         // some invalid ones too
-        { "66:03:31" },
-        { "31/04/06" },
-        { "bloordyblop" },
-        { "" },
+        { "66:03:31", 0, 0, 0, true },
+        { "31/04/06", 0, 0, 0, true },
+        { "bloordyblop", 0, 0, 0, true },
+        { "", 0, 0, 0, true },
     };
 
     for ( size_t n = 0; n < WXSIZEOF(parseTestDates); n++ )
@@ -1158,25 +1158,25 @@ void DateTimeTestCase::TestDateTimeParse()
     {
         {
             "Thu 22 Nov 2007 07:40:00 PM",
-            { 22, wxDateTime::Nov, 2007, 19, 40,  0 },
+            { 22, wxDateTime::Nov, 2007, 19, 40,  0, 0.0, wxDateTime::Inv_WeekDay, -1 },
             true
         },
 
         {
             "2010-01-04 14:30",
-            {  4, wxDateTime::Jan, 2010, 14, 30,  0 },
+            {  4, wxDateTime::Jan, 2010, 14, 30,  0, 0.0, wxDateTime::Inv_WeekDay, -1 },
             true
         },
 
         {
             "bloordyblop",
-            {  1, wxDateTime::Jan, 9999,  0,  0,  0},
+            {  1, wxDateTime::Jan, 9999,  0,  0,  0, 0.0, wxDateTime::Inv_WeekDay, -1 },
             false
         },
 
         {
             "2012-01-01 10:12:05 +0100",
-            {  1, wxDateTime::Jan, 2012,  10,  12,  5, -1 },
+            {  1, wxDateTime::Jan, 2012,  10,  12,  5, -1, wxDateTime::Inv_WeekDay, -1 },
             false // ParseDateTime does know yet +0100
         },
     };

--- a/tests/strings/strings.cpp
+++ b/tests/strings/strings.cpp
@@ -610,24 +610,24 @@ static const struct ToLongData
     bool IsOk() const { return !(flags & Number_Invalid); }
 } longData[] =
 {
-    { wxT("1"), 1, Number_Ok },
-    { wxT("0"), 0, Number_Ok },
-    { wxT("a"), 0, Number_Invalid },
-    { wxT("12345"), 12345, Number_Ok },
-    { wxT("--1"), 0, Number_Invalid },
+    { wxT("1"), 1, Number_Ok, 10 },
+    { wxT("0"), 0, Number_Ok, 10 },
+    { wxT("a"), 0, Number_Invalid, 10 },
+    { wxT("12345"), 12345, Number_Ok, 10 },
+    { wxT("--1"), 0, Number_Invalid, 10 },
 
-    { wxT("-1"), -1, Number_Signed | Number_Long },
+    { wxT("-1"), -1, Number_Signed | Number_Long, 10 },
     // this is surprising but consistent with strtoul() behaviour
-    { wxT("-1"), ULONG_MAX, Number_Unsigned | Number_Long },
+    { wxT("-1"), ULONG_MAX, Number_Unsigned | Number_Long, 10 },
 
     // this must overflow, even with 64 bit long
-    { wxT("922337203685477580711"), 0, Number_Invalid },
+    { wxT("922337203685477580711"), 0, Number_Invalid, 10 },
 
 #ifdef wxLongLong_t
-    { wxT("2147483648"), wxLL(2147483648), Number_LongLong },
-    { wxT("-2147483648"), wxLL(-2147483648), Number_LongLong | Number_Signed },
+    { wxT("2147483648"), wxLL(2147483648), Number_LongLong, 10 },
+    { wxT("-2147483648"), wxLL(-2147483648), Number_LongLong | Number_Signed, 10 },
     { wxT("9223372036854775808"), wxULL(9223372036854775808), Number_LongLong |
-                                                             Number_Unsigned },
+                                                             Number_Unsigned, 10 },
 #endif // wxLongLong_t
 
     // Base tests.
@@ -945,6 +945,10 @@ template<typename T> bool CheckStr(const wxString& expected, T s)
     return expected == wxString(s);
 }
 
+#ifdef __GNUC__
+    #pragma GCC diagnostic ignored "-Wwrite-strings"
+#endif
+
 void StringTestCase::DoCStrDataTernaryOperator(bool cond)
 {
     // test compilation of wxCStrData when used with operator?: (the asserts
@@ -968,6 +972,10 @@ void StringTestCase::DoCStrDataTernaryOperator(bool cond)
     CPPUNIT_ASSERT( CheckStr(empty, (cond ? empty.c_str() : wxEmptyString)) );
     CPPUNIT_ASSERT( CheckStr(empty, (cond ? wxEmptyString : empty.c_str())) );
 }
+
+#ifdef __GNUC__
+    #pragma GCC diagnostic pop
+#endif
 
 void StringTestCase::CStrDataOperators()
 {


### PR DESCRIPTION
There are a lot of warnings when compiling tests with gcc, about uninitialized variables. This patch fixes most of them.
