### PR TITLE
Pre-XP cleanup: Code targeted at Pre-XP, GetShell32Version, Documentation

### DIFF
--- a/include/wx/msw/app.h
+++ b/include/wx/msw/app.h
@@ -102,10 +102,6 @@ public:
     // wasn't found at all
     static int GetComCtl32Version();
 
-    // the same for shell32.dll: returns 400, 471, 500, 600, ... (4.70 not
-    // currently detected)
-    static int GetShell32Version();
-
     // the SW_XXX value to be used for the frames opened by the application
     // (currently seems unused which is a bug -- TODO)
     static int m_nCmdShow;

--- a/interface/wx/dc.h
+++ b/interface/wx/dc.h
@@ -164,9 +164,8 @@ struct wxFontMetrics
 
     @section Support for Transformation Matrix
 
-    On some platforms (currently only under MSW and only on Windows NT, i.e.
-    not Windows 9x/ME, systems) wxDC has support for applying an arbitrary
-    affine transformation matrix to its coordinate system. Call
+    On some platforms (currently only under MSW) wxDC has support for applying 
+    an arbitrary affine transformation matrix to its coordinate system. Call
     CanUseTransformMatrix() to check if this support is available and then call
     SetTransformMatrix() if it is. If the transformation matrix is not
     supported, SetTransformMatrix() always simply returns false and doesn't do
@@ -1516,10 +1515,7 @@ public:
         Check if the use of transformation matrix is supported by the current
         system.
 
-        Currently this function always returns @false for non-MSW platforms and
-        may return @false for old (Windows 9x/ME) Windows systems. Normally
-        support for the transformation matrix is always available in any
-        relatively recent Windows versions.
+        Currently this function always returns @false for non-MSW platforms.
 
         @since 2.9.2
     */

--- a/interface/wx/intl.h
+++ b/interface/wx/intl.h
@@ -485,7 +485,7 @@ public:
 
     /**
         Check whether the operating system and/or C run time environment supports
-        this locale. For example in Windows 2000 and Windows XP, support for many
+        this locale. For example in Windows, support for many
         locales is not installed by default. Returns @true if the locale is
         supported.
 

--- a/interface/wx/msw/registry.h
+++ b/interface/wx/msw/registry.h
@@ -110,9 +110,9 @@ public:
     HKCU,  ///< HKEY_CURRENT_USER
     HKLM,  ///< HKEY_LOCAL_MACHINE
     HKUSR, ///< HKEY_USERS
-    HKPD,  ///< HKEY_PERFORMANCE_DATA (Windows NT and 2K only)
+    HKPD,  ///< HKEY_PERFORMANCE_DATA
     HKCC,  ///< HKEY_CURRENT_CONFIG
-    HKDD,  ///< HKEY_DYN_DATA (Windows 95 and 98 only)
+    HKDD,  ///< HKEY_DYN_DATA (Obsolete: Windows 9x only)
     HKMAX
     };
 

--- a/interface/wx/notebook.h
+++ b/interface/wx/notebook.h
@@ -63,7 +63,7 @@ wxEventType wxEVT_NOTEBOOK_PAGE_CHANGING;
     @endStyleTable
 
     The styles wxNB_LEFT, RIGHT and BOTTOM are not supported under
-    Microsoft Windows XP when using visual themes.
+    Microsoft Windows when using visual themes.
 
     @beginEventEmissionTable{wxBookCtrlEvent}
     @event{EVT_NOTEBOOK_PAGE_CHANGED(id, func)}
@@ -78,7 +78,7 @@ wxEventType wxEVT_NOTEBOOK_PAGE_CHANGING;
 
     @section notebook_bg Page backgrounds
 
-    On Windows XP, the default theme paints a gradient on the notebook's pages.
+    On Windows, the default theme paints a background on the notebook's pages.
     If you wish to suppress this theme, for aesthetic or performance reasons,
     there are three ways of doing it.
     You can use @c wxNB_NOPAGETHEME to disable themed drawing for a particular

--- a/interface/wx/platinfo.h
+++ b/interface/wx/platinfo.h
@@ -29,7 +29,7 @@ enum wxOperatingSystemId
     wxOS_MAC = wxOS_MAC_OS|wxOS_MAC_OSX_DARWIN,
 
     wxOS_WINDOWS_9X     = 1 << 2,     //!< Windows 9x family (95/98/ME)
-    wxOS_WINDOWS_NT     = 1 << 3,     //!< Windows NT family (NT/2000/XP/Vista/7)
+    wxOS_WINDOWS_NT     = 1 << 3,     //!< Windows NT family (XP/Vista/7/8/10)
     wxOS_WINDOWS_MICRO  = 1 << 4,     //!< MicroWindows
     wxOS_WINDOWS_CE     = 1 << 5,     //!< Windows CE (Windows Mobile)
     

--- a/interface/wx/print.h
+++ b/interface/wx/print.h
@@ -526,8 +526,8 @@ public:
     /**
         Invokes the print setup dialog.
 
-        @remarks
-        The setup dialog is obsolete from Windows 95, though retained
+        @deprecated
+        The setup dialog is obsolete, though retained
         for backward compatibility.
     */
     virtual bool Setup(wxWindow* parent);

--- a/interface/wx/settings.h
+++ b/interface/wx/settings.h
@@ -28,7 +28,7 @@ enum wxSystemFont
     /// dialog box controls, and text.
     wxSYS_SYSTEM_FONT,
 
-    /// Device-dependent font (Windows NT and later only).
+    /// Device-dependent font.
     wxSYS_DEVICE_DEFAULT_FONT,
 
     /**

--- a/interface/wx/splitter.h
+++ b/interface/wx/splitter.h
@@ -52,8 +52,8 @@ enum
     @style{wxSP_NOBORDER}
            No border (default).
     @style{wxSP_NO_XP_THEME}
-           Under Windows XP, switches off the attempt to draw the splitter
-           using Windows XP theming, so the borders and sash will take on the
+           Under Windows, switches off the attempt to draw the splitter
+           using Windows theming, so the borders and sash will take on the
            pre-XP look.
     @style{wxSP_PERMIT_UNSPLIT}
            Always allow to unsplit, even with the minimum pane size other than zero.

--- a/interface/wx/statbmp.h
+++ b/interface/wx/statbmp.h
@@ -10,8 +10,7 @@
 
     A static bitmap control displays a bitmap. Native implementations on some
     platforms are only meant for display of the small icons in the dialog
-    boxes. In particular, under Windows 9x the size of bitmap is limited
-    to 64*64 pixels.
+    boxes.
 
     If you want to display larger images portably, you may use generic
     implementation wxGenericStaticBitmap declared in \<wx/generic/statbmpg.h\>.

--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -1005,8 +1005,7 @@ enum
         Under Unix, if the process is the group leader then passing
         wxKILL_CHILDREN to wxKill() kills all children as well as pid.
 
-        Under MSW, applies only to console applications and is only supported
-        under NT family (i.e. not under Windows 9x). It corresponds to the
+        Under MSW, applies only to console applications. It corresponds to the
         native @c CREATE_NEW_PROCESS_GROUP and, in particular, ensures that
         Ctrl-Break signals will be sent to all children of this process as well
         to the process itself. Support for this flag under MSW was added in
@@ -1341,7 +1340,7 @@ bool wxShell(const wxString& command = wxEmptyString);
     the @a flags.
 
     @note Note that performing the shutdown requires the corresponding access
-        rights (superuser under Unix, SE_SHUTDOWN privilege under Windows NT)
+        rights (superuser under Unix, SE_SHUTDOWN privilege under Windows)
         and that this function is only implemented under Unix and MSW.
 
     @param flags

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -137,7 +137,7 @@ enum wxWindowVariant
            is the old name for this style. Windows only.
     @style{wxBORDER_THEME}
            Displays a native border suitable for a control, on the current
-           platform. On Windows XP or Vista, this will be a themed border; on
+           platform. On Windows, this will be a themed border; on
            most other platforms a sunken border will be used. For more
            information for themed borders on Windows, please see Themed
            borders on Windows.

--- a/src/msw/app.cpp
+++ b/src/msw/app.cpp
@@ -892,47 +892,10 @@ int wxApp::GetComCtl32Version()
     return s_verComCtl32;
 }
 
-/* static */
-int wxApp::GetShell32Version()
-{
-    static int s_verShell32 = -1;
-    if ( s_verShell32 == -1 )
-    {
-        // we're prepared to handle the errors
-        wxLogNull noLog;
-
-        wxDynamicLibrary dllShell32(wxT("shell32.dll"), wxDL_VERBATIM);
-        if ( dllShell32.IsLoaded() )
-        {
-            s_verShell32 = CallDllGetVersion(dllShell32);
-
-            if ( !s_verShell32 )
-            {
-                // there doesn't seem to be any way to distinguish between 4.00
-                // and 4.70 (starting from 4.71 we have DllGetVersion()) so
-                // just assume it is 4.0
-                s_verShell32 = 400;
-            }
-        }
-        else // failed load the DLL?
-        {
-            s_verShell32 = 0;
-        }
-    }
-
-    return s_verShell32;
-}
-
 #else // !wxUSE_DYNLIB_CLASS
 
 /* static */
 int wxApp::GetComCtl32Version()
-{
-    return 0;
-}
-
-/* static */
-int wxApp::GetShell32Version()
 {
     return 0;
 }

--- a/src/msw/app.cpp
+++ b/src/msw/app.cpp
@@ -377,10 +377,7 @@ bool wxConsoleStderr::DoInit()
     if ( !m_dllKernel32.Load(wxT("kernel32.dll")) )
         return false;
 
-    typedef BOOL (WINAPI *AttachConsole_t)(DWORD dwProcessId);
-    AttachConsole_t wxDL_INIT_FUNC(pfn, AttachConsole, m_dllKernel32);
-
-    if ( !pfnAttachConsole || !pfnAttachConsole(ATTACH_PARENT_PROCESS) )
+    if ( !::AttachConsole(ATTACH_PARENT_PROCESS) )
         return false;
 
     // console attached, set m_hStderr now to ensure that we free it in the

--- a/src/msw/datecontrols.cpp
+++ b/src/msw/datecontrols.cpp
@@ -54,13 +54,6 @@ bool wxMSWDateControls::CheckInitialization()
         // it's enough to give the error only once
         s_initResult = false;
 
-        if ( wxApp::GetComCtl32Version() < 470 )
-        {
-            wxLogError(_("This system doesn't support date controls, please upgrade your version of comctl32.dll"));
-
-            return false;
-        }
-
 #if wxUSE_DYNLIB_CLASS
         INITCOMMONCONTROLSEX icex;
         icex.dwSize = sizeof(icex);

--- a/src/msw/datectrl.cpp
+++ b/src/msw/datectrl.cpp
@@ -70,9 +70,7 @@ WXDWORD wxDatePickerCtrl::MSWGetStyle(long style, WXDWORD *exstyle) const
 {
     WXDWORD styleMSW = wxDatePickerCtrlBase::MSWGetStyle(style, exstyle);
 
-    // although MSDN doesn't mention it, DTS_UPDOWN doesn't work with
-    // comctl32.dll 4.72
-    if ( wxApp::GetComCtl32Version() > 472 && (style & wxDP_SPIN) )
+    if ( style & wxDP_SPIN )
         styleMSW |= DTS_UPDOWN;
     //else: drop down by default
 

--- a/src/msw/dirdlg.cpp
+++ b/src/msw/dirdlg.cpp
@@ -267,19 +267,14 @@ int wxDirDialog::ShowSHBrowseForFolder(WXHWND owner)
 
     static const int verComCtl32 = wxApp::GetComCtl32Version();
 
-    // we always add the edit box (it doesn't hurt anybody, does it?) if it is
-    // supported by the system
-    if ( verComCtl32 >= 471 )
-    {
-        bi.ulFlags |= BIF_EDITBOX;
-    }
+    // we always add the edit box (it doesn't hurt anybody, does it?)
+    bi.ulFlags |= BIF_EDITBOX;
 
     // to have the "New Folder" button we must use the "new" dialog style which
     // is also the only way to have a resizable dialog
     //
-    // "new" style is only available in the version 5.0+ of comctl32.dll
     const bool needNewDir = !HasFlag(wxDD_DIR_MUST_EXIST);
-    if ( (needNewDir || HasFlag(wxRESIZE_BORDER)) && (verComCtl32 >= 500) )
+    if ( needNewDir || HasFlag(wxRESIZE_BORDER) )
     {
         if (needNewDir)
         {

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -277,26 +277,23 @@ bool wxListCtrl::Create(wxWindow *parent,
 
 void wxListCtrl::MSWSetExListStyles()
 {
-    // for comctl32.dll v 4.70+ we want to have some non default extended
+    // we want to have some non default extended
     // styles because it's prettier (and also because wxGTK does it like this)
-    if ( wxApp::GetComCtl32Version() >= 470 )
-    {
-        ::SendMessage
-        (
-            GetHwnd(), LVM_SETEXTENDEDLISTVIEWSTYLE, 0,
-            // LVS_EX_LABELTIP shouldn't be used under Windows CE where it's
-            // not defined in the SDK headers
+    ::SendMessage
+    (
+        GetHwnd(), LVM_SETEXTENDEDLISTVIEWSTYLE, 0,
+        // LVS_EX_LABELTIP shouldn't be used under Windows CE where it's
+        // not defined in the SDK headers
 #ifdef LVS_EX_LABELTIP
-            LVS_EX_LABELTIP |
+        LVS_EX_LABELTIP |
 #endif
-            LVS_EX_FULLROWSELECT |
-            LVS_EX_SUBITEMIMAGES |
-            // normally this should be governed by a style as it's probably not
-            // always appropriate, but we don't have any free styles left and
-            // it seems better to enable it by default than disable
-            LVS_EX_HEADERDRAGDROP
-        );
-    }
+        LVS_EX_FULLROWSELECT |
+        LVS_EX_SUBITEMIMAGES |
+        // normally this should be governed by a style as it's probably not
+        // always appropriate, but we don't have any free styles left and
+        // it seems better to enable it by default than disable
+        LVS_EX_HEADERDRAGDROP
+    );
 }
 
 WXDWORD wxListCtrl::MSWGetStyle(long style, WXDWORD *exstyle) const
@@ -359,13 +356,6 @@ WXDWORD wxListCtrl::MSWGetStyle(long style, WXDWORD *exstyle) const
 #if !( defined(__GNUWIN32__) && !wxCHECK_W32API_VERSION( 1, 0 ) )
     if ( style & wxLC_VIRTUAL )
     {
-        int ver = wxApp::GetComCtl32Version();
-        if ( ver < 470 )
-        {
-            wxLogWarning(_("Please install a newer version of comctl32.dll\n(at least version 4.70 is required but you have %d.%02d)\nor this program won't operate correctly."),
-                        ver / 100, ver % 100);
-        }
-
         wstyle |= LVS_OWNERDATA;
     }
 #endif // ancient cygwin
@@ -1622,7 +1612,7 @@ wxListCtrl::HitTest(const wxPoint& point, int& flags, long *ptrSubItem) const
 
     long item;
 #ifdef LVM_SUBITEMHITTEST
-    if ( ptrSubItem && wxApp::GetComCtl32Version() >= 470 )
+    if ( ptrSubItem )
     {
         item = ListView_SubItemHitTest(GetHwnd(), &hitTestInfo);
         *ptrSubItem = hitTestInfo.iSubItem;
@@ -3280,40 +3270,36 @@ static void wxConvertToMSWListCol(HWND hwndList,
 #ifdef NM_CUSTOMDRAW // _WIN32_IE >= 0x0300
     if ( item.m_mask & wxLIST_MASK_IMAGE )
     {
-        if ( wxApp::GetComCtl32Version() >= 470 )
+        lvCol.mask |= LVCF_IMAGE;
+
+        // we use LVCFMT_BITMAP_ON_RIGHT because the images on the right
+        // seem to be generally nicer than on the left and the generic
+        // version only draws them on the right (we don't have a flag to
+        // specify the image location anyhow)
+        //
+        // we don't use LVCFMT_COL_HAS_IMAGES because it doesn't seem to
+        // make any difference in my tests -- but maybe we should?
+        if ( item.m_image != -1 )
         {
-            lvCol.mask |= LVCF_IMAGE;
-
-            // we use LVCFMT_BITMAP_ON_RIGHT because the images on the right
-            // seem to be generally nicer than on the left and the generic
-            // version only draws them on the right (we don't have a flag to
-            // specify the image location anyhow)
-            //
-            // we don't use LVCFMT_COL_HAS_IMAGES because it doesn't seem to
-            // make any difference in my tests -- but maybe we should?
-            if ( item.m_image != -1 )
+            // as we're going to overwrite the format field, get its
+            // current value first -- unless we want to overwrite it anyhow
+            if ( !(lvCol.mask & LVCF_FMT) )
             {
-                // as we're going to overwrite the format field, get its
-                // current value first -- unless we want to overwrite it anyhow
-                if ( !(lvCol.mask & LVCF_FMT) )
+                LV_COLUMN lvColOld;
+                wxZeroMemory(lvColOld);
+                lvColOld.mask = LVCF_FMT;
+                if ( ListView_GetColumn(hwndList, col, &lvColOld) )
                 {
-                    LV_COLUMN lvColOld;
-                    wxZeroMemory(lvColOld);
-                    lvColOld.mask = LVCF_FMT;
-                    if ( ListView_GetColumn(hwndList, col, &lvColOld) )
-                    {
-                        lvCol.fmt = lvColOld.fmt;
-                    }
-
-                    lvCol.mask |= LVCF_FMT;
+                    lvCol.fmt = lvColOld.fmt;
                 }
 
-                lvCol.fmt |= LVCFMT_BITMAP_ON_RIGHT | LVCFMT_IMAGE;
+                lvCol.mask |= LVCF_FMT;
             }
 
-            lvCol.iImage = item.m_image;
+            lvCol.fmt |= LVCFMT_BITMAP_ON_RIGHT | LVCFMT_IMAGE;
         }
-        //else: it doesn't support item images anyhow
+
+        lvCol.iImage = item.m_image;
     }
 #endif // _WIN32_IE >= 0x0300
 }

--- a/src/msw/menu.cpp
+++ b/src/msw/menu.cpp
@@ -580,21 +580,11 @@ bool wxMenu::DoInsertOrAppend(wxMenuItem *pItem, size_t pos)
                     // boxes are used together with bitmaps and this is not the
                     // case in wx API
                     WinStruct<MENUINFO> mi;
-
-                    // don't call SetMenuInfo() directly, this would prevent
-                    // the app from starting up under Windows 95/NT 4
-                    typedef BOOL (WINAPI *SetMenuInfo_t)(HMENU, MENUINFO *);
-
-                    wxDynamicLibrary dllUser(wxT("user32"));
-                    wxDYNLIB_FUNCTION(SetMenuInfo_t, SetMenuInfo, dllUser);
-                    if ( pfnSetMenuInfo )
+                    mi.fMask = MIM_STYLE;
+                    mi.dwStyle = MNS_CHECKORBMP;
+                    if ( !::SetMenuInfo(GetHmenu(), &mi) )
                     {
-                        mi.fMask = MIM_STYLE;
-                        mi.dwStyle = MNS_CHECKORBMP;
-                        if ( !(*pfnSetMenuInfo)(GetHmenu(), &mi) )
-                        {
-                            wxLogLastError(wxT("SetMenuInfo(MNS_NOCHECK)"));
-                        }
+                        wxLogLastError(wxT("SetMenuInfo(MNS_NOCHECK)"));
                     }
                 }
         }

--- a/src/msw/mimetype.cpp
+++ b/src/msw/mimetype.cpp
@@ -227,31 +227,13 @@ wxString wxAssocQueryString(ASSOCSTR assoc,
                             wxString ext,
                             const wxString& verb = wxString())
 {
-    typedef HRESULT (WINAPI *AssocQueryString_t)(ASSOCF, ASSOCSTR,
-                                                  LPCTSTR, LPCTSTR, LPTSTR,
-                                                  DWORD *);
-    static AssocQueryString_t s_pfnAssocQueryString = (AssocQueryString_t)-1;
-    static wxDynamicLibrary s_dllShlwapi;
-
-    if ( s_pfnAssocQueryString == (AssocQueryString_t)-1 )
-    {
-        if ( !s_dllShlwapi.Load(wxT("shlwapi.dll"), wxDL_VERBATIM | wxDL_QUIET) )
-            s_pfnAssocQueryString = NULL;
-        else
-            wxDL_INIT_FUNC_AW(s_pfn, AssocQueryString, s_dllShlwapi);
-    }
-
-    if ( !s_pfnAssocQueryString )
-        return wxString();
-
-
     DWORD dwSize = MAX_PATH;
     TCHAR bufOut[MAX_PATH] = { 0 };
 
     if ( ext.empty() || ext[0] != '.' )
         ext.Prepend('.');
 
-    HRESULT hr = s_pfnAssocQueryString
+    HRESULT hr = ::AssocQueryString
                  (
                     wxASSOCF_NOTRUNCATE,// Fail if buffer is too small.
                     assoc,              // The association to retrieve.

--- a/src/msw/notifmsg.cpp
+++ b/src/msw/notifmsg.cpp
@@ -452,7 +452,7 @@ bool wxNotificationMessage::Show(int timeout)
 {
     if ( !m_impl )
     {
-        if ( !ms_alwaysUseGeneric && wxTheApp->GetShell32Version() >= 500 )
+        if ( !ms_alwaysUseGeneric )
         {
             if ( timeout == Timeout_Never )
                 m_impl = new wxManualNotifMsgImpl(GetParent());

--- a/src/msw/spinbutt.cpp
+++ b/src/msw/spinbutt.cpp
@@ -168,17 +168,12 @@ int wxSpinButton::GetValue() const
 {
     int n;
 #ifdef UDM_GETPOS32
-    if ( wxApp::GetComCtl32Version() >= 580 )
-    {
-        // use the full 32 bit range if available
-        n = ::SendMessage(GetHwnd(), UDM_GETPOS32, 0, 0);
-    }
-    else
+    // use the full 32 bit range if available
+    n = ::SendMessage(GetHwnd(), UDM_GETPOS32, 0, 0);
+#else
+    // we're limited to 16 bit
+    n = (short)LOWORD(::SendMessage(GetHwnd(), UDM_GETPOS, 0, 0));
 #endif // UDM_GETPOS32
-    {
-        // we're limited to 16 bit
-        n = (short)LOWORD(::SendMessage(GetHwnd(), UDM_GETPOS, 0, 0));
-    }
 
     if (n < m_min) n = m_min;
     if (n > m_max) n = m_max;
@@ -191,16 +186,11 @@ void wxSpinButton::SetValue(int val)
     // wxSpinButtonBase::SetValue(val); -- no, it is pure virtual
 
 #ifdef UDM_SETPOS32
-    if ( wxApp::GetComCtl32Version() >= 580 )
-    {
-        // use the full 32 bit range if available
-        ::SendMessage(GetHwnd(), UDM_SETPOS32, 0, val);
-    }
-    else // we're limited to 16 bit
+    // use the full 32 bit range if available
+    ::SendMessage(GetHwnd(), UDM_SETPOS32, 0, val);
+#else
+    ::SendMessage(GetHwnd(), UDM_SETPOS, 0, MAKELONG((short) val, 0));
 #endif // UDM_SETPOS32
-    {
-        ::SendMessage(GetHwnd(), UDM_SETPOS, 0, MAKELONG((short) val, 0));
-    }
 }
 
 void wxSpinButton::NormalizeValue()
@@ -215,17 +205,13 @@ void wxSpinButton::SetRange(int minVal, int maxVal)
     wxSpinButtonBase::SetRange(minVal, maxVal);
 
 #ifdef UDM_SETRANGE32
-    if ( wxApp::GetComCtl32Version() >= 471 )
-    {
-        // use the full 32 bit range if available
-        ::SendMessage(GetHwnd(), UDM_SETRANGE32, minVal, maxVal);
-    }
-    else // we're limited to 16 bit
+    // use the full 32 bit range if available
+    ::SendMessage(GetHwnd(), UDM_SETRANGE32, minVal, maxVal);
+#else
+    // we're limited to 16 bit
+    ::SendMessage(GetHwnd(), UDM_SETRANGE, 0,
+                  (LPARAM) MAKELONG((short)maxVal, (short)minVal));
 #endif // UDM_SETRANGE32
-    {
-        ::SendMessage(GetHwnd(), UDM_SETRANGE, 0,
-                      (LPARAM) MAKELONG((short)maxVal, (short)minVal));
-    }
 
     // the current value might be out of the new range, force it to be in it
     NormalizeValue();

--- a/src/msw/taskbar.cpp
+++ b/src/msw/taskbar.cpp
@@ -45,14 +45,6 @@
     #define NIF_INFO        0x00000010
 #endif
 
-#ifndef NOTIFYICONDATA_V1_SIZE
-    #ifdef UNICODE
-        #define NOTIFYICONDATA_V1_SIZE 0x0098
-    #else
-        #define NOTIFYICONDATA_V1_SIZE 0x0058
-    #endif
-#endif
-
 #ifndef NOTIFYICONDATA_V2_SIZE
     #ifdef UNICODE
         #define NOTIFYICONDATA_V2_SIZE 0x03A8
@@ -122,12 +114,8 @@ struct NotifyIconData : public NOTIFYICONDATA
         // we could do complicated tests for the exact system version it's
         // easier to just use an old size which should be supported everywhere
         // from Windows 2000 up and which is all we need as we don't use any
-        // newer features so far. But if we're running under a really ancient
-        // system (Win9x), fall back to even smaller size -- then the balloon
-        // related features won't be available but the rest will still work.
-        cbSize = wxTheApp->GetShell32Version() >= 500
-                    ? NOTIFYICONDATA_V2_SIZE
-                    : NOTIFYICONDATA_V1_SIZE;
+        // newer features so far.
+        cbSize = NOTIFYICONDATA_V2_SIZE;
 
         hWnd = (HWND) hwnd;
         uCallbackMessage = gs_msgTaskbar;

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -386,8 +386,7 @@ bool wxToolBar::MSWCreateToolbar(const wxPoint& pos, const wxSize& size)
     ::SendMessage(GetHwnd(), TB_BUTTONSTRUCTSIZE, sizeof(TBBUTTON), 0);
 
 #ifdef TB_SETEXTENDEDSTYLE
-    if ( wxApp::GetComCtl32Version() >= 471 )
-        ::SendMessage(GetHwnd(), TB_SETEXTENDEDSTYLE, 0, TBSTYLE_EX_DRAWDDARROWS);
+    ::SendMessage(GetHwnd(), TB_SETEXTENDEDSTYLE, 0, TBSTYLE_EX_DRAWDDARROWS);
 #endif
 
     return true;
@@ -523,10 +522,10 @@ WXDWORD wxToolBar::MSWGetStyle(long style, WXDWORD *exstyle) const
     if ( !(style & wxTB_NO_TOOLTIPS) )
         msStyle |= TBSTYLE_TOOLTIPS;
 
-    if ( style & wxTB_FLAT && wxApp::GetComCtl32Version() > 400 )
+    if ( style & wxTB_FLAT )
         msStyle |= TBSTYLE_FLAT;
 
-    if ( style & wxTB_HORZ_LAYOUT && wxApp::GetComCtl32Version() >= 470 )
+    if ( style & wxTB_HORZ_LAYOUT )
         msStyle |= TBSTYLE_LIST;
 
     if ( style & wxTB_NODIVIDER )
@@ -607,34 +606,27 @@ void wxToolBar::CreateDisabledImageList()
 {
     wxDELETE(m_disabledImgList);
 
-    // as we can't use disabled image list with older versions of comctl32.dll,
-    // don't even bother creating it
-    if ( wxApp::GetComCtl32Version() >= 470 )
+    // search for the first disabled button img in the toolbar, if any
+    for ( wxToolBarToolsList::compatibility_iterator
+            node = m_tools.GetFirst(); node; node = node->GetNext() )
     {
-        // search for the first disabled button img in the toolbar, if any
-        for ( wxToolBarToolsList::compatibility_iterator
-                node = m_tools.GetFirst(); node; node = node->GetNext() )
+        wxToolBarToolBase *tool = node->GetData();
+        wxBitmap bmpDisabled = tool->GetDisabledBitmap();
+        if ( bmpDisabled.IsOk() )
         {
-            wxToolBarToolBase *tool = node->GetData();
-            wxBitmap bmpDisabled = tool->GetDisabledBitmap();
-            if ( bmpDisabled.IsOk() )
-            {
-                const wxSize sizeBitmap = bmpDisabled.GetSize();
-                m_disabledImgList = new wxImageList
-                                        (
-                                            sizeBitmap.x,
-                                            sizeBitmap.y,
-                                            // Don't use mask if we have alpha
-                                            // (wxImageList will fall back to
-                                            // mask if alpha not supported)
-                                            !bmpDisabled.HasAlpha(),
-                                            GetToolsCount()
-                                        );
-                break;
-            }
+            const wxSize sizeBitmap = bmpDisabled.GetSize();
+            m_disabledImgList = new wxImageList
+                                    (
+                                        sizeBitmap.x,
+                                        sizeBitmap.y,
+                                        // Don't use mask if we have alpha
+                                        // (wxImageList will fall back to
+                                        // mask if alpha not supported)
+                                        !bmpDisabled.HasAlpha(),
+                                        GetToolsCount()
+                                    );
+            break;
         }
-
-        // we don't have any disabled bitmaps
     }
 }
 
@@ -824,35 +816,30 @@ bool wxToolBar::Realize()
         if ( oldToolBarBitmap )
         {
 #ifdef TB_REPLACEBITMAP
-            if ( wxApp::GetComCtl32Version() >= 400 )
+            TBREPLACEBITMAP replaceBitmap;
+            replaceBitmap.hInstOld = NULL;
+            replaceBitmap.hInstNew = NULL;
+            replaceBitmap.nIDOld = (UINT_PTR)oldToolBarBitmap;
+            replaceBitmap.nIDNew = (UINT_PTR)hBitmap;
+            replaceBitmap.nButtons = nButtons;
+            if ( !::SendMessage(GetHwnd(), TB_REPLACEBITMAP,
+                                0, (LPARAM) &replaceBitmap) )
             {
-                TBREPLACEBITMAP replaceBitmap;
-                replaceBitmap.hInstOld = NULL;
-                replaceBitmap.hInstNew = NULL;
-                replaceBitmap.nIDOld = (UINT_PTR)oldToolBarBitmap;
-                replaceBitmap.nIDNew = (UINT_PTR)hBitmap;
-                replaceBitmap.nButtons = nButtons;
-                if ( !::SendMessage(GetHwnd(), TB_REPLACEBITMAP,
-                                    0, (LPARAM) &replaceBitmap) )
-                {
-                    wxFAIL_MSG(wxT("Could not replace the old bitmap"));
-                }
-
-                ::DeleteObject(oldToolBarBitmap);
-
-                // already done
-                addBitmap = false;
+                wxFAIL_MSG(wxT("Could not replace the old bitmap"));
             }
-            else
+
+            ::DeleteObject(oldToolBarBitmap);
+
+            // already done
+            addBitmap = false;
+#else
+            // we can't replace the old bitmap, so we will add another one
+            // (awfully inefficient, but what else to do?) and shift the bitmap
+            // indices accordingly
+            addBitmap = true;
+
+            bitmapId = m_nButtons;
 #endif // TB_REPLACEBITMAP
-            {
-                // we can't replace the old bitmap, so we will add another one
-                // (awfully inefficient, but what else to do?) and shift the bitmap
-                // indices accordingly
-                addBitmap = true;
-
-                bitmapId = m_nButtons;
-            }
         }
 
         if ( addBitmap ) // no old bitmap or we can't replace it
@@ -867,22 +854,18 @@ bool wxToolBar::Realize()
             }
         }
 
-        // disable image lists are only supported in comctl32.dll 4.70+
-        if ( wxApp::GetComCtl32Version() >= 470 )
-        {
-            HIMAGELIST hil = m_disabledImgList
-                                ? GetHimagelistOf(m_disabledImgList)
-                                : 0;
+        HIMAGELIST hil = m_disabledImgList
+                            ? GetHimagelistOf(m_disabledImgList)
+                            : 0;
 
-            // notice that we set the image list even if don't have one right
-            // now as we could have it before and need to reset it in this case
-            HIMAGELIST oldImageList = (HIMAGELIST)
-              ::SendMessage(GetHwnd(), TB_SETDISABLEDIMAGELIST, 0, (LPARAM)hil);
+        // notice that we set the image list even if don't have one right
+        // now as we could have it before and need to reset it in this case
+        HIMAGELIST oldImageList = (HIMAGELIST)
+          ::SendMessage(GetHwnd(), TB_SETDISABLEDIMAGELIST, 0, (LPARAM)hil);
 
-            // delete previous image list if any
-            if ( oldImageList )
-                ::DeleteObject(oldImageList);
-        }
+        // delete previous image list if any
+        if ( oldImageList )
+            ::DeleteObject(oldImageList);
     }
 
 
@@ -899,14 +882,6 @@ bool wxToolBar::Realize()
     for ( node = m_tools.GetFirst(); node; node = node->GetNext() )
     {
         wxToolBarTool *tool = static_cast<wxToolBarTool *>(node->GetData());
-
-        // don't add separators to the vertical toolbar with old comctl32.dll
-        // versions as they didn't handle this properly
-        if ( IsVertical() && tool->IsSeparator() &&
-                wxApp::GetComCtl32Version() <= 472 )
-        {
-            continue;
-        }
 
         TBBUTTON& button = buttons[i];
 
@@ -1492,21 +1467,9 @@ void wxToolBar::SetRows(int nRows)
 // The button size is bigger than the bitmap size
 wxSize wxToolBar::GetToolSize() const
 {
-    // TB_GETBUTTONSIZE is supported from version 4.70
-#if defined(_WIN32_IE) && (_WIN32_IE >= 0x300 ) \
-    && !( defined(__GNUWIN32__) && !wxCHECK_W32API_VERSION( 1, 0 ) )
-    if ( wxApp::GetComCtl32Version() >= 470 )
-    {
-        DWORD dw = ::SendMessage(GetHwnd(), TB_GETBUTTONSIZE, 0, 0);
+    DWORD dw = ::SendMessage(GetHwnd(), TB_GETBUTTONSIZE, 0, 0);
 
-        return wxSize(LOWORD(dw), HIWORD(dw));
-    }
-    else
-#endif // comctl32.dll 4.70+
-    {
-        // defaults
-        return wxSize(m_defaultWidth + 8, m_defaultHeight + 7);
-    }
+    return wxSize(LOWORD(dw), HIWORD(dw));
 }
 
 wxToolBarToolBase *wxToolBar::FindToolForPosition(wxCoord x, wxCoord y) const

--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -763,8 +763,7 @@ bool wxTreeCtrl::Create(wxWindow *parent,
 
     if ( m_windowStyle & wxTR_FULL_ROW_HIGHLIGHT )
     {
-        if ( wxApp::GetComCtl32Version() >= 471 )
-            wstyle |= TVS_FULLROWSELECT;
+        wstyle |= TVS_FULLROWSELECT;
     }
 
 #if defined(TVS_INFOTIP)

--- a/src/msw/utilsgui.cpp
+++ b/src/msw/utilsgui.cpp
@@ -29,9 +29,10 @@
     #include "wx/utils.h"
 #endif //WX_PRECOMP
 
-#include "wx/dynlib.h"
-
 #include "wx/msw/private.h"     // includes <windows.h>
+
+#include "wx/msw/wrapwin.h"
+#include <Shlwapi.h>
 
 // ============================================================================
 // implementation
@@ -264,34 +265,7 @@ void wxDrawLine(HDC hdc, int x1, int y1, int x2, int y2)
 
 extern bool wxEnableFileNameAutoComplete(HWND hwnd)
 {
-#if wxUSE_DYNLIB_CLASS
-    typedef HRESULT (WINAPI *SHAutoComplete_t)(HWND, DWORD);
-
-    static SHAutoComplete_t s_pfnSHAutoComplete = NULL;
-    static bool s_initialized = false;
-
-    if ( !s_initialized )
-    {
-        s_initialized = true;
-
-        wxLogNull nolog;
-        wxDynamicLibrary dll(wxT("shlwapi.dll"));
-        if ( dll.IsLoaded() )
-        {
-            s_pfnSHAutoComplete =
-                (SHAutoComplete_t)dll.GetSymbol(wxT("SHAutoComplete"));
-            if ( s_pfnSHAutoComplete )
-            {
-                // won't be unloaded until the process termination, no big deal
-                dll.Detach();
-            }
-        }
-    }
-
-    if ( !s_pfnSHAutoComplete )
-        return false;
-
-    HRESULT hr = s_pfnSHAutoComplete(hwnd, 0x10 /* SHACF_FILESYS_ONLY */);
+    HRESULT hr = ::SHAutoComplete(hwnd, 0x10 /* SHACF_FILESYS_ONLY */);
     if ( FAILED(hr) )
     {
         wxLogApiError(wxT("SHAutoComplete"), hr);
@@ -299,8 +273,4 @@ extern bool wxEnableFileNameAutoComplete(HWND hwnd)
     }
 
     return true;
-#else
-    wxUnusedVar(hwnd);
-    return false;
-#endif // wxUSE_DYNLIB_CLASS/!wxUSE_DYNLIB_CLASS
 }

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -637,24 +637,6 @@ wxWindowMSW::MSWShowWithEffect(bool show,
     if ( !wxWindowBase::Show(show) )
         return false;
 
-    typedef BOOL (WINAPI *AnimateWindow_t)(HWND, DWORD, DWORD);
-
-    static AnimateWindow_t s_pfnAnimateWindow = NULL;
-    static bool s_initDone = false;
-    if ( !s_initDone )
-    {
-        wxDynamicLibrary dllUser32(wxT("user32.dll"), wxDL_VERBATIM | wxDL_QUIET);
-        wxDL_INIT_FUNC(s_pfn, AnimateWindow, dllUser32);
-
-        s_initDone = true;
-
-        // notice that it's ok to unload user32.dll here as it won't be really
-        // unloaded, being still in use because we link to it statically too
-    }
-
-    if ( !s_pfnAnimateWindow )
-        return Show(show);
-
     // Show() has a side effect of sending a WM_SIZE to the window, which helps
     // ensuring that it's laid out correctly, but AnimateWindow() doesn't do
     // this so send the event ourselves
@@ -719,7 +701,7 @@ wxWindowMSW::MSWShowWithEffect(bool show,
             return false;
     }
 
-    if ( !(*s_pfnAnimateWindow)(GetHwnd(), timeout, dwFlags) )
+    if ( !::AnimateWindow(GetHwnd(), timeout, dwFlags) )
     {
         wxLogLastError(wxT("AnimateWindow"));
 


### PR DESCRIPTION
- Remove GetShell32Version as suggested in trac ticket [#17120](http://trac.wxwidgets.org/ticket/17120)
- Updated/Remove documentation referencing Win9X/WinNT differences
- Remove instances of GetComCtrl32Version checks aimed at Win9X
- Remove dynamic loading of various APIs which are available since Win2k or WinXP
