### PR TITLE
Fix wxCHECK_VISUALC_VERSION macro to correctly detect VC14

### DIFF
--- a/include/wx/compiler.h
+++ b/include/wx/compiler.h
@@ -102,7 +102,7 @@
         non existing (presumably for the superstitious reasons) VC13, so we now
         need to account for this with an extra offset.
      */
-#   define wxVISUALC_VERSION(major) ( (6 + (major >= 14 ? 1 : 0) + major) * 100 )
+#   define wxVISUALC_VERSION(major) ( (6 - (major >= 14 ? 1 : 0) + major) * 100 )
 #   define wxCHECK_VISUALC_VERSION(major) ( __VISUALC__ >= wxVISUALC_VERSION(major) )
 #endif
 


### PR DESCRIPTION
The expression `wxCHECK_VISUALC_VERSION(14)` failed to detect VC14 (Visual C++ 2015). Trivial patch to fix it.
