### PR TITLE
SetBackgroundColour overridden on wxAuiToolBar

### DIFF
--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -274,6 +274,8 @@ public:
     virtual unsigned int GetFlags() = 0;
     virtual void SetFont(const wxFont& font) = 0;
     virtual wxFont GetFont() = 0;
+    virtual void SetBackgroundColour(const wxColour& colour) = 0;
+    virtual wxColour GetBackgroundColour() = 0;
     virtual void SetTextOrientation(int orientation) = 0;
     virtual int GetTextOrientation() = 0;
 
@@ -360,6 +362,8 @@ public:
     virtual unsigned int GetFlags() wxOVERRIDE;
     virtual void SetFont(const wxFont& font) wxOVERRIDE;
     virtual wxFont GetFont() wxOVERRIDE;
+    virtual void SetBackgroundColour(const wxColour& colour) wxOVERRIDE;
+    virtual wxColour GetBackgroundColour() wxOVERRIDE;
     virtual void SetTextOrientation(int orientation) wxOVERRIDE;
     virtual int GetTextOrientation() wxOVERRIDE;
 
@@ -481,6 +485,7 @@ public:
     wxAuiToolBarArt* GetArtProvider() const;
 
     bool SetFont(const wxFont& font) wxOVERRIDE;
+    bool SetBackgroundColour(const wxColour &colour) wxOVERRIDE;
 
 
     wxAuiToolBarItem* AddTool(int toolId,

--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -269,13 +269,15 @@ public:
     wxAuiToolBarArt() { }
     virtual ~wxAuiToolBarArt() { }
 
-    virtual wxAuiToolBarArt* Clone() = 0;
+    virtual wxAuiToolBarArt* Clone() const = 0;
     virtual void SetFlags(unsigned int flags) = 0;
-    virtual unsigned int GetFlags() = 0;
+    virtual unsigned int GetFlags() const = 0;
     virtual void SetFont(const wxFont& font) = 0;
-    virtual wxFont GetFont() = 0;
+    virtual wxFont GetFont() const = 0;
+    virtual void SetBackgroundColour(const wxColour& colour) = 0;
+    virtual wxColour GetBackgroundColour() const = 0;
     virtual void SetTextOrientation(int orientation) = 0;
-    virtual int GetTextOrientation() = 0;
+    virtual int GetTextOrientation() const = 0;
 
     virtual void DrawBackground(
                          wxDC& dc,
@@ -355,13 +357,15 @@ public:
     wxAuiDefaultToolBarArt();
     virtual ~wxAuiDefaultToolBarArt();
 
-    virtual wxAuiToolBarArt* Clone() wxOVERRIDE;
+    virtual wxAuiToolBarArt* Clone() const wxOVERRIDE;
     virtual void SetFlags(unsigned int flags) wxOVERRIDE;
-    virtual unsigned int GetFlags() wxOVERRIDE;
+    virtual unsigned int GetFlags() const wxOVERRIDE;
     virtual void SetFont(const wxFont& font) wxOVERRIDE;
-    virtual wxFont GetFont() wxOVERRIDE;
+    virtual wxFont GetFont() const wxOVERRIDE;
+    virtual void SetBackgroundColour(const wxColour& colour) wxOVERRIDE;
+    virtual wxColour GetBackgroundColour() const wxOVERRIDE;
     virtual void SetTextOrientation(int orientation) wxOVERRIDE;
-    virtual int GetTextOrientation() wxOVERRIDE;
+    virtual int GetTextOrientation() const wxOVERRIDE;
 
     virtual void DrawBackground(
                 wxDC& dc,
@@ -481,6 +485,7 @@ public:
     wxAuiToolBarArt* GetArtProvider() const;
 
     bool SetFont(const wxFont& font) wxOVERRIDE;
+    bool SetBackgroundColour(const wxColour &colour) wxOVERRIDE;
 
 
     wxAuiToolBarItem* AddTool(int toolId,

--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -269,15 +269,13 @@ public:
     wxAuiToolBarArt() { }
     virtual ~wxAuiToolBarArt() { }
 
-    virtual wxAuiToolBarArt* Clone() const = 0;
+    virtual wxAuiToolBarArt* Clone() = 0;
     virtual void SetFlags(unsigned int flags) = 0;
-    virtual unsigned int GetFlags() const = 0;
+    virtual unsigned int GetFlags() = 0;
     virtual void SetFont(const wxFont& font) = 0;
-    virtual wxFont GetFont() const = 0;
-    virtual void SetBackgroundColour(const wxColour& colour) = 0;
-    virtual wxColour GetBackgroundColour() const = 0;
+    virtual wxFont GetFont() = 0;
     virtual void SetTextOrientation(int orientation) = 0;
-    virtual int GetTextOrientation() const = 0;
+    virtual int GetTextOrientation() = 0;
 
     virtual void DrawBackground(
                          wxDC& dc,
@@ -357,15 +355,13 @@ public:
     wxAuiDefaultToolBarArt();
     virtual ~wxAuiDefaultToolBarArt();
 
-    virtual wxAuiToolBarArt* Clone() const wxOVERRIDE;
+    virtual wxAuiToolBarArt* Clone() wxOVERRIDE;
     virtual void SetFlags(unsigned int flags) wxOVERRIDE;
-    virtual unsigned int GetFlags() const wxOVERRIDE;
+    virtual unsigned int GetFlags() wxOVERRIDE;
     virtual void SetFont(const wxFont& font) wxOVERRIDE;
-    virtual wxFont GetFont() const wxOVERRIDE;
-    virtual void SetBackgroundColour(const wxColour& colour) wxOVERRIDE;
-    virtual wxColour GetBackgroundColour() const wxOVERRIDE;
+    virtual wxFont GetFont() wxOVERRIDE;
     virtual void SetTextOrientation(int orientation) wxOVERRIDE;
-    virtual int GetTextOrientation() const wxOVERRIDE;
+    virtual int GetTextOrientation() wxOVERRIDE;
 
     virtual void DrawBackground(
                 wxDC& dc,
@@ -485,7 +481,6 @@ public:
     wxAuiToolBarArt* GetArtProvider() const;
 
     bool SetFont(const wxFont& font) wxOVERRIDE;
-    bool SetBackgroundColour(const wxColour &colour) wxOVERRIDE;
 
 
     wxAuiToolBarItem* AddTool(int toolId,

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -166,7 +166,7 @@ wxAuiDefaultToolBarArt::~wxAuiDefaultToolBarArt()
 }
 
 
-wxAuiToolBarArt* wxAuiDefaultToolBarArt::Clone()
+wxAuiToolBarArt* wxAuiDefaultToolBarArt::Clone() const
 {
     return static_cast<wxAuiToolBarArt*>(new wxAuiDefaultToolBarArt);
 }
@@ -181,22 +181,32 @@ void wxAuiDefaultToolBarArt::SetFont(const wxFont& font)
     m_font = font;
 }
 
+void wxAuiDefaultToolBarArt::SetBackgroundColour(const wxColour& colour)
+{
+  m_baseColour = colour;
+}
+
 void wxAuiDefaultToolBarArt::SetTextOrientation(int orientation)
 {
     m_textOrientation = orientation;
 }
 
-unsigned int wxAuiDefaultToolBarArt::GetFlags()
+unsigned int wxAuiDefaultToolBarArt::GetFlags() const
 {
     return m_flags;
 }
 
-wxFont wxAuiDefaultToolBarArt::GetFont()
+wxFont wxAuiDefaultToolBarArt::GetFont() const
 {
     return m_font;
 }
 
-int wxAuiDefaultToolBarArt::GetTextOrientation()
+wxColour wxAuiDefaultToolBarArt::GetBackgroundColour() const
+{
+  return m_baseColour;
+}
+
+int wxAuiDefaultToolBarArt::GetTextOrientation() const
 {
     return m_textOrientation;
 }
@@ -220,8 +230,7 @@ void wxAuiDefaultToolBarArt::DrawPlainBackground(wxDC& dc,
     wxRect rect = _rect;
     rect.height++;
 
-    dc.SetBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE));
-
+    dc.SetBrush(m_baseColour);
     dc.DrawRectangle(rect.GetX() - 1, rect.GetY() - 1,
                      rect.GetWidth() + 2, rect.GetHeight() + 1);
 }
@@ -1420,6 +1429,17 @@ bool wxAuiToolBar::SetFont(const wxFont& font)
     return res;
 }
 
+bool wxAuiToolBar::SetBackgroundColour(const wxColour &colour)
+{
+    bool res = wxWindow::SetBackgroundColour(colour);
+
+    if (m_art)
+    {
+      m_art->SetBackgroundColour(colour);
+    }
+
+    return res;
+}
 
 void wxAuiToolBar::SetHoverItem(wxAuiToolBarItem* pitem)
 {

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -166,7 +166,7 @@ wxAuiDefaultToolBarArt::~wxAuiDefaultToolBarArt()
 }
 
 
-wxAuiToolBarArt* wxAuiDefaultToolBarArt::Clone() const
+wxAuiToolBarArt* wxAuiDefaultToolBarArt::Clone()
 {
     return static_cast<wxAuiToolBarArt*>(new wxAuiDefaultToolBarArt);
 }
@@ -181,32 +181,22 @@ void wxAuiDefaultToolBarArt::SetFont(const wxFont& font)
     m_font = font;
 }
 
-void wxAuiDefaultToolBarArt::SetBackgroundColour(const wxColour& colour)
-{
-  m_baseColour = colour;
-}
-
 void wxAuiDefaultToolBarArt::SetTextOrientation(int orientation)
 {
     m_textOrientation = orientation;
 }
 
-unsigned int wxAuiDefaultToolBarArt::GetFlags() const
+unsigned int wxAuiDefaultToolBarArt::GetFlags()
 {
     return m_flags;
 }
 
-wxFont wxAuiDefaultToolBarArt::GetFont() const
+wxFont wxAuiDefaultToolBarArt::GetFont()
 {
     return m_font;
 }
 
-wxColour wxAuiDefaultToolBarArt::GetBackgroundColour() const
-{
-  return m_baseColour;
-}
-
-int wxAuiDefaultToolBarArt::GetTextOrientation() const
+int wxAuiDefaultToolBarArt::GetTextOrientation()
 {
     return m_textOrientation;
 }
@@ -230,7 +220,8 @@ void wxAuiDefaultToolBarArt::DrawPlainBackground(wxDC& dc,
     wxRect rect = _rect;
     rect.height++;
 
-    dc.SetBrush(m_baseColour);
+    dc.SetBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE));
+
     dc.DrawRectangle(rect.GetX() - 1, rect.GetY() - 1,
                      rect.GetWidth() + 2, rect.GetHeight() + 1);
 }
@@ -1429,17 +1420,6 @@ bool wxAuiToolBar::SetFont(const wxFont& font)
     return res;
 }
 
-bool wxAuiToolBar::SetBackgroundColour(const wxColour &colour)
-{
-    bool res = wxWindow::SetBackgroundColour(colour);
-
-    if (m_art)
-    {
-      m_art->SetBackgroundColour(colour);
-    }
-
-    return res;
-}
 
 void wxAuiToolBar::SetHoverItem(wxAuiToolBarItem* pitem)
 {

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -181,6 +181,11 @@ void wxAuiDefaultToolBarArt::SetFont(const wxFont& font)
     m_font = font;
 }
 
+void wxAuiDefaultToolBarArt::SetBackgroundColour(const wxColour& colour)
+{
+  m_baseColour = colour;
+}
+
 void wxAuiDefaultToolBarArt::SetTextOrientation(int orientation)
 {
     m_textOrientation = orientation;
@@ -194,6 +199,11 @@ unsigned int wxAuiDefaultToolBarArt::GetFlags()
 wxFont wxAuiDefaultToolBarArt::GetFont()
 {
     return m_font;
+}
+
+wxColour wxAuiDefaultToolBarArt::GetBackgroundColour()
+{
+  return m_baseColour;
 }
 
 int wxAuiDefaultToolBarArt::GetTextOrientation()
@@ -220,8 +230,7 @@ void wxAuiDefaultToolBarArt::DrawPlainBackground(wxDC& dc,
     wxRect rect = _rect;
     rect.height++;
 
-    dc.SetBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_3DFACE));
-
+    dc.SetBrush(m_baseColour);
     dc.DrawRectangle(rect.GetX() - 1, rect.GetY() - 1,
                      rect.GetWidth() + 2, rect.GetHeight() + 1);
 }
@@ -1420,6 +1429,17 @@ bool wxAuiToolBar::SetFont(const wxFont& font)
     return res;
 }
 
+bool wxAuiToolBar::SetBackgroundColour(const wxColour &colour)
+{
+    bool res = wxWindow::SetBackgroundColour(colour);
+
+    if (m_art)
+    {
+      m_art->SetBackgroundColour(colour);
+    }
+
+    return res;
+}
 
 void wxAuiToolBar::SetHoverItem(wxAuiToolBarItem* pitem)
 {


### PR DESCRIPTION
When the toolbar is set to draw a plain background instead of the
default gradient background (wxAUI_TB_PLAIN_BACKGROUND) there is no way
to control the colour.
Calling SetBackgroundColour on the toolbar currently sets the colour on
the wxAuiToolBar, but the art provider always uses the default system
color.
Setbackgroundcolour now forwards the colour to the art provider.

Getter functions not modifying the object is now const.
