### PR TITLE
Combine all Travis CI commands into a single one

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,25 +36,25 @@ notifications:
 
 before_install: ./build/tools/before_install.sh
 
-script:
-    - echo 'Configuring...' && echo -en 'travis_fold:start:script.1\\r'
-    - ./configure --disable-optimise $wxCONFIGURE_FLAGS
-    - echo -en 'travis_fold:end:script.1\\r'
-    - echo 'Building...' && echo -en 'travis_fold:start:script.2\\r'
-    - make
-    - echo -en 'travis_fold:end:script.2\\r'
-    - echo 'Testing...' && echo -en 'travis_fold:start:script.3\\r'
-    - make -C tests
-    - pushd tests
-    - ./test -t
-    - popd
-    - echo -en 'travis_fold:end:script.3\\r'
-    - echo 'Building the samples...' && echo -en 'travis_fold:start:script.4\\r'
-    - make samples
-    - echo -en 'travis_fold:end:script.4\\r'
-    - echo 'Installing...' && echo -en 'travis_fold:start:script.5\\r'
-    - sudo make install
-    - echo -en 'travis_fold:end:script.5\\r'
-    - echo 'Testing building with the installed version...' && echo -en 'travis_fold:start:script.6\\r'
-    - make -C samples/minimal -f makefile.unx $wxMAKEFILE_FLAGS
-    - echo -en 'travis_fold:end:script.6\\r'
+script: |
+    echo 'Configuring...' && echo -en 'travis_fold:start:script.1\\r' &&
+    ./configure --disable-optimise $wxCONFIGURE_FLAGS &&
+    echo -en 'travis_fold:end:script.1\\r' &&
+    echo 'Building...' && echo -en 'travis_fold:start:script.2\\r' &&
+    make &&
+    echo -en 'travis_fold:end:script.2\\r' &&
+    echo 'Testing...' && echo -en 'travis_fold:start:script.3\\r' &&
+    make -C tests &&
+    pushd tests &&
+    ./test -t &&
+    popd &&
+    echo -en 'travis_fold:end:script.3\\r' &&
+    echo 'Building the samples...' && echo -en 'travis_fold:start:script.4\\r' &&
+    make samples &&
+    echo -en 'travis_fold:end:script.4\\r' &&
+    echo 'Installing...' && echo -en 'travis_fold:start:script.5\\r' &&
+    sudo make install &&
+    echo -en 'travis_fold:end:script.5\\r' &&
+    echo 'Testing building with the installed version...' && echo -en 'travis_fold:start:script.6\\r' &&
+    make -C samples/minimal -f makefile.unx $wxMAKEFILE_FLAGS &&
+    echo -en 'travis_fold:end:script.6\\r'


### PR DESCRIPTION
Don't build if configure failed and don't build tests if building the library
failed and so on: contrary to the expectations, Travis continues to execute
the rest of the commands even if a previous one had failed, so chain them all
explicitly together using "&&" to make sure we fail as soon as possible.

See https://github.com/travis-ci/travis-ci/issues/1066
