### PR TITLE
Improve rendering of buttoms with custom bg color on Windows 10

### DIFF
--- a/src/msw/anybutton.cpp
+++ b/src/msw/anybutton.cpp
@@ -1140,7 +1140,19 @@ void DrawXPBackground(wxAnyButton *button, HDC hdc, RECT& rectBtn, UINT state)
         RECT rectClient;
         ::CopyRect(&rectClient, &rectBtn);
         ::InflateRect(&rectClient, -1, -1);
-        FillRect(hdc, &rectClient, hbrushBackground);
+
+        if ( wxGetWinVersion() >= wxWinVersion_10 )
+        {
+            // buttons have flat appearance so we can fully color them
+            // even outside the "safe" rectangle
+            SelectInHDC brush(hdc, hbrushBackground);
+            COLORREF colTheme = GetPixel(hdc, rectClient.left, rectClient.top);
+            ExtFloodFill(hdc, rectClient.left, rectClient.top, colTheme, FLOODFILLSURFACE);
+        }
+        else
+        {
+            FillRect(hdc, &rectClient, hbrushBackground);
+        }
     }
 }
 #endif // wxUSE_UXTHEME

--- a/src/msw/anybutton.cpp
+++ b/src/msw/anybutton.cpp
@@ -1131,7 +1131,7 @@ void DrawXPBackground(wxAnyButton *button, HDC hdc, RECT& rectBtn, UINT state)
     ::InflateRect(&rectBtn, -margins.cxLeftWidth, -margins.cyTopHeight);
     ::InflateRect(&rectBtn, -XP_BUTTON_EXTRA_MARGIN, -XP_BUTTON_EXTRA_MARGIN);
 
-    if ( button->UseBgCol() )
+    if ( button->UseBgCol() && iState != PBS_HOT )
     {
         COLORREF colBg = wxColourToRGB(button->GetBackgroundColour());
         AutoHBRUSH hbrushBackground(colBg);


### PR DESCRIPTION
This improves rendering of custom-drawn `wxButton` with a custom background color to be non-ugly at least on Windows 10.

Before:

![parallels picture](https://cloud.githubusercontent.com/assets/145881/20858638/ea2cf2c4-b949-11e6-9cc5-dfaea666a745.png)

After:

![parallels picture 2](https://cloud.githubusercontent.com/assets/145881/20858640/f327db3c-b949-11e6-9528-2b8654613602.png)

(This can't be done on Windows 8 where the button still uses a light gradient.)

I also tried to highlight the color dynamically in the `PBS_HOT` case to match the default behavior (where the background gray is boosted to (100%, 110%, 115%) to give it a slightly brighter blue-ish tint, but it doesn't work well for arbitrary colors:

![parallels picture 1](https://cloud.githubusercontent.com/assets/145881/20858652/655ad768-b94a-11e6-8f4c-c4657b6bef07.png)

...and of course doesn't at all for high-contrast themes (but then, neither do custom-colored buttons), but if you think the second variant is better, I'll do it.

Finally, I didn't simply tweak the rectangle's size (which would work on Windows 8 too), because I don't know how to do it. The problem is that the focus rect (which the comment in this code explains must not be covered) may have be thick in some configurations and I don't know how to detect that and its size:

![parallels picture 3](https://cloud.githubusercontent.com/assets/145881/20858666/d3720b36-b94a-11e6-8819-a37131967177.png)

