### PR TITLE
wxDataView performance with variable line height

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -4579,7 +4579,8 @@ COND_USE_GUI_1_WXUNIV_0___CORE_SRC_OBJECTS =  \
 	monodll_datavgen.o \
 	monodll_editlbox.o \
 	monodll_laywin.o \
-	monodll_calctrlg.o
+	monodll_calctrlg.o \
+	monodll_rowheightcache.o
 @COND_USE_GUI_1_WXUNIV_0@__CORE_SRC_OBJECTS = $(COND_USE_GUI_1_WXUNIV_0___CORE_SRC_OBJECTS)
 COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS =  \
 	$(__LOWLEVEL_SRC_OBJECTS_1) \
@@ -4839,7 +4840,8 @@ COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS =  \
 	monodll_datavgen.o \
 	monodll_editlbox.o \
 	monodll_laywin.o \
-	monodll_calctrlg.o
+	monodll_calctrlg.o \
+	monodll_rowheightcache.o
 @COND_USE_GUI_1_WXUNIV_1@__CORE_SRC_OBJECTS = $(COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS)
 COND_TOOLKIT_DFB___LOWLEVEL_SRC_OBJECTS =  \
 	monodll_fontmgrcmn.o \
@@ -6555,7 +6557,8 @@ COND_USE_GUI_1_WXUNIV_0___CORE_SRC_OBJECTS_1 =  \
 	monolib_datavgen.o \
 	monolib_editlbox.o \
 	monolib_laywin.o \
-	monolib_calctrlg.o
+	monolib_calctrlg.o \
+	monolib_rowheightcache.o
 @COND_USE_GUI_1_WXUNIV_0@__CORE_SRC_OBJECTS_1 = $(COND_USE_GUI_1_WXUNIV_0___CORE_SRC_OBJECTS_1)
 COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_1 =  \
 	$(__LOWLEVEL_SRC_OBJECTS_3) \
@@ -6815,7 +6818,8 @@ COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_1 =  \
 	monolib_datavgen.o \
 	monolib_editlbox.o \
 	monolib_laywin.o \
-	monolib_calctrlg.o
+	monolib_calctrlg.o \
+	monolib_rowheightcache.o
 @COND_USE_GUI_1_WXUNIV_1@__CORE_SRC_OBJECTS_1 = $(COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_1)
 COND_TOOLKIT_DFB___LOWLEVEL_SRC_OBJECTS_2 =  \
 	monolib_fontmgrcmn.o \
@@ -8678,7 +8682,8 @@ COND_USE_GUI_1_WXUNIV_0___CORE_SRC_OBJECTS_2 =  \
 	coredll_datavgen.o \
 	coredll_editlbox.o \
 	coredll_laywin.o \
-	coredll_calctrlg.o
+	coredll_calctrlg.o \
+	coredll_rowheightcache.o
 @COND_USE_GUI_1_WXUNIV_0@__CORE_SRC_OBJECTS_2 = $(COND_USE_GUI_1_WXUNIV_0___CORE_SRC_OBJECTS_2)
 COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_2 =  \
 	$(__LOWLEVEL_SRC_OBJECTS_5) \
@@ -8938,7 +8943,8 @@ COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_2 =  \
 	coredll_datavgen.o \
 	coredll_editlbox.o \
 	coredll_laywin.o \
-	coredll_calctrlg.o
+	coredll_calctrlg.o \
+	coredll_rowheightcache.o
 @COND_USE_GUI_1_WXUNIV_1@__CORE_SRC_OBJECTS_2 = $(COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_2)
 COND_TOOLKIT_DFB___LOWLEVEL_SRC_OBJECTS_4 =  \
 	coredll_fontmgrcmn.o \
@@ -10396,7 +10402,8 @@ COND_USE_GUI_1_WXUNIV_0___CORE_SRC_OBJECTS_3 =  \
 	corelib_datavgen.o \
 	corelib_editlbox.o \
 	corelib_laywin.o \
-	corelib_calctrlg.o
+	corelib_calctrlg.o \
+	corelib_rowheightcache.o
 @COND_USE_GUI_1_WXUNIV_0@__CORE_SRC_OBJECTS_3 = $(COND_USE_GUI_1_WXUNIV_0___CORE_SRC_OBJECTS_3)
 COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_3 =  \
 	$(__LOWLEVEL_SRC_OBJECTS_7) \
@@ -10656,7 +10663,8 @@ COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_3 =  \
 	corelib_datavgen.o \
 	corelib_editlbox.o \
 	corelib_laywin.o \
-	corelib_calctrlg.o
+	corelib_calctrlg.o \
+	corelib_rowheightcache.o
 @COND_USE_GUI_1_WXUNIV_1@__CORE_SRC_OBJECTS_3 = $(COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_3)
 COND_TOOLKIT_DFB___LOWLEVEL_SRC_OBJECTS_6 =  \
 	corelib_fontmgrcmn.o \
@@ -20698,6 +20706,9 @@ monodll_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(MONODLL_ODEP)
 @COND_USE_GUI_1@monodll_calctrlg.o: $(srcdir)/src/generic/calctrlg.cpp $(MONODLL_ODEP)
 @COND_USE_GUI_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/calctrlg.cpp
 
+@COND_USE_GUI_1@monodll_rowheightcache.o: $(srcdir)/src/generic/rowheightcache.cpp $(MONODLL_ODEP)
+@COND_USE_GUI_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/rowheightcache.cpp
+
 @COND_TOOLKIT_OSX_COCOA_USE_GUI_1@monodll_osx_cocoa_mediactrl.o: $(srcdir)/src/osx/cocoa/mediactrl.mm $(MONODLL_ODEP)
 @COND_TOOLKIT_OSX_COCOA_USE_GUI_1@	$(CXXC) -c -o $@ $(MONODLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/mediactrl.mm
 
@@ -25950,6 +25961,9 @@ monolib_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(MONOLIB_ODEP)
 
 @COND_USE_GUI_1@monolib_calctrlg.o: $(srcdir)/src/generic/calctrlg.cpp $(MONOLIB_ODEP)
 @COND_USE_GUI_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/calctrlg.cpp
+
+@COND_USE_GUI_1@monolib_rowheightcache.o: $(srcdir)/src/generic/rowheightcache.cpp $(MONOLIB_ODEP)
+@COND_USE_GUI_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/rowheightcache.cpp
 
 @COND_TOOLKIT_OSX_COCOA_USE_GUI_1@monolib_osx_cocoa_mediactrl.o: $(srcdir)/src/osx/cocoa/mediactrl.mm $(MONOLIB_ODEP)
 @COND_TOOLKIT_OSX_COCOA_USE_GUI_1@	$(CXXC) -c -o $@ $(MONOLIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/mediactrl.mm
@@ -31297,6 +31311,9 @@ coredll_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(COREDLL_ODEP)
 @COND_USE_GUI_1@coredll_calctrlg.o: $(srcdir)/src/generic/calctrlg.cpp $(COREDLL_ODEP)
 @COND_USE_GUI_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/calctrlg.cpp
 
+@COND_USE_GUI_1@coredll_rowheightcache.o: $(srcdir)/src/generic/rowheightcache.cpp $(COREDLL_ODEP)
+@COND_USE_GUI_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/rowheightcache.cpp
+
 corelib_event.o: $(srcdir)/src/common/event.cpp $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/common/event.cpp
 
@@ -35544,6 +35561,9 @@ corelib_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(CORELIB_ODEP)
 
 @COND_USE_GUI_1@corelib_calctrlg.o: $(srcdir)/src/generic/calctrlg.cpp $(CORELIB_ODEP)
 @COND_USE_GUI_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/calctrlg.cpp
+
+@COND_USE_GUI_1@corelib_rowheightcache.o: $(srcdir)/src/generic/rowheightcache.cpp $(CORELIB_ODEP)
+@COND_USE_GUI_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/rowheightcache.cpp
 
 advdll_version_rc.o: $(srcdir)/src/msw/version.rc $(ADVDLL_ODEP)
 	$(WINDRES) -i$< -o$@    --define __WX$(TOOLKIT)__ $(__WXUNIV_DEFINE_p_67) $(__DEBUG_DEFINE_p_66)  $(__EXCEPTIONS_DEFINE_p_65) $(__RTTI_DEFINE_p_65) $(__THREAD_DEFINE_p_65)  --define WXBUILDING --define WXDLLNAME=$(WXDLLNAMEPREFIXGUI)$(WXUNICODEFLAG)$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)_adv$(WXCOMPILER)$(VENDORTAG)$(WXDLLVERSIONTAG) $(__RCDEFDIR_p) --include-dir $(top_srcdir)/include $(__INC_TIFF_BUILD_p_66) $(__INC_TIFF_p_66) $(__INC_JPEG_p_66) $(__INC_PNG_p_65) $(__INC_ZLIB_p_67) $(__INC_REGEX_p_65) $(__INC_EXPAT_p_65) --define WXUSINGDLL --define WXMAKINGDLL_ADV

--- a/build/bakefiles/files.bkl
+++ b/build/bakefiles/files.bkl
@@ -1005,6 +1005,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     src/generic/editlbox.cpp
     src/generic/laywin.cpp
     src/generic/calctrlg.cpp
+    src/generic/rowheightcache.cpp
 </set>
 <set var="GUI_CMN_HDR" hints="files">
     wx/affinematrix2dbase.h

--- a/build/cmake/files.cmake
+++ b/build/cmake/files.cmake
@@ -908,6 +908,7 @@ set(GUI_CMN_SRC
     src/generic/wizard.cpp
     src/generic/editlbox.cpp
     src/generic/datavgen.cpp
+    src/generic/rowheightcache.cpp
 )
 
 set(GUI_CMN_HDR

--- a/build/files
+++ b/build/files
@@ -899,6 +899,7 @@ GUI_CMN_SRC =
     src/generic/renderg.cpp
     src/generic/richmsgdlgg.cpp
     src/generic/richtooltipg.cpp
+    src/generic/rowheightcache.cpp
     src/generic/sashwin.cpp
     src/generic/scrlwing.cpp
     src/generic/selstore.cpp

--- a/build/msw/makefile.bcc
+++ b/build/msw/makefile.bcc
@@ -2126,7 +2126,8 @@ ____CORE_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_datavgen.obj \
 	$(OBJS)\monodll_editlbox.obj \
 	$(OBJS)\monodll_laywin.obj \
-	$(OBJS)\monodll_calctrlg.obj
+	$(OBJS)\monodll_calctrlg.obj \
+	$(OBJS)\monodll_rowheightcache.obj
 !endif
 !if "$(USE_GUI)" == "1" && "$(WXUNIV)" == "1"
 ____CORE_SRC_FILENAMES_OBJECTS =  \
@@ -2451,7 +2452,8 @@ ____CORE_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_datavgen.obj \
 	$(OBJS)\monodll_editlbox.obj \
 	$(OBJS)\monodll_laywin.obj \
-	$(OBJS)\monodll_calctrlg.obj
+	$(OBJS)\monodll_calctrlg.obj \
+	$(OBJS)\monodll_rowheightcache.obj
 !endif
 !if "$(USE_STC)" == "1"
 ____MONOLIB_STC_SRC_FILENAMES_OBJECTS =  \
@@ -2955,7 +2957,8 @@ ____CORE_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_datavgen.obj \
 	$(OBJS)\monolib_editlbox.obj \
 	$(OBJS)\monolib_laywin.obj \
-	$(OBJS)\monolib_calctrlg.obj
+	$(OBJS)\monolib_calctrlg.obj \
+	$(OBJS)\monolib_rowheightcache.obj
 !endif
 !if "$(USE_GUI)" == "1" && "$(WXUNIV)" == "1"
 ____CORE_SRC_FILENAMES_1_OBJECTS =  \
@@ -3280,7 +3283,8 @@ ____CORE_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_datavgen.obj \
 	$(OBJS)\monolib_editlbox.obj \
 	$(OBJS)\monolib_laywin.obj \
-	$(OBJS)\monolib_calctrlg.obj
+	$(OBJS)\monolib_calctrlg.obj \
+	$(OBJS)\monolib_rowheightcache.obj
 !endif
 !if "$(USE_STC)" == "1"
 ____MONOLIB_STC_SRC_FILENAMES_1_OBJECTS =  \
@@ -3659,7 +3663,8 @@ ____CORE_SRC_FILENAMES_2_OBJECTS =  \
 	$(OBJS)\coredll_datavgen.obj \
 	$(OBJS)\coredll_editlbox.obj \
 	$(OBJS)\coredll_laywin.obj \
-	$(OBJS)\coredll_calctrlg.obj
+	$(OBJS)\coredll_calctrlg.obj \
+	$(OBJS)\coredll_rowheightcache.obj
 !endif
 !if "$(USE_GUI)" == "1" && "$(WXUNIV)" == "1"
 ____CORE_SRC_FILENAMES_2_OBJECTS =  \
@@ -3984,7 +3989,8 @@ ____CORE_SRC_FILENAMES_2_OBJECTS =  \
 	$(OBJS)\coredll_datavgen.obj \
 	$(OBJS)\coredll_editlbox.obj \
 	$(OBJS)\coredll_laywin.obj \
-	$(OBJS)\coredll_calctrlg.obj
+	$(OBJS)\coredll_calctrlg.obj \
+	$(OBJS)\coredll_rowheightcache.obj
 !endif
 !if "$(MONOLITHIC)" == "0" && "$(SHARED)" == "0" && "$(USE_GUI)" == "1"
 __corelib___depname = \
@@ -4329,7 +4335,8 @@ ____CORE_SRC_FILENAMES_3_OBJECTS =  \
 	$(OBJS)\corelib_datavgen.obj \
 	$(OBJS)\corelib_editlbox.obj \
 	$(OBJS)\corelib_laywin.obj \
-	$(OBJS)\corelib_calctrlg.obj
+	$(OBJS)\corelib_calctrlg.obj \
+	$(OBJS)\corelib_rowheightcache.obj
 !endif
 !if "$(USE_GUI)" == "1" && "$(WXUNIV)" == "1"
 ____CORE_SRC_FILENAMES_3_OBJECTS =  \
@@ -4654,7 +4661,8 @@ ____CORE_SRC_FILENAMES_3_OBJECTS =  \
 	$(OBJS)\corelib_datavgen.obj \
 	$(OBJS)\corelib_editlbox.obj \
 	$(OBJS)\corelib_laywin.obj \
-	$(OBJS)\corelib_calctrlg.obj
+	$(OBJS)\corelib_calctrlg.obj \
+	$(OBJS)\corelib_rowheightcache.obj
 !endif
 !if "$(SHARED)" == "1"
 ____wxcore_namedll_DEP = $(__coredll___depname)
@@ -8937,6 +8945,11 @@ $(OBJS)\monodll_calctrlg.obj: ..\..\src\generic\calctrlg.cpp
 	$(CXX) -q -c -P -o$@ $(MONODLL_CXXFLAGS) ..\..\src\generic\calctrlg.cpp
 !endif
 
+!if "$(USE_GUI)" == "1"
+$(OBJS)\monodll_rowheightcache.obj: ..\..\src\generic\rowheightcache.cpp
+	$(CXX) -q -c -P -o$@ $(MONODLL_CXXFLAGS) ..\..\src\generic\rowheightcache.cpp
+!endif
+
 $(OBJS)\monodll_version.res: ..\..\src\msw\version.rc
 	brcc32 -32 -r -fo$@ -i$(BCCDIR)\include    -d__WXMSW__ $(__WXUNIV_DEFINE_p_67) $(__DEBUG_DEFINE_p_66) $(__NDEBUG_DEFINE_p_65) $(__EXCEPTIONS_DEFINE_p_65) $(__RTTI_DEFINE_p_65) $(__THREAD_DEFINE_p_65) $(__UNICODE_DEFINE_p_67) -i$(SETUPHDIR) -i..\..\include $(____CAIRO_INCLUDEDIR_FILENAMES_4) -dWXBUILDING -dWXDLLNAME=wx$(PORTNAME)$(WXUNIVNAME)$(WX_VERSION_NODOT)$(WXUNICODEFLAG)$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)$(WXCOMPILER)$(VENDORTAG) -i$(BCCDIR)\include\windows\sdk  -i..\..\src\tiff\libtiff -i..\..\src\jpeg -i..\..\src\png -i..\..\src\zlib -i..\..\src\regex -i..\..\src\expat\expat\lib -i..\..\src\stc\scintilla\include -i..\..\src\stc\scintilla\lexlib -i..\..\src\stc\scintilla\src -d__WX__ -dSCI_LEXER -dNO_CXX11_REGEX -dLINK_LEXERS -dwxUSE_BASE=1 -dWXMAKINGDLL  ..\..\src\msw\version.rc
 
@@ -11478,6 +11491,11 @@ $(OBJS)\monolib_calctrlg.obj: ..\..\src\generic\calctrlg.cpp
 	$(CXX) -q -c -P -o$@ $(MONOLIB_CXXFLAGS) ..\..\src\generic\calctrlg.cpp
 !endif
 
+!if "$(USE_GUI)" == "1"
+$(OBJS)\monolib_rowheightcache.obj: ..\..\src\generic\rowheightcache.cpp
+	$(CXX) -q -c -P -o$@ $(MONOLIB_CXXFLAGS) ..\..\src\generic\rowheightcache.cpp
+!endif
+
 $(OBJS)\basedll_dummy.obj: ..\..\src\common\dummy.cpp
 	$(CXX) -q -c -P -o$@ $(BASEDLL_CXXFLAGS) -H ..\..\src\common\dummy.cpp
 
@@ -13983,6 +14001,11 @@ $(OBJS)\coredll_calctrlg.obj: ..\..\src\generic\calctrlg.cpp
 	$(CXX) -q -c -P -o$@ $(COREDLL_CXXFLAGS) ..\..\src\generic\calctrlg.cpp
 !endif
 
+!if "$(USE_GUI)" == "1"
+$(OBJS)\coredll_rowheightcache.obj: ..\..\src\generic\rowheightcache.cpp
+	$(CXX) -q -c -P -o$@ $(COREDLL_CXXFLAGS) ..\..\src\generic\rowheightcache.cpp
+!endif
+
 $(OBJS)\corelib_dummy.obj: ..\..\src\common\dummy.cpp
 	$(CXX) -q -c -P -o$@ $(CORELIB_CXXFLAGS) -H ..\..\src\common\dummy.cpp
 
@@ -15709,6 +15732,11 @@ $(OBJS)\corelib_laywin.obj: ..\..\src\generic\laywin.cpp
 !if "$(USE_GUI)" == "1"
 $(OBJS)\corelib_calctrlg.obj: ..\..\src\generic\calctrlg.cpp
 	$(CXX) -q -c -P -o$@ $(CORELIB_CXXFLAGS) ..\..\src\generic\calctrlg.cpp
+!endif
+
+!if "$(USE_GUI)" == "1"
+$(OBJS)\corelib_rowheightcache.obj: ..\..\src\generic\rowheightcache.cpp
+	$(CXX) -q -c -P -o$@ $(CORELIB_CXXFLAGS) ..\..\src\generic\rowheightcache.cpp
 !endif
 
 $(OBJS)\advdll_dummy.obj: ..\..\src\common\dummy.cpp

--- a/build/msw/makefile.gcc
+++ b/build/msw/makefile.gcc
@@ -2152,7 +2152,8 @@ ____CORE_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_datavgen.o \
 	$(OBJS)\monodll_editlbox.o \
 	$(OBJS)\monodll_laywin.o \
-	$(OBJS)\monodll_calctrlg.o
+	$(OBJS)\monodll_calctrlg.o \
+	$(OBJS)\monodll_rowheightcache.o
 endif
 endif
 ifeq ($(USE_GUI),1)
@@ -2479,7 +2480,8 @@ ____CORE_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_datavgen.o \
 	$(OBJS)\monodll_editlbox.o \
 	$(OBJS)\monodll_laywin.o \
-	$(OBJS)\monodll_calctrlg.o
+	$(OBJS)\monodll_calctrlg.o \
+	$(OBJS)\monodll_rowheightcache.o
 endif
 endif
 ifeq ($(USE_STC),1)
@@ -2987,7 +2989,8 @@ ____CORE_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_datavgen.o \
 	$(OBJS)\monolib_editlbox.o \
 	$(OBJS)\monolib_laywin.o \
-	$(OBJS)\monolib_calctrlg.o
+	$(OBJS)\monolib_calctrlg.o \
+	$(OBJS)\monolib_rowheightcache.o
 endif
 endif
 ifeq ($(USE_GUI),1)
@@ -3314,7 +3317,8 @@ ____CORE_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_datavgen.o \
 	$(OBJS)\monolib_editlbox.o \
 	$(OBJS)\monolib_laywin.o \
-	$(OBJS)\monolib_calctrlg.o
+	$(OBJS)\monolib_calctrlg.o \
+	$(OBJS)\monolib_rowheightcache.o
 endif
 endif
 ifeq ($(USE_STC),1)
@@ -3707,7 +3711,8 @@ ____CORE_SRC_FILENAMES_2_OBJECTS =  \
 	$(OBJS)\coredll_datavgen.o \
 	$(OBJS)\coredll_editlbox.o \
 	$(OBJS)\coredll_laywin.o \
-	$(OBJS)\coredll_calctrlg.o
+	$(OBJS)\coredll_calctrlg.o \
+	$(OBJS)\coredll_rowheightcache.o
 endif
 endif
 ifeq ($(USE_GUI),1)
@@ -4034,7 +4039,8 @@ ____CORE_SRC_FILENAMES_2_OBJECTS =  \
 	$(OBJS)\coredll_datavgen.o \
 	$(OBJS)\coredll_editlbox.o \
 	$(OBJS)\coredll_laywin.o \
-	$(OBJS)\coredll_calctrlg.o
+	$(OBJS)\coredll_calctrlg.o \
+	$(OBJS)\coredll_rowheightcache.o
 endif
 endif
 ifeq ($(MONOLITHIC),0)
@@ -4385,7 +4391,8 @@ ____CORE_SRC_FILENAMES_3_OBJECTS =  \
 	$(OBJS)\corelib_datavgen.o \
 	$(OBJS)\corelib_editlbox.o \
 	$(OBJS)\corelib_laywin.o \
-	$(OBJS)\corelib_calctrlg.o
+	$(OBJS)\corelib_calctrlg.o \
+	$(OBJS)\corelib_rowheightcache.o
 endif
 endif
 ifeq ($(USE_GUI),1)
@@ -4712,7 +4719,8 @@ ____CORE_SRC_FILENAMES_3_OBJECTS =  \
 	$(OBJS)\corelib_datavgen.o \
 	$(OBJS)\corelib_editlbox.o \
 	$(OBJS)\corelib_laywin.o \
-	$(OBJS)\corelib_calctrlg.o
+	$(OBJS)\corelib_calctrlg.o \
+	$(OBJS)\corelib_rowheightcache.o
 endif
 endif
 ifeq ($(SHARED),1)
@@ -9119,6 +9127,11 @@ $(OBJS)\monodll_calctrlg.o: ../../src/generic/calctrlg.cpp
 	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
 endif
 
+ifeq ($(USE_GUI),1)
+$(OBJS)\monodll_rowheightcache.o: ../../src/generic/rowheightcache.cpp
+	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
+endif
+
 $(OBJS)\monodll_version_rc.o: ../../src/msw/version.rc
 	$(WINDRES) -i$< -o$@    --define __WXMSW__ $(__WXUNIV_DEFINE_p_67) $(__DEBUG_DEFINE_p_66) $(__NDEBUG_DEFINE_p_65) $(__EXCEPTIONS_DEFINE_p_65) $(__RTTI_DEFINE_p_65) $(__THREAD_DEFINE_p_65) $(__UNICODE_DEFINE_p_67) --include-dir $(SETUPHDIR) --include-dir ../../include $(__CAIRO_INCLUDEDIR_p) --define WXBUILDING --define WXDLLNAME=wx$(PORTNAME)$(WXUNIVNAME)$(WX_VERSION_NODOT)$(WXUNICODEFLAG)$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)$(WXCOMPILER)$(VENDORTAG)  --include-dir ../../src/tiff/libtiff --include-dir ../../src/jpeg --include-dir ../../src/png --include-dir ../../src/zlib --include-dir ../../src/regex --include-dir ../../src/expat/expat/lib --include-dir ../../src/stc/scintilla/include --include-dir ../../src/stc/scintilla/lexlib --include-dir ../../src/stc/scintilla/src --define __WX__ --define SCI_LEXER --define NO_CXX11_REGEX --define LINK_LEXERS --define wxUSE_BASE=1 --define WXMAKINGDLL
 
@@ -11660,6 +11673,11 @@ $(OBJS)\monolib_calctrlg.o: ../../src/generic/calctrlg.cpp
 	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
 endif
 
+ifeq ($(USE_GUI),1)
+$(OBJS)\monolib_rowheightcache.o: ../../src/generic/rowheightcache.cpp
+	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
+endif
+
 $(OBJS)\basedll_dummy.o: ../../src/common/dummy.cpp
 	$(CXX) -c -o $@ $(BASEDLL_CXXFLAGS) $(CPPDEPS) $<
 
@@ -14165,6 +14183,11 @@ $(OBJS)\coredll_calctrlg.o: ../../src/generic/calctrlg.cpp
 	$(CXX) -c -o $@ $(COREDLL_CXXFLAGS) $(CPPDEPS) $<
 endif
 
+ifeq ($(USE_GUI),1)
+$(OBJS)\coredll_rowheightcache.o: ../../src/generic/rowheightcache.cpp
+	$(CXX) -c -o $@ $(COREDLL_CXXFLAGS) $(CPPDEPS) $<
+endif
+
 $(OBJS)\corelib_dummy.o: ../../src/common/dummy.cpp
 	$(CXX) -c -o $@ $(CORELIB_CXXFLAGS) $(CPPDEPS) $<
 
@@ -15890,6 +15913,11 @@ endif
 
 ifeq ($(USE_GUI),1)
 $(OBJS)\corelib_calctrlg.o: ../../src/generic/calctrlg.cpp
+	$(CXX) -c -o $@ $(CORELIB_CXXFLAGS) $(CPPDEPS) $<
+endif
+
+ifeq ($(USE_GUI),1)
+$(OBJS)\corelib_rowheightcache.o: ../../src/generic/rowheightcache.cpp
 	$(CXX) -c -o $@ $(CORELIB_CXXFLAGS) $(CPPDEPS) $<
 endif
 

--- a/build/msw/makefile.vc
+++ b/build/msw/makefile.vc
@@ -2443,7 +2443,8 @@ ____CORE_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_datavgen.obj \
 	$(OBJS)\monodll_editlbox.obj \
 	$(OBJS)\monodll_laywin.obj \
-	$(OBJS)\monodll_calctrlg.obj
+	$(OBJS)\monodll_calctrlg.obj \
+	$(OBJS)\monodll_rowheightcache.obj
 !endif
 !if "$(USE_GUI)" == "1" && "$(WXUNIV)" == "1"
 ____CORE_SRC_FILENAMES_OBJECTS =  \
@@ -2768,7 +2769,8 @@ ____CORE_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_datavgen.obj \
 	$(OBJS)\monodll_editlbox.obj \
 	$(OBJS)\monodll_laywin.obj \
-	$(OBJS)\monodll_calctrlg.obj
+	$(OBJS)\monodll_calctrlg.obj \
+	$(OBJS)\monodll_rowheightcache.obj
 !endif
 !if "$(USE_STC)" == "1"
 ____MONOLIB_STC_SRC_FILENAMES_OBJECTS =  \
@@ -3278,7 +3280,8 @@ ____CORE_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_datavgen.obj \
 	$(OBJS)\monolib_editlbox.obj \
 	$(OBJS)\monolib_laywin.obj \
-	$(OBJS)\monolib_calctrlg.obj
+	$(OBJS)\monolib_calctrlg.obj \
+	$(OBJS)\monolib_rowheightcache.obj
 !endif
 !if "$(USE_GUI)" == "1" && "$(WXUNIV)" == "1"
 ____CORE_SRC_FILENAMES_1_OBJECTS =  \
@@ -3603,7 +3606,8 @@ ____CORE_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_datavgen.obj \
 	$(OBJS)\monolib_editlbox.obj \
 	$(OBJS)\monolib_laywin.obj \
-	$(OBJS)\monolib_calctrlg.obj
+	$(OBJS)\monolib_calctrlg.obj \
+	$(OBJS)\monolib_rowheightcache.obj
 !endif
 !if "$(USE_STC)" == "1"
 ____MONOLIB_STC_SRC_FILENAMES_1_OBJECTS =  \
@@ -4048,7 +4052,8 @@ ____CORE_SRC_FILENAMES_2_OBJECTS =  \
 	$(OBJS)\coredll_datavgen.obj \
 	$(OBJS)\coredll_editlbox.obj \
 	$(OBJS)\coredll_laywin.obj \
-	$(OBJS)\coredll_calctrlg.obj
+	$(OBJS)\coredll_calctrlg.obj \
+	$(OBJS)\coredll_rowheightcache.obj
 !endif
 !if "$(USE_GUI)" == "1" && "$(WXUNIV)" == "1"
 ____CORE_SRC_FILENAMES_2_OBJECTS =  \
@@ -4373,7 +4378,8 @@ ____CORE_SRC_FILENAMES_2_OBJECTS =  \
 	$(OBJS)\coredll_datavgen.obj \
 	$(OBJS)\coredll_editlbox.obj \
 	$(OBJS)\coredll_laywin.obj \
-	$(OBJS)\coredll_calctrlg.obj
+	$(OBJS)\coredll_calctrlg.obj \
+	$(OBJS)\coredll_rowheightcache.obj
 !endif
 !if "$(MONOLITHIC)" == "0" && "$(SHARED)" == "0" && "$(USE_GUI)" == "1"
 __corelib___depname = \
@@ -4724,7 +4730,8 @@ ____CORE_SRC_FILENAMES_3_OBJECTS =  \
 	$(OBJS)\corelib_datavgen.obj \
 	$(OBJS)\corelib_editlbox.obj \
 	$(OBJS)\corelib_laywin.obj \
-	$(OBJS)\corelib_calctrlg.obj
+	$(OBJS)\corelib_calctrlg.obj \
+	$(OBJS)\corelib_rowheightcache.obj
 !endif
 !if "$(USE_GUI)" == "1" && "$(WXUNIV)" == "1"
 ____CORE_SRC_FILENAMES_3_OBJECTS =  \
@@ -5049,7 +5056,8 @@ ____CORE_SRC_FILENAMES_3_OBJECTS =  \
 	$(OBJS)\corelib_datavgen.obj \
 	$(OBJS)\corelib_editlbox.obj \
 	$(OBJS)\corelib_laywin.obj \
-	$(OBJS)\corelib_calctrlg.obj
+	$(OBJS)\corelib_calctrlg.obj \
+	$(OBJS)\corelib_rowheightcache.obj
 !endif
 !if "$(SHARED)" == "1"
 ____wxcore_namedll_DEP = $(__coredll___depname)
@@ -9646,6 +9654,11 @@ $(OBJS)\monodll_calctrlg.obj: ..\..\src\generic\calctrlg.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\generic\calctrlg.cpp
 !endif
 
+!if "$(USE_GUI)" == "1"
+$(OBJS)\monodll_rowheightcache.obj: ..\..\src\generic\rowheightcache.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\generic\rowheightcache.cpp
+!endif
+
 $(OBJS)\monodll_version.res: ..\..\src\msw\version.rc
 	rc /fo$@  /d WIN32 $(____DEBUGRUNTIME_6) /d _CRT_SECURE_NO_DEPRECATE=1 /d _CRT_NON_CONFORMING_SWPRINTFS=1 /d _SCL_SECURE_NO_WARNINGS=1 $(__NO_VC_CRTDBG_p_72)  /d __WXMSW__ $(__WXUNIV_DEFINE_p_67) $(__DEBUG_DEFINE_p_66) $(__NDEBUG_DEFINE_p_65) $(__EXCEPTIONS_DEFINE_p_65) $(__RTTI_DEFINE_p_65) $(__THREAD_DEFINE_p_65) $(__UNICODE_DEFINE_p_67) /i $(SETUPHDIR) /i ..\..\include $(____CAIRO_INCLUDEDIR_FILENAMES_4) /d WXBUILDING /d WXDLLNAME=wx$(PORTNAME)$(WXUNIVNAME)$(WX_VERSION_NODOT)$(WXUNICODEFLAG)$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)$(WXCOMPILER)$(VENDORTAG)  /i ..\..\src\tiff\libtiff /i ..\..\src\jpeg /i ..\..\src\png /i ..\..\src\zlib /i ..\..\src\regex /i ..\..\src\expat\expat\lib /i ..\..\src\stc\scintilla\include /i ..\..\src\stc\scintilla\lexlib /i ..\..\src\stc\scintilla\src /d __WX__ /d SCI_LEXER /d NO_CXX11_REGEX /d LINK_LEXERS /d wxUSE_BASE=1 /d WXMAKINGDLL  ..\..\src\msw\version.rc
 
@@ -12187,6 +12200,11 @@ $(OBJS)\monolib_calctrlg.obj: ..\..\src\generic\calctrlg.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\generic\calctrlg.cpp
 !endif
 
+!if "$(USE_GUI)" == "1"
+$(OBJS)\monolib_rowheightcache.obj: ..\..\src\generic\rowheightcache.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\generic\rowheightcache.cpp
+!endif
+
 $(OBJS)\basedll_dummy.obj: ..\..\src\common\dummy.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(BASEDLL_CXXFLAGS) /Ycwx/wxprec.h ..\..\src\common\dummy.cpp
 
@@ -14692,6 +14710,11 @@ $(OBJS)\coredll_calctrlg.obj: ..\..\src\generic\calctrlg.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(COREDLL_CXXFLAGS) ..\..\src\generic\calctrlg.cpp
 !endif
 
+!if "$(USE_GUI)" == "1"
+$(OBJS)\coredll_rowheightcache.obj: ..\..\src\generic\rowheightcache.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(COREDLL_CXXFLAGS) ..\..\src\generic\rowheightcache.cpp
+!endif
+
 $(OBJS)\corelib_dummy.obj: ..\..\src\common\dummy.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(CORELIB_CXXFLAGS) /Ycwx/wxprec.h ..\..\src\common\dummy.cpp
 
@@ -16418,6 +16441,11 @@ $(OBJS)\corelib_laywin.obj: ..\..\src\generic\laywin.cpp
 !if "$(USE_GUI)" == "1"
 $(OBJS)\corelib_calctrlg.obj: ..\..\src\generic\calctrlg.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(CORELIB_CXXFLAGS) ..\..\src\generic\calctrlg.cpp
+!endif
+
+!if "$(USE_GUI)" == "1"
+$(OBJS)\corelib_rowheightcache.obj: ..\..\src\generic\rowheightcache.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(CORELIB_CXXFLAGS) ..\..\src\generic\rowheightcache.cpp
 !endif
 
 $(OBJS)\advdll_dummy.obj: ..\..\src\common\dummy.cpp

--- a/build/msw/wx_core.vcxproj
+++ b/build/msw/wx_core.vcxproj
@@ -1061,6 +1061,7 @@
     <ClCompile Include="..\..\src\generic\hyperlinkg.cpp" />
     <ClCompile Include="..\..\src\generic\notifmsgg.cpp" />
     <ClCompile Include="..\..\src\common\bmpcboxcmn.cpp" />
+    <ClCompile Include="..\..\src\generic\rowheightcache.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\src\msw\version.rc">

--- a/build/msw/wx_core.vcxproj.filters
+++ b/build/msw/wx_core.vcxproj.filters
@@ -603,6 +603,9 @@
     <ClCompile Include="..\..\src\generic\richtooltipg.cpp">
       <Filter>Generic Sources</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\generic\rowheightcache.cpp">
+      <Filter>Generic Sources</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\generic\sashwin.cpp">
       <Filter>Generic Sources</Filter>
     </ClCompile>

--- a/build/msw/wx_vc7_core.vcproj
+++ b/build/msw/wx_vc7_core.vcproj
@@ -1287,6 +1287,9 @@
 				RelativePath="..\..\src\generic\richtooltipg.cpp">
 			</File>
 			<File
+				RelativePath="..\..\src\generic\rowheightcache.cpp">
+			</File>
+			<File
 				RelativePath="..\..\src\generic\sashwin.cpp">
 			</File>
 			<File

--- a/build/msw/wx_vc8_core.vcproj
+++ b/build/msw/wx_vc8_core.vcproj
@@ -2128,6 +2128,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\src\generic\rowheightcache.cpp"
+				>
+			</File>
+			<File
 				RelativePath="..\..\src\generic\sashwin.cpp"
 				>
 			</File>

--- a/build/msw/wx_vc9_core.vcproj
+++ b/build/msw/wx_vc9_core.vcproj
@@ -2124,6 +2124,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\src\generic\rowheightcache.cpp"
+				>
+			</File>
+			<File
 				RelativePath="..\..\src\generic\sashwin.cpp"
 				>
 			</File>

--- a/include/wx/generic/private/rowheightcache.h
+++ b/include/wx/generic/private/rowheightcache.h
@@ -1,0 +1,142 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/private/rowheightcache.h
+// Purpose:     height cache of rows in a dataview
+// Author:      Jens Goepfert (mail@jensgoepfert.de)
+// Created:     2018-03-06
+// Copyright:   (c) wxWidgets team
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_PRIVATE_ROWHEIGHTCACHE_H_
+#define _WX_PRIVATE_ROWHEIGHTCACHE_H_
+
+#include "wx/hashmap.h"
+#include "wx/vector.h"
+
+// struct describing a range of rows which contains rows <from> .. <to-1>
+struct RowRange
+{
+    unsigned int from;
+    unsigned int to;
+};
+
+/**
+@class RowRanges
+A helper class that manages a set of RowRange objects.
+It stores the indices that are members of a group in a memory
+efficiant way.
+*/
+//class WXDLLIMPEXP_ADV RowRanges
+class RowRanges
+{
+public:
+    /**
+    Adds a row index to this group by adding it to an existing RowRange
+    or by creating a new one.
+    */
+    void Add(unsigned int row);
+
+    /**
+    Removes a row index and all indices after idx from this group.
+    */
+    void Remove(unsigned int row);
+
+    /**
+    Checks whether a row index is contained in this group.
+    */
+    bool Has(unsigned int row) const;
+
+    /**
+    Returns the number of row indices that are contained in this group.
+    */
+    unsigned int CountAll() const;
+
+    /**
+    Returns the number of rows that are in this group before the given row index.
+    not including given row.
+    */
+    unsigned int CountTo(unsigned int row) const;
+    unsigned int GetSize() const; // for debugging statistics
+
+private:
+    wxVector<RowRange> m_ranges;
+    /**
+    If a new row index was inserted Cleanup checks if the neighbour ranges
+    of idx can includes the same row indices and discards
+    unnecessary RowRange objects.
+    */
+    void CleanUp(unsigned int idx);
+};
+
+WX_DECLARE_HASH_MAP(unsigned int, RowRanges*, wxIntegerHash, wxIntegerEqual,
+    HeightToRowRangesMap);
+
+/**
+@class HeightCache
+
+HeightCache implements a cache mechanism for the DataViewCtrl to give
+fast access to:
+* the height of one line (GetLineHeight)
+* the y-coordinate where a row starts (GetLineStart)
+* and vice versa (GetLineAt)
+
+The layout of the cache is a hashmap where the keys are all exisiting
+row heights in pixels. The values are RowRange objects that represents
+all having the specified height.
+
+{
+22: RowRange([0..10], [15..17], [20..2000]),
+42: RowRange([11..12], [18..18]),
+62: RowRange([13..14], [19..19])
+}
+
+Examples
+========
+
+GetLineStart
+------------
+To retrieve the y-coordinate of item 1000 it is neccessary to look into
+each key of the hashmap *m_heightToRowRange*. Get the row count of
+indices lower than 1000 (RowRange::CountTo) and multiplies it wich the
+according height.
+
+RowRange([0..10], [15..17], [20..2000]).CountTo(1000)
+--> 0..10 are 11 items, 15..17 are 3 items and 20..1000 are 980 items (1000-20)
+= 11 + 3 + 980 = 994 items
+
+GetLineStart(1000) --> (22 * 994) + (42 * 3) + (62 * 3) = 22180
+
+GetLineHeight
+-------------
+To retrieve the line height look into each key and check if row is
+contained in RowRange (RowRange::Has)
+
+GetLineAt
+---------
+To retrieve the row that starts at a specific y-coordinate.
+Look into each key and count all rows.
+Use bisect algorithm in combination with GetLineStart() to
+find the appropriate item
+*/
+class WXDLLIMPEXP_ADV HeightCache
+{
+public:
+    bool GetLineStart(unsigned int row, int &start);
+    bool GetLineHeight(unsigned int row, int &height);
+    bool GetLineAt(int y, unsigned int &row);
+
+    void Put(const unsigned int row, const int height);
+    /**
+    removes the stored height of the given row from the cache
+    and invalidates all cached rows (including row)
+    */
+    void Remove(const unsigned int row);
+    void Clear();
+
+private:
+    bool GetLineInfo(unsigned int row, int &start, int &height);
+    HeightToRowRangesMap  m_heightToRowRange;
+};
+
+
+#endif // _WX_PRIVATE_ROWHEIGHTCACHE_H_

--- a/include/wx/generic/private/rowheightcache.h
+++ b/include/wx/generic/private/rowheightcache.h
@@ -26,8 +26,8 @@ A helper class that manages a set of RowRange objects.
 It stores the indices that are members of a group in a memory
 efficiant way.
 */
-//class WXDLLIMPEXP_ADV RowRanges
-class RowRanges
+class WXDLLIMPEXP_CORE RowRanges
+//class RowRanges
 {
 public:
     /**

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -821,7 +821,7 @@ public:
 
     int GetLineStart( unsigned int row ) const;  // row * m_lineHeight in fixed mode
     int GetLineHeight( unsigned int row ) const; // m_lineHeight in fixed mode
-    int GetLineAt( int y ) const;                // y / m_lineHeight in fixed mode
+    int GetLineAt( unsigned int y ) const;       // y / m_lineHeight in fixed mode
 
     void SetRowHeight( int lineHeight ) { m_lineHeight = lineHeight; }
     int GetRowHeight() const { return m_lineHeight; }
@@ -3415,11 +3415,8 @@ int wxDataViewMainWindow::GetLineStart( unsigned int row ) const
     }
 }
 
-int wxDataViewMainWindow::GetLineAt( int y ) const
+int wxDataViewMainWindow::GetLineAt( unsigned int y ) const
 {
-    if (y < 0)
-        return -1;
-
     const wxDataViewModel *model = GetModel();
 
     // check for the easy case first

--- a/src/generic/rowheightcache.cpp
+++ b/src/generic/rowheightcache.cpp
@@ -1,0 +1,337 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/private/rowheightcache.h
+// Purpose:     height cache of rows in a dataview
+// Author:      Jens Goepfert (mail@jensgoepfert.de)
+// Created:     2018-03-06
+// Copyright:   (c) wxWidgets team
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+// ============================================================================
+// declarations
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// headers
+// ----------------------------------------------------------------------------
+
+// for compilers that support precompilation, includes "wx.h".
+#include "wx/wxprec.h"
+
+#ifdef __BORLANDC__
+#pragma hdrstop
+#endif
+
+#ifndef WX_PRECOMP
+    #include "wx/log.h"
+#endif // WX_PRECOMP
+
+#include "wx/generic/private/rowheightcache.h"
+
+// ----------------------------------------------------------------------------
+// private structs
+// ----------------------------------------------------------------------------
+
+// ============================================================================
+// implementation
+// ============================================================================
+
+
+// ----------------------------------------------------------------------------
+// RowRanges
+// ----------------------------------------------------------------------------
+
+void RowRanges::Add(const unsigned int row)
+{
+    size_t count = m_ranges.size();
+    size_t rngIdx = 0;
+    for (rngIdx = 0; rngIdx < count; ++rngIdx)
+    {
+        RowRange &rng = m_ranges[rngIdx];
+
+        if (row >= rng.from && rng.to > row)
+        {
+            // index already in range
+            return;
+        }
+
+        if (row == rng.from - 1)
+        {
+            // extend range at the beginning (to the left)
+            rng.from = row;
+            // no cleanup necessary
+            return;
+        }
+        if (row == rng.to)
+        {
+            // extend range at the end (set to row+1 because 'to' is not including)
+            rng.to = row + 1;
+            CleanUp(rngIdx);
+            return;
+        }
+
+        if (rng.from > row + 1)
+        {
+            // this range is already behind row index, so break here and insert a new range before
+            break;
+        }
+    }
+    //    wxLogMessage("New Range: %d" , count);
+
+    RowRange newRange;
+    newRange.from = row;
+    newRange.to = row + 1;
+    m_ranges.insert(m_ranges.begin() + rngIdx, newRange);
+}
+
+void RowRanges::Remove(const unsigned int row)
+{
+    size_t count = m_ranges.size();
+    size_t rngIdx = 0;
+    while (rngIdx < count)
+    {
+        RowRange &rng = m_ranges[rngIdx];
+        if (rng.from >= row)
+        {
+            // this range starts behind row index, so remove it
+            m_ranges.erase(m_ranges.begin() + rngIdx);
+            count--;
+            continue;
+        }
+        if (rng.to > row)
+        {
+            // this ranges includes row, so cut off at row index to exclude row
+            rng.to = row;
+        }
+
+        rngIdx += 1;
+    }
+}
+
+
+void RowRanges::CleanUp(unsigned int idx)
+{
+    size_t count = m_ranges.size();
+    size_t rngIdx = 0;
+    if (idx > 0)
+    {
+        // start one RowRange before
+        rngIdx = idx - 1;
+    }
+    if (idx >= count)
+    {
+        // should never reached, due CleanUp is private and internal called correctly
+        return;
+    }
+    RowRange *prevRng = &m_ranges[rngIdx];
+    rngIdx++;
+    while (rngIdx <= idx + 1 && rngIdx < count)
+    {
+        RowRange &rng = m_ranges[rngIdx];
+
+        if (prevRng->to == rng.from)
+        {
+            // this range starts where the previous range began, so remove this
+            // and set the to-value of the previous range to the to-value of this range
+            prevRng->to = rng.to;
+            m_ranges.erase(m_ranges.begin() + rngIdx);
+            count--;
+            continue;
+        }
+
+        prevRng = &rng;
+        rngIdx += 1;
+    }
+}
+
+bool RowRanges::Has(unsigned int row) const
+{
+    size_t count = m_ranges.size();
+    for (size_t rngIdx = 0; rngIdx < count; rngIdx++)
+    {
+        const RowRange &rng = m_ranges[rngIdx];
+        if (rng.from <= row && row < rng.to)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+unsigned int RowRanges::CountAll() const
+{
+    unsigned int ctr = 0;
+    size_t count = m_ranges.size();
+    for (size_t rngIdx = 0; rngIdx < count; rngIdx++)
+    {
+        const RowRange &rng = m_ranges[rngIdx];
+        ctr += rng.to - rng.from;
+    }
+    return ctr;
+}
+
+unsigned int RowRanges::CountTo(unsigned int row) const
+{
+    unsigned int ctr = 0;
+    size_t count = m_ranges.size();
+    for (size_t rngIdx = 0; rngIdx < count; rngIdx++)
+    {
+        const RowRange &rng = m_ranges[rngIdx];
+        if (rng.from > row)
+        {
+            break;
+        }
+        else if (rng.to < row)
+        {
+            ctr += rng.to - rng.from;
+        }
+        else
+        {
+            ctr += row - rng.from;
+            break;
+        }
+    }
+    return ctr;
+}
+
+unsigned int RowRanges::GetSize() const // for debugging statistics
+{
+    return m_ranges.size();
+}
+
+
+// ----------------------------------------------------------------------------
+// HeightCache
+// ----------------------------------------------------------------------------
+
+bool HeightCache::GetLineInfo(unsigned int row, int &start, int &height)
+{
+    int y = 0;
+    bool found = false;
+    HeightToRowRangesMap::iterator it;
+    for (it = m_heightToRowRange.begin(); it != m_heightToRowRange.end(); ++it)
+    {
+        int rowHeight = it->first;
+        RowRanges* rowRanges = it->second;
+        if (rowRanges->Has(row))
+        {
+            height = rowHeight;
+            found = true;
+        }
+        y += rowHeight * (rowRanges->CountTo(row));
+    }
+    if (found)
+    {
+        start = y;
+    }
+    return found;
+}
+
+bool HeightCache::GetLineStart(unsigned int row, int &start)
+{
+    int height = 0;
+    return GetLineInfo(row, start, height);
+}
+
+bool HeightCache::GetLineHeight(unsigned int row, int &height)
+{
+    HeightToRowRangesMap::iterator it;
+    for (it = m_heightToRowRange.begin(); it != m_heightToRowRange.end(); ++it)
+    {
+        int rowHeight = it->first;
+        RowRanges* rowRanges = it->second;
+        if (rowRanges->Has(row))
+        {
+            height = rowHeight;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool HeightCache::GetLineAt(int y, unsigned int &row)
+{
+    unsigned int total = 0;
+    HeightToRowRangesMap::iterator it;
+    for (it = m_heightToRowRange.begin(); it != m_heightToRowRange.end(); ++it)
+    {
+        RowRanges* rowRanges = it->second;
+        total += rowRanges->CountAll();
+    }
+
+    if (total == 0)
+    {
+        return false;
+    }
+
+    int lo = 0;
+    int hi = total;
+    int start, height;
+    while (lo < hi)
+    {
+        int mid = (lo + hi) / 2;
+        if (GetLineInfo(mid, start, height))
+        {
+            if (start + height <= y)
+            {
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid;
+            }
+        }
+        else
+        {
+            // should never happen, except the HeightCache has gaps which is an invalid state
+            return false;
+        }
+    }
+    if (GetLineInfo(lo, start, height))
+    {
+        if (y < start)
+        {
+            // given y point is before the first row
+            return false;
+        }
+        row = lo;
+        return true;
+    }
+    else
+    {
+        // given y point is after the last row
+        return false;
+    }
+}
+
+void HeightCache::Put(const unsigned int row, const int height)
+{
+    RowRanges *rowRanges = m_heightToRowRange[height];
+    if (rowRanges == NULL)
+    {
+        rowRanges = new RowRanges();
+        m_heightToRowRange[height] = rowRanges;
+    }
+    rowRanges->Add(row);
+}
+
+void HeightCache::Remove(const unsigned int row)
+{
+    HeightToRowRangesMap::iterator it;
+    for (it = m_heightToRowRange.begin(); it != m_heightToRowRange.end(); ++it)
+    {
+        RowRanges* rowRanges = it->second;
+        rowRanges->Remove(row);
+    }
+}
+
+void HeightCache::Clear()
+{
+    HeightToRowRangesMap::iterator it;
+    for (it = m_heightToRowRange.begin(); it != m_heightToRowRange.end(); ++it)
+    {
+        RowRanges* rowRanges = it->second;
+        delete rowRanges;
+    }
+    m_heightToRowRange.clear();
+}

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -254,6 +254,7 @@ TEST_GUI_OBJECTS =  \
 	test_gui_socket.o \
 	test_gui_tlw.o \
 	test_gui_dataview.o \
+	test_gui_rowheightcachetest.o \
 	test_gui_boxsizer.o \
 	test_gui_gridsizer.o \
 	test_gui_wrapsizer.o \
@@ -1029,6 +1030,9 @@ test_gui_tlw.o: $(srcdir)/persistence/tlw.cpp $(TEST_GUI_ODEP)
 
 test_gui_dataview.o: $(srcdir)/persistence/dataview.cpp $(TEST_GUI_ODEP)
 	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/persistence/dataview.cpp
+
+test_gui_rowheightcachetest.o: $(srcdir)/rowheightcache/rowheightcachetest.cpp $(TEST_GUI_ODEP)
+	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/rowheightcache/rowheightcachetest.cpp
 
 test_gui_boxsizer.o: $(srcdir)/sizers/boxsizer.cpp $(TEST_GUI_ODEP)
 	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/sizers/boxsizer.cpp

--- a/tests/makefile.bcc
+++ b/tests/makefile.bcc
@@ -241,6 +241,7 @@ TEST_GUI_OBJECTS =  \
 	$(OBJS)\test_gui_socket.obj \
 	$(OBJS)\test_gui_tlw.obj \
 	$(OBJS)\test_gui_dataview.obj \
+	$(OBJS)\test_gui_rowheightcachetest.obj \
 	$(OBJS)\test_gui_boxsizer.obj \
 	$(OBJS)\test_gui_gridsizer.obj \
 	$(OBJS)\test_gui_wrapsizer.obj \
@@ -1083,6 +1084,9 @@ $(OBJS)\test_gui_tlw.obj: .\persistence\tlw.cpp
 
 $(OBJS)\test_gui_dataview.obj: .\persistence\dataview.cpp
 	$(CXX) -q -c -P -o$@ $(TEST_GUI_CXXFLAGS) .\persistence\dataview.cpp
+
+$(OBJS)\test_gui_rowheightcachetest.obj: .\rowheightcache\rowheightcachetest.cpp
+	$(CXX) -q -c -P -o$@ $(TEST_GUI_CXXFLAGS) .\rowheightcache\rowheightcachetest.cpp
 
 $(OBJS)\test_gui_boxsizer.obj: .\sizers\boxsizer.cpp
 	$(CXX) -q -c -P -o$@ $(TEST_GUI_CXXFLAGS) .\sizers\boxsizer.cpp

--- a/tests/makefile.gcc
+++ b/tests/makefile.gcc
@@ -236,6 +236,7 @@ TEST_GUI_OBJECTS =  \
 	$(OBJS)\test_gui_socket.o \
 	$(OBJS)\test_gui_tlw.o \
 	$(OBJS)\test_gui_dataview.o \
+	$(OBJS)\test_gui_rowheightcachetest.o \
 	$(OBJS)\test_gui_boxsizer.o \
 	$(OBJS)\test_gui_gridsizer.o \
 	$(OBJS)\test_gui_wrapsizer.o \
@@ -1059,6 +1060,9 @@ $(OBJS)\test_gui_tlw.o: ./persistence/tlw.cpp
 	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\test_gui_dataview.o: ./persistence/dataview.cpp
+	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
+
+$(OBJS)\test_gui_rowheightcachetest.o: ./rowheightcache/rowheightcachetest.cpp
 	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\test_gui_boxsizer.o: ./sizers/boxsizer.cpp

--- a/tests/makefile.vc
+++ b/tests/makefile.vc
@@ -247,6 +247,7 @@ TEST_GUI_OBJECTS =  \
 	$(OBJS)\test_gui_socket.obj \
 	$(OBJS)\test_gui_tlw.obj \
 	$(OBJS)\test_gui_dataview.obj \
+	$(OBJS)\test_gui_rowheightcachetest.obj \
 	$(OBJS)\test_gui_boxsizer.obj \
 	$(OBJS)\test_gui_gridsizer.obj \
 	$(OBJS)\test_gui_wrapsizer.obj \
@@ -1274,6 +1275,9 @@ $(OBJS)\test_gui_tlw.obj: .\persistence\tlw.cpp
 
 $(OBJS)\test_gui_dataview.obj: .\persistence\dataview.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\persistence\dataview.cpp
+
+$(OBJS)\test_gui_rowheightcachetest.obj: .\rowheightcache\rowheightcachetest.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\rowheightcache\rowheightcachetest.cpp
 
 $(OBJS)\test_gui_boxsizer.obj: .\sizers\boxsizer.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\sizers\boxsizer.cpp

--- a/tests/rowheightcache/rowheightcachetest.cpp
+++ b/tests/rowheightcache/rowheightcachetest.cpp
@@ -28,178 +28,131 @@
 
 
 // ----------------------------------------------------------------------------
-// test class
-// ----------------------------------------------------------------------------
-
-class RowHeightCacheTestCase : public CppUnit::TestCase
-{
-public:
-    RowHeightCacheTestCase() { }
-
-    virtual void setUp();
-    virtual void tearDown();
-
-protected:
-
-private:
-    CPPUNIT_TEST_SUITE( RowHeightCacheTestCase );
-        CPPUNIT_TEST(TestRowRangesSimple);
-        CPPUNIT_TEST(TestRowRangesGapsMod2);
-        CPPUNIT_TEST(TestRowRangesCleanUp1);
-        CPPUNIT_TEST(TestRowRangesCleanUp2);
-        CPPUNIT_TEST(TestHeightCache);
-    CPPUNIT_TEST_SUITE_END();
-
-    void TestRowRangesSimple();
-    void TestRowRangesGapsMod2();
-    void TestHeightCache();
-    void TestRowRangesCleanUp1();
-    void TestRowRangesCleanUp2();
-
-    wxDECLARE_NO_COPY_CLASS(RowHeightCacheTestCase);
-};
-
-// register in the unnamed registry so that these tests are run by default
-CPPUNIT_TEST_SUITE_REGISTRATION( RowHeightCacheTestCase );
-
-// also include in its own registry so that these tests can be run alone
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( RowHeightCacheTestCase,
-                                        "RowHeightCacheTestCase" );
-
-void RowHeightCacheTestCase::setUp()
-{
-}
-
-void RowHeightCacheTestCase::tearDown()
-{
-}
-
-// ----------------------------------------------------------------------------
 // TestRowRangesAdd
 // ----------------------------------------------------------------------------
-void RowHeightCacheTestCase::TestRowRangesSimple()
+TEST_CASE("RowHeightCacheTestCase::TestRowRangesSimple", "[dataview][heightcache]")
 {
     RowRanges *rr = new RowRanges();
 
-    CPPUNIT_ASSERT_EQUAL(rr->CountAll(), 0);
+    CHECK(rr->CountAll() == 0);
 
     for (unsigned int i = 0; i <= 10; i++)
     {
-        CPPUNIT_ASSERT_EQUAL(rr->Has(i), false);
+        CHECK(rr->Has(i) == false);
 
         rr->Add(i);
 
-        CPPUNIT_ASSERT_EQUAL(rr->CountAll(), i+1);
-        CPPUNIT_ASSERT_EQUAL(rr->CountTo(i), i);
-        CPPUNIT_ASSERT_EQUAL(rr->Has(i), true);
+        CHECK(rr->CountAll() == i+1);
+        CHECK(rr->CountTo(i) == i);
+        CHECK(rr->Has(i) == true);
     }
 
-    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 1); // every row is sorted in the same range, so count == 1
-    CPPUNIT_ASSERT_EQUAL(rr->CountAll(), 11); // 11 rows collected
-    CPPUNIT_ASSERT_EQUAL(rr->CountTo(10), 10);
+    CHECK(rr->GetSize() == 1); // every row is sorted in the same range, so count == 1
+    CHECK(rr->CountAll() == 11); // 11 rows collected
+    CHECK(rr->CountTo(10) == 10);
 
     rr->Add(5); // row 5 already contained -> does nothing
 
-    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 1); // every row is sorted in the same range, so count == 1
-    CPPUNIT_ASSERT_EQUAL(rr->CountAll(), 11); // 11 rows collected
-    CPPUNIT_ASSERT_EQUAL(rr->CountTo(10), 10);
+    CHECK(rr->GetSize() == 1); // every row is sorted in the same range, so count == 1
+    CHECK(rr->CountAll() == 11); // 11 rows collected
+    CHECK(rr->CountTo(10) == 10);
 
     for (int i = 10; i >= 0; i--)
     {
-        CPPUNIT_ASSERT_EQUAL(rr->CountAll(), (unsigned)i+1);
-        CPPUNIT_ASSERT_EQUAL(rr->CountTo((unsigned)i), (unsigned)i);
+        CHECK(rr->CountAll() == (unsigned)i+1);
+        CHECK(rr->CountTo((unsigned)i) == (unsigned)i);
 
         rr->Remove(i);
 
-        CPPUNIT_ASSERT_EQUAL(rr->CountAll(), (unsigned)i);
-        CPPUNIT_ASSERT_EQUAL(rr->CountTo((unsigned)i), (unsigned)i);
+        CHECK(rr->CountAll() == (unsigned)i);
+        CHECK(rr->CountTo((unsigned)i) == (unsigned)i);
     }
 
-    CPPUNIT_ASSERT_EQUAL(rr->CountAll(), 0); // everything removed, no row range is left behind
+    CHECK(rr->CountAll() == 0); // everything removed, no row range is left behind
     for (int i = 10; i > 0; i--)
     {
-        CPPUNIT_ASSERT_EQUAL(rr->CountTo(i), 0);
+        CHECK(rr->CountTo(i) == 0);
     }
-    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 0);
+    CHECK(rr->GetSize() == 0);
 }
 
 // ----------------------------------------------------------------------------
 // TestRowRangesRemove
 // ----------------------------------------------------------------------------
-void RowHeightCacheTestCase::TestRowRangesGapsMod2()
+TEST_CASE("RowHeightCacheTestCase::TestRowRangesGapsMod2", "[dataview][heightcache]")
 {
     RowRanges *rr = new RowRanges();
     for (int i = 0; i < 100; i++)
     {
-        CPPUNIT_ASSERT_EQUAL(rr->Has(i), false);
+        CHECK(rr->Has(i) == false);
 
         if (i % 2 == 0)
         {
             rr->Add(i);
         }
     }
-    CPPUNIT_ASSERT_EQUAL(rr->CountAll(), 50);
-    CPPUNIT_ASSERT_EQUAL(rr->CountTo(100), 50);
+    CHECK(rr->CountAll() == 50);
+    CHECK(rr->CountTo(100) == 50);
 
     for (unsigned int i = 99; i > 0; i--)
     {
         if (i % 2 == 0)
         {
-            CPPUNIT_ASSERT_EQUAL(rr->Has(i), true);
+            CHECK(rr->Has(i) == true);
             rr->Remove(i);
-            CPPUNIT_ASSERT_EQUAL(rr->Has(i), false);
+            CHECK(rr->Has(i) == false);
         }
         else
         {
-            CPPUNIT_ASSERT_EQUAL(rr->Has(i), false);
+            CHECK(rr->Has(i) == false);
         }
     }
 
     // only row 0 is in the RowRanges, so remove 1 does nothing
     rr->Remove(1);
 
-    CPPUNIT_ASSERT_EQUAL(rr->CountAll(), 1);
-    CPPUNIT_ASSERT_EQUAL(rr->CountTo(0), 0);
-    CPPUNIT_ASSERT_EQUAL(rr->CountTo(1), 1);
-    CPPUNIT_ASSERT_EQUAL(rr->CountTo(100), 1);
-    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 1);
+    CHECK(rr->CountAll() == 1);
+    CHECK(rr->CountTo(0) == 0);
+    CHECK(rr->CountTo(1) == 1);
+    CHECK(rr->CountTo(100) == 1);
+    CHECK(rr->GetSize() == 1);
 
     rr->Remove(0); // last row is beeing removed
 
-    CPPUNIT_ASSERT_EQUAL(rr->CountAll(), 0);
-    CPPUNIT_ASSERT_EQUAL(rr->CountTo(0), 0);
-    CPPUNIT_ASSERT_EQUAL(rr->CountTo(1), 0);
-    CPPUNIT_ASSERT_EQUAL(rr->CountTo(100), 0);
-    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 0);
+    CHECK(rr->CountAll() == 0);
+    CHECK(rr->CountTo(0) == 0);
+    CHECK(rr->CountTo(1) == 0);
+    CHECK(rr->CountTo(100) == 0);
+    CHECK(rr->GetSize() == 0);
 
     rr->Add(10);
-    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 1);
-    CPPUNIT_ASSERT_EQUAL(rr->CountTo(1), 0); // tests CountTo first break
+    CHECK(rr->GetSize() == 1);
+    CHECK(rr->CountTo(1) == 0); // tests CountTo first break
     rr->Add(5); // inserts a range at the beginning
-    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 2);
+    CHECK(rr->GetSize() == 2);
     rr->Remove(10);
     rr->Remove(5);
-    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 0);
+    CHECK(rr->GetSize() == 0);
 }
 
 // ----------------------------------------------------------------------------
 // TestRowRangesCleanUp1
 // ----------------------------------------------------------------------------
-void RowHeightCacheTestCase::TestRowRangesCleanUp1()
+TEST_CASE("RowHeightCacheTestCase::TestRowRangesCleanUp1", "[dataview][heightcache]")
 {
     RowRanges *rr = new RowRanges();
     for (unsigned int i = 0; i < 100; i++)
     {
-        CPPUNIT_ASSERT_EQUAL(rr->Has(i), false);
+        CHECK(rr->Has(i) == false);
 
         if (i % 2 == 0)
         {
             rr->Add(i);
         }
     }
-    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 50); // adding 50 rows (only even) results in 50 range objects
-    CPPUNIT_ASSERT_EQUAL(rr->CountAll(), 50);
-    CPPUNIT_ASSERT_EQUAL(rr->CountTo(100), 50);
+    CHECK(rr->GetSize() == 50); // adding 50 rows (only even) results in 50 range objects
+    CHECK(rr->CountAll() == 50);
+    CHECK(rr->CountTo(100) == 50);
 
     for (unsigned int i = 0; i < 100; i++)
     {
@@ -209,41 +162,41 @@ void RowHeightCacheTestCase::TestRowRangesCleanUp1()
         }
     }
 
-    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 1); // adding 50 rows (only odd) should combined to 1 range object
-    CPPUNIT_ASSERT_EQUAL(rr->CountAll(), 100);
-    CPPUNIT_ASSERT_EQUAL(rr->CountTo(100), 100);
+    CHECK(rr->GetSize() == 1); // adding 50 rows (only odd) should combined to 1 range object
+    CHECK(rr->CountAll() == 100);
+    CHECK(rr->CountTo(100) == 100);
 }
 
 // ----------------------------------------------------------------------------
 // TestRowRangesCleanUp2
 // ----------------------------------------------------------------------------
-void RowHeightCacheTestCase::TestRowRangesCleanUp2()
+TEST_CASE("RowHeightCacheTestCase::TestRowRangesCleanUp2", "[dataview][heightcache]")
 {
     RowRanges *rr = new RowRanges();
     for (unsigned int i = 0; i < 10; i++)
     {
         rr->Add(i);
     }
-    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 1); // adding 10 sequent rows results in 1 range objects
-    CPPUNIT_ASSERT_EQUAL(rr->CountAll(), 10);
-    CPPUNIT_ASSERT_EQUAL(rr->CountTo(100), 10);
+    CHECK(rr->GetSize() == 1); // adding 10 sequent rows results in 1 range objects
+    CHECK(rr->CountAll() == 10);
+    CHECK(rr->CountTo(100) == 10);
 
     for (unsigned int i = 12; i < 20; i++)
     {
         rr->Add(i);
     }
 
-    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 2);
+    CHECK(rr->GetSize() == 2);
     rr->Add(11); // tests extending a range at the beginning (to the left)
-    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 2);
+    CHECK(rr->GetSize() == 2);
     rr->Add(10); // extends a range and reduces them
-    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 1);
+    CHECK(rr->GetSize() == 1);
 }
 
 // ----------------------------------------------------------------------------
 // TestHeightCache
 // ----------------------------------------------------------------------------
-void RowHeightCacheTestCase::TestHeightCache()
+TEST_CASE("RowHeightCacheTestCase::TestHeightCache", "[dataview][heightcache]")
 {
     HeightCache *hc = new HeightCache();
 
@@ -272,56 +225,56 @@ void RowHeightCacheTestCase::TestHeightCache()
     int height = 0;
     unsigned int row = 666;
 
-    CPPUNIT_ASSERT_EQUAL(hc->GetLineStart(1000, start), true);
-    CPPUNIT_ASSERT_EQUAL(start, 22180);
+    CHECK(hc->GetLineStart(1000, start) == true);
+    CHECK(start == 22180);
 
-    CPPUNIT_ASSERT_EQUAL(hc->GetLineHeight(1000, height), true);
-    CPPUNIT_ASSERT_EQUAL(height, 22);
+    CHECK(hc->GetLineHeight(1000, height) == true);
+    CHECK(height == 22);
 
-    CPPUNIT_ASSERT_EQUAL(hc->GetLineHeight(5000, start), false);
+    CHECK(hc->GetLineHeight(5000, start) == false);
 
     // test invalid y
-    CPPUNIT_ASSERT_EQUAL(hc->GetLineAt(-1, row), false);
-    CPPUNIT_ASSERT_EQUAL(row, 666);
+    CHECK(hc->GetLineAt(-1, row) == false);
+    CHECK(row == 666);
 
     // test start of first row
-    CPPUNIT_ASSERT_EQUAL(hc->GetLineAt(0, row), true);
-    CPPUNIT_ASSERT_EQUAL(row, 0);
+    CHECK(hc->GetLineAt(0, row) == true);
+    CHECK(row == 0);
 
     // test end of first row
-    CPPUNIT_ASSERT_EQUAL(hc->GetLineAt(21, row), true);
-    CPPUNIT_ASSERT_EQUAL(row, 0);
+    CHECK(hc->GetLineAt(21, row) == true);
+    CHECK(row == 0);
 
     // test start of second row
-    CPPUNIT_ASSERT_EQUAL(hc->GetLineAt(22, row), true);
-    CPPUNIT_ASSERT_EQUAL(row, 1);
+    CHECK(hc->GetLineAt(22, row) == true);
+    CHECK(row == 1);
 
     hc->Remove(1000); // Delete row 1000 and everything behind
 
-    CPPUNIT_ASSERT_EQUAL(hc->GetLineAt(22179, row), true);
-    CPPUNIT_ASSERT_EQUAL(row, 999);
-    CPPUNIT_ASSERT_EQUAL(hc->GetLineHeight(999, height), true);
-    CPPUNIT_ASSERT_EQUAL(height, 22);
+    CHECK(hc->GetLineAt(22179, row) == true);
+    CHECK(row == 999);
+    CHECK(hc->GetLineHeight(999, height) == true);
+    CHECK(height == 22);
 
     row = 666;
     height = 666;
-    CPPUNIT_ASSERT_EQUAL(hc->GetLineAt(22180, row), false);
-    CPPUNIT_ASSERT_EQUAL(row, 666);
-    CPPUNIT_ASSERT_EQUAL(hc->GetLineHeight(1000, height), false);
-    CPPUNIT_ASSERT_EQUAL(height, 666);
+    CHECK(hc->GetLineAt(22180, row) == false);
+    CHECK(row == 666);
+    CHECK(hc->GetLineHeight(1000, height) == false);
+    CHECK(height == 666);
 
     hc->Clear(); // Clear all items
     for (int i = 20; i <= 2000; i++)
     {
         height = 666;
-        CPPUNIT_ASSERT_EQUAL(hc->GetLineHeight(i, height), false);
-        CPPUNIT_ASSERT_EQUAL(height, 666);
+        CHECK(hc->GetLineHeight(i, height) == false);
+        CHECK(height == 666);
     }
 
     hc->Clear(); // Clear twice should not crash
 
     row = 666;
     height = 666;
-    CPPUNIT_ASSERT_EQUAL(hc->GetLineAt(22180, row), false);
-    CPPUNIT_ASSERT_EQUAL(row, 666);
+    CHECK(hc->GetLineAt(22180, row) == false);
+    CHECK(row == 666);
 }

--- a/tests/rowheightcache/rowheightcachetest.cpp
+++ b/tests/rowheightcache/rowheightcachetest.cpp
@@ -1,0 +1,327 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        tests/rowheightcache/rowheightcachetest.cpp
+// Purpose:     unit tests for the row height cache of a dataview
+// Author:      Jens Goepfert (mail@jensgoepfert.de)
+// Created:     2018-03-06
+// Copyright:   (c) wxWidgets team
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+// ----------------------------------------------------------------------------
+// headers
+// ----------------------------------------------------------------------------
+
+#include "testprec.h"
+
+#ifdef __BORLANDC__
+    #pragma hdrstop
+#endif
+
+#ifndef WX_PRECOMP
+#endif
+
+#include "wx/generic/private/rowheightcache.h"
+
+// ----------------------------------------------------------------------------
+// local functions
+// ----------------------------------------------------------------------------
+
+
+// ----------------------------------------------------------------------------
+// test class
+// ----------------------------------------------------------------------------
+
+class RowHeightCacheTestCase : public CppUnit::TestCase
+{
+public:
+    RowHeightCacheTestCase() { }
+
+    virtual void setUp();
+    virtual void tearDown();
+
+protected:
+
+private:
+    CPPUNIT_TEST_SUITE( RowHeightCacheTestCase );
+        CPPUNIT_TEST(TestRowRangesSimple);
+        CPPUNIT_TEST(TestRowRangesGapsMod2);
+        CPPUNIT_TEST(TestRowRangesCleanUp1);
+        CPPUNIT_TEST(TestRowRangesCleanUp2);
+        CPPUNIT_TEST(TestHeightCache);
+    CPPUNIT_TEST_SUITE_END();
+
+    void TestRowRangesSimple();
+    void TestRowRangesGapsMod2();
+    void TestHeightCache();
+    void TestRowRangesCleanUp1();
+    void TestRowRangesCleanUp2();
+
+    wxDECLARE_NO_COPY_CLASS(RowHeightCacheTestCase);
+};
+
+// register in the unnamed registry so that these tests are run by default
+CPPUNIT_TEST_SUITE_REGISTRATION( RowHeightCacheTestCase );
+
+// also include in its own registry so that these tests can be run alone
+CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( RowHeightCacheTestCase,
+                                        "RowHeightCacheTestCase" );
+
+void RowHeightCacheTestCase::setUp()
+{
+}
+
+void RowHeightCacheTestCase::tearDown()
+{
+}
+
+// ----------------------------------------------------------------------------
+// TestRowRangesAdd
+// ----------------------------------------------------------------------------
+void RowHeightCacheTestCase::TestRowRangesSimple()
+{
+    RowRanges *rr = new RowRanges();
+
+    CPPUNIT_ASSERT_EQUAL(rr->CountAll(), 0);
+
+    for (unsigned int i = 0; i <= 10; i++)
+    {
+        CPPUNIT_ASSERT_EQUAL(rr->Has(i), false);
+
+        rr->Add(i);
+
+        CPPUNIT_ASSERT_EQUAL(rr->CountAll(), i+1);
+        CPPUNIT_ASSERT_EQUAL(rr->CountTo(i), i);
+        CPPUNIT_ASSERT_EQUAL(rr->Has(i), true);
+    }
+
+    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 1); // every row is sorted in the same range, so count == 1
+    CPPUNIT_ASSERT_EQUAL(rr->CountAll(), 11); // 11 rows collected
+    CPPUNIT_ASSERT_EQUAL(rr->CountTo(10), 10);
+
+    rr->Add(5); // row 5 already contained -> does nothing
+
+    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 1); // every row is sorted in the same range, so count == 1
+    CPPUNIT_ASSERT_EQUAL(rr->CountAll(), 11); // 11 rows collected
+    CPPUNIT_ASSERT_EQUAL(rr->CountTo(10), 10);
+
+    for (int i = 10; i >= 0; i--)
+    {
+        CPPUNIT_ASSERT_EQUAL(rr->CountAll(), (unsigned)i+1);
+        CPPUNIT_ASSERT_EQUAL(rr->CountTo((unsigned)i), (unsigned)i);
+
+        rr->Remove(i);
+
+        CPPUNIT_ASSERT_EQUAL(rr->CountAll(), (unsigned)i);
+        CPPUNIT_ASSERT_EQUAL(rr->CountTo((unsigned)i), (unsigned)i);
+    }
+
+    CPPUNIT_ASSERT_EQUAL(rr->CountAll(), 0); // everything removed, no row range is left behind
+    for (int i = 10; i > 0; i--)
+    {
+        CPPUNIT_ASSERT_EQUAL(rr->CountTo(i), 0);
+    }
+    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 0);
+}
+
+// ----------------------------------------------------------------------------
+// TestRowRangesRemove
+// ----------------------------------------------------------------------------
+void RowHeightCacheTestCase::TestRowRangesGapsMod2()
+{
+    RowRanges *rr = new RowRanges();
+    for (int i = 0; i < 100; i++)
+    {
+        CPPUNIT_ASSERT_EQUAL(rr->Has(i), false);
+
+        if (i % 2 == 0)
+        {
+            rr->Add(i);
+        }
+    }
+    CPPUNIT_ASSERT_EQUAL(rr->CountAll(), 50);
+    CPPUNIT_ASSERT_EQUAL(rr->CountTo(100), 50);
+
+    for (unsigned int i = 99; i > 0; i--)
+    {
+        if (i % 2 == 0)
+        {
+            CPPUNIT_ASSERT_EQUAL(rr->Has(i), true);
+            rr->Remove(i);
+            CPPUNIT_ASSERT_EQUAL(rr->Has(i), false);
+        }
+        else
+        {
+            CPPUNIT_ASSERT_EQUAL(rr->Has(i), false);
+        }
+    }
+
+    // only row 0 is in the RowRanges, so remove 1 does nothing
+    rr->Remove(1);
+
+    CPPUNIT_ASSERT_EQUAL(rr->CountAll(), 1);
+    CPPUNIT_ASSERT_EQUAL(rr->CountTo(0), 0);
+    CPPUNIT_ASSERT_EQUAL(rr->CountTo(1), 1);
+    CPPUNIT_ASSERT_EQUAL(rr->CountTo(100), 1);
+    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 1);
+
+    rr->Remove(0); // last row is beeing removed
+
+    CPPUNIT_ASSERT_EQUAL(rr->CountAll(), 0);
+    CPPUNIT_ASSERT_EQUAL(rr->CountTo(0), 0);
+    CPPUNIT_ASSERT_EQUAL(rr->CountTo(1), 0);
+    CPPUNIT_ASSERT_EQUAL(rr->CountTo(100), 0);
+    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 0);
+
+    rr->Add(10);
+    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 1);
+    CPPUNIT_ASSERT_EQUAL(rr->CountTo(1), 0); // tests CountTo first break
+    rr->Add(5); // inserts a range at the beginning
+    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 2);
+    rr->Remove(10);
+    rr->Remove(5);
+    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 0);
+}
+
+// ----------------------------------------------------------------------------
+// TestRowRangesCleanUp1
+// ----------------------------------------------------------------------------
+void RowHeightCacheTestCase::TestRowRangesCleanUp1()
+{
+    RowRanges *rr = new RowRanges();
+    for (unsigned int i = 0; i < 100; i++)
+    {
+        CPPUNIT_ASSERT_EQUAL(rr->Has(i), false);
+
+        if (i % 2 == 0)
+        {
+            rr->Add(i);
+        }
+    }
+    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 50); // adding 50 rows (only even) results in 50 range objects
+    CPPUNIT_ASSERT_EQUAL(rr->CountAll(), 50);
+    CPPUNIT_ASSERT_EQUAL(rr->CountTo(100), 50);
+
+    for (unsigned int i = 0; i < 100; i++)
+    {
+        if (i % 2 == 1)
+        {
+            rr->Add(i);
+        }
+    }
+
+    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 1); // adding 50 rows (only odd) should combined to 1 range object
+    CPPUNIT_ASSERT_EQUAL(rr->CountAll(), 100);
+    CPPUNIT_ASSERT_EQUAL(rr->CountTo(100), 100);
+}
+
+// ----------------------------------------------------------------------------
+// TestRowRangesCleanUp2
+// ----------------------------------------------------------------------------
+void RowHeightCacheTestCase::TestRowRangesCleanUp2()
+{
+    RowRanges *rr = new RowRanges();
+    for (unsigned int i = 0; i < 10; i++)
+    {
+        rr->Add(i);
+    }
+    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 1); // adding 10 sequent rows results in 1 range objects
+    CPPUNIT_ASSERT_EQUAL(rr->CountAll(), 10);
+    CPPUNIT_ASSERT_EQUAL(rr->CountTo(100), 10);
+
+    for (unsigned int i = 12; i < 20; i++)
+    {
+        rr->Add(i);
+    }
+
+    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 2);
+    rr->Add(11); // tests extending a range at the beginning (to the left)
+    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 2);
+    rr->Add(10); // extends a range and reduces them
+    CPPUNIT_ASSERT_EQUAL(rr->GetSize(), 1);
+}
+
+// ----------------------------------------------------------------------------
+// TestHeightCache
+// ----------------------------------------------------------------------------
+void RowHeightCacheTestCase::TestHeightCache()
+{
+    HeightCache *hc = new HeightCache();
+
+    for (unsigned int i = 0; i <= 10; i++)
+    {
+        hc->Put(i, 22);
+    }
+    for (unsigned int i = 15; i <= 17; i++)
+    {
+        hc->Put(i, 22);
+    }
+    for (unsigned int i = 20; i <= 2000; i++)
+    {
+        hc->Put(i, 22);
+    }
+
+    hc->Put(11, 42);
+    hc->Put(12, 42);
+    hc->Put(18, 42);
+
+    hc->Put(13, 62);
+    hc->Put(14, 62);
+    hc->Put(19, 62);
+
+    int start = 0;
+    int height = 0;
+    unsigned int row = 666;
+
+    CPPUNIT_ASSERT_EQUAL(hc->GetLineStart(1000, start), true);
+    CPPUNIT_ASSERT_EQUAL(start, 22180);
+
+    CPPUNIT_ASSERT_EQUAL(hc->GetLineHeight(1000, height), true);
+    CPPUNIT_ASSERT_EQUAL(height, 22);
+
+    CPPUNIT_ASSERT_EQUAL(hc->GetLineHeight(5000, start), false);
+
+    // test invalid y
+    CPPUNIT_ASSERT_EQUAL(hc->GetLineAt(-1, row), false);
+    CPPUNIT_ASSERT_EQUAL(row, 666);
+
+    // test start of first row
+    CPPUNIT_ASSERT_EQUAL(hc->GetLineAt(0, row), true);
+    CPPUNIT_ASSERT_EQUAL(row, 0);
+
+    // test end of first row
+    CPPUNIT_ASSERT_EQUAL(hc->GetLineAt(21, row), true);
+    CPPUNIT_ASSERT_EQUAL(row, 0);
+
+    // test start of second row
+    CPPUNIT_ASSERT_EQUAL(hc->GetLineAt(22, row), true);
+    CPPUNIT_ASSERT_EQUAL(row, 1);
+
+    hc->Remove(1000); // Delete row 1000 and everything behind
+
+    CPPUNIT_ASSERT_EQUAL(hc->GetLineAt(22179, row), true);
+    CPPUNIT_ASSERT_EQUAL(row, 999);
+    CPPUNIT_ASSERT_EQUAL(hc->GetLineHeight(999, height), true);
+    CPPUNIT_ASSERT_EQUAL(height, 22);
+
+    row = 666;
+    height = 666;
+    CPPUNIT_ASSERT_EQUAL(hc->GetLineAt(22180, row), false);
+    CPPUNIT_ASSERT_EQUAL(row, 666);
+    CPPUNIT_ASSERT_EQUAL(hc->GetLineHeight(1000, height), false);
+    CPPUNIT_ASSERT_EQUAL(height, 666);
+
+    hc->Clear(); // Clear all items
+    for (int i = 20; i <= 2000; i++)
+    {
+        height = 666;
+        CPPUNIT_ASSERT_EQUAL(hc->GetLineHeight(i, height), false);
+        CPPUNIT_ASSERT_EQUAL(height, 666);
+    }
+
+    hc->Clear(); // Clear twice should not crash
+
+    row = 666;
+    height = 666;
+    CPPUNIT_ASSERT_EQUAL(hc->GetLineAt(22180, row), false);
+    CPPUNIT_ASSERT_EQUAL(row, 666);
+}

--- a/tests/test.bkl
+++ b/tests/test.bkl
@@ -266,6 +266,7 @@
             net/socket.cpp
             persistence/tlw.cpp
             persistence/dataview.cpp
+            rowheightcache/rowheightcachetest.cpp
             sizers/boxsizer.cpp
             sizers/gridsizer.cpp
             sizers/wrapsizer.cpp

--- a/tests/test_vc7_test_gui.vcproj
+++ b/tests/test_vc7_test_gui.vcproj
@@ -524,6 +524,9 @@
 				RelativePath=".\controls\richtextctrltest.cpp">
 			</File>
 			<File
+				RelativePath=".\rowheightcache\rowheightcachetest.cpp">
+			</File>
+			<File
 				RelativePath=".\misc\safearrayconverttest.cpp">
 			</File>
 			<File

--- a/tests/test_vc8_test_gui.vcproj
+++ b/tests/test_vc8_test_gui.vcproj
@@ -1167,6 +1167,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\rowheightcache\rowheightcachetest.cpp"
+				>
+			</File>
+			<File
 				RelativePath=".\misc\safearrayconverttest.cpp"
 				>
 			</File>

--- a/tests/test_vc9_test_gui.vcproj
+++ b/tests/test_vc9_test_gui.vcproj
@@ -1139,6 +1139,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\rowheightcache\rowheightcachetest.cpp"
+				>
+			</File>
+			<File
 				RelativePath=".\misc\safearrayconverttest.cpp"
 				>
 			</File>


### PR DESCRIPTION
This is most likely not a ready to merge pull request. It is more like a draft to start a discussion about wxDataView performance with variable line height. 

Currently the wxDataViewCtrl is unusable with the style flag wxDV_VARIABLE_LINE_HEIGHT set. A sample with approximately 100 items is enough to see laggy performance. The first commit in this PR is a quick try to reduces the calls to the method GetLineStart(). This makes performance a bit better but the result is still laggy. The next try (second commit) uses a cache for all the items line heights. This makes the DataViewCtrl really usable. 

Currently the caching is very stupid and is fully resetted when expanding or collapsing items in the tree. So i just want discuss some opportunities to get better performance into the official release. 

So suggestions are welcome.
