### PR TITLE
wxFileConfig: Expose {Set/Reset/Is}Dirty publically

### DIFF
--- a/include/wx/fileconf.h
+++ b/include/wx/fileconf.h
@@ -174,6 +174,11 @@ public:
   virtual bool DeleteGroup(const wxString& szKey) wxOVERRIDE;
   virtual bool DeleteAll() wxOVERRIDE;
 
+  // set/test the dirty flag
+  void SetDirty() { m_isDirty = true; }
+  void ResetDirty() { m_isDirty = false; }
+  bool IsDirty() const { return m_isDirty; }
+
   // additional, wxFileConfig-specific, functionality
 #if wxUSE_STREAMS
   // save the entire config file text to the given stream, note that the text
@@ -224,12 +229,6 @@ private:
   // real SetPath() implementation, returns true if path could be set or false
   // if path doesn't exist and createMissingComponents == false
   bool DoSetPath(const wxString& strPath, bool createMissingComponents);
-
-  // set/test the dirty flag
-  void SetDirty() { m_isDirty = true; }
-  void ResetDirty() { m_isDirty = false; }
-  bool IsDirty() const { return m_isDirty; }
-
 
   // member variables
   // ----------------

--- a/interface/wx/fileconf.h
+++ b/interface/wx/fileconf.h
@@ -129,5 +129,10 @@ public:
   virtual bool DeleteEntry(const wxString& key, bool bGroupIfEmptyAlso = true);
   virtual bool DeleteGroup(const wxString& szKey);
   virtual bool DeleteAll();
+
+  // set/test the dirty flag
+  void SetDirty();
+  void ResetDirty();
+  bool IsDirty();
 };
 


### PR DESCRIPTION
 * In some programs implementations, we might want
    to delete a wxFileConfig object without triggering
    a flush, for example if the config was opened and
    populated on init, but then only kept as a volative
    holder of configs to ignore

Change-Id: I1dcbc73ca4985b90c7ab54dd500636ca73364aa0
Signed-off-by: Adrian DC <radian.dc@gmail.com>