### PR TITLE
Add mouse wheel handling to wxGenericCalendarCtrl

### DIFF
--- a/include/wx/generic/calctrlg.h
+++ b/include/wx/generic/calctrlg.h
@@ -179,6 +179,7 @@ private:
     void OnPaint(wxPaintEvent& event);
     void OnClick(wxMouseEvent& event);
     void OnDClick(wxMouseEvent& event);
+    void OnWheel(wxMouseEvent& event);
     void OnChar(wxKeyEvent& event);
     void OnMonthChange(wxCommandEvent& event);
 

--- a/src/generic/calctrlg.cpp
+++ b/src/generic/calctrlg.cpp
@@ -59,6 +59,7 @@ BEGIN_EVENT_TABLE(wxGenericCalendarCtrl, wxControl)
 
     EVT_LEFT_DOWN(wxGenericCalendarCtrl::OnClick)
     EVT_LEFT_DCLICK(wxGenericCalendarCtrl::OnDClick)
+    EVT_MOUSEWHEEL(wxGenericCalendarCtrl::OnWheel)
 
     EVT_SYS_COLOUR_CHANGED(wxGenericCalendarCtrl::OnSysColourChanged)
 END_EVENT_TABLE()
@@ -1510,6 +1511,31 @@ wxCalendarHitTestResult wxGenericCalendarCtrl::HitTest(const wxPoint& pos,
     {
         return wxCAL_HITTEST_NOWHERE;
     }
+}
+
+void wxGenericCalendarCtrl::OnWheel(wxMouseEvent& event)
+{
+    wxDateSpan span;
+    switch ( event.GetWheelAxis() )
+    {
+        case wxMOUSE_WHEEL_VERTICAL:
+            // For consistency with the native controls, scrolling upwards
+            // should go to the past, even if the rotation is positive and
+            // could be normally expected to increase the date.
+            span = -wxDateSpan::Month();
+            break;
+
+        case wxMOUSE_WHEEL_HORIZONTAL:
+            span = wxDateSpan::Year();
+            break;
+    }
+
+    // Currently we only take into account the rotation direction, not its
+    // magnitude.
+    if ( event.GetWheelRotation() < 0 )
+        span = -span;
+
+    SetDateAndNotify(m_date + span);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Mimics the scrolling behaviour of native MSW and GTK calendars by allowing to
increment/decrement the month by scrolling anywhere on the generic calendar.

Additionally, use horizontal scrolling to increment/decrement the year.

Backport of 50daf1feabc42fdd14b534339b4b3bd654a5989c + 4177593aef9d50da0a19eb4940be17e883c08cc2 into WX_3_0_BRANCH.

See also https://github.com/wxWidgets/wxWidgets/commit/50daf1feabc42fdd14b534339b4b3bd654a5989c#commitcomment-13087042

(Adding a non-virtual function shouldn't break the ABI?)
