### PR TITLE
wxExecute with wxEXEC_SYNC missing pid under windows

### DIFF
--- a/src/msw/utilsexc.cpp
+++ b/src/msw/utilsexc.cpp
@@ -918,6 +918,10 @@ long wxExecute(const wxString& cmd, int flags, wxProcess *handler,
     data->dwProcessId = pi.dwProcessId;
     data->hWnd        = hwnd;
     data->state       = (flags & wxEXEC_SYNC) != 0;
+    
+    if (handler)
+        handler->SetPid(pi.dwProcessId);
+        
     if ( flags & wxEXEC_SYNC )
     {
         // handler may be !NULL for capturing program output, but we don't use
@@ -928,9 +932,6 @@ long wxExecute(const wxString& cmd, int flags, wxProcess *handler,
     {
         // may be NULL or not
         data->handler = handler;
-
-        if (handler)
-            handler->SetPid(pi.dwProcessId);
     }
 
     DWORD tid;


### PR DESCRIPTION
Hi,

Only under windows build of wxWidgets there is no way to retrieve the pid if we use wxExecute with wxEXEC_SYNC.

I don't understand the following sentence in the code:

```cpp
// handler may be !NULL for capturing program output, but we don't use
// it wxExecuteData struct in this case
```

Thanks