### PR TITLE
wxListCtrl with checkboxes

### DIFF
--- a/include/wx/listbase.h
+++ b/include/wx/listbase.h
@@ -460,6 +460,12 @@ public:
     void SetAlternateRowColour(const wxColour& colour);
     wxColour GetAlternateRowColour() const { return m_alternateRowColour.GetBackgroundColour(); }
 
+    //checkboxes
+    virtual bool HasCheckboxes() const { return false; }
+    virtual void EnableCheckboxes(bool WXUNUSED(enable) = true) { }
+    virtual bool IsItemChecked(long WXUNUSED(item)) const { return false; }
+    virtual void CheckItem(long WXUNUSED(item), bool WXUNUSED(check)) { }
+
 protected:
     // Real implementations methods to which our public forwards.
     virtual long DoInsertColumn(long col, const wxListItem& info) = 0;
@@ -563,6 +569,8 @@ wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_LIST_COL_BEGIN_DRAG, wxListEve
 wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_LIST_COL_DRAGGING, wxListEvent );
 wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_LIST_COL_END_DRAG, wxListEvent );
 wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_LIST_ITEM_FOCUSED, wxListEvent );
+wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_LIST_ITEM_CHECKED, wxListEvent );
+wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_LIST_ITEM_UNCHECKED, wxListEvent );
 
 typedef void (wxEvtHandler::*wxListEventFunction)(wxListEvent&);
 
@@ -593,6 +601,8 @@ typedef void (wxEvtHandler::*wxListEventFunction)(wxListEvent&);
 #define EVT_LIST_ITEM_MIDDLE_CLICK(id, fn) wx__DECLARE_LISTEVT(ITEM_MIDDLE_CLICK, id, fn)
 #define EVT_LIST_ITEM_ACTIVATED(id, fn) wx__DECLARE_LISTEVT(ITEM_ACTIVATED, id, fn)
 #define EVT_LIST_ITEM_FOCUSED(id, fn) wx__DECLARE_LISTEVT(ITEM_FOCUSED, id, fn)
+#define EVT_LIST_ITEM_CHECKED(id, fn) wx__DECLARE_LISTEVT(ITEM_CHECKED, id, fn)
+#define EVT_LIST_ITEM_UNCHECKED(id, fn) wx__DECLARE_LISTEVT(ITEM_UNCHECKED, id, fn)
 
 #define EVT_LIST_CACHE_HINT(id, fn) wx__DECLARE_LISTEVT(CACHE_HINT, id, fn)
 

--- a/include/wx/msw/listctrl.h
+++ b/include/wx/msw/listctrl.h
@@ -216,6 +216,12 @@ public:
     void SetItemFont( long item, const wxFont &f);
     wxFont GetItemFont( long item ) const;
 
+    // Checkbox state of an item
+    bool HasCheckboxes() const;
+    void EnableCheckboxes(bool enable = true);
+    bool IsItemChecked(long item) const;
+    void CheckItem(long item, bool check);
+
     // Gets the number of selected items in the list control
     int GetSelectedItemCount() const;
 

--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -256,6 +256,12 @@ enum
     @event{EVT_LIST_CACHE_HINT(id, func)}
            Prepare cache for a virtual list control.
            Processes a @c wxEVT_LIST_CACHE_HINT event type.
+    @event{EVT_LIST_ITEM_CHECKED(id, func)}
+           The item has been checked.
+           Processes a @c wxEVT_LIST_ITEM_CHECKED event type (new since wxWidgets 3.1.0).
+    @event{EVT_LIST_ITEM_UNCHECKED(id, func)}
+           The item has been unchecked.
+           Processes a @c wxEVT_LIST_ITEM_UNCHECKED event type (new since wxWidgets 3.1.0).
     @endEventTable
 
     @note Under wxMSW this control uses wxSystemThemedControl for an explorer
@@ -1221,6 +1227,54 @@ public:
     */
     bool SortItems(wxListCtrlCompare fnSortCallBack, wxIntPtr data);
 
+    /**
+        Returns true if checkboxes are enabled for list items.
+
+        @since 3.1.0
+
+        @onlyfor{wxmsw}
+    */
+    bool GetCheckboxesEnabled() const;
+
+    /**
+        Enable or disable checkboxes for list items.
+
+        @param enable
+        If @true, enable checkboxes, otherwise disable checkboxes.
+
+        @since 3.1.0
+
+        @onlyfor{wxmsw}
+    */
+    void EnableCheckboxes(bool enable = true);
+
+    /**
+        Return true if the checkbox if a wxListItem is checked.
+
+        @param item
+        Item (zero-based) index.
+
+        @since 3.1.0
+
+        @onlyfor{wxmsw}
+    */
+    bool IsItemChecked(long item) const;
+
+    /**
+        Check or uncheck a wxListItem.
+
+        @param item
+        Item (zero-based) index.
+
+        @param check
+        If @true, check the item, otherwise uncheck.
+
+        @since 3.1.0
+
+        @onlyfor{wxmsw}
+    */
+    void CheckItem(long item, bool check);
+
 protected:
 
     /**
@@ -1343,6 +1397,10 @@ protected:
         A column has been resized by the user.
     @event{EVT_LIST_CACHE_HINT(id, func)}
         Prepare cache for a virtual list control
+    @event{EVT_LIST_ITEM_CHECKED(id, func)}
+        The item has been checked (new since wxWidgets 3.1.0).
+    @event{EVT_LIST_ITEM_UNCHECKED(id, func)}
+        The item has been unchecked (new since wxWidgets 3.1.0).
     @endEventTable
 
 
@@ -1456,6 +1514,8 @@ wxEventType wxEVT_LIST_COL_BEGIN_DRAG;
 wxEventType wxEVT_LIST_COL_DRAGGING;
 wxEventType wxEVT_LIST_COL_END_DRAG;
 wxEventType wxEVT_LIST_ITEM_FOCUSED;
+wxEventType wxEVT_LIST_ITEM_CHECKED;
+wxEventType wxEVT_LIST_ITEM_UNCHECKED;
 
 
 /**

--- a/samples/listctrl/listtest.h
+++ b/samples/listctrl/listtest.h
@@ -61,6 +61,8 @@ public:
     void OnListKeyDown(wxListEvent& event);
     void OnActivated(wxListEvent& event);
     void OnFocused(wxListEvent& event);
+    void OnChecked(wxListEvent& event);
+    void OnUnChecked(wxListEvent& event);
     void OnCacheHint(wxListEvent& event);
 
     void OnChar(wxKeyEvent& event);
@@ -146,9 +148,13 @@ protected:
     void OnToggleMacUseGeneric(wxCommandEvent& event);
 #endif // __WXOSX__
     void OnFind(wxCommandEvent& event);
+    void OnToggleItemCheckbox(wxCommandEvent& event);
+    void OnGetItemCheckbox(wxCommandEvent& event);
+    void OnToggleCheckboxes(wxCommandEvent& event);
 
     void OnUpdateUIEnableInReport(wxUpdateUIEvent& event);
     void OnUpdateToggleMultiSel(wxUpdateUIEvent& event);
+    void OnUpdateToggleCheckboxes(wxUpdateUIEvent& event);
     void OnUpdateToggleHeader(wxUpdateUIEvent& event);
     void OnUpdateRowLines(wxUpdateUIEvent& event);
 
@@ -217,6 +223,9 @@ enum
     LIST_TOGGLE_MULTI_SEL,
     LIST_TOGGLE_HEADER,
     LIST_TOGGLE_BELL,
+    LIST_TOGGLE_CHECKBOX,
+    LIST_GET_CHECKBOX,
+    LIST_TOGGLE_CHECKBOXES,
     LIST_TOGGLE_FIRST,
     LIST_SHOW_COL_INFO,
     LIST_SHOW_SEL_INFO,

--- a/src/common/listctrlcmn.cpp
+++ b/src/common/listctrlcmn.cpp
@@ -52,6 +52,8 @@ wxDEFINE_EVENT( wxEVT_LIST_ITEM_RIGHT_CLICK, wxListEvent );
 wxDEFINE_EVENT( wxEVT_LIST_ITEM_MIDDLE_CLICK, wxListEvent );
 wxDEFINE_EVENT( wxEVT_LIST_ITEM_ACTIVATED, wxListEvent );
 wxDEFINE_EVENT( wxEVT_LIST_ITEM_FOCUSED, wxListEvent );
+wxDEFINE_EVENT( wxEVT_LIST_ITEM_CHECKED, wxListEvent );
+wxDEFINE_EVENT( wxEVT_LIST_ITEM_UNCHECKED, wxListEvent );
 wxDEFINE_EVENT( wxEVT_LIST_CACHE_HINT, wxListEvent );
 
 // -----------------------------------------------------------------------------

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -1219,8 +1219,9 @@ bool wxListCtrl::HasCheckboxes() const
 
 void wxListCtrl::EnableCheckboxes(bool enable)
 {
-    DWORD cbStyle = enable ? LVS_EX_CHECKBOXES : 0;
-    ListView_SetExtendedListViewStyleEx(GetHwnd(), LVS_EX_CHECKBOXES, cbStyle);
+    LPARAM newStyle = enable ? LVS_EX_CHECKBOXES : 0;
+    DWORD oldStyle = ListView_SetExtendedListViewStyleEx(GetHwnd(), LVS_EX_CHECKBOXES, newStyle);
+    wxUnusedVar(oldStyle);
 }
 
 void wxListCtrl::CheckItem(long item, bool state)


### PR DESCRIPTION
This PR adds support for native checkboxes to a wxListCtrl in MSW.

Done:
- Function to enable/disable use of checkboxes dynamically and a function to check whether checkboxes are enabled. There are no style-bits available to enable checkboxes on initialization.
- Functions to get/set the checkbox state of a wxListItem.
- Callback events when a checkbox is (un)checked.
- Dummy functions for other platforms.
- Documentation of new functions and events.
- Use new functions in listctrl sample.
- Verify functionality on Windows XP. [`LVS_EX_CHECKBOXES`](https://msdn.microsoft.com/en-us/library/windows/desktop/bb774732%28v=vs.85%29.aspx) is available since comctl32 4.70 (Windows 95), but the used `ListView_` macros only since Vista.
- Should the `@since` tag be added for the new events? I think I saw it used before somewhere.

TODO:
- Mention the new functionality in the changelog.

Example:
![checkboxes-sample](https://cloud.githubusercontent.com/assets/8088070/11806522/fd25b0a2-a313-11e5-8bb0-5cc3c892fe5e.png)
