### PR TITLE
Reuse wxSystemSettings from wxCocoa in wxOSX/Cocoa.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -5589,7 +5589,7 @@ COND_TOOLKIT_COCOA___GUI_SRC_OBJECTS =  \
 	monodll_src_cocoa_radiobut.o \
 	monodll_cocoa_region.o \
 	monodll_src_cocoa_scrolbar.o \
-	monodll_cocoa_settings.o \
+	monodll_src_cocoa_settings.o \
 	monodll_src_cocoa_slider.o \
 	monodll_cocoa_sound.o \
 	monodll_src_cocoa_spinbutt.o \
@@ -5944,7 +5944,8 @@ COND_TOOLKIT_OSX_CARBON___GUI_SRC_OBJECTS =  \
 	monodll_carbon_tglbtn.o \
 	monodll_carbon_toolbar.o \
 	monodll_carbon_tooltip.o \
-	monodll_carbon_window.o
+	monodll_carbon_window.o \
+	monodll_carbon_settings.o
 @COND_TOOLKIT_OSX_CARBON@__GUI_SRC_OBJECTS = $(COND_TOOLKIT_OSX_CARBON___GUI_SRC_OBJECTS)
 COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS =  \
 	$(__OSX_CARBON_COCOA_SRC_OBJECTS) \
@@ -5982,7 +5983,8 @@ COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS =  \
 	monodll_cocoa_tglbtn.o \
 	monodll_osx_cocoa_toolbar.o \
 	monodll_osx_cocoa_tooltip.o \
-	monodll_osx_cocoa_window.o
+	monodll_osx_cocoa_window.o \
+	monodll_osx_cocoa_settings.o
 @COND_TOOLKIT_OSX_COCOA@__GUI_SRC_OBJECTS = $(COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS)
 COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS =  \
 	$(__OSX_CARBON_COCOA_SRC_OBJECTS) \
@@ -7961,7 +7963,7 @@ COND_TOOLKIT_COCOA___GUI_SRC_OBJECTS_1 =  \
 	monolib_src_cocoa_radiobut.o \
 	monolib_cocoa_region.o \
 	monolib_src_cocoa_scrolbar.o \
-	monolib_cocoa_settings.o \
+	monolib_src_cocoa_settings.o \
 	monolib_src_cocoa_slider.o \
 	monolib_cocoa_sound.o \
 	monolib_src_cocoa_spinbutt.o \
@@ -8316,7 +8318,8 @@ COND_TOOLKIT_OSX_CARBON___GUI_SRC_OBJECTS_1 =  \
 	monolib_carbon_tglbtn.o \
 	monolib_carbon_toolbar.o \
 	monolib_carbon_tooltip.o \
-	monolib_carbon_window.o
+	monolib_carbon_window.o \
+	monolib_carbon_settings.o
 @COND_TOOLKIT_OSX_CARBON@__GUI_SRC_OBJECTS_1 = $(COND_TOOLKIT_OSX_CARBON___GUI_SRC_OBJECTS_1)
 COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS_1 =  \
 	$(__OSX_CARBON_COCOA_SRC_OBJECTS_12) \
@@ -8354,7 +8357,8 @@ COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS_1 =  \
 	monolib_cocoa_tglbtn.o \
 	monolib_osx_cocoa_toolbar.o \
 	monolib_osx_cocoa_tooltip.o \
-	monolib_osx_cocoa_window.o
+	monolib_osx_cocoa_window.o \
+	monolib_osx_cocoa_settings.o
 @COND_TOOLKIT_OSX_COCOA@__GUI_SRC_OBJECTS_1 = $(COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS_1)
 COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS_1 =  \
 	$(__OSX_CARBON_COCOA_SRC_OBJECTS_12) \
@@ -10485,7 +10489,7 @@ COND_TOOLKIT_COCOA___GUI_SRC_OBJECTS_2 =  \
 	coredll_src_cocoa_radiobut.o \
 	coredll_cocoa_region.o \
 	coredll_src_cocoa_scrolbar.o \
-	coredll_cocoa_settings.o \
+	coredll_src_cocoa_settings.o \
 	coredll_src_cocoa_slider.o \
 	coredll_sound.o \
 	coredll_src_cocoa_spinbutt.o \
@@ -10840,7 +10844,8 @@ COND_TOOLKIT_OSX_CARBON___GUI_SRC_OBJECTS_2 =  \
 	coredll_carbon_tglbtn.o \
 	coredll_carbon_toolbar.o \
 	coredll_carbon_tooltip.o \
-	coredll_carbon_window.o
+	coredll_carbon_window.o \
+	coredll_carbon_settings.o
 @COND_TOOLKIT_OSX_CARBON@__GUI_SRC_OBJECTS_2 = $(COND_TOOLKIT_OSX_CARBON___GUI_SRC_OBJECTS_2)
 COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS_2 =  \
 	$(__OSX_CARBON_COCOA_SRC_OBJECTS_14) \
@@ -10878,7 +10883,8 @@ COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS_2 =  \
 	coredll_cocoa_tglbtn.o \
 	coredll_osx_cocoa_toolbar.o \
 	coredll_osx_cocoa_tooltip.o \
-	coredll_osx_cocoa_window.o
+	coredll_osx_cocoa_window.o \
+	coredll_osx_cocoa_settings.o
 @COND_TOOLKIT_OSX_COCOA@__GUI_SRC_OBJECTS_2 = $(COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS_2)
 COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS_2 =  \
 	$(__OSX_CARBON_COCOA_SRC_OBJECTS_14) \
@@ -12264,7 +12270,7 @@ COND_TOOLKIT_COCOA___GUI_SRC_OBJECTS_3 =  \
 	corelib_src_cocoa_radiobut.o \
 	corelib_cocoa_region.o \
 	corelib_src_cocoa_scrolbar.o \
-	corelib_cocoa_settings.o \
+	corelib_src_cocoa_settings.o \
 	corelib_src_cocoa_slider.o \
 	corelib_sound.o \
 	corelib_src_cocoa_spinbutt.o \
@@ -12619,7 +12625,8 @@ COND_TOOLKIT_OSX_CARBON___GUI_SRC_OBJECTS_3 =  \
 	corelib_carbon_tglbtn.o \
 	corelib_carbon_toolbar.o \
 	corelib_carbon_tooltip.o \
-	corelib_carbon_window.o
+	corelib_carbon_window.o \
+	corelib_carbon_settings.o
 @COND_TOOLKIT_OSX_CARBON@__GUI_SRC_OBJECTS_3 = $(COND_TOOLKIT_OSX_CARBON___GUI_SRC_OBJECTS_3)
 COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS_3 =  \
 	$(__OSX_CARBON_COCOA_SRC_OBJECTS_1_0) \
@@ -12657,7 +12664,8 @@ COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS_3 =  \
 	corelib_cocoa_tglbtn.o \
 	corelib_osx_cocoa_toolbar.o \
 	corelib_osx_cocoa_tooltip.o \
-	corelib_osx_cocoa_window.o
+	corelib_osx_cocoa_window.o \
+	corelib_osx_cocoa_settings.o
 @COND_TOOLKIT_OSX_COCOA@__GUI_SRC_OBJECTS_3 = $(COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS_3)
 COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS_3 =  \
 	$(__OSX_CARBON_COCOA_SRC_OBJECTS_1_0) \
@@ -15093,7 +15101,6 @@ COND_PLATFORM_MACOSX_1___OSX_CARBON_COCOA_SRC_OBJECTS =  \
 	monodll_carbon_overlay.o \
 	monodll_carbon_popupwin.o \
 	monodll_carbon_renderer.o \
-	monodll_carbon_settings.o \
 	monodll_statbrma.o \
 	monodll_carbon_region.o \
 	monodll_utilscocoa.o \
@@ -15239,7 +15246,6 @@ COND_PLATFORM_MACOSX_1___OSX_CARBON_COCOA_SRC_OBJECTS_12 =  \
 	monolib_carbon_overlay.o \
 	monolib_carbon_popupwin.o \
 	monolib_carbon_renderer.o \
-	monolib_carbon_settings.o \
 	monolib_statbrma.o \
 	monolib_carbon_region.o \
 	monolib_utilscocoa.o \
@@ -15385,7 +15391,6 @@ COND_PLATFORM_MACOSX_1___OSX_CARBON_COCOA_SRC_OBJECTS_14 =  \
 	coredll_carbon_overlay.o \
 	coredll_carbon_popupwin.o \
 	coredll_carbon_renderer.o \
-	coredll_carbon_settings.o \
 	coredll_statbrma.o \
 	coredll_carbon_region.o \
 	coredll_utilscocoa.o \
@@ -15516,7 +15521,6 @@ COND_PLATFORM_MACOSX_1___OSX_CARBON_COCOA_SRC_OBJECTS_1_0 =  \
 	corelib_carbon_overlay.o \
 	corelib_carbon_popupwin.o \
 	corelib_carbon_renderer.o \
-	corelib_carbon_settings.o \
 	corelib_statbrma.o \
 	corelib_carbon_region.o \
 	corelib_utilscocoa.o \
@@ -18224,6 +18228,9 @@ monodll_carbon_tooltip.o: $(srcdir)/src/osx/carbon/tooltip.cpp $(MONODLL_ODEP)
 monodll_carbon_window.o: $(srcdir)/src/osx/carbon/window.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/osx/carbon/window.cpp
 
+monodll_carbon_settings.o: $(srcdir)/src/osx/carbon/settings.cpp $(MONODLL_ODEP)
+	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/osx/carbon/settings.cpp
+
 monodll_cocoa_anybutton.o: $(srcdir)/src/osx/cocoa/anybutton.mm $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/anybutton.mm
 
@@ -18328,6 +18335,9 @@ monodll_osx_cocoa_tooltip.o: $(srcdir)/src/osx/cocoa/tooltip.mm $(MONODLL_ODEP)
 
 monodll_osx_cocoa_window.o: $(srcdir)/src/osx/cocoa/window.mm $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/window.mm
+
+monodll_osx_cocoa_settings.o: $(srcdir)/src/osx/cocoa/settings.mm $(MONODLL_ODEP)
+	$(CXXC) -c -o $@ $(MONODLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/settings.mm
 
 monodll_iphone_anybutton.o: $(srcdir)/src/osx/iphone/anybutton.mm $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/anybutton.mm
@@ -18551,7 +18561,7 @@ monodll_cocoa_region.o: $(srcdir)/src/cocoa/region.mm $(MONODLL_ODEP)
 monodll_src_cocoa_scrolbar.o: $(srcdir)/src/cocoa/scrolbar.mm $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_OBJCXXFLAGS) $(srcdir)/src/cocoa/scrolbar.mm
 
-monodll_cocoa_settings.o: $(srcdir)/src/cocoa/settings.mm $(MONODLL_ODEP)
+monodll_src_cocoa_settings.o: $(srcdir)/src/cocoa/settings.mm $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_OBJCXXFLAGS) $(srcdir)/src/cocoa/settings.mm
 
 monodll_src_cocoa_slider.o: $(srcdir)/src/cocoa/slider.mm $(MONODLL_ODEP)
@@ -22235,15 +22245,6 @@ monodll_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(MONODLL_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@monodll_carbon_renderer.o: $(srcdir)/src/osx/carbon/renderer.cpp $(MONODLL_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/osx/carbon/renderer.cpp
 
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_CARBON_USE_GUI_1_WXUNIV_0@monodll_carbon_settings.o: $(srcdir)/src/osx/carbon/settings.cpp $(MONODLL_ODEP)
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_CARBON_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/osx/carbon/settings.cpp
-
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@monodll_carbon_settings.o: $(srcdir)/src/osx/carbon/settings.cpp $(MONODLL_ODEP)
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/osx/carbon/settings.cpp
-
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@monodll_carbon_settings.o: $(srcdir)/src/osx/carbon/settings.cpp $(MONODLL_ODEP)
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/osx/carbon/settings.cpp
-
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_CARBON_USE_GUI_1_WXUNIV_0@monodll_statbrma.o: $(srcdir)/src/osx/carbon/statbrma.cpp $(MONODLL_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_CARBON_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/osx/carbon/statbrma.cpp
 
@@ -24143,6 +24144,9 @@ monolib_carbon_tooltip.o: $(srcdir)/src/osx/carbon/tooltip.cpp $(MONOLIB_ODEP)
 monolib_carbon_window.o: $(srcdir)/src/osx/carbon/window.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/osx/carbon/window.cpp
 
+monolib_carbon_settings.o: $(srcdir)/src/osx/carbon/settings.cpp $(MONOLIB_ODEP)
+	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/osx/carbon/settings.cpp
+
 monolib_cocoa_anybutton.o: $(srcdir)/src/osx/cocoa/anybutton.mm $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/anybutton.mm
 
@@ -24247,6 +24251,9 @@ monolib_osx_cocoa_tooltip.o: $(srcdir)/src/osx/cocoa/tooltip.mm $(MONOLIB_ODEP)
 
 monolib_osx_cocoa_window.o: $(srcdir)/src/osx/cocoa/window.mm $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/window.mm
+
+monolib_osx_cocoa_settings.o: $(srcdir)/src/osx/cocoa/settings.mm $(MONOLIB_ODEP)
+	$(CXXC) -c -o $@ $(MONOLIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/settings.mm
 
 monolib_iphone_anybutton.o: $(srcdir)/src/osx/iphone/anybutton.mm $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/anybutton.mm
@@ -24470,7 +24477,7 @@ monolib_cocoa_region.o: $(srcdir)/src/cocoa/region.mm $(MONOLIB_ODEP)
 monolib_src_cocoa_scrolbar.o: $(srcdir)/src/cocoa/scrolbar.mm $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_OBJCXXFLAGS) $(srcdir)/src/cocoa/scrolbar.mm
 
-monolib_cocoa_settings.o: $(srcdir)/src/cocoa/settings.mm $(MONOLIB_ODEP)
+monolib_src_cocoa_settings.o: $(srcdir)/src/cocoa/settings.mm $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_OBJCXXFLAGS) $(srcdir)/src/cocoa/settings.mm
 
 monolib_src_cocoa_slider.o: $(srcdir)/src/cocoa/slider.mm $(MONOLIB_ODEP)
@@ -28154,15 +28161,6 @@ monolib_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(MONOLIB_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@monolib_carbon_renderer.o: $(srcdir)/src/osx/carbon/renderer.cpp $(MONOLIB_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/osx/carbon/renderer.cpp
 
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_CARBON_USE_GUI_1_WXUNIV_0@monolib_carbon_settings.o: $(srcdir)/src/osx/carbon/settings.cpp $(MONOLIB_ODEP)
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_CARBON_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/osx/carbon/settings.cpp
-
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@monolib_carbon_settings.o: $(srcdir)/src/osx/carbon/settings.cpp $(MONOLIB_ODEP)
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/osx/carbon/settings.cpp
-
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@monolib_carbon_settings.o: $(srcdir)/src/osx/carbon/settings.cpp $(MONOLIB_ODEP)
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/osx/carbon/settings.cpp
-
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_CARBON_USE_GUI_1_WXUNIV_0@monolib_statbrma.o: $(srcdir)/src/osx/carbon/statbrma.cpp $(MONOLIB_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_CARBON_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/osx/carbon/statbrma.cpp
 
@@ -30734,6 +30732,9 @@ coredll_carbon_tooltip.o: $(srcdir)/src/osx/carbon/tooltip.cpp $(COREDLL_ODEP)
 coredll_carbon_window.o: $(srcdir)/src/osx/carbon/window.cpp $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/osx/carbon/window.cpp
 
+coredll_carbon_settings.o: $(srcdir)/src/osx/carbon/settings.cpp $(COREDLL_ODEP)
+	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/osx/carbon/settings.cpp
+
 coredll_cocoa_anybutton.o: $(srcdir)/src/osx/cocoa/anybutton.mm $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/anybutton.mm
 
@@ -30838,6 +30839,9 @@ coredll_osx_cocoa_tooltip.o: $(srcdir)/src/osx/cocoa/tooltip.mm $(COREDLL_ODEP)
 
 coredll_osx_cocoa_window.o: $(srcdir)/src/osx/cocoa/window.mm $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/window.mm
+
+coredll_osx_cocoa_settings.o: $(srcdir)/src/osx/cocoa/settings.mm $(COREDLL_ODEP)
+	$(CXXC) -c -o $@ $(COREDLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/settings.mm
 
 coredll_iphone_anybutton.o: $(srcdir)/src/osx/iphone/anybutton.mm $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/anybutton.mm
@@ -31061,7 +31065,7 @@ coredll_cocoa_region.o: $(srcdir)/src/cocoa/region.mm $(COREDLL_ODEP)
 coredll_src_cocoa_scrolbar.o: $(srcdir)/src/cocoa/scrolbar.mm $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_OBJCXXFLAGS) $(srcdir)/src/cocoa/scrolbar.mm
 
-coredll_cocoa_settings.o: $(srcdir)/src/cocoa/settings.mm $(COREDLL_ODEP)
+coredll_src_cocoa_settings.o: $(srcdir)/src/cocoa/settings.mm $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_OBJCXXFLAGS) $(srcdir)/src/cocoa/settings.mm
 
 coredll_src_cocoa_slider.o: $(srcdir)/src/cocoa/slider.mm $(COREDLL_ODEP)
@@ -34178,15 +34182,6 @@ coredll_win32.o: $(srcdir)/src/univ/themes/win32.cpp $(COREDLL_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@coredll_carbon_renderer.o: $(srcdir)/src/osx/carbon/renderer.cpp $(COREDLL_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/osx/carbon/renderer.cpp
 
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_CARBON_USE_GUI_1_WXUNIV_0@coredll_carbon_settings.o: $(srcdir)/src/osx/carbon/settings.cpp $(COREDLL_ODEP)
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_CARBON_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/osx/carbon/settings.cpp
-
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@coredll_carbon_settings.o: $(srcdir)/src/osx/carbon/settings.cpp $(COREDLL_ODEP)
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/osx/carbon/settings.cpp
-
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@coredll_carbon_settings.o: $(srcdir)/src/osx/carbon/settings.cpp $(COREDLL_ODEP)
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/osx/carbon/settings.cpp
-
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_CARBON_USE_GUI_1_WXUNIV_0@coredll_statbrma.o: $(srcdir)/src/osx/carbon/statbrma.cpp $(COREDLL_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_CARBON_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/osx/carbon/statbrma.cpp
 
@@ -35138,6 +35133,9 @@ corelib_carbon_tooltip.o: $(srcdir)/src/osx/carbon/tooltip.cpp $(CORELIB_ODEP)
 corelib_carbon_window.o: $(srcdir)/src/osx/carbon/window.cpp $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/osx/carbon/window.cpp
 
+corelib_carbon_settings.o: $(srcdir)/src/osx/carbon/settings.cpp $(CORELIB_ODEP)
+	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/osx/carbon/settings.cpp
+
 corelib_cocoa_anybutton.o: $(srcdir)/src/osx/cocoa/anybutton.mm $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/anybutton.mm
 
@@ -35242,6 +35240,9 @@ corelib_osx_cocoa_tooltip.o: $(srcdir)/src/osx/cocoa/tooltip.mm $(CORELIB_ODEP)
 
 corelib_osx_cocoa_window.o: $(srcdir)/src/osx/cocoa/window.mm $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/window.mm
+
+corelib_osx_cocoa_settings.o: $(srcdir)/src/osx/cocoa/settings.mm $(CORELIB_ODEP)
+	$(CXXC) -c -o $@ $(CORELIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/settings.mm
 
 corelib_iphone_anybutton.o: $(srcdir)/src/osx/iphone/anybutton.mm $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/anybutton.mm
@@ -35465,7 +35466,7 @@ corelib_cocoa_region.o: $(srcdir)/src/cocoa/region.mm $(CORELIB_ODEP)
 corelib_src_cocoa_scrolbar.o: $(srcdir)/src/cocoa/scrolbar.mm $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_OBJCXXFLAGS) $(srcdir)/src/cocoa/scrolbar.mm
 
-corelib_cocoa_settings.o: $(srcdir)/src/cocoa/settings.mm $(CORELIB_ODEP)
+corelib_src_cocoa_settings.o: $(srcdir)/src/cocoa/settings.mm $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_OBJCXXFLAGS) $(srcdir)/src/cocoa/settings.mm
 
 corelib_src_cocoa_slider.o: $(srcdir)/src/cocoa/slider.mm $(CORELIB_ODEP)
@@ -38581,15 +38582,6 @@ corelib_win32.o: $(srcdir)/src/univ/themes/win32.cpp $(CORELIB_ODEP)
 
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@corelib_carbon_renderer.o: $(srcdir)/src/osx/carbon/renderer.cpp $(CORELIB_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/osx/carbon/renderer.cpp
-
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_CARBON_USE_GUI_1_WXUNIV_0@corelib_carbon_settings.o: $(srcdir)/src/osx/carbon/settings.cpp $(CORELIB_ODEP)
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_CARBON_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/osx/carbon/settings.cpp
-
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@corelib_carbon_settings.o: $(srcdir)/src/osx/carbon/settings.cpp $(CORELIB_ODEP)
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/osx/carbon/settings.cpp
-
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@corelib_carbon_settings.o: $(srcdir)/src/osx/carbon/settings.cpp $(CORELIB_ODEP)
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/osx/carbon/settings.cpp
 
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_CARBON_USE_GUI_1_WXUNIV_0@corelib_statbrma.o: $(srcdir)/src/osx/carbon/statbrma.cpp $(CORELIB_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_CARBON_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/osx/carbon/statbrma.cpp

--- a/build/bakefiles/files.bkl
+++ b/build/bakefiles/files.bkl
@@ -2328,7 +2328,6 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     src/osx/carbon/overlay.cpp
     src/osx/carbon/popupwin.cpp
     src/osx/carbon/renderer.cpp
-    src/osx/carbon/settings.cpp
     src/osx/carbon/statbrma.cpp
     src/osx/carbon/region.cpp
     <!-- cocoa bridge -->
@@ -2492,6 +2491,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     src/osx/carbon/toolbar.cpp
     src/osx/carbon/tooltip.cpp
     src/osx/carbon/window.cpp
+    src/osx/carbon/settings.cpp
 </set>
 
 <!-- wxMac Carbon header files -->
@@ -2548,6 +2548,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     src/osx/cocoa/toolbar.mm
     src/osx/cocoa/tooltip.mm
     src/osx/cocoa/window.mm
+    src/osx/cocoa/settings.mm
 </set>
 <set var="OSX_COCOA_HDR" hints="files">
     wx/osx/cocoa/chkconf.h

--- a/build/files
+++ b/build/files
@@ -1955,7 +1955,6 @@ OSX_CARBON_COCOA_SRC =
     src/osx/carbon/overlay.cpp
     src/osx/carbon/popupwin.cpp
     src/osx/carbon/renderer.cpp
-    src/osx/carbon/settings.cpp
     src/osx/carbon/statbrma.cpp
     src/osx/carbon/region.cpp
     # cocoa bridge
@@ -2103,6 +2102,7 @@ OSX_CARBON_SRC =
     src/osx/carbon/printdlg.cpp
     src/osx/carbon/radiobut.cpp
     src/osx/carbon/scrolbar.cpp
+    src/osx/carbon/settings.cpp
     src/osx/carbon/slider.cpp
     src/osx/carbon/spinbutt.cpp
     src/osx/carbon/srchctrl.cpp
@@ -2156,6 +2156,7 @@ OSX_COCOA_SRC =
     src/osx/cocoa/preferences.mm
     src/osx/cocoa/printdlg.mm
     src/osx/cocoa/scrolbar.mm
+    src/osx/cocoa/settings.mm
     src/osx/cocoa/slider.mm
     src/osx/cocoa/spinbutt.mm
     src/osx/cocoa/srchctrl.mm

--- a/build/osx/wxcocoa.xcodeproj/project.pbxproj
+++ b/build/osx/wxcocoa.xcodeproj/project.pbxproj
@@ -529,6 +529,9 @@
 		24A5A71C79733E9CB913C5B7 /* LexPB.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 8744F2C80ECF375999195935 /* LexPB.cxx */; };
 		24A5A71C79733E9CB913C5B8 /* LexPB.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 8744F2C80ECF375999195935 /* LexPB.cxx */; };
 		24A5A71C79733E9CB913C5B9 /* LexPB.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 8744F2C80ECF375999195935 /* LexPB.cxx */; };
+		24AC00E71BA6C3900042A970 /* settings.mm in Sources */ = {isa = PBXBuildFile; fileRef = 24AC00E61BA6C3900042A970 /* settings.mm */; };
+		24AC00E81BA6C3900042A970 /* settings.mm in Sources */ = {isa = PBXBuildFile; fileRef = 24AC00E61BA6C3900042A970 /* settings.mm */; };
+		24AC00E91BA6C3900042A970 /* settings.mm in Sources */ = {isa = PBXBuildFile; fileRef = 24AC00E61BA6C3900042A970 /* settings.mm */; };
 		254028D56649374E8D3CC85C /* libwx_osx_cocoau_html.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D9F65758E0363AF9AEC59A47 /* libwx_osx_cocoau_html.dylib */; };
 		254028D56649374E8D3CC85D /* libwx_osx_cocoau_html.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D9F65758E0363AF9AEC59A47 /* libwx_osx_cocoau_html.dylib */; };
 		2563C775427E3D68BD384F2F /* richtextstyles.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D30617843F33310089C1F77A /* richtextstyles.cpp */; };
@@ -841,9 +844,6 @@
 		42ED9BAFD6E936849F1D36CB /* xtixml.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4048A3523EC03409BD899BEF /* xtixml.cpp */; };
 		42ED9BAFD6E936849F1D36CC /* xtixml.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4048A3523EC03409BD899BEF /* xtixml.cpp */; };
 		42ED9BAFD6E936849F1D36CD /* xtixml.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4048A3523EC03409BD899BEF /* xtixml.cpp */; };
-		437519A6002A3A0FB2C9A8FC /* settings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6CC2B05353C3284B37B2DD7 /* settings.cpp */; };
-		437519A6002A3A0FB2C9A8FD /* settings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6CC2B05353C3284B37B2DD7 /* settings.cpp */; };
-		437519A6002A3A0FB2C9A8FE /* settings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6CC2B05353C3284B37B2DD7 /* settings.cpp */; };
 		438EAEA4B30C325C827F6197 /* xh_fontpicker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 87E609641B583666AB9D1D58 /* xh_fontpicker.cpp */; };
 		438EAEA4B30C325C827F6198 /* xh_fontpicker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 87E609641B583666AB9D1D58 /* xh_fontpicker.cpp */; };
 		438EAEA4B30C325C827F6199 /* xh_fontpicker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 87E609641B583666AB9D1D58 /* xh_fontpicker.cpp */; };
@@ -3935,6 +3935,7 @@
 		242BF97B558634A79322052C /* prntbase.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = prntbase.cpp; path = ../../src/common/prntbase.cpp; sourceTree = "<group>"; };
 		24396D584D053948A3FF0DCD /* imagpng.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = imagpng.cpp; path = ../../src/common/imagpng.cpp; sourceTree = "<group>"; };
 		24930711031D35288D28B04B /* choiccmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = choiccmn.cpp; path = ../../src/common/choiccmn.cpp; sourceTree = "<group>"; };
+		24AC00E61BA6C3900042A970 /* settings.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = settings.mm; path = ../../src/osx/cocoa/settings.mm; sourceTree = "<group>"; };
 		24BD2EF635673E819B8406CB /* LexRust.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexRust.cxx; path = ../../src/stc/scintilla/lexers/LexRust.cxx; sourceTree = "<group>"; };
 		24DF23D67E693D999B875101 /* toolbkg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = toolbkg.cpp; path = ../../src/generic/toolbkg.cpp; sourceTree = "<group>"; };
 		24E82A05E9A9323287CDB15B /* artstd.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = artstd.cpp; path = ../../src/common/artstd.cpp; sourceTree = "<group>"; };
@@ -4626,7 +4627,6 @@
 		E5357E76650035639844D15B /* stringimpl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = stringimpl.cpp; path = ../../src/common/stringimpl.cpp; sourceTree = "<group>"; };
 		E5A9B63746753EDFB2EC48D3 /* xh_frame.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_frame.cpp; path = ../../src/xrc/xh_frame.cpp; sourceTree = "<group>"; };
 		E6AB648BC5173104A96CAE66 /* xml.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xml.cpp; path = ../../src/xml/xml.cpp; sourceTree = "<group>"; };
-		E6CC2B05353C3284B37B2DD7 /* settings.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = settings.cpp; path = ../../src/osx/carbon/settings.cpp; sourceTree = "<group>"; };
 		E72CF5F9C1E53BCFAA2BC253 /* KeyMap.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = KeyMap.cxx; path = ../../src/stc/scintilla/src/KeyMap.cxx; sourceTree = "<group>"; };
 		E72F0A2EE3DB34E193D8CCA7 /* LexLaTeX.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexLaTeX.cxx; path = ../../src/stc/scintilla/lexers/LexLaTeX.cxx; sourceTree = "<group>"; };
 		E78CBF86AAE637CB982B2EC0 /* LexMarkdown.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexMarkdown.cxx; path = ../../src/stc/scintilla/lexers/LexMarkdown.cxx; sourceTree = "<group>"; };
@@ -5289,7 +5289,6 @@
 				2128AD8BD12E3F33AD57478E /* overlay.cpp */,
 				530DC2E26BF2313E8702AD43 /* popupwin.cpp */,
 				425BFA3FDB7D3EA7ADCE1087 /* renderer.cpp */,
-				E6CC2B05353C3284B37B2DD7 /* settings.cpp */,
 				E1F2E9C9052D3E53BBD17DE3 /* statbrma.cpp */,
 				00DA3D3EEF5E305CA73A1871 /* region.cpp */,
 				2AFC4A1CDA473688A590D19F /* utilscocoa.mm */,
@@ -5330,6 +5329,7 @@
 				835C22B71A0F3C469310E1E0 /* preferences.mm */,
 				C9E32802E8ED3E729FF34CFC /* printdlg.mm */,
 				CC2E24773D853A77B9FEFA4C /* scrolbar.mm */,
+				24AC00E61BA6C3900042A970 /* settings.mm */,
 				9B862D1027C4367BBF44420F /* slider.mm */,
 				3C4A7A93CAFC3E22A2A5F7F3 /* spinbutt.mm */,
 				14EF4B028AD63B4A885D29A1 /* srchctrl.mm */,
@@ -6883,6 +6883,8 @@
 /* Begin PBXProject section */
 		19367367C9323490BB936F06 /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = 6976B5F5F3A63A21A92029E3 /* Build configuration list for PBXProject "wxcocoa" */;
 			compatibilityVersion = "Xcode 3.1";
 			developmentRegion = English;
@@ -7448,6 +7450,7 @@
 				A3321FE2A87D3BD69E0BB00B /* notebook_osx.cpp in Sources */,
 				0C9A379D97B133FA831175A9 /* printdlg_osx.cpp in Sources */,
 				B1775EF7C72233408044034D /* radiobox_osx.cpp in Sources */,
+				24AC00E91BA6C3900042A970 /* settings.mm in Sources */,
 				6A081BF19747385CB4C18781 /* radiobut_osx.cpp in Sources */,
 				DF8CE011EAC23F73BDA1C44F /* scrolbar_osx.cpp in Sources */,
 				27E73CA5C35A30CE89946ECC /* slider_osx.cpp in Sources */,
@@ -7484,7 +7487,6 @@
 				CD2A9111B8A83AFA8B5B97E7 /* overlay.cpp in Sources */,
 				805CCAE64D023561AD334B55 /* popupwin.cpp in Sources */,
 				6832385DDBB33D1B90C73CBC /* renderer.cpp in Sources */,
-				437519A6002A3A0FB2C9A8FE /* settings.cpp in Sources */,
 				F6A1AC5CF84E32C19F91A616 /* statbrma.cpp in Sources */,
 				D070C3BE95483FE38BABA1C0 /* region.cpp in Sources */,
 				07158EBC05A637ECA9DC7B51 /* utilscocoa.mm in Sources */,
@@ -8155,7 +8157,6 @@
 				CD2A9111B8A83AFA8B5B97E6 /* overlay.cpp in Sources */,
 				805CCAE64D023561AD334B54 /* popupwin.cpp in Sources */,
 				6832385DDBB33D1B90C73CBB /* renderer.cpp in Sources */,
-				437519A6002A3A0FB2C9A8FD /* settings.cpp in Sources */,
 				F6A1AC5CF84E32C19F91A615 /* statbrma.cpp in Sources */,
 				D070C3BE95483FE38BABA1BF /* region.cpp in Sources */,
 				07158EBC05A637ECA9DC7B50 /* utilscocoa.mm in Sources */,
@@ -8376,6 +8377,7 @@
 				B84642DA949638A189032CE7 /* http.cpp in Sources */,
 				6CA1BAEBBDB4336E9E201F96 /* protocol.cpp in Sources */,
 				E39021D3CDCD33BAA646B007 /* sckaddr.cpp in Sources */,
+				24AC00E81BA6C3900042A970 /* settings.mm in Sources */,
 				9F608A33D52D327FAA295625 /* sckfile.cpp in Sources */,
 				BCD81FD3D1EC305F801E1C1C /* sckipc.cpp in Sources */,
 				A3A898DA3114311EB7F02228 /* sckstrm.cpp in Sources */,
@@ -9346,7 +9348,6 @@
 				CD2A9111B8A83AFA8B5B97E5 /* overlay.cpp in Sources */,
 				805CCAE64D023561AD334B53 /* popupwin.cpp in Sources */,
 				6832385DDBB33D1B90C73CBA /* renderer.cpp in Sources */,
-				437519A6002A3A0FB2C9A8FC /* settings.cpp in Sources */,
 				F6A1AC5CF84E32C19F91A614 /* statbrma.cpp in Sources */,
 				D070C3BE95483FE38BABA1BE /* region.cpp in Sources */,
 				07158EBC05A637ECA9DC7B4F /* utilscocoa.mm in Sources */,
@@ -9567,6 +9568,7 @@
 				B84642DA949638A189032CE6 /* http.cpp in Sources */,
 				6CA1BAEBBDB4336E9E201F95 /* protocol.cpp in Sources */,
 				E39021D3CDCD33BAA646B006 /* sckaddr.cpp in Sources */,
+				24AC00E71BA6C3900042A970 /* settings.mm in Sources */,
 				9F608A33D52D327FAA295624 /* sckfile.cpp in Sources */,
 				BCD81FD3D1EC305F801E1C1B /* sckipc.cpp in Sources */,
 				A3A898DA3114311EB7F02227 /* sckstrm.cpp in Sources */,

--- a/src/osx/cocoa/settings.mm
+++ b/src/osx/cocoa/settings.mm
@@ -1,0 +1,243 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        src/osx/cocoa/settings.mm
+// Purpose:     wxSettings
+// Author:      David Elliott
+// Modified by: Tobias Taschner
+// Created:     2005/01/11
+// Copyright:   (c) 2005 David Elliott
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
+#include "wx/wxprec.h"
+
+#include "wx/settings.h"
+
+#ifndef WX_PRECOMP
+    #include "wx/utils.h"
+    #include "wx/gdicmn.h"
+#endif
+
+#include "wx/osx/core/private.h"
+
+#import <AppKit/NSColor.h>
+
+// ----------------------------------------------------------------------------
+// wxSystemSettingsNative
+// ----------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------
+// colours
+// ----------------------------------------------------------------------------
+
+wxColour wxSystemSettingsNative::GetColour(wxSystemColour index)
+{
+    NSColor* sysColor = nil;
+    switch( index )
+    {
+    case wxSYS_COLOUR_SCROLLBAR:
+        sysColor = [NSColor scrollBarColor]; // color of slot
+        break;
+    case wxSYS_COLOUR_DESKTOP: // No idea how to get desktop background
+        // fall through, window background is reasonable
+    case wxSYS_COLOUR_ACTIVECAPTION: // No idea how to get this
+        // fall through, window background is reasonable
+    case wxSYS_COLOUR_INACTIVECAPTION: // No idea how to get this
+        // fall through, window background is reasonable
+    case wxSYS_COLOUR_MENU:
+    case wxSYS_COLOUR_MENUBAR:
+    case wxSYS_COLOUR_WINDOW:
+    case wxSYS_COLOUR_WINDOWFRAME:
+    case wxSYS_COLOUR_ACTIVEBORDER:
+    case wxSYS_COLOUR_INACTIVEBORDER:
+    case wxSYS_COLOUR_GRADIENTACTIVECAPTION:
+    case wxSYS_COLOUR_GRADIENTINACTIVECAPTION:
+        sysColor = [NSColor windowFrameColor];
+        break;
+    case wxSYS_COLOUR_BTNFACE:
+        sysColor = [NSColor controlColor];
+        break;
+    case wxSYS_COLOUR_LISTBOX:
+        sysColor = [NSColor controlBackgroundColor];
+        break;
+    case wxSYS_COLOUR_BTNSHADOW:
+        sysColor = [NSColor controlShadowColor];
+        break;
+    case wxSYS_COLOUR_BTNTEXT:
+    case wxSYS_COLOUR_MENUTEXT:
+    case wxSYS_COLOUR_WINDOWTEXT:
+    case wxSYS_COLOUR_CAPTIONTEXT:
+    case wxSYS_COLOUR_INFOTEXT:
+    case wxSYS_COLOUR_INACTIVECAPTIONTEXT:
+    case wxSYS_COLOUR_LISTBOXTEXT:
+        sysColor = [NSColor controlTextColor];
+        break;
+    case wxSYS_COLOUR_HIGHLIGHT:
+        sysColor = [NSColor selectedControlColor];
+        break;
+    case wxSYS_COLOUR_BTNHIGHLIGHT:
+        sysColor = [NSColor controlHighlightColor];
+        break;
+    case wxSYS_COLOUR_GRAYTEXT:
+        sysColor = [NSColor disabledControlTextColor];
+        break;
+    case wxSYS_COLOUR_3DDKSHADOW:
+        sysColor = [NSColor controlShadowColor];
+        break;
+    case wxSYS_COLOUR_3DLIGHT:
+        sysColor = [NSColor controlHighlightColor];
+        break;
+    case wxSYS_COLOUR_HIGHLIGHTTEXT:
+    case wxSYS_COLOUR_LISTBOXHIGHLIGHTTEXT:
+        sysColor = [NSColor alternateSelectedControlTextColor];
+        break;
+    case wxSYS_COLOUR_INFOBK:
+        // tooltip (bogus)
+        sysColor = [NSColor windowFrameColor];
+        break;
+    case wxSYS_COLOUR_APPWORKSPACE:
+        // MDI window color (bogus)
+        sysColor = [NSColor windowBackgroundColor];
+        break;
+    case wxSYS_COLOUR_HOTLIGHT:
+        // OSX doesn't change color on mouse hover
+        sysColor = [NSColor controlTextColor];
+        break;
+    case wxSYS_COLOUR_MENUHILIGHT:
+        sysColor = [NSColor selectedMenuItemColor];
+        break;
+    case wxSYS_COLOUR_MAX:
+    default:
+        if(index>=wxSYS_COLOUR_MAX)
+        {
+            wxFAIL_MSG(wxT("Invalid system colour index"));
+            return wxColour();
+        }
+    }
+    
+    if ( sysColor )
+    {
+        CGColorRef cgCol = sysColor.CGColor;
+        // wxColour takes ownership of CF reference
+        CFRetain(cgCol);
+        return wxColour(cgCol);
+    }
+    else
+    {
+        wxFAIL_MSG(wxT("Unimplemented system colour index"));
+        return wxColour();
+    }
+}
+
+// ----------------------------------------------------------------------------
+// fonts
+// ----------------------------------------------------------------------------
+
+wxFont wxSystemSettingsNative::GetFont(wxSystemFont index)
+{
+    switch (index)
+    {
+        case wxSYS_ANSI_VAR_FONT :
+        case wxSYS_SYSTEM_FONT :
+        case wxSYS_DEVICE_DEFAULT_FONT :
+        case wxSYS_DEFAULT_GUI_FONT :
+            {
+                return *wxSMALL_FONT ;
+            } ;
+            break ;
+        case wxSYS_OEM_FIXED_FONT :
+        case wxSYS_ANSI_FIXED_FONT :
+        case wxSYS_SYSTEM_FIXED_FONT :
+        default :
+            {
+                return *wxNORMAL_FONT ;
+            } ;
+            break ;
+
+    }
+    return *wxNORMAL_FONT;
+}
+
+// ----------------------------------------------------------------------------
+// system metrics/features
+// ----------------------------------------------------------------------------
+
+// Get a system metric, e.g. scrollbar size
+int wxSystemSettingsNative::GetMetric(wxSystemMetric index, wxWindow *WXUNUSED(win))
+{
+    switch ( index )
+    {
+        case wxSYS_MOUSE_BUTTONS:
+                    return 2; // we emulate a two button mouse (ctrl + click = right button )
+
+        // TODO case wxSYS_BORDER_X:
+        // TODO case wxSYS_BORDER_Y:
+        // TODO case wxSYS_CURSOR_X:
+        // TODO case wxSYS_CURSOR_Y:
+        // TODO case wxSYS_DCLICK_X:
+        // TODO case wxSYS_DCLICK_Y:
+        // TODO case wxSYS_DRAG_X:
+        // TODO case wxSYS_DRAG_Y:
+        // TODO case wxSYS_EDGE_X:
+        // TODO case wxSYS_EDGE_Y:
+
+        case wxSYS_HSCROLL_ARROW_X:
+            return 16;
+        case wxSYS_HSCROLL_ARROW_Y:
+            return 16;
+        case wxSYS_HTHUMB_X:
+            return 16;
+
+        // TODO case wxSYS_ICON_X:
+        // TODO case wxSYS_ICON_Y:
+        // TODO case wxSYS_ICONSPACING_X:
+        // TODO case wxSYS_ICONSPACING_Y:
+        // TODO case wxSYS_WINDOWMIN_X:
+        // TODO case wxSYS_WINDOWMIN_Y:
+        // TODO case wxSYS_SCREEN_X:
+        // TODO case wxSYS_SCREEN_Y:
+        // TODO case wxSYS_FRAMESIZE_X:
+        // TODO case wxSYS_FRAMESIZE_Y:
+        // TODO case wxSYS_SMALLICON_X:
+        // TODO case wxSYS_SMALLICON_Y:
+
+        case wxSYS_HSCROLL_Y:
+            return 16;
+        case wxSYS_VSCROLL_X:
+            return 16;
+        case wxSYS_VSCROLL_ARROW_X:
+            return 16;
+        case wxSYS_VSCROLL_ARROW_Y:
+            return 16;
+        case wxSYS_VTHUMB_Y:
+            return 16;
+
+        // TODO case wxSYS_CAPTION_Y:
+        // TODO case wxSYS_MENU_Y:
+        // TODO case wxSYS_NETWORK_PRESENT:
+
+        case wxSYS_PENWINDOWS_PRESENT:
+            return 0;
+
+        // TODO case wxSYS_SHOW_SOUNDS:
+
+        case wxSYS_SWAP_BUTTONS:
+            return 0;
+
+        default:
+            return -1;  // unsupported metric
+    }
+    return 0;
+}
+
+bool wxSystemSettingsNative::HasFeature(wxSystemFeature index)
+{
+    switch (index)
+    {
+        case wxSYS_CAN_ICONIZE_FRAME:
+        case wxSYS_CAN_DRAW_FRAME_DECORATIONS:
+            return true;
+
+        default:
+            return false;
+    }
+}


### PR DESCRIPTION
Use of NSColor’s various system defined color values seem to get more appropriate colors than the carbon implementation.

See ticket [#17141](http://trac.wxwidgets.org/ticket/17141)
