### PR TITLE
wxSpinCtrlDouble sends event when no value changed

### DIFF
--- a/src/generic/spinctlg.cpp
+++ b/src/generic/spinctlg.cpp
@@ -409,8 +409,8 @@ void wxSpinCtrlGenericBase::OnSpinButton(wxSpinEvent& event)
 
 void wxSpinCtrlGenericBase::OnTextLostFocus(wxFocusEvent& event)
 {
-    SyncSpinToText(SendEvent_Text);
-    DoSendEvent();
+    if (SyncSpinToText(SendEvent_Text))
+        DoSendEvent();
 
     event.Skip();
 }


### PR DESCRIPTION
This prevents wxSpinCtrlDouble from sending the event when the value has not changed in the text box.
Currently every time the focus is removed from the text-box wxSpinCtrlDouble sends the event!