### PR TITLE
Increment/decrement the month by scrolling anywhere on the generic calendar.

### DIFF
--- a/include/wx/generic/calctrlg.h
+++ b/include/wx/generic/calctrlg.h
@@ -179,6 +179,7 @@ private:
     void OnPaint(wxPaintEvent& event);
     void OnClick(wxMouseEvent& event);
     void OnDClick(wxMouseEvent& event);
+    void OnWheel(wxMouseEvent& event);
     void OnChar(wxKeyEvent& event);
     void OnMonthChange(wxCommandEvent& event);
 

--- a/src/generic/calctrlg.cpp
+++ b/src/generic/calctrlg.cpp
@@ -59,6 +59,7 @@ wxBEGIN_EVENT_TABLE(wxGenericCalendarCtrl, wxControl)
 
     EVT_LEFT_DOWN(wxGenericCalendarCtrl::OnClick)
     EVT_LEFT_DCLICK(wxGenericCalendarCtrl::OnDClick)
+    EVT_MOUSEWHEEL(wxGenericCalendarCtrl::OnWheel)
 
     EVT_SYS_COLOUR_CHANGED(wxGenericCalendarCtrl::OnSysColourChanged)
 wxEND_EVENT_TABLE()
@@ -1509,6 +1510,34 @@ wxCalendarHitTestResult wxGenericCalendarCtrl::HitTest(const wxPoint& pos,
     else
     {
         return wxCAL_HITTEST_NOWHERE;
+    }
+}
+
+void wxGenericCalendarCtrl::OnWheel(wxMouseEvent& event)
+{
+    const int rot = event.GetWheelRotation();
+    switch ( event.GetWheelAxis() )
+    {
+        case wxMOUSE_WHEEL_VERTICAL:
+        {
+            if ( rot > 0 )
+                SetDateAndNotify(m_date - wxDateSpan::Month());
+            else if ( rot < 0 )
+                SetDateAndNotify(m_date + wxDateSpan::Month());
+        }
+        break;
+
+        case wxMOUSE_WHEEL_HORIZONTAL:
+        {
+            if ( rot < 0 )
+                SetDateAndNotify(m_date - wxDateSpan::Year());
+            else if ( rot > 0 )
+                SetDateAndNotify(m_date + wxDateSpan::Year());
+        }
+        break;
+
+        default: // unknown axis
+            break;
     }
 }
 


### PR DESCRIPTION
Mimics the scrolling behaviour of native MSW and Gtk calendars. Additionally, horizontal scrolling increments/decrements the year.

Also applies to 3.0 branch.
