### PR TITLE
Fix inconsistency with newly created wxDatePickerCtrl on OSX

### DIFF
--- a/src/osx/cocoa/datetimectrl.mm
+++ b/src/osx/cocoa/datetimectrl.mm
@@ -174,6 +174,10 @@ wxDateTimeWidgetImpl::CreateDateTimePicker(wxDateTimePickerCtrl* wxpeer,
     {
         [v setDateValue: NSDateFromWX(dt)];
     }
+    else
+    {
+        [v setDateValue: NSDateFromWX(wxDateTime::Today())];
+    }
 
     wxDateTimeWidgetImpl* c = new wxDateTimeWidgetCocoaImpl(wxpeer, v);
 #if !wxOSX_USE_NATIVE_FLIPPED

--- a/src/osx/cocoa/datetimectrl.mm
+++ b/src/osx/cocoa/datetimectrl.mm
@@ -176,7 +176,7 @@ wxDateTimeWidgetImpl::CreateDateTimePicker(wxDateTimePickerCtrl* wxpeer,
     }
     else
     {
-        [v setDateValue: NSDateFromWX(wxDateTime::Today())];
+        [v setDateValue: [NSDate date]];
     }
 
     wxDateTimeWidgetImpl* c = new wxDateTimeWidgetCocoaImpl(wxpeer, v);


### PR DESCRIPTION
The documentation in interface/wx/datectrl.h says for the parameter `dt`:

> “The initial value of the control, if an invalid date (such as the default value) is used, the control is set to today.”

However, currently a default wxDatePickerCtrl on OSX gets not set to today, but to 2001-01-01.

As I am new to wxWidgets, I am not sure if the suggested solution using `NSDateFromWX(wxDateTime::Today())` is appropriate/correct. It would also be possible to use a `[NSDate date]` for the default date value.
