### PR TITLE
Add wxStandardPaths::GetUserDir() to get Desktop,Download,… folders.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -711,12 +711,12 @@ ALL_PORTS_BASE_HEADERS =  \
 	wx/unix/evtloop.h \
 	wx/unix/evtloopsrc.h \
 	wx/unix/pipe.h \
-	wx/unix/stdpaths.h \
 	wx/unix/stackwalk.h \
 	wx/unix/tls.h \
 	wx/unix/fswatcher_kqueue.h \
 	wx/unix/mimetype.h \
 	wx/unix/fswatcher_inotify.h \
+	wx/unix/stdpaths.h \
 	wx/msw/apptrait.h \
 	wx/msw/apptbase.h \
 	wx/msw/chkconf.h \
@@ -851,7 +851,6 @@ ALL_BASE_SOURCES =  \
 	src/unix/fdiounix.cpp \
 	src/unix/snglinst.cpp \
 	src/unix/stackwalk.cpp \
-	src/unix/stdpaths.cpp \
 	src/unix/timerunx.cpp \
 	src/unix/threadpsx.cpp \
 	src/unix/utilsunx.cpp \
@@ -859,6 +858,7 @@ ALL_BASE_SOURCES =  \
 	src/unix/fswatcher_kqueue.cpp \
 	src/unix/mimetype.cpp \
 	src/unix/fswatcher_inotify.cpp \
+	src/unix/stdpaths.cpp \
 	src/msw/basemsw.cpp \
 	src/msw/crashrpt.cpp \
 	src/msw/debughlp.cpp \
@@ -886,8 +886,11 @@ ALL_BASE_SOURCES =  \
 	src/common/utilscmn.cpp \
 	src/osx/carbon/utils.cpp \
 	src/osx/carbon/uma.cpp \
+	src/unix/stdpaths.cpp \
+	src/osx/core/stdpaths_cf.cpp \
 	src/osx/cocoa/utils.mm \
 	src/osx/cocoa/power.mm \
+	src/osx/cocoa/stdpaths.mm \
 	src/msw/main.cpp \
 	src/msw/volume.cpp \
 	src/common/fs_inet.cpp \
@@ -2238,7 +2241,6 @@ COND_TOOLKIT_OSX_CARBON_BASE_OSX_SRC =  \
 	src/osx/core/mimetype.cpp \
 	src/osx/core/cfstring.cpp \
 	src/osx/core/evtloop_cf.cpp \
-	src/osx/core/stdpaths_cf.cpp \
 	src/osx/core/strconv_cf.cpp \
 	src/osx/core/utilsexc_base.cpp \
 	src/common/fdiodispatcher.cpp \
@@ -2251,7 +2253,6 @@ COND_TOOLKIT_OSX_CARBON_BASE_OSX_SRC =  \
 	src/unix/fdiounix.cpp \
 	src/unix/snglinst.cpp \
 	src/unix/stackwalk.cpp \
-	src/unix/stdpaths.cpp \
 	src/unix/timerunx.cpp \
 	src/unix/threadpsx.cpp \
 	src/unix/utilsunx.cpp \
@@ -2263,7 +2264,6 @@ COND_TOOLKIT_OSX_COCOA_BASE_OSX_SRC =  \
 	src/osx/core/mimetype.cpp \
 	src/osx/core/cfstring.cpp \
 	src/osx/core/evtloop_cf.cpp \
-	src/osx/core/stdpaths_cf.cpp \
 	src/osx/core/strconv_cf.cpp \
 	src/osx/core/utilsexc_base.cpp \
 	src/common/fdiodispatcher.cpp \
@@ -2276,7 +2276,6 @@ COND_TOOLKIT_OSX_COCOA_BASE_OSX_SRC =  \
 	src/unix/fdiounix.cpp \
 	src/unix/snglinst.cpp \
 	src/unix/stackwalk.cpp \
-	src/unix/stdpaths.cpp \
 	src/unix/timerunx.cpp \
 	src/unix/threadpsx.cpp \
 	src/unix/utilsunx.cpp \
@@ -2288,7 +2287,6 @@ COND_TOOLKIT_OSX_IPHONE_BASE_OSX_SRC =  \
 	src/osx/core/mimetype.cpp \
 	src/osx/core/cfstring.cpp \
 	src/osx/core/evtloop_cf.cpp \
-	src/osx/core/stdpaths_cf.cpp \
 	src/osx/core/strconv_cf.cpp \
 	src/osx/core/utilsexc_base.cpp \
 	src/common/fdiodispatcher.cpp \
@@ -2301,7 +2299,6 @@ COND_TOOLKIT_OSX_IPHONE_BASE_OSX_SRC =  \
 	src/unix/fdiounix.cpp \
 	src/unix/snglinst.cpp \
 	src/unix/stackwalk.cpp \
-	src/unix/stdpaths.cpp \
 	src/unix/timerunx.cpp \
 	src/unix/threadpsx.cpp \
 	src/unix/utilsunx.cpp \
@@ -2320,7 +2317,6 @@ COND_TOOLKIT_COCOA_BASE_OSX_SRC =  \
 	src/unix/fdiounix.cpp \
 	src/unix/snglinst.cpp \
 	src/unix/stackwalk.cpp \
-	src/unix/stdpaths.cpp \
 	src/unix/timerunx.cpp \
 	src/unix/threadpsx.cpp \
 	src/unix/utilsunx.cpp \
@@ -2329,7 +2325,6 @@ COND_TOOLKIT_COCOA_BASE_OSX_SRC =  \
 	src/unix/mimetype.cpp \
 	src/osx/core/cfstring.cpp \
 	src/osx/core/evtloop_cf.cpp \
-	src/osx/core/stdpaths_cf.cpp \
 	src/osx/core/strconv_cf.cpp \
 	src/osx/core/utilsexc_base.cpp
 @COND_TOOLKIT_COCOA@BASE_OSX_SRC = $(COND_TOOLKIT_COCOA_BASE_OSX_SRC)
@@ -2344,7 +2339,6 @@ COND_TOOLKIT_GTK_BASE_OSX_SRC =  \
 	src/unix/fdiounix.cpp \
 	src/unix/snglinst.cpp \
 	src/unix/stackwalk.cpp \
-	src/unix/stdpaths.cpp \
 	src/unix/timerunx.cpp \
 	src/unix/threadpsx.cpp \
 	src/unix/utilsunx.cpp \
@@ -2353,7 +2347,6 @@ COND_TOOLKIT_GTK_BASE_OSX_SRC =  \
 	src/unix/mimetype.cpp \
 	src/osx/core/cfstring.cpp \
 	src/osx/core/evtloop_cf.cpp \
-	src/osx/core/stdpaths_cf.cpp \
 	src/osx/core/strconv_cf.cpp \
 	src/osx/core/utilsexc_base.cpp
 @COND_TOOLKIT_GTK@BASE_OSX_SRC = $(COND_TOOLKIT_GTK_BASE_OSX_SRC)
@@ -2368,7 +2361,6 @@ COND_TOOLKIT_X11_BASE_OSX_SRC =  \
 	src/unix/fdiounix.cpp \
 	src/unix/snglinst.cpp \
 	src/unix/stackwalk.cpp \
-	src/unix/stdpaths.cpp \
 	src/unix/timerunx.cpp \
 	src/unix/threadpsx.cpp \
 	src/unix/utilsunx.cpp \
@@ -2377,7 +2369,6 @@ COND_TOOLKIT_X11_BASE_OSX_SRC =  \
 	src/unix/mimetype.cpp \
 	src/osx/core/cfstring.cpp \
 	src/osx/core/evtloop_cf.cpp \
-	src/osx/core/stdpaths_cf.cpp \
 	src/osx/core/strconv_cf.cpp \
 	src/osx/core/utilsexc_base.cpp
 @COND_TOOLKIT_X11@BASE_OSX_SRC = $(COND_TOOLKIT_X11_BASE_OSX_SRC)
@@ -2392,7 +2383,6 @@ COND_TOOLKIT_MOTIF_BASE_OSX_SRC =  \
 	src/unix/fdiounix.cpp \
 	src/unix/snglinst.cpp \
 	src/unix/stackwalk.cpp \
-	src/unix/stdpaths.cpp \
 	src/unix/timerunx.cpp \
 	src/unix/threadpsx.cpp \
 	src/unix/utilsunx.cpp \
@@ -2401,7 +2391,6 @@ COND_TOOLKIT_MOTIF_BASE_OSX_SRC =  \
 	src/unix/mimetype.cpp \
 	src/osx/core/cfstring.cpp \
 	src/osx/core/evtloop_cf.cpp \
-	src/osx/core/stdpaths_cf.cpp \
 	src/osx/core/strconv_cf.cpp \
 	src/osx/core/utilsexc_base.cpp
 @COND_TOOLKIT_MOTIF@BASE_OSX_SRC = $(COND_TOOLKIT_MOTIF_BASE_OSX_SRC)
@@ -2416,7 +2405,6 @@ COND_TOOLKIT__BASE_OSX_SRC =  \
 	src/unix/fdiounix.cpp \
 	src/unix/snglinst.cpp \
 	src/unix/stackwalk.cpp \
-	src/unix/stdpaths.cpp \
 	src/unix/timerunx.cpp \
 	src/unix/threadpsx.cpp \
 	src/unix/utilsunx.cpp \
@@ -2425,7 +2413,6 @@ COND_TOOLKIT__BASE_OSX_SRC =  \
 	src/unix/mimetype.cpp \
 	src/osx/core/cfstring.cpp \
 	src/osx/core/evtloop_cf.cpp \
-	src/osx/core/stdpaths_cf.cpp \
 	src/osx/core/strconv_cf.cpp \
 	src/osx/core/utilsexc_base.cpp
 @COND_TOOLKIT_@BASE_OSX_SRC = $(COND_TOOLKIT__BASE_OSX_SRC)
@@ -2445,7 +2432,6 @@ COND_TOOLKIT_OSX_CARBON_BASE_OSX_HDR =  \
 	wx/unix/evtloop.h \
 	wx/unix/evtloopsrc.h \
 	wx/unix/pipe.h \
-	wx/unix/stdpaths.h \
 	wx/unix/stackwalk.h \
 	wx/unix/tls.h \
 	wx/unix/fswatcher_kqueue.h \
@@ -2467,7 +2453,6 @@ COND_TOOLKIT_OSX_COCOA_BASE_OSX_HDR =  \
 	wx/unix/evtloop.h \
 	wx/unix/evtloopsrc.h \
 	wx/unix/pipe.h \
-	wx/unix/stdpaths.h \
 	wx/unix/stackwalk.h \
 	wx/unix/tls.h \
 	wx/unix/fswatcher_kqueue.h \
@@ -2481,7 +2466,6 @@ COND_TOOLKIT_COCOA_BASE_OSX_HDR =  \
 	wx/unix/evtloop.h \
 	wx/unix/evtloopsrc.h \
 	wx/unix/pipe.h \
-	wx/unix/stdpaths.h \
 	wx/unix/stackwalk.h \
 	wx/unix/tls.h \
 	wx/unix/fswatcher_kqueue.h \
@@ -2503,7 +2487,6 @@ COND_TOOLKIT_GTK_BASE_OSX_HDR =  \
 	wx/unix/evtloop.h \
 	wx/unix/evtloopsrc.h \
 	wx/unix/pipe.h \
-	wx/unix/stdpaths.h \
 	wx/unix/stackwalk.h \
 	wx/unix/tls.h \
 	wx/unix/fswatcher_kqueue.h \
@@ -2525,7 +2508,6 @@ COND_TOOLKIT_X11_BASE_OSX_HDR =  \
 	wx/unix/evtloop.h \
 	wx/unix/evtloopsrc.h \
 	wx/unix/pipe.h \
-	wx/unix/stdpaths.h \
 	wx/unix/stackwalk.h \
 	wx/unix/tls.h \
 	wx/unix/fswatcher_kqueue.h \
@@ -2547,7 +2529,6 @@ COND_TOOLKIT_MOTIF_BASE_OSX_HDR =  \
 	wx/unix/evtloop.h \
 	wx/unix/evtloopsrc.h \
 	wx/unix/pipe.h \
-	wx/unix/stdpaths.h \
 	wx/unix/stackwalk.h \
 	wx/unix/tls.h \
 	wx/unix/fswatcher_kqueue.h \
@@ -2569,7 +2550,6 @@ COND_TOOLKIT__BASE_OSX_HDR =  \
 	wx/unix/evtloop.h \
 	wx/unix/evtloopsrc.h \
 	wx/unix/pipe.h \
-	wx/unix/stdpaths.h \
 	wx/unix/stackwalk.h \
 	wx/unix/tls.h \
 	wx/unix/fswatcher_kqueue.h \
@@ -2592,12 +2572,12 @@ COND_PLATFORM_UNIX_1_BASE_PLATFORM_HDR =  \
 	wx/unix/evtloop.h \
 	wx/unix/evtloopsrc.h \
 	wx/unix/pipe.h \
-	wx/unix/stdpaths.h \
 	wx/unix/stackwalk.h \
 	wx/unix/tls.h \
 	wx/unix/fswatcher_kqueue.h \
 	wx/unix/mimetype.h \
-	wx/unix/fswatcher_inotify.h
+	wx/unix/fswatcher_inotify.h \
+	wx/unix/stdpaths.h
 @COND_PLATFORM_UNIX_1@BASE_PLATFORM_HDR = $(COND_PLATFORM_UNIX_1_BASE_PLATFORM_HDR)
 COND_PLATFORM_WIN32_1_BASE_PLATFORM_HDR =  \
 	wx/msw/apptrait.h \
@@ -4501,7 +4481,6 @@ COND_PLATFORM_MACOSX_1___BASE_PLATFORM_SRC_OBJECTS =  \
 	monodll_core_mimetype.o \
 	monodll_cfstring.o \
 	monodll_evtloop_cf.o \
-	monodll_stdpaths_cf.o \
 	monodll_strconv_cf.o \
 	monodll_utilsexc_base.o \
 	monodll_fdiodispatcher.o \
@@ -4514,7 +4493,6 @@ COND_PLATFORM_MACOSX_1___BASE_PLATFORM_SRC_OBJECTS =  \
 	monodll_fdiounix.o \
 	monodll_unix_snglinst.o \
 	monodll_unix_stackwalk.o \
-	monodll_unix_stdpaths.o \
 	monodll_timerunx.o \
 	monodll_threadpsx.o \
 	monodll_utilsunx.o \
@@ -4533,14 +4511,14 @@ COND_PLATFORM_UNIX_1___BASE_PLATFORM_SRC_OBJECTS =  \
 	monodll_fdiounix.o \
 	monodll_unix_snglinst.o \
 	monodll_unix_stackwalk.o \
-	monodll_unix_stdpaths.o \
 	monodll_timerunx.o \
 	monodll_threadpsx.o \
 	monodll_utilsunx.o \
 	monodll_wakeuppipe.o \
 	monodll_fswatcher_kqueue.o \
 	monodll_unix_mimetype.o \
-	monodll_fswatcher_inotify.o
+	monodll_fswatcher_inotify.o \
+	monodll_unix_stdpaths.o
 @COND_PLATFORM_UNIX_1@__BASE_PLATFORM_SRC_OBJECTS = $(COND_PLATFORM_UNIX_1___BASE_PLATFORM_SRC_OBJECTS)
 COND_PLATFORM_WIN32_1___BASE_PLATFORM_SRC_OBJECTS =  \
 	monodll_basemsw.o \
@@ -4567,10 +4545,15 @@ COND_PLATFORM_WIN32_1___BASE_PLATFORM_SRC_OBJECTS =  \
 @COND_TOOLKIT_WINCE@__BASE_WINCE_SRC_OBJECTS = monodll_wince_time.o
 @COND_PLATFORM_WIN32_1@__BASE_AND_GUI_PLATFORM_SRC_OBJECTS \
 @COND_PLATFORM_WIN32_1@	= monodll_msw_main.o monodll_volume.o
-@COND_TOOLKIT_OSX_CARBON@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS \
-@COND_TOOLKIT_OSX_CARBON@	= monodll_carbon_utils.o monodll_uma.o
+COND_TOOLKIT_OSX_CARBON___BASE_AND_GUI_TOOLKIT_SRC_OBJECTS =  \
+	monodll_carbon_utils.o \
+	monodll_uma.o \
+	monodll_unix_stdpaths.o \
+	monodll_stdpaths_cf.o
+@COND_TOOLKIT_OSX_CARBON@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS = $(COND_TOOLKIT_OSX_CARBON___BASE_AND_GUI_TOOLKIT_SRC_OBJECTS)
 @COND_TOOLKIT_OSX_COCOA@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS \
-@COND_TOOLKIT_OSX_COCOA@	= monodll_osx_cocoa_utils.o monodll_cocoa_power.o
+@COND_TOOLKIT_OSX_COCOA@	= monodll_osx_cocoa_utils.o monodll_cocoa_power.o \
+@COND_TOOLKIT_OSX_COCOA@	monodll_cocoa_stdpaths.o
 @COND_PLATFORM_MACOSX_1@__NET_PLATFORM_SRC_OBJECTS \
 @COND_PLATFORM_MACOSX_1@	= monodll_socketiohandler.o monodll_sockunix.o \
 @COND_PLATFORM_MACOSX_1@	monodll_sockosx.o
@@ -6873,7 +6856,6 @@ COND_PLATFORM_MACOSX_1___BASE_PLATFORM_SRC_OBJECTS_1 =  \
 	monolib_core_mimetype.o \
 	monolib_cfstring.o \
 	monolib_evtloop_cf.o \
-	monolib_stdpaths_cf.o \
 	monolib_strconv_cf.o \
 	monolib_utilsexc_base.o \
 	monolib_fdiodispatcher.o \
@@ -6886,7 +6868,6 @@ COND_PLATFORM_MACOSX_1___BASE_PLATFORM_SRC_OBJECTS_1 =  \
 	monolib_fdiounix.o \
 	monolib_unix_snglinst.o \
 	monolib_unix_stackwalk.o \
-	monolib_unix_stdpaths.o \
 	monolib_timerunx.o \
 	monolib_threadpsx.o \
 	monolib_utilsunx.o \
@@ -6905,14 +6886,14 @@ COND_PLATFORM_UNIX_1___BASE_PLATFORM_SRC_OBJECTS_1 =  \
 	monolib_fdiounix.o \
 	monolib_unix_snglinst.o \
 	monolib_unix_stackwalk.o \
-	monolib_unix_stdpaths.o \
 	monolib_timerunx.o \
 	monolib_threadpsx.o \
 	monolib_utilsunx.o \
 	monolib_wakeuppipe.o \
 	monolib_fswatcher_kqueue.o \
 	monolib_unix_mimetype.o \
-	monolib_fswatcher_inotify.o
+	monolib_fswatcher_inotify.o \
+	monolib_unix_stdpaths.o
 @COND_PLATFORM_UNIX_1@__BASE_PLATFORM_SRC_OBJECTS_1 = $(COND_PLATFORM_UNIX_1___BASE_PLATFORM_SRC_OBJECTS_1)
 COND_PLATFORM_WIN32_1___BASE_PLATFORM_SRC_OBJECTS_1 =  \
 	monolib_basemsw.o \
@@ -6939,10 +6920,15 @@ COND_PLATFORM_WIN32_1___BASE_PLATFORM_SRC_OBJECTS_1 =  \
 @COND_TOOLKIT_WINCE@__BASE_WINCE_SRC_OBJECTS_1 = monolib_wince_time.o
 @COND_PLATFORM_WIN32_1@__BASE_AND_GUI_PLATFORM_SRC_OBJECTS_1 \
 @COND_PLATFORM_WIN32_1@	= monolib_msw_main.o monolib_volume.o
-@COND_TOOLKIT_OSX_CARBON@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_1 \
-@COND_TOOLKIT_OSX_CARBON@	= monolib_carbon_utils.o monolib_uma.o
+COND_TOOLKIT_OSX_CARBON___BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_1 =  \
+	monolib_carbon_utils.o \
+	monolib_uma.o \
+	monolib_unix_stdpaths.o \
+	monolib_stdpaths_cf.o
+@COND_TOOLKIT_OSX_CARBON@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_1 = $(COND_TOOLKIT_OSX_CARBON___BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_1)
 @COND_TOOLKIT_OSX_COCOA@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_1 \
-@COND_TOOLKIT_OSX_COCOA@	= monolib_osx_cocoa_utils.o monolib_cocoa_power.o
+@COND_TOOLKIT_OSX_COCOA@	= monolib_osx_cocoa_utils.o monolib_cocoa_power.o \
+@COND_TOOLKIT_OSX_COCOA@	monolib_cocoa_stdpaths.o
 @COND_PLATFORM_MACOSX_1@__NET_PLATFORM_SRC_OBJECTS_1 \
 @COND_PLATFORM_MACOSX_1@	= monolib_socketiohandler.o monolib_sockunix.o \
 @COND_PLATFORM_MACOSX_1@	monolib_sockosx.o
@@ -9298,7 +9284,6 @@ COND_PLATFORM_MACOSX_1___BASE_PLATFORM_SRC_OBJECTS_2 =  \
 	basedll_core_mimetype.o \
 	basedll_cfstring.o \
 	basedll_evtloop_cf.o \
-	basedll_stdpaths_cf.o \
 	basedll_strconv_cf.o \
 	basedll_utilsexc_base.o \
 	basedll_fdiodispatcher.o \
@@ -9311,7 +9296,6 @@ COND_PLATFORM_MACOSX_1___BASE_PLATFORM_SRC_OBJECTS_2 =  \
 	basedll_fdiounix.o \
 	basedll_unix_snglinst.o \
 	basedll_unix_stackwalk.o \
-	basedll_unix_stdpaths.o \
 	basedll_timerunx.o \
 	basedll_threadpsx.o \
 	basedll_utilsunx.o \
@@ -9330,14 +9314,14 @@ COND_PLATFORM_UNIX_1___BASE_PLATFORM_SRC_OBJECTS_2 =  \
 	basedll_fdiounix.o \
 	basedll_unix_snglinst.o \
 	basedll_unix_stackwalk.o \
-	basedll_unix_stdpaths.o \
 	basedll_timerunx.o \
 	basedll_threadpsx.o \
 	basedll_utilsunx.o \
 	basedll_wakeuppipe.o \
 	basedll_fswatcher_kqueue.o \
 	basedll_unix_mimetype.o \
-	basedll_fswatcher_inotify.o
+	basedll_fswatcher_inotify.o \
+	basedll_unix_stdpaths.o
 @COND_PLATFORM_UNIX_1@__BASE_PLATFORM_SRC_OBJECTS_2 = $(COND_PLATFORM_UNIX_1___BASE_PLATFORM_SRC_OBJECTS_2)
 COND_PLATFORM_WIN32_1___BASE_PLATFORM_SRC_OBJECTS_2 =  \
 	basedll_basemsw.o \
@@ -9364,10 +9348,15 @@ COND_PLATFORM_WIN32_1___BASE_PLATFORM_SRC_OBJECTS_2 =  \
 @COND_TOOLKIT_WINCE@__BASE_WINCE_SRC_OBJECTS_2 = basedll_wince_time.o
 @COND_PLATFORM_WIN32_1@__BASE_AND_GUI_PLATFORM_SRC_OBJECTS_2 \
 @COND_PLATFORM_WIN32_1@	= basedll_main.o basedll_volume.o
-@COND_TOOLKIT_OSX_CARBON@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_2 \
-@COND_TOOLKIT_OSX_CARBON@	= basedll_carbon_utils.o basedll_uma.o
+COND_TOOLKIT_OSX_CARBON___BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_2 =  \
+	basedll_carbon_utils.o \
+	basedll_uma.o \
+	basedll_unix_stdpaths.o \
+	basedll_stdpaths_cf.o
+@COND_TOOLKIT_OSX_CARBON@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_2 = $(COND_TOOLKIT_OSX_CARBON___BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_2)
 @COND_TOOLKIT_OSX_COCOA@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_2 \
-@COND_TOOLKIT_OSX_COCOA@	= basedll_cocoa_utils.o basedll_cocoa_power.o
+@COND_TOOLKIT_OSX_COCOA@	= basedll_cocoa_utils.o basedll_cocoa_power.o \
+@COND_TOOLKIT_OSX_COCOA@	basedll_cocoa_stdpaths.o
 COND_MONOLITHIC_0_SHARED_0___baselib___depname = \
 	$(LIBDIRNAME)/$(LIBPREFIX)wx_base$(WXBASEPORT)$(WXUNICODEFLAG)$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)-$(WX_RELEASE)$(HOST_SUFFIX)$(LIBEXT)
 @COND_MONOLITHIC_0_SHARED_0@__baselib___depname = $(COND_MONOLITHIC_0_SHARED_0___baselib___depname)
@@ -9383,7 +9372,6 @@ COND_PLATFORM_MACOSX_1___BASE_PLATFORM_SRC_OBJECTS_3 =  \
 	baselib_core_mimetype.o \
 	baselib_cfstring.o \
 	baselib_evtloop_cf.o \
-	baselib_stdpaths_cf.o \
 	baselib_strconv_cf.o \
 	baselib_utilsexc_base.o \
 	baselib_fdiodispatcher.o \
@@ -9396,7 +9384,6 @@ COND_PLATFORM_MACOSX_1___BASE_PLATFORM_SRC_OBJECTS_3 =  \
 	baselib_fdiounix.o \
 	baselib_unix_snglinst.o \
 	baselib_unix_stackwalk.o \
-	baselib_unix_stdpaths.o \
 	baselib_timerunx.o \
 	baselib_threadpsx.o \
 	baselib_utilsunx.o \
@@ -9415,14 +9402,14 @@ COND_PLATFORM_UNIX_1___BASE_PLATFORM_SRC_OBJECTS_3 =  \
 	baselib_fdiounix.o \
 	baselib_unix_snglinst.o \
 	baselib_unix_stackwalk.o \
-	baselib_unix_stdpaths.o \
 	baselib_timerunx.o \
 	baselib_threadpsx.o \
 	baselib_utilsunx.o \
 	baselib_wakeuppipe.o \
 	baselib_fswatcher_kqueue.o \
 	baselib_unix_mimetype.o \
-	baselib_fswatcher_inotify.o
+	baselib_fswatcher_inotify.o \
+	baselib_unix_stdpaths.o
 @COND_PLATFORM_UNIX_1@__BASE_PLATFORM_SRC_OBJECTS_3 = $(COND_PLATFORM_UNIX_1___BASE_PLATFORM_SRC_OBJECTS_3)
 COND_PLATFORM_WIN32_1___BASE_PLATFORM_SRC_OBJECTS_3 =  \
 	baselib_basemsw.o \
@@ -9449,10 +9436,15 @@ COND_PLATFORM_WIN32_1___BASE_PLATFORM_SRC_OBJECTS_3 =  \
 @COND_TOOLKIT_WINCE@__BASE_WINCE_SRC_OBJECTS_3 = baselib_wince_time.o
 @COND_PLATFORM_WIN32_1@__BASE_AND_GUI_PLATFORM_SRC_OBJECTS_3 \
 @COND_PLATFORM_WIN32_1@	= baselib_main.o baselib_volume.o
-@COND_TOOLKIT_OSX_CARBON@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_3 \
-@COND_TOOLKIT_OSX_CARBON@	= baselib_carbon_utils.o baselib_uma.o
+COND_TOOLKIT_OSX_CARBON___BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_3 =  \
+	baselib_carbon_utils.o \
+	baselib_uma.o \
+	baselib_unix_stdpaths.o \
+	baselib_stdpaths_cf.o
+@COND_TOOLKIT_OSX_CARBON@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_3 = $(COND_TOOLKIT_OSX_CARBON___BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_3)
 @COND_TOOLKIT_OSX_COCOA@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_3 \
-@COND_TOOLKIT_OSX_COCOA@	= baselib_cocoa_utils.o baselib_cocoa_power.o
+@COND_TOOLKIT_OSX_COCOA@	= baselib_cocoa_utils.o baselib_cocoa_power.o \
+@COND_TOOLKIT_OSX_COCOA@	baselib_cocoa_stdpaths.o
 @COND_SHARED_1@____wxbase_namedll_DEP = $(__basedll___depname)
 @COND_SHARED_0@____wxbase_namelib_DEP = $(__baselib___depname)
 COND_MONOLITHIC_0_SHARED_1___netdll___depname = \
@@ -9620,10 +9612,15 @@ COND_USE_SOVERSOLARIS_1___coredll___so_symlinks_uninst_cmd = rm -f \
 @COND_PLATFORM_WIN32_1@__coredll___win32rc = coredll_version_rc.o
 @COND_PLATFORM_WIN32_1@__BASE_AND_GUI_PLATFORM_SRC_OBJECTS_4 \
 @COND_PLATFORM_WIN32_1@	= coredll_msw_main.o coredll_volume.o
-@COND_TOOLKIT_OSX_CARBON@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_4 \
-@COND_TOOLKIT_OSX_CARBON@	= coredll_carbon_utils.o coredll_uma.o
+COND_TOOLKIT_OSX_CARBON___BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_4 =  \
+	coredll_carbon_utils.o \
+	coredll_uma.o \
+	coredll_unix_stdpaths.o \
+	coredll_stdpaths_cf.o
+@COND_TOOLKIT_OSX_CARBON@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_4 = $(COND_TOOLKIT_OSX_CARBON___BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_4)
 @COND_TOOLKIT_OSX_COCOA@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_4 \
-@COND_TOOLKIT_OSX_COCOA@	= coredll_osx_cocoa_utils.o coredll_power.o
+@COND_TOOLKIT_OSX_COCOA@	= coredll_osx_cocoa_utils.o coredll_power.o \
+@COND_TOOLKIT_OSX_COCOA@	coredll_cocoa_stdpaths.o
 COND_USE_GUI_1_WXUNIV_0___CORE_SRC_OBJECTS_2 =  \
 	$(__LOWLEVEL_SRC_OBJECTS_4) \
 	$(__PLATFORM_SRC_OBJECTS_8) \
@@ -11399,10 +11396,15 @@ COND_MONOLITHIC_0_SHARED_0_USE_GUI_1___corelib___depname = \
 @COND_USE_PCH_1@	= ./.pch/wxprec_corelib/wx/wxprec.h.gch
 @COND_PLATFORM_WIN32_1@__BASE_AND_GUI_PLATFORM_SRC_OBJECTS_5 \
 @COND_PLATFORM_WIN32_1@	= corelib_msw_main.o corelib_volume.o
-@COND_TOOLKIT_OSX_CARBON@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_5 \
-@COND_TOOLKIT_OSX_CARBON@	= corelib_carbon_utils.o corelib_uma.o
+COND_TOOLKIT_OSX_CARBON___BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_5 =  \
+	corelib_carbon_utils.o \
+	corelib_uma.o \
+	corelib_unix_stdpaths.o \
+	corelib_stdpaths_cf.o
+@COND_TOOLKIT_OSX_CARBON@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_5 = $(COND_TOOLKIT_OSX_CARBON___BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_5)
 @COND_TOOLKIT_OSX_COCOA@__BASE_AND_GUI_TOOLKIT_SRC_OBJECTS_5 \
-@COND_TOOLKIT_OSX_COCOA@	= corelib_osx_cocoa_utils.o corelib_power.o
+@COND_TOOLKIT_OSX_COCOA@	= corelib_osx_cocoa_utils.o corelib_power.o \
+@COND_TOOLKIT_OSX_COCOA@	corelib_cocoa_stdpaths.o
 COND_USE_GUI_1_WXUNIV_0___CORE_SRC_OBJECTS_3 =  \
 	$(__LOWLEVEL_SRC_OBJECTS_6) \
 	$(__PLATFORM_SRC_OBJECTS_9) \
@@ -17744,9 +17746,6 @@ monodll_cfstring.o: $(srcdir)/src/osx/core/cfstring.cpp $(MONODLL_ODEP)
 monodll_evtloop_cf.o: $(srcdir)/src/osx/core/evtloop_cf.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/osx/core/evtloop_cf.cpp
 
-monodll_stdpaths_cf.o: $(srcdir)/src/osx/core/stdpaths_cf.cpp $(MONODLL_ODEP)
-	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/osx/core/stdpaths_cf.cpp
-
 monodll_strconv_cf.o: $(srcdir)/src/osx/core/strconv_cf.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/osx/core/strconv_cf.cpp
 
@@ -17780,11 +17779,17 @@ monodll_carbon_utils.o: $(srcdir)/src/osx/carbon/utils.cpp $(MONODLL_ODEP)
 monodll_uma.o: $(srcdir)/src/osx/carbon/uma.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/osx/carbon/uma.cpp
 
+monodll_stdpaths_cf.o: $(srcdir)/src/osx/core/stdpaths_cf.cpp $(MONODLL_ODEP)
+	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/osx/core/stdpaths_cf.cpp
+
 monodll_osx_cocoa_utils.o: $(srcdir)/src/osx/cocoa/utils.mm $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/utils.mm
 
 monodll_cocoa_power.o: $(srcdir)/src/osx/cocoa/power.mm $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/power.mm
+
+monodll_cocoa_stdpaths.o: $(srcdir)/src/osx/cocoa/stdpaths.mm $(MONODLL_ODEP)
+	$(CXXC) -c -o $@ $(MONODLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/stdpaths.mm
 
 monodll_fs_inet.o: $(srcdir)/src/common/fs_inet.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/common/fs_inet.cpp
@@ -19235,12 +19240,6 @@ monodll_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(MONODLL_ODEP)
 @COND_PLATFORM_MACOSX_1@monodll_unix_stackwalk.o: $(srcdir)/src/unix/stackwalk.cpp $(MONODLL_ODEP)
 @COND_PLATFORM_MACOSX_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/unix/stackwalk.cpp
 
-@COND_PLATFORM_UNIX_1@monodll_unix_stdpaths.o: $(srcdir)/src/unix/stdpaths.cpp $(MONODLL_ODEP)
-@COND_PLATFORM_UNIX_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/unix/stdpaths.cpp
-
-@COND_PLATFORM_MACOSX_1@monodll_unix_stdpaths.o: $(srcdir)/src/unix/stdpaths.cpp $(MONODLL_ODEP)
-@COND_PLATFORM_MACOSX_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/unix/stdpaths.cpp
-
 @COND_PLATFORM_UNIX_1@monodll_timerunx.o: $(srcdir)/src/unix/timerunx.cpp $(MONODLL_ODEP)
 @COND_PLATFORM_UNIX_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/unix/timerunx.cpp
 
@@ -19270,6 +19269,12 @@ monodll_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(MONODLL_ODEP)
 
 @COND_PLATFORM_MACOSX_1@monodll_fswatcher_kqueue.o: $(srcdir)/src/unix/fswatcher_kqueue.cpp $(MONODLL_ODEP)
 @COND_PLATFORM_MACOSX_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/unix/fswatcher_kqueue.cpp
+
+@COND_PLATFORM_UNIX_1@monodll_unix_stdpaths.o: $(srcdir)/src/unix/stdpaths.cpp $(MONODLL_ODEP)
+@COND_PLATFORM_UNIX_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/unix/stdpaths.cpp
+
+@COND_TOOLKIT_OSX_CARBON@monodll_unix_stdpaths.o: $(srcdir)/src/unix/stdpaths.cpp $(MONODLL_ODEP)
+@COND_TOOLKIT_OSX_CARBON@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/unix/stdpaths.cpp
 
 @COND_PLATFORM_UNIX_1@monodll_socketiohandler.o: $(srcdir)/src/common/socketiohandler.cpp $(MONODLL_ODEP)
 @COND_PLATFORM_UNIX_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/common/socketiohandler.cpp
@@ -23663,9 +23668,6 @@ monolib_cfstring.o: $(srcdir)/src/osx/core/cfstring.cpp $(MONOLIB_ODEP)
 monolib_evtloop_cf.o: $(srcdir)/src/osx/core/evtloop_cf.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/osx/core/evtloop_cf.cpp
 
-monolib_stdpaths_cf.o: $(srcdir)/src/osx/core/stdpaths_cf.cpp $(MONOLIB_ODEP)
-	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/osx/core/stdpaths_cf.cpp
-
 monolib_strconv_cf.o: $(srcdir)/src/osx/core/strconv_cf.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/osx/core/strconv_cf.cpp
 
@@ -23699,11 +23701,17 @@ monolib_carbon_utils.o: $(srcdir)/src/osx/carbon/utils.cpp $(MONOLIB_ODEP)
 monolib_uma.o: $(srcdir)/src/osx/carbon/uma.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/osx/carbon/uma.cpp
 
+monolib_stdpaths_cf.o: $(srcdir)/src/osx/core/stdpaths_cf.cpp $(MONOLIB_ODEP)
+	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/osx/core/stdpaths_cf.cpp
+
 monolib_osx_cocoa_utils.o: $(srcdir)/src/osx/cocoa/utils.mm $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/utils.mm
 
 monolib_cocoa_power.o: $(srcdir)/src/osx/cocoa/power.mm $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/power.mm
+
+monolib_cocoa_stdpaths.o: $(srcdir)/src/osx/cocoa/stdpaths.mm $(MONOLIB_ODEP)
+	$(CXXC) -c -o $@ $(MONOLIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/stdpaths.mm
 
 monolib_fs_inet.o: $(srcdir)/src/common/fs_inet.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/common/fs_inet.cpp
@@ -25154,12 +25162,6 @@ monolib_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(MONOLIB_ODEP)
 @COND_PLATFORM_MACOSX_1@monolib_unix_stackwalk.o: $(srcdir)/src/unix/stackwalk.cpp $(MONOLIB_ODEP)
 @COND_PLATFORM_MACOSX_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/unix/stackwalk.cpp
 
-@COND_PLATFORM_UNIX_1@monolib_unix_stdpaths.o: $(srcdir)/src/unix/stdpaths.cpp $(MONOLIB_ODEP)
-@COND_PLATFORM_UNIX_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/unix/stdpaths.cpp
-
-@COND_PLATFORM_MACOSX_1@monolib_unix_stdpaths.o: $(srcdir)/src/unix/stdpaths.cpp $(MONOLIB_ODEP)
-@COND_PLATFORM_MACOSX_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/unix/stdpaths.cpp
-
 @COND_PLATFORM_UNIX_1@monolib_timerunx.o: $(srcdir)/src/unix/timerunx.cpp $(MONOLIB_ODEP)
 @COND_PLATFORM_UNIX_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/unix/timerunx.cpp
 
@@ -25189,6 +25191,12 @@ monolib_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(MONOLIB_ODEP)
 
 @COND_PLATFORM_MACOSX_1@monolib_fswatcher_kqueue.o: $(srcdir)/src/unix/fswatcher_kqueue.cpp $(MONOLIB_ODEP)
 @COND_PLATFORM_MACOSX_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/unix/fswatcher_kqueue.cpp
+
+@COND_PLATFORM_UNIX_1@monolib_unix_stdpaths.o: $(srcdir)/src/unix/stdpaths.cpp $(MONOLIB_ODEP)
+@COND_PLATFORM_UNIX_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/unix/stdpaths.cpp
+
+@COND_TOOLKIT_OSX_CARBON@monolib_unix_stdpaths.o: $(srcdir)/src/unix/stdpaths.cpp $(MONOLIB_ODEP)
+@COND_TOOLKIT_OSX_CARBON@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/unix/stdpaths.cpp
 
 @COND_PLATFORM_UNIX_1@monolib_socketiohandler.o: $(srcdir)/src/common/socketiohandler.cpp $(MONOLIB_ODEP)
 @COND_PLATFORM_UNIX_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/common/socketiohandler.cpp
@@ -29582,9 +29590,6 @@ basedll_cfstring.o: $(srcdir)/src/osx/core/cfstring.cpp $(BASEDLL_ODEP)
 basedll_evtloop_cf.o: $(srcdir)/src/osx/core/evtloop_cf.cpp $(BASEDLL_ODEP)
 	$(CXXC) -c -o $@ $(BASEDLL_CXXFLAGS) $(srcdir)/src/osx/core/evtloop_cf.cpp
 
-basedll_stdpaths_cf.o: $(srcdir)/src/osx/core/stdpaths_cf.cpp $(BASEDLL_ODEP)
-	$(CXXC) -c -o $@ $(BASEDLL_CXXFLAGS) $(srcdir)/src/osx/core/stdpaths_cf.cpp
-
 basedll_strconv_cf.o: $(srcdir)/src/osx/core/strconv_cf.cpp $(BASEDLL_ODEP)
 	$(CXXC) -c -o $@ $(BASEDLL_CXXFLAGS) $(srcdir)/src/osx/core/strconv_cf.cpp
 
@@ -29618,11 +29623,17 @@ basedll_carbon_utils.o: $(srcdir)/src/osx/carbon/utils.cpp $(BASEDLL_ODEP)
 basedll_uma.o: $(srcdir)/src/osx/carbon/uma.cpp $(BASEDLL_ODEP)
 	$(CXXC) -c -o $@ $(BASEDLL_CXXFLAGS) $(srcdir)/src/osx/carbon/uma.cpp
 
+basedll_stdpaths_cf.o: $(srcdir)/src/osx/core/stdpaths_cf.cpp $(BASEDLL_ODEP)
+	$(CXXC) -c -o $@ $(BASEDLL_CXXFLAGS) $(srcdir)/src/osx/core/stdpaths_cf.cpp
+
 basedll_cocoa_utils.o: $(srcdir)/src/osx/cocoa/utils.mm $(BASEDLL_ODEP)
 	$(CXXC) -c -o $@ $(BASEDLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/utils.mm
 
 basedll_cocoa_power.o: $(srcdir)/src/osx/cocoa/power.mm $(BASEDLL_ODEP)
 	$(CXXC) -c -o $@ $(BASEDLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/power.mm
+
+basedll_cocoa_stdpaths.o: $(srcdir)/src/osx/cocoa/stdpaths.mm $(BASEDLL_ODEP)
+	$(CXXC) -c -o $@ $(BASEDLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/stdpaths.mm
 
 @COND_PLATFORM_UNIX_1@basedll_fdiodispatcher.o: $(srcdir)/src/common/fdiodispatcher.cpp $(BASEDLL_ODEP)
 @COND_PLATFORM_UNIX_1@	$(CXXC) -c -o $@ $(BASEDLL_CXXFLAGS) $(srcdir)/src/common/fdiodispatcher.cpp
@@ -29684,12 +29695,6 @@ basedll_cocoa_power.o: $(srcdir)/src/osx/cocoa/power.mm $(BASEDLL_ODEP)
 @COND_PLATFORM_MACOSX_1@basedll_unix_stackwalk.o: $(srcdir)/src/unix/stackwalk.cpp $(BASEDLL_ODEP)
 @COND_PLATFORM_MACOSX_1@	$(CXXC) -c -o $@ $(BASEDLL_CXXFLAGS) $(srcdir)/src/unix/stackwalk.cpp
 
-@COND_PLATFORM_UNIX_1@basedll_unix_stdpaths.o: $(srcdir)/src/unix/stdpaths.cpp $(BASEDLL_ODEP)
-@COND_PLATFORM_UNIX_1@	$(CXXC) -c -o $@ $(BASEDLL_CXXFLAGS) $(srcdir)/src/unix/stdpaths.cpp
-
-@COND_PLATFORM_MACOSX_1@basedll_unix_stdpaths.o: $(srcdir)/src/unix/stdpaths.cpp $(BASEDLL_ODEP)
-@COND_PLATFORM_MACOSX_1@	$(CXXC) -c -o $@ $(BASEDLL_CXXFLAGS) $(srcdir)/src/unix/stdpaths.cpp
-
 @COND_PLATFORM_UNIX_1@basedll_timerunx.o: $(srcdir)/src/unix/timerunx.cpp $(BASEDLL_ODEP)
 @COND_PLATFORM_UNIX_1@	$(CXXC) -c -o $@ $(BASEDLL_CXXFLAGS) $(srcdir)/src/unix/timerunx.cpp
 
@@ -29719,6 +29724,12 @@ basedll_cocoa_power.o: $(srcdir)/src/osx/cocoa/power.mm $(BASEDLL_ODEP)
 
 @COND_PLATFORM_MACOSX_1@basedll_fswatcher_kqueue.o: $(srcdir)/src/unix/fswatcher_kqueue.cpp $(BASEDLL_ODEP)
 @COND_PLATFORM_MACOSX_1@	$(CXXC) -c -o $@ $(BASEDLL_CXXFLAGS) $(srcdir)/src/unix/fswatcher_kqueue.cpp
+
+@COND_PLATFORM_UNIX_1@basedll_unix_stdpaths.o: $(srcdir)/src/unix/stdpaths.cpp $(BASEDLL_ODEP)
+@COND_PLATFORM_UNIX_1@	$(CXXC) -c -o $@ $(BASEDLL_CXXFLAGS) $(srcdir)/src/unix/stdpaths.cpp
+
+@COND_TOOLKIT_OSX_CARBON@basedll_unix_stdpaths.o: $(srcdir)/src/unix/stdpaths.cpp $(BASEDLL_ODEP)
+@COND_TOOLKIT_OSX_CARBON@	$(CXXC) -c -o $@ $(BASEDLL_CXXFLAGS) $(srcdir)/src/unix/stdpaths.cpp
 
 baselib_any.o: $(srcdir)/src/common/any.cpp $(BASELIB_ODEP)
 	$(CXXC) -c -o $@ $(BASELIB_CXXFLAGS) $(srcdir)/src/common/any.cpp
@@ -30056,9 +30067,6 @@ baselib_cfstring.o: $(srcdir)/src/osx/core/cfstring.cpp $(BASELIB_ODEP)
 baselib_evtloop_cf.o: $(srcdir)/src/osx/core/evtloop_cf.cpp $(BASELIB_ODEP)
 	$(CXXC) -c -o $@ $(BASELIB_CXXFLAGS) $(srcdir)/src/osx/core/evtloop_cf.cpp
 
-baselib_stdpaths_cf.o: $(srcdir)/src/osx/core/stdpaths_cf.cpp $(BASELIB_ODEP)
-	$(CXXC) -c -o $@ $(BASELIB_CXXFLAGS) $(srcdir)/src/osx/core/stdpaths_cf.cpp
-
 baselib_strconv_cf.o: $(srcdir)/src/osx/core/strconv_cf.cpp $(BASELIB_ODEP)
 	$(CXXC) -c -o $@ $(BASELIB_CXXFLAGS) $(srcdir)/src/osx/core/strconv_cf.cpp
 
@@ -30092,11 +30100,17 @@ baselib_carbon_utils.o: $(srcdir)/src/osx/carbon/utils.cpp $(BASELIB_ODEP)
 baselib_uma.o: $(srcdir)/src/osx/carbon/uma.cpp $(BASELIB_ODEP)
 	$(CXXC) -c -o $@ $(BASELIB_CXXFLAGS) $(srcdir)/src/osx/carbon/uma.cpp
 
+baselib_stdpaths_cf.o: $(srcdir)/src/osx/core/stdpaths_cf.cpp $(BASELIB_ODEP)
+	$(CXXC) -c -o $@ $(BASELIB_CXXFLAGS) $(srcdir)/src/osx/core/stdpaths_cf.cpp
+
 baselib_cocoa_utils.o: $(srcdir)/src/osx/cocoa/utils.mm $(BASELIB_ODEP)
 	$(CXXC) -c -o $@ $(BASELIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/utils.mm
 
 baselib_cocoa_power.o: $(srcdir)/src/osx/cocoa/power.mm $(BASELIB_ODEP)
 	$(CXXC) -c -o $@ $(BASELIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/power.mm
+
+baselib_cocoa_stdpaths.o: $(srcdir)/src/osx/cocoa/stdpaths.mm $(BASELIB_ODEP)
+	$(CXXC) -c -o $@ $(BASELIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/stdpaths.mm
 
 @COND_PLATFORM_UNIX_1@baselib_fdiodispatcher.o: $(srcdir)/src/common/fdiodispatcher.cpp $(BASELIB_ODEP)
 @COND_PLATFORM_UNIX_1@	$(CXXC) -c -o $@ $(BASELIB_CXXFLAGS) $(srcdir)/src/common/fdiodispatcher.cpp
@@ -30158,12 +30172,6 @@ baselib_cocoa_power.o: $(srcdir)/src/osx/cocoa/power.mm $(BASELIB_ODEP)
 @COND_PLATFORM_MACOSX_1@baselib_unix_stackwalk.o: $(srcdir)/src/unix/stackwalk.cpp $(BASELIB_ODEP)
 @COND_PLATFORM_MACOSX_1@	$(CXXC) -c -o $@ $(BASELIB_CXXFLAGS) $(srcdir)/src/unix/stackwalk.cpp
 
-@COND_PLATFORM_UNIX_1@baselib_unix_stdpaths.o: $(srcdir)/src/unix/stdpaths.cpp $(BASELIB_ODEP)
-@COND_PLATFORM_UNIX_1@	$(CXXC) -c -o $@ $(BASELIB_CXXFLAGS) $(srcdir)/src/unix/stdpaths.cpp
-
-@COND_PLATFORM_MACOSX_1@baselib_unix_stdpaths.o: $(srcdir)/src/unix/stdpaths.cpp $(BASELIB_ODEP)
-@COND_PLATFORM_MACOSX_1@	$(CXXC) -c -o $@ $(BASELIB_CXXFLAGS) $(srcdir)/src/unix/stdpaths.cpp
-
 @COND_PLATFORM_UNIX_1@baselib_timerunx.o: $(srcdir)/src/unix/timerunx.cpp $(BASELIB_ODEP)
 @COND_PLATFORM_UNIX_1@	$(CXXC) -c -o $@ $(BASELIB_CXXFLAGS) $(srcdir)/src/unix/timerunx.cpp
 
@@ -30193,6 +30201,12 @@ baselib_cocoa_power.o: $(srcdir)/src/osx/cocoa/power.mm $(BASELIB_ODEP)
 
 @COND_PLATFORM_MACOSX_1@baselib_fswatcher_kqueue.o: $(srcdir)/src/unix/fswatcher_kqueue.cpp $(BASELIB_ODEP)
 @COND_PLATFORM_MACOSX_1@	$(CXXC) -c -o $@ $(BASELIB_CXXFLAGS) $(srcdir)/src/unix/fswatcher_kqueue.cpp
+
+@COND_PLATFORM_UNIX_1@baselib_unix_stdpaths.o: $(srcdir)/src/unix/stdpaths.cpp $(BASELIB_ODEP)
+@COND_PLATFORM_UNIX_1@	$(CXXC) -c -o $@ $(BASELIB_CXXFLAGS) $(srcdir)/src/unix/stdpaths.cpp
+
+@COND_TOOLKIT_OSX_CARBON@baselib_unix_stdpaths.o: $(srcdir)/src/unix/stdpaths.cpp $(BASELIB_ODEP)
+@COND_TOOLKIT_OSX_CARBON@	$(CXXC) -c -o $@ $(BASELIB_CXXFLAGS) $(srcdir)/src/unix/stdpaths.cpp
 
 netdll_version_rc.o: $(srcdir)/src/msw/version.rc $(NETDLL_ODEP)
 	$(WINDRES) -i$< -o$@    --define __WX$(TOOLKIT)__ $(__WXUNIV_DEFINE_p_67) $(__DEBUG_DEFINE_p_66)  $(__EXCEPTIONS_DEFINE_p_65) $(__RTTI_DEFINE_p_65) $(__THREAD_DEFINE_p_65)  --define WXBUILDING --define WXDLLNAME=$(WXDLLNAMEPREFIX)$(WXUNICODEFLAG)$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)_net$(WXCOMPILER)$(VENDORTAG)$(WXDLLVERSIONTAG) $(__RCDEFDIR_p) --include-dir $(top_srcdir)/include $(__INC_TIFF_BUILD_p_66) $(__INC_TIFF_p_66) $(__INC_JPEG_p_66) $(__INC_PNG_p_65) $(__INC_ZLIB_p_67) $(__INC_REGEX_p_65) $(__INC_EXPAT_p_65) --define wxUSE_GUI=0 --define WXUSINGDLL --define WXMAKINGDLL_NET
@@ -30332,11 +30346,20 @@ coredll_carbon_utils.o: $(srcdir)/src/osx/carbon/utils.cpp $(COREDLL_ODEP)
 coredll_uma.o: $(srcdir)/src/osx/carbon/uma.cpp $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/osx/carbon/uma.cpp
 
+coredll_unix_stdpaths.o: $(srcdir)/src/unix/stdpaths.cpp $(COREDLL_ODEP)
+	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/unix/stdpaths.cpp
+
+coredll_stdpaths_cf.o: $(srcdir)/src/osx/core/stdpaths_cf.cpp $(COREDLL_ODEP)
+	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/osx/core/stdpaths_cf.cpp
+
 coredll_osx_cocoa_utils.o: $(srcdir)/src/osx/cocoa/utils.mm $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/utils.mm
 
 coredll_power.o: $(srcdir)/src/osx/cocoa/power.mm $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/power.mm
+
+coredll_cocoa_stdpaths.o: $(srcdir)/src/osx/cocoa/stdpaths.mm $(COREDLL_ODEP)
+	$(CXXC) -c -o $@ $(COREDLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/stdpaths.mm
 
 coredll_gtk1_bmpbuttn.o: $(srcdir)/src/gtk1/bmpbuttn.cpp $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/gtk1/bmpbuttn.cpp
@@ -34736,11 +34759,20 @@ corelib_carbon_utils.o: $(srcdir)/src/osx/carbon/utils.cpp $(CORELIB_ODEP)
 corelib_uma.o: $(srcdir)/src/osx/carbon/uma.cpp $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/osx/carbon/uma.cpp
 
+corelib_unix_stdpaths.o: $(srcdir)/src/unix/stdpaths.cpp $(CORELIB_ODEP)
+	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/unix/stdpaths.cpp
+
+corelib_stdpaths_cf.o: $(srcdir)/src/osx/core/stdpaths_cf.cpp $(CORELIB_ODEP)
+	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/osx/core/stdpaths_cf.cpp
+
 corelib_osx_cocoa_utils.o: $(srcdir)/src/osx/cocoa/utils.mm $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/utils.mm
 
 corelib_power.o: $(srcdir)/src/osx/cocoa/power.mm $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/power.mm
+
+corelib_cocoa_stdpaths.o: $(srcdir)/src/osx/cocoa/stdpaths.mm $(CORELIB_ODEP)
+	$(CXXC) -c -o $@ $(CORELIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/stdpaths.mm
 
 corelib_gtk1_bmpbuttn.o: $(srcdir)/src/gtk1/bmpbuttn.cpp $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/gtk1/bmpbuttn.cpp

--- a/build/bakefiles/files.bkl
+++ b/build/bakefiles/files.bkl
@@ -69,7 +69,6 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     src/unix/fdiounix.cpp
     src/unix/snglinst.cpp
     src/unix/stackwalk.cpp
-    src/unix/stdpaths.cpp
     src/unix/timerunx.cpp
     src/unix/threadpsx.cpp
     src/unix/utilsunx.cpp
@@ -85,7 +84,6 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     wx/unix/evtloop.h
     wx/unix/evtloopsrc.h
     wx/unix/pipe.h
-    wx/unix/stdpaths.h
     wx/unix/stackwalk.h
     wx/unix/tls.h
     wx/unix/fswatcher_kqueue.h
@@ -115,10 +113,12 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
 <set var="BASE_UNIX_SRC" hints="files">
     $(BASE_UNIX_AND_DARWIN_NOTWXMAC_SRC)
     src/unix/fswatcher_inotify.cpp
+    src/unix/stdpaths.cpp
 </set>
 <set var="BASE_UNIX_HDR" hints="files">
     $(BASE_UNIX_AND_DARWIN_NOTWXMAC_HDR)
     wx/unix/fswatcher_inotify.h
+    wx/unix/stdpaths.h
 </set>
 
 <!-- =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- -->
@@ -190,7 +190,6 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
 <set var="BASE_COREFOUNDATION_SRC" hints="files">
     src/osx/core/cfstring.cpp
     src/osx/core/evtloop_cf.cpp
-    src/osx/core/stdpaths_cf.cpp
     src/osx/core/strconv_cf.cpp
     src/osx/core/utilsexc_base.cpp
 </set>
@@ -221,11 +220,14 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
 <set var="BASE_AND_GUI_OSX_CARBON_SRC" hints="files">
     src/osx/carbon/utils.cpp
     src/osx/carbon/uma.cpp
+    src/unix/stdpaths.cpp
+    src/osx/core/stdpaths_cf.cpp
 </set>
 
 <set var="BASE_AND_GUI_OSX_COCOA_SRC" hints="files">
     src/osx/cocoa/utils.mm
     src/osx/cocoa/power.mm
+    src/osx/cocoa/stdpaths.mm
 </set>
 
 <set var="BASE_AND_GUI_OSX_IPHONE_SRC" hints="files">

--- a/build/files
+++ b/build/files
@@ -33,7 +33,6 @@ BASE_UNIX_AND_DARWIN_SRC =
     src/unix/fdiounix.cpp
     src/unix/snglinst.cpp
     src/unix/stackwalk.cpp
-    src/unix/stdpaths.cpp
     src/unix/timerunx.cpp
     src/unix/threadpsx.cpp
     src/unix/utilsunx.cpp
@@ -48,7 +47,6 @@ BASE_UNIX_AND_DARWIN_HDR =
     wx/unix/evtloop.h
     wx/unix/evtloopsrc.h
     wx/unix/pipe.h
-    wx/unix/stdpaths.h
     wx/unix/stackwalk.h
     wx/unix/tls.h
     wx/unix/fswatcher_kqueue.h
@@ -71,10 +69,12 @@ BASE_UNIX_AND_DARWIN_NOTWXMAC_HDR =
 BASE_UNIX_SRC =
     $(BASE_UNIX_AND_DARWIN_NOTWXMAC_SRC)
     src/unix/fswatcher_inotify.cpp
+    src/unix/stdpaths.cpp
 
 BASE_UNIX_HDR =
     $(BASE_UNIX_AND_DARWIN_NOTWXMAC_HDR)
     wx/unix/fswatcher_inotify.h
+    wx/unix/stdpaths.h
 
 
 ## Windows
@@ -134,7 +134,6 @@ BASE_WIN32_HDR =
 BASE_COREFOUNDATION_SRC =
     src/osx/core/cfstring.cpp
     src/osx/core/evtloop_cf.cpp
-    src/osx/core/stdpaths_cf.cpp
     src/osx/core/strconv_cf.cpp
     src/osx/core/utilsexc_base.cpp
 
@@ -164,10 +163,13 @@ BASE_OSX_SHARED_HDR =
 BASE_AND_GUI_OSX_CARBON_SRC =
     src/osx/carbon/utils.cpp
     src/osx/carbon/uma.cpp
+    src/unix/stdpaths.cpp
+    src/osx/core/stdpaths_cf.cpp
 
 BASE_AND_GUI_OSX_COCOA_SRC =
     src/osx/cocoa/utils.mm
     src/osx/cocoa/power.mm
+    src/osx/cocoa/stdpaths.mm
 
 BASE_AND_GUI_OSX_IPHONE_SRC =
     src/osx/iphone/utils.mm

--- a/build/osx/wxcocoa.xcodeproj/project.pbxproj
+++ b/build/osx/wxcocoa.xcodeproj/project.pbxproj
@@ -253,9 +253,6 @@
 		131B879180AE3FB481F81CC8 /* fs_mem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9A305CEC03B3085B159B617 /* fs_mem.cpp */; };
 		131B879180AE3FB481F81CC9 /* fs_mem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9A305CEC03B3085B159B617 /* fs_mem.cpp */; };
 		131B879180AE3FB481F81CCA /* fs_mem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9A305CEC03B3085B159B617 /* fs_mem.cpp */; };
-		13250B531B1B3F9998C59DA9 /* stdpaths_cf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B2DEE3EC7CE374DB0CE6EEA /* stdpaths_cf.cpp */; };
-		13250B531B1B3F9998C59DAA /* stdpaths_cf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B2DEE3EC7CE374DB0CE6EEA /* stdpaths_cf.cpp */; };
-		13250B531B1B3F9998C59DAB /* stdpaths_cf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7B2DEE3EC7CE374DB0CE6EEA /* stdpaths_cf.cpp */; };
 		135DFCE48FC03D8294D01A89 /* xmlrsall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 29922DF1D0D63C33A186E783 /* xmlrsall.cpp */; };
 		135DFCE48FC03D8294D01A8A /* xmlrsall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 29922DF1D0D63C33A186E783 /* xmlrsall.cpp */; };
 		135DFCE48FC03D8294D01A8B /* xmlrsall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 29922DF1D0D63C33A186E783 /* xmlrsall.cpp */; };
@@ -529,6 +526,9 @@
 		24A5A71C79733E9CB913C5B7 /* LexPB.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 8744F2C80ECF375999195935 /* LexPB.cxx */; };
 		24A5A71C79733E9CB913C5B8 /* LexPB.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 8744F2C80ECF375999195935 /* LexPB.cxx */; };
 		24A5A71C79733E9CB913C5B9 /* LexPB.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 8744F2C80ECF375999195935 /* LexPB.cxx */; };
+		24D4E0F61BA05FC200586317 /* stdpaths.mm in Sources */ = {isa = PBXBuildFile; fileRef = 24D4E0F51BA05FC200586317 /* stdpaths.mm */; };
+		24D4E0F71BA05FC200586317 /* stdpaths.mm in Sources */ = {isa = PBXBuildFile; fileRef = 24D4E0F51BA05FC200586317 /* stdpaths.mm */; };
+		24D4E0F81BA05FC200586317 /* stdpaths.mm in Sources */ = {isa = PBXBuildFile; fileRef = 24D4E0F51BA05FC200586317 /* stdpaths.mm */; };
 		254028D56649374E8D3CC85C /* libwx_osx_cocoau_html.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D9F65758E0363AF9AEC59A47 /* libwx_osx_cocoau_html.dylib */; };
 		254028D56649374E8D3CC85D /* libwx_osx_cocoau_html.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D9F65758E0363AF9AEC59A47 /* libwx_osx_cocoau_html.dylib */; };
 		2563C775427E3D68BD384F2F /* richtextstyles.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D30617843F33310089C1F77A /* richtextstyles.cpp */; };
@@ -2524,9 +2524,6 @@
 		E8EE34F0A78C31B489B19FEE /* LexMSSQL.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 1C71BF55495034FFBE653C80 /* LexMSSQL.cxx */; };
 		E8EE34F0A78C31B489B19FEF /* LexMSSQL.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 1C71BF55495034FFBE653C80 /* LexMSSQL.cxx */; };
 		E8EE34F0A78C31B489B19FF0 /* LexMSSQL.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 1C71BF55495034FFBE653C80 /* LexMSSQL.cxx */; };
-		E8F0C87119C63E8E81423A7C /* stdpaths.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8C1E6D73ABD3A219B2C0603 /* stdpaths.cpp */; };
-		E8F0C87119C63E8E81423A7D /* stdpaths.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8C1E6D73ABD3A219B2C0603 /* stdpaths.cpp */; };
-		E8F0C87119C63E8E81423A7E /* stdpaths.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F8C1E6D73ABD3A219B2C0603 /* stdpaths.cpp */; };
 		E92EB502F79638B0BE569EF4 /* CallTip.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 4F58B88D42A93BD0B74ADF75 /* CallTip.cxx */; };
 		E92EB502F79638B0BE569EF5 /* CallTip.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 4F58B88D42A93BD0B74ADF75 /* CallTip.cxx */; };
 		E92EB502F79638B0BE569EF6 /* CallTip.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 4F58B88D42A93BD0B74ADF75 /* CallTip.cxx */; };
@@ -3936,6 +3933,7 @@
 		24396D584D053948A3FF0DCD /* imagpng.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = imagpng.cpp; path = ../../src/common/imagpng.cpp; sourceTree = "<group>"; };
 		24930711031D35288D28B04B /* choiccmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = choiccmn.cpp; path = ../../src/common/choiccmn.cpp; sourceTree = "<group>"; };
 		24BD2EF635673E819B8406CB /* LexRust.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexRust.cxx; path = ../../src/stc/scintilla/lexers/LexRust.cxx; sourceTree = "<group>"; };
+		24D4E0F51BA05FC200586317 /* stdpaths.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = stdpaths.mm; path = ../../src/osx/cocoa/stdpaths.mm; sourceTree = "<group>"; };
 		24DF23D67E693D999B875101 /* toolbkg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = toolbkg.cpp; path = ../../src/generic/toolbkg.cpp; sourceTree = "<group>"; };
 		24E82A05E9A9323287CDB15B /* artstd.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = artstd.cpp; path = ../../src/common/artstd.cpp; sourceTree = "<group>"; };
 		25A81E9028793C109D868068 /* xh_timectrl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_timectrl.cpp; path = ../../src/xrc/xh_timectrl.cpp; sourceTree = "<group>"; };
@@ -4233,7 +4231,6 @@
 		7A34C5BBBA543DC0A50DE1B6 /* event.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = event.cpp; path = ../../src/common/event.cpp; sourceTree = "<group>"; };
 		7A3F26F539473705AA82411D /* combobox.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = combobox.cpp; path = ../../src/osx/carbon/combobox.cpp; sourceTree = "<group>"; };
 		7AF8F8A78A5130DCB4D46729 /* LexCmake.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexCmake.cxx; path = ../../src/stc/scintilla/lexers/LexCmake.cxx; sourceTree = "<group>"; };
-		7B2DEE3EC7CE374DB0CE6EEA /* stdpaths_cf.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = stdpaths_cf.cpp; path = ../../src/osx/core/stdpaths_cf.cpp; sourceTree = "<group>"; };
 		7B389A14D6BF3AFD8CCE0807 /* protocol.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = protocol.cpp; path = ../../src/common/protocol.cpp; sourceTree = "<group>"; };
 		7BA6ADD758693BD180D3275B /* treebase.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = treebase.cpp; path = ../../src/common/treebase.cpp; sourceTree = "<group>"; };
 		7C6CC76872BA32D2B61EB8AB /* libwx_baseu_xml.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libwx_baseu_xml.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -4693,7 +4690,6 @@
 		F83172EE2DAE352FB969D4F2 /* jcapistd.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jcapistd.c; path = ../../src/jpeg/jcapistd.c; sourceTree = "<group>"; };
 		F84F0DB790A23D92A193D2B4 /* http.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = http.cpp; path = ../../src/common/http.cpp; sourceTree = "<group>"; };
 		F8638A6CCF773CCFB70DFC29 /* xh_collpane.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_collpane.cpp; path = ../../src/xrc/xh_collpane.cpp; sourceTree = "<group>"; };
-		F8C1E6D73ABD3A219B2C0603 /* stdpaths.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = stdpaths.cpp; path = ../../src/unix/stdpaths.cpp; sourceTree = "<group>"; };
 		FA59091E3ED83FB781FB9659 /* glcanvas_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = glcanvas_osx.cpp; path = ../../src/osx/glcanvas_osx.cpp; sourceTree = "<group>"; };
 		FA7029BB5751398AA02D8C24 /* imagtga.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = imagtga.cpp; path = ../../src/common/imagtga.cpp; sourceTree = "<group>"; };
 		FADE850169F7347F83FE1499 /* xh_statbar.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_statbar.cpp; path = ../../src/xrc/xh_statbar.cpp; sourceTree = "<group>"; };
@@ -5949,7 +5945,6 @@
 				7C97C1F26B5A38C49543060C /* mimetype.cpp */,
 				5168ADF7BE39351F8F24E1E6 /* cfstring.cpp */,
 				5BD6231188AB329CAA5E1171 /* evtloop_cf.cpp */,
-				7B2DEE3EC7CE374DB0CE6EEA /* stdpaths_cf.cpp */,
 				D5F9383D1CE931499F339D85 /* strconv_cf.cpp */,
 				81390F96937631078EFCD891 /* utilsexc_base.cpp */,
 				47F784C2BB5A3B5DAD276583 /* fdiodispatcher.cpp */,
@@ -5962,7 +5957,6 @@
 				3B548B1FF2A238809315C8A9 /* fdiounix.cpp */,
 				3D5D8B68EA743F6E97ADF612 /* snglinst.cpp */,
 				EA2520F427493A22A70A5C09 /* stackwalk.cpp */,
-				F8C1E6D73ABD3A219B2C0603 /* stdpaths.cpp */,
 				0CB2CC8E60833A6993BEA321 /* timerunx.cpp */,
 				AB466912FDA23F8B87A00A3C /* threadpsx.cpp */,
 				DC75C7251C1732B0B07C7BD3 /* utilsunx.cpp */,
@@ -5975,6 +5969,7 @@
 				4188821BBA833CCAA678B234 /* utilscmn.cpp */,
 				789F45D14FF23E248FCFB5FA /* utils.mm */,
 				60DFD5962DE3379F801AF78F /* power.mm */,
+				24D4E0F51BA05FC200586317 /* stdpaths.mm */,
 			);
 			name = base;
 			sourceTree = "<group>";
@@ -6883,6 +6878,8 @@
 /* Begin PBXProject section */
 		19367367C9323490BB936F06 /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = 6976B5F5F3A63A21A92029E3 /* Build configuration list for PBXProject "wxcocoa" */;
 			compatibilityVersion = "Xcode 3.1";
 			developmentRegion = English;
@@ -7351,7 +7348,6 @@
 				4657E7382E9E3EDC8DE24020 /* mimetype.cpp in Sources */,
 				1DBDF75500D73A3098015E81 /* cfstring.cpp in Sources */,
 				9FBC642677C63D01AA2511BE /* evtloop_cf.cpp in Sources */,
-				13250B531B1B3F9998C59DAB /* stdpaths_cf.cpp in Sources */,
 				AAAB5DF8E60736D88273DD00 /* strconv_cf.cpp in Sources */,
 				4E140367282F38C8A904A006 /* utilsexc_base.cpp in Sources */,
 				D36E76A4CAF5352D9397E201 /* fdiodispatcher.cpp in Sources */,
@@ -7360,11 +7356,11 @@
 				403FBA20CEFE3EAFB4E6B907 /* dir.cpp in Sources */,
 				20BEEFFA08F3396791596872 /* dlunix.cpp in Sources */,
 				CBBD7B32DB7B3E24AE745D7A /* epolldispatcher.cpp in Sources */,
+				24D4E0F81BA05FC200586317 /* stdpaths.mm in Sources */,
 				D18E2985C48733B2B7B3D444 /* evtloopunix.cpp in Sources */,
 				3D22FC202D903007AEE3D166 /* fdiounix.cpp in Sources */,
 				4B88254FF9963833A276A64E /* snglinst.cpp in Sources */,
 				5F78DB0417BF3CE1B4E35C81 /* stackwalk.cpp in Sources */,
-				E8F0C87119C63E8E81423A7E /* stdpaths.cpp in Sources */,
 				2F35A207C3993DE08E4FE0B2 /* timerunx.cpp in Sources */,
 				F5D2146C94E733FAAB6D286C /* threadpsx.cpp in Sources */,
 				B5C7FD8C27F43F3289A77FCB /* utilsunx.cpp in Sources */,
@@ -8055,7 +8051,6 @@
 				4657E7382E9E3EDC8DE2401F /* mimetype.cpp in Sources */,
 				1DBDF75500D73A3098015E80 /* cfstring.cpp in Sources */,
 				9FBC642677C63D01AA2511BD /* evtloop_cf.cpp in Sources */,
-				13250B531B1B3F9998C59DAA /* stdpaths_cf.cpp in Sources */,
 				AAAB5DF8E60736D88273DCFF /* strconv_cf.cpp in Sources */,
 				4E140367282F38C8A904A005 /* utilsexc_base.cpp in Sources */,
 				D36E76A4CAF5352D9397E200 /* fdiodispatcher.cpp in Sources */,
@@ -8068,7 +8063,6 @@
 				3D22FC202D903007AEE3D165 /* fdiounix.cpp in Sources */,
 				4B88254FF9963833A276A64D /* snglinst.cpp in Sources */,
 				5F78DB0417BF3CE1B4E35C80 /* stackwalk.cpp in Sources */,
-				E8F0C87119C63E8E81423A7D /* stdpaths.cpp in Sources */,
 				2F35A207C3993DE08E4FE0B1 /* timerunx.cpp in Sources */,
 				F5D2146C94E733FAAB6D286B /* threadpsx.cpp in Sources */,
 				B5C7FD8C27F43F3289A77FCA /* utilsunx.cpp in Sources */,
@@ -8195,6 +8189,7 @@
 				9241AAE354C53190BF3D5BA4 /* radiobut.mm in Sources */,
 				8EE5A2467401365C8217AF30 /* preferences.mm in Sources */,
 				22E90F33B5C9308EBF37A701 /* printdlg.mm in Sources */,
+				24D4E0F71BA05FC200586317 /* stdpaths.mm in Sources */,
 				5303FA25D0773FAEB963D8E4 /* scrolbar.mm in Sources */,
 				30AEDF41EC5C374DBF96EFFC /* slider.mm in Sources */,
 				5DA146A9F7653F53BF5299E9 /* spinbutt.mm in Sources */,
@@ -9246,7 +9241,6 @@
 				4657E7382E9E3EDC8DE2401E /* mimetype.cpp in Sources */,
 				1DBDF75500D73A3098015E7F /* cfstring.cpp in Sources */,
 				9FBC642677C63D01AA2511BC /* evtloop_cf.cpp in Sources */,
-				13250B531B1B3F9998C59DA9 /* stdpaths_cf.cpp in Sources */,
 				AAAB5DF8E60736D88273DCFE /* strconv_cf.cpp in Sources */,
 				4E140367282F38C8A904A004 /* utilsexc_base.cpp in Sources */,
 				D36E76A4CAF5352D9397E1FF /* fdiodispatcher.cpp in Sources */,
@@ -9259,7 +9253,6 @@
 				3D22FC202D903007AEE3D164 /* fdiounix.cpp in Sources */,
 				4B88254FF9963833A276A64C /* snglinst.cpp in Sources */,
 				5F78DB0417BF3CE1B4E35C7F /* stackwalk.cpp in Sources */,
-				E8F0C87119C63E8E81423A7C /* stdpaths.cpp in Sources */,
 				2F35A207C3993DE08E4FE0B0 /* timerunx.cpp in Sources */,
 				F5D2146C94E733FAAB6D286A /* threadpsx.cpp in Sources */,
 				B5C7FD8C27F43F3289A77FC9 /* utilsunx.cpp in Sources */,
@@ -9386,6 +9379,7 @@
 				9241AAE354C53190BF3D5BA3 /* radiobut.mm in Sources */,
 				8EE5A2467401365C8217AF2F /* preferences.mm in Sources */,
 				22E90F33B5C9308EBF37A700 /* printdlg.mm in Sources */,
+				24D4E0F61BA05FC200586317 /* stdpaths.mm in Sources */,
 				5303FA25D0773FAEB963D8E3 /* scrolbar.mm in Sources */,
 				30AEDF41EC5C374DBF96EFFB /* slider.mm in Sources */,
 				5DA146A9F7653F53BF5299E8 /* spinbutt.mm in Sources */,

--- a/include/wx/msw/stdpaths.h
+++ b/include/wx/msw/stdpaths.h
@@ -26,7 +26,7 @@ public:
     virtual wxString GetUserDataDir() const;
     virtual wxString GetUserLocalDataDir() const;
     virtual wxString GetPluginsDir() const;
-    virtual wxString GetDocumentsDir() const;
+    virtual wxString GetUserDir(Dir userDir) const wxOVERRIDE;
 
 
     // MSW-specific methods
@@ -71,6 +71,8 @@ protected:
 
     // get the path corresponding to the given standard CSIDL_XXX constant
     static wxString DoGetDirectory(int csidl);
+
+    static wxString DoGetKnownFolder(const GUID& rfid);
 
     // return the directory of the application itself
     wxString GetAppDir() const;

--- a/include/wx/osx/cocoa/stdpaths.h
+++ b/include/wx/osx/cocoa/stdpaths.h
@@ -1,0 +1,43 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        wx/osx/cocoa/stdpaths.h
+// Purpose:     wxStandardPaths for Cocoa
+// Author:      Tobias Taschner
+// Created:     2015-09-09
+// Copyright:   (c) 2015 wxWidgets development team
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_COCOA_STDPATHS_H_
+#define _WX_COCOA_STDPATHS_H_
+
+// ----------------------------------------------------------------------------
+// wxStandardPaths
+// ----------------------------------------------------------------------------
+
+class WXDLLIMPEXP_BASE wxStandardPaths : public wxStandardPathsBase
+{
+public:
+    virtual ~wxStandardPaths();
+
+    // implement base class pure virtuals
+    virtual wxString GetExecutablePath() const wxOVERRIDE;
+    virtual wxString GetConfigDir() const wxOVERRIDE;
+    virtual wxString GetUserConfigDir() const wxOVERRIDE;
+    virtual wxString GetDataDir() const wxOVERRIDE;
+    virtual wxString GetLocalDataDir() const wxOVERRIDE;
+    virtual wxString GetUserDataDir() const wxOVERRIDE;
+    virtual wxString GetPluginsDir() const wxOVERRIDE;
+    virtual wxString GetResourcesDir() const wxOVERRIDE;
+    virtual wxString
+    GetLocalizedResourcesDir(const wxString& lang,
+                             ResourceCat category = ResourceCat_None) const wxOVERRIDE;
+    virtual wxString GetUserDir(Dir userDir) const wxOVERRIDE;
+
+protected:
+    // Ctor is protected, use wxStandardPaths::Get() instead of instantiating
+    // objects of this class directly.
+    wxStandardPaths();
+};
+
+
+#endif // _WX_COCOA_STDPATHS_H_

--- a/include/wx/osx/core/stdpaths.h
+++ b/include/wx/osx/core/stdpaths.h
@@ -52,7 +52,7 @@ public:
     virtual wxString
     GetLocalizedResourcesDir(const wxString& lang,
                              ResourceCat category = ResourceCat_None) const;
-    virtual wxString GetDocumentsDir() const;
+    virtual wxString GetUserDir(Dir userDir) const wxOVERRIDE;
 
 protected:
     // Ctor is protected, use wxStandardPaths::Get() instead of instantiating

--- a/include/wx/stdpaths.h
+++ b/include/wx/stdpaths.h
@@ -187,6 +187,9 @@ protected:
     #if defined(__WINDOWS__)
         #include "wx/msw/stdpaths.h"
         #define wxHAS_NATIVE_STDPATHS
+    #elif defined(__WXOSX_COCOA__) || defined(__WXOSX_IPHONE__)
+        #include "wx/osx/cocoa/stdpaths.h"
+        #define wxHAS_NATIVE_STDPATHS
     // We want CoreFoundation paths on both CarbonLib and Darwin (for all ports)
     #elif defined(__WXMAC__) || defined(__DARWIN__)
         #include "wx/osx/core/stdpaths.h"

--- a/include/wx/stdpaths.h
+++ b/include/wx/stdpaths.h
@@ -49,6 +49,15 @@ public:
         AppInfo_VendorName = 2   // the vendor name
     };
 
+    enum Dir
+    {
+        Dir_Documents,
+        Dir_Desktop,
+        Dir_Downloads,
+        Dir_Music,
+        Dir_Pictures,
+        Dir_Videos
+    };
 
     // return the global standard paths object
     static wxStandardPaths& Get();
@@ -130,7 +139,10 @@ public:
     //
     // C:\Documents and Settings\username\My Documents under Windows,
     // $HOME under Unix and ~/Documents under Mac
-    virtual wxString GetDocumentsDir() const;
+    virtual wxString GetDocumentsDir() const
+    {
+        return GetUserDir(Dir_Documents);
+    }
 
     // return the directory for the documents files used by this application:
     // it's a subdirectory of GetDocumentsDir() constructed using the
@@ -140,6 +152,7 @@ public:
     // return the temporary directory for the current user
     virtual wxString GetTempDir() const;
 
+    virtual wxString GetUserDir(Dir userDir) const;
 
     // virtual dtor for the base class
     virtual ~wxStandardPathsBase();
@@ -205,7 +218,7 @@ public:
     virtual wxString GetLocalDataDir() const { return m_prefix; }
     virtual wxString GetUserDataDir() const { return m_prefix; }
     virtual wxString GetPluginsDir() const { return m_prefix; }
-    virtual wxString GetDocumentsDir() const { return m_prefix; }
+    virtual wxString GetUserDir(Dir WXUNUSED(userDir)) const { return m_prefix; }
 
 protected:
     // Ctor is protected because wxStandardPaths::Get() should always be used

--- a/include/wx/unix/stdpaths.h
+++ b/include/wx/unix/stdpaths.h
@@ -47,7 +47,7 @@ public:
     virtual wxString GetLocalizedResourcesDir(const wxString& lang,
                                               ResourceCat category) const wxOVERRIDE;
 #ifndef __VMS
-    virtual wxString GetDocumentsDir() const wxOVERRIDE;
+    virtual wxString GetUserDir(Dir userDir) const wxOVERRIDE;
 #endif
 
 protected:

--- a/interface/wx/stdpaths.h
+++ b/interface/wx/stdpaths.h
@@ -66,6 +66,64 @@ public:
         ResourceCat_Messages
     };
 
+    /// Possible values for userDir parameter of GetUserDir().
+    enum Dir
+    {
+        /**
+            Directory containing user documents.
+
+            Example return values:
+            - Unix/Mac: @c ~/Documents
+            - Windows: @c "C:\Users\username\Documents"
+        */
+        Dir_Documents,
+
+        /**
+            Directory containing files on the users desktop.
+
+            Example return values:
+            - Unix/Mac: @c ~/Desktop
+            - Windows: @c "C:\Users\username\Desktop"
+        */
+        Dir_Desktop,
+
+        /**
+            Directory for downloaded files
+
+            Example return values:
+            - Unix/Mac: @c ~/Downloads
+            - Windows: @c "C:\Users\username\Downloads" (Only available on Vista and newer)
+        */
+        Dir_Downloads,
+
+        /**
+            Directory containing music files.
+
+            Example return values:
+            - Unix/Mac: @c ~/Music
+            - Windows: @c "C:\Users\username\Music"
+        */
+        Dir_Music,
+
+        /**
+            Directory containing picture files.
+
+            Example return values:
+            - Unix/Mac: @c ~/Pictures
+            - Windows: @c "C:\Users\username\Pictures"
+        */
+        Dir_Pictures,
+
+        /**
+            Directory containing video files.
+
+            Example return values:
+            - Unix: @c ~/Videos
+            - Windows: @c "C:\Users\username\Videos"
+            - Mac: @c ~/Movies
+        */
+        Dir_Videos
+    };
 
     /**
         MSW-specific function undoing the effect of IgnoreAppSubDir() calls.
@@ -138,17 +196,11 @@ public:
     virtual wxString GetDataDir() const;
 
     /**
-        Return the directory containing the current user's documents.
-
-        Example return values:
-        - Unix: @c ~ (the home directory)
-        - Windows: @c "C:\Users\username\Documents" or
-                   @c "C:\Documents and Settings\username\My Documents"
-        - Mac: @c ~/Documents
+        Same as calling GetUserDir() with Dir_Documents parameter.
 
         @since 2.7.0
 
-        @see GetAppDocumentsDir()
+        @see GetAppDocumentsDir(), GetUserDir()
     */
     virtual wxString GetDocumentsDir() const;
 
@@ -258,6 +310,17 @@ public:
         - Mac: @c "~/Library/Application Support/appinfo"
     */
     virtual wxString GetUserDataDir() const;
+
+    /**
+        Return the path of the specified user data directory.
+
+        If the value could not be determined the users home directory is returned.
+
+        @note On Unix this supports the xdg user dirs specification.
+
+        @since 3.1.0
+    */
+    virtual wxString GetUserDir(Dir userDir) const;
 
     /**
         Return the directory for user data files which shouldn't be shared with

--- a/src/common/stdpbase.cpp
+++ b/src/common/stdpbase.cpp
@@ -114,11 +114,6 @@ wxString wxStandardPathsBase::GetUserLocalDataDir() const
     return GetUserDataDir();
 }
 
-wxString wxStandardPathsBase::GetDocumentsDir() const
-{
-    return wxFileName::GetHomeDir();
-}
-
 wxString wxStandardPathsBase::GetAppDocumentsDir() const
 {
     const wxString docsDir = GetDocumentsDir();
@@ -131,6 +126,11 @@ wxString wxStandardPathsBase::GetAppDocumentsDir() const
 wxString wxStandardPathsBase::GetTempDir() const
 {
     return wxFileName::GetTempDir();
+}
+
+wxString wxStandardPathsBase::GetUserDir(Dir WXUNUSED(userDir)) const
+{
+    return wxFileName::GetHomeDir();
 }
 
 /* static */

--- a/src/msw/stdpaths.cpp
+++ b/src/msw/stdpaths.cpp
@@ -36,6 +36,7 @@
 
 #include "wx/msw/private.h"
 #include "wx/msw/wrapshl.h"
+#include <initguid.h>
 
 // ----------------------------------------------------------------------------
 // types
@@ -43,6 +44,7 @@
 
 typedef HRESULT (WINAPI *SHGetFolderPath_t)(HWND, int, HANDLE, DWORD, LPTSTR);
 typedef HRESULT (WINAPI *SHGetSpecialFolderPath_t)(HWND, LPTSTR, int, BOOL);
+typedef HRESULT (WINAPI *SHGetKnownFolderPath_t)(const GUID&, DWORD, HANDLE, PWSTR *);
 
 // ----------------------------------------------------------------------------
 // constants
@@ -86,6 +88,9 @@ typedef HRESULT (WINAPI *SHGetSpecialFolderPath_t)(HWND, LPTSTR, int, BOOL);
 namespace
 {
 
+DEFINE_GUID(wxFOLDERID_Downloads,
+    0x374de290, 0x123f, 0x4565, 0x91, 0x64, 0x39, 0xc4, 0x92, 0x5e, 0x46, 0x7b);
+
 struct ShellFunctions
 {
     ShellFunctions()
@@ -97,6 +102,7 @@ struct ShellFunctions
 
     SHGetFolderPath_t pSHGetFolderPath;
     SHGetSpecialFolderPath_t pSHGetSpecialFolderPath;
+    SHGetKnownFolderPath_t pSHGetKnownFolderPath;
 
     bool initialized;
 };
@@ -153,6 +159,9 @@ void ResolveShellFunctions()
         gs_shellFuncs.pSHGetSpecialFolderPath = (SHGetSpecialFolderPath_t)
             dllShellFunctions.GetSymbol(funcname + UNICODE_SUFFIX);
     }
+
+    gs_shellFuncs.pSHGetKnownFolderPath = (SHGetKnownFolderPath_t)
+        dllShellFunctions.GetSymbol("SHGetKnownFolderPath");
 
     // finally we fall back on SHGetSpecialFolderLocation (shell32.dll 4.0),
     // but we don't need to test for it -- it is available even under Win95
@@ -250,6 +259,28 @@ wxString wxStandardPaths::DoGetDirectory(int csidl)
     return dir;
 }
 
+wxString wxStandardPaths::DoGetKnownFolder(const GUID& rfid)
+{
+    if (!gs_shellFuncs.initialized)
+        ResolveShellFunctions();
+
+    wxString dir;
+
+    if ( gs_shellFuncs.pSHGetKnownFolderPath )
+    {
+        PWSTR pDir;
+        HRESULT hr = gs_shellFuncs.pSHGetKnownFolderPath(rfid, 0, 0, &pDir);
+        if ( SUCCEEDED(hr) )
+        {
+            dir = pDir;
+            CoTaskMemFree(pDir);
+        }
+    }
+
+    return dir;
+}
+
+
 wxString wxStandardPaths::GetAppDir() const
 {
     if ( m_appDir.empty() )
@@ -260,9 +291,38 @@ wxString wxStandardPaths::GetAppDir() const
     return m_appDir;
 }
 
-wxString wxStandardPaths::GetDocumentsDir() const
+wxString wxStandardPaths::GetUserDir(Dir userDir) const
 {
-    return DoGetDirectory(CSIDL_PERSONAL);
+    int csidl;
+    switch (userDir)
+    {
+        case Dir_Desktop:
+            csidl = CSIDL_DESKTOPDIRECTORY;
+            break;
+        case Dir_Downloads:
+        {
+            csidl = CSIDL_PERSONAL;
+            // Downloads folder is only available since Vista
+            wxString dir = DoGetKnownFolder(wxFOLDERID_Downloads);
+            if ( !dir.empty() )
+                return dir;
+            break;
+        }
+        case Dir_Music:
+            csidl = CSIDL_MYMUSIC;
+            break;
+        case Dir_Pictures:
+            csidl = CSIDL_MYPICTURES;
+            break;
+        case Dir_Videos:
+            csidl = CSIDL_MYVIDEO;
+            break;
+        default:
+            csidl = CSIDL_PERSONAL;
+            break;
+    }
+
+    return DoGetDirectory(csidl);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/osx/cocoa/stdpaths.mm
+++ b/src/osx/cocoa/stdpaths.mm
@@ -1,0 +1,129 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        src/osx/cocoa/stdpaths.mm
+// Purpose:     wxStandardPaths for Cocoa
+// Author:      Tobias Taschner
+// Created:     2015-09-09
+// Copyright:   (c) 2015 wxWidgets development team
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
+// ============================================================================
+// declarations
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// headers
+// ----------------------------------------------------------------------------
+
+#include "wx/wxprec.h"
+
+#if wxUSE_STDPATHS
+
+#include "wx/stdpaths.h"
+#include "wx/osx/private.h"
+#include "wx/osx/core/cfstring.h"
+
+#import <CoreFoundation/CoreFoundation.h>
+
+// ============================================================================
+// implementation
+// ============================================================================
+
+static wxString GetFMDirectory(
+                                   NSSearchPathDirectory directory,
+                                   NSSearchPathDomainMask domainMask)
+{
+    NSURL* url = [[NSFileManager defaultManager] URLForDirectory:directory
+                                           inDomain:domainMask
+                                  appropriateForURL:nil
+                                             create:NO error:nil];
+    return wxCFStringRef::AsString(url.path);
+}
+
+wxStandardPaths::wxStandardPaths()
+{
+    
+}
+
+wxStandardPaths::~wxStandardPaths()
+{
+    
+}
+
+wxString wxStandardPaths::GetExecutablePath() const
+{
+    return wxCFStringRef::AsString([NSBundle mainBundle].executablePath);
+}
+
+wxString wxStandardPaths::GetConfigDir() const
+{
+    return GetFMDirectory(NSLibraryDirectory, NSLocalDomainMask) + "/Preferences";
+}
+
+wxString wxStandardPaths::GetUserConfigDir() const
+{
+    return GetFMDirectory(NSLibraryDirectory, NSUserDomainMask) + "/Preferences";
+}
+
+wxString wxStandardPaths::GetDataDir() const
+{
+    return wxCFStringRef::AsString([NSBundle mainBundle].sharedSupportPath);
+}
+
+wxString wxStandardPaths::GetLocalDataDir() const
+{
+    return AppendAppInfo(GetFMDirectory(NSApplicationSupportDirectory, NSLocalDomainMask));
+}
+
+wxString wxStandardPaths::GetUserDataDir() const
+{
+    return AppendAppInfo(GetFMDirectory(NSApplicationSupportDirectory, NSUserDomainMask));
+}
+
+wxString wxStandardPaths::GetPluginsDir() const
+{
+    return wxCFStringRef::AsString([NSBundle mainBundle].builtInPlugInsPath);
+}
+
+wxString wxStandardPaths::GetResourcesDir() const
+{
+    return wxCFStringRef::AsString([NSBundle mainBundle].resourcePath);
+}
+
+wxString
+wxStandardPaths::GetLocalizedResourcesDir(const wxString& lang,
+                                          ResourceCat category) const
+{
+    return wxStandardPathsBase::
+        GetLocalizedResourcesDir(lang, category) + wxT(".lproj");
+}
+
+wxString wxStandardPaths::GetUserDir(Dir userDir) const
+{
+    NSSearchPathDirectory dirType;
+    switch (userDir)
+    {
+        case Dir_Desktop:
+            dirType = NSDesktopDirectory;
+            break;
+        case Dir_Downloads:
+            dirType = NSDownloadsDirectory;
+            break;
+        case Dir_Music:
+            dirType = NSMusicDirectory;
+            break;
+        case Dir_Pictures:
+            dirType = NSPicturesDirectory;
+            break;
+        case Dir_Videos:
+            dirType = NSMoviesDirectory;
+            break;
+        default:
+            dirType = NSDocumentDirectory;
+            break;
+    }
+    
+    return GetFMDirectory(dirType, NSUserDomainMask);
+}
+
+#endif // wxUSE_STDPATHS

--- a/src/osx/core/stdpaths_cf.cpp
+++ b/src/osx/core/stdpaths_cf.cpp
@@ -96,17 +96,62 @@ wxString wxStandardPathsCF::GetFromFunc(wxCFURLRef (*func)(wxCFBundleRef)) const
     return ret;
 }
 
-wxString wxStandardPathsCF::GetDocumentsDir() const
+wxString wxStandardPathsCF::GetUserDir(Dir userDir) const
 {
 #if defined( __WXMAC__ ) && wxOSX_USE_CARBON
+    OSType folderType;
+    switch (userDir)
+    {
+        case Dir_Desktop:
+            folderType = kDesktopFolderType;
+            break;
+        case Dir_Downloads:
+            folderType = kDownloadsFolderType;
+            break;
+        case Dir_Music:
+            folderType = kMusicDocumentsFolderType;
+            break;
+        case Dir_Pictures:
+            folderType = kPictureDocumentsFolderType;
+            break;
+        case Dir_Videos:
+            folderType = kMovieDocumentsFolderType;
+            break;
+        default:
+            folderType = kDocumentsFolderType;
+            break;
+    }
+
     return wxMacFindFolderNoSeparator
         (
         kUserDomain,
-        kDocumentsFolderType,
+        folderType,
         kCreateFolder
         );
 #else
-    return wxFileName::GetHomeDir() + wxT("/Documents");
+    wxString userDirName;
+    switch (userDir)
+    {
+        case Dir_Desktop:
+            userDirName = "Desktop";
+            break;
+        case Dir_Downloads:
+            userDirName = "Downloads";
+            break;
+        case Dir_Music:
+            userDirName = "Music";
+            break;
+        case Dir_Pictures:
+            userDirName = "Pictures";
+            break;
+        case Dir_Videos:
+            userDirName = "Movies";
+            break;
+        default:
+            userDirName = "Documents";
+            break;
+    }
+    return wxFileName::GetHomeDir() + "/" + userDirName;
 #endif
 }
 

--- a/src/osx/core/utilsexc_cf.cpp
+++ b/src/osx/core/utilsexc_cf.cpp
@@ -160,7 +160,12 @@ wxStandardPaths& wxGUIAppTraits::GetStandardPaths()
     // Derive a class just to be able to create it: wxStandardPaths ctor is
     // protected to prevent its misuse, but it also means we can't create an
     // object of this class directly.
-    class wxStandardPathsDefault : public wxStandardPathsCF
+    class wxStandardPathsDefault : public
+#if defined(__WXOSX_COCOA__) || defined(__WXOSX_IPHONE__)
+    wxStandardPaths
+#else
+    wxStandardPathsCF
+#endif
     {
     public:
         wxStandardPathsDefault() { }

--- a/src/unix/stdpaths.cpp
+++ b/src/unix/stdpaths.cpp
@@ -233,7 +233,7 @@ wxStandardPaths::GetLocalizedResourcesDir(const wxString& lang,
     return GetInstallPrefix() + wxT("/share/locale/") + lang + wxT("/LC_MESSAGES");
 }
 
-wxString wxStandardPaths::GetDocumentsDir() const
+wxString wxStandardPaths::GetUserDir(Dir userDir) const
 {
     {
         wxLogNull logNull;
@@ -246,6 +246,29 @@ wxString wxStandardPaths::GetDocumentsDir() const
         wxString dirsFile = configPath + wxT("/user-dirs.dirs");
         if (wxFileExists(dirsFile))
         {
+            wxString userDirId;
+            switch (userDir)
+            {
+                case Dir_Desktop:
+                    userDirId = "XDG_DESKTOP_DIR";
+                    break;
+                case Dir_Downloads:
+                    userDirId = "XDG_DOWNLOAD_DIR";
+                    break;
+                case Dir_Music:
+                    userDirId = "XDG_MUSIC_DIR";
+                    break;
+                case Dir_Pictures:
+                    userDirId = "XDG_PICTURES_DIR";
+                    break;
+                case Dir_Videos:
+                    userDirId = "XDG_VIDEOS_DIR";
+                    break;
+                default:
+                    userDirId = "XDG_DOCUMENTS_DIR";
+                    break;
+            }
+
             wxTextFile textFile;
             if (textFile.Open(dirsFile))
             {
@@ -253,13 +276,15 @@ wxString wxStandardPaths::GetDocumentsDir() const
                 for (i = 0; i < textFile.GetLineCount(); i++)
                 {
                     wxString line(textFile[i]);
-                    int pos = line.Find(wxT("XDG_DOCUMENTS_DIR"));
+                    int pos = line.Find(userDirId);
                     if (pos != wxNOT_FOUND)
                     {
                         wxString value = line.AfterFirst(wxT('='));
                         value.Replace(wxT("$HOME"), homeDir);
                         value.Trim(true);
                         value.Trim(false);
+                        // Remove quotes
+                        value.Replace("\"", "", true /* replace all */);
                         if (!value.IsEmpty() && wxDirExists(value))
                             return value;
                         else
@@ -270,7 +295,7 @@ wxString wxStandardPaths::GetDocumentsDir() const
         }
     }
 
-    return wxStandardPathsBase::GetDocumentsDir();
+    return wxStandardPathsBase::GetUserDir(userDir);
 }
 
 #endif // __VMS/!__VMS

--- a/tests/interactive/output.cpp
+++ b/tests/interactive/output.cpp
@@ -404,6 +404,11 @@ void InteractiveOutputTestCase::TestStandardPaths()
     wxPrintf(wxT("Data dir (user):\t%s\n"), stdp.GetUserDataDir().c_str());
     wxPrintf(wxT("Data dir (user local):\t%s\n"), stdp.GetUserLocalDataDir().c_str());
     wxPrintf(wxT("Documents dir:\t\t%s\n"), stdp.GetDocumentsDir().c_str());
+    wxPrintf(wxT("Desktop dir:\t\t%s\n"), stdp.GetUserDir(wxStandardPaths::Dir_Desktop).c_str());
+    wxPrintf(wxT("Downloads dir:\t\t%s\n"), stdp.GetUserDir(wxStandardPaths::Dir_Downloads).c_str());
+    wxPrintf(wxT("Music dir:\t\t%s\n"), stdp.GetUserDir(wxStandardPaths::Dir_Music).c_str());
+    wxPrintf(wxT("Pictures dir:\t\t%s\n"), stdp.GetUserDir(wxStandardPaths::Dir_Pictures).c_str());
+    wxPrintf(wxT("Videos dir:\t\t%s\n"), stdp.GetUserDir(wxStandardPaths::Dir_Videos).c_str());
     wxPrintf(wxT("Executable path:\t%s\n"), stdp.GetExecutablePath().c_str());
     wxPrintf(wxT("Plugins dir:\t\t%s\n"), stdp.GetPluginsDir().c_str());
     wxPrintf(wxT("Resources dir:\t\t%s\n"), stdp.GetResourcesDir().c_str());


### PR DESCRIPTION
All major supported platforms have well defined user folders to store Downloads, Music, Pictures, Videos and the Desktop files. The new method wxStandardPaths::GetUserDir() allows for a unified way to access these on MSW, OS X and Unix (if xdg user dirs specification is implemented).
