### PR TITLE
Add mailmap file to normalize author names in git log

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,21 @@
+arata, mizuki							<minorinoki@gmail.com>
+Artur Wieczorek							<artwik@wp.pl>
+<dan@kulp.com>							<dkulp@apache.org>
+Dimitri Schoolwerth						<dimitri.schoolwerth@gmail.com>
+Dimitri Schoolwerth	<dimitri.schoolwerth@gmail.com>		<dimitri@schoolwerth.com>
+Ilya Bizyaev							<bizyaev.game@yandex.ru>
+Jouk Jansen							<joukj@hrem.nano.tudelft.nl>
+Julian Smart							<julian@anthemion.co.uk>
+Kinaou Hervé							<kinaouherve@gmail.com>
+Maarten Bent							<MaartenBent@users.noreply.github.com>
+Manuel Martin							<mmartin@ceyd.es>
+<paulcor@bullseye.com>						<paulcor@users.noreply.github.com>
+<paul@kulchenko.com>						<paulclinger@gmail.com>
+<tim.kosse@gmx.de>						<tim.kosse@filezilla-project.org>
+Tobias Taschner		<ttaschner@protect-software.com>	<TcT2k@users.noreply.github.com>
+			<ttaschner@protect-software.com>	<github@tc84.de>
+Václav Slavík		<vaclav@slavik.io>			<vslavik@fastmail.fm>
+Václav Slavík							<vaclav@slavik.io>
+Vadim Zeitlin		<vadim@wxwidgets.org>			<vz-github@zeitlins.org>
+Vadim Zeitlin		<vadim@wxwidgets.org>			<vadim@zeitlins.org>
+Xlord2			<b1146285@trbvn.com>			<b1223723@trbvn.com>


### PR DESCRIPTION
Avoid having entries differing just by name or email address (or, in the case
of Václav, by the use of composed vs decomposed form!) in "git shortlog"
output.

---

Submitting this as a PR to solicit comments from people about their preferred name/email address variants. Please let me know if anybody would prefer different defaults.

Of course, if you notice any other entries to merge in `git shortlog -s -e` output, please let me know too.
