### PR TITLE
OSX: fix apple magic quotes

### DIFF
--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -621,6 +621,7 @@ wxNSTextViewControl::wxNSTextViewControl( wxTextCtrl *wxPeer, WXWidget w, long s
     [tv setHorizontallyResizable:hasHScroll];
     [tv setAutoresizingMask:NSViewWidthSizable];
     [tv setAutomaticDashSubstitutionEnabled:false];
+    [tv setAutomaticQuoteSubstitutionEnabled:false];
     
     if ( hasHScroll )
     {


### PR DESCRIPTION
Similarly to "setAutomaticDashSubstitutionEnabled" fix the annoying quote substitution, too.
