### PR TITLE
Report libraries in EXTRALIBS_WEBVIEW when specifying "webview" with …

### DIFF
--- a/wx-config.in
+++ b/wx-config.in
@@ -1032,6 +1032,7 @@ ldlibs_html="@EXTRALIBS_HTML@"
 ldlibs_xml="@EXTRALIBS_XML@"
 ldlibs_adv="@EXTRALIBS_SDL@"
 ldlibs_stc="@EXTRALIBS_STC@"
+ldlibs_webview="@EXTRALIBS_WEBVIEW@"
 
 
 # Order the libraries passed to us correctly for static linking.


### PR DESCRIPTION
…--libs or --optional-libs.

Testing using gtk2-unicode-static. In 3.0.2 these libraries are reported by "wx-config --libs std", but not by "wx-config --libs webview". In 3.1 they are reported by neither command. It seems to me that the correct behaviour would be to report them when the user is specifying that they wish to use the webview libraries.
