### PR TITLE
Removed UMAGetSystemVersion to fix runtime warning on OS X >= 10.10

### DIFF
--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -54,8 +54,6 @@
 // wxBase part of it).
 #include <Carbon/Carbon.h>
 
-WXDLLIMPEXP_BASE long UMAGetSystemVersion() ;
-
 void WXDLLIMPEXP_CORE wxMacStringToPascal( const wxString&from , unsigned char * to );
 wxString WXDLLIMPEXP_CORE wxMacMakeStringFromPascal( const unsigned char * from );
 

--- a/src/osx/cocoa/filedlg.mm
+++ b/src/osx/cocoa/filedlg.mm
@@ -485,16 +485,6 @@ void wxFileDialog::SetupExtraControls(WXWindow nativeWindow)
     {
         m_filterPanel = CreateFilterPanel(extracontrol);
         accView = m_filterPanel->GetHandle();
-        if( HasFlag(wxFD_OPEN) )
-        {
-            if ( UMAGetSystemVersion() < 0x1060 || !HasAppKit_10_6() )
-            {
-                wxOpenPanelDelegate* del = [[wxOpenPanelDelegate alloc]init];
-                [del setFileDialog:this];
-                [panel setDelegate:del];
-                m_delegate = del;
-            }
-        }
     }
     else
     {
@@ -642,21 +632,11 @@ int wxFileDialog::ShowModal()
         [oPanel setMessage:cf.AsNSString()];
         [oPanel setAllowsMultipleSelection: (HasFlag(wxFD_MULTIPLE) ? YES : NO )];
 
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1060
-        if ( UMAGetSystemVersion() >= 0x1060 && HasAppKit_10_6() )
-        {
-            [oPanel setAllowedFileTypes: (m_delegate == nil ? types : nil)];
-            if ( !m_dir.IsEmpty() )
-                [oPanel setDirectoryURL:[NSURL fileURLWithPath:dir.AsNSString() 
-                                                   isDirectory:YES]];
-            returnCode = [oPanel runModal];
-        }
-        else 
-#endif
-        {
-            returnCode = [oPanel runModalForDirectory:m_dir.IsEmpty() ? nil : dir.AsNSString()
-                                                 file:file.AsNSString() types:(m_delegate == nil ? types : nil)];
-        }
+        [oPanel setAllowedFileTypes: (m_delegate == nil ? types : nil)];
+        if ( !m_dir.IsEmpty() )
+            [oPanel setDirectoryURL:[NSURL fileURLWithPath:dir.AsNSString() 
+                                               isDirectory:YES]];
+        returnCode = [oPanel runModal];
             
         ModalFinishedCallback(oPanel, returnCode);
     }

--- a/src/osx/cocoa/power.mm
+++ b/src/osx/cocoa/power.mm
@@ -15,6 +15,7 @@
 
 #include "wx/power.h"
 #include "wx/atomic.h"
+#include "wx/platinfo.h"
 #include "wx/osx/private.h"
 
 #include <IOKit/pwr_mgt/IOPMLib.h>
@@ -37,7 +38,7 @@ bool UpdatePowerResourceUsage(wxPowerResourceKind kind, const wxString& reason)
             cfreason = wxString("User Activity");
 
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_9
-        if ( UMAGetSystemVersion() >= 0x1090 )
+        if ( wxPlatformInfo::Get().CheckOSVersion(10, 9) )
         {
             // Use NSProcessInfo for 10.9 and newer
             if ( !g_processInfoActivity )
@@ -82,7 +83,7 @@ bool UpdatePowerResourceUsage(wxPowerResourceKind kind, const wxString& reason)
     {
         // Release power assertion
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_9
-        if ( UMAGetSystemVersion() >= 0x1090 )
+        if ( wxPlatformInfo::Get().CheckOSVersion(10, 9) )
         {
             // Use NSProcessInfo for 10.9 and newer
             if ( g_processInfoActivity )

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -1099,8 +1099,6 @@ wxWidgetImplType* wxWidgetImpl::CreateTextControl( wxTextCtrl* wxpeer,
             // we have to emulate this
             [v setBezeled:NO];
             [v setBordered:NO];
-            if ( UMAGetSystemVersion() < 0x1070 )
-                c->SetNeedsFocusRect( true );
         }
         else
         {

--- a/src/osx/cocoa/toolbar.mm
+++ b/src/osx/cocoa/toolbar.mm
@@ -1185,12 +1185,7 @@ bool wxToolBar::Realize()
                         if ( tool->IsStretchable() )
                             nsItemId = NSToolbarFlexibleSpaceItemIdentifier;
                         else 
-                        {
-                            if ( UMAGetSystemVersion() < 0x1070 )
-                                nsItemId = NSToolbarSeparatorItemIdentifier;
-                            else
-                                nsItemId = NSToolbarSpaceItemIdentifier;
-                        }
+                            nsItemId = NSToolbarSpaceItemIdentifier;
                     }
                     else
                     {
@@ -1443,12 +1438,7 @@ bool wxToolBar::DoInsertTool(size_t WXUNUSED(pos), wxToolBarToolBase *toolBase)
                     if ( tool->IsStretchable() )
                         nsItemId = NSToolbarFlexibleSpaceItemIdentifier;
                     else 
-                    {
-                        if ( UMAGetSystemVersion() < 0x1070 )
-                            nsItemId = NSToolbarSeparatorItemIdentifier;
-                        else
-                            nsItemId = NSToolbarSpaceItemIdentifier;
-                    }
+                        nsItemId = NSToolbarSpaceItemIdentifier;
 
                     NSToolbarItem* item = [[NSToolbarItem alloc] initWithItemIdentifier:nsItemId];
                     tool->SetToolbarItemRef( item );

--- a/src/osx/cocoa/utils.mm
+++ b/src/osx/cocoa/utils.mm
@@ -11,6 +11,7 @@
 #include "wx/wxprec.h"
 
 #include "wx/utils.h"
+#include "wx/platinfo.h"
 
 #ifndef WX_PRECOMP
     #include "wx/intl.h"
@@ -346,7 +347,7 @@ void wxBell()
     ProcessSerialNumber psn = { 0, kCurrentProcess };
     TransformProcessType(&psn, kProcessTransformToForegroundApplication);
     
-    if ( UMAGetSystemVersion() >= 0x1090 )
+    if ( wxPlatformInfo::Get().CheckOSVersion(10, 9) )
     {
         [[NSRunningApplication currentApplication] activateWithOptions:
          (NSApplicationActivateAllWindows | NSApplicationActivateIgnoringOtherApps)];

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -683,39 +683,15 @@ void wxWidgetCocoaImpl::SetupMouseEvent( wxMouseEvent &wxevent , NSEvent * nsEve
 
             wxevent.SetEventType( wxEVT_MOUSEWHEEL ) ;
 
-            if ( UMAGetSystemVersion() >= 0x1070 )
+            if ( [nsEvent hasPreciseScrollingDeltas] )
             {
-                if ( [nsEvent hasPreciseScrollingDeltas] )
-                {
-                    deltaX = [nsEvent scrollingDeltaX];
-                    deltaY = [nsEvent scrollingDeltaY];
-                }
-                else
-                {
-                    deltaX = [nsEvent scrollingDeltaX] * 10;
-                    deltaY = [nsEvent scrollingDeltaY] * 10;
-                }
+                deltaX = [nsEvent scrollingDeltaX];
+                deltaY = [nsEvent scrollingDeltaY];
             }
             else
             {
-                const EventRef cEvent = (EventRef) [nsEvent eventRef];
-                // see http://developer.apple.com/qa/qa2005/qa1453.html
-                // for more details on why we have to look for the exact type
-                
-                bool isMouseScrollEvent = false;
-                if ( cEvent )
-                    isMouseScrollEvent = ::GetEventKind(cEvent) == kEventMouseScroll;
-                
-                if ( isMouseScrollEvent )
-                {
-                    deltaX = [nsEvent deviceDeltaX];
-                    deltaY = [nsEvent deviceDeltaY];
-                }
-                else
-                {
-                    deltaX = ([nsEvent deltaX] * 10);
-                    deltaY = ([nsEvent deltaY] * 10);
-                }
+                deltaX = [nsEvent scrollingDeltaX] * 10;
+                deltaY = [nsEvent scrollingDeltaY] * 10;
             }
             
             wxevent.m_wheelDelta = 10;

--- a/src/osx/core/utilsexc_base.cpp
+++ b/src/osx/core/utilsexc_base.cpp
@@ -55,18 +55,6 @@ wxSocketManager *wxOSXSocketManagerCF = NULL;
 
 #if ( !wxUSE_GUI && !wxOSX_USE_IPHONE ) || wxOSX_USE_COCOA_OR_CARBON
 
-// have a fast version for mac code that returns the version as a return value
-
-long UMAGetSystemVersion()
-{
-    static SInt32 sUMASystemVersion = 0 ;
-    if ( sUMASystemVersion == 0 )
-    {
-        verify_noerr(Gestalt(gestaltSystemVersion, &sUMASystemVersion));
-    }
-    return sUMASystemVersion ;
-}
-
 // our OS version is the same in non GUI and GUI cases
 wxOperatingSystemId wxGetOsVersion(int *majorVsn, int *minorVsn)
 {

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -34,6 +34,7 @@
     #include "wx/menuitem.h"
     #include "wx/treectrl.h"
     #include "wx/listctrl.h"
+    #include "wx/platinfo.h"
 #endif
 
 #include "wx/tooltip.h"
@@ -2215,7 +2216,7 @@ bool wxWindowMac::MacHasScrollBarCorner() const
             if ( frame )
             {
                 // starting from 10.7 there are no resize indicators anymore
-                if ( (frame->GetWindowStyleFlag() & wxRESIZE_BORDER) && UMAGetSystemVersion() < 0x1070)
+                if ( (frame->GetWindowStyleFlag() & wxRESIZE_BORDER) && !wxPlatformInfo::Get().CheckOSVersion(10, 7) )
                 {
                     // Parent frame has resize handle
                     wxPoint frameBottomRight = frame->GetScreenRect().GetBottomRight();


### PR DESCRIPTION
On OS X 10.10 a call to UMAGetSystemVersion produces a warning on the console at runtime:

WARNING: The Gestalt selector gestaltSystemVersion is returning 10.9.4 instead of 10.10.4. Use NSProcessInfo's operatingSystemVersion property to get correct system version number.*

Many calls guarded by checks with UMAGetSystemVersion where guarding < 10.7.
As the minimum version for 3.1.x is 10.7 I've simply removed that occurances.

Other occurances have been replaced by wxPlatfromInfo::CheckOSVersion which internally uses wxGetOSVersion, which uses Gestalt calls not producing the runtime warning.
