### PR TITLE
Fixes for compiling on OpenIndiana

### DIFF
--- a/configure
+++ b/configure
@@ -28118,6 +28118,12 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 if test "$TOOLKIT" != "MSW"; then
 
 if test "$wxUSE_LIBICONV" != "no" ; then
+    ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+
 
 
 
@@ -28154,7 +28160,7 @@ iconv_t cd = iconv_open("","");
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
+if ac_fn_cxx_try_link "$LINENO"; then :
   am_cv_func_iconv=yes
 fi
 rm -f core conftest.err conftest.$ac_objext \
@@ -28176,7 +28182,7 @@ iconv_t cd = iconv_open("","");
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
+if ac_fn_cxx_try_link "$LINENO"; then :
   am_cv_lib_iconv=yes
         am_cv_func_iconv=yes
 fi
@@ -28220,7 +28226,7 @@ main ()
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
+if ac_fn_cxx_try_compile "$LINENO"; then :
   wx_cv_func_iconv_const="no"
 else
   wx_cv_func_iconv_const="yes"
@@ -28248,6 +28254,12 @@ _ACEOF
     LIBICONV="-liconv"
   fi
 
+
+    ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
     LIBS="$LIBICONV $LIBS"
 fi

--- a/configure
+++ b/configure
@@ -32621,20 +32621,58 @@ $as_echo "$as_me: WARNING: I18n code requires wxFile... disabled" >&2;}
 fi
 
 if test "$wxUSE_XLOCALE" = "yes" ; then
-    $as_echo "#define wxUSE_XLOCALE 1" >>confdefs.h
+            { $as_echo "$as_me:${as_lineno-$LINENO}: checking for complete xlocale" >&5
+$as_echo_n "checking for complete xlocale... " >&6; }
+if ${wx_cv_use_xlocale_local+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
-    ac_fn_c_check_type "$LINENO" "locale_t" "ac_cv_type_locale_t" "#include <xlocale.h>
-                    #include <locale.h>
-"
-if test "x$ac_cv_type_locale_t" = xyes; then :
+        ac_ext=cpp
+ac_cpp='$CXXCPP $CPPFLAGS'
+ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
-cat >>confdefs.h <<_ACEOF
-#define HAVE_LOCALE_T 1
+        cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+        #include <xlocale.h>
+        #include <locale.h>
+        #include <stdlib.h>
+
+int
+main ()
+{
+
+        locale_t t;
+        strtod_l(NULL, NULL, t);
+
+  ;
+  return 0;
+}
 _ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+  wx_cv_use_xlocale_local=yes
+else
+  wx_cv_use_xlocale_local=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+        ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $wx_cv_use_xlocale_local" >&5
+$as_echo "$wx_cv_use_xlocale_local" >&6; }
 
+    if test "$wx_cv_use_xlocale_local" = "yes" ; then
+        $as_echo "#define wxUSE_XLOCALE 1" >>confdefs.h
+
+    fi
 fi
 
 if test "$wxUSE_LOG" = "yes"; then

--- a/configure.in
+++ b/configure.in
@@ -5709,10 +5709,31 @@ if test "$wxUSE_INTL" = "yes" ; then
 fi
 
 if test "$wxUSE_XLOCALE" = "yes" ; then
-    AC_DEFINE(wxUSE_XLOCALE)
-    AC_CHECK_TYPES(locale_t,,,
-                   [#include <xlocale.h>
-                    #include <locale.h>])
+    dnl even if xlocale.h exists, it may not contain all that
+    dnl wx needs. check if strtod_l() really is available.
+    AC_CACHE_CHECK([for complete xlocale],
+                   wx_cv_use_xlocale_local,
+    [
+        AC_LANG_PUSH(C++)
+        AC_TRY_COMPILE(
+        [
+        #include <xlocale.h>
+        #include <locale.h>
+        #include <stdlib.h>
+        ],
+        [
+        locale_t t;
+        strtod_l(NULL, NULL, t);
+        ],
+        wx_cv_use_xlocale_local=yes,
+        wx_cv_use_xlocale_local=no
+        )
+        AC_LANG_POP()
+    ])
+
+    if test "$wx_cv_use_xlocale_local" = "yes" ; then
+        AC_DEFINE(wxUSE_XLOCALE)
+    fi
 fi
 
 if test "$wxUSE_LOG" = "yes"; then

--- a/configure.in
+++ b/configure.in
@@ -4117,7 +4117,9 @@ if test "$TOOLKIT" != "MSW"; then
 
 dnl check for available version of iconv()
 if test "$wxUSE_LIBICONV" != "no" ; then
+    AC_LANG_PUSH(C++)
     AM_ICONV
+    AC_LANG_POP()
     LIBS="$LIBICONV $LIBS"
 fi
 


### PR DESCRIPTION
Compilation even with `--disable-gui` on OpenIndiana fails for two reasons:
* incorrect use of of `iconv` API
* assuming the whole xlocale API is available when it is not.

In the second commit I am almost certainly using the `AC_CACHE_CHECK` macro in the wrong way by introducing a kind-of local variable. But I couldn't figure out how to have the compilation check actually run if using the global `wx_cv_use_xlocale`.