### PR TITLE
Add nullptr checks to wxGridTableBase::Set(Row|Col)Attr

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -1055,7 +1055,8 @@ void wxGridTableBase::SetRowAttr(wxGridCellAttr *attr, int row)
 {
     if ( m_attrProvider )
     {
-        attr->SetKind(wxGridCellAttr::Row);
+        if ( attr )
+            attr->SetKind(wxGridCellAttr::Row);
         m_attrProvider->SetRowAttr(attr, row);
     }
     else
@@ -1070,7 +1071,8 @@ void wxGridTableBase::SetColAttr(wxGridCellAttr *attr, int col)
 {
     if ( m_attrProvider )
     {
-        attr->SetKind(wxGridCellAttr::Col);
+        if ( attr )
+            attr->SetKind(wxGridCellAttr::Col);
         m_attrProvider->SetColAttr(attr, col);
     }
     else


### PR DESCRIPTION
`wxGridTableBase::SetAttr` (for cells) does check its `attr` parameter for `nullptr`, but the check was missing from the row and column functions.

Adding it makes it possible to use a `nullptr` argument to reset the attributes.
