### PR TITLE
Fix owner drawn dropdown row height.

### DIFF
--- a/src/generic/odcombo.cpp
+++ b/src/generic/odcombo.cpp
@@ -85,7 +85,7 @@ bool wxVListBoxComboPopup::Create(wxWindow* parent)
     wxVListBox::SetItemCount(m_strings.GetCount());
 
     // TODO: Move this to SetFont
-    m_itemHeight = GetCharHeight() + 0;
+    m_itemHeight = m_combo->GetCharHeight();
 
     return true;
 }


### PR DESCRIPTION
While m_combo->GetFont(); sets the proper font, the size of that font did not affect the character height.