### PR TITLE
Drop gstreamer 0.8

### DIFF
--- a/configure
+++ b/configure
@@ -1218,7 +1218,6 @@ enable_logdialog
 enable_mdi
 enable_mdidoc
 enable_mediactrl
-enable_gstreamer8
 enable_richtext
 enable_postscript
 enable_printarch
@@ -2147,7 +2146,6 @@ Optional Features:
   --enable-mdi            use multiple document interface architecture
   --enable-mdidoc         use docview architecture with MDI
   --enable-mediactrl      use wxMediaCtrl class
-  --enable-gstreamer8     force GStreamer 0.8 instead of 0.10 with the wxMediaCtrl class on unix
   --enable-richtext       use wxRichTextCtrl
   --enable-postscript     use wxPostscriptDC device context (default for gtk+)
   --enable-printarch      use printing architecture
@@ -3930,7 +3928,6 @@ DEFAULT_wxUSE_LIBSDL=no
 
 DEFAULT_wxUSE_ACCESSIBILITY=no
 DEFAULT_wxUSE_IPV6=no
-DEFAULT_wxUSE_GSTREAMER8=no
 DEFAULT_wxUSE_UNICODE_UTF8=no
 DEFAULT_wxUSE_UNICODE_UTF8_LOCALE=no
 
@@ -10424,50 +10421,6 @@ fi
             fi
           else
             result=$wxUSE_MEDIACTRL
-          fi
-
-          { $as_echo "$as_me:${as_lineno-$LINENO}: result: $result" >&5
-$as_echo "$result" >&6; }
-
-
-          enablestring=
-          defaultval=$wxUSE_ALL_FEATURES
-          if test -z "$defaultval"; then
-              if test x"$enablestring" = xdisable; then
-                  defaultval=yes
-              else
-                  defaultval=no
-              fi
-          fi
-
-          { $as_echo "$as_me:${as_lineno-$LINENO}: checking for --${enablestring:-enable}-gstreamer8" >&5
-$as_echo_n "checking for --${enablestring:-enable}-gstreamer8... " >&6; }
-          # Check whether --enable-gstreamer8 was given.
-if test "${enable_gstreamer8+set}" = set; then :
-  enableval=$enable_gstreamer8;
-                          if test "$enableval" = yes; then
-                            wx_cv_use_gstreamer8='wxUSE_GSTREAMER8=yes'
-                          else
-                            wx_cv_use_gstreamer8='wxUSE_GSTREAMER8=no'
-                          fi
-
-else
-
-                          wx_cv_use_gstreamer8='wxUSE_GSTREAMER8=${'DEFAULT_wxUSE_GSTREAMER8":-$defaultval}"
-
-fi
-
-
-          eval "$wx_cv_use_gstreamer8"
-
-          if test x"$enablestring" = xdisable; then
-            if test $wxUSE_GSTREAMER8 = no; then
-              result=yes
-            else
-              result=no
-            fi
-          else
-            result=$wxUSE_GSTREAMER8
           fi
 
           { $as_echo "$as_me:${as_lineno-$LINENO}: result: $result" >&5
@@ -37521,11 +37474,10 @@ if test "$wxUSE_MEDIACTRL" = "yes" -o "$wxUSE_MEDIACTRL" = "auto"; then
                 if test "$wxUSE_GTK" = 1; then
         wxUSE_GSTREAMER="no"
 
-                                                                GST_VERSION_MAJOR=0
+        GST_VERSION_MAJOR=0
         GST_VERSION_MINOR=10
         GST_VERSION=$GST_VERSION_MAJOR.$GST_VERSION_MINOR
 
-        if test "$wxUSE_GSTREAMER8" = "no"; then
 
 pkg_failed=no
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for GST" >&5
@@ -37586,16 +37538,14 @@ fi
 	echo "$GST_PKG_ERRORS" >&5
 
 
-                    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: GStreamer 0.10 not available, falling back to 0.8" >&5
-$as_echo "$as_me: WARNING: GStreamer 0.10 not available, falling back to 0.8" >&2;}
-                    GST_VERSION_MINOR=8
+                { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: GStreamer 0.10 not available" >&5
+$as_echo "$as_me: WARNING: GStreamer 0.10 not available" >&2;}
 
 
 elif test $pkg_failed = untried; then
 
-                    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: GStreamer 0.10 not available, falling back to 0.8" >&5
-$as_echo "$as_me: WARNING: GStreamer 0.10 not available, falling back to 0.8" >&2;}
-                    GST_VERSION_MINOR=8
+                { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: GStreamer 0.10 not available" >&5
+$as_echo "$as_me: WARNING: GStreamer 0.10 not available" >&2;}
 
 
 else
@@ -37604,93 +37554,10 @@ else
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 
-                    wxUSE_GSTREAMER="yes"
-                    GST_LIBS="$GST_LIBS -lgstinterfaces-$GST_VERSION"
+                wxUSE_GSTREAMER="yes"
+                GST_LIBS="$GST_LIBS -lgstinterfaces-$GST_VERSION"
 
 fi
-        else
-                        GST_VERSION_MINOR=8
-        fi
-
-        if test $GST_VERSION_MINOR = "8"; then
-            GST_VERSION=$GST_VERSION_MAJOR.$GST_VERSION_MINOR
-
-pkg_failed=no
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for GST" >&5
-$as_echo_n "checking for GST... " >&6; }
-
-if test -n "$PKG_CONFIG"; then
-    if test -n "$GST_CFLAGS"; then
-        pkg_cv_GST_CFLAGS="$GST_CFLAGS"
-    else
-        if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"gstreamer-\$GST_VERSION gstreamer-interfaces-\$GST_VERSION gstreamer-gconf-\$GST_VERSION\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "gstreamer-$GST_VERSION gstreamer-interfaces-$GST_VERSION gstreamer-gconf-$GST_VERSION") 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; then
-  pkg_cv_GST_CFLAGS=`$PKG_CONFIG --cflags "gstreamer-$GST_VERSION gstreamer-interfaces-$GST_VERSION gstreamer-gconf-$GST_VERSION" 2>/dev/null`
-else
-  pkg_failed=yes
-fi
-    fi
-else
-	pkg_failed=untried
-fi
-if test -n "$PKG_CONFIG"; then
-    if test -n "$GST_LIBS"; then
-        pkg_cv_GST_LIBS="$GST_LIBS"
-    else
-        if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"gstreamer-\$GST_VERSION gstreamer-interfaces-\$GST_VERSION gstreamer-gconf-\$GST_VERSION\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "gstreamer-$GST_VERSION gstreamer-interfaces-$GST_VERSION gstreamer-gconf-$GST_VERSION") 2>&5
-  ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; then
-  pkg_cv_GST_LIBS=`$PKG_CONFIG --libs "gstreamer-$GST_VERSION gstreamer-interfaces-$GST_VERSION gstreamer-gconf-$GST_VERSION" 2>/dev/null`
-else
-  pkg_failed=yes
-fi
-    fi
-else
-	pkg_failed=untried
-fi
-
-
-
-if test $pkg_failed = yes; then
-
-if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
-        _pkg_short_errors_supported=yes
-else
-        _pkg_short_errors_supported=no
-fi
-        if test $_pkg_short_errors_supported = yes; then
-	        GST_PKG_ERRORS=`$PKG_CONFIG --short-errors --errors-to-stdout --print-errors "gstreamer-$GST_VERSION gstreamer-interfaces-$GST_VERSION gstreamer-gconf-$GST_VERSION"`
-        else
-	        GST_PKG_ERRORS=`$PKG_CONFIG --errors-to-stdout --print-errors "gstreamer-$GST_VERSION gstreamer-interfaces-$GST_VERSION gstreamer-gconf-$GST_VERSION"`
-        fi
-	# Put the nasty error message in config.log where it belongs
-	echo "$GST_PKG_ERRORS" >&5
-
-
-                    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: GStreamer 0.8/0.10 not available." >&5
-$as_echo "$as_me: WARNING: GStreamer 0.8/0.10 not available." >&2;}
-
-elif test $pkg_failed = untried; then
-
-                    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: GStreamer 0.8/0.10 not available." >&5
-$as_echo "$as_me: WARNING: GStreamer 0.8/0.10 not available." >&2;}
-
-else
-	GST_CFLAGS=$pkg_cv_GST_CFLAGS
-	GST_LIBS=$pkg_cv_GST_LIBS
-        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-	wxUSE_GSTREAMER="yes"
-fi
-        fi
-
 
         if test "$wxUSE_GSTREAMER" = "yes"; then
             CPPFLAGS="$GST_CFLAGS $CPPFLAGS"
@@ -42684,3 +42551,4 @@ echo "                                       libmspack          ${wxUSE_LIBMSPAC
 echo "                                       sdl                ${wxUSE_LIBSDL}"
 
 echo ""
+

--- a/configure.in
+++ b/configure.in
@@ -335,7 +335,6 @@ DEFAULT_wxUSE_LIBSDL=no
 dnl features disabled by default
 DEFAULT_wxUSE_ACCESSIBILITY=no
 DEFAULT_wxUSE_IPV6=no
-DEFAULT_wxUSE_GSTREAMER8=no
 DEFAULT_wxUSE_UNICODE_UTF8=no
 DEFAULT_wxUSE_UNICODE_UTF8_LOCALE=no
 
@@ -772,7 +771,6 @@ WX_ARG_FEATURE(logdialog,   [  --enable-logdialog      use wxLogDialog], wxUSE_L
 WX_ARG_FEATURE(mdi,         [  --enable-mdi            use multiple document interface architecture], wxUSE_MDI)
 WX_ARG_FEATURE(mdidoc,      [  --enable-mdidoc         use docview architecture with MDI], wxUSE_MDI_ARCHITECTURE)
 WX_ARG_FEATURE(mediactrl,   [  --enable-mediactrl      use wxMediaCtrl class], wxUSE_MEDIACTRL)
-WX_ARG_FEATURE(gstreamer8,  [  --enable-gstreamer8     force GStreamer 0.8 instead of 0.10 with the wxMediaCtrl class on unix], wxUSE_GSTREAMER8)
 WX_ARG_FEATURE(richtext,    [  --enable-richtext       use wxRichTextCtrl], wxUSE_RICHTEXT)
 WX_ARG_FEATURE(postscript,  [  --enable-postscript     use wxPostscriptDC device context (default for gtk+)], wxUSE_POSTSCRIPT)
 WX_ARG_FEATURE(printarch,   [  --enable-printarch      use printing architecture], wxUSE_PRINTING_ARCHITECTURE)
@@ -7274,44 +7272,20 @@ if test "$wxUSE_MEDIACTRL" = "yes" -o "$wxUSE_MEDIACTRL" = "auto"; then
     if test "$wxUSE_GTK" = 1; then
         wxUSE_GSTREAMER="no"
 
-        dnl -------------------------------------------------------------------
-        dnl Test for at least 0.8 gstreamer module from pkg-config
-        dnl Even totem doesn't accept 0.9 evidently.
-        dnl
-        dnl So, we first check to see if 0.10 if available - if not we
-        dnl try the older 0.8 version
-        dnl -------------------------------------------------------------------
         GST_VERSION_MAJOR=0
         GST_VERSION_MINOR=10
         GST_VERSION=$GST_VERSION_MAJOR.$GST_VERSION_MINOR
 
-        if test "$wxUSE_GSTREAMER8" = "no"; then
-            PKG_CHECK_MODULES(GST,
-                [gstreamer-$GST_VERSION gstreamer-plugins-base-$GST_VERSION],
-                [
-                    wxUSE_GSTREAMER="yes"
-                    GST_LIBS="$GST_LIBS -lgstinterfaces-$GST_VERSION"
-                ],
-                [
-                    AC_MSG_WARN([GStreamer 0.10 not available, falling back to 0.8])
-                    GST_VERSION_MINOR=8
-                ]
-            )
-        else
-            dnl check only for 0.8
-            GST_VERSION_MINOR=8
-        fi
-
-        if test $GST_VERSION_MINOR = "8"; then
-            GST_VERSION=$GST_VERSION_MAJOR.$GST_VERSION_MINOR
-            PKG_CHECK_MODULES(GST,
-                [gstreamer-$GST_VERSION gstreamer-interfaces-$GST_VERSION gstreamer-gconf-$GST_VERSION],
-                wxUSE_GSTREAMER="yes",
-                [
-                    AC_MSG_WARN([GStreamer 0.8/0.10 not available.])
-                ])
-        fi
-
+        PKG_CHECK_MODULES(GST,
+            [gstreamer-$GST_VERSION gstreamer-plugins-base-$GST_VERSION],
+            [
+                wxUSE_GSTREAMER="yes"
+                GST_LIBS="$GST_LIBS -lgstinterfaces-$GST_VERSION"
+            ],
+            [
+                AC_MSG_WARN([GStreamer 0.10 not available])
+            ]
+        )
 
         if test "$wxUSE_GSTREAMER" = "yes"; then
             CPPFLAGS="$GST_CFLAGS $CPPFLAGS"

--- a/interface/wx/mediactrl.h
+++ b/interface/wx/mediactrl.h
@@ -202,8 +202,8 @@ public:
     - @b wxMEDIABACKEND_QUICKTIME: Use QuickTime. Mac Only.
       WARNING: May not working correctly embedded in a wxNotebook.
     - @b wxMEDIABACKEND_GSTREAMER, Use GStreamer. Unix Only.
-      Requires GStreamer 0.8 along with at the very least the xvimagesink, xoverlay,
-      and gst-play modules of gstreamer to function.
+      Requires GStreamer 0.10 along with at the very least the xvimagesink,
+      xoverlay and gst-play modules of gstreamer to function.
       You need the correct modules to play the relevant files, for example the
       mad module to play mp3s, etc.
     - @b wxMEDIABACKEND_WMP10, Uses Windows Media Player 10 (Windows only) -

--- a/src/unix/mediactrl.cpp
+++ b/src/unix/mediactrl.cpp
@@ -83,27 +83,6 @@
 //  Declarations
 //=============================================================================
 
-//-----------------------------------------------------------------------------
-//  GStreamer (most version compatibility) macros
-//-----------------------------------------------------------------------------
-
-// In 0.9 there was a HUGE change to GstQuery and the
-// gst_element_query function changed dramatically and split off
-// into two separate ones
-#if GST_VERSION_MAJOR == 0 && GST_VERSION_MINOR <= 8
-#    define wxGst_element_query_position(e, f, p) \
-                gst_element_query(e, GST_QUERY_POSITION, f, p)
-#elif GST_VERSION_MAJOR == 0 && GST_VERSION_MINOR == 9
-// However, the actual 0.9 version has a slightly different definition
-// and instead of gst_element_query_duration it has two parameters to
-// gst_element_query_position instead
-#    define wxGst_element_query_position(e, f, p) \
-                gst_element_query_position(e, f, p, 0)
-#else
-#    define wxGst_element_query_position \
-                gst_element_query_position
-#endif
-
 // Max wait time for element state waiting - GST_CLOCK_TIME_NONE for inf
 #define wxGSTREAMER_TIMEOUT (100 * GST_MSECOND) // Max 100 milliseconds
 
@@ -1297,7 +1276,7 @@ wxLongLong wxGStreamerMediaBackend::GetPosition()
         gint64 pos;
         GstFormat fmtTime = GST_FORMAT_TIME;
 
-        if (!wxGst_element_query_position(m_playbin, &fmtTime, &pos) ||
+        if (!gst_element_query_position(m_playbin, &fmtTime, &pos) ||
             fmtTime != GST_FORMAT_TIME || pos == -1)
             return 0;
         return pos / GST_MSECOND ;

--- a/src/unix/mediactrl.cpp
+++ b/src/unix/mediactrl.cpp
@@ -91,21 +91,15 @@
 // gst_element_query function changed dramatically and split off
 // into two separate ones
 #if GST_VERSION_MAJOR == 0 && GST_VERSION_MINOR <= 8
-#    define wxGst_element_query_duration(e, f, p) \
-                gst_element_query(e, GST_QUERY_TOTAL, f, p)
 #    define wxGst_element_query_position(e, f, p) \
                 gst_element_query(e, GST_QUERY_POSITION, f, p)
 #elif GST_VERSION_MAJOR == 0 && GST_VERSION_MINOR == 9
 // However, the actual 0.9 version has a slightly different definition
 // and instead of gst_element_query_duration it has two parameters to
 // gst_element_query_position instead
-#    define wxGst_element_query_duration(e, f, p) \
-                gst_element_query_position(e, f, 0, p)
 #    define wxGst_element_query_position(e, f, p) \
                 gst_element_query_position(e, f, p, 0)
 #else
-#    define wxGst_element_query_duration \
-                gst_element_query_duration
 #    define wxGst_element_query_position \
                 gst_element_query_position
 #endif
@@ -1350,7 +1344,7 @@ wxLongLong wxGStreamerMediaBackend::GetDuration()
     gint64 length;
     GstFormat fmtTime = GST_FORMAT_TIME;
 
-    if(!wxGst_element_query_duration(m_playbin, &fmtTime, &length) ||
+    if(!gst_element_query_duration(m_playbin, &fmtTime, &length) ||
        fmtTime != GST_FORMAT_TIME || length == -1)
         return 0;
     return length / GST_MSECOND ;
@@ -1452,7 +1446,7 @@ wxLongLong wxGStreamerMediaBackend::GetDownloadTotal()
     gint64 length;
     GstFormat fmtBytes = GST_FORMAT_BYTES;
 
-    if (!wxGst_element_query_duration(m_playbin, &fmtBytes, &length) ||
+    if (!gst_element_query_duration(m_playbin, &fmtBytes, &length) ||
           fmtBytes != GST_FORMAT_BYTES || length == -1)
         return 0;
     return length;

--- a/src/unix/mediactrl.cpp
+++ b/src/unix/mediactrl.cpp
@@ -110,14 +110,6 @@
                 gst_element_query_position
 #endif
 
-// Other 0.10 macros
-#if GST_VERSION_MAJOR > 0 || GST_VERSION_MINOR >= 10
-#   define gst_gconf_get_default_video_sink() \
-        gst_element_factory_make ("gconfvideosink", "video-sink");
-#   define gst_gconf_get_default_audio_sink() \
-        gst_element_factory_make ("gconfaudiosink", "audio-sink");
-#endif
-
 // Max wait time for element state waiting - GST_CLOCK_TIME_NONE for inf
 #define wxGSTREAMER_TIMEOUT (100 * GST_MSECOND) // Max 100 milliseconds
 
@@ -1034,7 +1026,7 @@ bool wxGStreamerMediaBackend::CreateControl(wxControl* ctrl, wxWindow* parent,
                      G_CALLBACK(gst_notify_stream_info_callback), this);
 
     // Get the audio sink
-    GstElement* audiosink = gst_gconf_get_default_audio_sink();
+    GstElement* audiosink = gst_element_factory_make ("gconfaudiosink", "audio-sink");
     if( !TryAudioSink(audiosink) )
     {
         // fallback to autodetection, then alsa, then oss as a stopgap
@@ -1056,7 +1048,7 @@ bool wxGStreamerMediaBackend::CreateControl(wxControl* ctrl, wxWindow* parent,
 
     // Setup video sink - first try gconf, then auto, then xvimage and
     // then finally plain ximage
-    GstElement* videosink = gst_gconf_get_default_video_sink();
+    GstElement* videosink = gst_element_factory_make ("gconfvideosink", "video-sink");
     if( !TryVideoSink(videosink) )
     {
         videosink = gst_element_factory_make ("autovideosink", "video-sink");


### PR DESCRIPTION
This patchset gets rid of ancient gstreamer-0.8 support. It's only compile tested so far, as I'm having troubles getting the mediaplayer sample working.
