### PR TITLE
Fix wxGetKeyState() on non-X11 wxGTK backends (e.g., Wayland)

### DIFF
--- a/src/unix/utilsx11.cpp
+++ b/src/unix/utilsx11.cpp
@@ -2535,7 +2535,7 @@ int wxUnicodeCharXToWX(WXKeySym keySym)
 // check current state of a key
 // ----------------------------------------------------------------------------
 
-bool wxGetKeyState(wxKeyCode key)
+static bool wxGetKeyStateX11(wxKeyCode key)
 {
     wxASSERT_MSG(key != WXK_LBUTTON && key != WXK_RBUTTON && key !=
         WXK_MBUTTON, wxT("can't use wxGetKeyState() for mouse buttons"));
@@ -2581,6 +2581,48 @@ bool wxGetKeyState(wxKeyCode key)
 }
 
 #endif // !defined(__WXGTK__) || defined(GDK_WINDOWING_X11)
+
+#ifdef __WXGTK__
+static bool wxGetKeyStateGTK(wxKeyCode key)
+{
+#if GTK_CHECK_VERSION(3,4,0)
+    GdkDisplay* display = gdk_window_get_display(wxGetTopLevelGDK());
+    GdkKeymap* keymap = gdk_keymap_get_for_display(display);
+    guint state = gdk_keymap_get_modifier_state(keymap);
+    guint mask = 0;
+    switch (key)
+    {
+        case WXK_ALT:
+            mask = GDK_MOD1_MASK;
+            break;
+        case WXK_CONTROL:
+            mask = GDK_CONTROL_MASK;
+            break;
+        case WXK_SHIFT:
+            mask = GDK_SHIFT_MASK;
+            break;
+        default:
+            break;
+    }
+    return state & mask;
+#else
+    return false;
+#endif
+}
+#endif // __WXGTK__
+
+bool wxGetKeyState(wxKeyCode key)
+{
+#ifdef __WXGTK__
+    GdkDisplay* display = gdk_window_get_display(wxGetTopLevelGDK());
+    const char* name = g_type_name(G_TYPE_FROM_INSTANCE(display));
+    if (strcmp(name, "GdkX11Display"))
+    {
+        return wxGetKeyStateGTK(key);
+    }
+#endif
+    return wxGetKeyStateX11(key);
+}
 
 // ----------------------------------------------------------------------------
 // Launch document with default app


### PR DESCRIPTION
wxGetKeyState() does not currently work on non-X11 GTK backends, and in some
cases it has been reported to crash.  It seems that the most likely use case
for wxGetKeyState() is to query the modifier keys, so on non-X11 backends, use
GTK+ calls to retrieve the modifier key state.  Non-modifier keys are not
currently implemented.

I'd request this be cherry-picked to 3.0 as well if/when you are happy with it.
