### PR TITLE
Include macOS 10.13 name in wxGetOsDescription()

### DIFF
--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -136,6 +136,9 @@ wxString wxGetOsDescription()
             case 12:
                 osName = "Sierra";
                 break;
+            case 13:
+                osName = "High Sierra";
+                break;
         };
     }
 #else


### PR DESCRIPTION
Include macOS 10.13 name in `wxGetOsDescription()`