### PR TITLE
Fix rare crash under XP when building with VS2015

### DIFF
--- a/build/msw/wx_setup.props
+++ b/build/msw/wx_setup.props
@@ -70,6 +70,9 @@
     <wxBaseLibNamePrefix>wxbase$(wxShortVersionString)$(wxSuffix)</wxBaseLibNamePrefix>
   </PropertyGroup>
   <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalOptions Condition="'$(PlatformToolset)' == 'v140_xp'">/Zc:threadSafeInit- %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
     <Link>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;comdlg32.lib;winspool.lib;shell32.lib;shlwapi.lib;ole32.lib;oleaut32.lib;uuid.lib;advapi32.lib;version.lib;comctl32.lib;rpcrt4.lib;wsock32.lib;wininet.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>

--- a/include/wx/msw/chkconf.h
+++ b/include/wx/msw/chkconf.h
@@ -132,7 +132,7 @@
  * the comments in wx/setup.h.
  */
 #if wxUSE_COMPILER_TLS == 1
-    #if !wxCHECK_VISUALC_VERSION(11) || defined(_USING_V110_SDK71_)
+    #if !wxCHECK_VISUALC_VERSION(11) || defined(_USING_V110_SDK71_) || defined(_ATL_XP_TARGETING)
         #undef wxUSE_COMPILER_TLS
         #define wxUSE_COMPILER_TLS 0
     #endif


### PR DESCRIPTION
Fix [#17403](http://trac.wxwidgets.org/ticket/17403)

EDIT: I dunno then if this change shouldn't also be backported to 3.0.3
