### PR TITLE
Avoid run-time warnings for OS X version checks under 10.10+.

### DIFF
--- a/src/osx/core/utilsexc_base.cpp
+++ b/src/osx/core/utilsexc_base.cpp
@@ -62,7 +62,16 @@ long UMAGetSystemVersion()
     static SInt32 sUMASystemVersion = 0 ;
     if ( sUMASystemVersion == 0 )
     {
-        verify_noerr(Gestalt(gestaltSystemVersion, &sUMASystemVersion));
+        // gestaltSystemVersion is deprecated since 10.8 and produces a runtime
+        // warning since 10.10 and will always return 0x109z. (z = micro version)
+        // As a workaround to the runtime warning return the hard coded value
+        // to supress the operating system warning.
+        int majorCur, minorCur;
+        wxGetOsVersion(&majorCur, &minorCur);
+        if ( majorCur > 10 || (majorCur == 10 && minorCur >= 10) )
+            sUMASystemVersion = 0x1090;
+        else
+            verify_noerr(Gestalt(gestaltSystemVersion, &sUMASystemVersion));
     }
     return sUMASystemVersion ;
 }


### PR DESCRIPTION
Implement workaround in UMAGetSystemVersion() function which produced the following
warning on the console for every application launch on OS X 10.10+:

WARNING: The Gestalt selector gestaltSystemVersion is returning 10.9.5 instead
of 10.10.5. Use NSProcessInfo's operatingSystemVersion property to get correct
system version number.*

Workaround for 3.0 branch instead of correct implementation in commit 658eca28961d79afd2dca23524410c8dd6f183fc
