### PR TITLE
Ensure COM library is active when D2D renderer is in use.

### DIFF
--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -3759,7 +3759,10 @@ public:
 
     virtual bool OnInit() wxOVERRIDE
     {
-        return true;
+        HRESULT hr = ::CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+        // RPC_E_CHANGED_MODE is not considered as an error
+        // - see remarks for wxOleInitialize().
+        return SUCCEEDED(hr) || hr == RPC_E_CHANGED_MODE;
     }
 
     virtual void OnExit() wxOVERRIDE
@@ -3781,6 +3784,8 @@ public:
             delete gs_D2DRenderer;
             gs_D2DRenderer = NULL;
         }
+
+        ::CoUninitialize();
     }
 
 private:


### PR DESCRIPTION
Modify the order of cleaning up the application in order to assure that modules are cleaned up when wxThpApp exists and its resources are still available.
See http://trac.wxwidgets.org/ticket/17308
