### PR TITLE
Fix RTTI build

### DIFF
--- a/src/common/xti.cpp
+++ b/src/common/xti.cpp
@@ -269,10 +269,10 @@ template<> void wxStringWriteValue(wxString &s, const wxString &data )
                              &wxFromStringConverter<type>, typeid(type).name());
 #else
     #define wxBUILTIN_TYPE_INFO( element, type )                                    \
-        void _toString##element( const wxAny& data, wxString &result )         \
-            { wxToStringConverter<type, data, result); }                            \
-        void _fromString##element( const wxString& data, wxAny &result )       \
-            { wxFromStringConverter<type, data, result); }                          \
+        void _toString##element( const wxAny& data, wxString &result )              \
+            { wxToStringConverter<type>(data, result); }                            \
+        void _fromString##element( const wxString& data, wxAny &result )            \
+            { wxFromStringConverter<type>(data, result); }                          \
         wxBuiltInTypeInfo s_typeInfo##type(element, &_toString##element,            \
                                            &_fromString##element, typeid(type).name());
 #endif
@@ -328,7 +328,7 @@ wxCUSTOM_TYPE_INFO(wxRange, wxToStringConverter<wxRange> , wxFromStringConverter
 
 wxCOLLECTION_TYPE_INFO( wxString, wxArrayString );
 
-template<> void wxCollectionToVariantArray( wxArrayString const &theArray, 
+template<> void wxCollectionToVariantArray( wxArrayString const &theArray,
                                             wxAnyList &value)
 {
     wxArrayCollectionToVariantArray( theArray, value );
@@ -346,35 +346,35 @@ wxTypeInfo *wxTypeInfo::FindType(const wxString& typeName)
     return (wxTypeInfo *)iter->second;
 }
 
-wxClassTypeInfo::wxClassTypeInfo( wxTypeKind kind, wxClassInfo* classInfo, 
-                                  wxVariant2StringFnc to, 
-                                  wxString2VariantFnc from, 
+wxClassTypeInfo::wxClassTypeInfo( wxTypeKind kind, wxClassInfo* classInfo,
+                                  wxVariant2StringFnc to,
+                                  wxString2VariantFnc from,
                                   const wxString &name) :
     wxTypeInfo( kind, to, from, name)
-{ 
-    wxASSERT_MSG( kind == wxT_OBJECT_PTR || kind == wxT_OBJECT, 
+{
+    wxASSERT_MSG( kind == wxT_OBJECT_PTR || kind == wxT_OBJECT,
                   wxT("Illegal Kind for Enum Type")); m_classInfo = classInfo;
 }
 
-wxEventSourceTypeInfo::wxEventSourceTypeInfo( int eventType, wxClassInfo* eventClass, 
-                                        wxVariant2StringFnc to, 
-                                        wxString2VariantFnc from ) :
-    wxTypeInfo ( wxT_DELEGATE, to, from, wxEmptyString )
-{ 
-    m_eventClass = eventClass; 
-    m_eventType = eventType; 
-    m_lastEventType = -1;
-}
-
-wxEventSourceTypeInfo::wxEventSourceTypeInfo( int eventType, int lastEventType, 
-                                        wxClassInfo* eventClass, 
+wxEventSourceTypeInfo::wxEventSourceTypeInfo( int eventType, wxClassInfo* eventClass,
                                         wxVariant2StringFnc to,
                                         wxString2VariantFnc from ) :
     wxTypeInfo ( wxT_DELEGATE, to, from, wxEmptyString )
-{ 
-    m_eventClass = eventClass; 
-    m_eventType = eventType; 
-    m_lastEventType = lastEventType; 
+{
+    m_eventClass = eventClass;
+    m_eventType = eventType;
+    m_lastEventType = -1;
+}
+
+wxEventSourceTypeInfo::wxEventSourceTypeInfo( int eventType, int lastEventType,
+                                        wxClassInfo* eventClass,
+                                        wxVariant2StringFnc to,
+                                        wxString2VariantFnc from ) :
+    wxTypeInfo ( wxT_DELEGATE, to, from, wxEmptyString )
+{
+    m_eventClass = eventClass;
+    m_eventType = eventType;
+    m_lastEventType = lastEventType;
 }
 
 void wxTypeInfo::Register()
@@ -621,7 +621,7 @@ wxObjectStreamingCallback wxClassInfo::GetStreamingCallback() const
     return retval;
 }
 
-bool wxClassInfo::BeforeWriteObject( const wxObject *obj, wxObjectWriter *streamer, 
+bool wxClassInfo::BeforeWriteObject( const wxObject *obj, wxObjectWriter *streamer,
                                      wxObjectWriterCallback *writercallback, const wxStringToAnyHashMap &metadata) const
 {
     wxObjectStreamingCallback sb = GetStreamingCallback();
@@ -631,7 +631,7 @@ bool wxClassInfo::BeforeWriteObject( const wxObject *obj, wxObjectWriter *stream
     return true;
 }
 
-void wxClassInfo::SetProperty(wxObject *object, const wxChar *propertyName, 
+void wxClassInfo::SetProperty(wxObject *object, const wxChar *propertyName,
                               const wxAny &value) const
 {
     const wxPropertyAccessor *accessor;
@@ -652,7 +652,7 @@ wxAny wxClassInfo::GetProperty(wxObject *object, const wxChar *propertyName) con
     return result;
 }
 
-wxAnyList wxClassInfo::GetPropertyCollection(wxObject *object, 
+wxAnyList wxClassInfo::GetPropertyCollection(wxObject *object,
                                                    const wxChar *propertyName) const
 {
     const wxPropertyAccessor *accessor;
@@ -664,7 +664,7 @@ wxAnyList wxClassInfo::GetPropertyCollection(wxObject *object,
     return result;
 }
 
-void wxClassInfo::AddToPropertyCollection(wxObject *object, const wxChar *propertyName, 
+void wxClassInfo::AddToPropertyCollection(wxObject *object, const wxChar *propertyName,
                                           const wxAny& value) const
 {
     const wxPropertyAccessor *accessor;
@@ -713,9 +713,9 @@ wxAny wxClassInfo::ObjectPtrToAny( wxObject* obj) const
     return m_objectToVariantConverter(obj);
 }
 
-bool wxClassInfo::NeedsDirectConstruction() const 
-{ 
-    return wx_dynamic_cast(wxObjectAllocator*, m_constructor) != NULL; 
+bool wxClassInfo::NeedsDirectConstruction() const
+{
+    return wx_dynamic_cast(wxObjectAllocator*, m_constructor) != NULL;
 }
 
 // ----------------------------------------------------------------------------
@@ -777,7 +777,7 @@ void wxDynamicObject::RemoveProperty( const wxChar *propertyName )
     m_data->m_properties.erase( propertyName );
 }
 
-void wxDynamicObject::RenameProperty( const wxChar *oldPropertyName, 
+void wxDynamicObject::RenameProperty( const wxChar *oldPropertyName,
                                       const wxChar *newPropertyName )
 {
     wxASSERT_MSG(m_classInfo->FindPropertyInfoInThisClass(oldPropertyName),
@@ -793,8 +793,8 @@ void wxDynamicObject::RenameProperty( const wxChar *oldPropertyName,
 // wxDynamicClassInfo
 // ----------------------------------------------------------------------------
 
-wxDynamicClassInfo::wxDynamicClassInfo( const wxChar *unitName, 
-                                        const wxChar *className, 
+wxDynamicClassInfo::wxDynamicClassInfo( const wxChar *unitName,
+                                        const wxChar *className,
                                         const wxClassInfo* superClass ) :
     wxClassInfo( unitName, className, new const wxClassInfo*[2])
 {
@@ -820,7 +820,7 @@ wxObject *wxDynamicClassInfo::AllocateObject() const
 bool wxDynamicClassInfo::Create (wxObject *object, int paramCount, wxAny *params) const
 {
     wxDynamicObject *dynobj = wx_dynamic_cast( wxDynamicObject *,  object );
-    wxASSERT_MSG( dynobj, 
+    wxASSERT_MSG( dynobj,
         wxT("cannot call wxDynamicClassInfo::Create on ")
         wxT("an object other than wxDynamicObject") );
 

--- a/src/common/xtixml.cpp
+++ b/src/common/xtixml.cpp
@@ -98,7 +98,7 @@ void wxObjectXmlWriter::DoBeginWriteTopLevelEntry( const wxString &name )
 {
     wxXmlNode *pnode;
     pnode = new wxXmlNode(wxXML_ELEMENT_NODE, wxT("entry"));
-    pnode->AddProperty(wxString(wxT("name")), name);
+    pnode->AddAttribute(wxString(wxT("name")), name);
     m_data->m_current->AddChild(pnode);
     m_data->Push( pnode );
 }
@@ -108,27 +108,27 @@ void wxObjectXmlWriter::DoEndWriteTopLevelEntry( const wxString &WXUNUSED(name) 
     m_data->Pop();
 }
 
-void wxObjectXmlWriter::DoBeginWriteObject(const wxObject *WXUNUSED(object), 
-                                     const wxClassInfo *classInfo, 
+void wxObjectXmlWriter::DoBeginWriteObject(const wxObject *WXUNUSED(object),
+                                     const wxClassInfo *classInfo,
                                      int objectID, const wxStringToAnyHashMap &metadata   )
 {
     wxXmlNode *pnode;
     pnode = new wxXmlNode(wxXML_ELEMENT_NODE, wxT("object"));
-    pnode->AddProperty(wxT("class"), wxString(classInfo->GetClassName()));
-    pnode->AddProperty(wxT("id"), wxString::Format( wxT("%d"), objectID ) );
+    pnode->AddAttribute(wxT("class"), wxString(classInfo->GetClassName()));
+    pnode->AddAttribute(wxT("id"), wxString::Format( wxT("%d"), objectID ) );
 
     wxStringToAnyHashMap::const_iterator it, en;
     for( it = metadata.begin(), en = metadata.end(); it != en; ++it )
     {
-        pnode->AddProperty( it->first, wxAnyGetAsString(it->second) );
+        pnode->AddAttribute( it->first, wxAnyGetAsString(it->second) );
     }
 
     m_data->m_current->AddChild(pnode);
     m_data->Push( pnode );
 }
 
-void wxObjectXmlWriter::DoEndWriteObject(const wxObject *WXUNUSED(object), 
-                                   const wxClassInfo *WXUNUSED(classInfo), 
+void wxObjectXmlWriter::DoEndWriteObject(const wxObject *WXUNUSED(object),
+                                   const wxClassInfo *WXUNUSED(classInfo),
                                    int WXUNUSED(objectID) )
 {
     m_data->Pop();
@@ -156,7 +156,7 @@ void wxObjectXmlWriter::DoBeginWriteProperty(const wxPropertyInfo *pi )
 {
     wxXmlNode *pnode;
     pnode = new wxXmlNode(wxXML_ELEMENT_NODE, wxT("prop") );
-    pnode->AddProperty(wxT("name"), pi->GetName() );
+    pnode->AddAttribute(wxT("name"), pi->GetName() );
     m_data->m_current->AddChild(pnode);
     m_data->Push( pnode );
 }
@@ -170,7 +170,7 @@ void wxObjectXmlWriter::DoWriteRepeatedObject( int objectID )
 {
     wxXmlNode *pnode;
     pnode = new wxXmlNode(wxXML_ELEMENT_NODE, wxT("object"));
-    pnode->AddProperty(wxString(wxT("href")), wxString::Format( wxT("%d"), objectID ) );
+    pnode->AddAttribute(wxString(wxT("href")), wxString::Format( wxT("%d"), objectID ) );
     m_data->m_current->AddChild(pnode);
 }
 
@@ -181,11 +181,11 @@ void wxObjectXmlWriter::DoWriteNullObject()
     m_data->m_current->AddChild(pnode);
 }
 
-void wxObjectXmlWriter::DoWriteDelegate( const wxObject *WXUNUSED(object), 
-                                   const wxClassInfo* WXUNUSED(classInfo), 
+void wxObjectXmlWriter::DoWriteDelegate( const wxObject *WXUNUSED(object),
+                                   const wxClassInfo* WXUNUSED(classInfo),
                                    const wxPropertyInfo *WXUNUSED(pi),
-                                   const wxObject *eventSink, int sinkObjectID, 
-                                   const wxClassInfo* WXUNUSED(eventSinkClassInfo), 
+                                   const wxObject *eventSink, int sinkObjectID,
+                                   const wxClassInfo* WXUNUSED(eventSinkClassInfo),
                                    const wxHandlerInfo* handlerInfo )
 {
     if ( eventSink != NULL && handlerInfo != NULL )
@@ -279,10 +279,10 @@ int wxObjectXmlReader::ReadComponent(wxXmlNode *node, wxObjectReaderCallback *ca
     SetObjectClassInfo( objectID, classInfo );
 
     wxStringToAnyHashMap metadata;
-    wxXmlProperty *xp = node->GetAttributes();
+    wxXmlAttribute *xp = node->GetAttributes();
     while ( xp )
     {
-        if ( xp->GetName() != wxString(wxT("class")) && 
+        if ( xp->GetName() != wxString(wxT("class")) &&
              xp->GetName() != wxString(wxT("id")) )
         {
             metadata[xp->GetName()] = wxAny( xp->GetValue() );
@@ -334,7 +334,7 @@ int wxObjectXmlReader::ReadComponent(wxXmlNode *node, wxObjectReaderCallback *ca
             if ( pi->GetTypeInfo()->IsObjectType() )
             {
                 createParamOids[i] = ReadComponent( prop, callbacks );
-                createClassInfos[i] = 
+                createClassInfos[i] =
                     wx_dynamic_cast(const wxClassTypeInfo*, pi->GetTypeInfo())->GetClassInfo();
             }
             else
@@ -343,7 +343,7 @@ int wxObjectXmlReader::ReadComponent(wxXmlNode *node, wxObjectReaderCallback *ca
                 createParams[i] = ReadValue( prop, pi->GetTypeInfo() );
                 if( pi->GetFlags() & wxPROP_ENUM_STORE_LONG )
                 {
-                    const wxEnumTypeInfo *eti = 
+                    const wxEnumTypeInfo *eti =
                         wx_dynamic_cast(const wxEnumTypeInfo*, pi->GetTypeInfo() );
                     if ( eti )
                     {
@@ -373,7 +373,7 @@ int wxObjectXmlReader::ReadComponent(wxXmlNode *node, wxObjectReaderCallback *ca
             if ( pi->GetTypeInfo()->IsObjectType() )
             {
                 createParamOids[i] = wxNullObjectID;
-                createClassInfos[i] = 
+                createClassInfos[i] =
                     wx_dynamic_cast(const wxClassTypeInfo*, pi->GetTypeInfo())->GetClassInfo();
             }
             else
@@ -394,7 +394,7 @@ int wxObjectXmlReader::ReadComponent(wxXmlNode *node, wxObjectReaderCallback *ca
             classInfo->GetCreateParamCount(),
             createParams, createParamOids, createClassInfos, metadata );
 
-    // now stream in the rest of the properties, in the sequence their 
+    // now stream in the rest of the properties, in the sequence their
     // properties were written in the xml
     for ( size_t j = 0; j < propertyNames.size(); ++j )
     {
@@ -404,11 +404,11 @@ int wxObjectXmlReader::ReadComponent(wxXmlNode *node, wxObjectReaderCallback *ca
             if ( propiter != propertyNodes.end() )
             {
                 wxXmlNode* prop = propiter->second;
-                const wxPropertyInfo* pi = 
+                const wxPropertyInfo* pi =
                     classInfo->FindPropertyInfo( propertyNames[j].c_str() );
                 if ( pi->GetTypeInfo()->GetKind() == wxT_COLLECTION )
                 {
-                    const wxCollectionTypeInfo* collType = 
+                    const wxCollectionTypeInfo* collType =
                         wx_dynamic_cast( const wxCollectionTypeInfo*, pi->GetTypeInfo() );
                     const wxTypeInfo * elementType = collType->GetElementType();
                     while( prop )
@@ -496,7 +496,7 @@ int wxObjectXmlReader::ReadComponent(wxXmlNode *node, wxObjectReaderCallback *ca
                     wxAny nodeval = ReadValue( prop, pi->GetTypeInfo() );
                     if( pi->GetFlags() & wxPROP_ENUM_STORE_LONG )
                     {
-                        const wxEnumTypeInfo *eti = 
+                        const wxEnumTypeInfo *eti =
                             wx_dynamic_cast(const wxEnumTypeInfo*, pi->GetTypeInfo() );
                         if ( eti )
                         {


### PR DESCRIPTION
Hello. This PR fixes compilation with `--enable-extended_rtti` configure flag.

I replaced `wxToStringConverter<type, data, result)` with `wxFromStringConverter<type>(data, result)`, which was broken for 7 years since the commit 13830d6

Changed xml properties to attributes in `xtixml.cpp`, this is probably a follow-up fix for commit from 10 years ago: 288b610

Also removed all trailing spaces in these two files.