### PR TITLE
Make the private.h header compatible with Clang.

### DIFF
--- a/include/wx/msw/private.h
+++ b/include/wx/msw/private.h
@@ -153,7 +153,7 @@ extern LONG APIENTRY
 #endif
 
 // close the handle in the class dtor
-template <wxUIntPtr INVALID_VALUE = (wxUIntPtr)INVALID_HANDLE_VALUE>
+template <wxUIntPtr INVALID_VALUE>
 class AutoHANDLE
 {
 public:


### PR DESCRIPTION
The include/wx/msw/private.h header contains a violation of the C++ standards that MSVC tolerates but Clang/LLVM does not.

WinBase.h contains the definition:
    #define INVALID_HANDLE_VALUE ((HANDLE)(LONG_PTR)-1)

Which wxWidgets uses as a template parameter.

The (effective) reinterpret_cast-ing of INVALID_HANDLE_VALUE means that the define isn't actually usable as a constant expression for template parameters.

Clang has indicated they have no intention of adding an MSVC compatibility workaround for this problem. See [LLVM bug 12116]( https://bugs.llvm.org/show_bug.cgi?id=12116).

Given this, rework the wxWidgets header to specify the value directly and use a regular cast. With this change, it's possible to compile wxWidgets applications using Clang/LLVM (5.0) under MSVC.