### PR TITLE
Remove checks for multiple WM_XXX symbols

### DIFF
--- a/src/msw/anybutton.cpp
+++ b/src/msw/anybutton.cpp
@@ -90,10 +90,6 @@ using namespace wxMSWImpl;
     #endif
 #endif // wxUSE_UXTHEME
 
-#ifndef WM_THEMECHANGED
-    #define WM_THEMECHANGED     0x031A
-#endif
-
 #ifndef ODS_NOACCEL
     #define ODS_NOACCEL         0x0100
 #endif

--- a/src/msw/evtloop.cpp
+++ b/src/msw/evtloop.cpp
@@ -328,9 +328,7 @@ void wxGUIEventLoop::DoYieldFor(long eventsToProcess)
             case WM_SYSKEYUP:
             case WM_SYSCHAR:
             case WM_SYSDEADCHAR:
-#ifdef WM_UNICHAR
             case WM_UNICHAR:
-#endif
             case WM_HOTKEY:
             case WM_IME_STARTCOMPOSITION:
             case WM_IME_ENDCOMPOSITION:
@@ -349,9 +347,7 @@ void wxGUIEventLoop::DoYieldFor(long eventsToProcess)
 
             case WM_MOUSEHOVER:
             case WM_MOUSELEAVE:
-#ifdef WM_NCMOUSELEAVE
             case WM_NCMOUSELEAVE:
-#endif
 
             case WM_CUT:
             case WM_COPY:

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -3157,12 +3157,10 @@ wxListCtrl::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam)
 {
     switch ( nMsg )
     {
-#ifdef WM_PRINT
         case WM_PRINT:
             // we should bypass our own WM_PRINT handling as we don't handle
             // PRF_CHILDREN flag, so leave it to the native control itself
             return MSWDefWindowProc(nMsg, wParam, lParam);
-#endif // WM_PRINT
 
         case WM_CONTEXTMENU:
             // because this message is propagated upwards the child-parent

--- a/src/msw/spinctrl.cpp
+++ b/src/msw/spinctrl.cpp
@@ -101,12 +101,10 @@ wxBuddyTextWndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
         case WM_DEADCHAR:
         case WM_KEYUP:
         case WM_KEYDOWN:
-#ifdef WM_HELP
         // we need to forward WM_HELP too to ensure that the context help
         // associated with wxSpinCtrl is shown when the text control part of it
         // is clicked with the "?" cursor
         case WM_HELP:
-#endif
             {
                 WXLRESULT result;
                 if ( spin->MSWHandleMessage(&result, message, wParam, lParam) )

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -71,9 +71,6 @@
     #include "wx/access.h"
     #include <ole2.h>
     #include <oleacc.h>
-    #ifndef WM_GETOBJECT
-        #define WM_GETOBJECT 0x003D
-    #endif
     #ifndef OBJID_CLIENT
         #define OBJID_CLIENT 0xFFFFFFFC
     #endif
@@ -3292,7 +3289,6 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
             }
 #endif
 
-#if defined(WM_HELP)
         case WM_HELP:
             {
                 // by default, WM_HELP is propagated by DefWindowProc() upwards
@@ -3328,7 +3324,6 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                 }
             }
             break;
-#endif // WM_HELP
 
         case WM_CONTEXTMENU:
             {


### PR DESCRIPTION
The concerned symbols are present at least since XP, and most of them since win2k.
[WM_HELP ](https://msdn.microsoft.com/en-us/library/windows/desktop/bb774305(v=vs.85).aspx)
[WM_UNICHAR](https://msdn.microsoft.com/en-us/library/windows/desktop/ms646288(v=vs.85).aspx)
[WM_NCMOUSELEAVE](https://msdn.microsoft.com/en-us/library/windows/desktop/ms645626(v=vs.85).aspx)
[WM_PRINT](https://msdn.microsoft.com/en-us/library/dd145216(v=vs.85).aspx)
[WM_THEMECHANGED](https://msdn.microsoft.com/en-us/library/windows/desktop/ms632650(v=vs.85).aspx)
[WM_GETOBJECT](https://msdn.microsoft.com/en-us/library/windows/desktop/dd373892(v=vs.85).aspx)

There are a few more WM_XXX symbol definitions in `include/wx/msw/missing.h` that could theoretically be removed, but they might still be missing from other compilers?