### PR TITLE
OSX/Cocoa: MouseEvent crash fix if wxWindow Destroyed

### DIFF
--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -3579,11 +3579,11 @@ bool wxWidgetCocoaImpl::DoHandleKeyEvent(NSEvent *event)
 
 bool wxWidgetCocoaImpl::DoHandleMouseEvent(NSEvent *event)
 {
+    (void)SetupCursor(event);
+
     wxMouseEvent wxevent(wxEVT_LEFT_DOWN);
     SetupMouseEvent(wxevent , event) ;
     bool result = GetWXPeer()->HandleWindowEvent(wxevent);
-    
-    (void)SetupCursor(event);
 
     return result;
 }


### PR DESCRIPTION
If the event handler destroys the wxWindow, then the subsequent call to SetupCursor(event) will miserably fail .
Moved setting the cursor before the event is handled.