### PR TITLE
DIP Fixes

### DIFF
--- a/include/wx/statbox.h
+++ b/include/wx/statbox.h
@@ -39,7 +39,7 @@ public:
     // borderOther is the margin on all other sides
     virtual void GetBordersForSizer(int *borderTop, int *borderOther) const
     {
-        const int BORDER = 5; // FIXME: hardcoded value
+        const int BORDER = FromDIP(5); // FIXME: hardcoded value
 
         *borderTop = GetLabel().empty() ? BORDER : GetCharHeight();
         *borderOther = BORDER;

--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -979,6 +979,21 @@ public:
     wxPoint FromDIP(const wxPoint& pt) const { return FromDIP(pt, this); }
     int FromDIP(int d) const { return FromDIP(d, this); }
 
+    static wxSize ToDIP(const wxSize& sz, const wxWindowBase* w);
+    static wxPoint ToDIP(const wxPoint& pt, const wxWindowBase* w)
+    {
+        const wxSize sz = ToDIP(wxSize(pt.x, pt.y), w);
+        return wxPoint(sz.x, sz.y);
+    }
+    static int ToDIP(int d, const wxWindowBase* w)
+    {
+        return ToDIP(wxSize(d, 0), w).x;
+    }
+
+    wxSize ToDIP(const wxSize& sz) const { return ToDIP(sz, this); }
+    wxPoint ToDIP(const wxPoint& pt) const { return ToDIP(pt, this); }
+    int ToDIP(int d) const { return ToDIP(d, this); }
+
 
         // Dialog units are based on the size of the current font.
 

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -994,6 +994,73 @@ public:
     /// @overload
     static wxSize FromDIP(const wxSize& sz, const wxWindow* w);
 
+
+    /**
+    Convert pixel values of the current toolkit to DPI-independent pixel values.
+
+    A DPI-independent pixel is just a pixel at the standard 96 DPI
+    resolution. To keep the same physical size at higher resolution, the
+    physical pixel value must be scaled by GetContentScaleFactor() but this
+    scaling may be already done by the underlying toolkit (GTK+, Cocoa,
+    ...) automatically. This method performs the conversion only if it is
+    not already done by the lower level toolkit, For example, you may
+    want to use this to store window sizes and positions so that they
+    can be re-used regardless of the display DPI:
+    @code
+    wxPoint pt(ToDIP(GetPosition()));
+    wxSize size(ToDIP(GetSize()));
+    @endcode
+
+    Also note that if either component of @a sz has the special value of
+    -1, it is returned unchanged independently of the current DPI, to
+    preserve the special value of -1 in wxWidgets API (it is often used to
+    mean "unspecified").
+
+    @since 3.1.0
+    */
+    wxSize ToDIP(const wxSize& sz) const;
+
+    /// @overload
+    wxPoint ToDIP(const wxPoint& pt) const;
+
+    /**
+    Convert pixel values of the current toolkit to DPI-independent pixel values.
+
+    This is the same as ToDIP(const wxSize& sz) overload, but assumes
+    that the resolution is the same in horizontal and vertical directions.
+
+    If @a d has the special value of -1, it is returned unchanged
+    independently of the current DPI.
+
+    @since 3.1.0
+    */
+    int ToDIP(int d) const;
+
+    /**
+    Non window-specific pixel to DPI-independent pixels conversion functions.
+
+    The display resolution depends on the window in general as different
+    windows can appear on different monitors using different resolutions,
+    however sometimes no window is available for converting the resolution
+    independent pixels to the physical values and in this case these static
+    overloads can be used with @NULL value for @a w argument.
+
+    Using these methods is discouraged as passing @NULL will prevent your
+    application from correctly supporting monitors with different
+    resolutions even in the future wxWidgets versions which will add
+    support for them, and passing non-@NULL window is just a less
+    convenient way of calling the non-static ToDIP() method.
+
+    @since 3.1.0
+    */
+    static wxSize ToDIP(const wxSize& sz, const wxWindow* w);
+
+    /// @overload
+    static wxPoint ToDIP(const wxPoint& pt, const wxWindow* w);
+
+    /// @overload
+    static wxSize ToDIP(const wxSize& sz, const wxWindow* w);
+
     /**
         This functions returns the best acceptable minimal size for the window.
 

--- a/src/common/combocmn.cpp
+++ b/src/common/combocmn.cpp
@@ -1223,7 +1223,7 @@ void wxComboCtrlBase::CalculateAreas( int btnWidth )
             // Make very small buttons square, as it makes
             // them accommodate arrow image better and still
             // looks decent.
-            if ( height > 18 )
+            if ( height > FromDIP(18) )
                 butWidth = (height*butWidth)/bestHeight;
             else
                 butWidth = butHeight;

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -2887,7 +2887,7 @@ wxWindowBase::ToDIP(const wxSize& sz, const wxWindowBase* WXUNUSED(w))
     // Take care to not scale -1 because it has a special meaning of
     // "unspecified" which should be preserved.
     return wxSize(sz.x == -1 ? -1 : wxMulDivInt32(sz.x, BASELINE_DPI, dpi.x),
-        sz.y == -1 ? -1 : wxMulDivInt32(sz.y, BASELINE_DPI, dpi.y));
+                  sz.y == -1 ? -1 : wxMulDivInt32(sz.y, BASELINE_DPI, dpi.y));
 }
 
 #endif // !wxHAVE_DPI_INDEPENDENT_PIXELS

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -2878,6 +2878,18 @@ wxWindowBase::FromDIP(const wxSize& sz, const wxWindowBase* WXUNUSED(w))
                   sz.y == -1 ? -1 : wxMulDivInt32(sz.y, dpi.y, BASELINE_DPI));
 }
 
+/* static */
+wxSize
+wxWindowBase::ToDIP(const wxSize& sz, const wxWindowBase* WXUNUSED(w))
+{
+    const wxSize dpi = wxScreenDC().GetPPI();
+
+    // Take care to not scale -1 because it has a special meaning of
+    // "unspecified" which should be preserved.
+    return wxSize(sz.x == -1 ? -1 : wxMulDivInt32(sz.x, BASELINE_DPI, dpi.x),
+        sz.y == -1 ? -1 : wxMulDivInt32(sz.y, BASELINE_DPI, dpi.y));
+}
+
 #endif // !wxHAVE_DPI_INDEPENDENT_PIXELS
 
 // Windows' computes dialog units using average character width over upper-

--- a/src/generic/renderg.cpp
+++ b/src/generic/renderg.cpp
@@ -358,8 +358,7 @@ wxRendererGeneric::DrawHeaderButtonContents(wxWindow *win,
         wxRect ar = rect;
 
         // make a rect for the arrow
-        ar.height = 4;
-        ar.width = 8;
+        ar.SetSize(wxWindow::FromDIP(wxSize(8, 4), win));
         ar.y += (rect.height - ar.height)/2;
         ar.x = ar.x + rect.width - 3*ar.width/2;
         arrowSpace = 3*ar.width/2; // space to preserve when drawing the label

--- a/src/msw/combo.cpp
+++ b/src/msw/combo.cpp
@@ -227,7 +227,7 @@ void wxComboCtrl::OnResize()
 
     // Technically Classic Windows style combo has more narrow button,
     // but the native renderer doesn't paint it well like that.
-    int btnWidth = 17;
+    int btnWidth = FromDIP(17);
     CalculateAreas(btnWidth);
 
     // Position textctrl using standard routine

--- a/src/msw/control.cpp
+++ b/src/msw/control.cpp
@@ -253,7 +253,7 @@ wxSize wxControl::DoGetBestSize() const
     if (m_windowSizer)
        return wxControlBase::DoGetBestSize();
 
-    return wxSize(DEFAULT_ITEM_WIDTH, DEFAULT_ITEM_HEIGHT);
+    return FromDIP(wxSize(DEFAULT_ITEM_WIDTH, DEFAULT_ITEM_HEIGHT));
 }
 
 wxBorder wxControl::GetDefaultBorder() const

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -604,10 +604,13 @@ int wxRendererMSW::GetHeaderButtonHeight(wxWindow * win)
 
     wxON_BLOCK_EXIT1( ::DestroyWindow, hwndHeader );
 
-    // Must ensure the proper font is set or the wrong value will be returned
-    // At 200% scaling it was returning a height of 28 when it should have been 40
-    WXHANDLE hFont = (win && win->GetFont().IsOk() ? win->GetFont() : wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT)).GetResourceHandle();
-    ::SendMessage(hwndHeader, WM_SETFONT, (WPARAM)hFont, MAKELPARAM(TRUE, 0));
+    // Set the font, even if it's the default one, before measuring the window.
+    wxFont font;
+    if ( win )
+        font = win->GetFont();
+    if ( !font.IsOk() )
+        wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
+    ::SendMessage(hwndHeader, WM_SETFONT, (WPARAM)GetHfontOf(font), 0);
 
     // initialize the struct filled with the values by Header_Layout()
     RECT parentRect = { 0, 0, 100, 100 };

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -589,11 +589,11 @@ wxSize wxRendererMSW::GetCheckBoxSize(wxWindow * WXUNUSED(win))
                   ::GetSystemMetrics(SM_CYMENUCHECK));
 }
 
-int wxRendererMSW::GetHeaderButtonHeight(wxWindow * WXUNUSED(win))
+int wxRendererMSW::GetHeaderButtonHeight(wxWindow * win)
 {
     // some "reasonable" value returned in case of error, it doesn't really
     // correspond to anything but it's better than returning 0
-    static const int DEFAULT_HEIGHT = 20;
+    static const int DEFAULT_HEIGHT = wxWindow::FromDIP(20, win);
 
 
     // create a temporary header window just to get its geometry
@@ -603,6 +603,11 @@ int wxRendererMSW::GetHeaderButtonHeight(wxWindow * WXUNUSED(win))
         return DEFAULT_HEIGHT;
 
     wxON_BLOCK_EXIT1( ::DestroyWindow, hwndHeader );
+
+    // Must ensure the proper font is set or the wrong value will be returned
+    // At 200% scaling it was returning a height of 28 when it should have been 40
+    WXHANDLE hFont = (win && win->GetFont().IsOk() ? win->GetFont() : wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT)).GetResourceHandle();
+    ::SendMessage(hwndHeader, WM_SETFONT, (WPARAM)hFont, MAKELPARAM(TRUE, 0));
 
     // initialize the struct filled with the values by Header_Layout()
     RECT parentRect = { 0, 0, 100, 100 };

--- a/src/msw/spinctrl.cpp
+++ b/src/msw/spinctrl.cpp
@@ -308,7 +308,7 @@ bool wxSpinCtrl::Create(wxWindow *parent,
     if ( sizeText.x <= 0 )
     {
         // DEFAULT_ITEM_WIDTH is the default width for the text control
-        sizeText.x = DEFAULT_ITEM_WIDTH + MARGIN_BETWEEN + sizeBtn.x;
+        sizeText.x = FromDIP(DEFAULT_ITEM_WIDTH) + MARGIN_BETWEEN + sizeBtn.x;
     }
 
     sizeText.x -= sizeBtn.x + MARGIN_BETWEEN;

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2259,7 +2259,7 @@ bool wxTextCtrl::AcceptsFocusFromKeyboard() const
 
 wxSize wxTextCtrl::DoGetBestSize() const
 {
-    return DoGetSizeFromTextSize( DEFAULT_ITEM_WIDTH );
+    return DoGetSizeFromTextSize( FromDIP(DEFAULT_ITEM_WIDTH) );
 }
 
 wxSize wxTextCtrl::DoGetSizeFromTextSize(int xlen, int ylen) const


### PR DESCRIPTION
These changes are primarily built around my testing of our application in Windows. I don't have a Linux or Mac system capable of 4k display to do any testing with at the moment. I also added in the ToDIP function since its pretty simple and mostly copy and paste of what you already had for FromDIP.

Changes include:
- Added wxWindow::ToDIP
- Use FromDIP in wxStaticBoxBase::GetBordersForSizer which fixes static box sizers with no label cutting off the top border
- Fixed hard-coded height check to use FromDIP on comboboxes for checking when to make square buttons
- Fixed the size sort arrow in wxRendererGeneric::DrawHeaderButtonContents to use FromDIP
- Use FromDIP in wxComboCtrl::OnResize for calculating the button width
- Fix default sizes of various controls by using FromDIP in wxControl::DoGetBestSize
- Fix height returned by GetHeaderButtonHeight to use FromDIP for the hard-coded value and also set the font on the WC_HEADER created to get the correct height. The return value now matches what is returned wxHeaderCtrl.
- Fixed default width of wxSpinCtrl by using FromDIP
- Fix default textbox widths by using FromDIP in wxTextCtrl::DoGetBestSize
