### PR TITLE
menu_osx: Fix typo in assert message in Refresh()

### DIFF
--- a/src/osx/menu_osx.cpp
+++ b/src/osx/menu_osx.cpp
@@ -645,7 +645,7 @@ wxMenuBar::~wxMenuBar()
 
 void wxMenuBar::Refresh(bool WXUNUSED(eraseBackground), const wxRect *WXUNUSED(rect))
 {
-    wxCHECK_RET( IsAttached(), wxT("can't refresh unatteched menubar") );
+    wxCHECK_RET( IsAttached(), wxT("can't refresh unattached menubar") );
 }
 
 void wxMenuBar::MacUninstallMenuBar()


### PR DESCRIPTION
Just a basic message amendment.