### PR TITLE
Get translated XRC text for wxCollapsiblePane

### DIFF
--- a/src/xrc/xh_collpane.cpp
+++ b/src/xrc/xh_collpane.cpp
@@ -61,7 +61,7 @@ wxObject *wxCollapsiblePaneXmlHandler::DoCreateResource()
     {
         XRC_MAKE_INSTANCE(ctrl, wxCollapsiblePane)
 
-        wxString label = GetParamValue(wxT("label"));
+        wxString label = GetText(wxT("label"));
         if (label.empty())
         {
             ReportParamError("label", "label cannot be empty");


### PR DESCRIPTION
The label text for wxCollapsiblePane isn't getting translated via the XRC handler right now. This fixes that by using GetText() instead of GetParamValue() without breaking the empty string check.