### PR TITLE
Fix the stop function of wxFontEnumerator for wxGTK

### DIFF
--- a/src/common/fontenumcmn.cpp
+++ b/src/common/fontenumcmn.cpp
@@ -124,7 +124,10 @@ bool wxFontEnumerator::EnumerateEncodingsUTF8(const wxString& facename)
 
     for ( size_t n = 0; n < count; n++ )
     {
-        OnFontEncoding(facenames[n], utf8);
+        if ( !OnFontEncoding(facenames[n], utf8) )
+        {
+            break;
+        }
     }
 
     return true;

--- a/src/unix/fontenum.cpp
+++ b/src/unix/fontenum.cpp
@@ -81,7 +81,10 @@ bool wxFontEnumerator::EnumerateFacenames(wxFontEncoding encoding,
 #endif
         {
             const gchar *name = pango_font_family_get_name(families[i]);
-            OnFacename(wxString(name, wxConvUTF8));
+            if ( !OnFacename(wxString(name, wxConvUTF8)) )
+            {
+                break;
+            }
         }
     }
     g_free(families);


### PR DESCRIPTION
In a wxFontEnumerator, if false is returned from OnFacename() or
OnFontEncoding(), the enumeration is supposed to stop.  This was not happening
on wxGTK.
