### PR TITLE
Fixes for Print tool count and text messages.

### DIFF
--- a/samples/toolbar/toolbar.cpp
+++ b/samples/toolbar/toolbar.cpp
@@ -481,6 +481,8 @@ void MyFrame::PopulateToolbar(wxToolBarBase* toolBar)
                          wxT("Delete this tool. This is a very long tooltip to test whether it does the right thing when the tooltip is more than Windows can cope with."));
     }
 
+    m_nPrint = 1;
+
     // add a stretchable space before the "Help" button to make it
     // right-aligned
     toolBar->AddStretchableSpace();
@@ -530,7 +532,7 @@ MyFrame::MyFrame(wxFrame* parent,
     m_searchTool = NULL;
 
     m_rows = 1;
-    m_nPrint = 1;
+    m_nPrint = 0; // set to 1 in PopulateToolbar()
 
 #if wxUSE_STATUSBAR
     // Give it a status line
@@ -638,7 +640,8 @@ MyFrame::MyFrame(wxFrame* parent,
     PopulateToolbar(m_extraToolBar);
 #endif
 
-    m_textWindow = new wxTextCtrl(m_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE);
+    // Use a read-only text control; Cut tool will not cut selected text anyway.
+    m_textWindow = new wxTextCtrl(m_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE|wxTE_READONLY);
 
     wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
     m_panel->SetSizer(sizer);
@@ -810,9 +813,9 @@ void MyFrame::OnQuit(wxCommandEvent& WXUNUSED(event))
 void MyFrame::OnAbout(wxCommandEvent& event)
 {
     if ( event.IsChecked() )
-        m_textWindow->WriteText( wxT("Help button down now.\n") );
+        m_textWindow->AppendText( wxT("Help button down now.\n") );
     else
-        m_textWindow->WriteText( wxT("Help button up now.\n") );
+        m_textWindow->AppendText( wxT("Help button up now.\n") );
 
     (void)wxMessageBox(wxT("wxWidgets toolbar sample"), wxT("About wxToolBar"));
 }
@@ -821,7 +824,7 @@ void MyFrame::OnToolLeftClick(wxCommandEvent& event)
 {
     wxString str;
     str.Printf( wxT("Clicked on tool %d\n"), event.GetId());
-    m_textWindow->WriteText( str );
+    m_textWindow->AppendText( str );
 
     if (event.GetId() == wxID_COPY)
     {
@@ -858,6 +861,7 @@ void MyFrame::DoEnablePrint()
 
     wxToolBarBase *tb = GetToolBar();
     tb->EnableTool(wxID_PRINT, !tb->GetToolEnabled(wxID_PRINT));
+    m_textWindow->AppendText("Print tool state changed.\n");
 }
 
 void MyFrame::DoDeletePrint()
@@ -867,6 +871,7 @@ void MyFrame::DoDeletePrint()
 
     wxToolBarBase *tb = GetToolBar();
     tb->DeleteTool( wxID_PRINT );
+    m_textWindow->AppendText("Print tool was deleted.\n");
 
     m_nPrint--;
 }
@@ -875,6 +880,7 @@ void MyFrame::DoToggleHelp()
 {
     wxToolBarBase *tb = GetToolBar();
     tb->ToggleTool( wxID_HELP, !tb->GetToolState( wxID_HELP ) );
+    m_textWindow->AppendText("Help tool was toggled.\n");
 }
 
 void MyFrame::OnToggleSearch(wxCommandEvent& WXUNUSED(event))
@@ -995,7 +1001,7 @@ void MyFrame::OnToolDropdown(wxCommandEvent& event)
 {
     wxString str;
     str.Printf( wxT("Dropdown on tool %d\n"), event.GetId());
-    m_textWindow->WriteText( str );
+    m_textWindow->AppendText( str );
 
     event.Skip();
 }


### PR DESCRIPTION
Correct the count of Print tools, i.e. in case more tools were inserted and then the toolbar is recreated in a different position.
Made the text control receiving messaged read-only. Append new messages at the end for readability, not at cursor position.
Added messages to show that Copy tool intentionally influences Print tool and Cut tool influences Help tool.
