### PR TITLE
Test UTF-8 build on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
     include:
         - compiler: gcc
         - compiler: gcc
-          env: wxCONFIGURE_FLAGS="--disable-precomp-headers --enable-monolithic"
+          env: wxCONFIGURE_FLAGS="--enable-utf8 --enable-utf8only --enable-monolithic"
         - dist: trusty
           compiler: gcc
         - dist: trusty


### PR DESCRIPTION
Instead of adding a separate build, just reuse the existing monolithic
build to also use UTF-8: this is unlikely to miss any problems with the
monolithic build that would be found without using these options, but
also gives us a chance to find the problems in UTF-8 build, both at
compile-time and in the test suite.