### PR TITLE
Improve firstResponder handling on macOS

### DIFF
--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -40,6 +40,7 @@ CGContextRef WXDLLIMPEXP_CORE wxOSXCreateBitmapContextFromNSImage( WX_NSImage ns
 
 wxBitmap WXDLLIMPEXP_CORE wxOSXCreateSystemBitmap(const wxString& id, const wxString &client, const wxSize& size);
 WXWindow WXDLLIMPEXP_CORE wxOSXGetMainWindow();
+WXWindow WXDLLIMPEXP_CORE wxOSXGetKeyWindow();
 
 class WXDLLIMPEXP_FWD_CORE wxDialog;
 

--- a/src/osx/carbon/utilscocoa.mm
+++ b/src/osx/carbon/utilscocoa.mm
@@ -345,6 +345,11 @@ WXWindow wxOSXGetMainWindow()
     return [NSApp mainWindow];
 }
 
+WXWindow wxOSXGetKeyWindow()
+{
+    return [NSApp keyWindow];
+}
+
 #endif
 // ----------------------------------------------------------------------------
 // NSImage Utils

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -71,7 +71,24 @@ NSView* GetFocusedViewInWindow( NSWindow* keyWindow )
 
 WXWidget wxWidgetImpl::FindFocus()
 {
-    return GetFocusedViewInWindow( [NSApp keyWindow] );;
+    NSWindow *key = [NSApp keyWindow];
+    if ( key == nil )
+    {
+        // Application's keyWindow property may still not be updated and be
+        // nil when windowDidBecomeKey: is called and even if the
+        // just-activated's window isKeyWindow already returns YES. To get
+        // accurate information about where the focus is at all times, we have
+        // to explicitly check all application windos as well:
+        for ( NSWindow *w in [NSApp windows] )
+        {
+            if ( [w isKeyWindow] )
+            {
+                key = w;
+                break;
+            }
+        }
+    }
+    return key ? GetFocusedViewInWindow(key) : nil;
 }
 
 wxWidgetImpl* wxWidgetImpl::FindBestFromWXWidget(WXWidget control)


### PR DESCRIPTION
This probably requires a longer explanation:

wx’s focus handling is modelled after Windows’ — focus is global, there’s one focused window and on active TLW, which the focus is inside of. In Cocoa, the two concepts are independent: there’s at most one *key window*, which is the TLW keyboard input goes to. Each TLW has at most (usually, if not always, exactly) one *first responder*, which is what keyboard input is directed to in the TLW. Notable, *inactive windows have first responders too*.

wxOSX implementation uses first responder heavily, of course (it’s what focus *mostly* is) and this could cause surprised to ports of Windows-first wx applications. So wxOSX tries hard to mimic MSW now, including doing some non-native things to provide expected events. See http://trac.wxwidgets.org/ticket/14269#comment:18 (as well as the rest of it, as well as other linked tickets) for subtle issues that were the motivating factor for doing the `[window makeFirstResponder:nil]` call in the first place.

Unfortunately, it seems that consistency of ports have taken priority over nativeness here, because by doing so wxOSX breaks *other* things — native behaviors that affect end users. I am aware of at least two issues that I keep getting complains from users about:

1. It was impossible to change input keyboard while in a wxTextCtrl if the user had *Automatically switch to a document’s input source* enabled. This seems to have been improved in 10.12 Sierra, but is still the case on older versions.

2. It breaks clipboard managers like [Paste](http://pasteapp.me): they work by showing some floating window and then pasting what the user selects into the first responder of the (previous) key window. wx would handle window deactivation as it cedes key status and would reset first responder, so there’s nowhere for the manager to paste.

And there’s also a cosmetic one:

3. Focus ring disappears (it shouldn’t) when the user uses menubar status icon’s menus.

It wasn’t until recently that I realized it should be possible to mitigate this relatively easily, and this PR does that: it doesn’t mess with the first responder and instead runs all the wx-side code *as if* first responder was resigned; when the window is activated again, it runs the code *as if* its first responder (which is the same as it was before, because we didn’t clear it) just became first responder. That should provide events compatibility with other ports while still acting native w.r.t. Cocoa.

In my testing, it seems to work fine. I can even see some improvement to how focus events are sent. Clicking into a text control in Poedit and then into another application previously resulted in this sequence:
```
Trace: (Focus) focus set(0x103831740)
Trace: (Focus) focus set(0x104873200)
Trace: (Focus) focus lost(0x104873200)
Trace: (Focus) focus lost(0x104873200)
```
But now it’s just
```
Trace: (Focus) focus set(0x104888000)
Trace: (Focus) focus lost(0x104888000)
```
(It’s still not perfect: changing focus within a TLW produces two loss events as it did before.)

But I’m not going to pretend: this change *is* risky. But short of putting it behind wxSystemOptions (ugh) or into private fork (for longer-term testing, but in Poedit code only), I think the only thing we can do is to apply it and see what happens. 

The PR also includes only a loosely related wxStatusBar change that is not controversial and serves as further illustration of the subtle issues present. It also relates to the difference between two `keyWindow` accessors that is addressed in the main part. 