### PR TITLE
Mention that temp dir is for current user.

### DIFF
--- a/interface/wx/filename.h
+++ b/interface/wx/filename.h
@@ -773,7 +773,8 @@ public:
     static wxULongLong GetSize(const wxString& filename);
 
     /**
-        Returns the directory used for temporary files.
+        Returns the directory used for temporary files, for current user. Same as
+        wxStandardPaths::GetTempDir().
     */
     static wxString GetTempDir();
 

--- a/interface/wx/stdpaths.h
+++ b/interface/wx/stdpaths.h
@@ -228,8 +228,9 @@ public:
     virtual wxString GetResourcesDir() const;
 
     /**
-        Return the directory for storing temporary files.
-        To create unique temporary files, it is best to use wxFileName::CreateTempFileName
+        Return the directory for storing temporary files, for the current user. Same as
+        wxFileName::GetTempDir().
+        To create unique temporary files, it is best to use wxFileName::CreateTempFileName()
         for correct behaviour when multiple processes are attempting to create temporary files.
 
         @since 2.7.2


### PR DESCRIPTION
Also mention that `wxStandardPaths::GetTempDir()` and `wxFileName::GetTempDir()` are identical.
