### PR TITLE
Fixed clang warning [-Wcomma]

### DIFF
--- a/include/wx/html/htmlcell.h
+++ b/include/wx/html/htmlcell.h
@@ -232,7 +232,7 @@ public:
     virtual wxHtmlCell* GetFirstChild() const { return NULL; }
 
     // members writing methods
-    virtual void SetPos(int x, int y) {m_PosX = x, m_PosY = y;}
+    virtual void SetPos(int x, int y) {m_PosX = x; m_PosY = y;}
     void SetLink(const wxHtmlLinkInfo& link);
     void SetNext(wxHtmlCell *cell) {m_Next = cell;}
 


### PR DESCRIPTION
Fixed clang warning [Wcomma]:

```
/usr/local/include/wx-3.1/wx/html/htmlcell.h:652:62: warning: possible misuse of comma operator here [-Wcomma]
          { m_Href = m_Target = wxEmptyString; m_Event = NULL, m_Cell = NULL; }
                                                             ^
/usr/local/include/wx-3.1/wx/html/htmlcell.h:652:48: note: cast expression to void to silence warning
          { m_Href = m_Target = wxEmptyString; m_Event = NULL, m_Cell = NULL; }
                                               ^~~~~~~~~~~~~~
                                               static_cast<void>( )
```