### PR TITLE
Allow specifying character set for wxLogStderr and wxLogStream.

### DIFF
--- a/include/wx/log.h
+++ b/include/wx/log.h
@@ -720,13 +720,16 @@ class WXDLLIMPEXP_BASE wxLogStderr : public wxLog
 {
 public:
     // redirect log output to a FILE
-    wxLogStderr(FILE *fp = NULL);
+    wxLogStderr(FILE *fp = NULL,
+                const wxMBConv &conv = wxConvWhateverWorks);
+    virtual ~wxLogStderr();
 
 protected:
     // implement sink function
     virtual void DoLogText(const wxString& msg) wxOVERRIDE;
 
     FILE *m_fp;
+    const wxMBConv *m_conv;
 
     wxDECLARE_NO_COPY_CLASS(wxLogStderr);
 };
@@ -738,7 +741,9 @@ class WXDLLIMPEXP_BASE wxLogStream : public wxLog
 {
 public:
     // redirect log output to an ostream
-    wxLogStream(wxSTD ostream *ostr = (wxSTD ostream *) NULL);
+    wxLogStream(wxSTD ostream *ostr = (wxSTD ostream *) NULL,
+                const wxMBConv &conv = wxConvWhateverWorks);
+    virtual ~wxLogStream();
 
 protected:
     // implement sink function
@@ -746,6 +751,7 @@ protected:
 
     // using ptr here to avoid including <iostream.h> from this file
     wxSTD ostream *m_ostr;
+    const wxMBConv *m_conv;
 };
 
 #endif // wxUSE_STD_IOSTREAM

--- a/include/wx/log.h
+++ b/include/wx/log.h
@@ -61,6 +61,7 @@ class WXDLLIMPEXP_FWD_BASE wxObject;
 
 #include "wx/dynarray.h"
 #include "wx/hashmap.h"
+#include "wx/msgout.h"
 
 #if wxUSE_THREADS
     #include "wx/thread.h"
@@ -716,20 +717,17 @@ private:
 
 
 // log everything to a "FILE *", stderr by default
-class WXDLLIMPEXP_BASE wxLogStderr : public wxLog
+class WXDLLIMPEXP_BASE wxLogStderr : public wxLog,
+                                     private wxMessageOutputStderr
 {
 public:
     // redirect log output to a FILE
     wxLogStderr(FILE *fp = NULL,
                 const wxMBConv &conv = wxConvWhateverWorks);
-    virtual ~wxLogStderr();
 
 protected:
     // implement sink function
     virtual void DoLogText(const wxString& msg) wxOVERRIDE;
-
-    FILE *m_fp;
-    const wxMBConv *m_conv;
 
     wxDECLARE_NO_COPY_CLASS(wxLogStderr);
 };
@@ -737,13 +735,13 @@ protected:
 #if wxUSE_STD_IOSTREAM
 
 // log everything to an "ostream", cerr by default
-class WXDLLIMPEXP_BASE wxLogStream : public wxLog
+class WXDLLIMPEXP_BASE wxLogStream : public wxLog,
+                                     private wxMessageOutputWithConv
 {
 public:
     // redirect log output to an ostream
     wxLogStream(wxSTD ostream *ostr = (wxSTD ostream *) NULL,
-                const wxMBConv &conv = wxConvWhateverWorks);
-    virtual ~wxLogStream();
+                const wxMBConv& conv = wxConvWhateverWorks);
 
 protected:
     // implement sink function
@@ -751,7 +749,8 @@ protected:
 
     // using ptr here to avoid including <iostream.h> from this file
     wxSTD ostream *m_ostr;
-    const wxMBConv *m_conv;
+
+    wxDECLARE_NO_COPY_CLASS(wxLogStream);
 };
 
 #endif // wxUSE_STD_IOSTREAM

--- a/include/wx/msgout.h
+++ b/include/wx/msgout.h
@@ -64,7 +64,9 @@ private:
 class WXDLLIMPEXP_BASE wxMessageOutputStderr : public wxMessageOutput
 {
 public:
-    wxMessageOutputStderr(FILE *fp = stderr) : m_fp(fp) { }
+    wxMessageOutputStderr(FILE *fp = stderr,
+                          const wxMBConv &conv = wxConvWhateverWorks);
+    virtual ~wxMessageOutputStderr();
 
     virtual void Output(const wxString& str) wxOVERRIDE;
 
@@ -74,6 +76,7 @@ protected:
     wxString AppendLineFeedIfNeeded(const wxString& str);
 
     FILE *m_fp;
+    const wxMBConv *m_conv;
 };
 
 // ----------------------------------------------------------------------------

--- a/include/wx/msgout.h
+++ b/include/wx/msgout.h
@@ -58,25 +58,51 @@ private:
 };
 
 // ----------------------------------------------------------------------------
-// implementation which sends output to stderr or specified file
+// helper mix-in for output targets that can use difference encodings
 // ----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_BASE wxMessageOutputStderr : public wxMessageOutput
+class WXDLLIMPEXP_BASE wxMessageOutputWithConv
 {
-public:
-    wxMessageOutputStderr(FILE *fp = stderr,
-                          const wxMBConv &conv = wxConvWhateverWorks);
-    virtual ~wxMessageOutputStderr();
-
-    virtual void Output(const wxString& str) wxOVERRIDE;
-
 protected:
+    explicit wxMessageOutputWithConv(const wxMBConv& conv)
+        : m_conv(conv.Clone())
+    {
+    }
+
+    ~wxMessageOutputWithConv()
+    {
+        delete m_conv;
+    }
+
     // return the string with "\n" appended if it doesn't already terminate
     // with it (in which case it's returned unchanged)
     wxString AppendLineFeedIfNeeded(const wxString& str);
 
+    // Prepare the given string for output by appending a new line to it, if
+    // necessary, and converting it to a narrow string using our conversion
+    // object.
+    wxCharBuffer PrepareForOutput(const wxString& str);
+
+    const wxMBConv* const m_conv;
+};
+
+// ----------------------------------------------------------------------------
+// implementation which sends output to stderr or specified file
+// ----------------------------------------------------------------------------
+
+class WXDLLIMPEXP_BASE wxMessageOutputStderr : public wxMessageOutput,
+                                               protected wxMessageOutputWithConv
+{
+public:
+    wxMessageOutputStderr(FILE *fp = stderr,
+                          const wxMBConv &conv = wxConvWhateverWorks);
+
+    virtual void Output(const wxString& str) wxOVERRIDE;
+
+protected:
     FILE *m_fp;
-    const wxMBConv *m_conv;
+
+    wxDECLARE_NO_COPY_CLASS(wxMessageOutputStderr);
 };
 
 // ----------------------------------------------------------------------------

--- a/interface/wx/log.h
+++ b/interface/wx/log.h
@@ -756,8 +756,24 @@ public:
     /**
         Constructs a log target which sends all the log messages to the given
         output stream. If it is @NULL, the messages are sent to @c cerr.
+        The messages will be written in the encoding specified by the
+        given @c wxMBConv.
+
+        The @a conv argument is only available in wxWidgets 3.1.1 and later.
+
+        @note
+            In practice, it is only advisable to specify @c wxConvUTF8 as
+            the @a conv.
+            If using @c wxMBConvUTF16(), the file should be opened in
+            @c std::ios::binary mode.
+
+        @warning
+            If a log message contains any characters that cannot be converted
+            to the character set given by @a conv, that message will be
+            silently ignored, i.e. it will not be written at all.
     */
-    wxLogStream(std::ostream *ostr = NULL);
+    wxLogStream(std::ostream *ostr = NULL,
+                const wxMBConv &conv = wxConvWhateverWorks);
 };
 
 
@@ -782,8 +798,24 @@ public:
     /**
         Constructs a log target which sends all the log messages to the given
         @c FILE. If it is @NULL, the messages are sent to @c stderr.
+        The messages will be written in the encoding specified by the
+        given @c wxMBConv.
+
+		The @a conv argument is only available in wxWidgets 3.1.1 and later.
+
+        @note
+            In practice, it is only advisable to specify @c wxConvUTF8 as
+            the @a conv.
+            If using @c wxMBConvUTF16(), the file should be opened in
+            @c "wb" mode.
+
+        @warning
+            If a log message contains any characters that cannot be converted
+            to the character set given by @a conv, that message will be
+            silently ignored, i.e. it will not be written at all.
     */
-    wxLogStderr(FILE* fp = NULL);
+    wxLogStderr(FILE *fp = NULL,
+                const wxMBConv &conv = wxConvWhateverWorks);
 };
 
 

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -839,7 +839,8 @@ void wxLogBuffer::DoLogTextAtLevel(wxLogLevel level, const wxString& msg)
 // wxLogStderr class implementation
 // ----------------------------------------------------------------------------
 
-wxLogStderr::wxLogStderr(FILE *fp)
+wxLogStderr::wxLogStderr(FILE *fp, const wxMBConv &conv):
+m_conv(conv.Clone())
 {
     if ( fp == NULL )
         m_fp = stderr;
@@ -847,12 +848,17 @@ wxLogStderr::wxLogStderr(FILE *fp)
         m_fp = fp;
 }
 
+wxLogStderr::~wxLogStderr()
+{
+    delete m_conv;
+}
+
 void wxLogStderr::DoLogText(const wxString& msg)
 {
     // First send it to stderr, even if we don't have it (e.g. in a Windows GUI
     // application under) it's not a problem to try to use it and it's easier
     // than determining whether we do have it or not.
-    wxMessageOutputStderr(m_fp).Output(msg);
+    wxMessageOutputStderr(m_fp, *m_conv).Output(msg);
 
     // under GUI systems such as Windows or Mac, programs usually don't have
     // stderr at all, so show the messages also somewhere else, typically in
@@ -874,7 +880,8 @@ void wxLogStderr::DoLogText(const wxString& msg)
 
 #if wxUSE_STD_IOSTREAM
 #include "wx/ioswrap.h"
-wxLogStream::wxLogStream(wxSTD ostream *ostr)
+wxLogStream::wxLogStream(wxSTD ostream *ostr, const wxMBConv &conv):
+m_conv(conv.Clone())
 {
     if ( ostr == NULL )
         m_ostr = &wxSTD cerr;
@@ -882,9 +889,30 @@ wxLogStream::wxLogStream(wxSTD ostream *ostr)
         m_ostr = ostr;
 }
 
+wxLogStream::~wxLogStream()
+{
+    delete m_conv;
+}
+
 void wxLogStream::DoLogText(const wxString& msg)
 {
-    (*m_ostr) << msg << wxSTD endl;
+    wxString msgLF(msg);
+    if ( msgLF.empty() || *msgLF.rbegin() != '\n' )
+        msgLF += '\n';
+
+#if defined(__WINDOWS__)
+    // Determine whether the encoding is UTF-16. In that case, the file
+    // should have been opened in "wb" mode, and EOL-style must be handled
+    // here.
+
+    if (m_conv->GetMBNulLen() == 2)
+    {
+        msgLF.Replace("\n", "\r\n");
+    }
+#endif
+
+    const wxCharBuffer buf = m_conv->cWX2MB(msgLF.c_str());
+    m_ostr->write(buf, buf.length());
 }
 #endif // wxUSE_STD_IOSTREAM
 


### PR DESCRIPTION
Until now, a mixture of non-UTF-8 and UTF-8 could be written in some circumstances.

This is the patch from trac ticket #[17385](http://trac.wxwidgets.org/ticket/17385) as a PR.