### PR TITLE
Implement background color support for generic wxDVC

### DIFF
--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -70,6 +70,7 @@ enum wxCompositionMode
     wxCOMPOSITION_ADD /* R = S + D */
 };
 
+class WXDLLIMPEXP_FWD_CORE wxDC;
 class WXDLLIMPEXP_FWD_CORE wxWindowDC;
 class WXDLLIMPEXP_FWD_CORE wxMemoryDC;
 #if wxUSE_PRINTING_ARCHITECTURE
@@ -435,6 +436,11 @@ public:
 #if wxUSE_ENH_METAFILE
     static wxGraphicsContext * Create( const wxEnhMetaFileDC& dc);
 #endif
+#endif
+
+#ifndef wxNO_RTTI
+    // Create a context from a DC of unknown type, if supported, returns NULL otherwise
+    static wxGraphicsContext* CreateFromUnknownDC(const wxDC& dc);
 #endif
 
     static wxGraphicsContext* CreateFromNative( void * context );

--- a/interface/wx/graphics.h
+++ b/interface/wx/graphics.h
@@ -439,6 +439,21 @@ public:
     static wxGraphicsContext* Create(const wxEnhMetaFileDC& metaFileDC);
 
     /**
+        Creates a wxGraphicsContext from a DC of unknown specific type.
+
+        Creates a wxGraphicsContext if @a dc is a supported type (i.e. has a
+        corresponding Create() method, e.g. wxWindowDC or wxMemoryDC).
+        Returns @NULL if the DC is unsupported.
+
+        This method is only useful as a helper in generic code that operates
+        with wxDC and doesn't known its exact type. Use Create() instead if
+        you know that the DC is e.g. wxWindowDC.
+
+        @since 3.1.1
+     */
+    static wxGraphicsContext* CreateFromUnknownDC(wxDC& dc);
+
+    /**
         Creates a wxGraphicsContext associated with a wxImage.
 
         The image specifies the size of the context as well as whether alpha is

--- a/src/common/graphcmn.cpp
+++ b/src/common/graphcmn.cpp
@@ -22,10 +22,16 @@
 #ifndef WX_PRECOMP
     #include "wx/icon.h"
     #include "wx/bitmap.h"
+    #include "wx/dcclient.h"
     #include "wx/dcmemory.h"
+    #include "wx/dcprint.h"
     #include "wx/math.h"
     #include "wx/region.h"
     #include "wx/log.h"
+#endif
+
+#ifdef __WXMSW__
+    #include "wx/msw/enhmeta.h"
 #endif
 
 #include "wx/private/graphics.h"
@@ -918,6 +924,31 @@ wxGraphicsBitmap wxGraphicsContext::CreateSubBitmap( const wxGraphicsBitmap &bmp
     return wxGraphicsRenderer::GetDefaultRenderer()->CreateContext(dc);
 }
 #endif
+#endif
+
+#ifndef wxNO_RTTI
+wxGraphicsContext* wxGraphicsContext::CreateFromUnknownDC(const wxDC& dc)
+{
+    if ( const wxWindowDC *windc = dynamic_cast<const wxWindowDC*>(&dc) )
+        return Create(*windc);
+
+    if ( const wxMemoryDC *memdc = dynamic_cast<const wxMemoryDC*>(&dc) )
+        return Create(*memdc);
+
+#if wxUSE_PRINTING_ARCHITECTURE
+    if ( const wxPrinterDC *printdc = dynamic_cast<const wxPrinterDC*>(&dc) )
+        return Create(*printdc);
+#endif
+
+#ifdef __WXMSW__
+#if wxUSE_ENH_METAFILE
+    if ( const wxEnhMetaFileDC *mfdc = dynamic_cast<const wxEnhMetaFileDC*>(&dc) )
+        return Create(*mfdc);
+#endif
+#endif
+
+    return NULL;
+}
 #endif
 
 wxGraphicsContext* wxGraphicsContext::CreateFromNative( void * context )


### PR DESCRIPTION
Unlike other ports, the generic wxDVC implementation ignored `bgcolor` — because it uses `DrawItemText()` which doesn’t respect it. 