### PR TITLE
wxFileConfig: Ignore leading Unicode byte-order mark in Parse

### DIFF
--- a/src/common/fileconf.cpp
+++ b/src/common/fileconf.cpp
@@ -57,6 +57,7 @@
 // ----------------------------------------------------------------------------
 
 #define FILECONF_TRACE_MASK wxT("fileconf")
+#define CHAR_BOM 0xFEFF
 
 // ----------------------------------------------------------------------------
 // global functions declarations
@@ -516,8 +517,8 @@ void wxFileConfig::Parse(const wxTextBuffer& buffer, bool bLocal)
       LineListAppend(strLine);
 
 
-    // skip leading spaces
-    for ( pStart = buf; wxIsspace(*pStart); pStart++ )
+    // skip leading spaces or Unicode byte-order mark
+    for ( pStart = buf; wxIsspace(*pStart) || *pStart == CHAR_BOM; pStart++ )
       ;
 
     // skip blank/comment lines


### PR DESCRIPTION
 * Files edited through tools like Notepad can have a leading
    initial 0xFEFF char as first byte of the file to hold
    the Unicode encoding tag, therefore ignore it to avoid
    full breakage of the file and groups parsing

Change-Id: I9b42847280c30400aff02d7a16e268952daf1d8d
Signed-off-by: Adrian DC <radian.dc@gmail.com>