### PR TITLE
Implement MSW native wxAuiTabArt

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1883,7 +1883,8 @@ AUIDLL_OBJECTS =  \
 	auidll_tabart.o \
 	auidll_xh_auinotbk.o \
 	auidll_xh_auitoolb.o \
-	$(__AUI_GTK_SRC_OBJECTS_2)
+	$(__AUI_GTK_SRC_OBJECTS_2) \
+	$(__AUI_PLATFORM_SRC_OBJECTS_2)
 AUIDLL_ODEP =  $(_____pch_wxprec_auidll_wx_wxprec_h_gch___depname)
 AUILIB_CXXFLAGS = $(__auilib_PCH_INC) -D__WX$(TOOLKIT)__ $(__WXUNIV_DEFINE_p) \
 	$(__DEBUG_DEFINE_p) $(__EXCEPTIONS_DEFINE_p) $(__RTTI_DEFINE_p) \
@@ -1900,7 +1901,8 @@ AUILIB_OBJECTS =  \
 	auilib_tabart.o \
 	auilib_xh_auinotbk.o \
 	auilib_xh_auitoolb.o \
-	$(__AUI_GTK_SRC_OBJECTS_3)
+	$(__AUI_GTK_SRC_OBJECTS_3) \
+	$(__AUI_PLATFORM_SRC_OBJECTS_3)
 AUILIB_ODEP =  $(_____pch_wxprec_auilib_wx_wxprec_h_gch___depname)
 RIBBONDLL_CXXFLAGS = $(__ribbondll_PCH_INC) -D__WX$(TOOLKIT)__ \
 	$(__WXUNIV_DEFINE_p) $(__DEBUG_DEFINE_p) $(__EXCEPTIONS_DEFINE_p) \
@@ -2226,6 +2228,7 @@ COND_TOOLKIT_MSW_WEBVIEW_HDR_PLATFORM =  \
 @COND_TOOLKIT_Qt@OPENGL_HDR_PLATFORM = wx/qt/glcanvas.h
 @COND_TOOLKIT_X11@OPENGL_HDR_PLATFORM = wx/x11/glcanvas.h wx/unix/glx11.h
 @COND_TOOLKIT_GTK_TOOLKIT_VERSION_2@AUI_GTK_HDR = wx/aui/tabartgtk.h
+@COND_TOOLKIT_MSW@AUI_PLATFORM_HDR = wx/aui/tabartmsw.h
 COND_TOOLKIT_OSX_CARBON_BASE_OSX_SRC =  \
 	src/osx/core/mimetype.cpp \
 	src/osx/core/cfstring.cpp \
@@ -4247,6 +4250,7 @@ COND_USE_GUI_1_ALL_GUI_HEADERS =  \
 	wx/xrc/xh_auinotbk.h \
 	wx/xrc/xh_auitoolb.h \
 	$(AUI_GTK_HDR) \
+	$(AUI_PLATFORM_HDR) \
 	wx/propgrid/advprops.h \
 	wx/propgrid/editors.h \
 	wx/propgrid/manager.h \
@@ -4554,6 +4558,7 @@ COND_USE_GUI_1___MONOLIB_GUI_SRC_OBJECTS =  \
 	monodll_xh_auinotbk.o \
 	monodll_xh_auitoolb.o \
 	$(__AUI_GTK_SRC_OBJECTS) \
+	$(__AUI_PLATFORM_SRC_OBJECTS) \
 	monodll_advprops.o \
 	monodll_editors.o \
 	monodll_manager.o \
@@ -6505,6 +6510,7 @@ COND_TOOLKIT_X11___ADVANCED_PLATFORM_SRC_OBJECTS_1 =  \
 @COND_TOOLKIT_MSW@__WEBVIEW_SRC_PLATFORM_OBJECTS = monodll_webview_ie.o
 @COND_TOOLKIT_GTK_TOOLKIT_VERSION_2@__AUI_GTK_SRC_OBJECTS \
 @COND_TOOLKIT_GTK_TOOLKIT_VERSION_2@	= monodll_tabartgtk.o
+@COND_TOOLKIT_MSW@__AUI_PLATFORM_SRC_OBJECTS = monodll_tabartmsw.o
 @COND_PLATFORM_UNIX_1_USE_PLUGINS_0@__PLUGIN_ADV_SRC_OBJECTS \
 @COND_PLATFORM_UNIX_1_USE_PLUGINS_0@	= monodll_sound_sdl.o
 @COND_PLATFORM_WIN32_1@__monodll___win32rc = monodll_version_rc.o
@@ -6716,6 +6722,7 @@ COND_USE_GUI_1___MONOLIB_GUI_SRC_OBJECTS_1 =  \
 	monolib_xh_auinotbk.o \
 	monolib_xh_auitoolb.o \
 	$(__AUI_GTK_SRC_OBJECTS_1) \
+	$(__AUI_PLATFORM_SRC_OBJECTS_1) \
 	monolib_advprops.o \
 	monolib_editors.o \
 	monolib_manager.o \
@@ -8669,6 +8676,7 @@ COND_TOOLKIT_X11___ADVANCED_PLATFORM_SRC_OBJECTS_3 =  \
 @COND_TOOLKIT_MSW@__WEBVIEW_SRC_PLATFORM_OBJECTS_1 = monolib_webview_ie.o
 @COND_TOOLKIT_GTK_TOOLKIT_VERSION_2@__AUI_GTK_SRC_OBJECTS_1 \
 @COND_TOOLKIT_GTK_TOOLKIT_VERSION_2@	= monolib_tabartgtk.o
+@COND_TOOLKIT_MSW@__AUI_PLATFORM_SRC_OBJECTS_1 = monolib_tabartmsw.o
 @COND_PLATFORM_UNIX_1_USE_PLUGINS_0@__PLUGIN_ADV_SRC_OBJECTS_1 \
 @COND_PLATFORM_UNIX_1_USE_PLUGINS_0@	= monolib_sound_sdl.o
 COND_MONOLITHIC_0_SHARED_1___basedll___depname = \
@@ -13565,6 +13573,7 @@ COND_USE_SOVERSOLARIS_1___auidll___so_symlinks_uninst_cmd = rm -f \
 @COND_PLATFORM_WIN32_1@__auidll___win32rc = auidll_version_rc.o
 @COND_TOOLKIT_GTK_TOOLKIT_VERSION_2@__AUI_GTK_SRC_OBJECTS_2 \
 @COND_TOOLKIT_GTK_TOOLKIT_VERSION_2@	= auidll_tabartgtk.o
+@COND_TOOLKIT_MSW@__AUI_PLATFORM_SRC_OBJECTS_2 = auidll_tabartmsw.o
 COND_MONOLITHIC_0_SHARED_0_USE_AUI_1___auilib___depname = \
 	$(LIBDIRNAME)/$(LIBPREFIX)wx_$(PORTNAME)$(WXUNIVNAME)$(WXUNICODEFLAG)$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)_aui-$(WX_RELEASE)$(HOST_SUFFIX)$(LIBEXT)
 @COND_MONOLITHIC_0_SHARED_0_USE_AUI_1@__auilib___depname = $(COND_MONOLITHIC_0_SHARED_0_USE_AUI_1___auilib___depname)
@@ -13579,6 +13588,7 @@ COND_MONOLITHIC_0_SHARED_0_USE_AUI_1___auilib___depname = \
 @COND_USE_PCH_1@	= ./.pch/wxprec_auilib/wx/wxprec.h.gch
 @COND_TOOLKIT_GTK_TOOLKIT_VERSION_2@__AUI_GTK_SRC_OBJECTS_3 \
 @COND_TOOLKIT_GTK_TOOLKIT_VERSION_2@	= auilib_tabartgtk.o
+@COND_TOOLKIT_MSW@__AUI_PLATFORM_SRC_OBJECTS_3 = auilib_tabartmsw.o
 @COND_SHARED_1@____wxaui_namedll_DEP = $(__auidll___depname)
 @COND_SHARED_0@____wxaui_namelib_DEP = $(__auilib___depname)
 COND_MONOLITHIC_0_SHARED_1_USE_RIBBON_1___ribbondll___depname = \
@@ -18251,6 +18261,9 @@ monodll_xh_auitoolb.o: $(srcdir)/src/xrc/xh_auitoolb.cpp $(MONODLL_ODEP)
 
 monodll_tabartgtk.o: $(srcdir)/src/aui/tabartgtk.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/aui/tabartgtk.cpp
+
+monodll_tabartmsw.o: $(srcdir)/src/aui/tabartmsw.cpp $(MONODLL_ODEP)
+	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/aui/tabartmsw.cpp
 
 monodll_advprops.o: $(srcdir)/src/propgrid/advprops.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/propgrid/advprops.cpp
@@ -23765,6 +23778,9 @@ monolib_xh_auitoolb.o: $(srcdir)/src/xrc/xh_auitoolb.cpp $(MONOLIB_ODEP)
 
 monolib_tabartgtk.o: $(srcdir)/src/aui/tabartgtk.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/aui/tabartgtk.cpp
+
+monolib_tabartmsw.o: $(srcdir)/src/aui/tabartmsw.cpp $(MONOLIB_ODEP)
+	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/aui/tabartmsw.cpp
 
 monolib_advprops.o: $(srcdir)/src/propgrid/advprops.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/propgrid/advprops.cpp
@@ -38346,6 +38362,9 @@ auidll_xh_auitoolb.o: $(srcdir)/src/xrc/xh_auitoolb.cpp $(AUIDLL_ODEP)
 auidll_tabartgtk.o: $(srcdir)/src/aui/tabartgtk.cpp $(AUIDLL_ODEP)
 	$(CXXC) -c -o $@ $(AUIDLL_CXXFLAGS) $(srcdir)/src/aui/tabartgtk.cpp
 
+auidll_tabartmsw.o: $(srcdir)/src/aui/tabartmsw.cpp $(AUIDLL_ODEP)
+	$(CXXC) -c -o $@ $(AUIDLL_CXXFLAGS) $(srcdir)/src/aui/tabartmsw.cpp
+
 auilib_framemanager.o: $(srcdir)/src/aui/framemanager.cpp $(AUILIB_ODEP)
 	$(CXXC) -c -o $@ $(AUILIB_CXXFLAGS) $(srcdir)/src/aui/framemanager.cpp
 
@@ -38375,6 +38394,9 @@ auilib_xh_auitoolb.o: $(srcdir)/src/xrc/xh_auitoolb.cpp $(AUILIB_ODEP)
 
 auilib_tabartgtk.o: $(srcdir)/src/aui/tabartgtk.cpp $(AUILIB_ODEP)
 	$(CXXC) -c -o $@ $(AUILIB_CXXFLAGS) $(srcdir)/src/aui/tabartgtk.cpp
+
+auilib_tabartmsw.o: $(srcdir)/src/aui/tabartmsw.cpp $(AUILIB_ODEP)
+	$(CXXC) -c -o $@ $(AUILIB_CXXFLAGS) $(srcdir)/src/aui/tabartmsw.cpp
 
 ribbondll_version_rc.o: $(srcdir)/src/msw/version.rc $(RIBBONDLL_ODEP)
 	$(WINDRES) -i$< -o$@    --define __WX$(TOOLKIT)__ $(__WXUNIV_DEFINE_p_67) $(__DEBUG_DEFINE_p_66)  $(__EXCEPTIONS_DEFINE_p_65) $(__RTTI_DEFINE_p_65) $(__THREAD_DEFINE_p_65)  --define WXBUILDING --define WXDLLNAME=$(WXDLLNAMEPREFIXGUI)$(WXUNICODEFLAG)$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)_ribbon$(WXCOMPILER)$(VENDORTAG)$(WXDLLVERSIONTAG) $(__RCDEFDIR_p) --include-dir $(top_srcdir)/include $(__INC_TIFF_BUILD_p_66) $(__INC_TIFF_p_66) $(__INC_JPEG_p_66) $(__INC_PNG_p_65) $(__INC_ZLIB_p_67) $(__INC_REGEX_p_65) $(__INC_EXPAT_p_65) --define WXUSINGDLL --define WXMAKINGDLL_RIBBON

--- a/build/bakefiles/files.bkl
+++ b/build/bakefiles/files.bkl
@@ -3653,6 +3653,18 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
         wx/aui/tabartgtk.h
     </if>
 </set>
+<set var="AUI_MSW_SRC" hints="files">
+    src/aui/tabartmsw.cpp
+</set>
+<set var="AUI_MSW_HDR" hints="files">
+    wx/aui/tabartmsw.h
+</set>
+<set var="AUI_PLATFORM_SRC" hints="files">
+    <if cond="TOOLKIT=='MSW'">$(AUI_MSW_SRC)</if>
+</set>
+<set var="AUI_PLATFORM_HDR" hints="files">
+    <if cond="TOOLKIT=='MSW'">$(AUI_MSW_HDR)</if>
+</set>
 <set var="AUI_CMN_SRC" hints="files">
     src/aui/framemanager.cpp
     src/aui/dockart.cpp
@@ -3667,6 +3679,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
 <set var="AUI_SRC" hints="files">
     $(AUI_CMN_SRC)
     $(AUI_GTK_SRC)
+    $(AUI_PLATFORM_SRC)
 </set>
 <set var="AUI_CMN_HDR" hints="files">
     wx/aui/framemanager.h
@@ -3683,6 +3696,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
 <set var="AUI_HDR" hints="files">
     $(AUI_CMN_HDR)
     $(AUI_GTK_HDR)
+    $(AUI_PLATFORM_HDR)
 </set>
 
 <!-- ====================================================================== -->

--- a/build/files
+++ b/build/files
@@ -3086,6 +3086,11 @@ AUI_CMN_HDR =
     wx/xrc/xh_auinotbk.h
     wx/xrc/xh_auitoolb.h
 
+AUI_MSW_HDR =
+    wx/aui/tabartmsw.h
+AUI_MSW_SRC =
+    src/aui/tabartmsw.cpp
+
 # wxRibbon
 
 RIBBON_SRC =

--- a/build/msw/makefile.bcc
+++ b/build/msw/makefile.bcc
@@ -1354,7 +1354,8 @@ AUIDLL_OBJECTS =  \
 	$(OBJS)\auidll_tabmdi.obj \
 	$(OBJS)\auidll_tabart.obj \
 	$(OBJS)\auidll_xh_auinotbk.obj \
-	$(OBJS)\auidll_xh_auitoolb.obj
+	$(OBJS)\auidll_xh_auitoolb.obj \
+	$(OBJS)\auidll_tabartmsw.obj
 AUILIB_CXXFLAGS = $(__RUNTIME_LIBS) -I$(BCCDIR)\include $(__DEBUGINFO) \
 	$(__OPTIMIZEFLAG) $(__THREADSFLAG) -D__WXMSW__ $(__WXUNIV_DEFINE_p) \
 	$(__DEBUG_DEFINE_p) $(__NDEBUG_DEFINE_p) $(__EXCEPTIONS_DEFINE_p) \
@@ -1373,7 +1374,8 @@ AUILIB_OBJECTS =  \
 	$(OBJS)\auilib_tabmdi.obj \
 	$(OBJS)\auilib_tabart.obj \
 	$(OBJS)\auilib_xh_auinotbk.obj \
-	$(OBJS)\auilib_xh_auitoolb.obj
+	$(OBJS)\auilib_xh_auitoolb.obj \
+	$(OBJS)\auilib_tabartmsw.obj
 RIBBONDLL_CXXFLAGS = $(__RUNTIME_LIBS) -I$(BCCDIR)\include $(__DEBUGINFO) \
 	$(__OPTIMIZEFLAG) $(__THREADSFLAG) -D__WXMSW__ $(__WXUNIV_DEFINE_p) \
 	$(__DEBUG_DEFINE_p) $(__NDEBUG_DEFINE_p) $(__EXCEPTIONS_DEFINE_p) \
@@ -1734,6 +1736,7 @@ ____MONOLIB_GUI_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_tabart.obj \
 	$(OBJS)\monodll_xh_auinotbk.obj \
 	$(OBJS)\monodll_xh_auitoolb.obj \
+	$(OBJS)\monodll_tabartmsw.obj \
 	$(OBJS)\monodll_advprops.obj \
 	$(OBJS)\monodll_editors.obj \
 	$(OBJS)\monodll_manager.obj \
@@ -2555,6 +2558,7 @@ ____MONOLIB_GUI_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_tabart.obj \
 	$(OBJS)\monolib_xh_auinotbk.obj \
 	$(OBJS)\monolib_xh_auitoolb.obj \
+	$(OBJS)\monolib_tabartmsw.obj \
 	$(OBJS)\monolib_advprops.obj \
 	$(OBJS)\monolib_editors.obj \
 	$(OBJS)\monolib_manager.obj \
@@ -7389,6 +7393,9 @@ $(OBJS)\monodll_xh_auinotbk.obj: ..\..\src\xrc\xh_auinotbk.cpp
 $(OBJS)\monodll_xh_auitoolb.obj: ..\..\src\xrc\xh_auitoolb.cpp
 	$(CXX) -q -c -P -o$@ $(MONODLL_CXXFLAGS) ..\..\src\xrc\xh_auitoolb.cpp
 
+$(OBJS)\monodll_tabartmsw.obj: ..\..\src\aui\tabartmsw.cpp
+	$(CXX) -q -c -P -o$@ $(MONODLL_CXXFLAGS) ..\..\src\aui\tabartmsw.cpp
+
 $(OBJS)\monodll_advprops.obj: ..\..\src\propgrid\advprops.cpp
 	$(CXX) -q -c -P -o$@ $(MONODLL_CXXFLAGS) ..\..\src\propgrid\advprops.cpp
 
@@ -9895,6 +9902,9 @@ $(OBJS)\monolib_xh_auinotbk.obj: ..\..\src\xrc\xh_auinotbk.cpp
 
 $(OBJS)\monolib_xh_auitoolb.obj: ..\..\src\xrc\xh_auitoolb.cpp
 	$(CXX) -q -c -P -o$@ $(MONOLIB_CXXFLAGS) ..\..\src\xrc\xh_auitoolb.cpp
+
+$(OBJS)\monolib_tabartmsw.obj: ..\..\src\aui\tabartmsw.cpp
+	$(CXX) -q -c -P -o$@ $(MONOLIB_CXXFLAGS) ..\..\src\aui\tabartmsw.cpp
 
 $(OBJS)\monolib_advprops.obj: ..\..\src\propgrid\advprops.cpp
 	$(CXX) -q -c -P -o$@ $(MONOLIB_CXXFLAGS) ..\..\src\propgrid\advprops.cpp
@@ -16082,6 +16092,9 @@ $(OBJS)\auidll_xh_auinotbk.obj: ..\..\src\xrc\xh_auinotbk.cpp
 $(OBJS)\auidll_xh_auitoolb.obj: ..\..\src\xrc\xh_auitoolb.cpp
 	$(CXX) -q -c -P -o$@ $(AUIDLL_CXXFLAGS) ..\..\src\xrc\xh_auitoolb.cpp
 
+$(OBJS)\auidll_tabartmsw.obj: ..\..\src\aui\tabartmsw.cpp
+	$(CXX) -q -c -P -o$@ $(AUIDLL_CXXFLAGS) ..\..\src\aui\tabartmsw.cpp
+
 $(OBJS)\auilib_dummy.obj: ..\..\src\common\dummy.cpp
 	$(CXX) -q -c -P -o$@ $(AUILIB_CXXFLAGS) -H ..\..\src\common\dummy.cpp
 
@@ -16111,6 +16124,9 @@ $(OBJS)\auilib_xh_auinotbk.obj: ..\..\src\xrc\xh_auinotbk.cpp
 
 $(OBJS)\auilib_xh_auitoolb.obj: ..\..\src\xrc\xh_auitoolb.cpp
 	$(CXX) -q -c -P -o$@ $(AUILIB_CXXFLAGS) ..\..\src\xrc\xh_auitoolb.cpp
+
+$(OBJS)\auilib_tabartmsw.obj: ..\..\src\aui\tabartmsw.cpp
+	$(CXX) -q -c -P -o$@ $(AUILIB_CXXFLAGS) ..\..\src\aui\tabartmsw.cpp
 
 $(OBJS)\ribbondll_dummy.obj: ..\..\src\common\dummy.cpp
 	$(CXX) -q -c -P -o$@ $(RIBBONDLL_CXXFLAGS) -H ..\..\src\common\dummy.cpp

--- a/build/msw/makefile.gcc
+++ b/build/msw/makefile.gcc
@@ -1360,7 +1360,8 @@ AUIDLL_OBJECTS =  \
 	$(OBJS)\auidll_tabmdi.o \
 	$(OBJS)\auidll_tabart.o \
 	$(OBJS)\auidll_xh_auinotbk.o \
-	$(OBJS)\auidll_xh_auitoolb.o
+	$(OBJS)\auidll_xh_auitoolb.o \
+	$(OBJS)\auidll_tabartmsw.o
 AUILIB_CXXFLAGS = $(__DEBUGINFO) $(__OPTIMIZEFLAG) $(__THREADSFLAG) $(GCCFLAGS) \
 	-DHAVE_W32API_H -D__WXMSW__ $(__WXUNIV_DEFINE_p) $(__DEBUG_DEFINE_p) \
 	$(__NDEBUG_DEFINE_p) $(__EXCEPTIONS_DEFINE_p) $(__RTTI_DEFINE_p) \
@@ -1379,7 +1380,8 @@ AUILIB_OBJECTS =  \
 	$(OBJS)\auilib_tabmdi.o \
 	$(OBJS)\auilib_tabart.o \
 	$(OBJS)\auilib_xh_auinotbk.o \
-	$(OBJS)\auilib_xh_auitoolb.o
+	$(OBJS)\auilib_xh_auitoolb.o \
+	$(OBJS)\auilib_tabartmsw.o
 RIBBONDLL_CXXFLAGS = $(__DEBUGINFO) $(__OPTIMIZEFLAG) $(__THREADSFLAG) \
 	$(GCCFLAGS) -DHAVE_W32API_H -D__WXMSW__ $(__WXUNIV_DEFINE_p) \
 	$(__DEBUG_DEFINE_p) $(__NDEBUG_DEFINE_p) $(__EXCEPTIONS_DEFINE_p) \
@@ -1752,6 +1754,7 @@ ____MONOLIB_GUI_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_tabart.o \
 	$(OBJS)\monodll_xh_auinotbk.o \
 	$(OBJS)\monodll_xh_auitoolb.o \
+	$(OBJS)\monodll_tabartmsw.o \
 	$(OBJS)\monodll_advprops.o \
 	$(OBJS)\monodll_editors.o \
 	$(OBJS)\monodll_manager.o \
@@ -2579,6 +2582,7 @@ ____MONOLIB_GUI_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_tabart.o \
 	$(OBJS)\monolib_xh_auinotbk.o \
 	$(OBJS)\monolib_xh_auitoolb.o \
+	$(OBJS)\monolib_tabartmsw.o \
 	$(OBJS)\monolib_advprops.o \
 	$(OBJS)\monolib_editors.o \
 	$(OBJS)\monolib_manager.o \
@@ -7564,6 +7568,9 @@ $(OBJS)\monodll_xh_auinotbk.o: ../../src/xrc/xh_auinotbk.cpp
 $(OBJS)\monodll_xh_auitoolb.o: ../../src/xrc/xh_auitoolb.cpp
 	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
 
+$(OBJS)\monodll_tabartmsw.o: ../../src/aui/tabartmsw.cpp
+	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
+
 $(OBJS)\monodll_advprops.o: ../../src/propgrid/advprops.cpp
 	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
 
@@ -10069,6 +10076,9 @@ $(OBJS)\monolib_xh_auinotbk.o: ../../src/xrc/xh_auinotbk.cpp
 	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\monolib_xh_auitoolb.o: ../../src/xrc/xh_auitoolb.cpp
+	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
+
+$(OBJS)\monolib_tabartmsw.o: ../../src/aui/tabartmsw.cpp
 	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\monolib_advprops.o: ../../src/propgrid/advprops.cpp
@@ -16257,6 +16267,9 @@ $(OBJS)\auidll_xh_auinotbk.o: ../../src/xrc/xh_auinotbk.cpp
 $(OBJS)\auidll_xh_auitoolb.o: ../../src/xrc/xh_auitoolb.cpp
 	$(CXX) -c -o $@ $(AUIDLL_CXXFLAGS) $(CPPDEPS) $<
 
+$(OBJS)\auidll_tabartmsw.o: ../../src/aui/tabartmsw.cpp
+	$(CXX) -c -o $@ $(AUIDLL_CXXFLAGS) $(CPPDEPS) $<
+
 $(OBJS)\auilib_dummy.o: ../../src/common/dummy.cpp
 	$(CXX) -c -o $@ $(AUILIB_CXXFLAGS) $(CPPDEPS) $<
 
@@ -16285,6 +16298,9 @@ $(OBJS)\auilib_xh_auinotbk.o: ../../src/xrc/xh_auinotbk.cpp
 	$(CXX) -c -o $@ $(AUILIB_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\auilib_xh_auitoolb.o: ../../src/xrc/xh_auitoolb.cpp
+	$(CXX) -c -o $@ $(AUILIB_CXXFLAGS) $(CPPDEPS) $<
+
+$(OBJS)\auilib_tabartmsw.o: ../../src/aui/tabartmsw.cpp
 	$(CXX) -c -o $@ $(AUILIB_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\ribbondll_dummy.o: ../../src/common/dummy.cpp

--- a/build/msw/makefile.vc
+++ b/build/msw/makefile.vc
@@ -1498,7 +1498,8 @@ AUIDLL_OBJECTS =  \
 	$(OBJS)\auidll_tabmdi.obj \
 	$(OBJS)\auidll_tabart.obj \
 	$(OBJS)\auidll_xh_auinotbk.obj \
-	$(OBJS)\auidll_xh_auitoolb.obj
+	$(OBJS)\auidll_xh_auitoolb.obj \
+	$(OBJS)\auidll_tabartmsw.obj
 AUIDLL_RESOURCES =  \
 	$(OBJS)\auidll_version.res
 AUILIB_CXXFLAGS = /M$(__RUNTIME_LIBS_472)$(__DEBUGRUNTIME) /DWIN32 \
@@ -1523,7 +1524,8 @@ AUILIB_OBJECTS =  \
 	$(OBJS)\auilib_tabmdi.obj \
 	$(OBJS)\auilib_tabart.obj \
 	$(OBJS)\auilib_xh_auinotbk.obj \
-	$(OBJS)\auilib_xh_auitoolb.obj
+	$(OBJS)\auilib_xh_auitoolb.obj \
+	$(OBJS)\auilib_tabartmsw.obj
 RIBBONDLL_CXXFLAGS = /M$(__RUNTIME_LIBS_488)$(__DEBUGRUNTIME) /DWIN32 \
 	$(__DEBUGINFO) \
 	/Fd$(LIBDIRNAME)\wx$(PORTNAME)$(WXUNIVNAME)$(WX_VERSION_NODOT)$(WXUNICODEFLAG)$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)_ribbon$(WXCOMPILER)$(VENDORTAG).pdb \
@@ -2034,6 +2036,7 @@ ____MONOLIB_GUI_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_tabart.obj \
 	$(OBJS)\monodll_xh_auinotbk.obj \
 	$(OBJS)\monodll_xh_auitoolb.obj \
+	$(OBJS)\monodll_tabartmsw.obj \
 	$(OBJS)\monodll_advprops.obj \
 	$(OBJS)\monodll_editors.obj \
 	$(OBJS)\monodll_manager.obj \
@@ -2861,6 +2864,7 @@ ____MONOLIB_GUI_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_tabart.obj \
 	$(OBJS)\monolib_xh_auinotbk.obj \
 	$(OBJS)\monolib_xh_auitoolb.obj \
+	$(OBJS)\monolib_tabartmsw.obj \
 	$(OBJS)\monolib_advprops.obj \
 	$(OBJS)\monolib_editors.obj \
 	$(OBJS)\monolib_manager.obj \
@@ -8081,6 +8085,9 @@ $(OBJS)\monodll_xh_auinotbk.obj: ..\..\src\xrc\xh_auinotbk.cpp
 $(OBJS)\monodll_xh_auitoolb.obj: ..\..\src\xrc\xh_auitoolb.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\xrc\xh_auitoolb.cpp
 
+$(OBJS)\monodll_tabartmsw.obj: ..\..\src\aui\tabartmsw.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\aui\tabartmsw.cpp
+
 $(OBJS)\monodll_advprops.obj: ..\..\src\propgrid\advprops.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\propgrid\advprops.cpp
 
@@ -10587,6 +10594,9 @@ $(OBJS)\monolib_xh_auinotbk.obj: ..\..\src\xrc\xh_auinotbk.cpp
 
 $(OBJS)\monolib_xh_auitoolb.obj: ..\..\src\xrc\xh_auitoolb.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\xrc\xh_auitoolb.cpp
+
+$(OBJS)\monolib_tabartmsw.obj: ..\..\src\aui\tabartmsw.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\aui\tabartmsw.cpp
 
 $(OBJS)\monolib_advprops.obj: ..\..\src\propgrid\advprops.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\propgrid\advprops.cpp
@@ -16774,6 +16784,9 @@ $(OBJS)\auidll_xh_auinotbk.obj: ..\..\src\xrc\xh_auinotbk.cpp
 $(OBJS)\auidll_xh_auitoolb.obj: ..\..\src\xrc\xh_auitoolb.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(AUIDLL_CXXFLAGS) ..\..\src\xrc\xh_auitoolb.cpp
 
+$(OBJS)\auidll_tabartmsw.obj: ..\..\src\aui\tabartmsw.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(AUIDLL_CXXFLAGS) ..\..\src\aui\tabartmsw.cpp
+
 $(OBJS)\auilib_dummy.obj: ..\..\src\common\dummy.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(AUILIB_CXXFLAGS) /Ycwx/wxprec.h ..\..\src\common\dummy.cpp
 
@@ -16803,6 +16816,9 @@ $(OBJS)\auilib_xh_auinotbk.obj: ..\..\src\xrc\xh_auinotbk.cpp
 
 $(OBJS)\auilib_xh_auitoolb.obj: ..\..\src\xrc\xh_auitoolb.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(AUILIB_CXXFLAGS) ..\..\src\xrc\xh_auitoolb.cpp
+
+$(OBJS)\auilib_tabartmsw.obj: ..\..\src\aui\tabartmsw.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(AUILIB_CXXFLAGS) ..\..\src\aui\tabartmsw.cpp
 
 $(OBJS)\ribbondll_dummy.obj: ..\..\src\common\dummy.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(RIBBONDLL_CXXFLAGS) /Ycwx/wxprec.h ..\..\src\common\dummy.cpp

--- a/build/msw/wx_aui.vcxproj
+++ b/build/msw/wx_aui.vcxproj
@@ -465,6 +465,7 @@
     <ClCompile Include="..\..\src\aui\tabmdi.cpp" />
     <ClCompile Include="..\..\src\xrc\xh_auinotbk.cpp" />
     <ClCompile Include="..\..\src\xrc\xh_auitoolb.cpp" />
+    <ClCompile Include="..\..\src\aui\tabartmsw.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\src\msw\version.rc">
@@ -505,6 +506,7 @@
     <ClInclude Include="..\..\include\wx\aui\tabmdi.h" />
     <ClInclude Include="..\..\include\wx\xrc\xh_auinotbk.h" />
     <ClInclude Include="..\..\include\wx\xrc\xh_auitoolb.h" />
+    <ClInclude Include="..\..\include\wx\aui\tabartmsw.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/build/msw/wx_aui.vcxproj.filters
+++ b/build/msw/wx_aui.vcxproj.filters
@@ -43,6 +43,9 @@
     <ClCompile Include="..\..\src\aui\tabart.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\aui\tabartmsw.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\aui\tabmdi.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -78,6 +81,9 @@
       <Filter>Common Headers</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\wx\aui\tabart.h">
+      <Filter>Common Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\wx\aui\tabartmsw.h">
       <Filter>Common Headers</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\wx\aui\tabmdi.h">

--- a/build/msw/wx_vc7_aui.vcproj
+++ b/build/msw/wx_vc7_aui.vcproj
@@ -435,6 +435,9 @@
 				RelativePath="..\..\include\wx\aui\tabart.h">
 			</File>
 			<File
+				RelativePath="..\..\include\wx\aui\tabartmsw.h">
+			</File>
+			<File
 				RelativePath="..\..\include\wx\aui\tabmdi.h">
 			</File>
 			<File
@@ -465,6 +468,9 @@
 			</File>
 			<File
 				RelativePath="..\..\src\aui\tabart.cpp">
+			</File>
+			<File
+				RelativePath="..\..\src\aui\tabartmsw.cpp">
 			</File>
 			<File
 				RelativePath="..\..\src\aui\tabmdi.cpp">

--- a/build/msw/wx_vc7_core.vcproj
+++ b/build/msw/wx_vc7_core.vcproj
@@ -2595,6 +2595,9 @@
 				RelativePath="..\..\include\wx\aui\tabart.h">
 			</File>
 			<File
+				RelativePath="..\..\include\wx\aui\tabartmsw.h">
+			</File>
+			<File
 				RelativePath="..\..\include\wx\aui\tabmdi.h">
 			</File>
 			<File

--- a/build/msw/wx_vc8_aui.vcproj
+++ b/build/msw/wx_vc8_aui.vcproj
@@ -1082,6 +1082,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\include\wx\aui\tabartmsw.h"
+				>
+			</File>
+			<File
 				RelativePath="..\..\include\wx\aui\tabmdi.h"
 				>
 			</File>
@@ -1121,6 +1125,10 @@
 			</File>
 			<File
 				RelativePath="..\..\src\aui\tabart.cpp"
+				>
+			</File>
+			<File
+				RelativePath="..\..\src\aui\tabartmsw.cpp"
 				>
 			</File>
 			<File

--- a/build/msw/wx_vc8_core.vcproj
+++ b/build/msw/wx_vc8_core.vcproj
@@ -3961,6 +3961,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\include\wx\aui\tabartmsw.h"
+				>
+			</File>
+			<File
 				RelativePath="..\..\include\wx\aui\tabmdi.h"
 				>
 			</File>

--- a/build/msw/wx_vc9_aui.vcproj
+++ b/build/msw/wx_vc9_aui.vcproj
@@ -1078,6 +1078,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\include\wx\aui\tabartmsw.h"
+				>
+			</File>
+			<File
 				RelativePath="..\..\include\wx\aui\tabmdi.h"
 				>
 			</File>
@@ -1117,6 +1121,10 @@
 			</File>
 			<File
 				RelativePath="..\..\src\aui\tabart.cpp"
+				>
+			</File>
+			<File
+				RelativePath="..\..\src\aui\tabartmsw.cpp"
 				>
 			</File>
 			<File

--- a/build/msw/wx_vc9_core.vcproj
+++ b/build/msw/wx_vc9_core.vcproj
@@ -3957,6 +3957,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\include\wx\aui\tabartmsw.h"
+				>
+			</File>
+			<File
 				RelativePath="..\..\include\wx\aui\tabmdi.h"
 				>
 			</File>

--- a/build/upmake
+++ b/build/upmake
@@ -69,7 +69,7 @@ if (!$only_bkl) {
     # containing the files that should appear in them.
     my %projects_vars = (
             adv      => [qw(ADVANCED_CMN ADVANCED_MSW ADVANCED_MSW_DESKTOP ADVANCED_MSW_NATIVE)],
-            aui      => [qw(AUI_CMN)],
+            aui      => [qw(AUI_CMN AUI_MSW)],
             base     => [qw(BASE_CMN BASE_AND_GUI_CMN BASE_WIN32 BASE_AND_GUI_WIN32)],
             core     => [qw(BASE_AND_GUI_CMN BASE_AND_GUI_WIN32 MSW_LOWLEVEL MSW_DESKTOP_LOWLEVEL MSW MSW_DESKTOP GUI_CMN)],
             gl       => [qw(OPENGL_CMN OPENGL_MSW)],

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -99,6 +99,7 @@ public:
     wxBitmap bitmap;      // tab's bitmap
     wxRect rect;          // tab's hit rectangle
     bool active;          // true if the page is currently active
+    bool hover;           // true if mouse hovering over tab
 };
 
 class WXDLLIMPEXP_AUI wxAuiTabContainerButton
@@ -233,6 +234,8 @@ protected:
     bool m_isDragging;
     wxAuiTabContainerButton* m_hoverButton;
     wxAuiTabContainerButton* m_pressedButton;
+
+    void SetHoverTab(wxWindow* wnd);
 
 #ifndef SWIG
     wxDECLARE_CLASS(wxAuiTabCtrl);

--- a/include/wx/aui/tabart.h
+++ b/include/wx/aui/tabart.h
@@ -312,6 +312,10 @@ protected:
         #define wxHAS_NATIVE_TABART
         #include "wx/aui/tabartgtk.h"
         #define wxAuiDefaultTabArt wxAuiGtkTabArt
+    #elif defined(__WXMSW__)
+        #define wxHAS_NATIVE_TABART
+        #include "wx/aui/tabartmsw.h"
+        #define wxAuiDefaultTabArt wxAuiMSWTabArt
     #endif
 #endif // !__WXUNIVERSAL__
 

--- a/include/wx/aui/tabartmsw.h
+++ b/include/wx/aui/tabartmsw.h
@@ -1,0 +1,90 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        wx/aui/tabartmsw.h
+// Purpose:     wxAuiMSWTabArt declaration
+// Author:      Tobias Taschner
+// Created:     2015-09-26
+// Copyright:   (c) 2015 wxWidgets development team
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_AUI_TABARTMSW_H_
+#define _WX_AUI_TABARTMSW_H_
+
+class WXDLLIMPEXP_AUI wxAuiMSWTabArt : public wxAuiGenericTabArt
+{
+
+public:
+
+    wxAuiMSWTabArt();
+    virtual ~wxAuiMSWTabArt();
+
+    wxAuiTabArt* Clone() wxOVERRIDE;
+    void SetSizingInfo(const wxSize& tabCtrlSize,
+        size_t tabCount) wxOVERRIDE;
+
+    void DrawBorder(
+        wxDC& dc,
+        wxWindow* wnd,
+        const wxRect& rect) wxOVERRIDE;
+
+    void DrawBackground(
+        wxDC& dc,
+        wxWindow* wnd,
+        const wxRect& rect) wxOVERRIDE;
+
+    void DrawTab(wxDC& dc,
+        wxWindow* wnd,
+        const wxAuiNotebookPage& pane,
+        const wxRect& inRect,
+        int closeButtonState,
+        wxRect* outTabRect,
+        wxRect* outButtonRect,
+        int* xExtent) wxOVERRIDE;
+
+    void DrawButton(
+        wxDC& dc,
+        wxWindow* wnd,
+        const wxRect& inRect,
+        int bitmapId,
+        int buttonState,
+        int orientation,
+        wxRect* outRect) wxOVERRIDE;
+
+    int GetIndentSize() wxOVERRIDE;
+
+    int GetBorderWidth(
+        wxWindow* wnd) wxOVERRIDE;
+
+    int GetAdditionalBorderSpace(
+        wxWindow* wnd) wxOVERRIDE;
+
+    wxSize GetTabSize(
+        wxDC& dc,
+        wxWindow* wnd,
+        const wxString& caption,
+        const wxBitmap& bitmap,
+        bool active,
+        int closeButtonState,
+        int* xExtent) wxOVERRIDE;
+
+    int ShowDropDown(
+        wxWindow* wnd,
+        const wxAuiNotebookPageArray& items,
+        int activeIdx) wxOVERRIDE;
+
+    int GetBestTabCtrlSize(wxWindow* wnd,
+        const wxAuiNotebookPageArray& pages,
+        const wxSize& requiredBmpSize) wxOVERRIDE;
+
+private:
+    bool m_themed;
+    wxSize m_closeBtnSize;
+    wxSize m_tabSize;
+    int m_maxTabHeight;
+
+    void InitSizes(wxWindow* wnd, wxDC& dc);
+
+    bool IsThemed() const;
+};
+
+#endif // _WX_AUI_TABARTMSW_H_

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -186,6 +186,7 @@ bool wxAuiTabContainer::AddPage(wxWindow* page,
     wxAuiNotebookPage page_info;
     page_info = info;
     page_info.window = page;
+    page_info.hover = false;
 
     m_pages.Add(page_info);
 
@@ -205,6 +206,7 @@ bool wxAuiTabContainer::InsertPage(wxWindow* page,
     wxAuiNotebookPage page_info;
     page_info = info;
     page_info.window = page;
+    page_info.hover = false;
 
     if (idx >= m_pages.GetCount())
         m_pages.Add(page_info);
@@ -1233,20 +1235,28 @@ void wxAuiTabCtrl::OnMotion(wxMouseEvent& evt)
         }
     }
 
-#if wxUSE_TOOLTIPS
     wxWindow* wnd = NULL;
     if (evt.Moving() && TabHitTest(evt.m_x, evt.m_y, &wnd))
     {
+        SetHoverTab(wnd);
+
+#if wxUSE_TOOLTIPS
         wxString tooltip(m_pages[GetIdxFromWindow(wnd)].tooltip);
 
         // If the text changes, set it else, keep old, to avoid
         // 'moving tooltip' effect
         if (GetToolTipText() != tooltip)
             SetToolTip(tooltip);
+#endif // wxUSE_TOOLTIPS
     }
     else
+    {
+        SetHoverTab(NULL);
+
+#if wxUSE_TOOLTIPS
         UnsetToolTip();
 #endif // wxUSE_TOOLTIPS
+    }
 
     if (!evt.LeftIsDown() || m_clickPt == wxDefaultPosition)
         return;
@@ -1287,6 +1297,8 @@ void wxAuiTabCtrl::OnLeaveWindow(wxMouseEvent& WXUNUSED(event))
         Refresh();
         Update();
     }
+
+    SetHoverTab(NULL);
 }
 
 void wxAuiTabCtrl::OnButton(wxAuiNotebookEvent& event)
@@ -3448,6 +3460,27 @@ int wxAuiNotebook::DoModifySelection(size_t n, bool events)
     }
 
     return m_curPage;
+}
+
+void wxAuiTabCtrl::SetHoverTab(wxWindow* wnd)
+{
+    bool hoverChanged = false;
+
+    const size_t page_count = m_pages.GetCount();
+    for ( size_t i = 0; i < page_count; ++i )
+    {
+        wxAuiNotebookPage& page = m_pages.Item(i);
+        bool oldHover = page.hover;
+        page.hover = (page.window == wnd);
+        if ( oldHover != page.hover )
+            hoverChanged = true;
+    }
+
+    if ( hoverChanged )
+    {
+        Refresh();
+        Update();
+    }
 }
 
 

--- a/src/aui/tabartmsw.cpp
+++ b/src/aui/tabartmsw.cpp
@@ -1,0 +1,497 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        wx/aui/tabartmsw.h
+// Purpose:     wxAuiMSWTabArt declaration
+// Author:      Tobias Taschner
+// Created:     2015-09-26
+// Copyright:   (c) 2015 wxWidgets development team
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
+#include "wx/wxprec.h"
+
+#ifdef __BORLANDC__
+#pragma hdrstop
+#endif
+
+#include "wx/aui/tabart.h"
+#include "wx/aui/auibook.h"
+#include "wx/msw/uxtheme.h"
+#include "wx/msw/private.h"
+#include "wx/renderer.h"
+
+#if wxUSE_AUI
+
+#ifndef CP_DROPDOWNBUTTON
+
+    #define TABP_TABITEM 1
+    #define TABP_TABITEMLEFTEDGE 2
+    #define TABP_TABITEMRIGHTEDGE 3
+    #define TABP_TABITEMBOTHEDGE 4
+    #define TABP_TOPTABITEM 5
+    #define TABP_TOPTABITEMLEFTEDGE 6
+    #define TABP_TOPTABITEMRIGHTEDGE 7
+    #define TABP_TOPTABITEMBOTHEDGE 8
+    #define TABP_PANE 9
+    #define TABP_BODY 10
+    #define TABP_AEROWIZARDBODY 11
+
+    #define TIS_NORMAL 1
+    #define TIS_HOT 2
+    #define TIS_SELECTED 3
+    #define TIS_DISABLED 4
+    #define TIS_FOCUSED 5
+
+    #define TTP_CLOSE 5
+
+    #define TTCS_NORMAL 1
+    #define TTCS_HOT 2
+    #define TTCS_PRESSED 3
+
+    #define SPNP_UPHORZ 3
+    #define SPNP_DOWNHORZ 4
+
+    #define CP_DROPDOWNBUTTON1  1
+
+    #define WP_CLOSEBUTTON 18
+#endif
+
+wxAuiMSWTabArt::wxAuiMSWTabArt()
+{
+    m_closeBtnSize = wxDefaultSize;
+    m_maxTabHeight = 0;
+
+    wxUxThemeEngine* te = wxUxThemeEngine::GetIfActive();
+    if ( te && te->IsAppThemed() )
+    {
+        m_themed = true;
+    }
+    else
+        m_themed = false;
+}
+
+wxAuiMSWTabArt::~wxAuiMSWTabArt()
+{
+}
+
+wxAuiTabArt* wxAuiMSWTabArt::Clone()
+{
+    return new wxAuiMSWTabArt(*this);
+}
+
+void wxAuiMSWTabArt::SetSizingInfo(const wxSize& tab_ctrl_size,
+    size_t tab_count)
+{
+    wxAuiGenericTabArt::SetSizingInfo(tab_ctrl_size, tab_count);
+}
+
+
+void wxAuiMSWTabArt::DrawBorder(wxDC& dc, wxWindow* wnd, const wxRect& rect)
+{
+    if ( !IsThemed() )
+    {
+        wxAuiGenericTabArt::DrawBorder(dc, wnd, rect);
+        return;
+    }
+
+    wxRect drawRect(rect);
+
+    drawRect.y += m_maxTabHeight + wnd->FromDIP(1);
+    drawRect.height -= m_maxTabHeight;
+
+    // Mask border not covered by native theme
+    wxRect topDrawRect(rect);
+    topDrawRect.height = drawRect.height;
+    dc.SetPen(wxPen(wnd->GetBackgroundColour(), GetBorderWidth(wnd)));
+    dc.DrawRectangle(topDrawRect);
+
+    RECT r;
+    wxCopyRectToRECT(drawRect, r);
+
+    wxUxThemeHandle hTheme(wnd, L"TAB");
+
+    wxUxThemeEngine::Get()->DrawThemeBackground(
+        hTheme,
+        GetHdcOf(dc.GetTempHDC()),
+        TABP_PANE,
+        0,
+        &r,
+        NULL);
+}
+
+void wxAuiMSWTabArt::DrawBackground(wxDC& dc,
+    wxWindow* wnd,
+    const wxRect& rect)
+{
+    if ( !IsThemed() )
+    {
+        wxAuiGenericTabArt::DrawBackground(dc, wnd, rect);
+        return;
+    }
+
+    int borderHeight = 2;
+
+    wxRect drawRect = rect;
+    drawRect.height -= borderHeight;
+
+    // Draw background
+    dc.SetBrush(wxBrush(wnd->GetBackgroundColour()));
+    dc.SetPen(*wxTRANSPARENT_PEN);
+    dc.DrawRectangle(drawRect);
+
+    // Draw top border
+    drawRect.y = drawRect.height;
+    drawRect.height = borderHeight + 2;
+
+    drawRect.Inflate(1, 0);
+
+    RECT r;
+    wxCopyRectToRECT(drawRect, r);
+
+    wxUxThemeHandle hTheme(wnd, L"TAB");
+
+    wxUxThemeEngine::Get()->DrawThemeBackground(
+        hTheme,
+        GetHdcOf(dc.GetTempHDC()),
+        TABP_PANE,
+        0,
+        &r,
+        NULL);
+}
+
+void wxAuiMSWTabArt::DrawTab(wxDC& dc,
+    wxWindow* wnd,
+    const wxAuiNotebookPage& page,
+    const wxRect& in_rect,
+    int close_button_state,
+    wxRect* out_tab_rect,
+    wxRect* out_button_rect,
+    int* x_extent)
+{
+    if ( !IsThemed() )
+    {
+        wxAuiGenericTabArt::DrawTab(dc, wnd, page, in_rect, close_button_state, out_tab_rect, out_button_rect, x_extent);
+        return;
+    }
+
+    if ( !m_closeBtnSize.IsFullySpecified() )
+        InitSizes(wnd, dc);
+
+    // figure out the size of the tab
+    wxSize tabSize = GetTabSize(dc,
+        wnd,
+        page.caption,
+        page.bitmap,
+        page.active,
+        close_button_state,
+        x_extent);
+
+    wxCoord tabHeight = tabSize.y;
+    wxCoord tabWidth = tabSize.x;
+    wxCoord tabX = in_rect.x;
+    wxCoord tabY = 0;
+
+    if (!page.active)
+    {
+        tabY += wnd->FromDIP(2);
+        tabHeight -= wnd->FromDIP(2);
+    }
+    else
+    {
+        tabX -= wnd->FromDIP(2);
+        tabWidth += wnd->FromDIP(4);
+        tabHeight += 2;
+    }
+
+    int clipWidth = tabWidth;
+    if ( tabX + clipWidth > in_rect.x + in_rect.width )
+        clipWidth = (in_rect.x + in_rect.width) - tabX;
+    dc.SetClippingRegion(tabX - wnd->FromDIP(2), tabY, clipWidth + wnd->FromDIP(4), tabHeight);
+
+
+    // draw tab
+    wxRect tabRect(tabX, tabY, tabWidth, tabHeight);
+
+    int tabState;
+    if ( page.active )
+        tabState = TIS_SELECTED;
+    else if ( page.hover )
+        tabState = TIS_HOT;
+    else
+        tabState = TIS_NORMAL;
+
+    wxUxThemeEngine* te = wxUxThemeEngine::Get();
+
+    wxUxThemeHandle hTabTheme(wnd, L"Tab");
+    RECT tabR;
+    wxCopyRectToRECT(tabRect, tabR);
+    te->DrawThemeBackground(hTabTheme, GetHdcOf(dc.GetTempHDC()), TABP_TABITEM, 
+        tabState,
+        &tabR, NULL);
+
+    wxRect textRect = tabRect;
+    if ( !page.active )
+        textRect.Offset(0, wnd->FromDIP(1));
+    if ( close_button_state != wxAUI_BUTTON_STATE_HIDDEN )
+        textRect.width -= m_closeBtnSize.x + wnd->FromDIP(3);
+
+    dc.SetFont(wnd->GetFont());
+    dc.DrawLabel(page.caption, page.bitmap, textRect, wxALIGN_CENTRE);
+
+    // draw focus rectangle
+    if ( page.active && (wnd->FindFocus() == wnd) )
+    {
+        wxRect focusRect = tabRect;
+        focusRect.Deflate(wnd->FromDIP(2));
+
+        wxRendererNative::Get().DrawFocusRect(wnd, dc, focusRect, 0);
+    }
+
+    // draw close button
+    if ( close_button_state != wxAUI_BUTTON_STATE_HIDDEN )
+    {
+        wxUxThemeHandle hToolTipTheme(wnd, L"TOOLTIP");
+
+        int btnState;
+        if ( close_button_state == wxAUI_BUTTON_STATE_HOVER )
+            btnState = TTCS_HOT;
+        else if ( close_button_state == wxAUI_BUTTON_STATE_PRESSED )
+            btnState = TTCS_PRESSED;
+        else
+            btnState = TTCS_NORMAL;
+
+        int offsetY = tabY;
+        if ( wxGetWinVersion() < wxWinVersion_Vista )
+            offsetY++; // WinXP theme needs a little more padding
+
+        wxRect rect(tabX + tabWidth - m_closeBtnSize.x - wnd->FromDIP(4),
+            offsetY + (tabHeight / 2) - (m_closeBtnSize.y / 2),
+            m_closeBtnSize.x,
+            m_closeBtnSize.y);
+
+        RECT btnR;
+        wxCopyRectToRECT(rect, btnR);
+        te->DrawThemeBackground(hToolTipTheme, GetHdcOf(dc.GetTempHDC()), TTP_CLOSE, btnState, &btnR, NULL);
+
+        if ( out_button_rect )
+            *out_button_rect = rect;
+    }
+
+    *out_tab_rect = wxRect(tabX, tabY, tabWidth, tabHeight);
+
+    dc.DestroyClippingRegion();
+}
+
+int wxAuiMSWTabArt::GetIndentSize()
+{
+    if ( IsThemed() )
+        return 3; // This should be 1 but we can't draw into the border from DrawTab
+    else
+        return wxAuiGenericTabArt::GetIndentSize();
+}
+
+int wxAuiMSWTabArt::GetBorderWidth(wxWindow* wnd)
+{
+    return wxAuiGenericTabArt::GetBorderWidth(wnd);
+}
+
+int wxAuiMSWTabArt::GetAdditionalBorderSpace(wxWindow* wnd)
+{
+    if ( IsThemed() )
+    {
+        return 4;
+    }
+    else
+        return wxAuiGenericTabArt::GetAdditionalBorderSpace(wnd);
+}
+
+wxSize wxAuiMSWTabArt::GetTabSize(wxDC& dc,
+    wxWindow* wnd,
+    const wxString& caption,
+    const wxBitmap& bitmap,
+    bool active,
+    int close_button_state,
+    int* x_extent)
+{
+    if ( !IsThemed() )
+        return wxAuiGenericTabArt::GetTabSize(dc, wnd, caption, bitmap, active, close_button_state, x_extent);
+
+    if ( !m_closeBtnSize.IsFullySpecified() )
+        InitSizes(wnd, dc);
+
+    wxCoord textWidth, textHeight, tmp;
+
+    dc.SetFont(wnd->GetFont());
+    dc.GetTextExtent(caption, &textWidth, &tmp);
+    dc.GetTextExtent("ABCDEFXj", &tmp, &textHeight);
+
+    wxCoord tabWidth = wxMax(m_tabSize.x, textWidth);
+    wxCoord tabHeight = wxMax(m_tabSize.y, textHeight);
+
+    // if the close button is showing, add space for it
+    if ( close_button_state != wxAUI_BUTTON_STATE_HIDDEN )
+    {
+        tabWidth += m_closeBtnSize.x;
+        tabHeight = wxMax(tabHeight, m_closeBtnSize.y);
+    }
+
+    // if there's a bitmap, add space for it
+    if ( bitmap.IsOk() )
+    {
+        tabWidth += bitmap.GetWidth() + wnd->FromDIP(3); // bitmap padding
+        tabHeight = wxMax(tabHeight, bitmap.GetHeight() + wnd->FromDIP(2));
+    }
+
+    // add padding
+    tabWidth += wnd->FromDIP(12);
+    tabHeight += wnd->FromDIP(3);
+
+    if ( m_flags & wxAUI_NB_TAB_FIXED_WIDTH )
+    {
+        tabWidth = m_fixedTabWidth;
+    }
+    else
+    {
+        int minTabWidth = wnd->FromDIP(46);
+        if (tabWidth < minTabWidth)
+            tabWidth = minTabWidth;
+    }
+
+    *x_extent = tabWidth;
+
+    if (tabHeight > m_maxTabHeight)
+        m_maxTabHeight = tabHeight;
+
+    return wxSize(tabWidth, tabHeight);
+}
+
+
+void wxAuiMSWTabArt::DrawButton(wxDC& dc,
+    wxWindow* wnd,
+    const wxRect& in_rect,
+    int bitmap_id,
+    int button_state,
+    int orientation,
+    wxRect* out_rect)
+{
+    if ( !IsThemed() )
+    {
+        wxAuiGenericTabArt::DrawButton(dc, wnd, in_rect, bitmap_id, button_state, orientation, out_rect);
+        return;
+    }
+
+    wxUxThemeEngine* te = wxUxThemeEngine::Get();
+
+    wchar_t* themeId = NULL;
+    int part = 0;
+
+    switch (bitmap_id)
+    {
+    case wxAUI_BUTTON_CLOSE:
+        themeId = L"Window";
+        part = WP_CLOSEBUTTON;
+        break;
+    case wxAUI_BUTTON_LEFT:
+        themeId = L"Spin";
+        part = SPNP_DOWNHORZ;
+        break;
+    case wxAUI_BUTTON_RIGHT:
+        themeId = L"Spin";
+        part = SPNP_UPHORZ;
+        break;
+    case wxAUI_BUTTON_WINDOWLIST:
+        themeId = L"Combobox";
+        part = CP_DROPDOWNBUTTON1;
+        break;
+    }
+
+    wxRect rect = in_rect;
+
+    if ( orientation == wxLEFT )
+    {
+        rect.SetX(in_rect.x);
+        rect.SetY(((in_rect.y + in_rect.height) / 2) - (m_closeBtnSize.GetHeight() / 2));
+        rect.SetWidth(m_closeBtnSize.GetWidth());
+        rect.SetHeight(m_closeBtnSize.GetHeight());
+    }
+    else
+    {
+        rect = wxRect(in_rect.x + in_rect.width - m_closeBtnSize.GetWidth(),
+            ((in_rect.y + in_rect.height) / 2) - (m_closeBtnSize.GetHeight() / 2),
+            m_closeBtnSize.GetWidth(), m_closeBtnSize.GetHeight());
+    }
+
+    if ( bitmap_id == wxAUI_BUTTON_LEFT ||
+        bitmap_id == wxAUI_BUTTON_RIGHT )
+    {
+        rect.y = in_rect.y;
+        rect.height = in_rect.height - 7;
+    }
+
+    dc.SetPen(*wxTRANSPARENT_PEN);
+    dc.SetBrush(wxBrush(m_baseColour));
+    dc.DrawRectangle(rect);
+
+    int btnState;
+    if ( button_state == wxAUI_BUTTON_STATE_DISABLED )
+        btnState = TTCS_PRESSED + 1;
+    else if ( button_state == wxAUI_BUTTON_STATE_HOVER )
+        btnState = TTCS_HOT;
+    else if ( button_state == wxAUI_BUTTON_STATE_PRESSED )
+        btnState = TTCS_PRESSED;
+    else
+        btnState = TTCS_NORMAL;
+
+    wxUxThemeHandle hTheme(wnd, themeId);
+
+    wxRect btnRect(rect);
+    btnRect.width -= wnd->FromDIP(1);
+
+    RECT btnR;
+    wxCopyRectToRECT(btnRect, btnR);
+    te->DrawThemeBackground(hTheme, GetHdcOf(dc.GetTempHDC()), part, btnState, &btnR, NULL);
+
+    if ( out_rect )
+        *out_rect = rect;
+}
+
+int wxAuiMSWTabArt::ShowDropDown(wxWindow* wnd,
+    const wxAuiNotebookPageArray& pages,
+    int active_idx)
+{
+    return wxAuiGenericTabArt::ShowDropDown(wnd, pages, active_idx);
+}
+
+int wxAuiMSWTabArt::GetBestTabCtrlSize(wxWindow* wnd,
+    const wxAuiNotebookPageArray& pages,
+    const wxSize& requiredBmp_size)
+{
+    return wxAuiGenericTabArt::GetBestTabCtrlSize(wnd, pages, requiredBmp_size);
+}
+
+void wxAuiMSWTabArt::InitSizes(wxWindow* wnd, wxDC& dc)
+{
+    wxUxThemeEngine* te = wxUxThemeEngine::Get();
+    SIZE uxSize;
+
+    // Borrow close button from tooltip (best fit on various backgrounds)
+    wxUxThemeHandle hTooltipTheme(wnd, L"Tooltip");
+
+    te->GetThemePartSize(hTooltipTheme, GetHdcOf(dc.GetTempHDC()),
+        TTP_CLOSE, 0, NULL, TS_TRUE, &uxSize);
+    m_closeBtnSize.Set(uxSize.cx, uxSize.cy);
+
+    wxUxThemeHandle hTabTheme(wnd, L"Tab");
+    te->GetThemePartSize(hTabTheme, GetHdcOf(dc.GetTempHDC()),
+        TABP_TABITEM, 0, NULL, TS_TRUE, &uxSize);
+    m_tabSize.Set(uxSize.cx, uxSize.cy);
+}
+
+bool wxAuiMSWTabArt::IsThemed() const
+{
+    return 
+        m_themed &&
+        !(m_flags & wxAUI_NB_BOTTOM); // Native theme does not support bottom tabs
+}
+
+
+#endif // wxUSE_AUI


### PR DESCRIPTION
This wxAuiTabArt uses Windows uxtheme API to draw AUI tabs. A fallback to generic tab art is implemented for bottom tabs or if uxtheme is not available (disabled by user or no manifest file).

This also scales good for on high resolution displays.

Sample screen shots in WinXP, Win7 and Win 10 (125%):
![wxaui_tab_winxp](https://cloud.githubusercontent.com/assets/5075894/10203320/7bdf4d26-67b5-11e5-8835-0fc4b3ceae53.png)
![wxaui_tab_win7](https://cloud.githubusercontent.com/assets/5075894/10145250/2ea1ee2c-6622-11e5-9ad7-1af79a332c2a.png)
![wxaui_tab_win10](https://cloud.githubusercontent.com/assets/5075894/10145251/2ea8a000-6622-11e5-9325-168af576909e.png)
