### PR TITLE
Make const_reference const and dereference const_iterator into a const_reference.

### DIFF
--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -702,7 +702,7 @@ public:
   typedef const wxChar* const_pointer;
 
   typedef size_t size_type;
-  typedef wxUniChar const_reference;
+  typedef const wxUniChar const_reference;
 
 #if wxUSE_STD_STRING
   #if wxUSE_UNICODE_UTF8
@@ -951,7 +951,7 @@ public:
       const_iterator(const const_iterator& i) : m_cur(i.m_cur) {}
       const_iterator(const iterator& i) : m_cur(i.m_cur) {}
 
-      reference operator*() const
+      const_reference operator*() const
         { return wxStringOperations::DecodeChar(m_cur); }
 
       const_iterator operator+(ptrdiff_t n) const


### PR DESCRIPTION
This prevents assignment to a dereferenced const_iterator by causing a compilation error. (As would happen with STL's const_iterators.)

A possible fix for http://trac.wxwidgets.org/ticket/17642
