### PR TITLE
Progress dialog fixes

### DIFF
--- a/include/wx/generic/progdlgg.h
+++ b/include/wx/generic/progdlgg.h
@@ -12,6 +12,7 @@
 #define __PROGDLGH_G__
 
 #include "wx/dialog.h"
+#include "wx/weakref.h"
 
 class WXDLLIMPEXP_FWD_CORE wxButton;
 class WXDLLIMPEXP_FWD_CORE wxEventLoop;
@@ -183,8 +184,9 @@ private:
                  *m_estimated,
                  *m_remaining;
 
-    // parent top level window (may be NULL)
-    wxWindow *m_parentTop;
+    // Reference to the parent top level window, automatically becomes NULL if
+    // it it is destroyed and could be always NULL if it's not given at all.
+    wxWindowRef m_parentTop;
 
     // Progress dialog styles: this is not the same as m_windowStyle because
     // wxPD_XXX constants clash with the existing TLW styles so to be sure we

--- a/include/wx/generic/progdlgg.h
+++ b/include/wx/generic/progdlgg.h
@@ -105,6 +105,9 @@ protected:
     // Converts seconds to HH:mm:ss format.
     static wxString GetFormattedTime(unsigned long timeInSec);
 
+    // Create a new event loop if there is no currently running one.
+    void EnsureActiveEventLoopExists();
+
     // callback for optional abort button
     void OnCancel(wxCommandEvent&);
 

--- a/include/wx/generic/progdlgg.h
+++ b/include/wx/generic/progdlgg.h
@@ -124,8 +124,8 @@ protected:
     // the dialog was shown
     void ReenableOtherWindows();
 
-    // Set the top level parent we store from the parent window provided when
-    // creating the dialog.
+    // Store the parent window as wxWindow::m_parent and also set the top level
+    // parent reference we store in this class itself.
     void SetTopParent(wxWindow* parent);
 
     // return the top level parent window of this dialog (may be NULL)

--- a/include/wx/generic/progdlgg.h
+++ b/include/wx/generic/progdlgg.h
@@ -44,7 +44,7 @@ public:
     virtual bool Update(int value, const wxString& newmsg = wxEmptyString, bool *skip = NULL);
     virtual bool Pulse(const wxString& newmsg = wxEmptyString, bool *skip = NULL);
 
-    void Resume();
+    virtual void Resume();
 
     int GetValue() const;
     int GetRange() const;

--- a/include/wx/generic/progdlgg.h
+++ b/include/wx/generic/progdlgg.h
@@ -46,16 +46,16 @@ public:
 
     virtual void Resume();
 
-    int GetValue() const;
-    int GetRange() const;
-    wxString GetMessage() const;
+    virtual int GetValue() const;
+    virtual int GetRange() const;
+    virtual wxString GetMessage() const;
 
-    void SetRange(int maximum);
+    virtual void SetRange(int maximum);
 
     // Return whether "Cancel" or "Skip" button was pressed, always return
     // false if the corresponding button is not shown.
-    bool WasCancelled() const;
-    bool WasSkipped() const;
+    virtual bool WasCancelled() const;
+    virtual bool WasSkipped() const;
 
     // Must provide overload to avoid hiding it (and warnings about it)
     virtual void Update() wxOVERRIDE { wxDialog::Update(); }

--- a/include/wx/msw/progdlg.h
+++ b/include/wx/msw/progdlg.h
@@ -28,15 +28,15 @@ public:
 
     virtual void Resume() wxOVERRIDE;
 
-    int GetValue() const;
-    wxString GetMessage() const;
+    virtual int GetValue() const wxOVERRIDE;
+    virtual wxString GetMessage() const wxOVERRIDE;
 
-    void SetRange(int maximum);
+    virtual void SetRange(int maximum) wxOVERRIDE;
 
     // Return whether "Cancel" or "Skip" button was pressed, always return
     // false if the corresponding button is not shown.
-    bool WasSkipped() const;
-    bool WasCancelled() const;
+    virtual bool WasSkipped() const wxOVERRIDE;
+    virtual bool WasCancelled() const wxOVERRIDE;
 
     virtual void SetTitle(const wxString& title) wxOVERRIDE;
     virtual wxString GetTitle() const wxOVERRIDE;

--- a/include/wx/msw/progdlg.h
+++ b/include/wx/msw/progdlg.h
@@ -44,6 +44,7 @@ public:
     virtual void SetIcons(const wxIconBundle& icons) wxOVERRIDE;
     virtual void DoMoveWindow(int x, int y, int width, int height) wxOVERRIDE;
     virtual void DoGetPosition(int *x, int *y) const wxOVERRIDE;
+    virtual void DoGetSize(int *width, int *height) const wxOVERRIDE;
     virtual void Fit() wxOVERRIDE;
 
     virtual bool Show( bool show = true ) wxOVERRIDE;

--- a/include/wx/msw/progdlg.h
+++ b/include/wx/msw/progdlg.h
@@ -44,6 +44,7 @@ public:
     virtual void SetIcons(const wxIconBundle& icons) wxOVERRIDE;
     virtual void DoMoveWindow(int x, int y, int width, int height) wxOVERRIDE;
     virtual void DoGetPosition(int *x, int *y) const wxOVERRIDE;
+    virtual void Fit() wxOVERRIDE;
 
     virtual bool Show( bool show = true ) wxOVERRIDE;
 

--- a/include/wx/msw/progdlg.h
+++ b/include/wx/msw/progdlg.h
@@ -54,8 +54,9 @@ public:
     virtual WXWidget GetHandle() const wxOVERRIDE;
 
 private:
-    // Performs common routines to Update() and Pulse(). Requires the
-    // shared object to have been entered.
+    // Common part of Update() and Pulse().
+    //
+    // Returns false if the user requested cancelling the dialog.
     bool DoNativeBeforeUpdate(bool *skip);
 
     // Updates the various timing informations for both determinate

--- a/include/wx/msw/progdlg.h
+++ b/include/wx/msw/progdlg.h
@@ -26,7 +26,7 @@ public:
     virtual bool Update(int value, const wxString& newmsg = wxEmptyString, bool *skip = NULL) wxOVERRIDE;
     virtual bool Pulse(const wxString& newmsg = wxEmptyString, bool *skip = NULL) wxOVERRIDE;
 
-    void Resume();
+    virtual void Resume() wxOVERRIDE;
 
     int GetValue() const;
     wxString GetMessage() const;

--- a/include/wx/msw/progdlg.h
+++ b/include/wx/msw/progdlg.h
@@ -59,6 +59,10 @@ private:
     // Returns false if the user requested cancelling the dialog.
     bool DoNativeBeforeUpdate(bool *skip);
 
+    // Dispatch the pending events to let the windows to update, just as the
+    // generic version does. This is done as part of DoNativeBeforeUpdate().
+    void DispatchEvents();
+
     // Updates the various timing informations for both determinate
     // and indeterminate modes. Requires the shared object to have
     // been entered.

--- a/include/wx/msw/progdlg.h
+++ b/include/wx/msw/progdlg.h
@@ -68,6 +68,10 @@ private:
     // been entered.
     void UpdateExpandedInformation(int value);
 
+    // Get the task dialog geometry when using the native dialog.
+    wxRect GetTaskDialogRect() const;
+
+
     wxProgressDialogTaskRunner *m_taskDialogRunner;
 
     wxProgressDialogSharedData *m_sharedData;

--- a/include/wx/msw/toplevel.h
+++ b/include/wx/msw/toplevel.h
@@ -90,6 +90,9 @@ public:
     // NULL if getting the system menu failed.
     wxMenu *MSWGetSystemMenu() const;
 
+    // Enable or disable the close button of the specified window.
+    static bool MSWEnableCloseButton(WXHWND hwnd, bool enable = true);
+
 
     // implementation from now on
     // --------------------------

--- a/interface/wx/progdlg.h
+++ b/interface/wx/progdlg.h
@@ -213,11 +213,14 @@ public:
         until this happens.
 
         Notice that if @a newmsg is longer than the currently shown message,
-        the dialog size will be automatically increased to account for it.
-        However if the new message is shorter than the previous one, the dialog
-        doesn't shrink back to avoid constant resizes if the message is changed
-        often. To shrink back the dialog to fit its current contents you may
-        call Fit() explicitly.
+        the dialog will be automatically made wider to account for it. However
+        if the new message is shorter than the previous one, the dialog doesn't
+        shrink back to avoid constant resizes if the message is changed often.
+        To do this and fit the dialog to its current contents you may call
+        Fit() explicitly. However the native MSW implementation of this class
+        does make the dialog shorter if the new text has fewer lines of text
+        than the old one, so it is recommended to keep the number of lines of
+        text constant in order to avoid jarring dialog size changes.
 
         @param value
             The new value of the progress meter. It should be less than or equal to

--- a/interface/wx/progdlg.h
+++ b/interface/wx/progdlg.h
@@ -49,6 +49,9 @@
             }
         }
     @endcode
+    Note that this becomes even more important if the dialog is instantiated
+    during the program initialization, e.g. from wxApp::OnInit(): the dialog
+    must be destroyed before the main event loop is started in this case.
 
     @beginStyleTable
     @style{wxPD_APP_MODAL}

--- a/interface/wx/progdlg.h
+++ b/interface/wx/progdlg.h
@@ -192,12 +192,12 @@ public:
         for the user to dismiss it, meaning that this function does not return
         until this happens.
 
-        Notice that you may want to call Fit() to change the dialog size to
-        conform to the length of the new message if desired. The dialog does
-        not do this automatically, except for the native MSW implementation
-        which does increase the dialog size if necessary (but still doesn't
-        shrink it back even if the text becomes shorter and you need to call
-        Fit() explicitly if you want this to happen).
+        Notice that if @a newmsg is longer than the currently shown message,
+        the dialog size will be automatically increased to account for it.
+        However if the new message is shorter than the previous one, the dialog
+        doesn't shrink back to avoid constant resizes if the message is changed
+        often. To shrink back the dialog to fit its current contents you may
+        call Fit() explicitly.
 
         @param value
             The new value of the progress meter. It should be less than or equal to

--- a/interface/wx/progdlg.h
+++ b/interface/wx/progdlg.h
@@ -33,6 +33,23 @@
     wxProgressDialog in a multi-threaded application you should be sure to use
     wxThreadEvent for your inter-threads communications).
 
+    Although wxProgressDialog is not really modal, it should be created on the
+    stack, and not the heap, as other modal dialogs, e.g. use it like this:
+    @code
+        void MyFrame::SomeFunc()
+        {
+            wxProgressDialog dialog(...);
+            for ( int i = 0; i < 100; ++i ) {
+                if ( !dialog.Update(i)) {
+                    // Cancelled by user.
+                    break;
+                }
+
+                ... do something time-consuming (but not too much) ...
+            }
+        }
+    @endcode
+
     @beginStyleTable
     @style{wxPD_APP_MODAL}
            Make the progress dialog modal. If this flag is not given, it is

--- a/interface/wx/progdlg.h
+++ b/interface/wx/progdlg.h
@@ -194,7 +194,9 @@ public:
 
         Notice that you may want to call Fit() to change the dialog size to
         conform to the length of the new message if desired. The dialog does
-        not do this automatically.
+        not do this automatically, except for the native MSW implementation
+        which does increase the dialog size if necessary (but still doesn't
+        shrink it back even if the text becomes shorter).
 
         @param value
             The new value of the progress meter. It should be less than or equal to

--- a/interface/wx/progdlg.h
+++ b/interface/wx/progdlg.h
@@ -196,7 +196,8 @@ public:
         conform to the length of the new message if desired. The dialog does
         not do this automatically, except for the native MSW implementation
         which does increase the dialog size if necessary (but still doesn't
-        shrink it back even if the text becomes shorter).
+        shrink it back even if the text becomes shorter and you need to call
+        Fit() explicitly if you want this to happen).
 
         @param value
             The new value of the progress meter. It should be less than or equal to

--- a/interface/wx/progdlg.h
+++ b/interface/wx/progdlg.h
@@ -220,7 +220,11 @@ public:
         Fit() explicitly. However the native MSW implementation of this class
         does make the dialog shorter if the new text has fewer lines of text
         than the old one, so it is recommended to keep the number of lines of
-        text constant in order to avoid jarring dialog size changes.
+        text constant in order to avoid jarring dialog size changes. You may
+        also want to make the initial message, specified when creating the
+        dialog, wide enough to avoid having to resize the dialog later, e.g. by
+        appending a long string of unbreakable spaces (@c wxString(L'\u00a0',
+        100)) to it.
 
         @param value
             The new value of the progress meter. It should be less than or equal to

--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -233,6 +233,9 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
 
 #if wxUSE_PROGRESSDLG
     EVT_MENU(DIALOGS_PROGRESS,                      MyFrame::ShowProgress)
+#ifdef wxHAS_NATIVE_PROGRESSDIALOG
+    EVT_MENU(DIALOGS_PROGRESS_GENERIC,              MyFrame::ShowProgressGeneric)
+#endif // wxHAS_NATIVE_PROGRESSDIALOG
 #endif // wxUSE_PROGRESSDLG
 
     EVT_MENU(DIALOGS_APP_PROGRESS,                  MyFrame::ShowAppProgress)
@@ -508,6 +511,10 @@ bool MyApp::OnInit()
 
     #if wxUSE_PROGRESSDLG
         info_menu->Append(DIALOGS_PROGRESS, wxT("Pro&gress dialog\tCtrl-G"));
+        #ifdef wxHAS_NATIVE_PROGRESSDIALOG
+            info_menu->Append(DIALOGS_PROGRESS_GENERIC,
+                              wxT("Generic progress dialog\tCtrl-Alt-G"));
+        #endif // wxHAS_NATIVE_PROGRESSDIALOG
     #endif // wxUSE_PROGRESSDLG
 
         info_menu->Append(DIALOGS_APP_PROGRESS, wxT("&App progress\tShift-Ctrl-G"));
@@ -2670,10 +2677,10 @@ void MyFrame::OnExit(wxCommandEvent& WXUNUSED(event) )
 
 #if wxUSE_PROGRESSDLG
 
+static const int max = 100;
+
 void MyFrame::ShowProgress( wxCommandEvent& WXUNUSED(event) )
 {
-    static const int max = 100;
-
     wxProgressDialog dialog("Progress dialog example",
                             // "Reserve" enough space for the multiline
                             // messages below, we'll change it anyhow
@@ -2691,6 +2698,30 @@ void MyFrame::ShowProgress( wxCommandEvent& WXUNUSED(event) )
                             wxPD_SMOOTH // - makes indeterminate mode bar on WinXP very small
                             );
 
+    DoShowProgress(dialog);
+}
+
+#ifdef wxHAS_NATIVE_PROGRESSDIALOG
+void MyFrame::ShowProgressGeneric( wxCommandEvent& WXUNUSED(event) )
+{
+    wxGenericProgressDialog dialog("Generic progress dialog example",
+                                   wxString(' ', 100) + "\n\n\n\n",
+                                   max,
+                                   this,
+                                   wxPD_CAN_ABORT |
+                                   wxPD_CAN_SKIP |
+                                   wxPD_APP_MODAL |
+                                   wxPD_ELAPSED_TIME |
+                                   wxPD_ESTIMATED_TIME |
+                                   wxPD_REMAINING_TIME |
+                                   wxPD_SMOOTH);
+
+    DoShowProgress(dialog);
+}
+#endif // wxHAS_NATIVE_PROGRESSDIALOG
+
+void MyFrame::DoShowProgress(wxGenericProgressDialog& dialog)
+{
     bool cont = true;
     for ( int i = 0; i <= max; i++ )
     {

--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -360,6 +360,11 @@ bool MyApp::OnInit()
                 case 30:
                     msg = "Back to brevity";
                     break;
+
+                case 80:
+                    msg = "Back and adjusted";
+                    dlg.Fit();
+                    break;
             }
 
             if ( !dlg.Update(i, msg) )

--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -2770,8 +2770,8 @@ void MyFrame::DoShowProgress(wxGenericProgressDialog& dialog)
         {
             i += max/4;
 
-            if ( i >= 100 )
-                i = 99;
+            if ( i >= max )
+                i = max - 1;
         }
 
         if ( !cont )

--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -2785,7 +2785,7 @@ void MyFrame::DoShowProgress(wxGenericProgressDialog& dialog)
             dialog.Resume();
         }
 
-        wxMilliSleep(200);
+        wxMilliSleep(100);
     }
 
     if ( !cont )
@@ -2817,7 +2817,7 @@ void MyFrame::ShowAppProgress( wxCommandEvent& WXUNUSED(event) )
     {
         progress.SetValue(i);
 
-        wxMilliSleep(500);
+        wxMilliSleep(200);
     }
 
     wxLogStatus("Progress finished");

--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -349,7 +349,20 @@ bool MyApp::OnInit()
                          );
         for ( int i = 0; i <= PROGRESS_COUNT; i++ )
         {
-            if ( !dlg.Update(i) )
+            wxString msg;
+            switch ( i )
+            {
+                case 15:
+                    msg = "And the same dialog but with a very, very, very long"
+                          " message, just to test how it appears in this case.";
+                    break;
+
+                case 30:
+                    msg = "Back to brevity";
+                    break;
+            }
+
+            if ( !dlg.Update(i, msg) )
                 break;
 
             wxMilliSleep(50);

--- a/samples/dialogs/dialogs.h
+++ b/samples/dialogs/dialogs.h
@@ -452,6 +452,10 @@ public:
 
 #if wxUSE_PROGRESSDLG
     void ShowProgress(wxCommandEvent& event);
+#ifdef wxHAS_NATIVE_PROGRESSDIALOG
+    void ShowProgressGeneric(wxCommandEvent& event);
+#endif // wxHAS_NATIVE_PROGRESSDIALOG
+    void DoShowProgress(wxGenericProgressDialog& dialog);
 #endif // wxUSE_PROGRESSDLG
     void ShowAppProgress(wxCommandEvent& event);
 
@@ -596,6 +600,7 @@ enum
     DIALOGS_ONTOP,
     DIALOGS_MODELESS_BTN,
     DIALOGS_PROGRESS,
+    DIALOGS_PROGRESS_GENERIC,
     DIALOGS_APP_PROGRESS,
     DIALOGS_ABOUTDLG_SIMPLE,
     DIALOGS_ABOUTDLG_FANCY,

--- a/src/generic/progdlgg.cpp
+++ b/src/generic/progdlgg.cpp
@@ -144,7 +144,6 @@ bool wxGenericProgressDialog::Create( const wxString& title,
 {
     SetTopParent(parent);
 
-    m_parentTop = wxGetTopLevelParent(parent);
     m_pdStyle = style;
 
     wxWindow* const

--- a/src/generic/progdlgg.cpp
+++ b/src/generic/progdlgg.cpp
@@ -160,11 +160,7 @@ bool wxGenericProgressDialog::Create( const wxString& title,
     // even if this means we have to start it ourselves (this happens most
     // commonly during the program initialization, e.g. for the progress
     // dialogs shown from overridden wxApp::OnInit()).
-    if ( !wxEventLoopBase::GetActive() )
-    {
-        m_tempEventLoop = new wxEventLoop;
-        wxEventLoop::SetActive(m_tempEventLoop);
-    }
+    EnsureActiveEventLoopExists();
 
 #if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
     // we have to remove the "Close" button from the title bar then as it is
@@ -361,6 +357,15 @@ wxString wxGenericProgressDialog::GetFormattedTime(unsigned long timeInSec)
     }
 
     return timeAsHMS;
+}
+
+void wxGenericProgressDialog::EnsureActiveEventLoopExists()
+{
+    if ( !wxEventLoopBase::GetActive() )
+    {
+        m_tempEventLoop = new wxEventLoop;
+        wxEventLoop::SetActive(m_tempEventLoop);
+    }
 }
 
 wxStaticText *

--- a/src/generic/progdlgg.cpp
+++ b/src/generic/progdlgg.cpp
@@ -133,6 +133,7 @@ wxGenericProgressDialog::wxGenericProgressDialog(const wxString& title,
 
 void wxGenericProgressDialog::SetTopParent(wxWindow* parent)
 {
+    m_parent = parent;
     m_parentTop = GetParentForModalDialog(parent, GetWindowStyle());
 }
 

--- a/src/generic/progdlgg.cpp
+++ b/src/generic/progdlgg.cpp
@@ -146,10 +146,7 @@ bool wxGenericProgressDialog::Create( const wxString& title,
 
     m_pdStyle = style;
 
-    wxWindow* const
-        realParent = GetParentForModalDialog(parent, GetWindowStyle());
-
-    if (!wxDialog::Create(realParent, wxID_ANY, title, wxDefaultPosition, wxDefaultSize, GetWindowStyle()))
+    if (!wxDialog::Create(m_parentTop, wxID_ANY, title, wxDefaultPosition, wxDefaultSize, GetWindowStyle()))
         return false;
 
     SetMaximum(maximum);

--- a/src/generic/progdlgg.cpp
+++ b/src/generic/progdlgg.cpp
@@ -765,7 +765,16 @@ void wxGenericProgressDialog::UpdateMessage(const wxString &newmsg)
 {
     if ( !newmsg.empty() && newmsg != m_msg->GetLabel() )
     {
+        const wxSize sizeOld = m_msg->GetSize();
+
         m_msg->SetLabel(newmsg);
+
+        if ( m_msg->GetSize().x > sizeOld.x )
+        {
+            // Resize the dialog to fit its new, longer contents instead of
+            // just truncating it.
+            Fit();
+        }
 
         // allow the window to repaint:
         // NOTE: since we yield only for UI events with this call, there

--- a/src/generic/progdlgg.cpp
+++ b/src/generic/progdlgg.cpp
@@ -697,6 +697,21 @@ wxGenericProgressDialog::~wxGenericProgressDialog()
 
     if ( m_tempEventLoop )
     {
+        // If another event loop has been installed as active during the life
+        // time of this object, we shouldn't deactivate it, but we also can't
+        // delete our m_tempEventLoop in this case because it risks leaving the
+        // new event loop with a dangling pointer, which it will set back as
+        // the active loop when it exits, resulting in a crash. So we have no
+        // choice but to just leak this pointer then, which is, of course, bad
+        // and usually easily avoidable by just destroying the progress dialog
+        // sooner, so warn the programmer about it.
+        wxCHECK_RET
+        (
+            wxEventLoopBase::GetActive() == m_tempEventLoop,
+            "current event loop must not be changed during "
+            "wxGenericProgressDialog lifetime"
+        );
+
         wxEventLoopBase::SetActive(NULL);
         delete m_tempEventLoop;
     }

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -746,6 +746,7 @@ void wxProgressDialog::DoGetPosition(int *x, int *y) const
     if ( HasNativeTaskDialog() )
     {
         wxPoint pos;
+        if ( m_sharedData )
         {
             wxCriticalSectionLocker locker(m_sharedData->m_cs);
             pos = m_sharedData->m_winPosition;

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -748,7 +748,6 @@ void wxProgressDialog::DoGetPosition(int *x, int *y) const
         wxPoint pos;
         {
             wxCriticalSectionLocker locker(m_sharedData->m_cs);
-            m_sharedData->m_state = m_state;
             pos = m_sharedData->m_winPosition;
         }
         if (x)

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -190,6 +190,16 @@ BOOL CALLBACK DisplayCloseButton(HWND hwnd, LPARAM lParam)
     return TRUE;
 }
 
+// This function enables or disables both the cancel button in the task dialog
+// and the close button in its title bar, as they perform the same function and
+// so should be kept in the same state.
+void EnableCloseButtons(HWND hwnd, bool enable)
+{
+    ::SendMessage(hwnd, TDM_ENABLE_BUTTON, IDCANCEL, enable ? TRUE : FALSE);
+
+    wxTopLevelWindow::MSWEnableCloseButton(hwnd, enable);
+}
+
 void PerformNotificationUpdates(HWND hwnd,
                                 wxProgressDialogSharedData *sharedData)
 {
@@ -315,7 +325,7 @@ void PerformNotificationUpdates(HWND hwnd,
         ::SendMessage( hwnd, TDM_ENABLE_BUTTON, Id_SkipBtn, TRUE );
 
     if ( sharedData->m_notifications & wxSPDD_ENABLE_ABORT )
-        ::SendMessage( hwnd, TDM_ENABLE_BUTTON, IDCANCEL, TRUE );
+        EnableCloseButtons(hwnd, true);
 
     if ( sharedData->m_notifications & wxSPDD_DISABLE_SKIP )
         ::SendMessage( hwnd, TDM_ENABLE_BUTTON, Id_SkipBtn, FALSE );
@@ -329,7 +339,7 @@ void PerformNotificationUpdates(HWND hwnd,
         {
             // Change Cancel into Close and activate the button.
             ::SendMessage( hwnd, TDM_ENABLE_BUTTON, Id_SkipBtn, FALSE );
-            ::SendMessage( hwnd, TDM_ENABLE_BUTTON, IDCANCEL, TRUE );
+            EnableCloseButtons(hwnd, true);
             ::EnumChildWindows( hwnd, DisplayCloseButton,
                                 (LPARAM) sharedData );
         }
@@ -1116,7 +1126,7 @@ wxProgressDialogTaskRunner::TaskDialogCallbackProc
             // If we can't be aborted, the "Close" button will only be enabled
             // when the progress ends (and not even then with wxPD_AUTO_HIDE).
             if ( !(sharedData->m_style & wxPD_CAN_ABORT) )
-                ::SendMessage( hwnd, TDM_ENABLE_BUTTON, IDCANCEL, FALSE );
+                EnableCloseButtons(hwnd, false);
             break;
 
         case TDN_BUTTON_CLICKED:
@@ -1151,7 +1161,7 @@ wxProgressDialogTaskRunner::TaskDialogCallbackProc
                         );
 
                         ::SendMessage(hwnd, TDM_ENABLE_BUTTON, Id_SkipBtn, FALSE);
-                        ::SendMessage(hwnd, TDM_ENABLE_BUTTON, IDCANCEL, FALSE);
+                        EnableCloseButtons(hwnd, false);
 
                         sharedData->m_timeStop = wxGetCurrentTime();
                         sharedData->m_state = wxProgressDialog::Canceled;

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -459,10 +459,13 @@ bool wxProgressDialog::Update(int value, const wxString& newmsg, bool *skip)
         {
             wxCriticalSectionLocker locker(m_sharedData->m_cs);
 
-            m_sharedData->m_value = value;
-            m_sharedData->m_notifications |= wxSPDD_VALUE_CHANGED;
+            if ( value != m_sharedData->m_value )
+            {
+                m_sharedData->m_value = value;
+                m_sharedData->m_notifications |= wxSPDD_VALUE_CHANGED;
+            }
 
-            if ( !newmsg.empty() )
+            if ( !newmsg.empty() && newmsg != m_message )
             {
                 m_message = newmsg;
                 m_sharedData->m_message = newmsg;
@@ -532,7 +535,7 @@ bool wxProgressDialog::Pulse(const wxString& newmsg, bool *skip)
             m_sharedData->m_notifications |= wxSPDD_PBMARQUEE_CHANGED;
         }
 
-        if ( !newmsg.empty() )
+        if ( !newmsg.empty() && newmsg != m_message )
         {
             m_message = newmsg;
             m_sharedData->m_message = newmsg;
@@ -1197,7 +1200,9 @@ wxProgressDialogTaskRunner::TaskDialogCallbackProc
             break;
 
         case TDN_TIMER:
-            PerformNotificationUpdates(hwnd, sharedData);
+            // Don't perform updates if nothing needs to be done.
+            if ( sharedData->m_notifications )
+                PerformNotificationUpdates(hwnd, sharedData);
 
             /*
                 Decide whether we should end the dialog. This is done if either

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -767,6 +767,24 @@ void wxProgressDialog::DoGetPosition(int *x, int *y) const
     wxGenericProgressDialog::DoGetPosition(x, y);
 }
 
+void wxProgressDialog::Fit()
+{
+#ifdef wxHAS_MSW_TASKDIALOG
+    if ( HasNativeTaskDialog() )
+    {
+        wxCriticalSectionLocker locker(m_sharedData->m_cs);
+
+        // Force the task dialog to use this message to adjust it layout.
+        m_sharedData->m_msgChangeElementText = TDM_SET_ELEMENT_TEXT;
+
+        // Don't change the message, but pretend that it did change.
+        m_sharedData->m_notifications |= wxSPDD_MESSAGE_CHANGED;
+    }
+#endif // wxHAS_MSW_TASKDIALOG
+
+    wxGenericProgressDialog::Fit();
+}
+
 bool wxProgressDialog::Show(bool show)
 {
 #ifdef wxHAS_MSW_TASKDIALOG

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -571,15 +571,16 @@ void wxProgressDialog::Resume()
 #endif // wxHAS_MSW_TASKDIALOG
 }
 
-WXWidget wxProgressDialog::GetHandle() const 
-{ 
+WXWidget wxProgressDialog::GetHandle() const
+{
 #ifdef wxHAS_MSW_TASKDIALOG
     if ( HasNativeTaskDialog() )
     {
         wxCriticalSectionLocker locker(m_sharedData->m_cs);
         return m_sharedData->m_hwnd;
     }
-#endif
+#endif // wxHAS_MSW_TASKDIALOG
+
     return wxGenericProgressDialog::GetHandle();
 }
 

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -889,7 +889,6 @@ void* wxProgressDialogTaskRunner::Entry()
 
         // Undo some of the effects of MSWCommonTaskDialogInit().
         tdc.dwFlags &= ~TDF_EXPAND_FOOTER_AREA; // Expand in content area.
-        tdc.dwCommonButtons = 0; // Don't use common buttons.
 
         if ( m_sharedData.m_style & wxPD_CAN_SKIP )
             wxTdc.AddTaskDialogButton( tdc, Id_SkipBtn, 0, _("Skip") );

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -1028,26 +1028,6 @@ void* wxProgressDialogTaskRunner::Entry()
         parent = m_sharedData.m_parent;
     }
 
-    if ( parent )
-    {
-        // Force the creation of the message queue for this thread.
-        MSG msg;
-        ::PeekMessage(&msg, NULL, WM_USER, WM_USER, PM_NOREMOVE);
-
-        // Attach its message queue to the main thread in order to allow using
-        // the parent window created by the main thread as task dialog parent.
-        if ( !::AttachThreadInput(::GetCurrentThreadId(),
-                                  wxThread::GetMainId(),
-                                  TRUE) )
-        {
-            wxLogLastError(wxT("AttachThreadInput"));
-
-            // Don't even try using the parent window from another thread, this
-            // won't work.
-            parent = NULL;
-        }
-    }
-
     WinStruct<TASKDIALOGCONFIG> tdc;
     wxMSWTaskDialogConfig wxTdc;
 

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -838,6 +838,24 @@ void wxProgressDialog::DoGetPosition(int *x, int *y) const
     wxGenericProgressDialog::DoGetPosition(x, y);
 }
 
+void wxProgressDialog::DoGetSize(int *width, int *height) const
+{
+#ifdef wxHAS_MSW_TASKDIALOG
+    if ( HasNativeTaskDialog() )
+    {
+        const wxRect r = GetTaskDialogRect();
+        if ( width )
+            *width = r.width;
+        if ( height )
+            *height = r.height;
+
+        return;
+    }
+#endif // wxHAS_MSW_TASKDIALOG
+
+    wxGenericProgressDialog::DoGetSize(width, height);
+}
+
 void wxProgressDialog::Fit()
 {
 #ifdef wxHAS_MSW_TASKDIALOG

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -543,7 +543,7 @@ void wxProgressDialog::Resume()
 
         {
             wxCriticalSectionLocker locker(m_sharedData->m_cs);
-            m_sharedData->m_state = m_state;
+            m_sharedData->m_state = Continue;
 
             // "Skip" was disabled when "Cancel" had been clicked, so re-enable
             // it now.

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -1047,22 +1047,16 @@ void wxProgressDialog::UpdateExpandedInformation(int value)
 
 void* wxProgressDialogTaskRunner::Entry()
 {
-    // If we have a parent, we must use it to have correct Z-order and icon,
-    // but this can only be done if we attach this thread input to the thread
-    // that created the parent window, i.e. the main thread.
-    wxWindow* parent = NULL;
-    {
-        wxCriticalSectionLocker locker(m_sharedData.m_cs);
-        parent = m_sharedData.m_parent;
-    }
-
     WinStruct<TASKDIALOGCONFIG> tdc;
     wxMSWTaskDialogConfig wxTdc;
 
     {
         wxCriticalSectionLocker locker(m_sharedData.m_cs);
 
-        wxTdc.parent = parent;
+        // If we have a parent, we must use it to have correct Z-order and
+        // icon, even if this comes at the price of attaching this thread input
+        // to the thread that created the parent window, i.e. the main thread.
+        wxTdc.parent = m_sharedData.m_parent;
         wxTdc.caption = m_sharedData.m_title.wx_str();
         wxTdc.message = m_sharedData.m_message.wx_str();
 

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -808,16 +808,16 @@ void wxProgressDialog::DoGetPosition(int *x, int *y) const
 #ifdef wxHAS_MSW_TASKDIALOG
     if ( HasNativeTaskDialog() )
     {
-        wxPoint pos;
+        wxRect r;
         if ( m_sharedData )
         {
             wxCriticalSectionLocker locker(m_sharedData->m_cs);
-            pos = m_sharedData->m_winPosition;
+            r = wxRectFromRECT(wxGetWindowRect(m_sharedData->m_hwnd));
         }
         if (x)
-            *x = pos.x;
+            *x = r.x;
         if (y)
-            *y = pos.y;
+            *y = r.y;
 
         return;
     }
@@ -1115,14 +1115,6 @@ wxProgressDialogTaskRunner::TaskDialogCallbackProc
                                SWP_NOZORDER);
             }
 
-            // Store current position for the main thread use
-            // if no position update is pending.
-            if ( !(sharedData->m_notifications & wxSPDD_WINDOW_MOVED) )
-            {
-                RECT r = wxGetWindowRect(hwnd);
-                sharedData->m_winPosition = wxPoint(r.left, r.top);
-            }
-
             // If we can't be aborted, the "Close" button will only be enabled
             // when the progress ends (and not even then with wxPD_AUTO_HIDE).
             if ( !(sharedData->m_style & wxPD_CAN_ABORT) )
@@ -1192,12 +1184,6 @@ wxProgressDialogTaskRunner::TaskDialogCallbackProc
             }
 
             sharedData->m_notifications = 0;
-            {
-                // Update current position for the main thread use.
-                RECT r = wxGetWindowRect(hwnd);
-                sharedData->m_winPosition = wxPoint(r.left, r.top);
-            }
-
             return S_FALSE;
     }
 

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -987,14 +987,12 @@ void wxProgressDialog::UpdateExpandedInformation(int value)
     unsigned long remainingTime;
     UpdateTimeEstimates(value, elapsedTime, estimatedTime, remainingTime);
 
-    int realEstimatedTime = estimatedTime,
-        realRemainingTime = remainingTime;
     if ( m_sharedData->m_progressBarMarquee )
     {
         // In indeterminate mode we don't have any estimation neither for the
         // remaining nor for estimated time.
-        realEstimatedTime =
-        realRemainingTime = -1;
+        estimatedTime =
+        remainingTime = static_cast<unsigned long>(-1);
     }
 
     wxString expandedInformation;
@@ -1014,7 +1012,7 @@ void wxProgressDialog::UpdateExpandedInformation(int value)
 
         expandedInformation << GetEstimatedLabel()
                             << " "
-                            << GetFormattedTime(realEstimatedTime);
+                            << GetFormattedTime(estimatedTime);
     }
 
     if ( HasPDFlag(wxPD_REMAINING_TIME) )
@@ -1024,7 +1022,7 @@ void wxProgressDialog::UpdateExpandedInformation(int value)
 
         expandedInformation << GetRemainingLabel()
                             << " "
-                            << GetFormattedTime(realRemainingTime);
+                            << GetFormattedTime(remainingTime);
     }
 
     // Update with new timing information.

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -80,7 +80,7 @@ public:
         m_value = 0;
         m_progressBarMarquee = false;
         m_skipped = false;
-        m_msgChangeElementText = TDM_SET_ELEMENT_TEXT;
+        m_msgChangeElementText = TDM_UPDATE_ELEMENT_TEXT;
         m_notifications = 0;
         m_parent = NULL;
     }
@@ -106,11 +106,11 @@ public:
     bool m_skipped;
 
     // The task dialog message to use for changing the text of its elements:
-    // it's TDM_SET_ELEMENT_TEXT initially as this message should be used to
-    // let the dialog adjust itself to the size of its elements, but
-    // TDM_UPDATE_ELEMENT_TEXT later to prevent the dialog from performing a
-    // layout on each update, which is annoying as it can result in its size
-    // constantly changing.
+    // it is set to TDM_SET_ELEMENT_TEXT by Fit() to let the dialog adjust
+    // itself to the size of its elements during the next update, but otherwise
+    // TDM_UPDATE_ELEMENT_TEXT is used in order to prevent the dialog from
+    // performing a layout on each update, which is annoying as it can result
+    // in its size constantly changing.
     int m_msgChangeElementText;
 
     // Bit field that indicates fields that have been modified by the

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -569,8 +569,8 @@ bool wxProgressDialog::Pulse(const wxString& newmsg, bool *skip)
             m_sharedData->m_notifications |= wxSPDD_MESSAGE_CHANGED;
         }
 
-        // The value passed here doesn't matter, only elapsed time makes sense
-        // in indeterminate mode anyhow.
+        // Value of 0 is special and is used when we can't estimate the
+        // remaining and total times, which is exactly what we need here.
         UpdateExpandedInformation(0);
 
         return m_sharedData->m_state != Canceled;
@@ -990,8 +990,9 @@ void wxProgressDialog::UpdateExpandedInformation(int value)
     // The value of 0 is special, we can't estimate anything before we have at
     // least one update, so leave the times dependent on it indeterminate.
     //
-    // Similarly, in indeterminate mode we don't have any estimations neither.
-    if ( !value || m_sharedData->m_progressBarMarquee )
+    // This value is also used by Pulse(), as in the indeterminate mode we can
+    // never estimate anything.
+    if ( !value )
     {
         estimatedTime =
         remainingTime = static_cast<unsigned long>(-1);

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -511,31 +511,28 @@ bool wxProgressDialog::Pulse(const wxString& newmsg, bool *skip)
 bool wxProgressDialog::DoNativeBeforeUpdate(bool *skip)
 {
 #ifdef wxHAS_MSW_TASKDIALOG
-    if ( HasNativeTaskDialog() )
+    wxCriticalSectionLocker locker(m_sharedData->m_cs);
+
+    if ( m_sharedData->m_skipped  )
     {
-        wxCriticalSectionLocker locker(m_sharedData->m_cs);
-
-        if ( m_sharedData->m_skipped  )
+        if ( skip && !*skip )
         {
-            if ( skip && !*skip )
-            {
-                *skip = true;
-                m_sharedData->m_skipped = false;
-                m_sharedData->m_notifications |= wxSPDD_ENABLE_SKIP;
-            }
+            *skip = true;
+            m_sharedData->m_skipped = false;
+            m_sharedData->m_notifications |= wxSPDD_ENABLE_SKIP;
         }
-
-        if ( m_sharedData->m_state == Canceled )
-            m_timeStop = m_sharedData->m_timeStop;
-
-        return m_sharedData->m_state != Canceled;
     }
-#endif // wxHAS_MSW_TASKDIALOG
 
+    if ( m_sharedData->m_state == Canceled )
+        m_timeStop = m_sharedData->m_timeStop;
+
+    return m_sharedData->m_state != Canceled;
+#else // !wxHAS_MSW_TASKDIALOG
     wxUnusedVar(skip);
     wxFAIL_MSG( "unreachable" );
 
     return false;
+#endif // wxHAS_MSW_TASKDIALOG/!wxHAS_MSW_TASKDIALOG
 }
 
 void wxProgressDialog::Resume()

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -57,7 +57,6 @@ const int wxSPDD_EXPINFO_CHANGED   = 0x0020;
 const int wxSPDD_ENABLE_SKIP       = 0x0040;
 const int wxSPDD_ENABLE_ABORT      = 0x0080;
 const int wxSPDD_DISABLE_SKIP      = 0x0100;
-const int wxSPDD_DISABLE_ABORT     = 0x0200;
 const int wxSPDD_FINISHED          = 0x0400;
 const int wxSPDD_DESTROYED         = 0x0800;
 const int wxSPDD_ICON_CHANGED      = 0x1000;
@@ -320,9 +319,6 @@ void PerformNotificationUpdates(HWND hwnd,
 
     if ( sharedData->m_notifications & wxSPDD_DISABLE_SKIP )
         ::SendMessage( hwnd, TDM_ENABLE_BUTTON, Id_SkipBtn, FALSE );
-
-    if ( sharedData->m_notifications & wxSPDD_DISABLE_ABORT )
-        ::SendMessage( hwnd, TDM_ENABLE_BUTTON, IDCANCEL, FALSE );
 
     // Is the progress finished?
     if ( sharedData->m_notifications & wxSPDD_FINISHED )

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -987,10 +987,12 @@ void wxProgressDialog::UpdateExpandedInformation(int value)
     unsigned long remainingTime;
     UpdateTimeEstimates(value, elapsedTime, estimatedTime, remainingTime);
 
-    if ( m_sharedData->m_progressBarMarquee )
+    // The value of 0 is special, we can't estimate anything before we have at
+    // least one update, so leave the times dependent on it indeterminate.
+    //
+    // Similarly, in indeterminate mode we don't have any estimations neither.
+    if ( !value || m_sharedData->m_progressBarMarquee )
     {
-        // In indeterminate mode we don't have any estimation neither for the
-        // remaining nor for estimated time.
         estimatedTime =
         remainingTime = static_cast<unsigned long>(-1);
     }
@@ -1081,6 +1083,13 @@ void* wxProgressDialogTaskRunner::Entry()
         {
             tdc.pszExpandedInformation =
                 m_sharedData.m_expandedInformation.t_str();
+
+            // If we have elapsed/estimated/... times to show, show them from
+            // the beginning for consistency with the generic version and also
+            // because showing them later may be very sluggish if the main
+            // thread doesn't update the dialog sufficiently frequently, while
+            // hiding them still works reasonably well.
+            tdc.dwFlags |= TDF_EXPANDED_BY_DEFAULT;
         }
     }
 

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -803,17 +803,29 @@ void wxProgressDialog::DoMoveWindow(int x, int y, int width, int height)
     wxGenericProgressDialog::DoMoveWindow(x, y, width, height);
 }
 
+wxRect wxProgressDialog::GetTaskDialogRect() const
+{
+    wxRect r;
+
+#ifdef wxHAS_MSW_TASKDIALOG
+    if ( m_sharedData )
+    {
+        wxCriticalSectionLocker locker(m_sharedData->m_cs);
+        r = wxRectFromRECT(wxGetWindowRect(m_sharedData->m_hwnd));
+    }
+#else // !wxHAS_MSW_TASKDIALOG
+    wxFAIL_MSG( "unreachable" );
+#endif // wxHAS_MSW_TASKDIALOG/!wxHAS_MSW_TASKDIALOG
+
+    return r;
+}
+
 void wxProgressDialog::DoGetPosition(int *x, int *y) const
 {
 #ifdef wxHAS_MSW_TASKDIALOG
     if ( HasNativeTaskDialog() )
     {
-        wxRect r;
-        if ( m_sharedData )
-        {
-            wxCriticalSectionLocker locker(m_sharedData->m_cs);
-            r = wxRectFromRECT(wxGetWindowRect(m_sharedData->m_hwnd));
-        }
+        const wxRect r = GetTaskDialogRect();
         if (x)
             *x = r.x;
         if (y)

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -576,13 +576,8 @@ WXWidget wxProgressDialog::GetHandle() const
 #ifdef wxHAS_MSW_TASKDIALOG
     if ( HasNativeTaskDialog() )
     {
-        HWND hwnd;
-        {
-            wxCriticalSectionLocker locker(m_sharedData->m_cs);
-            m_sharedData->m_state = m_state;
-            hwnd = m_sharedData->m_hwnd;
-        }
-        return hwnd;
+        wxCriticalSectionLocker locker(m_sharedData->m_cs);
+        return m_sharedData->m_hwnd;
     }
 #endif
     return wxGenericProgressDialog::GetHandle();

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -1028,7 +1028,7 @@ wxProgressDialogTaskRunner::TaskDialogCallbackProc
                 case Id_SkipBtn:
                     ::SendMessage(hwnd, TDM_ENABLE_BUTTON, Id_SkipBtn, FALSE);
                     sharedData->m_skipped = true;
-                    return TRUE;
+                    return S_FALSE;
 
                 case IDCANCEL:
                     if ( sharedData->m_state == wxProgressDialog::Finished )
@@ -1038,7 +1038,7 @@ wxProgressDialogTaskRunner::TaskDialogCallbackProc
                         sharedData->m_state = wxProgressDialog::Dismissed;
 
                         // Let Windows close the dialog.
-                        return FALSE;
+                        return S_OK;
                     }
 
                     // Close button on the window triggers an IDCANCEL press,
@@ -1060,7 +1060,7 @@ wxProgressDialogTaskRunner::TaskDialogCallbackProc
                         sharedData->m_state = wxProgressDialog::Canceled;
                     }
 
-                    return TRUE;
+                    return S_FALSE;
             }
             break;
 
@@ -1091,11 +1091,11 @@ wxProgressDialogTaskRunner::TaskDialogCallbackProc
                 sharedData->m_winPosition = wxPoint(r.left, r.top);
             }
 
-            return TRUE;
+            return S_FALSE;
     }
 
     // Return anything.
-    return 0;
+    return S_OK;
 }
 
 #endif // wxHAS_MSW_TASKDIALOG

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -1128,27 +1128,6 @@ wxProgressDialogTaskRunner::TaskDialogCallbackProc
                            0,
                            MAKELPARAM(0, sharedData->m_range) );
 
-            // We always create this task dialog with NULL parent because our
-            // parent in wx sense is a window created from a different thread
-            // and so can't be used as our real parent. However we still center
-            // this window on the parent one as the task dialogs do with their
-            // real parent usually.
-            if ( sharedData->m_parent )
-            {
-                wxRect rect(wxRectFromRECT(wxGetWindowRect(hwnd)));
-                rect = rect.CentreIn(sharedData->m_parent->GetRect());
-                ::SetWindowPos(hwnd,
-                               NULL,
-                               rect.x,
-                               rect.y,
-                               -1,
-                               -1,
-                               SWP_NOACTIVATE |
-                               SWP_NOOWNERZORDER |
-                               SWP_NOSIZE |
-                               SWP_NOZORDER);
-            }
-
             // If we can't be aborted, the "Close" button will only be enabled
             // when the progress ends (and not even then with wxPD_AUTO_HIDE).
             if ( !(sharedData->m_style & wxPD_CAN_ABORT) )

--- a/src/msw/toplevel.cpp
+++ b/src/msw/toplevel.cpp
@@ -986,10 +986,11 @@ void wxTopLevelWindowMSW::SetIcons(const wxIconBundle& icons)
     DoSelectAndSetIcon(icons, SM_CXICON, SM_CYICON, ICON_BIG);
 }
 
-bool wxTopLevelWindowMSW::EnableCloseButton(bool enable)
+// static
+bool wxTopLevelWindowMSW::MSWEnableCloseButton(WXHWND hwnd, bool enable)
 {
     // get system (a.k.a. window) menu
-    HMENU hmenu = GetSystemMenu(GetHwnd(), FALSE /* get it */);
+    HMENU hmenu = GetSystemMenu(hwnd, FALSE /* get it */);
     if ( !hmenu )
     {
         // no system menu at all -- ok if we want to remove the close button
@@ -1008,12 +1009,17 @@ bool wxTopLevelWindowMSW::EnableCloseButton(bool enable)
         return false;
     }
     // update appearance immediately
-    if ( !::DrawMenuBar(GetHwnd()) )
+    if ( !::DrawMenuBar(hwnd) )
     {
         wxLogLastError(wxT("DrawMenuBar"));
     }
 
     return true;
+}
+
+bool wxTopLevelWindowMSW::EnableCloseButton(bool enable)
+{
+    return MSWEnableCloseButton(GetHwnd(), enable);
 }
 
 // Window must have wxCAPTION and either wxCLOSE_BOX or wxSYSTEM_MENU for the


### PR DESCRIPTION
Mostly this contains several important fixes for the native MSW version, but also a couple of changes to the generic version.

Using `AttachThreadInput()` is pretty dangerous, so it would be really great if people could please test this new approach and let me know about any new issues, notably any deadlocks. TIA!