### PR TITLE
Fixed cp warnings in help sample and updated MSys2 directions.

### DIFF
--- a/docs/msw/msys2-gtk.txt
+++ b/docs/msw/msys2-gtk.txt
@@ -12,7 +12,9 @@ These building steps are NOT the normal way to build MSys2 MinGW packages.
 But, they are a way the wxWidgets developers can test that wxWidgets
 can build the wxGTK/Win32 libraries under MSys2 MinGW.
 
-For the MSys2 way please see https://github.com/Alexpux/MINGW-packages
+For the MSys2 way please see 
+  https://github.com/Alexpux/MINGW-packages and
+  https://github.com/msys2/msys2/wiki/Creating-packages
 
 Building steps:
 
@@ -28,23 +30,22 @@ Building steps:
 #   The 32 bit Mingw packages are prefixed with "mingw-w64-i686-";
 #   Change the prefix to "mingw-w64-x86_64-" if you wish to do 64 bit.
 
-pacman -S make
-pacman -S mingw-w64-i686-cppunit
-pacman -S mingw-w64-i686-libjpeg-turbo
-pacman -S mingw-w64-i686-libpng
-pacman -S mingw-w64-i686-libtiff
-pacman -S mingw-w64-i686-gcc
-pacman -S mingw-w64-i686-pkg-config
+pacman -S --needed --noconfirm make
+pacman -S --needed --noconfirm mingw-w64-i686-libjpeg-turbo
+pacman -S --needed --noconfirm mingw-w64-i686-libpng
+pacman -S --needed --noconfirm mingw-w64-i686-libtiff
+pacman -S --needed --noconfirm mingw-w64-i686-gcc
+pacman -S --needed --noconfirm mingw-w64-i686-pkg-config
 ## gtk2 can take a long time to update/find fonts
-pacman -S mingw-w64-i686-gtk2
+pacman -S --needed --noconfirm mingw-w64-i686-gtk2
 
 
 # Packages that are needed but are normally installed already.
-pacman -S mingw-w64-i686-gcc-libs
-pacman -S mingw-w64-i686-expat
-pacman -S mingw-w64-i686-xz
-pacman -S mingw-w64-i686-zlib
-pacman -S mingw-w64-i686-gdk-pixbuf2
+pacman -S --needed --noconfirm mingw-w64-i686-gcc-libs
+pacman -S --needed --noconfirm mingw-w64-i686-expat
+pacman -S --needed --noconfirm mingw-w64-i686-xz
+pacman -S --needed --noconfirm mingw-w64-i686-zlib
+pacman -S --needed --noconfirm mingw-w64-i686-gdk-pixbuf2
 
 
 #2. Build the wxGTK/Win32 static library
@@ -58,39 +59,53 @@ mkdir -p build-gtk2-static
 
 #2d.Configure wxWidgets
 #   Option "--disable-precomp-headers" is NOT needed.
-#   I am doing it to check for compile issues;
-#   And, I think my old 32 bit Windows machine
-#   works best with it disabled.
+#   It is being used to test for compile issues.
+#
+#   Remove configure option "--disable-wxdib" to set wxUSE_WXDIB to 1.
+#   The directions docs/msw/gtk.txt results in wxUSE_WXDIB set to 1.
 cd build-gtk2-static && \
   ../configure --with-gtk=2 \
+    --disable-wxdib \
     --disable-shared \
     --disable-precomp-headers \
   && cd ..
 
-#2e.make the wxGTK static libraries
+#2e.clean the wxGTK static libraries
+cd build-gtk2-static && make clean && cd ..
+
+#2f.make the wxGTK static libraries
 cd build-gtk2-static && make && cd ..
 
 
 #3  Build and run the minimal static sample
-#3a.Build the minimal sample
+#3a.Clean the minimal sample
+cd build-gtk2-static/samples/minimal && make clean && cd ../../..
+
+#3b.Build the minimal sample
 cd build-gtk2-static/samples/minimal && make && cd ../../..
 
-#3b.Run the minimal sample
+#3c.Run the minimal sample
 ./build-gtk2-static/samples/minimal/minimal.exe
 
 
-#4  Build and run the typetest static sample to verify MIME database works
-cd build-gtk2-static/samples/typetest && make && cd ../../..
-./build-gtk2-static/samples/typetest/typetest.exe
+#4  Build most of the static samples
+#4a.Clean most of the static samples
+cd build-gtk2-static/samples && make clean && cd ../..
+#4b.Build most of the static samples
+cd build-gtk2-static/samples && make && cd ../..
 
-#5  Build and run the drawing static sample
-cd build-gtk2-static/samples/drawing && make && cd ../../..
+
+#5  Run the drawing static sample
 cd samples/drawing && ../../build-gtk2-static/samples/drawing/drawing.exe && cd ../..
 
-#6  Build and run the splash static sample
-cd build-gtk2-static/samples/splash && make && cd ../../..
+#6  Run the splash static sample
 cd samples/splash && ../../build-gtk2-static/samples/splash/splash.exe && cd ../..
 
-#7  Build and run the widgets static sample
-cd build-gtk2-static/samples/widgets && make && cd ../../..
+#7  Run the widgets static sample
 cd samples/widgets && ../../build-gtk2-static/samples/widgets/widgets.exe && cd ../..
+
+#8  Run the toolbar static sample
+cd samples/toolbar && ../../build-gtk2-static/samples/toolbar/toolbar.exe && cd ../..
+
+#9  Run the image static sample
+cd samples/image && ../../build-gtk2-static/samples/image/image.exe && cd ../..

--- a/docs/msw/msys2-msw.txt
+++ b/docs/msw/msys2-msw.txt
@@ -21,18 +21,17 @@ Building steps:
 #   The 32 bit Mingw packages are prefixed with "mingw-w64-i686-";
 #   Change the prefix to "mingw-w64-x86_64-" if you wish to do 64 bit.
 
-pacman -S make
-pacman -S mingw-w64-i686-cppunit
-pacman -S mingw-w64-i686-libjpeg-turbo
-pacman -S mingw-w64-i686-libpng
-pacman -S mingw-w64-i686-libtiff
-pacman -S mingw-w64-i686-gcc
+pacman -S --needed --noconfirm make
+pacman -S --needed --noconfirm mingw-w64-i686-libjpeg-turbo
+pacman -S --needed --noconfirm mingw-w64-i686-libpng
+pacman -S --needed --noconfirm mingw-w64-i686-libtiff
+pacman -S --needed --noconfirm mingw-w64-i686-gcc
 
 # Packages that are needed but are normally installed already.
-pacman -S mingw-w64-i686-gcc-libs
-pacman -S mingw-w64-i686-expat
-pacman -S mingw-w64-i686-xz
-pacman -S mingw-w64-i686-zlib
+pacman -S --needed --noconfirm mingw-w64-i686-gcc-libs
+pacman -S --needed --noconfirm mingw-w64-i686-expat
+pacman -S --needed --noconfirm mingw-w64-i686-xz
+pacman -S --needed --noconfirm mingw-w64-i686-zlib
 
 
 #2. Build the wxMSW static library
@@ -60,25 +59,34 @@ cd build-msw-static && make && cd ..
 
 
 #3  Build and run the minimal static sample
-#3a.Build the minimal sample
+#3a.Clean the minimal sample
+cd build-msw-static/samples/minimal && make clean && cd ../../..
+
+#3b.Build the minimal sample
 cd build-msw-static/samples/minimal && make && cd ../../..
 
-#3b.Run the minimal sample
+#3c.Run the minimal sample
 ./build-msw-static/samples/minimal/minimal.exe
 
 
-#4  Build and run the typetest static sample to verify MIME database works
+#4 Clean the static samples
+cd build-msw-static/samples && make clean && cd ../..
+
+#5  Build and run the typetest static sample to verify MIME database works
 cd build-msw-static/samples/typetest && make && cd ../../..
 ./build-msw-static/samples/typetest/typetest.exe
 
-#5  Build and run the drawing static sample
+#6  Build and run the drawing static sample
 cd build-msw-static/samples/drawing && make && cd ../../..
 cd samples/drawing && ../../build-msw-static/samples/drawing/drawing.exe && cd ../..
 
-#6  Build and run the splash static sample
+#7  Build and run the splash static sample
 cd build-msw-static/samples/splash && make && cd ../../..
 cd samples/splash && ../../build-msw-static/samples/splash/splash.exe && cd ../..
 
-#7  Build and run the widgets static sample
+#8  Build and run the widgets static sample
 cd build-msw-static/samples/widgets && make && cd ../../..
 cd samples/widgets && ../../build-msw-static/samples/widgets/widgets.exe && cd ../..
+
+#9  Build all the rest of the static samples
+cd build-msw-static/samples && make && cd ../..

--- a/samples/help/Makefile.in
+++ b/samples/help/Makefile.in
@@ -194,7 +194,7 @@ data:
 
 data_doc: 
 	@mkdir -p ./doc
-	@for f in aindex.html ClassGraph.class ClassGraphPanel.class ClassLayout.class down.gif dxxgifs.tex HIER.html HIERjava.html icon1.gif icon2.gif index.html logo.gif NavigatorButton.class USE_HELP.html wx204.htm wx34.htm wxExtHelpController.html wxhelp.map wx.htm; do \
+	@for f in aindex.html down.gif dxxgifs.tex HIER.html icon1.gif icon2.gif index.html logo.gif wx204.htm wx34.htm wxExtHelpController.html wxhelp.map wx.htm; do \
 	if test ! -f ./doc/$$f -a ! -d ./doc/$$f ; \
 	then x=yep ; \
 	else x=`find $(srcdir)/doc/$$f -newer ./doc/$$f -print` ; \


### PR DESCRIPTION
The help sample warnings were:

cp: cannot stat '../../../samples/help/doc/ClassGraph.class': No such file or directory
cp: cannot stat '../../../samples/help/doc/ClassGraphPanel.class': No such file or directory
cp: cannot stat '../../../samples/help/doc/ClassLayout.class': No such file or directory
cp: cannot stat '../../../samples/help/doc/HIERjava.html': No such file or directory
cp: cannot stat '../../../samples/help/doc/NavigatorButton.class': No such file or directory
cp: cannot stat '../../../samples/help/doc/USE_HELP.html': No such file or directory

See also: #17962

Tim S.