### PR TITLE
Trivial fixes to string-related code

### DIFF
--- a/include/wx/ustring.h
+++ b/include/wx/ustring.h
@@ -134,9 +134,9 @@ public:
        return utf16_str();
     }
 #else
-    wchar_t *wc_str() const
+    const wchar_t *wc_str() const
     {
-        return (wchar_t*) c_str();
+        return c_str();
     }
 #endif
 
@@ -154,18 +154,18 @@ public:
     }
 
 #if wxUSE_UNICODE_UTF8
-    wxScopedCharBuffer wx_str()
+    wxScopedCharBuffer wx_str() const
     {
         return utf8_str();
     }
 #else
 #if SIZEOF_WCHAR_T == 2
-    wxScopedWCharBuffer wx_str()
+    wxScopedWCharBuffer wx_str() const
     {
         return utf16_str();
     }
 #else
-    const wchar_t* wx_str()
+    const wchar_t* wx_str() const
     {
         return c_str();
     }

--- a/interface/wx/string.h
+++ b/interface/wx/string.h
@@ -1953,7 +1953,7 @@ public:
         Basically, this is equivalent to calling wxString::GetWriteBuf and
         saving the result.
     */
-    wxStringBufferLength(const wxString& str, size_t len);
+    wxStringBufferLength(wxString& str, size_t len);
 
     /**
         Restores the string passed to the constructor to the usable state by calling
@@ -2014,7 +2014,7 @@ public:
         Basically, this is equivalent to calling wxString::GetWriteBuf() and
         saving the result.
     */
-    wxStringBuffer(const wxString& str, size_t len);
+    wxStringBuffer(wxString& str, size_t len);
 
     /**
         Restores the string passed to the constructor to the usable state by calling

--- a/src/common/filefn.cpp
+++ b/src/common/filefn.cpp
@@ -1388,7 +1388,7 @@ bool wxSetWorkingDirectory(const wxString& d)
 {
     bool success = false;
 #if defined(__UNIX__) || defined(__WXMAC__)
-    success = (chdir(wxFNSTRINGCAST d.fn_str()) == 0);
+    success = (chdir(d.fn_str()) == 0);
 #elif defined(__WINDOWS__)
     success = (SetCurrentDirectory(d.t_str()) != 0);
 #endif

--- a/src/common/filefn.cpp
+++ b/src/common/filefn.cpp
@@ -1390,31 +1390,7 @@ bool wxSetWorkingDirectory(const wxString& d)
 #if defined(__UNIX__) || defined(__WXMAC__)
     success = (chdir(wxFNSTRINGCAST d.fn_str()) == 0);
 #elif defined(__WINDOWS__)
-
-#ifdef __WIN32__
     success = (SetCurrentDirectory(d.t_str()) != 0);
-#else
-    // Must change drive, too.
-    bool isDriveSpec = ((strlen(d) > 1) && (d[1] == ':'));
-    if (isDriveSpec)
-    {
-        wxChar firstChar = d[0];
-
-        // To upper case
-        if (firstChar > 90)
-            firstChar = firstChar - 32;
-
-        // To a drive number
-        unsigned int driveNo = firstChar - 64;
-        if (driveNo > 0)
-        {
-            unsigned int noDrives;
-            _dos_setdrive(driveNo, &noDrives);
-        }
-    }
-    success = (chdir(WXSTRINGCAST d) == 0);
-#endif
-
 #endif
     if ( !success )
     {

--- a/src/common/ftp.cpp
+++ b/src/common/ftp.cpp
@@ -237,7 +237,7 @@ char wxFTP::SendCommand(const wxString& command)
 
     wxString tmp_str = command + wxT("\r\n");
     const wxWX2MBbuf tmp_buf = tmp_str.mb_str();
-    if ( Write(wxMBSTRINGCAST tmp_buf, strlen(tmp_buf)).Error())
+    if ( Write(static_cast<const char *>(tmp_buf), strlen(tmp_buf)).Error())
     {
         m_lastError = wxPROTO_NETERR;
         return 0;

--- a/src/common/strconv.cpp
+++ b/src/common/strconv.cpp
@@ -122,18 +122,12 @@ static size_t decode_utf16(const wxUint16* input, wxUint32& output)
     }
 }
 
-#ifdef WC_UTF16
-    typedef wchar_t wxDecodeSurrogate_t;
-#else // !WC_UTF16
-    typedef wxUint16 wxDecodeSurrogate_t;
-#endif // WC_UTF16/!WC_UTF16
-
 // returns the next UTF-32 character from the wchar_t buffer and advances the
 // pointer to the character after this one
 //
 // if an invalid character is found, *pSrc is set to NULL, the caller must
 // check for this
-static wxUint32 wxDecodeSurrogate(const wxDecodeSurrogate_t **pSrc)
+static wxUint32 wxDecodeSurrogate(const wxChar16 **pSrc)
 {
     wxUint32 out;
     const size_t

--- a/src/generic/dcpsg.cpp
+++ b/src/generic/dcpsg.cpp
@@ -2336,7 +2336,7 @@ void wxPostScriptDCImpl::DoGetTextExtent(const wxString& string,
 
     long sum=0;
     float height=fontSize; /* by default */
-    unsigned char *p=(unsigned char *)wxMBSTRINGCAST strbuf;
+    const unsigned char *p=reinterpret_cast<const unsigned char *>(static_cast<const char *>(strbuf));
     if(!p)
     {
         // String couldn't be converted which used to SEGV as reported here:

--- a/src/msw/metafile.cpp
+++ b/src/msw/metafile.cpp
@@ -236,7 +236,7 @@ void wxMetafileDCImpl::DoGetTextExtent(const wxString& string,
 
     SIZE sizeRect;
     TEXTMETRIC tm;
-    ::GetTextExtentPoint32(dc, WXSTRINGCAST string, wxStrlen(WXSTRINGCAST string), &sizeRect);
+    ::GetTextExtentPoint32(dc, string.c_str(), string.length(), &sizeRect);
     ::GetTextMetrics(dc, &tm);
 
     if ( x )


### PR DESCRIPTION
- The signatures of `wxStringBuffer` / `wxStringBufferLength` constructors in `interface/wx/string.h` were wrong.
- Use `wxChar16` instead of ad hoc `wxDecodeSurrogate_t` for the parameter type of `wxDecodeSurrogate()`. These two types have the same definition.
- The return type of `wxUString::wc_str()` were wrongly mutable.
- Make `wxUString::wx_str()` a const member function.
- Remove uses of `WXSTRINGCAST`, `wxFNSTRINGCAST`, `wxMBSTRINGCAST`: According to the comment in `string.h`, they were "needed to call some broken functions which require `char *` instead of `const char *`", but no code in wxWidgets were using them for that purpose.
