### PR TITLE
Fix a issue that overflow button always showed up.

### DIFF
--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -2466,7 +2466,7 @@ void wxAuiToolBar::OnPaint(wxPaintEvent& WXUNUSED(evt))
     }
 
     // paint the overflow button
-    if (dropdown_size > 0 && m_overflowSizerItem)
+    if (dropdown_size > 0 && m_overflowSizerItem && m_overflowVisible)
     {
         wxRect dropDownRect = GetOverflowRect();
         m_art->DrawOverflowButton(dc, this, dropDownRect, m_overflowState);


### PR DESCRIPTION
When resize a wxAuiToolbar, the overflow button always showed up, and the SetOverflowVisible() doesn't work as expected. E.g. in wxAuiToolbar Size event:

```
tb->SetOverflowVisible(!tb->GetToolFitsByIndex(tb->GetToolCount()-1));
tb->Refresh()
```

This is caused by the logic in OnPaint() ignores the m_overflowVisible flag and alway draw (or not draw) the overflow button.  See https://github.com/wxWidgets/wxWidgets/blob/master/src/aui/auibar.cpp#L2469

This ci is proposed to fix this issue.
