### PR TITLE
Use standard `_WIN32` preprocessor symbol rather than `WIN32`

### DIFF
--- a/src/expat/lib/xmlparse.c
+++ b/src/expat/lib/xmlparse.c
@@ -7,7 +7,7 @@
 #include <assert.h>
 #include <limits.h>                     /* UINT_MAX */
 
-#ifdef WIN32
+#ifdef _WIN32
 #define getpid GetCurrentProcessId
 #else
 #include <sys/time.h>                   /* gettimeofday() */
@@ -17,7 +17,7 @@
 
 #define XML_BUILDING_EXPAT 1
 
-#ifdef WIN32
+#ifdef _WIN32
 #include "winconfig.h"
 #elif defined(MACOS_CLASSIC)
 #include "macconfig.h"
@@ -27,7 +27,7 @@
 #include "watcomconfig.h"
 #elif defined(HAVE_EXPAT_CONFIG_H)
 #include <expat_config.h>
-#endif /* ndef WIN32 */
+#endif /* ndef _WIN32 */
 
 #include "ascii.h"
 #include "expat.h"
@@ -700,7 +700,7 @@ static const XML_Char implicitContext[] = {
 static unsigned long
 gather_time_entropy(void)
 {
-#ifdef WIN32
+#ifdef _WIN32
   FILETIME ft;
   GetSystemTimeAsFileTime(&ft); /* never fails */
   return ft.dwHighDateTime ^ ft.dwLowDateTime;

--- a/src/expat/lib/xmlrole.c
+++ b/src/expat/lib/xmlrole.c
@@ -4,7 +4,7 @@
 
 #include <stddef.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include "winconfig.h"
 #elif defined(MACOS_CLASSIC)
 #include "macconfig.h"
@@ -16,7 +16,7 @@
 #ifdef HAVE_EXPAT_CONFIG_H
 #include <expat_config.h>
 #endif
-#endif /* ndef WIN32 */
+#endif /* ndef _WIN32 */
 
 #include "expat_external.h"
 #include "internal.h"

--- a/src/expat/lib/xmltok.c
+++ b/src/expat/lib/xmltok.c
@@ -4,7 +4,7 @@
 
 #include <stddef.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include "winconfig.h"
 #elif defined(MACOS_CLASSIC)
 #include "macconfig.h"
@@ -16,7 +16,7 @@
 #ifdef HAVE_EXPAT_CONFIG_H
 #include <expat_config.h>
 #endif
-#endif /* ndef WIN32 */
+#endif /* ndef _WIN32 */
 
 #include "expat_external.h"
 #include "internal.h"

--- a/src/expat/xmlwf/codepage.c
+++ b/src/expat/xmlwf/codepage.c
@@ -5,7 +5,7 @@
 #include "codepage.h"
 #include "internal.h"  /* for UNUSED_P only */
 
-#if (defined(WIN32) || (defined(__WATCOMC__) && defined(__NT__)))
+#if (defined(_WIN32) || (defined(__WATCOMC__) && defined(__NT__)))
 #define STRICT 1
 #define WIN32_LEAN_AND_MEAN 1
 
@@ -52,7 +52,7 @@ codepageConvert(int cp, const char *p)
   return -1;
 }
 
-#else /* not WIN32 */
+#else /* not _WIN32 */
 
 int
 codepageMap(int UNUSED_P(cp), int *UNUSED_P(map))
@@ -66,4 +66,4 @@ codepageConvert(int UNUSED_P(cp), const char *UNUSED_P(p))
   return -1;
 }
 
-#endif /* not WIN32 */
+#endif /* not _WIN32 */

--- a/src/expat/xmlwf/readfilemap.c
+++ b/src/expat/xmlwf/readfilemap.c
@@ -16,7 +16,7 @@
 #include <unistd.h>
 #endif
 #else
-# if !defined(WIN32) && !defined(_WIN32) && !defined(_WIN64)
+# if !defined(_WIN32) && !defined(_WIN64)
 #  include <unistd.h>
 # endif
 #endif

--- a/src/expat/xmlwf/xmlfile.c
+++ b/src/expat/xmlwf/xmlfile.c
@@ -8,7 +8,7 @@
 #include <string.h>
 #include <fcntl.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include "winconfig.h"
 #elif defined(MACOS_CLASSIC)
 #include "macconfig.h"
@@ -18,7 +18,7 @@
 #include "watcomconfig.h"
 #elif defined(HAVE_EXPAT_CONFIG_H)
 #include <expat_config.h>
-#endif /* ndef WIN32 */
+#endif /* ndef _WIN32 */
 
 #include "expat.h"
 #include "internal.h"  /* for UNUSED_P only */
@@ -88,7 +88,7 @@ processFile(const void *data, size_t size,
     *retPtr = 1;
 }
 
-#if (defined(WIN32) || defined(__WATCOMC__))
+#if (defined(_WIN32) || defined(__WATCOMC__))
 
 static int
 isAsciiLetter(XML_Char c)
@@ -96,7 +96,7 @@ isAsciiLetter(XML_Char c)
   return (T('a') <= c && c <= T('z')) || (T('A') <= c && c <= T('Z'));
 }
 
-#endif /* WIN32 */
+#endif /* _WIN32 */
 
 static const XML_Char *
 resolveSystemId(const XML_Char *base, const XML_Char *systemId,
@@ -106,7 +106,7 @@ resolveSystemId(const XML_Char *base, const XML_Char *systemId,
   *toFree = 0;
   if (!base
       || *systemId == T('/')
-#if (defined(WIN32) || defined(__WATCOMC__))
+#if (defined(_WIN32) || defined(__WATCOMC__))
       || *systemId == T('\\')
       || (isAsciiLetter(systemId[0]) && systemId[1] == T(':'))
 #endif
@@ -120,7 +120,7 @@ resolveSystemId(const XML_Char *base, const XML_Char *systemId,
   s = *toFree;
   if (tcsrchr(s, T('/')))
     s = tcsrchr(s, T('/')) + 1;
-#if (defined(WIN32) || defined(__WATCOMC__))
+#if (defined(_WIN32) || defined(__WATCOMC__))
   if (tcsrchr(s, T('\\')))
     s = tcsrchr(s, T('\\')) + 1;
 #endif

--- a/src/expat/xmlwf/xmlwf.c
+++ b/src/expat/xmlwf/xmlwf.c
@@ -608,7 +608,7 @@ showVersion(XML_Char *prog)
   const XML_Feature *features = XML_GetFeatureList();
   while ((ch = *s) != 0) {
     if (ch == '/'
-#if (defined(WIN32) || defined(__WATCOMC__))
+#if (defined(_WIN32) || defined(__WATCOMC__))
         || ch == '\\'
 #endif
         )
@@ -785,7 +785,7 @@ tmain(int argc, XML_Char **argv)
         const XML_Char * lastDelim = tcsrchr(file, delim[0]);
         if (lastDelim)
           file = lastDelim + 1;
-#if (defined(WIN32) || defined(__WATCOMC__))
+#if (defined(_WIN32) || defined(__WATCOMC__))
         else {
           const XML_Char * winDelim = T("\\");
           lastDelim = tcsrchr(file, winDelim[0]);


### PR DESCRIPTION
When compiling with tdm64-gcc-5.1.0 with `CFLAGS="-std=c11"`, it fails in `expat` code because when using that option the compiler would no longer define `WIN32`.