### PR TITLE
Fix building wxMediaCtrl with OS X 10.12 SDK

### DIFF
--- a/configure
+++ b/configure
@@ -3210,6 +3210,97 @@ fi
   as_fn_set_status $ac_retval
 
 } # ac_fn_cxx_try_run
+
+# ac_fn_c_check_header_mongrel LINENO HEADER VAR INCLUDES
+# -------------------------------------------------------
+# Tests whether HEADER exists, giving a warning if it cannot be compiled using
+# the include files in INCLUDES and setting the cache variable VAR
+# accordingly.
+ac_fn_c_check_header_mongrel ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  if eval \${$3+:} false; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
+$as_echo_n "checking for $2... " >&6; }
+if eval \${$3+:} false; then :
+  $as_echo_n "(cached) " >&6
+fi
+eval ac_res=\$$3
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+else
+  # Is the header compilable?
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking $2 usability" >&5
+$as_echo_n "checking $2 usability... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$4
+#include <$2>
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_header_compiler=yes
+else
+  ac_header_compiler=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_header_compiler" >&5
+$as_echo "$ac_header_compiler" >&6; }
+
+# Is the header present?
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking $2 presence" >&5
+$as_echo_n "checking $2 presence... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <$2>
+_ACEOF
+if ac_fn_c_try_cpp "$LINENO"; then :
+  ac_header_preproc=yes
+else
+  ac_header_preproc=no
+fi
+rm -f conftest.err conftest.i conftest.$ac_ext
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_header_preproc" >&5
+$as_echo "$ac_header_preproc" >&6; }
+
+# So?  What about this header?
+case $ac_header_compiler:$ac_header_preproc:$ac_c_preproc_warn_flag in #((
+  yes:no: )
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2: accepted by the compiler, rejected by the preprocessor!" >&5
+$as_echo "$as_me: WARNING: $2: accepted by the compiler, rejected by the preprocessor!" >&2;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2: proceeding with the compiler's result" >&5
+$as_echo "$as_me: WARNING: $2: proceeding with the compiler's result" >&2;}
+    ;;
+  no:yes:* )
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2: present but cannot be compiled" >&5
+$as_echo "$as_me: WARNING: $2: present but cannot be compiled" >&2;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2:     check for missing prerequisite headers?" >&5
+$as_echo "$as_me: WARNING: $2:     check for missing prerequisite headers?" >&2;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2: see the Autoconf documentation" >&5
+$as_echo "$as_me: WARNING: $2: see the Autoconf documentation" >&2;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2:     section \"Present But Cannot Be Compiled\"" >&5
+$as_echo "$as_me: WARNING: $2:     section \"Present But Cannot Be Compiled\"" >&2;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2: proceeding with the compiler's result" >&5
+$as_echo "$as_me: WARNING: $2: proceeding with the compiler's result" >&2;}
+( $as_echo "## -------------------------------------- ##
+## Report this to wx-dev@googlegroups.com ##
+## -------------------------------------- ##"
+     ) | sed "s/^/$as_me: WARNING:     /" >&2
+    ;;
+esac
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
+$as_echo_n "checking for $2... " >&6; }
+if eval \${$3+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  eval "$3=\$ac_header_compiler"
+fi
+eval ac_res=\$$3
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+fi
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+
+} # ac_fn_c_check_header_mongrel
 cat >config.log <<_ACEOF
 This file contains any messages produced by compilers while
 running configure, to aid debugging if configure makes a mistake.
@@ -35276,7 +35367,33 @@ fi
         if test "$wxUSE_OSX_IPHONE" = 1; then
                         GST_LIBS="-framework AVFoundation -framework CoreMedia"
         else
-                                    GST_LIBS="-framework QTKit"
+
+            old_CPPFLAGS="$CPPFLAGS"
+            CPPFLAGS="-x objective-c++ $CPPFLAGS"
+            ac_fn_c_check_header_mongrel "$LINENO" "QTKit/QTKit.h" "ac_cv_header_QTKit_QTKit_h" "$ac_includes_default"
+if test "x$ac_cv_header_QTKit_QTKit_h" = xyes; then :
+
+                                GST_LIBS="-framework QTKit"
+
+else
+
+                                $as_echo "#define wxOSX_USE_QTKIT 0" >>confdefs.h
+
+                                GST_LIBS="-framework AVFoundation -framework CoreMedia"
+
+fi
+
+
+                        ac_fn_c_check_header_mongrel "$LINENO" "AVKit/AVKit.h" "ac_cv_header_AVKit_AVKit_h" "$ac_includes_default"
+if test "x$ac_cv_header_AVKit_AVKit_h" = xyes; then :
+
+                                GST_LIBS="$GST_LIBS -framework AVKit"
+
+fi
+
+
+            CPPFLAGS="$old_CPPFLAGS"
+
         fi
     fi
 

--- a/configure.in
+++ b/configure.in
@@ -7411,7 +7411,25 @@ if test "$wxUSE_MEDIACTRL" = "yes" -o "$wxUSE_MEDIACTRL" = "auto"; then
         else
             dnl We always have the necessary libraries under Mac
             dnl but we need to link with it explicitly.
-            GST_LIBS="-framework QTKit"
+            dnl QTKit is no longer available as of 10.12 SDK
+
+            old_CPPFLAGS="$CPPFLAGS"
+            CPPFLAGS="-x objective-c++ $CPPFLAGS"
+            AC_CHECK_HEADER([QTKit/QTKit.h],
+                            [
+                                GST_LIBS="-framework QTKit"
+                            ],
+                            [
+                                AC_DEFINE(wxOSX_USE_QTKIT,0)
+                                GST_LIBS="-framework AVFoundation -framework CoreMedia"
+                            ])
+            dnl AVKit is only available since OS X 10.9
+            AC_CHECK_HEADER([AVKit/AVKit.h],
+                            [
+                                GST_LIBS="$GST_LIBS -framework AVKit"
+                            ])
+            CPPFLAGS="$old_CPPFLAGS"
+
         fi
     fi
 

--- a/setup.h.in
+++ b/setup.h.in
@@ -878,6 +878,11 @@
 #define wxUSE_WEBKIT 0
 
 /*
+ * wxMediaCtrl on OS X
+ */
+#undef wxOSX_USE_QTKIT
+
+/*
  * Objective-C class name uniquifying
  */
 #define wxUSE_OBJC_UNIQUIFYING 0

--- a/src/osx/cocoa/mediactrl.mm
+++ b/src/osx/cocoa/mediactrl.mm
@@ -578,7 +578,7 @@ private:
         id val = [change objectForKey:NSKeyValueChangeNewKey];
         if ( val != [NSNull null ] )
         {
-            AVPlayerStatus status = [ val integerValue];
+            AVPlayerStatus status = (AVPlayerStatus) [ val integerValue];
 
             switch (status)
             {


### PR DESCRIPTION
Since OS X Sierra 10.12 QTKit has been removed. wxMediaCtrl for OS X already had a fallback to AVFoundation implemented. This makes sure this will be used and the correct media Frameworks are used for linking.

This is related to:
[#17685](http://trac.wxwidgets.org/ticket/17685) and [#17639](http://trac.wxwidgets.org/ticket/17639)
