### PR TITLE
Configure and other changes needed for wxGTK/win32.

### DIFF
--- a/configure
+++ b/configure
@@ -24491,7 +24491,9 @@ rm -f core conftest.err conftest.$ac_objext \
                 if test -z "$wx_cv_lib_gtk"; then
                                         wx_cv_lib_gtk=none
                 else
-                                        GTK_LIBS="$GTK_LIBS -lX11"
+                    if test "$USE_WIN32" != 1 ; then
+                                                GTK_LIBS="$GTK_LIBS -lX11"
+                    fi
 
                                                             wx_cv_cflags_gtk=$GTK_CFLAGS
                     wx_cv_libs_gtk=$GTK_LIBS
@@ -31092,7 +31094,7 @@ else
 $as_echo "$as_me: WARNING: wxGetDiskSpace() function won't work without statfs()" >&2;}
 fi
 
-if test "$wxUSE_SNGLINST_CHECKER" = "yes"; then
+if test "$wxUSE_SNGLINST_CHECKER" = "yes" -a "$USE_WIN32" != 1 ; then
     for ac_func in fcntl flock
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
@@ -33580,7 +33582,7 @@ fi
 
 
 if test "$wxUSE_FSWATCHER" = "yes"; then
-                if test "$wxUSE_MSW" != "1"; then
+                if test "$USE_WIN32" != 1; then
         if test "$wxUSE_UNIX" = "yes"; then
             for ac_header in sys/inotify.h
 do :
@@ -35827,7 +35829,7 @@ done
 
 
 if test "$wxUSE_SOCKETS" = "yes"; then
-        if test "$TOOLKIT" != "MSW"; then
+        if test "$USE_WIN32" != 1 ; then
                 ac_fn_c_check_func "$LINENO" "socket" "ac_cv_func_socket"
 if test "x$ac_cv_func_socket" = xyes; then :
 
@@ -35890,7 +35892,7 @@ fi
 fi
 
 if test "$wxUSE_SOCKETS" = "yes" ; then
-                if test "$TOOLKIT" != "MSW"; then
+        if test "$USE_WIN32" != 1 ; then
                                         { $as_echo "$as_me:${as_lineno-$LINENO}: checking what is the type of the third argument of getsockname" >&5
 $as_echo_n "checking what is the type of the third argument of getsockname... " >&6; }
 if ${wx_cv_type_getsockname3+:} false; then :

--- a/configure.in
+++ b/configure.in
@@ -2892,8 +2892,10 @@ if test "$wxUSE_GUI" = "yes"; then
                     dnl looks better in AC_MSG_RESULT
                     wx_cv_lib_gtk=none
                 else
-                    dnl we use symbols from X11 directly so we should link with it
-                    GTK_LIBS="$GTK_LIBS -lX11"
+                    if test "$USE_WIN32" != 1 ; then
+                        dnl we use symbols from X11 directly so we should link with it
+                        GTK_LIBS="$GTK_LIBS -lX11"
+                    fi
 
                     dnl we need to cache GTK_CFLAGS and GTK_LIBS for the
                     dnl subsequent runs
@@ -4551,7 +4553,7 @@ fi
 
 dnl check for fcntl() or at least flock() needed by Unix implementation of
 dnl wxSingleInstanceChecker
-if test "$wxUSE_SNGLINST_CHECKER" = "yes"; then
+if test "$wxUSE_SNGLINST_CHECKER" = "yes" -a "$USE_WIN32" != 1 ; then
     AC_CHECK_FUNCS(fcntl flock, break)
 
     if test "$ac_cv_func_fcntl" != "yes" -a "$ac_cv_func_flock" != "yes"; then
@@ -5506,10 +5508,10 @@ dnl File system watcher checks
 dnl ---------------------------------------------------------------------------
 
 if test "$wxUSE_FSWATCHER" = "yes"; then
-    dnl wxFileSystemWatcher is always available under MSW but we need either
+    dnl wxFileSystemWatcher is always available under Windows but we need either
     dnl inotify or kqueue support in the system for it under Unix (this
     dnl includes OS X which does have kqueue but no other platforms)
-    if test "$wxUSE_MSW" != "1"; then
+    if test "$USE_WIN32" != 1; then
         if test "$wxUSE_UNIX" = "yes"; then
             AC_CHECK_HEADERS(sys/inotify.h,,, [AC_INCLUDES_DEFAULT()])
             if test "$ac_cv_header_sys_inotify_h" = "yes"; then
@@ -6167,8 +6169,8 @@ dnl wxSocket
 dnl ------------------------------------------------------------------------
 
 if test "$wxUSE_SOCKETS" = "yes"; then
-    dnl under MSW we always have sockets
-    if test "$TOOLKIT" != "MSW"; then
+    dnl under Windows we always have sockets
+    if test "$USE_WIN32" != 1 ; then
         dnl under Solaris and OS/2, socket functions live in -lsocket
         AC_CHECK_FUNC(socket,,
             [
@@ -6187,10 +6189,8 @@ if test "$wxUSE_SOCKETS" = "yes"; then
 fi
 
 if test "$wxUSE_SOCKETS" = "yes" ; then
-    dnl this test may be appropriate if building under cygwin
-    dnl right now I'm assuming it also uses the winsock stuff
-    dnl like mingw does..  -- RL
-    if test "$TOOLKIT" != "MSW"; then
+    dnl under Windows we do not use getsockname
+    if test "$USE_WIN32" != 1 ; then
         dnl determine the type of third argument for getsockname
         dnl This test needs to be done in C++ mode since gsocket.cpp now
         dnl is C++ code and pointer cast that are possible even without

--- a/docs/msw/msys2-gtk.txt
+++ b/docs/msw/msys2-gtk.txt
@@ -1,0 +1,111 @@
+Building wxGTK port with Win32 MSys2 GDK backend
+------------------------------------------------
+
+GTK+ widget toolkit has multiple GDK backends and one of them is Win32.
+It is a wrapper around Windows API.
+
+These notes don't consider building wxGTK with X11 backend under Windows.
+
+The MSys2 website is http://www.msys2.org/
+
+These building steps are NOT the normal way to build MSys2 MinGW packages.
+But, they are a way the wxWidgets developers can test that wxWidgets
+can build the wxGTK/Win32 libraries under MSys2 MinGW.
+
+For the MSys2 way please see 
+  https://github.com/Alexpux/MINGW-packages and
+  https://github.com/msys2/msys2/wiki/Creating-packages
+
+Building steps:
+
+#Note: The "#" is used in front of a comment to help the people who cut
+#      and paste these directions.
+#Warning: At the time these directions were written the GTK version 3
+#         was NOT able to create wxGTK/Win32 libraries that were usable.
+
+#1. Install the mingw32 packages needed to build wxGTK/Win32 using the 
+#   configure/make build method. 
+#   From the MSys2 prompt or MSys2 MinGW prompt:
+
+#   The 32 bit Mingw packages are prefixed with "mingw-w64-i686-";
+#   Change the prefix to "mingw-w64-x86_64-" if you wish to do 64 bit.
+
+pacman -S --needed --noconfirm make
+pacman -S --needed --noconfirm mingw-w64-i686-cppunit
+pacman -S --needed --noconfirm mingw-w64-i686-libjpeg-turbo
+pacman -S --needed --noconfirm mingw-w64-i686-libpng
+pacman -S --needed --noconfirm mingw-w64-i686-libtiff
+pacman -S --needed --noconfirm mingw-w64-i686-gcc
+pacman -S --needed --noconfirm mingw-w64-i686-pkg-config
+## gtk2 can take a long time to update/find fonts
+pacman -S --needed --noconfirm mingw-w64-i686-gtk2
+
+
+# Packages that are needed but are normally installed already.
+pacman -S --needed --noconfirm mingw-w64-i686-gcc-libs
+pacman -S --needed --noconfirm mingw-w64-i686-expat
+pacman -S --needed --noconfirm mingw-w64-i686-xz
+pacman -S --needed --noconfirm mingw-w64-i686-zlib
+pacman -S --needed --noconfirm mingw-w64-i686-gdk-pixbuf2
+
+
+#2. Build the wxGTK/Win32 static library
+#2a.Open MSys2 MinGW Prompt
+#   (These steps were tested on MinGW32; but, should work under MinGW64)
+#2b.Use the cd command to change directory to the wxWidgets top folder.
+
+
+#2c.Create the "build-gtk2-static" folder to build the static libraries
+mkdir -p build-gtk2-static
+
+#2d.Configure wxWidgets
+#   Option "--disable-precomp-headers" is NOT needed.
+#   It is being used to test for compile issues.
+#
+#   Use configure option "--enable-wxdib" to set wxUSE_WXDIB to 1.
+#   The directions docs/msw/gtk.txt has wxUSE_WXDIB set to 1.
+cd build-gtk2-static && \
+  ../configure --with-gtk=2 \
+    --disable-shared \
+    --disable-precomp-headers \
+  && cd ..
+
+#2e.clean the wxGTK static libraries
+cd build-gtk2-static && make clean && cd ..
+
+#2f.make the wxGTK static libraries
+cd build-gtk2-static && make && cd ..
+
+
+#3  Build and run the minimal static sample
+#3a.Clean the minimal sample
+cd build-gtk2-static/samples/minimal && make clean && cd ../../..
+
+#3b.Build the minimal sample
+cd build-gtk2-static/samples/minimal && make && cd ../../..
+
+#3c.Run the minimal sample
+./build-gtk2-static/samples/minimal/minimal.exe
+
+
+#4  Build most of the static samples
+#4a.Clean most of the static samples
+cd build-gtk2-static/samples && make clean && cd ../..
+#4b.Build most of the static samples
+cd build-gtk2-static/samples && make && cd ../..
+
+
+#5  Run the drawing static sample
+cd samples/drawing && ../../build-gtk2-static/samples/drawing/drawing.exe && cd ../..
+
+#6  Run the splash static sample
+cd samples/splash && ../../build-gtk2-static/samples/splash/splash.exe && cd ../..
+
+#7  Run the widgets static sample
+cd samples/widgets && ../../build-gtk2-static/samples/widgets/widgets.exe && cd ../..
+
+#8  Run the toolbar static sample
+cd samples/toolbar && ../../build-gtk2-static/samples/toolbar/toolbar.exe && cd ../..
+
+#9  Run the image static sample
+cd samples/image && ../../build-gtk2-static/samples/image/image.exe && cd ../..

--- a/docs/msw/msys2-msw.txt
+++ b/docs/msw/msys2-msw.txt
@@ -1,0 +1,88 @@
+Building wxMSW port with Win32 MSys2 backend
+------------------------------------------------
+
+The MSys2 website is http://www.msys2.org/
+
+These building steps are NOT the normal way to build MSys2 MinGW packages.
+But, they are a way the wxWidgets developers can test that wxWidgets
+can build the wxMSW libraries under MSys2 MinGW.
+
+For the MSys2 way please see https://github.com/Alexpux/MINGW-packages
+
+Building steps:
+
+#Note: The "#" is used in front of a comment to help the people who cut
+#      and paste these directions.
+
+#1. Install the mingw32 packages needed to build wxMSW using the 
+#   configure/make build method. 
+#   From the MSys2 prompt or MSys2 MinGW prompt:
+
+#   The 32 bit Mingw packages are prefixed with "mingw-w64-i686-";
+#   Change the prefix to "mingw-w64-x86_64-" if you wish to do 64 bit.
+
+pacman -S --needed --noconfirm make
+pacman -S --needed --noconfirm mingw-w64-i686-cppunit
+pacman -S --needed --noconfirm mingw-w64-i686-libjpeg-turbo
+pacman -S --needed --noconfirm mingw-w64-i686-libpng
+pacman -S --needed --noconfirm mingw-w64-i686-libtiff
+pacman -S --needed --noconfirm mingw-w64-i686-gcc
+
+# Packages that are needed but are normally installed already.
+pacman -S --needed --noconfirm mingw-w64-i686-gcc-libs
+pacman -S --needed --noconfirm mingw-w64-i686-expat
+pacman -S --needed --noconfirm mingw-w64-i686-xz
+pacman -S --needed --noconfirm mingw-w64-i686-zlib
+
+
+#2. Build the wxMSW static library
+#2a.Open MSys2 MinGW Prompt
+#   (These steps were tested on MinGW32; but, should work under MinGW64)
+#2b.Use the cd command to change directory to the wxWidgets top folder.
+
+
+#2c.Create the "build-msw-static" folder to build the static libraries
+mkdir -p build-msw-static
+
+#2d.Configure wxWidgets
+#   Option "--disable-precomp-headers" is NOT needed.
+#   It is being done to check for compile issues.
+cd build-msw-static && \
+  ../configure --with-msw \
+    --disable-shared \
+    --disable-precomp-headers \
+  && cd ..
+
+#2e.clean the wxMSW static libraries
+cd build-msw-static && make clean && cd ..
+
+#2f.make the wxMSW static libraries
+cd build-msw-static && make && cd ..
+
+
+#3  Build, clean, and run the minimal static sample
+#3a.Clean the minimal sample
+cd build-msw-static/samples/minimal && make clean && cd ../../..
+
+#3b.Build the minimal sample
+cd build-msw-static/samples/minimal && make && cd ../../..
+
+#3c.Run the minimal sample
+./build-msw-static/samples/minimal/minimal.exe
+
+
+#4  Build and clean most of the static samples
+#4a.Clean most of the static samples
+cd build-msw-static/samples && make clean && cd ../..
+#4b.Build most of the static samples
+cd build-msw-static/samples && make && cd ../..
+
+
+#5  Run the drawing static sample
+cd samples/drawing && ../../build-msw-static/samples/drawing/drawing.exe && cd ../..
+
+#6  Run the splash static sample
+cd samples/splash && ../../build-msw-static/samples/splash/splash.exe && cd ../..
+
+#7  Run the widgets static sample
+cd samples/widgets && ../../build-msw-static/samples/widgets/widgets.exe && cd ../..

--- a/include/wx/gdicmn.h
+++ b/include/wx/gdicmn.h
@@ -159,7 +159,7 @@ enum wxStockCursor
 // macros
 // ---------------------------------------------------------------------------
 
-#if defined(__WINDOWS__) || defined(__WXPM__)
+#if (defined(__WINDOWS__) && wxUSE_WXDIB) || defined(__WXPM__)
     #define wxHAS_IMAGES_IN_RESOURCES
 #endif
 
@@ -173,10 +173,7 @@ enum wxStockCursor
     wxIcon *icon = new wxIcon(sample_xpm);    // On wxGTK/Linux
  */
 
-#ifdef __WINDOWS__
-    // Load from a resource
-    #define wxICON(X) wxIcon(wxT(#X))
-#elif defined(__WXPM__)
+#ifdef wxHAS_IMAGES_IN_RESOURCES
     // Load from a resource
     #define wxICON(X) wxIcon(wxT(#X))
 #elif defined(__WXDFB__)
@@ -203,7 +200,7 @@ enum wxStockCursor
    under Unix bitmaps live in XPMs and under Windows they're in ressources.
  */
 
-#if defined(__WINDOWS__) || defined(__WXPM__)
+#if (defined(__WINDOWS__) && wxUSE_WXDIB) || defined(__WXPM__)
     #define wxBITMAP(name) wxBitmap(wxT(#name), wxBITMAP_TYPE_BMP_RESOURCE)
 #elif defined(__WXGTK__)   || \
       defined(__WXMOTIF__) || \
@@ -233,7 +230,7 @@ enum wxStockCursor
 // resource type and under OS X the PNG file with the specified name must be
 // available in the resource subdirectory of the bundle. Elsewhere, this is
 // exactly the same thing as wxBITMAP_PNG_FROM_DATA() described above.
-#if defined(__WINDOWS__) || defined(__WXOSX__)
+#if (defined(__WINDOWS__) && wxUSE_WXDIB) || defined(__WXOSX__)
     #define wxBITMAP_PNG(name) wxBitmap(wxS(#name), wxBITMAP_TYPE_PNG_RESOURCE)
 #else
     #define wxBITMAP_PNG(name) wxBITMAP_PNG_FROM_DATA(name)

--- a/include/wx/msw/chkconf.h
+++ b/include/wx/msw/chkconf.h
@@ -217,11 +217,6 @@
 #   define wxUSE_DRAG_AND_DROP 0
 #endif
 
-#if !wxUSE_OWNER_DRAWN && !defined(__WXUNIVERSAL__)
-#   undef wxUSE_CHECKLISTBOX
-#   define wxUSE_CHECKLISTBOX 0
-#endif
-
 #if wxUSE_SPINCTRL
 #   if !wxUSE_SPINBTN
 #       ifdef wxABORT_ON_CONFIG_ERROR
@@ -230,6 +225,16 @@
 #           undef wxUSE_SPINBTN
 #           define wxUSE_SPINBTN 1
 #       endif
+#   endif
+#endif
+
+/* wxMSW-specific checks: notice that this file is also used with wxUniv
+   and can even be used with wxGTK, when building it under Windows.
+ */
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#   if !wxUSE_OWNER_DRAWN
+#       undef wxUSE_CHECKLISTBOX
+#       define wxUSE_CHECKLISTBOX 0
 #   endif
 #endif
 

--- a/samples/toolbar/toolbar.cpp
+++ b/samples/toolbar/toolbar.cpp
@@ -36,7 +36,7 @@
 
 // define this to use XPMs everywhere (by default, BMPs are used under Win)
 // BMPs use less space, but aren't compiled into the executable on other platforms
-#ifdef __WINDOWS__
+#if defined(__WINDOWS__) && wxUSE_WXDIB
     #define USE_XPM_BITMAPS 0
 #else
     #define USE_XPM_BITMAPS 1

--- a/src/gtk/display.cpp
+++ b/src/gtk/display.cpp
@@ -20,6 +20,8 @@
 #endif
 #include "wx/gtk/private/gtk2-compat.h"
 
+#if !defined(GDK_WINDOWING_WIN32)
+
 GtkWidget* wxGetRootWindow();
 
 //-----------------------------------------------------------------------------
@@ -239,3 +241,5 @@ wxDisplayFactory* wxDisplay::CreateFactory()
     return new wxDisplayFactoryGTK;
 }
 #endif // wxUSE_DISPLAY
+
+#endif // !defined(GDK_WINDOWING_WIN32)


### PR DESCRIPTION
Backport of changes needed for Configure build of wxGTK/win32 from git master.

These changes default to wxUSE_WXDIB set to zero; instead of one under wxGTK/win32.

Tim S.

