### PR TITLE
Multiple wxDataViewCtrl item rendering fixes

### DIFF
--- a/include/wx/generic/private/markuptext.h
+++ b/include/wx/generic/private/markuptext.h
@@ -11,9 +11,9 @@
 #define _WX_GENERIC_PRIVATE_MARKUPTEXT_H_
 
 #include "wx/defs.h"
+#include "wx/gdicmn.h"
 
 class WXDLLIMPEXP_FWD_CORE wxDC;
-class WXDLLIMPEXP_FWD_CORE wxRect;
 
 class wxMarkupParserOutput;
 
@@ -84,10 +84,14 @@ public:
     // The meaning of the flags here is different than in the overload above:
     // they're passed to DrawItemText() and Render_ShowAccels is not supported
     // here.
+    //
+    // Currently the only supported ellipsize modes are wxELLIPSIZE_NONE and
+    // wxELLIPSIZE_END, the others are treated as wxELLIPSIZE_END.
     void RenderItemText(wxWindow *win,
                         wxDC& dc,
                         const wxRect& rect,
-                        int rendererFlags);
+                        int rendererFlags,
+                        wxEllipsizeMode ellipsizeMode);
 
 private:
     wxString m_markup;

--- a/include/wx/osx/cocoa/private/markuptoattr.h
+++ b/include/wx/osx/cocoa/private/markuptoattr.h
@@ -22,8 +22,8 @@ public:
     // We don't care about the original colours because we never use them but
     // we do need the correct initial font as we apply modifiers (e.g. create a
     // font larger than it) to it and so it must be valid.
-    wxMarkupToAttrString(wxWindow *win, const wxString& markup)
-        : wxMarkupParserAttrOutput(win->GetFont(), wxColour(), wxColour())
+    wxMarkupToAttrString(const wxFont& font, const wxString& markup)
+        : wxMarkupParserAttrOutput(font, wxColour(), wxColour())
     {
         const wxCFStringRef
             label(wxControl::RemoveMnemonics(wxMarkupParser::Strip(markup)));
@@ -39,7 +39,7 @@ public:
         // default which is different from the system "Lucida Grande" font. So
         // we need to explicitly change the font for the entire string.
         [m_attrString addAttribute:NSFontAttributeName
-                      value:win->GetFont().OSXGetNSFont()
+                      value:font.OSXGetNSFont()
                       range:NSMakeRange(0, [m_attrString length])];
 
         // Now translate the markup tags to corresponding attributes.

--- a/include/wx/private/markupparserattr.h
+++ b/include/wx/private/markupparserattr.h
@@ -30,19 +30,42 @@
 class wxMarkupParserAttrOutput : public wxMarkupParserOutput
 {
 public:
-    // A simple container of font and colours.
+    // A container of font and colours with inheritance support. It holds two
+    // sets of attributes:
+    // 1. The currently specified ones from parsed tags that contain
+    //    information on on what should change in the output; some of them
+    //    may be invalid if only the others are affected by a change.
+    // 2. The _effective_ attributes that are always valid and accumulate
+    //    all past changes as the markup is being parser; these are used
+    //    to restore state when unwinding nested attributes.
     struct Attr
     {
-        Attr(const wxFont& font_,
+        Attr(const Attr *attrInEffect,
+             const wxFont& font_,
              const wxColour& foreground_ = wxColour(),
              const wxColour& background_ = wxColour())
             : font(font_), foreground(foreground_), background(background_)
         {
+            if (attrInEffect)
+            {
+                effectiveFont = font.IsOk() ? font : attrInEffect->effectiveFont;
+                effectiveForeground = foreground_.IsOk() ? foreground_ : attrInEffect->effectiveForeground;
+                effectiveBackground = background.IsOk() ? background : attrInEffect->effectiveBackground;
+            }
+            else
+            {
+                effectiveFont = font;
+                effectiveForeground = foreground;
+                effectiveBackground = background;
+            }
         }
 
         wxFont font;
         wxColour foreground,
                  background;
+        wxFont   effectiveFont;
+        wxColour effectiveForeground,
+                 effectiveBackground;
     };
 
 
@@ -52,7 +75,7 @@ public:
                              const wxColour& foreground,
                              const wxColour& background)
     {
-        m_attrs.push(Attr(font, foreground, background));
+        m_attrs.push(Attr(NULL, font, foreground, background));
     }
 
     // Indicates the change of the font and/or colours used. Any of the
@@ -141,7 +164,7 @@ public:
         }
 
 
-        const Attr attr(font, spanAttr.m_fgCol, spanAttr.m_bgCol);
+        const Attr attr(&m_attrs.top(), font, spanAttr.m_fgCol, spanAttr.m_bgCol);
         OnAttrStart(attr);
 
         m_attrs.push(attr);
@@ -171,7 +194,7 @@ private:
     // about the change and update the attributes stack.
     void DoSetFont(const wxFont& font)
     {
-        const Attr attr(font);
+        const Attr attr(&m_attrs.top(), font);
 
         OnAttrStart(attr);
 

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -1095,7 +1095,7 @@ bool wxDataViewTextRenderer::Render(wxRect rect, wxDC *dc, int state)
         int flags = 0;
         if ( state & wxDATAVIEW_CELL_SELECTED )
             flags |= wxCONTROL_SELECTED;
-        m_markupText->RenderItemText(GetView(), *dc, rect, flags);
+        m_markupText->RenderItemText(GetView(), *dc, rect, flags, GetEllipsizeMode());
     }
     else
 #endif // wxUSE_MARKUP

--- a/src/generic/markuptext.cpp
+++ b/src/generic/markuptext.cpp
@@ -237,18 +237,22 @@ public:
     wxMarkupParserRenderItemOutput(wxWindow *win,
                                    wxDC& dc,
                                    const wxRect& rect,
-                                   int rendererFlags)
+                                   int rendererFlags,
+                                   wxEllipsizeMode ellipsizeMode)
         : wxMarkupParserRenderOutput(dc, rect, wxMarkupText::Render_Default),
           m_win(win),
           m_rendererFlags(rendererFlags),
           m_renderer(&wxRendererNative::Get())
     {
+        // TODO: Support all ellipsizing modes
+        m_ellipsizeMode = ellipsizeMode == wxELLIPSIZE_NONE ? wxELLIPSIZE_NONE : wxELLIPSIZE_END;
     }
 
     virtual void OnText(const wxString& text) wxOVERRIDE
     {
         wxRect rect(m_rect);
         rect.x = m_pos;
+        rect.SetRight(m_rect.GetRight());
 
         m_renderer->DrawItemText(m_win,
                                  m_dc,
@@ -256,7 +260,7 @@ public:
                                  rect,
                                  wxALIGN_LEFT | wxALIGN_CENTRE_VERTICAL,
                                  m_rendererFlags,
-                                 wxELLIPSIZE_NONE);
+                                 m_ellipsizeMode);
 
         m_pos += m_dc.GetTextExtent(text).x;
     }
@@ -264,6 +268,7 @@ public:
 private:
     wxWindow* const m_win;
     int const m_rendererFlags;
+    wxEllipsizeMode m_ellipsizeMode;
     wxRendererNative* const m_renderer;
 
     wxDECLARE_NO_COPY_CLASS(wxMarkupParserRenderItemOutput);
@@ -310,9 +315,10 @@ void wxMarkupText::Render(wxDC& dc, const wxRect& rect, int flags)
 void wxMarkupText::RenderItemText(wxWindow *win,
                                   wxDC& dc,
                                   const wxRect& rect,
-                                  int rendererFlags)
+                                  int rendererFlags,
+                                  wxEllipsizeMode ellipsizeMode)
 {
-    wxMarkupParserRenderItemOutput out(win, dc, rect, rendererFlags);
+    wxMarkupParserRenderItemOutput out(win, dc, rect, rendererFlags, ellipsizeMode);
     wxMarkupParser parser(out);
     parser.Parse(m_markup);
 }

--- a/src/generic/markuptext.cpp
+++ b/src/generic/markuptext.cpp
@@ -156,11 +156,11 @@ public:
 
         // ...but we only need to restore the colours if we had changed them.
         if ( attr.foreground.IsOk() )
-            m_dc.SetTextForeground(GetAttr().foreground);
+            m_dc.SetTextForeground(GetAttr().effectiveForeground);
 
         if ( attr.background.IsOk() )
         {
-            wxColour background = GetAttr().background;
+            wxColour background = GetAttr().effectiveBackground;
             if ( !background.IsOk() )
             {
                 // Invalid background colour indicates that the background

--- a/src/osx/cocoa/button.mm
+++ b/src/osx/cocoa/button.mm
@@ -107,7 +107,7 @@ void wxButtonCocoaImpl::SetBitmap(const wxBitmap& bitmap)
 #if wxUSE_MARKUP
 void wxButtonCocoaImpl::SetLabelMarkup(const wxString& markup)
 {
-    wxMarkupToAttrString toAttr(GetWXPeer(), markup);
+    wxMarkupToAttrString toAttr(GetWXPeer()->GetFont(), markup);
     NSMutableAttributedString *attrString = toAttr.GetNSAttributedString();
     
     // Button text is always centered.

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2825,17 +2825,29 @@ void wxDataViewTextRenderer::EnableMarkup(bool enable)
 
 bool wxDataViewTextRenderer::MacRender()
 {
+    NSCell *cell = GetNativeData()->GetItemCell();
 #if wxUSE_MARKUP
     if ( m_useMarkup )
     {
         wxMarkupToAttrString toAttr(GetView(), GetValue().GetString());
+        NSMutableAttributedString *str = toAttr.GetNSAttributedString();
 
-        [GetNativeData()->GetItemCell() setAttributedStringValue:toAttr.GetNSAttributedString()];
+        if ( [cell lineBreakMode] != NSLineBreakByClipping )
+        {
+            NSMutableParagraphStyle *par = [[NSMutableParagraphStyle defaultParagraphStyle] mutableCopy];
+            [par setLineBreakMode:[cell lineBreakMode]];
+            [str addAttribute:NSParagraphStyleAttributeName
+                        value:par
+                        range:NSMakeRange(0, [str length])];
+            [par release];
+        }
+
+        [cell setAttributedStringValue:str];
         return true;
     }
 #endif // wxUSE_MARKUP
 
-    [GetNativeData()->GetItemCell() setObjectValue:wxCFStringRef(GetValue().GetString()).AsNSString()];
+    [cell setObjectValue:wxCFStringRef(GetValue().GetString()).AsNSString()];
     return true;
 }
 

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2829,7 +2829,7 @@ bool wxDataViewTextRenderer::MacRender()
 #if wxUSE_MARKUP
     if ( m_useMarkup )
     {
-        wxMarkupToAttrString toAttr(GetView(), GetValue().GetString());
+        wxMarkupToAttrString toAttr(wxFont([cell font]), GetValue().GetString());
         NSMutableAttributedString *str = toAttr.GetNSAttributedString();
 
         if ( [cell lineBreakMode] != NSLineBreakByClipping )

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2733,7 +2733,7 @@ void wxDataViewRenderer::SetAttr(const wxDataViewItemAttr& attr)
         //else: can't change font if the cell doesn't have any
     }
 
-    if ( attr.HasColour() )
+    if ( attr.HasColour() && ![cell isHighlighted] )
     {
         // we can set font for any cell but only NSTextFieldCell provides
         // a method for setting text colour so check that this method is
@@ -2840,6 +2840,12 @@ bool wxDataViewTextRenderer::MacRender()
                         value:par
                         range:NSMakeRange(0, [str length])];
             [par release];
+        }
+
+        if ( [cell isHighlighted] )
+        {
+            [str removeAttribute:NSForegroundColorAttributeName range:NSMakeRange(0, [str length])];
+            [str removeAttribute:NSBackgroundColorAttributeName range:NSMakeRange(0, [str length])];
         }
 
         [cell setAttributedStringValue:str];

--- a/src/osx/cocoa/stattext.mm
+++ b/src/osx/cocoa/stattext.mm
@@ -104,7 +104,7 @@ public:
 #if wxUSE_MARKUP
     virtual void SetLabelMarkup( const wxString& markup) wxOVERRIDE
     {
-        wxMarkupToAttrString toAttr(GetWXPeer(), markup);
+        wxMarkupToAttrString toAttr(GetWXPeer()->GetFont(), markup);
 
         DoSetAttrString(toAttr.GetNSAttributedString());
     }


### PR DESCRIPTION
This is a bit of a mixed bag, but it’s all closely related and covers ellipsizing of markup and proper handling of colors/fonts with and without markup. I’d appreciate a quick look especially at the generic parts to see if I’m not doing something stupid.
