### PR TITLE
[wxMSW] Removed old fix from wxTreeCtrl::DoInsertAfter()

### DIFF
--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -1505,10 +1505,26 @@ wxTreeItemId wxTreeCtrl::DoInsertAfter(const wxTreeItemId& parent,
     tvIns.item.lParam = (LPARAM)param;
     tvIns.item.mask = mask;
 
+    // don't use the hack below for the children of hidden root: this results
+    // in a crash inside comctl32.dll when we call TreeView_GetItemRect()
+    const bool firstChild = !IsHiddenRoot(parent) &&
+                                !TreeView_GetChild(GetHwnd(), HITEM(parent));
+
     HTREEITEM id = TreeView_InsertItem(GetHwnd(), &tvIns);
     if ( id == 0 )
     {
         wxLogLastError(wxT("TreeView_InsertItem"));
+    }
+
+    // apparently some Windows versions (2000 and XP are reported to do this)
+    // sometimes don't refresh the tree after adding the first child and so we
+    // need this to make the "[+]" appear
+    if ( firstChild )
+    {
+        TVGetItemRectParam param2;
+
+        wxTreeView_GetItemRect(GetHwnd(), HITEM(parent), param2, FALSE);
+        ::InvalidateRect(GetHwnd(), &param2.rect, FALSE);
     }
 
     // associate the application tree item with Win32 tree item handle

--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -1505,26 +1505,10 @@ wxTreeItemId wxTreeCtrl::DoInsertAfter(const wxTreeItemId& parent,
     tvIns.item.lParam = (LPARAM)param;
     tvIns.item.mask = mask;
 
-    // don't use the hack below for the children of hidden root: this results
-    // in a crash inside comctl32.dll when we call TreeView_GetItemRect()
-    const bool firstChild = !IsHiddenRoot(parent) &&
-                                !TreeView_GetChild(GetHwnd(), HITEM(parent));
-
     HTREEITEM id = TreeView_InsertItem(GetHwnd(), &tvIns);
     if ( id == 0 )
     {
         wxLogLastError(wxT("TreeView_InsertItem"));
-    }
-
-    // apparently some Windows versions (2000 and XP are reported to do this)
-    // sometimes don't refresh the tree after adding the first child and so we
-    // need this to make the "[+]" appear
-    if ( firstChild )
-    {
-        TVGetItemRectParam param2;
-
-        wxTreeView_GetItemRect(GetHwnd(), HITEM(parent), param2, FALSE);
-        ::InvalidateRect(GetHwnd(), &param2.rect, FALSE);
     }
 
     // associate the application tree item with Win32 tree item handle

--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -1505,10 +1505,26 @@ wxTreeItemId wxTreeCtrl::DoInsertAfter(const wxTreeItemId& parent,
     tvIns.item.lParam = (LPARAM)param;
     tvIns.item.mask = mask;
 
+    // don't use the hack below for the children of hidden root: this results
+    // in a crash inside comctl32.dll when we call TreeView_GetItemRect()
+    const bool firstChild = !IsHiddenRoot(parent) &&
+                                !TreeView_GetChild(GetHwnd(), HITEM(parent));
+
     HTREEITEM id = TreeView_InsertItem(GetHwnd(), &tvIns);
     if ( id == 0 )
     {
         wxLogLastError(wxT("TreeView_InsertItem"));
+    }
+
+    // apparently some Windows versions (2000 and XP are reported to do this)
+    // sometimes don't refresh the tree after adding the first child and so we
+    // need this to make the "[+]" appear
+    if ( firstChild && (wxGetWinVersion() >= wxWinVersion_Vista) )
+    {
+        TVGetItemRectParam param2;
+
+        wxTreeView_GetItemRect(GetHwnd(), HITEM(parent), param2, FALSE);
+        ::InvalidateRect(GetHwnd(), &param2.rect, FALSE);
     }
 
     // associate the application tree item with Win32 tree item handle

--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -1507,7 +1507,8 @@ wxTreeItemId wxTreeCtrl::DoInsertAfter(const wxTreeItemId& parent,
 
     // don't use the hack below for the children of hidden root: this results
     // in a crash inside comctl32.dll when we call TreeView_GetItemRect()
-    const bool firstChild = !IsHiddenRoot(parent) &&
+    const bool oldWinVersion = (wxGetWinVersion() < wxWinVersion_Vista);
+    const bool firstChild = oldWinVersion && !IsHiddenRoot(parent) &&
                                 !TreeView_GetChild(GetHwnd(), HITEM(parent));
 
     HTREEITEM id = TreeView_InsertItem(GetHwnd(), &tvIns);
@@ -1519,7 +1520,7 @@ wxTreeItemId wxTreeCtrl::DoInsertAfter(const wxTreeItemId& parent,
     // apparently some Windows versions (2000 and XP are reported to do this)
     // sometimes don't refresh the tree after adding the first child and so we
     // need this to make the "[+]" appear
-    if ( firstChild && (wxGetWinVersion() >= wxWinVersion_Vista) )
+    if ( firstChild )
     {
         TVGetItemRectParam param2;
 


### PR DESCRIPTION
Removed (apparently) outdated fix for MSW implementation of wxTreeCtrl::DoInsertAfter().
The old fix changes slow down the insertion of first child items in big trees.