### PR TITLE
Fix deletion of registry keys from alternate registry view

### DIFF
--- a/src/msw/registry.cpp
+++ b/src/msw/registry.cpp
@@ -757,11 +757,10 @@ bool wxRegKey::DeleteSelf()
 #if wxUSE_DYNLIB_CLASS
   wxDynamicLibrary dllAdvapi32(wxT("advapi32"));
   // Minimum supported OS for RegDeleteKeyEx: Vista, XP Pro x64, Win Server 2008, Win Server 2003 SP1
-  if(dllAdvapi32.HasSymbol(wxT("RegDeleteKeyEx")))
+  typedef LONG (WINAPI *RegDeleteKeyEx_t)(HKEY, LPCTSTR, REGSAM, DWORD);
+  RegDeleteKeyEx_t wxDL_INIT_FUNC_AW(pfn, RegDeleteKeyEx, dllAdvapi32);
+  if (pfnRegDeleteKeyEx)
   {
-    typedef LONG (WINAPI *RegDeleteKeyEx_t)(HKEY, LPCTSTR, REGSAM, DWORD);
-    wxDYNLIB_FUNCTION(RegDeleteKeyEx_t, RegDeleteKeyEx, dllAdvapi32);
-
     m_dwLastError = (*pfnRegDeleteKeyEx)((HKEY) m_hRootKey, m_strKey.t_str(),
         GetMSWViewFlags(m_viewMode),
         0);    // This parameter is reserved and must be zero.

--- a/tests/config/regconf.cpp
+++ b/tests/config/regconf.cpp
@@ -35,6 +35,7 @@ public:
 private:
     CPPUNIT_TEST_SUITE( RegConfigTestCase );
         CPPUNIT_TEST( ReadWrite );
+        CPPUNIT_TEST( DeleteRegistryKeyFromRedirectedView );
     CPPUNIT_TEST_SUITE_END();
 
     void ReadWrite();
@@ -78,6 +79,26 @@ void RegConfigTestCase::ReadWrite()
 
     config->DeleteAll();
     delete config;
+}
+
+void RegConfigTestCase::DeleteRegistryKeyFromRedirectedView()
+{
+    if ( !wxIsPlatform64Bit() )
+    {
+        // Test needs WoW64.
+        return;
+    }
+
+    // Test inside a key that's known to be redirected and is in HKCU so that
+    // admin rights are not required (unlike with HKLM).
+    wxRegKey key(wxRegKey::HKCU, "SOFTWARE\\Classes\\CLSID\\wxWidgetsTestKey",
+        sizeof(void *) == 4
+            ? wxRegKey::WOW64ViewMode_64
+            : wxRegKey::WOW64ViewMode_32);
+
+    CPPUNIT_ASSERT( key.Create() );
+    CPPUNIT_ASSERT( key.DeleteSelf() );
+    CPPUNIT_ASSERT( !key.Exists() );
 }
 
 #endif // wxUSE_CONFIG && wxUSE_REGKEY


### PR DESCRIPTION
Note: The commit with the added test is more there to demonstrate failure prior to the fix and not necessarily for inclusion. For one because I added the test at a slightly odd place (regconf.cpp) instead of perhaps adding a new source file.