### PR TITLE
Use custom Windows class name for wxDataViewCtrl in wxMSW

### DIFF
--- a/include/wx/msw/app.h
+++ b/include/wx/msw/app.h
@@ -53,6 +53,16 @@ public:
     // variant registered without CS_[HV]REDRAW styles
     static const wxChar *GetNoRedrawClassSuffix() { return wxT("NR"); }
 
+    // Flags for GetRegisteredClassName()
+    enum
+    {
+        // Just a symbolic name indicating absence of any special flags.
+        RegClass_Default = 0,
+
+        // Return the name with the GetNoRedrawClassSuffix() appended to it.
+        RegClass_ReturnNR = 1
+    };
+
     // get the name of the registered Win32 class with the given (unique) base
     // name: this function constructs the unique class name using this name as
     // prefix, checks if the class is already registered and registers it if it
@@ -68,7 +78,8 @@ public:
     // or (default) -1 meaning that the class paints its background itself
     static const wxChar *GetRegisteredClassName(const wxChar *name,
                                                 int bgBrushCol = -1,
-                                                int extraStyles = 0);
+                                                int extraStyles = 0,
+                                                int flags = RegClass_Default);
 
     // return true if this name corresponds to one of the classes we registered
     // in the previous GetRegisteredClassName() calls

--- a/include/wx/msw/app.h
+++ b/include/wx/msw/app.h
@@ -60,7 +60,14 @@ public:
         RegClass_Default = 0,
 
         // Return the name with the GetNoRedrawClassSuffix() appended to it.
-        RegClass_ReturnNR = 1
+        RegClass_ReturnNR = 1,
+
+        // Don't register the class with CS_[HV]REDRAW styles. This is useful
+        // for internal windows for which we can guarantee that they will be
+        // never created with wxFULL_REPAINT_ON_RESIZE flag.
+        //
+        // Notice that this implies RegClass_ReturnNR.
+        RegClass_OnlyNR = 3
     };
 
     // get the name of the registered Win32 class with the given (unique) base

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -52,7 +52,23 @@ public:
                 const wxPoint& pos = wxDefaultPosition,
                 const wxSize& size = wxDefaultSize,
                 long style = 0,
-                const wxString& name = wxPanelNameStr);
+                const wxString& name = wxPanelNameStr)
+    {
+        return CreateUsingMSWClass(GetMSWClassName(),
+                                   parent, id, pos, size, style, name);
+    }
+
+    // Non-portable, MSW-specific Create() variant allowing to create the
+    // window with a custom Windows class name. This can be useful to assign a
+    // custom Windows class, that can be recognized from the outside of the
+    // application, for windows of specific type.
+    bool CreateUsingMSWClass(const wxChar* classname,
+                             wxWindow *parent,
+                             wxWindowID id,
+                             const wxPoint& pos = wxDefaultPosition,
+                             const wxSize& size = wxDefaultSize,
+                             long style = 0,
+                             const wxString& name = wxPanelNameStr);
 
     // implement base class pure virtuals
     virtual void SetLabel(const wxString& label) wxOVERRIDE;

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -230,8 +230,11 @@ public:
     // get the HWND to be used as parent of this window with CreateWindow()
     virtual WXHWND MSWGetParent() const;
 
-    // get the Win32 window class name used by all wxWindow objects by default
-    static const wxChar *MSWGetRegisteredClassName();
+    // Return the name of the Win32 class that should be used by this wxWindow
+    // object, taking into account wxFULL_REPAINT_ON_RESIZE style (if it's not
+    // specified, the wxApp::GetNoRedrawClassSuffix()-suffixed version of the
+    // class is used).
+    const wxChar *GetMSWClassName() const;
 
     // creates the window of specified Windows class with given style, extended
     // style, title and geometry (default values

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -1689,9 +1689,26 @@ wxBEGIN_EVENT_TABLE(wxDataViewMainWindow,wxWindow)
 wxEND_EVENT_TABLE()
 
 wxDataViewMainWindow::wxDataViewMainWindow( wxDataViewCtrl *parent, wxWindowID id,
-    const wxPoint &pos, const wxSize &size, const wxString &name ) :
-    wxWindow( parent, id, pos, size, wxWANTS_CHARS|wxBORDER_NONE, name )
+    const wxPoint &pos, const wxSize &size, const wxString &name )
 {
+    // We want to use a specific class name for this window in wxMSW to make it
+    // possible to configure screen readers to handle it specifically.
+#ifdef __WXMSW__
+    CreateUsingMSWClass
+    (
+      wxApp::GetRegisteredClassName
+             (
+                  wxT("wxDataView"),
+                  -1, // no specific background brush
+                  0, // no special styles neither
+                  wxApp::RegClass_OnlyNR
+             ),
+      parent, id, pos, size, wxWANTS_CHARS|wxBORDER_NONE, name
+    );
+#else
+    wxWindow( parent, id, pos, size, wxWANTS_CHARS|wxBORDER_NONE, name )
+#endif
+
     SetOwner( parent );
 
     m_editorRenderer = NULL;

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -22,6 +22,7 @@
 
 #ifndef WX_PRECOMP
     #ifdef __WXMSW__
+        #include "wx/app.h"          // GetRegisteredClassName()
         #include "wx/msw/private.h"
         #include "wx/msw/wrapwin.h"
         #include "wx/msw/wrapcctl.h" // include <commctrl.h> "properly"
@@ -1706,7 +1707,7 @@ wxDataViewMainWindow::wxDataViewMainWindow( wxDataViewCtrl *parent, wxWindowID i
       parent, id, pos, size, wxWANTS_CHARS|wxBORDER_NONE, name
     );
 #else
-    wxWindow( parent, id, pos, size, wxWANTS_CHARS|wxBORDER_NONE, name )
+    Create( parent, id, pos, size, wxWANTS_CHARS|wxBORDER_NONE, name )
 #endif
 
     SetOwner( parent );

--- a/src/msw/app.cpp
+++ b/src/msw/app.cpp
@@ -112,6 +112,13 @@ struct ClassRegInfo
     {
     }
 
+    // Return the appropriate string depending on the presence of
+    // RegClass_ReturnNR bit in the flags.
+    const wxChar* GetRequestedName(int flags) const
+    {
+        return (flags & wxApp::RegClass_ReturnNR ? regnameNR : regname).t_str();
+    }
+
     // the name of the registered class with and without CS_[HV]REDRAW styles
     wxString regname;
     wxString regnameNR;
@@ -630,13 +637,14 @@ bool wxApp::Initialize(int& argc_, wxChar **argv_)
 /* static */
 const wxChar *wxApp::GetRegisteredClassName(const wxChar *name,
                                             int bgBrushCol,
-                                            int extraStyles)
+                                            int extraStyles,
+                                            int flags)
 {
     const size_t count = gs_regClassesInfo.size();
     for ( size_t n = 0; n < count; n++ )
     {
         if ( gs_regClassesInfo[n].regname == name )
-            return gs_regClassesInfo[n].regname.c_str();
+            return gs_regClassesInfo[n].GetRequestedName(flags);
     }
 
     // we need to register this class
@@ -675,7 +683,7 @@ const wxChar *wxApp::GetRegisteredClassName(const wxChar *name,
     // function returns (it could be invalidated later if new elements are
     // added to the vector and it's reallocated but this shouldn't matter as
     // this pointer should be used right now, not stored)
-    return gs_regClassesInfo.back().regname.t_str();
+    return gs_regClassesInfo.back().GetRequestedName(flags);
 }
 
 bool wxApp::IsRegisteredClassName(const wxString& name)

--- a/src/msw/toplevel.cpp
+++ b/src/msw/toplevel.cpp
@@ -407,8 +407,7 @@ bool wxTopLevelWindowMSW::CreateFrame(const wxString& title,
     if ( wxApp::MSWGetDefaultLayout(m_parent) == wxLayout_RightToLeft )
         exflags |= WS_EX_LAYOUTRTL;
 
-    return MSWCreate(MSWGetRegisteredClassName(),
-                     title.t_str(), pos, sz, flags, exflags);
+    return MSWCreate(GetMSWClassName(), title.t_str(), pos, sz, flags, exflags);
 }
 
 bool wxTopLevelWindowMSW::Create(wxWindow *parent,

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -468,10 +468,16 @@ wxWindowMSW::~wxWindowMSW()
 
 }
 
-/* static */
-const wxChar *wxWindowMSW::MSWGetRegisteredClassName()
+const wxChar *wxWindowMSW::GetMSWClassName() const
 {
-    return wxApp::GetRegisteredClassName(wxT("wxWindow"), COLOR_BTNFACE);
+    return wxApp::GetRegisteredClassName
+                  (
+                    wxT("wxWindow"),
+                    COLOR_BTNFACE,
+                    0, // no special extra style
+                    HasFlag(wxFULL_REPAINT_ON_RESIZE) ? wxApp::RegClass_Default
+                                                      : wxApp::RegClass_ReturnNR
+                  );
 }
 
 // real construction (Init() must have been called before!)
@@ -506,8 +512,7 @@ bool wxWindowMSW::Create(wxWindow *parent,
         msflags |= WS_VISIBLE;
     }
 
-    if ( !MSWCreate(MSWGetRegisteredClassName(),
-                    NULL, pos, size, msflags, exstyle) )
+    if ( !MSWCreate(GetMSWClassName(), NULL, pos, size, msflags, exstyle) )
         return false;
 
     InheritAttributes();
@@ -3695,22 +3700,13 @@ bool wxWindowMSW::MSWCreate(const wxChar *wclass,
     // unless we're creating a child window
     int controlId = style & WS_CHILD ? GetId() : 0;
 
-    // for each class "Foo" we have we also have "FooNR" ("no repaint") class
-    // which is the same but without CS_[HV]REDRAW class styles so using it
-    // ensures that the window is not fully repainted on each resize
-    wxString className(wclass);
-    if ( !HasFlag(wxFULL_REPAINT_ON_RESIZE) )
-    {
-        className += wxApp::GetNoRedrawClassSuffix();
-    }
-
     // do create the window
     wxWindowCreationHook hook(this);
 
     m_hWnd = (WXHWND)::CreateWindowEx
                        (
                         extendedStyle,
-                        className.t_str(),
+                        wclass,
                         title ? title : m_windowName.t_str(),
                         style,
                         x, y, w, h,
@@ -3722,7 +3718,7 @@ bool wxWindowMSW::MSWCreate(const wxChar *wclass,
 
     if ( !m_hWnd )
     {
-        wxLogSysError(_("Can't create window of class %s"), className.c_str());
+        wxLogSysError(_("Can't create window of class %s"), wclass);
 
         return false;
     }

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -481,12 +481,13 @@ const wxChar *wxWindowMSW::GetMSWClassName() const
 }
 
 // real construction (Init() must have been called before!)
-bool wxWindowMSW::Create(wxWindow *parent,
-                         wxWindowID id,
-                         const wxPoint& pos,
-                         const wxSize& size,
-                         long style,
-                         const wxString& name)
+bool wxWindowMSW::CreateUsingMSWClass(const wxChar* classname,
+                                      wxWindow *parent,
+                                      wxWindowID id,
+                                      const wxPoint& pos,
+                                      const wxSize& size,
+                                      long style,
+                                      const wxString& name)
 {
     wxCHECK_MSG( parent, false, wxT("can't create wxWindow without parent") );
 
@@ -512,7 +513,7 @@ bool wxWindowMSW::Create(wxWindow *parent,
         msflags |= WS_VISIBLE;
     }
 
-    if ( !MSWCreate(GetMSWClassName(), NULL, pos, size, msflags, exstyle) )
+    if ( !MSWCreate(classname, NULL, pos, size, msflags, exstyle) )
         return false;
 
     InheritAttributes();


### PR DESCRIPTION
The real change is in the last commit, the previous one all just lay ground for it.

Notice that I chose to add `CreateUsingMSWClass()` instead of making `GetMSWClassName()` virtual and allowing to override it, which would have worked too. The advantage of doing it like this is that we don't add yet another entry to all wxWindow-derived classes (i.e. quite a few of them) and we avoid the problem of overriding `GetMSWClassName()` and then using non-default base class ctor instead of calling `Create()` -- which would compile, but use the base class version of `GetMSWClassName()` and so completely ignore the custom name. Of course, it's not a huge problem once you know about the problem, but I still prefer to make it impossible for it to happen in the first place.

The disadvantage, of course, is that using the new function is ugly, see the change to wxDVC. But hopefully it should be used so rarely (especially in non-MSW-specific code) that it's not that bad.