### PR TITLE
Fix linking of extra system libs in static monolithic build

### DIFF
--- a/configure
+++ b/configure
@@ -35896,20 +35896,47 @@ WXCONFIG_LIBS="$LIBS"
 if test "$wxUSE_REGEX" = "builtin" ; then
     wxconfig_3rdparty="regex${lib_unicode_suffix} $wxconfig_3rdparty"
 fi
-if test "$wxUSE_EXPAT" = "builtin" ; then
-    wxconfig_3rdparty="expat $wxconfig_3rdparty"
-fi
-if test "$wxUSE_LIBTIFF" = "builtin" ; then
-    wxconfig_3rdparty="tiff $wxconfig_3rdparty"
-fi
-if test "$wxUSE_LIBJPEG" = "builtin" ; then
-    wxconfig_3rdparty="jpeg $wxconfig_3rdparty"
-fi
-if test "$wxUSE_LIBPNG" = "builtin" ; then
-    wxconfig_3rdparty="png $wxconfig_3rdparty"
-fi
-if test "$wxUSE_ZLIB" = "builtin" ; then
-    wxconfig_3rdparty="zlib $wxconfig_3rdparty"
+case "$wxUSE_EXPAT" in
+    builtin)
+        wxconfig_3rdparty="expat $wxconfig_3rdparty"
+        ;;
+    sys)
+        WXCONFIG_LIBS="$EXPAT_LINK $WXCONFIG_LIBS"
+        ;;
+esac
+case "$wxUSE_ZLIB" in
+    builtin)
+        wxconfig_3rdparty="zlib $wxconfig_3rdparty"
+        ;;
+    sys)
+        WXCONFIG_LIBS="$ZLIB_LINK $WXCONFIG_LIBS"
+        ;;
+esac
+if test "$wxUSE_GUI" = "yes"; then
+    case "$wxUSE_LIBTIFF" in
+        builtin)
+            wxconfig_3rdparty="tiff $wxconfig_3rdparty"
+            ;;
+        sys)
+            WXCONFIG_LIBS="$TIFF_LINK $LZMA_LINK $JBIG_LINK $WXCONFIG_LIBS"
+            ;;
+    esac
+    case "$wxUSE_LIBJPEG" in
+        builtin)
+            wxconfig_3rdparty="jpeg $wxconfig_3rdparty"
+            ;;
+        sys)
+            WXCONFIG_LIBS="$JPEG_LINK $WXCONFIG_LIBS"
+            ;;
+    esac
+    case "$wxUSE_LIBPNG" in
+        builtin)
+            wxconfig_3rdparty="png $wxconfig_3rdparty"
+            ;;
+        sys)
+            WXCONFIG_LIBS="$PNG_LINK $WXCONFIG_LIBS"
+            ;;
+    esac
 fi
 
 for i in $wxconfig_3rdparty ; do

--- a/configure.in
+++ b/configure.in
@@ -7817,24 +7817,51 @@ LDFLAGS="$LDFLAGS $PROFILE_FLAGS"
 
 WXCONFIG_LIBS="$LIBS"
 
-dnl wx-config must output builtin 3rd party libs in --libs in static build:
+dnl wx-config must output 3rd party libs in --libs in static build:
 if test "$wxUSE_REGEX" = "builtin" ; then
     wxconfig_3rdparty="regex${lib_unicode_suffix} $wxconfig_3rdparty"
 fi
-if test "$wxUSE_EXPAT" = "builtin" ; then
-    wxconfig_3rdparty="expat $wxconfig_3rdparty"
-fi
-if test "$wxUSE_LIBTIFF" = "builtin" ; then
-    wxconfig_3rdparty="tiff $wxconfig_3rdparty"
-fi
-if test "$wxUSE_LIBJPEG" = "builtin" ; then
-    wxconfig_3rdparty="jpeg $wxconfig_3rdparty"
-fi
-if test "$wxUSE_LIBPNG" = "builtin" ; then
-    wxconfig_3rdparty="png $wxconfig_3rdparty"
-fi
-if test "$wxUSE_ZLIB" = "builtin" ; then
-    wxconfig_3rdparty="zlib $wxconfig_3rdparty"
+case "$wxUSE_EXPAT" in
+    builtin)
+        wxconfig_3rdparty="expat $wxconfig_3rdparty"
+        ;;
+    sys)
+        WXCONFIG_LIBS="$EXPAT_LINK $WXCONFIG_LIBS"
+        ;;
+esac
+case "$wxUSE_ZLIB" in
+    builtin)
+        wxconfig_3rdparty="zlib $wxconfig_3rdparty"
+        ;;
+    sys)
+        WXCONFIG_LIBS="$ZLIB_LINK $WXCONFIG_LIBS"
+        ;;
+esac
+if test "$wxUSE_GUI" = "yes"; then
+    case "$wxUSE_LIBTIFF" in
+        builtin)
+            wxconfig_3rdparty="tiff $wxconfig_3rdparty"
+            ;;
+        sys)
+            WXCONFIG_LIBS="$TIFF_LINK $LZMA_LINK $JBIG_LINK $WXCONFIG_LIBS"
+            ;;
+    esac
+    case "$wxUSE_LIBJPEG" in
+        builtin)
+            wxconfig_3rdparty="jpeg $wxconfig_3rdparty"
+            ;;
+        sys)
+            WXCONFIG_LIBS="$JPEG_LINK $WXCONFIG_LIBS"
+            ;;
+    esac
+    case "$wxUSE_LIBPNG" in
+        builtin)
+            wxconfig_3rdparty="png $wxconfig_3rdparty"
+            ;;
+        sys)
+            WXCONFIG_LIBS="$PNG_LINK $WXCONFIG_LIBS"
+            ;;
+    esac
 fi
 
 for i in $wxconfig_3rdparty ; do


### PR DESCRIPTION
wx-config didn't report extra dependency libs for static monolithic build.
Non-monolithic build doesn't have this problem.

I've only had problems with missing "-lexpat" so far, but I suspect `ldlibs_html`, `ldlibs_adv` and `ldlibs_webview` should also be added to this line, am I right? If so, I can update the PR.