### PR TITLE
wx/xml: Implement line-ending modes for xml saves

### DIFF
--- a/include/wx/xml/xml.h
+++ b/include/wx/xml/xml.h
@@ -18,6 +18,7 @@
 #include "wx/string.h"
 #include "wx/object.h"
 #include "wx/list.h"
+#include "wx/textbuf.h"
 #include "wx/versioninfo.h"
 
 #ifdef WXMAKINGDLL_XML
@@ -317,6 +318,9 @@ public:
     // encoding of in-memory representation!
     const wxString& GetFileEncoding() const { return m_fileEncoding; }
     const wxXmlDoctype& GetDoctype() const { return m_doctype; }
+    // Returns file type of document
+    wxTextFileType GetFileType() const { return m_fileType; }
+    wxString GetEOL() const { return m_eol; }
 
     // Write-access methods:
     wxXmlNode *DetachDocumentNode() { wxXmlNode *old=m_docNode; m_docNode=NULL; return old; }
@@ -326,6 +330,7 @@ public:
     void SetVersion(const wxString& version) { m_version = version; }
     void SetFileEncoding(const wxString& encoding) { m_fileEncoding = encoding; }
     void SetDoctype(const wxXmlDoctype& doctype) { m_doctype = doctype; }
+    void SetFileType(wxTextFileType fileType);
     void AppendToProlog(wxXmlNode *node);
 
 #if !wxUSE_UNICODE
@@ -346,6 +351,8 @@ private:
 #endif
     wxXmlDoctype m_doctype;
     wxXmlNode *m_docNode;
+    wxTextFileType m_fileType;
+    wxString m_eol;
 
     void DoCopy(const wxXmlDocument& doc);
 

--- a/interface/wx/xml/xml.h
+++ b/interface/wx/xml/xml.h
@@ -787,6 +787,16 @@ public:
     const wxXmlDoctype& GetDoctype() const;
 
     /**
+        Returns the output line ending format used for documents.
+    */
+    wxTextFileType GetFileType() const;
+
+    /**
+        Returns the output line ending string used for documents.
+    */
+    wxString GetEOL() const;
+
+    /**
         Returns the document node of the document.
 
         @since 2.9.2
@@ -881,6 +891,11 @@ public:
         @since 3.1.0
     */
     void SetDoctype(const wxXmlDoctype& doctype);
+
+    /**
+        Sets the output line ending formats when the document is saved.
+    */
+    void SetFileType(wxTextFileType fileType);
 
     /**
         Sets the root element node of this document.


### PR DESCRIPTION
 * Add 'wxTextFileType m_fileType' to hold the type
 * Add 'wxString m_eol' to hold the end of lines string

 * Add SetFileType() and GetFileType() to set and get the type
 * Add GetEOL() to get the end of lines wxString

 * Backwards compatibility preserved by using wxTextFileType_Unix

Change-Id: I3e8547b377e2c4060a3a2d97c299a08ea2c0a376
Signed-off-by: Adrian DC <radian.dc@gmail.com>