### PR TITLE
Suppress clang warnings

### DIFF
--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -696,6 +696,29 @@ typedef short int WXTYPE;
 #endif
 
 /*
+   Macros to suppress and restore clang warning only when it is valid.
+
+   Example:
+        wxCLANG_WARNING_SUPPRESS(inconsistent-missing-override)
+        virtual wxClassInfo *GetClassInfo() const
+        wxCLANG_WARNING_RESTORE(inconsistent-missing-override)
+*/
+#if defined(__has_warning)
+#    define wxCLANG_HAS_WARNING(x) __has_warning(x) /* allow macro expansion for the warning name */
+#    define wxCLANG_IF_VALID_WARNING(x,y) \
+         wxCONCAT(wxCLANG_IF_VALID_WARNING_,wxCLANG_HAS_WARNING(wxSTRINGIZE(wxCONCAT(-W,x))))(y)
+#    define wxCLANG_IF_VALID_WARNING_0(x)
+#    define wxCLANG_IF_VALID_WARNING_1(x) x
+#    define wxCLANG_WARNING_SUPPRESS(x) \
+         wxCLANG_IF_VALID_WARNING(x,wxGCC_WARNING_SUPPRESS(x))
+#    define wxCLANG_WARNING_RESTORE(x) \
+         wxCLANG_IF_VALID_WARNING(x,wxGCC_WARNING_RESTORE(x))
+#else
+#    define wxCLANG_WARNING_SUPPRESS(x)
+#    define wxCLANG_WARNING_RESTORE(x)
+#endif
+
+/*
     Combination of the two variants above: should be used for deprecated
     functions which are defined inline and are used by wxWidgets itself.
  */

--- a/include/wx/richtext/richtextuicustomization.h
+++ b/include/wx/richtext/richtextuicustomization.h
@@ -103,11 +103,13 @@ protected:
 /// of the formatting dialog.
 
 #define DECLARE_HELP_PROVISION() \
+    wxCLANG_WARNING_SUPPRESS(inconsistent-missing-override) \
     virtual long GetHelpId() const { return sm_helpInfo.GetHelpId(); } \
     virtual void SetHelpId(long id) { sm_helpInfo.SetHelpId(id); } \
     virtual wxRichTextUICustomization* GetUICustomization() const { return sm_helpInfo.GetUICustomization(); } \
     virtual void SetUICustomization(wxRichTextUICustomization* customization) { sm_helpInfo.SetUICustomization(customization); } \
     virtual bool ShowHelp(wxWindow* win) { return sm_helpInfo.ShowHelp(win); } \
+    wxCLANG_WARNING_RESTORE(inconsistent-missing-override) \
 public: \
     static wxRichTextHelpInfo& GetHelpInfo() { return sm_helpInfo; }\
 protected: \

--- a/include/wx/rtti.h
+++ b/include/wx/rtti.h
@@ -128,7 +128,9 @@ WXDLLIMPEXP_BASE wxObject *wxCreateDynamicObject(const wxString& name);
 #define wxDECLARE_ABSTRACT_CLASS(name)                                        \
     public:                                                                   \
         static wxClassInfo ms_classInfo;                                      \
-        virtual wxClassInfo *GetClassInfo() const
+        wxCLANG_WARNING_SUPPRESS(inconsistent-missing-override)               \
+        virtual wxClassInfo *GetClassInfo() const                             \
+        wxCLANG_WARNING_RESTORE(inconsistent-missing-override)
 
 #define wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(name)                               \
     wxDECLARE_NO_ASSIGN_CLASS(name);                                          \


### PR DESCRIPTION
This PR suppresses some clang warnings described below:
1. `GetClassInfo()` in `wxDECLARE_ABSTRACT_CLASS` [-Winconsistent-missing-override]
   This is a virtual function defined in the macro. Adding `override` to the function can potentially break user code (as commented in Trac), so I concluded that using compiler pragmas is the best fix (or workaroud) here.
   See also [Trac #17017](http://trac.wxwidgets.org/ticket/17017).
2. Some virtual functions defined in `DECLARE_HELP_PROVISION()` [-Winconsistent-missing-override]
   Similar situation to 1.
3. "Expression with side effects ..." in `WX_DECLARE_ANY_VALUE_TYPE` [-Wpotentially-evaluated-expression]
   This one is reported and a fix was attempted in [Trac #16968](http://trac.wxwidgets.org/ticket/16968), but on my environment (clang 3.6.2 and 3.7.0), that fix was not working. So I'm just using pragmas to silence the compiler.

I added a pair of macros to silence these warnings, named `wxCLANG_WARNING_SUPPRESS_IF_VALID` and `wxCLANG_WARNING_RESTORE_IF_VALID`. They work like `wxGCC_WARNING_SUPPRESS` and `wxGCC_WARNING_RESTORE`, but only emit the pragma when the compiler recognizes the warning. So there will be no complaint of unknown-warning-name from GCC or older clang (~3.5).
