### PR TITLE
Change non-const wxFont ref to const wxFont ref

### DIFF
--- a/src/stc/stc.cpp
+++ b/src/stc/stc.cpp
@@ -4646,7 +4646,7 @@ wxFont wxStyledTextCtrl::StyleGetFont(int style) {
 
 // Set style size, face, bold, italic, and underline attributes from
 // a wxFont's attributes.
-void wxStyledTextCtrl::StyleSetFont(int styleNum, wxFont& font) {
+void wxStyledTextCtrl::StyleSetFont(int styleNum, const wxFont& font) {
 #ifdef __WXGTK__
     // Ensure that the native font is initialized
     int x, y;


### PR DESCRIPTION
Since wxStyledTextCtrl::StyleSetFont does not change its 'font' parameter, it should be a constant reference to allow passing in temporary wxFont objects.
