### PR TITLE
Allow pasting using Cmd+V in wxTextCtrl with wxTE_PASSWORD style

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -164,6 +164,7 @@ wxOSX:
 - Implement wxDataViewCtrl::SetRowHeight().
 - Add OSXEnableAutomaticQuoteSubstitution(), OSXEnableAutomaticDashSubstitution()
   and OSXDisableAllSmartSubstitutions() to control wxTextCtrl smart behavior.
+- Allow pasting using Cmd+V in wxTextCtrl with wxTE_PASSWORD style.
 
 Unix:
 

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -258,6 +258,25 @@ NSView* wxMacEditHelper::ms_viewCurrentlyEdited = nil;
                      }
                 }
             }
+            else if ( commandSelector == @selector(noop:) )
+            {
+                // We are called with this strange "noop:" selector when an
+                // attempt to paste the text into a password text control using
+                // Cmd+V is made. Check if we're really in this case and, if
+                // we're, do paste as otherwise nothing happens by default
+                // which is annoying, it is pretty common and useful to paste
+                // passwords, e.g. from a password manager.
+                NSEvent* cevent = [[NSApplication sharedApplication] currentEvent];
+                if ( [cevent type] == NSKeyDown &&
+                        [cevent keyCode] == 9 /* V */ &&
+                            ([cevent modifierFlags] & NSCommandKeyMask) == NSCommandKeyMask )
+                {
+                    wxTextWidgetImpl* impl = (wxNSTextFieldControl * ) wxWidgetImpl::FindFromWXWidget( self );
+                    wxTextEntry * const entry = impl->GetTextEntry();
+                    entry->Paste();
+                    handled = YES;
+                }
+            }
         }
     }
     


### PR DESCRIPTION
For some reason known only to Apple, NSSecureTextField allows pasting text
into it using its standard context menu, but not using the standard Cmd+V
keyboard shortcut. Moreover, apparently the control does something special to
disable it because pressing Cmd+V does result in a call to
-[NSSecureTextField control:textView:doCommandBySelector:], but with a dummy
"noop:" selector.

Detect this specific situation and check if we're called while handling Cmd+V
event and, if this is indeed the case, do paste the text into the control.

While it could be argued that this changes the platform behaviour, it seems
very hard, if not impossible, to imagine a situation in which this would be a
problem while not being able to easily paste into password fields is
definitely a real usability bug.

---

@vslavik I'd appreciate any comments about this, TIA!