### PR TITLE
Fix wxTextWrapper::Wrap with widthMax=-1

### DIFF
--- a/src/common/stattextcmn.cpp
+++ b/src/common/stattextcmn.cpp
@@ -118,6 +118,13 @@ void wxTextWrapper::Wrap(wxWindow *win, const wxString& text, int widthMax)
             OnNewLine();
         }
 
+        // Is this a special case when wrapping is disabled?
+        if ( widthMax < 0 )
+        {
+            DoOutputLine(line);
+            continue;
+        }
+
         for ( bool newLine = false; !line.empty(); newLine = true )
         {
             if ( newLine )


### PR DESCRIPTION
Fix regression introduced in cb2474f where `Wrap()` stopped treating negative `widthMax` as documented, i.e. not doing any wrapping at all and only respecting newlines.

(This had fun consequences for `wxLogDialog` which relies on this special case. PR in case I'm missing something, but I don't think I am.)