### PR TITLE
Generalize MSVC Zc:threadSafeInit- conditional

### DIFF
--- a/build/msw/wx_setup.props
+++ b/build/msw/wx_setup.props
@@ -71,7 +71,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalOptions Condition="'$(PlatformToolset)' == 'v140_xp'">/Zc:threadSafeInit- %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(PlatformToolset)' == 'v$(PlatformToolsetVersion)_xp' And '$(PlatformToolsetVersion)' >= 140">/Zc:threadSafeInit- %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;comdlg32.lib;winspool.lib;shell32.lib;shlwapi.lib;ole32.lib;oleaut32.lib;uuid.lib;advapi32.lib;version.lib;comctl32.lib;rpcrt4.lib;wsock32.lib;wininet.lib;winmm.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
As I was saying in #406, pretty [stupid](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-conditions) change (this time I at least tried to build it though!). 

EDIT: appveyor seems happy too
