### PR TITLE
Update URLs in documentation in 3.0 branch

### DIFF
--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -208,7 +208,7 @@ ALIASES += rightCurly="}"
 #---------------------------------------------------------------------------
 
 # For indicating a sample location
-ALIASES += sampledir{1}="@e Location: @c samples/\1 subdirectory of your wxWidgets installation or http://svn.wxwidgets.org/viewvc/wx/wxWidgets/trunk/samples/\1"
+ALIASES += sampledir{1}="@e Location: @c samples/\1 subdirectory of your wxWidgets installation or https://github.com/wxWidgets/wxWidgets/tree/WX_3_0_BRANCH/samples/\1"
 
 # For refering to the corresponding sample in a class document or a overview
 # Usually placed in the queue of @see

--- a/docs/doxygen/mainpages/introduction.h
+++ b/docs/doxygen/mainpages/introduction.h
@@ -111,12 +111,10 @@ configurations but at least 1GB and possibly more is required.
 
 @section page_introduction_where Where to get wxWidgets and support for it
 
-The download links can be found at http://www.wxwidgets.org. The primary
-download location is https://sourceforge.net/downloads/wxwindows/ and there is
-also an FTP mirror at ftp://ftp.wxwidgets.org/pub/. Additionally, the latest
-version can always be retrieved from our version control system using either
-Subversion (http://svn.wxwidgets.org/svn/wx/wxWidgets/) or Git
-(https://github.com/wxWidgets/wxWidgets).
+The download links can be found at https://www.wxwidgets.org. The primary
+download location is https://github.com/wxWidgets/wxWidgets/releases/latest.
+Additionally, the latest version can always be retrieved from our version
+control system using Git (https://github.com/wxWidgets/wxWidgets).
 
 wxWidgets documentation that you are reading is also available online at
 http://docs.wxwidgets.org/trunk/ and please also visit our wiki at
@@ -124,9 +122,10 @@ http://wiki.wxwidgets.org/ for user-contributed contents.
 
 And if you have any questions, you can join wxWidgets community using
 
-- Web-based <a href="http://forums.wxwidgets.org/">wxForum</a>.
-- <a href="http://www.wxwidgets.org/support/maillst2.htm">Mailing lists</a>.
-- @c #wxwidgets IRC channel.
-- Or asking questions with @c wxwidgets tag on http://stackoverflow.com/
+- Web-based <a href="https://forums.wxwidgets.org/">wxForum</a>
+- <a href="https://www.wxwidgets.org/support/mailing-lists/">Mailing lists</a>
+- <a href="https://www.wxwidgets.org/support/irc/">IRC Channel</a>
+- Or asking questions with @c wxwidgets tag on Stack Overflow:
+  https://stackoverflow.com/questions/tagged/wxwidgets
 
 */

--- a/docs/doxygen/mainpages/samples.h
+++ b/docs/doxygen/mainpages/samples.h
@@ -46,7 +46,7 @@ subdirectory of the library distribution. When a @c foobar sample is mentioned
 below, its sources can be found in @c samples/foobar directory of your
 wxWidgets tree. If you installed wxWidgets from a binary package, you might not
 have this directory. In this case, you may view the samples online at
-http://svn.wxwidgets.org/viewvc/wx/wxWidgets/trunk/samples/ but you need to
+https://github.com/wxWidgets/wxWidgets/tree/WX_3_0_BRANCH/samples/ but you need to
 download the source distribution in order to be able to build them (highly
 recommended).
 

--- a/docs/doxygen/mainpages/translations.h
+++ b/docs/doxygen/mainpages/translations.h
@@ -451,7 +451,7 @@ Here are the steps you should follow:
    <a href="https://www.wxwidgets.org/develop/code-repository/">git</a>   
    you should already have it. Otherwise you can always retrieve it directly 
    from the git repository
-   <a href="https://raw.githubusercontent.com/wxWidgets/wxWidgets/WX_3_0_BRANCH/locale/wxstd.pot=co">Web interface</a>.
+   <a href="https://raw.githubusercontent.com/wxWidgets/wxWidgets/WX_3_0_BRANCH/locale/wxstd.pot">locale/wxstd.pot</a>.
 -# Rename it to <tt>XY.po</tt> where <tt>"XY"</tt> is the 2 letter
    <a href="http://www.loc.gov/standards/iso639-2/php/English_list.php">ISO 639-2 language code</a>
    for your language.

--- a/docs/doxygen/mainpages/translations.h
+++ b/docs/doxygen/mainpages/translations.h
@@ -448,11 +448,10 @@ Here are the steps you should follow:
 
 -# Get the latest version of the file <tt>locale/wxstd.pot</tt> from the
    wxWidgets source tree: if you're using
-   <a href="http://www.wxwidgets.org/develop/svn.htm">Subversion</a>
-   or the <a href="http://wxwindows.sourceforge.net/snapshots/">daily snapshots</a>
-   you should already have it.
-   Otherwise you can always retrieve it directly from the Subversion repository via the
-   <a href="http://svn.wxwidgets.org/viewvc/wx/wxWidgets/trunk/locale/wxstd.pot?view=co">Web interface</a>.
+   <a href="https://www.wxwidgets.org/develop/code-repository/">git</a>   
+   you should already have it. Otherwise you can always retrieve it directly 
+   from the git repository
+   <a href="https://raw.githubusercontent.com/wxWidgets/wxWidgets/WX_3_0_BRANCH/locale/wxstd.pot=co">Web interface</a>.
 -# Rename it to <tt>XY.po</tt> where <tt>"XY"</tt> is the 2 letter
    <a href="http://www.loc.gov/standards/iso639-2/php/English_list.php">ISO 639-2 language code</a>
    for your language.


### PR DESCRIPTION
I have replaced links which led to the SVN repository with their GIT counterparts.  Not only wxWidgets switched to GIT before releasing 3.0.3, the SVN links are now invalid despite the SVN repo being still accessible.

There are still two technical notes that mention SVN but I left those alone. I have also replaced a couple of `http://` with `https://`.

I believe that it would be best if this was done for 3.0.3 docs as well, considering it is the latest officially released stable version but it is probably not possible as the branch is "locked".