### PR TITLE
Correct initialization order in wxD2DPathData constructor.

### DIFF
--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -1028,8 +1028,8 @@ private :
 
 wxD2DPathData::wxD2DPathData(wxGraphicsRenderer* renderer, ID2D1Factory* d2dFactory) :
     wxGraphicsPathData(renderer), m_direct2dfactory(d2dFactory),
-    m_transformMatrix(D2D1::Matrix3x2F::Identity()),
     m_currentPoint(D2D1::Point2F(0.0f, 0.0f)),
+    m_transformMatrix(D2D1::Matrix3x2F::Identity()),
     m_figureOpened(false), m_geometryWritable(true)
 {
     m_direct2dfactory->CreatePathGeometry(&m_pathGeometry);


### PR DESCRIPTION
Resolves warning introduced in 602fe6cb:

```
if not exist ..\..\lib\gcc_lib64\mswu\wx mkdir ..\..\lib\gcc_lib64\mswu\wx
../../src/msw/graphicsd2d.cpp: In constructor 'wxD2DPathData::wxD2DPathData(wxGraphicsRenderer*, ID2D1Factory*)':
../../src/msw/graphicsd2d.cpp:1018:23: warning: 'wxD2DPathData::m_transformMatrix' will be initialized after [-Wreorder]
     D2D1_MATRIX_3X2_F m_transformMatrix;
                       ^
../../src/msw/graphicsd2d.cpp:1016:19: warning:   'D2D1_POINT_2F wxD2DPathData::m_currentPoint' [-Wreorder]
     D2D1_POINT_2F m_currentPoint;
                   ^
../../src/msw/graphicsd2d.cpp:1029:1: warning:   when initialized here [-Wreorder]
 wxD2DPathData::wxD2DPathData(wxGraphicsRenderer* renderer, ID2D1Factory* d2dFactory) :
 ^
```
