### PR TITLE
Fixes for PCH-less build for wxD2DContext.

### DIFF
--- a/include/wx/math.h
+++ b/include/wx/math.h
@@ -53,12 +53,15 @@
 
 #ifdef __cplusplus
 
+#ifdef __WINDOWS__
+    #include <cfloat>
+#endif
+
 /* Any C++11 compiler should provide isfinite() */
 #if __cplusplus >= 201103
     #include <cmath>
     #define wxFinite(x) std::isfinite(x)
 #elif defined(__VISUALC__) || defined(__BORLANDC__)
-    #include <float.h>
     #define wxFinite(x) _finite(x)
 #elif defined(__MINGW64_TOOLCHAIN__) || defined(__clang__)
     /*


### PR DESCRIPTION
`<cfloat>` is required for FLT_MAX in Direct2D graphics context.
In CustomDraw, `"wx/msw/private.h"` is needed for wxColour, wxFont and wxColourToRGB.

Fixed warnings about deleting polymorphic class type that has no virtual destructor when deleting CustomDraw objects.
