### PR TITLE
Don't destroy the native window in wxNativeWindow itself by default

### DIFF
--- a/include/wx/nativewin.h
+++ b/include/wx/nativewin.h
@@ -69,7 +69,10 @@ class WXDLLIMPEXP_CORE wxNativeWindow : public wxWindow
 {
 public:
     // Default ctor, Create() must be called later to really create the window.
-    wxNativeWindow() { }
+    wxNativeWindow()
+    {
+        Init();
+    }
 
     // Create a window from an existing native window handle.
     //
@@ -80,13 +83,45 @@ public:
     // 0 if the handle was invalid.
     wxNativeWindow(wxWindow* parent, wxWindowID winid, wxNativeWindowHandle handle)
     {
+        Init();
+
         Create(parent, winid, handle);
     }
 
     // Same as non-default ctor, but with a return code.
     bool Create(wxWindow* parent, wxWindowID winid, wxNativeWindowHandle handle);
 
+    // By default the native window with which this wxWindow is associated is
+    // owned by the user code and needs to be destroyed by it in a platform
+    // specific way, however this function can be called to let the native
+    // window be destroyed with this object itself.
+    void Disown()
+    {
+        wxCHECK_RET( m_ownedByUser, wxS("Can't disown more than once") );
+
+        m_ownedByUser = false;
+
+        DoDisown();
+    }
+
+#ifdef __WXMSW__
+    // Prevent the native window, not owned by us, from being destroyed by the
+    // base class dtor, unless Disown() had been called.
+    virtual ~wxNativeWindow();
+#endif // __WXMSW__
+
 private:
+    void Init()
+    {
+        m_ownedByUser = true;
+    }
+
+    // This is implemented in platform-specific code.
+    void DoDisown();
+
+    // If the native widget owned by the user code.
+    bool m_ownedByUser;
+
     wxDECLARE_NO_COPY_CLASS(wxNativeWindow);
 };
 

--- a/interface/wx/nativewin.h
+++ b/interface/wx/nativewin.h
@@ -15,8 +15,8 @@
     This class can be used as a bridge between wxWidgets and native GUI
     toolkit, i.e. standard Windows controls under MSW, GTK+ widgets or Cocoa
     views. Using it involves writing code specific to each platform, at the
-    very least for creating the native window, but possibly also to handle its
-    events, but this class takes care of all the generic parts.
+    very least for creating and destroying the native window, but possibly also
+    to handle its events, but this class takes care of all the generic parts.
 
     @note Check whether @c wxHAS_NATIVE_WINDOW is defined before using this
         class as it is not available under all platforms.
@@ -26,14 +26,24 @@
     @code
         #include <wx/nativewin.h>
 
-        wxNativeWindow* switch = new wxNativeWindow(parent, wxID_ANY, gtk_switch_new());
+        GtkWidget* w = gtk_switch_new();
+        wxNativeWindow* switch = new wxNativeWindow(parent, wxID_ANY, w);
+        g_object_unref(w);
     @endcode
     and then use @c switch as usual, e.g. add it to a sizer to layout it
     correctly. Of course, you will still have to use the native GTK+ functions
     to handle its events and change or retrieve its state.
 
-    See the "native" page of the widgets sample for another example of using
-    it.
+    Notice that the native window still remains owned by the caller, to allow
+    reusing it later independently of wxWidgets. If you want wxWidgets to
+    delete the native window when the wxNativeWindow itself is destroyed, you
+    need to explicitly call Disown(). Otherwise you need to perform the
+    necessary cleanup in your own code by calling the appropriate
+    platform-specific function: under MSW, this is @c ::DestroyWindow(), under
+    GTK @c g_object_unref() and under Cocoa -- @c -release:.
+
+    See the "native" page of the widgets sample for the examples of using
+    this class under all major platforms.
 
     @since 3.1.0
 
@@ -76,4 +86,12 @@ public:
             typically because the supplied parameters are invalid.
      */
     bool Create(wxWindow* parent, wxWindowID winid, wxNativeWindowHandle handle);
+
+    /**
+        Indicate that the user code yields ownership of the native window.
+
+        This method can be called at most once and after calling it, the native
+        window will be destroyed when this wxNativeWindow object is.
+     */
+    void Disown();
 };

--- a/samples/widgets/native.cpp
+++ b/samples/widgets/native.cpp
@@ -95,6 +95,16 @@ public:
         (void)Create(parent, wxID_ANY, hwnd);
     }
 
+    virtual ~NativeWindow()
+    {
+        // If you don't call this, you need to call DestroyWindow() later.
+        //
+        // Also notice that a HWND can't continue to exist under MSW if its
+        // parent its destroyed, so you may also want to reparent it under some
+        // other window if the parent of this window is also getting destroyed.
+        Disown();
+    }
+
 protected:
     // This code requires NMBCDROPDOWN to work, we don't really want to
     // reproduce its definition here for very old compilers not having it.
@@ -146,7 +156,16 @@ public:
         );
 #endif // GTK+ 3.6/earlier
 
+        g_object_ref_sink(widget);
+
         (void)Create(parent, wxID_ANY, widget);
+    }
+
+    virtual ~NativeWindow()
+    {
+        // If you don't call this, you need to call g_object_unref() on the
+        // widget from elsewhere later.
+        Disown();
     }
 
 private:
@@ -184,6 +203,13 @@ public:
         [v setAutoenablesItems:NO];
 
         (void)Create(parent, wxID_ANY, v);
+    }
+
+    virtual ~NativeWindow()
+    {
+        // If you don't call this, you need to call -release: on the button
+        // from elsewhere later.
+        Disown();
     }
 };
 

--- a/src/gtk/nativewin.cpp
+++ b/src/gtk/nativewin.cpp
@@ -54,11 +54,9 @@ wxNativeWindow::Create(wxWindow* parent,
     if ( !CreateBase(parent, winid) )
         return false;
 
-    // Add a reference to the widget to match g_object_unref() in wxWindow dtor
-    // (and by using the "_sink" version we avoid memory leaks when we're
-    // passed a newly allocated widget, as is typically the case).
+    // Add a reference to the widget to match g_object_unref() in wxWindow dtor.
     m_widget = widget;
-    g_object_ref_sink(m_widget);
+    g_object_ref(m_widget);
 
     parent->DoAddChild(this);
 
@@ -71,6 +69,11 @@ wxNativeWindow::Create(wxWindow* parent,
     SetInitialSize(wxSize(req.width, req.height));
 
     return true;
+}
+
+void wxNativeWindow::DoDisown()
+{
+    g_object_unref(m_widget);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/msw/nativewin.cpp
+++ b/src/msw/nativewin.cpp
@@ -79,6 +79,19 @@ wxNativeWindow::Create(wxWindow* parent,
     return true;
 }
 
+void wxNativeWindow::DoDisown()
+{
+    // We don't do anything here, clearing m_ownedByUser flag is enough.
+}
+
+wxNativeWindow::~wxNativeWindow()
+{
+    // Restore the original window proc and reset HWND to 0 to prevent it from
+    // being destroyed in the base class dtor if it's owned by user code.
+    if ( m_ownedByUser )
+        UnsubclassWin();
+}
+
 // ----------------------------------------------------------------------------
 // wxNativeContainerWindow
 // ----------------------------------------------------------------------------

--- a/src/osx/cocoa/nativewin.mm
+++ b/src/osx/cocoa/nativewin.mm
@@ -59,10 +59,18 @@ wxNativeWindow::Create(wxWindow* parent,
     else if ( [view respondsToSelector:@selector(stringValue)] )
         m_label = wxCFStringRef::AsString([(id)view stringValue]);
 
+    // As wxWidgets will release the view when this object is destroyed, retain
+    // it here to avoid destroying the view owned by the user code.
+    [view retain];
     SetPeer(new wxWidgetCocoaImpl(this, view));
 
     // It doesn't seem necessary to use MacPostControlCreate() here as we never
     // change the native control geometry here.
 
     return true;
+}
+
+void wxNativeWindow::DoDisown()
+{
+    [GetPeer()->GetWXWidget() release];
 }


### PR DESCRIPTION
Leave ownership of the native window to the user code as it may want to reuse
it for some other purpose and provide an explicit Disown() function that can
be called if the user really wants wxWidgets to take ownership of the native
window.

In particular, this avoids problems when using ARC under OS X which resulted
in a double "release" before.
