### PR TITLE
Add support for loading wxIconBundle from MS Windows resource

### DIFF
--- a/include/wx/iconbndl.h
+++ b/include/wx/iconbndl.h
@@ -58,7 +58,7 @@ public:
     // initializes the bundle with a single icon
     wxIconBundle(const wxIcon& icon);
 
-#ifdef __WINDOWS__
+#if defined( __WINDOWS__) && wxUSE_ICO_CUR
     // initializes the bundle with the icons from a group icon stored as an MS Windows resource
     wxIconBundle(const wxString& resourceName, WXHINSTANCE module);
 #endif
@@ -75,7 +75,7 @@ public:
     void AddIcon(wxInputStream& stream, wxBitmapType type = wxBITMAP_TYPE_ANY);
 #endif // wxUSE_STREAMS && wxUSE_IMAGE
 
-#ifdef __WINDOWS__
+#if defined( __WINDOWS__) && wxUSE_ICO_CUR
     // loads all the icons from a group icon stored in an MS Windows resource
     void AddIcon(const wxString& resourceName, WXHINSTANCE module);
 #endif

--- a/include/wx/iconbndl.h
+++ b/include/wx/iconbndl.h
@@ -58,6 +58,11 @@ public:
     // initializes the bundle with a single icon
     wxIconBundle(const wxIcon& icon);
 
+#ifdef __WINDOWS__
+    // initializes the bundle with the icons from a group icon stored as an MS Windows resource
+    wxIconBundle(const wxString& resourceName, WXHINSTANCE module);
+#endif
+
     // default copy ctor and assignment operator are OK
 
     // adds all the icons contained in the file to the collection,
@@ -69,6 +74,11 @@ public:
 #endif // wxUSE_FFILE || wxUSE_FILE
     void AddIcon(wxInputStream& stream, wxBitmapType type = wxBITMAP_TYPE_ANY);
 #endif // wxUSE_STREAMS && wxUSE_IMAGE
+
+#ifdef __WINDOWS__
+    // loads all the icons from a group icon stored in an MS Windows resource
+    void AddIcon(const wxString& resourceName, WXHINSTANCE module);
+#endif
 
     // adds the icon to the collection, if the collection already
     // contains an icon with the same width and height, it is

--- a/include/wx/private/icondir.h
+++ b/include/wx/private/icondir.h
@@ -1,0 +1,94 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/private/icondir.h
+// Purpose:     Declarations of structs used for loading MS icons
+// Author:      wxWidgets team
+// Created:     2017-05-19
+// Copyright:   (c) 2017 wxWidgets team
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_PRIVATE_ICONDIR_H_
+#define _WX_PRIVATE_ICONDIR_H_
+
+#include "wx/defs.h"          // wxUint* declarations
+
+
+// Structs declared here are used for loading group icons from 
+// .ICO files or MS Windows resources.
+// Icon entry and directory structs for .ICO files and
+// MS Windows resources are very similar but not identical.
+
+
+#if wxUSE_ICO_CUR
+
+
+#if wxUSE_STREAMS
+
+// icon entry in .ICO files
+struct ICONDIRENTRY
+{
+    wxUint8         bWidth;               // Width of the image
+    wxUint8         bHeight;              // Height of the image (times 2)
+    wxUint8         bColorCount;          // Number of colors in image (0 if >=8bpp)
+    wxUint8         bReserved;            // Reserved
+
+    // these two are different in icons and cursors:
+                                          // icon           or  cursor
+    wxUint16        wPlanes;              // Color Planes   or  XHotSpot
+    wxUint16        wBitCount;            // Bits per pixel or  YHotSpot
+
+    wxUint32        dwBytesInRes;         // how many bytes in this resource?
+    wxUint32        dwImageOffset;        // where in the file is this image
+};
+
+// icon directory in .ICO files
+struct ICONDIR
+{
+    wxUint16     idReserved;   // Reserved
+    wxUint16     idType;       // resource type (1 for icons, 2 for cursors)
+    wxUint16     idCount;      // how many images?
+};
+
+#endif // #if wxUSE_STREAMS
+
+
+#ifdef __WINDOWS__
+
+#pragma pack(push)
+#pragma pack(2)
+
+// icon entry in MS Windows resources
+struct GRPICONDIRENTRY
+{
+    wxUint8         bWidth;               // Width of the image
+    wxUint8         bHeight;              // Height of the image (times 2)
+    wxUint8         bColorCount;          // Number of colors in image (0 if >=8bpp)
+    wxUint8         bReserved;            // Reserved
+
+    // these two are different in icons and cursors:
+                                          // icon           or  cursor
+    wxUint16        wPlanes;              // Color Planes   or  XHotSpot
+    wxUint16        wBitCount;            // Bits per pixel or  YHotSpot
+
+    wxUint32        dwBytesInRes;         // how many bytes in this resource?
+    
+    wxUint16        nID;                  // actual icon resource ID
+};
+
+// icon directory in MS Windows resources
+struct GRPICONDIR
+{
+    wxUint16        idReserved;   // Reserved
+    wxUint16        idType;       // resource type (1 for icons, 2 for cursors)
+    wxUint16        idCount;      // how many images?
+    GRPICONDIRENTRY idEntries[1]; // The entries for each image
+};
+
+#pragma pack(pop)
+
+#endif // #ifdef __WINDOWS__
+
+
+#endif // #if wxUSE_ICO_CUR
+
+#endif // #ifndef _WX_PRIVATE_ICONDIR_H_

--- a/interface/wx/iconbndl.h
+++ b/interface/wx/iconbndl.h
@@ -69,6 +69,18 @@ public:
     wxIconBundle(const wxIcon& icon);
 
     /**
+    Initializes the bundle with all sizes of a group icon with @a resourceName
+    stored as an MS Windows resource in @a module. When @a module is 0, the current
+    instance is used.
+    
+    @see AddIcon(const wxString&, WXHINSTANCE)
+    
+    @onlyfor{wxmsw}
+    @since 3.1.1
+    */
+    wxIconBundle(const wxString& resourceName, WXHINSTANCE module);
+
+    /**
         Copy constructor.
     */
     wxIconBundle(const wxIconBundle& ic);
@@ -97,6 +109,15 @@ public:
         @since 2.9.0
     */
     void AddIcon(wxInputStream& stream, wxBitmapType type = wxBITMAP_TYPE_ANY);
+
+    /**
+    Loads all sizes of a group icon with @a resourceName stored as an MS Windows 
+    resource in @a module. When @a module is 0, the current instance is used.
+    
+    @onlyfor{wxmsw}
+    @since 3.1.1
+    */
+    void AddIcon(const wxString& resourceName, WXHINSTANCE module);
 
     /**
         Adds the icon to the collection; if the collection already

--- a/src/common/iconbndl.cpp
+++ b/src/common/iconbndl.cpp
@@ -105,7 +105,7 @@ wxIconBundle::wxIconBundle(const wxString& resourceName, WXHINSTANCE module)
     AddIcon(resourceName, module);
 }
 
-#endif #if defined( __WINDOWS__) && wxUSE_ICO_CUR
+#endif // #if defined( __WINDOWS__) && wxUSE_ICO_CUR
 
 wxGDIRefData *wxIconBundle::CreateGDIRefData() const
 {

--- a/src/common/imagbmp.cpp
+++ b/src/common/imagbmp.cpp
@@ -36,6 +36,7 @@
 #include "wx/scopedarray.h"
 #include "wx/scopedptr.h"
 #include "wx/anidecod.h"
+#include "wx/private/icondir.h"
 
 // For memcpy
 #include <string.h>
@@ -1240,30 +1241,6 @@ bool wxBMPHandler::DoCanRead(wxInputStream& stream)
 wxIMPLEMENT_DYNAMIC_CLASS(wxICOHandler, wxBMPHandler);
 
 #if wxUSE_STREAMS
-
-struct ICONDIRENTRY
-{
-    wxUint8         bWidth;               // Width of the image
-    wxUint8         bHeight;              // Height of the image (times 2)
-    wxUint8         bColorCount;          // Number of colors in image (0 if >=8bpp)
-    wxUint8         bReserved;            // Reserved
-
-    // these two are different in icons and cursors:
-                                          // icon           or  cursor
-    wxUint16        wPlanes;              // Color Planes   or  XHotSpot
-    wxUint16        wBitCount;            // Bits per pixel or  YHotSpot
-
-    wxUint32        dwBytesInRes;         // how many bytes in this resource?
-    wxUint32        dwImageOffset;        // where in the file is this image
-};
-
-struct ICONDIR
-{
-    wxUint16     idReserved;   // Reserved
-    wxUint16     idType;       // resource type (1 for icons, 2 for cursors)
-    wxUint16     idCount;      // how many images?
-};
-
 
 bool wxICOHandler::SaveFile(wxImage *image,
                             wxOutputStream& stream,


### PR DESCRIPTION
wxIconBundle supports loading all available sizes of an icon stored in an .ICO file or an input stream. This PR adds analogous functionality for icons stored as MS Windows resources.

By the way, it came to my mind that wxIconBundle may have kind of a limitation. It allows storing only one icon with a certain height and width. However, there are .ico files that contain several icons that have the same size but different bit depth, see e.g. those in WXWIN/include/wx/msw included in the standard wxWidgets resource file. One possible, simple but backwards-incompatible, workaround would be in wxIconBundle::AddIcon(const wxIcon&) to never replace the same-dimension icon with ne with a lower bit depth, as the systems with limited color displays are uncommon.
But I guess that such icons have not been very common since the true colour became the norm, so the issue may be moot. It also possible that it is somehow guaranteed that the icons with lower bit depth are always stored before the ones with higher bit depth.