### PR TITLE
CMake build fixes and improvements

### DIFF
--- a/build/cmake/demos/CMakeLists.txt
+++ b/build/cmake/demos/CMakeLists.txt
@@ -26,7 +26,7 @@ function(wx_add_demo name)
         foreach(data_file ${DEMO_DATA})
             list(APPEND cmds COMMAND ${CMAKE_COMMAND}
                 -E copy ${wxSOURCE_DIR}/demos/${name}/${data_file}
-                ${wxOUTPUT_DIR}/${data_file})
+                ${wxOUTPUT_DIR}/${wxPLATFORM_LIB_DIR}/${data_file})
         endforeach()
         add_custom_command(
             TARGET ${DEMO_NAME} ${cmds}

--- a/build/cmake/demos/CMakeLists.txt
+++ b/build/cmake/demos/CMakeLists.txt
@@ -38,6 +38,9 @@ function(wx_add_demo name)
     target_link_libraries(${DEMO_NAME} core ${DEMO_LIBRARIES})
     wx_set_common_target_properties(${DEMO_NAME})
     set_target_properties(${DEMO_NAME} PROPERTIES FOLDER "Demos")
+    set_target_properties(${DEMO_NAME} PROPERTIES
+        VS_DEBUGGER_WORKING_DIRECTORY "${wxOUTPUT_DIR}/${wxCOMPILER_PREFIX}${wxARCH_SUFFIX}_${lib_suffix}"
+        )
 endfunction()
 
 wx_add_demo(bombs

--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -610,6 +610,9 @@ function(wx_add_sample name)
     set_target_properties(${target_name} PROPERTIES
         FOLDER ${folder}
         )
+    set_target_properties(${target_name} PROPERTIES
+        VS_DEBUGGER_WORKING_DIRECTORY "${wxOUTPUT_DIR}/${wxCOMPILER_PREFIX}${wxARCH_SUFFIX}_${lib_suffix}"
+        )
 endfunction()
 
 # Link libraries to a sample
@@ -704,6 +707,9 @@ function(wx_add_test name)
     endif()
     wx_set_common_target_properties(${name})
     set_target_properties(${name} PROPERTIES FOLDER "Tests")
+    set_target_properties(${name} PROPERTIES
+        VS_DEBUGGER_WORKING_DIRECTORY "${wxSOURCE_DIR}/tests"
+        )
 
     add_test(NAME ${name}
         COMMAND ${name}

--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -175,6 +175,7 @@ function(wx_set_target_properties target_name is_base)
             _CRT_SECURE_NO_DEPRECATE=1
             _CRT_NON_CONFORMING_SWPRINTFS=1
             _SCL_SECURE_NO_WARNINGS=1
+            _WINSOCK_DEPRECATED_NO_WARNINGS=1
             )
     endif()
 
@@ -381,7 +382,10 @@ function(wx_set_builtin_target_properties target_name)
         # standard C functions in the 3rd party libraries (these warnings
         # are only given by VC8+ but it's simpler to just always define
         # this symbol which disables them, even for previous VC versions)
-        target_compile_definitions(${target_name} PRIVATE _CRT_SECURE_NO_WARNINGS)
+        target_compile_definitions(${target_name} PRIVATE
+            _CRT_SECURE_NO_DEPRECATE=1
+            _SCL_SECURE_NO_WARNINGS=1
+        )
     endif()
 
     set_target_properties(${target_name} PROPERTIES FOLDER "Third Party Libraries")

--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -574,7 +574,7 @@ function(wx_add_sample name)
         foreach(data_file ${SAMPLE_DATA})
             list(APPEND cmds COMMAND ${CMAKE_COMMAND}
                 -E copy ${wxSOURCE_DIR}/samples/${wxSAMPLE_SUBDIR}${name}/${data_file}
-                ${wxOUTPUT_DIR}/${data_file})
+                ${wxOUTPUT_DIR}/${wxPLATFORM_LIB_DIR}/${data_file})
         endforeach()
         add_custom_command(
             TARGET ${target_name} ${cmds}

--- a/build/cmake/lib/xml/CMakeLists.txt
+++ b/build/cmake/lib/xml/CMakeLists.txt
@@ -9,45 +9,14 @@
 
 include(../../source_groups.cmake)
 
-if(WIN32)
-    set(EXPAT_POSTFIX $<$<CONFIG:Debug>:d>)
-endif(WIN32)
-
 if(wxUSE_EXPAT STREQUAL "builtin")
-    ExternalProject_Add(wxexpat
-        DOWNLOAD_COMMAND ""
-        SOURCE_DIR ${wxSOURCE_DIR}/src/expat/expat
-        CMAKE_ARGS
-            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-            -DBUILD_tools=OFF
-            -DBUILD_examples=OFF
-            -DBUILD_tests=OFF
-            -DBUILD_shared=OFF
-        INSTALL_COMMAND
-            ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<CONFIGURATION> --target install
-        COMMAND
-            ${CMAKE_COMMAND} -E make_directory <INSTALL_DIR>/wxlib
-        COMMAND
-            ${CMAKE_COMMAND} -E rename
-                <INSTALL_DIR>/lib/${CMAKE_STATIC_LIBRARY_PREFIX}expat${EXPAT_POSTFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}
-                <INSTALL_DIR>/wxlib/${CMAKE_STATIC_LIBRARY_PREFIX}wxexpat$<$<CONFIG:Debug>:d>${CMAKE_STATIC_LIBRARY_SUFFIX}
-        )
-    ExternalProject_Get_Property(wxexpat INSTALL_DIR)
-    add_library(expat STATIC IMPORTED)
-    set_target_properties(expat PROPERTIES
-        IMPORTED_LOCATION "${INSTALL_DIR}/wxlib/${CMAKE_STATIC_LIBRARY_PREFIX}wxexpat${CMAKE_STATIC_LIBRARY_SUFFIX}"
-        IMPORTED_LOCATION_DEBUG "${INSTALL_DIR}/wxlib/${CMAKE_STATIC_LIBRARY_PREFIX}wxexpatd${CMAKE_STATIC_LIBRARY_SUFFIX}"
-        FOLDER "Third Party Libraries"
-        )
-    add_dependencies(expat wxexpat)
-    set(EXPAT_INCLUDE_DIRS "${INSTALL_DIR}/include")
-    set(EXPAT_LIBRARIES expat)
-    if(NOT wxBUILD_SHARED)
-        wx_install(
-            FILES ${INSTALL_DIR}/wxlib/${CMAKE_STATIC_LIBRARY_PREFIX}wxexpat$<$<CONFIG:Debug>:d>${CMAKE_STATIC_LIBRARY_SUFFIX}
-            DESTINATION "lib${wxPLATFORM_LIB_DIR}")
-    endif()
+    wx_add_builtin_library(wxexpat
+        src/expat/expat/lib/xmlparse.c
+        src/expat/expat/lib/xmlrole.c
+        src/expat/expat/lib/xmltok.c
+    )
+    set(EXPAT_LIBRARIES wxexpat)
+    set(EXPAT_INCLUDE_DIRS ${wxSOURCE_DIR}/src/expat/expat/lib)
 elseif(wxUSE_EXPAT)
     find_package(EXPAT)
 endif()

--- a/build/cmake/modules/cotire.cmake
+++ b/build/cmake/modules/cotire.cmake
@@ -3,7 +3,7 @@
 # See the cotire manual for usage hints.
 #
 #=============================================================================
-# Copyright 2012-2016 Sascha Kratky
+# Copyright 2012-2017 Sascha Kratky
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -43,7 +43,7 @@ if (NOT CMAKE_SCRIPT_MODE_FILE)
 endif()
 
 set (COTIRE_CMAKE_MODULE_FILE "${CMAKE_CURRENT_LIST_FILE}")
-set (COTIRE_CMAKE_MODULE_VERSION "1.7.9")
+set (COTIRE_CMAKE_MODULE_VERSION "1.7.10")
 
 # activate select policies
 if (POLICY CMP0025)
@@ -104,6 +104,11 @@ endif()
 if (POLICY CMP0054)
 	# only interpret if() arguments as variables or keywords when unquoted
 	cmake_policy(SET CMP0054 NEW)
+endif()
+
+if (POLICY CMP0055)
+	# strict checking for break() command
+	cmake_policy(SET CMP0055 NEW)
 endif()
 
 include(CMakeParseArguments)
@@ -293,7 +298,7 @@ function (cotire_get_source_file_property_values _valuesVar _property)
 	set (${_valuesVar} ${_values} PARENT_SCOPE)
 endfunction()
 
-function (cotire_resolve_config_properites _configurations _propertiesVar)
+function (cotire_resolve_config_properties _configurations _propertiesVar)
 	set (_properties "")
 	foreach (_property ${ARGN})
 		if ("${_property}" MATCHES "<CONFIG>")
@@ -309,8 +314,8 @@ function (cotire_resolve_config_properites _configurations _propertiesVar)
 	set (${_propertiesVar} ${_properties} PARENT_SCOPE)
 endfunction()
 
-function (cotire_copy_set_properites _configurations _type _source _target)
-	cotire_resolve_config_properites("${_configurations}" _properties ${ARGN})
+function (cotire_copy_set_properties _configurations _type _source _target)
+	cotire_resolve_config_properties("${_configurations}" _properties ${ARGN})
 	foreach (_property ${_properties})
 		get_property(_isSet ${_type} ${_source} PROPERTY ${_property} SET)
 		if (_isSet)
@@ -320,13 +325,18 @@ function (cotire_copy_set_properites _configurations _type _source _target)
 	endforeach()
 endfunction()
 
-function (cotire_get_target_usage_requirements _target _targetRequirementsVar)
+function (cotire_get_target_usage_requirements _target _config _targetRequirementsVar)
 	set (_targetRequirements "")
 	get_target_property(_librariesToProcess ${_target} LINK_LIBRARIES)
 	while (_librariesToProcess)
 		# remove from head
 		list (GET _librariesToProcess 0 _library)
 		list (REMOVE_AT _librariesToProcess 0)
+		if (_library MATCHES "^\\$<\\$<CONFIG:${_config}>:([A-Za-z0-9_:-]+)>$")
+			set (_library "${CMAKE_MATCH_1}")
+		elseif (_config STREQUAL "None" AND _library MATCHES "^\\$<\\$<CONFIG:>:([A-Za-z0-9_:-]+)>$")
+			set (_library "${CMAKE_MATCH_1}")
+		endif()
 		if (TARGET ${_library})
 			list (FIND _targetRequirements ${_library} _index)
 			if (_index LESS 0)
@@ -441,7 +451,7 @@ function (cotire_get_target_compile_flags _config _language _target _flagsVar)
 	# interface compile options from linked library targets
 	if (_target)
 		set (_linkedTargets "")
-		cotire_get_target_usage_requirements(${_target} _linkedTargets)
+		cotire_get_target_usage_requirements(${_target} ${_config} _linkedTargets)
 		foreach (_linkedTarget ${_linkedTargets})
 			get_target_property(_targetOptions ${_linkedTarget} INTERFACE_COMPILE_OPTIONS)
 			if (_targetOptions)
@@ -573,7 +583,7 @@ function (cotire_get_target_include_directories _config _language _target _inclu
 	# interface include directories from linked library targets
 	if (_target)
 		set (_linkedTargets "")
-		cotire_get_target_usage_requirements(${_target} _linkedTargets)
+		cotire_get_target_usage_requirements(${_target} ${_config} _linkedTargets)
 		foreach (_linkedTarget ${_linkedTargets})
 			get_target_property(_linkedTargetType ${_linkedTarget} TYPE)
 			if (CMAKE_INCLUDE_CURRENT_DIR_IN_INTERFACE AND NOT CMAKE_VERSION VERSION_LESS "3.4.0" AND
@@ -627,7 +637,7 @@ function (cotire_get_target_include_directories _config _language _target _inclu
 	if (CMAKE_${_language}_IMPLICIT_INCLUDE_DIRECTORIES)
 		list (REMOVE_ITEM _includeDirs ${CMAKE_${_language}_IMPLICIT_INCLUDE_DIRECTORIES})
 	endif()
-	if (WIN32)
+	if (WIN32 AND NOT MINGW)
 		# convert Windows paths in include directories to CMake paths
 		if (_includeDirs)
 			set (_paths "")
@@ -703,7 +713,7 @@ function (cotire_get_target_compile_definitions _config _language _target _defin
 	endif()
 	# interface compile definitions from linked library targets
 	set (_linkedTargets "")
-	cotire_get_target_usage_requirements(${_target} _linkedTargets)
+	cotire_get_target_usage_requirements(${_target} ${_config} _linkedTargets)
 	foreach (_linkedTarget ${_linkedTargets})
 		get_target_property(_definitions ${_linkedTarget} INTERFACE_COMPILE_DEFINITIONS)
 		if (_definitions)
@@ -859,6 +869,9 @@ macro (cotire_set_cmd_to_prologue _cmdVar)
 		list (APPEND ${_cmdVar} "--warn-uninitialized")
 	endif()
 	list (APPEND ${_cmdVar} "-DCOTIRE_BUILD_TYPE:STRING=$<CONFIGURATION>")
+	if (XCODE)
+		list (APPEND ${_cmdVar} "-DXCODE:BOOL=TRUE")
+	endif()
 	if (COTIRE_VERBOSE)
 		list (APPEND ${_cmdVar} "-DCOTIRE_VERBOSE:BOOL=ON")
 	elseif("${CMAKE_GENERATOR}" MATCHES "Makefiles")
@@ -902,16 +915,16 @@ function (cotire_add_includes_to_cmd _cmdVar _language _includesVar _systemInclu
 		foreach (_include ${_includeDirs})
 			if (WIN32 AND CMAKE_${_language}_COMPILER_ID MATCHES "MSVC|Intel")
 				file (TO_NATIVE_PATH "${_include}" _include)
-				list (APPEND ${_cmdVar} "${CMAKE_INCLUDE_FLAG_${_language}}${CMAKE_INCLUDE_FLAG_${_language}_SEP}${_include}")
+				list (APPEND ${_cmdVar} "${CMAKE_INCLUDE_FLAG_${_language}}${CMAKE_INCLUDE_FLAG_SEP_${_language}}${_include}")
 			else()
 				set (_index -1)
 				if ("${CMAKE_INCLUDE_SYSTEM_FLAG_${_language}}" MATCHES ".+")
 					list (FIND ${_systemIncludesVar} "${_include}" _index)
 				endif()
 				if (_index GREATER -1)
-					list (APPEND ${_cmdVar} "${CMAKE_INCLUDE_SYSTEM_FLAG_${_language}}${_include}")
+					list (APPEND ${_cmdVar} "${CMAKE_INCLUDE_SYSTEM_FLAG_${_language}}${CMAKE_INCLUDE_FLAG_SEP_${_language}}${_include}")
 				else()
-					list (APPEND ${_cmdVar} "${CMAKE_INCLUDE_FLAG_${_language}}${CMAKE_INCLUDE_FLAG_${_language}_SEP}${_include}")
+					list (APPEND ${_cmdVar} "${CMAKE_INCLUDE_FLAG_${_language}}${CMAKE_INCLUDE_FLAG_SEP_${_language}}${_include}")
 				endif()
 			endif()
 		endforeach()
@@ -1657,6 +1670,10 @@ function (cotire_add_pch_compilation_flags _language _compilerID _compilerVersio
 			get_filename_component(_pchName "${_pchFile}" NAME)
 			set (_xLanguage_C "c-header")
 			set (_xLanguage_CXX "c++-header")
+			set (_pchSuppressMessages FALSE)
+			if ("${CMAKE_${_language}_FLAGS}" MATCHES ".*-Wno-pch-messages.*")
+				set(_pchSuppressMessages TRUE)
+			endif()
 			if (_flags)
 				# append to list
 				if ("${_language}" STREQUAL "CXX")
@@ -1664,13 +1681,17 @@ function (cotire_add_pch_compilation_flags _language _compilerID _compilerVersio
 				endif()
 				list (APPEND _flags "-include" "${_prefixFile}" "-pch-dir" "${_pchDir}" "-pch-create" "${_pchName}" "-fsyntax-only" "${_hostFile}")
 				if (NOT "${_compilerVersion}" VERSION_LESS "13.1.0")
-					list (APPEND _flags "-Wpch-messages")
+					if (NOT _pchSuppressMessages)
+						list (APPEND _flags "-Wpch-messages")
+					endif()
 				endif()
 			else()
 				# return as a flag string
 				set (_flags "-include \"${_prefixFile}\" -pch-dir \"${_pchDir}\" -pch-create \"${_pchName}\"")
 				if (NOT "${_compilerVersion}" VERSION_LESS "13.1.0")
-					set (_flags "${_flags} -Wpch-messages")
+					if (NOT _pchSuppressMessages)
+						set (_flags "${_flags} -Wpch-messages")
+					endif()
 				endif()
 			endif()
 		endif()
@@ -1781,17 +1802,25 @@ function (cotire_add_prefix_pch_inclusion_flags _language _compilerID _compilerV
 			if (_pchFile)
 				get_filename_component(_pchDir "${_pchFile}" DIRECTORY)
 				get_filename_component(_pchName "${_pchFile}" NAME)
+				set (_pchSuppressMessages FALSE)
+				if ("${CMAKE_${_language}_FLAGS}" MATCHES ".*-Wno-pch-messages.*")
+					set(_pchSuppressMessages TRUE)
+				endif()
 				if (_flags)
 					# append to list
 					list (APPEND _flags "-include" "${_prefixFile}" "-pch-dir" "${_pchDir}" "-pch-use" "${_pchName}")
 					if (NOT "${_compilerVersion}" VERSION_LESS "13.1.0")
-						list (APPEND _flags "-Wpch-messages")
+						if (NOT _pchSuppressMessages)
+							list (APPEND _flags "-Wpch-messages")
+						endif()
 					endif()
 				else()
 					# return as a flag string
 					set (_flags "-include \"${_prefixFile}\" -pch-dir \"${_pchDir}\" -pch-use \"${_pchName}\"")
 					if (NOT "${_compilerVersion}" VERSION_LESS "13.1.0")
-						set (_flags "${_flags} -Wpch-messages")
+						if (NOT _pchSuppressMessages)
+							set (_flags "${_flags} -Wpch-messages")
+						endif()
 					endif()
 				endif()
 			else()
@@ -1839,6 +1868,14 @@ function (cotire_precompile_prefix_header _prefixFile _pchFile _hostFile)
 	if (_option_COMPILER_ID MATCHES "MSVC")
 		# cl.exe messes with the output streams unless the environment variable VS_UNICODE_OUTPUT is cleared
 		unset (ENV{VS_UNICODE_OUTPUT})
+	elseif (_option_COMPILER_ID MATCHES "GNU|Clang")
+		if (_option_COMPILER_LAUNCHER MATCHES "ccache" OR
+			_option_COMPILER_EXECUTABLE MATCHES "ccache")
+			# Newer versions of Clang and GCC seem to embed a compilation timestamp into the precompiled header binary,
+			# which results in "file has been modified since the precompiled header was built" errors if ccache is used.
+			# We work around the problem by disabling ccache upon pre-compiling the prefix header.
+			set (ENV{CCACHE_DISABLE} "true")
+		endif()
 	endif()
 	execute_process(
 		COMMAND ${_cmd}
@@ -2191,7 +2228,7 @@ function (cotire_generate_target_script _language _configurations _target _targe
 		XCODE MSVC CMAKE_GENERATOR CMAKE_BUILD_TYPE CMAKE_CONFIGURATION_TYPES
 		CMAKE_${_language}_COMPILER_ID CMAKE_${_language}_COMPILER_VERSION
 		CMAKE_${_language}_COMPILER_LAUNCHER CMAKE_${_language}_COMPILER CMAKE_${_language}_COMPILER_ARG1
-		CMAKE_INCLUDE_FLAG_${_language} CMAKE_INCLUDE_FLAG_${_language}_SEP
+		CMAKE_INCLUDE_FLAG_${_language} CMAKE_INCLUDE_FLAG_SEP_${_language}
 		CMAKE_INCLUDE_SYSTEM_FLAG_${_language}
 		CMAKE_${_language}_FRAMEWORK_SEARCH_FLAG
 		CMAKE_${_language}_SYSTEM_FRAMEWORK_SEARCH_FLAG
@@ -2989,8 +3026,13 @@ function (cotire_setup_unity_build_target _languages _configurations _target)
 	if (_targetAutoMoc OR _targetAutoUic OR _targetAutoRcc)
 		# if the original target sources are subject to CMake's automatic Qt processing,
 		# also include implicitly generated <targetname>_automoc.cpp file
-		list (APPEND _unityTargetSources "${_target}_automoc.cpp")
-		set_property (SOURCE "${_target}_automoc.cpp" PROPERTY GENERATED TRUE)
+		if (CMAKE_VERSION VERSION_LESS "3.8.0")
+			list (APPEND _unityTargetSources "${_target}_automoc.cpp")
+			set_property (SOURCE "${_target}_automoc.cpp" PROPERTY GENERATED TRUE)
+		else()
+			list (APPEND _unityTargetSources "${_target}_autogen/moc_compilation.cpp")
+			set_property (SOURCE "${_target}_autogen/moc_compilation.cpp" PROPERTY GENERATED TRUE)
+		endif()
 	endif()
 	# prevent AUTOMOC, AUTOUIC and AUTORCC properties from being set when the unity target is created
 	set (CMAKE_AUTOMOC OFF)
@@ -3013,7 +3055,11 @@ function (cotire_setup_unity_build_target _languages _configurations _target)
 	else()
 		if (_targetAutoMoc OR _targetAutoUic OR _targetAutoRcc)
 			# depend on the original target's implicity generated <targetname>_automoc target
-			add_dependencies(${_unityTargetName} ${_target}_automoc)
+			if (CMAKE_VERSION VERSION_LESS "3.8.0")
+				add_dependencies(${_unityTargetName} ${_target}_automoc)
+			else()
+				add_dependencies(${_unityTargetName} ${_target}_autogen)
+			endif()
 		endif()
 	endif()
 	# copy output location properties
@@ -3027,8 +3073,8 @@ function (cotire_setup_unity_build_target _languages _configurations _target)
 			set (_outputDir "${COTIRE_UNITY_OUTPUT_DIRECTORY}")
 		else()
 			# append relative COTIRE_UNITY_OUTPUT_DIRECTORY to target's actual output directory
-			cotire_copy_set_properites("${_configurations}" TARGET ${_target} ${_unityTargetName} ${_outputDirProperties})
-			cotire_resolve_config_properites("${_configurations}" _properties ${_outputDirProperties})
+			cotire_copy_set_properties("${_configurations}" TARGET ${_target} ${_unityTargetName} ${_outputDirProperties})
+			cotire_resolve_config_properties("${_configurations}" _properties ${_outputDirProperties})
 			foreach (_property ${_properties})
 				get_property(_outputDir TARGET ${_target} PROPERTY ${_property})
 				if (_outputDir)
@@ -3048,11 +3094,11 @@ function (cotire_setup_unity_build_target _languages _configurations _target)
 				RUNTIME_OUTPUT_DIRECTORY "${_outputDir}")
 		endif()
 	else()
-		cotire_copy_set_properites("${_configurations}" TARGET ${_target} ${_unityTargetName}
+		cotire_copy_set_properties("${_configurations}" TARGET ${_target} ${_unityTargetName}
 			${_outputDirProperties})
 	endif()
 	# copy output name
-	cotire_copy_set_properites("${_configurations}" TARGET ${_target} ${_unityTargetName}
+	cotire_copy_set_properties("${_configurations}" TARGET ${_target} ${_unityTargetName}
 		ARCHIVE_OUTPUT_NAME ARCHIVE_OUTPUT_NAME_<CONFIG>
 		LIBRARY_OUTPUT_NAME LIBRARY_OUTPUT_NAME_<CONFIG>
 		OUTPUT_NAME OUTPUT_NAME_<CONFIG>
@@ -3060,7 +3106,7 @@ function (cotire_setup_unity_build_target _languages _configurations _target)
 		PREFIX <CONFIG>_POSTFIX SUFFIX
 		IMPORT_PREFIX IMPORT_SUFFIX)
 	# copy compile stuff
-	cotire_copy_set_properites("${_configurations}" TARGET ${_target} ${_unityTargetName}
+	cotire_copy_set_properties("${_configurations}" TARGET ${_target} ${_unityTargetName}
 		COMPILE_DEFINITIONS COMPILE_DEFINITIONS_<CONFIG>
 		COMPILE_FLAGS COMPILE_OPTIONS
 		Fortran_FORMAT Fortran_MODULE_DIRECTORY
@@ -3072,12 +3118,12 @@ function (cotire_setup_unity_build_target _languages _configurations _target)
 		C_VISIBILITY_PRESET CXX_VISIBILITY_PRESET VISIBILITY_INLINES_HIDDEN
 		C_CLANG_TIDY CXX_CLANG_TIDY)
 	# copy compile features
-	cotire_copy_set_properites("${_configurations}" TARGET ${_target} ${_unityTargetName}
+	cotire_copy_set_properties("${_configurations}" TARGET ${_target} ${_unityTargetName}
 		C_EXTENSIONS C_STANDARD C_STANDARD_REQUIRED
 		CXX_EXTENSIONS CXX_STANDARD CXX_STANDARD_REQUIRED
 		COMPILE_FEATURES)
 	# copy interface stuff
-	cotire_copy_set_properites("${_configurations}" TARGET ${_target} ${_unityTargetName}
+	cotire_copy_set_properties("${_configurations}" TARGET ${_target} ${_unityTargetName}
 		COMPATIBLE_INTERFACE_BOOL COMPATIBLE_INTERFACE_NUMBER_MAX COMPATIBLE_INTERFACE_NUMBER_MIN
 		COMPATIBLE_INTERFACE_STRING
 		INTERFACE_COMPILE_DEFINITIONS INTERFACE_COMPILE_FEATURES INTERFACE_COMPILE_OPTIONS
@@ -3085,7 +3131,7 @@ function (cotire_setup_unity_build_target _languages _configurations _target)
 		INTERFACE_POSITION_INDEPENDENT_CODE INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
 		INTERFACE_AUTOUIC_OPTIONS NO_SYSTEM_FROM_IMPORTED)
 	# copy link stuff
-	cotire_copy_set_properites("${_configurations}" TARGET ${_target} ${_unityTargetName}
+	cotire_copy_set_properties("${_configurations}" TARGET ${_target} ${_unityTargetName}
 		BUILD_WITH_INSTALL_RPATH INSTALL_RPATH INSTALL_RPATH_USE_LINK_PATH SKIP_BUILD_RPATH
 		LINKER_LANGUAGE LINK_DEPENDS LINK_DEPENDS_NO_SHARED
 		LINK_FLAGS LINK_FLAGS_<CONFIG>
@@ -3094,18 +3140,18 @@ function (cotire_setup_unity_build_target _languages _configurations _target)
 		LINK_SEARCH_START_STATIC LINK_SEARCH_END_STATIC
 		STATIC_LIBRARY_FLAGS STATIC_LIBRARY_FLAGS_<CONFIG>
 		NO_SONAME SOVERSION VERSION
-		LINK_WHAT_YOU_USE)
+		LINK_WHAT_YOU_USE BUILD_RPATH)
 	# copy cmake stuff
-	cotire_copy_set_properites("${_configurations}" TARGET ${_target} ${_unityTargetName}
+	cotire_copy_set_properties("${_configurations}" TARGET ${_target} ${_unityTargetName}
 		IMPLICIT_DEPENDS_INCLUDE_TRANSFORM RULE_LAUNCH_COMPILE RULE_LAUNCH_CUSTOM RULE_LAUNCH_LINK)
 	# copy Apple platform specific stuff
-	cotire_copy_set_properites("${_configurations}" TARGET ${_target} ${_unityTargetName}
+	cotire_copy_set_properties("${_configurations}" TARGET ${_target} ${_unityTargetName}
 		BUNDLE BUNDLE_EXTENSION FRAMEWORK FRAMEWORK_VERSION INSTALL_NAME_DIR
 		MACOSX_BUNDLE MACOSX_BUNDLE_INFO_PLIST MACOSX_FRAMEWORK_INFO_PLIST MACOSX_RPATH
 		OSX_ARCHITECTURES OSX_ARCHITECTURES_<CONFIG> PRIVATE_HEADER PUBLIC_HEADER RESOURCE XCTEST
-		IOS_INSTALL_COMBINED)
+		IOS_INSTALL_COMBINED XCODE_EXPLICIT_FILE_TYPE XCODE_PRODUCT_TYPE)
 	# copy Windows platform specific stuff
-	cotire_copy_set_properites("${_configurations}" TARGET ${_target} ${_unityTargetName}
+	cotire_copy_set_properties("${_configurations}" TARGET ${_target} ${_unityTargetName}
 		GNUtoMS
 		COMPILE_PDB_NAME COMPILE_PDB_NAME_<CONFIG>
 		COMPILE_PDB_OUTPUT_DIRECTORY COMPILE_PDB_OUTPUT_DIRECTORY_<CONFIG>
@@ -3119,9 +3165,9 @@ function (cotire_setup_unity_build_target _languages _configurations _target)
 		VS_WINRT_COMPONENT VS_WINRT_EXTENSIONS VS_WINRT_REFERENCES
 		WIN32_EXECUTABLE WINDOWS_EXPORT_ALL_SYMBOLS
 		DEPLOYMENT_REMOTE_DIRECTORY VS_CONFIGURATION_TYPE
-		VS_SDK_REFERENCES)
+		VS_SDK_REFERENCES VS_USER_PROPS VS_DEBUGGER_WORKING_DIRECTORY)
 	# copy Android platform specific stuff
-	cotire_copy_set_properites("${_configurations}" TARGET ${_target} ${_unityTargetName}
+	cotire_copy_set_properties("${_configurations}" TARGET ${_target} ${_unityTargetName}
 		ANDROID_API ANDROID_API_MIN ANDROID_GUI
 		ANDROID_ANT_ADDITIONAL_OPTIONS ANDROID_ARCH ANDROID_ASSETS_DIRECTORIES
 		ANDROID_JAR_DEPENDENCIES ANDROID_JAR_DIRECTORIES ANDROID_JAVA_SOURCE_DIR

--- a/build/cmake/samples/CMakeLists.txt
+++ b/build/cmake/samples/CMakeLists.txt
@@ -8,10 +8,10 @@
 #############################################################################
 
 wx_add_sample(access accesstest.cpp)
-wx_add_sample(animate anitest.cpp LIBRARIES adv DATA throbber.gif hourglass.ani)
+wx_add_sample(animate anitest.cpp anitest.h LIBRARIES adv DATA throbber.gif hourglass.ani)
 wx_add_sample(artprov arttest.cpp artbrows.cpp artbrows.h)
 wx_add_sample(aui auidemo.cpp LIBRARIES adv aui html NAME auidemo)
-wx_add_sample(calendar LIBRARIES adv)
+wx_add_sample(calendar RES calendar.rc LIBRARIES adv)
 wx_add_sample(caret)
 wx_add_sample(clipboard)
 wx_add_sample(collpane LIBRARIES adv)
@@ -30,20 +30,18 @@ wx_add_sample(dragimag dragimag.cpp dragimag.h RES dragimag.rc
     DATA backgrnd.png shape01.png shape02.png shape03.png)
 wx_add_sample(drawing DATA pat4.bmp pat35.bmp pat36.bmp image.bmp mask.bmp)
 wx_add_sample(erase)
-wx_add_sample(event)
+wx_add_sample(event event.cpp gestures.cpp gestures.h)
 wx_add_sample(except)
 wx_add_sample(exec)
-wx_add_sample(font)
+wx_add_sample(font DATA wxprivate.ttf)
 wx_add_sample(fswatcher)
 wx_add_sample(grid griddemo.cpp griddemo.h LIBRARIES adv)
 
 wx_list_add_prefix(HELP_DOC_FILES doc/
-    aindex.html ClassGraph.class ClassGraphPanel.class ClassLayout.class
-    down.gif dxxgifs.tex HIER.html HIERjava.html icon1.gif icon2.gif
-    index.html logo.gif NavigatorButton.class USE_HELP.html wx204.htm
-    wx34.htm wxExtHelpController.html wxhelp.map wx.htm
+    aindex.html down.gif dxxgifs.tex HIER.html icon1.gif icon2.gif index.html
+    logo.gif wx204.htm wx34.htm wxExtHelpController.html wxhelp.map wx.htm
     )
-wx_add_sample(help demo.cpp doc.h LIBRARIES html adv
+wx_add_sample(help demo.cpp LIBRARIES html adv
     DATA
     back.gif bullet.bmp contents.gif cshelp.txt doc.chm doc.cnt doc.hhc
     doc.hhk doc.hhp doc.hlp doc.hpj doc.zip forward.gif up.gif
@@ -52,7 +50,7 @@ wx_add_sample(help demo.cpp doc.h LIBRARIES html adv
     )
 wx_add_sample(htlbox LIBRARIES html)
 include(html.cmake)
-wx_add_sample(image image.cpp canvas.cpp canvas.h RES image.rc
+wx_add_sample(image image.cpp canvas.cpp canvas.h cursor_png.c RES image.rc
     DATA horse.png horse.jpg horse.bmp horse.gif horse.pcx horse.pnm
     horse_ag.pnm horse_rg.pnm horse.tif horse.tga horse.xpm horse.cur
     horse.ico horse3.ani smile.xbm toucan.png cmyk.jpg cursor.png)
@@ -105,7 +103,7 @@ wx_add_sample(render FOLDER render)
 wx_add_sample(render DLL renddll.cpp NAME renddll FOLDER render)
 wx_add_sample(ribbon ribbondemo.cpp LIBRARIES ribbon adv NAME ribbondemo)
 wx_add_sample(richtext LIBRARIES richtext adv html xml NAME richtextdemo)
-wx_add_sample(sashtest sashtest.cpp sashtest.h LIBRARIES adv)
+wx_add_sample(sashtest sashtest.cpp sashtest.h RES sashtest.rc LIBRARIES adv)
 wx_add_sample(scroll)
 wx_add_sample(secretstore CONSOLE DEPENDS wxUSE_SECRETSTORE)
 wx_add_sample(shaped DATA star.png)
@@ -122,7 +120,7 @@ wx_add_sample(splitter)
 wx_add_sample(statbar)
 wx_add_sample(stc stctest.cpp edit.cpp prefs.cpp edit.h defsext.h prefs.h
     DATA stctest.cpp NAME stctest LIBRARIES stc)
-wx_add_sample(svg svgtest.cpp)
+wx_add_sample(svg svgtest.cpp RES svgtest.rc)
 wx_add_sample(taborder)
 wx_add_sample(taskbar tbtest.cpp tbtest.h LIBRARIES adv DEPENDS wxUSE_TASKBARICON)
 wx_add_sample(text)
@@ -132,7 +130,7 @@ wx_add_sample(treectrl treetest.cpp treetest.h)
 wx_add_sample(treelist LIBRARIES adv)
 wx_add_sample(typetest typetest.cpp typetest.h)
 wx_add_sample(uiaction)
-wx_add_sample(validate)
+wx_add_sample(validate validate.cpp validate.h)
 wx_add_sample(vscroll vstest.cpp)
 wx_add_sample(webview LIBRARIES webview stc adv NAME webviewsample)
 # widgets Sample
@@ -210,26 +208,27 @@ wx_add_sample(xrc
     myframe.h
     custclas.h
     objrefdlg.h
-    ${XRC_RC_FILES}
+    DATA ${XRC_RC_FILES}
     LIBRARIES aui ribbon xrc html adv
     NAME xrcdemo
     )
-wx_add_sample(xti xti.cpp classlist.cpp codereadercallback.cpp LIBRARIES xml
+wx_add_sample(xti xti.cpp classlist.cpp codereadercallback.cpp
+    classlist.h codereadercallback.h LIBRARIES xml
     DEPENDS wxUSE_EXTENDED_RTTI)
 
 if(WIN32)
     # Windows only samples
 
     # DLL Sample
-    wx_add_sample(dll DLL my_dll.cpp NAME my_dll FOLDER dll
+    wx_add_sample(dll DLL my_dll.cpp my_dll.h NAME my_dll FOLDER dll
         DEFINITIONS MY_DLL_BUILDING)
     if(NOT wxBUILD_SHARED)
         # this test only makes sense with statically built wx, otherwise
         # the same copy of wx would be used
-        wx_add_sample(dll wx_exe.cpp NAME wx_exe FOLDER dll LIBRARIES my_dll)
+        wx_add_sample(dll wx_exe.cpp my_dll.h NAME wx_exe FOLDER dll LIBRARIES my_dll)
     endif()
 
-    wx_add_sample(dll sdk_exe.cpp NAME sdk_exe FOLDER dll LIBRARIES my_dll)
+    wx_add_sample(dll sdk_exe.cpp my_dll.h NAME sdk_exe FOLDER dll LIBRARIES my_dll)
     wx_add_sample(flash)
     #TODO: renable when sample is fixed
     #wx_add_sample(mfc mfctest.cpp mfctest.h resource.h stdafx.h RES mfctest.rc)

--- a/samples/dialogs/dialogs.h
+++ b/samples/dialogs/dialogs.h
@@ -28,12 +28,6 @@ of MSW, MAC and OS2
     #define USE_WXUNIVERSAL 0
 #endif
 
-#ifdef WXUSINGDLL
-    #define USE_DLL 1
-#else
-    #define USE_DLL 0
-#endif
-
 #if defined(__WXMSW__)
     #define USE_WXMSW 1
 #else
@@ -58,16 +52,14 @@ of MSW, MAC and OS2
     #define USE_WXGTK 0
 #endif
 
-#define USE_GENERIC_DIALOGS (!USE_WXUNIVERSAL && !USE_DLL)
-
 #define USE_COLOURDLG_GENERIC \
-    ((USE_WXMSW || USE_WXMAC) && USE_GENERIC_DIALOGS && wxUSE_COLOURDLG)
+    ((USE_WXMSW || USE_WXMAC) && USE_WXUNIVERSAL && wxUSE_COLOURDLG)
 #define USE_DIRDLG_GENERIC \
-    ((USE_WXMSW || USE_WXMAC) && USE_GENERIC_DIALOGS && wxUSE_DIRDLG)
+    ((USE_WXMSW || USE_WXMAC) && USE_WXUNIVERSAL && wxUSE_DIRDLG)
 #define USE_FILEDLG_GENERIC \
-    ((USE_WXMSW || USE_WXMAC) && USE_GENERIC_DIALOGS  && wxUSE_FILEDLG)
+    ((USE_WXMSW || USE_WXMAC) && USE_WXUNIVERSAL  && wxUSE_FILEDLG)
 #define USE_FONTDLG_GENERIC \
-    ((USE_WXMSW || USE_WXMACFONTDLG) && USE_GENERIC_DIALOGS && wxUSE_FONTDLG)
+    ((USE_WXMSW || USE_WXMACFONTDLG) && USE_WXUNIVERSAL && wxUSE_FONTDLG)
 
 // Turn USE_MODAL_PRESENTATION to 0 if there is any reason for not presenting difference
 // between modal and modeless dialogs (ie. not implemented it in your port yet)


### PR DESCRIPTION
Here are some fixes and improvements for the CMake build system.
I tested them with Visual Studio 2017, shared and static libraries.

@vadz the fix for the help sample should also be applied to its `Makefile.in` (you accidentally re-added some files in 5d134711). Could you do this (as it requires rebaking)?

@TcT2k can you have a look?

Thanks