### PR TITLE
Updated interface headers to avoid using wxWindowBase as it's not a public class

### DIFF
--- a/interface/wx/cshelp.h
+++ b/interface/wx/cshelp.h
@@ -36,7 +36,7 @@ public:
         Although all help providers have these functions to allow making
         wxWindow::SetHelpText() work, not all of them implement the functions.
     */
-    virtual void AddHelp(wxWindowBase* window, const wxString& text);
+    virtual void AddHelp(wxWindow* window, const wxString& text);
 
     /**
         Associates the text with the given ID.
@@ -65,7 +65,7 @@ public:
         May be used to set the same help string for all Cancel buttons in
         the application, for example.
     */
-    virtual wxString GetHelp(const wxWindowBase* window) = 0;
+    virtual wxString GetHelp(const wxWindow* window) = 0;
 
     /**
         Removes the association between the window pointer and the help text.
@@ -73,7 +73,7 @@ public:
         help strings will fill up and when window pointers are reused, the
         wrong help string will be found.
     */
-    virtual void RemoveHelp(wxWindowBase* window);
+    virtual void RemoveHelp(wxWindow* window);
 
     /**
         Set the current, application-wide help provider.
@@ -90,7 +90,7 @@ public:
         Returns @true if help was shown, or @false if no help was available for
         this window.
     */
-    virtual bool ShowHelp(wxWindowBase* window);
+    virtual bool ShowHelp(wxWindow* window);
 
     /**
         This function may be overridden to show help for the window when it
@@ -110,7 +110,7 @@ public:
 
         @since 2.7.0
     */
-    virtual bool ShowHelpAtPoint(wxWindowBase* window, const wxPoint& point,
+    virtual bool ShowHelpAtPoint(wxWindow* window, const wxPoint& point,
                                  wxHelpEvent::Origin origin);
 };
 

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -548,7 +548,7 @@ public:
 
         @since 2.9.4
      */
-    bool IsDescendant(wxWindowBase* win) const;
+    bool IsDescendant(wxWindow* win) const;
 
     /**
         Reparents the window, i.e.\ the window will be removed from its


### PR DESCRIPTION
Per earlier discussion: https://groups.google.com/forum/#!topic/wx-dev/LrJaKTTjco4
