### PR TITLE
add check for append item

### DIFF
--- a/include/wx/dataview.h
+++ b/include/wx/dataview.h
@@ -1128,7 +1128,19 @@ public:
           int width = -1, wxAlignment align = wxALIGN_LEFT, int flags = wxDATAVIEW_COL_RESIZABLE );
 
     void AppendItem( const wxVector<wxVariant> &values, wxUIntPtr data = 0 )
-        { GetStore()->AppendItem( values, data ); }
+    {
+        wxDataViewListStore *store = GetStore();
+        if(values.size() < store->GetColumnCount())
+        {
+            wxVector<wxVariant> temp = values;
+            temp.resize(store->GetColumnCount());
+            store->AppendItem( temp, data );
+        }
+        else
+        {
+            store->AppendItem( values, data );
+        }
+    }
     void PrependItem( const wxVector<wxVariant> &values, wxUIntPtr data = 0 )
         { GetStore()->PrependItem( values, data ); }
     void InsertItem(  unsigned int row, const wxVector<wxVariant> &values, wxUIntPtr data = 0 )


### PR DESCRIPTION
If into wxDataViewListCtrl was appended item with non-full wxVector<wxVariant> then we get out of range in this [line](https://github.com/wxWidgets/wxWidgets/blob/master/src/common/datavcmn.cpp#L2259). 

I propose resize input vector when it's size less than count of columns. 
But I don't sure is this correct for case when size of values greater, so maybe really better use condition `if(values.size() != store->GetColumnCount())`