### PR TITLE
Building wxGTK/Win32 using MSys2 with configure fixes.

### DIFF
--- a/configure
+++ b/configure
@@ -7913,6 +7913,8 @@ fi
 
           eval "$wx_cv_use_iniconf"
 
+fi
+
 
           enablestring=
           defaultval=$wxUSE_ALL_FEATURES
@@ -7942,7 +7944,6 @@ fi
 
           eval "$wx_cv_use_regkey"
 
-fi
 
 if test "$wxUSE_GUI" = "yes"; then
 
@@ -22106,7 +22107,9 @@ rm -f core conftest.err conftest.$ac_objext \
                 if test -z "$wx_cv_lib_gtk"; then
                                         wx_cv_lib_gtk=none
                 else
-                                        GTK_LIBS="$GTK_LIBS -lX11"
+                    if test "$USE_WIN32" != 1 ; then
+                                                GTK_LIBS="$GTK_LIBS -lX11"
+                    fi
 
                                                             wx_cv_cflags_gtk=$GTK_CFLAGS
                     wx_cv_libs_gtk=$GTK_LIBS
@@ -28749,7 +28752,7 @@ else
 $as_echo "$as_me: WARNING: wxGetDiskSpace() function won't work without statfs()" >&2;}
 fi
 
-if test "$wxUSE_SNGLINST_CHECKER" = "yes"; then
+if test "$wxUSE_SNGLINST_CHECKER" = "yes" -a "$USE_WIN32" != 1 ; then
     for ac_func in fcntl flock
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
@@ -31289,7 +31292,7 @@ fi
 
 
 if test "$wxUSE_FSWATCHER" = "yes"; then
-                if test "$wxUSE_MSW" != "1"; then
+                if test "$USE_WIN32" != 1; then
         if test "$wxUSE_UNIX" = "yes"; then
             for ac_header in sys/inotify.h
 do :
@@ -32983,7 +32986,7 @@ done
 
 
 if test "$wxUSE_SOCKETS" = "yes"; then
-        if test "$TOOLKIT" != "MSW"; then
+        if test "$USE_WIN32" != 1 ; then
                 ac_fn_c_check_func "$LINENO" "socket" "ac_cv_func_socket"
 if test "x$ac_cv_func_socket" = xyes; then :
 
@@ -33046,7 +33049,7 @@ fi
 fi
 
 if test "$wxUSE_SOCKETS" = "yes" ; then
-                if test "$TOOLKIT" != "MSW"; then
+        if test "$USE_WIN32" != 1 ; then
                                         { $as_echo "$as_me:${as_lineno-$LINENO}: checking what is the type of the third argument of getsockname" >&5
 $as_echo_n "checking what is the type of the third argument of getsockname... " >&6; }
 if ${wx_cv_type_getsockname3+:} false; then :
@@ -34771,11 +34774,6 @@ if test "$wxUSE_MSW" = 1 ; then
 
     fi
 
-    if test "$wxUSE_DIB" = "yes"; then
-        $as_echo "#define wxUSE_WXDIB 1" >>confdefs.h
-
-    fi
-
     if test "$wxUSE_POSTSCRIPT_ARCHITECTURE_IN_MSW" = "yes"; then
         $as_echo "#define wxUSE_POSTSCRIPT_ARCHITECTURE_IN_MSW 1" >>confdefs.h
 
@@ -34852,6 +34850,11 @@ $as_echo "$wx_cv_lib_debughlp" >&6; }
             { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Debug help API and wxStackWalker won't be available" >&5
 $as_echo "$as_me: WARNING: Debug help API and wxStackWalker won't be available" >&2;}
         fi
+    fi
+
+    if test "$wxUSE_DIB" = "yes"; then
+        $as_echo "#define wxUSE_WXDIB 1" >>confdefs.h
+
     fi
 
     if test "$wxUSE_INICONF" = "yes"; then

--- a/configure.in
+++ b/configure.in
@@ -5950,7 +5950,7 @@ if test "$wxUSE_SOCKETS" = "yes"; then
 fi
 
 if test "$wxUSE_SOCKETS" = "yes" ; then
-    dnl under Windows we always have sockets
+    dnl under Windows we do not use getsockname
     if test "$USE_WIN32" != 1 ; then
         dnl determine the type of third argument for getsockname
         dnl This test needs to be done in C++ mode since gsocket.cpp now

--- a/configure.in
+++ b/configure.in
@@ -749,8 +749,9 @@ WX_ARG_FEATURE(threads,     [  --enable-threads        use threads], wxUSE_THREA
 if test "$wxUSE_MSW" = 1 ; then
 WX_ARG_DISABLE(dbghelp,     [  --enable-dbghelp        use dbghelp.dll API (Win32 only)], wxUSE_DBGHELP)
 WX_ARG_ENABLE(iniconf,      [  --enable-iniconf        use wxIniConfig (Win32 only)], wxUSE_INICONF)
-WX_ARG_FEATURE(regkey,      [  --enable-regkey         use wxRegKey class (Win32 only)], wxUSE_REGKEY)
 fi
+
+WX_ARG_FEATURE(regkey,      [  --enable-regkey         use wxRegKey class (Win32 only)], wxUSE_REGKEY)
 
 if test "$wxUSE_GUI" = "yes"; then
 
@@ -2782,8 +2783,10 @@ if test "$wxUSE_GUI" = "yes"; then
                     dnl looks better in AC_MSG_RESULT
                     wx_cv_lib_gtk=none
                 else
-                    dnl we use symbols from X11 directly so we should link with it
-                    GTK_LIBS="$GTK_LIBS -lX11"
+                    if test "$USE_WIN32" != 1 ; then
+                        dnl we use symbols from X11 directly so we should link with it
+                        GTK_LIBS="$GTK_LIBS -lX11"
+                    fi
 
                     dnl we need to cache GTK_CFLAGS and GTK_LIBS for the
                     dnl subsequent runs
@@ -4343,7 +4346,7 @@ fi
 
 dnl check for fcntl() or at least flock() needed by Unix implementation of
 dnl wxSingleInstanceChecker
-if test "$wxUSE_SNGLINST_CHECKER" = "yes"; then
+if test "$wxUSE_SNGLINST_CHECKER" = "yes" -a "$USE_WIN32" != 1 ; then
     AC_CHECK_FUNCS(fcntl flock, break)
 
     if test "$ac_cv_func_fcntl" != "yes" -a "$ac_cv_func_flock" != "yes"; then
@@ -5291,10 +5294,10 @@ dnl File system watcher checks
 dnl ---------------------------------------------------------------------------
 
 if test "$wxUSE_FSWATCHER" = "yes"; then
-    dnl wxFileSystemWatcher is always available under MSW but we need either
+    dnl wxFileSystemWatcher is always available under Windows but we need either
     dnl inotify or kqueue support in the system for it under Unix (this
     dnl includes OS X which does have kqueue but no other platforms)
-    if test "$wxUSE_MSW" != "1"; then
+    if test "$USE_WIN32" != 1; then
         if test "$wxUSE_UNIX" = "yes"; then
             AC_CHECK_HEADERS(sys/inotify.h,,, [AC_INCLUDES_DEFAULT()])
             if test "$ac_cv_header_sys_inotify_h" = "yes"; then
@@ -5927,8 +5930,8 @@ dnl wxSocket
 dnl ------------------------------------------------------------------------
 
 if test "$wxUSE_SOCKETS" = "yes"; then
-    dnl under MSW we always have sockets
-    if test "$TOOLKIT" != "MSW"; then
+    dnl under Windows we always have sockets
+    if test "$USE_WIN32" != 1 ; then
         dnl under Solaris and OS/2, socket functions live in -lsocket
         AC_CHECK_FUNC(socket,,
             [
@@ -5947,10 +5950,8 @@ if test "$wxUSE_SOCKETS" = "yes"; then
 fi
 
 if test "$wxUSE_SOCKETS" = "yes" ; then
-    dnl this test may be appropriate if building under cygwin
-    dnl right now I'm assuming it also uses the winsock stuff
-    dnl like mingw does..  -- RL
-    if test "$TOOLKIT" != "MSW"; then
+    dnl under Windows we always have sockets
+    if test "$USE_WIN32" != 1 ; then
         dnl determine the type of third argument for getsockname
         dnl This test needs to be done in C++ mode since gsocket.cpp now
         dnl is C++ code and pointer cast that are possible even without
@@ -7211,10 +7212,6 @@ if test "$wxUSE_MSW" = 1 ; then
         AC_DEFINE(wxUSE_DC_CACHEING)
     fi
 
-    if test "$wxUSE_DIB" = "yes"; then
-        AC_DEFINE(wxUSE_WXDIB)
-    fi
-
     if test "$wxUSE_POSTSCRIPT_ARCHITECTURE_IN_MSW" = "yes"; then
         AC_DEFINE(wxUSE_POSTSCRIPT_ARCHITECTURE_IN_MSW)
     fi
@@ -7261,6 +7258,10 @@ if test "$USE_WIN32" = 1 ; then
         else
             AC_MSG_WARN([Debug help API and wxStackWalker won't be available])
         fi
+    fi
+
+    if test "$wxUSE_DIB" = "yes"; then
+        AC_DEFINE(wxUSE_WXDIB)
     fi
 
     if test "$wxUSE_INICONF" = "yes"; then

--- a/docs/msw/msys2-gtk.txt
+++ b/docs/msw/msys2-gtk.txt
@@ -1,0 +1,74 @@
+Building wxGTK port with Win32 MSys2 GDK backend
+------------------------------------------------
+
+GTK+ widget toolkit has multiple GDK backends and one of them is Win32.
+It is a wrapper around Windows API.
+
+These notes don't consider building wxGTK with X11 backend under Windows.
+
+The MSys2 website is http://www.msys2.org/
+
+These building steps are NOT the normal way to build MSys2 MinGW packages.
+But, they are a way the wxWidgets developers can test that wxWidgets
+can build the wxGTK/Win32 libraries under MSys2 MinGW.
+
+For the MSys2 way please see https://github.com/Alexpux/MINGW-packages
+
+Building steps:
+
+#Note: The "#" is used in front of a comment to help the people who cut
+#      and paste these directions.
+#Warning: At the time these directions were written the GTK version 3
+#         was NOT able to create wxGTK/Win32 libraries that were usable.
+
+#1. Install the mingw32 packages needed to build wxGTK/Win32 using the 
+#   configure/make build method. 
+#   From the MSys2 prompt or MSys2 MinGW prompt:
+
+#   The 32 bit Mingw packages are prefixed with "mingw-w64-i686-";
+#   Change the prefix to "mingw-w64-x86_64-" if you wish to do 64 bit.
+
+pacman -S make
+pacman -S mingw-w64-i686-cppunit
+pacman -S mingw-w64-i686-libjpeg-turbo
+pacman -S mingw-w64-i686-libpng
+pacman -S mingw-w64-i686-libtiff
+# Not all of toolchain is needed; but, easiest to install all of it.
+pacman -S mingw-w64-i686-toolchain
+# gtk2 takes a very long time after install fontconfig updating font cache
+pacman -S mingw-w64-i686-webkitgtk2
+
+# Packages that are needed but are normally installed already.
+pacman -S mingw-w64-i686-gcc-libs
+pacman -S mingw-w64-i686-expat
+pacman -S mingw-w64-i686-xz
+pacman -S mingw-w64-i686-zlib
+pacman -S mingw-w64-i686-gdk-pixbuf2
+pacman -S mingw-w64-i686-gtk2 
+
+
+#2. Build the wxGTK/Win32 static library
+#2a.Open MSys2 MinGW Prompt
+#   (These steps were tested on MinGW32; but, should work under MinGW64)
+#2b.Use the cd command to change directory to the wxWidgets top folder.
+
+
+#2c.Create the "build-gtk2-static" folder to build the static libraries
+mkdir -p build-gtk2-static
+
+#2d.Configure wxWidgets
+cd build-gtk2-static && \
+  ../configure --with-gtk=2 \
+    --disable-shared \
+  && cd ..
+
+#2e.make the wxGTK static libraries
+cd build-gtk2-static && make && cd ..
+
+
+#3  Build and run the minimal static sample
+#3a.Build the minimal sample
+cd build-gtk2-static/samples/minimal && make && cd ../../..
+
+#3b.Run the minimal sample
+cd samples && ../build-gtk2-static/samples/minimal/minimal.exe && cd ..

--- a/docs/msw/msys2-gtk.txt
+++ b/docs/msw/msys2-gtk.txt
@@ -33,10 +33,11 @@ pacman -S mingw-w64-i686-cppunit
 pacman -S mingw-w64-i686-libjpeg-turbo
 pacman -S mingw-w64-i686-libpng
 pacman -S mingw-w64-i686-libtiff
-# Not all of toolchain is needed; but, easiest to install all of it.
-pacman -S mingw-w64-i686-toolchain
-# gtk2 takes a very long time after install fontconfig updating font cache
-pacman -S mingw-w64-i686-webkitgtk2
+pacman -S mingw-w64-i686-gcc
+pacman -S mingw-w64-i686-pkg-config
+## gtk2 can take a long time to update/find fonts
+pacman -S mingw-w64-i686-gtk2
+
 
 # Packages that are needed but are normally installed already.
 pacman -S mingw-w64-i686-gcc-libs
@@ -44,7 +45,6 @@ pacman -S mingw-w64-i686-expat
 pacman -S mingw-w64-i686-xz
 pacman -S mingw-w64-i686-zlib
 pacman -S mingw-w64-i686-gdk-pixbuf2
-pacman -S mingw-w64-i686-gtk2 
 
 
 #2. Build the wxGTK/Win32 static library
@@ -57,9 +57,14 @@ pacman -S mingw-w64-i686-gtk2
 mkdir -p build-gtk2-static
 
 #2d.Configure wxWidgets
+#   Option "--disable-precomp-headers" is NOT needed.
+#   I am doing it to check for compile issues;
+#   And, I think my old 32 bit Windows machine
+#   works best with it disabled.
 cd build-gtk2-static && \
   ../configure --with-gtk=2 \
     --disable-shared \
+    --disable-precomp-headers \
   && cd ..
 
 #2e.make the wxGTK static libraries
@@ -71,4 +76,21 @@ cd build-gtk2-static && make && cd ..
 cd build-gtk2-static/samples/minimal && make && cd ../../..
 
 #3b.Run the minimal sample
-cd samples && ../build-gtk2-static/samples/minimal/minimal.exe && cd ..
+./build-gtk2-static/samples/minimal/minimal.exe
+
+
+#4  Build and run the typetest static sample to verify MIME database works
+cd build-gtk2-static/samples/typetest && make && cd ../../..
+./build-gtk2-static/samples/typetest/typetest.exe
+
+#5  Build and run the drawing static sample
+cd build-gtk2-static/samples/drawing && make && cd ../../..
+cd samples/drawing && ../../build-gtk2-static/samples/drawing/drawing.exe && cd ../..
+
+#6  Build and run the splash static sample
+cd build-gtk2-static/samples/splash && make && cd ../../..
+cd samples/splash && ../../build-gtk2-static/samples/splash/splash.exe && cd ../..
+
+#7  Build and run the widgets static sample
+cd build-gtk2-static/samples/widgets && make && cd ../../..
+cd samples/widgets && ../../build-gtk2-static/samples/widgets/widgets.exe && cd ../..

--- a/docs/msw/msys2-msw.txt
+++ b/docs/msw/msys2-msw.txt
@@ -1,0 +1,84 @@
+Building wxMSW port with Win32 MSys2 backend
+------------------------------------------------
+
+The MSys2 website is http://www.msys2.org/
+
+These building steps are NOT the normal way to build MSys2 MinGW packages.
+But, they are a way the wxWidgets developers can test that wxWidgets
+can build the wxMSW libraries under MSys2 MinGW.
+
+For the MSys2 way please see https://github.com/Alexpux/MINGW-packages
+
+Building steps:
+
+#Note: The "#" is used in front of a comment to help the people who cut
+#      and paste these directions.
+
+#1. Install the mingw32 packages needed to build wxMSW using the 
+#   configure/make build method. 
+#   From the MSys2 prompt or MSys2 MinGW prompt:
+
+#   The 32 bit Mingw packages are prefixed with "mingw-w64-i686-";
+#   Change the prefix to "mingw-w64-x86_64-" if you wish to do 64 bit.
+
+pacman -S make
+pacman -S mingw-w64-i686-cppunit
+pacman -S mingw-w64-i686-libjpeg-turbo
+pacman -S mingw-w64-i686-libpng
+pacman -S mingw-w64-i686-libtiff
+pacman -S mingw-w64-i686-gcc
+
+# Packages that are needed but are normally installed already.
+pacman -S mingw-w64-i686-gcc-libs
+pacman -S mingw-w64-i686-expat
+pacman -S mingw-w64-i686-xz
+pacman -S mingw-w64-i686-zlib
+
+
+#2. Build the wxMSW static library
+#2a.Open MSys2 MinGW Prompt
+#   (These steps were tested on MinGW32; but, should work under MinGW64)
+#2b.Use the cd command to change directory to the wxWidgets top folder.
+
+
+#2c.Create the "build-msw-static" folder to build the static libraries
+mkdir -p build-msw-static
+
+#2d.Configure wxWidgets
+#   Option "--disable-precomp-headers" is NOT needed.
+#   I am doing it to check for compile issues;
+#   And, I think my old 32 bit Windows machine
+#   works best with it disabled.
+cd build-msw-static && \
+  ../configure --with-msw \
+    --disable-shared \
+    --disable-precomp-headers \
+  && cd ..
+
+#2e.make the wxMSW static libraries
+cd build-msw-static && make && cd ..
+
+
+#3  Build and run the minimal static sample
+#3a.Build the minimal sample
+cd build-msw-static/samples/minimal && make && cd ../../..
+
+#3b.Run the minimal sample
+./build-msw-static/samples/minimal/minimal.exe
+
+
+#4  Build and run the typetest static sample to verify MIME database works
+cd build-msw-static/samples/typetest && make && cd ../../..
+./build-msw-static/samples/typetest/typetest.exe
+
+#5  Build and run the drawing static sample
+cd build-msw-static/samples/drawing && make && cd ../../..
+cd samples/drawing && ../../build-msw-static/samples/drawing/drawing.exe && cd ../..
+
+#6  Build and run the splash static sample
+cd build-msw-static/samples/splash && make && cd ../../..
+cd samples/splash && ../../build-msw-static/samples/splash/splash.exe && cd ../..
+
+#7  Build and run the widgets static sample
+cd build-msw-static/samples/widgets && make && cd ../../..
+cd samples/widgets && ../../build-msw-static/samples/widgets/widgets.exe && cd ../..

--- a/include/wx/gtk/mimetype.h
+++ b/include/wx/gtk/mimetype.h
@@ -25,8 +25,6 @@ class WXDLLIMPEXP_CORE wxGTKMimeTypesManagerImpl : public wxMimeTypesManagerImpl
 protected:
 #if defined(__UNIX__)
     wxString GetIconFromMimeType(const wxString& mime) wxOVERRIDE;
-#else
-    wxString GetIconFromMimeType(const wxString& mime);
 #endif
 };
 

--- a/include/wx/gtk/mimetype.h
+++ b/include/wx/gtk/mimetype.h
@@ -23,7 +23,11 @@
 class WXDLLIMPEXP_CORE wxGTKMimeTypesManagerImpl : public wxMimeTypesManagerImpl
 {
 protected:
+#if defined(__UNIX__)
     wxString GetIconFromMimeType(const wxString& mime) wxOVERRIDE;
+#else
+    wxString GetIconFromMimeType(const wxString& mime);
+#endif
 };
 
 

--- a/include/wx/msw/chkconf.h
+++ b/include/wx/msw/chkconf.h
@@ -183,7 +183,7 @@
     #define wxUSE_SECRETSTORE 0
 #endif
 
-#if !wxUSE_OWNER_DRAWN && !defined(__WXUNIVERSAL__)
+#if !wxUSE_OWNER_DRAWN && !defined(__WXUNIVERSAL__) && defined(__WXMSW__)
 #   undef wxUSE_CHECKLISTBOX
 #   define wxUSE_CHECKLISTBOX 0
 #endif

--- a/include/wx/msw/chkconf.h
+++ b/include/wx/msw/chkconf.h
@@ -183,11 +183,6 @@
     #define wxUSE_SECRETSTORE 0
 #endif
 
-#if !wxUSE_OWNER_DRAWN && !defined(__WXUNIVERSAL__) && defined(__WXMSW__)
-#   undef wxUSE_CHECKLISTBOX
-#   define wxUSE_CHECKLISTBOX 0
-#endif
-
 #if wxUSE_SPINCTRL
 #   if !wxUSE_SPINBTN
 #       ifdef wxABORT_ON_CONFIG_ERROR
@@ -196,6 +191,16 @@
 #           undef wxUSE_SPINBTN
 #           define wxUSE_SPINBTN 1
 #       endif
+#   endif
+#endif
+
+/* wxMSW-specific checks: notice that this file is also used with wxUniv
+   and can even be used with wxGTK, when building it under Windows.
+ */
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#   if !wxUSE_OWNER_DRAWN
+#       undef wxUSE_CHECKLISTBOX
+#       define wxUSE_CHECKLISTBOX 0
 #   endif
 #endif
 

--- a/src/gtk/mimetype.cpp
+++ b/src/gtk/mimetype.cpp
@@ -19,6 +19,7 @@
 #include "wx/gtk/private/string.h"
 #include "wx/gtk/private/object.h"
 
+#if defined(__UNIX__)
 wxString wxGTKMimeTypesManagerImpl::GetIconFromMimeType(const wxString& mime)
 {
     wxString icon;
@@ -58,6 +59,7 @@ wxString wxGTKMimeTypesManagerImpl::GetIconFromMimeType(const wxString& mime)
 #endif // GTK_CHECK_VERSION(2,14,0)
     return icon;
 }
+#endif // defined(__UNIX__)
 
 wxMimeTypesManagerImpl *wxGTKMimeTypesManagerFactory::CreateMimeTypesManagerImpl()
 {


### PR DESCRIPTION
First attempted fix:  "Fix to build wxGTK under Win32"   #415
Second attempted fix: "Building wxGTK/Win32 using MSys2" #426

I redid the code changes in this third attempt at an wxGTK/Win32 fix.
And, I added more configure fixes to stop the message when running the 
minimal sample. I included "docs/msw/msys2-gtk.txt" as the readme, vadz 
requested to added on the first attempted fix. And, I tested the 
minimal sample and it now works without issue.

Tim S.
