### PR TITLE
Include OSX 10.12 name and branding in wxGetOsDescription()

### DIFF
--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -109,7 +109,8 @@ wxString wxGetOsDescription()
     // Notice that neither the OS name itself nor the code names seem to be
     // ever translated, OS X itself uses the English words even for the
     // languages not using Roman alphabet.
-    wxString osBrand = "OS X";
+    // Starting with 10.12 the macOS branding is used
+    wxString osBrand = (wxCheckOsVersion(10, 12)) ? "macOS" : "OS X";
     wxString osName;
     if (majorVer == 10)
     {
@@ -131,6 +132,9 @@ wxString wxGetOsDescription()
                 break;
             case 11:
                 osName = "El Capitan";
+                break;
+            case 12:
+                osName = "Sierra";
                 break;
         };
     }


### PR DESCRIPTION
Starting with 10.12 OSX will be renamed to macOS. The name for version 10.12 is Sierra.

![screen shot 2016-06-14 at 11 43 48 am](https://cloud.githubusercontent.com/assets/5075894/16038508/7ea000d8-3225-11e6-9166-e1449f24cbba.png)
