### PR TITLE
Simplify and optimize wxTextCtrl text insertion methods in wxGTK

### DIFF
--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -158,7 +158,6 @@ protected:
     // override this and return true.
     virtual bool UseGTKStyleBase() const wxOVERRIDE { return true; }
 
-    virtual void DoSetValue(const wxString &value, int flags = 0) wxOVERRIDE;
     virtual wxString DoGetValue() const wxOVERRIDE;
 
     // Override this to use either GtkEntry or GtkTextView IME depending on the

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -1044,7 +1044,7 @@ void wxTextCtrl::WriteText( const wxString &text )
     }
 
 #if wxUSE_UNICODE
-    const wxCharBuffer buffer(text.utf8_str());
+    const wxScopedCharBuffer buffer(text.utf8_str());
 #else
     // check if we have a specific style for the current position
     wxFontEncoding enc = wxFONTENCODING_SYSTEM;
@@ -1057,7 +1057,7 @@ void wxTextCtrl::WriteText( const wxString &text )
     if ( enc == wxFONTENCODING_SYSTEM )
         enc = GetTextEncoding();
 
-    const wxCharBuffer buffer(wxGTK_CONV_ENC(text, enc));
+    const wxScopedCharBuffer buffer(wxGTK_CONV_ENC(text, enc));
     if ( !buffer )
     {
         // we must log an error here as losing the text like this can be a
@@ -1083,7 +1083,7 @@ void wxTextCtrl::WriteText( const wxString &text )
     GdkEventKey* const imKeyEvent_save = m_imKeyEvent;
     m_imKeyEvent = NULL;
 
-    gtk_text_buffer_insert( m_buffer, &iter, buffer, strlen(buffer) );
+    gtk_text_buffer_insert( m_buffer, &iter, buffer, buffer.length() );
 
     m_imKeyEvent = imKeyEvent_save;
 

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -1030,102 +1030,12 @@ bool wxTextCtrl::IsEmpty() const
     return wxTextEntry::IsEmpty();
 }
 
-// Helper class used by DoSetValue() and WriteText() to temporarily reset
-// m_imKeyEvent to NULL and restore its original value in the dtor.
-class TemporarilyUnsetIMKeyEvent
-{
-public:
-    explicit TemporarilyUnsetIMKeyEvent(GdkEventKey*& event)
-        : m_event(event),
-          m_eventOrig(event)
-    {
-        m_event = NULL;
-    }
-
-    ~TemporarilyUnsetIMKeyEvent()
-    {
-        m_event = m_eventOrig;
-    }
-
-private:
-    GdkEventKey*& m_event;
-    GdkEventKey* const m_eventOrig;
-
-    wxDECLARE_NO_COPY_CLASS(TemporarilyUnsetIMKeyEvent);
-};
-
-void wxTextCtrl::DoSetValue( const wxString &value, int flags )
-{
-    wxCHECK_RET( m_text != NULL, wxT("invalid text ctrl") );
-
-    m_modified = false;
-
-    if ( !IsMultiLine() )
-    {
-        wxTextEntry::DoSetValue(value, flags);
-        return;
-    }
-
-    if (value.IsEmpty())
-    {
-        if ( !(flags & SetValue_SendEvent) )
-            EnableTextChangedEvents(false);
-
-        gtk_text_buffer_set_text( m_buffer, "", 0 );
-
-        if ( !(flags & SetValue_SendEvent) )
-            EnableTextChangedEvents(true);
-
-        return;
-    }
-
-#if wxUSE_UNICODE
-    const wxCharBuffer buffer(value.utf8_str());
-#else
-    wxFontEncoding enc = m_defaultStyle.HasFont()
-                            ? m_defaultStyle.GetFont().GetEncoding()
-                            : wxFONTENCODING_SYSTEM;
-    if ( enc == wxFONTENCODING_SYSTEM )
-        enc = GetTextEncoding();
-
-    const wxCharBuffer buffer(wxGTK_CONV_ENC(value, enc));
-    if ( !buffer )
-    {
-        // see comment in WriteText() as to why we must warn the user about
-        // this
-        wxLogWarning(_("Failed to set text in the text control."));
-        return;
-    }
-#endif
-
-    if ( !(flags & SetValue_SendEvent) )
-    {
-        EnableTextChangedEvents(false);
-    }
-
-    // This will emit insert-text signal which assumes that if m_imKeyEvent is
-    // set, it is called in response to this key press -- which is not the case
-    // here (but m_imKeyEvent might still be set e.g. because we're called from
-    // a menu event handler triggered by a keyboard accelerator).
-    TemporarilyUnsetIMKeyEvent unset(m_imKeyEvent);
-
-    gtk_text_buffer_set_text( m_buffer, buffer, strlen(buffer) );
-
-    if ( !(flags & SetValue_SendEvent) )
-    {
-        EnableTextChangedEvents(true);
-    }
-}
-
 void wxTextCtrl::WriteText( const wxString &text )
 {
     wxCHECK_RET( m_text != NULL, wxT("invalid text ctrl") );
 
     // we're changing the text programmatically
     DontMarkDirtyOnNextChange();
-
-    // avoid generating wxEVT_CHAR when called from wxEVT_CHAR handler
-    TemporarilyUnsetIMKeyEvent unset(m_imKeyEvent);
 
     if ( !IsMultiLine() )
     {
@@ -1165,7 +1075,17 @@ void wxTextCtrl::WriteText( const wxString &text )
     GtkTextIter iter;
     gtk_text_buffer_get_iter_at_mark( m_buffer, &iter,
                                       gtk_text_buffer_get_insert (m_buffer) );
+
+    // This will emit insert-text signal which assumes that if m_imKeyEvent is
+    // set, it is called in response to this key press -- which is not the case
+    // here (but m_imKeyEvent might still be set e.g. because we're called from
+    // a menu event handler triggered by a keyboard accelerator).
+    GdkEventKey* const imKeyEvent_save = m_imKeyEvent;
+    m_imKeyEvent = NULL;
+
     gtk_text_buffer_insert( m_buffer, &iter, buffer, strlen(buffer) );
+
+    m_imKeyEvent = imKeyEvent_save;
 
     // Scroll to cursor, but only if scrollbar thumb is at the very bottom
     // won't work when frozen, text view is not using m_buffer then


### PR DESCRIPTION
Does anybody see anything wrong with removing `DoSetValue()` as I did? It seems to work in the text sample and in the unit tests, but they are, of course, not exhaustive...