### PR TITLE
clean up style context handling to reflect gtk 3.19+

### DIFF
--- a/src/gtk/control.cpp
+++ b/src/gtk/control.cpp
@@ -252,7 +252,8 @@ wxControl::GetDefaultAttributesFromGTKWidget(GtkWidget* widget,
     GtkStyleContext* sc = gtk_widget_get_style_context(widget);
     GdkRGBA *fc, *bc;
     wxNativeFontInfo info;
-    gtk_style_context_get(sc, stateFlag,
+    gtk_style_context_set_state(sc, stateFlag);
+    gtk_style_context_get(sc, gtk_style_context_get_state(sc),
         "color", &fc, "background-color", &bc,
         GTK_STYLE_PROPERTY_FONT, &info.description, NULL);
     attr.colFg = wxColour(*fc);

--- a/src/gtk/settings.cpp
+++ b/src/gtk/settings.cpp
@@ -156,14 +156,16 @@ static void get_color(const char* name, GtkWidget* widget, GtkStateFlags state, 
 {
     GtkStyleContext* sc = gtk_widget_get_style_context(widget);
     GdkRGBA* rgba;
-    gtk_style_context_get(sc, state, name, &rgba, NULL);
+    gtk_style_context_set_state(sc, state);
+    gtk_style_context_get(sc, gtk_style_context_get_state(sc), name, &rgba, NULL);
     gdkRGBA = *rgba;
     gdk_rgba_free(rgba);
     if (gdkRGBA.alpha <= 0)
     {
         widget = gtk_widget_get_parent(GTK_WIDGET(ContainerWidget()));
         sc = gtk_widget_get_style_context(widget);
-        gtk_style_context_get(sc, state, name, &rgba, NULL);
+        gtk_style_context_set_state(sc, state);
+        gtk_style_context_get(sc, gtk_style_context_get_state(sc), name, &rgba, NULL);
         gdkRGBA = *rgba;
         gdk_rgba_free(rgba);
     }
@@ -448,7 +450,8 @@ wxFont wxSystemSettingsNative::GetFont( wxSystemFont index )
                 wxNativeFontInfo info;
 #ifdef __WXGTK3__
                 GtkStyleContext* sc = gtk_widget_get_style_context(ButtonWidget());
-                gtk_style_context_get(sc, GTK_STATE_FLAG_NORMAL,
+                gtk_style_context_set_state(sc, GTK_STATE_FLAG_NORMAL);
+                gtk_style_context_get(sc, gtk_style_context_get_state(sc),
                     GTK_STYLE_PROPERTY_FONT, &info.description, NULL);
 #else
                 info.description = ButtonStyle()->font_desc;

--- a/src/gtk/spinbutt.cpp
+++ b/src/gtk/spinbutt.cpp
@@ -194,7 +194,7 @@ wxSize wxSpinButton::DoGetBestSize() const
 #ifdef __WXGTK3__
     GtkStyleContext* sc = gtk_widget_get_style_context(m_widget);
     GtkBorder pad = { 0, 0, 0, 0 };
-    gtk_style_context_get_padding(sc, GtkStateFlags(0), &pad);
+    gtk_style_context_get_padding(sc, gtk_style_context_get_state(sc), &pad);
     best.x -= pad.left + pad.right;
 #else
     gtk_widget_ensure_style(m_widget);

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -373,7 +373,8 @@ draw_border(GtkWidget* widget, GdkEventExpose* gdk_event, wxWindow* win)
 #ifdef __WXGTK3__
         GtkStyleContext* sc = gtk_widget_get_style_context(win->m_wxwindow);
         GdkRGBA* c;
-        gtk_style_context_get(sc, GTK_STATE_FLAG_NORMAL, "border-color", &c, NULL);
+        gtk_style_context_set_state(sc, GTK_STATE_FLAG_NORMAL);
+        gtk_style_context_get(sc, gtk_style_context_get_state(sc), "border-color", &c, NULL);
         gdk_cairo_set_source_rgba(cr, c);
         gdk_rgba_free(c);
         cairo_set_line_width(cr, 1);
@@ -4561,8 +4562,9 @@ void wxWindowGTK::GTKApplyStyle(GtkWidget* widget, GtkRcStyle* WXUNUSED_IN_GTK3(
     cairo_pattern_t* pattern = NULL;
     if (m_backgroundColour.IsOk())
     {
+        gtk_style_context_set_state(context, GTK_STATE_FLAG_NORMAL);
         gtk_style_context_get(context,
-            GTK_STATE_FLAG_NORMAL, "background-image", &pattern, NULL);
+            gtk_style_context_get_state(context), "background-image", &pattern, NULL);
     }
     if (pattern)
     {


### PR DESCRIPTION
This removes the flood of messages I get when I launch wxGTK3 apps in Fedora rawhide:

Gtk-WARNING *_: State 0 for GtkButton 0x55fed89ea1f0 doesn't match state 128 set via gtk_style_context_set_state ()
Gtk-WARNING *_: State 0 for GtkWindow 0x55fed8aba260 doesn't match state 128 set via gtk_style_context_set_state ()
