### PR TITLE
Ensure that AdjustStaticBoxZOrder is always defined.

### DIFF
--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -1522,8 +1522,6 @@ void wxWindowMSW::Update()
 // drag and drop
 // ---------------------------------------------------------------------------
 
-#if wxUSE_DRAG_AND_DROP
-
 #if wxUSE_STATBOX
 
 // we need to lower the sibling static boxes so controls contained within can be
@@ -1555,9 +1553,8 @@ static inline void AdjustStaticBoxZOrder(wxWindow * WXUNUSED(parent))
 
 #endif // wxUSE_STATBOX/!wxUSE_STATBOX
 
-#endif // drag and drop is used
-
 #if wxUSE_DRAG_AND_DROP
+
 void wxWindowMSW::SetDropTarget(wxDropTarget *pDropTarget)
 {
     if ( m_dropTarget != 0 ) {
@@ -1572,6 +1569,7 @@ void wxWindowMSW::SetDropTarget(wxDropTarget *pDropTarget)
         m_dropTarget->Register(m_hWnd);
     }
 }
+
 #endif // wxUSE_DRAG_AND_DROP
 
 // old-style file manager drag&drop support: we retain the old-style


### PR DESCRIPTION
When `wxUSE_STATBOX` and `wxUSE_DRAG_AND_DROP` are false, `AdjustStaticBoxZOrder` is undefined.
