### PR TITLE
Check for C/POSIX locale just after we truncate language string

### DIFF
--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -615,11 +615,6 @@ inline bool wxGetNonEmptyEnvVar(const wxString& name, wxString* value)
         return wxLANGUAGE_ENGLISH_US;
     }
 
-    if ( langFull == wxS("C") || langFull == wxS("POSIX") )
-    {
-        // default C locale is English too
-        return wxLANGUAGE_ENGLISH_US;
-    }
 #endif
 
     // the language string has the following form
@@ -653,6 +648,12 @@ inline bool wxGetNonEmptyEnvVar(const wxString& name, wxString* value)
     if ( posEndLang != wxString::npos )
     {
         langFull.Truncate(posEndLang);
+    }
+
+    if ( langFull == wxS("C") || langFull == wxS("POSIX") )
+    {
+        // default C locale is English too
+        return wxLANGUAGE_ENGLISH_US;
     }
 
     // do we have just the language (or sublang too)?


### PR DESCRIPTION
Check for C/POSIX locale just after we truncate language string
This way we can correctly detect C.UTF-8 as C locale.
