### PR TITLE
Add support for double buffering wxTreeCtrl in wxMSW

### DIFF
--- a/include/wx/msw/listctrl.h
+++ b/include/wx/msw/listctrl.h
@@ -363,6 +363,7 @@ public:
     ////////////////////////////////////////////////////////////////////////////
     // Necessary for drawing hrules and vrules, if specified
     void OnPaint(wxPaintEvent& event);
+    void OnEraseBackground(wxEraseEvent& event);
 
 
     virtual bool ShouldInheritColours() const wxOVERRIDE { return false; }
@@ -382,6 +383,8 @@ public:
     virtual WXLRESULT MSWWindowProc(WXUINT nMsg,
                                     WXWPARAM wParam,
                                     WXLPARAM lParam) wxOVERRIDE;
+
+    virtual bool IsDoubleBuffered() const wxOVERRIDE;
 
 protected:
     // common part of all ctors

--- a/include/wx/msw/missing.h
+++ b/include/wx/msw/missing.h
@@ -239,6 +239,10 @@
     #define TV_FIRST                0x1100
 #endif
 
+#ifndef TVS_EX_DOUBLEBUFFER
+    #define TVS_EX_DOUBLEBUFFER     0x0004
+#endif
+
 #ifndef TVS_FULLROWSELECT
     #define TVS_FULLROWSELECT       0x1000
 #endif
@@ -246,6 +250,11 @@
 #ifndef TVM_SETBKCOLOR
     #define TVM_SETBKCOLOR          (TV_FIRST + 29)
     #define TVM_SETTEXTCOLOR        (TV_FIRST + 30)
+#endif
+
+#ifndef TVM_SETEXTENDEDSTYLE
+    #define TVM_SETEXTENDEDSTYLE    (TV_FIRST + 44)
+    #define TVM_GETEXTENDEDSTYLE    (TV_FIRST + 45)
 #endif
 
  /*

--- a/include/wx/msw/treectrl.h
+++ b/include/wx/msw/treectrl.h
@@ -202,6 +202,10 @@ public:
     // returns true if the platform should explicitly apply a theme border
     virtual bool CanApplyThemeBorder() const wxOVERRIDE { return false; }
 
+    virtual bool IsDoubleBuffered() const wxOVERRIDE;
+
+    virtual void SetDoubleBuffered(bool on) wxOVERRIDE;
+
 protected:
     // Implement "update locking" in a custom way for this control.
     virtual void DoFreeze() wxOVERRIDE;
@@ -259,6 +263,10 @@ protected:
     //
     // return true if the key was processed, false otherwise
     bool MSWHandleSelectionKey(unsigned vkey);
+
+    // Event handlers
+    ////////////////////////////////////////////////////////////////////////////
+    void OnEraseBackground(wxEraseEvent& event);
 
 
     // data used only while editing the item label:
@@ -342,6 +350,7 @@ private:
 
     wxDECLARE_DYNAMIC_CLASS(wxTreeCtrl);
     wxDECLARE_NO_COPY_CLASS(wxTreeCtrl);
+    wxDECLARE_EVENT_TABLE();
 };
 
 #endif // wxUSE_TREECTRL

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -516,7 +516,7 @@ public:
     // check if a native double-buffering applies for this window
     virtual bool IsDoubleBuffered() const wxOVERRIDE;
 
-    void SetDoubleBuffered(bool on);
+    virtual void SetDoubleBuffered(bool on);
 
     // synthesize a wxEVT_LEAVE_WINDOW event and set m_mouseInWindow to false
     void GenerateMouseLeave();

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -260,6 +260,7 @@ private:
 
 wxBEGIN_EVENT_TABLE(wxListCtrl, wxListCtrlBase)
     EVT_PAINT(wxListCtrl::OnPaint)
+    EVT_ERASE_BACKGROUND(wxListCtrl::OnEraseBackground)
     EVT_CHAR_HOOK(wxListCtrl::OnCharHook)
 wxEND_EVENT_TABLE()
 
@@ -508,6 +509,11 @@ void wxListCtrl::SetWindowStyleFlag(long flag)
 
         Refresh();
     }
+}
+
+bool wxListCtrl::IsDoubleBuffered() const
+{
+    return (GetHwnd() && (ListView_GetExtendedListViewStyle(GetHwnd()) & LVS_EX_DOUBLEBUFFER) != 0);
 }
 
 // ----------------------------------------------------------------------------
@@ -3129,6 +3135,12 @@ void wxListCtrl::OnPaint(wxPaintEvent& event)
             }
         }
     }
+}
+
+void wxListCtrl::OnEraseBackground(wxEraseEvent& event)
+{
+    // If double buffered then don't skip this event because the control will paint its own background
+    event.Skip(!IsDoubleBuffered());
 }
 
 void wxListCtrl::OnCharHook(wxKeyEvent& event)

--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -670,6 +670,10 @@ static /* const */ wxEventType gs_expandEvents[IDX_WHAT_MAX][IDX_HOW_MAX];
 };
 */
 
+wxBEGIN_EVENT_TABLE(wxTreeCtrl, wxTreeCtrlBase)
+    EVT_ERASE_BACKGROUND(wxTreeCtrl::OnEraseBackground)
+wxEND_EVENT_TABLE()
+
 // ============================================================================
 // implementation
 // ============================================================================
@@ -789,6 +793,20 @@ bool wxTreeCtrl::Create(wxWindow *parent,
     }
 
     return true;
+}
+
+bool wxTreeCtrl::IsDoubleBuffered() const
+{
+    return (GetHwnd() && ((DWORD)::SendMessage(GetHwnd(), TVM_GETEXTENDEDSTYLE, 0, 0) & TVS_EX_DOUBLEBUFFER) != 0);
+}
+
+void wxTreeCtrl::SetDoubleBuffered(bool on)
+{
+    // Check for required support before enabling double buffering
+    if (GetHwnd() && wxApp::GetComCtl32Version() >= 610)
+    {
+        ::SendMessage(GetHwnd(), TVM_SETEXTENDEDSTYLE, TVS_EX_DOUBLEBUFFER, on ? TVS_EX_DOUBLEBUFFER : 0);
+    }
 }
 
 wxTreeCtrl::~wxTreeCtrl()
@@ -2625,6 +2643,12 @@ bool wxTreeCtrl::MSWHandleTreeKeyDownEvent(WXWPARAM wParam, WXLPARAM lParam)
     }
 
     return processed;
+}
+
+void wxTreeCtrl::OnEraseBackground(wxEraseEvent& event)
+{
+    // If double buffered then don't skip this event because the control will paint its own background
+    event.Skip(!IsDoubleBuffered());
 }
 
 // we hook into WndProc to process WM_MOUSEMOVE/WM_BUTTONUP messages - as we


### PR DESCRIPTION
I know this won't be ABI compatible and this should probably go with the changes from pull request #209.

I was going to add the same logic to wxListCtrl, but noticed the LVS_EX_DOUBLEBUFFER style is there by default now. However, the default background style is still wxBG_STYLE_ERASE which will cause flicker between the erase background event and the paint event. I'm not sure if setting the BG style in the constructor would be the better option or not.

I'm wondering if wxTreeCtrl should just always use the TVS_EX_DOUBLEBUFFER style to be consistent. It does require a higher comctl version though. The docs just say Windows Vista, so I'm not sure if that translates to 5.82 or 6.10, but I assume the latter. I'm specifically checking the build number though, but I could change it to a comctl check.