### PR TITLE
Add support for micro version in OS version information

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -34,6 +34,10 @@ Changes in behaviour not resulting in compilation errors
 - wxOSX/Carbon port doesn't exist any more, wxOSX/Cocoa will be silently used
   instead even if configure --with-osx_carbon option is used.
 
+- The pure virtual function wxAppTrait::GetToolkitVersion() now has a parameter
+  for getting the micro version. If you override GetToolkitVersion() you need
+  to add this new third parameter.
+
 Changes in behaviour which may result in build errors
 -----------------------------------------------------
 
@@ -88,6 +92,8 @@ All:
 - Fix wxStringTokenizer copy ctor and assignment operator.
 - Added wxASSERT_MSG_AT() and wxFAIL_MSG_AT() macros.
 - Accept replacement character in wxString::ToAscii() (Stefano D. Mtangoo).
+- Add parameter to get the micro version to OS and toolkit version
+  functions. See wxGetOsVersion(), wxPlatformInfo, and wxAppTraits.
 
 Unix:
 

--- a/include/wx/apptrait.h
+++ b/include/wx/apptrait.h
@@ -130,7 +130,9 @@ public:
     // runtime (not compile-time) version.
     // returns wxPORT_BASE for console applications and one of the remaining
     // wxPORT_* values for GUI applications.
-    virtual wxPortId GetToolkitVersion(int *majVer = NULL, int *minVer = NULL) const = 0;
+    virtual wxPortId GetToolkitVersion(int *majVer = NULL,
+                                       int *minVer = NULL,
+                                       int *microVer = NULL) const = 0;
 
     // return true if the port is using wxUniversal for the GUI, false if not
     virtual bool IsUsingUniversalWidgets() const = 0;
@@ -209,13 +211,16 @@ public:
     virtual bool HasStderr() wxOVERRIDE;
 
     // the GetToolkitVersion for console application is always the same
-    virtual wxPortId GetToolkitVersion(int *verMaj = NULL, int *verMin = NULL) const wxOVERRIDE
+    wxPortId GetToolkitVersion(int *verMaj = NULL,
+                               int *verMin = NULL,
+                               int *verMicro = NULL) const wxOVERRIDE
     {
         // no toolkits (wxBase is for console applications without GUI support)
         // NB: zero means "no toolkit", -1 means "not initialized yet"
         //     so we must use zero here!
         if (verMaj) *verMaj = 0;
         if (verMin) *verMin = 0;
+        if (verMicro) *verMicro = 0;
         return wxPORT_BASE;
     }
 

--- a/include/wx/msw/apptrait.h
+++ b/include/wx/msw/apptrait.h
@@ -49,7 +49,9 @@ public:
     virtual bool DoMessageFromThreadWait();
     virtual WXDWORD WaitForThread(WXHANDLE hThread, int flags);
 #endif // wxUSE_THREADS
-    virtual wxPortId GetToolkitVersion(int *majVer = NULL, int *minVer = NULL) const;
+    wxPortId GetToolkitVersion(int *majVer = NULL,
+                               int *minVer = NULL,
+                               int *microVer = NULL) const wxOVERRIDE;
 
     virtual bool CanUseStderr();
     virtual bool WriteToStderr(const wxString& text);
@@ -77,7 +79,9 @@ public:
     virtual WXDWORD WaitForThread(WXHANDLE hThread, int WXUNUSED(flags))
         { return DoSimpleWaitForThread(hThread); }
 #endif // wxUSE_THREADS
-    virtual wxPortId GetToolkitVersion(int *majVer = NULL, int *minVer = NULL) const;
+    virtual wxPortId GetToolkitVersion(int *majVer = NULL,
+                                       int *minVer = NULL,
+                                       int *microVer = NULL) const;
 
     virtual bool CanUseStderr() { return false; }
     virtual bool WriteToStderr(const wxString& WXUNUSED(text)) { return false; }

--- a/include/wx/platinfo.h
+++ b/include/wx/platinfo.h
@@ -188,9 +188,11 @@ public:
         { return m_osVersionMajor; }
     int GetOSMinorVersion() const
         { return m_osVersionMinor; }
+    int GetOSMicroVersion() const
+        { return m_osVersionMicro; }
 
     // return true if the OS version >= major.minor
-    bool CheckOSVersion(int major, int minor) const;
+    bool CheckOSVersion(int major, int minor, int micro = 0) const;
 
     int GetToolkitMajorVersion() const
         { return m_tkVersionMajor; }
@@ -201,8 +203,10 @@ public:
     {
         return DoCheckVersion(GetToolkitMajorVersion(),
                               GetToolkitMinorVersion(),
+                              0,
                               major,
-                              minor);
+                              minor,
+                              0);
     }
 
     bool IsUsingUniversalWidgets() const
@@ -249,8 +253,13 @@ public:
     // setters
     // -----------------
 
-    void SetOSVersion(int major, int minor)
-        { m_osVersionMajor=major; m_osVersionMinor=minor; }
+    void SetOSVersion(int major, int minor, int micro = 0)
+    {
+        m_osVersionMajor = major;
+        m_osVersionMinor = minor;
+        m_osVersionMicro = micro;
+    }
+
     void SetToolkitVersion(int major, int minor)
         { m_tkVersionMajor=major; m_tkVersionMinor=minor; }
 
@@ -277,6 +286,7 @@ public:
     bool IsOk() const
     {
         return m_osVersionMajor != -1 && m_osVersionMinor != -1 &&
+               m_osVersionMicro != -1 &&
                m_os != wxOS_UNKNOWN &&
                !m_osDesc.IsEmpty() &&
                m_tkVersionMajor != -1 && m_tkVersionMinor != -1 &&
@@ -289,9 +299,12 @@ public:
 
 
 protected:
-    static bool DoCheckVersion(int majorCur, int minorCur, int major, int minor)
+    static bool DoCheckVersion(int majorCur, int minorCur, int microCur,
+                               int major, int minor, int micro)
     {
-        return majorCur > major || (majorCur == major && minorCur >= minor);
+        return majorCur > major
+            || (majorCur == major && minorCur > minor)
+            || (majorCur == major && minorCur == minor && microCur >= micro);
     }
 
     bool m_initializedForCurrentPlatform;
@@ -305,7 +318,8 @@ protected:
     // Version of the OS; valid if m_os != wxOS_UNKNOWN
     // (-1 means not initialized yet).
     int m_osVersionMajor,
-        m_osVersionMinor;
+        m_osVersionMinor,
+        m_osVersionMicro;
 
     // Operating system ID.
     wxOperatingSystemId m_os;

--- a/include/wx/platinfo.h
+++ b/include/wx/platinfo.h
@@ -198,15 +198,17 @@ public:
         { return m_tkVersionMajor; }
     int GetToolkitMinorVersion() const
         { return m_tkVersionMinor; }
+    int GetToolkitMicroVersion() const
+        { return m_tkVersionMicro; }
 
-    bool CheckToolkitVersion(int major, int minor) const
+    bool CheckToolkitVersion(int major, int minor, int micro = 0) const
     {
         return DoCheckVersion(GetToolkitMajorVersion(),
                               GetToolkitMinorVersion(),
-                              0,
+                              GetToolkitMicroVersion(),
                               major,
                               minor,
-                              0);
+                              micro);
     }
 
     bool IsUsingUniversalWidgets() const
@@ -260,8 +262,12 @@ public:
         m_osVersionMicro = micro;
     }
 
-    void SetToolkitVersion(int major, int minor)
-        { m_tkVersionMajor=major; m_tkVersionMinor=minor; }
+    void SetToolkitVersion(int major, int minor, int micro = 0)
+    {
+        m_tkVersionMajor = major;
+        m_tkVersionMinor = minor;
+        m_tkVersionMicro = micro;
+    }
 
     void SetOperatingSystemId(wxOperatingSystemId n)
         { m_os = n; }
@@ -290,6 +296,7 @@ public:
                m_os != wxOS_UNKNOWN &&
                !m_osDesc.IsEmpty() &&
                m_tkVersionMajor != -1 && m_tkVersionMinor != -1 &&
+               m_tkVersionMicro != -1 &&
                m_port != wxPORT_UNKNOWN &&
                m_arch != wxARCH_INVALID &&
                m_endian != wxENDIAN_INVALID;
@@ -340,7 +347,7 @@ protected:
 
     // Version of the underlying toolkit
     // (-1 means not initialized yet; zero means no toolkit).
-    int m_tkVersionMajor, m_tkVersionMinor;
+    int m_tkVersionMajor, m_tkVersionMinor, m_tkVersionMicro;
 
     // name of the wxWidgets port
     wxPortId m_port;

--- a/include/wx/unix/apptrait.h
+++ b/include/wx/unix/apptrait.h
@@ -61,7 +61,9 @@ public:
 #if defined(__WXMAC__) && wxUSE_STDPATHS
     virtual wxStandardPaths& GetStandardPaths() wxOVERRIDE;
 #endif
-    virtual wxPortId GetToolkitVersion(int *majVer = NULL, int *minVer = NULL) const wxOVERRIDE;
+    wxPortId GetToolkitVersion(int *majVer = NULL,
+                               int *minVer = NULL,
+                               int *microVer = NULL) const wxOVERRIDE;
 
 #ifdef __WXGTK20__
     virtual wxString GetDesktopEnvironment() const wxOVERRIDE;

--- a/include/wx/utils.h
+++ b/include/wx/utils.h
@@ -145,7 +145,7 @@ WXDLLIMPEXP_BASE wxOperatingSystemId wxGetOsVersion(int *verMaj = NULL,
                                                     int *verMicro = NULL);
 
 // Check is OS version is at least the specified major and minor version
-WXDLLIMPEXP_BASE bool wxCheckOsVersion(int majorVsn, int minorVsn = 0);
+WXDLLIMPEXP_BASE bool wxCheckOsVersion(int majorVsn, int minorVsn = 0, int microVsn = 0);
 
 // Get platform endianness
 WXDLLIMPEXP_BASE bool wxIsPlatformLittleEndian();

--- a/include/wx/utils.h
+++ b/include/wx/utils.h
@@ -141,7 +141,8 @@ WXDLLIMPEXP_BASE wxString wxGetOsDescription();
 
 // Get OS version
 WXDLLIMPEXP_BASE wxOperatingSystemId wxGetOsVersion(int *verMaj = NULL,
-                                                    int *verMin = NULL);
+                                                    int *verMin = NULL,
+                                                    int *verMicro = NULL);
 
 // Check is OS version is at least the specified major and minor version
 WXDLLIMPEXP_BASE bool wxCheckOsVersion(int majorVsn, int minorVsn = 0);

--- a/include/wx/utils.h
+++ b/include/wx/utils.h
@@ -140,8 +140,8 @@ WXDLLIMPEXP_CORE wxVersionInfo wxGetLibraryVersionInfo();
 WXDLLIMPEXP_BASE wxString wxGetOsDescription();
 
 // Get OS version
-WXDLLIMPEXP_BASE wxOperatingSystemId wxGetOsVersion(int *majorVsn = NULL,
-                                                    int *minorVsn = NULL);
+WXDLLIMPEXP_BASE wxOperatingSystemId wxGetOsVersion(int *verMaj = NULL,
+                                                    int *verMin = NULL);
 
 // Check is OS version is at least the specified major and minor version
 WXDLLIMPEXP_BASE bool wxCheckOsVersion(int majorVsn, int minorVsn = 0);

--- a/interface/wx/apptrait.h
+++ b/interface/wx/apptrait.h
@@ -100,8 +100,8 @@ public:
 
     /**
         Returns the wxWidgets port ID used by the running program and eventually
-        fills the given pointers with the values of the major and minor digits
-        of the native toolkit currently used.
+        fills the given pointers with the values of the major, minor, and micro
+        digits of the native toolkit currently used.
 
         The version numbers returned are thus detected at run-time and not compile-time
         (except when this is not possible e.g. wxMotif).
@@ -109,8 +109,12 @@ public:
         E.g. if your program is using wxGTK port this function will return wxPORT_GTK
         and put in given pointers the versions of the GTK library in use.
         See wxPlatformInfo for more details.
+
+        If a micro version is not available it will have a value of 0.
     */
-    virtual wxPortId GetToolkitVersion(int* major = NULL, int* minor = NULL) const = 0;
+    virtual wxPortId GetToolkitVersion(int* major = NULL,
+                                       int* minor = NULL,
+                                       int* micro = NULL) const = 0;
 
     /**
         Returns @true if @c fprintf(stderr) goes somewhere, @false otherwise.

--- a/interface/wx/platinfo.h
+++ b/interface/wx/platinfo.h
@@ -185,13 +185,12 @@ public:
     bool CheckOSVersion(int major, int minor, int micro = 0) const;
 
     /**
-        Returns @true if the toolkit version is at least @c major.minor.
+        Returns @true if the toolkit version is at least @c major.minor.micro.
 
-        @see GetToolkitMajorVersion(),
-             GetToolkitMinorVersion(), CheckOSVersion()
+        @see GetToolkitMajorVersion(), GetToolkitMinorVersion(),
+             GetToolkitMicroVersion(), CheckOSVersion()
     */
-    bool CheckToolkitVersion(int major, int minor) const;
-    
+    bool CheckToolkitVersion(int major, int minor, int micro = 0) const;
 
     /**
         Returns @true if this instance is fully initialized with valid values.
@@ -417,6 +416,21 @@ public:
     */
     int GetToolkitMinorVersion() const;
     
+    /**
+        Returns the run-time micro version of the toolkit associated with this
+        wxPlatformInfo instance.
+
+        Note that if GetPortId() returns @c wxPORT_BASE, then this value is zero
+        (unless externally modified with SetToolkitVersion()); that is, no native
+        toolkit is in use.
+        See wxAppTraits::GetToolkitVersion() for more info.
+
+        @see CheckToolkitVersion()
+
+        @since 3.1.1
+    */
+    int GetToolkitMicroVersion() const;
+    
     //@}
 
 
@@ -497,7 +511,7 @@ public:
     /**
         Sets the version of the toolkit associated with this wxPlatformInfo instance.
     */
-    void SetToolkitVersion(int major, int minor);
+    void SetToolkitVersion(int major, int minor, int micro = 0);
 
     /**
         Sets the operating system description associated with this wxPlatformInfo instance.

--- a/interface/wx/platinfo.h
+++ b/interface/wx/platinfo.h
@@ -12,11 +12,11 @@
 
     The values of the constants are chosen so that they can be combined as flags;
     this allows to check for operating system families like e.g. @c wxOS_MAC and @c wxOS_UNIX.
-    
+
     Note that you can obtain more detailed information about the current OS
-    version in use by checking the major and minor version numbers returned
-    by ::wxGetOsVersion() or by wxPlatformInfo::GetOSMajorVersion(), 
-    wxPlatformInfo::GetOSMinorVersion().
+    version in use by checking the major, minor, and micro version numbers
+    returned by ::wxGetOsVersion() or by wxPlatformInfo::GetOSMajorVersion(),
+    wxPlatformInfo::GetOSMinorVersion(), and wxPlatformInfo::GetOSMicroVersion().
 */
 enum wxOperatingSystemId
 {
@@ -177,12 +177,12 @@ public:
 
 
     /**
-        Returns @true if the OS version is at least @c major.minor.
+        Returns @true if the OS version is at least @c major.minor.micro.
 
-        @see GetOSMajorVersion(), GetOSMinorVersion(),
+        @see GetOSMajorVersion(), GetOSMinorVersion(), GetOSMicroVersion(),
              CheckToolkitVersion()
     */
-    bool CheckOSVersion(int major, int minor) const;
+    bool CheckOSVersion(int major, int minor, int micro = 0) const;
 
     /**
         Returns @true if the toolkit version is at least @c major.minor.
@@ -349,6 +349,16 @@ public:
     int GetOSMinorVersion() const;
 
     /**
+        Returns the run-time micro version of the OS associated with this
+        wxPlatformInfo instance.
+
+        @see ::wxGetOsVersion(), CheckOSVersion()
+
+        @since 3.1.1
+    */
+    int GetOSMicroVersion() const;
+
+    /**
         Returns the operating system ID of this wxPlatformInfo instance.
         
         See wxGetOsVersion() for more info.
@@ -472,7 +482,7 @@ public:
         Sets the version of the operating system associated with this wxPlatformInfo
         instance.
     */
-    void SetOSVersion(int major, int minor);
+    void SetOSVersion(int major, int minor, int micro = 0);
 
     /**
         Sets the operating system associated with this wxPlatformInfo instance.

--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -851,9 +851,10 @@ wxString wxGetOsDescription();
     On systems where only the micro version can't be detected or doesn't make
     sense such as Windows, it will have a value of 0.
 
-    For Unix-like systems (@c wxOS_UNIX) the major and minor version integers will 
-    contain the kernel major and minor version numbers (as returned by the
-    'uname -r' command); e.g. "4" and "1" if the machine is using kernel 4.1.4.
+    For Unix-like systems (@c wxOS_UNIX) the major, minor, and micro version
+    integers will contain the kernel's major, minor, and micro version
+    numbers (as returned by the 'uname -r' command); e.g. "4", "1", and "4" if
+    the machine is using kernel 4.1.4.
 
     For OS X systems (@c wxOS_MAC) the major and minor version integers are the
     natural version numbers associated with the OS; e.g. "10", "11" and "2" if

--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -897,7 +897,7 @@ wxOperatingSystemId wxGetOsVersion(int* major = NULL, int* minor = NULL, int* mi
 
     @header{wx/utils.h}
 */
-bool wxCheckOsVersion(int majorVsn, int minorVsn = 0);
+bool wxCheckOsVersion(int majorVsn, int minorVsn = 0, int microVsn = 0);
 
 /**
     Returns @true if the operating system the program is running under is 64

--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -842,16 +842,22 @@ wxString wxGetOsDescription();
 /**
     Gets the version and the operating system ID for currently running OS. 
     The returned wxOperatingSystemId value can be used for a basic categorization
-    of the OS family; the major and minor version numbers allows to detect a specific
-    system.
-    
+    of the OS family; the major, minor, and micro version numbers allows to
+    detect a specific system.
+
+    If on Unix-like systems the version can't be detected all three version
+    numbers will have a value of -1.
+
+    On systems where only the micro version can't be detected or doesn't make
+    sense such as Windows, it will have a value of 0.
+
     For Unix-like systems (@c wxOS_UNIX) the major and minor version integers will 
     contain the kernel major and minor version numbers (as returned by the
     'uname -r' command); e.g. "4" and "1" if the machine is using kernel 4.1.4.
 
     For OS X systems (@c wxOS_MAC) the major and minor version integers are the
-    natural version numbers associated with the OS; e.g. "10" and "11" if the machine
-    is using OS X El Capitan.
+    natural version numbers associated with the OS; e.g. "10", "11" and "2" if
+    the machine is using OS X El Capitan 10.11.2.
     
     For Windows-like systems (@c wxOS_WINDOWS) the major and minor version integers will 
     contain the following values:
@@ -878,7 +884,7 @@ wxString wxGetOsDescription();
 
     @header{wx/utils.h}
 */
-wxOperatingSystemId wxGetOsVersion(int* major = NULL, int* minor = NULL);
+wxOperatingSystemId wxGetOsVersion(int* major = NULL, int* minor = NULL, int* micro = NULL);
 
 /**
     Returns @true if the version of the operating system on which the program

--- a/src/common/platinfo.cpp
+++ b/src/common/platinfo.cpp
@@ -139,6 +139,7 @@ wxPlatformInfo::wxPlatformInfo(wxPortId pid, int tkMajor, int tkMinor,
 
     m_tkVersionMajor = tkMajor;
     m_tkVersionMinor = tkMinor;
+    m_tkVersionMicro = -1;
     m_port = pid;
     m_usingUniversal = usingUniversal;
 
@@ -155,6 +156,7 @@ bool wxPlatformInfo::operator==(const wxPlatformInfo &t) const
 {
     return m_tkVersionMajor == t.m_tkVersionMajor &&
            m_tkVersionMinor == t.m_tkVersionMinor &&
+           m_tkVersionMicro == t.m_tkVersionMicro &&
            m_osVersionMajor == t.m_osVersionMajor &&
            m_osVersionMinor == t.m_osVersionMinor &&
            m_osVersionMicro == t.m_osVersionMicro &&
@@ -181,11 +183,12 @@ void wxPlatformInfo::InitForCurrentPlatform()
         m_port = wxPORT_UNKNOWN;
         m_usingUniversal = false;
         m_tkVersionMajor =
-                m_tkVersionMinor = 0;
+                m_tkVersionMinor = m_tkVersionMicro = 0;
     }
     else
     {
-        m_port = traits->GetToolkitVersion(&m_tkVersionMajor, &m_tkVersionMinor);
+        m_port = traits->GetToolkitVersion(&m_tkVersionMajor, &m_tkVersionMinor,
+                                           &m_tkVersionMicro);
         m_usingUniversal = traits->IsUsingUniversalWidgets();
         m_desktopEnv = traits->GetDesktopEnvironment();
     }

--- a/src/common/platinfo.cpp
+++ b/src/common/platinfo.cpp
@@ -145,6 +145,7 @@ wxPlatformInfo::wxPlatformInfo(wxPortId pid, int tkMajor, int tkMinor,
     m_os = id;
     m_osVersionMajor = osMajor;
     m_osVersionMinor = osMinor;
+    m_osVersionMicro = -1;
 
     m_endian = endian;
     m_arch = arch;
@@ -156,6 +157,7 @@ bool wxPlatformInfo::operator==(const wxPlatformInfo &t) const
            m_tkVersionMinor == t.m_tkVersionMinor &&
            m_osVersionMajor == t.m_osVersionMajor &&
            m_osVersionMinor == t.m_osVersionMinor &&
+           m_osVersionMicro == t.m_osVersionMicro &&
            m_os == t.m_os &&
            m_osDesc == t.m_osDesc &&
            m_ldi == t.m_ldi &&
@@ -188,7 +190,7 @@ void wxPlatformInfo::InitForCurrentPlatform()
         m_desktopEnv = traits->GetDesktopEnvironment();
     }
 
-    m_os = wxGetOsVersion(&m_osVersionMajor, &m_osVersionMinor);
+    m_os = wxGetOsVersion(&m_osVersionMajor, &m_osVersionMinor, &m_osVersionMicro);
     m_osDesc = wxGetOsDescription();
     m_endian = wxIsPlatformLittleEndian() ? wxENDIAN_LITTLE : wxENDIAN_BIG;
     m_arch = wxIsPlatform64Bit() ? wxARCH_64 : wxARCH_32;
@@ -298,7 +300,7 @@ wxString wxPlatformInfo::GetEndiannessName(wxEndianness end)
     return wxEndiannessNames[end];
 }
 
-bool wxPlatformInfo::CheckOSVersion(int major, int minor) const
+bool wxPlatformInfo::CheckOSVersion(int major, int minor, int micro) const
 {
     // If this instance of wxPlatformInfo has been initialized by InitForCurrentPlatform()
     // this check gets forwarded to the wxCheckOsVersion which might do more than a simple
@@ -308,8 +310,10 @@ bool wxPlatformInfo::CheckOSVersion(int major, int minor) const
     else
         return DoCheckVersion(GetOSMajorVersion(),
                             GetOSMinorVersion(),
+                            GetOSMicroVersion(),
                             major,
-                            minor);
+                            minor,
+                            micro);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/common/platinfo.cpp
+++ b/src/common/platinfo.cpp
@@ -309,7 +309,7 @@ bool wxPlatformInfo::CheckOSVersion(int major, int minor, int micro) const
     // this check gets forwarded to the wxCheckOsVersion which might do more than a simple
     // number check if supported by the platform
     if (m_initializedForCurrentPlatform)
-        return wxCheckOsVersion(major, minor);
+        return wxCheckOsVersion(major, minor, micro);
     else
         return DoCheckVersion(GetOSMajorVersion(),
                             GetOSMinorVersion(),

--- a/src/dfb/utils.cpp
+++ b/src/dfb/utils.cpp
@@ -30,10 +30,13 @@
 // toolkit info
 // ----------------------------------------------------------------------------
 
-wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj, int *verMin) const
+wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj,
+                                           int *verMin,
+                                           int *verMicro) const
 {
     if ( verMaj ) *verMaj = DIRECTFB_MAJOR_VERSION;
     if ( verMin ) *verMaj = DIRECTFB_MINOR_VERSION;
+    if ( verMicro ) *verMicro = DIRECTFB_MICRO_VERSION;
 
     return wxPORT_DFB;
 }

--- a/src/gtk/utilsgtk.cpp
+++ b/src/gtk/utilsgtk.cpp
@@ -183,12 +183,16 @@ const gchar *wx_pango_version_check (int major, int minor, int micro)
 // wxPlatformInfo-related
 // ----------------------------------------------------------------------------
 
-wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj, int *verMin) const
+wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj,
+                                           int *verMin,
+                                           int *verMicro) const
 {
     if ( verMaj )
         *verMaj = gtk_major_version;
     if ( verMin )
         *verMin = gtk_minor_version;
+    if ( verMicro )
+        *verMicro = gtk_micro_version;
 
     return wxPORT_GTK;
 }

--- a/src/gtk1/utilsgtk.cpp
+++ b/src/gtk1/utilsgtk.cpp
@@ -136,12 +136,16 @@ wxTimerImpl* wxGUIAppTraits::CreateTimerImpl(wxTimer *timer)
 // wxPlatformInfo-related
 // ----------------------------------------------------------------------------
 
-wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj, int *verMin) const
+wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj,
+                                           int *verMin,
+                                           int *verMicro) const
 {
     if ( verMaj )
         *verMaj = gtk_major_version;
     if ( verMin )
         *verMin = gtk_minor_version;
+    if ( verMicro )
+        *verMicro = gtk_micro_version;
 
     return wxPORT_GTK;
 }

--- a/src/motif/utils.cpp
+++ b/src/motif/utils.cpp
@@ -176,13 +176,17 @@ void wxBell()
     XBell (wxGlobalDisplay(), 0);
 }
 
-wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj, int *verMin) const
+wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj,
+                                           int *verMin,
+                                           int *verMicro) const
 {
     // XmVERSION and XmREVISION are defined in Xm/Xm.h
     if ( verMaj )
         *verMaj = XmVERSION;
     if ( verMin )
         *verMin = XmREVISION;
+    if ( verMicro )
+        *verMicro = 0;
 
     return wxPORT_MOTIF;
 }

--- a/src/msw/app.cpp
+++ b/src/msw/app.cpp
@@ -238,11 +238,13 @@ WXDWORD wxGUIAppTraits::WaitForThread(WXHANDLE hThread, int flags)
 }
 #endif // wxUSE_THREADS
 
-wxPortId wxGUIAppTraits::GetToolkitVersion(int *majVer, int *minVer) const
+wxPortId wxGUIAppTraits::GetToolkitVersion(int *majVer,
+                                           int *minVer,
+                                           int *microVer) const
 {
     // on Windows, the toolkit version is the same of the OS version
     // as Windows integrates the OS kernel with the GUI toolkit.
-    wxGetOsVersion(majVer, minVer);
+    wxGetOsVersion(majVer, minVer, microVer);
 
     return wxPORT_MSW;
 }

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -1244,7 +1244,8 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
         wxOperatingSystemId os;
 
         int verMaj,
-            verMin;
+            verMin,
+            verMicro;
     } s_version;
 
     // query the OS info only once as it's not supposed to change
@@ -1267,6 +1268,7 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
 
         s_version.verMaj = info.dwMajorVersion;
         s_version.verMin = info.dwMinorVersion;
+        s_version.verMicro = info.dwBuildNumber;
     }
 
     if ( verMaj )
@@ -1274,7 +1276,7 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
     if ( verMin )
         *verMin = s_version.verMin;
     if ( verMicro )
-        *verMicro = 0;
+        *verMicro = s_version.verMicro;
 
     return s_version.os;
 }

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -1235,7 +1235,7 @@ bool wxIsPlatform64Bit()
 #endif // Win64/Win32
 }
 
-wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin)
+wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
 {
     static struct
     {
@@ -1273,6 +1273,8 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin)
         *verMaj = s_version.verMaj;
     if ( verMin )
         *verMin = s_version.verMin;
+    if ( verMicro )
+        *verMicro = 0;
 
     return s_version.os;
 }

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -1281,7 +1281,7 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
     return s_version.os;
 }
 
-bool wxCheckOsVersion(int majorVsn, int minorVsn)
+bool wxCheckOsVersion(int majorVsn, int minorVsn, int microVsn)
 {
     OSVERSIONINFOEX osvi;
     wxZeroMemory(osvi);
@@ -1290,13 +1290,17 @@ bool wxCheckOsVersion(int majorVsn, int minorVsn)
     DWORDLONG const dwlConditionMask =
         ::VerSetConditionMask(
         ::VerSetConditionMask(
+        ::VerSetConditionMask(
         0, VER_MAJORVERSION, VER_GREATER_EQUAL),
-        VER_MINORVERSION, VER_GREATER_EQUAL);
+        VER_MINORVERSION, VER_GREATER_EQUAL),
+        VER_BUILDNUMBER, VER_GREATER_EQUAL);
 
     osvi.dwMajorVersion = majorVsn;
     osvi.dwMinorVersion = minorVsn;
+    osvi.dwBuildNumber = microVsn;
 
-    return ::VerifyVersionInfo(&osvi, VER_MAJORVERSION | VER_MINORVERSION, dwlConditionMask) != FALSE;
+    return ::VerifyVersionInfo(&osvi,
+        VER_MAJORVERSION | VER_MINORVERSION | VER_BUILDNUMBER, dwlConditionMask) != FALSE;
 }
 
 wxWinVersion wxGetWinVersion()

--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -75,7 +75,7 @@ wxGCC_WARNING_RESTORE()
     return wxOS_MAC_OSX_DARWIN;
 }
 
-bool wxCheckOsVersion(int majorVsn, int minorVsn)
+bool wxCheckOsVersion(int majorVsn, int minorVsn, int microVsn)
 {
 #ifdef wxHAS_NSPROCESSINFO
     if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)])
@@ -83,17 +83,19 @@ bool wxCheckOsVersion(int majorVsn, int minorVsn)
         NSOperatingSystemVersion osVer;
         osVer.majorVersion = majorVsn;
         osVer.minorVersion = minorVsn;
-        osVer.patchVersion = 0;
+        osVer.patchVersion = microVsn;
 
         return [[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:osVer] != NO;
     }
     else
 #endif
     {
-        int majorCur, minorCur;
-        wxGetOsVersion(&majorCur, &minorCur);
+        int majorCur, minorCur, microCur;
+        wxGetOsVersion(&majorCur, &minorCur, &microCur);
 
-        return majorCur > majorVsn || (majorCur == majorVsn && minorCur >= minorVsn);
+        return majorCur > majorVsn
+            || (majorCur == majorVsn && minorCur >= minorVsn)
+            || (majorCur == majorVsn && minorCur == minorVsn && microCur >= microVsn);
     }
 }
 

--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -28,7 +28,7 @@
 #endif
 
 // our OS version is the same in non GUI and GUI cases
-wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin)
+wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
 {
 #ifdef wxHAS_NSPROCESSINFO
     if ([NSProcessInfo instancesRespondToSelector:@selector(operatingSystemVersion)])
@@ -40,6 +40,9 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin)
 
         if ( verMin != NULL )
             *verMin = osVer.minorVersion;
+
+        if ( verMicro != NULL )
+            *verMicro = osVer.patchVersion;
     }
     else
 #endif
@@ -47,13 +50,15 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin)
         // On OS X versions prior to 10.10 NSProcessInfo does not provide the OS version
         // Deprecated Gestalt calls are required instead
 wxGCC_WARNING_SUPPRESS(deprecated-declarations)
-        SInt32 maj, min;
+        SInt32 maj, min, micro;
 #ifdef __WXOSX_IPHONE__
         maj = 7;
         min = 0;
+        micro = 0;
 #else
         Gestalt(gestaltSystemVersionMajor, &maj);
         Gestalt(gestaltSystemVersionMinor, &min);
+        Gestalt(gestaltSystemVersionBugFix, &micro);
 #endif
 wxGCC_WARNING_RESTORE()
 
@@ -62,6 +67,9 @@ wxGCC_WARNING_RESTORE()
 
         if ( verMin != NULL )
             *verMin = min;
+
+        if ( verMicro != NULL )
+            *verMicro = micro;
     }
 
     return wxOS_MAC_OSX_DARWIN;

--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -28,18 +28,18 @@
 #endif
 
 // our OS version is the same in non GUI and GUI cases
-wxOperatingSystemId wxGetOsVersion(int *majorVsn, int *minorVsn)
+wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin)
 {
 #ifdef wxHAS_NSPROCESSINFO
     if ([NSProcessInfo instancesRespondToSelector:@selector(operatingSystemVersion)])
     {
         NSOperatingSystemVersion osVer = [NSProcessInfo processInfo].operatingSystemVersion;
 
-        if ( majorVsn != NULL )
-            *majorVsn = osVer.majorVersion;
+        if ( verMaj != NULL )
+            *verMaj = osVer.majorVersion;
 
-        if ( minorVsn != NULL )
-            *minorVsn = osVer.minorVersion;
+        if ( verMin != NULL )
+            *verMin = osVer.minorVersion;
     }
     else
 #endif
@@ -57,11 +57,11 @@ wxGCC_WARNING_SUPPRESS(deprecated-declarations)
 #endif
 wxGCC_WARNING_RESTORE()
 
-        if ( majorVsn != NULL )
-            *majorVsn = maj;
+        if ( verMaj != NULL )
+            *verMaj = maj;
 
-        if ( minorVsn != NULL )
-            *minorVsn = min;
+        if ( verMin != NULL )
+            *verMin = min;
     }
 
     return wxOS_MAC_OSX_DARWIN;

--- a/src/osx/utils_osx.cpp
+++ b/src/osx/utils_osx.cpp
@@ -169,10 +169,12 @@ void wxDisplaySizeMM(int *width, int *height)
 }
 
 
-wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj, int *verMin) const
+wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj,
+                                           int *verMin,
+                                           int *verMicro) const
 {
     // We suppose that toolkit version is the same as OS version under Mac
-    wxGetOsVersion(verMaj, verMin);
+    wxGetOsVersion(verMaj, verMin, verMicro);
 
     return wxPORT_OSX;
 }

--- a/src/qt/apptraits.cpp
+++ b/src/qt/apptraits.cpp
@@ -39,12 +39,16 @@ wxTimerImpl *wxGUIAppTraits::CreateTimerImpl(wxTimer *timer)
 
 // #endif
 
-wxPortId wxGUIAppTraits::GetToolkitVersion(int *majVer, int *minVer) const
+wxPortId wxGUIAppTraits::GetToolkitVersion(int *majVer,
+                                           int *minVer,
+                                           int *microVer) const
 {
     if ( majVer )
         *majVer = QT_VERSION >> 16;
     if ( minVer )
         *minVer = (QT_VERSION >> 8) & 0xFF;
+    if ( microVer )
+        *microVer = QT_VERSION & 0xFF;
 
     return wxPORT_QT;
 }

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -1117,14 +1117,19 @@ wxLinuxDistributionInfo wxGetLinuxDistributionInfo()
 wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
 {
     // get OS version
-    int major, minor;
+    int major = -1, minor = -1, micro = -1;
     wxString release = wxGetCommandOutput(wxT("uname -r"));
-    if ( release.empty() ||
-         wxSscanf(release.c_str(), wxT("%d.%d"), &major, &minor) != 2 )
+    if ( !release.empty() )
     {
-        // failed to get version string or unrecognized format
-        major =
-        minor = -1;
+        if ( wxSscanf(release.c_str(), wxT("%d.%d.%d"), &major, &minor, &micro ) != 3 )
+        {
+            micro = 0;
+            if ( wxSscanf(release.c_str(), wxT("%d.%d"), &major, &minor ) != 2 )
+            {
+                // failed to get version string or unrecognized format
+                major = minor = micro = -1;
+            }
+        }
     }
 
     if ( verMaj )
@@ -1132,7 +1137,7 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
     if ( verMin )
         *verMin = minor;
     if ( verMicro )
-        *verMicro = (major == -1) ? -1 : 0;
+        *verMicro = micro;
 
     // try to understand which OS are we running
     wxString kernel = wxGetCommandOutput(wxT("uname -s"));

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -1114,7 +1114,7 @@ wxLinuxDistributionInfo wxGetLinuxDistributionInfo()
 // these functions are in src/osx/utilsexc_base.cpp for wxMac
 #ifndef __DARWIN__
 
-wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin)
+wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
 {
     // get OS version
     int major, minor;
@@ -1131,6 +1131,8 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin)
         *verMaj = major;
     if ( verMin )
         *verMin = minor;
+    if ( verMicro )
+        *verMicro = (major == -1) ? -1 : 0;
 
     // try to understand which OS are we running
     wxString kernel = wxGetCommandOutput(wxT("uname -s"));

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -1155,12 +1155,14 @@ wxString wxGetOsDescription()
     return wxGetCommandOutput(wxT("uname -s -r -m"));
 }
 
-bool wxCheckOsVersion(int majorVsn, int minorVsn)
+bool wxCheckOsVersion(int majorVsn, int minorVsn, int microVsn)
 {
-    int majorCur, minorCur;
-    wxGetOsVersion(&majorCur, &minorCur);
+    int majorCur, minorCur, microCur;
+    wxGetOsVersion(&majorCur, &minorCur, &microCur);
 
-    return majorCur > majorVsn || (majorCur == majorVsn && minorCur >= minorVsn);
+    return majorCur > majorVsn
+        || (majorCur == majorVsn && minorCur >= minorVsn)
+        || (majorCur == majorVsn && minorCur == minorVsn && microCur >= microVsn);
 }
 
 #endif // !__DARWIN__

--- a/src/x11/utils.cpp
+++ b/src/x11/utils.cpp
@@ -100,7 +100,9 @@ void wxBell()
     XBell ((Display*) wxGetDisplay(), 0);
 }
 
-wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj, int *verMin) const
+wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj,
+                                           int *verMin,
+                                           int *verMicro) const
 {
     // get X protocol version
     Display *display = wxGlobalDisplay();
@@ -110,6 +112,8 @@ wxPortId wxGUIAppTraits::GetToolkitVersion(int *verMaj, int *verMin) const
             *verMaj = ProtocolVersion (display);
         if ( verMin )
             *verMin = ProtocolRevision (display);
+        if ( verMicro )
+            *verMicro = 0;
     }
 
     return wxPORT_X11;


### PR DESCRIPTION
This rebases the work done in #44 by @discnl on the current master, resolving conflicts and adding the micro version to `wxCheckOsVersion()`
