### PR TITLE
Turn off the -- dash replacement

### DIFF
--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -603,7 +603,8 @@ wxNSTextViewControl::wxNSTextViewControl( wxTextCtrl *wxPeer, WXWidget w, long s
     [tv setVerticallyResizable:YES];
     [tv setHorizontallyResizable:hasHScroll];
     [tv setAutoresizingMask:NSViewWidthSizable];
-
+    [tv setAutomaticDashSubstitutionEnabled:false];
+    
     if ( hasHScroll )
     {
         [[tv textContainer] setContainerSize:NSMakeSize(FLT_MAX, FLT_MAX)];


### PR DESCRIPTION
Turn off the -- dash replacement to make the text control match the other platforms as well as makeit usable for entering compiler or command line flags for programs.  (CodeBlocks)

(likely could be a setting/style, but not sure if any other platform would support it)
