### PR TITLE
Add wxDataViewRenderer::HasDarkBackground()

### DIFF
--- a/include/wx/generic/dvrenderer.h
+++ b/include/wx/generic/dvrenderer.h
@@ -52,6 +52,12 @@ public:
                                 const wxMouseEvent* WXUNUSED(mouseEvent))
         { return false; }
 
+    void SetState(int state) { m_state = state; }
+
+protected:
+    virtual bool IsHighlighted() const wxOVERRIDE
+        { return m_state & wxDATAVIEW_CELL_SELECTED; }
+
 private:
     int                          m_align;
     wxDataViewCellMode           m_mode;
@@ -59,6 +65,8 @@ private:
     wxEllipsizeMode m_ellipsizeMode;
 
     wxDC *m_dc;
+
+    int m_state;
 
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxDataViewRenderer);
 };

--- a/include/wx/gtk/dvrenderer.h
+++ b/include/wx/gtk/dvrenderer.h
@@ -64,6 +64,8 @@ public:
     // different from the editor control widget for the custom renderers
     virtual GtkWidget* GtkGetEditorWidget() const;
 
+    void GtkSetCurrentItem(const wxDataViewItem& item) { m_itemBeingRendered = item; }
+
 private:
     // Change the mode at GTK level without touching m_mode, this is useful for
     // temporarily making the renderer insensitive but does mean that GetMode()
@@ -73,6 +75,8 @@ private:
 protected:
     virtual void SetAttr(const wxDataViewItemAttr& attr) wxOVERRIDE;
     virtual void SetEnabled(bool enabled) wxOVERRIDE;
+
+    virtual bool IsHighlighted() const wxOVERRIDE;
 
     virtual void GtkOnCellChanged(const wxVariant& value,
                                   const wxDataViewItem& item,
@@ -92,6 +96,9 @@ protected:
     // true if we hadn't changed any visual attributes or restored them since
     // doing this
     bool m_usingDefaultAttrs;
+
+    // the item currently being rendered
+    wxDataViewItem m_itemBeingRendered;
 
 protected:
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxDataViewRenderer);

--- a/include/wx/osx/dvrenderer.h
+++ b/include/wx/osx/dvrenderer.h
@@ -93,6 +93,8 @@ protected:
     void SetEnabled(bool WXUNUSED(enabled)) wxOVERRIDE { };
 #endif
 
+    virtual bool IsHighlighted() const wxOVERRIDE;
+
 private:
     // contains the alignment flags
     int m_alignment;

--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -658,12 +658,14 @@ wxDataViewRendererBase::wxDataViewRendererBase( const wxString &varianttype,
 {
     m_variantType = varianttype;
     m_owner = NULL;
+    m_valueAdjuster = NULL;
 }
 
 wxDataViewRendererBase::~wxDataViewRendererBase()
 {
     if ( m_editorCtrl )
         DestroyEditControl();
+    delete m_valueAdjuster;
 }
 
 wxDataViewCtrl* wxDataViewRendererBase::GetView() const
@@ -830,7 +832,14 @@ wxDataViewRendererBase::PrepareForItem(const wxDataViewModel *model,
     // Now check if we have a value and remember it for rendering it later.
     // Notice that we do it even if it's null, as the cell should be empty then
     // and not show the last used value.
-    const wxVariant& value = CheckedGetValue(model, item, column);
+    wxVariant value = CheckedGetValue(model, item, column);
+
+    if ( m_valueAdjuster )
+    {
+        if ( IsHighlighted() )
+            value = m_valueAdjuster->MakeHighlighted(value);
+    }
+
     SetValue(value);
 
     if ( !value.IsNull() )

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -969,6 +969,7 @@ wxDataViewRenderer::wxDataViewRenderer( const wxString &varianttype,
     m_mode = mode;
     m_ellipsizeMode = wxELLIPSIZE_MIDDLE;
     m_dc = NULL;
+    m_state = 0;
 }
 
 wxDataViewRenderer::~wxDataViewRenderer()
@@ -2264,10 +2265,16 @@ void wxDataViewMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
             cell_rect.y = GetLineStart( item );
             cell_rect.height = GetLineHeight( item );
 
+            bool selected = m_selection.IsSelected(item);
+
+            int state = 0;
+            if (m_hasFocus && selected)
+                state |= wxDATAVIEW_CELL_SELECTED;
+
+            cell->SetState(state);
             cell->PrepareForItem(model, dataitem, col->GetModelColumn());
 
             // draw the background
-            bool selected = m_selection.IsSelected(item);
             if ( !selected )
                 DrawCellBackground( cell, dc, cell_rect );
 
@@ -2322,10 +2329,6 @@ void wxDataViewMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
 
             if ( item_rect.width <= 0 )
                 continue;
-
-            int state = 0;
-            if (m_hasFocus && selected)
-                state |= wxDATAVIEW_CELL_SELECTED;
 
             // TODO: it would be much more efficient to create a clipping
             //       region for the entire column being rendered (in the OnPaint

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -2128,6 +2128,12 @@ wxEllipsizeMode wxDataViewRenderer::GetEllipsizeMode() const
     return mode;
 }
 
+bool wxDataViewRenderer::IsHighlighted() const
+{
+    return m_itemBeingRendered.IsOk() &&
+           GetOwner()->GetOwner()->IsSelected(m_itemBeingRendered);
+}
+
 void
 wxDataViewRenderer::GtkOnTextEdited(const char *itempath, const wxString& str)
 {
@@ -3078,6 +3084,7 @@ static void wxGtkTreeCellDataFunc( GtkTreeViewColumn *WXUNUSED(column),
             return;
     }
 
+    cell->GtkSetCurrentItem(item);
     cell->PrepareForItem(wx_model, item, column);
 }
 

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2767,6 +2767,11 @@ wxEllipsizeMode wxDataViewRenderer::GetEllipsizeMode() const
     return GetNativeData()->GetEllipsizeMode();
 }
 
+bool wxDataViewRenderer::IsHighlighted() const
+{
+    return [GetNativeData()->GetColumnCell() backgroundStyle] == NSBackgroundStyleDark;
+}
+
 void
 wxDataViewRenderer::OSXOnCellChanged(NSObject *object,
                                      const wxDataViewItem& item,


### PR DESCRIPTION
Let me start with a motivating example: in theory, you can render anything using a custom renderer — but that’s quite a bit of work, not to mention having worse accessibility on non-MSW platforms. In lot of cases, text renderer with markup support is all you need to accomplish good results.

One thing that can’t be done well automatically is custom text background, which typically won’t look good on a dark/selection background and needs to be replaced with some other color — *what* color that would be isn’t obvious or easily computed (human perception is a nasty thing) and I think would be best left to the application. Custom renderers react to the `wxDATAVIEW_CELL_SELECTED` state flag for this purpose, but text renderer with a markup can’t.

Another is bitmaps: it makes sense and is often done (see e.g. Apple Mail) that the bitmap is rendered inverted or kinda-inverted in selection.

This PR allows easy customization of stock renderers by overriding their `SetValue` and use this new method to determine how to adjust the value:

```cpp
    bool SetValue(const wxVariant& value) override
    {
        if (HasDarkBackground())
        {
            auto s = value.GetString();
            auto pos = s.find("bgcolor=\"");
            if (pos != wxString::npos)
            {
                s.replace(pos + 9, 7, "#ffffff5a");
                return wxDataViewTextRenderer::SetValue(s);
            }
        }
        return wxDataViewTextRenderer::SetValue(value);
    }
```

I don’t think this can be done in the model, where such messy rewriting could be avoided, under GTK+. (Conceptually, it would be wrong too, but then the wxDVC “model” isn’t really a model separated from presentation anyway.)

I wasn’t really sure about the name, but eventually settled on this one because it is descriptive, easier to find and more accurate than the alternatives. Which were: `IsHighlighted` (confusion with NSCell’s `isHighlighted` which is for out of focus too), `IsSelected` (ditto, non-descriptive) or `GetState` returning same flags as `Render` uses (couldn’t be implemented to return full set on all platforms consistently). If you think something else is better, I’ll rename it — I’m not *happy* about this name either.

This PR also includes some prep work (fixing poor wxDVC behavior on macOS) that is not a dependency, but is loosely related and illustrates how the similar problem is solved in macOS (and for that matter our generic implementation). 