### PR TITLE
Multimedia keys improvements.

### DIFF
--- a/samples/keyboard/keyboard.cpp
+++ b/samples/keyboard/keyboard.cpp
@@ -456,6 +456,23 @@ const char* GetVirtualKeyCodeName(int keycode)
 #ifdef __WXOSX__
         WXK_(RAW_CONTROL)
 #endif
+        WXK_(BROWSER_BACK)
+        WXK_(BROWSER_FORWARD)
+        WXK_(BROWSER_REFRESH)
+        WXK_(BROWSER_STOP)
+        WXK_(BROWSER_SEARCH)
+        WXK_(BROWSER_FAVORITES)
+        WXK_(BROWSER_HOME)
+        WXK_(VOLUME_MUTE)
+        WXK_(VOLUME_DOWN)
+        WXK_(VOLUME_UP)
+        WXK_(MEDIA_NEXT_TRACK)
+        WXK_(MEDIA_PREV_TRACK)
+        WXK_(MEDIA_STOP)
+        WXK_(MEDIA_PLAY_PAUSE)
+        WXK_(LAUNCH_MAIL)
+        WXK_(LAUNCH_APP1)
+        WXK_(LAUNCH_APP2)
 #undef WXK_
 
     default:

--- a/samples/text/text.cpp
+++ b/samples/text/text.cpp
@@ -692,6 +692,23 @@ void MyTextCtrl::LogKeyEvent(const wxChar *name, wxKeyEvent& event) const
             case WXK_NUMPAD_SEPARATOR: key = wxT("NUMPAD_SEPARATOR"); break;
             case WXK_NUMPAD_SUBTRACT: key = wxT("NUMPAD_SUBTRACT"); break;
             case WXK_NUMPAD_DECIMAL: key = wxT("NUMPAD_DECIMAL"); break;
+            case WXK_BROWSER_BACK: key = wxT("BROWSER_BACK"); break;
+            case WXK_BROWSER_FORWARD: key = wxT("BROWSER_FORWARD"); break;
+            case WXK_BROWSER_REFRESH: key = wxT("BROWSER_REFRESH"); break;
+            case WXK_BROWSER_STOP: key = wxT("BROWSER_STOP"); break;
+            case WXK_BROWSER_SEARCH: key = wxT("BROWSER_SEARCH"); break;
+            case WXK_BROWSER_FAVORITES: key = wxT("BROWSER_FAVORITES"); break;
+            case WXK_BROWSER_HOME: key = wxT("BROWSER_HOME"); break;
+            case WXK_VOLUME_MUTE: key = wxT("VOLUME_MUTE"); break;
+            case WXK_VOLUME_DOWN: key = wxT("VOLUME_DOWN"); break;
+            case WXK_VOLUME_UP: key = wxT("VOLUME_UP"); break;
+            case WXK_MEDIA_NEXT_TRACK: key = wxT("MEDIA_NEXT_TRACK"); break;
+            case WXK_MEDIA_PREV_TRACK: key = wxT("MEDIA_PREV_TRACK"); break;
+            case WXK_MEDIA_STOP: key = wxT("MEDIA_STOP"); break;
+            case WXK_MEDIA_PLAY_PAUSE: key = wxT("MEDIA_PLAY_PAUSE"); break;
+            case WXK_LAUNCH_MAIL: key = wxT("LAUNCH_MAIL"); break;
+            case WXK_LAUNCH_APP1: key = wxT("LAUNCH_APP1"); break;
+            case WXK_LAUNCH_APP2: key = wxT("LAUNCH_APP2"); break;
 
             default:
             {

--- a/samples/treectrl/treetest.cpp
+++ b/samples/treectrl/treetest.cpp
@@ -1432,6 +1432,23 @@ void LogKeyEvent(const wxChar *name, const wxKeyEvent& event)
             case WXK_NUMPAD_SEPARATOR: key = wxT("NUMPAD_SEPARATOR"); break;
             case WXK_NUMPAD_SUBTRACT: key = wxT("NUMPAD_SUBTRACT"); break;
             case WXK_NUMPAD_DECIMAL: key = wxT("NUMPAD_DECIMAL"); break;
+            case WXK_BROWSER_BACK: key = wxT("BROWSER_BACK"); break;
+            case WXK_BROWSER_FORWARD: key = wxT("BROWSER_FORWARD"); break;
+            case WXK_BROWSER_REFRESH: key = wxT("BROWSER_REFRESH"); break;
+            case WXK_BROWSER_STOP: key = wxT("BROWSER_STOP"); break;
+            case WXK_BROWSER_SEARCH: key = wxT("BROWSER_SEARCH"); break;
+            case WXK_BROWSER_FAVORITES: key = wxT("BROWSER_FAVORITES"); break;
+            case WXK_BROWSER_HOME: key = wxT("BROWSER_HOME"); break;
+            case WXK_VOLUME_MUTE: key = wxT("VOLUME_MUTE"); break;
+            case WXK_VOLUME_DOWN: key = wxT("VOLUME_DOWN"); break;
+            case WXK_VOLUME_UP: key = wxT("VOLUME_UP"); break;
+            case WXK_MEDIA_NEXT_TRACK: key = wxT("MEDIA_NEXT_TRACK"); break;
+            case WXK_MEDIA_PREV_TRACK: key = wxT("MEDIA_PREV_TRACK"); break;
+            case WXK_MEDIA_STOP: key = wxT("MEDIA_STOP"); break;
+            case WXK_MEDIA_PLAY_PAUSE: key = wxT("MEDIA_PLAY_PAUSE"); break;
+            case WXK_LAUNCH_MAIL: key = wxT("LAUNCH_MAIL"); break;
+            case WXK_LAUNCH_APP1: key = wxT("LAUNCH_APP1"); break;
+            case WXK_LAUNCH_APP2: key = wxT("LAUNCH_APP2"); break;
 
             default:
             {

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -6007,6 +6007,24 @@ const struct wxKeyMapping
     { VK_RWIN,          WXK_WINDOWS_RIGHT },
     { VK_APPS,          WXK_WINDOWS_MENU },
 #endif // VK_APPS defined
+
+    { VK_BROWSER_BACK,        WXK_BROWSER_BACK },
+    { VK_BROWSER_FORWARD,     WXK_BROWSER_FORWARD },
+    { VK_BROWSER_REFRESH,     WXK_BROWSER_REFRESH },
+    { VK_BROWSER_STOP,        WXK_BROWSER_STOP },
+    { VK_BROWSER_SEARCH,      WXK_BROWSER_SEARCH },
+    { VK_BROWSER_FAVORITES,   WXK_BROWSER_FAVORITES },
+    { VK_BROWSER_HOME,        WXK_BROWSER_HOME },
+    { VK_VOLUME_MUTE,         WXK_VOLUME_MUTE },
+    { VK_VOLUME_DOWN,         WXK_VOLUME_DOWN },
+    { VK_VOLUME_UP,           WXK_VOLUME_UP },
+    { VK_MEDIA_NEXT_TRACK,    WXK_MEDIA_NEXT_TRACK },
+    { VK_MEDIA_PREV_TRACK,    WXK_MEDIA_PREV_TRACK },
+    { VK_MEDIA_STOP,          WXK_MEDIA_STOP },
+    { VK_MEDIA_PLAY_PAUSE,    WXK_MEDIA_PLAY_PAUSE },
+    { VK_LAUNCH_MAIL,         WXK_LAUNCH_MAIL },
+    { VK_LAUNCH_APP1,         WXK_LAUNCH_APP1 },
+    { VK_LAUNCH_APP2,         WXK_LAUNCH_APP2 },
 };
 
 } // anonymous namespace
@@ -6132,58 +6150,6 @@ int VKToWX(WXWORD vk, WXLPARAM lParam, wchar_t *uc)
 
             if ( uc )
                 *uc = WXK_RETURN;
-            break;
-
-        case VK_BROWSER_BACK:
-            wxk = WXK_BROWSER_BACK;
-            break;
-        case VK_BROWSER_FORWARD:
-            wxk = WXK_BROWSER_FORWARD;
-            break;
-        case VK_BROWSER_REFRESH:
-            wxk = WXK_BROWSER_REFRESH;
-            break;
-        case VK_BROWSER_STOP:
-            wxk = WXK_BROWSER_STOP;
-            break;
-        case VK_BROWSER_SEARCH:
-            wxk = WXK_BROWSER_SEARCH;
-            break;
-        case VK_BROWSER_FAVORITES:
-            wxk = WXK_BROWSER_FAVORITES;
-            break;
-        case VK_BROWSER_HOME:
-            wxk = WXK_BROWSER_HOME;
-            break;
-        case VK_VOLUME_MUTE:
-            wxk = WXK_VOLUME_MUTE;
-            break;
-        case VK_VOLUME_DOWN:
-            wxk = WXK_VOLUME_DOWN;
-            break;
-        case VK_VOLUME_UP:
-            wxk = WXK_VOLUME_UP;
-            break;
-        case VK_MEDIA_NEXT_TRACK:
-            wxk = WXK_MEDIA_NEXT_TRACK;
-            break;
-        case VK_MEDIA_PREV_TRACK:
-            wxk = WXK_MEDIA_PREV_TRACK;
-            break;
-        case VK_MEDIA_STOP:
-            wxk = WXK_MEDIA_STOP;
-            break;
-        case VK_MEDIA_PLAY_PAUSE:
-            wxk = WXK_MEDIA_PLAY_PAUSE;
-            break;
-        case VK_LAUNCH_MAIL:
-            wxk = WXK_LAUNCH_MAIL;
-            break;
-        case VK_LAUNCH_APP1:
-            wxk = WXK_LAUNCH_APP1;
-            break;
-        case VK_LAUNCH_APP2:
-            wxk = WXK_LAUNCH_APP2;
             break;
 
         default:

--- a/src/richtext/richtextctrl.cpp
+++ b/src/richtext/richtextctrl.cpp
@@ -1218,6 +1218,23 @@ void wxRichTextCtrl::OnChar(wxKeyEvent& event)
             case WXK_NUMPAD_BEGIN:
             case WXK_NUMPAD_INSERT:
             case WXK_WINDOWS_LEFT:
+            case WXK_BROWSER_BACK:
+            case WXK_BROWSER_FORWARD:
+            case WXK_BROWSER_REFRESH:
+            case WXK_BROWSER_STOP:
+            case WXK_BROWSER_SEARCH:
+            case WXK_BROWSER_FAVORITES:
+            case WXK_BROWSER_HOME:
+            case WXK_VOLUME_MUTE:
+            case WXK_VOLUME_DOWN:
+            case WXK_VOLUME_UP:
+            case WXK_MEDIA_NEXT_TRACK:
+            case WXK_MEDIA_PREV_TRACK:
+            case WXK_MEDIA_STOP:
+            case WXK_MEDIA_PLAY_PAUSE:
+            case WXK_LAUNCH_MAIL:
+            case WXK_LAUNCH_APP1:
+            case WXK_LAUNCH_APP2:
             {
                 return;
             }


### PR DESCRIPTION
Follow up for PR #157.
- Simplified mapping keys on Windows.
- ~~Added key names to accelerator table (based on `gdk/keynames.txt`)~~
  - ~~What to do with `back`? It is also used for backspace. Maybe add `Browser` to the names?~~
  - ~~Does `\src\gtk\menu.cpp GetGtkHotKey` need to be updated?~~
- Handle keys in richtextctrl.
  - Using media keys resulted in tabs(?) being inserted.
- Support the keys in the samples that print pressed keys.
