### PR TITLE
Build child controls of config sample following UI rules.

### DIFF
--- a/samples/config/conftest.cpp
+++ b/samples/config/conftest.cpp
@@ -169,11 +169,16 @@ MyFrame::MyFrame()
 
     // child controls
     wxPanel *panel = new wxPanel(this);
-    (void)new wxStaticText(panel, wxID_ANY, wxT("These controls remember their values!"),
-                            wxPoint(10, 10), wxSize(300, 20));
-    m_text = new wxTextCtrl(panel, wxID_ANY, wxT(""), wxPoint(10, 40), wxSize(300, 20));
-    m_check = new wxCheckBox(panel, wxID_ANY, wxT("show welcome message box at startup"),
-                            wxPoint(10, 70), wxSize(300, 20));
+    wxStaticText* st = new wxStaticText(panel, wxID_ANY, wxT("These controls remember their values!"));
+    m_text = new wxTextCtrl(panel, wxID_ANY);
+    m_check = new wxCheckBox(panel, wxID_ANY, wxT("show welcome message box at startup"));
+
+    // put evreything in a sizer
+    wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
+    sizer->Add(st, wxSizerFlags().Border(wxLEFT|wxBOTTOM|wxTOP, 10));
+    sizer->Add(m_text, wxSizerFlags().Border(wxLEFT|wxBOTTOM|wxRIGHT, 10).Expand());
+    sizer->Add(m_check, wxSizerFlags().Border(wxLEFT, 10));
+    panel->SetSizer(sizer);
 
     // restore the control's values from the config
 


### PR DESCRIPTION
When using absolute size and position, the text of m_text is clipped at the bottom (Win 7).
