### PR TITLE
Better assert dialog

### DIFF
--- a/src/common/appbase.cpp
+++ b/src/common/appbase.cpp
@@ -1307,7 +1307,7 @@ bool DoShowAssertDialog(const wxString& msg)
               wxT("further warnings.");
 
     switch ( ::MessageBox(NULL, msgDlg.t_str(), wxT("wxWidgets Debug Alert"),
-                          MB_YESNOCANCEL | MB_ICONSTOP ) )
+                          MB_YESNOCANCEL | MB_DEFBUTTON2 | MB_ICONSTOP ) )
     {
         case IDYES:
             // If we called wxTrap() directly from here, the programmer would

--- a/src/common/appcmn.cpp
+++ b/src/common/appcmn.cpp
@@ -489,7 +489,9 @@ bool wxGUIAppTraitsBase::ShowAssertDialog(const wxString& msg)
                               wxYES_NO | wxCANCEL | wxICON_STOP ) )
         {
             case wxYES:
-                wxTrap();
+                // See the comment about using the same variable in
+                // DoShowAssertDialog().
+                wxTrapInAssert = true;
                 break;
 
             case wxCANCEL:

--- a/src/common/appcmn.cpp
+++ b/src/common/appcmn.cpp
@@ -485,8 +485,11 @@ bool wxGUIAppTraitsBase::ShowAssertDialog(const wxString& msg)
                   wxT("You can also choose [Cancel] to suppress ")
                   wxT("further warnings.");
 
+        // "No" button means to continue execution, so it should be the default
+        // action as leaving the "Yes" button the default one would mean that
+        // accidentally pressing Space or Enter would trap and kill the program.
         switch ( wxMessageBox(msgDlg, wxT("wxWidgets Debug Alert"),
-                              wxYES_NO | wxCANCEL | wxICON_STOP ) )
+                              wxYES_NO | wxCANCEL | wxNO_DEFAULT | wxICON_STOP ) )
         {
             case wxYES:
                 // See the comment about using the same variable in


### PR DESCRIPTION
Some assert dialog improvements (at least for non-wxGTK, wxGTK already has a decent assert dialog).

The main change is the last commit, any thoughts about using (or not) `wxRichMessageDialog` here are welcome.