### PR TITLE
Also disable thread-safe statics with VS17 toolset

### DIFF
--- a/build/msw/wx_setup.props
+++ b/build/msw/wx_setup.props
@@ -71,7 +71,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalOptions Condition="'$(PlatformToolset)' == 'v140_xp'">/Zc:threadSafeInit- %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(PlatformToolset)' == 'v140_xp' Or 'v141_xp'">/Zc:threadSafeInit- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;comdlg32.lib;winspool.lib;shell32.lib;shlwapi.lib;ole32.lib;oleaut32.lib;uuid.lib;advapi32.lib;version.lib;comctl32.lib;rpcrt4.lib;wsock32.lib;wininet.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
Tbh I haven't tested it (haven't yet installed vs17) but it should just be a pretty [basic](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-conditions) change. 