### PR TITLE
Fix wxGetWinVersion() for Windows 10

### DIFF
--- a/include/wx/msw/private.h
+++ b/include/wx/msw/private.h
@@ -935,7 +935,7 @@ inline wxString wxGetFullModuleName()
 //      0x0601      Windows 7
 //      0x0602      Windows 8 (currently also returned for 8.1 if program does not have a manifest indicating 8.1 support)
 //      0x0603      Windows 8.1 (currently only returned for 8.1 if program has a manifest indicating 8.1 support)
-//      0x0604      Windows 10 (currently only returned for 10 if program has a manifest indicating 10 support)
+//      0x1000      Windows 10 (currently only returned for 10 if program has a manifest indicating 10 support)
 //
 // for the other Windows versions 0 is currently returned
 enum wxWinVersion
@@ -968,7 +968,7 @@ enum wxWinVersion
     wxWinVersion_8 = 0x602,
     wxWinVersion_8_1 = 0x603,
 
-    wxWinVersion_10 = 0x604
+    wxWinVersion_10 = 0x1000
 };
 
 WXDLLIMPEXP_BASE wxWinVersion wxGetWinVersion();

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -1391,10 +1391,11 @@ wxWinVersion wxGetWinVersion()
                         case 3:
                             return wxWinVersion_8_1;
 
-                        case 4:
-                            return wxWinVersion_10;
-					}
+                    }
                     break;
+                    
+                case 10:
+                    return wxWinVersion_10;
             }
         default:
             // Do nothing just to silence GCC warning


### PR DESCRIPTION
Same issue as wxGetOsVersion previously. Check for Windows 10 was implemented as check for version 6.4 but the final version of Windows 10 actually returns 10.0.
