### PR TITLE
Fix 64-bit crash

### DIFF
--- a/src/msw/helpchm.cpp
+++ b/src/msw/helpchm.cpp
@@ -36,10 +36,10 @@
 // ----------------------------------------------------------------------------
 
 #ifndef UNICODE
-    typedef HWND ( WINAPI * HTMLHELP )( HWND, LPCSTR, UINT, DWORD );
+    typedef HWND ( WINAPI * HTMLHELP )( HWND, LPCSTR, UINT, ULONG_PTR );
     #define HTMLHELP_NAME wxT("HtmlHelpA")
 #else // ANSI
-    typedef HWND ( WINAPI * HTMLHELP )( HWND, LPCWSTR, UINT, DWORD );
+    typedef HWND ( WINAPI * HTMLHELP )( HWND, LPCWSTR, UINT, ULONG_PTR );
     #define HTMLHELP_NAME wxT("HtmlHelpW")
 #endif
 


### PR DESCRIPTION
The HtmlHelp functions are using a wrong signature and crash on 64-bit. Should be using ULONG_PTR instead:
https://msdn.microsoft.com/en-us/library/windows/desktop/bb762267%28v=vs.85%29.aspx
