### PR TITLE
Hide wxSpinButton's underlying GtkEntry on GTK 3.22+ using CSS

### DIFF
--- a/src/gtk/spinbutt.cpp
+++ b/src/gtk/spinbutt.cpp
@@ -107,6 +107,10 @@ bool wxSpinButton::Create(wxWindow *parent,
     if (gtk_check_version(3,12,0) == NULL)
         gtk_entry_set_max_width_chars(GTK_ENTRY(m_widget), 0);
 #endif
+#if GTK_CHECK_VERSION(3,22,0)
+    if (gtk_check_version(3,22,0) == NULL)
+        GTKApplyCssStyle("entry { min-width:0; padding-left:0; padding-right:0 } button.down { border-style:none }");
+#endif
     gtk_spin_button_set_wrap( GTK_SPIN_BUTTON(m_widget),
                               (int)(m_windowStyle & wxSP_WRAP) );
 


### PR DESCRIPTION
Fixes #17847