### PR TITLE
Fixed setting some state flags in wxNotebook::HitTest (wxMSW)

### DIFF
--- a/include/wx/bookctrl.h
+++ b/include/wx/bookctrl.h
@@ -38,7 +38,7 @@ enum
     wxBK_HITTEST_NOWHERE = 1,   // not on tab
     wxBK_HITTEST_ONICON  = 2,   // on icon
     wxBK_HITTEST_ONLABEL = 4,   // on label
-    wxBK_HITTEST_ONITEM  = wxBK_HITTEST_ONICON | wxBK_HITTEST_ONLABEL,
+    wxBK_HITTEST_ONITEM  = 16,  // on tab control but not on its icon or label
     wxBK_HITTEST_ONPAGE  = 8    // not on tab control, but over the selected page
 };
 

--- a/interface/wx/bookctrl.h
+++ b/interface/wx/bookctrl.h
@@ -8,6 +8,8 @@
 /**
     Bit flags returned by wxBookCtrl::HitTest().
 
+    Only one of wxBK_HITTEST_ONICON, wxBK_HITTEST_ONLABEL, wxBK_HITTEST_ONITEM
+    bits is set if point is over a tab.
     Notice that wxOSX currently only returns wxBK_HITTEST_ONLABEL or
     wxBK_HITTEST_NOWHERE and never the other values, so you should only test
     for these two in the code that should be portable under OS X.
@@ -24,7 +26,7 @@ enum
     wxBK_HITTEST_ONLABEL = 4,
 
     /// The point if over a tab item but not over its icon or label.
-    wxBK_HITTEST_ONITEM  = wxBK_HITTEST_ONICON | wxBK_HITTEST_ONLABEL,
+    wxBK_HITTEST_ONITEM  = 16,
 
     /// The point is over the page area.
     wxBK_HITTEST_ONPAGE  = 8

--- a/samples/notebook/notebook.cpp
+++ b/samples/notebook/notebook.cpp
@@ -679,6 +679,7 @@ void MyFrame::OnHitTest(wxCommandEvent& WXUNUSED(event))
     AddFlagStrIfFlagPresent( flagsStr, flags, wxBK_HITTEST_NOWHERE, wxT("wxBK_HITTEST_NOWHERE") );
     AddFlagStrIfFlagPresent( flagsStr, flags, wxBK_HITTEST_ONICON,  wxT("wxBK_HITTEST_ONICON") );
     AddFlagStrIfFlagPresent( flagsStr, flags, wxBK_HITTEST_ONLABEL, wxT("wxBK_HITTEST_ONLABEL") );
+    AddFlagStrIfFlagPresent( flagsStr, flags, wxBK_HITTEST_ONITEM,  wxT("wxBK_HITTEST_ONITEM") );
     AddFlagStrIfFlagPresent( flagsStr, flags, wxBK_HITTEST_ONPAGE,  wxT("wxBK_HITTEST_ONPAGE") );
 
     wxLogMessage(wxT("HitTest at (%d,%d): %d: %s"),

--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -750,15 +750,18 @@ int wxNotebook::HitTest(const wxPoint& pt, long *flags) const
         *flags = 0;
 
         if ((hitTestInfo.flags & TCHT_NOWHERE) == TCHT_NOWHERE)
+        {
+            wxASSERT( item == wxNOT_FOUND );
             *flags |= wxBK_HITTEST_NOWHERE;
-        if ((hitTestInfo.flags & TCHT_ONITEM) == TCHT_ONITEM)
+            if ( GetPageSize().Contains(pt) )
+                *flags |= wxBK_HITTEST_ONPAGE;
+        }
+        else if ((hitTestInfo.flags & TCHT_ONITEM) == TCHT_ONITEM)
             *flags |= wxBK_HITTEST_ONITEM;
-        if ((hitTestInfo.flags & TCHT_ONITEMICON) == TCHT_ONITEMICON)
+        else if ((hitTestInfo.flags & TCHT_ONITEMICON) == TCHT_ONITEMICON)
             *flags |= wxBK_HITTEST_ONICON;
-        if ((hitTestInfo.flags & TCHT_ONITEMLABEL) == TCHT_ONITEMLABEL)
+        else if ((hitTestInfo.flags & TCHT_ONITEMLABEL) == TCHT_ONITEMLABEL)
             *flags |= wxBK_HITTEST_ONLABEL;
-        if ( item == wxNOT_FOUND && GetPageSize().Contains(pt) )
-            *flags |= wxBK_HITTEST_ONPAGE;
     }
 
     return item;


### PR DESCRIPTION
State represented by TCHT_ONITEM Win API flag is not a superposition TCHT_ONITEMICON and TCHT_ONITLABEL states but it represents a separate state. The same applies to wxBK_HITTEST_xxx flags where state represented by wxBK_HITTEST_ONITEM is not a superposition of wxBK_HITTEST_ONICON and wxBK_HITTEST_ONLABEL.

In the current implementation it can be observed (in the notebook sample) that pointing over a tab item but not over its icon or label is reported as wxBK_HITTEST_ONICON | wxBK_HITTEST_ONLABEL.
