### PR TITLE
1-pixel layout distortion

### DIFF
--- a/src/msw/stattext.cpp
+++ b/src/msw/stattext.cpp
@@ -113,7 +113,7 @@ wxSize wxStaticText::DoGetBestClientSize() const
     // controls vertically, otherwise we simply can't ensure that the text is
     // always on the same line, e.g. even with this hack wxComboBox text is
     // still not aligned to the same position.
-    heightTextTotal += 1;
+    //heightTextTotal += 1;
 
     return wxSize(widthTextMax, heightTextTotal);
 }


### PR DESCRIPTION
Fixes the graphics layout being off by one pixel. If one really needs this, he should set the height of the control manually instead.
