### PR TITLE
Fix NSFont bridging crash with Asian input methods on 10.11

### DIFF
--- a/src/osx/carbon/font.cpp
+++ b/src/osx/carbon/font.cpp
@@ -680,35 +680,6 @@ CGFontRef wxFont::OSXGetCGFont() const
 
 #endif
 
-
-#if wxOSX_USE_COCOA
-
-NSFont* wxFont::OSXGetNSFont() const
-{
-    wxCHECK_MSG( M_FONTDATA != NULL , 0, wxT("invalid font") );
-
-    // cast away constness otherwise lazy font resolution is not possible
-    const_cast<wxFont *>(this)->RealizeResource();
-
-    return const_cast<NSFont*>(reinterpret_cast<const NSFont*>(OSXGetCTFont()));
-}
-
-#endif
-
-#if wxOSX_USE_IPHONE
-
-UIFont* wxFont::OSXGetUIFont() const
-{
-    wxCHECK_MSG( M_FONTDATA != NULL , 0, wxT("invalid font") );
-
-    // cast away constness otherwise lazy font resolution is not possible
-    const_cast<wxFont *>(this)->RealizeResource();
-
-    return const_cast<UIFont*>(reinterpret_cast<const UIFont*>(OSXGetCTFont()));
-}
-
-#endif
-
 const wxNativeFontInfo * wxFont::GetNativeFontInfo() const
 {
     wxCHECK_MSG( M_FONTDATA != NULL , NULL, wxT("invalid font") );


### PR DESCRIPTION
The changes from #507 (a77066d530ff0f23f4d67a3bc8ecbc5019a1caf6) introduced a non-obvious regression: certain inputs in Asian input methods in rich `wxTextCtrl` crash on OS X 10.11 — but not, as far as I can tell, earlier or newer versions of the OS. 

I couldn't reproduce the crash, but got multiple reports of it, all from 10.11.{3,6} only, with no from older or newer OS versions, and was able to git bisect it with a cooperating user and confirm that a) #507 caused it and b) this fix works. The crashes reported to me involved typing ASCII characters inside Chinese or Japanese text, i.e. something that often involves a font change under the hood.

The crash always looks like this:

```
Application Specific Information:
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason:
*** -[NSXPCEncoder _checkObject:]: This coder only encodes objects that adopt
    NSSecureCoding (object is of class '__NSCFCharacterSet').'

Last Exception Backtrace:
0   CoreFoundation                       0x00007fff969c343a __exceptionPreprocess + 154
1   libobjc.A.dylib                      0x00007fff8d43bf7e objc_exception_throw + 48
2   CoreFoundation                       0x00007fff96a2a49d +[NSException raise:format:] + 205
3   Foundation                           0x00007fff8ef78fb1 -[NSXPCEncoder _checkObject:] + 326
4   Foundation                           0x00007fff8ef8782c -[NSXPCEncoder _encodeArrayOfObjects:forKey:] + 260
5   Foundation                           0x00007fff8efdd7ab -[NSDictionary(NSDictionary) encodeWithCoder:] + 892
6   Foundation                           0x00007fff8ef795fe -[NSXPCEncoder _encodeObject:] + 610
7   Foundation                           0x00007fff8ef795fe -[NSXPCEncoder _encodeObject:] + 610
8   UIFoundation                         0x00007fff8e1158d5 -[NSCTFont encodeWithCoder:] + 1045
9   Foundation                           0x00007fff8ef795fe -[NSXPCEncoder _encodeObject:] + 610
10  Foundation                           0x00007fff8ef8783c -[NSXPCEncoder _encodeArrayOfObjects:forKey:] + 276
11  Foundation                           0x00007fff8efdd7ab -[NSDictionary(NSDictionary) encodeWithCoder:] + 892
12  Foundation                           0x00007fff8ef795fe -[NSXPCEncoder _encodeObject:] + 610
13  Foundation                           0x00007fff8ef8783c -[NSXPCEncoder _encodeArrayOfObjects:forKey:] + 276
14  Foundation                           0x00007fff8ef795fe -[NSXPCEncoder _encodeObject:] + 610
15  Foundation                           0x00007fff8f0736f2 -[NSAttributedString encodeWithCoder:] + 1032
16  HIToolbox                            0x00007fff89f15e7d -[IMKSecureAttributedString encodeWithCoder:] + 38
17  Foundation                           0x00007fff8ef795fe -[NSXPCEncoder _encodeObject:] + 610
18  Foundation                           0x00007fff8ef79a5d encodeInvocationArguments + 257
19  Foundation                           0x00007fff8ef79788 -[NSXPCEncoder encodeInvocation:] + 337
20  Foundation                           0x00007fff8ef795fe -[NSXPCEncoder _encodeObject:] + 610
21  Foundation                           0x00007fff8efd88b1 __51-[NSXPCConnection _decodeAndInvokeMessageWithData:]_block_invoke133 + 604
22  CoreFoundation                       0x00007fff9697e521 __forwarding_prep_b___ + 113
23  HIToolbox                            0x00007fff89f323f5 __61-[IMKInputSession imkxpc_attributedSubstringFromRange:reply:]_block_invoke_2 + 982
24  HIToolbox                            0x00007fff89f41d00 __66-[IMKInputSession attributedSubstringFromRange:completionHandler:]_block_invoke1793 + 666
25  HIToolbox                            0x00007fff89d15b41 ___ZL23DispatchEventToHandlersP14EventTargetRecP14OpaqueEventRefP14HandlerCallRec_block_invoke + 107
26  AppKit                               0x00007fff887ec77d __55-[NSTextInputContext handleTSMEvent:completionHandler:]_block_invoke774 + 410
27  AppKit                               0x00007fff887ec4c2 __55-[NSTextInputContext handleTSMEvent:completionHandler:]_block_invoke758 + 471
28  AppKit                               0x00007fff880d8843 -[NSTextInputContext handleTSMEvent:completionHandler:] + 2428

…omitting a lot of internal backtrace...

133 AppKit                               0x00007fff880d7d0b __61-[NSTextInputContext _handleEvent:options:completionHandler:]_block_invoke955 + 130
134 AppKit                               0x00007fff880d69ed -[NSTextInputContext tryTSMProcessRawKeyEvent:dispatchCondition:setupForDispatch:furtherCondition:dispatchWork:continuation:] + 130
135 AppKit                               0x00007fff880d66e7 -[NSTextInputContext _handleEvent:options:completionHandler:] + 1265
136 AppKit                               0x00007fff880d61ba -[NSTextInputContext handleEvent:] + 108
137 AppKit                               0x00007fff880d60c3 -[NSView interpretKeyEvents:] + 203
138 AppKit                               0x00007fff880d5eee -[NSTextView keyDown:] + 657
139 Poedit                               0x00000001048dfdd4 wxWidgetCocoaImpl::keyEvent(NSEvent*, NSView*, void*) (window.mm:1426)
```

Notice the mention of `__NSCFCharacterSet` which looks like something related to toll-free bridging — and apparently doesn't conform to `NSSecureCoding`, even though `NSCharacterSet` is documented as conforming. I suspect this is the bit fixed in 10.12, hence why it no longer crashes there.

Also notice XPC bits in the stacktrace — as Apple moves more and more code that previously ran in-process into isolated XPC services, I think it's a reasonable guess that this happened for input methods in 10.11 for the first time. This in turn triggered the need to serialize `NSFont` with `NSSecureCoding`… and because toll-free bridged use of `NSFont` originally created in CT (as wx now does) is bound to be rare, the bug wasn't caught.

This PR fixes the issue by essentially doing pre-#507 handling, i.e. recreating `NSFont` from its description, but on 10.11 only, using NSFont's rather than our code and a bit less efficiently (no caching of NSFont instances). I think it's acceptable tradeoff — it keeps the code simple and is efficient on other versions. 