### PR TITLE
ARGB wxBitmap to wxImage conversion (wxMSW).

### DIFF
--- a/include/wx/msw/dib.h
+++ b/include/wx/msw/dib.h
@@ -164,7 +164,18 @@ public:
     bool Create(const wxImage& image, PixelFormat pf = PixelFormat_PreMultiplied);
 
     // create wxImage having the same data as this DIB
-    wxImage ConvertToImage() const;
+
+    // Possible options of conversion to wxImage
+    enum ConversionFlags
+    {
+        // Determine whether 32bpp DIB contains real alpha channel
+        // and return wxImage with or without alpha channel values.
+        Convert_AlphaAuto,
+        // Assume that 32bpp DIB contains valid alpha channel and always
+        // return wxImage with alpha channel values in this case.
+        Convert_AlphaAlwaysIf32bpp
+    };
+    wxImage ConvertToImage(ConversionFlags flags = Convert_AlphaAuto) const;
 #endif // wxUSE_IMAGE
 
 

--- a/src/msw/bitmap.cpp
+++ b/src/msw/bitmap.cpp
@@ -932,7 +932,14 @@ wxImage wxBitmap::ConvertToImage() const
     }
 
     // and then DIB to our wxImage
-    wxImage image = dib.ConvertToImage();
+    // By default, we autodetect the presence of alpha and consider unnecessary
+    // to create the alpha channel in wxImage if we don't have any effective
+    // alpha in the bitmap because its depth, on its own, is not an indicator
+    // that it uses alpha as it could be just the default screen depth. However
+    // if the user had explicitly called UseAlpha(), then we consider
+    // that the resulting image should really have the alpha channel too.
+    wxImage image = dib.ConvertToImage(HasAlpha() ?
+               wxDIB::Convert_AlphaAlwaysIf32bpp : wxDIB::Convert_AlphaAuto);
     if ( !image.IsOk() )
     {
         return wxNullImage;

--- a/src/msw/dib.cpp
+++ b/src/msw/dib.cpp
@@ -676,7 +676,7 @@ bool wxDIB::Create(const wxImage& image, PixelFormat pf)
     return true;
 }
 
-wxImage wxDIB::ConvertToImage() const
+wxImage wxDIB::ConvertToImage(ConversionFlags flags) const
 {
     wxCHECK_MSG( IsOk(), wxNullImage,
                     wxT("can't convert invalid DIB to wxImage") );
@@ -776,7 +776,7 @@ wxImage wxDIB::ConvertToImage() const
     if ( hasOpaque && hasTransparent )
         hasAlpha = true;
 
-    if ( !hasAlpha && image.HasAlpha() )
+    if ( !hasAlpha && image.HasAlpha() && flags == Convert_AlphaAuto )
         image.ClearAlpha();
 
     return image;


### PR DESCRIPTION
Added ability to convert 32bpp wxBitmap explicitly marked as ARGB to wxImage with alpha channel values.
See http://trac.wxwidgets.org/ticket/14582
