### PR TITLE
Improvement of the documentation of wxPropertyGrid::MakeColumnEditable:

### DIFF
--- a/interface/wx/propgrid/propgrid.h
+++ b/interface/wx/propgrid/propgrid.h
@@ -942,6 +942,10 @@ public:
         @param editable
             Using @false here will disable column from being editable.
 
+        Note that @param column must be != 1.
+        To make column #1 (second column) read-only, use
+        wxPGProperty::ChangeFlag(wxPG_PROP_READONLY, true).
+
         @see BeginLabelEdit(), EndLabelEdit()
     */
     void MakeColumnEditable( unsigned int column, bool editable = true );

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -964,6 +964,8 @@ void wxPropertyGrid::DoSetSelection( const wxArrayPGProperty& newSelection,
 void wxPropertyGrid::MakeColumnEditable( unsigned int column,
                                          bool editable )
 {
+    // The second column is always editable. To make it read-only is a property
+    // by property decision by setting its wxPG_PROP_READONLY flag.
     wxASSERT( column != 1 );
 
     wxArrayInt& cols = m_pState->m_editableColumns;


### PR DESCRIPTION
explain that column must be != 0.