### PR TITLE
Determine correct checkbox size when using theme.

### DIFF
--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -1152,9 +1152,7 @@ bool wxDataViewToggleRenderer::WXActivateCell(const wxRect& WXUNUSED(cellRect),
 
 wxSize wxDataViewToggleRenderer::GetSize() const
 {
-    // the window parameter is not used by GetCheckBoxSize() so it's
-    // safe to pass NULL
-    return wxRendererNative::Get().GetCheckBoxSize(NULL);
+    return wxRendererNative::Get().GetCheckBoxSize(GetView());
 }
 
 // ---------------------------------------------------------

--- a/src/generic/renderg.cpp
+++ b/src/generic/renderg.cpp
@@ -712,9 +712,9 @@ wxRendererGeneric::DrawCheckBox(wxWindow *WXUNUSED(win),
     }
 }
 
-wxSize wxRendererGeneric::GetCheckBoxSize(wxWindow *WXUNUSED(win))
+wxSize wxRendererGeneric::GetCheckBoxSize(wxWindow *win)
 {
-    return wxSize(16, 16);
+    return win->FromDIP(wxSize(16, 16));
 }
 
 void

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -939,7 +939,7 @@ wxRendererXP::DrawCollapseButton(wxWindow *win,
     if ( flags & wxCONTROL_EXPANDED )
         state += 3;
 
-    if ( te->IsThemePartDefined(hTheme, TDLG_EXPANDOBUTTON, state) )
+    if ( te->IsThemePartDefined(hTheme, TDLG_EXPANDOBUTTON, 0) )
     {
         if (flags & wxCONTROL_EXPANDED)
             flags |= wxCONTROL_CHECKED;
@@ -970,7 +970,7 @@ wxSize wxRendererXP::GetCollapseButtonSize(wxWindow *win, wxDC& dc)
 
     // EXPANDOBUTTON scales ugly if not using the correct size, get size from theme
 
-    if ( te->IsThemePartDefined(hTheme, TDLG_EXPANDOBUTTON, TDLGEBS_NORMAL) )
+    if ( te->IsThemePartDefined(hTheme, TDLG_EXPANDOBUTTON, 0) )
     {
         SIZE s;
         te->GetThemePartSize(hTheme,
@@ -998,7 +998,7 @@ wxRendererXP::DrawItemSelectionRect(wxWindow *win,
     const int itemState = GetListItemState(flags);
 
     wxUxThemeEngine* const te = wxUxThemeEngine::Get();
-    if ( te->IsThemePartDefined(hTheme, LVP_LISTITEM, itemState) )
+    if ( te->IsThemePartDefined(hTheme, LVP_LISTITEM, 0) )
     {
         RECT rc;
         wxCopyRectToRECT(rect, rc);
@@ -1027,7 +1027,7 @@ void wxRendererXP::DrawItemText(wxWindow* win,
 
     wxUxThemeEngine* te = wxUxThemeEngine::Get();
     if ( te->DrawThemeTextEx && // Might be not available if we're under XP
-            te->IsThemePartDefined(hTheme, LVP_LISTITEM, itemState) )
+            te->IsThemePartDefined(hTheme, LVP_LISTITEM, 0) )
     {
         RECT rc;
         wxCopyRectToRECT(rect, rc);

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -1036,10 +1036,20 @@ void wxRendererXP::DrawItemText(wxWindow* win,
         textOpts.dwSize = sizeof(textOpts);
         textOpts.dwFlags = DTT_STATEID;
         textOpts.iStateId = itemState;
-        if (flags & wxCONTROL_DISABLED)
+
+        wxColour textColour = dc.GetTextForeground();
+        if (flags & wxCONTROL_SELECTED)
         {
+            textColour = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT);
+        }
+        else if (flags & wxCONTROL_DISABLED)
+        {
+            textColour = wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT);
+        }
+
+        if (textColour.IsOk()) {
             textOpts.dwFlags |= DTT_TEXTCOLOR;
-            textOpts.crText = wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT).GetPixel();
+            textOpts.crText = textColour.GetPixel();
         }
 
         DWORD textFlags = DT_NOPREFIX;

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -327,6 +327,8 @@ public:
                                     wxTitleBarButton button,
                                     int flags = 0);
 
+    virtual wxSize GetCheckBoxSize(wxWindow *win);
+
     virtual void DrawGauge(wxWindow* win,
                            wxDC& dc,
                            const wxRect& rect,
@@ -900,6 +902,21 @@ wxRendererXP::DrawTitleBarBitmap(wxWindow *win,
     }
 
     DoDrawButtonLike(hTheme, part, dc, rect, flags);
+}
+
+wxSize wxRendererXP::GetCheckBoxSize(wxWindow* win)
+{
+    wxUxThemeHandle hTheme(win, L"BUTTON");
+    wxUxThemeEngine* const te = wxUxThemeEngine::Get();
+
+    if (te->IsThemePartDefined(hTheme, BP_CHECKBOX, 0))
+    {
+        SIZE checkSize;
+        te->GetThemePartSize(hTheme, NULL, BP_CHECKBOX, CBS_UNCHECKEDNORMAL, NULL, TS_DRAW, &checkSize);
+        return wxSize(checkSize.cx, checkSize.cy);
+    }
+    else
+        return m_rendererNative.GetCheckBoxSize(win);
 }
 
 void

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -907,16 +907,18 @@ wxRendererXP::DrawTitleBarBitmap(wxWindow *win,
 wxSize wxRendererXP::GetCheckBoxSize(wxWindow* win)
 {
     wxUxThemeHandle hTheme(win, L"BUTTON");
-    wxUxThemeEngine* const te = wxUxThemeEngine::Get();
-
-    if (te->IsThemePartDefined(hTheme, BP_CHECKBOX, 0))
+    if (hTheme)
     {
-        SIZE checkSize;
-        te->GetThemePartSize(hTheme, NULL, BP_CHECKBOX, CBS_UNCHECKEDNORMAL, NULL, TS_DRAW, &checkSize);
-        return wxSize(checkSize.cx, checkSize.cy);
+        wxUxThemeEngine* const te = wxUxThemeEngine::Get();
+
+        if (te && te->IsThemePartDefined(hTheme, BP_CHECKBOX, 0))
+        {
+            SIZE checkSize;
+            if (te->GetThemePartSize(hTheme, NULL, BP_CHECKBOX, CBS_UNCHECKEDNORMAL, NULL, TS_DRAW, &checkSize) == S_OK)
+                return wxSize(checkSize.cx, checkSize.cy);
+        }
     }
-    else
-        return m_rendererNative.GetCheckBoxSize(win);
+    return m_rendererNative.GetCheckBoxSize(win);
 }
 
 void


### PR DESCRIPTION
See [#17290](http://trac.wxwidgets.org/ticket/17290).
I also made the generic version DPI-proof.

While fixing the checkbox problem, I saw that `IsThemePartDefined` was used incorrectly. And as a consequence the generic method was sometimes used instead.

This was most obvious in the dataview example. It used the generic version when drawing the items. Once fixed, it appeared the custom foreground colour was not drawn. I fixed this by setting the text colour to the DC foreground colour, and applying the same colour changes as used in the generic version.

(NOTE: In both the generic and the themed version the selection colour is white (`wxSYS_COLOUR_HIGHLIGHTTEXT`) on a light-blue background making it quite unreadable),
