### PR TITLE
Add support for UTF8 filenames in wxZipOutputStream

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -74,6 +74,9 @@ INCOMPATIBLE CHANGES SINCE 3.1.0:
 
 - The enum value wxTASKBAR_JUMP_LIST_DESTIONATION, which was added in 3.1.0,
   contains a typo and has been renamed to wxTASKBAR_JUMP_LIST_DESTINATION.
+  
+- wxZipOutputStream will now automatically convert filenames to UTF-8, if the
+  wxMBConv used when calling the constructor supports UTF-8 encoding.
 
 
 All:
@@ -98,6 +101,7 @@ All:
 - Add wxCMD_LINE_HIDDEN wxCmdLineParser flag (Lauri Nurmi).
 - Fix wxRmdir() with non-ASCII paths (trivia21).
 - Don't crash in wxFFile::Eof() or Error() on closed file (jprotopopov).
+- Add UTF-8 support to wxZipOutputStream (Tobias Taschner).
 
 All (GUI):
 

--- a/include/wx/strconv.h
+++ b/include/wx/strconv.h
@@ -133,12 +133,10 @@ public:
     // encoding
     static size_t GetMaxMBNulLen() { return 4 /* for UTF-32 */; }
 
-#if wxUSE_UNICODE_UTF8
     // return true if the converter's charset is UTF-8, i.e. char* strings
     // decoded using this object can be directly copied to wxString's internal
     // storage without converting to WC and than back to UTF-8 MB string
     virtual bool IsUTF8() const { return false; }
-#endif
 
     // The old conversion functions. The existing classes currently mostly
     // implement these ones but we're in transition to using To/FromWChar()
@@ -180,9 +178,7 @@ public:
 
     virtual wxMBConv *Clone() const wxOVERRIDE { return new wxMBConvLibc; }
 
-#if wxUSE_UNICODE_UTF8
     virtual bool IsUTF8() const wxOVERRIDE { return wxLocaleIsUtf8; }
-#endif
 };
 
 #ifdef __UNIX__
@@ -221,9 +217,7 @@ public:
         return m_conv->GetMBNulLen();
     }
 
-#if wxUSE_UNICODE_UTF8
     virtual bool IsUTF8() const wxOVERRIDE { return m_conv->IsUTF8(); }
-#endif
 
     virtual wxMBConv *Clone() const wxOVERRIDE { return new wxConvBrokenFileNames(*this); }
 
@@ -342,11 +336,9 @@ public:
 
     virtual wxMBConv *Clone() const wxOVERRIDE { return new wxMBConvStrictUTF8(); }
 
-#if wxUSE_UNICODE_UTF8
     // NB: other mapping modes are not, strictly speaking, UTF-8, so we can't
     //     take the shortcut in that case
     virtual bool IsUTF8() const wxOVERRIDE { return true; }
-#endif
 };
 
 class WXDLLIMPEXP_BASE wxMBConvUTF8 : public wxMBConvStrictUTF8
@@ -368,11 +360,9 @@ public:
 
     virtual wxMBConv *Clone() const wxOVERRIDE { return new wxMBConvUTF8(m_options); }
 
-#if wxUSE_UNICODE_UTF8
     // NB: other mapping modes are not, strictly speaking, UTF-8, so we can't
     //     take the shortcut in that case
     virtual bool IsUTF8() const wxOVERRIDE { return m_options == MAP_INVALID_UTF8_NOT; }
-#endif
 
 private:
     int m_options;
@@ -496,9 +486,7 @@ public:
                              const wchar_t *src, size_t srcLen = wxNO_LEN) const wxOVERRIDE;
     virtual size_t GetMBNulLen() const wxOVERRIDE;
 
-#if wxUSE_UNICODE_UTF8
     virtual bool IsUTF8() const wxOVERRIDE;
-#endif
 
     virtual wxMBConv *Clone() const wxOVERRIDE { return new wxCSConv(*this); }
 

--- a/include/wx/wxcrtbase.h
+++ b/include/wx/wxcrtbase.h
@@ -75,7 +75,6 @@
    ------------------------------------------------------------------------- */
 
 #ifdef __cplusplus
-    #if wxUSE_UNICODE_UTF8
         /* flag indicating whether the current locale uses UTF-8 or not; must be
            updated every time the locale is changed! */
         #if wxUSE_UTF8_LOCALE_ONLY
@@ -85,9 +84,6 @@
         #endif
         /* function used to update the flag: */
         extern WXDLLIMPEXP_BASE void wxUpdateLocaleIsUtf8();
-    #else /* !wxUSE_UNICODE_UTF8 */
-        inline void wxUpdateLocaleIsUtf8() {}
-    #endif /* wxUSE_UNICODE_UTF8/!wxUSE_UNICODE_UTF8 */
 #endif /* __cplusplus */
 
 

--- a/include/wx/zipstrm.h
+++ b/include/wx/zipstrm.h
@@ -236,6 +236,8 @@ private:
 
     bool LoadExtraInfo(const char* extraData, wxUint16 extraLen, bool localInfo);
 
+    wxUint16 GetInternalFlags(bool checkForUTF8) const;
+
     wxUint8      m_SystemMadeBy;       // one of enum wxZipSystem
     wxUint8      m_VersionMadeBy;      // major * 10 + minor
 
@@ -278,10 +280,10 @@ class WXDLLIMPEXP_BASE wxZipOutputStream : public wxArchiveOutputStream
 public:
     wxZipOutputStream(wxOutputStream& stream,
                       int level = -1,
-                      wxMBConv& conv = wxConvLocal);
+                      wxMBConv& conv = wxConvUTF8);
     wxZipOutputStream(wxOutputStream *stream,
                       int level = -1,
-                      wxMBConv& conv = wxConvLocal);
+                      wxMBConv& conv = wxConvUTF8);
     virtual WXZIPFIX ~wxZipOutputStream();
 
     bool PutNextEntry(wxZipEntry *entry)        { return DoCreate(entry); }

--- a/interface/wx/strconv.h
+++ b/interface/wx/strconv.h
@@ -69,6 +69,13 @@ public:
     static size_t GetMaxMBNulLen();
 
     /**
+        return true if the converter's charset is UTF-8, i.e. char* strings
+        decoded using this object can be directly copied to wxString's internal
+        storage without converting to WC and than back to UTF-8 MB string
+    */
+    virtual bool IsUTF8() const;
+
+    /**
         Convert multibyte string to a wide character one.
 
         This is the most general function for converting a multibyte string to

--- a/interface/wx/zipstrm.h
+++ b/interface/wx/zipstrm.h
@@ -479,11 +479,18 @@ public:
         In a Unicode build the third parameter @a conv is used to translate
         the filename and comment fields to an 8-bit encoding.
         It has no effect on the stream's data.
+
+        Since version 3.1.1, filenames in the generated archive will be encoded
+        using UTF-8 and marked according to ZIP specification. To get the
+        previous behaviour wxConvLocal may be provided as the conv object.
+        Please note that not all unzip applications are fully ZIP spec
+        compatible and may not correctly decode UTF-8 characters. For the best
+        interoperability using only ASCII characters is the safest option.
     */
     wxZipOutputStream(wxOutputStream& stream, int level = -1,
-                      wxMBConv& conv = wxConvLocal);
+                      wxMBConv& conv = wxConvUTF8);
     wxZipOutputStream(wxOutputStream* stream, int level = -1,
-                      wxMBConv& conv = wxConvLocal);
+                      wxMBConv& conv = wxConvUTF8);
     //@}
 
     /**

--- a/src/common/strconv.cpp
+++ b/src/common/strconv.cpp
@@ -2128,9 +2128,7 @@ public:
                              const wchar_t *src, size_t srcLen = wxNO_LEN) const wxOVERRIDE;
     virtual size_t GetMBNulLen() const wxOVERRIDE;
 
-#if wxUSE_UNICODE_UTF8
     virtual bool IsUTF8() const wxOVERRIDE;
-#endif
 
     virtual wxMBConv *Clone() const wxOVERRIDE
     {
@@ -2516,13 +2514,11 @@ size_t wxMBConv_iconv::GetMBNulLen() const
     return m_minMBCharWidth;
 }
 
-#if wxUSE_UNICODE_UTF8
 bool wxMBConv_iconv::IsUTF8() const
 {
     return wxStricmp(m_name, "UTF-8") == 0 ||
            wxStricmp(m_name, "UTF8") == 0;
 }
-#endif
 
 #endif // HAVE_ICONV
 
@@ -3250,7 +3246,6 @@ size_t wxCSConv::GetMBNulLen() const
     return 1;
 }
 
-#if wxUSE_UNICODE_UTF8
 bool wxCSConv::IsUTF8() const
 {
     if ( m_convReal )
@@ -3259,7 +3254,6 @@ bool wxCSConv::IsUTF8() const
     // otherwise, we are ISO-8859-1
     return false;
 }
-#endif
 
 
 // ============================================================================

--- a/src/common/wxcrt.cpp
+++ b/src/common/wxcrt.cpp
@@ -1091,8 +1091,6 @@ char *strdup(const char *s)
 // wxLocaleIsUtf8
 // ============================================================================
 
-#if wxUSE_UNICODE_UTF8
-
 #if !wxUSE_UTF8_LOCALE_ONLY
 bool wxLocaleIsUtf8 = false; // the safer setting if not known
 #endif
@@ -1146,8 +1144,6 @@ void wxUpdateLocaleIsUtf8()
     wxLocaleIsUtf8 = wxIsLocaleUtf8();
 #endif
 }
-
-#endif // wxUSE_UNICODE_UTF8
 
 // ============================================================================
 // wx wrappers for CRT functions


### PR DESCRIPTION
Zip filenames containing non ASCII characters will be marked with
bit 11 in the general purpose flags and will use UTF-8 encoding.

By only setting the flag when non ASCII characters are used the
created archives should be binary identical to previous versions.

The old behavior can be achieved by explicitly using a wxMBConv
object with the constructor. This should also ensure that
existing code using a custom wxMBConv should work as before.

_This probably needs a few unit tests._