### PR TITLE
Automatically determine first weekday in wxCalendarCtrl

### DIFF
--- a/configure
+++ b/configure
@@ -32987,6 +32987,47 @@ $as_echo "$wx_cv_struct_tm_has_gmtoff" >&6; }
 
     fi
 
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for _NL_TIME_FIRST_WEEKDAY in langinfo.h" >&5
+$as_echo_n "checking for _NL_TIME_FIRST_WEEKDAY in langinfo.h... " >&6; }
+if ${wx_cv_have_nl_time_first_weekday+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
+        cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+                     #define _GNU_SOURCE
+                     #include <langinfo.h>
+
+int
+main ()
+{
+
+                     _NL_TIME_FIRST_WEEKDAY;
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+                     wx_cv_have_nl_time_first_weekday=yes
+
+else
+  wx_cv_have_nl_time_first_weekday=no
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $wx_cv_have_nl_time_first_weekday" >&5
+$as_echo "$wx_cv_have_nl_time_first_weekday" >&6; }
+
+    if test "$wx_cv_have_nl_time_first_weekday" = "yes"; then
+        $as_echo "#define HAVE_NL_TIME_FIRST_WEEKDAY 1" >>confdefs.h
+
+    fi
+
     SAMPLES_SUBDIRS="$SAMPLES_SUBDIRS typetest"
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -5949,6 +5949,28 @@ if test "$wxUSE_DATETIME" = "yes"; then
         AC_DEFINE(WX_GMTOFF_IN_TM)
     fi
 
+    AC_CACHE_CHECK([for _NL_TIME_FIRST_WEEKDAY in langinfo.h],
+                   wx_cv_have_nl_time_first_weekday,
+    [
+        AC_TRY_COMPILE(
+                [
+                     #define _GNU_SOURCE
+                     #include <langinfo.h>
+                ],
+                [
+                     _NL_TIME_FIRST_WEEKDAY;
+                ],
+                [
+                     wx_cv_have_nl_time_first_weekday=yes
+                ],
+                wx_cv_have_nl_time_first_weekday=no
+        )
+    ])
+
+    if test "$wx_cv_have_nl_time_first_weekday" = "yes"; then
+        AC_DEFINE(HAVE_NL_TIME_FIRST_WEEKDAY)
+    fi
+
     SAMPLES_SUBDIRS="$SAMPLES_SUBDIRS typetest"
 fi
 

--- a/include/wx/calctrl.h
+++ b/include/wx/calctrl.h
@@ -27,7 +27,7 @@
 enum
 {
     // show Sunday as the first day of the week (default)
-    wxCAL_SUNDAY_FIRST               = 0x0000,
+    wxCAL_SUNDAY_FIRST               = 0x0080,
 
     // show Monday as the first day of the week
     wxCAL_MONDAY_FIRST               = 0x0001,
@@ -332,6 +332,9 @@ protected:
 
     // called by EnableHolidayDisplay()
     virtual void RefreshHolidays() { }
+
+    // does the week start on monday based on flags and OS settings?
+    bool WeekStartsOnMonday() const;
 };
 
 // ----------------------------------------------------------------------------

--- a/include/wx/datetime.h
+++ b/include/wx/datetime.h
@@ -392,6 +392,9 @@ public:
         // returns true if the given year is a leap year in the given calendar
     static bool IsLeapYear(int year = Inv_Year, Calendar cal = Gregorian);
 
+        // acquires the first day of week based on locale and/or OS settings
+    static bool GetFirstWeekDay(WeekDay *firstDay);
+
         // get the century (19 for 1999, 20 for 2000 and -5 for 492 BC)
     static int GetCentury(int year);
 

--- a/include/wx/datetime.h
+++ b/include/wx/datetime.h
@@ -1145,6 +1145,9 @@ private:
     // functions
     inline bool IsInStdRange() const;
 
+    // assign the preferred first day of a week to flags, if necessary
+    void UseEffectiveWeekDayFlags(WeekFlags &flags) const;
+
     // the internal representation of the time is the amount of milliseconds
     // elapsed since the origin which is set by convention to the UNIX/C epoch
     // value: the midnight of January 1, 1970 (UTC)

--- a/include/wx/generic/calctrlg.h
+++ b/include/wx/generic/calctrlg.h
@@ -202,13 +202,13 @@ private:
     // get the first/last days of the week corresponding to the current style
     wxDateTime::WeekDay GetWeekStart() const
     {
-        return HasFlag(wxCAL_MONDAY_FIRST) ? wxDateTime::Mon
+        return WeekStartsOnMonday() ? wxDateTime::Mon
                                            : wxDateTime::Sun;
     }
 
     wxDateTime::WeekDay GetWeekEnd() const
     {
-        return HasFlag(wxCAL_MONDAY_FIRST) ? wxDateTime::Sun
+        return WeekStartsOnMonday() ? wxDateTime::Sun
                                            : wxDateTime::Sat;
     }
 

--- a/interface/wx/calctrl.h
+++ b/interface/wx/calctrl.h
@@ -8,7 +8,7 @@
 enum
 {
     // show Sunday as the first day of the week (default)
-    wxCAL_SUNDAY_FIRST               = 0x0000,
+    wxCAL_SUNDAY_FIRST               = 0x0080,
 
     // show Monday as the first day of the week
     wxCAL_MONDAY_FIRST               = 0x0001,
@@ -253,6 +253,11 @@ enum wxCalendarHitTestResult
     As the attributes are specified for each day, they may change when the
     month is changed, so you will often want to update them in
     @c EVT_CALENDAR_PAGE_CHANGED event handler.
+
+    If neither the @c wxCAL_SUNDAY_FIRST or @c wxCAL_MONDAY_FIRST style is given,
+    the first day of the week is determined from operating system's settings,
+    if possible. The native wxGTK calendar chooses the first weekday based on
+    locale, and these styles have no effect on it.
 
     @beginStyleTable
     @style{wxCAL_SUNDAY_FIRST}

--- a/interface/wx/datetime.h
+++ b/interface/wx/datetime.h
@@ -1484,6 +1484,18 @@ public:
                                   Country country = Country_Default);
 
     /**
+         Acquires the first weekday of a week based on locale and/or OS settings.
+         If the information was not available, returns @c Sun.
+         @param firstDay
+             The address of a WeekDay variable to which the first weekday will be
+             assigned to.
+	     @return If the first day could not be determined, returns false,
+		     and firstDay is set to a fallback value.
+         @since 3.1.1
+    */
+    static bool GetFirstWeekDay(WeekDay *firstDay);
+
+    /**
         Returns @true if the @a year is a leap one in the specified calendar.
         This functions supports Gregorian and Julian calendars.
     */

--- a/samples/calendar/calendar.cpp
+++ b/samples/calendar/calendar.cpp
@@ -70,7 +70,9 @@
 // Define a new application type, each program should derive a class from wxApp
 class MyApp : public wxApp
 {
+    wxLocale m_locale;
 public:
+	MyApp();
     // override base class virtuals
     // ----------------------------
 
@@ -153,6 +155,8 @@ public:
     }
 #endif // wxHAS_NATIVE_CALENDARCTRL
 
+    void OnCalAutoWeekday(wxCommandEvent& event);
+    void OnCalSunday(wxCommandEvent& event);
     void OnCalMonday(wxCommandEvent& event);
     void OnCalHolidays(wxCommandEvent& event);
     void OnCalSpecial(wxCommandEvent& event);
@@ -240,6 +244,8 @@ enum
     Calendar_File_ClearLog = wxID_CLEAR,
     Calendar_File_Quit = wxID_EXIT,
     Calendar_Cal_Generic = 200,
+    Calendar_Cal_AutoWeekday,
+    Calendar_Cal_Sunday,
     Calendar_Cal_Monday,
     Calendar_Cal_Holidays,
     Calendar_Cal_Special,
@@ -298,6 +304,8 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(Calendar_Cal_Generic, MyFrame::OnCalGeneric)
 #endif // wxHAS_NATIVE_CALENDARCTRL
 
+    EVT_MENU(Calendar_Cal_AutoWeekday, MyFrame::OnCalAutoWeekday)
+    EVT_MENU(Calendar_Cal_Sunday, MyFrame::OnCalSunday)
     EVT_MENU(Calendar_Cal_Monday, MyFrame::OnCalMonday)
     EVT_MENU(Calendar_Cal_Holidays, MyFrame::OnCalHolidays)
     EVT_MENU(Calendar_Cal_Special, MyFrame::OnCalSpecial)
@@ -319,6 +327,8 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
 
     EVT_UPDATE_UI(Calendar_Cal_SeqMonth, MyFrame::OnUpdateUIGenericOnly)
 #ifdef __WXGTK20__
+    EVT_UPDATE_UI(Calendar_Cal_AutoWeekday, MyFrame::OnUpdateUIGenericOnly)
+    EVT_UPDATE_UI(Calendar_Cal_Sunday, MyFrame::OnUpdateUIGenericOnly)
     EVT_UPDATE_UI(Calendar_Cal_Monday, MyFrame::OnUpdateUIGenericOnly)
     EVT_UPDATE_UI(Calendar_Cal_Holidays, MyFrame::OnUpdateUIGenericOnly)
 #endif
@@ -348,6 +358,13 @@ wxIMPLEMENT_APP(MyApp);
 // ----------------------------------------------------------------------------
 // the application class
 // ----------------------------------------------------------------------------
+
+MyApp::MyApp() :
+    // Locale affects on the language used in the calendar, and may affect
+    // on the first day of the week.
+    m_locale(wxLANGUAGE_DEFAULT)
+{
+}
 
 // `Main program' equivalent: the program execution "starts" here
 bool MyApp::OnInit()
@@ -396,10 +413,12 @@ MyFrame::MyFrame(const wxString& title, const wxPoint& pos, const wxSize& size)
                              "Toggle between native and generic control");
     menuCal->AppendSeparator();
 #endif // wxHAS_NATIVE_CALENDARCTRL
-    menuCal->Append(Calendar_Cal_Monday,
-                    wxT("Monday &first weekday\tCtrl-F"),
-                    wxT("Toggle between Mon and Sun as the first week day"),
-                    true);
+    menuCal->AppendRadioItem(Calendar_Cal_AutoWeekday,
+                    wxT("Automatic &first weekday\tCtrl-V"));
+    menuCal->AppendRadioItem(Calendar_Cal_Sunday,
+                    wxT("Sunday &first weekday\tCtrl-Z"));
+    menuCal->AppendRadioItem(Calendar_Cal_Monday,
+                    wxT("Monday &first weekday\tCtrl-F"));
     menuCal->Append(Calendar_Cal_Holidays, wxT("Show &holidays\tCtrl-H"),
                     wxT("Toggle highlighting the holidays"),
                     true);
@@ -462,7 +481,9 @@ MyFrame::MyFrame(const wxString& title, const wxPoint& pos, const wxSize& size)
     menuBar->Append(menuTime, wxT("&Time picker"));
 #endif // wxUSE_TIMEPICKCTRL
 
-    menuBar->Check(Calendar_Cal_Monday, true);
+    menuBar->Check(Calendar_Cal_AutoWeekday, true);
+    menuBar->Check(Calendar_Cal_Sunday, false);
+    menuBar->Check(Calendar_Cal_Monday, false);
     menuBar->Check(Calendar_Cal_Holidays, true);
     menuBar->Check(Calendar_Cal_Month, true);
     menuBar->Check(Calendar_Cal_LimitDates, false);
@@ -503,8 +524,21 @@ void MyFrame::OnClearLog(wxCommandEvent& WXUNUSED(event))
     m_logWindow->Clear();
 }
 
+void MyFrame::OnCalAutoWeekday(wxCommandEvent&)
+{
+    m_panel->ToggleCalStyle(false, wxCAL_SUNDAY_FIRST);
+    m_panel->ToggleCalStyle(false, wxCAL_MONDAY_FIRST);
+}
+
+void MyFrame::OnCalSunday(wxCommandEvent& event)
+{
+    m_panel->ToggleCalStyle(false, wxCAL_MONDAY_FIRST);
+    m_panel->ToggleCalStyle(event.IsChecked(), wxCAL_SUNDAY_FIRST);
+}
+
 void MyFrame::OnCalMonday(wxCommandEvent& event)
 {
+    m_panel->ToggleCalStyle(false, wxCAL_SUNDAY_FIRST);
     m_panel->ToggleCalStyle(event.IsChecked(), wxCAL_MONDAY_FIRST);
 }
 
@@ -702,7 +736,7 @@ MyPanel::MyPanel(wxWindow *parent)
                 wxDateTime::Today().FormatISODate().c_str());
     m_date = new wxStaticText(this, wxID_ANY, date);
     m_calendar = DoCreateCalendar(wxDefaultDateTime,
-                                  wxCAL_MONDAY_FIRST | wxCAL_SHOW_HOLIDAYS);
+                                  wxCAL_SHOW_HOLIDAYS);
 
     // adjust to vertical/horizontal display
     bool horizontal = ( wxSystemSettings::GetMetric(wxSYS_SCREEN_X) > wxSystemSettings::GetMetric(wxSYS_SCREEN_Y) );

--- a/setup.h.in
+++ b/setup.h.in
@@ -935,6 +935,9 @@
 /* struct tm doesn't always have the tm_gmtoff field, define this if it does */
 #undef WX_GMTOFF_IN_TM
 
+/* check if nl_langinfo() can be called with argument _NL_TIME_FIRST_WEEKDAY */
+#undef HAVE_NL_TIME_FIRST_WEEKDAY
+
 /* Define if you have poll(2) function */
 #undef HAVE_POLL
 

--- a/src/common/calctrlcmn.cpp
+++ b/src/common/calctrlcmn.cpp
@@ -195,5 +195,26 @@ bool wxCalendarCtrlBase::SetHolidayAttrs()
     return true;
 }
 
+bool wxCalendarCtrlBase::WeekStartsOnMonday() const
+{
+    if ( HasFlag(wxCAL_MONDAY_FIRST) )
+    {
+        return true;
+    }
+    else if ( HasFlag(wxCAL_SUNDAY_FIRST) )
+    {
+        return false;
+    }
+    else
+    {
+        // Neither flag was explicitly given, let's make a best guess
+        // based on locale and/or OS settings.
+
+        wxDateTime::WeekDay firstDay;
+        wxDateTime::GetFirstWeekDay(&firstDay);
+        return firstDay == wxDateTime::Mon;
+    }
+}
+
 #endif // wxUSE_CALENDARCTRL
 

--- a/src/common/datetime.cpp
+++ b/src/common/datetime.cpp
@@ -1770,10 +1770,7 @@ wxDateTime& wxDateTime::SetToWeekDayInSameWeek(WeekDay weekday, WeekFlags flags)
         return *this;
     }
 
-    if ( flags == Default_First )
-    {
-        flags = GetCountry() == USA ? Sunday_First : Monday_First;
-    }
+    UseEffectiveWeekDayFlags(flags);
 
     // the logic below based on comparing weekday and wdayThis works if Sun (0)
     // is the first day in the week, but breaks down for Monday_First case so
@@ -1928,10 +1925,7 @@ wxDateTime::wxDateTime_t wxDateTime::GetDayOfYear(const TimeZone& tz) const
 wxDateTime::wxDateTime_t
 wxDateTime::GetWeekOfYear(wxDateTime::WeekFlags flags, const TimeZone& tz) const
 {
-    if ( flags == Default_First )
-    {
-        flags = GetCountry() == USA ? Sunday_First : Monday_First;
-    }
+    UseEffectiveWeekDayFlags(flags);
 
     Tm tm(GetTm(tz));
     wxDateTime_t nDayInYear = GetDayOfYearFromTm(tm);
@@ -2018,10 +2012,7 @@ wxDateTime::wxDateTime_t wxDateTime::GetWeekOfMonth(wxDateTime::WeekFlags flags,
     const wxDateTime dateFirst = wxDateTime(1, tm.mon, tm.year);
     const wxDateTime::WeekDay wdFirst = dateFirst.GetWeekDay();
 
-    if ( flags == Default_First )
-    {
-        flags = GetCountry() == USA ? Sunday_First : Monday_First;
-    }
+    UseEffectiveWeekDayFlags(flags);
 
     // compute offset of dateFirst from the beginning of the week
     int firstOffset;
@@ -2132,6 +2123,16 @@ wxDateTime& wxDateTime::MakeFromTimezone(const TimeZone& tz, bool noDST)
     }
 
     return Subtract(wxTimeSpan::Seconds(secDiff));
+}
+
+void wxDateTime::UseEffectiveWeekDayFlags(WeekFlags &flags) const
+{
+    if ( flags == Default_First )
+    {
+        WeekDay firstDay;
+        GetFirstWeekDay(&firstDay);
+        flags = firstDay == Sun ? Sunday_First : Monday_First;
+    }
 }
 
 // ============================================================================

--- a/src/common/datetime.cpp
+++ b/src/common/datetime.cpp
@@ -541,6 +541,55 @@ bool wxDateTime::IsLeapYear(int year, wxDateTime::Calendar cal)
     }
 }
 
+#ifdef __WINDOWS__
+#include "wx/msw/registry.h"
+
+/* static */
+bool wxDateTime::GetFirstWeekDay(wxDateTime::WeekDay *firstDay)
+{
+    wxCHECK_MSG( firstDay, false, wxS("output parameter must be non-null") );
+    wxRegKey key(wxRegKey::HKCU, "Control Panel\\International");
+    wxString val;
+
+    if ( key.Exists() && key.HasValue("iFirstDayOfWeek") )
+    {
+        key.QueryValue("iFirstDayOfWeek", val);
+        *firstDay = wxDateTime::WeekDay((wxAtoi(val) + 1) % 7);
+        return true;
+    }
+    else
+    {
+        *firstDay = wxDateTime::Sun;
+        return false;
+    }
+}
+
+#elif defined(__APPLE__)
+// implementation in utils_base.mm
+#elif defined(HAVE_NL_TIME_FIRST_WEEKDAY)
+
+#include <langinfo.h>
+
+/* static */
+bool wxDateTime::GetFirstWeekDay(wxDateTime::WeekDay *firstDay)
+{
+    wxCHECK_MSG( firstDay, false, wxS("output parameter must be non-null") );
+    *firstDay = wxDateTime::WeekDay((*nl_langinfo(_NL_TIME_FIRST_WEEKDAY) - 1) % 7);
+    return true;
+}
+
+#else
+
+/* static */
+bool wxDateTime::GetFirstWeekDay(wxDateTime::WeekDay *firstDay)
+{
+    wxCHECK_MSG( firstDay, false, wxS("output parameter must be non-null") );
+    *firstDay = wxDateTime::Sun;
+    return false;
+}
+
+#endif
+
 /* static */
 int wxDateTime::GetCentury(int year)
 {

--- a/src/generic/calctrlg.cpp
+++ b/src/generic/calctrlg.cpp
@@ -245,6 +245,10 @@ void wxGenericCalendarCtrl::SetWindowStyleFlag(long style)
                     (m_windowStyle & wxCAL_SEQUENTIAL_MONTH_SELECTION),
                   wxT("wxCAL_SEQUENTIAL_MONTH_SELECTION can't be changed after creation") );
 
+    wxASSERT_MSG( !((style & wxCAL_SUNDAY_FIRST) &&
+                   (style & wxCAL_MONDAY_FIRST)),
+                 "wxCAL_SUNDAY_FIRST and wxCAL_MONDAY_FIRST cannot be both used" );
+
     wxControl::SetWindowStyleFlag(style);
 }
 
@@ -644,7 +648,7 @@ bool wxGenericCalendarCtrl::AdjustDateToRange(wxDateTime *date) const
 
 size_t wxGenericCalendarCtrl::GetWeek(const wxDateTime& date) const
 {
-    size_t retval = date.GetWeekOfMonth(HasFlag(wxCAL_MONDAY_FIRST)
+    size_t retval = date.GetWeekOfMonth(WeekStartsOnMonday()
                                    ? wxDateTime::Monday_First
                                    : wxDateTime::Sunday_First);
 
@@ -891,7 +895,7 @@ void wxGenericCalendarCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
         dc.SetPen(wxPen(m_colHeaderBg, 1, wxPENSTYLE_SOLID));
         dc.DrawRectangle(0, y, GetClientSize().x, m_heightRow);
 
-        bool startOnMonday = HasFlag(wxCAL_MONDAY_FIRST);
+        bool startOnMonday = WeekStartsOnMonday();
         for ( int wd = 0; wd < 7; wd++ )
         {
             size_t n;
@@ -1238,7 +1242,7 @@ bool wxGenericCalendarCtrl::GetDateCoord(const wxDateTime& date, int *day, int *
 
     if ( IsDateShown(date) )
     {
-        bool startOnMonday = HasFlag(wxCAL_MONDAY_FIRST);
+        bool startOnMonday = WeekStartsOnMonday();
 
         // Find day
         *day = date.GetWeekDay();
@@ -1479,7 +1483,7 @@ wxCalendarHitTestResult wxGenericCalendarCtrl::HitTest(const wxPoint& pos,
         {
             if ( wd )
             {
-                if ( HasFlag(wxCAL_MONDAY_FIRST) )
+                if ( WeekStartsOnMonday() )
                 {
                     wday = wday == 6 ? 0 : wday + 1;
                 }

--- a/src/msw/calctrl.cpp
+++ b/src/msw/calctrl.cpp
@@ -152,11 +152,11 @@ WXDWORD wxCalendarCtrl::MSWGetStyle(long style, WXDWORD *exstyle) const
 
 void wxCalendarCtrl::SetWindowStyleFlag(long style)
 {
-    const bool hadMondayFirst = HasFlag(wxCAL_MONDAY_FIRST);
+    const bool hadMondayFirst = WeekStartsOnMonday();
 
     wxCalendarCtrlBase::SetWindowStyleFlag(style);
 
-    if ( HasFlag(wxCAL_MONDAY_FIRST) != hadMondayFirst )
+    if ( WeekStartsOnMonday() != hadMondayFirst )
         UpdateFirstDayOfWeek();
 }
 
@@ -427,7 +427,7 @@ void wxCalendarCtrl::UpdateMarks()
 void wxCalendarCtrl::UpdateFirstDayOfWeek()
 {
     MonthCal_SetFirstDayOfWeek(GetHwnd(),
-                               HasFlag(wxCAL_MONDAY_FIRST) ? MonthCal_Monday
+                               WeekStartsOnMonday() ? MonthCal_Monday
                                                            : MonthCal_Sunday);
 }
 

--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -16,6 +16,7 @@
 #ifndef WX_PRECOMP
     #include "wx/intl.h"
     #include "wx/app.h"
+    #include "wx/datetime.h"
 #endif
 
 #include "wx/apptrait.h"
@@ -157,3 +158,14 @@ wxString wxGetOsDescription()
     return osDesc;
 }
 
+/* static */
+bool wxDateTime::GetFirstWeekDay(wxDateTime::WeekDay *firstDay)
+{
+    wxCHECK_MSG( firstDay, false, wxS("output parameter must be non-null") );
+	
+    NSCalendar *calendar = [NSCalendar currentCalendar];
+    [calendar setLocale:[NSLocale autoupdatingCurrentLocale]];
+
+    *firstDay = wxDateTime::WeekDay(([calendar firstWeekday] - 1) % 7);
+    return true;
+}

--- a/src/qt/calctrl.cpp
+++ b/src/qt/calctrl.cpp
@@ -107,9 +107,9 @@ void wxCalendarCtrl::UpdateStyle()
     if ( !m_qtCalendar )
         return;
 
-    if ( m_windowStyle & wxCAL_MONDAY_FIRST )
+    if ( WeekStartsOnMOnday() )
         m_qtCalendar->setFirstDayOfWeek(Qt::Monday);
-    else // wxCAL_SUNDAY_FIRST
+    else
         m_qtCalendar->setFirstDayOfWeek(Qt::Sunday);
 
     if ( m_windowStyle & wxCAL_SHOW_WEEK_NUMBERS )


### PR DESCRIPTION
Implement wxDateTime::GetFirstWeekDay(), and use is in wxCalendarCtrl to determine the preferred first weekday.

The implementation works on the three platforms it was tested on, but with platform-dependent code and a huge number of different locales it could potentially be used on, not every possible combination has been tested.

Also posted some information about this on wx-dev.