### PR TITLE
Fix docs for wxGrid and friends

### DIFF
--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -1198,12 +1198,12 @@ public:
     virtual wxGridCellAttr *GetAttr(int row, int col,
                                     wxGridCellAttr::wxAttrKind kind) const;
 
-    /**
-        Setting attributes.
+    /*!
+        @name Setting attributes.
 
         All these functions take ownership of the attribute passed to them,
         i.e. will call DecRef() on it themselves later and so it should not be
-        destroyed by the caller. And the attribute can be @NULL to reset a
+        destroyed by the caller. The attribute can be @NULL to reset a
         previously set value.
      */
     //@{
@@ -1220,7 +1220,7 @@ public:
     //@}
 
     /**
-        Getting header renderers.
+        @name Getting header renderers.
 
         These functions return the renderers for the given row or column header
         label and the corner window. Unlike cell attributes, these objects are
@@ -1557,13 +1557,14 @@ public:
     virtual wxGrid *GetView() const;
 
 
-    /**
+    /*!
         @name Table Structure Modifiers
 
-        Notice that none of these functions are pure virtual as they don't have
+        Note that none of these functions are pure virtual as they don't have
         to be implemented if the table structure is never modified after
-        creation, i.e. neither rows nor columns are never added or deleted but
-        that you do need to implement them if they are called, i.e. if your
+        creation, i.e. neither rows nor columns are ever added or deleted.
+
+        Also note that you do need to implement them if they are called, i.e. if your
         code either calls them directly or uses the matching wxGrid methods, as
         by default they simply do nothing which is definitely inappropriate.
      */
@@ -1629,7 +1630,7 @@ public:
 
     //@}
 
-    /**
+    /*!
         @name Table Row and Column Labels
 
         By default the numbers are used for labeling rows and Latin letters for
@@ -2413,7 +2414,7 @@ public:
     //@}
 
 
-    /**
+    /*!
         @name Cell Formatting
 
         Note that wxGridCellAttr can be used alternatively to most of these
@@ -2555,7 +2556,7 @@ public:
     //@}
 
 
-    /**
+    /*!
         @name Cell Values, Editors, and Renderers
 
         Note that wxGridCellAttr can be used alternatively to most of these


### PR DESCRIPTION
Add a couple of missing `@name` commands; the corresponding comments were appearing in the wrong place without them.

Avoid unintended effects of `JAVADOC_AUTOBRIEF` by using Qt-style comments instead of Javadoc.

A couple of minor wording corrections.
