### PR TITLE
Fix wxUxThemeEngine on WinXP.

### DIFF
--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -983,7 +983,8 @@ void wxRendererXP::DrawItemText(wxWindow* win,
         itemState |= LISS_DISABLED;
 
     wxUxThemeEngine* te = wxUxThemeEngine::Get();
-    if ( te->IsThemePartDefined(hTheme, LVP_LISTITEM, itemState) )
+    if ( te->IsThemePartDefined(hTheme, LVP_LISTITEM, itemState) &&
+         te->DrawThemeTextEx)
     {
         RECT rc;
         wxCopyRectToRECT(rect, rc);

--- a/src/msw/uxtheme.cpp
+++ b/src/msw/uxtheme.cpp
@@ -112,11 +112,14 @@ bool wxUxThemeEngine::Initialize()
     // we're prepared to handle the errors
     wxLogNull noLog;
 
-    if ( !m_dllUxTheme.Load(wxT("uxtheme.dll")) )
+    if (!m_dllUxTheme.Load(wxT("uxtheme.dll")))
         return false;
 
+#define RESOLVE_OPTIONAL_UXTHEME_FUNCTION(type, funcname)                     \
+    funcname = (type)m_dllUxTheme.GetSymbol(wxT(#funcname))
+
 #define RESOLVE_UXTHEME_FUNCTION(type, funcname)                              \
-    funcname = (type)m_dllUxTheme.GetSymbol(wxT(#funcname));                   \
+    RESOLVE_OPTIONAL_UXTHEME_FUNCTION(type, funcname);						  \
     if ( !funcname )                                                          \
         return false
 
@@ -124,7 +127,7 @@ bool wxUxThemeEngine::Initialize()
     RESOLVE_UXTHEME_FUNCTION(PFNWXUCLOSETHEMEDATA, CloseThemeData);
     RESOLVE_UXTHEME_FUNCTION(PFNWXUDRAWTHEMEBACKGROUND, DrawThemeBackground);
     RESOLVE_UXTHEME_FUNCTION(PFNWXUDRAWTHEMETEXT, DrawThemeText);
-    RESOLVE_UXTHEME_FUNCTION(PFNWXUDRAWTHEMETEXTEX, DrawThemeTextEx);
+    RESOLVE_OPTIONAL_UXTHEME_FUNCTION(PFNWXUDRAWTHEMETEXTEX, DrawThemeTextEx);
     RESOLVE_UXTHEME_FUNCTION(PFNWXUGETTHEMEBACKGROUNDCONTENTRECT, GetThemeBackgroundContentRect);
     RESOLVE_UXTHEME_FUNCTION(PFNWXUGETTHEMEBACKGROUNDEXTENT, GetThemeBackgroundExtent);
     RESOLVE_UXTHEME_FUNCTION(PFNWXUGETTHEMEPARTSIZE, GetThemePartSize);


### PR DESCRIPTION
The recent addition of `DrawThemeTextEx` in b7a89f8746b8861712b4e066aaeca4f93083afea (Add wxRendererNative::DrawItemText() for list-like controls) broke initialization of uxtheme on WinXP as DrawThemeEx is only available on Vista+.
