### PR TITLE
Fix for definitions in defs.h to work around a bug in clang < 3.3

### DIFF
--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -392,36 +392,36 @@ typedef short int WXTYPE;
         Since 4.9.2, g++ provides __has_include() but, unlike clang, refuses to
         compile the C++11 headers in C++98 mode (and we are sure we use the
         latter because we explicitly checked for C++11 above).
+
+        Note that clang < 3.3 does not support the following syntax:
+            #define foo(h) __has_include(h)
+            #foo(<bar>)
      */
-    #if defined(__GNUC__) && !defined(__clang__)
-        #define wx_has_cpp11_include(h) 0
-    #else
-        #define wx_has_cpp11_include(h) __has_include(h)
-    #endif
-
-    #if !defined(HAVE_TYPE_TRAITS) && !defined(HAVE_TR1_TYPE_TRAITS)
-        #if wx_has_cpp11_include(<type_traits>)
-            #define HAVE_TYPE_TRAITS
-        #elif __has_include(<tr1/type_traits>)
-            #define HAVE_TR1_TYPE_TRAITS
+    #if defined(__GNUC__)
+        #if !defined(HAVE_TYPE_TRAITS) && !defined(HAVE_TR1_TYPE_TRAITS)
+            #if defined(__clang__) && __has_include(<type_traits>)
+                #define HAVE_TYPE_TRAITS
+            #elif __has_include(<tr1/type_traits>)
+                #define HAVE_TR1_TYPE_TRAITS
+            #endif
         #endif
-    #endif
 
-    #if !defined(HAVE_STD_UNORDERED_MAP) && !defined(HAVE_TR1_UNORDERED_MAP)
-        #if wx_has_cpp11_include(<unordered_map>)
-            #define HAVE_STD_UNORDERED_MAP
-        #elif __has_include(<tr1/unordered_map>)
-            #define HAVE_TR1_UNORDERED_MAP
+        #if !defined(HAVE_STD_UNORDERED_MAP) && !defined(HAVE_TR1_UNORDERED_MAP)
+            #if defined(__clang__) && __has_include(<unordered_map>)
+                #define HAVE_STD_UNORDERED_MAP
+            #elif __has_include(<tr1/unordered_map>)
+                #define HAVE_TR1_UNORDERED_MAP
+            #endif
         #endif
-    #endif
 
-    #if !defined(HAVE_STD_UNORDERED_SET) && !defined(HAVE_TR1_UNORDERED_SET)
-        #if wx_has_cpp11_include(<unordered_set>)
-            #define HAVE_STD_UNORDERED_SET
-        #elif __has_include(<tr1/unordered_set>)
-            #define HAVE_TR1_UNORDERED_SET
+        #if !defined(HAVE_STD_UNORDERED_SET) && !defined(HAVE_TR1_UNORDERED_SET)
+            #if defined(__clang__) && __has_include(<unordered_set>)
+                #define HAVE_STD_UNORDERED_SET
+            #elif __has_include(<tr1/unordered_set>)
+                #define HAVE_TR1_UNORDERED_SET
+            #endif
         #endif
-    #endif
+    #endif /* defined(__GNUC__) */
 #endif /* defined(__has_include) */
 
 #endif /* __cplusplus */


### PR DESCRIPTION
I have a humble request to fix a build error for clang < 3.3. The definitions in `include/wx/defs.h` lead to a compiler crash with `clang` on OS X 10.7 (or 10.8) with Xcode 4 installed. This is what an older clang compiler cannot handle for some reason:

```
#define foo __has_include(h)
#foo(<bar>)
```

and which leads to a crash. My initial idea was to do `#define wx_has_cpp11_include(h) 0` for clang < 3.3, but this is a bad idea when `--stdlib=libc++` is used because `__has_include(<type_traits>)` would be true and `__has_include(<tr1/type_traits>)` is not, but the first test would be skipped.

So I came up with what I hope is still reasonable code which I tested against clang 3.2 (`Apple LLVM version 4.2 (clang-425.0.28) (based on LLVM 3.2svn)`) as well as against clang 3.3 and 3.4 compiled from source. I did some basic testing against `libc++` as well and the code compiles on all platforms from 10.7 to 10.11. I wasn't able to test gcc 4.9 because Apple's frameworks (Objective C) and gcc didn't get along too well.

By avoiding an additional definition of `wx_has_cpp11_include` clang < 3.3 is happily processing the code as intended. I hope that I didn't break compatibility with gcc on other platforms, but this is something that you can probably check easier than me. The logic should stay the same as before.
