### PR TITLE
copy setup0.h to setup.h only if none already exists

### DIFF
--- a/build/msw/wx_custom_build.vcxproj
+++ b/build/msw/wx_custom_build.vcxproj
@@ -131,6 +131,12 @@
     <TargetName Condition="'$(Configuration)|$(Platform)'=='DLL Release|Win32'">$(wxToolkitDllNamePrefix)$(ProjectName)$(wxToolkitDllNameSuffix)</TargetName>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='DLL Release|x64'">$(wxToolkitDllNamePrefix)$(ProjectName)$(wxToolkitDllNameSuffix)</TargetName>
   </PropertyGroup>
+  <ItemDefinitionGroup Condition="!Exists('..\..\include\wx\msw\setup.h')">
+    <PreBuildEvent>
+      <Message>Didn't find "include\wx\setup.h", copying setup0.h</Message>
+      <Command>copy ..\..\include\wx\msw\setup0.h ..\..\include\wx\msw\setup.h</Command>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">


### PR DESCRIPTION
Seems like many people aren't great at reading readmes.

This might be a happy medium of not overwriting existing setup.h files but still working for the simple "open sln, hit F5" reflex that many people seem to have.
