### PR TITLE
Fix a bug so that wxCmdLineArgsArray::FreeArgs() can be called more than once

### DIFF
--- a/include/wx/cmdargs.h
+++ b/include/wx/cmdargs.h
@@ -128,7 +128,9 @@ private:
     void FreeArgs()
     {
         Free(m_argsA);
+        m_argsA = NULL;
         Free(m_argsW);
+        m_argsW = NULL;
     }
 
     wxArrayString m_args;


### PR DESCRIPTION
Calling wxCmdLineArgsArray::FreeArgs() more than once causes the program crashed. wxCmdLineArgsArray::operator=(T **argv) can't be called when m_argsA or m_argsW is not NULL; otherwise the wxCmdLineArgsArray::~wxCmdLineArgsArray() will crash,
