### PR TITLE
Add a flag for hidden arguments not shown by Usage()

### DIFF
--- a/include/wx/cmdline.h
+++ b/include/wx/cmdline.h
@@ -43,7 +43,8 @@ enum wxCmdLineEntryFlags
     wxCMD_LINE_PARAM_MULTIPLE   = 0x04, // the parameter may be repeated
     wxCMD_LINE_OPTION_HELP      = 0x08, // this option is a help request
     wxCMD_LINE_NEEDS_SEPARATOR  = 0x10, // must have sep before the value
-    wxCMD_LINE_SWITCH_NEGATABLE = 0x20  // this switch can be negated (e.g. /S-)
+    wxCMD_LINE_SWITCH_NEGATABLE = 0x20, // this switch can be negated (e.g. /S-)
+    wxCMD_LINE_HIDDEN           = 0x40  // this switch is not listed by Usage()
 };
 
 // an option value or parameter may be a string (the most common case), a

--- a/interface/wx/cmdline.h
+++ b/interface/wx/cmdline.h
@@ -30,6 +30,11 @@
     /R-). You will need to use wxCmdLineParser::FoundSwitch() to distinguish
     between the normal and negated forms of the switch. This flag is new since
     wxWidgets 2.9.2.
+
+    @c wxCMD_LINE_HIDDEN can be specified for arguments that should exist but
+    are not to be included in the output of Usage(). These could be, for
+    example, diagnostics switches that are not useful to the end user.
+    This flags is new since wxWidgets 3.1.1.
 */
 enum wxCmdLineEntryFlags
 {
@@ -38,7 +43,8 @@ enum wxCmdLineEntryFlags
     wxCMD_LINE_PARAM_MULTIPLE   = 0x04, ///< The parameter may be repeated.
     wxCMD_LINE_OPTION_HELP      = 0x08, ///< This option is a help request.
     wxCMD_LINE_NEEDS_SEPARATOR  = 0x10, ///< Must have a separator before the value.
-    wxCMD_LINE_SWITCH_NEGATABLE = 0x20  ///< This switch can be negated (e.g. /S-)
+    wxCMD_LINE_SWITCH_NEGATABLE = 0x20, ///< This switch can be negated (e.g. /S-)
+    wxCMD_LINE_HIDDEN           = 0x40  ///< This switch is not listed by Usage()
 };
 
 /**

--- a/samples/console/console.cpp
+++ b/samples/console/console.cpp
@@ -41,6 +41,8 @@ static const wxCmdLineEntryDesc cmdLineDesc[] =
     { wxCMD_LINE_SWITCH, "h", "help", "show this help message",
         wxCMD_LINE_VAL_NONE, wxCMD_LINE_OPTION_HELP },
     { wxCMD_LINE_SWITCH, "d", "dummy", "a dummy switch" },
+    { wxCMD_LINE_SWITCH, "s", "secret", "a secret switch",
+        wxCMD_LINE_VAL_NONE, wxCMD_LINE_HIDDEN },
     // ... your other command line options here...
 
     { wxCMD_LINE_NONE }
@@ -96,6 +98,11 @@ int main(int argc, char **argv)
                         wxPrintf("Bad luck!\n");
                 }
             }
+            if (parser.Found("s"))
+            {
+                wxPrintf("Secret switch was given...\n");
+            }
+
             break;
 
         default:

--- a/src/common/cmdline.cpp
+++ b/src/common/cmdline.cpp
@@ -1337,6 +1337,9 @@ wxString wxCmdLineParser::GetUsageString() const
         wxCmdLineOption& opt = m_data->m_options[n];
         wxString option, negator;
 
+        if ( opt.flags & wxCMD_LINE_HIDDEN )
+            continue;
+
         if ( opt.kind != wxCMD_LINE_USAGE_TEXT )
         {
             usage << wxT(' ');
@@ -1402,6 +1405,9 @@ wxString wxCmdLineParser::GetUsageString() const
     for ( n = 0; n < count; n++ )
     {
         wxCmdLineParam& param = m_data->m_paramDesc[n];
+
+        if ( param.flags & wxCMD_LINE_HIDDEN )
+            continue;
 
         usage << wxT(' ');
         if ( param.flags & wxCMD_LINE_PARAM_OPTIONAL )


### PR DESCRIPTION
An unlisted argument is processed as usual, but not shown in the output
given by Usage(). A use case for such could be diagnostics switches that
should exist but are not useful to the end user.