### PR TITLE
XRC text escapes cleanup/fixes

### DIFF
--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -1611,7 +1611,7 @@ Example:
         <item tooltip="E=mc^2">Energy 98.3</item>
         <item helptext="Favourite chukcha's radio">CHUM FM</item>
         <item>92FM</item>
-        <item hidden="1">Very quit station</item>
+        <item hidden="1">Very quiet station</item>
     </content>
 </object>
 @endcode

--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -1595,6 +1595,11 @@ can also have some optional XML @em attributes (not properties!):
      Is the button enabled (default: 1)?}
 @row3col{hidden, @ref overview_xrcformat_type_bool,
      Is the button hidden initially (default: 0)?}
+@row3col{label, @ref overview_xrcformat_type_bool,
+     Should this item text be interpreted as a label, i.e. escaping underscores
+     in it as done for the label properties of other controls? This attribute
+     exists since wxWidgets 3.1.1 and was always treated as having the value of
+     0, which still remains its default, until then.}
 @endTable
 
 Example:

--- a/include/wx/xrc/xmlres.h
+++ b/include/wx/xrc/xmlres.h
@@ -513,7 +513,10 @@ public:
     // - replaces \n, \r, \t by respective chars (according to C syntax)
     // - replaces _ by & and __ by _ (needed for _File => &File because of XML)
     // - calls wxGetTranslations (unless disabled in wxXmlResource)
-    wxString GetText(const wxString& param, bool translate = true) wxOVERRIDE;
+    //
+    // The first two conversions can be disabled by using wxXRC_TEXT_NO_ESCAPE
+    // in flags and the last one -- by using wxXRC_TEXT_NO_TRANSLATE.
+    wxString GetNodeText(const wxXmlNode *node, int flags = 0) wxOVERRIDE;
 
     // Returns the XRCID.
     int GetID() wxOVERRIDE;

--- a/include/wx/xrc/xmlreshandler.h
+++ b/include/wx/xrc/xmlreshandler.h
@@ -32,6 +32,13 @@ class WXDLLIMPEXP_FWD_CORE wxXmlResourceHandler;
 // by wxXmlResourceHandler implementation itself.
 #define XRC_ADD_STYLE(style) AddStyle(wxT(#style), style)
 
+// Flags for GetNodeText().
+enum
+{
+    wxXRC_TEXT_NO_TRANSLATE = 1,
+    wxXRC_TEXT_NO_ESCAPE    = 2
+};
+
 // Abstract base class for the implementation object used by
 // wxXmlResourceHandlerImpl. The real implementation is in
 // wxXmlResourceHandlerImpl class in the "xrc" library while this class is in
@@ -61,7 +68,7 @@ public:
     virtual wxString GetParamValue(const wxString& param) = 0;
     virtual wxString GetParamValue(const wxXmlNode* node) = 0;
     virtual int GetStyle(const wxString& param = wxT("style"), int defaults = 0) = 0;
-    virtual wxString GetText(const wxString& param, bool translate = true) = 0;
+    virtual wxString GetNodeText(const wxXmlNode *node, int flags = 0) = 0;
     virtual int GetID() = 0;
     virtual wxString GetName() = 0;
     virtual bool GetBool(const wxString& param, bool defaultv = false) = 0;
@@ -254,9 +261,14 @@ protected:
     {
         return GetImpl()->GetStyle(param, defaults);
     }
+    wxString GetNodeText(const wxXmlNode *node, int flags = 0)
+    {
+        return GetImpl()->GetNodeText(node, flags);
+    }
     wxString GetText(const wxString& param, bool translate = true)
     {
-        return GetImpl()->GetText(param, translate);
+        return GetImpl()->GetNodeText(GetImpl()->GetParamNode(param),
+                                      translate ? 0 : wxXRC_TEXT_NO_TRANSLATE);
     }
     int GetID() const
     {

--- a/misc/schema/xrc_schema.rnc
+++ b/misc/schema/xrc_schema.rnc
@@ -1225,6 +1225,7 @@ wxRadioBox =
                 attribute helptext { t_string }?,
                 attribute enabled  { t_bool }?,
                 attribute hidden   { t_bool }?,
+                attribute label    { t_bool }?,
                 t_text
             }*
         }?

--- a/samples/xrc/rc/controls.xrc
+++ b/samples/xrc/rc/controls.xrc
@@ -779,7 +779,7 @@ lay them out using wxSizers, absolute positioning, everything you like!
                                         <item tooltip="E=mc^2">Energy 98.3</item>
                                         <item helptext="Favourite chukcha's radio">CHUM FM</item>
                                         <item>92FM</item>
-                                        <item hidden="1">Very quite station</item>
+                                        <item hidden="1">Very quiet station</item>
                                     </content>
                                 </object>
                             </object>

--- a/src/xrc/xh_chckl.cpp
+++ b/src/xrc/xh_chckl.cpp
@@ -94,10 +94,7 @@ wxObject *wxCheckListBoxXmlHandler::DoCreateResource()
         // handle <item checked="boolean">Label</item>
 
         // add to the list
-        wxString str = GetNodeContent(m_node);
-        if (m_resource->GetFlags() & wxXRC_USE_LOCALE)
-            str = wxGetTranslation(str, m_resource->GetDomain());
-        strList.Add(str);
+        strList.Add(GetNodeText(m_node, wxXRC_TEXT_NO_ESCAPE));
         return NULL;
     }
 }

--- a/src/xrc/xh_choic.cpp
+++ b/src/xrc/xh_choic.cpp
@@ -70,10 +70,7 @@ wxObject *wxChoiceXmlHandler::DoCreateResource()
         // handle <item>Label</item>
 
         // add to the list
-        wxString str = GetNodeContent(m_node);
-        if (m_resource->GetFlags() & wxXRC_USE_LOCALE)
-            str = wxGetTranslation(str, m_resource->GetDomain());
-        strList.Add(str);
+        strList.Add(GetNodeText(m_node, wxXRC_TEXT_NO_ESCAPE));
 
         return NULL;
     }

--- a/src/xrc/xh_combo.cpp
+++ b/src/xrc/xh_combo.cpp
@@ -77,10 +77,7 @@ wxObject *wxComboBoxXmlHandler::DoCreateResource()
         // handle <item>Label</item>
 
         // add to the list
-        wxString str = GetNodeContent(m_node);
-        if (m_resource->GetFlags() & wxXRC_USE_LOCALE)
-            str = wxGetTranslation(str, m_resource->GetDomain());
-        strList.Add(str);
+        strList.Add(GetNodeText(m_node, wxXRC_TEXT_NO_ESCAPE));
 
         return NULL;
     }

--- a/src/xrc/xh_editlbox.cpp
+++ b/src/xrc/xh_editlbox.cpp
@@ -99,10 +99,7 @@ wxObject *wxEditableListBoxXmlHandler::DoCreateResource()
     }
     else if ( m_insideBox && m_node->GetName() == EDITLBOX_ITEM_NAME )
     {
-        wxString str = GetNodeContent(m_node);
-        if ( m_resource->GetFlags() & wxXRC_USE_LOCALE )
-            str = wxGetTranslation(str, m_resource->GetDomain());
-        m_items.push_back(str);
+        m_items.push_back(GetNodeText(m_node, wxXRC_TEXT_NO_ESCAPE));
 
         return NULL;
     }

--- a/src/xrc/xh_htmllbox.cpp
+++ b/src/xrc/xh_htmllbox.cpp
@@ -69,10 +69,7 @@ wxObject *wxSimpleHtmlListBoxXmlHandler::DoCreateResource()
         // handle <item>Label</item>
 
         // add to the list
-        wxString str = GetNodeContent(m_node);
-        if (m_resource->GetFlags() & wxXRC_USE_LOCALE)
-            str = wxGetTranslation(str, m_resource->GetDomain());
-        strList.Add(str);
+        strList.Add(GetNodeText(m_node, wxXRC_TEXT_NO_ESCAPE));
 
         return NULL;
     }

--- a/src/xrc/xh_listb.cpp
+++ b/src/xrc/xh_listb.cpp
@@ -77,10 +77,7 @@ wxObject *wxListBoxXmlHandler::DoCreateResource()
         // handle <item>Label</item>
 
         // add to the list
-        wxString str = GetNodeContent(m_node);
-        if (m_resource->GetFlags() & wxXRC_USE_LOCALE)
-            str = wxGetTranslation(str, m_resource->GetDomain());
-        strList.Add(str);
+        strList.Add(GetNodeText(m_node, wxXRC_TEXT_NO_ESCAPE));
 
         return NULL;
     }

--- a/src/xrc/xh_odcombo.cpp
+++ b/src/xrc/xh_odcombo.cpp
@@ -85,10 +85,7 @@ wxObject *wxOwnerDrawnComboBoxXmlHandler::DoCreateResource()
         // handle <item>Label</item>
 
         // add to the list
-        wxString str = GetNodeContent(m_node);
-        if (m_resource->GetFlags() & wxXRC_USE_LOCALE)
-            str = wxGetTranslation(str, m_resource->GetDomain());
-        strList.Add(str);
+        strList.Add(GetNodeText(m_node, wxXRC_TEXT_NO_ESCAPE));
 
         return NULL;
     }

--- a/src/xrc/xh_radbx.cpp
+++ b/src/xrc/xh_radbx.cpp
@@ -107,30 +107,15 @@ wxObject *wxRadioBoxXmlHandler::DoCreateResource()
         // we handle handle <item>Label</item> constructs here, and the item
         // tag can have tooltip, helptext, enabled and hidden attributes
 
-        wxString label = GetNodeContent(m_node);
-
-        wxString tooltip;
-        m_node->GetAttribute(wxT("tooltip"), &tooltip);
-
-        wxString helptext;
-        bool hasHelptext = m_node->GetAttribute(wxT("helptext"), &helptext);
-
-        if (m_resource->GetFlags() & wxXRC_USE_LOCALE)
-        {
-            label = wxGetTranslation(label, m_resource->GetDomain());
-            if ( !tooltip.empty() )
-                tooltip = wxGetTranslation(tooltip, m_resource->GetDomain());
-            if ( hasHelptext )
-                helptext = wxGetTranslation(helptext, m_resource->GetDomain());
-        }
-
-        m_labels.push_back(label);
+        m_labels.push_back(GetNodeText(m_node, wxXRC_TEXT_NO_ESCAPE));
 #if wxUSE_TOOLTIPS
-        m_tooltips.push_back(tooltip);
+        m_tooltips.push_back(GetNodeText(GetParamNode(wxT("tooltip")),
+                                         wxXRC_TEXT_NO_ESCAPE));
 #endif // wxUSE_TOOLTIPS
 #if wxUSE_HELP
-        m_helptexts.push_back(helptext);
-        m_helptextSpecified.push_back(hasHelptext);
+        const wxXmlNode* const nodeHelp = GetParamNode(wxT("helptext"));
+        m_helptexts.push_back(GetNodeText(nodeHelp, wxXRC_TEXT_NO_ESCAPE));
+        m_helptextSpecified.push_back(nodeHelp != NULL);
 #endif // wxUSE_HELP
         m_isEnabled.push_back(GetBoolAttr("enabled", 1));
         m_isShown.push_back(!GetBoolAttr("hidden", 0));

--- a/src/xrc/xh_radbx.cpp
+++ b/src/xrc/xh_radbx.cpp
@@ -107,7 +107,13 @@ wxObject *wxRadioBoxXmlHandler::DoCreateResource()
         // we handle handle <item>Label</item> constructs here, and the item
         // tag can have tooltip, helptext, enabled and hidden attributes
 
-        m_labels.push_back(GetNodeText(m_node, wxXRC_TEXT_NO_ESCAPE));
+        // For compatibility, labels are not escaped in XRC by default and
+        // label="1" attribute needs to be explicitly specified to handle them
+        // consistently with the other labels.
+        m_labels.push_back(GetNodeText(m_node,
+                                       GetBoolAttr("label", 0)
+                                        ? 0
+                                        : wxXRC_TEXT_NO_ESCAPE));
 #if wxUSE_TOOLTIPS
         m_tooltips.push_back(GetNodeText(GetParamNode(wxT("tooltip")),
                                          wxXRC_TEXT_NO_ESCAPE));

--- a/utils/wxrc/wxrc.cpp
+++ b/utils/wxrc/wxrc.cpp
@@ -949,6 +949,46 @@ static wxString ConvertText(const wxString& str)
 }
 
 
+enum ContentsKind
+{
+    Contents_NotTrans,  // Not a translatable text at all.
+    Contents_TransOnly, // Translatable but not escaped text.
+    Contents_Text       // Text, i.e. both translatable and escaped.
+};
+
+// Check if the given node contains translatable text and, if it does, whether
+// it's escaped (i.e. parsed using GetText()) or not.
+ContentsKind
+GetNodeContentsKind(wxXmlNode& node, const wxString& contents)
+{
+    if ( node.GetName() == wxT("label") ||
+         (node.GetName() == wxT("value") && !contents.IsNumber()) ||
+         node.GetName() == wxT("help") ||
+         node.GetName() == wxT("hint") ||
+         node.GetName() == wxT("longhelp") ||
+         node.GetName() == wxT("tooltip") ||
+         node.GetName() == wxT("htmlcode") ||
+         node.GetName() == wxT("title") ||
+         node.GetName() == wxT("message") ||
+         node.GetName() == wxT("note") ||
+         node.GetName() == wxT("defaultdirectory") ||
+         node.GetName() == wxT("defaultfilename") ||
+         node.GetName() == wxT("defaultfolder") ||
+         node.GetName() == wxT("filter") ||
+         node.GetName() == wxT("caption") )
+    {
+        return Contents_Text;
+    }
+
+    // This one is special: it is translated in XRC, but its contents is not
+    // escaped.
+    if ( node.GetName() == wxT("item") )
+        return Contents_TransOnly;
+
+    return Contents_NotTrans;
+}
+
+
 ExtractedStrings
 XmlResApp::FindStrings(const wxString& filename, wxXmlNode *node)
 {
@@ -963,41 +1003,26 @@ XmlResApp::FindStrings(const wxString& filename, wxXmlNode *node)
         if ((node->GetType() == wxXML_ELEMENT_NODE) &&
             // parent is an element, i.e. has subnodes...
             (n->GetType() == wxXML_TEXT_NODE ||
-            n->GetType() == wxXML_CDATA_SECTION_NODE) &&
+            n->GetType() == wxXML_CDATA_SECTION_NODE))
             // ...it is textnode...
-            (
-                node/*not n!*/->GetName() == wxT("label") ||
-                (node/*not n!*/->GetName() == wxT("value") &&
-                               !n->GetContent().IsNumber()) ||
-                node/*not n!*/->GetName() == wxT("help") ||
-                node/*not n!*/->GetName() == wxT("hint") ||
-                node/*not n!*/->GetName() == wxT("longhelp") ||
-                node/*not n!*/->GetName() == wxT("tooltip") ||
-                node/*not n!*/->GetName() == wxT("htmlcode") ||
-                node/*not n!*/->GetName() == wxT("title") ||
-                node/*not n!*/->GetName() == wxT("item") ||
-                node/*not n!*/->GetName() == wxT("message") ||
-                node/*not n!*/->GetName() == wxT("note") ||
-                node/*not n!*/->GetName() == wxT("defaultdirectory") ||
-                node/*not n!*/->GetName() == wxT("defaultfilename") ||
-                node/*not n!*/->GetName() == wxT("defaultfolder") ||
-                node/*not n!*/->GetName() == wxT("filter") ||
-                node/*not n!*/->GetName() == wxT("caption")
-            ))
-            // ...and known to contain translatable string
         {
-            if (!flagGettext ||
-                node->GetAttribute(wxT("translate"), wxT("1")) != wxT("0"))
+            wxString s = n->GetContent();
+            switch ( GetNodeContentsKind(*node, s) )
             {
-                arr.push_back
-                    (
-                        ExtractedString
-                        (
-                            ConvertText(n->GetContent()),
-                            filename,
-                            n->GetLineNumber()
-                        )
-                    );
+                case Contents_NotTrans:
+                    break;
+
+                case Contents_Text:
+                    s = ConvertText(s);
+                    wxFALLTHROUGH;
+
+                case Contents_TransOnly:
+                    if (!flagGettext ||
+                        node->GetAttribute(wxT("translate"), wxT("1")) != wxT("0"))
+                    {
+                        arr.push_back(ExtractedString(s, filename, n->GetLineNumber()));
+                    }
+                    break;
             }
         }
 

--- a/utils/wxrc/wxrc.cpp
+++ b/utils/wxrc/wxrc.cpp
@@ -981,9 +981,14 @@ GetNodeContentsKind(wxXmlNode& node, const wxString& contents)
     }
 
     // This one is special: it is translated in XRC, but its contents is not
-    // escaped.
+    // escaped, except for the special case of wxRadioBox when it can be, if
+    // "label" attribute is supplied.
     if ( node.GetName() == wxT("item") )
-        return Contents_TransOnly;
+    {
+        return node.GetAttribute(wxT("label"), wxT("0")) == wxT("1")
+                ? Contents_Text
+                : Contents_TransOnly;
+    }
 
     return Contents_NotTrans;
 }


### PR DESCRIPTION
This initially started as a fix for [this bug](https://trac.wxwidgets.org/ticket/18033#comment:6) and slightly escalated from there.

The changes in `xmlres.cpp` should be viewed ignoring whitespace, otherwise the big block which just got indented confuses them.