### PR TITLE
Do not crash when an invalid widget is handled

### DIFF
--- a/samples/widgets/widgets.cpp
+++ b/samples/widgets/widgets.cpp
@@ -1253,6 +1253,8 @@ void WidgetsPage::SetUpWidget()
             it != widgets.end();
             ++it )
     {
+        wxCHECK_RET(*it, "NULL widget");
+
 #if wxUSE_TOOLTIPS
         (*it)->SetToolTip(GetAttrs().m_tooltip);
 #endif // wxUSE_TOOLTIPS


### PR DESCRIPTION
Do not crash when an invalid widget is handled, i.e. null StaticBitmap widget when the image file could not be found.
