### PR TITLE
Fix generic wxTimePickerCtrl's mouse click handling on Gtk

### DIFF
--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -1439,8 +1439,15 @@ wxTextCtrl::HitTest(const wxPoint& pt, long *pos) const
 {
     if ( !IsMultiLine() )
     {
-        // not supported
-        return wxTE_HT_UNKNOWN;
+        // This is a hack that happens to work pretty well with
+        // wxTimePickerCtrl with some font sizes.
+        if ( pos )
+        {
+            *pos = (double(10 * pt.x) / (0.7 * GetSize().x));
+            if ( *pos > 0 && *pos > long(GetValue().length()) )
+                *pos = GetValue().length();
+        }
+        return wxTE_HT_ON_TEXT;
     }
 
     int x, y;


### PR DESCRIPTION
Implement HitTest() for single-line wxTextCtrls.

The generic wxTimePickerCtrl relies on HitTest(), yet it isn't supported for single-line textctrls on Gtk. However, this fact is silently ignored in code, and as a result the mouse doesn't work at all with wxTimePickerCtrl. The active hour/minute/second field can only be changed through keyboard.

This fix is obviously a proof-of-conceptish hack, as it doesn't take font size and other things into account. It may not work well for textctrls other than the timepicker.