### PR TITLE
Implemented wxPOWER_RESOURCE_SCREEN for OS X versions < 10.9

### DIFF
--- a/interface/wx/power.h
+++ b/interface/wx/power.h
@@ -106,8 +106,7 @@ wxEventType wxEVT_POWER_RESUME;
     powering off the screen and Acquire() method can be used to do this.
 
     Notice that currently this functionality is only implemented for MSW and
-    OS X and on the latter only ::wxPOWER_RESOURCE_SYSTEM is supported for
-    versions earlier than 10.9.
+    OS X.
 
     If possible, use wxPowerResourceBlocker class to ensure that Release() is
     called instead of calling it manually.

--- a/src/osx/cocoa/power.mm
+++ b/src/osx/cocoa/power.mm
@@ -60,10 +60,16 @@ bool UpdatePowerResourceUsage(wxPowerResourceKind kind, const wxString& reason)
 #endif
         if ( !g_pmAssertionID )
         {
+            CFStringRef assertType;
+            if ( kind == wxPOWER_RESOURCE_SCREEN )
+                assertType = kIOPMAssertionTypeNoDisplaySleep;
+            else
+                assertType = kIOPMAssertionTypeNoIdleSleep;
+
             // Use power manager API for < 10.9 systems
             IOReturn success = IOPMAssertionCreateWithName
                                (
-                                    kIOPMAssertionTypeNoIdleSleep,
+                                    assertType,
                                     kIOPMAssertionLevelOn,
                                     cfreason,
                                     &g_pmAssertionID


### PR DESCRIPTION
When I implemented wxPowerResource I wasn't aware of the possibility to block the screen power off on OSX versions older than 10.9.
With this patch both wxPOWER_RESOURCE_SCREEN and wxPOWER_RESOURCE_SYSTEM can be used on any supported OSX version.
