### PR TITLE
Specify char in the test as signed.

### DIFF
--- a/tests/strings/vararg.cpp
+++ b/tests/strings/vararg.cpp
@@ -139,8 +139,10 @@ void VarArgTestCase::CharPrintf()
     #ifdef _MSC_VER
         #pragma warning(default:4309)
     #endif
+    #ifndef __CHAR_UNSIGNED__
     s.Printf("value is %i (int)", c);
     CPPUNIT_ASSERT_EQUAL( wxString("value is -16 (int)"), s );
+    #endif
 
     unsigned char u = 240;
     s.Printf("value is %i (int)", u);


### PR DESCRIPTION
The variable `c` is later checked against a negative integer value, and the
check will obviously fail when char is unsigned.

With this change the test will test a slightly different thing than before, but at present the test is not portable, and I don't suppose the intention of the test is to say `char` is not allowed to be unsigned by default.

The platform where unsigned-by-default `char` was encountered:
`Linux raspberrypi 4.1.19-v7+ #858 SMP Tue Mar 15 15:56:00 GMT 2016 armv7l GNU/Linux`
