### PR TITLE
Simplify GTK+ 2 version checks with a helper function

### DIFF
--- a/include/wx/gtk/private/gtk2-compat.h
+++ b/include/wx/gtk/private/gtk2-compat.h
@@ -530,5 +530,23 @@ static inline void wx_gtk_widget_get_preferred_size(GtkWidget* widget, GtkRequis
 // backend is determined at compile time in that version.
 #define GDK_IS_X11_DISPLAY(dpy) true
 
-#endif // !__WXGTK3__
+// Do perform runtime checks for GTK+ 2 version: we only take the minor version
+// component here, major must be 2 and we never need to test for the micro one
+// anyhow.
+inline bool wx_is_at_least_gtk2(int minor)
+{
+    return gtk_check_version(2, minor, 0) == NULL;
+}
+
+#else // __WXGTK3__
+
+// With GTK+ 3 we don't need to check for GTK+ 2 version and
+// gtk_check_version() would fail due to major version mismatch.
+inline bool wx_is_at_least_gtk2(int WXUNUSED(minor))
+{
+    return true;
+}
+
+#endif // !__WXGTK3__/__WXGTK3__
+
 #endif // _WX_GTK_PRIVATE_COMPAT_H_

--- a/include/wx/gtk/private/messagetype.h
+++ b/include/wx/gtk/private/messagetype.h
@@ -12,6 +12,8 @@
 
 #include <gtk/gtk.h>
 
+#include "wx/gtk/private/gtk2-compat.h"
+
 namespace wxGTKImpl
 {
 
@@ -20,7 +22,7 @@ namespace wxGTKImpl
 inline bool ConvertMessageTypeFromWX(int style, GtkMessageType *type)
 {
 #ifdef __WXGTK210__
-    if ( gtk_check_version(2, 10, 0) == NULL && (style & wxICON_NONE))
+    if ( wx_is_at_least_gtk2(10) && (style & wxICON_NONE))
         *type = GTK_MESSAGE_OTHER;
     else
 #endif // __WXGTK210__

--- a/src/generic/statusbr.cpp
+++ b/src/generic/statusbr.cpp
@@ -130,11 +130,7 @@ bool wxStatusBarGeneric::Create(wxWindow *parent,
 
 #if defined( __WXGTK20__ )
 #if GTK_CHECK_VERSION(2,12,0)
-    if (HasFlag(wxSTB_SHOW_TIPS)
-#ifndef __WXGTK3__
-        && gtk_check_version(2,12,0) == NULL
-#endif
-        )
+    if (HasFlag(wxSTB_SHOW_TIPS) && wx_is_at_least_gtk2(12))
     {
         g_object_set(m_widget, "has-tooltip", TRUE, NULL);
         g_signal_connect(m_widget, "query-tooltip",

--- a/src/gtk/activityindicator.cpp
+++ b/src/gtk/activityindicator.cpp
@@ -29,13 +29,14 @@
 #include "wx/math.h"
 
 #include <gtk/gtk.h>
+#include "wx/gtk/private/gtk2-compat.h"
 
 // Macro return the specified expression only if GTK+ run time version is less
 // than 2.20 and compiling it only if it is less than 3.0 (which is why this
 // has to be a macro and not a function).
 #if defined(__WXGTK220__) && !defined(__WXGTK3__)
     #define RETURN_IF_NO_GTK_SPINNER(expr) \
-        if ( gtk_check_version(2, 20, 0) != 0 ) { return expr; }
+        if ( !wx_is_at_least_gtk2(20) ) { return expr; }
 #else
     #define RETURN_IF_NO_GTK_SPINNER(expr)
 #endif

--- a/src/gtk/anybutton.cpp
+++ b/src/gtk/anybutton.cpp
@@ -389,9 +389,7 @@ void wxAnyButton::DoSetBitmap(const wxBitmap& bitmap, State which)
 void wxAnyButton::DoSetBitmapPosition(wxDirection dir)
 {
 #ifdef __WXGTK210__
-#ifndef __WXGTK3__
-    if ( !gtk_check_version(2,10,0) )
-#endif
+    if ( wx_is_at_least_gtk2(10) )
     {
         GtkPositionType gtkpos;
         switch ( dir )

--- a/src/gtk/bitmap.cpp
+++ b/src/gtk/bitmap.cpp
@@ -522,7 +522,7 @@ wxBitmap::wxBitmap(GdkPixmap* pixmap)
 wxBitmap::wxBitmap(const wxCursor& cursor)
 {
 #if GTK_CHECK_VERSION(2,8,0)
-    if (gtk_check_version(2,8,0) == NULL)
+    if (wx_is_at_least_gtk2(8))
     {
         GdkPixbuf *pixbuf = gdk_cursor_get_image(cursor.GetCursor());
         *this = wxBitmap(pixbuf);

--- a/src/gtk/combobox.cpp
+++ b/src/gtk/combobox.cpp
@@ -194,9 +194,7 @@ bool wxComboBox::Create( wxWindow *parent, wxWindowID id, const wxString& value,
     g_signal_connect_after (m_widget, "changed",
                         G_CALLBACK (gtkcombobox_changed_callback), this);
 
-#ifndef __WXGTK3__
-    if ( !gtk_check_version(2,10,0) )
-#endif
+    if ( wx_is_at_least_gtk2(10) )
     {
         g_signal_connect (m_widget, "notify::popup-shown",
                           G_CALLBACK (gtkcombobox_popupshown_callback), this);

--- a/src/gtk/control.cpp
+++ b/src/gtk/control.cpp
@@ -123,7 +123,7 @@ void wxControl::PostCreation(const wxSize& size)
 void wxControl::GTKFixSensitivity(bool WXUNUSED_IN_GTK3(onlyIfUnderMouse))
 {
 #ifndef __WXGTK3__
-    if (gtk_check_version(2,14,0)
+    if (!wx_is_at_least_gtk2(14)
 #if wxUSE_SYSTEM_OPTIONS
         && (wxSystemOptions::GetOptionInt(wxT("gtk.control.disable-sensitivity-fix")) != 1)
 #endif
@@ -348,7 +348,7 @@ wxPoint wxControl::GTKGetEntryMargins(GtkEntry* entry) const
 #if GTK_CHECK_VERSION(2,10,0)
     // The margins we have previously set
     const GtkBorder* border = NULL;
-    if (gtk_check_version(2,10,0) == NULL)
+    if (wx_is_at_least_gtk2(10))
         border = gtk_entry_get_inner_border(entry);
 
     if ( border )

--- a/src/gtk/cursor.cpp
+++ b/src/gtk/cursor.cpp
@@ -175,7 +175,7 @@ wxPoint wxCursor::GetHotSpot() const
 #if GTK_CHECK_VERSION(2,8,0)
     if (GetCursor())
     {
-        if (gtk_check_version(2,8,0) == NULL)
+        if (wx_is_at_least_gtk2(8))
         {
             GdkPixbuf *pixbuf = gdk_cursor_get_image(GetCursor());
             if (pixbuf)

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -158,10 +158,8 @@ private:
         // We can only use gtk_tree_selection_get_select_function() with 2.14+
         // so check for its availability both during compile- and run-time.
 #if GTK_CHECK_VERSION(2, 14, 0)
-#ifndef __WXGTK3__
-        if ( gtk_check_version(2, 14, 0) != NULL )
+        if ( !wx_is_at_least_gtk2(14) )
             return;
-#endif
 
         // If this assert is triggered, it means the code elsewhere has called
         // gtk_tree_selection_set_select_function() but currently doing this
@@ -2335,10 +2333,8 @@ void wxDataViewTextRenderer::GtkUpdateAlignment()
 {
     wxDataViewRenderer::GtkUpdateAlignment();
 
-#ifndef __WXGTK3__
-    if (gtk_check_version(2,10,0))
+    if (!wx_is_at_least_gtk2(10))
         return;
-#endif
 
     int align = GetEffectiveAlignmentIfKnown();
     if ( align == wxDVR_DEFAULT_ALIGNMENT )
@@ -2874,10 +2870,8 @@ void wxDataViewChoiceRenderer::GtkUpdateAlignment()
 {
     wxDataViewCustomRenderer::GtkUpdateAlignment();
 
-#ifndef __WXGTK3__
-    if (gtk_check_version(2,10,0))
+    if (!wx_is_at_least_gtk2(10))
         return;
-#endif
 
     int align = GetEffectiveAlignmentIfKnown();
     if ( align == wxDVR_DEFAULT_ALIGNMENT )
@@ -4605,9 +4599,7 @@ bool wxDataViewCtrl::Create(wxWindow *parent,
     gtk_tree_view_set_headers_visible( GTK_TREE_VIEW(m_treeview), (style & wxDV_NO_HEADER) == 0 );
 
 #ifdef __WXGTK210__
-#ifndef __WXGTK3__
-    if (!gtk_check_version(2,10,0))
-#endif
+    if (wx_is_at_least_gtk2(10))
     {
         GtkTreeViewGridLines grid = GTK_TREE_VIEW_GRID_LINES_NONE;
 
@@ -4920,10 +4912,9 @@ void wxDataViewCtrl::DoSetCurrentItem(const wxDataViewItem& item)
 wxDataViewItem wxDataViewCtrl::GetTopItem() const
 {
 #if GTK_CHECK_VERSION(2,8,0)
-#ifndef __WXGTK3__
-    if (gtk_check_version(2,8,0))
+    if (!wx_is_at_least_gtk2(8))
         return wxDataViewItem();
-#endif
+
     wxGtkTreePath start;
     if ( gtk_tree_view_get_visible_range
           (
@@ -5241,7 +5232,7 @@ void wxDataViewCtrl::DoSetExpanderColumn()
 void wxDataViewCtrl::DoSetIndent()
 {
 #if GTK_CHECK_VERSION(2, 12, 0)
-    if ( gtk_check_version(2, 12, 0) == NULL )
+    if ( wx_is_at_least_gtk2(12) )
     {
         gtk_tree_view_set_level_indentation(GTK_TREE_VIEW(m_treeview), GetIndent());
     }

--- a/src/gtk/dcclient.cpp
+++ b/src/gtk/dcclient.cpp
@@ -382,7 +382,7 @@ void wxWindowDCImpl::SetUpDC( bool isMemDC )
 #if GTK_CHECK_VERSION(2,12,0)
         // gdk_screen_get_rgba_colormap was added in 2.8, but this code is for
         // compositing which requires 2.12
-        else if (gtk_check_version(2,12,0) == NULL &&
+        else if (wx_is_at_least_gtk2(12) &&
             m_cmap == gdk_screen_get_rgba_colormap(gdk_colormap_get_screen(m_cmap)))
         {
             m_penGC = wxGetPoolGC( m_gdkwindow, wxPEN_COLOUR_ALPHA );

--- a/src/gtk/dialog.cpp
+++ b/src/gtk/dialog.cpp
@@ -148,10 +148,8 @@ int wxDialog::ShowModal()
 #if GTK_CHECK_VERSION(2,10,0)
     unsigned sigId = 0;
     gulong hookId = 0;
-#ifndef __WXGTK3__
     // Ubuntu overlay scrollbar uses at least GTK 2.24
-    if (gtk_check_version(2,24,0) == NULL)
-#endif
+    if (wx_is_at_least_gtk2(24))
     {
         sigId = g_signal_lookup("realize", GTK_TYPE_WIDGET);
         hookId = g_signal_add_emission_hook(sigId, 0, realize_hook, NULL, NULL);

--- a/src/gtk/dirdlg.cpp
+++ b/src/gtk/dirdlg.cpp
@@ -94,9 +94,7 @@ bool wxDirDialog::Create(wxWindow* parent,
 
     gtk_dialog_set_default_response(GTK_DIALOG(m_widget), GTK_RESPONSE_ACCEPT);
 #if GTK_CHECK_VERSION(2,18,0)
-#ifndef __WXGTK3__
-    if (gtk_check_version(2,18,0) == NULL)
-#endif
+    if (wx_is_at_least_gtk2(18))
     {
         gtk_file_chooser_set_create_folders(
             GTK_FILE_CHOOSER(m_widget), (style & wxDD_DIR_MUST_EXIST) == 0);

--- a/src/gtk/display.cpp
+++ b/src/gtk/display.cpp
@@ -35,7 +35,7 @@ static inline int wx_gdk_screen_get_primary_monitor(GdkScreen* screen)
 {
     int monitor = 0;
 #if GTK_CHECK_VERSION(2,20,0)
-    if (gtk_check_version(2,20,0) == NULL)
+    if (wx_is_at_least_gtk2(20))
         monitor = gdk_screen_get_primary_monitor(screen);
 #endif
     return monitor;

--- a/src/gtk/filedlg.cpp
+++ b/src/gtk/filedlg.cpp
@@ -44,7 +44,7 @@ static void gtk_filedialog_ok_callback(GtkWidget *widget, wxFileDialog *dialog)
     // gtk version numbers must be identical with the one in ctor (that calls set_do_overwrite_confirmation)
 #ifndef __WXGTK3__
 #if GTK_CHECK_VERSION(2,7,3)
-    if (gtk_check_version(2, 7, 3) != NULL)
+    if (!wx_is_at_least_gtk2(8))
 #endif
     {
         if ((style & wxFD_SAVE) && (style & wxFD_OVERWRITE_PROMPT))
@@ -306,11 +306,7 @@ bool wxFileDialog::Create(wxWindow *parent, const wxString& message,
         }
 
 #if GTK_CHECK_VERSION(2,7,3)
-        if ((style & wxFD_OVERWRITE_PROMPT)
-#ifndef __WXGTK3__
-            && gtk_check_version(2,7,3) == NULL
-#endif
-            )
+        if ((style & wxFD_OVERWRITE_PROMPT) && wx_is_at_least_gtk2(8))
         {
             gtk_file_chooser_set_do_overwrite_confirmation(file_chooser, true);
         }

--- a/src/gtk/filehistory.cpp
+++ b/src/gtk/filehistory.cpp
@@ -43,9 +43,7 @@ void wxFileHistory::AddFileToHistory(const wxString& file)
 
 #ifdef __WXGTK210__
     const wxString fullPath = wxFileName(file).GetFullPath();
-#ifndef __WXGTK3__
-    if ( !gtk_check_version(2,10,0) )
-#endif
+    if ( wx_is_at_least_gtk2(10) )
     {
         wxGtkString uri(g_filename_to_uri(wxGTK_CONV_FN(fullPath), NULL, NULL));
 

--- a/src/gtk/hyperlink.cpp
+++ b/src/gtk/hyperlink.cpp
@@ -39,11 +39,7 @@
 static inline bool UseNative()
 {
     // native gtk_link_button widget is only available in GTK+ 2.10 and later
-#ifdef __WXGTK3__
-    return true;
-#else
-    return !gtk_check_version(2, 10, 0);
-#endif
+    return wx_is_at_least_gtk2(10);
 }
 
 // ============================================================================
@@ -289,9 +285,7 @@ void wxHyperlinkCtrl::SetVisited(bool visited)
 {
     base_type::SetVisited(visited);
 #if GTK_CHECK_VERSION(2,14,0)
-#ifndef __WXGTK3__
-    if (gtk_check_version(2,14,0) == NULL)
-#endif
+    if (wx_is_at_least_gtk2(14))
     {
         gtk_link_button_set_visited(GTK_LINK_BUTTON(m_widget), visited);
     }
@@ -301,9 +295,7 @@ void wxHyperlinkCtrl::SetVisited(bool visited)
 bool wxHyperlinkCtrl::GetVisited() const
 {
 #if GTK_CHECK_VERSION(2,14,0)
-#ifndef __WXGTK3__
-    if (gtk_check_version(2,14,0) == NULL)
-#endif
+    if (wx_is_at_least_gtk2(14))
     {
         return gtk_link_button_get_visited(GTK_LINK_BUTTON(m_widget)) != 0;
     }

--- a/src/gtk/infobar.cpp
+++ b/src/gtk/infobar.cpp
@@ -81,12 +81,8 @@ namespace
 
 inline bool UseNative()
 {
-#ifdef __WXGTK3__
-    return true;
-#else
     // native GtkInfoBar widget is only available in GTK+ 2.18 and later
-    return gtk_check_version(2, 18, 0) == 0;
-#endif
+    return wx_is_at_least_gtk2(18);
 }
 
 } // anonymous namespace

--- a/src/gtk/listbox.cpp
+++ b/src/gtk/listbox.cpp
@@ -765,9 +765,7 @@ int wxListBox::GetTopItem() const
 #if GTK_CHECK_VERSION(2,8,0)
     wxGtkTreePath start;
     if (
-#ifndef __WXGTK3__
-        gtk_check_version(2,8,0) == NULL &&
-#endif
+        wx_is_at_least_gtk2(8) &&
         gtk_tree_view_get_visible_range(m_treeview, start.ByRef(), NULL))
     {
         gint *ptr = gtk_tree_path_get_indices(start);

--- a/src/gtk/mimetype.cpp
+++ b/src/gtk/mimetype.cpp
@@ -18,16 +18,16 @@
 
 #include "wx/gtk/private/string.h"
 #include "wx/gtk/private/object.h"
+#include "wx/gtk/private/gtk2-compat.h"
 
 #if defined(__UNIX__)
 wxString wxGTKMimeTypesManagerImpl::GetIconFromMimeType(const wxString& mime)
 {
     wxString icon;
 #if GTK_CHECK_VERSION(2,14,0)
-#ifndef __WXGTK3__
-    if (gtk_check_version(2,14,0))
+    if (!wx_is_at_least_gtk2(14))
         return icon;
-#endif
+
     wxGtkString type(g_content_type_from_mime_type(mime.utf8_str()));
 
     wxGtkObject<GIcon> gicon(g_content_type_get_icon(type));

--- a/src/gtk/print.cpp
+++ b/src/gtk/print.cpp
@@ -46,6 +46,7 @@
 wxFORCE_LINK_THIS_MODULE(gtk_print)
 
 #include "wx/gtk/private/object.h"
+#include "wx/gtk/private/gtk2-compat.h"
 
 // Useful to convert angles from degrees to radians.
 static const double DEG2RAD  = M_PI / 180.0;
@@ -185,9 +186,7 @@ static GtkPaperSize* wxGetGtkPaperSize(wxPaperSize paperId, const wxSize& size)
         return gtk_paper_size_new(gtk_paper_size_get_default());
 
 #if GTK_CHECK_VERSION(2,12,0)
-#ifndef __WXGTK3__
-    if (gtk_check_version(2,12,0) == NULL)
-#endif
+    if (wx_is_at_least_gtk2(12))
     {
         // look for a size match in GTK's GtkPaperSize list
         const double w = size.x;
@@ -242,9 +241,7 @@ private:
 
 bool wxGtkPrintModule::OnInit()
 {
-#ifndef __WXGTK3__
-    if (gtk_check_version(2,10,0) == NULL)
-#endif
+    if (wx_is_at_least_gtk2(10))
     {
         wxPrintFactory::SetPrintFactory( new wxGtkPrintFactory );
     }
@@ -405,9 +402,7 @@ void wxGtkPrintNativeData::SetPrintJob(GtkPrintOperation* job)
 #if GTK_CHECK_VERSION(2,18,0)
     if (job)
     {
-#ifndef __WXGTK3__
-        if (gtk_check_version(2,18,0) == NULL)
-#endif
+        if (wx_is_at_least_gtk2(18))
         {
             gtk_print_operation_set_embed_page_setup(job, true);
         }

--- a/src/gtk/settings.cpp
+++ b/src/gtk/settings.cpp
@@ -132,7 +132,7 @@ static GtkWidget* ToolTipWidget()
         g_signal_connect_swapped(ContainerWidget(), "destroy",
             G_CALLBACK(gtk_widget_destroy), s_widget);
         const char* name = "gtk-tooltip";
-        if (gtk_check_version(2, 11, 0))
+        if (!wx_is_at_least_gtk2(11))
             name = "gtk-tooltips";
         gtk_widget_set_name(s_widget, name);
         gtk_widget_ensure_style(s_widget);

--- a/src/gtk/statbox.cpp
+++ b/src/gtk/statbox.cpp
@@ -101,7 +101,7 @@ bool wxStaticBox::Create( wxWindow *parent,
     gtk_frame_set_label_align(GTK_FRAME(m_widget), xalign, 0.5);
 
 #ifndef __WXGTK3__
-    if (gtk_check_version(2, 12, 0))
+    if (!wx_is_at_least_gtk2(12))
     {
         // we connect this signal to perform label-clipping as GTK >= 2.12 does
         g_signal_connect(m_widget, "size_allocate", G_CALLBACK(size_allocate), NULL);

--- a/src/gtk/taskbar.cpp
+++ b/src/gtk/taskbar.cpp
@@ -185,7 +185,7 @@ wxTaskBarIcon::Private::~Private()
 void wxTaskBarIcon::Private::SetIcon()
 {
 #if GTK_CHECK_VERSION(2,10,0)
-    if (GTK_CHECK_VERSION(3,0,0) || gtk_check_version(2,10,0) == NULL)
+    if (wx_is_at_least_gtk2(10))
     {
         if (m_statusIcon)
             gtk_status_icon_set_from_pixbuf(m_statusIcon, m_bitmap.GetPixbuf());
@@ -235,7 +235,7 @@ void wxTaskBarIcon::Private::SetIcon()
     if (m_statusIcon)
     {
 #if GTK_CHECK_VERSION(2,16,0)
-        if (GTK_CHECK_VERSION(3,0,0) || gtk_check_version(2,16,0) == NULL)
+        if (wx_is_at_least_gtk2(16))
             gtk_status_icon_set_tooltip_text(m_statusIcon, tip_text);
         else
 #endif

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -181,7 +181,7 @@ static void wxGtkTextApplyTagsFromAttr(GtkWidget *text,
 #elif GTK_CHECK_VERSION(2,11,0)
 // gtk+ doesn't support justify before gtk+-2.11.0 with pango-1.17 being available
 // (but if new enough pango isn't available it's a mere gtk warning)
-                if (!gtk_check_version(2,11,0))
+                if (wx_is_at_least_gtk2(11))
                 {
                     align = GTK_JUSTIFY_FILL;
                     break;
@@ -858,18 +858,14 @@ int wxTextCtrl::GTKIMFilterKeypress(GdkEventKey* event) const
     if (IsSingleLine())
         return wxTextEntry::GTKIMFilterKeypress(event);
 
-    int result;
+    int result = false;
 #if GTK_CHECK_VERSION(2, 22, 0)
-#ifndef __WXGTK3__
-    result = false;
-    if (gtk_check_version(2,22,0) == NULL)
-#endif
+    if (wx_is_at_least_gtk2(22))
     {
         result = gtk_text_view_im_context_filter_keypress(GTK_TEXT_VIEW(m_text), event);
     }
 #else // GTK+ < 2.22
     wxUnusedVar(event);
-    result = false;
 #endif // GTK+ 2.22+
 
     return result;

--- a/src/gtk/textentry.cpp
+++ b/src/gtk/textentry.cpp
@@ -42,9 +42,7 @@
 static unsigned int GetEntryTextLength(GtkEntry* entry)
 {
 #if GTK_CHECK_VERSION(2, 14, 0)
-#ifndef __WXGTK3__
-    if ( gtk_check_version(2, 14, 0) == NULL )
-#endif // !GTK+ 3
+    if ( wx_is_at_least_gtk2(14) )
     {
         return gtk_entry_get_text_length(entry);
     }
@@ -370,7 +368,7 @@ void wxTextEntry::SetSelection(long from, long to)
 #ifndef __WXGTK3__
     // avoid reported problem with RHEL 5 GTK+ 2.10 where selection is reset by
     // a clipboard callback, see #13277
-    if (gtk_check_version(2,12,0))
+    if (!wx_is_at_least_gtk2(12))
     {
         GtkEntry* entry = GTK_ENTRY(GetEditable());
         if (to < 0)
@@ -493,18 +491,14 @@ void wxTextEntry::ForceUpper()
 
 int wxTextEntry::GTKIMFilterKeypress(GdkEventKey* event) const
 {
-    int result;
+    int result = false;
 #if GTK_CHECK_VERSION(2, 22, 0)
-#ifndef __WXGTK3__
-    result = false;
-    if (gtk_check_version(2,22,0) == NULL)
-#endif
+    if (wx_is_at_least_gtk2(22))
     {
         result = gtk_entry_im_context_filter_keypress(GetEntry(), event);
     }
 #else // GTK+ < 2.22
     wxUnusedVar(event);
-    result = false;
 #endif // GTK+ 2.22+
 
     return result;
@@ -532,10 +526,8 @@ bool wxTextEntry::DoSetMargins(const wxPoint& margins)
 
     if ( !entry )
         return false;
-#ifndef __WXGTK3__
-    if (gtk_check_version(2,10,0))
+    if ( !wx_is_at_least_gtk2(10) )
         return false;
-#endif
 
     const GtkBorder* oldBorder = gtk_entry_get_inner_border(entry);
     GtkBorder newBorder;
@@ -576,9 +568,7 @@ wxPoint wxTextEntry::DoGetMargins() const
     GtkEntry* entry = GetEntry();
     if (entry)
     {
-#ifndef __WXGTK3__
-        if (gtk_check_version(2,10,0) == NULL)
-#endif
+        if (wx_is_at_least_gtk2(10))
         {
             const GtkBorder* border = gtk_entry_get_inner_border(entry);
             if (border)

--- a/src/gtk/toolbar.cpp
+++ b/src/gtk/toolbar.cpp
@@ -408,7 +408,7 @@ bool wxToolBar::Create( wxWindow *parent,
 
     m_toolbar = GTK_TOOLBAR( gtk_toolbar_new() );
 #ifndef __WXGTK3__
-    if (gtk_check_version(2, 12, 0))
+    if (!wx_is_at_least_gtk2(12))
     {
         m_tooltips = gtk_tooltips_new();
         g_object_ref(m_tooltips);
@@ -580,7 +580,7 @@ bool wxToolBar::DoInsertTool(size_t pos, wxToolBarToolBase *toolBase)
             if (!HasFlag(wxTB_NO_TOOLTIPS) && !tool->GetShortHelp().empty())
             {
 #if GTK_CHECK_VERSION(2, 12, 0)
-                if (GTK_CHECK_VERSION(3,0,0) || gtk_check_version(2,12,0) == NULL)
+                if (wx_is_at_least_gtk2(12))
                 {
                     gtk_tool_item_set_tooltip_text(tool->m_item,
                         wxGTK_CONV(tool->GetShortHelp()));
@@ -754,7 +754,7 @@ void wxToolBar::SetToolShortHelp( int id, const wxString& helpString )
         if (tool->m_item)
         {
 #if GTK_CHECK_VERSION(2, 12, 0)
-            if (GTK_CHECK_VERSION(3,0,0) || gtk_check_version(2,12,0) == NULL)
+            if (wx_is_at_least_gtk2(12))
             {
                 gtk_tool_item_set_tooltip_text(tool->m_item,
                     wxGTK_CONV(helpString));

--- a/src/gtk/tooltip.cpp
+++ b/src/gtk/tooltip.cpp
@@ -57,7 +57,7 @@ void wxToolTip::GTKSetWindow(wxWindow* win)
 void wxToolTip::GTKApply(GtkWidget* widget, const char* tip)
 {
 #if GTK_CHECK_VERSION(2, 12, 0)
-    if (GTK_CHECK_VERSION(3,0,0) || gtk_check_version(2,12,0) == NULL)
+    if (wx_is_at_least_gtk2(12))
         gtk_widget_set_tooltip_text(widget, tip);
     else
 #endif
@@ -74,7 +74,7 @@ void wxToolTip::GTKApply(GtkWidget* widget, const char* tip)
 void wxToolTip::Enable( bool flag )
 {
 #if GTK_CHECK_VERSION(2, 12, 0)
-    if (GTK_CHECK_VERSION(3,0,0) || gtk_check_version(2,12,0) == NULL)
+    if (wx_is_at_least_gtk2(12))
     {
         GtkSettings* settings = gtk_settings_get_default();
         if (settings)
@@ -98,7 +98,7 @@ void wxToolTip::Enable( bool flag )
 void wxToolTip::SetDelay( long msecs )
 {
 #if GTK_CHECK_VERSION(2, 12, 0)
-    if (GTK_CHECK_VERSION(3,0,0) || gtk_check_version(2,12,0) == NULL)
+    if (wx_is_at_least_gtk2(12))
     {
         GtkSettings* settings = gtk_settings_get_default();
         if (settings)

--- a/src/gtk/toplevel.cpp
+++ b/src/gtk/toplevel.cpp
@@ -99,7 +99,7 @@ static void wxgtk_window_set_urgency_hint (GtkWindow *win,
                                            gboolean setting)
 {
 #if GTK_CHECK_VERSION(2,7,0)
-    if (gtk_check_version(2,7,0) == NULL)
+    if (wx_is_at_least_gtk2(7))
         gtk_window_set_urgency_hint(win, setting);
     else
 #endif
@@ -1582,28 +1582,29 @@ bool wxTopLevelWindowGTK::SetTransparent(wxByte alpha)
 {
     if (m_widget == NULL)
         return false;
-#if GTK_CHECK_VERSION(2,12,0)
-#ifndef __WXGTK3__
-    if (gtk_check_version(2,12,0) == NULL)
-#endif
-    {
+
+#ifdef __WXGTK3__
 #if GTK_CHECK_VERSION(3,8,0)
-        if(gtk_check_version(3,8,0) == NULL)
-        {
-            gtk_widget_set_opacity(m_widget, alpha / 255.0);
-        }
-        else
-#endif
-        {
-            // Can't avoid using this deprecated function with older GTK+.
-            wxGCC_WARNING_SUPPRESS(deprecated-declarations);
-            gtk_window_set_opacity(GTK_WINDOW(m_widget), alpha / 255.0);
-            wxGCC_WARNING_RESTORE();
-        }
+    if(gtk_check_version(3,8,0) == NULL)
+    {
+        gtk_widget_set_opacity(m_widget, alpha / 255.0);
+    }
+    else
+#endif // GTK+ 3.8+
+    {
+        gtk_window_set_opacity(GTK_WINDOW(m_widget), alpha / 255.0);
+    }
+
+    return true;
+#else // !__WXGTK3__
+
+#if GTK_CHECK_VERSION(2,12,0)
+    if (wx_is_at_least_gtk2(12))
+    {
+        gtk_window_set_opacity(GTK_WINDOW(m_widget), alpha / 255.0);
         return true;
     }
 #endif // GTK_CHECK_VERSION(2,12,0)
-#ifndef __WXGTK3__
 #ifdef GDK_WINDOWING_X11
     GdkWindow* window = gtk_widget_get_window(m_widget);
     if (window == NULL)
@@ -1626,7 +1627,7 @@ bool wxTopLevelWindowGTK::SetTransparent(wxByte alpha)
 #else // !GDK_WINDOWING_X11
     return false;
 #endif // GDK_WINDOWING_X11 / !GDK_WINDOWING_X11
-#endif // !__WXGTK3__
+#endif // __WXGTK3__/!__WXGTK3__
 }
 
 bool wxTopLevelWindowGTK::CanSetTransparent()
@@ -1638,11 +1639,8 @@ bool wxTopLevelWindowGTK::CanSetTransparent()
         return wxSystemOptions::GetOptionInt(SYSOPT_TRANSPARENT) != 0;
     }
 
-#ifdef __WXGTK3__
-    return gtk_widget_is_composited(m_widget) != 0;
-#else
 #if GTK_CHECK_VERSION(2,10,0)
-    if (!gtk_check_version(2,10,0))
+    if (wx_is_at_least_gtk2(10))
     {
         return gtk_widget_is_composited(m_widget) != 0;
     }
@@ -1651,7 +1649,6 @@ bool wxTopLevelWindowGTK::CanSetTransparent()
     {
         return false;
     }
-#endif // !__WXGTK3__
 
 #if 0 // Don't be optimistic here for the sake of wxAUI
     int opcode, event, error;

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -58,7 +58,6 @@ typedef guint KeySym;
 #endif
 
 // gdk_window_set_composited() is only supported since 2.12
-#define wxGTK_VERSION_REQUIRED_FOR_COMPOSITING 2,12,0
 #define wxGTK_HAS_COMPOSITING_SUPPORT (GTK_CHECK_VERSION(2,12,0) && wxUSE_CAIRO)
 
 #ifndef PANGO_VERSION_CHECK
@@ -2766,9 +2765,7 @@ void wxWindowGTK::PostCreation()
 #endif
 
 #if GTK_CHECK_VERSION(2, 8, 0)
-#ifndef __WXGTK3__
-    if ( gtk_check_version(2,8,0) == NULL )
-#endif
+    if ( wx_is_at_least_gtk2(8) )
     {
         // Make sure we can notify the app when mouse capture is lost
         if ( m_wxwindow )
@@ -4653,7 +4650,7 @@ bool wxWindowGTK::IsTransparentBackgroundSupported(wxString* reason) const
 {
 #if wxGTK_HAS_COMPOSITING_SUPPORT
 #ifndef __WXGTK3__
-    if (gtk_check_version(wxGTK_VERSION_REQUIRED_FOR_COMPOSITING) != NULL)
+    if (!wx_is_at_least_gtk2(12))
     {
         if (reason)
         {

--- a/src/unix/utilsx11.cpp
+++ b/src/unix/utilsx11.cpp
@@ -2680,9 +2680,7 @@ wxDoLaunchDefaultBrowser(const wxLaunchBrowserParams& params)
 {
 #ifdef __WXGTK__
 #if GTK_CHECK_VERSION(2,14,0)
-#ifndef __WXGTK3__
-    if (gtk_check_version(2,14,0) == NULL)
-#endif
+    if (wx_is_at_least_gtk2(14))
     {
         GdkScreen* screen = gdk_window_get_screen(wxGetTopLevelGDK());
         if (gtk_show_uri(screen, params.url.utf8_str(), GDK_CURRENT_TIME, NULL))


### PR DESCRIPTION
Use wx_is_at_least_gtk2(minor) instead of gtk_check_version(2, minor)
because it is more clear and also works as expected (i.e. returns true)
when using GTK+ 3 instead of creating difficult to notice bugs in the
code by failing the version check in this case.

See #18004.