### PR TITLE
Target latest Windows API

### DIFF
--- a/include/wx/msw/winver.h
+++ b/include/wx/msw/winver.h
@@ -22,15 +22,15 @@
 // even higher version of the API which will become available later.
 
 #ifndef WINVER
-    #define WINVER 0x0603
+    #define WINVER 0x0A00
 #endif
 
 #ifndef _WIN32_WINNT
-    #define _WIN32_WINNT 0x0603
+    #define _WIN32_WINNT 0x0A00
 #endif
 
 #ifndef _WIN32_IE
-    #define _WIN32_IE 0x0700
+    #define _WIN32_IE 0x0A00
 #endif
 
 #endif // _WX_MSW_WINVER_H_


### PR DESCRIPTION
While playing around with the latest Windows SDK (15063) I noticed a lot of new functions were not accessible because an older Windows version is targeted. Increase the defines to the latest version as suggested in the header of `winver.h`.