### PR TITLE
Fix invalid characters in source files. Note: The character encodings…

### DIFF
--- a/src/stc/scintilla/lexers/LexErlang.cxx
+++ b/src/stc/scintilla/lexers/LexErlang.cxx
@@ -5,7 +5,7 @@
  ** Lexer for Erlang.
  ** Enhanced by Etienne 'Lenain' Girondel (lenaing@gmail.com)
  ** Originally wrote by Peter-Henry Mander,
- ** based on Matlab lexer by José Fonseca.
+ ** based on Matlab lexer by Jos\u00E9 Fonseca.
  **/
 
 #include <stdlib.h>

--- a/src/stc/scintilla/src/CaseConvert.h
+++ b/src/stc/scintilla/src/CaseConvert.h
@@ -32,7 +32,7 @@ const char *CaseConvert(int character, enum CaseConversion conversion);
 
 // When performing CaseConvertString, the converted value may be up to 3 times longer than the input.
 // Ligatures are often decomposed into multiple characters and long cases include:
-// ΐ "\xce\x90" folds to ΐ "\xce\xb9\xcc\x88\xcc\x81"
+// "\xce\x90" (u8"\u0390") folds to "\xce\xb9\xcc\x88\xcc\x81" (u8"\u03B9\u0308\u0301")
 const int maxExpansionCaseConversion=3;
 
 // Converts a mixed case string using a particular conversion.


### PR DESCRIPTION
… for C++ source codes are optional even with C++11. Besides \uXXXX and \UXXXXXXXX forms are valid anywhere (but decoding them as c-string is toolkit dependent) from C++98 at the latest. 

warning C4819 is raised from Visual C++ running on Japanese Environment, may or may not be on all version except English one. 
