### PR TITLE
Add support for cache directory to wxStandardPaths::GetUserDir()

### DIFF
--- a/include/wx/stdpaths.h
+++ b/include/wx/stdpaths.h
@@ -51,6 +51,7 @@ public:
 
     enum Dir
     {
+        Dir_Cache,
         Dir_Documents,
         Dir_Desktop,
         Dir_Downloads,

--- a/interface/wx/stdpaths.h
+++ b/interface/wx/stdpaths.h
@@ -70,6 +70,16 @@ public:
     enum Dir
     {
         /**
+            Directory for caching files.
+
+            Example return values:
+            - Unix: @c ~/.cache
+            - Windows: @c "C:\Users\username\AppData\Local"
+            - Mac: @c ~/Library/Caches
+        */
+        Dir_Cache,
+
+        /**
             Directory containing user documents.
 
             Example return values:

--- a/src/msw/stdpaths.cpp
+++ b/src/msw/stdpaths.cpp
@@ -223,6 +223,9 @@ wxString wxStandardPaths::GetUserDir(Dir userDir) const
     int csidl;
     switch (userDir)
     {
+        case Dir_Cache:
+            csidl = CSIDL_LOCAL_APPDATA;
+            break;
         case Dir_Desktop:
             csidl = CSIDL_DESKTOPDIRECTORY;
             break;

--- a/src/osx/cocoa/stdpaths.mm
+++ b/src/osx/cocoa/stdpaths.mm
@@ -103,6 +103,9 @@ wxString wxStandardPaths::GetUserDir(Dir userDir) const
     NSSearchPathDirectory dirType;
     switch (userDir)
     {
+        case Dir_Cache:
+            dirType = NSCachesDirectory;
+            break;
         case Dir_Desktop:
             dirType = NSDesktopDirectory;
             break;

--- a/src/unix/stdpaths.cpp
+++ b/src/unix/stdpaths.cpp
@@ -238,6 +238,14 @@ wxString wxStandardPaths::GetUserDir(Dir userDir) const
     {
         wxLogNull logNull;
         wxString homeDir = wxFileName::GetHomeDir();
+        if (userDir == Dir_Cache)
+        {
+           if (wxGetenv(wxT("XDG_CACHE_HOME")))
+              return wxGetenv(wxT("XDG_CACHE_HOME"));
+           else
+              return homeDir + wxT("/.cache");
+        }
+
         wxString configPath;
         if (wxGetenv(wxT("XDG_CONFIG_HOME")))
             configPath = wxGetenv(wxT("XDG_CONFIG_HOME"));

--- a/tests/interactive/output.cpp
+++ b/tests/interactive/output.cpp
@@ -404,6 +404,7 @@ void InteractiveOutputTestCase::TestStandardPaths()
     wxPrintf(wxT("Data dir (user):\t%s\n"), stdp.GetUserDataDir().c_str());
     wxPrintf(wxT("Data dir (user local):\t%s\n"), stdp.GetUserLocalDataDir().c_str());
     wxPrintf(wxT("Documents dir:\t\t%s\n"), stdp.GetDocumentsDir().c_str());
+    wxPrintf(wxT("Cache dir:\t\t%s\n"), stdp.GetUserDir(wxStandardPaths::Dir_Cache).c_str());
     wxPrintf(wxT("Desktop dir:\t\t%s\n"), stdp.GetUserDir(wxStandardPaths::Dir_Desktop).c_str());
     wxPrintf(wxT("Downloads dir:\t\t%s\n"), stdp.GetUserDir(wxStandardPaths::Dir_Downloads).c_str());
     wxPrintf(wxT("Music dir:\t\t%s\n"), stdp.GetUserDir(wxStandardPaths::Dir_Music).c_str());


### PR DESCRIPTION
This has direct equivalent under macOS and when using XDG.

See http://trac.wxwidgets.org/ticket/17727