### PR TITLE
Added Since 2.9.3 tag to wxEXEC_HIDE_CONSOLE flag

### DIFF
--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -1030,6 +1030,8 @@ enum
         even if its IO is not redirected.
 
         This flag is ignored under the other platforms.
+
+        @since 2.9.3
      */
     wxEXEC_HIDE_CONSOLE = 32,
 


### PR DESCRIPTION
`wxEXEC_HIDE_CONSOLE` was added in [r69964](http://trac.wxwidgets.org/changeset/69964/svn-wx).
