### PR TITLE
Really fix deleting all wxDVC items with wxGTK

### DIFF
--- a/include/wx/gtk/dataview.h
+++ b/include/wx/gtk/dataview.h
@@ -188,6 +188,25 @@ public:
 
     int GTKGetUniformRowHeight() const { return m_uniformRowHeight; }
 
+    // Simple RAII helper for disabling selection events during its lifetime.
+    class SelectionEventsSuppressor
+    {
+    public:
+        explicit SelectionEventsSuppressor(wxDataViewCtrl* ctrl)
+            : m_ctrl(ctrl)
+        {
+            m_ctrl->GtkDisableSelectionEvents();
+        }
+
+        ~SelectionEventsSuppressor()
+        {
+            m_ctrl->GtkEnableSelectionEvents();
+        }
+
+    private:
+        wxDataViewCtrl* const m_ctrl;
+    };
+
 protected:
     virtual void DoSetExpanderColumn() wxOVERRIDE;
     virtual void DoSetIndent() wxOVERRIDE;

--- a/samples/treelist/treelist.cpp
+++ b/samples/treelist/treelist.cpp
@@ -65,6 +65,8 @@ enum
     Id_CheckboxesUser3State,
     Id_Checkboxes_End,
 
+    Id_DeleteAllItems,
+
     Id_DumpSelection,
     Id_Check_HTMLDocs,
     Id_Uncheck_HTMLDocs,
@@ -187,6 +189,8 @@ private:
     void OnAbout(wxCommandEvent& event);
     void OnExit(wxCommandEvent& event);
 
+    void OnDeleteAllItems(wxCommandEvent& event);
+
     void OnSelectionChanged(wxTreeListEvent& event);
     void OnItemExpanding(wxTreeListEvent& event);
     void OnItemExpanded(wxTreeListEvent& event);
@@ -272,6 +276,8 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(wxID_ABOUT, MyFrame::OnAbout)
     EVT_MENU(wxID_EXIT, MyFrame::OnExit)
 
+    EVT_MENU(Id_DeleteAllItems, MyFrame::OnDeleteAllItems)
+
     EVT_TREELIST_SELECTION_CHANGED(wxID_ANY, MyFrame::OnSelectionChanged)
     EVT_TREELIST_ITEM_EXPANDING(wxID_ANY, MyFrame::OnItemExpanding)
     EVT_TREELIST_ITEM_EXPANDED(wxID_ANY, MyFrame::OnItemExpanded)
@@ -313,6 +319,8 @@ MyFrame::MyFrame()
     treeOper->Append(Id_Uncheck_HTMLDocs, "&Uncheck Doc/HTML item\tCtrl-U");
     treeOper->Append(Id_Indet_HTMLDocs, "Make Doc/HTML &indeterminate\tCtrl-I");
     treeOper->Append(Id_Select_HTMLDocs, "&Select Doc/HTML item\tCtrl-S");
+
+    treeOper->Append(Id_DeleteAllItems, "DeleteAllItems");
 
     wxMenu* helpMenu = new wxMenu;
     helpMenu->Append(wxID_ABOUT);
@@ -575,6 +583,11 @@ void MyFrame::OnAbout(wxCommandEvent& WXUNUSED(event))
 void MyFrame::OnExit(wxCommandEvent& WXUNUSED(event))
 {
     Close(true);
+}
+
+void MyFrame::OnDeleteAllItems(wxCommandEvent& WXUNUSED(event))
+{
+    m_treelist->DeleteAllItems();
 }
 
 wxString MyFrame::DumpItem(wxTreeListItem item) const

--- a/src/generic/treelist.cpp
+++ b/src/generic/treelist.cpp
@@ -572,16 +572,12 @@ void wxTreeListModel::DeleteItem(Node* item)
 
 void wxTreeListModel::DeleteAllItems()
 {
-    // Note that this must be called before actually deleting the items as
-    // clearing GTK+ wxDataViewCtrl results in SELECTION_CHANGED events being
-    // sent and these events contain pointers to the model items, so they must
-    // still be valid.
-    Cleared();
-
     while ( m_root->GetChild() )
     {
         m_root->DeleteChild();
     }
+
+    Cleared();
 }
 
 const wxString& wxTreeListModel::GetItemText(Node* item, unsigned col) const

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -5068,7 +5068,7 @@ void wxDataViewCtrl::SetSelections( const wxDataViewItemArray & sel )
 {
     wxCHECK_RET( m_internal, "model must be associated before calling SetSelections" );
 
-    GtkDisableSelectionEvents();
+    SelectionEventsSuppressor noSelection(this);
 
     GtkTreeSelection *selection = gtk_tree_view_get_selection( GTK_TREE_VIEW(m_treeview) );
 
@@ -5093,8 +5093,6 @@ void wxDataViewCtrl::SetSelections( const wxDataViewItemArray & sel )
         iter.user_data = (gpointer) item.GetID();
         gtk_tree_selection_select_iter( selection, &iter );
     }
-
-    GtkEnableSelectionEvents();
 }
 
 void wxDataViewCtrl::Select( const wxDataViewItem & item )
@@ -5103,7 +5101,7 @@ void wxDataViewCtrl::Select( const wxDataViewItem & item )
 
     ExpandAncestors(item);
 
-    GtkDisableSelectionEvents();
+    SelectionEventsSuppressor noSelection(this);
 
     GtkTreeSelection *selection = gtk_tree_view_get_selection( GTK_TREE_VIEW(m_treeview) );
 
@@ -5111,15 +5109,13 @@ void wxDataViewCtrl::Select( const wxDataViewItem & item )
     iter.stamp = m_internal->GetGtkModel()->stamp;
     iter.user_data = (gpointer) item.GetID();
     gtk_tree_selection_select_iter( selection, &iter );
-
-    GtkEnableSelectionEvents();
 }
 
 void wxDataViewCtrl::Unselect( const wxDataViewItem & item )
 {
     wxCHECK_RET( m_internal, "model must be associated before calling Unselect" );
 
-    GtkDisableSelectionEvents();
+    SelectionEventsSuppressor noSelection(this);
 
     GtkTreeSelection *selection = gtk_tree_view_get_selection( GTK_TREE_VIEW(m_treeview) );
 
@@ -5127,8 +5123,6 @@ void wxDataViewCtrl::Unselect( const wxDataViewItem & item )
     iter.stamp = m_internal->GetGtkModel()->stamp;
     iter.user_data = (gpointer) item.GetID();
     gtk_tree_selection_unselect_iter( selection, &iter );
-
-    GtkEnableSelectionEvents();
 }
 
 bool wxDataViewCtrl::IsSelected( const wxDataViewItem & item ) const
@@ -5146,24 +5140,20 @@ bool wxDataViewCtrl::IsSelected( const wxDataViewItem & item ) const
 
 void wxDataViewCtrl::SelectAll()
 {
-    GtkDisableSelectionEvents();
+    SelectionEventsSuppressor noSelection(this);
 
     GtkTreeSelection *selection = gtk_tree_view_get_selection( GTK_TREE_VIEW(m_treeview) );
 
     gtk_tree_selection_select_all( selection );
-
-    GtkEnableSelectionEvents();
 }
 
 void wxDataViewCtrl::UnselectAll()
 {
-    GtkDisableSelectionEvents();
+    SelectionEventsSuppressor noSelection(this);
 
     GtkTreeSelection *selection = gtk_tree_view_get_selection( GTK_TREE_VIEW(m_treeview) );
 
     gtk_tree_selection_unselect_all( selection );
-
-    GtkEnableSelectionEvents();
 }
 
 void wxDataViewCtrl::EnsureVisible(const wxDataViewItem& item,

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -1902,10 +1902,6 @@ bool wxGtkDataViewModelNotifier::Cleared()
     // has been deleted so call row_deleted() for every
     // child of root...
 
-    int count = m_internal->iter_n_children( NULL ); // number of children of root
-
-    GtkTreePath *path = gtk_tree_path_new_first();  // points to root
-
     // It is important to avoid selection changed events being generated from
     // here as they would reference the already deleted model items, which
     // would result in crashes in any code attempting to handle these events.
@@ -1917,11 +1913,12 @@ bool wxGtkDataViewModelNotifier::Cleared()
     const gint stampOrig = wxgtk_model->stamp;
     wxgtk_model->stamp = 0;
 
-    int i;
-    for (i = 0; i < count; i++)
-        gtk_tree_model_row_deleted( GTK_TREE_MODEL(wxgtk_model), path );
-
-    gtk_tree_path_free( path );
+    {
+        wxGtkTreePath path(gtk_tree_path_new_first());  // points to root
+        const int count = m_internal->iter_n_children( NULL ); // number of children of root
+        for (int i = 0; i < count; i++)
+            gtk_tree_model_row_deleted( GTK_TREE_MODEL(wxgtk_model), path );
+    }
 
     wxgtk_model->stamp = stampOrig;
 

--- a/tests/controls/treelistctrltest.cpp
+++ b/tests/controls/treelistctrltest.cpp
@@ -39,7 +39,6 @@ private:
         CPPUNIT_TEST( Traversal );
         CPPUNIT_TEST( ItemText );
         CPPUNIT_TEST( ItemCheck );
-        CPPUNIT_TEST( DeleteAll );
     CPPUNIT_TEST_SUITE_END();
 
     // Create the control with the given style.
@@ -56,7 +55,6 @@ private:
     void Traversal();
     void ItemText();
     void ItemCheck();
-    void DeleteAll();
 
 
     // The control itself.
@@ -231,13 +229,6 @@ void TreeListCtrlTestCase::ItemCheck()
                           m_treelist->GetCheckedState(m_code_osx) );
     CPPUNIT_ASSERT_EQUAL( wxCHK_UNDETERMINED,
                           m_treelist->GetCheckedState(m_code) );
-}
-
-void TreeListCtrlTestCase::DeleteAll()
-{
-    m_treelist->DeleteAllItems();
-
-    CHECK( !m_treelist->GetFirstChild(m_treelist->GetRootItem()).IsOk() );
 }
 
 #endif // wxUSE_TREELISTCTRL


### PR DESCRIPTION
See [this ticket](https://trac.wxwidgets.org/ticket/18045).

The [main commit](https://github.com/wxWidgets/wxWidgets/commit/27f705686de5dd83c8cd2df68e3ff070d13021da) is really ugly and not very safe, but I just don't see any other way to do it. Paul, please let me know if I'm missing something about the way GTK+ works here (wouldn't be the first time...), TIA!

Note to self: this must be backported to 3.0 as the previous wrong fix was.