### PR TITLE
wxWidgets 3.1 performance issue with wxDrawBitmap

### DIFF
--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -2609,6 +2609,7 @@ static bool AlphaBlt(wxMSWDCImpl* dcDst,
     // this to avoid "losing" the existing bitmap contents outside of
     // the area affected by AlphaBlt(), see #14403.
 #ifdef wxHAS_RAW_BITMAP
+/*
     const wxBitmap& bmpDst = dcDst->GetSelectedBitmap();
     if ( bmpDst.IsOk() && !bmpDst.HasAlpha() && bmpDst.GetDepth() == 32 )
     {
@@ -2659,6 +2660,7 @@ static bool AlphaBlt(wxMSWDCImpl* dcDst,
 
         dcDst->DoSelect(bmpOld);
     }
+*/
 #endif // wxHAS_RAW_BITMAP
 
     return true;


### PR DESCRIPTION
This is a regression compared to wxWidgets 3.0.2:

In my test case the runtime of wxDC::DrawBitmap goes up from 0.019ms to 1.372ms per call for wxWidgets 3.0.2 compared to wxWidgets 3.1.0. This is a performance degradation of 72x!

The runtime of 1.372ms per call to wxDC::DrawBitmap is a real problem now when you have a grid rendering houndreds of images at a time. The 100% CPU for the main thread is quickly hit when you update the grid a few times per second and the application is now sluggish in comparison to wxWidgets 3.0.2.

The root of this perf problem are the changes to AlphaBlt() in https://github.com/Xlordd/wxWidgets/blob/2c3d43bbd39c91f274a214d7144f4bb09365a492/src/msw/dc.cpp#L2600

If this "#ifdef wxHAS_RAW_BITMAP" section is left out, the behavior is essentially the same as it was on wxWidgets 3.0.2 and the performance problem is solved. I'm not sure what exactly the problem is that this new wxWidgets 3.1.0 code solves, at least for me these changes are not needed and the perf problem the code creates are a real show stopper. Maybe there exists a more elegant solution that is also fast, but this needs someone with a deeper understanding of AlphaBlt().
