### PR TITLE
Allow loading translations for any language, not just the current one

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -69,6 +69,7 @@ All:
   functions. See wxGetOsVersion(), wxPlatformInfo, and wxAppTraits.
 - wxLogInfo() now logs messages if the log level is high enough, even without
   wxLog::SetVerbose() which now only affects wxLogVerbose().
+- Allow loading translations for any language, not just the current one.
 - Add wxFileType::GetExpandedCommand() (troelsk).
 - Make it easier to convert to/from UTF-8-encoded std::string (ARATA Mizuki).
 - Add support for loading dynamic lexer in wxStyledTextCtrl (New Pagodi).

--- a/include/wx/translation.h
+++ b/include/wx/translation.h
@@ -141,8 +141,8 @@ public:
 
     // add catalog with given domain name and language, looking it up via
     // wxTranslationsLoader
-    bool AddCatalog(const wxString& domain);
-    bool AddCatalog(const wxString& domain, wxLanguage msgIdLanguage);
+    bool AddCatalog(const wxString& domain,
+                    wxLanguage msgIdLanguage = wxLANGUAGE_ENGLISH_US);
 #if !wxUSE_UNICODE
     bool AddCatalog(const wxString& domain,
                     wxLanguage msgIdLanguage,

--- a/include/wx/translation.h
+++ b/include/wx/translation.h
@@ -149,6 +149,10 @@ public:
                     const wxString& msgIdCharset);
 #endif
 
+    bool AddCatalogFor(wxLanguage lang,
+                       const wxString& domain,
+                       wxLanguage msgIdLanguage = wxLANGUAGE_ENGLISH_US);
+
     // check if the given catalog is loaded
     bool IsLoaded(const wxString& domain) const;
 

--- a/interface/wx/translation.h
+++ b/interface/wx/translation.h
@@ -157,20 +157,10 @@ public:
         All loaded catalogs will be used for message lookup by GetString() for
         the current locale.
 
-        In this overload, @c msgid strings are assumed
+        Bu default, i.e. if @a msgIdLanguage is not given, @c msgid strings are assumed
         to be in English and written only using 7-bit ASCII characters.
         If you have to deal with non-English strings or 8-bit characters in the
         source code, see the instructions in @ref overview_nonenglish.
-
-        @return
-            @true if catalog was successfully loaded, @false otherwise (which might
-            mean that the catalog is not found or that it isn't in the correct format).
-     */
-    bool AddCatalog(const wxString& domain);
-
-    /**
-        Same as AddCatalog(const wxString&), but takes an additional argument,
-        @a msgIdLanguage.
 
         @param domain
             The catalog domain to add.
@@ -186,7 +176,8 @@ public:
             @true if catalog was successfully loaded, @false otherwise (which might
             mean that the catalog is not found or that it isn't in the correct format).
      */
-    bool AddCatalog(const wxString& domain, wxLanguage msgIdLanguage);
+    bool AddCatalog(const wxString& domain,
+                    wxLanguage msgIdLanguage = wxLANGUAGE_ENGLISH_US);
 
     /**
         Same as AddCatalog(const wxString&, wxLanguage), but takes two

--- a/interface/wx/translation.h
+++ b/interface/wx/translation.h
@@ -208,6 +208,26 @@ public:
                     const wxString& msgIdCharset);
 
     /**
+        Add a catalog for use with the specified language.
+
+        This is a generalization of AddCatalog() which loads the catalog with
+        the translations for the current locale and allows to load translations
+        for any language, not necessarily the current one. This is especially
+        useful if the system doesn't support some locale, preventing it from
+        being set, as it still allows to at least show the translations in it
+        even if the rest of the program behaviour (e.g. numeric or calendar
+        conventions) is not localized.
+
+        The additional, compared to AddCatalog(), parameter @a lang specifies
+        the language to load the translations for.
+
+        @since 3.1.1
+     */
+    bool AddCatalogFor(wxLanguage lang,
+                       const wxString& domain,
+                       wxLanguage msgIdLanguage = wxLANGUAGE_ENGLISH_US);
+
+    /**
         Check if the given catalog is loaded, and returns @true if it is.
 
         According to GNU gettext tradition, each catalog normally corresponds to

--- a/src/common/translation.cpp
+++ b/src/common/translation.cpp
@@ -1485,12 +1485,6 @@ bool wxTranslations::AddStdCatalog()
     return true;
 }
 
-
-bool wxTranslations::AddCatalog(const wxString& domain)
-{
-    return AddCatalog(domain, wxLANGUAGE_ENGLISH_US);
-}
-
 #if !wxUSE_UNICODE
 bool wxTranslations::AddCatalog(const wxString& domain,
                                 wxLanguage msgIdLanguage,

--- a/src/common/translation.cpp
+++ b/src/common/translation.cpp
@@ -1517,6 +1517,18 @@ bool wxTranslations::AddCatalog(const wxString& domain,
 }
 
 
+bool wxTranslations::AddCatalogFor(wxLanguage lang,
+                                   const wxString& domain,
+                                   wxLanguage msgIdLanguage)
+{
+    return LoadCatalog
+           (
+                domain,
+                wxLocale::GetLanguageCanonicalName(lang),
+                wxLocale::GetLanguageCanonicalName(msgIdLanguage)
+           );
+}
+
 bool wxTranslations::LoadCatalog(const wxString& domain, const wxString& lang, const wxString& msgIdLang)
 {
     wxCHECK_MSG( m_loader, false, "loader can't be NULL" );


### PR DESCRIPTION
I was surprised to find that, unless I've missed something, there is no way to use the translations into some language without setting the locale to match this language, which might be impossible if the system doesn't support it. So I've added `AddCatalogFor()` to allow doing it.

@vslavik I'd be grateful for a review/comments, TIA!
