### PR TITLE
Fix few minor issues in wxAutomationObject documentation

### DIFF
--- a/interface/wx/msw/ole/automtn.h
+++ b/interface/wx/msw/ole/automtn.h
@@ -443,7 +443,7 @@ public:
     */
     wxVariant CallMethod(const wxString& method, int noArgs,
                          wxVariant args[]) const;
-    const wxVariant  CallMethod(const wxString& method, ... ) const;
+    wxVariant CallMethod(const wxString& method, ... ) const;
     //@}
 
     /**
@@ -471,7 +471,7 @@ public:
         Notice that the return value of this function is an untyped pointer but
         it can be safely cast to @c IDispatch.
     */
-    void* GetDispatchPtr() const;
+    WXIDISPATCH* GetDispatchPtr() const;
 
     /**
         Retrieves the current object associated with the specified ProgID, and
@@ -541,7 +541,7 @@ public:
     */
     wxVariant GetProperty(const wxString& property, int noArgs,
                           wxVariant args[]) const;
-    const wxVariant  GetProperty(const wxString& property, ... ) const;
+    wxVariant GetProperty(const wxString& property, ... ) const;
     //@}
 
     /**
@@ -596,7 +596,7 @@ public:
     */
     bool PutProperty(const wxString& property, int noArgs,
                      wxVariant args[]);
-    const bool PutProperty(const wxString& property, ... );
+    bool PutProperty(const wxString& property, ... );
     //@}
 
     /**


### PR DESCRIPTION
I believe that it could be improved how the `wxAutomationObject` methods taking 6 `const wxVariant&`s  are documented; additionally the three `*Array` methods are still not documented at all. I was not sure how to go around it, so I let it be (for now?).