### PR TITLE
Use wxString::GetChar(i) instead of ::operator[] in GetPathSeparator

### DIFF
--- a/include/wx/filename.h
+++ b/include/wx/filename.h
@@ -457,7 +457,7 @@ public:
 
     // get the canonical path separator for this format
     static wxUniChar GetPathSeparator(wxPathFormat format = wxPATH_NATIVE)
-        { return GetPathSeparators(format)[0u]; }
+        { return GetPathSeparators(format).GetChar(0u); }
 
     // is the char a path separator for this format?
     static bool IsPathSeparator(wxChar ch, wxPathFormat format = wxPATH_NATIVE);


### PR DESCRIPTION
In some circumstances this caused 'ambiguous overload' messages, and use of wxString::operator[] is apparently discouraged anyway: [https://forums.wxwidgets.org/viewtopic.php?t=39539#p159853](https://forums.wxwidgets.org/viewtopic.php?t=39539#p159853)