### PR TITLE
Fixes for the gesture sample

### DIFF
--- a/samples/event/gestures.cpp
+++ b/samples/event/gestures.cpp
@@ -17,6 +17,10 @@ MyGestureFrame::MyGestureFrame()
     sizer->Add(m_logText, wxSizerFlags().Expand());
     SetSizer(sizer);
 
+    // Set a minimum size for the frame
+    wxSize dsplySz = wxGetDisplaySize();
+    SetSizeHints(wxMin(800,dsplySz.GetWidth()), wxMin(600,dsplySz.GetHeight()));
+
     // Log to the text control
     delete wxLog::SetActiveTarget(new wxLogTextCtrl(m_logText));
 

--- a/samples/event/gestures.cpp
+++ b/samples/event/gestures.cpp
@@ -1,5 +1,6 @@
 #include "gestures.h"
 #include "wx/dcgraph.h"
+#include "wx/dcbuffer.h"
 
 #include "../image/horse.xpm"
 
@@ -40,6 +41,7 @@ MyGesturePanel::MyGesturePanel(MyGestureFrame *parent)
     : wxPanel(parent, wxID_ANY),
       m_bitmap(horse_xpm)
 {
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
     Bind(wxEVT_PAINT, &MyGesturePanel::OnPaint, this);
 
     if ( !EnableTouchEvents(wxTOUCH_ALL_GESTURES) )
@@ -75,12 +77,10 @@ void MyGestureFrame::OnGesture(wxGestureEvent& event)
 
 void MyGesturePanel::OnPaint(wxPaintEvent& WXUNUSED(event))
 {
-    wxPaintDC paintDC(this);
+    wxAutoBufferedPaintDC paintDC(this);
+    paintDC.Clear();
 
     wxGCDC dc(paintDC);
-
-    dc.Clear();
-
     dc.SetTransformMatrix(m_affineMatrix);
     dc.DrawBitmap(m_bitmap, wxRound(m_translateDistance.m_x), wxRound(m_translateDistance.m_y));
 }

--- a/samples/event/gestures.cpp
+++ b/samples/event/gestures.cpp
@@ -89,7 +89,7 @@ void MyGesturePanel::OnPan(wxPanGestureEvent& event)
 {
     if ( event.IsGestureStart() )
     {
-        wxLogMessage("Pan gesture started\n");
+        wxLogMessage("Pan gesture started");
     }
 
     const wxPoint delta = event.GetDelta();
@@ -111,7 +111,7 @@ void MyGesturePanel::OnPan(wxPanGestureEvent& event)
 
     if ( event.IsGestureEnd() )
     {
-        wxLogMessage("Pan gesture Ended\n");
+        wxLogMessage("Pan gesture Ended");
     }
 
     Refresh();
@@ -121,12 +121,12 @@ void MyGesturePanel::OnZoom(wxZoomGestureEvent& event)
 {
     if ( event.IsGestureStart() )
     {
-        wxLogMessage("Zoom gesture started\n");
+        wxLogMessage("Zoom gesture started");
 
         m_lastZoomFactor = 1.0;
     }
 
-    wxLogMessage("Zoom gesture performed with zoom center at (%d, %d) and zoom Factor = %f\n",
+    wxLogMessage("Zoom gesture performed with zoom center at (%d, %d) and zoom Factor = %f",
         event.GetPosition().x, event.GetPosition().y, event.GetZoomFactor());
 
     const wxPoint& zoomCenter = event.GetPosition();
@@ -140,7 +140,7 @@ void MyGesturePanel::OnZoom(wxZoomGestureEvent& event)
 
     if ( event.IsGestureEnd() )
     {
-        wxLogMessage("Zoom gesture Ended\n");
+        wxLogMessage("Zoom gesture Ended");
     }
 
     m_lastZoomFactor = event.GetZoomFactor();
@@ -152,12 +152,12 @@ void MyGesturePanel::OnRotate(wxRotateGestureEvent& event)
 {
     if ( event.IsGestureStart() )
     {
-        wxLogMessage("Rotate gesture started\n");
+        wxLogMessage("Rotate gesture started");
 
         m_lastRotationAngle = 0.0;
     }
 
-    wxLogMessage("Rotate gesture performed with rotation center at (%d, %d) and cumulative rotation angle = %f\n",
+    wxLogMessage("Rotate gesture performed with rotation center at (%d, %d) and cumulative rotation angle = %f",
         event.GetPosition().x, event.GetPosition().y, event.GetRotationAngle());
 
     const wxPoint& rotationCenter = event.GetPosition();
@@ -171,7 +171,7 @@ void MyGesturePanel::OnRotate(wxRotateGestureEvent& event)
 
     if ( event.IsGestureEnd() )
     {
-        wxLogMessage("Rotate gesture Ended\n");
+        wxLogMessage("Rotate gesture Ended");
     }
 
     m_lastRotationAngle = event.GetRotationAngle();
@@ -183,14 +183,14 @@ void MyGesturePanel::OnTwoFingerTap(wxTwoFingerTapEvent& event)
 {
     if ( event.IsGestureStart() )
     {
-        wxLogMessage("Two Finger Tap gesture gesture started\n");
+        wxLogMessage("Two Finger Tap gesture gesture started");
     }
 
-    wxLogMessage("Two Finger Tap gesture performed at (%d, %d)\n", event.GetPosition().x, event.GetPosition().y);
+    wxLogMessage("Two Finger Tap gesture performed at (%d, %d)", event.GetPosition().x, event.GetPosition().y);
 
     if ( event.IsGestureEnd() )
     {
-        wxLogMessage("Two Finger Tap gesture Ended\n");
+        wxLogMessage("Two Finger Tap gesture Ended");
     }
 }
 
@@ -198,14 +198,14 @@ void MyGesturePanel::OnLongPress(wxLongPressEvent& event)
 {
     if ( event.IsGestureStart() )
     {
-        wxLogMessage("Long Press gesture started\n");
+        wxLogMessage("Long Press gesture started");
     }
 
-    wxLogMessage("Long Press gesture performed at (%d,%d)\n", event.GetPosition().x, event.GetPosition().y);
+    wxLogMessage("Long Press gesture performed at (%d,%d)", event.GetPosition().x, event.GetPosition().y);
 
     if ( event.IsGestureEnd() )
     {
-        wxLogMessage("Long Press gesture Ended\n");
+        wxLogMessage("Long Press gesture Ended");
     }
 }
 
@@ -213,13 +213,13 @@ void MyGesturePanel::OnPressAndTap(wxPressAndTapEvent& event)
 {
     if ( event.IsGestureStart() )
     {
-        wxLogMessage("Press and Tap gesture started\n");
+        wxLogMessage("Press and Tap gesture started");
     }
 
-    wxLogMessage("Press and Tap gesture performed at (%d,%d)\n", event.GetPosition().x, event.GetPosition().y);
+    wxLogMessage("Press and Tap gesture performed at (%d,%d)", event.GetPosition().x, event.GetPosition().y);
 
     if ( event.IsGestureEnd() )
     {
-        wxLogMessage("Press and Tap gesture Ended\n");
+        wxLogMessage("Press and Tap gesture Ended");
     }
 }

--- a/samples/event/gestures.cpp
+++ b/samples/event/gestures.cpp
@@ -111,7 +111,7 @@ void MyGesturePanel::OnPan(wxPanGestureEvent& event)
 
     if ( event.IsGestureEnd() )
     {
-        wxLogMessage("Pan gesture Ended");
+        wxLogMessage("Pan gesture ended");
     }
 
     Refresh();
@@ -140,7 +140,7 @@ void MyGesturePanel::OnZoom(wxZoomGestureEvent& event)
 
     if ( event.IsGestureEnd() )
     {
-        wxLogMessage("Zoom gesture Ended");
+        wxLogMessage("Zoom gesture ended");
     }
 
     m_lastZoomFactor = event.GetZoomFactor();
@@ -171,7 +171,7 @@ void MyGesturePanel::OnRotate(wxRotateGestureEvent& event)
 
     if ( event.IsGestureEnd() )
     {
-        wxLogMessage("Rotate gesture Ended");
+        wxLogMessage("Rotate gesture ended");
     }
 
     m_lastRotationAngle = event.GetRotationAngle();
@@ -190,7 +190,7 @@ void MyGesturePanel::OnTwoFingerTap(wxTwoFingerTapEvent& event)
 
     if ( event.IsGestureEnd() )
     {
-        wxLogMessage("Two Finger Tap gesture Ended");
+        wxLogMessage("Two Finger Tap gesture ended");
     }
 }
 
@@ -205,7 +205,7 @@ void MyGesturePanel::OnLongPress(wxLongPressEvent& event)
 
     if ( event.IsGestureEnd() )
     {
-        wxLogMessage("Long Press gesture Ended");
+        wxLogMessage("Long Press gesture ended");
     }
 }
 
@@ -220,6 +220,6 @@ void MyGesturePanel::OnPressAndTap(wxPressAndTapEvent& event)
 
     if ( event.IsGestureEnd() )
     {
-        wxLogMessage("Press and Tap gesture Ended");
+        wxLogMessage("Press and Tap gesture ended");
     }
 }


### PR DESCRIPTION
This is 4 small changes for the gesture sample:

1.  Set a minimum size for the sample application frame.  Otherwise the sample comes out with an almost zero sized frame with GTK+ (at least on Raspian which is the only distro where I have my touch screen working).
2.  Use an autobuffered DC to reduce flicker on windows.
3.  Remove newline characters from the log messages.  Otherwise there is an extra blank line for most of the messages.
4.  Slightly alter some log messages to keep letter case consistent.