### PR TITLE
Fixes for issues involving dialogs ending up behind their parent

### DIFF
--- a/src/osx/cocoa/nonownedwnd.mm
+++ b/src/osx/cocoa/nonownedwnd.mm
@@ -812,8 +812,16 @@ bool wxNonOwnedWindowCocoaImpl::Show(bool show)
                 if ( parentView )
                 {
                     NSWindow* parentNSWindow = [parentView window];
-                    if ( parentNSWindow )
+                    if ( parentNSWindow ) {
                         [parentNSWindow addChildWindow:m_macWindow ordered:NSWindowAbove];
+                        // If the parent is modal, windows with wxFRAME_FLOAT_ON_PARENT style need
+                        // to be in kCGUtilityWindowLevel and not kCGFloatingWindowLevel to stay
+                        // above the parent.
+                        if ([m_macWindow level] == kCGFloatingWindowLevel) {
+                            m_macWindowLevel = kCGUtilityWindowLevel;
+                            [m_macWindow setLevel:m_macWindowLevel];
+                        }
+                    }
                 }
             }
             

--- a/src/osx/cocoa/nonownedwnd.mm
+++ b/src/osx/cocoa/nonownedwnd.mm
@@ -671,7 +671,7 @@ long style, long extraStyle, const wxString& WXUNUSED(name) )
 
     [m_macWindow setAcceptsMouseMovedEvents:YES];
 
-    CGWindowLevel level = kCGNormalWindowLevel;
+    NSInteger level = NSNormalWindowLevel;
 
     if ( style & wxFRAME_TOOL_WINDOW )
     {
@@ -679,7 +679,7 @@ long style, long extraStyle, const wxString& WXUNUSED(name) )
     }
     else if ( ( style & wxPOPUP_WINDOW ) )
     {
-        level = kCGPopUpMenuWindowLevel;
+        level = NSPopUpMenuWindowLevel;
     }
     else if ( ( style & wxFRAME_DRAWER ) )
     {
@@ -890,7 +890,7 @@ void wxNonOwnedWindowCocoaImpl::SetWindowStyleFlag( long style )
     // don't mess with native wrapped windows, they might throw an exception when their level is changed
     if (!m_wxPeer->IsNativeWindowWrapper() && m_macWindow)
     {
-        CGWindowLevel level = kCGNormalWindowLevel;
+        NSInteger level = NSNormalWindowLevel;
         
         if (style & wxSTAY_ON_TOP)
             level = NSModalPanelWindowLevel;

--- a/src/osx/cocoa/nonownedwnd.mm
+++ b/src/osx/cocoa/nonownedwnd.mm
@@ -806,7 +806,7 @@ bool wxNonOwnedWindowCocoaImpl::Show(bool show)
         {
             // add to parent window before showing
             wxDialog * const dialog = wxDynamicCast(wxpeer, wxDialog);
-            if ( wxpeer->GetParent() && dialog && dialog->IsModal())
+            if ( wxpeer->GetParent() && dialog )
             {
                 NSView * parentView = wxpeer->GetParent()->GetPeer()->GetWXWidget();
                 if ( parentView )

--- a/src/osx/cocoa/nonownedwnd.mm
+++ b/src/osx/cocoa/nonownedwnd.mm
@@ -709,10 +709,10 @@ long style, long extraStyle, const wxString& WXUNUSED(name) )
         windowstyle |= NSTexturedBackgroundWindowMask;
 
     if ( ( style & wxFRAME_FLOAT_ON_PARENT ) || ( style & wxFRAME_TOOL_WINDOW ) )
-        level = kCGFloatingWindowLevel;
+        level = NSFloatingWindowLevel;
 
     if ( ( style & wxSTAY_ON_TOP ) )
-        level = kCGUtilityWindowLevel;
+        level = NSModalPanelWindowLevel;
 
     NSRect r = wxToNSRect( NULL, wxRect( pos, size) );
 
@@ -734,20 +734,20 @@ long style, long extraStyle, const wxString& WXUNUSED(name) )
     }
     
     // If the parent is modal, windows with wxFRAME_FLOAT_ON_PARENT style need
-    // to be in kCGUtilityWindowLevel and not kCGFloatingWindowLevel to stay
+    // to be in NSModalPanelWindowLevel and not NSFloatingWindowLevel to stay
     // above the parent.
     wxDialog * const parentDialog = parent == NULL ? NULL : wxDynamicCast(parent->MacGetTopLevelWindow(), wxDialog);
     if (parentDialog && parentDialog->IsModal())
     {
-        if (level == kCGFloatingWindowLevel)
+        if (level == NSFloatingWindowLevel)
         {
-            level = kCGUtilityWindowLevel;
+            level = NSModalPanelWindowLevel;
         }
 
         // Cocoa's modal loop does not process other windows by default, but
         // don't call this on normal window levels so nested modal dialogs will
         // still behave modally.
-        if (level != kCGNormalWindowLevel)
+        if (level != NSNormalWindowLevel)
         {
             if ([m_macWindow isKindOfClass:[NSPanel class]])
             {
@@ -815,10 +815,11 @@ bool wxNonOwnedWindowCocoaImpl::Show(bool show)
                     if ( parentNSWindow ) {
                         [parentNSWindow addChildWindow:m_macWindow ordered:NSWindowAbove];
                         // If the parent is modal, windows with wxFRAME_FLOAT_ON_PARENT style need
-                        // to be in kCGUtilityWindowLevel and not kCGFloatingWindowLevel to stay
+                        // to be in NSModalPanelWindowLevel and not NSFloatingWindowLevel to stay
                         // above the parent.
-                        if ([m_macWindow level] == kCGFloatingWindowLevel) {
-                            m_macWindowLevel = kCGUtilityWindowLevel;
+                        if ([m_macWindow level] == NSFloatingWindowLevel ||
+                            [m_macWindow level] == NSModalPanelWindowLevel) {
+                            m_macWindowLevel = NSModalPanelWindowLevel;
                             [m_macWindow setLevel:m_macWindowLevel];
                         }
                     }
@@ -892,9 +893,9 @@ void wxNonOwnedWindowCocoaImpl::SetWindowStyleFlag( long style )
         CGWindowLevel level = kCGNormalWindowLevel;
         
         if (style & wxSTAY_ON_TOP)
-            level = kCGUtilityWindowLevel;
+            level = NSModalPanelWindowLevel;
         else if (( style & wxFRAME_FLOAT_ON_PARENT ) || ( style & wxFRAME_TOOL_WINDOW ))
-            level = kCGFloatingWindowLevel;
+            level = NSFloatingWindowLevel;
         
         [m_macWindow setLevel: level];
         m_macWindowLevel = level;


### PR DESCRIPTION
Dialogs with a wxFRAME_FLOAT_ON_PARENT frame as parent were left behind their parent when switching back to the application. Modal dialogs move with their parent, and the non-active parent could completely obscure the dialog behind it, leaving no way to close the dialog.

Also a fix dialogs showing behind their wxSTAY_ON_TOP parent.