### PR TITLE
Some Documentation Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ wxWidgets currently supports the following primary platforms:
 
 - Windows XP, Vista, 7, 8 and 10 (32/64 bits).
 - Most Unix variants using the GTK+ toolkit (version 2.6 or newer or 3.x).
-- Mac OS X (10.7 or newer) using Cocoa (32/64 bits).
+- OS X (10.7 or newer) using Cocoa (32/64 bits).
 
 Most popular C++ compilers are supported including but not limited to:
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Further information
 If you are looking for support, you can get it from
 
 - [Mailing Lists](https://www.wxwidgets.org/support/mailing-lists/)
-- [Discussion Forums][https://forums.wxwidgets.org/]
-- [#wxwidgets IRC channel][https://www.wxwidgets.org/support/irc/]
+- [Discussion Forums](https://forums.wxwidgets.org/)
+- [#wxwidgets IRC channel](https://www.wxwidgets.org/support/irc/)
 - Stack Overflow (tag your questions with @c wxwidgets):
   https://stackoverflow.com/questions/tagged/wxwidgets
 - Please report bugs at http://trac.wxwidgets.org/newticket

--- a/docs/base/readme.txt
+++ b/docs/base/readme.txt
@@ -30,7 +30,7 @@ executing simultaneously (portably!) and so on.
 --------------------------------------
 
  wxBase can be compiled and used under Win32, mostly any modern Unix system
-(including Mac OS X), VMS and BeOS (this release couldn't be tested under
+(including OS X), VMS and BeOS (this release couldn't be tested under
 these platforms so you might encounter some problems but they should be easy
 to solve -- please contact us in this case!)
 

--- a/docs/doxygen/groups/funcmacro_atomic.h
+++ b/docs/doxygen/groups/funcmacro_atomic.h
@@ -14,7 +14,7 @@ When using multi-threaded applications, it is often required to access or
 modify memory which is shared between threads. Atomic integer and pointer
 operations are an efficient way to handle this issue (another, less efficient,
 way is to use a wxMutex or wxCriticalSection). A native implementation exists
-for Windows, Linux, Solaris and Mac OS X; for others, a wxCriticalSection is
+for Windows, Linux, Solaris and OS X; for others, a wxCriticalSection is
 used to protect the data.
 
 One particular application is reference counting (used by so-called

--- a/docs/doxygen/mainpages/const_cpp.h
+++ b/docs/doxygen/mainpages/const_cpp.h
@@ -39,8 +39,8 @@ applications under Windows as well, but it should only be used in the GUI code
 while <tt>__WINDOWS__</tt> should be used for the platform tests.}
 @itemdef{__WXOSX__, OS X GUI using any Apple widget framework (AppKit or UIKit)}
 @itemdef{__WXOSX_IPHONE__, OS X iPhone (UIKit)}
-@itemdef{__WXOSX_COCOA__, Mac OS X using Cocoa (AppKit)}
-@itemdef{__WXOSX_MAC__, Mac OS X (Cocoa)}
+@itemdef{__WXOSX_COCOA__, OS X using Cocoa (AppKit)}
+@itemdef{__WXOSX_MAC__, OS X (Cocoa)}
 @itemdef{__WXPM__, OS/2 native Presentation Manager (not used any longer).}
 @itemdef{__WXSTUBS__, Stubbed version ('template' wxWin implementation)}
 @itemdef{__WXXT__, Xt; mutually exclusive with WX_MOTIF, not implemented in wxWidgets 2.x}
@@ -58,7 +58,7 @@ versions: Cocoa for the desktop and a very early iPhone port. To summarize:
     <tt>__WXOSX_MAC__</tt>.
 @li If you want to test for wxOSX on the iPhone, use
     <tt>__WXOSX_IPHONE__</tt>.
-@li If you want to test for any port under Mac OS X, including, for
+@li If you want to test for any port under OS X, including, for
     example, wxGTK and also wxBase, use <tt>__DARWIN__</tt> (see below).
 
 The convention is to use the <tt>__WX</tt> prefix for these
@@ -73,13 +73,13 @@ symbols, although this has not always been followed.
 @itemdef{__AIX__, AIX}
 @itemdef{__BSD__, Any *BSD system}
 @itemdef{__CYGWIN__, Cygwin: Unix on Win32}
-@itemdef{__DARWIN__, Mac OS X (with BSD C library), using any port (see also <tt>__WXOSX__</tt>)}
+@itemdef{__DARWIN__, OS X (with BSD C library), using any port (see also <tt>__WXOSX__</tt>)}
 @itemdef{__DATA_GENERAL__, DG-UX}
 @itemdef{__FREEBSD__, FreeBSD}
 @itemdef{__HPUX__, HP-UX (Unix)}
 @itemdef{__GNU__, GNU Hurd}
 @itemdef{__LINUX__, Linux}
-@itemdef{__MACH__, Mach-O Architecture (Mac OS X only builds)}
+@itemdef{__MACH__, Mach-O Architecture (OS X only builds)}
 @itemdef{__OSF__, OSF/1}
 @itemdef{__QNX__, QNX Neutrino RTOS}
 @itemdef{__SGI__, IRIX}

--- a/docs/doxygen/mainpages/introduction.h
+++ b/docs/doxygen/mainpages/introduction.h
@@ -89,13 +89,13 @@ mature. Both ports work on almost any Unix system (Linux, FreeBSD, OpenBSD,
 NetBSD, Solaris, AIX, ...) and require GTK+ 2.6 or later or GTK+ 3.x. The
 primary supported compiler is GNU g++.
 
-@li wxOSX: wxOSX/Cocoa is the only port for Apple computers. wxOSX/Cocoa
+@li wxOSX/Cocoa: This is the native port for Apple computers. wxOSX/Cocoa
 supports 32 or 64 bit Intel Macs running OS X 10.7 or later. The port can be
 built either with g++ or clang.
 
 Other platforms (e.g. iOS), compilers (Borland C++ under Windows,
 Sun CC, HP-UX aCC, IBM xlC or SGI mipsPro under Unix) and ports (
-wxGTK1, wxX11, wxDFB, wxPM...) are also supported but to a lesser extent.
+wxQT, wxGTK1, wxX11, wxDFB...) are also supported but to a lesser extent.
 Please see the @subpage page_port "platform details page" for more information.
 
 There are no CPU speed requirements but the faster (and more) CPU(s) you have,

--- a/docs/doxygen/mainpages/platdetails.h
+++ b/docs/doxygen/mainpages/platdetails.h
@@ -57,17 +57,10 @@ distribution.
 
 
 
-@section page_port_wxosx wxOSX
+@section page_port_wxosx wxOSX/Cocoa
 
-@subsection page_port_wxosx_cocoa wxOSX/Cocoa
-
-wxOSX/Cocoa is the only port of wxWidgets for the OS X platform. It requires
+wxOSX/Cocoa is the port of wxWidgets for the OS X platform. It requires
 OS X 10.7 or later and fully supports 64 bit builds.
-
-This is the default port when building wxOSX, but in order to select it
-explicitly you can use
-
-@verbatim configure --with-osx_cocoa @endverbatim
 
 For further information, please see the files in @c docs/osx in the
 distribution.

--- a/docs/doxygen/mainpages/platdetails.h
+++ b/docs/doxygen/mainpages/platdetails.h
@@ -163,6 +163,12 @@ create a window with no border (for example, notebook pages). So wxPanel
 overrides GetDefaultBorder() in order to call the generic
 wxWindowBase::GetDefaultBorder(), returning wxBORDER_NONE.
 
+@section page_port_wxQt wxQt
+
+wxQt is a port of wxWidgets using Qt libraries. It requires Qt 5 or later.
+
+For further information, please see the files in docs/qt in the distribution.
+
 @section page_port_nativedocs Native Toolkit Documentation
 
 It's sometimes useful to interface directly with the underlying toolkit

--- a/docs/doxygen/overviews/richtextctrl.h
+++ b/docs/doxygen/overviews/richtextctrl.h
@@ -42,7 +42,7 @@ list styles with a renumber option.
 There are a few disadvantages to using wxRichTextCtrl. It is not native, so
 does not behave exactly as a native wxTextCtrl, although common editing
 conventions are followed. Users may miss the built-in spelling correction on
-Mac OS X, or any special character input that may be provided by the native
+OS X, or any special character input that may be provided by the native
 control. It would also be a poor choice if intended users rely on screen
 readers that would be not work well with non-native text input implementation.
 You might mitigate this by providing the choice between wxTextCtrl and
@@ -495,7 +495,7 @@ tables, text boxes, and floating images, in addition to a simplified-HTML mode f
 
 There are also things that could be done to take advantage of the underlying
 text capabilities of the platform; higher-level text formatting APIs are
-available on some platforms, such as Mac OS X, and some of translation from
+available on some platforms, such as OS X, and some of translation from
 high level to low level wxDC API is unnecessary. However this would require
 additions to the wxWidgets API.
 

--- a/docs/doxygen/overviews/unicode.h
+++ b/docs/doxygen/overviews/unicode.h
@@ -182,7 +182,7 @@ aware of the potential problems covered by the following section.
 wxWidgets uses the system @c wchar_t in wxString implementation by default
 under all systems. Thus, under Microsoft Windows, UCS-2 (simplified version of
 UTF-16 without support for surrogate characters) is used as @c wchar_t is 2
-bytes on this platform. Under Unix systems, including Mac OS X, UCS-4 (also
+bytes on this platform. Under Unix systems, including OS X, UCS-4 (also
 known as UTF-32) is used by default, however it is also possible to build
 wxWidgets to use UTF-8 internally by passing @c --enable-utf8 option to
 configure.

--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -2458,7 +2458,7 @@ should be processed on. It is filtered out and ignored on any other platforms.
 Possible elemental values are:
 @beginDefList
 @itemdef{ @c win, Windows }
-@itemdef{ @c mac, Mac OS X (or Mac Classic in wxWidgets version supporting it) }
+@itemdef{ @c mac, OS X (or Mac Classic in wxWidgets version supporting it) }
 @itemdef{ @c unix, Any Unix platform @em except OS X }
 @endDefList
 
@@ -2466,7 +2466,7 @@ Examples:
 @code
 <label platform="win">Windows</label>
 <label platform="unix">Unix</label>
-<label platform="mac">Mac OS X</label>
+<label platform="mac">OS X</label>
 <help platform="mac|unix">Not a Windows machine</help>
 @endcode
 

--- a/docs/osx/install.txt
+++ b/docs/osx/install.txt
@@ -4,7 +4,7 @@ wxWidgets for Mac OS X installation
 wxWidgets can be compiled using Apple's Cocoa library.
 
 Most Mac OS X developers should start by downloading and installing Xcode 
-from http://developer.apple.com.  It is a free IDE from Apple that provides
+from the App Store.  It is a free IDE from Apple that provides
 all of the tools you need for working with wxWidgets.
 
 After Xcode is installed, download wxWidgets-{version}.tar.bz2 and then 
@@ -12,7 +12,7 @@ double-click on it to unpack it to create a wxWidgets directory.
 
 Next use Terminal (under Applications, Utilities, Terminal) to access a command 
 prompt.  Use cd to change directories to your wxWidgets directory and execute 
-one of the following sets of commands from the wxWidgets directory.
+the following sets of commands from the wxWidgets directory.
 
 ---------
 

--- a/docs/osx/install.txt
+++ b/docs/osx/install.txt
@@ -1,9 +1,9 @@
-wxWidgets for Mac OS X installation
+wxWidgets for OS X installation
 -----------------------------------
 
 wxWidgets can be compiled using Apple's Cocoa library.
 
-Most Mac OS X developers should start by downloading and installing Xcode 
+Most OS X developers should start by downloading and installing Xcode 
 from the App Store.  It is a free IDE from Apple that provides
 all of the tools you need for working with wxWidgets.
 
@@ -35,7 +35,7 @@ The source code for the demos is in wxWidgets/demos
 
 ---------
 
-More information about building on Mac OS X is available in the wxWiki.
+More information about building on OS X is available in the wxWiki.
 Here are two useful links
   http://wiki.wxwidgets.org/Guides_%26_Tutorials
   http://wiki.wxwidgets.org/Development:_wxMac 

--- a/docs/osx/readme.txt
+++ b/docs/osx/readme.txt
@@ -4,15 +4,14 @@ More Information is available from the wxWidgets project home page at
 
 https://www.wxwidgets.org 
 
-For more information, please see install.txt, todo.txt, and the
-manuals.
+For more information, please see install.txt and the manuals.
 
 Please send problems concerning installation, feature requests,
 bug reports or comments to the wxWidgets users list. Information
 on how to subscribe is available from the wxWidgets.org homepage.
 
-Questions/Problems related directly to the mac port can be sent directly
-csomor@advancedconcepts.ch.
+Questions/Problems related directly to the mac port can be reported
+at http://trac.wxwidgets.org.
 
 wxWidgets/Mac doesn't come with any guarantee whatsoever. It
 might crash your harddisk or destroy your monitor. It doesn't

--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -37,7 +37,7 @@ wxWidgets currently supports the following primary platforms:
 
 * Windows XP, Vista, 7, 8 and 10 (32/64 bits).
 * Most Unix variants using the GTK+ toolkit (version 2.6 or newer)
-* Mac OS X (10.7 or newer) using Cocoa (32/64 bits)
+* OS X (10.7 or newer) using Cocoa (32/64 bits)
 
 There is some support for the following platforms:
 


### PR DESCRIPTION
- Wording changes after carbon removal
- Refer to OS X instead of Mac OS X
- Fix invalid links in README.md
- Include wxQt in the platfom details page
