### PR TITLE
taskbar - Fix shutdown crash

### DIFF
--- a/src/msw/taskbar.cpp
+++ b/src/msw/taskbar.cpp
@@ -81,6 +81,11 @@ public:
           m_icon(icon)
     {
     }
+    
+	virtual bool Destroy()
+	{
+		return true;
+	}
 
     WXLRESULT MSWWindowProc(WXUINT msg,
                             WXWPARAM wParam, WXLPARAM lParam)


### PR DESCRIPTION
Fix crash when class is deleted twice when WM_CLOSE events are sent to all top-level windows, for example by task scheduler when manually ending tasks.
The second time it is deleted directly in wxTaskBarIcon::~wxTaskBarIcon, even if this was already done by WM_CLOSE.
