### PR TITLE
Always attempt to remove trailing separators from temp dir.

### DIFF
--- a/src/common/filename.cpp
+++ b/src/common/filename.cpp
@@ -1249,7 +1249,8 @@ wxString wxFileName::GetTempDir()
         dir = wxMacFindFolderNoSeparator(short(kOnSystemDisk), kTemporaryFolderType, kCreateFolder);
 #endif // systems with native way
     }
-    else // we got directory from an environment variable
+
+    if ( !dir.empty() )
     {
         // remove any trailing path separators, we don't want to ever return
         // them from this function for consistency
@@ -1266,7 +1267,7 @@ wxString wxFileName::GetTempDir()
     }
 
     // fall back to hard coded value
-    if ( dir.empty() )
+    else
     {
 #ifdef __UNIX_LIKE__
         dir = CheckIfDirExists("/tmp");


### PR DESCRIPTION
If [GetTempPath()](https://msdn.microsoft.com/en-us/library/windows/desktop/aa364992%28v=vs.85%29.aspx) is executed, the trailing path separator is not removed.
