### PR TITLE
Detect correct Windows version for 8.1 and later.

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -181,7 +181,7 @@ wxMSW:
 - Correct wxGetOsDescription() for Windows 10 (Tobias Taschner).
 - Make wxListCtrl &c appearance more native on modern systems (Tobias Taschner).
 - Don't send wxActivateEvent for minimized windows (bzcdr).
-- Return correct OS version under Windows 8 and later.
+- Return correct OS version under Windows 8.1 and later.
 
 wxOSX/Cocoa:
 

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -1009,12 +1009,12 @@ OSVERSIONINFOEXW wxGetWindowsVersionInfo()
     // RtlGetVersion() directly, if it is available.
 #if wxUSE_DYNLIB_CLASS
     wxDynamicLibrary dllNtDll;
-    if ( dllNtDll.RawLoad(wxS("ntdll.dll")) )
+    if ( dllNtDll.Load(wxS("ntdll.dll")) )
     {
         typedef LONG /* NTSTATUS */ (WINAPI *RtlGetVersion_t)(OSVERSIONINFOEXW*);
 
         RtlGetVersion_t wxDL_INIT_FUNC(pfn, RtlGetVersion, dllNtDll);
-        if ( pfnRtlGetVersion && pfnRtlGetVersion(&info) )
+        if ( pfnRtlGetVersion && (pfnRtlGetVersion(&info) == 0) )
             return info;
     }
 #endif // wxUSE_DYNLIB_CLASS
@@ -1355,7 +1355,7 @@ wxWinVersion wxGetWinVersion()
 
                     }
                     break;
-                    
+
                 case 10:
                     return wxWinVersion_10;
             }


### PR DESCRIPTION
This PR fixes the detection of Windows 8.1 and 10 by using  [RtlGetVersion](https://msdn.microsoft.com/en-us/library/windows/hardware/ff561910%28v=vs.85%29.aspx). This is broken since [GetVersionEx](https://msdn.microsoft.com/en-us/library/windows/desktop/ms724451%28v=vs.85%29.aspx) was deprecated (see [#15321](http://trac.wxwidgets.org/ticket/15321)).

The default Windows SDK does not include the required headers, so dynamic loading is necessary.
Looking at the source of  RTL_OSVERSIONINFO (winnt.h), only an unicode version is available.

Theoretically GetVersionEx could be replaced, as both functions are available since XP.
But to ensure compatibility with old operating systems, it is only used for Windows 8 (6.2) and later.

![Minimal Sample](http://i.imgur.com/GqYrbIS.png)

This PR could also be useful in `WX_3_0_BRANCH`.
