### PR TITLE
wx/msw/clipbrd.h: Remove unreferenced wxGetClipboardData prototype

### DIFF
--- a/include/wx/msw/clipbrd.h
+++ b/include/wx/msw/clipbrd.h
@@ -27,8 +27,6 @@ WXDLLIMPEXP_CORE bool wxEmptyClipboard();
 WXDLLIMPEXP_CORE bool wxSetClipboardData(wxDataFormat dataFormat,
                                     const void *data,
                                     int width = 0, int height = 0);
-WXDLLIMPEXP_CORE void* wxGetClipboardData(wxDataFormat dataFormat,
-                                     long *len = NULL);
 
 // clipboard formats
 WXDLLIMPEXP_CORE bool wxIsClipboardFormatAvailable(wxDataFormat dataFormat);


### PR DESCRIPTION
 * wxGetClipboardData was removed through commit
    b375d814997341ef3f1541a9b23b202deeadc092 "Use wxDataObject methods..."
    but former usages will break with unreferenced
    function as the header still advertises the function

Change-Id: I77e756d2b7d0db7c3833578d2846f4e922a55262