### PR TITLE
Fix AVKit availability check for OS X SDK 10.7 and 10.8

### DIFF
--- a/configure
+++ b/configure
@@ -35277,8 +35277,8 @@ fi
         if test "$wxUSE_OSX_IPHONE" != 1; then
                                     old_CPPFLAGS="$CPPFLAGS"
             CPPFLAGS="-x objective-c++ $CPPFLAGS"
-            { $as_echo "$as_me:${as_lineno-$LINENO}: checking if AVKit is availble" >&5
-$as_echo_n "checking if AVKit is availble... " >&6; }
+            { $as_echo "$as_me:${as_lineno-$LINENO}: checking if AVKit is available" >&5
+$as_echo_n "checking if AVKit is available... " >&6; }
             cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include "AvailabilityMacros.h"
@@ -35286,7 +35286,7 @@ int
 main ()
 {
 
-                    #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_9
+                    #if defined(MAC_OS_X_VERSION_10_9) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_9
                         // AVKit available
                     #else
                         choke me
@@ -35297,7 +35297,11 @@ main ()
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-  GST_LIBS="$GST_LIBS -framework AVKit"
+  GST_LIBS="$GST_LIBS -framework AVKit"; { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext

--- a/configure.in
+++ b/configure.in
@@ -7413,17 +7413,18 @@ if test "$wxUSE_MEDIACTRL" = "yes" -o "$wxUSE_MEDIACTRL" = "auto"; then
             dnl AVKit is only available since OS X 10.9
             old_CPPFLAGS="$CPPFLAGS"
             CPPFLAGS="-x objective-c++ $CPPFLAGS"
-            AC_MSG_CHECKING([if AVKit is availble])
+            AC_MSG_CHECKING([if AVKit is available])
             AC_TRY_COMPILE(
                 [#include "AvailabilityMacros.h"],
                 [
-                    #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_9
+                    #if defined(MAC_OS_X_VERSION_10_9) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_9
                         // AVKit available
                     #else
                         choke me
                     #endif
                 ],
-                GST_LIBS="$GST_LIBS -framework AVKit"
+                [GST_LIBS="$GST_LIBS -framework AVKit"; AC_MSG_RESULT(yes)],
+                AC_MSG_RESULT(no)
             )
             CPPFLAGS="$old_CPPFLAGS"
         fi


### PR DESCRIPTION
This fixes the check for older SDKs and outputs the check result.

See #337 and #342