### PR TITLE
Remove MONITOR-related definitions as they are present since Win2k

### DIFF
--- a/src/msw/display.cpp
+++ b/src/msw/display.cpp
@@ -43,31 +43,6 @@
 #include "wx/msw/private.h"
 #include "wx/msw/private/hiddenwin.h"
 
-    // Older versions of windef.h don't define HMONITOR.  Unfortunately, we
-    // can't directly test whether HMONITOR is defined or not in windef.h as
-    // it's not a macro but a typedef, so we test for an unrelated symbol which
-    // is only defined in winuser.h if WINVER >= 0x0500
-    #if !defined(HMONITOR_DECLARED) && !defined(MNS_NOCHECK)
-        DECLARE_HANDLE(HMONITOR);
-        typedef BOOL(CALLBACK * MONITORENUMPROC )(HMONITOR, HDC, LPRECT, LPARAM);
-        typedef struct tagMONITORINFO
-        {
-            DWORD   cbSize;
-            RECT    rcMonitor;
-            RECT    rcWork;
-            DWORD   dwFlags;
-        } MONITORINFO, *LPMONITORINFO;
-        typedef struct tagMONITORINFOEX : public tagMONITORINFO
-        {
-            TCHAR       szDevice[CCHDEVICENAME];
-        } MONITORINFOEX, *LPMONITORINFOEX;
-        #define MONITOR_DEFAULTTONULL       0x00000000
-        #define MONITOR_DEFAULTTOPRIMARY    0x00000001
-        #define MONITOR_DEFAULTTONEAREST    0x00000002
-        #define MONITORINFOF_PRIMARY        0x00000001
-        #define HMONITOR_DECLARED
-    #endif
-
 static const wxChar displayDllName[] = wxT("user32.dll");
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
<https://msdn.microsoft.com/en-us/library/dd145065(v=vs.85).aspx>

BTW, in the same file, function `wxDisplayFactoryMSW::GetFromWindow()` has different implementation whether `__WXMSW__` is defined or not. But according to [Preprocessor Symbols](http://docs.wxwidgets.org/3.1.0/page_cppconst.html#page_cppconst_guisystem), this symbol "is defined for console applications under Windows as well". So does that check have any effect after all?