### PR TITLE
Fix Visual C++ XP targetting

### DIFF
--- a/include/wx/msw/setup0.h
+++ b/include/wx/msw/setup0.h
@@ -1560,7 +1560,7 @@
 // SDK components manually, you need to change this setting.
 //
 // Recommended setting: 1
-#if #if defined(_MSC_VER) && _MSC_VER >= 1700 && !defined(_USING_V110_SDK71_)
+#if defined(_MSC_VER) && _MSC_VER >= 1700 && !defined(_USING_V110_SDK71_)
     #define wxUSE_WINRT 1
 #else
     #define wxUSE_WINRT 0

--- a/include/wx/msw/setup0.h
+++ b/include/wx/msw/setup0.h
@@ -1560,7 +1560,7 @@
 // SDK components manually, you need to change this setting.
 //
 // Recommended setting: 1
-#if defined(_MSC_VER) && _MSC_VER >= 1700
+#if #if defined(_MSC_VER) && _MSC_VER >= 1700 && !defined(_USING_V110_SDK71_)
     #define wxUSE_WINRT 1
 #else
     #define wxUSE_WINRT 0


### PR DESCRIPTION
Fix wxWidgets not compiling on Visual C++ when platform toolset is set to XP targetting due to missing "winstring.h" header.
https://blogs.msdn.microsoft.com/vcblog/2012/10/08/windows-xp-targeting-with-c-in-visual-studio-2012/
