### PR TITLE
Don't create wxWindowAccessible by default

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -38,6 +38,10 @@ Changes in behaviour not resulting in compilation errors
   for getting the micro version. If you override GetToolkitVersion() you need
   to add this new third parameter.
 
+- wxWindow::CreateAccessible() doesn't return accessible object by default
+  anymore and GetOrCreateAccessible() may return NULL, indicating that native
+  system-provided accessibility should be used.
+
 Changes in behaviour which may result in build errors
 -----------------------------------------------------
 

--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -1449,7 +1449,7 @@ public:
     // ----------------------
 #if wxUSE_ACCESSIBILITY
     // Override to create a specific accessible object.
-    virtual wxAccessible* CreateAccessible();
+    virtual wxAccessible* CreateAccessible() { return NULL; }
 
     // Sets the accessible object.
     void SetAccessible(wxAccessible* accessible) ;
@@ -1457,7 +1457,8 @@ public:
     // Returns the accessible object.
     wxAccessible* GetAccessible() { return m_accessible; }
 
-    // Returns the accessible object, creating if necessary.
+    // Returns the accessible object, calling CreateAccessible if necessary.
+    // May return NULL, in which case system-provide accessible is used.
     wxAccessible* GetOrCreateAccessible() ;
 #endif
 

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -3186,12 +3186,6 @@ wxAccessible* wxWindowBase::GetOrCreateAccessible()
     return m_accessible;
 }
 
-// Override to create a specific accessible object.
-wxAccessible* wxWindowBase::CreateAccessible()
-{
-    return new wxWindowAccessible((wxWindow*) this);
-}
-
 #endif
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
**tl;dr:** This reduces the impact of `wxUSE_ACCESSIBILITY` to only windows that actively use it, instead of the current all-or-nothing situation that degrades accessibility interface of all windows. It also makes it safe to enable the flag by default (I think we should, especially in light of Artur's work).

The change deserves a longer explanation. Let me preface it by saying that I _really_ didn’t want to do this. I’ve been agonizing over it for a week, but ultimately didn’t find any other acceptable solution.

The problem it addresses is three-fold:
1. `wxUSE_ACCESSIBILITY` is not in a good shape. The last non-trivial change to its `IAccessible` code was in 2009(!), the last _substantial_ change is even older. `IAccessible` isn’t fully implemented, neither is `wxWindowAccessible`, most of which is doing things native code already does, sometimes in worse ways (focus problems, not getting proper labels for anything but wxButtons).
2. It’s off by default, making it very unlikely for bugs to be fixed or even noticed.
3. It is _intrusive_. Enable the flag and suddenly your application starts behaving very differently under screen readers or MSAA inspectors. It replaces perfectly good standard Windows implementations of `IAccessible` for common controls or even for things like a plain container window with wx's implementation. There’s nothing gained by doing that and due to 1., it actually _degrades_ the quality of accessibility support by substituting inferior implementations.

Let me show you an example of Poedit inspected with `inspect.exe`. This is wx with no accessibility whatsoever:

![accessibility_off](https://cloud.githubusercontent.com/assets/145881/19562113/6684691a-96db-11e6-91dd-a7787384c8ee.png)

And this is with `wxUSE_ACCESSIBILITY` enabled:

![vanilla_wx](https://cloud.githubusercontent.com/assets/145881/19562122/6fbb9c38-96db-11e6-9615-483bff328e1b.png)

The latter is worse in highlighted areas and that’s without considering the behavior.

So what this patch does (finally!) is that it reduces the _impact_ of accessibility code by making sure it is used only when it servers a useful role: in other words, for custom controls with custom `wxAccessible` implementations. `wxWindowAcessible` is still useful as their base class, but it is no longer used as the default implementation for anything.

This has compatibility consequences:
1. Code may be expecting accessible objects always, no longer true.
2. We loose the “help” text hooks into help providers. I looked around in various applications and didn’t see this property set anywhere. If needed, explicitly instantiating `wxWindowAccessible` fixes it.

But most importantly, it makes wx apps behave as expected even with `wxUSE_ACCESSIBILITY` enabled, while still allowing custom controls to do the right thing.

Ideally, this would be followed by more work: namely removing all the redundant implementations from `wxWindowAccessible` and removing any extra work from `wxIAccessible` so that it servers as a pure proxy to the standard implementation, allowing custom controls to easily customize only the relevant bits of functionality. But the most important part is taking `wxIAccessible` out of the equation in 99% of places where no customization is intended.

Some other alternatives I considered:
1. Just fix the wx implementation. Unrealistic and a moving target.
2. Cut the wx code to the bone, only leave things that are not-default (help text) and rigorously proxy everything else to the native standard impl. from `CreateStdAccessibleObject` (or `CreateStdAccessibleProxy`, but I don’t think wx is subclassing in a way that matters here, is it?). Nice in theory, but the standard proxy _also_ doesn’t behave as the native thing returned from `WM_GETOBJECT`. Probably because it is, per MSDN, intended to help with implementing custom controls, not to be used for _every single window_.
3. Likewise, but use the object returned from default wnd proc `WM_GETOBJECT`. This would require use of `ObjectFromLresult`, which is explicitly documented as being for internal use and “should not call”. I’m not comfortable with using it.
4. Have `wxUSE_ACCESSIBILITY_SUPPORT` in addition to the old setting, which would differ from `wxUSE_ACCESSIBILITY` only in lack of `CreateAccessible` implementation — it would provide the API needed by custom controls, but wouldn’t force the impl. everywhere. But I think the behavior pre-this-patch was so buggy that it doesn’t make sense to retain it.

It’s also worth noting that Microsoft realized MSAA was deeply flawed, hence UI Automation, and _even within MSAA_, providing custom `IAccessible` is meant for the custom control scenario that needs it. Simple accessibility annotations (the kind that any wx app would benefit from) can and should be done in a lighter way with properties annotation. So it really makes little sense to force the custom impl in such a heavy-handed way.

So in the end, I think this small change, even though not backwards compatible, really is the best thing to do.

/cc @vadz @a-wi
