### PR TITLE
wxGTK: Fix default Button in wxMessageDialog as OK

### DIFF
--- a/src/gtk/msgdlg.cpp
+++ b/src/gtk/msgdlg.cpp
@@ -214,6 +214,8 @@ void wxMessageDialog::GTKCreateMsgDialog()
         defaultButton = GTK_RESPONSE_NO;
     else if ( m_dialogStyle & wxYES_NO )
         defaultButton = GTK_RESPONSE_YES;
+    else if ( m_dialogStyle & wxOK )
+        defaultButton = GTK_RESPONSE_OK;
     else // No need to change the default value, whatever it is.
         defaultButton = GTK_RESPONSE_NONE;
 


### PR DESCRIPTION
Under wxGTK the default button in wxMessageDialog with style wxOK was not set to the OK button instead the Cancel button was focused wether the wxOK_DEFAULT style is set or not. Now the style is not really honored, but the OK button is set as the default action explicitly instead of relying on GTK to do the selection.

I have tested the behaviour and the fix under Debian Jessie with GTK 2 and 3.

I'm not sure this is the best solution, maybe the wxOK_DEFAULT style should get a real value and it should be tested so that the default GTK behaviour is preserved when no wx*_DEFAULT style is given.
