### PR TITLE
wxString::ToAscii pass parameter for replacement char

### DIFF
--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -1556,13 +1556,13 @@ public:
     static wxString FromAscii(const char *ascii, size_t len);
     static wxString FromAscii(const char *ascii);
     static wxString FromAscii(char ascii);
-    const wxScopedCharBuffer ToAscii() const;
+    const wxScopedCharBuffer wxString::ToAscii(const char replaceWith='_') const
 #else // ANSI
     static wxString FromAscii(const char *ascii) { return wxString( ascii ); }
     static wxString FromAscii(const char *ascii, size_t len)
         { return wxString( ascii, len ); }
     static wxString FromAscii(char ascii) { return wxString( ascii ); }
-    const char *ToAscii() const { return c_str(); }
+    const char *ToAscii(const char WXUNUSED(replaceWith)) const { return c_str(); }
 #endif // Unicode/!Unicode
 
     // also provide unsigned char overloads as signed/unsigned doesn't matter

--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -1556,13 +1556,13 @@ public:
     static wxString FromAscii(const char *ascii, size_t len);
     static wxString FromAscii(const char *ascii);
     static wxString FromAscii(char ascii);
-    const wxScopedCharBuffer ToAscii(const char replaceWith='_') const;
+    const wxScopedCharBuffer ToAscii(char replaceWith='_') const;
 #else // ANSI
     static wxString FromAscii(const char *ascii) { return wxString( ascii ); }
     static wxString FromAscii(const char *ascii, size_t len)
         { return wxString( ascii, len ); }
     static wxString FromAscii(char ascii) { return wxString( ascii ); }
-    const char *ToAscii(const char WXUNUSED(replaceWith)) const { return c_str(); }
+    const char *ToAscii(char WXUNUSED(replaceWith)) const { return c_str(); }
 #endif // Unicode/!Unicode
 
     // also provide unsigned char overloads as signed/unsigned doesn't matter

--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -1556,7 +1556,7 @@ public:
     static wxString FromAscii(const char *ascii, size_t len);
     static wxString FromAscii(const char *ascii);
     static wxString FromAscii(char ascii);
-    const wxScopedCharBuffer wxString::ToAscii(const char replaceWith='_') const;
+    const wxScopedCharBuffer ToAscii(const char replaceWith='_') const;
 #else // ANSI
     static wxString FromAscii(const char *ascii) { return wxString( ascii ); }
     static wxString FromAscii(const char *ascii, size_t len)

--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -1556,7 +1556,7 @@ public:
     static wxString FromAscii(const char *ascii, size_t len);
     static wxString FromAscii(const char *ascii);
     static wxString FromAscii(char ascii);
-    const wxScopedCharBuffer wxString::ToAscii(const char replaceWith='_') const
+    const wxScopedCharBuffer wxString::ToAscii(const char replaceWith='_') const;
 #else // ANSI
     static wxString FromAscii(const char *ascii) { return wxString( ascii ); }
     static wxString FromAscii(const char *ascii, size_t len)

--- a/interface/wx/string.h
+++ b/interface/wx/string.h
@@ -745,14 +745,16 @@ public:
         Use mb_str() or utf8_str() to convert to other encodings.
         
         @param replaceWith
-            The Character that will replace found unicode character. defaults to underscore "_"
+            The character that will replace found unicode character. 
+            Defaults to underscore "_".
+            This parameter is new since wxWidgets 3.1.0.
     */
-    const char* ToAscii(const char replaceWith) const;
+    const char* ToAscii(char replaceWith) const;
 
     /**
         @overload
     */
-    const wxCharBuffer ToAscii(const char replaceWith) const;
+    const wxCharBuffer ToAscii(char replaceWith) const;
 
     /**
         Return the string as an std::string in current locale encoding.

--- a/interface/wx/string.h
+++ b/interface/wx/string.h
@@ -743,13 +743,16 @@ public:
         (underscore) character.
 
         Use mb_str() or utf8_str() to convert to other encodings.
+        
+        @param replaceWith
+            The Character that will replace found unicode character. defaults to underscore "_"
     */
-    const char* ToAscii() const;
+    const char* ToAscii(const char replaceWith) const;
 
     /**
         @overload
     */
-    const wxCharBuffer ToAscii() const;
+    const wxCharBuffer ToAscii(const char replaceWith) const;
 
     /**
         Return the string as an std::string in current locale encoding.

--- a/src/common/string.cpp
+++ b/src/common/string.cpp
@@ -1205,7 +1205,7 @@ wxString wxString::FromAscii(char ascii)
     return wxString(wxUniChar((wchar_t)c));
 }
 
-const wxScopedCharBuffer wxString::ToAscii(const char replaceWith) const
+const wxScopedCharBuffer wxString::ToAscii(char replaceWith) const
 {
     // this will allocate enough space for the terminating NUL too
     wxCharBuffer buffer(length());

--- a/src/common/string.cpp
+++ b/src/common/string.cpp
@@ -1205,7 +1205,7 @@ wxString wxString::FromAscii(char ascii)
     return wxString(wxUniChar((wchar_t)c));
 }
 
-const wxScopedCharBuffer wxString::ToAscii() const
+const wxScopedCharBuffer wxString::ToAscii(const char replaceWith) const
 {
     // this will allocate enough space for the terminating NUL too
     wxCharBuffer buffer(length());
@@ -1215,7 +1215,7 @@ const wxScopedCharBuffer wxString::ToAscii() const
     {
         wxUniChar c(*i);
         // FIXME-UTF8: unify substituted char ('_') with wxUniChar ('?')
-        *dest++ = c.IsAscii() ? (char)c : '_';
+        *dest++ = c.IsAscii() ? (char)c : replaceWith;
 
         // the output string can't have embedded NULs anyhow, so we can safely
         // stop at first of them even if we do have any


### PR DESCRIPTION
wxString::ToAscii  replaces Unicode chars with underscore. I have a use case where the character should be something than underscore. This PR adds that feature. I tested its compiling fine
