### PR TITLE
Add Visual Studio 2015 specific folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@
 /build/msw/wx_vc12.opensdf
 /build/msw/wx_vc12.sdf
 /build/msw/*.suo
+/build/msw/.vs/
 
 # /demos/
 /demos/*/*.sln


### PR DESCRIPTION
VS 2015 specific folder .vs (with solution user options) should be ignored in commits by default.
