### PR TITLE
Allow to pass $wx_cv_std_libpath to configure script

### DIFF
--- a/configure
+++ b/configure
@@ -1003,6 +1003,7 @@ GTK_LIBS
 GTK_CFLAGS
 PKG_CONFIG
 subdirs
+wx_cv_std_libpath
 CXXCPP
 AR
 ac_ct_CXX
@@ -1386,6 +1387,7 @@ CXX
 CXXFLAGS
 CCC
 CXXCPP
+wx_cv_std_libpath
 PKG_CONFIG
 DIRECTFB_CFLAGS
 DIRECTFB_LIBS
@@ -2366,6 +2368,8 @@ Some influential environment variables:
   CXX         C++ compiler command
   CXXFLAGS    C++ compiler flags
   CXXCPP      C++ preprocessor
+  wx_cv_std_libpath
+              Name of library directory
   PKG_CONFIG  path to pkg-config utility
   DIRECTFB_CFLAGS
               C compiler flags for DIRECTFB, overriding pkg-config
@@ -21938,22 +21942,24 @@ SEARCH_INCLUDE="\
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libraries directories" >&5
 $as_echo_n "checking for libraries directories... " >&6; }
 
-case "${host}" in
-    *-*-irix6* )
-        if ${wx_cv_std_libpath+:} false; then :
+
+if test -z "$wx_cv_std_libpath"; then
+    case "${host}" in
+        *-*-irix6* )
+            if ${wx_cv_std_libpath+:} false; then :
   $as_echo_n "(cached) " >&6
 else
 
-                for d in /usr/lib /usr/lib32 /usr/lib/64 /usr/lib64; do
-                    for e in a so sl dylib dll.a; do
-                        libc="$d/libc.$e"
-                        if test -f $libc; then
-                            save_LIBS="$LIBS"
-                            LIBS="$libc"
-                            cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+                    for d in /usr/lib /usr/lib32 /usr/lib/64 /usr/lib64; do
+                        for e in a so sl dylib dll.a; do
+                            libc="$d/libc.$e"
+                            if test -f $libc; then
+                                save_LIBS="$LIBS"
+                                LIBS="$libc"
+                                cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-                                    int main() { return 0; }
+                                        int main() { return 0; }
 
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
@@ -21961,46 +21967,47 @@ if ac_fn_c_try_link "$LINENO"; then :
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
-                            LIBS="$save_LIBS"
-                            if test "x$wx_cv_std_libpath" != "x"; then
-                                break 2
+                                LIBS="$save_LIBS"
+                                if test "x$wx_cv_std_libpath" != "x"; then
+                                    break 2
+                                fi
                             fi
-                        fi
+                        done
                     done
-                done
 
 
 fi
 
-        ;;
+            ;;
 
-    *-*-solaris2* )
-                if test "$ac_cv_sizeof_void_p" = 8 -a -d "/usr/lib/64"; then
-            wx_cv_std_libpath="lib/64"
-        fi
-        ;;
-
-    *-*-linux* )
-                                        if test "$ac_cv_sizeof_void_p" = 8; then
-            if test -d "/usr/lib/`uname -m`-linux-gnu"; then
-                wx_cv_std_libfullpath="/usr/lib/`uname -m`-linux-gnu"
-            elif test -d "/usr/lib64" -a ! -h "/usr/lib64"; then
-                wx_cv_std_libpath="lib64"
+        *-*-solaris2* )
+                        if test "$ac_cv_sizeof_void_p" = 8 -a -d "/usr/lib/64"; then
+                wx_cv_std_libpath="lib/64"
             fi
-        else
-            case "${host}" in
-                i*86-*-linux* )
-                    if test -d '/usr/lib/i386-linux-gnu'; then
-                        wx_cv_std_libfullpath='/usr/lib/i386-linux-gnu'
-                    fi
-            esac
-        fi
+            ;;
 
-                                if test -n "$wx_cv_std_libfullpath" -a -d "/usr/lib"; then
-            wx_cv_std_libfullpath="$wx_cv_std_libfullpath /usr/lib"
-        fi
-        ;;
-esac
+        *-*-linux* )
+                                                            if test "$ac_cv_sizeof_void_p" = 8; then
+                if test -d "/usr/lib/`uname -m`-linux-gnu"; then
+                    wx_cv_std_libfullpath="/usr/lib/`uname -m`-linux-gnu"
+                elif test -d "/usr/lib64" -a ! -h "/usr/lib64"; then
+                    wx_cv_std_libpath="lib64"
+                fi
+            else
+                case "${host}" in
+                    i*86-*-linux* )
+                        if test -d '/usr/lib/i386-linux-gnu'; then
+                            wx_cv_std_libfullpath='/usr/lib/i386-linux-gnu'
+                        fi
+                esac
+            fi
+
+                                                if test -n "$wx_cv_std_libfullpath" -a -d "/usr/lib"; then
+                wx_cv_std_libfullpath="$wx_cv_std_libfullpath /usr/lib"
+            fi
+            ;;
+    esac
+fi
 
 if test -z "$wx_cv_std_libpath"; then
     wx_cv_std_libpath="lib"

--- a/configure.in
+++ b/configure.in
@@ -2047,68 +2047,71 @@ SEARCH_INCLUDE="\
 dnl try to find out the standard lib locations for the systems with multiple
 dnl ABIs
 AC_MSG_CHECKING([for libraries directories])
+AC_ARG_VAR(wx_cv_std_libpath, [Name of library directory])
 
-case "${host}" in
-    *-*-irix6* )
-        AC_CACHE_VAL(
-            wx_cv_std_libpath,
-            [
-                for d in WX_STD_LIBPATH(); do
-                    for e in a so sl dylib dll.a; do
-                        libc="$d/libc.$e"
-                        if test -f $libc; then
-                            save_LIBS="$LIBS"
-                            LIBS="$libc"
-                            AC_LINK_IFELSE([
-                                    AC_LANG_SOURCE([int main() { return 0; }])
-                                ],
-                                wx_cv_std_libpath=`echo $d | sed s@/usr/@@`)
-                            LIBS="$save_LIBS"
-                            if test "x$wx_cv_std_libpath" != "x"; then
-                                break 2
+if test -z "$wx_cv_std_libpath"; then
+    case "${host}" in
+        *-*-irix6* )
+            AC_CACHE_VAL(
+                wx_cv_std_libpath,
+                [
+                    for d in WX_STD_LIBPATH(); do
+                        for e in a so sl dylib dll.a; do
+                            libc="$d/libc.$e"
+                            if test -f $libc; then
+                                save_LIBS="$LIBS"
+                                LIBS="$libc"
+                                AC_LINK_IFELSE([
+                                        AC_LANG_SOURCE([int main() { return 0; }])
+                                    ],
+                                    wx_cv_std_libpath=`echo $d | sed s@/usr/@@`)
+                                LIBS="$save_LIBS"
+                                if test "x$wx_cv_std_libpath" != "x"; then
+                                    break 2
+                                fi
                             fi
-                        fi
+                        done
                     done
-                done
-            ]
-        )
-        ;;
+                ]
+            )
+            ;;
 
-    *-*-solaris2* )
-        dnl use ../lib or ../lib/64 depending on the size of void*
-        if test "$ac_cv_sizeof_void_p" = 8 -a -d "/usr/lib/64"; then
-            wx_cv_std_libpath="lib/64"
-        fi
-        ;;
-
-    *-*-linux* )
-        dnl Recent Debian versions (as of 2011) use new approach to multiarch
-        dnl and put the libraries under /usr/lib/arch-linux-gnu. Annoyingly,
-        dnl "arch" here is not `uname -m` because it is "i386" even when uname
-        dnl returns e.g. "i686". So we need to test for it explicitly.
-        if test "$ac_cv_sizeof_void_p" = 8; then
-            if test -d "/usr/lib/`uname -m`-linux-gnu"; then
-                wx_cv_std_libfullpath="/usr/lib/`uname -m`-linux-gnu"
-            elif test -d "/usr/lib64" -a ! -h "/usr/lib64"; then
-                wx_cv_std_libpath="lib64"
+        *-*-solaris2* )
+            dnl use ../lib or ../lib/64 depending on the size of void*
+            if test "$ac_cv_sizeof_void_p" = 8 -a -d "/usr/lib/64"; then
+                wx_cv_std_libpath="lib/64"
             fi
-        else
-            case "${host}" in
-                i*86-*-linux* )
-                    if test -d '/usr/lib/i386-linux-gnu'; then
-                        wx_cv_std_libfullpath='/usr/lib/i386-linux-gnu'
-                    fi
-            esac
-        fi
+            ;;
 
-        dnl And on top of all this, some packages haven't been updated for
-        dnl full multiarch support yet so we still need to look in /usr/lib
-        dnl too as well.
-        if test -n "$wx_cv_std_libfullpath" -a -d "/usr/lib"; then
-            wx_cv_std_libfullpath="$wx_cv_std_libfullpath /usr/lib"
-        fi
-        ;;
-esac
+        *-*-linux* )
+            dnl Recent Debian versions (as of 2011) use new approach to multiarch
+            dnl and put the libraries under /usr/lib/arch-linux-gnu. Annoyingly,
+            dnl "arch" here is not `uname -m` because it is "i386" even when uname
+            dnl returns e.g. "i686". So we need to test for it explicitly.
+            if test "$ac_cv_sizeof_void_p" = 8; then
+                if test -d "/usr/lib/`uname -m`-linux-gnu"; then
+                    wx_cv_std_libfullpath="/usr/lib/`uname -m`-linux-gnu"
+                elif test -d "/usr/lib64" -a ! -h "/usr/lib64"; then
+                    wx_cv_std_libpath="lib64"
+                fi
+            else
+                case "${host}" in
+                    i*86-*-linux* )
+                        if test -d '/usr/lib/i386-linux-gnu'; then
+                            wx_cv_std_libfullpath='/usr/lib/i386-linux-gnu'
+                        fi
+                esac
+            fi
+
+            dnl And on top of all this, some packages haven't been updated for
+            dnl full multiarch support yet so we still need to look in /usr/lib
+            dnl too as well.
+            if test -n "$wx_cv_std_libfullpath" -a -d "/usr/lib"; then
+                wx_cv_std_libfullpath="$wx_cv_std_libfullpath /usr/lib"
+            fi
+            ;;
+    esac
+fi
 
 if test -z "$wx_cv_std_libpath"; then
     wx_cv_std_libpath="lib"


### PR DESCRIPTION
In Gentoo Linux we using /usr/libx32 directory for x86-64 x32 libraries and wxWidgets configure script unable to detect correct library path ([see corresponding bug request](https://bugs.gentoo.org/show_bug.cgi?id=421851)).
For years simple sed was used to fix library path in configure script but now it causes overhead for out of source directory builds with new multilib build system.
That simple patch allows to pass correct $wx_cv_std_libpath variable to configure script.
