### PR TITLE
wxBitmapComboBox is always enabled after re-creating in wxMSW.

### DIFF
--- a/src/msw/bmpcbox.cpp
+++ b/src/msw/bmpcbox.cpp
@@ -212,6 +212,10 @@ void wxBitmapComboBox::RecreateControl()
     // Revert the old string value
     if ( !HasFlag(wxCB_READONLY) )
         ChangeValue(value);
+
+    // If disabled we'll have to disable it again after re-creating
+    if (!IsEnabled())
+        DoEnable(false);
 }
 
 wxBitmapComboBox::~wxBitmapComboBox()


### PR DESCRIPTION
If you disable the wxBitmapComboBox prior to adding the first item then it will be enabled until the next time you enable/disable it agian.