### PR TITLE
Use more descriptive argument names for wxCopyFile() and others

### DIFF
--- a/include/wx/filefn.h
+++ b/include/wx/filefn.h
@@ -527,17 +527,17 @@ WXDLLIMPEXP_BASE bool wxIsWild(const wxString& pattern);
 WXDLLIMPEXP_BASE bool wxMatchWild(const wxString& pattern,  const wxString& text, bool dot_special = true);
 
 // Concatenate two files to form third
-WXDLLIMPEXP_BASE bool wxConcatFiles(const wxString& file1, const wxString& file2, const wxString& file3);
+WXDLLIMPEXP_BASE bool wxConcatFiles(const wxString& src1, const wxString& src2, const wxString& dest);
 
-// Copy file1 to file2
-WXDLLIMPEXP_BASE bool wxCopyFile(const wxString& file1, const wxString& file2,
+// Copy file
+WXDLLIMPEXP_BASE bool wxCopyFile(const wxString& src, const wxString& dest,
                                  bool overwrite = true);
 
 // Remove file
 WXDLLIMPEXP_BASE bool wxRemoveFile(const wxString& file);
 
 // Rename file
-WXDLLIMPEXP_BASE bool wxRenameFile(const wxString& file1, const wxString& file2, bool overwrite = true);
+WXDLLIMPEXP_BASE bool wxRenameFile(const wxString& oldpath, const wxString& newpath, bool overwrite = true);
 
 // Get current working directory.
 WXDLLIMPEXP_BASE wxString wxGetCwd();

--- a/interface/wx/filefn.h
+++ b/interface/wx/filefn.h
@@ -245,21 +245,21 @@ void wxSplitPath(const wxString& fullname,
 time_t wxFileModificationTime(const wxString& filename);
 
 /**
-    Renames @a file1 to @e file2, returning @true if successful.
+    Renames @a oldpath to @e newpath, returning @true if successful.
 
-    If @a file2 is a directory, @a file1 is moved into it (@a overwrite is
-    ignored in this case). Otherwise, if @a file2 is an existing file, it is
+    If @a newpath is a directory, @a oldpath is moved into it (@a overwrite is
+    ignored in this case). Otherwise, if @a newpath is an existing file, it is
     overwritten if @a overwrite is @true (default) and the function fails if @a
     overwrite is @false.
 
     @header{wx/filefn.h}
 */
-bool wxRenameFile(const wxString& file1,
-                   const wxString& file2,
+bool wxRenameFile(const wxString& oldpath,
+                   const wxString& newpath,
                    bool overwrite = true);
 
 /**
-    Copies @a file1 to @e file2, returning @true if successful. If @a overwrite
+    Copies @a src to @e dest, returning @true if successful. If @a overwrite
     parameter is @true (default), the destination file is overwritten if it
     exists, but if @a overwrite is @false, the functions fails in this case.
 
@@ -267,8 +267,8 @@ bool wxRenameFile(const wxString& file1,
 
     @header{wx/filefn.h}
 */
-bool wxCopyFile(const wxString& file1,
-                 const wxString& file2,
+bool wxCopyFile(const wxString& src,
+                 const wxString& dest,
                  bool overwrite = true);
 
 /**
@@ -345,14 +345,14 @@ wxString wxGetCwd();
 bool wxSetWorkingDirectory(const wxString& dir);
 
 /**
-    Concatenates @a file1 and @a file2 to @e file3, returning @true if
+    Concatenates @a src1 and @a src2 to @e dest, returning @true if
     successful.
 
     @header{wx/filefn.h}
 */
-bool wxConcatFiles(const wxString& file1,
-                    const wxString& file2,
-                    const wxString& file3);
+bool wxConcatFiles(const wxString& src1,
+                    const wxString& src2,
+                    const wxString& dest);
 
 /**
     Removes @e file, returning @true if successful.


### PR DESCRIPTION
wxConcatFiles, wxCopyFile, and wxRenameFile had non-self-descriptive arguments called file1, file2, ...