### PR TITLE
Fix linking of wxscintilla in static monolithic build

### DIFF
--- a/configure
+++ b/configure
@@ -35905,6 +35905,9 @@ WXCONFIG_LIBS="$LIBS"
 if test "$wxUSE_REGEX" = "builtin" ; then
     wxconfig_3rdparty="regex${lib_unicode_suffix} $wxconfig_3rdparty"
 fi
+if test "$wxUSE_STC" = "yes" ; then
+    wxconfig_3rdparty="scintilla $wxconfig_3rdparty"
+fi
 case "$wxUSE_EXPAT" in
     builtin)
         wxconfig_3rdparty="expat $wxconfig_3rdparty"

--- a/configure.in
+++ b/configure.in
@@ -7831,6 +7831,9 @@ dnl wx-config must output 3rd party libs in --libs in static build:
 if test "$wxUSE_REGEX" = "builtin" ; then
     wxconfig_3rdparty="regex${lib_unicode_suffix} $wxconfig_3rdparty"
 fi
+if test "$wxUSE_STC" = "yes" ; then
+    wxconfig_3rdparty="scintilla $wxconfig_3rdparty"
+fi
 case "$wxUSE_EXPAT" in
     builtin)
         wxconfig_3rdparty="expat $wxconfig_3rdparty"


### PR DESCRIPTION
wx-config didn't report `-lwxscintilla` for `wx-config --libs stc` in static monolithic build.

Since stc is a part of monolithic lib, `-lwxscintilla` will be reported for `wx-config --libs` now as well.