### PR TITLE
Unset m_deferShow when calling wxFrame::Show(false)

### DIFF
--- a/src/gtk/toplevel.cpp
+++ b/src/gtk/toplevel.cpp
@@ -958,6 +958,10 @@ bool wxTopLevelWindowGTK::Show( bool show )
     wxCHECK_MSG(m_widget, false, "invalid frame");
 
 #ifdef GDK_WINDOWING_X11
+    if (!show && m_deferShow)
+    {
+        m_deferShow = false; // Cancel pending show event.
+    }
     bool deferShow = show && !m_isShown && m_deferShow;
     if (deferShow)
     {


### PR DESCRIPTION
Using wxGTK I have the situation that a wxFrame will be shown, if I call `wxFrame::Show(false)` immediately after `wxFrame::Show(true)`.

I wasn't able to create a minimal test program which reproduces the issue as it sometimes even goes away when just setting breakpoints at some places. With this change, it never appears. Please tell me if you think it makes sense :)