### PR TITLE
Fix wxMemoryDC::Blit() with itself as source in wxMSW

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -134,6 +134,7 @@ wxMSW:
 - Fix wxGraphicsMatrix::TransformDistance for Direct2D renderer.
 - Fix wxDC::Clear() for rotated DC.
 - Fix wxDC::GetClippingBox() for transformed wxDC.
+- Fix wxMemoryDC::Blit() with itself as source (Tim Roberts).
 
 wxOSX:
 

--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -2294,8 +2294,10 @@ bool wxMSWDCImpl::DoStretchBlit(wxCoord xdest, wxCoord ydest,
         // if we already have a DIB, draw it using StretchDIBits(), otherwise
         // use StretchBlt() if available and finally fall back to BitBlt()
 
+        // Notice that we can't use StretchDIBits() when source and destination
+        // are the same as it can't, apparently, handle overlapping surfaces.
         const int caps = ::GetDeviceCaps(GetHdc(), RASTERCAPS);
-        if ( bmpSrc.IsOk() && (caps & RC_STRETCHDIB) )
+        if ( bmpSrc.IsOk() && (GetHdc() != hdcSrc) && (caps & RC_STRETCHDIB) )
         {
             DIBSECTION ds;
             wxZeroMemory(ds);


### PR DESCRIPTION
Don't use StretchDIBits() native function as it doesn't seem to handle the
case when its source and destination are the same correctly.
