### PR TITLE
Fix typo in wxPropertyGrid documentation

### DIFF
--- a/include/wx/propgrid/propgrid.h
+++ b/include/wx/propgrid/propgrid.h
@@ -942,7 +942,7 @@ public:
 
     // Resets column sizes and splitter positions, based on proportions.
     // enableAutoResizing - If true, automatic column resizing is enabled
-    // (only applicapple if window style wxPG_SPLITTER_AUTO_CENTER is used).
+    // (only applicable if window style wxPG_SPLITTER_AUTO_CENTER is used).
     void ResetColumnSizes( bool enableAutoResizing = false );
 
     // Selects a property.

--- a/interface/wx/propgrid/propgrid.h
+++ b/interface/wx/propgrid/propgrid.h
@@ -984,7 +984,7 @@ public:
         Resets column sizes and splitter positions, based on proportions.
 
         @param enableAutoResizing
-            If @true, automatic column resizing is enabled (only applicapple
+            If @true, automatic column resizing is enabled (only applicable
             if window style wxPG_SPLITTER_AUTO_CENTER is used).
 
         @see wxPropertyGridInterface::SetColumnProportion()

--- a/interface/wx/propgrid/propgridiface.h
+++ b/interface/wx/propgrid/propgridiface.h
@@ -884,7 +884,7 @@ public:
                                wxVariant value, long argFlags = 0 );
 
     /**
-        Sets property attribute for all applicapple properties.
+        Sets property attribute for all applicable properties.
         Be sure to use this method only after all properties have been
         added to the grid.
 


### PR DESCRIPTION
i.e. applicapple -> applicable.