### PR TITLE
Correct the addition of wxLANGUAGE_KABYLE.

### DIFF
--- a/include/wx/intl.h
+++ b/include/wx/intl.h
@@ -190,7 +190,6 @@ enum wxLanguage
     wxLANGUAGE_ITALIAN_SWISS,
     wxLANGUAGE_JAPANESE,
     wxLANGUAGE_JAVANESE,
-    wxLANGUAGE_KABYLE,
     wxLANGUAGE_KANNADA,
     wxLANGUAGE_KASHMIRI,
     wxLANGUAGE_KASHMIRI_INDIA,
@@ -309,6 +308,7 @@ enum wxLanguage
     wxLANGUAGE_YORUBA,
     wxLANGUAGE_ZHUANG,
     wxLANGUAGE_ZULU,
+    wxLANGUAGE_KABYLE,
 
     // for custom, user-defined languages:
     wxLANGUAGE_USER_DEFINED

--- a/misc/languages/langtabl.txt
+++ b/misc/languages/langtabl.txt
@@ -230,3 +230,4 @@ wxLANGUAGE_YIDDISH                     yi     -                -                
 wxLANGUAGE_YORUBA                      yo     -                -                                   LTR    "Yoruba"
 wxLANGUAGE_ZHUANG                      za     -                -                                   LTR    "Zhuang"
 wxLANGUAGE_ZULU                        zu     -                -                                   LTR    "Zulu"
+wxLANGUAGE_KABYLE                      kab    LANG_KABYLE      SUBLANG_DEFAULT                     LTR    "Kabyle"

--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -3143,9 +3143,6 @@ IMPLEMENT_DYNAMIC_CLASS(wxLocaleModule, wxModule)
 #ifndef LANG_JAPANESE
 #define LANG_JAPANESE (0)
 #endif
-#ifndef LANG_KABYLE
-#define LANG_KABYLE (0)
-#endif
 #ifndef LANG_KANNADA
 #define LANG_KANNADA (0)
 #endif
@@ -3262,6 +3259,9 @@ IMPLEMENT_DYNAMIC_CLASS(wxLocaleModule, wxModule)
 #endif
 #ifndef LANG_VIETNAMESE
 #define LANG_VIETNAMESE (0)
+#endif
+#ifndef LANG_KABYLE
+#define LANG_KABYLE (0)
 #endif
 #ifndef SUBLANG_ARABIC_ALGERIA
 #define SUBLANG_ARABIC_ALGERIA SUBLANG_DEFAULT
@@ -3657,7 +3657,6 @@ void wxLocale::InitLanguagesDB()
    LNG(wxLANGUAGE_ITALIAN_SWISS,              "it_CH", LANG_ITALIAN   , SUBLANG_ITALIAN_SWISS             , wxLayout_LeftToRight, "Italian (Swiss)")
    LNG(wxLANGUAGE_JAPANESE,                   "ja_JP", LANG_JAPANESE  , SUBLANG_DEFAULT                   , wxLayout_LeftToRight, "Japanese")
    LNG(wxLANGUAGE_JAVANESE,                   "jw"   , 0              , 0                                 , wxLayout_LeftToRight, "Javanese")
-   LNG(wxLANGUAGE_KABYLE,                     "kab"  , LANG_KABYLE    , SUBLANG_DEFAULT                   , wxLayout_LeftToRight, "Kabyle")
    LNG(wxLANGUAGE_KANNADA,                    "kn"   , LANG_KANNADA   , SUBLANG_DEFAULT                   , wxLayout_LeftToRight, "Kannada")
    LNG(wxLANGUAGE_KASHMIRI,                   "ks"   , LANG_KASHMIRI  , SUBLANG_DEFAULT                   , wxLayout_LeftToRight, "Kashmiri")
    LNG(wxLANGUAGE_KASHMIRI_INDIA,             "ks_IN", LANG_KASHMIRI  , SUBLANG_KASHMIRI_INDIA            , wxLayout_LeftToRight, "Kashmiri (India)")
@@ -3780,6 +3779,7 @@ void wxLocale::InitLanguagesDB()
    LNG(wxLANGUAGE_YORUBA,                     "yo"   , 0              , 0                                 , wxLayout_LeftToRight, "Yoruba")
    LNG(wxLANGUAGE_ZHUANG,                     "za"   , 0              , 0                                 , wxLayout_LeftToRight, "Zhuang")
    LNG(wxLANGUAGE_ZULU,                       "zu"   , 0              , 0                                 , wxLayout_LeftToRight, "Zulu")
+   LNG(wxLANGUAGE_KABYLE,                     "kab"  , LANG_KABYLE    , SUBLANG_DEFAULT                   , wxLayout_LeftToRight, "Kabyle")
 }
 #undef LNG
 


### PR DESCRIPTION
Backport 644af9fa6ce5d751856616eb97a1a8773dc9857a into 2.8 branch:
Repair (too late?) the ABI breakage for all the language constants following
wxLANGUAGE_KABYLE in alphabetical order by adding this enum element at the end
of the enum instead of in the middle.

Also add wxLANGUAGE_KABYLE to langtabl.txt so that it doesn't disappear when
the generated fragments are updated by running misc/languages/genlang.py the
next time.
