### PR TITLE
wxGraphicsContext: support double pen width

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,11 @@
+*.o
+lib*.so
+lib*.so.*
+lib*.a
+
 # /
+/.deps
+/.pch
 /.gdb_history
 /config.cache
 /configarg.cache

--- a/include/wx/gtk/pen.h
+++ b/include/wx/gtk/pen.h
@@ -33,6 +33,7 @@ public:
     void SetJoin( wxPenJoin joinStyle ) wxOVERRIDE;
     void SetStyle( wxPenStyle style ) wxOVERRIDE;
     void SetWidth( int width ) wxOVERRIDE;
+    void SetWidthF( double widthF ) wxOVERRIDE;
     void SetDashes( int number_of_dashes, const wxDash *dash ) wxOVERRIDE;
     void SetStipple(const wxBitmap& stipple) wxOVERRIDE;
 
@@ -41,6 +42,7 @@ public:
     wxPenJoin GetJoin() const wxOVERRIDE;
     wxPenStyle GetStyle() const wxOVERRIDE;
     int GetWidth() const wxOVERRIDE;
+    double GetWidthF() const wxOVERRIDE;
     int GetDashes(wxDash **ptr) const wxOVERRIDE;
     int GetDashCount() const;
     wxDash* GetDash() const;

--- a/include/wx/msw/pen.h
+++ b/include/wx/msw/pen.h
@@ -35,6 +35,7 @@ public:
     void SetColour(unsigned char r, unsigned char g, unsigned char b) wxOVERRIDE;
 
     void SetWidth(int width) wxOVERRIDE;
+    void SetWidthF(double widthF) wxOVERRIDE;
     void SetStyle(wxPenStyle style) wxOVERRIDE;
     void SetStipple(const wxBitmap& stipple) wxOVERRIDE;
     void SetDashes(int nb_dashes, const wxDash *dash) wxOVERRIDE;
@@ -43,6 +44,7 @@ public:
 
     wxColour GetColour() const wxOVERRIDE;
     int GetWidth() const wxOVERRIDE;
+    double GetWidthF() const wxOVERRIDE;
     wxPenStyle GetStyle() const wxOVERRIDE;
     wxPenJoin GetJoin() const wxOVERRIDE;
     wxPenCap GetCap() const wxOVERRIDE;

--- a/include/wx/osx/pen.h
+++ b/include/wx/osx/pen.h
@@ -33,6 +33,7 @@ public:
     void SetColour(unsigned char r, unsigned char g, unsigned char b) ;
 
     void SetWidth(int width)  ;
+    void SetWidthF(double widthF)  ;
     void SetStyle(wxPenStyle style)  ;
     void SetStipple(const wxBitmap& stipple)  ;
     void SetDashes(int nb_dashes, const wxDash *dash)  ;
@@ -41,6 +42,7 @@ public:
 
     wxColour GetColour() const ;
     int GetWidth() const;
+    double GetWidthF() const;
     wxPenStyle GetStyle() const;
     wxPenJoin GetJoin() const;
     wxPenCap GetCap() const;

--- a/include/wx/pen.h
+++ b/include/wx/pen.h
@@ -69,6 +69,7 @@ public:
     virtual void SetColour(unsigned char r, unsigned char g, unsigned char b) = 0;
 
     virtual void SetWidth(int width) = 0;
+    virtual void SetWidthF(double WXUNUSED(width)) { /* no-op */ };
     virtual void SetStyle(wxPenStyle style) = 0;
     virtual void SetStipple(const wxBitmap& stipple) = 0;
     virtual void SetDashes(int nb_dashes, const wxDash *dash) = 0;
@@ -81,6 +82,7 @@ public:
     virtual wxPenJoin GetJoin() const = 0;
     virtual wxPenCap GetCap() const = 0;
     virtual int GetWidth() const = 0;
+    virtual double GetWidthF() const { return -1.0; };
     virtual int GetDashes(wxDash **ptr) const = 0;
 
     // Convenient helpers for testing whether the pen is a transparent one:

--- a/interface/wx/pen.h
+++ b/interface/wx/pen.h
@@ -273,6 +273,15 @@ public:
     virtual int GetWidth() const;
 
     /**
+        Returns the pen floating-point width, or -1.0 if unset.
+
+        @see SetWidthF()
+
+        @since 3.1.0.
+    */
+    virtual double GetWidthF() const;
+
+    /**
         Returns @true if the pen is initialised.
 
         Notice that an uninitialized pen object can't be queried for any pen
@@ -371,6 +380,20 @@ public:
         @see GetWidth()
     */
     virtual void SetWidth(int width);
+
+    /**
+        Sets the pen width as floating-point value.
+
+        Note: only GDI+/Direct2D (wxMSW), CoreGraphics (wxOSX) and Cairo (wxGTK etc.)
+        support floating-point pen width.
+
+        @onlyfor{wxmsw,wxosx,wxgtk}
+
+        @see GetWidthF()
+
+        @since 3.1.0.
+    */
+    virtual void SetWidthF(double width);
 
     /**
         Inequality operator.

--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -22,7 +22,7 @@
 
 // keep cairo.h from defining dllimport as we're defining the symbols inside
 // the wx dll in order to load them dynamically.
-#define cairo_public 
+#define cairo_public
 
 #include <cairo.h>
 #include <float.h>
@@ -440,7 +440,7 @@ public:
     {
         if ( !m_enableOffset )
             return false;
-        
+
         int penwidth = 0 ;
         if ( !m_pen.IsNull() )
         {
@@ -736,7 +736,9 @@ wxCairoPenData::wxCairoPenData( wxGraphicsRenderer* renderer, const wxPen &pen )
     : wxCairoPenBrushBaseData(renderer, pen.GetColour(), pen.IsTransparent())
 {
     Init();
-    m_width = pen.GetWidth();
+    m_width = pen.GetWidthF();
+    if (m_width < 0.0)
+        m_width = pen.GetWidth();
     if (m_width <= 0.0)
         m_width = 0.1;
 
@@ -1539,7 +1541,7 @@ wxCairoBitmapData::wxCairoBitmapData( wxGraphicsRenderer* renderer, const wxBitm
     }
 
 #if defined(__WXMSW__) || defined(__WXGTK3__)
-    // if there is a mask, set the alpha bytes in the target buffer to 
+    // if there is a mask, set the alpha bytes in the target buffer to
     // fully transparent or fully opaque
 #if defined(__WXMSW__)
     if (bmp.GetMask() != NULL && !bmp.HasAlpha())
@@ -1772,7 +1774,7 @@ wxCairoContext::wxCairoContext( wxGraphicsRenderer* renderer, const wxPrinterDC&
 : wxGraphicsContext(renderer)
 {
 #ifdef __WXMSW__
-    // wxMSW contexts always use MM_ANISOTROPIC, which messes up 
+    // wxMSW contexts always use MM_ANISOTROPIC, which messes up
     // text rendering when printing using Cairo. Switch it to MM_TEXT
     // map mode to avoid this problem.
     HDC hdc = (HDC)dc.GetHDC();
@@ -2035,7 +2037,7 @@ wxCairoContext::wxCairoContext( wxGraphicsRenderer* renderer, const wxMemoryDC& 
     if ( adjustTransformFromDC )
         ApplyTransformFromDC(dc);
 #endif // __WXMSW__
-    
+
 #ifdef __WXGTK3__
     cairo_t* cr = static_cast<cairo_t*>(dc.GetImpl()->GetCairoContext());
     Init(cr ? cairo_reference(cr) : NULL);

--- a/src/gtk/pen.cpp
+++ b/src/gtk/pen.cpp
@@ -27,6 +27,7 @@ public:
     wxPenRefData()
     {
         m_width = 1;
+        m_widthF = -1.0;
         m_style = wxPENSTYLE_SOLID;
         m_joinStyle = wxJOIN_ROUND;
         m_capStyle = wxCAP_ROUND;
@@ -39,6 +40,7 @@ public:
     {
         m_style = data.m_style;
         m_width = data.m_width;
+        m_widthF = data.m_widthF;
         m_joinStyle = data.m_joinStyle;
         m_capStyle = data.m_capStyle;
         m_colour = data.m_colour;
@@ -67,12 +69,14 @@ public:
 
         return m_style == data.m_style &&
                m_width == data.m_width &&
+               m_widthF == data.m_widthF &&
                m_joinStyle == data.m_joinStyle &&
                m_capStyle == data.m_capStyle &&
                m_colour == data.m_colour;
     }
 
     int        m_width;
+    double     m_widthF;
     wxPenStyle m_style;
     wxPenJoin  m_joinStyle;
     wxPenCap   m_capStyle;
@@ -91,6 +95,7 @@ wxPen::wxPen( const wxColour &colour, int width, wxPenStyle style )
 {
     m_refData = new wxPenRefData();
     M_PENDATA->m_width = width;
+    M_PENDATA->m_widthF = -1.0;
     M_PENDATA->m_style = style;
     M_PENDATA->m_colour = colour;
 }
@@ -99,6 +104,7 @@ wxPen::wxPen(const wxColour& colour, int width, int style)
 {
     m_refData = new wxPenRefData();
     M_PENDATA->m_width = width;
+    M_PENDATA->m_widthF = -1.0;
     M_PENDATA->m_style = (wxPenStyle)style;
     M_PENDATA->m_colour = colour;
 }
@@ -177,6 +183,13 @@ void wxPen::SetWidth( int width )
     M_PENDATA->m_width = width;
 }
 
+void wxPen::SetWidthF( double widthF )
+{
+    AllocExclusive();
+
+    M_PENDATA->m_widthF = widthF;
+}
+
 int wxPen::GetDashes( wxDash **ptr ) const
 {
     wxCHECK_MSG( IsOk(), -1, wxT("invalid pen") );
@@ -225,6 +238,13 @@ int wxPen::GetWidth() const
     wxCHECK_MSG( IsOk(), -1, wxT("invalid pen") );
 
     return M_PENDATA->m_width;
+}
+
+double wxPen::GetWidthF() const
+{
+    wxCHECK_MSG( IsOk(), -1, wxT("invalid pen") );
+
+    return M_PENDATA->m_widthF;
 }
 
 wxColour wxPen::GetColour() const

--- a/src/msw/graphics.cpp
+++ b/src/msw/graphics.cpp
@@ -400,7 +400,7 @@ public:
     virtual bool SetAntialiasMode(wxAntialiasMode antialias) wxOVERRIDE;
 
     virtual bool SetInterpolationQuality(wxInterpolationQuality interpolation) wxOVERRIDE;
-    
+
     virtual bool SetCompositionMode(wxCompositionMode op) wxOVERRIDE;
 
     virtual void BeginLayer(wxDouble opacity) wxOVERRIDE;
@@ -647,7 +647,9 @@ wxGDIPlusPenData::wxGDIPlusPenData( wxGraphicsRenderer* renderer, const wxPen &p
 : wxGraphicsObjectRefData(renderer)
 {
     Init();
-    m_width = pen.GetWidth();
+    m_width = pen.GetWidthF();
+    if (m_width < 0.0)
+        m_width = pen.GetWidth();
     if (m_width <= 0.0)
         m_width = 0.1;
 
@@ -2047,7 +2049,7 @@ void wxGDIPlusContext::DoDrawText(const wxString& str,
 
     wxGDIPlusFontData * const
         fontData = (wxGDIPlusFontData *)m_font.GetRefData();
- 
+
     m_context->DrawString
                (
                     str.wc_str(*wxConvUI),  // string to draw, always Unicode
@@ -2160,7 +2162,7 @@ bool wxGDIPlusContext::ShouldOffset() const
 {
     if ( !m_enableOffset )
         return false;
-    
+
     int penwidth = 0 ;
     if ( !m_pen.IsNull() )
     {

--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -2497,8 +2497,12 @@ wxD2DPenData::wxD2DPenData(
     wxGraphicsRenderer* renderer,
     ID2D1Factory* direct2dFactory,
     const wxPen& pen)
-    : wxGraphicsObjectRefData(renderer), m_sourcePen(pen), m_width(pen.GetWidth())
+    : wxGraphicsObjectRefData(renderer), m_sourcePen(pen)
 {
+    m_width = pen.GetWidthF();
+    if (m_width < 0.0)
+        m_width = pen.GetWidth();
+
     CreateStrokeStyle(direct2dFactory);
 
     wxBrush strokeBrush;

--- a/src/msw/pen.cpp
+++ b/src/msw/pen.cpp
@@ -55,6 +55,7 @@ public:
         // we intentionally don't compare m_hPen fields here
         return m_style == data.m_style &&
                m_width == data.m_width &&
+               m_widthF == data.m_widthF &&
                m_join == data.m_join &&
                m_cap == data.m_cap &&
                m_colour == data.m_colour &&
@@ -70,6 +71,7 @@ public:
 
     wxColour& GetColour() const { return const_cast<wxColour&>(m_colour); }
     int GetWidth() const { return m_width; }
+    double GetWidthF() const { return m_widthF; }
     wxPenStyle GetStyle() const { return m_style; }
     wxPenJoin GetJoin() const { return m_join; }
     wxPenCap GetCap() const { return m_cap; }
@@ -79,6 +81,7 @@ public:
 
     void SetColour(const wxColour& col) { Free(); m_colour = col; }
     void SetWidth(int width) { Free(); m_width = width; }
+    void SetWidthF(double widthF) { Free(); m_widthF = widthF; }
     void SetStyle(wxPenStyle style) { Free(); m_style = style; }
     void SetStipple(const wxBitmap& stipple)
     {
@@ -126,9 +129,11 @@ private:
         m_nbDash = 0;
         m_dash = NULL;
         m_hPen = 0;
+        m_widthF = -1.0;
     }
 
     int           m_width;
+    double        m_widthF;
     wxPenStyle    m_style;
     wxPenJoin     m_join;
     wxPenCap      m_cap;
@@ -162,6 +167,7 @@ wxPenRefData::wxPenRefData(const wxPenRefData& data)
 {
     m_style = data.m_style;
     m_width = data.m_width;
+    m_widthF = data.m_widthF;
     m_join = data.m_join;
     m_cap = data.m_cap;
     m_nbDash = data.m_nbDash;
@@ -294,7 +300,8 @@ bool wxPenRefData::Alloc()
             m_cap == wxCAP_ROUND &&
                 m_style != wxPENSTYLE_USER_DASH &&
                     m_style != wxPENSTYLE_STIPPLE &&
-                        (m_width <= 1 || m_style == wxPENSTYLE_SOLID) )
+                        (m_width <= 1 || m_style == wxPENSTYLE_SOLID) &&
+                            m_widthF < 0 )
    {
        m_hPen = ::CreatePen(ConvertPenStyle(m_style), m_width, col);
    }
@@ -366,7 +373,7 @@ bool wxPenRefData::Alloc()
            dash = NULL;
        }
 
-       m_hPen = ::ExtCreatePen(styleMSW, m_width, &lb, m_nbDash, (LPDWORD)dash);
+       m_hPen = ::ExtCreatePen(styleMSW, m_widthF >= 0 ? m_widthF : m_width, &lb, m_nbDash, (LPDWORD)dash);
 
        delete [] dash;
    }
@@ -472,6 +479,13 @@ void wxPen::SetWidth(int width)
     M_PENDATA->SetWidth(width);
 }
 
+void wxPen::SetWidthF(double widthF)
+{
+    AllocExclusive();
+
+    M_PENDATA->SetWidthF(widthF);
+}
+
 void wxPen::SetStyle(wxPenStyle style)
 {
     AllocExclusive();
@@ -519,6 +533,13 @@ int wxPen::GetWidth() const
     wxCHECK_MSG( IsOk(), -1, wxT("invalid pen") );
 
     return M_PENDATA->GetWidth();
+}
+
+double wxPen::GetWidthF() const
+{
+    wxCHECK_MSG( IsOk(), -1, wxT("invalid pen") );
+
+    return M_PENDATA->GetWidthF();
 }
 
 wxPenStyle wxPen::GetStyle() const

--- a/src/osx/carbon/graphics.cpp
+++ b/src/osx/carbon/graphics.cpp
@@ -346,7 +346,9 @@ wxMacCoreGraphicsPenData::wxMacCoreGraphicsPenData( wxGraphicsRenderer* renderer
     m_color.reset( wxMacCreateCGColor( pen.GetColour() ) ) ;
 
     // TODO: * m_dc->m_scaleX
-    m_width = pen.GetWidth();
+    m_width = pen.GetWidthF();
+    if (m_width < 0.0)
+        m_width = pen.GetWidth();
     if (m_width <= 0.0)
         m_width = (CGFloat) 0.1;
 
@@ -1315,7 +1317,7 @@ public:
     virtual bool SetAntialiasMode(wxAntialiasMode antialias) wxOVERRIDE;
 
     virtual bool SetInterpolationQuality(wxInterpolationQuality interpolation) wxOVERRIDE;
-    
+
     virtual bool SetCompositionMode(wxCompositionMode op) wxOVERRIDE;
 
     virtual void BeginLayer(wxDouble opacity) wxOVERRIDE;
@@ -1360,7 +1362,7 @@ public:
     {
         if ( !m_enableOffset )
             return false;
-        
+
         int penwidth = 0 ;
         if ( !m_pen.IsNull() )
         {
@@ -1388,10 +1390,10 @@ public:
     virtual void DrawBitmap( const wxGraphicsBitmap &bmp, wxDouble x, wxDouble y, wxDouble w, wxDouble h ) wxOVERRIDE;
 
     virtual void DrawIcon( const wxIcon &icon, wxDouble x, wxDouble y, wxDouble w, wxDouble h ) wxOVERRIDE;
-    
+
     // fast convenience methods
-    
-    
+
+
     virtual void DrawRectangle( wxDouble x, wxDouble y, wxDouble w, wxDouble h ) wxOVERRIDE;
 
     void SetNativeContext( CGContextRef cg );
@@ -1563,7 +1565,7 @@ void wxMacCoreGraphicsContext::Flush()
 bool wxMacCoreGraphicsContext::EnsureIsValid()
 {
     CheckInvariants();
-    
+
     if ( !m_cgContext )
     {
         if (m_invisible)
@@ -1666,14 +1668,14 @@ bool wxMacCoreGraphicsContext::SetInterpolationQuality(wxInterpolationQuality in
 {
     if (!EnsureIsValid())
         return true;
-    
+
     if (m_interpolation == interpolation)
         return true;
 
     m_interpolation = interpolation;
     CGInterpolationQuality quality;
-    
-    switch (interpolation) 
+
+    switch (interpolation)
     {
         case wxINTERPOLATION_DEFAULT:
             quality = kCGInterpolationDefault;
@@ -1864,7 +1866,7 @@ void wxMacCoreGraphicsContext::Clip( const wxRegion &region )
     // allow usage as measuring context
     // wxASSERT_MSG( m_cgContext != NULL, "Needs a valid context for clipping" );
 #endif
-    CheckInvariants();    
+    CheckInvariants();
 }
 
 // clips drawings to the rect
@@ -1889,7 +1891,7 @@ void wxMacCoreGraphicsContext::Clip( wxDouble x, wxDouble y, wxDouble w, wxDoubl
     // wxFAIL_MSG( "Needs a valid context for clipping" );
 #endif
     }
-    CheckInvariants();    
+    CheckInvariants();
 }
 
     // resets the clipping to original extent
@@ -1916,7 +1918,7 @@ void wxMacCoreGraphicsContext::ResetClip()
     // wxFAIL_MSG( "Needs a valid context for clipping" );
 #endif
     }
-    CheckInvariants();    
+    CheckInvariants();
 }
 
 void wxMacCoreGraphicsContext::GetClipBox(wxDouble* x, wxDouble* y, wxDouble* w, wxDouble* h)
@@ -1967,7 +1969,7 @@ void wxMacCoreGraphicsContext::StrokePath( const wxGraphicsPath &path )
     ((wxMacCoreGraphicsPenData*)m_pen.GetRefData())->Apply(this);
     CGContextAddPath( m_cgContext , (CGPathRef) path.GetNativePath() );
     CGContextStrokePath( m_cgContext );
-    
+
     CheckInvariants();
 }
 
@@ -2022,7 +2024,7 @@ void wxMacCoreGraphicsContext::DrawPath( const wxGraphicsPath &path , wxPolygonF
 
     CGContextAddPath( m_cgContext , (CGPathRef) path.GetNativePath() );
     CGContextDrawPath( m_cgContext , mode );
-    
+
     CheckInvariants();
 }
 
@@ -2054,7 +2056,7 @@ void wxMacCoreGraphicsContext::FillPath( const wxGraphicsPath &path , wxPolygonF
         else
             CGContextFillPath( m_cgContext );
     }
-    
+
     CheckInvariants();
 }
 
@@ -2167,7 +2169,7 @@ void wxMacCoreGraphicsContext::DrawBitmap( const wxGraphicsBitmap &bmp, wxDouble
         wxMacDrawCGImage( m_cgContext , &r , image );
     }
 #endif
-    
+
     CheckInvariants();
 }
 
@@ -2183,12 +2185,12 @@ void wxMacCoreGraphicsContext::DrawIcon( const wxIcon &icon, wxDouble x, wxDoubl
     {
         CGRect r = CGRectMake( (CGFloat) x , (CGFloat) y , (CGFloat) w , (CGFloat) h );
         const WX_NSImage nsImage = icon.GetNSImage();
-    
+
         CGImageRef cgImage = wxOSXGetCGImageFromNSImage( nsImage , &r, m_cgContext );
         wxMacDrawCGImage( m_cgContext, &r, cgImage);
     }
 #endif
-    
+
     CheckInvariants();
 }
 
@@ -2253,7 +2255,7 @@ void wxMacCoreGraphicsContext::DoDrawText( const wxString &str, wxDouble x, wxDo
         CGFloat width = CTLineGetTypographicBounds(line, NULL, NULL, NULL);
 
         CGPoint points[] = { {0.0, -2.0},  {width, -2.0} };
-        
+
         CGContextSetStrokeColorWithColor(m_cgContext, col);
         CGContextSetShouldAntialias(m_cgContext, false);
         CGContextSetLineWidth(m_cgContext, 1.0);
@@ -2342,7 +2344,7 @@ void wxMacCoreGraphicsContext::GetTextExtent( const wxString &str, wxDouble *wid
     if ( externalLeading )
         *externalLeading = l;
 
-    CheckInvariants();    
+    CheckInvariants();
 }
 
 void wxMacCoreGraphicsContext::GetPartialTextExtents(const wxString& text, wxArrayDouble& widths) const
@@ -2392,10 +2394,10 @@ void wxMacCoreGraphicsContext::DrawRectangle( wxDouble x, wxDouble y, wxDouble w
     if (!EnsureIsValid())
         return;
 
-    if (m_composition == wxCOMPOSITION_DEST) 
-        return; 
+    if (m_composition == wxCOMPOSITION_DEST)
+        return;
 
-    // when using shading, we have to go back to drawing paths 
+    // when using shading, we have to go back to drawing paths
     if ( !m_brush.IsNull() && ((wxMacCoreGraphicsBrushData*)m_brush.GetRefData())->IsShading() )
     {
         wxGraphicsContext::DrawRectangle( x,y,w,h );
@@ -2408,7 +2410,7 @@ void wxMacCoreGraphicsContext::DrawRectangle( wxDouble x, wxDouble y, wxDouble w
         ((wxMacCoreGraphicsBrushData*)m_brush.GetRefData())->Apply(this);
         CGContextFillRect(m_cgContext, rect);
     }
-    
+
     wxQuartzOffsetHelper helper( m_cgContext , ShouldOffset() );
     if ( !m_pen.IsNull() )
     {
@@ -2613,7 +2615,7 @@ wxGraphicsContext * wxMacCoreGraphicsRenderer::CreateContext( const wxWindowDC& 
 
         // having a cgctx being NULL is fine (will be created on demand)
         // this is the case for all wxWindowDCs except wxPaintDC
-        wxMacCoreGraphicsContext *context = 
+        wxMacCoreGraphicsContext *context =
             new wxMacCoreGraphicsContext( this, cgctx, (wxDouble) w, (wxDouble) h );
         context->EnableOffset(dc.GetContentScaleFactor() < 2);
         return context;

--- a/src/osx/pen.cpp
+++ b/src/osx/pen.cpp
@@ -32,6 +32,7 @@ public:
         // we intentionally don't compare m_hPen fields here
         return m_style == data.m_style &&
             m_width == data.m_width &&
+            m_widthF == data.m_widthF &&
             m_join == data.m_join &&
             m_cap == data.m_cap &&
             m_colour == data.m_colour &&
@@ -43,6 +44,7 @@ public:
 
 protected:
     int           m_width;
+    double        m_widthF;
     wxPenStyle    m_style;
     wxPenJoin     m_join ;
     wxPenCap      m_cap ;
@@ -61,6 +63,7 @@ wxPenRefData::wxPenRefData()
 {
     m_style = wxPENSTYLE_SOLID;
     m_width = 1;
+    m_widthF = -1.0; // no decimal pen width set
     m_join = wxJOIN_ROUND ;
     m_cap = wxCAP_ROUND ;
     m_nbDash = 0 ;
@@ -72,6 +75,7 @@ wxPenRefData::wxPenRefData(const wxPenRefData& data)
 {
     m_style = data.m_style;
     m_width = data.m_width;
+    m_widthF = data.m_widthF;
     m_join = data.m_join;
     m_cap = data.m_cap;
     m_nbDash = data.m_nbDash;
@@ -102,6 +106,7 @@ wxPen::wxPen(const wxColour& col, int Width, wxPenStyle Style)
 
     M_PENDATA->m_colour = col;
     M_PENDATA->m_width = Width;
+    M_PENDATA->m_widthF = -1.0;
     M_PENDATA->m_style = Style;
     M_PENDATA->m_join = wxJOIN_ROUND ;
     M_PENDATA->m_cap = wxCAP_ROUND ;
@@ -117,6 +122,7 @@ wxPen::wxPen(const wxColour& col, int Width, int Style)
 
     M_PENDATA->m_colour = col;
     M_PENDATA->m_width = Width;
+    M_PENDATA->m_widthF = -1.0;
     M_PENDATA->m_style = (wxPenStyle)Style;
     M_PENDATA->m_join = wxJOIN_ROUND ;
     M_PENDATA->m_cap = wxCAP_ROUND ;
@@ -132,6 +138,7 @@ wxPen::wxPen(const wxBitmap& stipple, int Width)
 
     M_PENDATA->m_stipple = stipple;
     M_PENDATA->m_width = Width;
+    M_PENDATA->m_widthF = -1.0;
     M_PENDATA->m_style = wxPENSTYLE_STIPPLE;
     M_PENDATA->m_join = wxJOIN_ROUND ;
     M_PENDATA->m_cap = wxCAP_ROUND ;
@@ -171,6 +178,13 @@ int wxPen::GetWidth() const
     wxCHECK_MSG( IsOk(), -1, wxT("invalid pen") );
 
     return M_PENDATA->m_width;
+}
+
+double wxPen::GetWidthF() const
+{
+    wxCHECK_MSG( IsOk(), -1, wxT("invalid pen") );
+
+    return M_PENDATA->m_widthF;
 }
 
 wxPenStyle wxPen::GetStyle() const
@@ -252,6 +266,15 @@ void wxPen::SetWidth(int Width)
     Unshare();
 
     M_PENDATA->m_width = Width;
+
+    RealizeResource();
+}
+
+void wxPen::SetWidthF(double WidthF)
+{
+    Unshare();
+
+    M_PENDATA->m_widthF = WidthF;
 
     RealizeResource();
 }


### PR DESCRIPTION
This adds GetWidthF()/SetWidthF() stub methods to the base wxPen class with no-op setter and a getter that returns -1.0, relevant backends can then implement those, storing an additional m_widthF variable (with a default value of -1.0).  
GDI+/D2D (wxMSW), CoreGraphics (wxOSX), Cairo (wxGTK) query GetWidthF() first and fall back to GetWidth() if the returned value is less than 0 (i.e., wasn't set).

I haven't had a chance to try this yet (I'm using wxPython and it can't build master branch wxWidgets/Phoenix#282), I can say it compiles fine with wxGTK though.

Closes trac/17087.

r? @vadz