### PR TITLE
Choose lighter color for wxOSX/Cocoa wxSYS_COLOUR_INFOBK.

### DIFF
--- a/src/osx/cocoa/settings.mm
+++ b/src/osx/cocoa/settings.mm
@@ -92,7 +92,7 @@ wxColour wxSystemSettingsNative::GetColour(wxSystemColour index)
         break;
     case wxSYS_COLOUR_INFOBK:
         // tooltip (bogus)
-        sysColor = [NSColor windowFrameColor];
+        sysColor = [NSColor windowBackgroundColor];
         break;
     case wxSYS_COLOUR_APPWORKSPACE:
         // MDI window color (bogus)


### PR DESCRIPTION
`[NSColor windowFrameColor]` from commit 515fcc66e64a8fbd241f023a2932e0451560240e was way to dark `[NSColor windowBackgroundColor]` gives a much better contrast with the text.
