### PR TITLE
Document missing wxGrid methods

### DIFF
--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -2808,6 +2808,13 @@ public:
     bool IsCellEditControlEnabled() const;
 
     /**
+        Returns @true if the in-place edit control is currently shown.
+
+        @see HideCellEditControl()
+    */
+    bool IsCellEditControlShown() const;
+
+    /**
         Returns @true if the current cell is read-only.
 
         @see SetReadOnly(), IsReadOnly()
@@ -3764,6 +3771,21 @@ public:
     void ClearSelection();
 
     /**
+        Deselects a row of cells.
+    */
+    void DeselectRow( int row );
+
+    /**
+        Deselects a column of cells.
+    */
+    void DeselectCol( int col );
+
+    /**
+        Deselects a cell.
+    */
+    void DeselectCell( int row, int col );
+
+    /**
         Returns an array of individually selected cells.
 
         Notice that this array does @em not contain all the selected cells in
@@ -4393,6 +4415,16 @@ public:
                  const wxGridCellCoords& topLeft = wxGridCellCoords( -1, -1 ),
                  const wxGridCellCoords& bottomRight = wxGridCellCoords( -1, -1 ),
                  int style = wxGRID_DRAW_DEFAULT );
+
+    /**
+        Sets the cell attributes for the specified cell.
+
+        The grid takes ownership of the attribute pointer.
+
+        See the wxGridCellAttr class for more information about controlling
+        cell attributes.
+    */
+    void SetAttr(int row, int col, wxGridCellAttr *attr);
 
     /**
         Sets the cell attributes for all cells in the specified column.


### PR DESCRIPTION
This adds documentation for a few methods that I found missing from the interface headers as someone reported that Deselect was missing from Phoenix.  Please cherry-pick to 3.0 also so Phoenix gets the changes.