### PR TITLE
Native wxAuiToolbarArt for MSW.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -2225,7 +2225,7 @@ COND_TOOLKIT_MSW_WEBVIEW_HDR_PLATFORM =  \
 @COND_TOOLKIT_MOTIF@OPENGL_HDR_PLATFORM = wx/x11/glcanvas.h wx/unix/glx11.h
 @COND_TOOLKIT_X11@OPENGL_HDR_PLATFORM = wx/x11/glcanvas.h wx/unix/glx11.h
 @COND_TOOLKIT_GTK_TOOLKIT_VERSION_2@AUI_GTK_HDR = wx/aui/tabartgtk.h
-@COND_TOOLKIT_MSW@AUI_PLATFORM_HDR = wx/aui/tabartmsw.h
+@COND_TOOLKIT_MSW@AUI_PLATFORM_HDR = wx/aui/tabartmsw.h wx/aui/barartmsw.h
 COND_TOOLKIT_OSX_COCOA_BASE_OSX_SRC =  \
 	src/osx/core/mimetype.cpp \
 	src/osx/core/cfstring.cpp \
@@ -6056,7 +6056,8 @@ COND_TOOLKIT_X11___ADVANCED_PLATFORM_SRC_OBJECTS_1 =  \
 @COND_TOOLKIT_MSW@__WEBVIEW_SRC_PLATFORM_OBJECTS = monodll_webview_ie.o
 @COND_TOOLKIT_GTK_TOOLKIT_VERSION_2@__AUI_GTK_SRC_OBJECTS \
 @COND_TOOLKIT_GTK_TOOLKIT_VERSION_2@	= monodll_tabartgtk.o
-@COND_TOOLKIT_MSW@__AUI_PLATFORM_SRC_OBJECTS = monodll_tabartmsw.o
+@COND_TOOLKIT_MSW@__AUI_PLATFORM_SRC_OBJECTS = \
+@COND_TOOLKIT_MSW@	monodll_tabartmsw.o monodll_barartmsw.o
 @COND_PLATFORM_UNIX_1_USE_PLUGINS_0@__PLUGIN_ADV_SRC_OBJECTS \
 @COND_PLATFORM_UNIX_1_USE_PLUGINS_0@	= monodll_sound_sdl.o
 @COND_PLATFORM_WIN32_1@__monodll___win32rc = monodll_version_rc.o
@@ -8054,7 +8055,8 @@ COND_TOOLKIT_X11___ADVANCED_PLATFORM_SRC_OBJECTS_3 =  \
 @COND_TOOLKIT_MSW@__WEBVIEW_SRC_PLATFORM_OBJECTS_1 = monolib_webview_ie.o
 @COND_TOOLKIT_GTK_TOOLKIT_VERSION_2@__AUI_GTK_SRC_OBJECTS_1 \
 @COND_TOOLKIT_GTK_TOOLKIT_VERSION_2@	= monolib_tabartgtk.o
-@COND_TOOLKIT_MSW@__AUI_PLATFORM_SRC_OBJECTS_1 = monolib_tabartmsw.o
+@COND_TOOLKIT_MSW@__AUI_PLATFORM_SRC_OBJECTS_1 = \
+@COND_TOOLKIT_MSW@	monolib_tabartmsw.o monolib_barartmsw.o
 @COND_PLATFORM_UNIX_1_USE_PLUGINS_0@__PLUGIN_ADV_SRC_OBJECTS_1 \
 @COND_PLATFORM_UNIX_1_USE_PLUGINS_0@	= monolib_sound_sdl.o
 COND_MONOLITHIC_0_SHARED_1___basedll___depname = \
@@ -12611,7 +12613,8 @@ COND_USE_SOVERSOLARIS_1___auidll___so_symlinks_uninst_cmd = rm -f \
 @COND_PLATFORM_WIN32_1@__auidll___win32rc = auidll_version_rc.o
 @COND_TOOLKIT_GTK_TOOLKIT_VERSION_2@__AUI_GTK_SRC_OBJECTS_2 \
 @COND_TOOLKIT_GTK_TOOLKIT_VERSION_2@	= auidll_tabartgtk.o
-@COND_TOOLKIT_MSW@__AUI_PLATFORM_SRC_OBJECTS_2 = auidll_tabartmsw.o
+@COND_TOOLKIT_MSW@__AUI_PLATFORM_SRC_OBJECTS_2 = \
+@COND_TOOLKIT_MSW@	auidll_tabartmsw.o auidll_barartmsw.o
 COND_MONOLITHIC_0_SHARED_0_USE_AUI_1___auilib___depname = \
 	$(LIBDIRNAME)/$(LIBPREFIX)wx_$(PORTNAME)$(WXUNIVNAME)$(WXUNICODEFLAG)$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)_aui-$(WX_RELEASE)$(HOST_SUFFIX)$(LIBEXT)
 @COND_MONOLITHIC_0_SHARED_0_USE_AUI_1@__auilib___depname = $(COND_MONOLITHIC_0_SHARED_0_USE_AUI_1___auilib___depname)
@@ -12626,7 +12629,8 @@ COND_MONOLITHIC_0_SHARED_0_USE_AUI_1___auilib___depname = \
 @COND_USE_PCH_1@	= ./.pch/wxprec_auilib/wx/wxprec.h.gch
 @COND_TOOLKIT_GTK_TOOLKIT_VERSION_2@__AUI_GTK_SRC_OBJECTS_3 \
 @COND_TOOLKIT_GTK_TOOLKIT_VERSION_2@	= auilib_tabartgtk.o
-@COND_TOOLKIT_MSW@__AUI_PLATFORM_SRC_OBJECTS_3 = auilib_tabartmsw.o
+@COND_TOOLKIT_MSW@__AUI_PLATFORM_SRC_OBJECTS_3 = \
+@COND_TOOLKIT_MSW@	auilib_tabartmsw.o auilib_barartmsw.o
 @COND_SHARED_1@____wxaui_namedll_DEP = $(__auidll___depname)
 @COND_SHARED_0@____wxaui_namelib_DEP = $(__auilib___depname)
 COND_MONOLITHIC_0_SHARED_1_USE_RIBBON_1___ribbondll___depname = \
@@ -16963,6 +16967,9 @@ monodll_tabartgtk.o: $(srcdir)/src/aui/tabartgtk.cpp $(MONODLL_ODEP)
 
 monodll_tabartmsw.o: $(srcdir)/src/aui/tabartmsw.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/aui/tabartmsw.cpp
+
+monodll_barartmsw.o: $(srcdir)/src/aui/barartmsw.cpp $(MONODLL_ODEP)
+	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/aui/barartmsw.cpp
 
 monodll_advprops.o: $(srcdir)/src/propgrid/advprops.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/propgrid/advprops.cpp
@@ -21766,6 +21773,9 @@ monolib_tabartgtk.o: $(srcdir)/src/aui/tabartgtk.cpp $(MONOLIB_ODEP)
 
 monolib_tabartmsw.o: $(srcdir)/src/aui/tabartmsw.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/aui/tabartmsw.cpp
+
+monolib_barartmsw.o: $(srcdir)/src/aui/barartmsw.cpp $(MONOLIB_ODEP)
+	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/aui/barartmsw.cpp
 
 monolib_advprops.o: $(srcdir)/src/propgrid/advprops.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/propgrid/advprops.cpp
@@ -34523,6 +34533,9 @@ auidll_tabartgtk.o: $(srcdir)/src/aui/tabartgtk.cpp $(AUIDLL_ODEP)
 auidll_tabartmsw.o: $(srcdir)/src/aui/tabartmsw.cpp $(AUIDLL_ODEP)
 	$(CXXC) -c -o $@ $(AUIDLL_CXXFLAGS) $(srcdir)/src/aui/tabartmsw.cpp
 
+auidll_barartmsw.o: $(srcdir)/src/aui/barartmsw.cpp $(AUIDLL_ODEP)
+	$(CXXC) -c -o $@ $(AUIDLL_CXXFLAGS) $(srcdir)/src/aui/barartmsw.cpp
+
 auilib_framemanager.o: $(srcdir)/src/aui/framemanager.cpp $(AUILIB_ODEP)
 	$(CXXC) -c -o $@ $(AUILIB_CXXFLAGS) $(srcdir)/src/aui/framemanager.cpp
 
@@ -34555,6 +34568,9 @@ auilib_tabartgtk.o: $(srcdir)/src/aui/tabartgtk.cpp $(AUILIB_ODEP)
 
 auilib_tabartmsw.o: $(srcdir)/src/aui/tabartmsw.cpp $(AUILIB_ODEP)
 	$(CXXC) -c -o $@ $(AUILIB_CXXFLAGS) $(srcdir)/src/aui/tabartmsw.cpp
+
+auilib_barartmsw.o: $(srcdir)/src/aui/barartmsw.cpp $(AUILIB_ODEP)
+	$(CXXC) -c -o $@ $(AUILIB_CXXFLAGS) $(srcdir)/src/aui/barartmsw.cpp
 
 ribbondll_version_rc.o: $(srcdir)/src/msw/version.rc $(RIBBONDLL_ODEP)
 	$(WINDRES) -i$< -o$@    --define __WX$(TOOLKIT)__ $(__WXUNIV_DEFINE_p_67) $(__DEBUG_DEFINE_p_66)  $(__EXCEPTIONS_DEFINE_p_65) $(__RTTI_DEFINE_p_65) $(__THREAD_DEFINE_p_65)  --define WXBUILDING --define WXDLLNAME=$(WXDLLNAMEPREFIXGUI)$(WXUNICODEFLAG)$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)_ribbon$(WXCOMPILER)$(VENDORTAG)$(WXDLLVERSIONTAG) $(__RCDEFDIR_p) --include-dir $(top_srcdir)/include $(__INC_TIFF_BUILD_p_66) $(__INC_TIFF_p_66) $(__INC_JPEG_p_66) $(__INC_PNG_p_65) $(__INC_ZLIB_p_67) $(__INC_REGEX_p_65) $(__INC_EXPAT_p_65) --define WXUSINGDLL --define WXMAKINGDLL_RIBBON

--- a/build/bakefiles/files.bkl
+++ b/build/bakefiles/files.bkl
@@ -3356,9 +3356,11 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
 </set>
 <set var="AUI_MSW_SRC" hints="files">
     src/aui/tabartmsw.cpp
+    src/aui/barartmsw.cpp
 </set>
 <set var="AUI_MSW_HDR" hints="files">
     wx/aui/tabartmsw.h
+    wx/aui/barartmsw.h
 </set>
 <set var="AUI_PLATFORM_SRC" hints="files">
     <if cond="TOOLKIT=='MSW'">$(AUI_MSW_SRC)</if>

--- a/build/files
+++ b/build/files
@@ -2805,8 +2805,10 @@ AUI_CMN_HDR =
 
 AUI_MSW_HDR =
     wx/aui/tabartmsw.h
+	wx/aui/barartmsw.h
 AUI_MSW_SRC =
     src/aui/tabartmsw.cpp
+	src/aui/barartmsw.cpp
 
 # wxRibbon
 

--- a/build/msw/makefile.bcc
+++ b/build/msw/makefile.bcc
@@ -1355,7 +1355,8 @@ AUIDLL_OBJECTS =  \
 	$(OBJS)\auidll_tabart.obj \
 	$(OBJS)\auidll_xh_auinotbk.obj \
 	$(OBJS)\auidll_xh_auitoolb.obj \
-	$(OBJS)\auidll_tabartmsw.obj
+	$(OBJS)\auidll_tabartmsw.obj \
+	$(OBJS)\auidll_barartmsw.obj
 AUILIB_CXXFLAGS = $(__RUNTIME_LIBS) -I$(BCCDIR)\include $(__DEBUGINFO) \
 	$(__OPTIMIZEFLAG) $(__THREADSFLAG) -D__WXMSW__ $(__WXUNIV_DEFINE_p) \
 	$(__DEBUG_DEFINE_p) $(__NDEBUG_DEFINE_p) $(__EXCEPTIONS_DEFINE_p) \
@@ -1375,7 +1376,8 @@ AUILIB_OBJECTS =  \
 	$(OBJS)\auilib_tabart.obj \
 	$(OBJS)\auilib_xh_auinotbk.obj \
 	$(OBJS)\auilib_xh_auitoolb.obj \
-	$(OBJS)\auilib_tabartmsw.obj
+	$(OBJS)\auilib_tabartmsw.obj \
+	$(OBJS)\auilib_barartmsw.obj
 RIBBONDLL_CXXFLAGS = $(__RUNTIME_LIBS) -I$(BCCDIR)\include $(__DEBUGINFO) \
 	$(__OPTIMIZEFLAG) $(__THREADSFLAG) -D__WXMSW__ $(__WXUNIV_DEFINE_p) \
 	$(__DEBUG_DEFINE_p) $(__NDEBUG_DEFINE_p) $(__EXCEPTIONS_DEFINE_p) \
@@ -1737,6 +1739,7 @@ ____MONOLIB_GUI_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_xh_auinotbk.obj \
 	$(OBJS)\monodll_xh_auitoolb.obj \
 	$(OBJS)\monodll_tabartmsw.obj \
+	$(OBJS)\monodll_barartmsw.obj \
 	$(OBJS)\monodll_advprops.obj \
 	$(OBJS)\monodll_editors.obj \
 	$(OBJS)\monodll_manager.obj \
@@ -2559,6 +2562,7 @@ ____MONOLIB_GUI_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_xh_auinotbk.obj \
 	$(OBJS)\monolib_xh_auitoolb.obj \
 	$(OBJS)\monolib_tabartmsw.obj \
+	$(OBJS)\monolib_barartmsw.obj \
 	$(OBJS)\monolib_advprops.obj \
 	$(OBJS)\monolib_editors.obj \
 	$(OBJS)\monolib_manager.obj \
@@ -7396,6 +7400,9 @@ $(OBJS)\monodll_xh_auitoolb.obj: ..\..\src\xrc\xh_auitoolb.cpp
 $(OBJS)\monodll_tabartmsw.obj: ..\..\src\aui\tabartmsw.cpp
 	$(CXX) -q -c -P -o$@ $(MONODLL_CXXFLAGS) ..\..\src\aui\tabartmsw.cpp
 
+$(OBJS)\monodll_barartmsw.obj: ..\..\src\aui\barartmsw.cpp
+	$(CXX) -q -c -P -o$@ $(MONODLL_CXXFLAGS) ..\..\src\aui\barartmsw.cpp
+
 $(OBJS)\monodll_advprops.obj: ..\..\src\propgrid\advprops.cpp
 	$(CXX) -q -c -P -o$@ $(MONODLL_CXXFLAGS) ..\..\src\propgrid\advprops.cpp
 
@@ -9905,6 +9912,9 @@ $(OBJS)\monolib_xh_auitoolb.obj: ..\..\src\xrc\xh_auitoolb.cpp
 
 $(OBJS)\monolib_tabartmsw.obj: ..\..\src\aui\tabartmsw.cpp
 	$(CXX) -q -c -P -o$@ $(MONOLIB_CXXFLAGS) ..\..\src\aui\tabartmsw.cpp
+
+$(OBJS)\monolib_barartmsw.obj: ..\..\src\aui\barartmsw.cpp
+	$(CXX) -q -c -P -o$@ $(MONOLIB_CXXFLAGS) ..\..\src\aui\barartmsw.cpp
 
 $(OBJS)\monolib_advprops.obj: ..\..\src\propgrid\advprops.cpp
 	$(CXX) -q -c -P -o$@ $(MONOLIB_CXXFLAGS) ..\..\src\propgrid\advprops.cpp
@@ -16095,6 +16105,9 @@ $(OBJS)\auidll_xh_auitoolb.obj: ..\..\src\xrc\xh_auitoolb.cpp
 $(OBJS)\auidll_tabartmsw.obj: ..\..\src\aui\tabartmsw.cpp
 	$(CXX) -q -c -P -o$@ $(AUIDLL_CXXFLAGS) ..\..\src\aui\tabartmsw.cpp
 
+$(OBJS)\auidll_barartmsw.obj: ..\..\src\aui\barartmsw.cpp
+	$(CXX) -q -c -P -o$@ $(AUIDLL_CXXFLAGS) ..\..\src\aui\barartmsw.cpp
+
 $(OBJS)\auilib_dummy.obj: ..\..\src\common\dummy.cpp
 	$(CXX) -q -c -P -o$@ $(AUILIB_CXXFLAGS) -H ..\..\src\common\dummy.cpp
 
@@ -16127,6 +16140,9 @@ $(OBJS)\auilib_xh_auitoolb.obj: ..\..\src\xrc\xh_auitoolb.cpp
 
 $(OBJS)\auilib_tabartmsw.obj: ..\..\src\aui\tabartmsw.cpp
 	$(CXX) -q -c -P -o$@ $(AUILIB_CXXFLAGS) ..\..\src\aui\tabartmsw.cpp
+
+$(OBJS)\auilib_barartmsw.obj: ..\..\src\aui\barartmsw.cpp
+	$(CXX) -q -c -P -o$@ $(AUILIB_CXXFLAGS) ..\..\src\aui\barartmsw.cpp
 
 $(OBJS)\ribbondll_dummy.obj: ..\..\src\common\dummy.cpp
 	$(CXX) -q -c -P -o$@ $(RIBBONDLL_CXXFLAGS) -H ..\..\src\common\dummy.cpp

--- a/build/msw/makefile.gcc
+++ b/build/msw/makefile.gcc
@@ -1361,7 +1361,8 @@ AUIDLL_OBJECTS =  \
 	$(OBJS)\auidll_tabart.o \
 	$(OBJS)\auidll_xh_auinotbk.o \
 	$(OBJS)\auidll_xh_auitoolb.o \
-	$(OBJS)\auidll_tabartmsw.o
+	$(OBJS)\auidll_tabartmsw.o \
+	$(OBJS)\auidll_barartmsw.o
 AUILIB_CXXFLAGS = $(__DEBUGINFO) $(__OPTIMIZEFLAG) $(__THREADSFLAG) $(GCCFLAGS) \
 	-DHAVE_W32API_H -D__WXMSW__ $(__WXUNIV_DEFINE_p) $(__DEBUG_DEFINE_p) \
 	$(__NDEBUG_DEFINE_p) $(__EXCEPTIONS_DEFINE_p) $(__RTTI_DEFINE_p) \
@@ -1381,7 +1382,8 @@ AUILIB_OBJECTS =  \
 	$(OBJS)\auilib_tabart.o \
 	$(OBJS)\auilib_xh_auinotbk.o \
 	$(OBJS)\auilib_xh_auitoolb.o \
-	$(OBJS)\auilib_tabartmsw.o
+	$(OBJS)\auilib_tabartmsw.o \
+	$(OBJS)\auilib_barartmsw.o
 RIBBONDLL_CXXFLAGS = $(__DEBUGINFO) $(__OPTIMIZEFLAG) $(__THREADSFLAG) \
 	$(GCCFLAGS) -DHAVE_W32API_H -D__WXMSW__ $(__WXUNIV_DEFINE_p) \
 	$(__DEBUG_DEFINE_p) $(__NDEBUG_DEFINE_p) $(__EXCEPTIONS_DEFINE_p) \
@@ -1755,6 +1757,7 @@ ____MONOLIB_GUI_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_xh_auinotbk.o \
 	$(OBJS)\monodll_xh_auitoolb.o \
 	$(OBJS)\monodll_tabartmsw.o \
+	$(OBJS)\monodll_barartmsw.o \
 	$(OBJS)\monodll_advprops.o \
 	$(OBJS)\monodll_editors.o \
 	$(OBJS)\monodll_manager.o \
@@ -2583,6 +2586,7 @@ ____MONOLIB_GUI_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_xh_auinotbk.o \
 	$(OBJS)\monolib_xh_auitoolb.o \
 	$(OBJS)\monolib_tabartmsw.o \
+	$(OBJS)\monolib_barartmsw.o \
 	$(OBJS)\monolib_advprops.o \
 	$(OBJS)\monolib_editors.o \
 	$(OBJS)\monolib_manager.o \
@@ -7571,6 +7575,9 @@ $(OBJS)\monodll_xh_auitoolb.o: ../../src/xrc/xh_auitoolb.cpp
 $(OBJS)\monodll_tabartmsw.o: ../../src/aui/tabartmsw.cpp
 	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
 
+$(OBJS)\monodll_barartmsw.o: ../../src/aui/barartmsw.cpp
+	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
+
 $(OBJS)\monodll_advprops.o: ../../src/propgrid/advprops.cpp
 	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
 
@@ -10079,6 +10086,9 @@ $(OBJS)\monolib_xh_auitoolb.o: ../../src/xrc/xh_auitoolb.cpp
 	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\monolib_tabartmsw.o: ../../src/aui/tabartmsw.cpp
+	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
+
+$(OBJS)\monolib_barartmsw.o: ../../src/aui/barartmsw.cpp
 	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\monolib_advprops.o: ../../src/propgrid/advprops.cpp
@@ -16270,6 +16280,9 @@ $(OBJS)\auidll_xh_auitoolb.o: ../../src/xrc/xh_auitoolb.cpp
 $(OBJS)\auidll_tabartmsw.o: ../../src/aui/tabartmsw.cpp
 	$(CXX) -c -o $@ $(AUIDLL_CXXFLAGS) $(CPPDEPS) $<
 
+$(OBJS)\auidll_barartmsw.o: ../../src/aui/barartmsw.cpp
+	$(CXX) -c -o $@ $(AUIDLL_CXXFLAGS) $(CPPDEPS) $<
+
 $(OBJS)\auilib_dummy.o: ../../src/common/dummy.cpp
 	$(CXX) -c -o $@ $(AUILIB_CXXFLAGS) $(CPPDEPS) $<
 
@@ -16301,6 +16314,9 @@ $(OBJS)\auilib_xh_auitoolb.o: ../../src/xrc/xh_auitoolb.cpp
 	$(CXX) -c -o $@ $(AUILIB_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\auilib_tabartmsw.o: ../../src/aui/tabartmsw.cpp
+	$(CXX) -c -o $@ $(AUILIB_CXXFLAGS) $(CPPDEPS) $<
+
+$(OBJS)\auilib_barartmsw.o: ../../src/aui/barartmsw.cpp
 	$(CXX) -c -o $@ $(AUILIB_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\ribbondll_dummy.o: ../../src/common/dummy.cpp

--- a/build/msw/makefile.vc
+++ b/build/msw/makefile.vc
@@ -1499,7 +1499,8 @@ AUIDLL_OBJECTS =  \
 	$(OBJS)\auidll_tabart.obj \
 	$(OBJS)\auidll_xh_auinotbk.obj \
 	$(OBJS)\auidll_xh_auitoolb.obj \
-	$(OBJS)\auidll_tabartmsw.obj
+	$(OBJS)\auidll_tabartmsw.obj \
+	$(OBJS)\auidll_barartmsw.obj
 AUIDLL_RESOURCES =  \
 	$(OBJS)\auidll_version.res
 AUILIB_CXXFLAGS = /M$(__RUNTIME_LIBS_472)$(__DEBUGRUNTIME) /DWIN32 \
@@ -1525,7 +1526,8 @@ AUILIB_OBJECTS =  \
 	$(OBJS)\auilib_tabart.obj \
 	$(OBJS)\auilib_xh_auinotbk.obj \
 	$(OBJS)\auilib_xh_auitoolb.obj \
-	$(OBJS)\auilib_tabartmsw.obj
+	$(OBJS)\auilib_tabartmsw.obj \
+	$(OBJS)\auilib_barartmsw.obj
 RIBBONDLL_CXXFLAGS = /M$(__RUNTIME_LIBS_488)$(__DEBUGRUNTIME) /DWIN32 \
 	$(__DEBUGINFO) \
 	/Fd$(LIBDIRNAME)\wx$(PORTNAME)$(WXUNIVNAME)$(WX_VERSION_NODOT)$(WXUNICODEFLAG)$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)_ribbon$(WXCOMPILER)$(VENDORTAG).pdb \
@@ -2037,6 +2039,7 @@ ____MONOLIB_GUI_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_xh_auinotbk.obj \
 	$(OBJS)\monodll_xh_auitoolb.obj \
 	$(OBJS)\monodll_tabartmsw.obj \
+	$(OBJS)\monodll_barartmsw.obj \
 	$(OBJS)\monodll_advprops.obj \
 	$(OBJS)\monodll_editors.obj \
 	$(OBJS)\monodll_manager.obj \
@@ -2865,6 +2868,7 @@ ____MONOLIB_GUI_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_xh_auinotbk.obj \
 	$(OBJS)\monolib_xh_auitoolb.obj \
 	$(OBJS)\monolib_tabartmsw.obj \
+	$(OBJS)\monolib_barartmsw.obj \
 	$(OBJS)\monolib_advprops.obj \
 	$(OBJS)\monolib_editors.obj \
 	$(OBJS)\monolib_manager.obj \
@@ -8088,6 +8092,9 @@ $(OBJS)\monodll_xh_auitoolb.obj: ..\..\src\xrc\xh_auitoolb.cpp
 $(OBJS)\monodll_tabartmsw.obj: ..\..\src\aui\tabartmsw.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\aui\tabartmsw.cpp
 
+$(OBJS)\monodll_barartmsw.obj: ..\..\src\aui\barartmsw.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\aui\barartmsw.cpp
+
 $(OBJS)\monodll_advprops.obj: ..\..\src\propgrid\advprops.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\propgrid\advprops.cpp
 
@@ -10597,6 +10604,9 @@ $(OBJS)\monolib_xh_auitoolb.obj: ..\..\src\xrc\xh_auitoolb.cpp
 
 $(OBJS)\monolib_tabartmsw.obj: ..\..\src\aui\tabartmsw.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\aui\tabartmsw.cpp
+
+$(OBJS)\monolib_barartmsw.obj: ..\..\src\aui\barartmsw.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\aui\barartmsw.cpp
 
 $(OBJS)\monolib_advprops.obj: ..\..\src\propgrid\advprops.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\propgrid\advprops.cpp
@@ -16787,6 +16797,9 @@ $(OBJS)\auidll_xh_auitoolb.obj: ..\..\src\xrc\xh_auitoolb.cpp
 $(OBJS)\auidll_tabartmsw.obj: ..\..\src\aui\tabartmsw.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(AUIDLL_CXXFLAGS) ..\..\src\aui\tabartmsw.cpp
 
+$(OBJS)\auidll_barartmsw.obj: ..\..\src\aui\barartmsw.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(AUIDLL_CXXFLAGS) ..\..\src\aui\barartmsw.cpp
+
 $(OBJS)\auilib_dummy.obj: ..\..\src\common\dummy.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(AUILIB_CXXFLAGS) /Ycwx/wxprec.h ..\..\src\common\dummy.cpp
 
@@ -16819,6 +16832,9 @@ $(OBJS)\auilib_xh_auitoolb.obj: ..\..\src\xrc\xh_auitoolb.cpp
 
 $(OBJS)\auilib_tabartmsw.obj: ..\..\src\aui\tabartmsw.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(AUILIB_CXXFLAGS) ..\..\src\aui\tabartmsw.cpp
+
+$(OBJS)\auilib_barartmsw.obj: ..\..\src\aui\barartmsw.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(AUILIB_CXXFLAGS) ..\..\src\aui\barartmsw.cpp
 
 $(OBJS)\ribbondll_dummy.obj: ..\..\src\common\dummy.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(RIBBONDLL_CXXFLAGS) /Ycwx/wxprec.h ..\..\src\common\dummy.cpp

--- a/build/msw/wx_aui.vcxproj
+++ b/build/msw/wx_aui.vcxproj
@@ -466,6 +466,7 @@
     <ClCompile Include="..\..\src\xrc\xh_auinotbk.cpp" />
     <ClCompile Include="..\..\src\xrc\xh_auitoolb.cpp" />
     <ClCompile Include="..\..\src\aui\tabartmsw.cpp" />
+    <ClCompile Include="..\..\src\aui\barartmsw.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\src\msw\version.rc">
@@ -507,6 +508,7 @@
     <ClInclude Include="..\..\include\wx\xrc\xh_auinotbk.h" />
     <ClInclude Include="..\..\include\wx\xrc\xh_auitoolb.h" />
     <ClInclude Include="..\..\include\wx\aui\tabartmsw.h" />
+    <ClInclude Include="..\..\include\wx\aui\barartmsw.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/build/msw/wx_aui.vcxproj.filters
+++ b/build/msw/wx_aui.vcxproj.filters
@@ -31,6 +31,9 @@
     <ClCompile Include="..\..\src\aui\auibook.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\aui\barartmsw.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\aui\dockart.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -69,6 +72,9 @@
       <Filter>Common Headers</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\wx\aui\auibook.h">
+      <Filter>Common Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\wx\aui\barartmsw.h">
       <Filter>Common Headers</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\wx\aui\dockart.h">

--- a/build/msw/wx_vc7_aui.vcproj
+++ b/build/msw/wx_vc7_aui.vcproj
@@ -423,6 +423,9 @@
 				RelativePath="..\..\include\wx\aui\auibook.h">
 			</File>
 			<File
+				RelativePath="..\..\include\wx\aui\barartmsw.h">
+			</File>
+			<File
 				RelativePath="..\..\include\wx\aui\dockart.h">
 			</File>
 			<File
@@ -456,6 +459,9 @@
 			</File>
 			<File
 				RelativePath="..\..\src\aui\auibook.cpp">
+			</File>
+			<File
+				RelativePath="..\..\src\aui\barartmsw.cpp">
 			</File>
 			<File
 				RelativePath="..\..\src\aui\dockart.cpp">

--- a/build/msw/wx_vc7_core.vcproj
+++ b/build/msw/wx_vc7_core.vcproj
@@ -1932,6 +1932,9 @@
 				RelativePath="..\..\include\wx\ribbon\bar.h">
 			</File>
 			<File
+				RelativePath="..\..\include\wx\aui\barartmsw.h">
+			</File>
+			<File
 				RelativePath="..\..\include\wx\bitmap.h">
 			</File>
 			<File

--- a/build/msw/wx_vc8_aui.vcproj
+++ b/build/msw/wx_vc8_aui.vcproj
@@ -1066,6 +1066,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\include\wx\aui\barartmsw.h"
+				>
+			</File>
+			<File
 				RelativePath="..\..\include\wx\aui\dockart.h"
 				>
 			</File>
@@ -1109,6 +1113,10 @@
 			</File>
 			<File
 				RelativePath="..\..\src\aui\auibook.cpp"
+				>
+			</File>
+			<File
+				RelativePath="..\..\src\aui\barartmsw.cpp"
 				>
 			</File>
 			<File

--- a/build/msw/wx_vc8_core.vcproj
+++ b/build/msw/wx_vc8_core.vcproj
@@ -3077,6 +3077,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\include\wx\aui\barartmsw.h"
+				>
+			</File>
+			<File
 				RelativePath="..\..\include\wx\bitmap.h"
 				>
 			</File>

--- a/build/msw/wx_vc9_aui.vcproj
+++ b/build/msw/wx_vc9_aui.vcproj
@@ -1062,6 +1062,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\include\wx\aui\barartmsw.h"
+				>
+			</File>
+			<File
 				RelativePath="..\..\include\wx\aui\dockart.h"
 				>
 			</File>
@@ -1105,6 +1109,10 @@
 			</File>
 			<File
 				RelativePath="..\..\src\aui\auibook.cpp"
+				>
+			</File>
+			<File
+				RelativePath="..\..\src\aui\barartmsw.cpp"
 				>
 			</File>
 			<File

--- a/build/msw/wx_vc9_core.vcproj
+++ b/build/msw/wx_vc9_core.vcproj
@@ -3073,6 +3073,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\include\wx\aui\barartmsw.h"
+				>
+			</File>
+			<File
 				RelativePath="..\..\include\wx\bitmap.h"
 				>
 			</File>

--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -347,13 +347,13 @@ public:
 
 
 
-class WXDLLIMPEXP_AUI wxAuiDefaultToolBarArt : public wxAuiToolBarArt
+class WXDLLIMPEXP_AUI wxAuiGenericToolBarArt : public wxAuiToolBarArt
 {
 
 public:
 
-    wxAuiDefaultToolBarArt();
-    virtual ~wxAuiDefaultToolBarArt();
+    wxAuiGenericToolBarArt();
+    virtual ~wxAuiGenericToolBarArt();
 
     virtual wxAuiToolBarArt* Clone() wxOVERRIDE;
     virtual void SetFlags(unsigned int flags) wxOVERRIDE;
@@ -749,6 +749,10 @@ typedef void (wxEvtHandler::*wxAuiToolBarEventFunction)(wxAuiToolBarEvent&);
 #define wxEVT_COMMAND_AUITOOLBAR_RIGHT_CLICK      wxEVT_AUITOOLBAR_RIGHT_CLICK
 #define wxEVT_COMMAND_AUITOOLBAR_MIDDLE_CLICK     wxEVT_AUITOOLBAR_MIDDLE_CLICK
 #define wxEVT_COMMAND_AUITOOLBAR_BEGIN_DRAG       wxEVT_AUITOOLBAR_BEGIN_DRAG
+
+#ifndef wxHAS_NATIVE_TOOLBAR_ART
+    #define wxAuiDefaultToolBarArt wxAuiGenericToolBarArt
+#endif
 
 #endif  // wxUSE_AUI
 #endif  // _WX_AUIBAR_H_

--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -750,6 +750,12 @@ typedef void (wxEvtHandler::*wxAuiToolBarEventFunction)(wxAuiToolBarEvent&);
 #define wxEVT_COMMAND_AUITOOLBAR_MIDDLE_CLICK     wxEVT_AUITOOLBAR_MIDDLE_CLICK
 #define wxEVT_COMMAND_AUITOOLBAR_BEGIN_DRAG       wxEVT_AUITOOLBAR_BEGIN_DRAG
 
+#ifdef __WXMSW__
+    #define wxHAS_NATIVE_TOOLBAR_ART
+    #include "wx/aui/barartmsw.h"
+    #define wxAuiDefaultToolBarArt wxAuiMSWToolBarArt
+#endif
+
 #ifndef wxHAS_NATIVE_TOOLBAR_ART
     #define wxAuiDefaultToolBarArt wxAuiGenericToolBarArt
 #endif

--- a/include/wx/aui/barartmsw.h
+++ b/include/wx/aui/barartmsw.h
@@ -1,0 +1,88 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        wx/aui/barartmsw.h
+// Purpose:     Interface of wxAuiMSWToolBarArt
+// Author:      Tobias Taschner
+// Created:     2015-09-22
+// Copyright:   (c) 2015 wxWidgets development team
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_AUI_BARART_MSW_H_
+#define _WX_AUI_BARART_MSW_H_
+
+class WXDLLIMPEXP_AUI wxAuiMSWToolBarArt : public wxAuiGenericToolBarArt
+{
+public:
+
+    wxAuiMSWToolBarArt();
+    virtual ~wxAuiMSWToolBarArt();
+
+    virtual wxAuiToolBarArt* Clone() wxOVERRIDE;
+
+    virtual void DrawBackground(
+        wxDC& dc,
+        wxWindow* wnd,
+        const wxRect& rect) wxOVERRIDE;
+
+    virtual void DrawLabel(
+        wxDC& dc,
+        wxWindow* wnd,
+        const wxAuiToolBarItem& item,
+        const wxRect& rect) wxOVERRIDE;
+
+    virtual void DrawButton(
+        wxDC& dc,
+        wxWindow* wnd,
+        const wxAuiToolBarItem& item,
+        const wxRect& rect) wxOVERRIDE;
+
+    virtual void DrawDropDownButton(
+        wxDC& dc,
+        wxWindow* wnd,
+        const wxAuiToolBarItem& item,
+        const wxRect& rect) wxOVERRIDE;
+
+    virtual void DrawControlLabel(
+        wxDC& dc,
+        wxWindow* wnd,
+        const wxAuiToolBarItem& item,
+        const wxRect& rect) wxOVERRIDE;
+
+    virtual void DrawSeparator(
+        wxDC& dc,
+        wxWindow* wnd,
+        const wxRect& rect) wxOVERRIDE;
+
+    virtual void DrawGripper(
+        wxDC& dc,
+        wxWindow* wnd,
+        const wxRect& rect) wxOVERRIDE;
+
+    virtual void DrawOverflowButton(
+        wxDC& dc,
+        wxWindow* wnd,
+        const wxRect& rect,
+        int state) wxOVERRIDE;
+
+    virtual wxSize GetLabelSize(
+        wxDC& dc,
+        wxWindow* wnd,
+        const wxAuiToolBarItem& item) wxOVERRIDE;
+
+    virtual wxSize GetToolSize(
+        wxDC& dc,
+        wxWindow* wnd,
+        const wxAuiToolBarItem& item) wxOVERRIDE;
+
+    virtual int GetElementSize(int element) wxOVERRIDE;
+    virtual void SetElementSize(int elementId, int size) wxOVERRIDE;
+
+    virtual int ShowDropDown(wxWindow* wnd,
+        const wxAuiToolBarItemArray& items) wxOVERRIDE;
+
+private:
+    bool m_themed;
+    wxSize m_buttonSize;
+};
+
+#endif // _WX_AUI_BARART_MSW_H_

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -124,7 +124,7 @@ const wxColour DISABLED_TEXT_COLOR(DISABLED_TEXT_GREY_HUE,
                                    DISABLED_TEXT_GREY_HUE,
                                    DISABLED_TEXT_GREY_HUE);
 
-wxAuiDefaultToolBarArt::wxAuiDefaultToolBarArt()
+wxAuiGenericToolBarArt::wxAuiGenericToolBarArt()
 {
     m_baseColour = GetBaseColor();
 
@@ -160,48 +160,48 @@ wxAuiDefaultToolBarArt::wxAuiDefaultToolBarArt()
     m_font = *wxNORMAL_FONT;
 }
 
-wxAuiDefaultToolBarArt::~wxAuiDefaultToolBarArt()
+wxAuiGenericToolBarArt::~wxAuiGenericToolBarArt()
 {
     m_font = *wxNORMAL_FONT;
 }
 
 
-wxAuiToolBarArt* wxAuiDefaultToolBarArt::Clone()
+wxAuiToolBarArt* wxAuiGenericToolBarArt::Clone()
 {
-    return static_cast<wxAuiToolBarArt*>(new wxAuiDefaultToolBarArt);
+    return static_cast<wxAuiToolBarArt*>(new wxAuiGenericToolBarArt);
 }
 
-void wxAuiDefaultToolBarArt::SetFlags(unsigned int flags)
+void wxAuiGenericToolBarArt::SetFlags(unsigned int flags)
 {
     m_flags = flags;
 }
 
-void wxAuiDefaultToolBarArt::SetFont(const wxFont& font)
+void wxAuiGenericToolBarArt::SetFont(const wxFont& font)
 {
     m_font = font;
 }
 
-void wxAuiDefaultToolBarArt::SetTextOrientation(int orientation)
+void wxAuiGenericToolBarArt::SetTextOrientation(int orientation)
 {
     m_textOrientation = orientation;
 }
 
-unsigned int wxAuiDefaultToolBarArt::GetFlags()
+unsigned int wxAuiGenericToolBarArt::GetFlags()
 {
     return m_flags;
 }
 
-wxFont wxAuiDefaultToolBarArt::GetFont()
+wxFont wxAuiGenericToolBarArt::GetFont()
 {
     return m_font;
 }
 
-int wxAuiDefaultToolBarArt::GetTextOrientation()
+int wxAuiGenericToolBarArt::GetTextOrientation()
 {
     return m_textOrientation;
 }
 
-void wxAuiDefaultToolBarArt::DrawBackground(
+void wxAuiGenericToolBarArt::DrawBackground(
                                     wxDC& dc,
                                     wxWindow* WXUNUSED(wnd),
                                     const wxRect& _rect)
@@ -213,7 +213,7 @@ void wxAuiDefaultToolBarArt::DrawBackground(
     dc.GradientFillLinear(rect, startColour, endColour, wxSOUTH);
 }
 
-void wxAuiDefaultToolBarArt::DrawPlainBackground(wxDC& dc,
+void wxAuiGenericToolBarArt::DrawPlainBackground(wxDC& dc,
                                                    wxWindow* WXUNUSED(wnd),
                                                    const wxRect& _rect)
 {
@@ -226,7 +226,7 @@ void wxAuiDefaultToolBarArt::DrawPlainBackground(wxDC& dc,
                      rect.GetWidth() + 2, rect.GetHeight() + 1);
 }
 
-void wxAuiDefaultToolBarArt::DrawLabel(
+void wxAuiGenericToolBarArt::DrawLabel(
                                     wxDC& dc,
                                     wxWindow* WXUNUSED(wnd),
                                     const wxAuiToolBarItem& item,
@@ -253,7 +253,7 @@ void wxAuiDefaultToolBarArt::DrawLabel(
 }
 
 
-void wxAuiDefaultToolBarArt::DrawButton(
+void wxAuiGenericToolBarArt::DrawButton(
                                     wxDC& dc,
                                     wxWindow* WXUNUSED(wnd),
                                     const wxAuiToolBarItem& item,
@@ -354,7 +354,7 @@ void wxAuiDefaultToolBarArt::DrawButton(
 }
 
 
-void wxAuiDefaultToolBarArt::DrawDropDownButton(
+void wxAuiGenericToolBarArt::DrawDropDownButton(
                                     wxDC& dc,
                                     wxWindow* WXUNUSED(wnd),
                                     const wxAuiToolBarItem& item,
@@ -480,7 +480,7 @@ void wxAuiDefaultToolBarArt::DrawDropDownButton(
     }
 }
 
-void wxAuiDefaultToolBarArt::DrawControlLabel(
+void wxAuiGenericToolBarArt::DrawControlLabel(
                                     wxDC& dc,
                                     wxWindow* WXUNUSED(wnd),
                                     const wxAuiToolBarItem& item,
@@ -522,7 +522,7 @@ void wxAuiDefaultToolBarArt::DrawControlLabel(
     }
 }
 
-wxSize wxAuiDefaultToolBarArt::GetLabelSize(
+wxSize wxAuiGenericToolBarArt::GetLabelSize(
                                         wxDC& dc,
                                         wxWindow* WXUNUSED(wnd),
                                         const wxAuiToolBarItem& item)
@@ -545,7 +545,7 @@ wxSize wxAuiDefaultToolBarArt::GetLabelSize(
     return wxSize(width, height);
 }
 
-wxSize wxAuiDefaultToolBarArt::GetToolSize(
+wxSize wxAuiGenericToolBarArt::GetToolSize(
                                         wxDC& dc,
                                         wxWindow* WXUNUSED(wnd),
                                         const wxAuiToolBarItem& item)
@@ -594,7 +594,7 @@ wxSize wxAuiDefaultToolBarArt::GetToolSize(
     return wxSize(width, height);
 }
 
-void wxAuiDefaultToolBarArt::DrawSeparator(
+void wxAuiGenericToolBarArt::DrawSeparator(
                                     wxDC& dc,
                                     wxWindow* WXUNUSED(wnd),
                                     const wxRect& _rect)
@@ -627,7 +627,7 @@ void wxAuiDefaultToolBarArt::DrawSeparator(
     dc.GradientFillLinear(rect, startColour, endColour, horizontal ? wxSOUTH : wxEAST);
 }
 
-void wxAuiDefaultToolBarArt::DrawGripper(wxDC& dc,
+void wxAuiGenericToolBarArt::DrawGripper(wxDC& dc,
                                     wxWindow* WXUNUSED(wnd),
                                     const wxRect& rect)
 {
@@ -666,7 +666,7 @@ void wxAuiDefaultToolBarArt::DrawGripper(wxDC& dc,
 
 }
 
-void wxAuiDefaultToolBarArt::DrawOverflowButton(wxDC& dc,
+void wxAuiGenericToolBarArt::DrawOverflowButton(wxDC& dc,
                                           wxWindow* /*wnd*/,
                                           const wxRect& rect,
                                           int state)
@@ -699,7 +699,7 @@ void wxAuiDefaultToolBarArt::DrawOverflowButton(wxDC& dc,
     dc.DrawBitmap(m_overflowBmp, x, y, true);
 }
 
-int wxAuiDefaultToolBarArt::GetElementSize(int element_id)
+int wxAuiGenericToolBarArt::GetElementSize(int element_id)
 {
     switch (element_id)
     {
@@ -710,7 +710,7 @@ int wxAuiDefaultToolBarArt::GetElementSize(int element_id)
     }
 }
 
-void wxAuiDefaultToolBarArt::SetElementSize(int element_id, int size)
+void wxAuiGenericToolBarArt::SetElementSize(int element_id, int size)
 {
     switch (element_id)
     {
@@ -720,7 +720,7 @@ void wxAuiDefaultToolBarArt::SetElementSize(int element_id, int size)
     }
 }
 
-int wxAuiDefaultToolBarArt::ShowDropDown(wxWindow* wnd,
+int wxAuiGenericToolBarArt::ShowDropDown(wxWindow* wnd,
                                          const wxAuiToolBarItemArray& items)
 {
     wxMenu menuPopup;

--- a/src/aui/barartmsw.cpp
+++ b/src/aui/barartmsw.cpp
@@ -1,0 +1,520 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        src/aui/barartmsw.cpp
+// Purpose:     Implementation of wxAuiMSWToolBarArt
+// Author:      Tobias Taschner
+// Created:     2015-09-22
+// Copyright:   (c) 2015 wxWidgets development team
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
+#include "wx/wxprec.h"
+
+#ifdef __BORLANDC__
+#pragma hdrstop
+#endif
+
+#ifndef WX_PRECOMP
+    #include "wx/bitmap.h"
+    #include "wx/dcclient.h"
+    #include "wx/app.h"
+    #include "wx/dc.h"
+#endif
+
+#include "wx/aui/auibar.h"
+#include "wx/aui/framemanager.h"
+#include "wx/msw/uxtheme.h"
+#include "wx/msw/private.h"
+
+#if wxUSE_AUI
+
+#define RP_GRIPPER 1
+#define RP_GRIPPERVERT 2
+#define RP_BAND 3
+#define RP_CHEVRON 4
+#define RP_CHEVRONVERT 5
+#define RP_BACKGROUND 6
+#define RP_SPLITTER 7
+#define RP_SPLITTERVERT 8
+
+#define CHEVS_NORMAL 1
+#define CHEVS_HOT 2
+#define CHEVS_PRESSED 3
+
+#define TP_BUTTON 1
+#define TP_DROPDOWNBUTTON 2
+#define TP_SPLITBUTTON 3
+#define TP_SPLITBUTTONDROPDOWN 4
+#define TP_SEPARATOR 5
+#define TP_SEPARATORVERT 6
+#define TP_DROPDOWNBUTTONGLYPH 7
+
+#define TS_NORMAL 1
+#define TS_HOT 2
+#define TS_PRESSED 3
+#define TS_DISABLED 4
+#define TS_CHECKED 5
+#define TS_HOTCHECKED 6
+#define TS_NEARHOT 7
+#define TS_OTHERSIDEHOT 8
+
+
+wxAuiMSWToolBarArt::wxAuiMSWToolBarArt()
+{
+    wxUxThemeEngine* te = wxUxThemeEngine::GetIfActive();
+    if ( te && te->IsAppThemed() )
+    {
+        m_themed = true;
+
+        // Determine sizes from theme
+        wxWindow* window = static_cast<wxApp*>(wxApp::GetInstance())->GetTopWindow();
+        wxUxThemeHandle hTheme(window, L"Rebar");
+
+        SIZE overflowSize;
+        te->GetThemePartSize(hTheme, NULL, RP_CHEVRON, 0,
+            NULL, TS_TRUE, &overflowSize);
+        m_overflowSize = overflowSize.cx;
+
+        SIZE gripperSize;
+        te->GetThemePartSize(hTheme, NULL, RP_GRIPPER, 0,
+            NULL, TS_TRUE, &gripperSize);
+        m_gripperSize = gripperSize.cx;
+
+        wxUxThemeHandle hThemeToolbar(window, L"Toolbar");
+
+        SIZE seperatorSize;
+        te->GetThemePartSize(hThemeToolbar, NULL, TP_SEPARATOR, 0,
+            NULL, TS_TRUE, &seperatorSize);
+        m_separatorSize = seperatorSize.cx;
+
+        SIZE buttonSize;
+        te->GetThemePartSize(hThemeToolbar, NULL, TP_BUTTON, 0,
+            NULL, TS_TRUE, &buttonSize);
+        m_buttonSize.Set(buttonSize.cx, buttonSize.cy);
+    }
+    else
+        m_themed = false;
+}
+
+wxAuiMSWToolBarArt::~wxAuiMSWToolBarArt()
+{
+
+}
+
+wxAuiToolBarArt* wxAuiMSWToolBarArt::Clone()
+{
+    return static_cast<wxAuiToolBarArt*>(new wxAuiMSWToolBarArt);
+}
+
+void wxAuiMSWToolBarArt::DrawBackground(
+    wxDC& dc,
+    wxWindow* wnd,
+    const wxRect& rect)
+{
+    if ( m_themed )
+    {
+        RECT r;
+        wxCopyRectToRECT(rect, r);
+
+        wxUxThemeHandle hTheme(wnd, L"Rebar");
+
+        wxUxThemeEngine::Get()->DrawThemeBackground(
+            hTheme,
+            GetHdcOf(dc.GetTempHDC()),
+            RP_BACKGROUND,
+            0,
+            &r,
+            NULL);
+    }
+    else
+        wxAuiGenericToolBarArt::DrawBackground(dc, wnd, rect);
+}
+
+void wxAuiMSWToolBarArt::DrawLabel(
+    wxDC& dc,
+    wxWindow* wnd,
+    const wxAuiToolBarItem& item,
+    const wxRect& rect)
+{
+    wxAuiGenericToolBarArt::DrawLabel(dc, wnd, item, rect);
+}
+
+static const unsigned char
+DISABLED_TEXT_GREY_HUE = wxColour::AlphaBlend(0, 255, 0.4);
+const wxColour DISABLED_TEXT_COLOR(DISABLED_TEXT_GREY_HUE,
+    DISABLED_TEXT_GREY_HUE,
+    DISABLED_TEXT_GREY_HUE);
+
+void wxAuiMSWToolBarArt::DrawButton(
+    wxDC& dc,
+    wxWindow* wnd,
+    const wxAuiToolBarItem& item,
+    const wxRect& rect)
+{
+    if ( m_themed )
+    {
+        RECT r;
+        wxCopyRectToRECT(rect, r);
+
+        wxUxThemeHandle hTheme(wnd, L"Toolbar");
+
+        wxUxThemeEngine* te = wxUxThemeEngine::Get();
+
+        int btnState;
+        if ( item.GetState() & wxAUI_BUTTON_STATE_DISABLED )
+            btnState = TS_DISABLED;
+        else if ( item.GetState() & wxAUI_BUTTON_STATE_PRESSED )
+            btnState = TS_PRESSED;
+        else if ( item.GetState() & wxAUI_BUTTON_STATE_HOVER &&
+            item.GetState() & wxAUI_BUTTON_STATE_CHECKED )
+            btnState = TS_HOTCHECKED;
+        else if ( item.GetState() & wxAUI_BUTTON_STATE_CHECKED )
+            btnState = TS_CHECKED;
+        else if ( item.GetState() & wxAUI_BUTTON_STATE_HOVER )
+            btnState = TS_HOT;
+        else
+            btnState = TS_NORMAL;
+
+        te->DrawThemeBackground(
+            hTheme,
+            GetHdcOf(dc.GetTempHDC()),
+            TP_BUTTON,
+            btnState,
+            &r,
+            NULL);
+
+        int textWidth = 0, textHeight = 0;
+
+        if ( m_flags & wxAUI_TB_TEXT )
+        {
+            dc.SetFont(m_font);
+
+            int tx, ty;
+
+            dc.GetTextExtent(wxT("ABCDHgj"), &tx, &textHeight);
+            textWidth = 0;
+            dc.GetTextExtent(item.GetLabel(), &textWidth, &ty);
+        }
+
+        int bmpX = 0, bmpY = 0;
+        int textX = 0, textY = 0;
+
+        if ( m_textOrientation == wxAUI_TBTOOL_TEXT_BOTTOM )
+        {
+            bmpX = rect.x +
+                (rect.width / 2) -
+                (item.GetBitmap().GetWidth() / 2);
+
+            bmpY = rect.y +
+                ((rect.height - textHeight) / 2) -
+                (item.GetBitmap().GetHeight() / 2);
+
+            textX = rect.x + (rect.width / 2) - (textWidth / 2) + 1;
+            textY = rect.y + rect.height - textHeight - 1;
+        }
+        else if ( m_textOrientation == wxAUI_TBTOOL_TEXT_RIGHT )
+        {
+            bmpX = rect.x + 3;
+
+            bmpY = rect.y +
+                (rect.height / 2) -
+                (item.GetBitmap().GetHeight() / 2);
+
+            textX = bmpX + 3 + item.GetBitmap().GetWidth();
+            textY = rect.y +
+                (rect.height / 2) -
+                (textHeight / 2);
+        }
+
+        wxBitmap bmp;
+        if ( item.GetState() & wxAUI_BUTTON_STATE_DISABLED )
+            bmp = item.GetDisabledBitmap();
+        else
+            bmp = item.GetBitmap();
+
+        if ( bmp.IsOk() )
+            dc.DrawBitmap(bmp, bmpX, bmpY, true);
+
+        // set the item's text color based on if it is disabled
+        dc.SetTextForeground(*wxBLACK);
+        if ( item.GetState() & wxAUI_BUTTON_STATE_DISABLED )
+            dc.SetTextForeground(DISABLED_TEXT_COLOR);
+
+        if ( (m_flags & wxAUI_TB_TEXT) && !item.GetLabel().empty() )
+        {
+            dc.DrawText(item.GetLabel(), textX, textY);
+        }
+    }
+    else
+        wxAuiGenericToolBarArt::DrawButton(dc, wnd, item, rect);
+}
+
+void wxAuiMSWToolBarArt::DrawDropDownButton(
+    wxDC& dc,
+    wxWindow* wnd,
+    const wxAuiToolBarItem& item,
+    const wxRect& rect)
+{
+    if ( m_themed )
+    {
+        wxUxThemeHandle hTheme(wnd, L"Toolbar");
+        wxUxThemeEngine* const te = wxUxThemeEngine::Get();
+
+        int dropDownWidth = 14;
+
+        int textWidth = 0, textHeight = 0, textX = 0, textY = 0;
+        int bmpX = 0, bmpY = 0, dropBmpX = 0, dropBmpY = 0;
+
+        wxRect buttonRect = wxRect(rect.x,
+            rect.y,
+            rect.width - dropDownWidth,
+            rect.height);
+        wxRect dropDownRect = wxRect(rect.x + rect.width - dropDownWidth - 1,
+            rect.y,
+            dropDownWidth + 1,
+            rect.height);
+
+        if ( m_flags & wxAUI_TB_TEXT )
+        {
+            dc.SetFont(m_font);
+
+            int tx, ty;
+            if ( m_flags & wxAUI_TB_TEXT )
+            {
+                dc.GetTextExtent(wxT("ABCDHgj"), &tx, &textHeight);
+                textWidth = 0;
+            }
+
+            dc.GetTextExtent(item.GetLabel(), &textWidth, &ty);
+        }
+
+        RECT btnR;
+        wxCopyRectToRECT(buttonRect, btnR);
+        RECT dropDownR;
+        wxCopyRectToRECT(dropDownRect, dropDownR);
+
+        int btnState;
+        if ( item.GetState() & wxAUI_BUTTON_STATE_DISABLED )
+            btnState = TS_DISABLED;
+        else if ( item.GetState() & wxAUI_BUTTON_STATE_PRESSED )
+            btnState = TS_PRESSED;
+        else if ( item.GetState() & wxAUI_BUTTON_STATE_HOVER )
+            btnState = TS_HOT;
+        else
+            btnState = TS_NORMAL;
+
+        te->DrawThemeBackground(
+            hTheme,
+            GetHdcOf(dc.GetTempHDC()),
+            TP_SPLITBUTTON,
+            btnState,
+            &btnR,
+            NULL);
+
+        te->DrawThemeBackground(
+            hTheme,
+            GetHdcOf(dc.GetTempHDC()),
+            TP_SPLITBUTTONDROPDOWN,
+            btnState,
+            &dropDownR,
+            NULL);
+
+        dropBmpX = dropDownRect.x +
+            (dropDownRect.width / 2) -
+            (m_buttonDropDownBmp.GetWidth() / 2);
+        dropBmpY = dropDownRect.y +
+            (dropDownRect.height / 2) -
+            (m_buttonDropDownBmp.GetHeight() / 2);
+
+
+        if ( m_textOrientation == wxAUI_TBTOOL_TEXT_BOTTOM )
+        {
+            bmpX = buttonRect.x +
+                (buttonRect.width / 2) -
+                (item.GetBitmap().GetWidth() / 2);
+            bmpY = buttonRect.y +
+                ((buttonRect.height - textHeight) / 2) -
+                (item.GetBitmap().GetHeight() / 2);
+
+            textX = rect.x + (rect.width / 2) - (textWidth / 2) + 1;
+            textY = rect.y + rect.height - textHeight - 1;
+        }
+        else if ( m_textOrientation == wxAUI_TBTOOL_TEXT_RIGHT )
+        {
+            bmpX = rect.x + 3;
+
+            bmpY = rect.y +
+                (rect.height / 2) -
+                (item.GetBitmap().GetHeight() / 2);
+
+            textX = bmpX + 3 + item.GetBitmap().GetWidth();
+            textY = rect.y +
+                (rect.height / 2) -
+                (textHeight / 2);
+        }
+
+        wxBitmap bmp;
+        if ( item.GetState() & wxAUI_BUTTON_STATE_DISABLED )
+        {
+            bmp = item.GetDisabledBitmap();
+        }
+        else
+        {
+            bmp = item.GetBitmap();
+        }
+
+        if ( !bmp.IsOk() )
+            return;
+
+        dc.DrawBitmap(bmp, bmpX, bmpY, true);
+
+        // set the item's text color based on if it is disabled
+        dc.SetTextForeground(*wxBLACK);
+        if ( item.GetState() & wxAUI_BUTTON_STATE_DISABLED )
+            dc.SetTextForeground(DISABLED_TEXT_COLOR);
+
+        if ( (m_flags & wxAUI_TB_TEXT) && !item.GetLabel().empty() )
+        {
+            dc.DrawText(item.GetLabel(), textX, textY);
+        }
+
+    }
+    else
+        wxAuiGenericToolBarArt::DrawDropDownButton(dc, wnd, item, rect);
+}
+
+void wxAuiMSWToolBarArt::DrawControlLabel(
+    wxDC& dc,
+    wxWindow* wnd,
+    const wxAuiToolBarItem& item,
+    const wxRect& rect)
+{
+    wxAuiGenericToolBarArt::DrawControlLabel(dc, wnd, item, rect);
+}
+
+void wxAuiMSWToolBarArt::DrawSeparator(
+    wxDC& dc,
+    wxWindow* wnd,
+    const wxRect& rect)
+{
+    if ( m_themed )
+    {
+        RECT r;
+        wxCopyRectToRECT(rect, r);
+
+        wxUxThemeHandle hTheme(wnd, L"Toolbar");
+
+        wxUxThemeEngine::Get()->DrawThemeBackground(
+            hTheme,
+            GetHdcOf(dc.GetTempHDC()),
+            (m_flags & wxAUI_TB_VERTICAL) ? TP_SEPARATORVERT : TP_SEPARATOR,
+            0,
+            &r,
+            NULL);
+    }
+    else
+        wxAuiGenericToolBarArt::DrawSeparator(dc, wnd, rect);
+}
+
+void wxAuiMSWToolBarArt::DrawGripper(
+    wxDC& dc,
+    wxWindow* wnd,
+    const wxRect& rect)
+{
+    if ( m_themed )
+    {
+        RECT r;
+        wxCopyRectToRECT(rect, r);
+
+        wxUxThemeHandle hTheme(wnd, L"Rebar");
+
+        wxUxThemeEngine::Get()->DrawThemeBackground(
+            hTheme,
+            GetHdcOf(dc.GetTempHDC()),
+            (m_flags & wxAUI_TB_VERTICAL) ? RP_GRIPPERVERT : RP_GRIPPER,
+            0,
+            &r,
+            NULL);
+    }
+    else
+        wxAuiGenericToolBarArt::DrawGripper(dc, wnd, rect);
+}
+
+void wxAuiMSWToolBarArt::DrawOverflowButton(
+    wxDC& dc,
+    wxWindow* wnd,
+    const wxRect& rect,
+    int state)
+{
+    if ( m_themed )
+    {
+        RECT r;
+        wxCopyRectToRECT(rect, r);
+
+        wxUxThemeHandle hTheme(wnd, L"Rebar");
+
+        int chevState;
+        if ( state & wxAUI_BUTTON_STATE_PRESSED )
+            chevState = CHEVS_PRESSED;
+        else if ( state & wxAUI_BUTTON_STATE_HOVER )
+                chevState = CHEVS_HOT;
+        else
+            chevState = CHEVS_NORMAL;
+
+        wxUxThemeEngine::Get()->DrawThemeBackground(
+            hTheme,
+            GetHdcOf(dc.GetTempHDC()),
+            (m_flags & wxAUI_TB_VERTICAL) ? RP_CHEVRONVERT : RP_CHEVRON,
+            chevState,
+            &r,
+            NULL);
+    }
+    else
+        wxAuiGenericToolBarArt::DrawOverflowButton(dc, wnd, rect, state);
+}
+
+wxSize wxAuiMSWToolBarArt::GetLabelSize(
+    wxDC& dc,
+    wxWindow* wnd,
+    const wxAuiToolBarItem& item)
+{
+    return wxAuiGenericToolBarArt::GetLabelSize(dc, wnd, item);
+}
+
+wxSize wxAuiMSWToolBarArt::GetToolSize(
+    wxDC& dc,
+    wxWindow* wnd,
+    const wxAuiToolBarItem& item)
+{
+    if ( m_themed )
+    {
+        if ( !item.GetBitmap().IsOk() && !(m_flags & wxAUI_TB_TEXT) )
+            return m_buttonSize;
+
+        wxSize size = wxAuiGenericToolBarArt::GetToolSize(dc, wnd, item);
+
+        size.IncBy(3); // Add some padding for native theme
+
+        return size;
+    }
+    else
+        return wxAuiGenericToolBarArt::GetToolSize(dc, wnd, item);
+}
+
+int wxAuiMSWToolBarArt::GetElementSize(int element)
+{
+    return wxAuiGenericToolBarArt::GetElementSize(element);
+}
+
+void wxAuiMSWToolBarArt::SetElementSize(int elementId, int size)
+{
+    wxAuiGenericToolBarArt::SetElementSize(elementId, size);
+}
+
+int wxAuiMSWToolBarArt::ShowDropDown(wxWindow* wnd,
+    const wxAuiToolBarItemArray& items)
+{
+    return wxAuiGenericToolBarArt::ShowDropDown(wnd, items);
+}
+
+
+#endif // wxUSE_AUI


### PR DESCRIPTION
Use theme services to draw native wxAuiToolbarArt on MSW. A fallback to generic art is implemented and other platforms still use the generic tab art. Implementing additional native bar art is prepared like native tab art already was.

Windows XP:
![wxaui_bar_winxp](https://cloud.githubusercontent.com/assets/5075894/12858831/b1beb22c-cc52-11e5-9c0c-31f3fdbfcc26.png)
Windows 7:
![wxaui_bar_win7](https://cloud.githubusercontent.com/assets/5075894/12874923/c5c9ba7c-cdde-11e5-959a-9eb4de8d51ea.png)
Windows 10:
![wxaui_bar_win10](https://cloud.githubusercontent.com/assets/5075894/12858829/b159a2ba-cc52-11e5-9394-c6b383e8198f.png)
