### PR TITLE
removed excess macro parameter

### DIFF
--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -645,7 +645,7 @@ typedef short int WXTYPE;
 #    define wxCLANG_HAS_WARNING(x) __has_warning(x) /* allow macro expansion for the warning name */
 #    define wxCLANG_IF_VALID_WARNING(x,y) \
          wxCONCAT(wxCLANG_IF_VALID_WARNING_,wxCLANG_HAS_WARNING(wxSTRINGIZE(wxCONCAT(-W,x))))(y)
-#    define wxCLANG_IF_VALID_WARNING_0(x)
+#    define wxCLANG_IF_VALID_WARNING_0()
 #    define wxCLANG_IF_VALID_WARNING_1(x) x
 #    define wxCLANG_WARNING_SUPPRESS(x) \
          wxCLANG_IF_VALID_WARNING(x,wxGCC_WARNING_SUPPRESS(x))


### PR DESCRIPTION
This pull request removes noisy warning created by the macro definition for wxCLANG_IF_VALID_WARNING_0 by removing the parameter in the definition since no use of the macro provides a parameter.