### PR TITLE
Fix PPI returned from wxGTK wxDC

### DIFF
--- a/include/wx/gtk/dc.h
+++ b/include/wx/gtk/dc.h
@@ -15,7 +15,6 @@
 
 class wxGTKCairoDCImpl: public wxGCDCImpl
 {
-    typedef wxGCDCImpl base_type;
 public:
     wxGTKCairoDCImpl(wxDC* owner);
     wxGTKCairoDCImpl(wxDC* owner, int);
@@ -42,7 +41,6 @@ protected:
 
 class wxWindowDCImpl: public wxGTKCairoDCImpl
 {
-    typedef wxGTKCairoDCImpl base_type;
 public:
     wxWindowDCImpl(wxWindowDC* owner, wxWindow* window);
 
@@ -52,7 +50,6 @@ public:
 
 class wxClientDCImpl: public wxGTKCairoDCImpl
 {
-    typedef wxGTKCairoDCImpl base_type;
 public:
     wxClientDCImpl(wxClientDC* owner, wxWindow* window);
 
@@ -62,7 +59,6 @@ public:
 
 class wxPaintDCImpl: public wxGTKCairoDCImpl
 {
-    typedef wxGTKCairoDCImpl base_type;
 public:
     wxPaintDCImpl(wxPaintDC* owner, wxWindow* window);
 
@@ -72,7 +68,6 @@ public:
 
 class wxScreenDCImpl: public wxGTKCairoDCImpl
 {
-    typedef wxGTKCairoDCImpl base_type;
 public:
     wxScreenDCImpl(wxScreenDC* owner);
 
@@ -82,7 +77,6 @@ public:
 
 class wxMemoryDCImpl: public wxGTKCairoDCImpl
 {
-    typedef wxGTKCairoDCImpl base_type;
 public:
     wxMemoryDCImpl(wxMemoryDC* owner);
     wxMemoryDCImpl(wxMemoryDC* owner, wxBitmap& bitmap);
@@ -102,7 +96,6 @@ private:
 
 class WXDLLIMPEXP_CORE wxGTKCairoDC: public wxDC
 {
-    typedef wxDC base_type;
 public:
     wxGTKCairoDC(cairo_t* cr, wxWindow* window);
 

--- a/include/wx/gtk/dc.h
+++ b/include/wx/gtk/dc.h
@@ -32,8 +32,13 @@ public:
     virtual bool DoStretchBlit(int xdest, int ydest, int dstWidth, int dstHeight, wxDC* source, int xsrc, int ysrc, int srcWidth, int srcHeight, wxRasterOperationMode rop, bool useMask, int xsrcMask, int ysrcMask) wxOVERRIDE;
     virtual void* GetCairoContext() const wxOVERRIDE;
 
+    virtual wxSize GetPPI() const wxOVERRIDE;
+
 protected:
     int m_width, m_height;
+
+private:
+    bool TryGetWindowSize(wxSize& size, wxSize& sizeMM) const;
 
     wxDECLARE_NO_COPY_CLASS(wxGTKCairoDCImpl);
 };

--- a/include/wx/gtk/dc.h
+++ b/include/wx/gtk/dc.h
@@ -76,6 +76,8 @@ class wxScreenDCImpl: public wxGTKCairoDCImpl
 public:
     wxScreenDCImpl(wxScreenDC* owner);
 
+    virtual wxSize GetPPI() const wxOVERRIDE;
+
     wxDECLARE_NO_COPY_CLASS(wxScreenDCImpl);
 };
 //-----------------------------------------------------------------------------

--- a/src/gtk/dc.cpp
+++ b/src/gtk/dc.cpp
@@ -15,6 +15,7 @@
 #include "wx/dcclient.h"
 #include "wx/dcmemory.h"
 #include "wx/dcscreen.h"
+#include "wx/gdicmn.h"
 #include "wx/icon.h"
 #include "wx/gtk/dc.h"
 
@@ -235,6 +236,18 @@ void* wxGTKCairoDCImpl::GetCairoContext() const
     if (m_graphicContext)
         cr = static_cast<cairo_t*>(m_graphicContext->GetNativeContext());
     return cr;
+}
+
+wxSize wxGTKCairoDCImpl::GetPPI() const
+{
+    if ( m_window )
+    {
+        return wxGetDisplayPPI();
+    }
+
+    // For a non-window-based DC the concept of PPI doesn't make much sense
+    // anyhow, so just return the hardcoded value used by the base class.
+    return wxGCDCImpl::GetPPI();
 }
 
 //-----------------------------------------------------------------------------

--- a/src/gtk/dc.cpp
+++ b/src/gtk/dc.cpp
@@ -21,21 +21,21 @@
 #include <gtk/gtk.h>
 
 wxGTKCairoDCImpl::wxGTKCairoDCImpl(wxDC* owner)
-    : base_type(owner)
+    : wxGCDCImpl(owner)
 {
     m_width = 0;
     m_height = 0;
 }
 
 wxGTKCairoDCImpl::wxGTKCairoDCImpl(wxDC* owner, int)
-    : base_type(owner, 0)
+    : wxGCDCImpl(owner, 0)
 {
     m_width = 0;
     m_height = 0;
 }
 
 wxGTKCairoDCImpl::wxGTKCairoDCImpl(wxDC* owner, double scaleFactor)
-    : base_type(owner, 0)
+    : wxGCDCImpl(owner, 0)
 {
     m_width = 0;
     m_height = 0;
@@ -43,7 +43,7 @@ wxGTKCairoDCImpl::wxGTKCairoDCImpl(wxDC* owner, double scaleFactor)
 }
 
 wxGTKCairoDCImpl::wxGTKCairoDCImpl(wxDC* owner, wxWindow* window)
-    : base_type(owner, 0)
+    : wxGCDCImpl(owner, 0)
 {
     m_window = window;
     m_font = window->GetFont();
@@ -236,10 +236,11 @@ void* wxGTKCairoDCImpl::GetCairoContext() const
         cr = static_cast<cairo_t*>(m_graphicContext->GetNativeContext());
     return cr;
 }
+
 //-----------------------------------------------------------------------------
 
 wxWindowDCImpl::wxWindowDCImpl(wxWindowDC* owner, wxWindow* window)
-    : base_type(owner, window)
+    : wxGTKCairoDCImpl(owner, window)
 {
     GtkWidget* widget = window->m_wxwindow;
     if (widget == NULL)
@@ -285,7 +286,7 @@ wxWindowDCImpl::wxWindowDCImpl(wxWindowDC* owner, wxWindow* window)
 //-----------------------------------------------------------------------------
 
 wxClientDCImpl::wxClientDCImpl(wxClientDC* owner, wxWindow* window)
-    : base_type(owner, window)
+    : wxGTKCairoDCImpl(owner, window)
 {
     GtkWidget* widget = window->m_wxwindow;
     if (widget == NULL)
@@ -325,7 +326,7 @@ wxClientDCImpl::wxClientDCImpl(wxClientDC* owner, wxWindow* window)
 //-----------------------------------------------------------------------------
 
 wxPaintDCImpl::wxPaintDCImpl(wxPaintDC* owner, wxWindow* window)
-    : base_type(owner, window)
+    : wxGTKCairoDCImpl(owner, window)
 {
     cairo_t* cr = window->GTKPaintContext();
     wxCHECK_RET(cr, "using wxPaintDC without being in a native paint event");
@@ -339,7 +340,7 @@ wxPaintDCImpl::wxPaintDCImpl(wxPaintDC* owner, wxWindow* window)
 //-----------------------------------------------------------------------------
 
 wxScreenDCImpl::wxScreenDCImpl(wxScreenDC* owner)
-    : base_type(owner, 0)
+    : wxGTKCairoDCImpl(owner, 0)
 {
     GdkWindow* window = gdk_get_default_root_window();
     m_width = gdk_window_get_width(window);
@@ -353,20 +354,20 @@ wxScreenDCImpl::wxScreenDCImpl(wxScreenDC* owner)
 //-----------------------------------------------------------------------------
 
 wxMemoryDCImpl::wxMemoryDCImpl(wxMemoryDC* owner)
-    : base_type(owner)
+    : wxGTKCairoDCImpl(owner)
 {
     m_ok = false;
 }
 
 wxMemoryDCImpl::wxMemoryDCImpl(wxMemoryDC* owner, wxBitmap& bitmap)
-    : base_type(owner, 0)
+    : wxGTKCairoDCImpl(owner, 0)
     , m_bitmap(bitmap)
 {
     Setup();
 }
 
 wxMemoryDCImpl::wxMemoryDCImpl(wxMemoryDC* owner, wxDC*)
-    : base_type(owner)
+    : wxGTKCairoDCImpl(owner)
 {
     m_ok = false;
 }
@@ -411,7 +412,7 @@ void wxMemoryDCImpl::Setup()
 //-----------------------------------------------------------------------------
 
 wxGTKCairoDC::wxGTKCairoDC(cairo_t* cr, wxWindow* window)
-    : base_type(new wxGTKCairoDCImpl(this, window->GetContentScaleFactor()))
+    : wxDC(new wxGTKCairoDCImpl(this, window->GetContentScaleFactor()))
 {
     wxGraphicsContext* gc = wxGraphicsContext::CreateFromNative(cr);
     gc->EnableOffset(window->GetContentScaleFactor() <= 1);

--- a/src/gtk/dc.cpp
+++ b/src/gtk/dc.cpp
@@ -364,6 +364,12 @@ wxScreenDCImpl::wxScreenDCImpl(wxScreenDC* owner)
     gc->EnableOffset(m_contentScaleFactor <= 1);
     SetGraphicsContext(gc);
 }
+
+wxSize wxScreenDCImpl::GetPPI() const
+{
+    return wxGetDisplayPPI();
+}
+
 //-----------------------------------------------------------------------------
 
 wxMemoryDCImpl::wxMemoryDCImpl(wxMemoryDC* owner)


### PR DESCRIPTION
This is a minimal reasonable fix for the problem described in [this message](https://groups.google.com/d/msg/wx-users/S62blBSUc3g/TO_ufyJDAwAJ).

There are many things to be still improved here that I'd like to do one day, e.g.

- Encapsulate all this code in `wxDisplay` and just use it here (and/or possibly extend `wxGetDisplaySize()` and `wxGetDisplaySizeMM()` functions with `wxWindow*` argument).
- Either set `wxDCImpl::m_mm_to_pix_[xy]` correctly (i.e. using the right display instead of always using the primary one) or get rid of them entirely.
- Provide default implementation of `DoGetSizeMM()` in terms of `DoGetSize()` and `GetPPI()` (or vice versa? But currently these methods are both pure virtual and one of them is redundant).
- Clean up the mess of `wx{Window,Client,Paint}DCImpl` being declared in `wx/gtk/dc.h` for wxGTK3 and `wx/gtk/dcclient.h` for wxGTK2 -- this is very confusing and requires using preprocessor checks whenever one of these classes is needed.

But for now this should already be an improvement.