### PR TITLE
Fix crash on calltip click on MacOS.

### DIFF
--- a/src/stc/ScintillaWX.cpp
+++ b/src/stc/ScintillaWX.cpp
@@ -490,9 +490,10 @@ void ScintillaWX::NotifyParent(SCNotification scn) {
 // a side effect that the AutoComp will also not be destroyed when switching
 // to another window, but I think that is okay.
 void ScintillaWX::CancelModes() {
-    if (! focusEvent)
+    if (! focusEvent) {
         AutoCompleteCancel();
-    ct.CallTipCancel();
+        ct.CallTipCancel();
+    }
     Editor::CancelModes();
 }
 


### PR DESCRIPTION
Commit b0d0494f fixed it for autocomplete popup, but a similar issue is still present for calltips. This patch fixes it.

Here is the stacktrace for the non-patched version when the calltip is clicked:

```
Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       KERN_INVALID_ADDRESS at 0x0000000000000000

VM Regions Near 0:
--> 
    __TEXT                 0000000000001000-0000000000003000 [    8K] r-x/rwx SM=COW  /Users/USER/*/lua.app/Contents/MacOS/lua

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libwx.dylib                   	0x01ad86b3 Window::Destroy() + 39
1   libwx.dylib                   	0x01ff82f2 CallTip::CallTipCancel() + 30
2   libwx.dylib                   	0x01adcf11 ScintillaWX::CancelModes() + 39
3   libwx.dylib                   	0x020216c2 Editor::SetFocusState(bool) + 54
4   libwx.dylib                   	0x01ade6f3 ScintillaWX::DoLoseFocus() + 33
5   libwx.dylib                   	0x01ac4561 wxStyledTextCtrl::OnLoseFocus(wxFocusEvent&) + 25
6   libwx.dylib                   	0x01e24603 wxAppConsoleBase::HandleEvent(wxEvtHandler*, void (wxEvtHandler::*)(wxEvent&), wxEvent&) const + 39
7   libwx.dylib                   	0x01e24651 wxAppConsoleBase::CallEventHandler(wxEvtHandler*, wxEventFunctor&, wxEvent&) const + 71
8   libwx.dylib                   	0x01f4798a wxEvtHandler::ProcessEventIfMatchesId(wxEventTableEntryBase const&, wxEvtHandler*, wxEvent&) + 104
9   libwx.dylib                   	0x01f478a5 wxEventHashTable::HandleEvent(wxEvent&, wxEvtHandler*) + 119
10  libwx.dylib                   	0x01f48b58 wxEvtHandler::TryHereOnly(wxEvent&) + 80
11  libwx.dylib                   	0x01f48a85 wxEvtHandler::ProcessEventLocally(wxEvent&) + 45
12  libwx.dylib                   	0x01f48a12 wxEvtHandler::ProcessEvent(wxEvent&) + 192
13  libwx.dylib                   	0x01f48d6c wxEvtHandler::SafelyProcessEvent(wxEvent&) + 34
14  libwx.dylib                   	0x01db9ed9 wxWindowBase::HandleWindowEvent(wxEvent&) const + 27
15  libwx.dylib                   	0x01cc7714 wxWidgetCocoaImpl::DoNotifyFocusEvent(bool, wxWidgetImpl*) + 1828
16  libwx.dylib                   	0x01cc6fe9 wxWidgetCocoaImpl::DoNotifyFocusLost() + 105
17  libwx.dylib                   	0x01cc1696 wxWidgetCocoaImpl::resignFirstResponder(NSView*, void*) + 150
18  libwx.dylib                   	0x01cbfac5 wxOSX_resignFirstResponder(NSView*, objc_selector*) + 85
19  com.apple.AppKit              	0x9b7529e0 -[NSWindow makeFirstResponder:] + 469
20  libwx.dylib                   	0x01ca44d1 -[wxNSWindow makeFirstResponder:] + 161
21  libwx.dylib                   	0x01ca5486 -[wxNonOwnedWindowController windowDidResignKey:] + 198
22  com.apple.Foundation          	0x933d20f3 __57-[NSNotificationCenter addObserver:selector:name:object:]_block_invoke + 50
23  com.apple.CoreFoundation      	0x9076ec34 __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 20
24  com.apple.CoreFoundation      	0x9064e901 _CFXNotificationPost + 3713
25  com.apple.Foundation          	0x933b32c4 -[NSNotificationCenter postNotificationName:object:userInfo:] + 92
26  com.apple.Foundation          	0x933c6812 -[NSNotificationCenter postNotificationName:object:] + 56
27  com.apple.AppKit              	0x9b8a899e -[NSWindow resignKeyWindow] + 753
28  com.apple.AppKit              	0x9b76b369 -[NSWindow _changeKeyAndMainLimitedOK:] + 806
29  com.apple.AppKit              	0x9bebdaac -[NSWindow _reallySendEvent:isDelayedEvent:] + 11311
30  com.apple.AppKit              	0x9b7a03ca -[NSWindow sendEvent:] + 526
31  libwx.dylib                   	0x01ca4825 -[wxNSPanel sendEvent:] + 261
32  com.apple.AppKit              	0x9b79c9c4 -[NSApplication sendEvent:] + 4765
33  libwx.dylib                   	0x01bf7d31 -[wxNSApplication sendEvent:] + 209
34  com.apple.AppKit              	0x9b6bcbfc -[NSApplication run] + 1003
35  libwx.dylib                   	0x01c93208 wxGUIEventLoop::OSXDoRun() + 184
36  libwx.dylib                   	0x01f182ea wxCFEventLoop::DoRun() + 40
37  libwx.dylib                   	0x01e56677 wxEventLoopBase::Run() + 173
38  libwx.dylib                   	0x01e23b90 wxAppConsoleBase::MainLoop() + 98
```

In most cases a calltip window is shown on mouse dwell and is hidden when the mouse is moved (so it's not possible to click on it), but it can be shown explicitly, in which case it's clickable. Even worse, it supports up/down arrows that can be clicked and that generates CALLTIP_CLICK event that can be handled, so the clicks on the calltip should be supported.

I tested the patch on MacOS and confirmed that it eliminates the issue and still works for the clicks. I also tested the patch on Windows and it continues to work there as expected (although it works without the patch too, but I wanted to make sure the behavior there is not affected).