### PR TITLE
Implement wxLB_NO_SB style for wxListBox/GTK2

### DIFF
--- a/interface/wx/listbox.h
+++ b/interface/wx/listbox.h
@@ -46,7 +46,7 @@
     @style{wxLB_NEEDED_SB}
         Only create a vertical scrollbar if needed.
     @style{wxLB_NO_SB}
-        Don't create vertical scrollbar (wxMSW only).
+        Don't create vertical scrollbar (wxMSW/wxGTK only).
     @style{wxLB_SORT}
         The listbox contents are sorted in alphabetical order.
     @endStyleTable

--- a/src/gtk/listbox.cpp
+++ b/src/gtk/listbox.cpp
@@ -275,16 +275,15 @@ bool wxListBox::Create( wxWindow *parent, wxWindowID id,
 
     m_widget = gtk_scrolled_window_new( NULL, NULL );
     g_object_ref(m_widget);
+
+    GtkPolicyType gtk_vpolicy = GTK_POLICY_AUTOMATIC;
     if (style & wxLB_ALWAYS_SB)
-    {
-      gtk_scrolled_window_set_policy( GTK_SCROLLED_WINDOW(m_widget),
-        GTK_POLICY_AUTOMATIC, GTK_POLICY_ALWAYS );
-    }
-    else
-    {
-      gtk_scrolled_window_set_policy( GTK_SCROLLED_WINDOW(m_widget),
-        GTK_POLICY_AUTOMATIC, GTK_POLICY_AUTOMATIC );
-    }
+        gtk_vpolicy = GTK_POLICY_ALWAYS;
+    else if (style & wxLB_NO_SB)
+        gtk_vpolicy = GTK_POLICY_NEVER;
+
+    gtk_scrolled_window_set_policy( GTK_SCROLLED_WINDOW(m_widget),
+        GTK_POLICY_AUTOMATIC, gtk_vpolicy );
 
 
     GTKScrolledWindowSetBorder(m_widget, style);


### PR DESCRIPTION
Based on:
https://developer.gnome.org/gtk2/stable/GtkScrolledWindow.html#gtk-scrolled-window-set-policy

Code wasn't tested but it ought to behave as expected. Documentation would require an update http://docs.wxwidgets.org/3.1/classwx_list_box.html