### PR TITLE
Fixed inserting owner drawn menu item to the menu (wxMSW).

### DIFF
--- a/src/msw/menu.cpp
+++ b/src/msw/menu.cpp
@@ -632,7 +632,11 @@ bool wxMenu::DoInsertOrAppend(wxMenuItem *pItem, size_t pos)
                 {
                     wxMenuItem* item = node->GetData();
 
-                    if ( !item->IsOwnerDrawn())
+                    // Current item is already added to the list of items
+                    // but is not yet physically attached to the menu
+                    // so we have to skip setting it as an owner drawn.
+                    // It will be done later on when the item will be created.
+                    if ( !item->IsOwnerDrawn() && item != pItem )
                     {
                         item->SetOwnerDrawn(true);
                         SetOwnerDrawnMenuItem(GetHmenu(), position,
@@ -642,7 +646,12 @@ bool wxMenu::DoInsertOrAppend(wxMenuItem *pItem, size_t pos)
                     item->SetMarginWidth(m_maxBitmapWidth);
 
                     node = node->GetNext();
-                    position++;
+                    // Current item is already added to the list of items
+                    // but is not yet physically attached to the menu
+                    // so it cannot be counted while determining position
+                    // in the menu.
+                    if ( item != pItem )
+                        position++;
                 }
 
                 // set menu as ownerdrawn


### PR DESCRIPTION
When menu item is inserted to the menu (in wxMenu::DoInsert) then it is first added to the list of menu items (in wxMenuBase::DoAppend() and after that it is added to the physical menu (in wxMenu::DoInsertOrAppend).
Prior to adding menu item to the menu all already existing menu items are set as owner drawn so the list of items is iterated and SetOwnerDrawnMenuItem is called for each item. Because new item is on the list but it doesn't yet physically exist it has to be skipped in the iteration to avoid assigning wrong data (like address of handler) to the wrong item.

This fixes issue reported in http://trac.wxwidgets.org/ticket/17350
