### PR TITLE
Introduce wxFontInfo LetterSpacing property

### DIFF
--- a/include/wx/font.h
+++ b/include/wx/font.h
@@ -155,6 +155,9 @@ public:
     wxFontInfo& Encoding(wxFontEncoding encoding)
         { m_encoding = encoding; return *this; }
 
+    wxFontInfo& LetterSpacing(wxDouble spacing)
+        { m_spacing = spacing; return *this; }
+
 
     // Set all flags at once.
     wxFontInfo& AllFlags(int flags)
@@ -205,6 +208,7 @@ public:
 
     wxFontEncoding GetEncoding() const { return m_encoding; }
 
+    wxDouble GetLetterSpacing() const { return m_spacing; }
 
     // Default copy ctor, assignment operator and dtor are OK.
 
@@ -216,6 +220,7 @@ private:
         m_family = wxFONTFAMILY_DEFAULT;
         m_flags = wxFONTFLAG_DEFAULT;
         m_encoding = wxFONTENCODING_DEFAULT;
+        m_spacing = 0;
     }
 
     void InitPointSize(int pointSize)
@@ -247,6 +252,7 @@ private:
     wxString m_faceName;
     int m_flags;
     wxFontEncoding m_encoding;
+    wxDouble m_spacing;
 };
 
 // ----------------------------------------------------------------------------
@@ -345,6 +351,8 @@ public:
     virtual wxFontEncoding GetEncoding() const = 0;
     virtual const wxNativeFontInfo *GetNativeFontInfo() const = 0;
 
+    virtual wxDouble GetLetterSpacing() const;
+
     virtual bool IsFixedWidth() const;
 
     wxString GetNativeFontInfoDesc() const;
@@ -363,6 +371,8 @@ public:
     virtual bool SetFaceName( const wxString& faceName );
     void SetNativeFontInfo(const wxNativeFontInfo& info)
         { DoSetNativeFontInfo(info); }
+
+    virtual void SetLetterSpacing(wxDouble spacing);
 
     bool SetNativeFontInfo(const wxString& info);
     bool SetNativeFontInfoUserDesc(const wxString& info);

--- a/include/wx/fontutil.h
+++ b/include/wx/fontutil.h
@@ -79,6 +79,7 @@ public:
     // separately and handle them ourselves in {To,From}String() methods.
     bool m_underlined;
     bool m_strikethrough;
+    wxDouble m_spacing;
 #elif defined(_WX_X_FONTLIKE)
     // the members can't be accessed directly as we only parse the
     // xFontName on demand
@@ -170,6 +171,7 @@ public:
     bool          m_strikethrough;
     wxString      m_faceName;
     wxFontEncoding m_encoding;
+    wxDouble      m_spacing;
 public :
 #elif defined(__WXQT__)
     QFont m_qtFont;
@@ -188,6 +190,7 @@ public :
     bool          strikethrough;
     wxString      faceName;
     wxFontEncoding encoding;
+    wxDouble      spacing;
 #endif // platforms
 
     // default ctor (default copy ctor is ok)
@@ -260,6 +263,7 @@ public:
     wxString GetFaceName() const;
     wxFontFamily GetFamily() const;
     wxFontEncoding GetEncoding() const;
+    wxDouble GetLetterSpacing() const;
 
     void SetPointSize(int pointsize);
     void SetPixelSize(const wxSize& pixelSize);
@@ -270,6 +274,7 @@ public:
     bool SetFaceName(const wxString& facename);
     void SetFamily(wxFontFamily family);
     void SetEncoding(wxFontEncoding encoding);
+    void SetLetterSpacing(wxDouble spacing);
 
     // sets the first facename in the given array which is found
     // to be valid. If no valid facename is given, sets the

--- a/include/wx/gtk/font.h
+++ b/include/wx/gtk/font.h
@@ -71,6 +71,7 @@ public:
     virtual bool GetUnderlined() const wxOVERRIDE;
     virtual bool GetStrikethrough() const wxOVERRIDE;
     virtual wxFontEncoding GetEncoding() const wxOVERRIDE;
+    virtual wxDouble GetLetterSpacing() const wxOVERRIDE;
     virtual const wxNativeFontInfo *GetNativeFontInfo() const wxOVERRIDE;
     virtual bool IsFixedWidth() const wxOVERRIDE;
 
@@ -82,6 +83,7 @@ public:
     virtual void SetUnderlined( bool underlined ) wxOVERRIDE;
     virtual void SetStrikethrough(bool strikethrough) wxOVERRIDE;
     virtual void SetEncoding(wxFontEncoding encoding) wxOVERRIDE;
+    virtual void SetLetterSpacing(wxDouble spacing) wxOVERRIDE;
 
     wxDECLARE_COMMON_FONT_METHODS();
 

--- a/include/wx/msw/font.h
+++ b/include/wx/msw/font.h
@@ -94,6 +94,7 @@ public:
     virtual bool GetStrikethrough() const wxOVERRIDE;
     virtual wxString GetFaceName() const wxOVERRIDE;
     virtual wxFontEncoding GetEncoding() const wxOVERRIDE;
+    virtual wxDouble GetLetterSpacing() const wxOVERRIDE;
     virtual const wxNativeFontInfo *GetNativeFontInfo() const wxOVERRIDE;
 
     virtual void SetPointSize(int pointSize) wxOVERRIDE;
@@ -105,6 +106,7 @@ public:
     virtual void SetUnderlined(bool underlined) wxOVERRIDE;
     virtual void SetStrikethrough(bool strikethrough) wxOVERRIDE;
     virtual void SetEncoding(wxFontEncoding encoding) wxOVERRIDE;
+    virtual void SetLetterSpacing(wxDouble spacing) wxOVERRIDE;
 
     wxDECLARE_COMMON_FONT_METHODS();
 

--- a/include/wx/osx/font.h
+++ b/include/wx/osx/font.h
@@ -48,6 +48,9 @@ public:
 
         if ( info.IsUsingSizeInPixels() )
             SetPixelSize(info.GetPixelSize());
+
+        if ( info.GetLetterSpacing() )
+            SetLetterSpacing(info.GetLetterSpacing());
     }
 
     wxFont( wxOSXSystemFont systemFont );
@@ -107,6 +110,7 @@ public:
     virtual bool GetStrikethrough() const;
     virtual wxString GetFaceName() const;
     virtual wxFontEncoding GetEncoding() const;
+    virtual wxDouble GetLetterSpacing() const;
     virtual const wxNativeFontInfo *GetNativeFontInfo() const;
 
     virtual bool IsFixedWidth() const;
@@ -119,6 +123,7 @@ public:
     virtual void SetUnderlined(bool underlined);
     virtual void SetStrikethrough(bool strikethrough);
     virtual void SetEncoding(wxFontEncoding encoding);
+    virtual void SetLetterSpacing(wxDouble spacing);
 
     wxDECLARE_COMMON_FONT_METHODS();
 

--- a/src/common/fontcmn.cpp
+++ b/src/common/fontcmn.cpp
@@ -118,6 +118,8 @@ wxPROPERTY( Face, wxString, SetFaceName, GetFaceName, wxEMPTY_PARAMETER_VALUE, \
            0 /*flags*/, wxT("Helpstring"), wxT("group"))
 wxPROPERTY( Encoding, wxFontEncoding, SetEncoding, GetEncoding, \
            wxFONTENCODING_DEFAULT, 0 /*flags*/, wxT("Helpstring"), wxT("group"))
+wxPROPERTY( LetterSpacing, wxDouble, SetLetterSpacing, GetLetterSpacing, \
+            0, 0 /*flags*/, wxT("Helpstring"), wxT("group"))
 wxEND_PROPERTIES_TABLE()
 
 wxCONSTRUCTOR_6( wxFont, int, Size, wxFontFamily, Family, wxFontStyle, Style, wxFontWeight, Weight, \
@@ -298,6 +300,18 @@ void wxFontBase::SetPixelSize( const wxSize& pixelSize )
 
     if (currentSize != largestGood)
         SetPointSize(largestGood);
+}
+
+wxDouble wxFontBase::GetLetterSpacing() const
+{
+    // ?
+    return 0;
+}
+
+void wxFontBase::SetLetterSpacing(wxDouble spacing)
+{
+    // ?
+    WXUNUSED(spacing);
 }
 
 void wxFontBase::DoSetNativeFontInfo(const wxNativeFontInfo& info)
@@ -699,6 +713,7 @@ void wxNativeFontInfo::Init()
     strikethrough = false;
     faceName.clear();
     encoding = wxFONTENCODING_DEFAULT;
+    spacing = 0;
 }
 
 int wxNativeFontInfo::GetPointSize() const
@@ -741,6 +756,11 @@ wxFontEncoding wxNativeFontInfo::GetEncoding() const
     return encoding;
 }
 
+wxDouble wxNativeFontInfo::GetLetterSpacing() const
+{
+    return spacing;
+}
+
 void wxNativeFontInfo::SetPointSize(int pointsize)
 {
     pointSize = pointsize;
@@ -780,6 +800,11 @@ void wxNativeFontInfo::SetFamily(wxFontFamily family_)
 void wxNativeFontInfo::SetEncoding(wxFontEncoding encoding_)
 {
     encoding = encoding_;
+}
+
+void wxNativeFontInfo::SetLetterSpacing(wxDouble spacing_)
+{
+    spacing = spacing_;
 }
 
 #endif // generic wxNativeFontInfo implementation

--- a/src/msw/font.cpp
+++ b/src/msw/font.cpp
@@ -160,6 +160,11 @@ public:
         return m_nativeFontInfo.GetEncoding();
     }
 
+    wxDouble GetLetterSpacing() const
+    {
+        return m_nativeFontInfo.GetLetterSpacing();
+    }
+
     WXHFONT GetHFONT() const
     {
         AllocIfNeeded();
@@ -241,6 +246,13 @@ public:
         Free();
 
         m_nativeFontInfo.SetEncoding(encoding);
+    }
+
+    void SetLetterSpacing(wxDouble spacing)
+    {
+        Free();
+
+        m_nativeFontInfo.SetLetterSpacing(spacing);
     }
 
     const wxNativeFontInfo& GetNativeFontInfo() const
@@ -811,6 +823,9 @@ wxFont::wxFont(const wxFontInfo& info)
                                   info.IsStrikethrough(),
                                   info.GetFaceName(),
                                   info.GetEncoding());
+
+    if ( info.GetLetterSpacing() )
+        M_FONTDATA->SetLetterSpacing(info.GetLetterSpacing());
 }
 
 bool wxFont::Create(const wxNativeFontInfo& info, WXHFONT hFont)
@@ -818,6 +833,9 @@ bool wxFont::Create(const wxNativeFontInfo& info, WXHFONT hFont)
     UnRef();
 
     m_refData = new wxFontRefData(info, hFont);
+
+    if ( info.GetLetterSpacing() )
+        M_FONTDATA->SetLetterSpacing(info.GetLetterSpacing());
 
     return RealizeResource();
 }
@@ -979,6 +997,13 @@ void wxFont::SetEncoding(wxFontEncoding encoding)
     M_FONTDATA->SetEncoding(encoding);
 }
 
+void wxFont::SetLetterSpacing(wxDouble spacing)
+{
+    AllocExclusive();
+
+    M_FONTDATA->SetLetterSpacing(spacing);
+}
+
 void wxFont::DoSetNativeFontInfo(const wxNativeFontInfo& info)
 {
     AllocExclusive();
@@ -1056,6 +1081,13 @@ wxFontEncoding wxFont::GetEncoding() const
     wxCHECK_MSG( IsOk(), wxFONTENCODING_DEFAULT, wxT("invalid font") );
 
     return M_FONTDATA->GetEncoding();
+}
+
+wxDouble wxFont::GetLetterSpacing() const
+{
+    wxCHECK_MSG( IsOk(), 0, wxT("invalid font") );
+
+    return M_FONTDATA->GetLetterSpacing();
 }
 
 const wxNativeFontInfo *wxFont::GetNativeFontInfo() const

--- a/src/osx/carbon/font.cpp
+++ b/src/osx/carbon/font.cpp
@@ -146,6 +146,33 @@ public:
 
     wxFontEncoding GetEncoding() const { return m_info.GetEncoding(); }
     
+    void SetLetterSpacing( wxDouble spacing )
+    {
+        //if ( m_info.m_spacing != spacing )
+        //{
+        //    m_info.SetLetterSpacing( spacing );
+        //    Free();
+        //}
+
+        // Note: do NOT set kCTKernAttribute to zero, that's used to disable kerning! (tristate attr)
+        if (!spacing)
+        {
+            return;
+        }
+        CFDictionarySetValue(
+            m_ctFontAttributes, kCTKernAttributeName, CFNumberCreate( NULL, kCFNumberFloatType, &spacing));
+    }
+
+    wxDouble GetLetterSpacing() const {
+        //return m_info.GetLetterSpacing();
+        wxDouble spacing = 0;
+        CFNumberRef sp_ = CFNumberCreate(kCFAllocatorDefault, kCFNumberFloatType, &spacing);
+        CFNumberGetValue((CFNumberRef) CFDictionaryGetValue(
+            m_ctFontAttributes, kCTKernAttributeName), kCFNumberFloatType, &spacing);
+        CFRelease(sp_);
+        return spacing;
+    }
+
     bool IsFixedWidth() const;
 
     void Free();
@@ -158,7 +185,7 @@ protected:
 public:
     bool            m_fontValid;
     wxCFRef<CTFontRef> m_ctFont;
-    wxCFRef<CFDictionaryRef> m_ctFontAttributes;
+    wxCFRef<CFMutableDictionaryRef> m_ctFontAttributes;
     wxCFRef<CGFontRef> m_cgFont;
     wxNativeFontInfo  m_info;
 };
@@ -561,6 +588,13 @@ void wxFont::SetStrikethrough(bool strikethrough)
      M_FONTDATA->SetStrikethrough( strikethrough );
 }
 
+void wxFont::SetLetterSpacing(wxDouble spacing)
+{
+    AllocExclusive();
+
+    M_FONTDATA->SetLetterSpacing( spacing );
+}
+
 // ----------------------------------------------------------------------------
 // accessors
 // ----------------------------------------------------------------------------
@@ -644,6 +678,13 @@ wxFontEncoding wxFont::GetEncoding() const
     wxCHECK_MSG( M_FONTDATA != NULL , wxFONTENCODING_DEFAULT , wxT("invalid font") );
 
     return M_FONTDATA->GetEncoding() ;
+}
+
+wxDouble wxFont::GetLetterSpacing() const
+{
+    wxCHECK_MSG( M_FONTDATA != NULL , 0 , wxT("invalid font") );
+
+    return M_FONTDATA->GetLetterSpacing() ;
 }
 
 CTFontRef wxFont::OSXGetCTFont() const
@@ -791,6 +832,7 @@ void wxNativeFontInfo::Init()
     m_strikethrough = false;
     m_faceName.clear();
     m_encoding = wxFont::GetDefaultEncoding();
+    //m_spacing = 0;
 }
 
 void wxNativeFontInfo::Init(CTFontDescriptorRef descr)
@@ -829,6 +871,7 @@ void wxNativeFontInfo::Init(const wxNativeFontInfo& info)
     m_strikethrough = info.m_strikethrough;
     m_faceName = info.m_faceName;
     m_encoding = info.m_encoding;
+    //m_spacing = info.m_spacing;
 }
 
 void wxNativeFontInfo::Init(int size,
@@ -986,6 +1029,11 @@ wxFontEncoding wxNativeFontInfo::GetEncoding() const
     return m_encoding;
 }
 
+//wxDouble wxNativeFontInfo::GetLetterSpacing() const
+//{
+//    return m_spacing;
+//}
+
 bool wxNativeFontInfo::GetStrikethrough() const
 {
     return m_strikethrough;
@@ -1056,6 +1104,11 @@ void wxNativeFontInfo::SetEncoding(wxFontEncoding encoding_)
     m_encoding = encoding_;
     // not reflected in native descriptors
 }
+
+//void wxNativeFontInfo::SetLetterSpacing(wxDouble spacing_)
+//{
+//    m_spacing = spacing_;
+//}
 
 void wxNativeFontInfo::SetStrikethrough(bool strikethrough)
 {


### PR DESCRIPTION
First shot, let's see how buildbots like it.

todo:

- [x] AAPL api is in points so need to convert dip to points
  edit: according to [here](https://github.com/behdad/harfbuzz/commit/95883fc5d486ecd194253bb223802f930de73e28) points are like CSS pixels so like dip on Windows. no conversion needed then
- [ ] make sure GetTextExtent() takes spacing into account
- [ ] fill interface files