### PR TITLE
wxGetOsDescription(): Use Windows Server 2016 and include OS X name

### DIFF
--- a/interface/wx/srchctrl.h
+++ b/interface/wx/srchctrl.h
@@ -120,8 +120,6 @@ public:
         Returns the search button visibility value.
         If there is a menu attached, the search button will be visible regardless of
         the search button visibility value.
-
-        This always returns @false in Mac OS X v10.3
     */
     virtual bool IsSearchButtonVisible() const;
 
@@ -148,8 +146,6 @@ public:
         Sets the search button visibility value on the search control.
         If there is a menu attached, the search button will be visible regardless of
         the search button visibility value.
-
-        This has no effect in Mac OS X v10.3
     */
     virtual void ShowSearchButton(bool show);
 

--- a/interface/wx/sysopt.h
+++ b/interface/wx/sysopt.h
@@ -118,7 +118,6 @@
         Tells wxListCtrl to use the generic control even when it is capable of
         using the native control instead. Also known as wxMAC_ALWAYS_USE_GENERIC_LISTCTRL.
     @flag{mac.textcontrol-use-spell-checker}
-        This option only has effect for Mac OS X 10.4 and higher.
         If 1 activates the spell checking in wxTextCtrl.
     @flag{osx.openfiledialog.always-show-types}
         Per default a wxFileDialog with wxFD_OPEN does not show a types-popup on OS X but allows

--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -858,6 +858,7 @@ wxString wxGetOsDescription();
     @beginTable
     @row3col{<b>Windows OS name</b>, <b>Major version</b>, <b>Minor version</b>}
     @row3col{Windows 10,               10, 0}
+    @row3col{Windows Server 2016,      10, 0}
     @row3col{Windows 8.1,               6, 3}
     @row3col{Windows Server 2012 R2,    6, 3}
     @row3col{Windows 8,                 6, 2}

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -1226,7 +1226,7 @@ wxString wxGetOsDescription()
 
                 case 10:
                     str = wxIsWindowsServer() == 1
-                            ? _("Windows Server 10")
+                            ? _("Windows Server 2016")
                             : _("Windows 10");
                     break;
             }

--- a/src/osx/cocoa/utils.mm
+++ b/src/osx/cocoa/utils.mm
@@ -677,9 +677,45 @@ bool wxCheckOsVersion(int majorVsn, int minorVsn)
 
 wxString wxGetOsDescription()
 {
-    NSString* osDesc = [NSProcessInfo processInfo].operatingSystemVersionString;
 
-    return wxString::Format("%s %s", _("Mac OS X"), wxCFStringRef::AsString(osDesc));
+    int majorVer, minorVer;
+    wxGetOsVersion(&majorVer, &minorVer);
+
+    wxString osBrand = _("OS X");
+    wxString osName;
+    if (majorVer == 10)
+    {
+        switch (minorVer)
+        {
+            case 7:
+                osName = _("Lion");
+                // 10.7 was the last version where the "Mac" prefix was used
+                osBrand = _("Mac OS X");
+                break;
+            case 8:
+                osName = _("Mountain Lion");
+                break;
+            case 9:
+                osName = _("Mavericks");
+                break;
+            case 10:
+                osName = _("Yosemite");
+                break;
+            case 11:
+                osName = _("El Capitan");
+                break;
+        };
+    }
+
+    wxString osDesc = osBrand;
+    if (!osName.empty())
+        osDesc += " " + osName;
+
+    NSString* osVersionString = [NSProcessInfo processInfo].operatingSystemVersionString;
+    if (osVersionString)
+        osDesc += " " + wxCFStringRef::AsString(osVersionString);
+
+    return osDesc;
 }
 
 #endif // wxOSX_USE_COCOA


### PR DESCRIPTION
Windows Server 2016 is the final name of the Windows 10 server edition.

For OS X the marketing/code name seems to be very public so it makes sense to include it in wxGetOsDescription() (unfortunately it does not seem to be available programmatically, so as a fallback it will be left empty for future versions). Also since 10.8 it is called OS X instead of Mac OS X.
