### PR TITLE
3.0 branch: Include Windows 10 in documentation

### DIFF
--- a/docs/doxygen/mainpages/introduction.h
+++ b/docs/doxygen/mainpages/introduction.h
@@ -78,9 +78,9 @@ paragraphs, but here are some of the benefits:
 wxWidgets first-tier "ports", ie implementations of wxWidgets API, are:
 
 @li wxMSW: This is the native port for Microsoft Windows systems (from Windows
-95 up to Windows 8.1 with at least Windows XP being recommended), either 32 or
+95 up to Windows 10 with at least Windows XP being recommended), either 32 or
 64 bits. The primarily supported compilers are Microsoft Visual C++ (versions 6
-up to 2013 are supported, at least 2005 is recommended) and GNU g++ (either
+up to 2015 are supported, at least 2005 is recommended) and GNU g++ (either
 from the traditional MinGW, TDM-GCC or MinGW-w64 distributions).
 
 @li wxGTK: wxGTK2 and wxGTK3 are the ports using GTK+ library version 2.x and

--- a/docs/msw/install.txt
+++ b/docs/msw/install.txt
@@ -2,7 +2,7 @@
                    --------------------------------
 
 This is wxWidgets for Microsoft Windows 9x/ME, Windows NT
-and later (2000, XP, Vista, 7, 8, etc) including both 32 bit and 64
+and later (2000, XP, Vista, 7, 8, 10, etc) including both 32 bit and 64
 bit versions.
 
 
@@ -19,11 +19,11 @@ Installation
 If you are using one of the supported compilers, you can download the
 pre-built in binaries from
 
-    https://sourceforge.net/projects/wxwindows/files/3.0.0/binaries/
+    https://sourceforge.net/projects/wxwindows/files/3.0.3/binaries/
 
 or
 
-             ftp://ftp.wxwidgets.org/pub/3.0.0/binaries/
+             ftp://ftp.wxwidgets.org/pub/3.0.3/binaries/
 
 In this case, just uncompress the binaries archive under any directory
 and skip to "Building Applications Using wxWidgets" part.
@@ -98,8 +98,8 @@ Microsoft Visual C++ Compilation
 
 Ready to use project files are provided for VC++ versions 6, 7, 8, 9
 and 10 (also known as MSVS 6, 2003, 2005, 2008 and 2010 respectively).
-For VC++ 11 (2012, respectively), you need to import the existing VC10
-project files into VC11 IDE first.
+For VC++ 11, 12 and 14 (2012, 2013 and 2015 respectively), you need to
+import the existing VC10 project files into VC11, VC12 or VC14 IDE first.
 
 Simply open wx_vcN.sln (for N=7, 8, 9 or 10) or wx.dsw (for VC6) file,
 select the appropriate configuration (Debug or Release, static or DLL)

--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -81,7 +81,7 @@ to earlier versions of wxWidgets, please read it, and especially its
 "INCOMPATIBLE CHANGES" section, if you are upgrading from wxWidgets
 2.8 or earlier. And for even more details, please see
 
-    http://docs.wxwidgets.org/3.0.0/overview_changes_since28.html
+    http://docs.wxwidgets.org/3.0.3/overview_changes_since28.html
 
 
 Platforms supported
@@ -89,7 +89,7 @@ Platforms supported
 
 wxWidgets currently supports the following primary platforms:
 
-- Windows 95/98/ME, NT, 2000, XP, Vista, 7 (32/64 bits).
+- Windows 95/98/ME, NT, 2000, XP, Vista, 7, 8, 10 (32/64 bits).
 - Most Unix variants using the GTK+ toolkit (version 2.6 or newer)
 - Mac OS X (10.5 or newer) using Cocoa (32/64 bits) or Carbon (32 only)
 

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -1336,7 +1336,7 @@ wxString wxGetOsDescription()
 
                 case 10:
                     str = wxIsWindowsServer() == 1
-                            ? _("Windows Server 10")
+                            ? _("Windows Server 2016")
                             : _("Windows 10");
                     break;
             }


### PR DESCRIPTION
- Include Windows 10 in the documentation where appropriate
- Include VS2013 and VS2015 in MSW build instructions.
- Use the official name of Windows Server 2016 in wxGetOsDescription()
