### PR TITLE
Fix popup menu items being always disabled in Mac OS X

### DIFF
--- a/src/osx/cocoa/menu.mm
+++ b/src/osx/cocoa/menu.mm
@@ -239,6 +239,9 @@ public :
     {
         win->ScreenToClient( &x , &y ) ;
         NSView *view = win->GetPeer()->GetWXWidget();
+        // Turn off auto-enable; it caused popup menus inside of dialogs
+        // to be entirely disabled.
+        [m_osxMenu setAutoenablesItems:NO];
         [m_osxMenu popUpMenuPositioningItem:nil atLocation:NSMakePoint(x, y) inView:view];
     }
     


### PR DESCRIPTION
Menus on Mac use automatic menu enabling, meaning that the system will enable
menu items only if the app responds to the menu item action. If I understand
correctly, the responder chain for menus in popup dialogs stop at the dialog
window, so the system thinks that the app does not handle the menu items.

This fix should not affect existing code since the wxWidgets user-facing API
dictates that apps specifically disable menu items.

Fix #17459 at https://trac.wxwidgets.org/ticket/17459

See Apple docs on automatic menu enabling at

https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/MenuList/Articles/EnablingMenuItems.html#//apple_ref/doc/uid/20000261-BAJBFGED