### PR TITLE
Resolved warnings in MSW source.

### DIFF
--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -2624,11 +2624,11 @@ static bool AlphaBlt(wxMSWDCImpl* dcDst,
             if ( data )
             {
                 wxAlphaPixelData::Iterator p(data);
-                for ( int yy = 0; yy < data.GetHeight(); yy++ )
+                for ( int old_y = 0; old_y < data.GetHeight(); old_y++ )
                 {
                     wxAlphaPixelData::Iterator rowStart = p;
 
-                    for ( int xx = 0; xx < data.GetWidth(); xx++ )
+                    for ( int old_x = 0; old_x < data.GetWidth(); old_x++ )
                     {
                         // We choose to use wxALPHA_TRANSPARENT instead
                         // of perhaps more logical wxALPHA_OPAQUE here

--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -2624,11 +2624,11 @@ static bool AlphaBlt(wxMSWDCImpl* dcDst,
             if ( data )
             {
                 wxAlphaPixelData::Iterator p(data);
-                for ( int y = 0; y < data.GetHeight(); y++ )
+                for ( int yy = 0; yy < data.GetHeight(); yy++ )
                 {
                     wxAlphaPixelData::Iterator rowStart = p;
 
-                    for ( int x = 0; x < data.GetWidth(); x++ )
+                    for ( int xx = 0; xx < data.GetWidth(); xx++ )
                     {
                         // We choose to use wxALPHA_TRANSPARENT instead
                         // of perhaps more logical wxALPHA_OPAQUE here

--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -2118,6 +2118,8 @@ wxD2DFontData::wxD2DFontData(wxGraphicsRenderer* renderer, ID2D1Factory* d2dFact
         L"en-us",
         &m_textFormat);
 
+    wxUnusedVar(hr);
+
     delete[] name;
 }
 
@@ -2149,6 +2151,8 @@ wxCOMPtr<IDWriteTextLayout> wxD2DFontData::CreateTextLayout(const wxString& text
     {
         textLayout->SetStrikethrough(true, textRange);
     }
+
+    wxUnusedVar(hr);
 
     return textLayout;
 }
@@ -3340,7 +3344,7 @@ void wxD2DContext::Flush()
 {
     HRESULT result = m_renderTargetHolder->Flush();
 
-    if (result == D2DERR_RECREATE_TARGET)
+    if (result == (HRESULT)D2DERR_RECREATE_TARGET)
     {
         ReleaseDeviceDependentResources();
     }
@@ -3471,7 +3475,9 @@ wxD2DRenderer::wxD2DRenderer()
     result = D2D1CreateFactory(D2D1_FACTORY_TYPE_SINGLE_THREADED, &m_direct2dFactory);
 
     if (FAILED(result))
+    {
         wxFAIL_MSG("Could not create Direct2D Factory.");
+    }
 }
 
 wxD2DRenderer::~wxD2DRenderer()

--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -2078,6 +2078,7 @@ wxD2DFontData::wxD2DFontData(wxGraphicsRenderer* renderer, ID2D1Factory* d2dFact
 
     wxCOMPtr<IDWriteGdiInterop> gdiInterop;
     hr = wxDWriteFactory()->GetGdiInterop(&gdiInterop);
+    wxCHECK_HRESULT_RET(hr);
 
     LOGFONTW logfont;
     GetObjectW(font.GetHFONT(), sizeof(logfont), &logfont);
@@ -2092,6 +2093,7 @@ wxD2DFontData::wxD2DFontData(wxGraphicsRenderer* renderer, ID2D1Factory* d2dFact
     }
 
     hr = gdiInterop->CreateFontFromLOGFONT(&logfont, &m_font);
+    wxCHECK_HRESULT_RET(hr);
 
     wxCOMPtr<IDWriteFontFamily> fontFamily;
     m_font->GetFontFamily(&fontFamily);
@@ -2118,9 +2120,9 @@ wxD2DFontData::wxD2DFontData(wxGraphicsRenderer* renderer, ID2D1Factory* d2dFact
         L"en-us",
         &m_textFormat);
 
-    wxUnusedVar(hr);
-
     delete[] name;
+
+    wxCHECK_HRESULT_RET(hr);
 }
 
 wxCOMPtr<IDWriteTextLayout> wxD2DFontData::CreateTextLayout(const wxString& text) const
@@ -2139,6 +2141,7 @@ wxCOMPtr<IDWriteTextLayout> wxD2DFontData::CreateTextLayout(const wxString& text
         MAX_WIDTH,
         MAX_HEIGHT,
         &textLayout);
+    wxCHECK2_HRESULT_RET(hr, wxCOMPtr<IDWriteTextLayout>(NULL));
 
     DWRITE_TEXT_RANGE textRange = { 0, (UINT32) text.length() };
 
@@ -2151,8 +2154,6 @@ wxCOMPtr<IDWriteTextLayout> wxD2DFontData::CreateTextLayout(const wxString& text
     {
         textLayout->SetStrikethrough(true, textRange);
     }
-
-    wxUnusedVar(hr);
 
     return textLayout;
 }

--- a/src/msw/menu.cpp
+++ b/src/msw/menu.cpp
@@ -742,6 +742,7 @@ wxMenuItem *wxMenu::DoRemove(wxMenuItem *item)
 
         wxASSERT_MSG( !inExistingGroup || item->GetKind() == wxITEM_RADIO,
                       wxT("Removing non radio button from radio group?") );
+        wxUnusedVar(inExistingGroup);
     }
 
     // remove the item from the menu

--- a/src/msw/menuitem.cpp
+++ b/src/msw/menuitem.cpp
@@ -1403,7 +1403,7 @@ int wxMenuItem::MSGetMenuItemPos() const
     if ( !hMenu )
         return -1;
 
-    const UINT id = GetMSWId();
+    const WXWPARAM id = GetMSWId();
     const int menuItems = ::GetMenuItemCount(hMenu);
     for ( int i = 0; i < menuItems; i++ )
     {

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -1265,7 +1265,10 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin)
 
 bool wxCheckOsVersion(int majorVsn, int minorVsn)
 {
-    OSVERSIONINFOEX osvi = { sizeof(osvi), 0, 0, 0, 0, { 0 }, 0, 0 };
+    OSVERSIONINFOEX osvi;
+    wxZeroMemory(osvi);
+    osvi.dwOSVersionInfoSize = sizeof(osvi);
+
     DWORDLONG const dwlConditionMask =
         ::VerSetConditionMask(
         ::VerSetConditionMask(
@@ -1341,7 +1344,7 @@ wxWinVersion wxGetWinVersion()
 
                     }
                     break;
-                    
+
                 case 10:
                     return wxWinVersion_10;
             }


### PR DESCRIPTION
The following GCC warnings are resolved:

```
../../src/msw/utils.cpp: In function 'bool wxCheckOsVersion(int, int)':
../../src/msw/utils.cpp:1268:68: warning: missing initializer for member '_OSVERSIONINFOEXW::wSuiteMask' [-Wmissing-field-initializers]
     OSVERSIONINFOEX osvi = { sizeof(osvi), 0, 0, 0, 0, { 0 }, 0, 0 };
                                                                    ^
../../src/msw/utils.cpp:1268:68: warning: missing initializer for member '_OSVERSIONINFOEXW::wProductType' [-Wmissing-field-initializers]
../../src/msw/utils.cpp:1268:68: warning: missing initializer for member '_OSVERSIONINFOEXW::wReserved' [-Wmissing-field-initializers]
```

```
../../src/msw/graphicsd2d.cpp: In constructor 'wxD2DFontData::wxD2DFontData(wxGraphicsRenderer*, ID2D1Factory*, const wxFont&, const wxColour&)':
../../src/msw/graphicsd2d.cpp:2077:13: warning: variable 'hr' set but not used [-Wunused-but-set-variable]
     HRESULT hr;
             ^
../../src/msw/graphicsd2d.cpp: In member function 'wxCOMPtr<IDWriteTextLayout> wxD2DFontData::CreateTextLayout(const wxString&) const':
../../src/msw/graphicsd2d.cpp:2129:13: warning: variable 'hr' set but not used [-Wunused-but-set-variable]
     HRESULT hr;
             ^
../../src/msw/graphicsd2d.cpp: In member function 'virtual void wxD2DContext::Flush()':
../../src/msw/graphicsd2d.cpp:3343:16: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (result == D2DERR_RECREATE_TARGET)
                ^
../../src/msw/graphicsd2d.cpp: In constructor 'wxD2DRenderer::wxD2DRenderer()':
../../src/msw/graphicsd2d.cpp:3474:57: warning: suggest braces around empty body in an 'if' statement [-Wempty-body]
         wxFAIL_MSG("Could not create Direct2D Factory.");
```

```
../../src/msw/menu.cpp: In member function 'virtual wxMenuItem* wxMenu::DoRemove(wxMenuItem*)':
../../src/msw/menu.cpp:741:14: warning: unused variable 'inExistingGroup' [-Wunused-variable]
         bool inExistingGroup = m_radioData->UpdateOnRemoveItem(pos);
              ^
../../src/msw/menuitem.cpp: In member function 'int wxMenuItem::MSGetMenuItemPos() const':
../../src/msw/menuitem.cpp:1420:51: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
             if ( ::GetSubMenu(hMenu, i) == (HMENU)id )
```

And a MSVC warning:

```
..\..\src\msw\dc.cpp(2627): warning C4457: declaration of 'y' hides function parameter
  ..\..\src\msw\dc.cpp(2573): note: see declaration of 'y'
..\..\src\msw\dc.cpp(2631): warning C4457: declaration of 'x' hides function parameter
  ..\..\src\msw\dc.cpp(2573): note: see declaration of 'x'
```
