### PR TITLE
Fix building iOS and provide minimal documentation on wxiOS

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -5398,7 +5398,8 @@ COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS =  \
 	monodll_iphone_toolbar.o \
 	monodll_iphone_utils.o \
 	monodll_iphone_window.o \
-	monodll_cocoa_stdpaths.o
+	monodll_cocoa_stdpaths.o \
+	monodll_iphone_settings.o
 @COND_TOOLKIT_OSX_IPHONE@__GUI_SRC_OBJECTS = $(COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS)
 @COND_TOOLKIT_QT@__GUI_SRC_OBJECTS = 
 COND_TOOLKIT_DFB___LOWLEVEL_SRC_OBJECTS_1 =  \
@@ -7394,7 +7395,8 @@ COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS_1 =  \
 	monolib_iphone_toolbar.o \
 	monolib_iphone_utils.o \
 	monolib_iphone_window.o \
-	monolib_cocoa_stdpaths.o
+	monolib_cocoa_stdpaths.o \
+	monolib_iphone_settings.o
 @COND_TOOLKIT_OSX_IPHONE@__GUI_SRC_OBJECTS_1 = $(COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS_1)
 @COND_TOOLKIT_QT@__GUI_SRC_OBJECTS_1 = 
 COND_TOOLKIT_DFB___LOWLEVEL_SRC_OBJECTS_3 =  \
@@ -9533,7 +9535,8 @@ COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS_2 =  \
 	coredll_iphone_toolbar.o \
 	coredll_iphone_utils.o \
 	coredll_iphone_window.o \
-	coredll_stdpaths.o
+	coredll_stdpaths.o \
+	coredll_iphone_settings.o
 @COND_TOOLKIT_OSX_IPHONE@__GUI_SRC_OBJECTS_2 = $(COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS_2)
 @COND_TOOLKIT_QT@__GUI_SRC_OBJECTS_2 = 
 COND_TOOLKIT_DFB___LOWLEVEL_SRC_OBJECTS_5 =  \
@@ -10998,7 +11001,8 @@ COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS_3 =  \
 	corelib_iphone_toolbar.o \
 	corelib_iphone_utils.o \
 	corelib_iphone_window.o \
-	corelib_stdpaths.o
+	corelib_stdpaths.o \
+	corelib_iphone_settings.o
 @COND_TOOLKIT_OSX_IPHONE@__GUI_SRC_OBJECTS_3 = $(COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS_3)
 @COND_TOOLKIT_QT@__GUI_SRC_OBJECTS_3 = 
 COND_TOOLKIT_DFB___LOWLEVEL_SRC_OBJECTS_7 =  \
@@ -16463,6 +16467,9 @@ monodll_iphone_utils.o: $(srcdir)/src/osx/iphone/utils.mm $(MONODLL_ODEP)
 monodll_iphone_window.o: $(srcdir)/src/osx/iphone/window.mm $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/window.mm
 
+monodll_iphone_settings.o: $(srcdir)/src/osx/iphone/settings.mm $(MONODLL_ODEP)
+	$(CXXC) -c -o $@ $(MONODLL_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/settings.mm
+
 monodll_univ_anybutton.o: $(srcdir)/src/univ/anybutton.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/univ/anybutton.cpp
 
@@ -21265,6 +21272,9 @@ monolib_iphone_utils.o: $(srcdir)/src/osx/iphone/utils.mm $(MONOLIB_ODEP)
 
 monolib_iphone_window.o: $(srcdir)/src/osx/iphone/window.mm $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/window.mm
+
+monolib_iphone_settings.o: $(srcdir)/src/osx/iphone/settings.mm $(MONOLIB_ODEP)
+	$(CXXC) -c -o $@ $(MONOLIB_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/settings.mm
 
 monolib_univ_anybutton.o: $(srcdir)/src/univ/anybutton.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/univ/anybutton.cpp
@@ -26723,6 +26733,9 @@ coredll_iphone_window.o: $(srcdir)/src/osx/iphone/window.mm $(COREDLL_ODEP)
 coredll_stdpaths.o: $(srcdir)/src/osx/cocoa/stdpaths.mm $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/stdpaths.mm
 
+coredll_iphone_settings.o: $(srcdir)/src/osx/iphone/settings.mm $(COREDLL_ODEP)
+	$(CXXC) -c -o $@ $(COREDLL_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/settings.mm
+
 coredll_univ_anybutton.o: $(srcdir)/src/univ/anybutton.cpp $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/univ/anybutton.cpp
 
@@ -30106,6 +30119,9 @@ corelib_iphone_window.o: $(srcdir)/src/osx/iphone/window.mm $(CORELIB_ODEP)
 
 corelib_stdpaths.o: $(srcdir)/src/osx/cocoa/stdpaths.mm $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/stdpaths.mm
+
+corelib_iphone_settings.o: $(srcdir)/src/osx/iphone/settings.mm $(CORELIB_ODEP)
+	$(CXXC) -c -o $@ $(CORELIB_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/settings.mm
 
 corelib_univ_anybutton.o: $(srcdir)/src/univ/anybutton.cpp $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/univ/anybutton.cpp

--- a/build/bakefiles/files.bkl
+++ b/build/bakefiles/files.bkl
@@ -2478,6 +2478,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     src/osx/iphone/utils.mm
     src/osx/iphone/window.mm
     src/osx/cocoa/stdpaths.mm
+    src/osx/iphone/settings.mm
 </set>
 
 <set var="OSX_IPHONE_HDR" hints="files">

--- a/build/files
+++ b/build/files
@@ -2109,6 +2109,7 @@ OSX_IPHONE_SRC =
     src/osx/iphone/msgdlg.mm
     src/osx/iphone/nonownedwnd.mm
     src/osx/iphone/scrolbar.mm
+    src/osx/iphone/settings.mm
     src/osx/iphone/slider.mm
     src/osx/iphone/stattext.mm
     src/osx/iphone/textctrl.mm

--- a/build/osx/wxiphone.xcodeproj/project.pbxproj
+++ b/build/osx/wxiphone.xcodeproj/project.pbxproj
@@ -141,6 +141,8 @@
 		23E9AF567E873B948EFEA180 /* gauge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 98A7F0605AAC3D28A8C9F253 /* gauge.mm */; };
 		242E1D1A9BF331BA918134EC /* pngwtran.c in Sources */ = {isa = PBXBuildFile; fileRef = 0964797530CF3FE7B8DB6242 /* pngwtran.c */; };
 		246B4FF96BA135258FE45F4F /* encconv.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C269E9CA99DF3AE5B1BD6AFA /* encconv.cpp */; };
+		247B3B991C6C9731001ABFA2 /* utils_base.mm in Sources */ = {isa = PBXBuildFile; fileRef = 247B3B981C6C9731001ABFA2 /* utils_base.mm */; };
+		247B3B9B1C6C975B001ABFA2 /* settings.mm in Sources */ = {isa = PBXBuildFile; fileRef = 247B3B9A1C6C975B001ABFA2 /* settings.mm */; };
 		2480859662ED399799E120A5 /* pen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4BA819575B5136B09FA8FEB1 /* pen.cpp */; };
 		249C9177B1A33EFEAB30F93F /* tipwin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9E8BF36D3A7C309482CBA9EC /* tipwin.cpp */; };
 		24A5A71C79733E9CB913C5B7 /* LexPB.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 8744F2C80ECF375999195935 /* LexPB.cxx */; };
@@ -238,7 +240,6 @@
 		427E6AF88CF73D799206E37D /* checkboxcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4FC2F076657431458896115A /* checkboxcmn.cpp */; };
 		42AC484FDD7D3E948CEA801C /* inflate.c in Sources */ = {isa = PBXBuildFile; fileRef = B5370A676AAC32419D7FDD87 /* inflate.c */; };
 		42ED9BAFD6E936849F1D36CB /* xtixml.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4048A3523EC03409BD899BEF /* xtixml.cpp */; };
-		437519A6002A3A0FB2C9A8FC /* settings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E6CC2B05353C3284B37B2DD7 /* settings.cpp */; };
 		438EAEA4B30C325C827F6197 /* xh_fontpicker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 87E609641B583666AB9D1D58 /* xh_fontpicker.cpp */; };
 		4442EA28B0B3373B9A2D0862 /* collheaderctrlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 92F377099B8B37F18C26716B /* collheaderctrlg.cpp */; };
 		447FEC72F3C234378CE28DE7 /* effects.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 48D72D20DB1D3E1CA5ED112A /* effects.cpp */; };
@@ -962,6 +963,8 @@
 		23FC98E2305230E2990471E3 /* wxcrt.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = wxcrt.cpp; path = ../../src/common/wxcrt.cpp; sourceTree = "<group>"; };
 		242BF97B558634A79322052C /* prntbase.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = prntbase.cpp; path = ../../src/common/prntbase.cpp; sourceTree = "<group>"; };
 		24396D584D053948A3FF0DCD /* imagpng.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = imagpng.cpp; path = ../../src/common/imagpng.cpp; sourceTree = "<group>"; };
+		247B3B981C6C9731001ABFA2 /* utils_base.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = utils_base.mm; path = ../../src/osx/cocoa/utils_base.mm; sourceTree = "<group>"; };
+		247B3B9A1C6C975B001ABFA2 /* settings.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = settings.mm; path = ../../src/osx/iphone/settings.mm; sourceTree = "<group>"; };
 		24930711031D35288D28B04B /* choiccmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = choiccmn.cpp; path = ../../src/common/choiccmn.cpp; sourceTree = "<group>"; };
 		24BD2EF635673E819B8406CB /* LexRust.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexRust.cxx; path = ../../src/stc/scintilla/lexers/LexRust.cxx; sourceTree = "<group>"; };
 		24DF23D67E693D999B875101 /* toolbkg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = toolbkg.cpp; path = ../../src/generic/toolbkg.cpp; sourceTree = "<group>"; };
@@ -1612,7 +1615,6 @@
 		E5A9B63746753EDFB2EC48D3 /* xh_frame.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_frame.cpp; path = ../../src/xrc/xh_frame.cpp; sourceTree = "<group>"; };
 		E685D81FB9FF3081B6C5C321 /* EditModel.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = EditModel.cxx; path = ../../src/stc/scintilla/src/EditModel.cxx; sourceTree = "<group>"; };
 		E6AB648BC5173104A96CAE66 /* xml.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xml.cpp; path = ../../src/xml/xml.cpp; sourceTree = "<group>"; };
-		E6CC2B05353C3284B37B2DD7 /* settings.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = settings.cpp; path = ../../src/osx/carbon/settings.cpp; sourceTree = "<group>"; };
 		E72CF5F9C1E53BCFAA2BC253 /* KeyMap.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = KeyMap.cxx; path = ../../src/stc/scintilla/src/KeyMap.cxx; sourceTree = "<group>"; };
 		E72F0A2EE3DB34E193D8CCA7 /* LexLaTeX.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexLaTeX.cxx; path = ../../src/stc/scintilla/lexers/LexLaTeX.cxx; sourceTree = "<group>"; };
 		E78CBF86AAE637CB982B2EC0 /* LexMarkdown.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexMarkdown.cxx; path = ../../src/stc/scintilla/lexers/LexMarkdown.cxx; sourceTree = "<group>"; };
@@ -2019,7 +2021,6 @@
 				A3BF8C9FF2D5314591329D0D /* toolbar.mm */,
 				789F45D14FF23E248FCFB5FA /* utils.mm */,
 				C94DC3402FAE3C4FA776DEEA /* window.mm */,
-				E6CC2B05353C3284B37B2DD7 /* settings.cpp */,
 				190409DF8A3C3D9580FBB8AA /* stdpaths.mm */,
 				A436B55DC44E3827A757A6D8 /* accelcmn.cpp */,
 				8555204EBA8930809B732842 /* accesscmn.cpp */,
@@ -2647,6 +2648,8 @@
 				C9A305CEC03B3085B159B617 /* fs_mem.cpp */,
 				E968913A9A593B258BD8EACB /* msgout.cpp */,
 				4188821BBA833CCAA678B234 /* utilscmn.cpp */,
+				247B3B9A1C6C975B001ABFA2 /* settings.mm */,
+				247B3B981C6C9731001ABFA2 /* utils_base.mm */,
 			);
 			name = base;
 			sourceTree = "<group>";
@@ -2804,7 +2807,9 @@
 /* Begin PBXProject section */
 		19367367C9323490BB936F06 /* Project object */ = {
 			isa = PBXProject;
-			buildConfigurationList = A66311F47C8832F6A58105B6 /* Build configuration list for PBXProject "wxiphone" */;
+			attributes = {
+			};
+			buildConfigurationList = A66311F47C8832F6A58105B6 /* Build configuration list for PBXProject "wxiPhone" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
@@ -2921,6 +2926,7 @@
 				DAAFBED07FF8365B96D20B99 /* unichar.cpp in Sources */,
 				2E8440A2BDD53BE7B01547C2 /* uri.cpp in Sources */,
 				C425A172B0AB3EBD9AC9A590 /* ustring.cpp in Sources */,
+				247B3B991C6C9731001ABFA2 /* utils_base.mm in Sources */,
 				65E8A5F333D7336C816F0D0C /* variant.cpp in Sources */,
 				E53AFF04877D34C386D77380 /* wfstream.cpp in Sources */,
 				319EA32592DA3C74B86DDDFF /* wxcrt.cpp in Sources */,
@@ -3066,7 +3072,6 @@
 				A53B8C3ED0D33A1D9AA8219A /* toolbar.mm in Sources */,
 				A1A7D793B034398B8696EF33 /* utils.mm in Sources */,
 				815AE3FED68330F4933AA16F /* window.mm in Sources */,
-				437519A6002A3A0FB2C9A8FC /* settings.cpp in Sources */,
 				DA71FBB9EFB2350ABB3CEC80 /* stdpaths.mm in Sources */,
 				3CDE2B6BF88D326189F069BD /* accelcmn.cpp in Sources */,
 				BDB8EF0E0DA03693BFB77EF7 /* accesscmn.cpp in Sources */,
@@ -3492,6 +3497,7 @@
 				894D43C8F224394FB3171F26 /* jcapimin.c in Sources */,
 				743BB23211B336A6A0F26E57 /* jcapistd.c in Sources */,
 				CCE4ECA9CE883B008065C6FB /* jctrans.c in Sources */,
+				247B3B9B1C6C975B001ABFA2 /* settings.mm in Sources */,
 				ACD644CFA85A3B70A3E3B118 /* jcparam.c in Sources */,
 				76A83A293C9F33BCB7DFDE26 /* jdatadst.c in Sources */,
 				86003C8EB906304F9025F788 /* jcinit.c in Sources */,
@@ -3743,7 +3749,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		A66311F47C8832F6A58105B6 /* Build configuration list for PBXProject "wxiphone" */ = {
+		A66311F47C8832F6A58105B6 /* Build configuration list for PBXProject "wxiPhone" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				55C93151F6053EBCBDD70DF9 /* Debug */,

--- a/docs/doxygen/mainpages/platdetails.h
+++ b/docs/doxygen/mainpages/platdetails.h
@@ -169,6 +169,14 @@ wxQt is a port of wxWidgets using Qt libraries. It requires Qt 5 or later.
 
 For further information, please see the files in docs/qt in the distribution.
 
+@section page_port_wxiOS wxiOS
+
+wxiOS is a port of wxWidgets using Cocoa touch libraries for iOS. It is very
+basic in it current form, but is included for further improvements and very
+simple applications.
+
+For further information, please see the files in docs/ios in the distribution.
+
 @section page_port_nativedocs Native Toolkit Documentation
 
 It's sometimes useful to interface directly with the underlying toolkit

--- a/docs/index.htm
+++ b/docs/index.htm
@@ -48,7 +48,8 @@
       <a href="motif/readme.txt">wxMotif</a>,
       <a href="qt/readme.txt">wxQt</a>
       <a href="x11/readme.txt">wxX11</a>,
-      <a href="univ/readme.txt">Univ</a>
+      <a href="univ/readme.txt">Univ</a>,
+      <a href="ios/readme.txt">wxiOS</a>
     </li>
     <li>Installation:
       <a href="msw/install.txt">wxMSW</a>,

--- a/docs/ios/readme.txt
+++ b/docs/ios/readme.txt
@@ -1,0 +1,45 @@
+   Welcome to wxWidgets for iOS
+   ----------------------------
+
+wxiOS is far from a full supported port, but can be used
+as base for simple applications and future improvements.
+
+It requires Xcode with iOS SDK 9.0 or later. Xcode is available
+for free in the OS X app store.
+
+More info about the wxWidgets project (including all the
+other ports and version of wxWidgets) can be found at the
+main wxWidgets homepage at:
+
+    https://www.wxwidgets.org/
+
+To build wxiOS you should use Xcode to open the minimal samples
+Xcode project file located at:
+
+    samples/minimal/minimal_iphone.xcodeproj
+
+That project files includes wxiphone.xcodeproj so you just need
+to hit run in order to see the minimal sample running in the
+simulator.
+
+The library can also be build via configure/make:
+
+    mkdir build_ios
+    cd build_ios
+    ../configure --with-osx_iphone --enable-monolithic \
+        --with-macosx-version-min=8.0 --disable-shared \
+        --with-macosx-sdk=$(xcrun --sdk iphonesimulator --show-sdk-path)
+    make
+
+
+Please send problems concerning installation, feature requests,
+bug reports or comments to the wxWidgets users list. These can
+be found at https://www.wxwidgets.org/support/mailing-lists/
+
+wxWidgets doesn't come with any guarantee whatsoever. It
+might crash your harddisk or destroy your monitor. It doesn't
+claim to be suitable for any special or general purpose.
+
+  Regards,
+
+    The wxWidgets Team

--- a/samples/minimal/minimal.cpp
+++ b/samples/minimal/minimal.cpp
@@ -164,6 +164,12 @@ MyFrame::MyFrame(const wxString& title)
 
     // ... and attach this menu bar to the frame
     SetMenuBar(menuBar);
+#else
+    // If menus are not available add a button to access the about box
+    wxSizer* sizer = new wxBoxSizer(wxHORIZONTAL);
+    wxButton* aboutBtn = new wxButton(this, wxID_ANY, "About...");
+    aboutBtn->Bind(wxEVT_BUTTON, &MyFrame::OnAbout, this);
+    sizer->Add(aboutBtn, wxSizerFlags().Center());
 #endif // wxUSE_MENUS
 
 #if wxUSE_STATUSBAR

--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -25,7 +25,7 @@
 // our OS version is the same in non GUI and GUI cases
 wxOperatingSystemId wxGetOsVersion(int *majorVsn, int *minorVsn)
 {
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_10
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_10 || defined(__WXOSX_IPHONE__)
     if ([NSProcessInfo instancesRespondToSelector:@selector(operatingSystemVersion)])
     {
         NSOperatingSystemVersion osVer = [NSProcessInfo processInfo].operatingSystemVersion;
@@ -43,8 +43,13 @@ wxOperatingSystemId wxGetOsVersion(int *majorVsn, int *minorVsn)
         // Deprecated Gestalt calls are required instead
 wxGCC_WARNING_SUPPRESS(deprecated-declarations)
         SInt32 maj, min;
+#ifdef __WXOSX_IPHONE__
+		maj = 7;
+		min = 0;
+#else
         Gestalt(gestaltSystemVersionMajor, &maj);
         Gestalt(gestaltSystemVersionMinor, &min);
+#endif
 wxGCC_WARNING_RESTORE()
 
         if ( majorVsn != NULL )
@@ -59,7 +64,7 @@ wxGCC_WARNING_RESTORE()
 
 bool wxCheckOsVersion(int majorVsn, int minorVsn)
 {
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_10
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_10 || defined(__WXOSX_IPHONE__)
     if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)])
     {
         NSOperatingSystemVersion osVer;
@@ -85,6 +90,7 @@ wxString wxGetOsDescription()
     int majorVer, minorVer;
     wxGetOsVersion(&majorVer, &minorVer);
 
+#ifndef __WXOSX_IPHONE__
     // Notice that neither the OS name itself nor the code names seem to be
     // ever translated, OS X itself uses the English words even for the
     // languages not using Roman alphabet.
@@ -113,6 +119,10 @@ wxString wxGetOsDescription()
                 break;
         };
     }
+#else
+    wxString osBrand = "iOS";
+    wxString osName;
+#endif
 
     wxString osDesc = osBrand;
     if (!osName.empty())

--- a/src/osx/iphone/evtloop.mm
+++ b/src/osx/iphone/evtloop.mm
@@ -80,6 +80,10 @@ wxGUIEventLoop::wxGUIEventLoop()
 {
 }
 
+wxGUIEventLoop::~wxGUIEventLoop()
+{
+}
+
 void wxGUIEventLoop::OSXDoRun()
 {
     if ( IsMain() )

--- a/src/osx/iphone/settings.mm
+++ b/src/osx/iphone/settings.mm
@@ -1,0 +1,250 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        src/osx/iphone/settings.mm
+// Purpose:     wxSettings
+// Author:      David Elliott
+// Modified by: Tobias Taschner
+// Created:     2005/01/11
+// Copyright:   (c) 2005 David Elliott
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
+#include "wx/wxprec.h"
+
+#include "wx/settings.h"
+
+#ifndef WX_PRECOMP
+    #include "wx/utils.h"
+    #include "wx/gdicmn.h"
+#endif
+
+#include "wx/osx/core/private.h"
+
+#include "UIKit/UIKit.h"
+
+// ----------------------------------------------------------------------------
+// wxSystemSettingsNative
+// ----------------------------------------------------------------------------
+
+// ----------------------------------------------------------------------------
+// colours
+// ----------------------------------------------------------------------------
+
+wxColour wxSystemSettingsNative::GetColour(wxSystemColour index)
+{
+    wxColour resultColor;
+#if wxOSX_USE_COCOA_OR_CARBON
+    ThemeBrush colorBrushID;
+#endif
+
+    switch ( index )
+    {
+        case wxSYS_COLOUR_WINDOW:
+            resultColor = *wxWHITE;
+            break ;
+        case wxSYS_COLOUR_SCROLLBAR :
+        case wxSYS_COLOUR_BACKGROUND:
+        case wxSYS_COLOUR_ACTIVECAPTION:
+        case wxSYS_COLOUR_INACTIVECAPTION:
+        case wxSYS_COLOUR_MENU:
+        case wxSYS_COLOUR_WINDOWFRAME:
+        case wxSYS_COLOUR_ACTIVEBORDER:
+        case wxSYS_COLOUR_INACTIVEBORDER:
+        case wxSYS_COLOUR_BTNFACE:
+        case wxSYS_COLOUR_MENUBAR:
+            resultColor = wxColour( 0xBE, 0xBE, 0xBE ) ;
+            break ;
+
+        case wxSYS_COLOUR_LISTBOX :
+            resultColor = *wxWHITE ;
+            break ;
+
+        case wxSYS_COLOUR_BTNSHADOW:
+            resultColor = wxColour( 0xBE, 0xBE, 0xBE );
+            break ;
+
+        case wxSYS_COLOUR_BTNTEXT:
+        case wxSYS_COLOUR_MENUTEXT:
+        case wxSYS_COLOUR_WINDOWTEXT:
+        case wxSYS_COLOUR_CAPTIONTEXT:
+        case wxSYS_COLOUR_INFOTEXT:
+        case wxSYS_COLOUR_INACTIVECAPTIONTEXT:
+        case wxSYS_COLOUR_LISTBOXTEXT:
+            resultColor = *wxBLACK;
+            break ;
+
+        case wxSYS_COLOUR_HIGHLIGHT:
+            {
+                resultColor = wxColor( 0xCC, 0xCC, 0xFF );
+            }
+            break ;
+
+        case wxSYS_COLOUR_BTNHIGHLIGHT:
+        case wxSYS_COLOUR_GRAYTEXT:
+            resultColor = wxColor( 0xCC, 0xCC, 0xCC );
+            break ;
+
+        case wxSYS_COLOUR_3DDKSHADOW:
+            resultColor = wxColor( 0x44, 0x44, 0x44 );
+            break ;
+
+        case wxSYS_COLOUR_3DLIGHT:
+            resultColor = wxColor( 0xCC, 0xCC, 0xCC );
+            break ;
+
+        case wxSYS_COLOUR_HIGHLIGHTTEXT :
+        case wxSYS_COLOUR_LISTBOXHIGHLIGHTTEXT :
+            resultColor = *wxWHITE ;
+            break ;
+
+        case wxSYS_COLOUR_INFOBK :
+            // we don't have a way to detect tooltip color, so use the
+            // standard value used at least on 10.4:
+            resultColor = wxColour( 0xFF, 0xFF, 0xD3 ) ;
+            break ;
+        case wxSYS_COLOUR_APPWORKSPACE:
+            resultColor =  wxColor( 0x80, 0x80, 0x80 ); ;
+            break ;
+
+        case wxSYS_COLOUR_HOTLIGHT:
+        case wxSYS_COLOUR_GRADIENTACTIVECAPTION:
+        case wxSYS_COLOUR_GRADIENTINACTIVECAPTION:
+        case wxSYS_COLOUR_MENUHILIGHT:
+            // TODO:
+            resultColor = *wxBLACK;
+            break ;
+
+        default:
+            resultColor = *wxWHITE;
+            break ;
+    }
+
+    return resultColor;
+}
+
+// ----------------------------------------------------------------------------
+// fonts
+// ----------------------------------------------------------------------------
+
+wxFont wxSystemSettingsNative::GetFont(wxSystemFont index)
+{
+    switch (index)
+    {
+        case wxSYS_ANSI_VAR_FONT :
+        case wxSYS_SYSTEM_FONT :
+        case wxSYS_DEVICE_DEFAULT_FONT :
+        case wxSYS_DEFAULT_GUI_FONT :
+            {
+                return *wxSMALL_FONT ;
+            } ;
+            break ;
+        case wxSYS_OEM_FIXED_FONT :
+        case wxSYS_ANSI_FIXED_FONT :
+        case wxSYS_SYSTEM_FIXED_FONT :
+        default :
+            {
+                return *wxNORMAL_FONT ;
+            } ;
+            break ;
+
+    }
+    return *wxNORMAL_FONT;
+}
+
+// ----------------------------------------------------------------------------
+// system metrics/features
+// ----------------------------------------------------------------------------
+
+// Get a system metric, e.g. scrollbar size
+int wxSystemSettingsNative::GetMetric(wxSystemMetric index, wxWindow *WXUNUSED(win))
+{
+    int value;
+
+    switch ( index )
+    {
+        case wxSYS_MOUSE_BUTTONS:
+                    return 2; // we emulate a two button mouse (ctrl + click = right button )
+
+        // TODO case wxSYS_BORDER_X:
+        // TODO case wxSYS_BORDER_Y:
+        // TODO case wxSYS_CURSOR_X:
+        // TODO case wxSYS_CURSOR_Y:
+        // TODO case wxSYS_DCLICK_X:
+        // TODO case wxSYS_DCLICK_Y:
+        // TODO case wxSYS_DRAG_X:
+        // TODO case wxSYS_DRAG_Y:
+        // TODO case wxSYS_EDGE_X:
+        // TODO case wxSYS_EDGE_Y:
+
+        case wxSYS_HSCROLL_ARROW_X:
+            return 16;
+        case wxSYS_HSCROLL_ARROW_Y:
+            return 16;
+        case wxSYS_HTHUMB_X:
+            return 16;
+
+        // TODO case wxSYS_ICON_X:
+        // TODO case wxSYS_ICON_Y:
+        // TODO case wxSYS_ICONSPACING_X:
+        // TODO case wxSYS_ICONSPACING_Y:
+        // TODO case wxSYS_WINDOWMIN_X:
+        // TODO case wxSYS_WINDOWMIN_Y:
+
+        case wxSYS_SCREEN_X:
+            wxDisplaySize(&value, NULL);
+            return value;
+
+        case wxSYS_SCREEN_Y:
+            wxDisplaySize(NULL, &value);
+            return value;
+
+        // TODO case wxSYS_FRAMESIZE_X:
+        // TODO case wxSYS_FRAMESIZE_Y:
+        // TODO case wxSYS_SMALLICON_X:
+        // TODO case wxSYS_SMALLICON_Y:
+
+        case wxSYS_HSCROLL_Y:
+            return 16;
+        case wxSYS_VSCROLL_X:
+            return 16;
+        case wxSYS_VSCROLL_ARROW_X:
+            return 16;
+        case wxSYS_VSCROLL_ARROW_Y:
+            return 16;
+        case wxSYS_VTHUMB_Y:
+            return 16;
+
+        // TODO case wxSYS_CAPTION_Y:
+        // TODO case wxSYS_MENU_Y:
+        // TODO case wxSYS_NETWORK_PRESENT:
+
+        case wxSYS_PENWINDOWS_PRESENT:
+            return 0;
+
+        // TODO case wxSYS_SHOW_SOUNDS:
+
+        case wxSYS_SWAP_BUTTONS:
+            return 0;
+
+        case wxSYS_DCLICK_MSEC:
+            // default on mac is 30 ticks, we shouldn't really use wxSYS_DCLICK_MSEC anyway
+            // but rather rely on the 'click-count' by the system delivered in a mouse event
+            return 500;
+
+        default:
+            return -1;  // unsupported metric
+    }
+    return 0;
+}
+
+bool wxSystemSettingsNative::HasFeature(wxSystemFeature index)
+{
+    switch (index)
+    {
+        case wxSYS_CAN_ICONIZE_FRAME:
+        case wxSYS_CAN_DRAW_FRAME_DECORATIONS:
+            return true;
+
+        default:
+            return false;
+    }
+}

--- a/src/osx/iphone/utils.mm
+++ b/src/osx/iphone/utils.mm
@@ -317,48 +317,4 @@ wxBitmap wxWindowDCImpl::DoGetAsBitmap(const wxRect *subrect) const
 
 #endif // wxUSE_GUI
 
-// TODO move these into a BASE file
-
-wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin)
-{
-    // get OS version
-    int major, minor;
-
-    wxString release = wxCFStringRef( wxCFRetain( [ [UIDevice currentDevice] systemVersion] ) ).AsString() ;
-
-    if ( release.empty() ||
-        // TODO use wx method
-         scanf(release.c_str(), wxT("%d.%d"), &major, &minor) != 2 )
-    {
-        // failed to get version string or unrecognized format
-        major =
-        minor = -1;
-    }
-
-    if ( verMaj )
-        *verMaj = major;
-    if ( verMin )
-        *verMin = minor;
-
-    return wxOS_MAC_OSX_DARWIN;
-}
-
-wxString wxGetOsDescription()
-{
-    wxString release = wxCFStringRef( wxCFRetain([ [UIDevice currentDevice] systemName] )).AsString() ;
-
-    return release;
-}
-
-// FIXME: This duplicates the function in src/unix/utilsunx.cpp, we should just
-//        reuse it instead of there is no iOS-specific implementation of this.
-bool wxCheckOsVersion(int majorVsn, int minorVsn)
-{
-    int majorCur, minorCur;
-    wxGetOsVersion(&majorCur, &minorCur);
-
-    return majorCur > majorVsn || (majorCur == majorVsn && minorCur >= minorVsn);
-}
-
-
 #endif // wxOSX_USE_IPHONE


### PR DESCRIPTION
Building the iOS version was broken since at least the removal of carbon.

I've fixed the Xcode and make builds and added minimal documentation so interested developers might at least know of it's existence and current status.
Additionally an "About" button was added to the minimal sample for ports not providing menus.

Obviously wxIOS is far from a usable port, but it probably helps if it can at least be built :)

<img src="https://cloud.githubusercontent.com/assets/5075894/12974790/fe9da5ea-d0b6-11e5-9334-3df256592d36.png" width=320 height=568>
