### PR TITLE
Clarify the description of wxStringTokenizer::GetString()

### DIFF
--- a/interface/wx/tokenzr.h
+++ b/interface/wx/tokenzr.h
@@ -142,7 +142,8 @@ public:
     size_t GetPosition() const;
 
     /**
-        Returns the part of the starting string without all token already extracted.
+        Returns the part of the initial string which is yet to be tokenized.
+        That is, the substring from the current position upto the end.
     */
     wxString GetString() const;
 


### PR DESCRIPTION
(Attempt to) clarify the description of `wxStringTokenizer::GetString()`. After reading the old description I really couldn't tell what does `GetString` actually return.
