### PR TITLE
Fix BSTR leaks in mediactrl and webview code in 3.0 branch

### DIFF
--- a/src/msw/mediactrl_am.cpp
+++ b/src/msw/mediactrl_am.cpp
@@ -1766,7 +1766,7 @@ bool wxAMMediaBackend::Load(const wxURI& location, const wxURI& proxy)
     if(pPlay)
     {
         pPlay->put_UseHTTPProxy(VARIANT_TRUE);
-        pPlay->put_HTTPProxyHost(wxBasicString(proxy.GetServer()).Get());
+        pPlay->put_HTTPProxyHost(wxBasicString(proxy.GetServer()));
         pPlay->put_HTTPProxyPort(wxAtoi(proxy.GetPort()));
         pPlay->Release();
     }
@@ -1789,9 +1789,9 @@ bool wxAMMediaBackend::DoLoad(const wxString& location)
     // the docs say its async and put_FileName is not -
     // but in practice they both seem to be async anyway
     if(GetMP())
-        hr = GetMP()->Open( wxBasicString(location).Get() );
+        hr = GetMP()->Open( wxBasicString(location) );
     else
-        hr = GetAM()->put_FileName( wxBasicString(location).Get() );
+        hr = GetAM()->put_FileName( wxBasicString(location) );
 
     if(FAILED(hr))
     {

--- a/src/msw/mediactrl_wmp10.cpp
+++ b/src/msw/mediactrl_wmp10.cpp
@@ -911,21 +911,21 @@ bool wxWMP10MediaBackend::Load(const wxURI& location,
     {
         long lOldSetting;
         if( pWMPNetwork->getProxySettings(
-                    wxBasicString(location.GetScheme()).Get(), &lOldSetting
+                    wxBasicString(location.GetScheme()), &lOldSetting
                                         ) == 0 &&
 
             pWMPNetwork->setProxySettings(
-                    wxBasicString(location.GetScheme()).Get(), // protocol
+                    wxBasicString(location.GetScheme()), // protocol
                                 2) == 0) // 2 == manually specify
         {
             BSTR bsOldName = NULL;
             long lOldPort = 0;
 
             pWMPNetwork->getProxyName(
-                        wxBasicString(location.GetScheme()).Get(),
+                        wxBasicString(location.GetScheme()),
                         &bsOldName);
             pWMPNetwork->getProxyPort(
-                        wxBasicString(location.GetScheme()).Get(),
+                        wxBasicString(location.GetScheme()),
                         &lOldPort);
 
             long lPort;
@@ -942,11 +942,11 @@ bool wxWMP10MediaBackend::Load(const wxURI& location,
             }
 
             if( pWMPNetwork->setProxyName(
-                        wxBasicString(location.GetScheme()).Get(), // proto
-                        wxBasicString(server).Get() ) == 0  &&
+                        wxBasicString(location.GetScheme()), // proto
+                        wxBasicString(server) ) == 0  &&
 
                 pWMPNetwork->setProxyPort(
-                        wxBasicString(location.GetScheme()).Get(), // proto
+                        wxBasicString(location.GetScheme()), // proto
                         lPort
                                          ) == 0
               )
@@ -954,16 +954,18 @@ bool wxWMP10MediaBackend::Load(const wxURI& location,
                 bOK = DoLoad(location.BuildURI());
 
                 pWMPNetwork->setProxySettings(
-                    wxBasicString(location.GetScheme()).Get(), // protocol
+                    wxBasicString(location.GetScheme()), // protocol
                                 lOldSetting);
                 if(bsOldName)
+                {
                     pWMPNetwork->setProxyName(
-                        wxBasicString(location.GetScheme()).Get(), // protocol
+                        wxBasicString(location.GetScheme()), // protocol
                                     bsOldName);
-
+                    SysFreeString(bsOldName);
+                }
                 if(lOldPort)
                     pWMPNetwork->setProxyPort(
-                        wxBasicString(location.GetScheme()).Get(), // protocol
+                        wxBasicString(location.GetScheme()), // protocol
                                 lOldPort);
 
                 pWMPNetwork->Release();
@@ -1003,7 +1005,7 @@ bool wxWMP10MediaBackend::DoLoad(const wxString& location)
     {
         IWMPMedia* pWMPMedia;
 
-        if( (hr = pWMPCore3->newMedia(wxBasicString(location).Get(),
+        if( (hr = pWMPCore3->newMedia(wxBasicString(location),
                                &pWMPMedia)) == 0)
         {
             // this (get_duration) will actually FAIL, but it will work.
@@ -1018,7 +1020,7 @@ bool wxWMP10MediaBackend::DoLoad(const wxString& location)
 #endif
     {
         // just load it the "normal" way
-        hr = m_pWMPPlayer->put_URL( wxBasicString(location).Get() );
+        hr = m_pWMPPlayer->put_URL( wxBasicString(location) );
     }
 
     if(FAILED(hr))
@@ -1067,12 +1069,12 @@ bool wxWMP10MediaBackend::ShowPlayerControls(wxMediaCtrlPlayerControls flags)
     if(!flags)
     {
         m_pWMPPlayer->put_enabled(VARIANT_FALSE);
-        m_pWMPPlayer->put_uiMode(wxBasicString(wxT("none")).Get());
+        m_pWMPPlayer->put_uiMode(wxBasicString(wxT("none")));
     }
     else
     {
         // TODO: use "custom"? (note that CE only supports none/full)
-        m_pWMPPlayer->put_uiMode(wxBasicString(wxT("full")).Get());
+        m_pWMPPlayer->put_uiMode(wxBasicString(wxT("full")));
         m_pWMPPlayer->put_enabled(VARIANT_TRUE);
     }
 
@@ -1363,14 +1365,15 @@ wxLongLong wxWMP10MediaBackend::GetDownloadTotal()
     IWMPMedia* pWMPMedia;
     if(m_pWMPPlayer->get_currentMedia(&pWMPMedia) == 0)
     {
-        BSTR bsOut;
-        pWMPMedia->getItemInfo(wxBasicString(wxT("FileSize")).Get(),
+        BSTR bsOut = NULL;
+        pWMPMedia->getItemInfo(wxBasicString(wxT("FileSize")),
                                &bsOut);
 
         wxString sFileSize = wxConvertStringFromOle(bsOut);
         long lFS;
         sFileSize.ToLong(&lFS);
         pWMPMedia->Release();
+        SysFreeString(bsOut);
         return lFS;
     }
 


### PR DESCRIPTION
I have attempted to fix the BSTR leaks in the 3.0 branch as well. Due to preserving ABI compatibility, I could not do the same I did in #502 but had to use SysFreeString() instead in the wxWebViewIE code. 