### PR TITLE
Resolve Wsuggest-override and Wmisleading-indentation warnings.

### DIFF
--- a/include/wx/generic/custombgwin.h
+++ b/include/wx/generic/custombgwin.h
@@ -61,7 +61,7 @@ public:
     wxCustomBackgroundWindow() { }
 
 protected:
-    virtual void DoSetBackgroundBitmap(const wxBitmap& bmp)
+    virtual void DoSetBackgroundBitmap(const wxBitmap& bmp) wxOVERRIDE
     {
         m_bitmapBg = bmp;
 

--- a/include/wx/generic/timectrl.h
+++ b/include/wx/generic/timectrl.h
@@ -46,19 +46,19 @@ public:
                 const wxString& name = wxTimePickerCtrlNameStr);
 
     // Implement pure virtual wxTimePickerCtrlBase methods.
-    virtual void SetValue(const wxDateTime& date);
-    virtual wxDateTime GetValue() const;
+    virtual void SetValue(const wxDateTime& date) wxOVERRIDE;
+    virtual wxDateTime GetValue() const wxOVERRIDE;
 
 protected:
-    virtual wxSize DoGetBestSize() const;
+    virtual wxSize DoGetBestSize() const wxOVERRIDE;
 
-    virtual void DoMoveWindow(int x, int y, int width, int height);
+    virtual void DoMoveWindow(int x, int y, int width, int height) wxOVERRIDE;
 
 private:
     void Init();
 
     // Return the list of the windows composing this one.
-    virtual wxWindowList GetCompositeWindowParts() const;
+    virtual wxWindowList GetCompositeWindowParts() const wxOVERRIDE;
 
     // Implementation data.
     class wxTimePickerGenericImpl* m_impl;

--- a/include/wx/gtk/private/textmeasure.h
+++ b/include/wx/gtk/private/textmeasure.h
@@ -35,18 +35,18 @@ protected:
     // Common part of both ctors.
     void Init();
 
-    virtual void BeginMeasuring();
-    virtual void EndMeasuring();
+    virtual void BeginMeasuring() wxOVERRIDE;
+    virtual void EndMeasuring() wxOVERRIDE;
 
     virtual void DoGetTextExtent(const wxString& string,
                                  wxCoord *width,
                                  wxCoord *height,
                                  wxCoord *descent = NULL,
-                                 wxCoord *externalLeading = NULL);
+                                 wxCoord *externalLeading = NULL) wxOVERRIDE;
 
     virtual bool DoGetPartialTextExtents(const wxString& text,
                                          wxArrayInt& widths,
-                                         double scaleX);
+                                         double scaleX) wxOVERRIDE;
 
     // This class is only used for DC text measuring with GTK+ 2 as GTK+ 3 uses
     // Cairo and not Pango for this. However it's still used even with GTK+ 3

--- a/include/wx/gtk/private/timer.h
+++ b/include/wx/gtk/private/timer.h
@@ -22,9 +22,9 @@ class WXDLLIMPEXP_CORE wxGTKTimerImpl : public wxTimerImpl
 public:
     wxGTKTimerImpl(wxTimer* timer) : wxTimerImpl(timer) { m_sourceId = 0; }
 
-    virtual bool Start( int millisecs = -1, bool oneShot = false );
-    virtual void Stop();
-    virtual bool IsRunning() const { return m_sourceId != 0; }
+    virtual bool Start( int millisecs = -1, bool oneShot = false ) wxOVERRIDE;
+    virtual void Stop() wxOVERRIDE;
+    virtual bool IsRunning() const wxOVERRIDE { return m_sourceId != 0; }
 
 protected:
     int m_sourceId;

--- a/include/wx/gtk/scrolwin.h
+++ b/include/wx/gtk/scrolwin.h
@@ -26,15 +26,15 @@ public:
     virtual void SetScrollbars(int pixelsPerUnitX, int pixelsPerUnitY,
                                int noUnitsX, int noUnitsY,
                                int xPos = 0, int yPos = 0,
-                               bool noRefresh = false);
-    virtual void AdjustScrollbars();
+                               bool noRefresh = false) wxOVERRIDE;
+    virtual void AdjustScrollbars() wxOVERRIDE;
 
-    virtual bool IsScrollbarShown(int orient) const;
+    virtual bool IsScrollbarShown(int orient) const wxOVERRIDE;
 
 protected:
-    virtual void DoScroll(int x, int y);
+    virtual void DoScroll(int x, int y) wxOVERRIDE;
     virtual void DoShowScrollbars(wxScrollbarVisibility horz,
-                                  wxScrollbarVisibility vert);
+                                  wxScrollbarVisibility vert) wxOVERRIDE;
 
 private:
     // this does (each) half of AdjustScrollbars() work

--- a/include/wx/unix/private/epolldispatcher.h
+++ b/include/wx/unix/private/epolldispatcher.h
@@ -30,11 +30,11 @@ public:
     virtual ~wxEpollDispatcher();
 
     // implement base class pure virtual methods
-    virtual bool RegisterFD(int fd, wxFDIOHandler* handler, int flags = wxFDIO_ALL);
-    virtual bool ModifyFD(int fd, wxFDIOHandler* handler, int flags = wxFDIO_ALL);
-    virtual bool UnregisterFD(int fd);
-    virtual bool HasPending() const;
-    virtual int Dispatch(int timeout = TIMEOUT_INFINITE);
+    virtual bool RegisterFD(int fd, wxFDIOHandler* handler, int flags = wxFDIO_ALL) wxOVERRIDE;
+    virtual bool ModifyFD(int fd, wxFDIOHandler* handler, int flags = wxFDIO_ALL) wxOVERRIDE;
+    virtual bool UnregisterFD(int fd) wxOVERRIDE;
+    virtual bool HasPending() const wxOVERRIDE;
+    virtual int Dispatch(int timeout = TIMEOUT_INFINITE) wxOVERRIDE;
 
 private:
     // ctor is private, use Create()

--- a/include/wx/unix/private/executeiohandler.h
+++ b/include/wx/unix/private/executeiohandler.h
@@ -31,7 +31,7 @@ public:
     }
 
     // Called when the associated descriptor is available for reading.
-    virtual void OnReadWaiting()
+    virtual void OnReadWaiting() wxOVERRIDE
     {
         // Sync process, process all data coming at us from the pipe so that
         // the pipe does not get full and cause a deadlock situation.
@@ -44,8 +44,8 @@ public:
     // These methods are never called as we only monitor the associated FD for
     // reading, but we still must implement them as they're pure virtual in the
     // base class.
-    virtual void OnWriteWaiting() { }
-    virtual void OnExceptionWaiting() { }
+    virtual void OnWriteWaiting() wxOVERRIDE { }
+    virtual void OnExceptionWaiting() wxOVERRIDE { }
 
     // Disable any future calls to our OnReadWaiting(), can be called when
     // we're sure that no more input is forthcoming.
@@ -93,7 +93,7 @@ public:
     }
 
 private:
-    virtual void DoDisable()
+    virtual void DoDisable() wxOVERRIDE
     {
         m_dispatcher.UnregisterFD(m_fd);
     }
@@ -122,7 +122,7 @@ public:
     }
 
 private:
-    virtual void DoDisable()
+    virtual void DoDisable() wxOVERRIDE
     {
         delete m_source;
         m_source = NULL;

--- a/include/wx/unix/private/fdiounix.h
+++ b/include/wx/unix/private/fdiounix.h
@@ -19,8 +19,8 @@
 class wxFDIOManagerUnix : public wxFDIOManager
 {
 public:
-    virtual int AddInput(wxFDIOHandler *handler, int fd, Direction d);
-    virtual void RemoveInput(wxFDIOHandler *handler, int fd, Direction d);
+    virtual int AddInput(wxFDIOHandler *handler, int fd, Direction d) wxOVERRIDE;
+    virtual void RemoveInput(wxFDIOHandler *handler, int fd, Direction d) wxOVERRIDE;
 };
 
 #endif // _UNIX_PRIVATE_FDIOUNIX_H_

--- a/include/wx/unix/private/fswatcher_inotify.h
+++ b/include/wx/unix/private/fswatcher_inotify.h
@@ -60,9 +60,9 @@ public:
         m_service(service)
     {  }
 
-    virtual void OnReadWaiting();
-    virtual void OnWriteWaiting();
-    virtual void OnExceptionWaiting();
+    virtual void OnReadWaiting() wxOVERRIDE;
+    virtual void OnWriteWaiting() wxOVERRIDE;
+    virtual void OnExceptionWaiting() wxOVERRIDE;
 
 protected:
     wxFSWatcherImplUnix* m_service;

--- a/include/wx/unix/private/pipestream.h
+++ b/include/wx/unix/private/pipestream.h
@@ -21,7 +21,7 @@ public:
     bool IsOpened() const { return !Eof(); }
 
     // return true if we have anything to read, don't block
-    virtual bool CanRead() const;
+    virtual bool CanRead() const wxOVERRIDE;
 };
 
 class wxPipeOutputStream : public wxFileOutputStream
@@ -31,7 +31,7 @@ public:
 
     // Override the base class version to ignore "pipe full" errors: this is
     // not an error for this class.
-    size_t OnSysWrite(const void *buffer, size_t size);
+    size_t OnSysWrite(const void *buffer, size_t size) wxOVERRIDE;
 };
 
 #endif // _WX_UNIX_PRIVATE_PIPESTREAM_H_

--- a/include/wx/unix/private/sockunix.h
+++ b/include/wx/unix/private/sockunix.h
@@ -34,9 +34,9 @@ public:
         m_fds[1] = -1;
     }
 
-    virtual wxSocketError GetLastError() const;
+    virtual wxSocketError GetLastError() const wxOVERRIDE;
 
-    virtual void ReenableEvents(wxSocketEventFlags flags)
+    virtual void ReenableEvents(wxSocketEventFlags flags) wxOVERRIDE
     {
         // enable the notifications about input/output being available again in
         // case they were disabled by OnRead/WriteWaiting()
@@ -54,20 +54,20 @@ public:
     }
 
     // wxFDIOHandler methods
-    virtual void OnReadWaiting();
-    virtual void OnWriteWaiting();
-    virtual void OnExceptionWaiting();
-    virtual bool IsOk() const { return m_fd != INVALID_SOCKET; }
+    virtual void OnReadWaiting() wxOVERRIDE;
+    virtual void OnWriteWaiting() wxOVERRIDE;
+    virtual void OnExceptionWaiting() wxOVERRIDE;
+    virtual bool IsOk() const wxOVERRIDE { return m_fd != INVALID_SOCKET; }
 
 private:
-    virtual void DoClose()
+    virtual void DoClose() wxOVERRIDE
     {
         DisableEvents();
 
         close(m_fd);
     }
 
-    virtual void UnblockAndRegisterWithEventLoop()
+    virtual void UnblockAndRegisterWithEventLoop() wxOVERRIDE
     {
         int trueArg = 1;
         ioctl(m_fd, FIONBIO, &trueArg);
@@ -114,16 +114,16 @@ public:
         m_fdioManager = NULL;
     }
 
-    virtual bool OnInit();
-    virtual void OnExit() { }
+    virtual bool OnInit() wxOVERRIDE;
+    virtual void OnExit() wxOVERRIDE { }
 
-    virtual wxSocketImpl *CreateSocket(wxSocketBase& wxsocket)
+    virtual wxSocketImpl *CreateSocket(wxSocketBase& wxsocket) wxOVERRIDE
     {
         return new wxSocketImplUnix(wxsocket);
     }
 
-    virtual void Install_Callback(wxSocketImpl *socket_, wxSocketNotify event);
-    virtual void Uninstall_Callback(wxSocketImpl *socket_, wxSocketNotify event);
+    virtual void Install_Callback(wxSocketImpl *socket_, wxSocketNotify event) wxOVERRIDE;
+    virtual void Uninstall_Callback(wxSocketImpl *socket_, wxSocketNotify event) wxOVERRIDE;
 
 protected:
     // get the FD index corresponding to the given wxSocketNotify

--- a/include/wx/unix/private/timer.h
+++ b/include/wx/unix/private/timer.h
@@ -30,9 +30,9 @@ public:
     wxUnixTimerImpl(wxTimer *timer);
     virtual ~wxUnixTimerImpl();
 
-    virtual bool IsRunning() const;
-    virtual bool Start(int milliseconds = -1, bool oneShot = false);
-    virtual void Stop();
+    virtual bool IsRunning() const wxOVERRIDE;
+    virtual bool Start(int milliseconds = -1, bool oneShot = false) wxOVERRIDE;
+    virtual void Stop() wxOVERRIDE;
 
     // for wxTimerScheduler only: resets the internal flag indicating that the
     // timer is running

--- a/include/wx/unix/private/wakeuppipe.h
+++ b/include/wx/unix/private/wakeuppipe.h
@@ -44,9 +44,9 @@ public:
 
 
     // Implement wxEventLoopSourceHandler pure virtual methods
-    virtual void OnReadWaiting();
-    virtual void OnWriteWaiting() { }
-    virtual void OnExceptionWaiting() { }
+    virtual void OnReadWaiting() wxOVERRIDE;
+    virtual void OnWriteWaiting() wxOVERRIDE { }
+    virtual void OnExceptionWaiting() wxOVERRIDE { }
 
 private:
     wxPipe m_pipe;
@@ -80,7 +80,7 @@ public:
         WakeUpNoLock();
     }
 
-    virtual void OnReadWaiting()
+    virtual void OnReadWaiting() wxOVERRIDE
     {
         wxCriticalSectionLocker lock(m_pipeLock);
 

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -227,7 +227,7 @@ void wxDataViewColumn::SetSortOrder(bool ascending)
         m_owner->UseColumnForSorting(idx);
         m_sort = true;
     }
-    
+
    m_sortAscending = ascending;
 
     // Call this directly instead of using UpdateDisplay() as we already have
@@ -3381,42 +3381,42 @@ void wxDataViewMainWindow::Collapse(unsigned int row)
     if (!node->HasChildren())
         return;
 
-        if (node->IsOpen())
+    if (node->IsOpen())
+    {
+        if ( !SendExpanderEvent(wxEVT_DATAVIEW_ITEM_COLLAPSING,node->GetItem()) )
         {
-            if ( !SendExpanderEvent(wxEVT_DATAVIEW_ITEM_COLLAPSING,node->GetItem()) )
-            {
-                // Vetoed by the event handler.
-                return;
-            }
-
-            const unsigned countDeletedRows = node->GetSubTreeCount();
-
-            if ( m_selection.OnItemsDeleted(row + 1, countDeletedRows) )
-            {
-                SendSelectionChangedEvent(GetItemByRow(row));
-            }
-
-            node->ToggleOpen();
-
-            // Adjust the current row if necessary.
-            if ( m_currentRow > row )
-            {
-                // If the current row was among the collapsed items, make the
-                // parent itself current.
-                if ( m_currentRow <= row + countDeletedRows )
-                    ChangeCurrentRow(row);
-                else // Otherwise just update the index.
-                    ChangeCurrentRow(m_currentRow - countDeletedRows);
-            }
-
-            if ( m_count != -1 )
-                m_count -= countDeletedRows;
-
-            GetOwner()->InvalidateColBestWidths();
-
-            UpdateDisplay();
-            SendExpanderEvent(wxEVT_DATAVIEW_ITEM_COLLAPSED,node->GetItem());
+            // Vetoed by the event handler.
+            return;
         }
+
+        const unsigned countDeletedRows = node->GetSubTreeCount();
+
+        if ( m_selection.OnItemsDeleted(row + 1, countDeletedRows) )
+        {
+            SendSelectionChangedEvent(GetItemByRow(row));
+        }
+
+        node->ToggleOpen();
+
+        // Adjust the current row if necessary.
+        if ( m_currentRow > row )
+        {
+            // If the current row was among the collapsed items, make the
+            // parent itself current.
+            if ( m_currentRow <= row + countDeletedRows )
+                ChangeCurrentRow(row);
+            else // Otherwise just update the index.
+                ChangeCurrentRow(m_currentRow - countDeletedRows);
+        }
+
+        if ( m_count != -1 )
+            m_count -= countDeletedRows;
+
+        GetOwner()->InvalidateColBestWidths();
+
+        UpdateDisplay();
+        SendExpanderEvent(wxEVT_DATAVIEW_ITEM_COLLAPSED,node->GetItem());
+    }
 }
 
 wxDataViewTreeNode * wxDataViewMainWindow::FindNode( const wxDataViewItem & item )

--- a/src/generic/preferencesg.cpp
+++ b/src/generic/preferencesg.cpp
@@ -156,7 +156,7 @@ public:
             m_win->Destroy();
     }
 
-    virtual void Show(wxWindow* parent)
+    virtual void Show(wxWindow* parent) wxOVERRIDE
     {
         if ( !m_win )
         {
@@ -174,7 +174,7 @@ public:
         }
     }
 
-    virtual void Dismiss()
+    virtual void Dismiss() wxOVERRIDE
     {
         if ( m_win )
         {

--- a/src/msw/registry.cpp
+++ b/src/msw/registry.cpp
@@ -1124,11 +1124,11 @@ bool wxRegKey::GetFirstValue(wxString& strValueName, long& lIndex)
 
 bool wxRegKey::GetNextValue(wxString& strValueName, long& lIndex) const
 {
-  wxASSERT( IsOpened() );
+    wxASSERT( IsOpened() );
 
-  // are we already at the end of enumeration?
-  if ( lIndex == -1 )
-    return false;
+    // are we already at the end of enumeration?
+    if ( lIndex == -1 )
+        return false;
 
     wxChar  szValueName[1024];                  // @@ use RegQueryInfoKey...
     DWORD dwValueLen = WXSIZEOF(szValueName);

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1633,7 +1633,7 @@ wxToolBarToolBase *wxToolBar::FindToolForPosition(wxCoord x, wxCoord y) const
         // it's a separator or there is no tool at all there
         return NULL;
 
-        return m_tools.Item((size_t)index)->GetData();
+    return m_tools.Item((size_t)index)->GetData();
 }
 
 void wxToolBar::UpdateSize()

--- a/src/unix/fswatcher_inotify.cpp
+++ b/src/unix/fswatcher_inotify.cpp
@@ -61,7 +61,7 @@ public:
         delete m_handler;
     }
 
-    bool Init()
+    bool Init() wxOVERRIDE
     {
         wxCHECK_MSG( !IsOk(), false, "Inotify already initialized" );
 
@@ -98,7 +98,7 @@ public:
         }
     }
 
-    virtual bool DoAdd(wxSharedPtr<wxFSWatchEntryUnix> watch)
+    virtual bool DoAdd(wxSharedPtr<wxFSWatchEntryUnix> watch) wxOVERRIDE
     {
         wxCHECK_MSG( IsOk(), false,
                     "Inotify not initialized or invalid inotify descriptor" );
@@ -121,7 +121,7 @@ public:
         return true;
     }
 
-    virtual bool DoRemove(wxSharedPtr<wxFSWatchEntryUnix> watch)
+    virtual bool DoRemove(wxSharedPtr<wxFSWatchEntryUnix> watch) wxOVERRIDE
     {
         wxCHECK_MSG( IsOk(), false,
                     "Inotify not initialized or invalid inotify descriptor" );
@@ -157,7 +157,7 @@ public:
         return true;
     }
 
-    virtual bool RemoveAll()
+    virtual bool RemoveAll() wxOVERRIDE
     {
         wxFSWatchEntries::iterator it = m_watches.begin();
         for ( ; it != m_watches.end(); ++it )


### PR DESCRIPTION
Fixed three indentation warnings, like:
```
../../src/msw/registry.cpp: In member function 'bool wxRegKey::GetNextValue(wxString&, long int&) const':
../../src/msw/registry.cpp:1130:3: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
   if ( lIndex == -1 )
   ^~
../../src/msw/registry.cpp:1133:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
     wxChar  szValueName[1024];                  // @@ use RegQueryInfoKey...
     ^~~~~~
```

Add some more `wxOVERRIDE` declarations, following https://github.com/wxWidgets/wxWidgets/pull/329.