### PR TITLE
Set HDS_NOSIZING in wxHeaderCtrl when appropriate

### DIFF
--- a/src/msw/headerctrl.cpp
+++ b/src/msw/headerctrl.cpp
@@ -386,6 +386,27 @@ void wxHeaderCtrl::DoInsertItem(const wxHeaderColumn& col, unsigned int idx)
     {
         wxLogLastError(wxT("Header_InsertItem()"));
     }
+
+    // Resizing cursor that correctly reflects per-column IsResizable() cannot
+    // be implemented, it is per-control rather than per-column in the native
+    // control. Enable resizing cursor if at least one column is resizeble.
+    bool hasResizableColumns = false;
+    for ( unsigned n = 0; n < GetColumnCount(); n++ )
+    {
+        const wxHeaderColumn& c = GetColumn(n);
+        if (c.IsShown() && c.IsResizeable())
+        {
+            hasResizableColumns = true;
+            break;
+        }
+    }
+
+    long controlStyle = ::GetWindowLong(GetHwnd(), GWL_STYLE);
+    if ( hasResizableColumns )
+        controlStyle &= ~HDS_NOSIZING;
+    else
+        controlStyle |= HDS_NOSIZING;
+    ::SetWindowLong(GetHwnd(), GWL_STYLE, controlStyle);
 }
 
 void wxHeaderCtrl::DoSetColumnsOrder(const wxArrayInt& order)


### PR DESCRIPTION
Native Windows header control doesn't have the ability to show
per-column resizing cursor and it's only possible to enable or disable
it for the entire control, so we can't fully support the wxHeaderColumn
API. But we can at least hide the resizing cursor if none of the columns
are resizable.
