### PR TITLE
Add Icon to wxMimeTypesManager in GTK under UNIX

### DIFF
--- a/include/wx/gtk/mimetype.h
+++ b/include/wx/gtk/mimetype.h
@@ -1,0 +1,37 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        wx/gtk/mimetype.h
+// Purpose:     classes and functions to manage MIME types
+// Author:      Hans Mackowiak
+// Modified by:
+// Created:     05.06.2016
+// Copyright:   (c) 2016 Hans Mackowiak <hanmac@gmx.de>
+// Licence:     wxWindows licence (part of wxExtra library)
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef _GTK_MIMETYPE_IMPL_H
+#define _GTK_MIMETYPE_IMPL_H
+
+#include "wx/unix/mimetype.h"
+
+#if wxUSE_MIMETYPE
+
+class WXDLLIMPEXP_CORE wxGTKMimeTypesManagerImpl : public wxMimeTypesManagerImpl
+{
+protected:
+    wxString GetIconFromMimeType(const wxString& mime) wxOVERRIDE;
+};
+
+
+class WXDLLIMPEXP_CORE wxGTKMimeTypesManagerFactory : public wxMimeTypesManagerFactory
+{
+public:
+    wxGTKMimeTypesManagerFactory() {}
+    virtual ~wxGTKMimeTypesManagerFactory() {}
+    wxMimeTypesManagerImpl *CreateMimeTypesManagerImpl() wxOVERRIDE;
+};
+
+#endif // wxUSE_MIMETYPE
+
+#endif // _GTK_MIMETYPE_IMPL_H
+
+

--- a/include/wx/gtk/mimetype.h
+++ b/include/wx/gtk/mimetype.h
@@ -2,14 +2,13 @@
 // Name:        wx/gtk/mimetype.h
 // Purpose:     classes and functions to manage MIME types
 // Author:      Hans Mackowiak
-// Modified by:
-// Created:     05.06.2016
+// Created:     2016-06-05
 // Copyright:   (c) 2016 Hans Mackowiak <hanmac@gmx.de>
-// Licence:     wxWindows licence (part of wxExtra library)
+// Licence:     wxWindows licence (part of wxGTK library)
 /////////////////////////////////////////////////////////////////////////////
 
-#ifndef _GTK_MIMETYPE_IMPL_H
-#define _GTK_MIMETYPE_IMPL_H
+#ifndef _WX_GTK_MIMETYPE_IMPL_H
+#define _WX_GTK_MIMETYPE_IMPL_H
 
 #include "wx/unix/mimetype.h"
 
@@ -25,13 +24,11 @@ protected:
 class WXDLLIMPEXP_CORE wxGTKMimeTypesManagerFactory : public wxMimeTypesManagerFactory
 {
 public:
-    wxGTKMimeTypesManagerFactory() {}
-    virtual ~wxGTKMimeTypesManagerFactory() {}
     wxMimeTypesManagerImpl *CreateMimeTypesManagerImpl() wxOVERRIDE;
 };
 
 #endif // wxUSE_MIMETYPE
 
-#endif // _GTK_MIMETYPE_IMPL_H
+#endif // _WX_GTK_MIMETYPE_IMPL_H
 
 

--- a/include/wx/gtk/private/object.h
+++ b/include/wx/gtk/private/object.h
@@ -19,7 +19,7 @@ class wxGtkObject
 {
 public:
     explicit wxGtkObject(T *p) : m_ptr(p) { }
-    ~wxGtkObject() { g_object_unref(m_ptr); }
+    ~wxGtkObject() { if(m_ptr) g_object_unref(m_ptr); }
 
     operator T *() const { return m_ptr; }
 

--- a/include/wx/unix/mimetype.h
+++ b/include/wx/unix/mimetype.h
@@ -99,6 +99,8 @@ protected:
                        const wxArrayString& strExtensions,
                        const wxString& strDesc);
 
+    virtual wxString GetIconFromMimeType(const wxString& mime);
+
     // give it access to m_aXXX variables
     friend class WXDLLIMPEXP_FWD_BASE wxFileTypeImpl;
 };

--- a/samples/typetest/typetest.cpp
+++ b/samples/typetest/typetest.cpp
@@ -945,8 +945,11 @@ void MyApp::DoMIMEDemo(wxCommandEvent& WXUNUSED(event))
         else
         {
             wxString type, desc, open;
+            wxIconLocation loc;
+
             filetype->GetMimeType(&type);
             filetype->GetDescription(&desc);
+            filetype->GetIcon(&loc);
 
             wxString filename = wxT("filename");
             filename << wxT(".") << ext;
@@ -958,6 +961,8 @@ void MyApp::DoMIMEDemo(wxCommandEvent& WXUNUSED(event))
                      << wxT("\tDescription: ") << ( !desc ? wxString(wxEmptyString) : desc )
                         << wxT('\n')
                      << wxT("\tCommand to open: ") << ( !open ? wxString("no") : open )
+                        << wxT('\n')
+                     << wxT("\tIcon: ") << ( loc.IsOk() ? loc.GetFileName() : wxString("no") )
                         << wxT('\n');
 
             delete filetype;

--- a/src/gtk/app.cpp
+++ b/src/gtk/app.cpp
@@ -31,6 +31,9 @@
 #include <gtk/gtk.h>
 #include "wx/gtk/private.h"
 
+#if wxUSE_MIMETYPE
+#include "wx/gtk/mimetype.h"
+#endif
 //-----------------------------------------------------------------------------
 // link GnomeVFS
 //-----------------------------------------------------------------------------
@@ -434,6 +437,10 @@ bool wxApp::Initialize(int& argc_, wxChar **argv_)
         wxLogError(_("Unable to initialize GTK+, is DISPLAY set properly?"));
         return false;
     }
+
+#if wxUSE_MIMETYPE
+    wxMimeTypesManagerFactory::Set(new wxGTKMimeTypesManagerFactory());
+#endif
 
     // we cannot enter threads before gtk_init is done
     gdk_threads_enter();

--- a/src/gtk/app.cpp
+++ b/src/gtk/app.cpp
@@ -31,9 +31,7 @@
 #include <gtk/gtk.h>
 #include "wx/gtk/private.h"
 
-#if wxUSE_MIMETYPE
 #include "wx/gtk/mimetype.h"
-#endif
 //-----------------------------------------------------------------------------
 // link GnomeVFS
 //-----------------------------------------------------------------------------

--- a/src/gtk/mimetype.cpp
+++ b/src/gtk/mimetype.cpp
@@ -2,10 +2,9 @@
 // Name:        src/gtk/mimetype.cpp
 // Purpose:     classes and functions to manage MIME types
 // Author:      Hans Mackowiak
-// Modified by:
-// Created:     05.06.2016
+// Created:     2016-06-05
 // Copyright:   (c) 2016 Hans Mackowiak <hanmac@gmx.de>
-// Licence:     wxWindows licence (part of wxExtra library)
+// Licence:     wxWindows licence (part of wxGTK library)
 /////////////////////////////////////////////////////////////////////////////
 
 
@@ -15,7 +14,7 @@
     #pragma hdrstop
 #endif
 
-#if wxUSE_MIMETYPE && wxUSE_FILE
+#if wxUSE_MIMETYPE
 
 #include "wx/gtk/mimetype.h"
 
@@ -23,24 +22,26 @@
 #include <gtk/gtk.h>
 
 #include "wx/gtk/private/string.h"
+#include "wx/gtk/private/object.h"
 
 wxString wxGTKMimeTypesManagerImpl::GetIconFromMimeType(const wxString& mime)
 {
     wxString icon;
-    wxGtkString type(g_content_type_from_mime_type(mime.mb_str()));
+    wxGtkString type(g_content_type_from_mime_type(mime.utf8_str()));
 
-    GIcon *gicon(g_content_type_get_icon(type));
-    if (gicon) {
+    wxGtkObject<GIcon> gicon(g_content_type_get_icon(type));
+    if (gicon)
+    {
         GtkIconTheme *theme(gtk_icon_theme_get_default());
-        if (theme) {
-            GtkIconInfo *ticon(gtk_icon_theme_lookup_by_gicon(theme, gicon, 256, GTK_ICON_LOOKUP_NO_SVG));
+        if (theme)
+        {
+            wxGtkObject<GtkIconInfo> ticon(gtk_icon_theme_lookup_by_gicon(theme, gicon, 256, GTK_ICON_LOOKUP_NO_SVG));
 
-            if (ticon) {
+            if (ticon)
+            {
                 icon = wxString(gtk_icon_info_get_filename(ticon));
-                g_object_unref(ticon);
             }
         }
-        g_object_unref(gicon);
     }
     return icon;
 }
@@ -50,5 +51,4 @@ wxMimeTypesManagerImpl *wxGTKMimeTypesManagerFactory::CreateMimeTypesManagerImpl
     return new wxGTKMimeTypesManagerImpl();
 }
 
-#endif
-  // wxUSE_MIMETYPE && wxUSE_FILE
+#endif // wxUSE_MIMETYPE

--- a/src/gtk/mimetype.cpp
+++ b/src/gtk/mimetype.cpp
@@ -1,0 +1,54 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        src/gtk/mimetype.cpp
+// Purpose:     classes and functions to manage MIME types
+// Author:      Hans Mackowiak
+// Modified by:
+// Created:     05.06.2016
+// Copyright:   (c) 2016 Hans Mackowiak <hanmac@gmx.de>
+// Licence:     wxWindows licence (part of wxExtra library)
+/////////////////////////////////////////////////////////////////////////////
+
+
+#include "wx/wxprec.h"
+
+#ifdef __BORLANDC__
+    #pragma hdrstop
+#endif
+
+#if wxUSE_MIMETYPE && wxUSE_FILE
+
+#include "wx/gtk/mimetype.h"
+
+#include <gio/gio.h>
+#include <gtk/gtk.h>
+
+#include "wx/gtk/private/string.h"
+
+wxString wxGTKMimeTypesManagerImpl::GetIconFromMimeType(const wxString& mime)
+{
+    wxString icon;
+    wxGtkString type(g_content_type_from_mime_type(mime.mb_str()));
+
+    GIcon *gicon(g_content_type_get_icon(type));
+    if (gicon) {
+        GtkIconTheme *theme(gtk_icon_theme_get_default());
+        if (theme) {
+            GtkIconInfo *ticon(gtk_icon_theme_lookup_by_gicon(theme, gicon, 256, GTK_ICON_LOOKUP_NO_SVG));
+
+            if (ticon) {
+                icon = wxString(gtk_icon_info_get_filename(ticon));
+                g_object_unref(ticon);
+            }
+        }
+        g_object_unref(gicon);
+    }
+    return icon;
+}
+
+wxMimeTypesManagerImpl *wxGTKMimeTypesManagerFactory::CreateMimeTypesManagerImpl()
+{
+    return new wxGTKMimeTypesManagerImpl();
+}
+
+#endif
+  // wxUSE_MIMETYPE && wxUSE_FILE

--- a/src/unix/mimetype.cpp
+++ b/src/unix/mimetype.cpp
@@ -262,7 +262,9 @@ void wxMimeTypesManagerImpl::LoadXDGGlobs(const wxString& filename)
        wxArrayString exts;
        exts.Add( ext );
 
-       AddToMimeData(mime, wxEmptyString, NULL, exts, wxEmptyString, true );
+       wxString icon = GetIconFromMimeType(mime);
+
+       AddToMimeData(mime, icon, NULL, exts, wxEmptyString, true );
     }
 }
 
@@ -687,6 +689,11 @@ wxFileType * wxMimeTypesManagerImpl::Associate(const wxFileTypeInfo& ftInfo)
     return GetFileTypeFromMimeType(strType);
 }
 
+wxString wxMimeTypesManagerImpl::GetIconFromMimeType(const wxString& WXUNUSED(mime))
+{
+    return wxString();
+}
+
 bool wxMimeTypesManagerImpl::DoAssociation(const wxString& strType,
                                            const wxString& strIcon,
                                            wxMimeTypeCommands *entry,
@@ -967,7 +974,7 @@ void wxMimeTypesManagerImpl::AddMimeTypeInfo(const wxString& strMimeType,
     // reading mailcap may find image/* , while
     // reading mime.types finds image/gif and no match is made
     // this means all the get functions don't work  fix this
-    wxString strIcon;
+    wxString strIcon = GetIconFromMimeType(strMimeType);
     wxString sTmp = strExtensions;
 
     wxArrayString sExts;


### PR DESCRIPTION
this is the development of: http://trac.wxwidgets.org/ticket/17536

with improving the Unix wxMimeTypesManagerImpl to get an icon location from giving mimetype.
then adding a GTK implementing that (might be done for other ports later too)

updating the samples to show that icon location.
(might be interesting if the icon should be shown in a wxStaticBitmap too)

for the bakefiles it might be the best to do a GTK_UNIX_SRC variable because the others already have Icon stuff.

means the PR is not complete yet, but i would like it if you others would help me finish it.
