### PR TITLE
Fix wxPenInfo* compilation with GCC 4.4.7 on CentOS 6

### DIFF
--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -143,7 +143,7 @@ public:
     explicit wxGraphicsPenInfo(const wxColour& colour = wxColour(),
                                wxDouble width = 1.0,
                                wxPenStyle style = wxPENSTYLE_SOLID)
-        : wxPenInfoBase(colour, style)
+        : wxPenInfoBase<wxGraphicsPenInfo>(colour, style)
     {
         m_width = width;
     }

--- a/include/wx/pen.h
+++ b/include/wx/pen.h
@@ -24,7 +24,7 @@ public:
     explicit wxPenInfo(const wxColour& colour = wxColour(),
                        int width = 1,
                        wxPenStyle style = wxPENSTYLE_SOLID)
-        : wxPenInfoBase(colour, style)
+        : wxPenInfoBase<wxPenInfo>(colour, style)
     {
         m_width = width;
     }


### PR DESCRIPTION
`../include/wx/pen.h: In constructor ‘wxPenInfo::wxPenInfo(const wxColour&, int, wxPenStyle)’:
../include/wx/pen.h:27: error: class ‘wxPenInfo’ does not have any field named ‘wxPenInfoBase’
../include/wx/pen.h:27: error: no matching function for call to ‘wxPenInfoBase<wxPenInfo>::wxPenInfoBase()’
../include/wx/peninfobase.h:105: note: candidates are: wxPenInfoBase<T>::wxPenInfoBase(const wxColour&, wxPenStyle) [with T = wxPenInfo]
../include/wx/peninfobase.h:69: note:                 wxPenInfoBase<wxPenInfo>::wxPenInfoBase(const wxPenInfoBase<wxPenInfo>&)`