### PR TITLE
OSX foreground color issues #16284

### DIFF
--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -2444,7 +2444,8 @@ void wxWidgetCocoaImpl::SetLabel( const wxString& title, wxFontEncoding encoding
     if ( [m_osxView respondsToSelector:@selector(setAttributedTitle:) ] )
     {
         wxFont f = GetWXPeer()->GetFont();
-        if ( f.GetStrikethrough() || f.GetUnderlined() )
+        wxColour col = GetWXPeer()->GetForegroundColour();
+        if ( f.GetStrikethrough() || f.GetUnderlined() || col.IsOk() )
         {
             wxCFStringRef cf(title, encoding );
 
@@ -2471,6 +2472,13 @@ void wxWidgetCocoaImpl::SetLabel( const wxString& title, wxFontEncoding encoding
                                    value:@(NSUnderlineStyleSingle)
                                    range:NSMakeRange(0, [attrString length])];
 
+            }
+
+            if ( col.IsOk() )
+            {
+                [attrString addAttribute:NSForegroundColorAttributeName
+                                   value:col.OSXGetNSColor()
+                                   range:NSMakeRange(0, [attrString length])];
             }
 
             [attrString endEditing];
@@ -2722,11 +2730,15 @@ void wxWidgetCocoaImpl::SetFont(wxFont const& font, wxColour const&col, long, bo
     NSView* targetView = m_osxView;
     if ( [m_osxView isKindOfClass:[NSScrollView class] ] )
         targetView = [(NSScrollView*) m_osxView documentView];
+    else if ( [m_osxView isKindOfClass:[NSBox class] ] )
+        targetView = [(NSBox*) m_osxView titleCell];
 
     if ([targetView respondsToSelector:@selector(setFont:)])
         [targetView setFont: font.OSXGetNSFont()];
     if ([targetView respondsToSelector:@selector(setTextColor:)])
         [targetView setTextColor: col.OSXGetNSColor()];
+    if ([m_osxView respondsToSelector:@selector(setAttributedTitle:)])
+        SetLabel(wxStripMenuCodes(GetWXPeer()->GetLabel(), wxStrip_Mnemonics), GetWXPeer()->GetFont().GetEncoding());
 }
 
 void wxWidgetCocoaImpl::SetToolTip(wxToolTip* tooltip)


### PR DESCRIPTION
Fixed OSX foreground color issues with wxStaticBox, wxCheckBox, wxRadoButton and any other controls that use NSBox and NSButton. Fixes #16284. Theoretically SetFont on wxStaticBox should be working too, but it doesn't seem to be. I also tried setTitleFont, but that didn't work either so it may be a limitation with some NSBoxes. As far as I know setTitleFont should be the equivalent of setFont on the titleCell which is why I say it should be working even with the current code. I'm not really as concerned with setting the font as I am the foreground color though for what I'm currently working on.