### PR TITLE
Rename wxListCtrl::HasCheckboxes() and EnableCheckboxes()

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -55,6 +55,13 @@ Changes in behaviour which may result in build errors
 3.1.1: (not released yet)
 ----------------------------
 
+INCOMPATIBLE CHANGES SINCE 3.1.0:
+
+- wxListCtrl::HasCheckboxes() and EnableCheckboxes(), which were added in
+  3.1.0, have been renamed to HasCheckBoxes and EnableCheckBoxes respectively
+  for consistency with wxCheckBox naming.
+
+
 All:
 
 - Add support for the micro version (third component) to OS and toolkit version

--- a/include/wx/generic/listctrl.h
+++ b/include/wx/generic/listctrl.h
@@ -101,8 +101,8 @@ public:
     void SetTextColour(const wxColour& col);
     long GetTopItem() const;
 
-    virtual bool HasCheckboxes() const wxOVERRIDE;
-    virtual bool EnableCheckboxes(bool enable = true) wxOVERRIDE;
+    virtual bool HasCheckBoxes() const wxOVERRIDE;
+    virtual bool EnableCheckBoxes(bool enable = true) wxOVERRIDE;
     virtual bool IsItemChecked(long item) const wxOVERRIDE;
     virtual void CheckItem(long item, bool check) wxOVERRIDE;
 

--- a/include/wx/generic/private/listctrl.h
+++ b/include/wx/generic/private/listctrl.h
@@ -641,8 +641,8 @@ public:
     bool GetItemPosition( long item, wxPoint& pos ) const;
     int GetSelectedItemCount() const;
 
-    bool HasCheckboxes() const;
-    bool EnableCheckboxes(bool enable = true);
+    bool HasCheckBoxes() const;
+    bool EnableCheckBoxes(bool enable = true);
     bool IsItemChecked(long item) const;
     void CheckItem(long item, bool check);
 
@@ -789,7 +789,7 @@ protected:
            m_lineBeforeLastClicked,
            m_lineSelectSingleOnUp;
 
-    bool m_hasCheckboxes;
+    bool m_hasCheckBoxes;
 
 protected:
     wxWindow *GetMainWindowOfCompositeControl() wxOVERRIDE { return GetParent(); }

--- a/include/wx/generic/private/listctrl.h
+++ b/include/wx/generic/private/listctrl.h
@@ -853,7 +853,7 @@ private:
     // Check if the given point is inside the checkbox of this item.
     //
     // Always returns false if there are no checkboxes.
-    bool IsInsideCheckbox(long item, int x, int y);
+    bool IsInsideCheckBox(long item, int x, int y);
 
     // the height of one line using the current font
     wxCoord m_lineHeight;

--- a/include/wx/listbase.h
+++ b/include/wx/listbase.h
@@ -461,8 +461,8 @@ public:
     wxColour GetAlternateRowColour() const { return m_alternateRowColour.GetBackgroundColour(); }
 
     // Checkboxes support: only implemented in wxMSW currently.
-    virtual bool HasCheckboxes() const { return false; }
-    virtual bool EnableCheckboxes(bool WXUNUSED(enable) = true) { return false; }
+    virtual bool HasCheckBoxes() const { return false; }
+    virtual bool EnableCheckBoxes(bool WXUNUSED(enable) = true) { return false; }
     virtual bool IsItemChecked(long WXUNUSED(item)) const { return false; }
     virtual void CheckItem(long WXUNUSED(item), bool WXUNUSED(check)) { }
 

--- a/include/wx/msw/listctrl.h
+++ b/include/wx/msw/listctrl.h
@@ -217,8 +217,8 @@ public:
     wxFont GetItemFont( long item ) const;
 
     // Checkbox state of an item
-    virtual bool HasCheckboxes() const wxOVERRIDE;
-    virtual bool EnableCheckboxes(bool enable = true) wxOVERRIDE;
+    virtual bool HasCheckBoxes() const wxOVERRIDE;
+    virtual bool EnableCheckBoxes(bool enable = true) wxOVERRIDE;
     virtual bool IsItemChecked(long item) const wxOVERRIDE;
     virtual void CheckItem(long item, bool check) wxOVERRIDE;
 

--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -1230,11 +1230,11 @@ public:
     /**
         Returns true if checkboxes are enabled for list items.
 
-        @see EnableCheckboxes()
+        @see EnableCheckBoxes()
 
         @since 3.1.0
     */
-    bool HasCheckboxes() const;
+    bool HasCheckBoxes() const;
 
     /**
         Enable or disable checkboxes for list items.
@@ -1244,7 +1244,7 @@ public:
 
         @since 3.1.0
     */
-    bool EnableCheckboxes(bool enable = true);
+    bool EnableCheckBoxes(bool enable = true);
 
     /**
         Return true if the checkbox for the given wxListItem is checked.
@@ -1261,7 +1261,7 @@ public:
         Check or uncheck a wxListItem in a control using checkboxes.
 
         This method only works if checkboxes support had been successfully
-        enabled using EnableCheckboxes().
+        enabled using EnableCheckBoxes().
 
         @param item Item (zero-based) index.
         @param check If @true, check the item, otherwise uncheck.

--- a/samples/listctrl/listtest.cpp
+++ b/samples/listctrl/listtest.cpp
@@ -847,20 +847,20 @@ void MyFrame::OnUpdateToggleMultiSel(wxUpdateUIEvent& event)
 
 void MyFrame::OnToggleCheckboxes(wxCommandEvent& WXUNUSED(event))
 {
-    if ( !m_listCtrl->EnableCheckboxes(!m_listCtrl->HasCheckboxes()) )
+    if ( !m_listCtrl->EnableCheckBoxes(!m_listCtrl->HasCheckBoxes()) )
     {
         wxLogMessage("Failed to toggle checkboxes (not supported?)");
     }
     else
     {
         wxLogMessage("Checkboxes are now %s",
-                     m_listCtrl->HasCheckboxes() ? "enabled" : "disabled");
+                     m_listCtrl->HasCheckBoxes() ? "enabled" : "disabled");
     }
 }
 
 void MyFrame::OnUpdateToggleCheckboxes(wxUpdateUIEvent& event)
 {
-    bool cbEnabled = m_listCtrl->HasCheckboxes();
+    bool cbEnabled = m_listCtrl->HasCheckBoxes();
     event.Check(cbEnabled);
     GetMenuBar()->Enable(LIST_TOGGLE_CHECKBOX, cbEnabled);
     GetMenuBar()->Enable(LIST_GET_CHECKBOX, cbEnabled);

--- a/samples/listctrl/listtest.cpp
+++ b/samples/listctrl/listtest.cpp
@@ -154,15 +154,15 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(LIST_MAC_USE_GENERIC, MyFrame::OnToggleMacUseGeneric)
 #endif // __WXOSX__
     EVT_MENU(LIST_FIND, MyFrame::OnFind)
-    EVT_MENU(LIST_TOGGLE_CHECKBOX, MyFrame::OnToggleItemCheckbox)
-    EVT_MENU(LIST_GET_CHECKBOX, MyFrame::OnGetItemCheckbox)
-    EVT_MENU(LIST_TOGGLE_CHECKBOXES, MyFrame::OnToggleCheckboxes)
+    EVT_MENU(LIST_TOGGLE_CHECKBOX, MyFrame::OnToggleItemCheckBox)
+    EVT_MENU(LIST_GET_CHECKBOX, MyFrame::OnGetItemCheckBox)
+    EVT_MENU(LIST_TOGGLE_CHECKBOXES, MyFrame::OnToggleCheckBoxes)
 
     EVT_UPDATE_UI(LIST_SHOW_COL_INFO, MyFrame::OnUpdateUIEnableInReport)
     EVT_UPDATE_UI(LIST_TOGGLE_HEADER, MyFrame::OnUpdateUIEnableInReport)
 
     EVT_UPDATE_UI(LIST_TOGGLE_MULTI_SEL, MyFrame::OnUpdateToggleMultiSel)
-    EVT_UPDATE_UI(LIST_TOGGLE_CHECKBOXES, MyFrame::OnUpdateToggleCheckboxes)
+    EVT_UPDATE_UI(LIST_TOGGLE_CHECKBOXES, MyFrame::OnUpdateToggleCheckBoxes)
     EVT_UPDATE_UI(LIST_TOGGLE_HEADER, MyFrame::OnUpdateToggleHeader)
     EVT_UPDATE_UI(LIST_ROW_LINES, MyFrame::OnUpdateRowLines)
 wxEND_EVENT_TABLE()
@@ -845,7 +845,7 @@ void MyFrame::OnUpdateToggleMultiSel(wxUpdateUIEvent& event)
      event.Check(!m_listCtrl->HasFlag(wxLC_SINGLE_SEL));
 }
 
-void MyFrame::OnToggleCheckboxes(wxCommandEvent& WXUNUSED(event))
+void MyFrame::OnToggleCheckBoxes(wxCommandEvent& WXUNUSED(event))
 {
     if ( !m_listCtrl->EnableCheckBoxes(!m_listCtrl->HasCheckBoxes()) )
     {
@@ -858,7 +858,7 @@ void MyFrame::OnToggleCheckboxes(wxCommandEvent& WXUNUSED(event))
     }
 }
 
-void MyFrame::OnUpdateToggleCheckboxes(wxUpdateUIEvent& event)
+void MyFrame::OnUpdateToggleCheckBoxes(wxUpdateUIEvent& event)
 {
     bool cbEnabled = m_listCtrl->HasCheckBoxes();
     event.Check(cbEnabled);
@@ -924,7 +924,7 @@ void MyFrame::OnEdit(wxCommandEvent& WXUNUSED(event))
     }
 }
 
-void MyFrame::OnToggleItemCheckbox(wxCommandEvent& WXUNUSED(event))
+void MyFrame::OnToggleItemCheckBox(wxCommandEvent& WXUNUSED(event))
 {
     long item = m_listCtrl->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
     while (item != -1)
@@ -937,7 +937,7 @@ void MyFrame::OnToggleItemCheckbox(wxCommandEvent& WXUNUSED(event))
     }
 }
 
-void MyFrame::OnGetItemCheckbox(wxCommandEvent& WXUNUSED(event))
+void MyFrame::OnGetItemCheckBox(wxCommandEvent& WXUNUSED(event))
 {
     long item = m_listCtrl->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
     while (item != -1)

--- a/samples/listctrl/listtest.h
+++ b/samples/listctrl/listtest.h
@@ -149,13 +149,13 @@ protected:
     void OnToggleMacUseGeneric(wxCommandEvent& event);
 #endif // __WXOSX__
     void OnFind(wxCommandEvent& event);
-    void OnToggleItemCheckbox(wxCommandEvent& event);
-    void OnGetItemCheckbox(wxCommandEvent& event);
-    void OnToggleCheckboxes(wxCommandEvent& event);
+    void OnToggleItemCheckBox(wxCommandEvent& event);
+    void OnGetItemCheckBox(wxCommandEvent& event);
+    void OnToggleCheckBoxes(wxCommandEvent& event);
 
     void OnUpdateUIEnableInReport(wxUpdateUIEvent& event);
     void OnUpdateToggleMultiSel(wxUpdateUIEvent& event);
-    void OnUpdateToggleCheckboxes(wxUpdateUIEvent& event);
+    void OnUpdateToggleCheckBoxes(wxUpdateUIEvent& event);
     void OnUpdateToggleHeader(wxUpdateUIEvent& event);
     void OnUpdateRowLines(wxUpdateUIEvent& event);
 

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -2579,7 +2579,7 @@ void wxListMainWindow::OnMouse( wxMouseEvent &event )
         bool cmdModifierDown = event.CmdDown();
         if ( IsSingleSel() || !(cmdModifierDown || event.ShiftDown()) )
         {
-            if (IsInsideCheckbox(current, x, y))
+            if (IsInsideCheckBox(current, x, y))
             {
                 CheckItem(current, !IsItemChecked(current));
             }
@@ -3736,7 +3736,7 @@ bool wxListMainWindow::IsItemChecked(long item) const
     return line->IsChecked();
 }
 
-bool wxListMainWindow::IsInsideCheckbox(long item, int x, int y)
+bool wxListMainWindow::IsInsideCheckBox(long item, int x, int y)
 {
     if ( HasCheckBoxes() )
     {

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -797,7 +797,7 @@ void wxListLineData::DrawInReportMode( wxDC *dc,
     x += 2;
 #endif
 
-    if ( m_owner->HasCheckboxes() )
+    if ( m_owner->HasCheckBoxes() )
     {
         wxSize cbSize = wxRendererNative::Get().GetCheckBoxSize(m_owner);
         int yOffset = (rect.height - cbSize.GetHeight()) / 2;
@@ -820,7 +820,7 @@ void wxListLineData::DrawInReportMode( wxDC *dc,
         wxListItemData *item = node->GetData();
 
         int width = m_owner->GetColumnWidth(col);
-        if (col == 0 && m_owner->HasCheckboxes())
+        if (col == 0 && m_owner->HasCheckBoxes())
             width -= x;
         int xOld = x;
         x += width;
@@ -1609,7 +1609,7 @@ void wxListMainWindow::Init()
     m_lineSelectSingleOnUp =
     m_lineBeforeLastClicked = (size_t)-1;
 
-    m_hasCheckboxes = false;
+    m_hasCheckBoxes = false;
 }
 
 wxListMainWindow::wxListMainWindow()
@@ -3703,14 +3703,14 @@ bool wxListMainWindow::GetItemPosition(long item, wxPoint& pos) const
 // checkboxes
 // ----------------------------------------------------------------------------
 
-bool wxListMainWindow::HasCheckboxes() const
+bool wxListMainWindow::HasCheckBoxes() const
 {
-    return m_hasCheckboxes;
+    return m_hasCheckBoxes;
 }
 
-bool wxListMainWindow::EnableCheckboxes(bool enable)
+bool wxListMainWindow::EnableCheckBoxes(bool enable)
 {
-    m_hasCheckboxes = enable;
+    m_hasCheckBoxes = enable;
 
     m_dirty = true;
     m_headerWidth = 0;
@@ -3738,7 +3738,7 @@ bool wxListMainWindow::IsItemChecked(long item) const
 
 bool wxListMainWindow::IsInsideCheckbox(long item, int x, int y)
 {
-    if ( HasCheckboxes() )
+    if ( HasCheckBoxes() )
     {
         wxRect lineRect = GetLineRect(item);
         wxSize cbSize = wxRendererNative::Get().GetCheckBoxSize(this);
@@ -4769,20 +4769,20 @@ void wxGenericListCtrl::OnScroll(wxScrollWinEvent& event)
     event.Skip();
 }
 
-bool wxGenericListCtrl::HasCheckboxes() const
+bool wxGenericListCtrl::HasCheckBoxes() const
 {
     if (!InReportView())
         return false;
 
-    return m_mainWin->HasCheckboxes();
+    return m_mainWin->HasCheckBoxes();
 }
 
-bool wxGenericListCtrl::EnableCheckboxes(bool enable)
+bool wxGenericListCtrl::EnableCheckBoxes(bool enable)
 {
     if (!InReportView())
         return false;
 
-    return m_mainWin->EnableCheckboxes(enable);
+    return m_mainWin->EnableCheckBoxes(enable);
 }
 
 void wxGenericListCtrl::CheckItem(long item, bool state)

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -1211,13 +1211,13 @@ wxFont wxListCtrl::GetItemFont( long item ) const
     return f;
 }
 
-bool wxListCtrl::HasCheckboxes() const
+bool wxListCtrl::HasCheckBoxes() const
 {
     const DWORD currStyle = ListView_GetExtendedListViewStyle(GetHwnd());
     return (currStyle & LVS_EX_CHECKBOXES) != 0;
 }
 
-bool wxListCtrl::EnableCheckboxes(bool enable)
+bool wxListCtrl::EnableCheckBoxes(bool enable)
 {
     (void)ListView_SetExtendedListViewStyleEx(GetHwnd(), LVS_EX_CHECKBOXES,
                                               enable ? LVS_EX_CHECKBOXES : 0);


### PR DESCRIPTION
Rename them to HasCheckBoxes and EnableCheckBoxes for consistency with
wxCheckBox naming.

See also PR https://github.com/wxWidgets/wxWidgets/pull/153

I made this a PR because I wasn't certain about how to mention the changes in docs/changes.txt.
