### PR TITLE
Update outdated year references to 2017.

### DIFF
--- a/docs/doxygen/mainpages/copyright.h
+++ b/docs/doxygen/mainpages/copyright.h
@@ -11,7 +11,7 @@
 
 @section section_copyright wxWidgets Copyrights and Licenses
 
-Copyright (c) 1992-2016 Julian Smart, Vadim Zeitlin, Stefan Csomor, Robert
+Copyright (c) 1992-2017 Julian Smart, Vadim Zeitlin, Stefan Csomor, Robert
 Roebling, and other members of the wxWidgets team, please see the
 acknowledgements section below.
 

--- a/docs/doxygen/regen.sh
+++ b/docs/doxygen/regen.sh
@@ -183,7 +183,7 @@ if [[ "$1" = "docset" ]]; then
     defaults write $DESTINATIONDIR/$DOCSETNAME/Contents/Info DocSetFeedURL $ATOMDIR/$ATOM
     defaults write $DESTINATIONDIR/$DOCSETNAME/Contents/Info DocSetFallbackURL http://docs.wxwidgets.org
     defaults write $DESTINATIONDIR/$DOCSETNAME/Contents/Info DocSetDescription "API reference and conceptual documentation for wxWidgets 3.0"
-    defaults write $DESTINATIONDIR/$DOCSETNAME/Contents/Info NSHumanReadableCopyright "Copyright 1992-2016 wxWidgets team, Portions 1996 Artificial Intelligence Applications Institute"
+    defaults write $DESTINATIONDIR/$DOCSETNAME/Contents/Info NSHumanReadableCopyright "Copyright 1992-2017 wxWidgets team, Portions 1996 Artificial Intelligence Applications Institute"
     defaults write $DESTINATIONDIR/$DOCSETNAME/Contents/Info isJavaScriptEnabled true
     defaults write $DESTINATIONDIR/$DOCSETNAME/Contents/Info dashIndexFilePath index.html
     defaults write $DESTINATIONDIR/$DOCSETNAME/Contents/Info DocSetPlatformFamily wx

--- a/interface/wx/aboutdlg.h
+++ b/interface/wx/aboutdlg.h
@@ -37,7 +37,7 @@
         aboutInfo.SetName("MyApp");
         aboutInfo.SetVersion(MY_APP_VERSION_STRING);
         aboutInfo.SetDescription(_("My wxWidgets-based application!"));
-        aboutInfo.SetCopyright("(C) 1992-2016");
+        aboutInfo.SetCopyright("(C) 1992-2017");
         aboutInfo.SetWebSite("http://myapp.org");
         aboutInfo.AddDeveloper("My Self");
 

--- a/interface/wx/generic/aboutdlgg.h
+++ b/interface/wx/generic/aboutdlgg.h
@@ -34,7 +34,7 @@
         aboutInfo.SetName("MyApp");
         aboutInfo.SetVersion(MY_APP_VERSION_STRING);
         aboutInfo.SetDescription(_("My wxWidgets-based application!"));
-        aboutInfo.SetCopyright("(C) 1992-2016");
+        aboutInfo.SetCopyright("(C) 1992-2017");
         aboutInfo.SetWebSite("http://myapp.org");
         aboutInfo.AddDeveloper("My Self");
 

--- a/samples/Info.plist
+++ b/samples/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleGetInfoString</key>
-	<string>$(PRODUCT_NAME) version 3.1.1, (c) 2005-2016 wxWidgets</string>
+	<string>$(PRODUCT_NAME) version 3.1.1, (c) 2005-2017 wxWidgets</string>
 	<key>CFBundleIconFile</key>
 	<string>wxmac.icns</string>
 	<key>CFBundleIdentifier</key>
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleLongVersionString</key>
-	<string>3.1.1, (c) 2005-2016 wxWidgets</string>
+	<string>3.1.1, (c) 2005-2017 wxWidgets</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
@@ -31,6 +31,6 @@
 	<key>LSRequiresCarbon</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright 2005-2016 wxWidgets</string>
+	<string>Copyright 2005-2017 wxWidgets</string>
 </dict>
 </plist>

--- a/samples/docview/Info.plist
+++ b/samples/docview/Info.plist
@@ -51,7 +51,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleGetInfoString</key>
-	<string>$(PRODUCT_NAME) version 3.1.1, (c) 2005-2016 wxWidgets</string>
+	<string>$(PRODUCT_NAME) version 3.1.1, (c) 2005-2017 wxWidgets</string>
 	<key>CFBundleIconFile</key>
 	<string>doc</string>
 	<key>CFBundleIdentifier</key>
@@ -66,7 +66,7 @@
 		<string>it</string>
 	</array>
 	<key>CFBundleLongVersionString</key>
-	<string>3.1.1, (c) 2005-2016 wxWidgets</string>
+	<string>3.1.1, (c) 2005-2017 wxWidgets</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
@@ -82,6 +82,6 @@
 	<key>LSRequiresCarbon</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright 2005-2016 wxWidgets</string>
+	<string>Copyright 2005-2017 wxWidgets</string>
 </dict>
 </plist>

--- a/samples/minimal/Info_cocoa.plist
+++ b/samples/minimal/Info_cocoa.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleGetInfoString</key>
-	<string>$(PRODUCT_NAME) version 3.1.1, (c) 2005-2016 wxWidgets</string>
+	<string>$(PRODUCT_NAME) version 3.1.1, (c) 2005-2017 wxWidgets</string>
 	<key>CFBundleIconFile</key>
 	<string>wxmac.icns</string>
 	<key>CFBundleIdentifier</key>
@@ -22,7 +22,7 @@
 		<string>it</string>
 	</array>
 	<key>CFBundleLongVersionString</key>
-	<string>3.1.1, (c) 2005-2016 wxWidgets</string>
+	<string>3.1.1, (c) 2005-2017 wxWidgets</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
@@ -34,7 +34,7 @@
 	<key>CFBundleVersion</key>
 	<string>3.1.1</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright 2005-2016 wxWidgets</string>
+	<string>Copyright 2005-2017 wxWidgets</string>
 	<key>NSPrincipalClass</key>
 	<string>wxNSApplication</string>
 </dict>

--- a/src/common/utilscmn.cpp
+++ b/src/common/utilscmn.cpp
@@ -1411,7 +1411,7 @@ wxVersionInfo wxGetLibraryVersionInfo()
                          wxMINOR_VERSION,
                          wxRELEASE_NUMBER,
                          msg,
-                         wxS("Copyright (c) 1995-2016 wxWidgets team"));
+                         wxS("Copyright (c) 1995-2017 wxWidgets team"));
 }
 
 void wxInfoMessageBox(wxWindow* parent)

--- a/src/msw/version.rc
+++ b/src/msw/version.rc
@@ -92,7 +92,7 @@ BEGIN
             VALUE "FileDescription", "wxWidgets " WXLIBDESC " library\0"
             VALUE "FileVersion", wxVERSION_NUM_DOT_STRING "\0"
             VALUE "InternalName", wxSTRINGIZE(WXDLLNAME) "\0"
-            VALUE "LegalCopyright", "Copyright © 1993-2016 wxWidgets development team\0"
+            VALUE "LegalCopyright", "Copyright © 1993-2017 wxWidgets development team\0"
             VALUE "OriginalFilename", wxSTRINGIZE(WXDLLNAME) ".dll\0"
             VALUE "ProductName", "wxWidgets\0"
             VALUE "ProductVersion", wxVERSION_NUM_DOT_STRING "\0"

--- a/src/osx/carbon/Info.plist.in
+++ b/src/osx/carbon/Info.plist.in
@@ -32,11 +32,11 @@
 	<key>CFBundleShortVersionString</key>
 	<string>VERSION</string>
 	<key>CFBundleGetInfoString</key>
-	<string>EXECUTABLE version VERSION, (c) 2002-2016 wxWidgets</string>
+	<string>EXECUTABLE version VERSION, (c) 2002-2017 wxWidgets</string>
 	<key>CFBundleLongVersionString</key>
-	<string>VERSION, (c) 2002-2016 wxWidgets</string>
+	<string>VERSION, (c) 2002-2017 wxWidgets</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright 2002-2016 wxWidgets</string>
+	<string>Copyright 2002-2017 wxWidgets</string>
 	<key>LSRequiresCarbon</key>
 	<true/>
 	<key>CSResourcesFileMapped</key>


### PR DESCRIPTION
Use 2017 instead of 2016, mostly in version info files.