### PR TITLE
bug fixed (MSW Generic): SetSelections(const wxDataViewItemArray & sel) was not setting the current item

### DIFF
--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -5434,8 +5434,8 @@ void wxDataViewCtrl::SetSelections( const wxDataViewItemArray & sel )
 
     if (sel.size() > 0)
     {
-        // Also make the first item as current item
-        DoSetCurrentItem(sel.front());
+        // Also make the last item as current item
+        DoSetCurrentItem(sel.Last());
     }
 }
 

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -5431,6 +5431,12 @@ void wxDataViewCtrl::SetSelections( const wxDataViewItemArray & sel )
         if( row >= 0 )
             m_clientArea->SelectRow(static_cast<unsigned int>(row), true);
     }
+
+    if (sel.size() > 0)
+    {
+        // Also make the first item as current item
+        DoSetCurrentItem(sel.front());
+    }
 }
 
 void wxDataViewCtrl::Select( const wxDataViewItem & item )


### PR DESCRIPTION
Description: SetSelections was clearing the previous selections and after selecting new selections, it was not setting the current item.

This was causing issues in keyboard selection.
Example: Select 0th row via SetSelctions() and then press (Shift + Click) tp select last row.
Observation: First and last rows gets selected instead of continuos all rows selected.

Signed-off-by: Anil Kumar <anilkumar8753@gmail.com>