### PR TITLE
Add API to create wxGraphicsContext from win32 HDC

### DIFF
--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -445,6 +445,10 @@ public:
 
     static wxGraphicsContext* CreateFromNativeWindow( void * window );
 
+#ifdef __WXMSW__
+    static wxGraphicsContext* CreateFromNativeHDC(WXHDC dc);
+#endif
+
     static wxGraphicsContext* Create( wxWindow* window );
 
 #if wxUSE_IMAGE
@@ -829,6 +833,10 @@ public:
     virtual wxGraphicsContext * CreateContextFromNativeContext( void * context ) = 0;
 
     virtual wxGraphicsContext * CreateContextFromNativeWindow( void * window ) = 0;
+
+#ifdef __WXMSW__
+    virtual wxGraphicsContext * CreateContextFromNativeHDC(WXHDC dc) = 0;
+#endif
 
     virtual wxGraphicsContext * CreateContext( wxWindow* window ) = 0;
 

--- a/interface/wx/graphics.h
+++ b/interface/wx/graphics.h
@@ -483,6 +483,15 @@ public:
     static wxGraphicsContext* CreateFromNativeWindow(void* window);
 
     /**
+        Creates a wxGraphicsContext from a native DC handle. Windows only.
+
+        @see wxGraphicsRenderer::CreateContextFromNativeHDC()
+
+        @since 3.1.1
+    */
+    static wxGraphicsContext* CreateFromNativeHDC(WXHDC dc);
+
+    /**
        Create a lightweight context that can be used only for measuring text.
     */
     static wxGraphicsContext* Create();
@@ -1320,6 +1329,13 @@ public:
         Creates a wxGraphicsContext from a native window.
     */
     virtual wxGraphicsContext* CreateContextFromNativeWindow(void* window) = 0;
+
+    /**
+        Creates a wxGraphicsContext from a native DC handle. Windows only.
+
+        @since 3.1.1
+    */
+    static wxGraphicsContext* CreateContextFromNativeHDC(WXHDC dc);
 
     /**
         Creates a wxGraphicsContext that can be used for measuring texts only.

--- a/src/common/graphcmn.cpp
+++ b/src/common/graphcmn.cpp
@@ -961,6 +961,13 @@ wxGraphicsContext* wxGraphicsContext::CreateFromNativeWindow( void * window )
     return wxGraphicsRenderer::GetDefaultRenderer()->CreateContextFromNativeWindow(window);
 }
 
+#ifdef __WXMSW__
+wxGraphicsContext* wxGraphicsContext::CreateFromNativeHDC(WXHDC dc)
+{
+    return wxGraphicsRenderer::GetDefaultRenderer()->CreateContextFromNativeHDC(dc);
+}
+#endif
+
 wxGraphicsContext* wxGraphicsContext::Create( wxWindow* window )
 {
     return wxGraphicsRenderer::GetDefaultRenderer()->CreateContext(window);

--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -2823,6 +2823,11 @@ public :
     virtual wxGraphicsContext * CreateContextFromNativeContext( void * context ) wxOVERRIDE;
 
     virtual wxGraphicsContext * CreateContextFromNativeWindow( void * window ) wxOVERRIDE;
+
+#ifdef __WXMSW__
+    virtual wxGraphicsContext * CreateContextFromNativeHDC(WXHDC dc) wxOVERRIDE;
+#endif
+
 #if wxUSE_IMAGE
     virtual wxGraphicsContext * CreateContextFromImage(wxImage& image) wxOVERRIDE;
 #endif // wxUSE_IMAGE
@@ -2960,6 +2965,14 @@ wxGraphicsContext * wxCairoRenderer::CreateContextFromNativeWindow( void * windo
     return NULL;
 #endif
 }
+
+#ifdef __WXMSW__
+wxGraphicsContext * wxCairoRenderer::CreateContextFromNativeHDC(WXHDC dc)
+{
+    ENSURE_LOADED_OR_RETURN(NULL);
+    return new wxCairoContext(this, (HDC)dc);
+}
+#endif
 
 #if wxUSE_IMAGE
 wxGraphicsContext * wxCairoRenderer::CreateContextFromImage(wxImage& image)

--- a/src/msw/graphics.cpp
+++ b/src/msw/graphics.cpp
@@ -553,6 +553,8 @@ public :
 
     virtual wxGraphicsContext * CreateContextFromNativeWindow( void * window ) wxOVERRIDE;
 
+    virtual wxGraphicsContext * CreateContextFromNativeHDC(WXHDC dc) wxOVERRIDE;
+
     virtual wxGraphicsContext * CreateContext( wxWindow* window ) wxOVERRIDE;
 
 #if wxUSE_IMAGE
@@ -2407,6 +2409,12 @@ wxGraphicsContext * wxGDIPlusRenderer::CreateContextFromNativeWindow( void * win
 {
     ENSURE_LOADED_OR_RETURN(NULL);
     return new wxGDIPlusContext(this,(HWND) window);
+}
+
+wxGraphicsContext * wxGDIPlusRenderer::CreateContextFromNativeHDC(WXHDC dc)
+{
+    ENSURE_LOADED_OR_RETURN(NULL);
+    return new wxGDIPlusContext(this, new Graphics((HDC)dc));
 }
 
 wxGraphicsContext * wxGDIPlusRenderer::CreateContext( wxWindow* window )

--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -4346,6 +4346,8 @@ public :
 
     wxGraphicsContext* CreateContextFromNativeWindow(void* window) wxOVERRIDE;
 
+    wxGraphicsContext * CreateContextFromNativeHDC(WXHDC dc) wxOVERRIDE;
+
     wxGraphicsContext* CreateContext(wxWindow* window) wxOVERRIDE;
 
 #if wxUSE_IMAGE
@@ -4484,6 +4486,11 @@ wxGraphicsContext* wxD2DRenderer::CreateContextFromNativeContext(void* nativeCon
 wxGraphicsContext* wxD2DRenderer::CreateContextFromNativeWindow(void* window)
 {
     return new wxD2DContext(this, m_direct2dFactory, (HWND)window);
+}
+
+wxGraphicsContext* wxD2DRenderer::CreateContextFromNativeHDC(WXHDC dc)
+{
+    return new wxD2DContext(this, m_direct2dFactory, (HDC)dc, wxSize(0, 0));
 }
 
 wxGraphicsContext* wxD2DRenderer::CreateContext(wxWindow* window)


### PR DESCRIPTION
This PR adds `wxGraphicsContext::CreateFromNativeHDC()` and `wxGraphicsRenderer::CreateContextFromNativeHDC()` helpers to facilitate creation of wxGC from native HDCs, which is useful in e.g. custom `MSWOnDraw` implementations and elsewhere where wx code is mixed with native.

In theory, `CreateFromNative(void*)` was probably meant for such uses. In practice, it’s less than ideal: 
1. You can’t create a GDI+ `Context` instance before initializing the GDI+ library — and that’s done internally in the GDI+ implementation of `wxGraphicsContext`.
2. If you use the default renderer (a reasonable thing to do), you can’t be sure what the actual renderer is (GDI+, Direct2D).

Because all renderers already support creation from HDC internally and this change is trivial for all of them and adds very little code, I think it’s worth having for the added flexibility.
