### PR TITLE
Use std::isnan() on C++ 11 compiler

### DIFF
--- a/include/wx/math.h
+++ b/include/wx/math.h
@@ -87,7 +87,11 @@
 #endif
 
 
-#if defined(__VISUALC__)||defined(__BORLAND__)
+/* Any C++11 compiler should provide isnan() */
+#if __cplusplus >= 201103
+    #include <cmath>
+    #define wxIsNaN(x) std::isnan(x)
+#elif defined(__VISUALC__)||defined(__BORLAND__)
     #define wxIsNaN(x) _isnan(x)
 #elif defined(__GNUG__)||defined(__GNUWIN32__)|| \
       defined(__SGI_CC__)||defined(__SUNCC__)||defined(__XLC__)|| \


### PR DESCRIPTION
Audacity fails to build on Ubuntu 16.04 with g++ 5.3.1:

```
In file included from /usr/include/wx-3.0/wx/gdicmn.h:23:0,
                 from /usr/include/wx-3.0/wx/utils.h:26,
                 from BlockFile.cpp:51:
BlockFile.cpp: In function ‘void ComputeMinMax256(float*, float*, float*, int*)’:
/usr/include/wx-3.0/wx/math.h:91:31: error: ‘isnan’ was not declared in this scope
     #define wxIsNaN(x) isnan(x)
                               ^
BlockFile.cpp:325:11: note: in expansion of macro ‘wxIsNaN’
       if (wxIsNaN(summary256[3*i+2]))
           ^
/usr/include/wx-3.0/wx/math.h:91:31: note: suggested alternative:
     #define wxIsNaN(x) isnan(x)
                               ^
BlockFile.cpp:325:11: note: in expansion of macro ‘wxIsNaN’
       if (wxIsNaN(summary256[3*i+2]))
           ^
In file included from /usr/include/wx-3.0/wx/math.h:58:0,
                 from /usr/include/wx-3.0/wx/gdicmn.h:23,
                 from /usr/include/wx-3.0/wx/utils.h:26,
                 from BlockFile.cpp:51:
/usr/include/c++/5/cmath:641:5: note:   ‘std::isnan’
     isnan(_Tp __x)
     ^
make[3]: *** [audacity-BlockFile.o] Error 1
```

isnan() is not defined, but std::isnan() is defined. Thus use
std::isnan() for all C++11 compilers, since isnan() is part of C++11.
