### PR TITLE
Fix wxStringOperationsUtf8::IsValidUtf8String

### DIFF
--- a/src/common/stringops.cpp
+++ b/src/common/stringops.cpp
@@ -94,7 +94,7 @@ bool wxStringOperationsUtf8::IsValidUtf8String(const char *str, size_t len)
     const unsigned char *c = (const unsigned char*)str;
     const unsigned char * const end = (len == wxStringImpl::npos) ? NULL : c + len;
 
-    for ( ; c != end && *c; ++c )
+    for ( ; end != NULL ? c != end : *c; ++c )
     {
         unsigned char b = *c;
 


### PR DESCRIPTION
The current code incorrectly returns true if the string contained an invalid UTF-8 sequence after an embedded NUL.

Test code (compile with UTF-8 build of wxWidgets):

``` c++
#include <wx/wx.h>
#include <stdio.h>

int main()
{
    // Passing a valid UTF-8 string to FromUTF8.
    // The length should be 5.
    printf("%d\n", static_cast<int>(wxString::FromUTF8("abc\0\x32", 5).length()));

    // OTOH, passing an invalid UTF-8 string to FromUTF8 should return an empty string.
    printf("%d\n", static_cast<int>(wxString::FromUTF8("abc\0\xFF", 5).length()));
}
```

Expected output:

```
5
0
```

Actual output (with the UTF-8 build of master):

```
5
/home/***/wxWidgets/include/wx/stringops.h(75): assert "IsValidUtf8LeadByte(*i)" failed in IncIter().
5
```
