### PR TITLE
Fix to build wxGTK under Win32

### DIFF
--- a/configure
+++ b/configure
@@ -7913,6 +7913,8 @@ fi
 
           eval "$wx_cv_use_iniconf"
 
+fi
+
 
           enablestring=
           defaultval=$wxUSE_ALL_FEATURES
@@ -7942,7 +7944,6 @@ fi
 
           eval "$wx_cv_use_regkey"
 
-fi
 
 if test "$wxUSE_GUI" = "yes"; then
 
@@ -22106,7 +22107,9 @@ rm -f core conftest.err conftest.$ac_objext \
                 if test -z "$wx_cv_lib_gtk"; then
                                         wx_cv_lib_gtk=none
                 else
-                                        GTK_LIBS="$GTK_LIBS -lX11"
+                    if test "$USE_WIN32" != 1 ; then
+                                                GTK_LIBS="$GTK_LIBS -lX11"
+                    fi
 
                                                             wx_cv_cflags_gtk=$GTK_CFLAGS
                     wx_cv_libs_gtk=$GTK_LIBS
@@ -28749,7 +28752,7 @@ else
 $as_echo "$as_me: WARNING: wxGetDiskSpace() function won't work without statfs()" >&2;}
 fi
 
-if test "$wxUSE_SNGLINST_CHECKER" = "yes"; then
+if test "$wxUSE_SNGLINST_CHECKER" = "yes" -a "$USE_WIN32" != 1 ; then
     for ac_func in fcntl flock
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
@@ -31289,7 +31292,7 @@ fi
 
 
 if test "$wxUSE_FSWATCHER" = "yes"; then
-                if test "$wxUSE_MSW" != "1"; then
+                if test "$USE_WIN32" != 1; then
         if test "$wxUSE_UNIX" = "yes"; then
             for ac_header in sys/inotify.h
 do :
@@ -32983,7 +32986,7 @@ done
 
 
 if test "$wxUSE_SOCKETS" = "yes"; then
-        if test "$TOOLKIT" != "MSW"; then
+        if test "$USE_WIN32" != 1 ; then
                 ac_fn_c_check_func "$LINENO" "socket" "ac_cv_func_socket"
 if test "x$ac_cv_func_socket" = xyes; then :
 
@@ -33046,7 +33049,7 @@ fi
 fi
 
 if test "$wxUSE_SOCKETS" = "yes" ; then
-                if test "$TOOLKIT" != "MSW"; then
+        if test "$USE_WIN32" != 1 ; then
                                         { $as_echo "$as_me:${as_lineno-$LINENO}: checking what is the type of the third argument of getsockname" >&5
 $as_echo_n "checking what is the type of the third argument of getsockname... " >&6; }
 if ${wx_cv_type_getsockname3+:} false; then :

--- a/configure.in
+++ b/configure.in
@@ -749,8 +749,9 @@ WX_ARG_FEATURE(threads,     [  --enable-threads        use threads], wxUSE_THREA
 if test "$wxUSE_MSW" = 1 ; then
 WX_ARG_DISABLE(dbghelp,     [  --enable-dbghelp        use dbghelp.dll API (Win32 only)], wxUSE_DBGHELP)
 WX_ARG_ENABLE(iniconf,      [  --enable-iniconf        use wxIniConfig (Win32 only)], wxUSE_INICONF)
-WX_ARG_FEATURE(regkey,      [  --enable-regkey         use wxRegKey class (Win32 only)], wxUSE_REGKEY)
 fi
+
+WX_ARG_FEATURE(regkey,      [  --enable-regkey         use wxRegKey class (Win32 only)], wxUSE_REGKEY)
 
 if test "$wxUSE_GUI" = "yes"; then
 
@@ -2782,8 +2783,10 @@ if test "$wxUSE_GUI" = "yes"; then
                     dnl looks better in AC_MSG_RESULT
                     wx_cv_lib_gtk=none
                 else
-                    dnl we use symbols from X11 directly so we should link with it
-                    GTK_LIBS="$GTK_LIBS -lX11"
+                    if test "$USE_WIN32" != 1 ; then
+                        dnl we use symbols from X11 directly so we should link with it
+                        GTK_LIBS="$GTK_LIBS -lX11"
+                    fi
 
                     dnl we need to cache GTK_CFLAGS and GTK_LIBS for the
                     dnl subsequent runs
@@ -4343,7 +4346,7 @@ fi
 
 dnl check for fcntl() or at least flock() needed by Unix implementation of
 dnl wxSingleInstanceChecker
-if test "$wxUSE_SNGLINST_CHECKER" = "yes"; then
+if test "$wxUSE_SNGLINST_CHECKER" = "yes" -a "$USE_WIN32" != 1 ; then
     AC_CHECK_FUNCS(fcntl flock, break)
 
     if test "$ac_cv_func_fcntl" != "yes" -a "$ac_cv_func_flock" != "yes"; then
@@ -5291,10 +5294,10 @@ dnl File system watcher checks
 dnl ---------------------------------------------------------------------------
 
 if test "$wxUSE_FSWATCHER" = "yes"; then
-    dnl wxFileSystemWatcher is always available under MSW but we need either
+    dnl wxFileSystemWatcher is always available under Windows but we need either
     dnl inotify or kqueue support in the system for it under Unix (this
     dnl includes OS X which does have kqueue but no other platforms)
-    if test "$wxUSE_MSW" != "1"; then
+    if test "$USE_WIN32" != 1; then
         if test "$wxUSE_UNIX" = "yes"; then
             AC_CHECK_HEADERS(sys/inotify.h,,, [AC_INCLUDES_DEFAULT()])
             if test "$ac_cv_header_sys_inotify_h" = "yes"; then
@@ -5927,8 +5930,8 @@ dnl wxSocket
 dnl ------------------------------------------------------------------------
 
 if test "$wxUSE_SOCKETS" = "yes"; then
-    dnl under MSW we always have sockets
-    if test "$TOOLKIT" != "MSW"; then
+    dnl under Windows we always have sockets
+    if test "$USE_WIN32" != 1 ; then
         dnl under Solaris and OS/2, socket functions live in -lsocket
         AC_CHECK_FUNC(socket,,
             [
@@ -5947,10 +5950,8 @@ if test "$wxUSE_SOCKETS" = "yes"; then
 fi
 
 if test "$wxUSE_SOCKETS" = "yes" ; then
-    dnl this test may be appropriate if building under cygwin
-    dnl right now I'm assuming it also uses the winsock stuff
-    dnl like mingw does..  -- RL
-    if test "$TOOLKIT" != "MSW"; then
+    dnl under Windows we always have sockets
+    if test "$USE_WIN32" != 1 ; then
         dnl determine the type of third argument for getsockname
         dnl This test needs to be done in C++ mode since gsocket.cpp now
         dnl is C++ code and pointer cast that are possible even without

--- a/include/wx/confbase.h
+++ b/include/wx/confbase.h
@@ -45,8 +45,12 @@ class WXDLLIMPEXP_FWD_BASE wxArrayString;
 /// should we use registry instead of configuration files under Windows?
 // (i.e. whether wxConfigBase::Create() will create a wxFileConfig (if it's
 //  false) or wxRegConfig (if it's true and we're under Win32))
-#ifndef   wxUSE_CONFIG_NATIVE
-  #define wxUSE_CONFIG_NATIVE 1
+#ifndef wxUSE_CONFIG_NATIVE
+    #if defined(__WINDOWS__) && !wxUSE_REGKEY
+        #define wxUSE_CONFIG_NATIVE 0
+    #else
+        #define wxUSE_CONFIG_NATIVE 1
+    #endif
 #endif
 
 // not all compilers can deal with template Read/Write() methods, define this

--- a/include/wx/gtk/mimetype.h
+++ b/include/wx/gtk/mimetype.h
@@ -18,7 +18,7 @@
 #include "wx/msw/mimetype.h"
 #endif
 
-#if wxUSE_MIMETYPE
+#if wxUSE_MIMETYPE && defined(__UNIX__)
 
 class WXDLLIMPEXP_CORE wxGTKMimeTypesManagerImpl : public wxMimeTypesManagerImpl
 {
@@ -33,6 +33,6 @@ public:
     wxMimeTypesManagerImpl *CreateMimeTypesManagerImpl() wxOVERRIDE;
 };
 
-#endif // wxUSE_MIMETYPE
+#endif // wxUSE_MIMETYPE && defined(__UNIX__)
 
 #endif // _WX_GTK_MIMETYPE_IMPL_H

--- a/include/wx/msw/chkconf.h
+++ b/include/wx/msw/chkconf.h
@@ -183,7 +183,7 @@
     #define wxUSE_SECRETSTORE 0
 #endif
 
-#if !wxUSE_OWNER_DRAWN && !defined(__WXUNIVERSAL__)
+#if !wxUSE_OWNER_DRAWN && !defined(__WXUNIVERSAL__) && defined(__WXMSW__)
 #   undef wxUSE_CHECKLISTBOX
 #   define wxUSE_CHECKLISTBOX 0
 #endif
@@ -401,6 +401,24 @@
 #       define wxUSE_ACTIVITYINDICATOR 0
 #   endif
 #endif /* wxUSE_ACTIVITYINDICATOR */
+
+#if wxUSE_MIMETYPE && !wxUSE_REGKEY
+#   ifdef wxABORT_ON_CONFIG_ERROR
+#       error "wxUSE_MIMETYPE requires wxUSE_REGKEY under Windows"
+#   else
+#       undef wxUSE_REGKEY
+#       define wxUSE_REGKEY 1
+#   endif
+#endif /* wxUSE_MIMETYPE && !wxUSE_REGKEY */
+
+#if wxUSE_CONFIG_NATIVE && !wxUSE_REGKEY
+#   ifdef wxABORT_ON_CONFIG_ERROR
+#       error "wxUSE_CONFIG_NATIVE requires wxUSE_REGKEY under Windows"
+#   else
+#       undef wxUSE_REGKEY
+#       define wxUSE_REGKEY 1
+#   endif
+#endif /* wxUSE_MIMETYPE && !wxUSE_REGKEY */
 
 #if wxUSE_STACKWALKER && !wxUSE_DBGHELP
     /*

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -20,7 +20,11 @@
 #endif  //__BORLANDC__
 
 #ifndef wxUSE_CONFIG_NATIVE
-    #define wxUSE_CONFIG_NATIVE 1
+    #if defined(__WINDOWS__) && !wxUSE_REGKEY
+        #define wxUSE_CONFIG_NATIVE 0
+    #else
+        #define wxUSE_CONFIG_NATIVE 1
+    #endif
 #endif
 
 #include "wx/config.h"

--- a/src/gtk/app.cpp
+++ b/src/gtk/app.cpp
@@ -436,7 +436,7 @@ bool wxApp::Initialize(int& argc_, wxChar **argv_)
         return false;
     }
 
-#if wxUSE_MIMETYPE
+#if wxUSE_MIMETYPE && !defined(__WINDOWS__)
     wxMimeTypesManagerFactory::Set(new wxGTKMimeTypesManagerFactory());
 #endif
 

--- a/src/gtk/mimetype.cpp
+++ b/src/gtk/mimetype.cpp
@@ -9,7 +9,7 @@
 
 #include "wx/wxprec.h"
 
-#if wxUSE_MIMETYPE
+#if wxUSE_MIMETYPE && !defined(__WINDOWS__)
 
 #include "wx/gtk/mimetype.h"
 
@@ -64,4 +64,4 @@ wxMimeTypesManagerImpl *wxGTKMimeTypesManagerFactory::CreateMimeTypesManagerImpl
     return new wxGTKMimeTypesManagerImpl();
 }
 
-#endif // wxUSE_MIMETYPE
+#endif // wxUSE_MIMETYPE && !defined(__WINDOWS__)

--- a/src/msw/utilswin.cpp
+++ b/src/msw/utilswin.cpp
@@ -68,7 +68,7 @@ bool wxLaunchDefaultApplication(const wxString& document, int flags)
 
 bool wxDoLaunchDefaultBrowser(const wxLaunchBrowserParams& params)
 {
-#if wxUSE_IPC
+#if wxUSE_IPC && wxUSE_REGKEY
     if ( params.flags & wxBROWSER_NEW_WINDOW )
     {
         // ShellExecuteEx() opens the URL in an existing window by default so
@@ -134,7 +134,7 @@ bool wxDoLaunchDefaultBrowser(const wxLaunchBrowserParams& params)
             }
         }
     }
-#endif // wxUSE_IPC
+#endif // wxUSE_IPC && wxUSE_REGKEY
 
     WinStruct<SHELLEXECUTEINFO> sei;
     sei.lpFile = params.GetPathOrURL().t_str();


### PR DESCRIPTION
I have gotten wxGTK to build on windows using MSys2 GCC (Rev1, Built by MSYS2 project) 6.3.0

mkdir -p build_wxGTK-gtk3 && cd build_wxGTK-gtk3 && \
  ../configure --target=i686-w64-mingw32 --with-gtk=3 && \
  make
cd ..

I have NOT tested if the libraries that are built are usable.

Tim S.
