### PR TITLE
Add support for using the XTest extension in wxUIActionSimulator

### DIFF
--- a/configure
+++ b/configure
@@ -945,6 +945,8 @@ WEBKIT_LIBS
 WEBKIT_CFLAGS
 COND_PYTHON
 PYTHON
+XTST_LIBS
+XTST_CFLAGS
 LIBNOTIFY_LIBS
 LIBNOTIFY_CFLAGS
 GNOMEVFS_LIBS
@@ -1092,6 +1094,7 @@ with_gtkprint
 with_gnomevfs
 with_libnotify
 with_opengl
+with_xtest
 with_dmalloc
 with_sdl
 with_regex
@@ -1397,6 +1400,8 @@ GNOMEVFS_CFLAGS
 GNOMEVFS_LIBS
 LIBNOTIFY_CFLAGS
 LIBNOTIFY_LIBS
+XTST_CFLAGS
+XTST_LIBS
 WEBKIT_CFLAGS
 WEBKIT_LIBS
 CAIRO_CFLAGS
@@ -2318,6 +2323,7 @@ Optional Packages:
   --with-gnomevfs         use GNOME VFS for associating MIME types
   --with-libnotify        use libnotify for notifications
   --with-opengl           use OpenGL (or Mesa)
+  --with-xtest            use XTest extension
   --with-dmalloc          use dmalloc library (http://dmalloc.com/)
   --with-sdl              use SDL for audio on Unix
   --with-regex            enable support for wxRegEx class
@@ -2391,6 +2397,8 @@ Some influential environment variables:
               C compiler flags for LIBNOTIFY, overriding pkg-config
   LIBNOTIFY_LIBS
               linker flags for LIBNOTIFY, overriding pkg-config
+  XTST_CFLAGS C compiler flags for XTST, overriding pkg-config
+  XTST_LIBS   linker flags for XTST, overriding pkg-config
   WEBKIT_CFLAGS
               C compiler flags for WEBKIT, overriding pkg-config
   WEBKIT_LIBS linker flags for WEBKIT, overriding pkg-config
@@ -4821,6 +4829,35 @@ fi
 
 
           eval "$wx_cv_use_opengl"
+
+
+          withstring=
+          defaultval=$wxUSE_ALL_FEATURES
+          if test -z "$defaultval"; then
+              if test x"$withstring" = xwithout; then
+                  defaultval=yes
+              else
+                  defaultval=no
+              fi
+          fi
+
+# Check whether --with-xtest was given.
+if test "${with_xtest+set}" = set; then :
+  withval=$with_xtest;
+                        if test "$withval" = yes; then
+                          wx_cv_use_xtest='wxUSE_XTEST=yes'
+                        else
+                          wx_cv_use_xtest='wxUSE_XTEST=no'
+                        fi
+
+else
+
+                        wx_cv_use_xtest='wxUSE_XTEST=${'DEFAULT_wxUSE_XTEST":-$defaultval}"
+
+fi
+
+
+          eval "$wx_cv_use_xtest"
 
 
 fi
@@ -33532,6 +33569,93 @@ if test "$wxUSE_UIACTIONSIMULATOR" = "yes" ; then
     $as_echo "#define wxUSE_UIACTIONSIMULATOR 1" >>confdefs.h
 
     SAMPLES_SUBDIRS="$SAMPLES_SUBDIRS uiaction"
+    if test "$wxUSE_XTEST" = "yes" ; then
+
+pkg_failed=no
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for XTST" >&5
+$as_echo_n "checking for XTST... " >&6; }
+
+if test -n "$PKG_CONFIG"; then
+    if test -n "$XTST_CFLAGS"; then
+        pkg_cv_XTST_CFLAGS="$XTST_CFLAGS"
+    else
+        if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"xtst\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "xtst") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_XTST_CFLAGS=`$PKG_CONFIG --cflags "xtst" 2>/dev/null`
+else
+  pkg_failed=yes
+fi
+    fi
+else
+	pkg_failed=untried
+fi
+if test -n "$PKG_CONFIG"; then
+    if test -n "$XTST_LIBS"; then
+        pkg_cv_XTST_LIBS="$XTST_LIBS"
+    else
+        if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"xtst\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "xtst") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_XTST_LIBS=`$PKG_CONFIG --libs "xtst" 2>/dev/null`
+else
+  pkg_failed=yes
+fi
+    fi
+else
+	pkg_failed=untried
+fi
+
+
+
+if test $pkg_failed = yes; then
+
+if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+        _pkg_short_errors_supported=yes
+else
+        _pkg_short_errors_supported=no
+fi
+        if test $_pkg_short_errors_supported = yes; then
+	        XTST_PKG_ERRORS=`$PKG_CONFIG --short-errors --errors-to-stdout --print-errors "xtst"`
+        else
+	        XTST_PKG_ERRORS=`$PKG_CONFIG --errors-to-stdout --print-errors "xtst"`
+        fi
+	# Put the nasty error message in config.log where it belongs
+	echo "$XTST_PKG_ERRORS" >&5
+
+
+                { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: XTest extension not found" >&5
+$as_echo "$as_me: WARNING: XTest extension not found" >&2;}
+                wxUSE_XTEST="no"
+
+
+elif test $pkg_failed = untried; then
+
+                { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: XTest extension not found" >&5
+$as_echo "$as_me: WARNING: XTest extension not found" >&2;}
+                wxUSE_XTEST="no"
+
+
+else
+	XTST_CFLAGS=$pkg_cv_XTST_CFLAGS
+	XTST_LIBS=$pkg_cv_XTST_LIBS
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+                GUI_TK_LIBRARY="$GUI_TK_LIBRARY $XTST_LIBS"
+                CFLAGS="$XTST_CFLAGS $CFLAGS"
+                CXXFLAGS="$XTST_CFLAGS $CXXFLAGS"
+                $as_echo "#define wxUSE_XTEST 1" >>confdefs.h
+
+
+fi
+    fi
 fi
 
 if test "$wxUSE_DC_TRANSFORM_MATRIX" = "yes" ; then

--- a/configure.in
+++ b/configure.in
@@ -542,6 +542,7 @@ WX_ARG_WITHOUT(gtkprint,   [  --without-gtkprint      don't use GTK printing sup
 WX_ARG_WITH(gnomevfs,      [  --with-gnomevfs         use GNOME VFS for associating MIME types], wxUSE_LIBGNOMEVFS)
 WX_ARG_WITH(libnotify,     [  --with-libnotify        use libnotify for notifications], wxUSE_LIBNOTIFY)
 WX_ARG_WITH(opengl,        [  --with-opengl           use OpenGL (or Mesa)], wxUSE_OPENGL)
+WX_ARG_WITH(xtest,         [  --with-xtest            use XTest extension], wxUSE_XTEST)
 
 fi
 dnl for GUI only
@@ -6360,6 +6361,20 @@ fi
 if test "$wxUSE_UIACTIONSIMULATOR" = "yes" ; then
     AC_DEFINE(wxUSE_UIACTIONSIMULATOR)
     SAMPLES_SUBDIRS="$SAMPLES_SUBDIRS uiaction"
+    if test "$wxUSE_XTEST" = "yes" ; then
+        PKG_CHECK_MODULES(XTST, xtst,
+            [
+                GUI_TK_LIBRARY="$GUI_TK_LIBRARY $XTST_LIBS"
+                CFLAGS="$XTST_CFLAGS $CFLAGS"
+                CXXFLAGS="$XTST_CFLAGS $CXXFLAGS"
+                AC_DEFINE(wxUSE_XTEST)
+            ],
+            [
+                AC_MSG_WARN([XTest extension not found])
+                wxUSE_XTEST="no"
+            ]
+        )
+    fi
 fi
 
 if test "$wxUSE_DC_TRANSFORM_MATRIX" = "yes" ; then

--- a/docs/doxygen/mainpages/const_wxusedef.h
+++ b/docs/doxygen/mainpages/const_wxusedef.h
@@ -267,6 +267,7 @@ library:
 @itemdef{wxUSE_LIBSDL, Use SDL for wxSound implementation.}
 @itemdef{wxUSE_PLUGINS, See also wxUSE_LIBSDL.}
 @itemdef{wxUSE_UNIX, Enabled on Unix Platform.}
+@itemdef(wxUSE_XTEST, Use XTest extension.}
 @endDefList
 
 

--- a/include/wx/android/setup.h
+++ b/include/wx/android/setup.h
@@ -1403,6 +1403,9 @@
 // Compile wxUIActionSimulator class?
 #define wxUSE_UIACTIONSIMULATOR 1
 
+// Use the XTest extension for wxUIActionSimulator?
+#define wxUSE_XTEST 1
+
 // ----------------------------------------------------------------------------
 // wxDC classes for various output formats
 // ----------------------------------------------------------------------------

--- a/include/wx/chkconf.h
+++ b/include/wx/chkconf.h
@@ -1231,6 +1231,14 @@
 #   endif
 #endif /* !defined(wxUSE_XRC) */
 
+#ifndef wxUSE_XTEST
+#   ifdef wxABORT_ON_CONFIG_ERROR
+#       error "wxUSE_XTEST must be defined, please read comment near the top of this file."
+#   else
+#       define wxUSE_XTEST 0
+#   endif
+#endif /* !defined(wxUSE_XTEST) */
+
 #endif /* wxUSE_GUI */
 
 /*

--- a/include/wx/gtk/setup0.h
+++ b/include/wx/gtk/setup0.h
@@ -1404,6 +1404,9 @@
 // Compile wxUIActionSimulator class?
 #define wxUSE_UIACTIONSIMULATOR 1
 
+// Use the XTest extension for wxUIActionSimulator?
+#define wxUSE_XTEST 1
+
 // ----------------------------------------------------------------------------
 // wxDC classes for various output formats
 // ----------------------------------------------------------------------------

--- a/include/wx/motif/setup0.h
+++ b/include/wx/motif/setup0.h
@@ -1404,6 +1404,9 @@
 // Compile wxUIActionSimulator class?
 #define wxUSE_UIACTIONSIMULATOR 1
 
+// Use the XTest extension for wxUIActionSimulator?
+#define wxUSE_XTEST 1
+
 // ----------------------------------------------------------------------------
 // wxDC classes for various output formats
 // ----------------------------------------------------------------------------

--- a/include/wx/msw/setup0.h
+++ b/include/wx/msw/setup0.h
@@ -1404,6 +1404,9 @@
 // Compile wxUIActionSimulator class?
 #define wxUSE_UIACTIONSIMULATOR 1
 
+// Use the XTest extension for wxUIActionSimulator?
+#define wxUSE_XTEST 1
+
 // ----------------------------------------------------------------------------
 // wxDC classes for various output formats
 // ----------------------------------------------------------------------------

--- a/include/wx/osx/setup0.h
+++ b/include/wx/osx/setup0.h
@@ -1405,6 +1405,9 @@
 // Compile wxUIActionSimulator class?
 #define wxUSE_UIACTIONSIMULATOR 1
 
+// Use the XTest extension for wxUIActionSimulator?
+#define wxUSE_XTEST 1
+
 // ----------------------------------------------------------------------------
 // wxDC classes for various output formats
 // ----------------------------------------------------------------------------

--- a/include/wx/setup_inc.h
+++ b/include/wx/setup_inc.h
@@ -1400,6 +1400,9 @@
 // Compile wxUIActionSimulator class?
 #define wxUSE_UIACTIONSIMULATOR 1
 
+// Use the XTest extension for wxUIActionSimulator?
+#define wxUSE_XTEST 1
+
 // ----------------------------------------------------------------------------
 // wxDC classes for various output formats
 // ----------------------------------------------------------------------------

--- a/include/wx/univ/setup0.h
+++ b/include/wx/univ/setup0.h
@@ -1403,6 +1403,9 @@
 // Compile wxUIActionSimulator class?
 #define wxUSE_UIACTIONSIMULATOR 1
 
+// Use the XTest extension for wxUIActionSimulator?
+#define wxUSE_XTEST 1
+
 // ----------------------------------------------------------------------------
 // wxDC classes for various output formats
 // ----------------------------------------------------------------------------

--- a/setup.h.in
+++ b/setup.h.in
@@ -570,6 +570,8 @@
 
 #define wxUSE_UIACTIONSIMULATOR 0
 
+#define wxUSE_XTEST 0
+
 
 #define wxUSE_POSTSCRIPT  0
 


### PR DESCRIPTION
Fixes wxUIActionSimulator under wxGTK3, see #17530.
