### PR TITLE
Implement support for markup in wxDataViewCtrl

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -84,8 +84,10 @@ All (GUI):
 - Fix vertical scrollbar visibility in wxStyledTextCtrl (yenwu, NewPagodi).
 - Fix bug with not being able to select AUI tab after dragging.
 - Make wxDataViewCtrl::Expand() expand ancestors in native ports too.
+- Add wxDataViewTextRenderer::EnableMarkup().
 - Add wxDataViewCtrl::SetHeaderAttr().
 - Add wxListCtrl::SetHeaderAttr().
+- Add support for using markup in wxDataViewCtrl text items.
 - Implement auto complete in generic wxSearchCtrl (Eric Jensen).
 
 wxGTK:

--- a/include/wx/generic/dvrenderers.h
+++ b/include/wx/generic/dvrenderers.h
@@ -53,6 +53,11 @@ public:
     wxDataViewTextRenderer( const wxString &varianttype = GetDefaultType(),
                             wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
                             int align = wxDVR_DEFAULT_ALIGNMENT );
+    virtual ~wxDataViewTextRenderer();
+
+#if wxUSE_MARKUP
+    void EnableMarkup(bool enable = true);
+#endif // wxUSE_MARKUP
 
     virtual bool SetValue( const wxVariant &value );
     virtual bool GetValue( wxVariant &value ) const;
@@ -69,7 +74,11 @@ public:
 protected:
     wxString   m_text;
 
-protected:
+private:
+#if wxUSE_MARKUP
+    class wxMarkupText *m_markupText;
+#endif // wxUSE_MARKUP
+
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxDataViewTextRenderer);
 };
 

--- a/include/wx/generic/private/markuptext.h
+++ b/include/wx/generic/private/markuptext.h
@@ -15,6 +15,8 @@
 class WXDLLIMPEXP_FWD_CORE wxDC;
 class WXDLLIMPEXP_FWD_CORE wxRect;
 
+class wxMarkupParserOutput;
+
 // ----------------------------------------------------------------------------
 // wxMarkupText: allows to measure and draw the text containing markup.
 // ----------------------------------------------------------------------------
@@ -53,6 +55,11 @@ public:
     // The same rules for mnemonics as in the ctor apply to this string.
     void SetMarkup(const wxString& markup) { m_markup = markup; }
 
+    // This is a convenience method which can be used with the string in which
+    // mnemonics should be completely ignored, i.e. not interpreted in any way
+    // but just handled as ordinary characters.
+    void SetMarkupText(const wxString& markup);
+
 
     // Return the width and height required by the given string and optionally
     // the height of the visible part above the baseline (i.e. ascent minus
@@ -69,6 +76,18 @@ public:
     // (it centers the text in it), no clipping is done by it so use Measure()
     // and set the clipping region before rendering if necessary.
     void Render(wxDC& dc, const wxRect& rect, int flags);
+
+    // Similar to Render(), but uses wxRendererNative::DrawItemText() instead
+    // of generic wxDC::DrawLabel(), so is more suitable for use in controls
+    // that already use DrawItemText() for its items.
+    //
+    // The meaning of the flags here is different than in the overload above:
+    // they're passed to DrawItemText() and Render_ShowAccels is not supported
+    // here.
+    void RenderItemText(wxWindow* win,
+                        wxDC& dc,
+                        const wxRect& rect,
+                        int rendererFlags);
 
 private:
     wxString m_markup;

--- a/include/wx/gtk/dvrenderers.h
+++ b/include/wx/gtk/dvrenderers.h
@@ -31,6 +31,10 @@ public:
                             wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
                             int align = wxDVR_DEFAULT_ALIGNMENT );
 
+#if wxUSE_MARKUP
+    void EnableMarkup(bool enable = true);
+#endif // wxUSE_MARKUP
+
     virtual bool SetValue( const wxVariant &value ) wxOVERRIDE
     {
         return SetTextValue(value);
@@ -58,6 +62,14 @@ protected:
     bool SetTextValue(const wxString& str);
     bool GetTextValue(wxString& str) const;
 
+    // Return the name of the GtkCellRendererText property to use: "text" or
+    // "markup".
+    const char* GetTextPropertyName() const;
+
+#if wxUSE_MARKUP
+    // True if we should interpret markup in our text.
+    bool m_useMarkup;
+#endif // wxUSE_MARKUP
 
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxDataViewTextRenderer);
 };

--- a/include/wx/osx/dvrenderers.h
+++ b/include/wx/osx/dvrenderers.h
@@ -55,6 +55,10 @@ public:
                            wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
                            int align = wxDVR_DEFAULT_ALIGNMENT);
 
+#if wxUSE_MARKUP && wxOSX_USE_COCOA
+    void EnableMarkup(bool enable = true);
+#endif // wxUSE_MARKUP && Cocoa
+
     virtual bool MacRender();
 
     virtual void OSXOnCellChanged(NSObject *value,
@@ -62,6 +66,11 @@ public:
                                   unsigned col);
 
 private:
+#if wxUSE_MARKUP && wxOSX_USE_COCOA
+    // True if we should interpret markup in our text.
+    bool m_useMarkup;
+#endif // wxUSE_MARKUP && Cocoa
+
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxDataViewTextRenderer);
 };
 

--- a/interface/wx/dataview.h
+++ b/interface/wx/dataview.h
@@ -1966,6 +1966,49 @@ public:
     wxDataViewTextRenderer(const wxString& varianttype = GetDefaultType(),
                            wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
                            int align = wxDVR_DEFAULT_ALIGNMENT );
+
+    /**
+        Enable interpretation of markup in the cells data.
+
+        If this method is called with @true argument, markup (@ref
+        wxControl::SetLabelMarkup()) in the data of the items in this column
+        will be interpreted, which can be used for a more fine-grained
+        appearance control than just setting an attribute, which affects all of
+        the item text.
+
+        For example, as shown in the @ref page_samples_dataview, after creating
+        a column using a markup-enabled renderer:
+        @code
+            wxDataViewTextRenderer* renderer = new wxDataViewTextRenderer();
+            renderer->EnableMarkup();
+            dataViewCtrl->AppendColumn(new wxDataViewColumn("title", renderer, 0));
+        @endcode
+
+        The overridden model wxDataViewModel::GetValue() method may return
+        values containing markup for this column:
+        @code
+        void MyModel::GetValue(wxVariant& variant,
+                               const wxDataViewItem& item,
+                               unsigned int col) const
+        {
+            if ( col == 0 && item == ... )
+            {
+                variant = "<span color=\"#87ceeb\">light</span> and "
+                          "<span color=\"#000080\">dark</span> blue";
+            }
+
+            ...
+        }
+        @endcode
+
+        @note Currently wxDataViewIconTextRenderer only provides EnableMarkup()
+            EnableMarkup() in wxGTK, but not under the other platforms, so you
+            should only use it for plain wxDataViewTextRenderer columns,
+            without icons, in portable code.
+
+        @since 3.1.1
+     */
+    void EnableMarkup(bool enable = true);
 };
 
 

--- a/samples/dataview/dataview.cpp
+++ b/samples/dataview/dataview.cpp
@@ -702,9 +702,14 @@ void MyFrame::BuildDataViewCtrl(wxPanel* parent, unsigned int nPanel, unsigned l
 
             m_ctrl[1]->AppendDateColumn("date",
                                         MyListModel::Col_Date);
+
+            wxDataViewTextRenderer* const markupRenderer = new wxDataViewTextRenderer();
+#if wxUSE_MARKUP
+            markupRenderer->EnableMarkup();
+#endif // wxUSE_MARKUP
             m_attributes =
                 new wxDataViewColumn("attributes",
-                                     new wxDataViewTextRenderer,
+                                     markupRenderer,
                                      MyListModel::Col_TextWithAttr,
                                      wxCOL_WIDTH_AUTOSIZE,
                                      wxALIGN_RIGHT,

--- a/samples/dataview/mymodels.cpp
+++ b/samples/dataview/mymodels.cpp
@@ -436,7 +436,14 @@ void MyListModel::GetValueByRow( wxVariant &variant,
             {
                 static const char *labels[5] =
                 {
-                    "blue", "green", "red", "bold cyan", "default",
+                    // These strings will look wrong without wxUSE_MARKUP, but
+                    // it's just a sample, so we don't care.
+                    "<span color=\"#87ceeb\">light</span> and "
+                        "<span color=\"#000080\">dark</span> blue",
+                    "<big>growing green</big>",
+                    "<i>emphatic red</i>",
+                    "<b>bold cyan</b>",
+                    "<small><tt>dull default</tt></small>",
                 };
 
                 variant = labels[row % 5];

--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -1005,7 +1005,7 @@ wxDataViewCustomRendererBase::RenderText(const wxString& text,
 
     int flags = 0;
     if ( state & wxDATAVIEW_CELL_SELECTED )
-        flags |= wxCONTROL_SELECTED | wxCONTROL_FOCUSED;
+        flags |= wxCONTROL_SELECTED;
     if ( !GetOwner()->GetOwner()->IsEnabled() )
         flags |= wxCONTROL_DISABLED;
 

--- a/src/generic/markuptext.cpp
+++ b/src/generic/markuptext.cpp
@@ -30,6 +30,8 @@
     #include "wx/dc.h"
 #endif // WX_PRECOMP
 
+#include "wx/renderer.h"
+
 #include "wx/generic/private/markuptext.h"
 
 #include "wx/private/markupparserattr.h"
@@ -132,35 +134,6 @@ public:
         m_origTextBackground = dc.GetTextBackground();
     }
 
-    virtual void OnText(const wxString& text_) wxOVERRIDE
-    {
-        wxString text;
-        int indexAccel = wxControl::FindAccelIndex(text_, &text);
-        if ( !(m_flags & wxMarkupText::Render_ShowAccels) )
-            indexAccel = wxNOT_FOUND;
-
-        // Adjust the position (unfortunately we need to do this manually as
-        // there is no notion of current text position in wx API) rectangle to
-        // ensure that all text segments use the same baseline (as there is
-        // nothing equivalent to Windows SetTextAlign(TA_BASELINE) neither).
-        wxRect rect(m_rect);
-        rect.x = m_pos;
-
-        int descent;
-        m_dc.GetTextExtent(text, &rect.width, &rect.height, &descent);
-        rect.height -= descent;
-        rect.y += m_rect.height - rect.height;
-
-        wxRect bounds;
-        m_dc.DrawLabel(text, wxBitmap(),
-                       rect, wxALIGN_LEFT | wxALIGN_TOP,
-                       indexAccel,
-                       &bounds);
-
-        // TODO-MULTILINE-MARKUP: Must update vertical position too.
-        m_pos += bounds.width;
-    }
-
     virtual void OnAttrStart(const Attr& attr) wxOVERRIDE
     {
         m_dc.SetFont(attr.font);
@@ -202,7 +175,7 @@ public:
         }
     }
 
-private:
+protected:
     wxDC& m_dc;
     const wxRect m_rect;
     const int m_flags;
@@ -217,11 +190,95 @@ private:
     wxDECLARE_NO_COPY_CLASS(wxMarkupParserRenderOutput);
 };
 
+// An output renderer suitable for control labels.
+class wxMarkupParserRenderLabelOutput : public wxMarkupParserRenderOutput
+{
+public:
+    wxMarkupParserRenderLabelOutput(wxDC& dc,
+                                    const wxRect& rect,
+                                    int flags)
+        : wxMarkupParserRenderOutput(dc, rect, flags)
+    {
+    }
+
+    virtual void OnText(const wxString& text_) wxOVERRIDE
+    {
+        wxString text;
+        int indexAccel = wxControl::FindAccelIndex(text_, &text);
+        if ( !(m_flags & wxMarkupText::Render_ShowAccels) )
+            indexAccel = wxNOT_FOUND;
+
+        // Adjust the position (unfortunately we need to do this manually as
+        // there is no notion of current text position in wx API) rectangle to
+        // ensure that all text segments use the same baseline (as there is
+        // nothing equivalent to Windows SetTextAlign(TA_BASELINE) neither).
+        wxRect rect(m_rect);
+        rect.x = m_pos;
+
+        int descent;
+        m_dc.GetTextExtent(text, &rect.width, &rect.height, &descent);
+        rect.height -= descent;
+        rect.y += m_rect.height - rect.height;
+
+        wxRect bounds;
+        m_dc.DrawLabel(text, wxBitmap(),
+                       rect, wxALIGN_LEFT | wxALIGN_TOP,
+                       indexAccel,
+                       &bounds);
+
+        m_pos += bounds.width;
+    }
+};
+
+// An output renderer suitable for multi-item controls items.
+class wxMarkupParserRenderItemOutput : public wxMarkupParserRenderOutput
+{
+public:
+    wxMarkupParserRenderItemOutput(wxWindow* win,
+                                   wxDC& dc,
+                                   const wxRect& rect,
+                                   int rendererFlags)
+        : wxMarkupParserRenderOutput(dc, rect, wxMarkupText::Render_Default),
+          m_win(win),
+          m_rendererFlags(rendererFlags),
+          m_renderer(&wxRendererNative::Get())
+    {
+    }
+
+    virtual void OnText(const wxString& text) wxOVERRIDE
+    {
+        wxRect rect(m_rect);
+        rect.x = m_pos;
+
+        m_renderer->DrawItemText(m_win,
+                                 m_dc,
+                                 wxControl::RemoveMnemonics(text),
+                                 rect,
+                                 wxALIGN_LEFT | wxALIGN_CENTRE_VERTICAL,
+                                 m_rendererFlags,
+                                 wxELLIPSIZE_NONE);
+
+        m_pos += m_dc.GetTextExtent(text).x;
+    }
+
+private:
+    wxWindow* const m_win;
+    int const m_rendererFlags;
+    wxRendererNative* const m_renderer;
+
+    wxDECLARE_NO_COPY_CLASS(wxMarkupParserRenderItemOutput);
+};
+
 } // anonymous namespace
 
 // ============================================================================
 // wxMarkupText implementation
 // ============================================================================
+
+void wxMarkupText::SetMarkupText(const wxString& markup)
+{
+    m_markup = wxControl::EscapeMnemonics(markup);
+}
 
 wxSize wxMarkupText::Measure(wxDC& dc, int *visibleHeight) const
 {
@@ -245,7 +302,17 @@ void wxMarkupText::Render(wxDC& dc, const wxRect& rect, int flags)
     wxRect rectText(rect.GetPosition(), Measure(dc, &visibleHeight));
     rectText.height = visibleHeight;
 
-    wxMarkupParserRenderOutput out(dc, rectText.CentreIn(rect), flags);
+    wxMarkupParserRenderLabelOutput out(dc, rectText.CentreIn(rect), flags);
+    wxMarkupParser parser(out);
+    parser.Parse(m_markup);
+}
+
+void wxMarkupText::RenderItemText(wxWindow* win,
+                                  wxDC& dc,
+                                  const wxRect& rect,
+                                  int rendererFlags)
+{
+    wxMarkupParserRenderItemOutput out(win, dc, rect, rendererFlags);
     wxMarkupParser parser(out);
     parser.Parse(m_markup);
 }

--- a/src/generic/renderg.cpp
+++ b/src/generic/renderg.cpp
@@ -938,14 +938,7 @@ wxRendererGeneric::DrawItemText(wxWindow* WXUNUSED(win),
     wxColour textColour;
     if ( flags & wxCONTROL_SELECTED )
     {
-        if ( flags & wxCONTROL_FOCUSED )
-        {
-            textColour = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT);
-        }
-        else // !focused
-        {
-            textColour = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT);
-        }
+        textColour = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT);
     }
     else if ( flags & wxCONTROL_DISABLED )
     {

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -2277,6 +2277,10 @@ wxDataViewTextRenderer::wxDataViewTextRenderer( const wxString &varianttype, wxD
                                                 int align ) :
     wxDataViewRenderer( varianttype, mode, align )
 {
+#if wxUSE_MARKUP
+    m_useMarkup = false;
+#endif // wxUSE_MARKUP
+
     GtkWxCellRendererText *text_renderer = gtk_wx_cell_renderer_text_new();
     text_renderer->wx_renderer = this;
     m_renderer = (GtkCellRenderer*) text_renderer;
@@ -2298,12 +2302,29 @@ wxDataViewTextRenderer::wxDataViewTextRenderer( const wxString &varianttype, wxD
     SetAlignment(align);
 }
 
+#if wxUSE_MARKUP
+void wxDataViewTextRenderer::EnableMarkup(bool enable)
+{
+    m_useMarkup = enable;
+}
+#endif // wxUSE_MARKUP
+
+const char* wxDataViewTextRenderer::GetTextPropertyName() const
+{
+#if wxUSE_MARKUP
+    if ( m_useMarkup )
+        return "markup";
+#endif // wxUSE_MARKUP
+
+    return "text";
+}
+
 bool wxDataViewTextRenderer::SetTextValue(const wxString& str)
 {
     GValue gvalue = G_VALUE_INIT;
     g_value_init( &gvalue, G_TYPE_STRING );
     g_value_set_string( &gvalue, wxGTK_CONV_FONT( str, GetOwner()->GetOwner()->GetFont() ) );
-    g_object_set_property( G_OBJECT(m_renderer), "text", &gvalue );
+    g_object_set_property( G_OBJECT(m_renderer), GetTextPropertyName(), &gvalue );
     g_value_unset( &gvalue );
 
     return true;
@@ -2313,7 +2334,7 @@ bool wxDataViewTextRenderer::GetTextValue(wxString& str) const
 {
     GValue gvalue = G_VALUE_INIT;
     g_value_init( &gvalue, G_TYPE_STRING );
-    g_object_get_property( G_OBJECT(m_renderer), "text", &gvalue );
+    g_object_get_property( G_OBJECT(m_renderer), GetTextPropertyName(), &gvalue );
     str = wxGTK_CONV_BACK_FONT( g_value_get_string( &gvalue ), const_cast<wxDataViewTextRenderer*>(this)->GetOwner()->GetOwner()->GetFont() );
     g_value_unset( &gvalue );
 

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -30,6 +30,10 @@
 #include "wx/stopwatch.h"
 #include "wx/dcgraph.h"
 
+#if wxUSE_MARKUP
+    #include "wx/osx/cocoa/private/markuptoattr.h"
+#endif // wxUSE_MARKUP
+
 // ============================================================================
 // Constants used locally
 // ============================================================================
@@ -2730,6 +2734,10 @@ wxDataViewTextRenderer::wxDataViewTextRenderer(const wxString& varianttype,
                                                int align)
     : wxDataViewRenderer(varianttype,mode,align)
 {
+#if wxUSE_MARKUP
+    m_useMarkup = false;
+#endif // wxUSE_MARKUP
+
     NSTextFieldCell* cell;
 
 
@@ -2739,8 +2747,27 @@ wxDataViewTextRenderer::wxDataViewTextRenderer(const wxString& varianttype,
     [cell release];
 }
 
+#if wxUSE_MARKUP
+
+void wxDataViewTextRenderer::EnableMarkup(bool enable)
+{
+    m_useMarkup = enable;
+}
+
+#endif // wxUSE_MARKUP
+
 bool wxDataViewTextRenderer::MacRender()
 {
+#if wxUSE_MARKUP
+    if ( m_useMarkup )
+    {
+        wxMarkupToAttrString toAttr(GetView(), GetValue().GetString());
+
+        [GetNativeData()->GetItemCell() setAttributedStringValue:toAttr.GetNSAttributedString()];
+        return true;
+    }
+#endif // wxUSE_MARKUP
+
     [GetNativeData()->GetItemCell() setObjectValue:wxCFStringRef(GetValue().GetString()).AsNSString()];
     return true;
 }


### PR DESCRIPTION
Add `wxDataViewTextRenderer::EnableMarkup()` for finer-grained control over items appearance.
