### PR TITLE
Update to use wgetcwd when compiled with mingw to properly return Unicode paths.

### DIFF
--- a/src/common/filefn.cpp
+++ b/src/common/filefn.cpp
@@ -82,7 +82,7 @@
 #endif
 
 // TODO: Borland probably has _wgetcwd as well?
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
     #define HAVE_WGETCWD
 #endif
 


### PR DESCRIPTION
Currently `wxGetCwd` returns question marks instead of unicode characters (for example, if the path includes `привет`, it gets encoded as `??????`) when compiled with mingw (tested on gcc 4.8.x). This patch uses `wgetcwd`, which returns proper path.
