### PR TITLE
wxHtmlModalHelp broken for wxWidgets 3.1.0

### DIFF
--- a/src/html/helpdata.cpp
+++ b/src/html/helpdata.cpp
@@ -229,7 +229,10 @@ bool HP_TagHandler::HandleTag(const wxHtmlTag& tag)
         if (m_name.empty() && tag.GetParam(wxT("NAME")) == wxT("Name"))
             m_name = tag.GetParam(wxT("VALUE"));
         if (tag.GetParam(wxT("NAME")) == wxT("Local"))
-            m_page = tag.GetParam(wxT("VALUE"));
+    	{
+    		m_page = tag.GetParam(wxT("VALUE"));
+    		m_page.Replace("\\", "/");
+    	}
         if (tag.GetParam(wxT("NAME")) == wxT("ID"))
             tag.GetParamAsInt(wxT("VALUE"), &m_id);
         return false;
@@ -683,7 +686,10 @@ bool wxHtmlHelpData::AddBook(const wxString& book)
         if (wxStrstr(linebuf, wxT("title=")) == linebuf)
             title = linebuf + wxStrlen(wxT("title="));
         if (wxStrstr(linebuf, wxT("default topic=")) == linebuf)
-            start = linebuf + wxStrlen(wxT("default topic="));
+    	{
+    		start = linebuf + wxStrlen(wxT("default topic="));
+    		start.Replace("\\", "/");
+    	}
         if (wxStrstr(linebuf, wxT("index file=")) == linebuf)
             index = linebuf + wxStrlen(wxT("index file="));
         if (wxStrstr(linebuf, wxT("contents file=")) == linebuf)


### PR DESCRIPTION
Fix regression compared to wxWidgets 3.0.2 for wxHtmlModalHelp on Linux, OS X:
wxHtmlModalHelp fails to open relative html paths like "subfolder\file.html" because it is resolving them to an incorrect absolute path, e.g. "/user/.../subfolder\file.html", note the backslash instead of the expected slash. hhc and hhp are Windows formats, so wxWidgets should replace the backslash while parsing hhc and hhp.
