### PR TITLE
Fix custom editors in wxGTK wxDataViewCtrl for GTK+2

### DIFF
--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -1151,8 +1151,6 @@ extern "C" {
 
 #define GTK_TYPE_WX_CELL_EDITOR_BIN               (gtk_wx_cell_editor_bin_get_type ())
 #define GTK_WX_CELL_EDITOR_BIN(obj)               (G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_TYPE_WX_CELL_EDITOR_BIN, GtkWxCellEditorBin))
-#define GTK_IS_WX_CELL_EDITOR_BIN(obj)            (G_TYPE_CHECK_INSTANCE_TYPE ((obj), GTK_TYPE_WX_CELL_EDITOR_BIN))
-#define GTK_IS_WX_CELL_EDITOR_BIN_CLASS(klass)    (G_TYPE_CHECK_CLASS_TYPE ((klass), GTK_TYPE_WX_CELL_EDITOR_BIN))
 
 struct GtkWxCellEditorBin
 {

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -1152,9 +1152,33 @@ extern "C" {
 #define GTK_TYPE_WX_CELL_EDITOR_BIN               (gtk_wx_cell_editor_bin_get_type ())
 #define GTK_WX_CELL_EDITOR_BIN(obj)               (G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_TYPE_WX_CELL_EDITOR_BIN, GtkWxCellEditorBin))
 
+// In GTK+ < 3.8 GtkBin can't be used as widget base type without defining our
+// own size_allocate and related (either size_request for GTK+ 2 or
+// get_preferred_height for GTK+ 3) vfuncs, so we use GtkHBox instead. But in
+// GTK+ 4, GtkHBox is removed, so we do use GtkBin with it.
+#ifdef __WXGTK4__
+    typedef GtkBin GtkWxCellEditorBinBase;
+    typedef GtkBinClass GtkWxCellEditorBinBaseClass;
+
+    // Notice that this can't be just a (const) variable as GTK+ type constants
+    // are actually macros expanding into function calls, which shouldn't be
+    // performed before the library is initialized, so we need to use either an
+    // inline function or a define, which is simpler.
+    #define GtkWxCellEditorBinBaseType GTK_TYPE_BIN
+#else // GTK+ < 4
+    // GtkHBox is deprecated since 3.2, so avoid warnings about using it.
+    wxGCC_WARNING_SUPPRESS(deprecated-declarations)
+
+    typedef GtkHBox GtkWxCellEditorBinBase;
+    typedef GtkHBoxClass GtkWxCellEditorBinBaseClass;
+    #define GtkWxCellEditorBinBaseType GTK_TYPE_HBOX
+
+    wxGCC_WARNING_RESTORE(deprecated-declarations)
+#endif // GTK+ version
+
 struct GtkWxCellEditorBin
 {
-    GtkBin parent;
+    GtkWxCellEditorBinBase parent;
 
     // The actual user-created editor.
     wxWindow* editor;
@@ -1182,7 +1206,7 @@ gtk_wx_cell_editor_bin_get_type()
     {
         const GTypeInfo cell_editor_bin_info =
         {
-            sizeof (GtkBinClass),
+            sizeof (GtkWxCellEditorBinBaseClass),
             NULL, /* base_init */
             NULL, /* base_finalize */
             gtk_wx_cell_editor_bin_class_init,
@@ -1194,7 +1218,8 @@ gtk_wx_cell_editor_bin_get_type()
             NULL
         };
 
-        cell_editor_bin_type = g_type_register_static( GTK_TYPE_BIN,
+        cell_editor_bin_type = g_type_register_static(
+            GtkWxCellEditorBinBaseType,
             "GtkWxCellEditorBin", &cell_editor_bin_info, (GTypeFlags)0 );
 
 

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -1420,7 +1420,7 @@ gtk_wx_cell_renderer_new (void)
 static GtkCellEditable *gtk_wx_cell_renderer_start_editing(
                         GtkCellRenderer         *renderer,
                         GdkEvent                *WXUNUSED(event),
-                        GtkWidget               *widget,
+                        GtkWidget               *WXUNUSED(widget),
                         const gchar             *path,
                         wxConstGdkRect          *WXUNUSED(background_area),
                         wxConstGdkRect          *cell_area,
@@ -1437,25 +1437,10 @@ static GtkCellEditable *gtk_wx_cell_renderer_start_editing(
     if (cell->GetEditorCtrl())
         return NULL;
 
-    GdkRectangle rect;
-    gtk_wx_cell_renderer_get_size (renderer, widget, cell_area,
-                                   &rect.x,
-                                   &rect.y,
-                                   &rect.width,
-                                   &rect.height);
-
-    rect.x += cell_area->x;
-    rect.y += cell_area->y;
-//    rect.width  -= renderer->xpad * 2;
-//    rect.height -= renderer->ypad * 2;
-
-//    wxRect renderrect(wxRectFromGDKRect(&rect));
-    wxRect renderrect(wxRectFromGDKRect(cell_area));
-
     wxDataViewItem
         item(cell->GetOwner()->GetOwner()->GTKPathToItem(wxGtkTreePath(path)));
 
-    if (!cell->StartEditing(item, renderrect))
+    if (!cell->StartEditing(item, wxRectFromGDKRect(cell_area)))
         return NULL;
 
     wxrenderer->editor_bin = gtk_wx_cell_editor_bin_new(cell->GetEditorCtrl());


### PR DESCRIPTION
The important commit here is the [second one](https://github.com/wxWidgets/wxWidgets/commit/af8ba52fb0fad2a353b4fb85c43546144bb8002c), fixing [this ticket](http://trac.wxwidgets.org/ticket/17686).

Paul, if you could please check that I am not doing anything particularly stupid here, it would be appreciated. I still have no idea why using `GtkBin` worked with GTK+ 3 but not GTK+ 2, so it's not like I _really_ understand what's going on here... TIA!