### PR TITLE
Add support for getting micro version changes in OS and toolkit version functions

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -27,6 +27,10 @@ Changes in behaviour not resulting in compilation errors
 - Using invalid flags with wxBoxSizer or wxGridSizer items now triggers asserts
   when done from the code or error messages when done in XRC.
 
+- The pure virtual function wxAppTrait::GetToolkitVersion() now has a parameter
+  for getting the micro version. If you override GetToolkitVersion() you need
+  to add this new third parameter.
+
 Changes in behaviour which may result in build errors
 -----------------------------------------------------
 
@@ -66,6 +70,8 @@ All:
 - Add wxART_FULL_SCREEN standard bitmap (Igor Korot).
 - Fix wxStringTokenizer copy ctor and assignment operator.
 - Added wxASSERT_MSG_AT() and wxFAIL_MSG_AT() macros.
+- Add parameter to get the micro version to OS and toolkit version
+  functions. See wxGetOsVersion(), wxPlatformInfo, and wxAppTraits.
 
 Unix:
 

--- a/include/wx/apptrait.h
+++ b/include/wx/apptrait.h
@@ -130,7 +130,9 @@ public:
     // runtime (not compile-time) version.
     // returns wxPORT_BASE for console applications and one of the remaining
     // wxPORT_* values for GUI applications.
-    virtual wxPortId GetToolkitVersion(int *majVer = NULL, int *minVer = NULL) const = 0;
+    virtual wxPortId GetToolkitVersion(int *majVer = NULL,
+                                       int *minVer = NULL,
+                                       int *microVer = NULL) const = 0;
 
     // return true if the port is using wxUniversal for the GUI, false if not
     virtual bool IsUsingUniversalWidgets() const = 0;
@@ -209,13 +211,16 @@ public:
     virtual bool HasStderr() wxOVERRIDE;
 
     // the GetToolkitVersion for console application is always the same
-    virtual wxPortId GetToolkitVersion(int *verMaj = NULL, int *verMin = NULL) const wxOVERRIDE
+    wxPortId GetToolkitVersion(int *verMaj = NULL,
+                               int *verMin = NULL,
+                               int *verMicro = NULL) const wxOVERRIDE
     {
         // no toolkits (wxBase is for console applications without GUI support)
         // NB: zero means "no toolkit", -1 means "not initialized yet"
         //     so we must use zero here!
         if (verMaj) *verMaj = 0;
         if (verMin) *verMin = 0;
+        if (verMicro) *verMicro = 0;
         return wxPORT_BASE;
     }
 

--- a/include/wx/msdos/apptrait.h
+++ b/include/wx/msdos/apptrait.h
@@ -23,7 +23,9 @@ class wxGUIAppTraits : public wxGUIAppTraitsBase
 {
 public:
     virtual wxEventLoopBase *CreateEventLoop();
-    virtual wxPortId GetToolkitVersion(int *majVer = NULL, int *minVer = NULL) const;
+    wxPortId GetToolkitVersion(int *majVer = NULL,
+                               int *minVer = NULL,
+                               int *microVer = NULL) const wxOVERRIDE;
 
 #if wxUSE_TIMER
     virtual wxTimerImpl *CreateTimerImpl(wxTimer *timer);

--- a/include/wx/msw/apptrait.h
+++ b/include/wx/msw/apptrait.h
@@ -51,7 +51,9 @@ public:
     virtual bool DoMessageFromThreadWait();
     virtual WXDWORD WaitForThread(WXHANDLE hThread, int flags);
 #endif // wxUSE_THREADS
-    virtual wxPortId GetToolkitVersion(int *majVer = NULL, int *minVer = NULL) const;
+    wxPortId GetToolkitVersion(int *majVer = NULL,
+                               int *minVer = NULL,
+                               int *microVer = NULL) const wxOVERRIDE;
 
 #ifndef __WXWINCE__
     virtual bool CanUseStderr();
@@ -81,7 +83,9 @@ public:
     virtual WXDWORD WaitForThread(WXHANDLE hThread, int WXUNUSED(flags))
         { return DoSimpleWaitForThread(hThread); }
 #endif // wxUSE_THREADS
-    virtual wxPortId GetToolkitVersion(int *majVer = NULL, int *minVer = NULL) const;
+    virtual wxPortId GetToolkitVersion(int *majVer = NULL,
+                                       int *minVer = NULL,
+                                       int *microVer = NULL) const;
 
 #ifndef __WXWINCE__
     virtual bool CanUseStderr() { return false; }

--- a/include/wx/platinfo.h
+++ b/include/wx/platinfo.h
@@ -206,15 +206,17 @@ public:
         { return m_tkVersionMajor; }
     int GetToolkitMinorVersion() const
         { return m_tkVersionMinor; }
+    int GetToolkitMicroVersion() const
+        { return m_tkVersionMicro; }
 
-    bool CheckToolkitVersion(int major, int minor) const
+    bool CheckToolkitVersion(int major, int minor, int micro = 0) const
     {
         return DoCheckVersion(GetToolkitMajorVersion(),
                               GetToolkitMinorVersion(),
-                              0,
+                              GetToolkitMicroVersion(),
                               major,
                               minor,
-                              0);
+                              micro);
     }
 
     bool IsUsingUniversalWidgets() const
@@ -268,8 +270,12 @@ public:
         m_osVersionMicro = micro;
     }
 
-    void SetToolkitVersion(int major, int minor)
-        { m_tkVersionMajor=major; m_tkVersionMinor=minor; }
+    void SetToolkitVersion(int major, int minor, int micro = 0)
+    {
+        m_tkVersionMajor = major;
+        m_tkVersionMinor = minor;
+        m_tkVersionMicro = micro;
+    }
 
     void SetOperatingSystemId(wxOperatingSystemId n)
         { m_os = n; }
@@ -298,6 +304,7 @@ public:
                m_os != wxOS_UNKNOWN &&
                !m_osDesc.IsEmpty() &&
                m_tkVersionMajor != -1 && m_tkVersionMinor != -1 &&
+               m_tkVersionMicro != -1 &&
                m_port != wxPORT_UNKNOWN &&
                m_arch != wxARCH_INVALID &&
                m_endian != wxENDIAN_INVALID;
@@ -346,7 +353,7 @@ protected:
 
     // Version of the underlying toolkit
     // (-1 means not initialized yet; zero means no toolkit).
-    int m_tkVersionMajor, m_tkVersionMinor;
+    int m_tkVersionMajor, m_tkVersionMinor, m_tkVersionMicro;
 
     // name of the wxWidgets port
     wxPortId m_port;

--- a/include/wx/platinfo.h
+++ b/include/wx/platinfo.h
@@ -188,14 +188,18 @@ public:
         { return m_osVersionMajor; }
     int GetOSMinorVersion() const
         { return m_osVersionMinor; }
+    int GetOSMicroVersion() const
+        { return m_osVersionMicro; }
 
-    // return true if the OS version >= major.minor
-    bool CheckOSVersion(int major, int minor) const
+    // return true if the OS version >= major.minor.micro
+    bool CheckOSVersion(int major, int minor, int micro = 0) const
     {
         return DoCheckVersion(GetOSMajorVersion(),
                               GetOSMinorVersion(),
+                              GetOSMicroVersion(),
                               major,
-                              minor);
+                              minor,
+                              micro);
     }
 
     int GetToolkitMajorVersion() const
@@ -207,8 +211,10 @@ public:
     {
         return DoCheckVersion(GetToolkitMajorVersion(),
                               GetToolkitMinorVersion(),
+                              0,
                               major,
-                              minor);
+                              minor,
+                              0);
     }
 
     bool IsUsingUniversalWidgets() const
@@ -255,8 +261,13 @@ public:
     // setters
     // -----------------
 
-    void SetOSVersion(int major, int minor)
-        { m_osVersionMajor=major; m_osVersionMinor=minor; }
+    void SetOSVersion(int major, int minor, int micro = 0)
+    {
+        m_osVersionMajor = major;
+        m_osVersionMinor = minor;
+        m_osVersionMicro = micro;
+    }
+
     void SetToolkitVersion(int major, int minor)
         { m_tkVersionMajor=major; m_tkVersionMinor=minor; }
 
@@ -283,6 +294,7 @@ public:
     bool IsOk() const
     {
         return m_osVersionMajor != -1 && m_osVersionMinor != -1 &&
+               m_osVersionMicro != -1 &&
                m_os != wxOS_UNKNOWN &&
                !m_osDesc.IsEmpty() &&
                m_tkVersionMajor != -1 && m_tkVersionMinor != -1 &&
@@ -295,9 +307,12 @@ public:
 
 
 protected:
-    static bool DoCheckVersion(int majorCur, int minorCur, int major, int minor)
+    static bool DoCheckVersion(int majorCur, int minorCur, int microCur,
+                               int major, int minor, int micro)
     {
-        return majorCur > major || (majorCur == major && minorCur >= minor);
+        return majorCur > major
+            || (majorCur == major && minorCur > minor)
+            || (majorCur == major && minorCur == minor && microCur >= micro);
     }
 
     void InitForCurrentPlatform();
@@ -309,7 +324,8 @@ protected:
     // Version of the OS; valid if m_os != wxOS_UNKNOWN
     // (-1 means not initialized yet).
     int m_osVersionMajor,
-        m_osVersionMinor;
+        m_osVersionMinor,
+        m_osVersionMicro;
 
     // Operating system ID.
     wxOperatingSystemId m_os;

--- a/include/wx/unix/apptrait.h
+++ b/include/wx/unix/apptrait.h
@@ -61,7 +61,9 @@ public:
 #if defined(__WXMAC__) && wxUSE_STDPATHS
     virtual wxStandardPaths& GetStandardPaths();
 #endif
-    virtual wxPortId GetToolkitVersion(int *majVer = NULL, int *minVer = NULL) const wxOVERRIDE;
+    wxPortId GetToolkitVersion(int *majVer = NULL,
+                               int *minVer = NULL,
+                               int *microVer = NULL) const wxOVERRIDE;
 
 #ifdef __WXGTK20__
     virtual wxString GetDesktopEnvironment() const;

--- a/include/wx/utils.h
+++ b/include/wx/utils.h
@@ -141,7 +141,8 @@ WXDLLIMPEXP_BASE wxString wxGetOsDescription();
 
 // Get OS version
 WXDLLIMPEXP_BASE wxOperatingSystemId wxGetOsVersion(int *verMaj = NULL,
-                                                    int *verMin = NULL);
+                                                    int *verMin = NULL,
+                                                    int *verMicro = NULL);
 
 // Get platform endianness
 WXDLLIMPEXP_BASE bool wxIsPlatformLittleEndian();

--- a/include/wx/utils.h
+++ b/include/wx/utils.h
@@ -140,8 +140,8 @@ WXDLLIMPEXP_CORE wxVersionInfo wxGetLibraryVersionInfo();
 WXDLLIMPEXP_BASE wxString wxGetOsDescription();
 
 // Get OS version
-WXDLLIMPEXP_BASE wxOperatingSystemId wxGetOsVersion(int *majorVsn = NULL,
-                                                    int *minorVsn = NULL);
+WXDLLIMPEXP_BASE wxOperatingSystemId wxGetOsVersion(int *verMaj = NULL,
+                                                    int *verMin = NULL);
 
 // Get platform endianness
 WXDLLIMPEXP_BASE bool wxIsPlatformLittleEndian();

--- a/interface/wx/apptrait.h
+++ b/interface/wx/apptrait.h
@@ -100,8 +100,8 @@ public:
 
     /**
         Returns the wxWidgets port ID used by the running program and eventually
-        fills the given pointers with the values of the major and minor digits
-        of the native toolkit currently used.
+        fills the given pointers with the values of the major, minor, and micro
+        digits of the native toolkit currently used.
 
         The version numbers returned are thus detected at run-time and not compile-time
         (except when this is not possible e.g. wxMotif).
@@ -109,8 +109,12 @@ public:
         E.g. if your program is using wxGTK port this function will return wxPORT_GTK
         and put in given pointers the versions of the GTK library in use.
         See wxPlatformInfo for more details.
+
+        If a micro version is not available it will have a value of 0.
     */
-    virtual wxPortId GetToolkitVersion(int* major = NULL, int* minor = NULL) const = 0;
+    virtual wxPortId GetToolkitVersion(int* major = NULL,
+                                       int* minor = NULL,
+                                       int* micro = NULL) const = 0;
 
     /**
         Returns @true if @c fprintf(stderr) goes somewhere, @false otherwise.

--- a/interface/wx/platinfo.h
+++ b/interface/wx/platinfo.h
@@ -12,11 +12,11 @@
 
     The values of the constants are chosen so that they can be combined as flags;
     this allows to check for operating system families like e.g. @c wxOS_MAC and @c wxOS_UNIX.
-    
+
     Note that you can obtain more detailed information about the current OS
-    version in use by checking the major and minor version numbers returned
-    by ::wxGetOsVersion() or by wxPlatformInfo::GetOSMajorVersion(), 
-    wxPlatformInfo::GetOSMinorVersion().
+    version in use by checking the major, minor, and micro version numbers
+    returned by ::wxGetOsVersion() or by wxPlatformInfo::GetOSMajorVersion(),
+    wxPlatformInfo::GetOSMinorVersion(), and wxPlatformInfo::GetOSMicroVersion().
 */
 enum wxOperatingSystemId
 {
@@ -189,12 +189,12 @@ public:
 
 
     /**
-        Returns @true if the OS version is at least @c major.minor.
+        Returns @true if the OS version is at least @c major.minor.micro.
 
-        @see GetOSMajorVersion(), GetOSMinorVersion(),
+        @see GetOSMajorVersion(), GetOSMinorVersion(), GetOSMicroVersion(),
              CheckToolkitVersion()
     */
-    bool CheckOSVersion(int major, int minor) const;
+    bool CheckOSVersion(int major, int minor, int micro = 0) const;
 
     /**
         Returns @true if the toolkit version is at least @c major.minor.
@@ -361,6 +361,16 @@ public:
     int GetOSMinorVersion() const;
 
     /**
+        Returns the run-time micro version of the OS associated with this
+        wxPlatformInfo instance.
+
+        @see ::wxGetOsVersion(), CheckOSVersion()
+
+        @since 3.1.0
+    */
+    int GetOSMicroVersion() const;
+
+    /**
         Returns the operating system ID of this wxPlatformInfo instance.
         
         See wxGetOsVersion() for more info.
@@ -484,7 +494,7 @@ public:
         Sets the version of the operating system associated with this wxPlatformInfo
         instance.
     */
-    void SetOSVersion(int major, int minor);
+    void SetOSVersion(int major, int minor, int micro = 0);
 
     /**
         Sets the operating system associated with this wxPlatformInfo instance.

--- a/interface/wx/platinfo.h
+++ b/interface/wx/platinfo.h
@@ -197,13 +197,12 @@ public:
     bool CheckOSVersion(int major, int minor, int micro = 0) const;
 
     /**
-        Returns @true if the toolkit version is at least @c major.minor.
+        Returns @true if the toolkit version is at least @c major.minor.micro.
 
-        @see GetToolkitMajorVersion(),
-             GetToolkitMinorVersion(), CheckOSVersion()
+        @see GetToolkitMajorVersion(), GetToolkitMinorVersion(),
+             GetToolkitMicroVersion(), CheckOSVersion()
     */
-    bool CheckToolkitVersion(int major, int minor) const;
-    
+    bool CheckToolkitVersion(int major, int minor, int micro = 0) const;
 
     /**
         Returns @true if this instance is fully initialized with valid values.
@@ -429,6 +428,21 @@ public:
     */
     int GetToolkitMinorVersion() const;
     
+    /**
+        Returns the run-time micro version of the toolkit associated with this
+        wxPlatformInfo instance.
+
+        Note that if GetPortId() returns @c wxPORT_BASE, then this value is zero
+        (unless externally modified with SetToolkitVersion()); that is, no native
+        toolkit is in use.
+        See wxAppTraits::GetToolkitVersion() for more info.
+
+        @see CheckToolkitVersion()
+
+        @since 3.1.0
+    */
+    int GetToolkitMicroVersion() const;
+    
     //@}
 
 
@@ -509,7 +523,7 @@ public:
     /**
         Sets the version of the toolkit associated with this wxPlatformInfo instance.
     */
-    void SetToolkitVersion(int major, int minor);
+    void SetToolkitVersion(int major, int minor, int micro = 0);
 
     /**
         Sets the operating system description associated with this wxPlatformInfo instance.

--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -855,9 +855,10 @@ wxString wxGetOsDescription();
     On systems where only the micro version can't be detected or doesn't make
     sense such as Windows, it will have a value of 0.
 
-    For Unix-like systems (@c wxOS_UNIX) the major and minor version integers will 
-    contain the kernel major and minor version numbers (as returned by the
-    'uname -r' command); e.g. "2" and "6" if the machine is using kernel 2.6.19.
+    For Unix-like systems (@c wxOS_UNIX) the major, minor, and micro version
+    integers will  contain the kernel's major, minor, and micro version
+    numbers (as returned by the 'uname -r' command); e.g. "4", "0", and "6" if
+    the machine is using kernel 4.0.6.
 
     For OS X systems (@c wxOS_MAC) the major, minor, and micro version integers
     are the natural version numbers associated with the OS; e.g. "10", "9", and

--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -846,17 +846,23 @@ wxString wxGetOsDescription();
 /**
     Gets the version and the operating system ID for currently running OS. 
     The returned wxOperatingSystemId value can be used for a basic categorization
-    of the OS family; the major and minor version numbers allows to detect a specific
-    system.
-    
+    of the OS family; the major, minor, and micro version numbers allows to
+    detect a specific system.
+
+    If on Unix-like systems the version can't be detected all three version
+    numbers will have a value of -1.
+
+    On systems where only the micro version can't be detected or doesn't make
+    sense such as Windows, it will have a value of 0.
+
     For Unix-like systems (@c wxOS_UNIX) the major and minor version integers will 
     contain the kernel major and minor version numbers (as returned by the
     'uname -r' command); e.g. "2" and "6" if the machine is using kernel 2.6.19.
 
-    For Mac OS X systems (@c wxOS_MAC) the major and minor version integers are the
-    natural version numbers associated with the OS; e.g. "10" and "6" if the machine
-    is using Mac OS X Snow Leopard.    
-    
+    For OS X systems (@c wxOS_MAC) the major, minor, and micro version integers
+    are the natural version numbers associated with the OS; e.g. "10", "9", and
+    "5" if the machine is using OS X Yosemite 10.9.5.
+
     For Windows-like systems (@c wxOS_WINDOWS) the major and minor version integers will 
     contain the following values:
     @beginTable
@@ -877,7 +883,7 @@ wxString wxGetOsDescription();
 
     @header{wx/utils.h}
 */
-wxOperatingSystemId wxGetOsVersion(int* major = NULL, int* minor = NULL);
+wxOperatingSystemId wxGetOsVersion(int* major = NULL, int* minor = NULL, int* micro = NULL);
 
 /**
     Returns @true if the operating system the program is running under is 64

--- a/src/common/platinfo.cpp
+++ b/src/common/platinfo.cpp
@@ -143,6 +143,7 @@ wxPlatformInfo::wxPlatformInfo(wxPortId pid, int tkMajor, int tkMinor,
     m_os = id;
     m_osVersionMajor = osMajor;
     m_osVersionMinor = osMinor;
+    m_osVersionMicro = -1;
 
     m_endian = endian;
     m_arch = arch;
@@ -154,6 +155,7 @@ bool wxPlatformInfo::operator==(const wxPlatformInfo &t) const
            m_tkVersionMinor == t.m_tkVersionMinor &&
            m_osVersionMajor == t.m_osVersionMajor &&
            m_osVersionMinor == t.m_osVersionMinor &&
+           m_osVersionMicro == t.m_osVersionMicro &&
            m_os == t.m_os &&
            m_osDesc == t.m_osDesc &&
            m_ldi == t.m_ldi &&
@@ -184,7 +186,7 @@ void wxPlatformInfo::InitForCurrentPlatform()
         m_desktopEnv = traits->GetDesktopEnvironment();
     }
 
-    m_os = wxGetOsVersion(&m_osVersionMajor, &m_osVersionMinor);
+    m_os = wxGetOsVersion(&m_osVersionMajor, &m_osVersionMinor, &m_osVersionMicro);
     m_osDesc = wxGetOsDescription();
     m_endian = wxIsPlatformLittleEndian() ? wxENDIAN_LITTLE : wxENDIAN_BIG;
     m_arch = wxIsPlatform64Bit() ? wxARCH_64 : wxARCH_32;

--- a/src/common/platinfo.cpp
+++ b/src/common/platinfo.cpp
@@ -137,6 +137,7 @@ wxPlatformInfo::wxPlatformInfo(wxPortId pid, int tkMajor, int tkMinor,
 {
     m_tkVersionMajor = tkMajor;
     m_tkVersionMinor = tkMinor;
+    m_tkVersionMicro = -1;
     m_port = pid;
     m_usingUniversal = usingUniversal;
 
@@ -153,6 +154,7 @@ bool wxPlatformInfo::operator==(const wxPlatformInfo &t) const
 {
     return m_tkVersionMajor == t.m_tkVersionMajor &&
            m_tkVersionMinor == t.m_tkVersionMinor &&
+           m_tkVersionMicro == t.m_tkVersionMicro &&
            m_osVersionMajor == t.m_osVersionMajor &&
            m_osVersionMinor == t.m_osVersionMinor &&
            m_osVersionMicro == t.m_osVersionMicro &&
@@ -177,11 +179,12 @@ void wxPlatformInfo::InitForCurrentPlatform()
         m_port = wxPORT_UNKNOWN;
         m_usingUniversal = false;
         m_tkVersionMajor =
-                m_tkVersionMinor = 0;
+                m_tkVersionMinor = m_tkVersionMicro = 0;
     }
     else
     {
-        m_port = traits->GetToolkitVersion(&m_tkVersionMajor, &m_tkVersionMinor);
+        m_port = traits->GetToolkitVersion(&m_tkVersionMajor, &m_tkVersionMinor,
+                                           &m_tkVersionMicro);
         m_usingUniversal = traits->IsUsingUniversalWidgets();
         m_desktopEnv = traits->GetDesktopEnvironment();
     }

--- a/src/dfb/utils.cpp
+++ b/src/dfb/utils.cpp
@@ -30,10 +30,13 @@
 // toolkit info
 // ----------------------------------------------------------------------------
 
-wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj, int *verMin) const
+wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj,
+                                           int *verMin,
+                                           int *verMicro) const
 {
     if ( verMaj ) *verMaj = DIRECTFB_MAJOR_VERSION;
     if ( verMin ) *verMaj = DIRECTFB_MINOR_VERSION;
+    if ( verMicro ) *verMicro = DIRECTFB_MICRO_VERSION;
 
     return wxPORT_DFB;
 }

--- a/src/gtk/utilsgtk.cpp
+++ b/src/gtk/utilsgtk.cpp
@@ -182,12 +182,16 @@ const gchar *wx_pango_version_check (int major, int minor, int micro)
 // wxPlatformInfo-related
 // ----------------------------------------------------------------------------
 
-wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj, int *verMin) const
+wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj,
+                                           int *verMin,
+                                           int *verMicro) const
 {
     if ( verMaj )
         *verMaj = gtk_major_version;
     if ( verMin )
         *verMin = gtk_minor_version;
+    if ( verMicro )
+        *verMicro = gtk_micro_version;
 
     return wxPORT_GTK;
 }

--- a/src/gtk1/utilsgtk.cpp
+++ b/src/gtk1/utilsgtk.cpp
@@ -136,12 +136,16 @@ wxTimerImpl* wxGUIAppTraits::CreateTimerImpl(wxTimer *timer)
 // wxPlatformInfo-related
 // ----------------------------------------------------------------------------
 
-wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj, int *verMin) const
+wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj,
+                                           int *verMin,
+                                           int *verMicro) const
 {
     if ( verMaj )
         *verMaj = gtk_major_version;
     if ( verMin )
         *verMin = gtk_minor_version;
+    if ( verMicro )
+        *verMicro = gtk_micro_version;
 
     return wxPORT_GTK;
 }

--- a/src/motif/utils.cpp
+++ b/src/motif/utils.cpp
@@ -176,13 +176,17 @@ void wxBell()
     XBell (wxGlobalDisplay(), 0);
 }
 
-wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj, int *verMin) const
+wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj,
+                                           int *verMin,
+                                           int *verMicro) const
 {
     // XmVERSION and XmREVISION are defined in Xm/Xm.h
     if ( verMaj )
         *verMaj = XmVERSION;
     if ( verMin )
         *verMin = XmREVISION;
+    if ( verMicro )
+        *verMicro = 0;
 
     return wxPORT_MOTIF;
 }

--- a/src/msdos/utilsdos.cpp
+++ b/src/msdos/utilsdos.cpp
@@ -494,12 +494,16 @@ wxString wxGetOsDescription()
     return osname;
 }
 
-wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin)
+wxOperatingSystemId wxGetOsVersion(int *verMaj,
+                                   int *verMin,
+                                   int *verMicro)
 {
     if ( verMaj )
         *verMaj = _osmajor;
     if ( verMin )
         *verMin = _osminor;
+    if ( verMicro )
+        *verMicro = 0;
 
     return wxOS_DOS;
 }

--- a/src/msw/app.cpp
+++ b/src/msw/app.cpp
@@ -245,11 +245,13 @@ WXDWORD wxGUIAppTraits::WaitForThread(WXHANDLE hThread, int flags)
 }
 #endif // wxUSE_THREADS
 
-wxPortId wxGUIAppTraits::GetToolkitVersion(int *majVer, int *minVer) const
+wxPortId wxGUIAppTraits::GetToolkitVersion(int *majVer,
+                                           int *minVer,
+                                           int *microVer) const
 {
     // on Windows, the toolkit version is the same of the OS version
     // as Windows integrates the OS kernel with the GUI toolkit.
-    wxGetOsVersion(majVer, minVer);
+    wxGetOsVersion(majVer, minVer, microVer);
 
 #if defined(__WXHANDHELD__) || defined(__WXWINCE__)
     return wxPORT_WINCE;

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -1284,7 +1284,7 @@ bool wxIsPlatform64Bit()
 #endif // Win64/Win32
 }
 
-wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin)
+wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
 {
     static struct
     {
@@ -1328,6 +1328,8 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin)
         *verMaj = s_version.verMaj;
     if ( verMin )
         *verMin = s_version.verMin;
+    if ( verMicro )
+        *verMicro = 0;
 
     return s_version.os;
 }

--- a/src/osx/core/utilsexc_base.cpp
+++ b/src/osx/core/utilsexc_base.cpp
@@ -68,7 +68,7 @@ long UMAGetSystemVersion()
 }
 
 // our OS version is the same in non GUI and GUI cases
-wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin)
+wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
 {
     // This returns 10 and 6 for OS X 10.6, consistent with behaviour on
     // other platforms.
@@ -81,6 +81,11 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin)
     if (verMin)
     {
         Gestalt(gestaltSystemVersionMinor, verMin);
+    }
+
+    if (verMicro)
+    {
+        Gestalt(gestaltSystemVersionBugFix, verMicro);
     }
 
     return wxOS_MAC_OSX_DARWIN;

--- a/src/osx/core/utilsexc_base.cpp
+++ b/src/osx/core/utilsexc_base.cpp
@@ -82,16 +82,6 @@ wxOperatingSystemId wxGetOsVersion(int *majorVsn, int *minorVsn)
     if ( minorVsn != NULL )
         *minorVsn = min;
 
-#if 0
-    SInt32 theSystem;
-    Gestalt(gestaltSystemVersion, &theSystem);
-
-    if ( majorVsn != NULL )
-        *majorVsn = (theSystem >> 8);
-
-    if ( minorVsn != NULL )
-        *minorVsn = (theSystem & 0xFF);
-#endif
     return wxOS_MAC_OSX_DARWIN;
 }
 

--- a/src/osx/core/utilsexc_base.cpp
+++ b/src/osx/core/utilsexc_base.cpp
@@ -68,7 +68,7 @@ long UMAGetSystemVersion()
 }
 
 // our OS version is the same in non GUI and GUI cases
-wxOperatingSystemId wxGetOsVersion(int *majorVsn, int *minorVsn)
+wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin)
 {
     // This returns 10 and 6 for OS X 10.6, consistent with behaviour on
     // other platforms.
@@ -76,11 +76,11 @@ wxOperatingSystemId wxGetOsVersion(int *majorVsn, int *minorVsn)
     Gestalt(gestaltSystemVersionMajor, &maj);
     Gestalt(gestaltSystemVersionMinor, &min);
 
-    if ( majorVsn != NULL )
-        *majorVsn = maj;
+    if ( verMaj != NULL )
+        *verMaj = maj;
 
-    if ( minorVsn != NULL )
-        *minorVsn = min;
+    if ( verMin != NULL )
+        *verMin = min;
 
     return wxOS_MAC_OSX_DARWIN;
 }

--- a/src/osx/core/utilsexc_base.cpp
+++ b/src/osx/core/utilsexc_base.cpp
@@ -72,15 +72,16 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin)
 {
     // This returns 10 and 6 for OS X 10.6, consistent with behaviour on
     // other platforms.
-    SInt32 maj, min;
-    Gestalt(gestaltSystemVersionMajor, &maj);
-    Gestalt(gestaltSystemVersionMinor, &min);
 
-    if ( verMaj != NULL )
-        *verMaj = maj;
+    if (verMaj)
+    {
+        Gestalt(gestaltSystemVersionMajor, verMaj);
+    }
 
-    if ( verMin != NULL )
-        *verMin = min;
+    if (verMin)
+    {
+        Gestalt(gestaltSystemVersionMinor, verMin);
+    }
 
     return wxOS_MAC_OSX_DARWIN;
 }

--- a/src/osx/iphone/utils.mm
+++ b/src/osx/iphone/utils.mm
@@ -318,7 +318,7 @@ wxBitmap wxWindowDCImpl::DoGetAsBitmap(const wxRect *subrect) const
 
 // TODO move these into a BASE file
 
-wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin)
+wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
 {
     // get OS version
     int major, minor;
@@ -338,6 +338,8 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin)
         *verMaj = major;
     if ( verMin )
         *verMin = minor;
+    if ( verMicro )
+        *verMicro = (major == -1) ? -1 : 0;
 
     return wxOS_MAC_OSX_DARWIN;
 }

--- a/src/osx/utils_osx.cpp
+++ b/src/osx/utils_osx.cpp
@@ -166,10 +166,12 @@ void wxDisplaySizeMM(int *width, int *height)
 }
 
 
-wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj, int *verMin) const
+wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj,
+                                           int *verMin,
+                                           int *verMicro) const
 {
     // We suppose that toolkit version is the same as OS version under Mac
-    wxGetOsVersion(verMaj, verMin);
+    wxGetOsVersion(verMaj, verMin, verMicro);
 
     return wxPORT_OSX;
 }

--- a/src/qt/apptraits.cpp
+++ b/src/qt/apptraits.cpp
@@ -39,12 +39,16 @@ wxTimerImpl *wxGUIAppTraits::CreateTimerImpl(wxTimer *timer)
 
 // #endif
 
-wxPortId wxGUIAppTraits::GetToolkitVersion(int *majVer, int *minVer) const
+wxPortId wxGUIAppTraits::GetToolkitVersion(int *majVer,
+                                           int *minVer,
+                                           int *microVer) const
 {
     if ( majVer )
         *majVer = QT_VERSION >> 16;
     if ( minVer )
         *minVer = (QT_VERSION >> 8) & 0xFF;
+    if ( microVer )
+        *microVer = QT_VERSION & 0xFF;
 
     return wxPORT_QT;
 }

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -1117,14 +1117,19 @@ wxLinuxDistributionInfo wxGetLinuxDistributionInfo()
 wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
 {
     // get OS version
-    int major, minor;
+    int major = -1, minor = -1, micro = -1;
     wxString release = wxGetCommandOutput(wxT("uname -r"));
-    if ( release.empty() ||
-         wxSscanf(release.c_str(), wxT("%d.%d"), &major, &minor) != 2 )
+    if ( !release.empty() )
     {
-        // failed to get version string or unrecognized format
-        major =
-        minor = -1;
+        if ( wxSscanf(release.c_str(), wxT("%d.%d.%d"), &major, &minor, &micro ) != 3 )
+        {
+            micro = 0;
+            if ( wxSscanf(release.c_str(), wxT("%d.%d"), &major, &minor ) != 2 )
+            {
+                // failed to get version string or unrecognized format
+                major = minor = micro = -1;
+            }
+        }
     }
 
     if ( verMaj )
@@ -1132,7 +1137,7 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
     if ( verMin )
         *verMin = minor;
     if ( verMicro )
-        *verMicro = (major == -1) ? -1 : 0;
+        *verMicro = micro;
 
     // try to understand which OS are we running
     wxString kernel = wxGetCommandOutput(wxT("uname -s"));

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -1114,7 +1114,7 @@ wxLinuxDistributionInfo wxGetLinuxDistributionInfo()
 // these functions are in src/osx/utilsexc_base.cpp for wxMac
 #ifndef __DARWIN__
 
-wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin)
+wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
 {
     // get OS version
     int major, minor;
@@ -1131,6 +1131,8 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin)
         *verMaj = major;
     if ( verMin )
         *verMin = minor;
+    if ( verMicro )
+        *verMicro = (major == -1) ? -1 : 0;
 
     // try to understand which OS are we running
     wxString kernel = wxGetCommandOutput(wxT("uname -s"));

--- a/src/x11/utils.cpp
+++ b/src/x11/utils.cpp
@@ -100,7 +100,9 @@ void wxBell()
     XBell ((Display*) wxGetDisplay(), 0);
 }
 
-wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj, int *verMin) const
+wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj,
+                                           int *verMin,
+                                           int *verMicro) const
 {
     // get X protocol version
     Display *display = wxGlobalDisplay();
@@ -110,6 +112,8 @@ wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj, int *verMin) const
             *verMaj = ProtocolVersion (display);
         if ( verMin )
             *verMin = ProtocolRevision (display);
+        if ( verMicro )
+            *verMicro = 0;
     }
 
     return wxPORT_X11;


### PR DESCRIPTION
Also see the [wx-dev thread](http://comments.gmane.org/gmane.comp.lib.wxwidgets.devel/140470).

I mostly tried to remain backwards compatible and as such for example didn't modify the `wxPlatformInfo` ctor to take micro versions for the OS and toolkit. I don't suppose overriding it is common and if it is done it's easy to use `SetOSVersion()` and `SetToolkitVersion()` afterwards. If desired another ctor (with no default arguments I guess) could be added, or even the current one modified.
The only change with possible consequences that I'm aware of is the pure virtual function `wxAppTraits::GetToolkitVersion()` having its signature changed, and any user-overrides not being called in case it compiles (because of an existing override). This has been documented in `changes.txt`.
