### PR TITLE
Test for wxUSE_BASE64 in wxRegConfig

### DIFF
--- a/include/wx/msw/regconf.h
+++ b/include/wx/msw/regconf.h
@@ -91,11 +91,15 @@ protected:
   // implement read/write methods
   virtual bool DoReadString(const wxString& key, wxString *pStr) const wxOVERRIDE;
   virtual bool DoReadLong(const wxString& key, long *plResult) const wxOVERRIDE;
+#if wxUSE_BASE64
   virtual bool DoReadBinary(const wxString& key, wxMemoryBuffer* buf) const wxOVERRIDE;
+#endif // wxUSE_BASE64
 
   virtual bool DoWriteString(const wxString& key, const wxString& szValue) wxOVERRIDE;
   virtual bool DoWriteLong(const wxString& key, long lValue) wxOVERRIDE;
+#if wxUSE_BASE64
   virtual bool DoWriteBinary(const wxString& key, const wxMemoryBuffer& buf) wxOVERRIDE;
+#endif // wxUSE_BASE64
 
 private:
   // these keys are opened during all lifetime of wxRegConfig object

--- a/src/msw/regconf.cpp
+++ b/src/msw/regconf.cpp
@@ -624,6 +624,7 @@ bool wxRegConfig::DoReadLong(const wxString& key, long *plResult) const
   return false;
 }
 
+#if wxUSE_BASE64
 bool wxRegConfig::DoReadBinary(const wxString& key, wxMemoryBuffer *buf) const
 {
     wxCHECK_MSG( buf, false, wxT("wxRegConfig::Read(): NULL param") );
@@ -657,6 +658,7 @@ bool wxRegConfig::DoReadBinary(const wxString& key, wxMemoryBuffer *buf) const
 
   return false;
 }
+#endif // wxUSE_BASE64
 
 bool wxRegConfig::DoWriteString(const wxString& key, const wxString& szValue)
 {
@@ -682,6 +684,7 @@ bool wxRegConfig::DoWriteLong(const wxString& key, long lValue)
   return LocalKey().SetValue(path.Name(), lValue);
 }
 
+#if wxUSE_BASE64
 bool wxRegConfig::DoWriteBinary(const wxString& key, const wxMemoryBuffer& buf)
 {
   wxConfigPathChanger path(this, key);
@@ -693,6 +696,7 @@ bool wxRegConfig::DoWriteBinary(const wxString& key, const wxMemoryBuffer& buf)
 
   return LocalKey().SetValue(path.Name(), buf);
 }
+#endif // wxUSE_BASE64
 
 // ----------------------------------------------------------------------------
 // renaming


### PR DESCRIPTION
When you compile wxWidgets with base64 support disabled, then
wxConfigBase does not declare DoReadBinary and DoWriteBinary.
Add a guard to wxRegConfig, so wxOVERRIDE won't cause an error.