### PR TITLE
Avoid silently omitting writing log file lines containing Unicode on MSW

### DIFF
--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -882,7 +882,11 @@ wxLogStream::wxLogStream(wxSTD ostream *ostr)
 
 void wxLogStream::DoLogText(const wxString& msg)
 {
-    (*m_ostr) << msg << wxSTD endl;
+    const wxSTD string msgStdStr = msg.ToStdString();
+    if ( !msgStdStr.empty() )
+        (*m_ostr) << msgStdStr << wxSTD endl;
+    else // charset conversion probably has failed; log at least something
+        (*m_ostr) << msg.ToAscii() << wxSTD endl;
 }
 #endif // wxUSE_STD_IOSTREAM
 

--- a/src/common/msgout.cpp
+++ b/src/common/msgout.cpp
@@ -150,7 +150,7 @@ void wxMessageOutputStderr::Output(const wxString& str)
     const wxString strWithLF = AppendLineFeedIfNeeded(str);
     const wxWX2MBbuf buf = strWithLF.mb_str();
 
-    if ( buf )
+    if ( buf && strlen(buf) > 0 )
         fprintf(m_fp, "%s", (const char*) buf);
     else // print at least something
         fprintf(m_fp, "%s", (const char*) strWithLF.ToAscii());


### PR DESCRIPTION
If conversion from wxString to the local character set fails, write at least
what .ToAscii() can provide. The problem and solution is similar for both
wxLogStderr and wxLogStream.

A partial solution to http://trac.wxwidgets.org/ticket/17358.
