### PR TITLE
Fix OS X wxWebView ignoring javascript window.open() calls.

### DIFF
--- a/include/wx/osx/webview_webkit.h
+++ b/include/wx/osx/webview_webkit.h
@@ -145,6 +145,7 @@ public:
     void OnMouseEvents(wxMouseEvent &event);
 
     bool m_busy;
+    bool m_nextNavigationIsNewWindow;
 
 protected:
     virtual void DoSetPage(const wxString& html, const wxString& baseUrl);


### PR DESCRIPTION
On OS X (tested on 10.10.5) calls to window.open() with a different target than _self were simply ignored. No navigation and no EVT_WEBVIEW_NEWWINDOW as expected.

Unfortunately WebKit does not call the decidePolicyForNewWindowAction delegate method in these cases. A new delegate method createWebViewWithRequest has been implemented to handle this case and send EVT_WEBVIEW_NEWWINDOW as in other ports.
