### PR TITLE
Fixed building with wxUSE_UXTHEME 0.

### DIFF
--- a/src/msw/anybutton.cpp
+++ b/src/msw/anybutton.cpp
@@ -44,6 +44,7 @@
 #include "wx/stockitem.h"
 #include "wx/msw/private/button.h"
 #include "wx/msw/private/dc.h"
+#include "wx/msw/uxtheme.h"
 #include "wx/private/window.h"
 
 #if wxUSE_MARKUP
@@ -53,8 +54,6 @@
 using namespace wxMSWImpl;
 
 #if wxUSE_UXTHEME
-    #include "wx/msw/uxtheme.h"
-
     // no need to include tmschema.h
     #ifndef BP_PUSHBUTTON
         #define BP_PUSHBUTTON 1

--- a/src/msw/menuitem.cpp
+++ b/src/msw/menuitem.cpp
@@ -47,10 +47,7 @@
 
 #include "wx/msw/private.h"
 #include "wx/msw/dc.h"
-
-#if wxUSE_UXTHEME
-    #include "wx/msw/uxtheme.h"
-#endif
+#include "wx/msw/uxtheme.h"
 
 // ---------------------------------------------------------------------------
 // macro


### PR DESCRIPTION
In case anyone wants the Windows 98 look.

The include of `wx/msw/uxtheme.h` need to be outside the `#if wxUSE_UXTHEME`. The file is also included in a lot of other files so it shoudn't be a problem.

In `anybutton.cpp` the `wxUxThemeEngine::GetIfActive()` function is used. In `menuitem.cpp` the `MARGINS` struct need to be known.
