### PR TITLE
Remove checks for X button declarations

### DIFF
--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -141,12 +141,6 @@
     #define HAVE_TRACKMOUSEEVENT
 #endif // everything needed for TrackMouseEvent()
 
-// not all compilers/platforms have X button related declarations (notably
-// Windows CE doesn't, and probably some old SDKs don't neither)
-#ifdef WM_XBUTTONDOWN
-    #define wxHAS_XBUTTON
-#endif
-
 #ifndef MAPVK_VK_TO_CHAR
     #define MAPVK_VK_TO_CHAR 2
 #endif
@@ -2915,11 +2909,9 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
         case WM_MBUTTONDOWN:
         case WM_MBUTTONUP:
         case WM_MBUTTONDBLCLK:
-#ifdef wxHAS_XBUTTON
         case WM_XBUTTONDOWN:
         case WM_XBUTTONUP:
         case WM_XBUTTONDBLCLK:
-#endif // wxHAS_XBUTTON
             {
                 int x = GET_X_LPARAM(lParam),
                     y = GET_Y_LPARAM(lParam);
@@ -5311,10 +5303,8 @@ void wxWindowMSW::InitMouseEvent(wxMouseEvent& event,
     event.m_leftDown = (flags & MK_LBUTTON) != 0;
     event.m_middleDown = (flags & MK_MBUTTON) != 0;
     event.m_rightDown = (flags & MK_RBUTTON) != 0;
-#ifdef wxHAS_XBUTTON
     event.m_aux1Down = (flags & MK_XBUTTON1) != 0;
     event.m_aux2Down = (flags & MK_XBUTTON2) != 0;
-#endif // wxHAS_XBUTTON
     event.m_altDown = ::wxIsAltDown();
 
     event.SetTimestamp(::GetMessageTime());
@@ -5353,7 +5343,6 @@ bool wxWindowMSW::HandleMouseEvent(WXUINT msg, int x, int y, WXUINT flags)
         wxEVT_AUX2_DCLICK
     };
 
-#ifdef wxHAS_XBUTTON
     // the same messages are used for both auxiliary mouse buttons so we need
     // to adjust the index manually
     switch ( msg )
@@ -5364,7 +5353,6 @@ bool wxWindowMSW::HandleMouseEvent(WXUINT msg, int x, int y, WXUINT flags)
             if ( flags & MK_XBUTTON2 )
                 msg += wxEVT_AUX2_DOWN - wxEVT_AUX1_DOWN;
     }
-#endif // wxHAS_XBUTTON
 
     wxMouseEvent event(eventsMouse[msg - WM_MOUSEMOVE]);
     InitMouseEvent(event, x, y, flags);
@@ -6430,10 +6418,8 @@ wxMouseState wxGetMouseState()
     ms.SetLeftDown(wxIsKeyDown(VK_LBUTTON));
     ms.SetMiddleDown(wxIsKeyDown(VK_MBUTTON));
     ms.SetRightDown(wxIsKeyDown(VK_RBUTTON));
-#ifdef wxHAS_XBUTTON
     ms.SetAux1Down(wxIsKeyDown(VK_XBUTTON1));
     ms.SetAux2Down(wxIsKeyDown(VK_XBUTTON2));
-#endif // wxHAS_XBUTTON
 
     ms.SetControlDown(wxIsCtrlDown ());
     ms.SetShiftDown  (wxIsShiftDown());


### PR DESCRIPTION
X button declarations are available since Win2k.
https://msdn.microsoft.com/en-us/library/windows/desktop/ms646245(v=vs.85).aspx