### PR TITLE
Skip setting geometry hints for non resizeable windows in wxGTK

### DIFF
--- a/src/gtk/toplevel.cpp
+++ b/src/gtk/toplevel.cpp
@@ -1238,6 +1238,17 @@ void wxTopLevelWindowGTK::DoSetSizeHints( int minW, int minH,
                                           int incW, int incH )
 {
     base_type::DoSetSizeHints(minW, minH, maxW, maxH, incW, incH);
+
+    if (!HasFlag(wxRESIZE_BORDER))
+    {
+        // It's not useful to set size hints for the windows which can't be
+        // resized anyhow, and it even results in warnings from Gnome window
+        // manager, so just don't do it (but notice that it's not an error to
+        // call this for non-resizeable windows, e.g. because it's done
+        // implicitly by SetSizerAndFit() which is useful even in this case).
+        return;
+    }
+
     m_incWidth = incW;
     m_incHeight = incH;
 


### PR DESCRIPTION
Avoid calling gtk_window_set_geometry_hints() when the window can't be
resized anyhow, this doesn't seem to be necessary and results in
warnings like the following when using Gnome:

gnome-session[xxx]: Window manager warning: Window 0xxxx (Minimal wx)
sets an MWM hint indicating it isn't resizable, but sets min size 198 x
154 and max size 268435454 x 268435454; this doesn't make much sense.

---

Paul, I don't see any ill effects when doing this, but I'm not sure if there really are none. Could you please let me know if you think doing this is a bad idea? The warning is not that bad, even if it's annoying to see them in syslog. TIA!