### PR TITLE
Fix generic wxTimePickerCtrl to accept max values during keyboard input.

### DIFF
--- a/src/generic/timectrlg.cpp
+++ b/src/generic/timectrlg.cpp
@@ -492,7 +492,7 @@ private:
             // Check if the new value is acceptable. If not, we just handle
             // this digit as if it were the first one.
             int newValue = currentValue*10 + n;
-            if ( newValue < maxValue )
+            if ( newValue <= maxValue )
             {
                 n = newValue;
 


### PR DESCRIPTION
Right now, the generic wxTimePickerCtrl does not allow you to type in the hour 23 and the minute 59, because the validation checks require the input to be less than the max value, rather than less than or equal to the max value. The behavior can be seen in the widgets sample when trying to enter those numbers. This change fixes the comparison. 