### PR TITLE
Fix "unknown keyboard accel" with 1-char translations

### DIFF
--- a/src/common/accelcmn.cpp
+++ b/src/common/accelcmn.cpp
@@ -232,12 +232,18 @@ wxAcceleratorEntry::ParseAccel(const wxString& text, int *flagsOut, int *keyOut)
             // it's just a letter
             keyCode = current[0U];
 
-            // if the key is used with any modifiers, make it an uppercase one
-            // because Ctrl-A and Ctrl-a are the same; but keep it as is if it's
-            // used alone as 'a' and 'A' are different
-            if ( accelFlags != wxACCEL_NORMAL )
-                keyCode = wxToupper(keyCode);
-            break;
+            // ...or maybe not. A translation may be single character too (e.g.
+            // Chinese), but if it's a Latin character, that's unlikely
+            if ( keyCode < 128 )
+            {
+                // if the key is used with any modifiers, make it an uppercase one
+                // because Ctrl-A and Ctrl-a are the same; but keep it as is if it's
+                // used alone as 'a' and 'A' are different
+                if ( accelFlags != wxACCEL_NORMAL )
+                    keyCode = wxToupper(keyCode);
+                break;
+            }
+            wxFALLTHROUGH;
 
         default:
             keyCode = IsNumberedAccelKey(current, wxTRANSLATE("F"),


### PR DESCRIPTION
`wxAcceleratorEntry::ParseAccel()` incorrectly assumes that every single-character accelerator must be a direct character code. But that's not true, a human-friendly name for a key (e.g. "Down") may be translated with a single character in some languages (or because a translator decides to use a Unicode arrow…).

Amend the test to check if the character is a 7bit ASCII one. That would be extremely unlikely to be a translation.

Alternatively, the `default:` branch of the switch statement could be done unconditionally first to rule out translations at the cost of slight inefficiency. But doing this (or `< 256`) seems reasonable to me as it filters out the realistically possible translations (Unicode arrows and such, logographic languages).

See https://github.com/vslavik/poedit/issues/370 for a real-life example.