### PR TITLE
Undefine min and max before using them in wx/valnum.h

### DIFF
--- a/include/wx/valnum.h
+++ b/include/wx/valnum.h
@@ -18,6 +18,12 @@
 #include "wx/textentry.h"
 #include "wx/validate.h"
 
+// This header uses std::numeric_limits<>::min/max, but these symbols are,
+// unfortunately, often defined as macros and the code here wouldn't compile in
+// this case, so preventively undefine them to avoid this problem.
+#undef min
+#undef max
+
 #include <limits>
 
 // Bit masks used for numeric validator styles.


### PR DESCRIPTION
Avoid problems when using this header in code also include <windows.h>
(and not doing it via wx/msw/wrapwin.h) by ensuring that min and max
used here are not defined as macros.