### PR TITLE
Fix problem with wxASSERT when using wxELLIPSIZE_NONE mode

### DIFF
--- a/src/common/ctrlcmn.cpp
+++ b/src/common/ctrlcmn.cpp
@@ -520,6 +520,9 @@ wxString wxControlBase::Ellipsize(const wxString& label, const wxDC& dc,
                                   wxEllipsizeMode mode, int maxFinalWidth,
                                   int flags)
 {
+    if (mode == wxELLIPSIZE_NONE)
+        return label;
+    
     wxString ret;
 
     // these cannot be cached between different Ellipsize() calls as they can


### PR DESCRIPTION
This patch fixes problem caused by changes made with commit [44bcc3a723c082a825943953ee5f13c2fc6dff85](https://github.com/wxWidgets/wxWidgets/commit/44bcc3a723c082a825943953ee5f13c2fc6dff85)

An assert fires in DoEllipsizeSingleLine function when using wxELLIPSIZE_NONE mode. In the previous versions there was a check in the code, which did not execute ellipsize functions when user specified wxELLIPSIZE_NONE mode. The commit mentioned above removed this check, my patch brings it back.
