### PR TITLE
Fixed regression introduced in b9d46f0 (ZIP64)

### DIFF
--- a/src/common/zipstrm.cpp
+++ b/src/common/zipstrm.cpp
@@ -1073,7 +1073,7 @@ size_t wxZipEntry::ReadLocal(wxInputStream& stream, wxMBConv& conv)
             if (stream.LastRead() != extraLen + 0u)
                 return 0;
 
-            if (LoadExtraInfo(m_Extra->GetData(), extraLen, true))
+            if (LoadExtraInfo(m_LocalExtra->GetData(), extraLen, true))
             {
                 Release(m_LocalExtra);
                 m_LocalExtra = NULL;


### PR DESCRIPTION
Extra data are extracted from the wrong buffer and automatic tests on Travis fail with error:
/home/travis/build.sh: line 41: 26435 Segmentation fault      ./test -t
