### PR TITLE
Fix a bug in wxWMP10MediaBackend introduced by commit 294436c and add a comment that should help preventing such bugs in future

### DIFF
--- a/include/wx/msw/ole/oleutils.h
+++ b/include/wx/msw/ole/oleutils.h
@@ -70,8 +70,8 @@ public:
     wxBasicString() : m_bstrBuf(NULL) {}
 
     // Constructs with the owned BSTR created from a wxString
-    wxBasicString::wxBasicString(const wxString& str) :
-        m_bstrBuf(SysAllocString(str.wc_str(*wxConvCurrent))) {}
+    wxBasicString(const wxString& str)
+        : m_bstrBuf(SysAllocString(str.wc_str(*wxConvCurrent))) {}
 
     // Constructs the owned BSTR as a copy of the BSTR owned by bstr
     wxBasicString(const wxBasicString& bstr) : m_bstrBuf(bstr.Copy()) {}

--- a/include/wx/msw/ole/oleutils.h
+++ b/include/wx/msw/ole/oleutils.h
@@ -73,7 +73,7 @@ public:
     wxBasicString(const wxString& str)
         : m_bstrBuf(SysAllocString(str.wc_str(*wxConvCurrent))) {}
 
-    // Constructs the owned BSTR as a copy of the BSTR owned by bstr
+    // Constructs with the owned BSTR as a copy of the BSTR owned by bstr
     wxBasicString(const wxBasicString& bstr) : m_bstrBuf(bstr.Copy()) {}
 
     // Frees the owned BSTR

--- a/include/wx/msw/ole/oleutils.h
+++ b/include/wx/msw/ole/oleutils.h
@@ -65,29 +65,26 @@ inline void wxOleUninitialize()
 
 class WXDLLIMPEXP_CORE wxBasicString
 {
-public:    
-    // Takes over the ownership of bstr.
-    // Must NOT be called with bstr pointing to a wide string literal
-    // (e.g., wxBasicString(wxS("abc")), bstr must always be either NULL 
-    // or a BSTR allocated by Sys(Re)AllocString(), otherwise a wxBasicString's
-    // dtor or Free() method end up calling SysFreeString() on a string literal,
-    // which will result in a crash.
-    explicit wxBasicString(BSTR bstr = NULL);
+public:
+    // Constructs with the owned BSTR set to NULL
+    wxBasicString() : m_bstrBuf(NULL) {}
 
-    // Constructs the BSTR from wxString
-    wxBasicString(const wxString& str);
+    // Constructs with the owned BSTR created from a wxString
+    wxBasicString::wxBasicString(const wxString& str) :
+        m_bstrBuf(SysAllocString(str.wc_str(*wxConvCurrent))) {}
 
-    // Creates a copy of the BSTR owned by bstr
-    wxBasicString(const wxBasicString& bstr);
+    // Constructs the owned BSTR as a copy of the BSTR owned by bstr
+    wxBasicString(const wxBasicString& bstr) : m_bstrBuf(bstr.Copy()) {}
 
     // Frees the owned BSTR
-    ~wxBasicString();
+    ~wxBasicString() { SysFreeString(m_bstrBuf); }
 
-    // Returns the owned BSTR and gives up its ownership
+    // Creates the owned BSTR from a wxString
+    void AssignFromwxString(const wxString& str);
+
+    // Returns the owned BSTR and gives up its ownership,
+    // the caller is responsible for freeing it
     BSTR Detach();
-
-    // Frees the owned BSTR
-    void Free();
 
     // Returns a copy of the owned BSTR,
     // the caller is responsible for freeing it
@@ -100,19 +97,11 @@ public:
     // Sets its BSTR to a copy of the BSTR owned by bstr
     wxBasicString& operator=(const wxBasicString& bstr);
 
-    // Creates its BSTR from wxString
-    wxBasicString& operator=(const wxString& str);
-
-    // Takes over the ownership of bstr.
-    // bstr must be either NULL or a BSTR allocated by Sys(Re)AllocString(),
-    // see the comment for wxBasicString(BSTR) ctor.
-    wxBasicString& operator=(BSTR bstr);
-
-    /// Returns the owned BSTR while keeping its ownership    
+    /// Returns the owned BSTR while keeping its ownership
     operator BSTR() const { return m_bstrBuf; }
 
     // retrieve a copy of our string - caller must SysFreeString() it later!
-    wxDEPRECATED_MSG("use Copy() instead") 
+    wxDEPRECATED_MSG("use Copy() instead")
     BSTR Get() const { return Copy(); }
 private:
     // actual string

--- a/include/wx/msw/ole/oleutils.h
+++ b/include/wx/msw/ole/oleutils.h
@@ -66,7 +66,12 @@ inline void wxOleUninitialize()
 class WXDLLIMPEXP_CORE wxBasicString
 {
 public:    
-    // Takes over the ownership of bstr
+    // Takes over the ownership of bstr.
+    // Must NOT be called with bstr pointing to a wide string literal
+    // (e.g., wxBasicString(wxS("abc")), bstr must always be either NULL 
+    // or a BSTR allocated by Sys(Re)AllocString(), otherwise a wxBasicString's
+    // dtor or Free() method end up calling SysFreeString() on a string literal,
+    // which will result in a crash.
     explicit wxBasicString(BSTR bstr = NULL);
 
     // Constructs the BSTR from wxString
@@ -98,7 +103,9 @@ public:
     // Creates its BSTR from wxString
     wxBasicString& operator=(const wxString& str);
 
-    // Takes over the ownership of bstr
+    // Takes over the ownership of bstr.
+    // bstr must be either NULL or a BSTR allocated by Sys(Re)AllocString(),
+    // see the comment for wxBasicString(BSTR) ctor.
     wxBasicString& operator=(BSTR bstr);
 
     /// Returns the owned BSTR while keeping its ownership    

--- a/include/wx/msw/ole/oleutils.h
+++ b/include/wx/msw/ole/oleutils.h
@@ -80,7 +80,7 @@ public:
     ~wxBasicString() { SysFreeString(m_bstrBuf); }
 
     // Creates the owned BSTR from a wxString
-    void AssignFromwxString(const wxString& str);
+    void AssignFromString(const wxString& str);
 
     // Returns the owned BSTR and gives up its ownership,
     // the caller is responsible for freeing it

--- a/src/msw/mediactrl_wmp10.cpp
+++ b/src/msw/mediactrl_wmp10.cpp
@@ -1061,12 +1061,12 @@ bool wxWMP10MediaBackend::ShowPlayerControls(wxMediaCtrlPlayerControls flags)
     if(!flags)
     {
         m_pWMPPlayer->put_enabled(VARIANT_FALSE);
-        m_pWMPPlayer->put_uiMode(wxBasicString(wxT("none")));
+        m_pWMPPlayer->put_uiMode(wxBasicString(wxString(wxS("none"))));
     }
     else
     {
         // TODO: use "custom"? (note that CE only supports none/full)
-        m_pWMPPlayer->put_uiMode(wxBasicString(wxT("full")));
+        m_pWMPPlayer->put_uiMode(wxBasicString(wxString(wxS("full"))));
         m_pWMPPlayer->put_enabled(VARIANT_TRUE);
     }
 
@@ -1358,7 +1358,7 @@ wxLongLong wxWMP10MediaBackend::GetDownloadTotal()
     if(m_pWMPPlayer->get_currentMedia(&pWMPMedia) == 0)
     {
         BSTR bsOut;
-        pWMPMedia->getItemInfo(wxBasicString(wxT("FileSize")),
+        pWMPMedia->getItemInfo(wxBasicString(wxString(wxS("FileSize"))),
                                &bsOut);
 
         wxString sFileSize = wxConvertStringFromOle(bsOut);

--- a/src/msw/mediactrl_wmp10.cpp
+++ b/src/msw/mediactrl_wmp10.cpp
@@ -1061,12 +1061,12 @@ bool wxWMP10MediaBackend::ShowPlayerControls(wxMediaCtrlPlayerControls flags)
     if(!flags)
     {
         m_pWMPPlayer->put_enabled(VARIANT_FALSE);
-        m_pWMPPlayer->put_uiMode(wxBasicString(wxString(wxS("none"))));
+        m_pWMPPlayer->put_uiMode(wxBasicString(wxS("none")));
     }
     else
     {
         // TODO: use "custom"? (note that CE only supports none/full)
-        m_pWMPPlayer->put_uiMode(wxBasicString(wxString(wxS("full"))));
+        m_pWMPPlayer->put_uiMode(wxBasicString(wxS("full")));
         m_pWMPPlayer->put_enabled(VARIANT_TRUE);
     }
 
@@ -1358,7 +1358,7 @@ wxLongLong wxWMP10MediaBackend::GetDownloadTotal()
     if(m_pWMPPlayer->get_currentMedia(&pWMPMedia) == 0)
     {
         BSTR bsOut;
-        pWMPMedia->getItemInfo(wxBasicString(wxString(wxS("FileSize"))),
+        pWMPMedia->getItemInfo(wxBasicString(wxS("FileSize")),
                                &bsOut);
 
         wxString sFileSize = wxConvertStringFromOle(bsOut);

--- a/src/msw/ole/automtn.cpp
+++ b/src/msw/ole/automtn.cpp
@@ -130,8 +130,8 @@ bool wxAutomationObject::Invoke(const wxString& member, int action,
     }
 
     int namedArgStringCount = namedArgCount + 1;
-    wxVector<wxBasicString> argNames(namedArgStringCount, wxString());
-    argNames[0] = member;
+    wxVector<wxBasicString> argNames(namedArgStringCount);
+    argNames[0].AssignFromwxString(member);
 
     // Note that arguments are specified in reverse order
     // (all totally logical; hey, we're dealing with OLE here.)
@@ -141,7 +141,7 @@ bool wxAutomationObject::Invoke(const wxString& member, int action,
     {
         if ( !INVOKEARG(i).GetName().empty() )
         {
-            argNames[(namedArgCount-j)] = INVOKEARG(i).GetName();
+            argNames[(namedArgCount-j)].AssignFromwxString(INVOKEARG(i).GetName());
             j ++;
         }
     }

--- a/src/msw/ole/automtn.cpp
+++ b/src/msw/ole/automtn.cpp
@@ -131,7 +131,7 @@ bool wxAutomationObject::Invoke(const wxString& member, int action,
 
     int namedArgStringCount = namedArgCount + 1;
     wxVector<wxBasicString> argNames(namedArgStringCount);
-    argNames[0].AssignFromwxString(member);
+    argNames[0].AssignFromString(member);
 
     // Note that arguments are specified in reverse order
     // (all totally logical; hey, we're dealing with OLE here.)
@@ -141,7 +141,7 @@ bool wxAutomationObject::Invoke(const wxString& member, int action,
     {
         if ( !INVOKEARG(i).GetName().empty() )
         {
-            argNames[(namedArgCount-j)].AssignFromwxString(INVOKEARG(i).GetName());
+            argNames[(namedArgCount-j)].AssignFromString(INVOKEARG(i).GetName());
             j ++;
         }
     }

--- a/src/msw/ole/oleutils.cpp
+++ b/src/msw/ole/oleutils.cpp
@@ -70,7 +70,7 @@ WXDLLEXPORT wxString wxConvertStringFromOle(BSTR bStr)
 // ----------------------------------------------------------------------------
 // wxBasicString
 // ----------------------------------------------------------------------------
-void wxBasicString::AssignFromwxString(const wxString& str)
+void wxBasicString::AssignFromString(const wxString& str)
 {
     SysFreeString(m_bstrBuf);
     m_bstrBuf = SysAllocString(str.wc_str(*wxConvCurrent));

--- a/src/msw/ole/oleutils.cpp
+++ b/src/msw/ole/oleutils.cpp
@@ -70,25 +70,10 @@ WXDLLEXPORT wxString wxConvertStringFromOle(BSTR bStr)
 // ----------------------------------------------------------------------------
 // wxBasicString
 // ----------------------------------------------------------------------------
-
-wxBasicString::wxBasicString(BSTR bstr)
-{
-    m_bstrBuf = bstr;
-}
-
-wxBasicString::wxBasicString(const wxString& str)
-{
-    m_bstrBuf = SysAllocString(str.wc_str(*wxConvCurrent));
-}
-
-wxBasicString::wxBasicString(const wxBasicString& bstr)
-{
-    m_bstrBuf = bstr.Copy();
-}
-
-wxBasicString::~wxBasicString()
+void wxBasicString::AssignFromwxString(const wxString& str)
 {
     SysFreeString(m_bstrBuf);
+    m_bstrBuf = SysAllocString(str.wc_str(*wxConvCurrent));
 }
 
 BSTR wxBasicString::Detach()
@@ -98,12 +83,6 @@ BSTR wxBasicString::Detach()
     m_bstrBuf = NULL;
 
     return bstr;
-}
-
-void wxBasicString::Free()
-{
-    SysFreeString(m_bstrBuf);
-    m_bstrBuf = NULL;
 }
 
 BSTR* wxBasicString::ByRef()
@@ -122,25 +101,6 @@ wxBasicString& wxBasicString::operator=(const wxBasicString& src)
         SysFreeString(m_bstrBuf);
         m_bstrBuf = src.Copy();
     }
-
-    return *this;
-}
-
-wxBasicString& wxBasicString::operator=(const wxString& str)
-{
-    SysFreeString(m_bstrBuf);
-    m_bstrBuf = SysAllocString(str.wc_str(*wxConvCurrent));
-
-    return *this;
-}
-
-wxBasicString& wxBasicString::operator=(BSTR bstr)
-{
-    wxCHECK_MSG(m_bstrBuf == NULL || m_bstrBuf != bstr, 
-        *this, wxS("Attempting to assign already owned BSTR"));
-
-    SysFreeString(m_bstrBuf);
-    m_bstrBuf = bstr;
 
     return *this;
 }

--- a/src/msw/webview_ie.cpp
+++ b/src/msw/webview_ie.cpp
@@ -1009,8 +1009,8 @@ void wxWebViewIE::FindInternal(const wxString& text, int flags, int internal_fla
         if(SUCCEEDED(document->QueryInterface(wxIID_IMarkupContainer, (void **)&pIMC)))
         {
             wxCOMPtr<wxIMarkupPointer> ptrBegin, ptrEnd;
-            wxBasicString attr_bstr(wxString("style=\"background-color:#ffff00\""));
-            wxBasicString text_bstr(text.wc_str());
+            wxBasicString attr_bstr(wxS("style=\"background-color:#ffff00\""));
+            wxBasicString text_bstr(text);
             
             pIMS->CreateMarkupPointer(&ptrBegin);
             pIMS->CreateMarkupPointer(&ptrEnd);


### PR DESCRIPTION
I was aware of dangers of calling `wxBasicString` ctor/methods taking a `BSTR` with a string literal, yet in #502 I still forgot to take care about it in few places.

I suppose the potential dangers of `BSTR`/`wxString`/string literal ambiguity were the reasons why wxBasicString did not originally have a ctor/methods taking a `BSTR`. These bugs can happen with raw `BSTR`s too but with wxWidgets it is probably even trickier when (in Unicode UTF-16 build) `wxBasicString("abc")` is OK (results in calling `wxBasicString(const wxString&)` while `wxBasicString(wx{S|T}("abc"))` will result in a crash.

I have added some strongly worded comments to `wxBasicString` to assist in avoiding bugs like the one above. While the API documentation has never been enough to prevent someone from shooting himself in the foot, considering `wxBasicString` is a low-profile internal class, the chances of people misusing it are hopefully rather low.

The only other option would probably be, in the name of safety over convenience, to remove the ctor and method(s) taking a `BSTR` and have only `CreateFromBSTR()` (creates a copy of a `BSTR`) and `AttachBSTR()` (takes ownership of a `BSTR`). There would still be nothing to prevent anyone from calling call such a method with a wide string literal but the name could make it more obvious that a `BSTR` is expected.