### PR TITLE
Add C++11-style cbegin, cend, etc. to wxString's iterator interface

### DIFF
--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -1282,20 +1282,26 @@ public:
   // first valid index position
   const_iterator begin() const { return const_iterator(this, m_impl.begin()); }
   iterator begin() { return iterator(this, m_impl.begin()); }
+  const_iterator cbegin() const { return const_iterator(this, m_impl.begin()); }
   // position one after the last valid one
   const_iterator end() const { return const_iterator(this, m_impl.end()); }
   iterator end() { return iterator(this, m_impl.end()); }
+  const_iterator cend() const { return const_iterator(this, m_impl.end()); }
 
   // first element of the reversed string
   const_reverse_iterator rbegin() const
     { return const_reverse_iterator(end()); }
   reverse_iterator rbegin()
     { return reverse_iterator(end()); }
+  const_reverse_iterator crbegin() const
+    { return const_reverse_iterator(end()); }
   // one beyond the end of the reversed string
   const_reverse_iterator rend() const
     { return const_reverse_iterator(begin()); }
   reverse_iterator rend()
     { return reverse_iterator(begin()); }
+  const_reverse_iterator crend() const
+    { return const_reverse_iterator(begin()); }
 
   // std::string methods:
 #if wxUSE_UNICODE_UTF8

--- a/interface/wx/string.h
+++ b/interface/wx/string.h
@@ -1574,13 +1574,17 @@ public:
 
     const_iterator begin() const;
     iterator begin();
+    const_iterator cbegin() const;
     const_iterator end() const;
     iterator end();
+    const_iterator cend() const;
 
     const_reverse_iterator rbegin() const;
     reverse_iterator rbegin();
+    const_reverse_iterator crbegin() const;
     const_reverse_iterator rend() const;
     reverse_iterator rend();
+    const_reverse_iterator crend() const;
 
     //@}
 


### PR DESCRIPTION
These c-prefixed functions always return a const_iterator.
The full list of functions added: cbegin(), cend(), crbegin(), crend().
