### PR TITLE
Don't resize wxTreeCtrl for Freeze/Thaw in wxMSW.

### DIFF
--- a/include/wx/msw/treectrl.h
+++ b/include/wx/msw/treectrl.h
@@ -207,10 +207,6 @@ protected:
     virtual void DoFreeze() wxOVERRIDE;
     virtual void DoThaw() wxOVERRIDE;
 
-    virtual void DoSetSize(int x, int y,
-                           int width, int height,
-                           int sizeFlags = wxSIZE_AUTO) wxOVERRIDE;
-
     // SetImageList helper
     void SetAnyImageList(wxImageList *imageList, int which);
 
@@ -334,8 +330,8 @@ private:
     // whether we need to deselect other items on mouse up
     bool m_mouseUpDeselect;
 
-    // The size to restore the control to when it is thawed, see DoThaw().
-    wxSize m_thawnSize;
+    // whether we are waiting to freeze once the right conditions are met
+    bool m_pendingFreeze;
 
     friend class wxTreeItemIndirectData;
     friend class wxTreeSortHelper;

--- a/include/wx/msw/treectrl.h
+++ b/include/wx/msw/treectrl.h
@@ -330,7 +330,7 @@ private:
     // whether we need to deselect other items on mouse up
     bool m_mouseUpDeselect;
 
-    // whether we are waiting to freeze once the right conditions are met
+    // whether we are waiting to freeze once the control becomes non-empty
     bool m_pendingFreeze;
 
     friend class wxTreeItemIndirectData;

--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -1538,10 +1538,7 @@ wxTreeItemId wxTreeCtrl::DoInsertAfter(const wxTreeItemId& parent,
     // If we've been waiting for an item to be added before freezing the
     // control, our wait is over.
     if ( m_pendingFreeze )
-    {
-        m_pendingFreeze = false;
         DoFreeze();
-    }
 
     return wxTreeItemId(id);
 }
@@ -3928,9 +3925,15 @@ void wxTreeCtrl::DoFreeze()
 
 void wxTreeCtrl::DoThaw()
 {
-    if ( !m_pendingFreeze )
-        wxTreeCtrlBase::DoThaw();
-    //else: we never froze the control in the first place
+    if ( m_pendingFreeze )
+    {
+        // We never froze the control in the first place, so no need to thaw
+        // it. But we do need to reset the flag for the next time.
+        m_pendingFreeze = false;
+        return;
+    }
+
+    wxTreeCtrlBase::DoThaw();
 }
 
 #endif // wxUSE_TREECTRL

--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -722,6 +722,7 @@ void wxTreeCtrl::Init()
     m_changingSelection = false;
     m_triggerStateImageClick = false;
     m_mouseUpDeselect = false;
+    m_pendingFreeze = false;
 
     // initialize the global array of events now as it can't be done statically
     // with the wxEVT_XXX values being allocated during run-time only
@@ -1533,6 +1534,10 @@ wxTreeItemId wxTreeCtrl::DoInsertAfter(const wxTreeItemId& parent,
         param->SetData(data);
         data->SetId(id);
     }
+
+    // If we're frozen and pending a freeze complete the freeze process now that we have an item
+    if (IsFrozen() && m_pendingFreeze)
+        DoFreeze();
 
     return wxTreeItemId(id);
 }
@@ -3895,42 +3900,33 @@ void wxTreeCtrl::DoSetItemState(const wxTreeItemId& item, int state)
 // doesn't seem to do anything in other ones (e.g. under Windows 7 the tree
 // control keeps updating its scrollbars while the items are added to it,
 // resulting in horrible flicker when adding even a couple of dozen items).
-// So we resize it to the smallest possible size instead of freezing -- this
-// still flickers, but actually not as badly as it would if we didn't do it.
+// So we wait until at least one item (excluding virtual root) is added
 
 void wxTreeCtrl::DoFreeze()
 {
     if ( IsShown() )
     {
-        RECT rc;
-        ::GetWindowRect(GetHwnd(), &rc);
-        m_thawnSize = wxRectFromRECT(rc).GetSize();
+        m_pendingFreeze = true;
 
-        ::SetWindowPos(GetHwnd(), 0, 0, 0, 1, 1,
-                       SWP_NOMOVE | SWP_NOZORDER | SWP_NOREDRAW | SWP_NOACTIVATE);
+        // We can't freeze if we have no items added
+        wxTreeItemId root = GetRootItem();
+        if (!root.IsOk())
+            return;
+
+        // Ensure that the only item added isn't just a virtual root
+        // Must be an actual item
+        if (HasFlag(wxTR_HIDE_ROOT) && !HasChildren(root))
+            return;
+
+        m_pendingFreeze = false;
+        wxTreeCtrlBase::DoFreeze();
     }
 }
 
 void wxTreeCtrl::DoThaw()
 {
-    if ( IsShown() )
-    {
-        if ( m_thawnSize != wxDefaultSize )
-        {
-            ::SetWindowPos(GetHwnd(), 0, 0, 0, m_thawnSize.x, m_thawnSize.y,
-                           SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE);
-        }
-    }
-}
-
-// We also need to override DoSetSize() to ensure that m_thawnSize is reset if
-// the window is resized while being frozen -- in this case, we need to avoid
-// resizing it back to its original, pre-freeze, size when it's thawed.
-void wxTreeCtrl::DoSetSize(int x, int y, int width, int height, int sizeFlags)
-{
-    m_thawnSize = wxDefaultSize;
-
-    wxTreeCtrlBase::DoSetSize(x, y, width, height, sizeFlags);
+    if (!m_pendingFreeze)
+        wxTreeCtrlBase::DoThaw();
 }
 
 #endif // wxUSE_TREECTRL


### PR DESCRIPTION
I've seen this cause several problems so I'm just trying to propose a different solution. According to the original msdn article about the bug: "If a program uses the WM_SETREDRAW message to turn off updating of a TreeView control before adding items, the TreeView control can behave strangely." So since they are very specific that this issue happens when using WM_SETREDRAW *BEFORE* adding any items I'm proposing that we don't use it until after the first item has been added.

In our use of wxWidgets I've seen issues with a few trees that are on top of panels with different background colors. The flicker actually ends up being worse because sometimes a paint event will sneak in for the panel while the tree is frozen causing it to paint solid blue (or other colors) where the tree would normally be. I've also ran into issues where some pre-existing code was trying to do a HitTest while the tree was frozen which won't work.