### PR TITLE
Declare Objective-C protocols in the code using web view

### DIFF
--- a/src/html/htmlctrl/webkit/webkit.mm
+++ b/src/html/htmlctrl/webkit/webkit.mm
@@ -130,7 +130,7 @@ inline int wxNavTypeFromWebNavType(int type){
     return wxWEBKIT_NAV_OTHER;
 }
 
-@interface MyFrameLoadMonitor : NSObject
+@interface MyFrameLoadMonitor : NSObject <WebFrameLoadDelegate>
 {
     wxWebKitCtrl* webKitWindow;
 }
@@ -139,7 +139,7 @@ inline int wxNavTypeFromWebNavType(int type){
 
 @end
 
-@interface MyPolicyDelegate : NSObject
+@interface MyPolicyDelegate : NSObject <WebPolicyDelegate>
 {
     wxWebKitCtrl* webKitWindow;
 }
@@ -148,7 +148,7 @@ inline int wxNavTypeFromWebNavType(int type){
 
 @end
 
-@interface MyUIDelegate : NSObject
+@interface MyUIDelegate : NSObject <WebUIDelegate>
 {
     wxWebKitCtrl* webKitWindow;
 }

--- a/src/osx/webview_webkit.mm
+++ b/src/osx/webview_webkit.mm
@@ -50,7 +50,7 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxWebViewWebKit, wxWebView);
 wxBEGIN_EVENT_TABLE(wxWebViewWebKit, wxControl)
 wxEND_EVENT_TABLE()
 
-@interface WebViewLoadDelegate : NSObject
+@interface WebViewLoadDelegate : NSObject <WebFrameLoadDelegate>
 {
     wxWebViewWebKit* webKitWindow;
 }
@@ -59,7 +59,7 @@ wxEND_EVENT_TABLE()
 
 @end
 
-@interface WebViewPolicyDelegate : NSObject
+@interface WebViewPolicyDelegate : NSObject <WebPolicyDelegate>
 {
     wxWebViewWebKit* webKitWindow;
 }
@@ -68,7 +68,7 @@ wxEND_EVENT_TABLE()
 
 @end
 
-@interface WebViewUIDelegate : NSObject
+@interface WebViewUIDelegate : NSObject <WebUIDelegate>
 {
     wxWebViewWebKit* webKitWindow;
 }


### PR DESCRIPTION
This avoids clang -Wincompatible-pointer-types warnings when setting
delegates.

---

I am not sure about what am I doing here and rather surprised that we can declare an interface as conforming to some protocol without defining any methods, but this avoids warning when passing objects of these types to WebView.

Any reviews from people more knowledgeable about Objective-C would be very welcome, TIA!