### PR TITLE
OS X: Fix clipboard inadvertedly being cleared when using wxNotebook

### DIFF
--- a/src/osx/cocoa/notebook.mm
+++ b/src/osx/cocoa/notebook.mm
@@ -161,12 +161,6 @@
     m_image = image;
     if(!m_image)
         return;
-    [[NSPasteboard generalPasteboard]
-        declareTypes:[NSArray arrayWithObject:NSTIFFPboardType]
-        owner:nil];
-    [[NSPasteboard generalPasteboard]
-        setData:[m_image TIFFRepresentation]
-        forType:NSTIFFPboardType];
 }
 @end // implementation WXCTabViewImageItem : NSTabViewItem
 


### PR DESCRIPTION
Using wxNotebook::SetPageImage changes the global clipboard which it must not.
