### PR TITLE
Add ellipsizeMode parameter to wxRenderNative::DrawItemText().

### DIFF
--- a/include/wx/control.h
+++ b/include/wx/control.h
@@ -20,33 +20,10 @@
 #if wxUSE_CONTROLS
 
 #include "wx/window.h"      // base class
+#include "wx/gdicmn.h"      // wxEllipsize...
 
 extern WXDLLIMPEXP_DATA_CORE(const char) wxControlNameStr[];
 
-
-// ----------------------------------------------------------------------------
-// Ellipsize() constants
-// ----------------------------------------------------------------------------
-
-enum wxEllipsizeFlags
-{
-    wxELLIPSIZE_FLAGS_NONE = 0,
-    wxELLIPSIZE_FLAGS_PROCESS_MNEMONICS = 1,
-    wxELLIPSIZE_FLAGS_EXPAND_TABS = 2,
-
-    wxELLIPSIZE_FLAGS_DEFAULT = wxELLIPSIZE_FLAGS_PROCESS_MNEMONICS |
-                                wxELLIPSIZE_FLAGS_EXPAND_TABS
-};
-
-// NB: Don't change the order of these values, they're the same as in
-//     PangoEllipsizeMode enum.
-enum wxEllipsizeMode
-{
-    wxELLIPSIZE_NONE,
-    wxELLIPSIZE_START,
-    wxELLIPSIZE_MIDDLE,
-    wxELLIPSIZE_END
-};
 
 // ----------------------------------------------------------------------------
 // wxControl is the base class for all controls

--- a/include/wx/gdicmn.h
+++ b/include/wx/gdicmn.h
@@ -155,6 +155,30 @@ enum wxStockCursor
     #define wxCURSOR_CLOSED_HAND    wxCURSOR_HAND
 #endif
 
+// ----------------------------------------------------------------------------
+// Ellipsize() constants
+// ----------------------------------------------------------------------------
+
+enum wxEllipsizeFlags
+{
+    wxELLIPSIZE_FLAGS_NONE = 0,
+    wxELLIPSIZE_FLAGS_PROCESS_MNEMONICS = 1,
+    wxELLIPSIZE_FLAGS_EXPAND_TABS = 2,
+
+    wxELLIPSIZE_FLAGS_DEFAULT = wxELLIPSIZE_FLAGS_PROCESS_MNEMONICS |
+    wxELLIPSIZE_FLAGS_EXPAND_TABS
+};
+
+// NB: Don't change the order of these values, they're the same as in
+//     PangoEllipsizeMode enum.
+enum wxEllipsizeMode
+{
+    wxELLIPSIZE_NONE,
+    wxELLIPSIZE_START,
+    wxELLIPSIZE_MIDDLE,
+    wxELLIPSIZE_END
+};
+
 // ---------------------------------------------------------------------------
 // macros
 // ---------------------------------------------------------------------------

--- a/include/wx/renderer.h
+++ b/include/wx/renderer.h
@@ -346,7 +346,8 @@ public:
                               const wxString& text,
                               const wxRect& rect,
                               int align = wxALIGN_LEFT | wxALIGN_TOP,
-                              int flags = 0) = 0;
+                              int flags = 0,
+                              wxEllipsizeMode ellipsizeMode = wxELLIPSIZE_END) = 0;
 
     // geometry functions
     // ------------------
@@ -548,8 +549,9 @@ public:
                               const wxString& text,
                               const wxRect& rect,
                               int align = wxALIGN_LEFT | wxALIGN_TOP,
-                              int flags = 0)
-        { m_rendererNative.DrawItemText(win, dc, text, rect, align, flags); }
+                              int flags = 0,
+                              wxEllipsizeMode ellipsizeMode = wxELLIPSIZE_END)
+        { m_rendererNative.DrawItemText(win, dc, text, rect, align, flags, ellipsizeMode); }
 
     virtual wxSplitterRenderParams GetSplitterParams(const wxWindow *win)
         { return m_rendererNative.GetSplitterParams(win); }

--- a/interface/wx/control.h
+++ b/interface/wx/control.h
@@ -6,60 +6,6 @@
 /////////////////////////////////////////////////////////////////////////////
 
 /**
-    Flags used by wxControl::Ellipsize function.
-*/
-enum wxEllipsizeFlags
-{
-    /// No special flags.
-    wxELLIPSIZE_FLAGS_NONE = 0,
-
-    /**
-        Take mnemonics into account when calculating the text width.
-
-        With this flag when calculating the size of the passed string,
-        mnemonics characters (see wxControl::SetLabel) will be automatically
-        reduced to a single character. This leads to correct calculations only
-        if the string passed to Ellipsize() will be used with
-        wxControl::SetLabel. If you don't want ampersand to be interpreted as
-        mnemonics (e.g. because you use wxControl::SetLabelText) then don't use
-        this flag.
-     */
-    wxELLIPSIZE_FLAGS_PROCESS_MNEMONICS = 1,
-
-    /**
-        Expand tabs in spaces when calculating the text width.
-
-        This flag tells wxControl::Ellipsize() to calculate the width of tab
-        characters @c '\\t' as 6 spaces.
-     */
-    wxELLIPSIZE_FLAGS_EXPAND_TABS = 2,
-
-    /// The default flags for wxControl::Ellipsize.
-    wxELLIPSIZE_FLAGS_DEFAULT = wxELLIPSIZE_FLAGS_PROCESS_MNEMONICS|
-                                wxELLIPSIZE_FLAGS_EXPAND_TABS
-};
-
-
-/**
-    The different ellipsization modes supported by the
-    wxControl::Ellipsize function.
-*/
-enum wxEllipsizeMode
-{
-    /// Don't ellipsize the text at all. @since 2.9.1
-    wxELLIPSIZE_NONE,
-
-    /// Put the ellipsis at the start of the string, if the string needs ellipsization.
-    wxELLIPSIZE_START,
-
-    /// Put the ellipsis in the middle of the string, if the string needs ellipsization.
-    wxELLIPSIZE_MIDDLE,
-
-    /// Put the ellipsis at the end of the string, if the string needs ellipsization.
-    wxELLIPSIZE_END
-};
-
-/**
     @class wxControl
 
     This is the base class for a control or "widget".

--- a/interface/wx/gdicmn.h
+++ b/interface/wx/gdicmn.h
@@ -107,6 +107,60 @@ enum wxStockCursor
     wxCURSOR_MAX
 };
 
+/**
+    Flags used by wxControl::Ellipsize function.
+*/
+enum wxEllipsizeFlags
+{
+    /// No special flags.
+    wxELLIPSIZE_FLAGS_NONE = 0,
+
+    /**
+        Take mnemonics into account when calculating the text width.
+
+        With this flag when calculating the size of the passed string,
+        mnemonics characters (see wxControl::SetLabel) will be automatically
+        reduced to a single character. This leads to correct calculations only
+        if the string passed to Ellipsize() will be used with
+        wxControl::SetLabel. If you don't want ampersand to be interpreted as
+        mnemonics (e.g. because you use wxControl::SetLabelText) then don't use
+        this flag.
+     */
+    wxELLIPSIZE_FLAGS_PROCESS_MNEMONICS = 1,
+
+    /**
+        Expand tabs in spaces when calculating the text width.
+
+        This flag tells wxControl::Ellipsize() to calculate the width of tab
+        characters @c '\\t' as 6 spaces.
+     */
+    wxELLIPSIZE_FLAGS_EXPAND_TABS = 2,
+
+    /// The default flags for wxControl::Ellipsize.
+    wxELLIPSIZE_FLAGS_DEFAULT = wxELLIPSIZE_FLAGS_PROCESS_MNEMONICS|
+                                wxELLIPSIZE_FLAGS_EXPAND_TABS
+};
+
+
+/**
+    The different ellipsization modes supported by the
+    wxControl::Ellipsize and wxRendererNative::DrawItemText() functions.
+*/
+enum wxEllipsizeMode
+{
+    /// Don't ellipsize the text at all. @since 2.9.1
+    wxELLIPSIZE_NONE,
+
+    /// Put the ellipsis at the start of the string, if the string needs ellipsization.
+    wxELLIPSIZE_START,
+
+    /// Put the ellipsis in the middle of the string, if the string needs ellipsization.
+    wxELLIPSIZE_MIDDLE,
+
+    /// Put the ellipsis at the end of the string, if the string needs ellipsization.
+    wxELLIPSIZE_END
+};
+
 
 
 /**

--- a/interface/wx/renderer.h
+++ b/interface/wx/renderer.h
@@ -430,7 +430,8 @@ public:
                               const wxString& text,
                               const wxRect& rect,
                               int align = wxALIGN_LEFT | wxALIGN_TOP,
-                              int flags = 0) = 0;
+                              int flags = 0,
+                              wxEllipsizeMode ellipsizeMode = wxELLIPSIZE_END) = 0;
 
     /**
         Draw a blank push button that looks very similar to wxButton.

--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -981,20 +981,6 @@ wxDataViewCustomRendererBase::RenderText(const wxString& text,
     rectText.x += xoffset;
     rectText.width -= xoffset;
 
-    // check if we want to ellipsize the text if it doesn't fit
-    wxString ellipsizedText;
-    if ( GetEllipsizeMode() != wxELLIPSIZE_NONE )
-    {
-        ellipsizedText = wxControl::Ellipsize
-                                    (
-                                        text,
-                                        *dc,
-                                        GetEllipsizeMode(),
-                                        rectText.width,
-                                        wxELLIPSIZE_FLAGS_NONE
-                                    );
-    }
-
     int flags = 0;
     if ( state & wxDATAVIEW_CELL_SELECTED )
         flags |= wxCONTROL_SELECTED | wxCONTROL_FOCUSED;
@@ -1005,10 +991,11 @@ wxDataViewCustomRendererBase::RenderText(const wxString& text,
     wxRendererNative::Get().DrawItemText(
         GetOwner()->GetOwner(),
         *dc,
-        ellipsizedText.empty() ? text : ellipsizedText,
+        text,
         rectText,
         GetEffectiveAlignment(),
-        flags);
+        flags,
+        GetEllipsizeMode());
 }
 
 void wxDataViewCustomRendererBase::SetEnabled(bool enabled)

--- a/src/generic/renderg.cpp
+++ b/src/generic/renderg.cpp
@@ -884,7 +884,7 @@ void wxRendererGeneric::DrawGauge(wxWindow* win,
 }
 
 void
-wxRendererGeneric::DrawItemText(wxWindow* win,
+wxRendererGeneric::DrawItemText(wxWindow* WXUNUSED(win),
                                 wxDC& dc,
                                 const wxString& text,
                                 const wxRect& rect,
@@ -909,17 +909,14 @@ wxRendererGeneric::DrawItemText(wxWindow* win,
     {
         textColour = wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT);
     }
-    else // enabled but not selected
-    {
-        textColour = win->GetForegroundColour();
-    }
 
     const wxString paintText = wxControl::Ellipsize(text, dc,
                                                     ellipsizeMode,
                                                     rect.GetWidth());
 
     // Draw text
-    dc.SetTextForeground(textColour);
+    if (textColour.IsOk())
+        dc.SetTextForeground(textColour);
     dc.SetTextBackground(wxTransparentColour);
     dc.DrawLabel(paintText, rect, align);
 }

--- a/src/generic/renderg.cpp
+++ b/src/generic/renderg.cpp
@@ -150,7 +150,8 @@ public:
                               const wxString& text,
                               const wxRect& rect,
                               int align = wxALIGN_LEFT | wxALIGN_TOP,
-                              int flags = 0) wxOVERRIDE;
+                              int flags = 0,
+                              wxEllipsizeMode ellipsizeMode = wxELLIPSIZE_END) wxOVERRIDE;
 
     virtual wxSplitterRenderParams GetSplitterParams(const wxWindow *win) wxOVERRIDE;
 
@@ -888,7 +889,8 @@ wxRendererGeneric::DrawItemText(wxWindow* win,
                                 const wxString& text,
                                 const wxRect& rect,
                                 int align,
-                                int flags)
+                                int flags,
+                                wxEllipsizeMode ellipsizeMode)
 {
     // Determine text color
     wxColour textColour;
@@ -913,7 +915,7 @@ wxRendererGeneric::DrawItemText(wxWindow* win,
     }
 
     const wxString paintText = wxControl::Ellipsize(text, dc,
-                                                    wxELLIPSIZE_END,
+                                                    ellipsizeMode,
                                                     rect.GetWidth());
 
     // Draw text

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -616,6 +616,26 @@ int wxRendererMSW::GetHeaderButtonMargin(wxWindow *WXUNUSED(win))
 
 #if wxUSE_UXTHEME
 
+namespace
+{
+
+int GetListItemState(int flags)
+{
+    int itemState = (flags & wxCONTROL_CURRENT) ? LISS_HOT : LISS_NORMAL;
+    if (flags & wxCONTROL_SELECTED)
+    {
+        itemState = (flags & wxCONTROL_CURRENT) ? LISS_HOTSELECTED : LISS_SELECTED;
+        if (!(flags & wxCONTROL_FOCUSED))
+            itemState = LISS_SELECTEDNOTFOCUS;
+    }
+    if (flags & wxCONTROL_DISABLED)
+        itemState = LISS_DISABLED;
+
+    return itemState;
+}
+
+} // anonymous namespace
+
 /* static */
 wxRendererNative& wxRendererXP::Get()
 {
@@ -942,13 +962,7 @@ wxRendererXP::DrawItemSelectionRect(wxWindow *win,
 {
     wxUxThemeHandle hTheme(win, L"LISTVIEW");
 
-    int itemState = LISS_NORMAL;
-    if ( flags & wxCONTROL_SELECTED )
-        itemState = LISS_SELECTED;
-    if ( !(flags & wxCONTROL_FOCUSED) )
-        itemState = LISS_SELECTEDNOTFOCUS;
-    if ( flags & wxCONTROL_DISABLED )
-        itemState |= LISS_DISABLED;
+    int itemState = GetListItemState(flags);
 
     wxUxThemeEngine* const te = wxUxThemeEngine::Get();
     if ( te->IsThemePartDefined(hTheme, LVP_LISTITEM, itemState) )
@@ -976,13 +990,7 @@ void wxRendererXP::DrawItemText(wxWindow* win,
 {
     wxUxThemeHandle hTheme(win, L"LISTVIEW");
 
-    int itemState = LISS_NORMAL;
-    if ( flags & wxCONTROL_SELECTED )
-        itemState = LISS_SELECTED;
-    if ( !(flags & wxCONTROL_FOCUSED) )
-        itemState = LISS_SELECTEDNOTFOCUS;
-    if ( flags & wxCONTROL_DISABLED )
-        itemState |= LISS_DISABLED;
+    int itemState = GetListItemState(flags);
 
     wxUxThemeEngine* te = wxUxThemeEngine::Get();
     if ( te->DrawThemeTextEx && // Might be not available if we're under XP
@@ -1002,7 +1010,7 @@ void wxRendererXP::DrawItemText(wxWindow* win,
         }
 
         DWORD textFlags = DT_NOPREFIX;
-        if ( align & wxALIGN_CENTER )
+        if ( align & wxALIGN_CENTER_HORIZONTAL )
             textFlags |= DT_CENTER;
         else if ( align & wxALIGN_RIGHT )
             textFlags |= DT_RIGHT;


### PR DESCRIPTION
Instead of the default end ellipsize mode used in the native and generic implementation, allow specifying the mode with an additional parameter. `wxEllipsizeMode` has been moved from `controls.h` to `gdicmn.h`.
