### PR TITLE
Fix default window icon

### DIFF
--- a/src/msw/app.cpp
+++ b/src/msw/app.cpp
@@ -629,6 +629,7 @@ const wxChar *wxApp::GetRegisteredClassName(const wxChar *name,
     wndclass.lpfnWndProc   = (WNDPROC)wxWndProc;
     wndclass.hInstance     = wxGetInstance();
     wndclass.hCursor       = ::LoadCursor(NULL, IDC_ARROW);
+    wndclass.hIcon         = ::LoadIcon(NULL, IDI_APPLICATION);
     wndclass.hbrBackground = (HBRUSH)wxUIntToPtr(bgBrushCol + 1);
     wndclass.style         = CS_HREDRAW | CS_VREDRAW | CS_DBLCLKS | extraStyles;
 


### PR DESCRIPTION
This will make sure that wxWidgets will pick the correct default window icon for the Windows taskbar.
