### PR TITLE
Declare wxInvalidSize also in <wx/dir.h>

### DIFF
--- a/include/wx/dir.h
+++ b/include/wx/dir.h
@@ -45,6 +45,11 @@ enum wxDirTraverseResult
     wxDIR_CONTINUE          // continue into this directory
 };
 
+#if wxUSE_LONGLONG
+// error code of wxDir::GetTotalSize()
+extern WXDLLIMPEXP_DATA_BASE(const wxULongLong) wxInvalidSize;
+#endif // wxUSE_LONGLONG
+
 // ----------------------------------------------------------------------------
 // wxDirTraverser: helper class for wxDir::Traverse()
 // ----------------------------------------------------------------------------

--- a/interface/wx/dir.h
+++ b/interface/wx/dir.h
@@ -16,6 +16,11 @@ enum wxDirTraverseResult
 };
 
 /**
+    The return value of wxDir::GetTotalSize() in case of error.
+*/
+wxULongLong wxInvalidSize;
+
+/**
     @class wxDirTraverser
 
     wxDirTraverser is an abstract interface which must be implemented by


### PR DESCRIPTION
wxInvalidSize is a documented return value for
wxDir::GetTotalSize(), yet it was not available
by including only <wx/dir.h>.