### PR TITLE
Fix assert failure in wxApp::CleanUp() when not initialised

### DIFF
--- a/src/gtk/app.cpp
+++ b/src/gtk/app.cpp
@@ -428,7 +428,9 @@ void wxApp::CleanUp()
         g_source_remove(m_idleSourceId);
 
     // release reference acquired by Initialize()
-    g_type_class_unref(g_type_class_peek(GTK_TYPE_WIDGET));
+    gpointer gt = g_type_class_peek(GTK_TYPE_WIDGET);
+    if (gt != NULL)
+        g_type_class_unref(gt);
 
     gdk_threads_leave();
 


### PR DESCRIPTION
Veracrypt uses to wxWidgets but, in the same executable, it also provides CLI interface. When veracrypt is called from command line and no graphic device is available, the program will execute successfully in CLI but, upon exit when wxgtk is released, it will display bogus assertion failure:
GLib-GObject-CRITICAL **: g_type_class_unref: assertion 'g_class != NULL' failed

This change fixes this assertion.
