### PR TITLE
Fix wxTreeListCtrl items comparison when using checkboxes

### DIFF
--- a/include/wx/dataview.h
+++ b/include/wx/dataview.h
@@ -276,6 +276,16 @@ protected:
     // the user should not delete this class directly: he should use DecRef() instead!
     virtual ~wxDataViewModel() { }
 
+    // Helper function used by the default Compare() implementation to compare
+    // values of types it is not aware about. Can be overridden in the derived
+    // classes that use columns of custom types.
+    virtual int DoCompareValues(const wxVariant& WXUNUSED(value1),
+                                const wxVariant& WXUNUSED(value2)) const
+    {
+        return 0;
+    }
+
+
     wxDataViewModelNotifiers  m_notifiers;
 };
 

--- a/interface/wx/dataview.h
+++ b/interface/wx/dataview.h
@@ -138,7 +138,9 @@ public:
         The compare function to be used by the control. The default compare
         function sorts most data types implemented by wxVariant (i.e. bool,
         int, long, double, string) as well as datetime and wxDataViewIconText.
-        Override this for a different sorting behaviour.
+        Override this method to implement a different sorting behaviour or
+        override just DoCompareValues() to extend it to support other wxVariant
+        types.
 
         The function should return negative, null or positive for an ascending
         comparison, depending on whether the first item is less than, equal to
@@ -171,7 +173,8 @@ public:
 
             return (ascending == (id1 > id2)) ? : 1 : -1;
         @endcode
-        @see HasDefaultCompare().
+
+        @see HasDefaultCompare(), DoCompareValues()
     */
     virtual int Compare(const wxDataViewItem& item1,
                         const wxDataViewItem& item2,
@@ -377,6 +380,32 @@ protected:
         Destructor. This should not be called directly. Use DecRef() instead.
     */
     virtual ~wxDataViewModel();
+
+    /**
+        Virtual method that can be overridden to define comparison for values
+        of non-standard types.
+
+        This function is called from the default Compare() implementation to
+        compare values of types it is not aware about (i.e. not any of the
+        standard ones). As Compare() itself, this method should return a
+        negative value if @a value1 is less than (i.e. should appear above) @a
+        value2 and a positive value if @a value2 is less than @a value1.
+
+        Unlike Compare(), if the values are equal, this method should just
+        return 0 to indicate it and let Compare() order them by their items
+        values. It also doesn't have to care about the sort order direction,
+        making it simpler to override than Compare() itself.
+
+        The default implementation just returns 0, so the derived class version
+        can simply forward to it if it doesn't know how to compare the given
+        values.
+
+        @see Compare()
+
+        @since 3.1.1
+    */
+    virtual int DoCompareValues(const wxVariant& value1,
+                                const wxVariant& value2) const;
 };
 
 

--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -378,6 +378,12 @@ int wxDataViewModel::Compare( const wxDataViewItem &item1, const wxDataViewItem 
         if (res != 0)
           return res;
     }
+    else
+    {
+        int res = DoCompareValues(value1, value2);
+        if (res != 0)
+            return res;
+    }
 
 
     // items must be different

--- a/src/generic/treelist.cpp
+++ b/src/generic/treelist.cpp
@@ -387,6 +387,10 @@ public:
                         unsigned col,
                         bool ascending) const wxOVERRIDE;
 
+protected:
+    virtual int DoCompareValues(const wxVariant& value1,
+                                const wxVariant& value2) const wxOVERRIDE;
+
 private:
     // The control we're associated with.
     wxTreeListCtrl* const m_treelist;
@@ -1005,6 +1009,22 @@ wxTreeListModel::Compare(const wxDataViewItem& item1,
         result = -result;
 
     return result;
+}
+
+int wxTreeListModel::DoCompareValues(const wxVariant& value1,
+                                     const wxVariant& value2) const
+{
+    if ( value1.GetType() == wxS("wxDataViewCheckIconText") )
+    {
+        wxDataViewCheckIconText iconText1, iconText2;
+
+        iconText1 << value1;
+        iconText2 << value2;
+
+        return iconText1.GetText().Cmp(iconText2.GetText());
+    }
+
+    return wxDataViewModel::DoCompareValues(value1, value2);
 }
 
 // ============================================================================


### PR DESCRIPTION
And add a handy `DoCompareValues()` method to wxDVC.