### PR TITLE
Add footer text and icon to wxRichMessageDialog.

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -172,6 +172,7 @@ All (GUI):
 - Ensure that navigation order reflects layout of wxStdDialogButtonSizer.
 - Add Scintilla FineTicker methods to wxSTC (NewPagodi).
 - Add wxFontPickerCtrl::SetMinPointSize() (Andreas Falkenhahn).
+- Add Set/GetFooter/Text/Icon() to wxRichMessageDialog (Tobias Taschner)
 
 wxGTK:
 

--- a/include/wx/richmsgdlg.h
+++ b/include/wx/richmsgdlg.h
@@ -28,7 +28,8 @@ public:
         : wxGenericMessageDialog( parent, message, caption, style ),
           m_detailsExpanderCollapsedLabel( wxGetTranslation("&See details") ),
           m_detailsExpanderExpandedLabel( wxGetTranslation("&Hide details") ),
-          m_checkBoxValue( false )
+          m_checkBoxValue( false ),
+          m_footerIcon( 0 )
         { }
 
     void ShowCheckBox(const wxString& checkBoxText, bool checked = false)
@@ -46,6 +47,16 @@ public:
 
     virtual bool IsCheckBoxChecked() const { return m_checkBoxValue; }
 
+    void SetFooterText(const wxString& footerText)
+        { m_footerText = footerText; }
+
+    wxString GetFooterText() const { return m_footerText; }
+
+    void SetFooterIcon(int icon)
+        { m_footerIcon = icon; }
+
+    int GetFooterIcon() const { return m_footerIcon; }
+
 protected:
     const wxString m_detailsExpanderCollapsedLabel;
     const wxString m_detailsExpanderExpandedLabel;
@@ -53,6 +64,8 @@ protected:
     wxString m_checkBoxText;
     bool m_checkBoxValue;
     wxString m_detailedText;
+    wxString m_footerText;
+    int m_footerIcon;
 
 private:
     void ShowDetails(bool shown);

--- a/interface/wx/richmsgdlg.h
+++ b/interface/wx/richmsgdlg.h
@@ -108,6 +108,54 @@ public:
     wxString GetDetailedText() const;
 
     /**
+        Shows or hides a footer text that is used at the bottom of
+        the dialog together with an optional icon.
+
+        @param footerText
+            The footer text if empty no footer text will be used.
+
+        @see SetFooterIcon(), GetFooterText()
+        
+        @since 3.1.1
+    */
+    void SetFooterText(const wxString& footerText);
+
+    /**
+        Retrieves the footer text.
+
+        @return
+            The footer text or empty if footer text is not used.
+
+        @since 3.1.1
+    */
+    wxString GetFooterText() const;
+
+    /**
+        Specify the footer icon set together with the footer text.
+
+        Valid values are @c wxICON_INFORMATION, @c wxICON_WARNING,
+        @c wxICON_AUTH_NEEDED and @c wxICON_ERROR (notice that
+        @c wxICON_QUESTION is not allowed here).
+
+        @see GetFooterIcon(), SetFooterText()
+
+        @since 3.1.1
+    */
+    void SetFooterIcon(int icon);
+
+    /**
+        Retrieves the footer icon.
+
+        @return
+            The footer icon or 0 if footer icon is not used.
+
+        @see SetFooterIcon()
+
+        @since 3.1.1
+    */
+    int GetFooterIcon() const;
+
+    /**
         Retrieves the state of the checkbox.
 
         If this method is called before showing the dialog, the initial value

--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -3892,6 +3892,34 @@ void TestRichMessageDialog::AddAdditionalTextOptions(wxSizer *sizer)
                                     wxTE_MULTILINE);
     sizerMsgs->Add(m_textDetailed, wxSizerFlags().Expand());
 
+    // add option to show footer text
+    wxSizer * const sizerFooter = new wxBoxSizer(wxHORIZONTAL);
+    sizerFooter->Add(new wxStaticText(this, wxID_ANY, "&Footer Text:"),
+        wxSizerFlags().Centre().Border(wxRIGHT));
+    m_textFooter = new wxTextCtrl(this, wxID_ANY);
+    sizerFooter->Add(m_textFooter, wxSizerFlags(1).Centre());
+
+    // add option to select footer icon
+    const wxString icons[] =
+    {
+        "None",
+        "Info",
+        "Warning",
+        "Error",
+        "Auth needed"
+    };
+
+    sizerFooter->Add(new wxStaticText(this, wxID_ANY, "Icon:"),
+        wxSizerFlags().Centre().Border(wxLEFT));
+    m_iconsFooter = new wxChoice(this, wxID_ANY,
+        wxDefaultPosition, wxDefaultSize,
+        WXSIZEOF(icons), icons);
+    // Make the None the default:
+    m_iconsFooter->SetSelection(0);
+    sizerFooter->Add(m_iconsFooter, wxSizerFlags().Expand().Border());
+
+    sizerMsgs->Add(sizerFooter, wxSizerFlags().Expand().Border(wxTOP));
+
     sizer->Add(sizerMsgs, wxSizerFlags().Expand().Border());
 }
 
@@ -3912,6 +3940,25 @@ void TestRichMessageDialog::OnApply(wxCommandEvent& WXUNUSED(event))
     dlg.ShowCheckBox(m_textCheckBox->GetValue(),
                      m_initialValueCheckBox->GetValue());
     dlg.ShowDetailedText(m_textDetailed->GetValue());
+    dlg.SetFooterText(m_textFooter->GetValue());
+    switch ( m_iconsFooter->GetSelection() )
+    {
+        case 1:
+            dlg.SetFooterIcon(wxICON_INFORMATION);
+            break;
+
+        case 2:
+            dlg.SetFooterIcon(wxICON_WARNING);
+            break;
+
+        case 3:
+            dlg.SetFooterIcon(wxICON_ERROR);
+            break;
+
+        case 4:
+            dlg.SetFooterIcon(wxICON_AUTH_NEEDED);
+            break;
+    }
 
     ShowResult(dlg.ShowModal());
 }

--- a/samples/dialogs/dialogs.h
+++ b/samples/dialogs/dialogs.h
@@ -268,6 +268,8 @@ private:
     wxTextCtrl *m_textCheckBox;
     wxCheckBox *m_initialValueCheckBox;
     wxTextCtrl *m_textDetailed;
+    wxTextCtrl *m_textFooter;
+    wxChoice *m_iconsFooter;
 
     wxDECLARE_EVENT_TABLE();
 };

--- a/src/generic/richmsgdlgg.cpp
+++ b/src/generic/richmsgdlgg.cpp
@@ -18,12 +18,15 @@
 
 #ifndef WX_PRECOMP
     #include "wx/checkbox.h"
+    #include "wx/statbmp.h"
     #include "wx/stattext.h"
     #include "wx/sizer.h"
 #endif
 
 #include "wx/collpane.h"
 #include "wx/richmsgdlg.h"
+#include "wx/statline.h"
+#include "wx/artprov.h"
 
 wxIMPLEMENT_CLASS(wxRichMessageDialog, wxDialog)
 
@@ -76,6 +79,26 @@ void wxGenericRichMessageDialog::AddMessageDialogDetails(wxSizer *sizer)
 
         sizerDetails->Add( m_detailsPane, wxSizerFlags().Right().Expand() );
         sizer->Add( sizerDetails, 0, wxTOP|wxLEFT|wxRIGHT | wxALIGN_LEFT, 10 );
+    }
+
+    if ( !m_footerText.empty() )
+    {
+        // add footer
+        sizer->Add( new wxStaticLine(this), wxSizerFlags().Expand().Border() );
+        wxSizer *footerSizer = new wxBoxSizer(wxHORIZONTAL);
+        if (m_footerIcon)
+        {
+            wxSize iconSize = wxArtProvider::GetNativeSizeHint(wxART_MENU);
+
+            wxStaticBitmap* footerIcon = new wxStaticBitmap(this, wxID_ANY,
+                wxArtProvider::GetIcon(wxArtProvider::GetMessageBoxIconId(m_footerIcon),
+                wxART_MESSAGE_BOX, iconSize));
+            footerSizer->Add( footerIcon,
+                wxSizerFlags().Border(wxLEFT|wxRIGHT).CenterVertical() );
+        }
+        footerSizer->Add( new wxStaticText(this, wxID_ANY, m_footerText),
+            wxSizerFlags().CenterVertical() );
+        sizer->Add( footerSizer, wxSizerFlags().Border().Expand() );
     }
 }
 

--- a/src/msw/richmsgdlg.cpp
+++ b/src/msw/richmsgdlg.cpp
@@ -58,6 +58,27 @@ int wxRichMessageDialog::ShowModal()
         if ( !m_detailedText.empty() )
             tdc.pszExpandedInformation = m_detailedText.t_str();
 
+        // Add footer text
+        if ( !m_footerText.empty() )
+        {
+            tdc.pszFooter = m_footerText.t_str();
+            switch ( m_footerIcon )
+            {
+                case wxICON_INFORMATION:
+                    tdc.pszFooterIcon = TD_INFORMATION_ICON;
+                    break;
+                case wxICON_WARNING:
+                    tdc.pszFooterIcon = TD_WARNING_ICON;
+                    break;
+                case wxICON_ERROR:
+                    tdc.pszFooterIcon = TD_ERROR_ICON;
+                    break;
+                case wxICON_AUTH_NEEDED:
+                    tdc.pszFooterIcon = TD_SHIELD_ICON;
+                    break;
+            }
+        }
+
         TaskDialogIndirect_t taskDialogIndirect = GetTaskDialogIndirectFunc();
         if ( !taskDialogIndirect )
             return wxID_CANCEL;


### PR DESCRIPTION
The underlying Windows TaskDialog supports adding an additional footer
to the message dialog. This makes the native functionality available
and implements it in the generic version.