### PR TITLE
Rename variable CHAR_WIDTH in msw/msgdlg.cpp

### DIFF
--- a/src/msw/msgdlg.cpp
+++ b/src/msw/msgdlg.cpp
@@ -352,14 +352,14 @@ void wxMessageDialog::AdjustButtonLabels()
     // resize the message box to be wider if needed
     const int wBoxOld = wxGetClientRect(GetHwnd()).right;
 
-    const int CHAR_WIDTH = GetCharWidth();
-    const int MARGIN_OUTER = 2*CHAR_WIDTH;  // margin between box and buttons
-    const int MARGIN_INNER = CHAR_WIDTH;    // margin between buttons
+    const int char_width = GetCharWidth();
+    const int margin_outer = 2*char_width;  // margin between box and buttons
+    const int margin_inner = char_width;    // margin between buttons
 
     RECT rcBox = wxGetWindowRect(GetHwnd());
 
-    const int wAllButtons = numButtons*(wBtnNew + MARGIN_INNER) - MARGIN_INNER;
-    int wBoxNew = 2*MARGIN_OUTER + wAllButtons;
+    const int wAllButtons = numButtons*(wBtnNew + margin_inner) - margin_inner;
+    int wBoxNew = 2*margin_outer + wAllButtons;
     if ( wBoxNew > wBoxOld )
     {
         const int dw = wBoxNew - wBoxOld;
@@ -394,8 +394,8 @@ void wxMessageDialog::AdjustButtonLabels()
 
         MoveWindowToScreenRect(hwndBtn, rcBtn);
 
-        rcBtn.left += wBtnNew + MARGIN_INNER;
-        rcBtn.right += wBtnNew + MARGIN_INNER;
+        rcBtn.left += wBtnNew + margin_inner;
+        rcBtn.right += wBtnNew + margin_inner;
     }
 }
 

--- a/src/msw/msgdlg.cpp
+++ b/src/msw/msgdlg.cpp
@@ -352,14 +352,14 @@ void wxMessageDialog::AdjustButtonLabels()
     // resize the message box to be wider if needed
     const int wBoxOld = wxGetClientRect(GetHwnd()).right;
 
-    const int char_width = GetCharWidth();
-    const int margin_outer = 2*char_width;  // margin between box and buttons
-    const int margin_inner = char_width;    // margin between buttons
+    const int CHAR_WIDTH_IN_PIXELS = GetCharWidth();
+    const int MARGIN_OUTER = 2*CHAR_WIDTH_IN_PIXELS;  // margin between box and buttons
+    const int MARGIN_INNER = CHAR_WIDTH_IN_PIXELS;    // margin between buttons
 
     RECT rcBox = wxGetWindowRect(GetHwnd());
 
-    const int wAllButtons = numButtons*(wBtnNew + margin_inner) - margin_inner;
-    int wBoxNew = 2*margin_outer + wAllButtons;
+    const int wAllButtons = numButtons*(wBtnNew + MARGIN_INNER) - MARGIN_INNER;
+    int wBoxNew = 2*MARGIN_OUTER + wAllButtons;
     if ( wBoxNew > wBoxOld )
     {
         const int dw = wBoxNew - wBoxOld;
@@ -394,8 +394,8 @@ void wxMessageDialog::AdjustButtonLabels()
 
         MoveWindowToScreenRect(hwndBtn, rcBtn);
 
-        rcBtn.left += wBtnNew + margin_inner;
-        rcBtn.right += wBtnNew + margin_inner;
+        rcBtn.left += wBtnNew + MARGIN_INNER;
+        rcBtn.right += wBtnNew + MARGIN_INNER;
     }
 }
 


### PR DESCRIPTION
When you compile wxWidgets with MinGW64, then CHAR_WIDTH is already
defined as a macro somewhere. This clashes with a variable name in
msw/msgdlg.cpp.

This diff replaces CHAR_WIDTH, MARGIN_OUTER and MARGIN_INNER with their
lower case variant. They are not constants after all.