### PR TITLE
Fixed setting enabled state of toolbar tool with control (wxMSW).

### DIFF
--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1597,12 +1597,24 @@ void wxToolBar::SetWindowStyleFlag(long style)
 
 void wxToolBar::DoEnableTool(wxToolBarToolBase *tool, bool enable)
 {
-    ::SendMessage(GetHwnd(), TB_ENABLEBUTTON,
-                  (WPARAM)tool->GetId(), (LPARAM)MAKELONG(enable, 0));
+    if ( tool->IsButton() )
+    {
+        ::SendMessage(GetHwnd(), TB_ENABLEBUTTON,
+                      (WPARAM)tool->GetId(), (LPARAM)MAKELONG(enable, 0));
 
-    // Adjust displayed checked state -- it could have changed if the tool is
-    // disabled and has a custom "disabled state" bitmap.
-    DoToggleTool(tool, tool->IsToggled());
+        // Adjust displayed checked state -- it could have changed if the tool is
+        // disabled and has a custom "disabled state" bitmap.
+        DoToggleTool(tool, tool->IsToggled());
+    }
+    else if ( tool->IsControl() )
+    {
+        wxToolBarTool* tbTool = static_cast<wxToolBarTool*>(tool);
+
+        tbTool->GetControl()->Enable(enable);
+        wxStaticText* text = tbTool->GetStaticText();
+        if ( text )
+            text->Enable(enable);
+    }
 }
 
 void wxToolBar::DoToggleTool(wxToolBarToolBase *tool,


### PR DESCRIPTION
Tool containing control should be enabled/disabled in a different way then button tool. The control and its label (if exists) should be explicitly enabled/disabled in order to make wxToolBarBase::EnableTool work properly for such tool.
.
See http://trac.wxwidgets.org/ticket/17346
