### PR TITLE
Add Visual Studio 2015 specific ignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@
 /build/msw/wx_vc12.sdf
 /build/msw/*.suo
 /build/msw/.vs/
+/build/msw/wx_vc14.opensdf
+/build/msw/wx_vc14.VC.opendb
+/build/msw/wx_vc14.sdf
 
 # /demos/
 /demos/*/*.sln


### PR DESCRIPTION
VS 2015 cache files wx_vc14.sdf, wx_vc14.opensdf and wx_vc14.VC.opendb should be ignored.
