### PR TITLE
Add "EnsureVisible" support to wxTreeListCtrl

### DIFF
--- a/include/wx/treelist.h
+++ b/include/wx/treelist.h
@@ -286,7 +286,6 @@ public:
     void Collapse(wxTreeListItem item);
     bool IsExpanded(wxTreeListItem item) const;
 
-
     // Selection handling
     // ------------------
 
@@ -313,6 +312,7 @@ public:
     void SelectAll();
     void UnselectAll();
 
+    void EnsureVisible(wxTreeListItem item);
 
     // Checkbox handling
     // -----------------

--- a/interface/wx/treelist.h
+++ b/interface/wx/treelist.h
@@ -710,6 +710,11 @@ public:
      */
     void UnselectAll();
 
+    /**
+        Call this to ensure that the given item is visible.
+     */
+    void EnsureVisible(wxTreeListItem item);
+
     //@}
 
 

--- a/src/generic/treelist.cpp
+++ b/src/generic/treelist.cpp
@@ -1400,6 +1400,14 @@ void wxTreeListCtrl::UnselectAll()
     m_view->UnselectAll();
 }
 
+void wxTreeListCtrl::EnsureVisible(wxTreeListItem item)
+{
+    wxCHECK_RET( m_view, "Must create first" );
+
+    m_view->EnsureVisible(m_model->ToDVI(item));
+}
+
+
 // ----------------------------------------------------------------------------
 // Checkbox handling
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
I don't see why the TreeListCtrl couldn't support EnsureVisible. It works fine when I add it.
