### PR TITLE
Use multiple commands in Travis CI build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
         - os: osx
           osx_image: xcode6.4
           compiler: clang
-          env: wxCONFIGURE_FLAGS="--enable-cxx11" wxMAKEFILE_FLAGS="CXXFLAGS='-std=c++11 -stdlib=libc++'" wxSKIP_SAMPLES=1
+          env: wxCONFIGURE_FLAGS="--enable-cxx11" wxMAKEFILE_FLAGS="CXXFLAGS=-std=c++11" wxSKIP_SAMPLES=1
 
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,5 +54,6 @@ script:
     - sudo make install
     - echo -en 'travis_fold:end:script.install\\r'
     - echo 'Testing installation...' && echo -en 'travis_fold:start:script.testinstall\\r'
+    - make -C samples/minimal -f makefile.unx clean
     - make -C samples/minimal -f makefile.unx $wxMAKEFILE_FLAGS
     - echo -en 'travis_fold:end:script.testinstall\\r'

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,21 +38,21 @@ notifications:
 before_install: ./build/tools/before_install.sh
 
 script:
-    - set -e && echo 'Configuring...' && echo -en 'travis_fold:start:script.configure\\r'
+    - set -e && echo -n 'Configuring...' && echo -en 'travis_fold:start:script.configure\\r'
     - ./configure --disable-optimise $wxCONFIGURE_FLAGS
     - echo -en 'travis_fold:end:script.configure\\r'
-    - echo 'Building...' && echo -en 'travis_fold:start:script.build\\r'
+    - echo -n 'Building...' && echo -en 'travis_fold:start:script.build\\r'
     - make
     - echo -en 'travis_fold:end:script.build\\r'
-    - echo 'Testing...' && echo -en 'travis_fold:start:script.test\\r'
+    - echo -n 'Testing...' && echo -en 'travis_fold:start:script.test\\r'
     - make -C tests && pushd tests && ./test -t && popd
     - echo -en 'travis_fold:end:script.test\\r'
-    - echo 'Building samples...' && echo -en 'travis_fold:start:script.samples\\r'
-    - (test -n $wxSKIP_SAMPLES && echo 'SKIPPED') || make samples
+    - echo -n 'Building samples...' && echo -en 'travis_fold:start:script.samples\\r'
+    - (test -n "$wxSKIP_SAMPLES" && echo 'SKIPPED') || make samples
     - echo -en 'travis_fold:end:script.samples\\r'
-    - echo 'Installing...' && echo -en 'travis_fold:start:script.install\\r'
+    - echo -n 'Installing...' && echo -en 'travis_fold:start:script.install\\r'
     - sudo make install
     - echo -en 'travis_fold:end:script.install\\r'
-    - echo 'Testing installation...' && echo -en 'travis_fold:start:script.testinstall\\r'
+    - echo -n 'Testing installation...' && echo -en 'travis_fold:start:script.testinstall\\r'
     - make -C samples/minimal -f makefile.unx $wxMAKEFILE_FLAGS
     - echo -en 'travis_fold:end:script.testinstall\\r'

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,7 @@ notifications:
 before_install: ./build/tools/before_install.sh
 
 script:
-    - set -e
-    - echo 'Configuring...' && echo -en 'travis_fold:start:script.configure\\r'
+    - set -e && echo 'Configuring...' && echo -en 'travis_fold:start:script.configure\\r'
     - ./configure --disable-optimise $wxCONFIGURE_FLAGS
     - echo -en 'travis_fold:end:script.configure\\r'
     - echo 'Building...' && echo -en 'travis_fold:start:script.build\\r'
@@ -48,10 +47,9 @@ script:
     - echo 'Testing...' && echo -en 'travis_fold:start:script.test\\r'
     - make -C tests && pushd tests && ./test -t && popd
     - echo -en 'travis_fold:end:script.test\\r'
-    - test -z $wxSKIP_SAMPLES &&
-      echo 'Building samples...' && echo -en 'travis_fold:start:script.samples\\r' &&
-      make samples &&
-      echo -en 'travis_fold:end:script.samples\\r'
+    - echo 'Building samples...' && echo -en 'travis_fold:start:script.samples\\r'
+    - (test -n $wxSKIP_SAMPLES && echo 'SKIPPED') || make samples
+    - echo -en 'travis_fold:end:script.samples\\r'
     - echo 'Installing...' && echo -en 'travis_fold:start:script.install\\r'
     - sudo make install
     - echo -en 'travis_fold:end:script.install\\r'

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,25 +37,34 @@ notifications:
 
 before_install: ./build/tools/before_install.sh
 
-script: |
-    echo 'Configuring...' && echo -en 'travis_fold:start:script.1\\r' &&
-    ./configure --disable-optimise $wxCONFIGURE_FLAGS &&
-    echo -en 'travis_fold:end:script.1\\r' &&
-    echo 'Building...' && echo -en 'travis_fold:start:script.2\\r' &&
-    make &&
-    echo -en 'travis_fold:end:script.2\\r' &&
-    echo 'Testing...' && echo -en 'travis_fold:start:script.3\\r' &&
-    make -C tests &&
-    pushd tests &&
-    ./test -t &&
-    popd &&
-    echo -en 'travis_fold:end:script.3\\r' &&
-    echo 'Building the samples...' && echo -en 'travis_fold:start:script.4\\r' &&
-    (test -n "$wxSKIP_SAMPLES" && make samples || echo "*** Skipping building samples ***") &&
-    echo -en 'travis_fold:end:script.4\\r' &&
-    echo 'Installing...' && echo -en 'travis_fold:start:script.5\\r' &&
-    sudo make install &&
-    echo -en 'travis_fold:end:script.5\\r' &&
-    echo 'Testing building with the installed version...' && echo -en 'travis_fold:start:script.6\\r' &&
-    make -C samples/minimal -f makefile.unx $wxMAKEFILE_FLAGS &&
-    echo -en 'travis_fold:end:script.6\\r'
+script:
+    - set -e
+    - echo 'Configuring...'
+    - echo -en 'travis_fold:start:script.configure\\r'
+    - ./configure --disable-optimise $wxCONFIGURE_FLAGS
+    - echo -en 'travis_fold:end:script.configure\\r'
+    - echo 'Building...'
+    - echo -en 'travis_fold:start:script.build\\r'
+    - make
+    - echo -en 'travis_fold:end:script.build\\r'
+    - echo 'Testing...'
+    - echo -en 'travis_fold:start:script.test\\r'
+    - make -C tests
+    - pushd tests && ./test -t && popd
+    - echo -en 'travis_fold:end:script.test\\r'
+    - if [[ -z $wxSKIP_SAMPLES ]]; then
+        echo 'Building the samples...'
+        echo -en 'travis_fold:start:script.samples\\r'
+        make samples
+        echo -en 'travis_fold:end:script.samples\\r'
+      else
+        echo "*** Skipping building samples ***"
+      fi
+    - echo 'Installing...'
+    - echo -en 'travis_fold:start:script.install\\r'
+    - sudo make install
+    - echo -en 'travis_fold:end:script.install\\r'
+    - echo 'Testing building with the installed version...'
+    - echo -en 'travis_fold:start:script.testinstall\\r'
+    - make -C samples/minimal -f makefile.unx $wxMAKEFILE_FLAGS
+    - echo -en 'travis_fold:end:script.testinstall\\r'

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,22 +39,22 @@ before_install: ./build/tools/before_install.sh
 
 script:
     - set -e
-    - echo -en 'travis_fold:start:script.configure\\r'
+    - echo 'Configuring...' && echo -en 'travis_fold:start:script.configure\\r'
     - ./configure --disable-optimise $wxCONFIGURE_FLAGS
     - echo -en 'travis_fold:end:script.configure\\r'
-    - echo -en 'travis_fold:start:script.build\\r'
+    - echo 'Building...' && echo -en 'travis_fold:start:script.build\\r'
     - make
     - echo -en 'travis_fold:end:script.build\\r'
-    - echo -en 'travis_fold:start:script.test\\r'
+    - echo 'Testing...' && echo -en 'travis_fold:start:script.test\\r'
     - make -C tests && pushd tests && ./test -t && popd
     - echo -en 'travis_fold:end:script.test\\r'
-    - test -z $wxSKIP_SAMPLES && \
-      echo -en 'travis_fold:start:script.samples\\r' && \
-      make samples && \
+    - test -z $wxSKIP_SAMPLES &&
+      echo 'Building samples...' && echo -en 'travis_fold:start:script.samples\\r' &&
+      make samples &&
       echo -en 'travis_fold:end:script.samples\\r'
-    - echo -en 'travis_fold:start:script.install\\r'
+    - echo 'Installing...' && echo -en 'travis_fold:start:script.install\\r'
     - sudo make install
     - echo -en 'travis_fold:end:script.install\\r'
-    - echo -en 'travis_fold:start:script.testinstall\\r'
+    - echo 'Testing installation...' && echo -en 'travis_fold:start:script.testinstall\\r'
     - make -C samples/minimal -f makefile.unx $wxMAKEFILE_FLAGS
     - echo -en 'travis_fold:end:script.testinstall\\r'

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,32 +39,22 @@ before_install: ./build/tools/before_install.sh
 
 script:
     - set -e
-    - echo 'Configuring...'
     - echo -en 'travis_fold:start:script.configure\\r'
     - ./configure --disable-optimise $wxCONFIGURE_FLAGS
     - echo -en 'travis_fold:end:script.configure\\r'
-    - echo 'Building...'
     - echo -en 'travis_fold:start:script.build\\r'
     - make
     - echo -en 'travis_fold:end:script.build\\r'
-    - echo 'Testing...'
     - echo -en 'travis_fold:start:script.test\\r'
-    - make -C tests
-    - pushd tests && ./test -t && popd
+    - make -C tests && pushd tests && ./test -t && popd
     - echo -en 'travis_fold:end:script.test\\r'
-    - if [[ -z $wxSKIP_SAMPLES ]]; then
-        echo 'Building the samples...'
-        echo -en 'travis_fold:start:script.samples\\r'
-        make samples
-        echo -en 'travis_fold:end:script.samples\\r'
-      else
-        echo "*** Skipping building samples ***"
-      fi
-    - echo 'Installing...'
+    - test -z $wxSKIP_SAMPLES && \
+      echo -en 'travis_fold:start:script.samples\\r' && \
+      make samples && \
+      echo -en 'travis_fold:end:script.samples\\r'
     - echo -en 'travis_fold:start:script.install\\r'
     - sudo make install
     - echo -en 'travis_fold:end:script.install\\r'
-    - echo 'Testing building with the installed version...'
     - echo -en 'travis_fold:start:script.testinstall\\r'
     - make -C samples/minimal -f makefile.unx $wxMAKEFILE_FLAGS
     - echo -en 'travis_fold:end:script.testinstall\\r'

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,21 +38,21 @@ notifications:
 before_install: ./build/tools/before_install.sh
 
 script:
-    - set -e && echo -n 'Configuring...' && echo -en 'travis_fold:start:script.configure\\r'
+    - set -e && echo 'Configuring...' && echo -en 'travis_fold:start:script.configure\\r'
     - ./configure --disable-optimise $wxCONFIGURE_FLAGS
     - echo -en 'travis_fold:end:script.configure\\r'
-    - echo -n 'Building...' && echo -en 'travis_fold:start:script.build\\r'
+    - echo 'Building...' && echo -en 'travis_fold:start:script.build\\r'
     - make
     - echo -en 'travis_fold:end:script.build\\r'
-    - echo -n 'Testing...' && echo -en 'travis_fold:start:script.test\\r'
+    - echo 'Testing...' && echo -en 'travis_fold:start:script.test\\r'
     - make -C tests && pushd tests && ./test -t && popd
     - echo -en 'travis_fold:end:script.test\\r'
-    - echo -n 'Building samples...' && echo -en 'travis_fold:start:script.samples\\r'
-    - (test -n "$wxSKIP_SAMPLES" && echo 'SKIPPED') || make samples
+    - echo 'Building samples...' && echo -en 'travis_fold:start:script.samples\\r'
+    - (test "$wxSKIP_SAMPLES" && echo 'SKIPPED') || make samples
     - echo -en 'travis_fold:end:script.samples\\r'
-    - echo -n 'Installing...' && echo -en 'travis_fold:start:script.install\\r'
+    - echo 'Installing...' && echo -en 'travis_fold:start:script.install\\r'
     - sudo make install
     - echo -en 'travis_fold:end:script.install\\r'
-    - echo -n 'Testing installation...' && echo -en 'travis_fold:start:script.testinstall\\r'
+    - echo 'Testing installation...' && echo -en 'travis_fold:start:script.testinstall\\r'
     - make -C samples/minimal -f makefile.unx $wxMAKEFILE_FLAGS
     - echo -en 'travis_fold:end:script.testinstall\\r'


### PR DESCRIPTION
Using a single long command was always inconvenient and started displaying the
build results strangely since starting to build the samples conditionally in
62d2f4e5f5b24b1335e12dbdcf222488a0215845, so try using multiple commands with
"set -e" to ensure that we abort the build as soon as possible.