### PR TITLE
Fixed segmentation fault in OpenGL pyramid example.

### DIFF
--- a/src/msw/glcanvas.cpp
+++ b/src/msw/glcanvas.cpp
@@ -552,6 +552,7 @@ wxIMPLEMENT_CLASS(wxGLContext, wxObject);
 wxGLContext::wxGLContext(wxGLCanvas *win,
                          const wxGLContext *other,
                          const wxGLContextAttrs *ctxAttrs)
+    : m_glContext(NULL)
 {
     const int* contextAttribs = NULL;
     bool needsARB = false;
@@ -614,7 +615,10 @@ wxGLContext::wxGLContext(wxGLCanvas *win,
 wxGLContext::~wxGLContext()
 {
     // note that it's ok to delete the context even if it's the current one
-    wglDeleteContext(m_glContext);
+    if ( m_glContext )
+    {
+        wglDeleteContext(m_glContext);
+    }
 }
 
 bool wxGLContext::SetCurrent(const wxGLCanvas& win) const

--- a/src/osx/glcanvas_osx.cpp
+++ b/src/osx/glcanvas_osx.cpp
@@ -359,6 +359,7 @@ wxGLAttributes& wxGLAttributes::Defaults()
 wxGLContext::wxGLContext(wxGLCanvas *win,
                          const wxGLContext *other,
                          const wxGLContextAttrs *ctxAttrs)
+    : m_glContext(NULL)
 {
     const int* contextAttribs = NULL;
     int ctxSize = 0;

--- a/src/unix/glx11.cpp
+++ b/src/unix/glx11.cpp
@@ -454,6 +454,7 @@ wxIMPLEMENT_CLASS(wxGLContext, wxObject);
 wxGLContext::wxGLContext(wxGLCanvas *win,
                          const wxGLContext *other,
                          const wxGLContextAttrs *ctxAttrs)
+    : m_glContext(NULL)
 {
     const int* contextAttribs = NULL;
     Bool x11Direct = True;


### PR DESCRIPTION
I got a segmentation fault in my Ubuntu virtual machine when trying the new pyramid sample. It has OpenGL 2.1 so the context cannot be created. If it is not created, it can also not be deleted.

With this fix, I get the expected message box informing me about my incapable driver.
