### PR TITLE
Hide wxChoice before destroying it with GTK+ 3

### DIFF
--- a/src/gtk/choice.cpp
+++ b/src/gtk/choice.cpp
@@ -99,6 +99,15 @@ bool wxChoice::Create( wxWindow *parent, wxWindowID id,
 wxChoice::~wxChoice()
 {
     delete m_strings;
+
+ #ifdef __WXGTK3__
+    // At least with GTK+ 3.22.9, destroying a shown combobox widget results in
+    // a Gtk-CRITICAL debug message when the assertion fails inside a signal
+    // handler called from gtk_widget_unrealize(), which is annoying, so avoid
+    // it by hiding the widget before destroying it -- this doesn't look right,
+    // but shouldn't do any harm neither.
+    Hide();
+ #endif // __WXGTK3__
 }
 
 void wxChoice::GTKInsertComboBoxTextItem( unsigned int n, const wxString& text )


### PR DESCRIPTION
This works around GTK+ critical error messages that we get otherwise with at
least GTK+ 3.22.9 (but not with previous versions). These messages happen
because gtk_combo_box_popdown() ends up being called during the widget
destruction if it's still shown (it's called from a signal handler invoked as
a result of gtk_widget_unmap(), itself called from gtk_widget_unrealize(),
called by gtk_widget_unparent() called by the default GtkContainer "remove"
method, which we ourselves call from our own pizza_remove() which is called by
gtk_widget_destroy()).

It doesn't look like we do anything wrong here, so this might be a GTK+ bug
which could get fixed in a later version, but calling Hide() in the meanwhile
doesn't really do any harm, so add it to avoid the annoying debug messages.