### PR TITLE
wxMSW: Use locale name for Windows Vista and later

### DIFF
--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -49,6 +49,10 @@
 #ifdef __WIN32__
     #include "wx/dynlib.h"
     #include "wx/msw/private.h"
+
+    #ifndef LOCALE_SNAME
+    #define LOCALE_SNAME 0x5c
+    #endif
 #endif
 
 #include "wx/file.h"
@@ -147,6 +151,19 @@ wxString wxLanguageInfo::GetLocaleName() const
 
     wxChar buffer[256];
     buffer[0] = wxT('\0');
+    if ( wxGetWinVersion() >= wxWinVersion_Vista )
+    {
+        if ( ::GetLocaleInfo(lcid, LOCALE_SNAME, buffer, WXSIZEOF(buffer)) )
+        {
+            locale << buffer;
+        }
+        else
+        {
+            wxLogLastError(wxT("GetLocaleInfo(LOCALE_SNAME)"));
+        }
+        return locale;
+    }
+
     if ( !::GetLocaleInfo(lcid, LOCALE_SENGLANGUAGE, buffer, WXSIZEOF(buffer)) )
     {
         wxLogLastError(wxT("GetLocaleInfo(LOCALE_SENGLANGUAGE)"));


### PR DESCRIPTION
Instead of combining the language, country and codepage and passing the resulting string to setlocale(), the locale name can be used instead for setlocale() on Windows Vista and onwards.

This fixes a crash that occurs when switching locale from Korean to Norwegian Bokmål, since the language_country.codepage string resolves to "Norwegian Bokmål_Norway.1252" and mbstowcs trips up on the non-ASCII character.