### PR TITLE
Fix path/URL confusion in wxLaunchDefaultBrowser()

### DIFF
--- a/include/wx/private/launchbrowser.h
+++ b/include/wx/private/launchbrowser.h
@@ -1,0 +1,43 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/private/launchbrowser.h
+// Purpose:     Helpers for wxLaunchDefaultBrowser() implementation.
+// Author:      Vadim Zeitlin
+// Created:     2016-02-07
+// Copyright:   (c) 2016 Vadim Zeitlin <vadim@wxwidgets.org>
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_PRIVATE_LAUNCHBROWSER_H_
+#define _WX_PRIVATE_LAUNCHBROWSER_H_
+
+// ----------------------------------------------------------------------------
+// wxLaunchBrowserParams: passed to wxDoLaunchDefaultBrowser()
+// ----------------------------------------------------------------------------
+
+struct wxLaunchBrowserParams
+{
+    explicit wxLaunchBrowserParams(int f) : flags(f) { }
+
+    // Return either the URL or the file depending on our scheme.
+    const wxString& GetPathOrURL() const
+    {
+        return scheme == wxS("file") ? path : url;
+    }
+
+
+    // The URL is always specified and is the real URL, always with the scheme
+    // part, which can be "file://".
+    wxString url;
+
+    // The path is a local path which is only non-empty if the URL uses the
+    // "file://" scheme.
+    wxString path;
+
+    // The scheme of the URL, e.g. "file" or "http".
+    wxString scheme;
+
+    // The flags passed to wxLaunchDefaultBrowser().
+    int flags;
+};
+
+#endif // _WX_PRIVATE_LAUNCHBROWSER_H_

--- a/src/msw/utilswin.cpp
+++ b/src/msw/utilswin.cpp
@@ -18,6 +18,7 @@
     #include "wx/utils.h"
 #endif //WX_PRECOMP
 
+#include "wx/private/launchbrowser.h"
 #include "wx/msw/private.h"     // includes <windows.h>
 #include "wx/msw/registry.h"
 #include <shellapi.h> // needed for SHELLEXECUTEINFO
@@ -49,16 +50,30 @@ bool wxLaunchDefaultApplication(const wxString& document, int flags)
 // Launch default browser
 // ----------------------------------------------------------------------------
 
-bool wxDoLaunchDefaultBrowser(const wxString& url, const wxString& scheme, int flags)
-{
-    wxUnusedVar(flags);
+// NOTE: when testing wxMSW's wxLaunchDefaultBrowser all possible forms
+//       of the URL/flags should be tested; e.g.:
+//
+// for (int i=0; i<2; i++)
+// {
+//   // test arguments without a valid URL scheme:
+//   wxLaunchDefaultBrowser("C:\\test.txt", i==0 ? 0 : wxBROWSER_NEW_WINDOW);
+//   wxLaunchDefaultBrowser("wxwidgets.org", i==0 ? 0 : wxBROWSER_NEW_WINDOW);
+//
+//   // test arguments with different valid schemes:
+//   wxLaunchDefaultBrowser("file:/C%3A/test.txt", i==0 ? 0 : wxBROWSER_NEW_WINDOW);
+//   wxLaunchDefaultBrowser("http://wxwidgets.org", i==0 ? 0 : wxBROWSER_NEW_WINDOW);
+//   wxLaunchDefaultBrowser("mailto:user@host.org", i==0 ? 0 : wxBROWSER_NEW_WINDOW);
+// }
+// (assuming you have a C:\test.txt file)
 
+bool wxDoLaunchDefaultBrowser(const wxLaunchBrowserParams& params)
+{
 #if wxUSE_IPC
-    if ( flags & wxBROWSER_NEW_WINDOW )
+    if ( params.flags & wxBROWSER_NEW_WINDOW )
     {
         // ShellExecuteEx() opens the URL in an existing window by default so
         // we can't use it if we need a new window
-        wxRegKey key(wxRegKey::HKCR, scheme + wxT("\\shell\\open"));
+        wxRegKey key(wxRegKey::HKCR, params.scheme + wxT("\\shell\\open"));
         if ( !key.Exists() )
         {
             // try the default browser, it must be registered at least for http URLs
@@ -98,7 +113,7 @@ bool wxDoLaunchDefaultBrowser(const wxString& url, const wxString& scheme, int f
                     // contain a placeholder for the URL and we should fail if
                     // we didn't find it as this would mean that we have no way
                     // of passing the URL to the browser
-                    ok = ddeCmd.Replace(wxT("%1"), url, false) == 1;
+                    ok = ddeCmd.Replace(wxT("%1"), params.url, false) == 1;
                 }
 
                 if ( ok )
@@ -122,7 +137,7 @@ bool wxDoLaunchDefaultBrowser(const wxString& url, const wxString& scheme, int f
 #endif // wxUSE_IPC
 
     WinStruct<SHELLEXECUTEINFO> sei;
-    sei.lpFile = url.c_str();
+    sei.lpFile = params.GetPathOrURL().t_str();
     sei.lpVerb = wxT("open");
     sei.nShow = SW_SHOWNORMAL;
     sei.fMask = SEE_MASK_FLAG_NO_UI; // we give error message ourselves

--- a/src/osx/iphone/utils.mm
+++ b/src/osx/iphone/utils.mm
@@ -28,6 +28,7 @@
 #include "wx/osx/private.h"
 
 #if wxUSE_GUI
+    #include "wx/private/launchbrowser.h"
     #include "wx/osx/private/timer.h"
     #include "wx/osx/dcclient.h"
 #endif // wxUSE_GUI
@@ -102,9 +103,9 @@ void wxBell()
 // Launch default browser
 // ----------------------------------------------------------------------------
 
-bool wxDoLaunchDefaultBrowser(const wxString& url, int flags)
+bool wxDoLaunchDefaultBrowser(const wxLaunchBrowserParams& params)
 {
-    return [[UIApplication sharedApplication] openURL:[NSURL URLWithString:wxCFStringRef(url).AsNSString()]]
+    return [[UIApplication sharedApplication] openURL:[NSURL URLWithString:wxCFStringRef(params.url).AsNSString()]]
         == YES;
 }
 

--- a/src/osx/utils_osx.cpp
+++ b/src/osx/utils_osx.cpp
@@ -36,6 +36,10 @@
 
 #include <AudioToolbox/AudioServices.h>
 
+#if wxUSE_GUI
+    #include "wx/private/launchbrowser.h"
+#endif
+
 #include "wx/osx/private.h"
 #include "wx/osx/private/timer.h"
 
@@ -130,11 +134,10 @@ bool wxLaunchDefaultApplication(const wxString& document, int flags)
 // Launch default browser
 // ----------------------------------------------------------------------------
 
-bool wxDoLaunchDefaultBrowser(const wxString& url, int flags)
+bool wxDoLaunchDefaultBrowser(const wxLaunchBrowserParams& params)
 {
-    wxUnusedVar(flags);
     wxCFRef< CFURLRef > curl( CFURLCreateWithString( kCFAllocatorDefault,
-                              wxCFStringRef( url ), NULL ) );
+                              wxCFStringRef( params.url ), NULL ) );
     OSStatus err = LSOpenCFURLRef( curl , NULL );
 
     if (err == noErr)

--- a/src/unix/utilsx11.cpp
+++ b/src/unix/utilsx11.cpp
@@ -24,6 +24,7 @@
 
 #include "wx/iconbndl.h"
 #include "wx/apptrait.h"
+#include "wx/private/launchbrowser.h"
 
 #ifdef __VMS
 #pragma message disable nosimpint
@@ -2609,10 +2610,9 @@ bool wxLaunchDefaultApplication(const wxString& document, int flags)
 // Launch default browser
 // ----------------------------------------------------------------------------
 
-bool wxDoLaunchDefaultBrowser(const wxString& url, int flags)
+bool
+wxDoLaunchDefaultBrowser(const wxLaunchBrowserParams& params)
 {
-    wxUnusedVar(flags);
-
 #ifdef __WXGTK__
 #if GTK_CHECK_VERSION(2,14,0)
 #ifndef __WXGTK3__
@@ -2620,7 +2620,7 @@ bool wxDoLaunchDefaultBrowser(const wxString& url, int flags)
 #endif
     {
         GdkScreen* screen = gdk_window_get_screen(wxGetTopLevelGDK());
-        if (gtk_show_uri(screen, url.utf8_str(), GDK_CURRENT_TIME, NULL))
+        if (gtk_show_uri(screen, params.url.utf8_str(), GDK_CURRENT_TIME, NULL))
             return true;
     }
 #endif // GTK_CHECK_VERSION(2,14,0)
@@ -2636,7 +2636,7 @@ bool wxDoLaunchDefaultBrowser(const wxString& url, int flags)
     if ( wxGetEnv("PATH", &path) &&
          wxFindFileInPath(&xdg_open, path, "xdg-open") )
     {
-        if ( wxExecute(xdg_open + " " + url) )
+        if ( wxExecute(xdg_open + " " + params.GetPathOrURL()) )
             return true;
     }
 
@@ -2655,7 +2655,7 @@ bool wxDoLaunchDefaultBrowser(const wxString& url, int flags)
         if (res >= 0 && errors.GetCount() == 0)
         {
             wxString cmd = output[0];
-            cmd << wxT(' ') << url;
+            cmd << wxT(' ') << params.GetPathOrURL();
             if (wxExecute(cmd))
                 return true;
         }
@@ -2663,7 +2663,7 @@ bool wxDoLaunchDefaultBrowser(const wxString& url, int flags)
     else if (desktop == wxT("KDE"))
     {
         // kfmclient directly opens the given URL
-        if (wxExecute(wxT("kfmclient openURL ") + url))
+        if (wxExecute(wxT("kfmclient openURL ") + params.GetPathOrURL()))
             return true;
     }
 


### PR DESCRIPTION
Add a helper wxLaunchBrowserParams struct with clearly distinct "url" and
"path" fields and GetPathOrURL() accessor which returns whichever is
appropriate.

This makes the code more clear and ensures that we never pass URLs (but only
file paths) to xdg-open under Unix as it doesn't handle them.

See #17227.
