### PR TITLE
Add wxIMAGE_OPTION_GIF_TRANSPARENCY for GIF image loading

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -183,6 +183,7 @@ All (GUI):
 - Extend wxRendererNative::DrawGauge() to work for vertical gauges too.
 - Add wxHD_BITMAP_ON_RIGHT style to wxHeaderCtrl.
 - Send wxEVT_DATAVIEW_ITEM_EDITING_DONE when editing was cancelled too.
+- Add wxIMAGE_OPTION_GIF_TRANSPARENCY (Hugo Elias).
 
 wxGTK:
 

--- a/include/wx/imaggif.h
+++ b/include/wx/imaggif.h
@@ -20,6 +20,10 @@
 
 #define wxIMAGE_OPTION_GIF_COMMENT wxT("GifComment")
 
+#define wxIMAGE_OPTION_GIF_TRANSPARENCY           wxS("Transparency")
+#define wxIMAGE_OPTION_GIF_TRANSPARENCY_HIGHLIGHT wxS("Highlight")
+#define wxIMAGE_OPTION_GIF_TRANSPARENCY_UNCHANGED wxS("Unchanged")
+
 struct wxRGB;
 struct GifHashTableType;
 class WXDLLIMPEXP_FWD_CORE wxImageArray; // anidecod.h

--- a/interface/wx/image.h
+++ b/interface/wx/image.h
@@ -93,6 +93,9 @@ enum wxImagePNGType
 #define wxIMAGE_OPTION_CUR_HOTSPOT_Y                    wxString("HotSpotY")
 
 #define wxIMAGE_OPTION_GIF_COMMENT                      wxString("GifComment")
+#define wxIMAGE_OPTION_GIF_TRANSPARENCY                 wxString("Transparency")
+#define wxIMAGE_OPTION_GIF_TRANSPARENCY_HIGHLIGHT       wxString("Highlight")
+#define wxIMAGE_OPTION_GIF_TRANSPARENCY_UNCHANGED       wxString("Unchanged")
 
 #define wxIMAGE_OPTION_PNG_FORMAT                       wxString("PngFormat")
 #define wxIMAGE_OPTION_PNG_BITDEPTH                     wxString("PngBitDepth")
@@ -1286,6 +1289,19 @@ public:
             @c wxIMAGE_OPTION_TIFF_PHOTOMETRIC and set it to either
             PHOTOMETRIC_MINISWHITE or PHOTOMETRIC_MINISBLACK. The other values
             are taken care of.
+
+        Options specific to wxGIFHandler:
+        @li @c wxIMAGE_OPTION_GIF_TRANSPARENCY: How to deal with transparent pixels.
+            By default, the color of transparent pixels is changed to bright pink, so
+            that if the image is accidentally drawn without transparency, it will be
+            obvious.
+            Normally, this would not be noticed, as these pixels will not be rendered.
+            But in some cases it might be useful to load a GIF without making any
+            modifications to its colours.
+            Use @c wxIMAGE_OPTION_GIF_TRANSPARENCY_UNCHANGED to keep the colors correct.
+            Use @c wxIMAGE_OPTION_GIF_TRANSPARENCY_HIGHLIGHT to convert transparent pixels
+            to pink (default).
+            This option has been added in wxWidgets 3.1.1.
 
         @note
         Be careful when combining the options @c wxIMAGE_OPTION_TIFF_SAMPLESPERPIXEL,


### PR DESCRIPTION
Allow to keep the originally defined transparent pixels colour instead
of replacing it with bright pink (which is still the default behaviour).

Closes #18014.

---

See https://trac.wxwidgets.org/ticket/18014