### PR TITLE
Fix expat config for "NMake Makefiles" target.

### DIFF
--- a/build/cmake/lib/xml/CMakeLists.txt
+++ b/build/cmake/lib/xml/CMakeLists.txt
@@ -9,6 +9,10 @@
 
 include(../../source_groups.cmake)
 
+if(WIN32)
+    set(EXPAT_POSTFIX $<$<CONFIG:Debug>:d>)
+endif(WIN32)
+
 if(wxUSE_EXPAT STREQUAL "builtin")
     ExternalProject_Add(wxexpat
         DOWNLOAD_COMMAND ""
@@ -26,7 +30,7 @@ if(wxUSE_EXPAT STREQUAL "builtin")
             ${CMAKE_COMMAND} -E make_directory <INSTALL_DIR>/wxlib
         COMMAND
             ${CMAKE_COMMAND} -E rename
-                <INSTALL_DIR>/lib/${CMAKE_STATIC_LIBRARY_PREFIX}expat${CMAKE_STATIC_LIBRARY_SUFFIX}
+                <INSTALL_DIR>/lib/${CMAKE_STATIC_LIBRARY_PREFIX}expat${EXPAT_POSTFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}
                 <INSTALL_DIR>/wxlib/${CMAKE_STATIC_LIBRARY_PREFIX}wxexpat$<$<CONFIG:Debug>:d>${CMAKE_STATIC_LIBRARY_SUFFIX}
         )
     ExternalProject_Get_Property(wxexpat INSTALL_DIR)

--- a/build/cmake/lib/xml/CMakeLists.txt
+++ b/build/cmake/lib/xml/CMakeLists.txt
@@ -15,6 +15,7 @@ if(wxUSE_EXPAT STREQUAL "builtin")
         SOURCE_DIR ${wxSOURCE_DIR}/src/expat/expat
         CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
             -DBUILD_tools=OFF
             -DBUILD_examples=OFF
             -DBUILD_tests=OFF


### PR DESCRIPTION
For target "NMake Makefiles", expat always build "Debug" config and has runtime conflict if wxWidgets config is "Ralease"