### PR TITLE
Document missing overridden methods in wxFileSystemHandler subclasses

### DIFF
--- a/interface/wx/fs_arc.h
+++ b/interface/wx/fs_arc.h
@@ -15,6 +15,43 @@ class wxArchiveFSHandler : public wxFileSystemHandler
 {
 public:
     wxArchiveFSHandler();
+
+    /**
+        Returns @true if the handler is able to open this file. This function doesn't
+        check whether the file exists or not, it only checks if it knows the protocol.
+    */
+    virtual bool CanOpen(const wxString& location);
+
+    /**
+        Opens the file and returns wxFSFile pointer or @NULL if failed.
+
+        @param fs
+            Parent FS (the FS from that OpenFile was called).
+            See the ZIP handler for details of how to use it.
+        @param location
+            The absolute location of file.
+    */
+    virtual wxFSFile* OpenFile(wxFileSystem& fs, const wxString& location);
+
+    /**
+        Works like ::wxFindFirstFile().
+
+        Returns the name of the first filename (within filesystem's current path)
+        that matches @e wildcard. @a flags may be one of wxFILE (only files),
+        wxDIR (only directories) or 0 (both).
+
+        This method is only called if CanOpen() returns @true.
+    */
+    virtual wxString FindFirst(const wxString& spec, int flags = 0);
+
+    /**
+        Returns next filename that matches parameters passed to wxFileSystem::FindFirst.
+
+        This method is only called if CanOpen() returns @true and FindFirst()
+        returned a non-empty string.
+    */
+    virtual wxString FindNext();
+
     virtual ~wxArchiveFSHandler();
     void Cleanup();
 };

--- a/interface/wx/fs_filter.h
+++ b/interface/wx/fs_filter.h
@@ -17,5 +17,41 @@ class wxFilterFSHandler : public wxFileSystemHandler
 public:
     wxFilterFSHandler();
     virtual ~wxFilterFSHandler();
+
+    /**
+        Returns @true if the handler is able to open this file. This function doesn't
+        check whether the file exists or not, it only checks if it knows the protocol.
+    */
+    virtual bool CanOpen(const wxString& location);
+
+    /**
+        Opens the file and returns wxFSFile pointer or @NULL if failed.
+
+        @param fs
+            Parent FS (the FS from that OpenFile was called).
+            See the ZIP handler for details of how to use it.
+        @param location
+            The absolute location of file.
+    */
+    virtual wxFSFile* OpenFile(wxFileSystem& fs, const wxString& location);
+
+    /**
+        Works like ::wxFindFirstFile().
+
+        Returns the name of the first filename (within filesystem's current path)
+        that matches @e wildcard. @a flags may be one of wxFILE (only files),
+        wxDIR (only directories) or 0 (both).
+
+        This method is only called if CanOpen() returns @true.
+    */
+    virtual wxString FindFirst(const wxString& spec, int flags = 0);
+
+    /**
+        Returns next filename that matches parameters passed to wxFileSystem::FindFirst.
+
+        This method is only called if CanOpen() returns @true and FindFirst()
+        returned a non-empty string.
+    */
+    virtual wxString FindNext();
 };
 

--- a/interface/wx/fs_inet.h
+++ b/interface/wx/fs_inet.h
@@ -15,5 +15,22 @@ class wxInternetFSHandler : public wxFileSystemHandler
 {
 public:
     wxInternetFSHandler();
+
+    /**
+        Returns @true if the handler is able to open this file. This function doesn't
+        check whether the file exists or not, it only checks if it knows the protocol.
+    */
+    virtual bool CanOpen(const wxString& location);
+
+    /**
+        Opens the file and returns wxFSFile pointer or @NULL if failed.
+
+        @param fs
+            Parent FS (the FS from that OpenFile was called).
+            See the ZIP handler for details of how to use it.
+        @param location
+            The absolute location of file.
+    */
+    virtual wxFSFile* OpenFile(wxFileSystem& fs, const wxString& location);
 };
 

--- a/interface/wx/fs_mem.h
+++ b/interface/wx/fs_mem.h
@@ -116,5 +116,41 @@ public:
         Removes a file from memory FS and frees the occupied memory.
     */
     static void RemoveFile(const wxString& filename);
+
+    /**
+        Returns @true if the handler is able to open this file. This function doesn't
+        check whether the file exists or not, it only checks if it knows the protocol.
+    */
+    virtual bool CanOpen(const wxString& location);
+
+    /**
+        Opens the file and returns wxFSFile pointer or @NULL if failed.
+
+        @param fs
+            Parent FS (the FS from that OpenFile was called).
+            See the ZIP handler for details of how to use it.
+        @param location
+            The absolute location of file.
+    */
+    virtual wxFSFile* OpenFile(wxFileSystem& fs, const wxString& location);
+
+    /**
+        Works like ::wxFindFirstFile().
+
+        Returns the name of the first filename (within filesystem's current path)
+        that matches @e wildcard. @a flags may be one of wxFILE (only files),
+        wxDIR (only directories) or 0 (both).
+
+        This method is only called if CanOpen() returns @true.
+    */
+    virtual wxString FindFirst(const wxString& spec, int flags = 0);
+
+    /**
+        Returns next filename that matches parameters passed to wxFileSystem::FindFirst.
+
+        This method is only called if CanOpen() returns @true and FindFirst()
+        returned a non-empty string.
+    */
+    virtual wxString FindNext();
 };
 


### PR DESCRIPTION
This is part of resolving a Phoenix issue, see:
https://github.com/wxWidgets/Phoenix/issues/175
