### PR TITLE
Remove remaining MSDOS support code.

### DIFF
--- a/docs/doxygen/mainpages/const_cpp.h
+++ b/docs/doxygen/mainpages/const_cpp.h
@@ -125,7 +125,6 @@ compiler used.
 @beginDefList
 @itemdef{__BORLANDC__, Borland C++. The value of the macro corresponds
                         to the compiler version: 500 is 5.0.}
-@itemdef{__DJGPP__, DJGPP}
 @itemdef{__DIGITALMARS__, Digital Mars (not used any more).}
 @itemdef{__GNUG__, Gnu C++ on any platform, see also wxCHECK_GCC_VERSION}
 @itemdef{__GNUWIN32__, Gnu-Win32 compiler, see also wxCHECK_W32API_VERSION}

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -1130,8 +1130,7 @@ typedef wxUint32 wxDword;
     #define wxLongLongFmtSpec "I64"
 #elif (defined(SIZEOF_LONG_LONG) && SIZEOF_LONG_LONG >= 8)  || \
         defined(__GNUC__) || \
-        defined(__CYGWIN__) || \
-        (defined(__DJGPP__) && __DJGPP__ >= 2)
+        defined(__CYGWIN__)
     #define wxLongLong_t long long
     #define wxLongLongSuffix ll
     #define wxLongLongFmtSpec "ll"

--- a/include/wx/filefn.h
+++ b/include/wx/filefn.h
@@ -32,13 +32,6 @@
 #endif // __WINDOWS__
 #endif // native Win compiler
 
-#if defined(__DOS__)
-    #ifdef __DJGPP__
-        #include <io.h>
-        #include <unistd.h>
-    #endif
-#endif
-
 #ifdef __BORLANDC__ // Please someone tell me which version of Borland needs
                     // this (3.1 I believe) and how to test for it.
                     // If this works for Borland 4.0 as well, then no worries.

--- a/include/wx/filename.h
+++ b/include/wx/filename.h
@@ -28,7 +28,7 @@ class WXDLLIMPEXP_FWD_BASE wxFFile;
 
 // this symbol is defined for the platforms where file systems use volumes in
 // paths
-#if defined(__WINDOWS__) || defined(__DOS__)
+#if defined(__WINDOWS__)
     #define wxHAS_FILESYSTEM_VOLUMES
 #endif
 

--- a/include/wx/math.h
+++ b/include/wx/math.h
@@ -75,7 +75,7 @@
     wxDECL_FOR_STRICT_MINGW32(int, _finite, (double))
 
     #define wxFinite(x) _finite(x)
-#elif ( defined(__GNUG__)||defined(__GNUWIN32__)||defined(__DJGPP__)|| \
+#elif ( defined(__GNUG__)||defined(__GNUWIN32__)|| \
       defined(__SGI_CC__)||defined(__SUNCC__)||defined(__XLC__)|| \
       defined(__HPUX__) ) && ( !defined(wxOSX_USE_IPHONE) || wxOSX_USE_IPHONE == 0 )
 #ifdef __SOLARIS__
@@ -89,7 +89,7 @@
 
 #if defined(__VISUALC__)||defined(__BORLAND__)
     #define wxIsNaN(x) _isnan(x)
-#elif defined(__GNUG__)||defined(__GNUWIN32__)||defined(__DJGPP__)|| \
+#elif defined(__GNUG__)||defined(__GNUWIN32__)|| \
       defined(__SGI_CC__)||defined(__SUNCC__)||defined(__XLC__)|| \
       defined(__HPUX__)
     #define wxIsNaN(x) isnan(x)

--- a/include/wx/platform.h
+++ b/include/wx/platform.h
@@ -238,21 +238,6 @@
 #endif /* __BORLANDC__ */
 
 /*
-   OS: first of all, test for MS-DOS platform. We must do this before testing
-       for Unix, because DJGPP compiler defines __unix__ under MS-DOS
- */
-#if defined(__GO32__) || defined(__DJGPP__) || defined(__DOS__)
-#    ifndef __DOS__
-#        define __DOS__
-#    endif
-    /* define it if it hadn't been done by configure yet */
-#    if !defined(wxSIZE_T_IS_UINT) && !defined(wxSIZE_T_IS_ULONG)
-#        ifdef __DJGPP__
-#            define wxSIZE_T_IS_ULONG
-#        endif
-#    endif
-
-/*
    OS: then test for generic Unix defines, then for particular flavours and
        finally for Unix-like systems
        Mac OS X matches this case (__MACH__), prior Mac OS do not.
@@ -369,7 +354,6 @@
  */
 #if ( defined( __GNUWIN32__ ) || defined( __MINGW32__ ) || \
     ( defined( __CYGWIN__ ) && defined( __WINDOWS__ ) ) ) && \
-    !defined(__DOS__) && \
     !defined(__WXMOTIF__) && \
     !defined(__WXX11__)
 #    include "wx/msw/gccpriv.h"

--- a/include/wx/wxcrtbase.h
+++ b/include/wx/wxcrtbase.h
@@ -228,7 +228,7 @@ extern unsigned long android_wcstoul(const wchar_t *nptr, wchar_t **endptr, int 
 
 /* define wxCRT_StricmpA/W and wxCRT_StrnicmpA/W for various compilers */
 
-#if defined(__BORLANDC__) || defined(__DJGPP__)
+#if defined(__BORLANDC__)
     #define wxCRT_StricmpA stricmp
     #define wxCRT_StrnicmpA strnicmp
 #elif defined(__VISUALC__)

--- a/src/common/file.cpp
+++ b/src/common/file.cpp
@@ -53,14 +53,6 @@
     #ifdef __GNUWIN32__
         #include "wx/msw/wrapwin.h"
     #endif
-#elif defined(__DOS__)
-    #if defined(__DJGPP__)
-       #include <io.h>
-       #include <unistd.h>
-       #include <stdio.h>
-    #else
-        #error  "Please specify the header with file functions declarations."
-    #endif
 #elif (defined(__WXSTUBS__))
     // Have to ifdef this for different environments
     #include <io.h>
@@ -483,7 +475,7 @@ bool wxFile::Eof() const
 
     wxFileOffset iRc;
 
-#if defined(__DOS__) || defined(__UNIX__) || defined(__GNUWIN32__)
+#if defined(__UNIX__) || defined(__GNUWIN32__)
     // @@ this doesn't work, of course, on unseekable file descriptors
     wxFileOffset ofsCur = Tell(),
     ofsMax = Length();

--- a/src/common/filefn.cpp
+++ b/src/common/filefn.cpp
@@ -1159,7 +1159,7 @@ bool wxMkdir(const wxString& dir, int perm)
 
     // assume mkdir() has 2 args on non Windows-OS/2 platforms and on Windows too
     // for the GNU compiler
-#elif (!(defined(__WINDOWS__) || defined(__DOS__))) || \
+#elif (!defined(__WINDOWS__)) || \
       (defined(__GNUWIN32__) && !defined(__MINGW32__)) ||                \
       defined(__WINE__)
     const wxChar *dirname = dir.c_str();
@@ -1169,14 +1169,7 @@ bool wxMkdir(const wxString& dir, int perm)
   #else
     if ( mkdir(wxFNCONV(dirname), perm) != 0 )
   #endif
-#elif defined(__DOS__)
-    const wxChar *dirname = dir.c_str();
-  #if defined(__DJGPP__)
-    if ( mkdir(wxFNCONV(dirname), perm) != 0 )
-  #else
-    #error "Unsupported DOS compiler!"
-  #endif
-#else  // !MSW, !DOS and !OS/2 VAC++
+#else  // !MSW and !OS/2 VAC++
     wxUnusedVar(perm);
     if ( wxMkDir(dir.fn_str()) != 0 )
 #endif // !MSW/MSW
@@ -1353,16 +1346,6 @@ wxChar *wxDoGetCwd(wxChar *buf, int sz)
     }
     else // ok, but we might need to massage the path into the right format
     {
-#ifdef __DJGPP__
-        // VS: DJGPP is a strange mix of DOS and UNIX API and returns paths
-        //     with / deliminers. We don't like that.
-        for (wxChar *ch = buf; *ch; ch++)
-        {
-            if (*ch == wxT('/'))
-                *ch = wxT('\\');
-        }
-#endif // __DJGPP__
-
 // MBN: we hope that in the case the user is compiling a GTK+/Motif app,
 //      he needs Unix as opposed to Win32 pathnames
 #if defined( __CYGWIN__ ) && defined( __WINDOWS__ )
@@ -1404,7 +1387,7 @@ wxString wxGetCwd()
 bool wxSetWorkingDirectory(const wxString& d)
 {
     bool success = false;
-#if defined(__UNIX__) || defined(__WXMAC__) || defined(__DOS__)
+#if defined(__UNIX__) || defined(__WXMAC__)
     success = (chdir(wxFNSTRINGCAST d.fn_str()) == 0);
 #elif defined(__WINDOWS__)
 

--- a/src/common/filename.cpp
+++ b/src/common/filename.cpp
@@ -118,10 +118,6 @@
 #include <unistd.h>
 #endif
 
-#ifdef __DJGPP__
-#include <unistd.h>
-#endif
-
 #ifndef S_ISREG
     #define S_ISREG(mode) ((mode) & S_IFREG)
 #endif
@@ -1000,11 +996,9 @@ static wxString wxCreateTempImpl(
     {
         path = wxConvFile.cMB2WX( (const char*) buf );
     }
-#else // !HAVE_MKTEMP (includes __DOS__)
+#else // !HAVE_MKTEMP
     // generate the unique file name ourselves
-    #if !defined(__DOS__)
     path << (unsigned int)getpid();
-    #endif
 
     wxString pathTry;
 
@@ -2280,7 +2274,7 @@ wxPathFormat wxFileName::GetFormat( wxPathFormat format )
 {
     if (format == wxPATH_NATIVE)
     {
-#if defined(__WINDOWS__) || defined(__DOS__)
+#if defined(__WINDOWS__)
         format = wxPATH_DOS;
 #elif defined(__VMS)
         format = wxPATH_VMS;

--- a/src/common/textbuf.cpp
+++ b/src/common/textbuf.cpp
@@ -36,7 +36,7 @@
 // default type is the native one
 
 const wxTextFileType wxTextBuffer::typeDefault =
-#if defined(__WINDOWS__) || defined(__DOS__)
+#if defined(__WINDOWS__)
   wxTextFileType_Dos;
 #elif defined(__UNIX__)
   wxTextFileType_Unix;

--- a/src/common/time.cpp
+++ b/src/common/time.cpp
@@ -71,7 +71,7 @@
     #include <sys/timeb.h>
 #endif
 
-#if defined(__DJGPP__) || defined(__WINE__)
+#if defined(__WINE__)
     #include <sys/timeb.h>
     #include <values.h>
 #endif
@@ -172,7 +172,7 @@ int wxGetTimeZone()
             gmtoffset += 3600;
     }
     return (int)gmtoffset;
-#elif defined(__DJGPP__) || defined(__WINE__)
+#elif defined(__WINE__)
     struct timeb tb;
     ftime(&tb);
     return tb.timezone*60;

--- a/src/generic/dirctrlg.cpp
+++ b/src/generic/dirctrlg.cpp
@@ -204,24 +204,7 @@ size_t wxGetAvailableDrives(wxArrayString &paths, wxArrayString &names, wxArrayI
 // wxIsDriveAvailable
 // ----------------------------------------------------------------------------
 
-#if defined(__DOS__)
-
-bool wxIsDriveAvailable(const wxString& dirName)
-{
-    if ( dirName.length() == 3 && dirName[1u] == wxT(':') )
-    {
-        wxString dirNameLower(dirName.Lower());
-        // VS: always return true for removable media, since Win95 doesn't
-        //     like it when MS-DOS app accesses empty floppy drive
-        return (dirNameLower[0u] == wxT('a') ||
-                dirNameLower[0u] == wxT('b') ||
-                wxDirExists(dirNameLower));
-    }
-    else
-        return true;
-}
-
-#elif defined(__WINDOWS__)
+#if defined(__WINDOWS__)
 
 int setdrive(int drive)
 {
@@ -444,7 +427,7 @@ bool wxGenericDirCtrl::Create(wxWindow *parent,
 
     wxString rootName;
 
-#if defined(__WINDOWS__) || defined(__DOS__)
+#if defined(__WINDOWS__)
     rootName = _("Computer");
 #else
     rootName = _("Sections");
@@ -702,7 +685,7 @@ void wxGenericDirCtrl::PopulateNode(wxTreeItemId parentId)
 
     wxString dirName(data->m_path);
 
-#if defined(__WINDOWS__) || defined(__DOS__)
+#if defined(__WINDOWS__)
     // Check if this is a root directory and if so,
     // whether the drive is available.
     if (!wxIsDriveAvailable(dirName))
@@ -716,7 +699,7 @@ void wxGenericDirCtrl::PopulateNode(wxTreeItemId parentId)
     // This may take a longish time. Go to busy cursor
     wxBusyCursor busy;
 
-#if defined(__WINDOWS__) || defined(__DOS__)
+#if defined(__WINDOWS__)
     if (dirName.Last() == ':')
         dirName += wxString(wxFILE_SEP_PATH);
 #endif
@@ -866,7 +849,7 @@ wxTreeItemId wxGenericDirCtrl::FindChild(wxTreeItemId parentId, const wxString& 
     path2 += wxString(wxFILE_SEP_PATH);
 
     // In MSW case is not significant
-#if defined(__WINDOWS__) || defined(__DOS__)
+#if defined(__WINDOWS__)
     path2.MakeLower();
 #endif
 
@@ -883,7 +866,7 @@ wxTreeItemId wxGenericDirCtrl::FindChild(wxTreeItemId parentId, const wxString& 
                 childPath += wxString(wxFILE_SEP_PATH);
 
             // In MSW case is not significant
-#if defined(__WINDOWS__) || defined(__DOS__)
+#if defined(__WINDOWS__)
             childPath.MakeLower();
 #endif
 

--- a/src/generic/dirdlgg.cpp
+++ b/src/generic/dirdlgg.cpp
@@ -94,13 +94,10 @@ bool wxGenericDirDialog::Create(wxWindow* parent,
     // 0) 'New' and 'Home' Buttons
     wxSizer* buttonsizer = new wxBoxSizer( wxHORIZONTAL );
 
-    // VS: 'Home directory' concept is unknown to MS-DOS
-#if !defined(__DOS__)
     wxBitmapButton* homeButton =
         new wxBitmapButton(this, ID_GO_HOME,
                            wxArtProvider::GetBitmap(wxART_GO_HOME, wxART_BUTTON));
     buttonsizer->Add( homeButton, 0, wxLEFT|wxRIGHT, 10 );
-#endif
 
     // I'm not convinced we need a New button, and we tend to get annoying
     // accidental-editing with label editing enabled.

--- a/src/generic/filectrlg.cpp
+++ b/src/generic/filectrlg.cpp
@@ -38,7 +38,7 @@
     #include "wx/msw/wrapwin.h"
 #endif
 
-#if defined(__DOS__) || defined(__WINDOWS__)
+#if defined(__WINDOWS__)
 #define IsTopMostDir(dir)   (dir.empty())
 #else
 #define IsTopMostDir(dir)   (dir == wxT("/"))
@@ -173,7 +173,7 @@ void wxFileData::ReadData()
         return;
     }
 
-#if defined(__DOS__) || defined(__WINDOWS__)
+#if defined(__WINDOWS__)
     // c:\.. is a drive don't stat it
     if ((m_fileName == wxT("..")) && (m_filePath.length() <= 5))
     {
@@ -181,7 +181,7 @@ void wxFileData::ReadData()
         m_size = 0;
         return;
     }
-#endif // __DOS__ || __WINDOWS__
+#endif // __WINDOWS__
 
     // OTHER PLATFORMS
 
@@ -498,7 +498,7 @@ void wxFileListCtrl::UpdateFiles()
     item.m_itemId = 0;
     item.m_col = 0;
 
-#if defined(__WINDOWS__) || defined(__DOS__) || defined(__WXMAC__)
+#if defined(__WINDOWS__) || defined(__WXMAC__)
     if ( IsTopMostDir(m_dirName) )
     {
         wxArrayString names, paths;
@@ -527,7 +527,7 @@ void wxFileListCtrl::UpdateFiles()
         }
     }
     else
-#endif // defined(__DOS__) || defined(__WINDOWS__)
+#endif // defined(__WINDOWS__) || defined(__WXMAC__)
     {
         // Real directory...
         if ( !IsTopMostDir(m_dirName) && !m_dirName.empty() )
@@ -544,10 +544,10 @@ void wxFileListCtrl::UpdateFiles()
         }
 
         wxString dirname(m_dirName);
-#if defined(__DOS__) || defined(__WINDOWS__)
+#if defined(__WINDOWS__)
         if (dirname.length() == 2 && dirname[1u] == wxT(':'))
             dirname << wxT('\\');
-#endif // defined(__DOS__) || defined(__WINDOWS__)
+#endif // defined(__WINDOWS__)
 
         if (dirname.empty())
             dirname = wxFILE_SEP_PATH;
@@ -669,7 +669,7 @@ void wxFileListCtrl::GoToParentDir()
             m_dirName.Remove( len-1, 1 );
         wxString fname( wxFileNameFromPath(m_dirName) );
         m_dirName = wxPathOnly( m_dirName );
-#if defined(__DOS__) || defined(__WINDOWS__)
+#if defined(__WINDOWS__)
         if (!m_dirName.empty())
         {
             if (m_dirName.Last() == wxT('.'))

--- a/src/generic/filedlgg.cpp
+++ b/src/generic/filedlgg.cpp
@@ -18,7 +18,7 @@
 #if wxUSE_FILEDLG
 
 // NOTE : it probably also supports MAC, untested
-#if !defined(__UNIX__) && !defined(__DOS__) && !defined(__WIN32__)
+#if !defined(__UNIX__) && !defined(__WIN32__)
 #error wxGenericFileDialog currently only supports Unix, win32 and DOS
 #endif
 
@@ -70,11 +70,11 @@
 
 #include <time.h>
 
-#if defined(__UNIX__) || defined(__DOS__)
+#if defined(__UNIX__)
 #include <unistd.h>
 #endif
 
-#if defined(__DOS__) || defined(__WINDOWS__)
+#if defined(__WINDOWS__)
 #define IsTopMostDir(dir)   (dir.empty())
 #else
 #define IsTopMostDir(dir)   (dir == wxT("/"))
@@ -103,9 +103,9 @@ wxBEGIN_EVENT_TABLE(wxGenericFileDialog,wxDialog)
     EVT_FILECTRL_FILEACTIVATED(ID_FILE_CTRL, wxGenericFileDialog::OnFileActivated)
 
     EVT_UPDATE_UI(ID_UP_DIR, wxGenericFileDialog::OnUpdateButtonsUI)
-#if defined(__DOS__) || defined(__WINDOWS__)
+#if defined(__WINDOWS__)
     EVT_UPDATE_UI(ID_NEW_DIR, wxGenericFileDialog::OnUpdateButtonsUI)
-#endif // defined(__DOS__) || defined(__WINDOWS__)
+#endif // defined(__WINDOWS__)
 wxEND_EVENT_TABLE()
 
 long wxGenericFileDialog::ms_lastViewStyle = wxLC_LIST;
@@ -204,11 +204,9 @@ bool wxGenericFileDialog::Create( wxWindow *parent,
     m_upDirButton = AddBitmapButton( ID_UP_DIR, wxART_GO_DIR_UP,
                                      _("Go to parent directory"), buttonsizer );
 
-#ifndef __DOS__ // VS: Home directory is meaningless in MS-DOS...
     AddBitmapButton( ID_HOME_DIR, wxART_GO_HOME,
                      _("Go to home directory"), buttonsizer );
     buttonsizer->Add( 20, 20 );
-#endif //!__DOS__
 
     m_newDirButton = AddBitmapButton( ID_NEW_DIR, wxART_NEW_DIR,
                                       _("Create new directory"), buttonsizer );


### PR DESCRIPTION
The remaining DOS source files where already removed in 26a0a24f3862b585c3f65e34b1725d97fa1ac54d. This removes the remaining `__DOS__` and  `__DJGPP__` (the DOS gcc) code paths.
