### PR TITLE
Fix warning by changing "wxUSE_WEB" to "wxUSE_WEBVIEW".

### DIFF
--- a/include/wx/msw/chkconf.h
+++ b/include/wx/msw/chkconf.h
@@ -383,12 +383,12 @@
 #           define wxUSE_MEDIACTRL 0
 #       endif
 #   endif
-#    if wxUSE_WEB
+#    if wxUSE_WEBVIEW
 #       ifdef wxABORT_ON_CONFIG_ERROR
 #           error "wxWebView requires wxActiveXContainer under MSW"
 #       else
-#           undef wxUSE_WEB
-#           define wxUSE_WEB 0
+#           undef wxUSE_WEBVIEW
+#           define wxUSE_WEBVIEW 0
 #       endif
 #   endif
 #endif /* !wxUSE_ACTIVEX */
@@ -431,12 +431,12 @@
 
 
 #if !wxUSE_OLE_AUTOMATION
-#    if wxUSE_WEB
+#    if wxUSE_WEBVIEW
 #       ifdef wxABORT_ON_CONFIG_ERROR
 #           error "wxWebView requires wxUSE_OLE_AUTOMATION under MSW"
 #       else
-#           undef wxUSE_WEB
-#           define wxUSE_WEB 0
+#           undef wxUSE_WEBVIEW
+#           define wxUSE_WEBVIEW 0
 #       endif
 #   endif
 #endif /* !wxUSE_OLE_AUTOMATION */


### PR DESCRIPTION
The warning: "wxUSE_WEB" is not defined [-Wundef] happens when compiling wxWidgets.

Tim S.

MSys2 short test command:
mkdir -p build_nogui_nofeatures && cd build_nogui_nofeatures && \
  ../configure --target=i686-w64-mingw32 --disable-gui --disable-all-features && \
  make
cd ..

MSys2 long test command:
mkdir -p build_webview && cd build_webview && \
../configure --target=i686-w64-mingw32 --disable-shared \
    --disable-ole --disable-dataobj \
    --disable-mediactrl --disable-accessibility \
    --disable-dirpicker --disable-filepicker \
    --disable-dirdlg --disable-filedlg \
    --disable-htmlhelp --disable-docview --disable-mdidoc \
    --disable-printarch --disable-filectrl \
    --disable-propgrid --disable-stc \
    --enable-webview \
    --enable-universal --disable-actindicator \
    --disable-accessibility --disable-aui && \
make
cd .. 
