### PR TITLE
3.0: Fix OS X wxWebView ignoring JavaScript window.open() calls

### DIFF
--- a/include/wx/osx/webview_webkit.h
+++ b/include/wx/osx/webview_webkit.h
@@ -146,6 +146,7 @@ public:
     void OnMouseEvents(wxMouseEvent &event);
 
     bool m_busy;
+    bool m_nextNavigationIsNewWindow;
 
 protected:
     virtual void DoSetPage(const wxString& html, const wxString& baseUrl);

--- a/src/osx/webview_webkit.mm
+++ b/src/osx/webview_webkit.mm
@@ -1223,7 +1223,7 @@ wxString nsErrorToWxHtmlError(NSError* error, wxWebViewNavigationError* out)
 
         wxWebViewEvent event(wxEVT_WEBVIEW_NEWWINDOW,
                              webKitWindow->GetId(),
-                             wxCFStringRef::AsString( url ), "");
+                             wxStringWithNSString( url ), "");
 
         if (webKitWindow && webKitWindow->GetEventHandler())
             webKitWindow->GetEventHandler()->ProcessEvent(event);

--- a/src/osx/webview_webkit.mm
+++ b/src/osx/webview_webkit.mm
@@ -340,6 +340,7 @@ bool wxWebViewWebKit::Create(wxWindow *parent,
                                  const wxString& name)
 {
     m_busy = false;
+    m_nextNavigationIsNewWindow = false;
 
     DontCreatePeer();
     wxControl::Create(parent, winID, pos, size, style, wxDefaultValidator, name);
@@ -1212,8 +1213,26 @@ wxString nsErrorToWxHtmlError(NSError* error, wxWebViewNavigationError* out)
 {
     wxUnusedVar(frame);
 
-    webKitWindow->m_busy = true;
     NSString *url = [[request URL] absoluteString];
+    if (webKitWindow->m_nextNavigationIsNewWindow)
+    {
+        // This navigation has been marked as a new window
+        // cancel the request here and send an apropriate event
+        // to the application code
+        webKitWindow->m_nextNavigationIsNewWindow = false;
+
+        wxWebViewEvent event(wxEVT_WEBVIEW_NEWWINDOW,
+                             webKitWindow->GetId(),
+                             wxCFStringRef::AsString( url ), "");
+
+        if (webKitWindow && webKitWindow->GetEventHandler())
+            webKitWindow->GetEventHandler()->ProcessEvent(event);
+
+        [listener ignore];
+        return;
+    }
+
+    webKitWindow->m_busy = true;
     wxString target = wxStringWithNSString([frame name]);
     wxWebViewEvent event(wxEVT_WEBVIEW_NAVIGATING,
                          webKitWindow->GetId(),
@@ -1340,6 +1359,15 @@ wxString nsErrorToWxHtmlError(NSError* error, wxWebViewNavigationError* out)
     [super init];
     webKitWindow = inWindow;    // non retained
     return self;
+}
+
+- (WebView *)webView:(WebView *)sender createWebViewWithRequest:(NSURLRequest *)request
+{
+    // This method is called when window.open() is used in javascript with a target != _self
+    // request is always nil, so it can't be used for event generation
+    // Mark the next navigation as "new window"
+    webKitWindow->m_nextNavigationIsNewWindow = true;
+    return sender;
 }
 
 - (void)webView:(WebView *)sender printFrameView:(WebFrameView *)frameView


### PR DESCRIPTION
On OS X (tested on 10.10.5) calls to window.open() with a different target
than _self were simply ignored. No navigation and no EVT_WEBVIEW_NEWWINDOW as
expected.

Unfortunately WebKit does not call the decidePolicyForNewWindowAction delegate
method in these cases. A new delegate method createWebViewWithRequest has been
implemented to handle this case and send EVT_WEBVIEW_NEWWINDOW as in other
ports.

Closes https://github.com/wxWidgets/wxWidgets/pull/85

(cherry picked from commit e6b31adefea35a12828e75972cc6802a2ae13019)
