### PR TITLE
Allow creation of debug reports in custom directory

### DIFF
--- a/include/wx/debugrpt.h
+++ b/include/wx/debugrpt.h
@@ -32,8 +32,9 @@ public:
 
 
     // ctor creates a temporary directory where we create the files which will
-    // be included in the report, use IsOk() to check for errors
-    wxDebugReport();
+    // be included in the report, use IsOk() to check for errors, specify a
+    // non-empty string to specify a custom temporary directory
+    wxDebugReport(const wxString &tmpDir = wxEmptyString);
 
     // dtor normally destroys the temporary directory created in the ctor (with
     // all the files it contains), call Reset() to prevent this from happening
@@ -131,7 +132,9 @@ private:
 class WXDLLIMPEXP_QA wxDebugReportCompress : public wxDebugReport
 {
 public:
-    wxDebugReportCompress() { }
+    // pass a non-empty string to specify a custom temporary directory to be
+    // used for report construction
+    wxDebugReportCompress(const wxString &tmpDir = wxEmptyString);
 
     // you can optionally specify the directory and/or name of the file where
     // the debug report should be generated, a default location under the

--- a/interface/wx/debugrpt.h
+++ b/interface/wx/debugrpt.h
@@ -63,8 +63,10 @@ class wxDebugReportCompress : public wxDebugReport
 public:
     /**
         Default constructor does nothing special.
+
+        @see wxDebugReport::wxDebugReport(const wxString &tmpDir)
     */
-    wxDebugReportCompress();
+    wxDebugReportCompress(const wxString &tmpDir = wxEmptyString);
 
     /**
         Set the directory where the debug report should be generated.
@@ -164,8 +166,10 @@ public:
     /**
         The constructor creates a temporary directory where the files that will
         be included in the report are created. Use IsOk() to check for errors.
+        Specify a non-empty string to use a custom directory for report
+        construction.
     */
-    wxDebugReport();
+    wxDebugReport(const wxString &tmpDir = wxEmptyString);
 
     /**
         The destructor normally destroys the temporary directory created in the
@@ -221,8 +225,8 @@ public:
         is copied to a file in the debug report directory with the same name.
         Otherwise the file will be searched in the temporary directory returned
         by GetDirectory().
-        
-        The argument @a description only exists to be displayed to the user in 
+
+        The argument @a description only exists to be displayed to the user in
         the report summary shown by wxDebugReportPreview.
 
         @see GetDirectory(), AddText()
@@ -385,4 +389,3 @@ protected:
     */
     virtual bool OnServerReply(const wxArrayString& reply);
 };
-

--- a/src/common/debugrpt.cpp
+++ b/src/common/debugrpt.cpp
@@ -182,10 +182,13 @@ void XmlStackWalker::OnStackFrame(const wxStackFrame& frame)
 // initialization and cleanup
 // ----------------------------------------------------------------------------
 
-wxDebugReport::wxDebugReport()
+wxDebugReport::wxDebugReport(const wxString &tmpDir)
 {
     // get a temporary directory name
     wxString appname = GetReportName();
+
+    // use default temporary directory, if no custom one specified
+    wxString dir = tmpDir.IsEmpty() ? wxFileName::GetTempDir() : tmpDir;
 
     // we can't use CreateTempFileName() because it creates a file, not a
     // directory, so do our best to create a unique name ourselves
@@ -193,12 +196,12 @@ wxDebugReport::wxDebugReport()
     // of course, this doesn't protect us against malicious users...
 #if wxUSE_DATETIME
     m_dir.Printf(wxT("%s%c%s_dbgrpt-%lu-%s"),
-                 wxFileName::GetTempDir(), wxFILE_SEP_PATH, appname,
+                 dir, wxFILE_SEP_PATH, appname,
                  wxGetProcessId(),
                  wxDateTime::Now().Format(wxT("%Y%m%dT%H%M%S")));
 #else
     m_dir.Printf(wxT("%s%c%s_dbgrpt-%lu"),
-                 wxFileName::GetTempDir(), wxFILE_SEP_PATH, appname,
+                 dir, wxFILE_SEP_PATH, appname,
                  wxGetProcessId());
 #endif
 
@@ -603,6 +606,12 @@ bool wxDebugReport::DoProcess()
 // ----------------------------------------------------------------------------
 // wxDebugReportCompress
 // ----------------------------------------------------------------------------
+
+wxDebugReportCompress::wxDebugReportCompress(const wxString &tmpDir)
+                     : wxDebugReport(tmpDir)
+{
+    // nothing here
+}
 
 void wxDebugReportCompress::SetCompressedFileDirectory(const wxString& dir)
 {


### PR DESCRIPTION
Being able to specify custom directories is especially useful in situations where wxFileName::GetTempName() does not work properly (e.g. Mac OS with app sandboxing). The behaviour is backwards compatible through the use of standard arguments.