### PR TITLE
add wxFC_NOSHOWHIDDEN to the wxGtkFileCtrl::Create

### DIFF
--- a/src/gtk/filectrl.cpp
+++ b/src/gtk/filectrl.cpp
@@ -368,6 +368,9 @@ bool wxGtkFileCtrl::Create( wxWindow *parent,
     if ( style & wxFC_MULTIPLE )
         gtk_file_chooser_set_select_multiple( m_fcWidget, true );
 
+    if ( style & wxFC_NOSHOWHIDDEN )
+        gtk_file_chooser_set_show_hidden(m_fcWidget, true);
+
     SetWildcard( wildCard );
 
     // if defaultDir is specified it should contain the directory and


### PR DESCRIPTION
the wxFileCtrl in wxGTK does not respect the wxFC_NOSHOWHIDDEN in style in the Create function.

this little patch does add it like wxFC_MULTIPLE.
