### PR TITLE
Add missing include utils.h to rgncmn.cpp

### DIFF
--- a/src/common/rgncmn.cpp
+++ b/src/common/rgncmn.cpp
@@ -25,6 +25,7 @@
     #include "wx/dcmemory.h"
     #include "wx/bitmap.h"
     #include "wx/image.h"
+    #include "wx/utils.h"
 #endif //WX_PRECOMP
 
 // ============================================================================


### PR DESCRIPTION
When you compile wxWidgets without precompiled headers, then
src/common/rgncmn.cpp needs to import wx/utils.h explicitly,
as it uses wxMin.