### PR TITLE
Removed unused EVT_HIBERNATE

### DIFF
--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -774,7 +774,6 @@ wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_SIZING, wxSizeEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_MOVING, wxMoveEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_MOVE_START, wxMoveEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_MOVE_END, wxMoveEvent);
-wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_HIBERNATE, wxActivateEvent);
 
     // Clipboard events
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_TEXT_COPY, wxClipboardTextEvent);
@@ -4178,7 +4177,6 @@ typedef void (wxEvtHandler::*wxClipboardTextEventFunction)(wxClipboardTextEvent&
 #define EVT_CHILD_FOCUS(func)  wx__DECLARE_EVT0(wxEVT_CHILD_FOCUS, wxChildFocusEventHandler(func))
 #define EVT_ACTIVATE(func)  wx__DECLARE_EVT0(wxEVT_ACTIVATE, wxActivateEventHandler(func))
 #define EVT_ACTIVATE_APP(func)  wx__DECLARE_EVT0(wxEVT_ACTIVATE_APP, wxActivateEventHandler(func))
-#define EVT_HIBERNATE(func)  wx__DECLARE_EVT0(wxEVT_HIBERNATE, wxActivateEventHandler(func))
 #define EVT_END_SESSION(func)  wx__DECLARE_EVT0(wxEVT_END_SESSION, wxCloseEventHandler(func))
 #define EVT_QUERY_END_SESSION(func)  wx__DECLARE_EVT0(wxEVT_QUERY_END_SESSION, wxCloseEventHandler(func))
 #define EVT_DROP_FILES(func)  wx__DECLARE_EVT0(wxEVT_DROP_FILES, wxDropFilesEventHandler(func))

--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -798,8 +798,6 @@ public:
         See wxCloseEvent.
     @event{EVT_ACTIVATE_APP(func)}
         Process a @c wxEVT_ACTIVATE_APP event. See wxActivateEvent.
-    @event{EVT_HIBERNATE(func)}
-        Process a hibernate event. See wxActivateEvent.
     @event{EVT_DIALUP_CONNECTED(func)}
         A connection with the network was established. See wxDialUpEvent.
     @event{EVT_DIALUP_DISCONNECTED(func)}

--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -2993,12 +2993,6 @@ public:
     @event{EVT_ACTIVATE_APP(func)}
         Process a @c wxEVT_ACTIVATE_APP event.
         This event is received by the wxApp-derived instance only.
-    @event{EVT_HIBERNATE(func)}
-        Process a hibernate event, supplying the member function. This event applies
-        to wxApp only, and only on Windows SmartPhone and PocketPC.
-        It is generated when the system is low on memory; the application should free
-        up as much memory as possible, and restore full working state when it receives
-        a @c wxEVT_ACTIVATE or @c wxEVT_ACTIVATE_APP event.
     @endEventTable
 
     @note Until wxWidgets 3.1.0 activation events could be sent by wxMSW when
@@ -4789,7 +4783,6 @@ wxEventType wxEVT_SIZING;
 wxEventType wxEVT_MOVING;
 wxEventType wxEVT_MOVE_START;
 wxEventType wxEVT_MOVE_END;
-wxEventType wxEVT_HIBERNATE;
 wxEventType wxEVT_TEXT_COPY;
 wxEventType wxEVT_TEXT_CUT;
 wxEventType wxEVT_TEXT_PASTE;

--- a/src/common/event.cpp
+++ b/src/common/event.cpp
@@ -268,7 +268,6 @@ wxDEFINE_EVENT( wxEVT_MOVE_END, wxMoveEvent );
 wxDEFINE_EVENT( wxEVT_CLOSE_WINDOW, wxCloseEvent );
 wxDEFINE_EVENT( wxEVT_END_SESSION, wxCloseEvent );
 wxDEFINE_EVENT( wxEVT_QUERY_END_SESSION, wxCloseEvent );
-wxDEFINE_EVENT( wxEVT_HIBERNATE, wxActivateEvent );
 wxDEFINE_EVENT( wxEVT_ACTIVATE_APP, wxActivateEvent );
 wxDEFINE_EVENT( wxEVT_ACTIVATE, wxActivateEvent );
 wxDEFINE_EVENT( wxEVT_CREATE, wxWindowCreateEvent );


### PR DESCRIPTION
The event was only used in WinCE port and should have been removed along with WindowsCE support in 8282c1be0f358f5fa00c6aab21c3298af7d8ce02.
