### PR TITLE
Fix AppVeyor mingw build with USE_GUI=1.

### DIFF
--- a/build/tools/appveyor.bat
+++ b/build/tools/appveyor.bat
@@ -18,11 +18,12 @@ echo --- Tools versions:
 g++ --version | head -1
 mingw32-make --version | head -1
 ar --version | head -1
+path C:\MinGW\bin;
 echo.
 echo --- Starting the build
 echo.
-mingw32-make SHELL=cmd -f makefile.gcc setup_h BUILD=debug SHARED=0 USE_GUI=0
-mingw32-make SHELL=cmd -j3 -f makefile.gcc BUILD=debug SHARED=0 USE_GUI=0
+mingw32-make -f makefile.gcc setup_h BUILD=debug SHARED=0
+mingw32-make -j3 -f makefile.gcc BUILD=debug SHARED=0
 goto :eof
 
 :msys2


### PR DESCRIPTION
`SHELL=cmd` is the root of the problem. It cant handle arguments larger than 8191 characters (which is exceeded by `ar rcu ..\..\lib\gcc_lib\libwxmsw31u_core.a`).

Removing it from the make argument causes a new problem:
`process_begin: CreateProcess(NULL, -c "if not exist ..\..\lib\gcc_lib mkdir ..\..\lib\gcc_lib", ...) failed`

This one can be fixed by removing all the garbage from the `PATH`. `head` isn't available anymore, so use powershell instead.

Also keep building the `USE_GUI=0` version.

See [#17274](http://trac.wxwidgets.org/ticket/17274)
