### PR TITLE
Use `MIIM_FTYPE` symbol rather than `MIIM_TYPE`

### DIFF
--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -5685,19 +5685,13 @@ int wxWindowMSW::HandleMenuChar(int chAccel,
 
     WinStruct<MENUITEMINFO> mii;
 
-    // we could use MIIM_FTYPE here as we only need to know if the item is
-    // ownerdrawn or not and not dwTypeData which MIIM_TYPE also returns, but
-    // MIIM_FTYPE is not supported under Win95
-    mii.fMask = MIIM_TYPE | MIIM_DATA;
+    // use MIIM_FTYPE to know if the item is ownerdrawn or not
+    mii.fMask = MIIM_FTYPE | MIIM_DATA;
 
     // find if we have this letter in any owner drawn item
     const int count = ::GetMenuItemCount(hmenu);
     for ( int i = 0; i < count; i++ )
     {
-        // previous loop iteration could modify it, reset it back before
-        // calling GetMenuItemInfo() to prevent it from overflowing dwTypeData
-        mii.cch = 0;
-
         if ( ::GetMenuItemInfo(hmenu, i, TRUE, &mii) )
         {
             if ( mii.fType == MFT_OWNERDRAW )


### PR DESCRIPTION
Use `MIIM_FTYPE` to know if a menu item is ownerdrawn or not.
Also, according to [MSDN](https://msdn.microsoft.com/en-us/library/windows/desktop/ms647578(v=vs.85).aspx), `MENUITEMINFO::cch` is used if `MIIM_TYPE` or `MIIM_STRING` flags are set in the fMask member.