### PR TITLE
Fixed wxListView issues for ComCtl32 5.x (wxMSW)

### DIFF
--- a/src/msw/imaglist.cpp
+++ b/src/msw/imaglist.cpp
@@ -230,6 +230,19 @@ int wxImageList::Add(const wxBitmap& bitmap, const wxColour& maskColour)
 // Adds a bitmap and mask from an icon.
 int wxImageList::Add(const wxIcon& icon)
 {
+    // ComCtl32 prior 6.0 doesn't support images with alpha
+    // channel so if we have 32-bit icon with transparency
+    // we need to add it as a wxBitmap via dedicated method
+    // where alpha channel will be converted to the mask.
+    if ( wxApp::GetComCtl32Version() < 600 )
+    {
+        wxBitmap bmp(icon);
+        if ( bmp.HasAlpha() )
+        {
+            return Add(bmp);
+        }
+    }
+
     int index = ImageList_AddIcon(GetHImageList(), GetHiconOf(icon));
     if ( index == -1 )
     {
@@ -292,6 +305,19 @@ bool wxImageList::Replace(int index,
 // Replaces a bitmap and mask from an icon.
 bool wxImageList::Replace(int i, const wxIcon& icon)
 {
+    // ComCtl32 prior 6.0 doesn't support images with alpha
+    // channel so if we have 32-bit icon with transparency
+    // we need to replace it as a wxBitmap via dedicated method
+    // where alpha channel will be converted to the mask.
+    if ( wxApp::GetComCtl32Version() < 600 )
+    {
+        wxBitmap bmp(icon);
+        if ( bmp.HasAlpha() )
+        {
+            return Replace(i, bmp);
+        }
+    }
+
     bool ok = ImageList_ReplaceIcon(GetHImageList(), i, GetHiconOf(icon)) != -1;
     if ( !ok )
     {

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -1341,6 +1341,18 @@ void wxListCtrl::SetImageList(wxImageList *imageList, int which)
         m_ownsImageListState = false;
     }
     (void) ListView_SetImageList(GetHwnd(), (HIMAGELIST) imageList ? imageList->GetHIMAGELIST() : 0, flags);
+
+    // For ComCtl32 prior 6.0 we need to re-assign all existing
+    // text labels in order to position them correctly.
+    if ( wxApp::GetComCtl32Version() < 600 )
+    {
+        const int n = GetItemCount();
+        for( int i = 0; i < n; i++ )
+        {
+            wxString text = GetItemText(i);
+            SetItemText(i, text);
+        }
+    }
 }
 
 void wxListCtrl::AssignImageList(wxImageList *imageList, int which)


### PR DESCRIPTION
Fixed issues with wxListView which occurs for ComCtl32 prior to 6.0:
1. 32-bit icon with transparency added to wxImageList is displayed improperly.
2. Text labels  can be displayed improperly after assigning wxImageList to non-empty wxListCtrl.

See http://trac.wxwidgets.org/ticket/17378
