### PR TITLE
re-enable features in AppVeyor builds

### DIFF
--- a/build/tools/appveyor.bat
+++ b/build/tools/appveyor.bat
@@ -32,7 +32,7 @@ set CHERE_INVOKING=yes
 :: Workaround for "configure: Bad file descriptor"
 perl -i".bak" -pe "s/^test -n \".DJDIR\"/#$&/" configure
 bash -lc "g++ --version"
-bash -lc "CXXFLAGS=-Wno-deprecated-declarations ./configure --disable-optimise --disable-xrc && make -j3"
+bash -lc "CXXFLAGS=-Wno-deprecated-declarations ./configure --disable-optimise && make -j3"
 goto :eof
 
 :cygwin
@@ -42,5 +42,5 @@ set CHERE_INVOKING=yes
 :: Workaround for "configure: Bad file descriptor"
 perl -i".bak" -pe "s/^test -n \".DJDIR\"/#$&/" configure
 bash -lc "g++ --version"
-bash -lc "LDFLAGS=-L/usr/lib/w32api ./configure --disable-optimise --disable-shared --disable-aui --disable-html --disable-ribbon --disable-richtext --disable-stc && make -j3"
+bash -lc "LDFLAGS=-L/usr/lib/w32api ./configure --disable-optimise --disable-shared && make -j3"
 goto :eof


### PR DESCRIPTION
Build boxes have been upgraded, and should be able to handle the
extra time required to build these features now.

See: http://www.appveyor.com/blog/2016/07/16/migration-to-rackspace

Our builds appear to be approximately 3 to 4 times faster so far.
