### PR TITLE
wxGrid sample OnGridRender fixes

### DIFF
--- a/samples/grid/griddemo.cpp
+++ b/samples/grid/griddemo.cpp
@@ -2232,7 +2232,7 @@ void GridFrame::OnGridRender( wxCommandEvent& event )
     int styleRender = 0, i;
     bool useLometric = false, defSize = false;
     double zoom = 1;
-    wxSize sizeMargin( 0, 0 );
+    wxSize sizeOffset( 0, 0 );
     wxPoint pointOrigin( 0, 0 );
 
     wxMenu* menu = GetMenuBar()->GetMenu( 0 );
@@ -2255,7 +2255,7 @@ void GridFrame::OnGridRender( wxCommandEvent& event )
     {
         pointOrigin.x += 50;
         pointOrigin.y += 50;
-        sizeMargin.IncBy( 50 );
+        sizeOffset.IncBy( 50 );
     }
     if ( menu->FindItem( ID_RENDER_ZOOM )->IsChecked() )
         zoom = 1.25;
@@ -2310,26 +2310,19 @@ void GridFrame::OnGridRender( wxCommandEvent& event )
     sizeRender.y *= zoom;
 
     // delete any existing render frame and create new one
-    wxWindow* win = FindWindow( "frameRender" );
+    wxWindow* win = FindWindowByName( "frameRender" );
     if ( win )
         win->Destroy();
 
+    // create a frame large enough for the rendered bitmap
     wxFrame* frame = new wxFrame( this, wxID_ANY, "Grid Render" );
-    frame->SetClientSize( 780, 400 );
+    frame->SetClientSize( sizeRender + sizeOffset * 2 );
     frame->SetName( "frameRender" );
 
     wxPanel* canvas = new wxPanel( frame, wxID_ANY );
 
-    // make bitmap large enough for margins if any
-    if ( !defSize )
-        sizeRender.IncBy( sizeMargin * 2 );
-    else
-        sizeRender.IncBy( sizeMargin );
-
-    wxBitmap bmp( sizeRender );
-    // don't leave it larger or drawing will be scaled
-    sizeRender.DecBy( sizeMargin * 2 );
-
+    // make a bitmap large enough for any top/left offset
+    wxBitmap bmp( sizeRender + sizeOffset );
     wxMemoryDC memDc(bmp);
 
     // default row labels have no background colour so set background


### PR DESCRIPTION
 Destroy current frameRender when creating a new render.
 Streamline bmp and frame size calculations .