### PR TITLE
Fix wxFULL_REPAINT_ON_RESIZE handling in wxMSW

### DIFF
--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -54,7 +54,7 @@ public:
                 long style = 0,
                 const wxString& name = wxPanelNameStr)
     {
-        return CreateUsingMSWClass(GetMSWClassName(),
+        return CreateUsingMSWClass(GetMSWClassName(style),
                                    parent, id, pos, size, style, name);
     }
 
@@ -250,7 +250,7 @@ public:
     // object, taking into account wxFULL_REPAINT_ON_RESIZE style (if it's not
     // specified, the wxApp::GetNoRedrawClassSuffix()-suffixed version of the
     // class is used).
-    const wxChar *GetMSWClassName() const;
+    static const wxChar *GetMSWClassName(long style);
 
     // creates the window of specified Windows class with given style, extended
     // style, title and geometry (default values

--- a/src/msw/toplevel.cpp
+++ b/src/msw/toplevel.cpp
@@ -407,7 +407,7 @@ bool wxTopLevelWindowMSW::CreateFrame(const wxString& title,
     if ( wxApp::MSWGetDefaultLayout(m_parent) == wxLayout_RightToLeft )
         exflags |= WS_EX_LAYOUTRTL;
 
-    return MSWCreate(GetMSWClassName(), title.t_str(), pos, sz, flags, exflags);
+    return MSWCreate(GetMSWClassName(GetWindowStyle()), title.t_str(), pos, sz, flags, exflags);
 }
 
 bool wxTopLevelWindowMSW::Create(wxWindow *parent,

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -468,15 +468,15 @@ wxWindowMSW::~wxWindowMSW()
 
 }
 
-const wxChar *wxWindowMSW::GetMSWClassName() const
+const wxChar *wxWindowMSW::GetMSWClassName(long style)
 {
     return wxApp::GetRegisteredClassName
                   (
                     wxT("wxWindow"),
                     COLOR_BTNFACE,
                     0, // no special extra style
-                    HasFlag(wxFULL_REPAINT_ON_RESIZE) ? wxApp::RegClass_Default
-                                                      : wxApp::RegClass_ReturnNR
+                    (style & wxFULL_REPAINT_ON_RESIZE) ? wxApp::RegClass_Default
+                                                       : wxApp::RegClass_ReturnNR
                   );
 }
 


### PR DESCRIPTION
Fix regression introduced in d4e595adb02f433ea31e45f7a3b39cc5a26d67a8
where the wxFULL_REPAINT_ON_RESIZE flag was accidentally ignored in most cases.