### PR TITLE
Stop AppVeyor PR build if newer PR commit exists.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,10 @@ before_build:
       %{$_ -replace "define wxUSE_STL 0", "define wxUSE_STL $env:wxUSE_STL"} |
       sc include\wx\msw\setup.h
     }
+    if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
 
 build_script: build\tools\appveyor.bat
 


### PR DESCRIPTION
With a build time of almost 2 and a half hours, it can be useful to automatically stop non-essential AppVeyor builds. For example multiple commits for the same Pull Request.

With this change, if a newer commit for a Pull Request is detected, the current build will stop.
Suggested in https://github.com/appveyor/ci/issues/38#issuecomment-70628826.
