### PR TITLE
Don't rely on argv being NULL-terminated under MSW

### DIFF
--- a/include/wx/cmdargs.h
+++ b/include/wx/cmdargs.h
@@ -31,19 +31,17 @@ public:
     wxCmdLineArgsArray() { m_argsA = NULL; m_argsW = NULL; }
 
     template <typename T>
-    wxCmdLineArgsArray& operator=(T **argv)
+    void Init(int argc, T **argv)
     {
         FreeArgs();
 
         m_args.clear();
+        m_args.reserve(argc);
 
-        if ( argv )
+        for ( int i = 0; i < argc; i++ )
         {
-            while ( *argv )
-                m_args.push_back(*argv++);
+            m_args.push_back(argv[i]);
         }
-
-        return *this;
     }
 
     operator char**() const

--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -335,8 +335,7 @@ bool wxEntryStart(int& argc, wxChar **argv)
 
     // remember, possibly modified (e.g. due to removal of toolkit-specific
     // parameters), command line arguments in member variables
-    app->argc = argc;
-    app->argv = argv;
+    app->argv.Init(argc, argv);
 
     wxCallAppCleanup callAppCleanup(app.get());
 

--- a/src/gtk/app.cpp
+++ b/src/gtk/app.cpp
@@ -396,7 +396,7 @@ bool wxApp::Initialize(int& argc_, wxChar **argv_)
 
     // update internal arg[cv] as GTK+ may have removed processed options:
     this->argc = argc_;
-    this->argv = argv_;
+    this->argv.Init(argc_, argv_);
 
     if ( m_traits )
     {


### PR DESCRIPTION
Since the changes of c9a458bfe87445dd4042b50522d9e0fed1c2f694 ("Use Win32
::CommandLineToArgvW() to tokenize command line"), this is not guaranteed any
more as this Win32 function doesn't necessarily ensure it under older MSW
versions such as XP.

Just use "argc" explicitly instead of relying on this in wxCmdLineArgsArray to
fix crashing under XP.