### PR TITLE
Add a method inherited from wxListCtrlBase into interface's wxListCtrl

### DIFF
--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -369,6 +369,13 @@ public:
                 const wxString& name = wxListCtrlNameStr);
 
     /**
+        Deletes all columns in the list control.
+        
+        @return @true if all columns were successfully deleted, @false otherwise.
+    */
+    bool DeleteAllColumns();
+
+    /**
         Deletes all items in the list control.
 
         This function does @e not send the @c wxEVT_LIST_DELETE_ITEM


### PR DESCRIPTION
As pointed out in Phoenix's issue: https://github.com/wxWidgets/Phoenix/issues/486,
DeleteAllColumns, inherited from wxListCtrlBase, was missing in ListCtrl's interface header.

This adds that prototype in along with a simple description.