### PR TITLE
Allow specifying the maximum width of static text in dialogs

### DIFF
--- a/include/wx/dialog.h
+++ b/include/wx/dialog.h
@@ -116,13 +116,15 @@ public:
 
 #if wxUSE_STATTEXT // && wxUSE_TEXTCTRL
     // splits text up at newlines and places the lines into a vertical
-    // wxBoxSizer
-    wxSizer *CreateTextSizer( const wxString& message );
+    // wxBoxSizer, with the given maximum width, lines will not be wrapped
+    // for negative values of widthMax
+    wxSizer *CreateTextSizer(const wxString& message, int widthMax = -1);
 
     // same as above but uses a customized wxTextSizerWrapper to create
     // non-standard controls for the lines
-    wxSizer *CreateTextSizer( const wxString& message,
-                              wxTextSizerWrapper& wrapper );
+    wxSizer *CreateTextSizer(const wxString& message,
+                             wxTextSizerWrapper& wrapper,
+                             int widthMax = -1);
 #endif // wxUSE_STATTEXT // && wxUSE_TEXTCTRL
 
     // returns a horizontal wxBoxSizer containing the given buttons

--- a/interface/wx/dialog.h
+++ b/interface/wx/dialog.h
@@ -292,9 +292,15 @@ public:
 
     /**
        Splits text up at newlines and places the lines into wxStaticText
-       objects in a vertical wxBoxSizer.
+       objects with the specified maximum width in a vertical wxBoxSizer.
+
+       @a widthMax is available since 3.1.0
+
+       @param widthMax Specifies the text's maximum width.
+
+       @see wxStaticText::Wrap(int width)
     */
-    wxSizer *CreateTextSizer( const wxString& message );
+    wxSizer *CreateTextSizer(const wxString& message, int widthMax = -1);
 
     /**
         Performs layout adaptation, usually if the dialog is too large to fit

--- a/src/common/dlgcmn.cpp
+++ b/src/common/dlgcmn.cpp
@@ -196,19 +196,19 @@ wxDialogBase::GetParentForModalDialog(wxWindow *parent, long style) const
 
 #if wxUSE_STATTEXT
 
-wxSizer *wxDialogBase::CreateTextSizer(const wxString& message)
+wxSizer *wxDialogBase::CreateTextSizer(const wxString& message, int widthMax)
 {
     wxTextSizerWrapper wrapper(this);
 
-    return CreateTextSizer(message, wrapper);
+    return CreateTextSizer(message, wrapper, widthMax);
 }
 
 wxSizer *wxDialogBase::CreateTextSizer(const wxString& message,
-                                       wxTextSizerWrapper& wrapper)
+                                       wxTextSizerWrapper& wrapper,
+                                       int widthMax)
 {
     // I admit that this is complete bogus, but it makes
     // message boxes work for pda screens temporarily..
-    int widthMax = -1;
     const bool is_pda = wxSystemSettings::GetScreenType() <= wxSYS_SCREEN_PDA;
     if (is_pda)
     {


### PR DESCRIPTION
This patch allows specification of the maximum width of static texts
created with wxDialog::CreateTextSizer.

The patch preserves backwards compatibility by setting the previous
width value as standard argument.