### PR TITLE
Pull request for trac issue 17555 - Bug in wxTranslations::GetHeaderValue

### DIFF
--- a/src/common/translation.cpp
+++ b/src/common/translation.cpp
@@ -1721,7 +1721,7 @@ wxString wxTranslations::GetHeaderValue(const wxString& header,
     if ( !trans || trans->empty() )
         return wxEmptyString;
 
-    size_t found = trans->find(header);
+    size_t found = trans->find(header + wxS(": "));
     if ( found == wxString::npos )
         return wxEmptyString;
 


### PR DESCRIPTION
Pull request for trac issue [17555](http://trac.wxwidgets.org/ticket/17555).

The wxTranslations::GetHeaderValue does not really look up the complete header name matching the specified name, it only looks if the beginning of the name matches.

E.g. Poedit adds a header "Language" to the po files it creates, which contains the language of the translation, and there is also another header "Language-Team" just before:

"Language-Team: wxWidgets Team wx-dev@wxwidgets.org\n"
"Language: de\n"

If now doing a wxTranslations::GetHeaderValue("Language"), the result is
"eam: wxWidgets Team wx-dev@wxwidgets.org".

The code behind that is really stupid: It searches e.g. for "Language" and if found it goes 2 chars forward, assuming there is a ": " behind the pattern, but not really checking that.

The solution is simple, just let it search e.g. for "Language: ", i.e. append the ": " to the search string.

The issue is present in 3.0.2 and in 3.1.0.

I have successfully tested the correction I provide with this PR with both 3.0.2 and 3.1.0 on Windows 10 with msvc14 and CentOS 7 with gcc 4.8.5 for all configurations Debug, Release, DLL Debug and DLL Release for 64 bit.

**To test the correction**, add following code to your non-English wxWidgets app somewhere after the wxLocale is set and the standard translations catalogue has been loaded:

`wxTranslations* translations = wxTranslations::Get();
wxMessageBox(translations->GetHeaderValue("Language"));`

**Before the patch**, you will get something like "eam: wxWidgets Team wx-dev@wxwidgets.org", depending on which translation you use.

**After the patch**, you will get the value of the "Language" header, if there is one in the .po file and so also the .mo file for your translation, or an empty string if the header is not there.

I think the correction should also go into 3.0.3.

Should I also make a PR to the 3.0 branch? Or will someone cherry pick that from the master branch after this PR has been merged (if so)?
