### PR TITLE
Change wxSecretStore API to allow retrieving the username

### DIFF
--- a/include/wx/private/secretstore.h
+++ b/include/wx/private/secretstore.h
@@ -79,14 +79,14 @@ class wxSecretStoreImpl : public wxRefCounter
 {
 public:
     virtual bool Save(const wxString& service,
-                      const wxString& user,
-                      const wxSecretValueImpl& secret,
+                      const wxString& username,
+                      const wxSecretValueImpl& password,
                       wxString& errmsg) = 0;
-    virtual wxSecretValueImpl* Load(const wxString& service,
-                                    const wxString& user,
-                                    wxString& errmsg) const = 0;
+    virtual bool Load(const wxString& service,
+                      wxString* username,
+                      wxSecretValueImpl** password,
+                      wxString& errmsg) const = 0;
     virtual bool Delete(const wxString& service,
-                        const wxString& user,
                         wxString& errmsg) = 0;
 };
 

--- a/include/wx/secretstore.h
+++ b/include/wx/secretstore.h
@@ -16,6 +16,13 @@
 
 #include "wx/string.h"
 
+// Initial version of wxSecretStore required passing user name to Load(), which
+// didn't make much sense without support for multiple usernames per service,
+// so the API was changed to load the username too. Test for this symbol to
+// distinguish between the old and the new API, it wasn't defined before the
+// API change.
+#define wxHAS_SECRETSTORE_LOAD_USERNAME
+
 class wxSecretStoreImpl;
 class wxSecretValueImpl;
 
@@ -123,36 +130,35 @@ public:
     bool IsOk() const { return m_impl != NULL; }
 
 
-    // Store a secret.
+    // Store a username/password combination.
     //
     // The service name should be user readable and unique.
     //
-    // If a secret with the same service name and user already exists, it will
-    // be overwritten with the new value.
+    // If a secret with the same service name already exists, it will be
+    // overwritten with the new value.
     //
     // Returns false after logging an error message if an error occurs,
     // otherwise returns true indicating that the secret has been stored.
     bool Save(const wxString& service,
-              const wxString& user,
-              const wxSecretValue& secret);
+              const wxString& username,
+              const wxSecretValue& password);
 
-    // Look up a secret.
+    // Look up the username/password for the given service.
     //
-    // If no such secret is found, an empty value is returned, but no error is
-    // logged (however an error may still be logged if some other error occurs).
-    // If more than one secret matching the parameters exist, only one
-    // arbitrarily chosen of them is returned (notice that it's impossible to
-    // get into such situation using this API only).
-    wxSecretValue Load(const wxString& service, const wxString& user) const;
+    // If no username/password is found for the given service, false is
+    // returned.
+    //
+    // Otherwise the function returns true and updates the provided user name
+    // and password arguments.
+    bool Load(const wxString& service,
+              wxString& username,
+              wxSecretValue& password) const;
 
-    // Delete a previously stored secret.
+    // Delete a previously stored username/password combination.
     //
-    // If there is more than one matching secret, all of them are deleted.
-    //
-    // If any secrets were deleted, returns true. Otherwise returns false and
-    // logs an error if any error other than not finding any matching secrets
-    // occurred.
-    bool Delete(const wxString& service, const wxString& user);
+    // If anything was deleted, returns true. Otherwise returns false and
+    // logs an error if any error other than not finding any matches occurred.
+    bool Delete(const wxString& service);
 
 private:
     // Ctor takes ownership of the passed pointer.

--- a/src/common/secretstore.cpp
+++ b/src/common/secretstore.cpp
@@ -176,49 +176,53 @@ wxSecretStore::Save(const wxString& service,
     wxString err;
     if ( !m_impl->Save(service, user, *secret.m_impl, err) )
     {
-        wxLogError(_("Saving password for \"%s/%s\" failed: %s."),
-                   service, user, err);
+        wxLogError(_("Saving password for \"%s\" failed: %s."),
+                   service, err);
         return false;
     }
 
     return true;
 }
 
-wxSecretValue
-wxSecretStore::Load(const wxString& service, const wxString& user) const
-{
-    if ( !m_impl )
-        return wxSecretValue();
-
-    wxString err;
-    wxSecretValueImpl* const secret = m_impl->Load(service, user, err);
-    if ( !secret )
-    {
-        if ( !err.empty() )
-        {
-            wxLogError(_("Reading password for \"%s/%s\" failed: %s."),
-                       service, user, err);
-        }
-
-        return wxSecretValue();
-    }
-
-    return wxSecretValue(secret);
-}
-
 bool
-wxSecretStore::Delete(const wxString& service, const wxString& user)
+wxSecretStore::Load(const wxString& service,
+                    wxString& user,
+                    wxSecretValue& secret) const
 {
     if ( !m_impl )
         return false;
 
     wxString err;
-    if ( !m_impl->Delete(service, user, err) )
+    wxSecretValueImpl* secretImpl = NULL;
+    if ( !m_impl->Load(service, &user, &secretImpl, err) )
     {
         if ( !err.empty() )
         {
-            wxLogError(_("Deleting password for \"%s/%s\" failed: %s."),
-                       service, user, err);
+            wxLogError(_("Reading password for \"%s\" failed: %s."),
+                       service, err);
+        }
+
+        return false;
+    }
+
+    secret = wxSecretValue(secretImpl);
+
+    return true;
+}
+
+bool
+wxSecretStore::Delete(const wxString& service)
+{
+    if ( !m_impl )
+        return false;
+
+    wxString err;
+    if ( !m_impl->Delete(service, err) )
+    {
+        if ( !err.empty() )
+        {
+            wxLogError(_("Deleting password for \"%s\" failed: %s."),
+                       service, err);
         }
         return false;
     }

--- a/src/msw/secretstore.cpp
+++ b/src/msw/secretstore.cpp
@@ -64,12 +64,10 @@ public:
                       const wxSecretValueImpl& secret,
                       wxString& errmsg) wxOVERRIDE
     {
-        const wxString target = MakeTargetName(service, user);
-
         CREDENTIAL cred;
         wxZeroMemory(cred);
         cred.Type = CRED_TYPE_GENERIC;
-        cred.TargetName = const_cast<TCHAR*>(static_cast<const TCHAR*>(target.t_str()));
+        cred.TargetName = const_cast<TCHAR*>(static_cast<const TCHAR*>(service.t_str()));
         cred.UserName = const_cast<TCHAR*>(static_cast<const TCHAR*>(user.t_str()));
         cred.CredentialBlobSize = secret.GetSize();
         cred.CredentialBlob = static_cast<BYTE *>(const_cast<void*>(secret.GetData()));
@@ -91,35 +89,35 @@ public:
         return true;
     }
 
-    virtual wxSecretValueImpl* Load(const wxString& service,
-                                    const wxString& user,
-                                    wxString& errmsg) const wxOVERRIDE
+    virtual bool Load(const wxString& service,
+                      wxString* user,
+                      wxSecretValueImpl** secret,
+                      wxString& errmsg) const wxOVERRIDE
     {
-        const wxString target = MakeTargetName(service, user);
-
         CREDENTIAL* pcred = NULL;
-        if ( !::CredRead(target.t_str(), CRED_TYPE_GENERIC, 0, &pcred) || !pcred )
+        if ( !::CredRead(service.t_str(), CRED_TYPE_GENERIC, 0, &pcred) || !pcred )
         {
             // Not having the password for this service/user combination is not
             // an error, but anything else is.
             if ( ::GetLastError() != ERROR_NOT_FOUND )
                 errmsg = wxSysErrorMsgStr();
 
-            return NULL;
+            return false;
         }
 
         CredentialPtr ensureFree(pcred);
-        return new wxSecretValueGenericImpl(pcred->CredentialBlobSize,
-                                            pcred->CredentialBlob);
+
+        *user = pcred->UserName;
+        *secret = new wxSecretValueGenericImpl(pcred->CredentialBlobSize,
+                                               pcred->CredentialBlob);
+
+        return true;
     }
 
     virtual bool Delete(const wxString& service,
-                        const wxString& user,
                         wxString& errmsg) wxOVERRIDE
     {
-        const wxString target = MakeTargetName(service, user);
-
-        if ( !::CredDelete(target.t_str(), CRED_TYPE_GENERIC, 0) )
+        if ( !::CredDelete(service.t_str(), CRED_TYPE_GENERIC, 0) )
         {
             // Same logic as in Load() above.
             if ( ::GetLastError() != ERROR_NOT_FOUND )
@@ -129,25 +127,6 @@ public:
         }
 
         return true;
-    }
-
-private:
-    // Return the string used as the "target name" for the API functions.
-    // We need to combine both service and user into a single string as it
-    // needs to be unique, i.e. otherwise we couldn't store two different
-    // passwords for two different users of the same service and we do want to
-    // be able to do this.
-    static
-    wxString MakeTargetName(const wxString& service, const wxString& user)
-    {
-        // The exact way of combining the service and user strings together is
-        // completely arbitrary, we could also use "service:user" or
-        // "user@service", there doesn't seem to be any standard about it, but
-        // doing it like this has the advantage of keeping all passwords for
-        // the given service together in the "Credential Manager" GUI and slash
-        // is used by some standard programs, e.g. the built-in RDP client
-        // stores its passwords under "TERMSRV/hostname".
-        return service + wxS("/") + user;
     }
 };
 

--- a/src/unix/secretstore.cpp
+++ b/src/unix/secretstore.cpp
@@ -33,6 +33,8 @@
 #include <libsecret/secret.h>
 
 #include "wx/gtk/private/error.h"
+#include "wx/gtk/private/list.h"
+#include "wx/gtk/private/object.h"
 
 namespace
 {
@@ -131,10 +133,9 @@ public:
                       wxString& errmsg) wxOVERRIDE
     {
         // We don't have any argument for the user-visible secret description
-        // supported by libsecret, so we just concatenate the service and user
-        // strings. It might be a good idea to add a possibility to specify a
-        // more informative description later.
-        const wxString label = service + wxS("/") + user;
+        // supported by libsecret, so we just reuse the service string. It
+        // might be a good idea to add a possibility to specify a more
+        // informative description later.
 
         // Notice that we can't use secret_password_store_sync() here because
         // our secret can contain NULs, so we must pass by the lower level API.
@@ -145,7 +146,7 @@ public:
                 GetSchema(),
                 BuildAttributes(service, user),
                 SECRET_COLLECTION_DEFAULT,
-                label.utf8_str(),
+                service.utf8_str(),
                 static_cast<const wxSecretValueLibSecretImpl&>(secret).GetValue(),
                 NULL,                           // Can't be cancelled
                 error.Out()
@@ -158,21 +159,27 @@ public:
         return true;
     }
 
-    virtual wxSecretValueImpl* Load(const wxString& service,
-                                    const wxString& user,
-                                    wxString& errmsg) const wxOVERRIDE
+    virtual bool Load(const wxString& service,
+                      wxString* user,
+                      wxSecretValueImpl** secret,
+                      wxString& errmsg) const wxOVERRIDE
     {
         wxGtkError error;
-        SecretValue* const value = secret_service_lookup_sync
-              (
+        GList* const found = secret_service_search_sync
+            (
                 NULL,                           // Default service
                 GetSchema(),
-                BuildAttributes(service, user),
+                BuildAttributes(service),
+                static_cast<SecretSearchFlags>
+                (
+                    SECRET_SEARCH_UNLOCK |
+                    SECRET_SEARCH_LOAD_SECRETS
+                ),
                 NULL,                           // Can't be cancelled
                 error.Out()
-              );
+            );
 
-        if ( !value )
+        if ( !found )
         {
             // There can be no error message if the secret was just not found
             // and no other error occurred -- just leave the error message
@@ -180,21 +187,32 @@ public:
             // behave.
             if ( error )
                 errmsg = error.GetMessage();
-            return NULL;
+            return false;
         }
 
-        return new wxSecretValueLibSecretImpl(value);
+        wxGtkList ensureListFreed(found);
+
+        SecretItem* const item = static_cast<SecretItem*>(found->data);
+        wxGtkObject<SecretItem> ensureItemFreed(item);
+
+        const wxGHashTable attrs(secret_item_get_attributes(item));
+        const gpointer field = g_hash_table_lookup(attrs, FIELD_USER);
+        if ( field )
+            *user = wxString::FromUTF8(static_cast<char*>(field));
+
+        *secret = new wxSecretValueLibSecretImpl(secret_item_get_secret(item));
+
+        return true;
     }
 
     virtual bool Delete(const wxString& service,
-                        const wxString& user,
                         wxString& errmsg) wxOVERRIDE
     {
         wxGtkError error;
         if ( !secret_password_clearv_sync
               (
                 GetSchema(),
-                BuildAttributes(service, user),
+                BuildAttributes(service),
                 NULL,                           // Can't be cancelled
                 error.Out()
               ) )
@@ -232,8 +250,18 @@ private:
     }
 
     // Return attributes for the schema defined above.
+    static wxGHashTable BuildAttributes(const wxString& service)
+    {
+        return wxGHashTable(secret_attributes_build
+                            (
+                                GetSchema(),
+                                FIELD_SERVICE,  service.utf8_str().data(),
+                                NULL
+                            ));
+    }
+
     static wxGHashTable BuildAttributes(const wxString& service,
-                                       const wxString& user)
+                                        const wxString& user)
     {
         return wxGHashTable(secret_attributes_build
                             (


### PR DESCRIPTION
The old API didn't make any sense for the most common case when both the
user name and password need to be stored, as it required providing the
user name as input, which couldn't work (but somehow this went
unnoticed for more than a year...).

Fix this by returning the username, and not only the password, from
Load() instead of taking it as parameter and removing this parameter
from Delete() as well.

Also improve the documentation, notably include a simple example of
using this class.

Notice that this is a backwards-incompatible change, but the old API was
really badly broken and didn't appear in 3.1.0 yet, so the breakage is
both unavoidable and, hopefully, shouldn't affect much code.
Nevertheless, a special wxHAS_SECRETSTORE_LOAD_USERNAME symbol is added
to allow testing for it if necessary.