### PR TITLE
Support for hiding all of a sizer's items in XRC

### DIFF
--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -2282,13 +2282,17 @@ Example of sizers XRC code:
 @endcode
 
 The sizer classes that can be used are listed below, together with their
-class-specific properties. All classes support the following properties:
+class-specific properties. All classes except wxStdDialogButtonSizer 
+support the following properties:
 
 @beginTable
 @hdr3col{property, type, description}
 @row3col{minsize, @ref overview_xrcformat_type_size,
     Minimal size that this sizer will have, see wxSizer::SetMinSize()
     (default: no min size).}
+@row3col{hideitems, @ref overview_xrcformat_type_bool,
+    Whether the sizer will be created with all its items hidden
+    (default: 0).}
 @endTable
 
 @subsection overview_xrcformat_wxboxsizer wxBoxSizer

--- a/misc/schema/xrc_schema.rnc
+++ b/misc/schema/xrc_schema.rnc
@@ -1772,6 +1772,11 @@ wxSizerGB_item =
         }*
     }
 
+# All sizer objects except wxStdDialogButtonSizer have these properties.
+stdSizerProperties = 
+        [xrc:p="o"] element minsize   {_, t_size }* &
+        [xrc:p="o"] element hideitems {_, t_bool }*
+
 # Notice that horizontal orientation is the default (only for backwards
 # compatibility reasons, it would make more sense to require always specifying
 # it probably).
@@ -1779,7 +1784,7 @@ wxBoxSizer_horz =
     element object {
         attribute class { "wxBoxSizer" } &
         stdObjectNodeAttributes &
-        [xrc:p="o"] element minsize {_, t_size }* &
+        stdSizerProperties &
         [xrc:p="o"] element orient {_, "wxHORIZONTAL" }* &
         (wxBoxSizer_horz_item | objectRef)*
     }
@@ -1788,7 +1793,7 @@ wxBoxSizer_vert =
     element object {
         attribute class { "wxBoxSizer" } &
         stdObjectNodeAttributes &
-        [xrc:p="o"] element minsize {_, t_size }* &
+        stdSizerProperties &
         element orient {_, "wxVERTICAL" } &
         (wxBoxSizer_vert_item | objectRef)*
     }
@@ -1797,7 +1802,7 @@ wxStaticBoxSizer_horz =
     element object {
         attribute class { "wxStaticBoxSizer" } &
         stdObjectNodeAttributes &
-        [xrc:p="o"] element minsize {_, t_size }* &
+        stdSizerProperties &
         [xrc:p="important"] element label {_, t_text }* &
         [xrc:p="o"] element orient  {_, "wxHORIZONTAL" }* &
         (wxBoxSizer_horz_item | objectRef)*
@@ -1807,7 +1812,7 @@ wxStaticBoxSizer_vert =
     element object {
         attribute class { "wxStaticBoxSizer" } &
         stdObjectNodeAttributes &
-        [xrc:p="o"] element minsize {_, t_size }* &
+        stdSizerProperties &
         [xrc:p="important"] element label {_, t_text }* &
         element orient {_, "wxVERTICAL" } &
         (wxBoxSizer_vert_item | objectRef)*
@@ -1817,7 +1822,7 @@ wxGridSizer =
     element object {
         attribute class { "wxGridSizer" } &
         stdObjectNodeAttributes &
-        [xrc:p="o"] element minsize {_, t_size }* &
+        stdSizerProperties &
         [xrc:p="o"] element rows    {_, t_unsigned }* &
         [xrc:p="o"] element cols    {_, t_unsigned }* &
         [xrc:p="o"] element vgap    {_, t_dimension }* &
@@ -1829,7 +1834,7 @@ wxFlexGridSizer =
     element object {
         attribute class { "wxFlexGridSizer" } &
         stdObjectNodeAttributes &
-        [xrc:p="o"] element minsize             {_, t_size }* &
+        stdSizerProperties &
         [xrc:p="o"] element rows                {_, t_unsigned }* &
         [xrc:p="o"] element cols                {_, t_unsigned }* &
         [xrc:p="o"] element vgap                {_, t_dimension }* &
@@ -1847,7 +1852,7 @@ wxGridBagSizer =
     element object {
         attribute class { "wxGridBagSizer" } &
         stdObjectNodeAttributes &
-        [xrc:p="o"] element minsize             {_, t_size }* &
+        stdSizerProperties &
         [xrc:p="o"] element vgap                {_, t_dimension }* &
         [xrc:p="o"] element hgap                {_, t_dimension }* &
         [xrc:p="o"] element flexibledirection   {_, ("wxVERTICAL" | "wxHORIZONTAL" | "wxBOTH") }* &
@@ -1863,7 +1868,7 @@ wxWrapSizer_horz =
     element object {
         attribute class { "wxWrapSizer" } &
         stdObjectNodeAttributes &
-        [xrc:p="o"] element minsize {_, t_size }* &
+        stdSizerProperties &
         [xrc:p="important"] element orient {_, "wxHORIZONTAL" }* &
         [xrc:p="o"] element flag    {_, t_style }* &
         (wxBoxSizer_horz_item | objectRef)*
@@ -1873,7 +1878,7 @@ wxWrapSizer_vert =
     element object {
         attribute class { "wxWrapSizer" } &
         stdObjectNodeAttributes &
-        [xrc:p="o"] element minsize {_, t_size }* &
+        stdSizerProperties &
         element orient {_, "wxVERTICAL" } &
         [xrc:p="o"] element flag    {_, t_style }* &
         (wxBoxSizer_vert_item | objectRef)*

--- a/src/xrc/xh_sizer.cpp
+++ b/src/xrc/xh_sizer.cpp
@@ -267,6 +267,10 @@ wxObject* wxSizerXmlHandler::Handle_sizer()
 
     CreateChildren(parent, true/*only this handler*/);
 
+    // This has to be done after CreateChildren().
+    if(GetBool(wxT("hideitems"), 0) == 1)
+        sizer->ShowItems(false);
+
     // set growable rows and cols for sizers which support this
     if ( wxFlexGridSizer *flexsizer = wxDynamicCast(sizer, wxFlexGridSizer) )
     {


### PR DESCRIPTION
Sizer objects don't have a `hidden` property (as window objects have) in XRC, which is consistent with `wxSizer` not having such a property. However, you can hide all of a sizer's items, which makes the sizer effectively hidden - this is the logic in the code as well. It would be useful to be able to express this directly in XRC, and that's what this tiny patch does - it allows one to specify `<hideitems>1</hideitems>` on a sizer, meaning the sizer will be created with all its items hidden.

This came up in this SO question: http://stackoverflow.com/q/32697966/4326278.
