### PR TITLE
taskbar - Fix shutdown crash

### DIFF
--- a/src/msw/taskbar.cpp
+++ b/src/msw/taskbar.cpp
@@ -82,6 +82,12 @@ public:
     {
     }
 
+    //wxFrame may receive WM_CLOSE events, but we're owned by wxTaskBarIcon below!
+    virtual bool Destroy()
+	{
+		return true;
+	}
+	
     WXLRESULT MSWWindowProc(WXUINT msg,
                             WXWPARAM wParam, WXLPARAM lParam)
     {


### PR DESCRIPTION
This is in reference to https://github.com/wxWidgets/wxWidgets/pull/242
I'm not sure if replies to closed pull requests are shown, hence this reopening.

Meanwhile I've found some official documentation from Microsoft about the Windows Taskplanner behavior of sending WM_CLOSE events in order to close an app from outside:

How To Terminate an Application "Cleanly" in Win32 using WM_CLOSE
https://support.microsoft.com/en-us/kb/178893
