### PR TITLE
fix compiler error: MSWShouldSetDefaultFont() const' marked 'override', but does not override.

### DIFF
--- a/include/wx/msw/listctrl.h
+++ b/include/wx/msw/listctrl.h
@@ -380,7 +380,7 @@ protected:
     // common part of all ctors
     void Init();
 
-    virtual bool MSWShouldSetDefaultFont() const wxOVERRIDE { return false; }
+    virtual bool MSWShouldSetDefaultFont() const { return false; }
 
     // Implement constrained best size calculation.
     virtual int DoGetBestClientHeight(int width) const wxOVERRIDE

--- a/include/wx/msw/treectrl.h
+++ b/include/wx/msw/treectrl.h
@@ -211,7 +211,7 @@ protected:
                            int width, int height,
                            int sizeFlags = wxSIZE_AUTO) wxOVERRIDE;
 
-    virtual bool MSWShouldSetDefaultFont() const wxOVERRIDE { return false; }
+    virtual bool MSWShouldSetDefaultFont() const { return false; }
 
     // SetImageList helper
     void SetAnyImageList(wxImageList *imageList, int which);


### PR DESCRIPTION
fix compiler error: 'virtual bool wxListCtrl::MSWShouldSetDefaultFont() const' marked 'override', but does not override.

say  definition of MSWShouldSetDefaultFont() at

https://github.com/wxWidgets/wxWidgets/blob/master/include/wx/msw/control.h#L77

```cxx
virtual bool MSWShouldSetDefaultFont() const { return true; }
```
