### PR TITLE
Re-enable automatic substitutions in wxTextCtrl on OS X

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -152,7 +152,6 @@ wxOSX:
 - Implement wxGetDisplaySizeMM() and fix printing DPI (David Vanderson).
 - Remove extra borders around wxFilePickerCtrl (John Roberts).
 - Set up extensions filter correctly in wxFileDialog (nick863).
-- Turn off automatic quotes substitutions in wxTextCtrl (Xlord2).
 - Implement wxDataViewChoiceByIndexRenderer (wanup).
 - Fix unnecessary indentation in list-like wxDataViewCtrl (Andreas Falkenhahn).
 - Recognize macOS 10.12 Sierra in wxGetOsDescription() (Tobias Taschner).

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -157,6 +157,8 @@ wxOSX:
 - Recognize macOS 10.12 Sierra in wxGetOsDescription() (Tobias Taschner).
 - Don't try to open command line arguments as files (Jeff Hostetler).
 - Implement wxDataViewCtrl::SetRowHeight().
+- Add OSXEnableAutomaticQuoteSubstitution(), OSXEnableAutomaticDashSubstitution()
+  and OSXDisableAllSmartSubstitutions() to control wxTextCtrl smart behavior.
 
 Unix:
 

--- a/include/wx/osx/cocoa/private/textimpl.h
+++ b/include/wx/osx/cocoa/private/textimpl.h
@@ -95,6 +95,9 @@ public:
     virtual bool HasOwnContextMenu() const { return true; }
 
     virtual void CheckSpelling(bool check);
+    virtual void EnableAutomaticQuoteSubstitution(bool enable);
+    virtual void EnableAutomaticDashSubstitution(bool enable);
+
     virtual wxSize GetBestSize() const;
 
 protected:

--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -688,6 +688,8 @@ public :
     virtual int GetLineLength(long lineNo) const ;
     virtual wxString GetLineText(long lineNo) const ;
     virtual void CheckSpelling(bool WXUNUSED(check)) { }
+    virtual void EnableAutomaticQuoteSubstitution(bool WXUNUSED(enable)) {}
+    virtual void EnableAutomaticDashSubstitution(bool WXUNUSED(enable)) {}
 
     virtual wxSize GetBestSize() const { return wxDefaultSize; }
 

--- a/include/wx/osx/textctrl.h
+++ b/include/wx/osx/textctrl.h
@@ -130,6 +130,10 @@ public:
     virtual void MacSuperChangedPosition() wxOVERRIDE;
     virtual void MacCheckSpelling(bool check);
 
+    void OSXEnableAutomaticQuoteSubstitution(bool enable);
+    void OSXEnableAutomaticDashSubstitution(bool enable);
+    void OSXDisableAllSmartSubstitutions();
+
 protected:
     // common part of all ctors
     void Init();

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -620,8 +620,6 @@ wxNSTextViewControl::wxNSTextViewControl( wxTextCtrl *wxPeer, WXWidget w, long s
     [tv setVerticallyResizable:YES];
     [tv setHorizontallyResizable:hasHScroll];
     [tv setAutoresizingMask:NSViewWidthSizable];
-    [tv setAutomaticDashSubstitutionEnabled:false];
-    [tv setAutomaticQuoteSubstitutionEnabled:false];
     
     if ( hasHScroll )
     {

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -863,6 +863,18 @@ void wxNSTextViewControl::CheckSpelling(bool check)
         [m_textView setContinuousSpellCheckingEnabled: check];
 }
 
+void wxNSTextViewControl::EnableAutomaticQuoteSubstitution(bool enable)
+{
+    if (m_textView)
+        [m_textView setAutomaticQuoteSubstitutionEnabled:enable];
+}
+
+void wxNSTextViewControl::EnableAutomaticDashSubstitution(bool enable)
+{
+    if (m_textView)
+        [m_textView setAutomaticDashSubstitutionEnabled:enable];
+}
+
 wxSize wxNSTextViewControl::GetBestSize() const
 {
     if (m_textView && [m_textView layoutManager])

--- a/src/osx/textctrl_osx.cpp
+++ b/src/osx/textctrl_osx.cpp
@@ -139,6 +139,22 @@ void wxTextCtrl::MacCheckSpelling(bool check)
     GetTextPeer()->CheckSpelling(check);
 }
 
+void wxTextCtrl::OSXEnableAutomaticQuoteSubstitution(bool enable)
+{
+    GetTextPeer()->EnableAutomaticQuoteSubstitution(enable);
+}
+
+void wxTextCtrl::OSXEnableAutomaticDashSubstitution(bool enable)
+{
+    GetTextPeer()->EnableAutomaticDashSubstitution(enable);
+}
+
+void wxTextCtrl::OSXDisableAllSmartSubstitutions()
+{
+    OSXEnableAutomaticDashSubstitution(false);
+    OSXEnableAutomaticQuoteSubstitution(false);
+}
+
 bool wxTextCtrl::SetFont( const wxFont& font )
 {
     if ( !wxTextCtrlBase::SetFont( font ) )


### PR DESCRIPTION
This reverts ill-advised commits c07523734f2d93a8c9042d80fdd458954b0e1d41 and 8d42890df49564d6d81e413bcd4428bf6a8b10e6 that disabled native OS X behavior of substituting dashes and quotes with typographically correct characters _if the user has this feature enabled._

This was a bad idea for two reasons:
1. It made wx applications behave non-natively, and thus be worse, in a highly noticeable area.
2. It made it impossible for applications that want to behave correctly   to restore the native behavior, because once   `setAutomaticDashSubstitutionEnabled` or   `setAutomaticQuoteSubstitutionEnabled` is called (as `wxTextCtrl`   constructor does), it's no longer possible to obtain its original,   default setting.

It's not better to disable native functionality by default, it's better to be native and make customizations possible. `wxWindow` API exposes access to the native control and if an application desires to disable substitution behavior, it can easily do so from user code.

See also #186 and #241.
