### PR TITLE
WX 3.0: Fix AVKit availability check for OS X SDK 10.7 and 10.8

### DIFF
--- a/configure
+++ b/configure
@@ -37531,8 +37531,8 @@ fi
 
             fi
             if test "$wxOSX_USE_QTKIT" = "no"; then
-                                { $as_echo "$as_me:${as_lineno-$LINENO}: checking if AVKit is availble" >&5
-$as_echo_n "checking if AVKit is availble... " >&6; }
+                                { $as_echo "$as_me:${as_lineno-$LINENO}: checking if AVKit is available" >&5
+$as_echo_n "checking if AVKit is available... " >&6; }
                 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include "AvailabilityMacros.h"
@@ -37540,7 +37540,7 @@ int
 main ()
 {
 
-                        #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_9
+                        #if defined(MAC_OS_X_VERSION_10_9) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_9
                             // AVKit available
                         #else
                             choke me
@@ -37551,7 +37551,11 @@ main ()
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-  GST_LIBS="$GST_LIBS -framework AVKit"
+  GST_LIBS="$GST_LIBS -framework AVKit"; { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext

--- a/configure.in
+++ b/configure.in
@@ -7621,17 +7621,18 @@ if test "$wxUSE_MEDIACTRL" = "yes" -o "$wxUSE_MEDIACTRL" = "auto"; then
             fi
             if test "$wxOSX_USE_QTKIT" = "no"; then
                 dnl AVKit is only available since OS X 10.9
-                AC_MSG_CHECKING([if AVKit is availble])
+                AC_MSG_CHECKING([if AVKit is available])
                 AC_TRY_COMPILE(
                     [#include "AvailabilityMacros.h"],
                     [
-                        #if MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_9
+                        #if defined(MAC_OS_X_VERSION_10_9) && MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_9
                             // AVKit available
                         #else
                             choke me
                         #endif
                     ],
-                    GST_LIBS="$GST_LIBS -framework AVKit"
+                    [GST_LIBS="$GST_LIBS -framework AVKit"; AC_MSG_RESULT(yes)],
+                    AC_MSG_RESULT(no)
                 )
             fi
             CPPFLAGS="$old_CPPFLAGS"


### PR DESCRIPTION
This fixes the check for older SDKs and outputs the check result.

(cherry picked from commit 159186d656f711bb1059dc3b74370d03bbc8d24c)