### PR TITLE
Show wxART_EDIT icon in artprov sample.

### DIFF
--- a/samples/artprov/artbrows.cpp
+++ b/samples/artprov/artbrows.cpp
@@ -110,6 +110,7 @@ static void FillBitmaps(wxImageList *images, wxListCtrl *list,
     ART_ICON(wxART_QUIT)
     ART_ICON(wxART_FIND)
     ART_ICON(wxART_FIND_AND_REPLACE)
+    ART_ICON(wxART_EDIT)
     ART_ICON(wxART_FULL_SCREEN)
     ART_ICON(wxART_HARDDISK)
     ART_ICON(wxART_FLOPPY)


### PR DESCRIPTION
Add this new icon to the resource browser.
