### PR TITLE
Improve button options and fix crash

### DIFF
--- a/samples/widgets/button.cpp
+++ b/samples/widgets/button.cpp
@@ -446,13 +446,11 @@ void ButtonWidgetsPage::CreateButton()
             break;
     }
 
-#if wxUSE_COMMANDLINKBUTTON
-    m_sizerNote->Show(m_chkCommandLink->GetValue());
-#endif
-
     bool showsBitmap = false;
     if ( m_chkBitmapOnly->GetValue() )
     {
+        m_chkCommandLink->SetValue(false); // wxCommandLinkButton cannot be "Bitmap only"
+
         showsBitmap = true;
 
         wxButton *bbtn;
@@ -503,6 +501,10 @@ void ButtonWidgetsPage::CreateButton()
         }
     }
 
+#if wxUSE_COMMANDLINKBUTTON
+    m_sizerNote->Show(m_chkCommandLink->GetValue());
+#endif
+
     if ( !showsBitmap && m_chkTextAndBitmap->GetValue() )
     {
         showsBitmap = true;
@@ -525,6 +527,9 @@ void ButtonWidgetsPage::CreateButton()
             m_button->SetBitmapDisabled(wxArtProvider::GetIcon(wxART_MISSING_IMAGE, wxART_BUTTON));
     }
 
+    m_chkTextAndBitmap->Enable(!m_chkBitmapOnly->IsChecked());
+    m_chkBitmapOnly->Enable(!m_chkTextAndBitmap->IsChecked());
+    m_chkCommandLink->Enable(!m_chkBitmapOnly->IsChecked());
     m_chkUseBitmapClass->Enable(showsBitmap);
 
     m_chkUsePressed->Enable(showsBitmap);


### PR DESCRIPTION
In Button page, allow only permitted combinations of text, bitmap and command link.
Also avoid null pointer crash when combining "Bitmap only" with "Use command link button".