### PR TITLE
Cmake options

### DIFF
--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -193,6 +193,33 @@ function(wx_set_target_properties target_name is_base)
         target_include_directories(${target_name}
             PUBLIC ${wxTOOLKIT_INCLUDE_DIRS})
     endif()
+
+    if (WXMSW)
+        set(WXMSW_LIBRARIES
+            kernel32
+            user32
+            gdi32
+            comdlg32
+            winspool
+            winmm
+            shell32
+            shlwapi
+            comctl32
+            ole32
+            oleaut32
+            uuid
+            rpcrt4
+            advapi32
+            version
+            wsock32
+            wininet
+            oleacc
+            uxtheme
+        )
+        target_link_libraries(${target_name}
+            PUBLIC ${WXMSW_LIBRARIES})
+    endif()
+
     if(wxTOOLKIT_LIBRARIES)
         target_link_libraries(${target_name}
             PUBLIC ${wxTOOLKIT_LIBRARIES})

--- a/build/cmake/init.cmake
+++ b/build/cmake/init.cmake
@@ -119,18 +119,24 @@ set(wxUSE_STD_DEFAULT ON)
 if(wxUSE_UNICODE)
     set(wxUSE_WCHAR_T ON)
 endif()
-if(wxUSE_EXPAT)
-    set(wxUSE_XML ON)
-else()
-    set(wxUSE_XML OFF)
+if(NOT wxUSE_EXPAT)
+    set(wxUSE_XRC OFF)
 endif()
+set(wxUSE_XML ${wxUSE_XRC})
 if(wxUSE_CONFIG)
     set(wxUSE_CONFIG_NATIVE ON)
 endif()
 
 if(DEFINED wxUSE_OLE AND wxUSE_OLE)
     set(wxUSE_OLE_AUTOMATION ON)
-    set(wxUSE_ACTIVEX ON)
+endif()
+
+if(DEFINED wxUSE_GRAPHICS_DIRECT2D AND NOT wxUSE_GRAPHICS_CONTEXT)
+    set(wxUSE_GRAPHICS_DIRECT2D OFF)
+endif()
+
+if(wxUSE_OPENGL)
+    set(wxUSE_GLCANVAS ON)
 endif()
 
 if(wxUSE_THREADS)
@@ -138,20 +144,9 @@ if(wxUSE_THREADS)
 endif()
 
 if(wxUSE_GUI)
-    # Constants for GUI
-    set(wxUSE_COMMON_DIALOGS ON)
-
-    if(wxUSE_TASKBARICON)
-        set(wxUSE_TASKBARICON_BALLOONS ON)
-    endif()
-
     if(WIN32 AND wxUSE_METAFILE)
         # this one should probably be made separately configurable
         set(wxUSE_ENH_METAFILE ON)
-    endif()
-
-    if(wxUSE_IMAGE)
-        set(wxUSE_WXDIB ON)
     endif()
 
     if(wxUSE_OPENGL)

--- a/build/cmake/lib/CMakeLists.txt
+++ b/build/cmake/lib/CMakeLists.txt
@@ -20,7 +20,7 @@ if(wxBUILD_MONOLITHIC)
 endif()
 
 # Define third party libraries
-set(LIBS_THIRDPARTY regex zlib)
+set(LIBS_THIRDPARTY regex zlib expat)
 if(wxUSE_GUI)
     list(APPEND LIBS_THIRDPARTY jpeg png tiff)
 endif()

--- a/build/cmake/lib/expat.cmake
+++ b/build/cmake/lib/expat.cmake
@@ -7,8 +7,6 @@
 # Licence:     wxWindows licence
 #############################################################################
 
-wx_add_thirdparty_library(wxUSE_EXPAT EXPAT "use expat for XML parsing" DEFAULT_APPLE sys)
-
 if(wxUSE_EXPAT STREQUAL "builtin")
     wx_add_builtin_library(wxexpat
         src/expat/expat/lib/xmlparse.c

--- a/build/cmake/lib/expat.cmake
+++ b/build/cmake/lib/expat.cmake
@@ -1,0 +1,22 @@
+#############################################################################
+# Name:        build/cmake/lib/expat.cmake
+# Purpose:     Use external or internal expat lib
+# Author:      Tobias Taschner
+# Created:     2016-09-21
+# Copyright:   (c) 2016 wxWidgets development team
+# Licence:     wxWindows licence
+#############################################################################
+
+wx_add_thirdparty_library(wxUSE_EXPAT EXPAT "use expat for XML parsing" DEFAULT_APPLE sys)
+
+if(wxUSE_EXPAT STREQUAL "builtin")
+    wx_add_builtin_library(wxexpat
+        src/expat/expat/lib/xmlparse.c
+        src/expat/expat/lib/xmlrole.c
+        src/expat/expat/lib/xmltok.c
+    )
+    set(EXPAT_LIBRARIES wxexpat)
+    set(EXPAT_INCLUDE_DIRS ${wxSOURCE_DIR}/src/expat/expat/lib)
+elseif(wxUSE_EXPAT)
+    find_package(EXPAT REQUIRED)
+endif()

--- a/build/cmake/lib/jpeg.cmake
+++ b/build/cmake/lib/jpeg.cmake
@@ -7,8 +7,6 @@
 # Licence:     wxWindows licence
 #############################################################################
 
-wx_add_thirdparty_library(wxUSE_LIBJPEG JPEG "use libjpeg (JPEG file format)")
-
 if(wxUSE_LIBJPEG STREQUAL "builtin")
     wx_add_builtin_library(wxjpeg
         src/jpeg/jaricom.c

--- a/build/cmake/lib/png.cmake
+++ b/build/cmake/lib/png.cmake
@@ -7,8 +7,6 @@
 # Licence:     wxWindows licence
 #############################################################################
 
-wx_add_thirdparty_library(wxUSE_LIBPNG PNG "use libpng (PNG image format)")
-
 if(wxUSE_LIBPNG STREQUAL "builtin")
     wx_add_builtin_library(wxpng
             src/png/png.c

--- a/build/cmake/lib/regex.cmake
+++ b/build/cmake/lib/regex.cmake
@@ -7,8 +7,6 @@
 # Licence:     wxWindows licence
 #############################################################################
 
-wx_add_thirdparty_library(wxUSE_REGEX REGEX "enable support for wxRegEx class" DEFAULT builtin)
-
 if(wxUSE_REGEX)
     # TODO: Forcing builtin until sys is implemented
     set(wxUSE_REGEX builtin)

--- a/build/cmake/lib/tiff.cmake
+++ b/build/cmake/lib/tiff.cmake
@@ -7,8 +7,6 @@
 # Licence:     wxWindows licence
 #############################################################################
 
-wx_add_thirdparty_library(wxUSE_LIBTIFF TIFF "use libtiff (TIFF file format)")
-
 if(wxUSE_LIBTIFF STREQUAL "builtin")
     # TODO: implement building libtiff via ExternalProject_Add()
     if(UNIX AND NOT APPLE)

--- a/build/cmake/lib/xml/CMakeLists.txt
+++ b/build/cmake/lib/xml/CMakeLists.txt
@@ -9,18 +9,6 @@
 
 include(../../source_groups.cmake)
 
-if(wxUSE_EXPAT STREQUAL "builtin")
-    wx_add_builtin_library(wxexpat
-        src/expat/expat/lib/xmlparse.c
-        src/expat/expat/lib/xmlrole.c
-        src/expat/expat/lib/xmltok.c
-    )
-    set(EXPAT_LIBRARIES wxexpat)
-    set(EXPAT_INCLUDE_DIRS ${wxSOURCE_DIR}/src/expat/expat/lib)
-elseif(wxUSE_EXPAT)
-    find_package(EXPAT)
-endif()
-
 wx_append_sources(XML_FILES XML)
 wx_add_library(xml IS_BASE ${XML_FILES})
 wx_lib_link_libraries(xml

--- a/build/cmake/lib/zlib.cmake
+++ b/build/cmake/lib/zlib.cmake
@@ -7,9 +7,6 @@
 # Licence:     wxWindows licence
 #############################################################################
 
-wx_add_thirdparty_library(wxUSE_ZLIB ZLIB "use zlib for LZW compression"
-    DEFAULT_APPLE sys)
-
 if(wxUSE_ZLIB STREQUAL "builtin")
     wx_add_builtin_library(wxzlib
         src/zlib/adler32.c

--- a/build/cmake/main.cmake
+++ b/build/cmake/main.cmake
@@ -67,9 +67,9 @@ wx_print_thirdparty_library_summary()
 
 message(STATUS "Configured wxWidgets ${wxVERSION} for ${CMAKE_SYSTEM}
     Min OS Version required at runtime:                ${wxREQUIRED_OS_DESC}
-    Which GUI toolkit should wxWidgets use?:           ${wxBUILD_TOOLKIT} ${wxTOOLKIT_VERSION}
+    Which GUI toolkit should wxWidgets use?            ${wxBUILD_TOOLKIT} ${wxTOOLKIT_VERSION}
     Should wxWidgets be compiled into single library?  ${wxBUILD_MONOLITHIC}
     Should wxWidgets be linked as a shared library?    ${wxBUILD_SHARED}
     Should wxWidgets support Unicode?                  ${wxUSE_UNICODE}
-    What level of wxWidgets compatibility should be enabled? ${wxBUILD_COMPATIBILITY}"
+    What wxWidgets compatibility level should be used? ${wxBUILD_COMPATIBILITY}"
     )

--- a/build/cmake/options.cmake
+++ b/build/cmake/options.cmake
@@ -56,8 +56,6 @@ wx_option(wxUSE_VISIBILITY "use of ELF symbols visibility")
 # ---------------------------------------------------------------------------
 # external libraries
 # ---------------------------------------------------------------------------
-wx_add_thirdparty_library(wxUSE_EXPAT EXPAT "use expat for XML parsing"
-    DEFAULT_APPLE sys)
 
 wx_option(wxUSE_OPENGL "use OpenGL (or Mesa)")
 

--- a/build/cmake/options.cmake
+++ b/build/cmake/options.cmake
@@ -59,6 +59,13 @@ wx_option(wxUSE_REPRODUCIBLE_BUILD "enable reproducable build" OFF)
 # external libraries
 # ---------------------------------------------------------------------------
 
+wx_add_thirdparty_library(wxUSE_REGEX REGEX "enable support for wxRegEx class" DEFAULT builtin)
+wx_add_thirdparty_library(wxUSE_ZLIB ZLIB "use zlib for LZW compression" DEFAULT_APPLE sys)
+wx_add_thirdparty_library(wxUSE_EXPAT EXPAT "use expat for XML parsing" DEFAULT_APPLE sys)
+wx_add_thirdparty_library(wxUSE_LIBJPEG JPEG "use libjpeg (JPEG file format)")
+wx_add_thirdparty_library(wxUSE_LIBPNG PNG "use libpng (PNG image format)")
+wx_add_thirdparty_library(wxUSE_LIBTIFF TIFF "use libtiff (TIFF file format)")
+
 wx_option(wxUSE_OPENGL "use OpenGL (or Mesa)")
 
 if(NOT WIN32)

--- a/build/cmake/setup.cmake
+++ b/build/cmake/setup.cmake
@@ -471,24 +471,6 @@ endif() # CMAKE_USE_PTHREADS_INIT
 check_symbol_exists(localtime_r time.h HAVE_LOCALTIME_R)
 check_symbol_exists(gmtime_r time.h HAVE_GMTIME_R)
 
-if(WXMSW)
-    set(wxUSE_WEBVIEW_IE ON)
-elseif(WXGTK OR APPLE)
-    set(wxUSE_WEBVIEW_WEBKIT ON)
-endif()
-
-if(MSVC)
-    set(wxUSE_GRAPHICS_CONTEXT ON)
-endif()
-
-if(MSVC_VERSION GREATER 1600 AND NOT CMAKE_VS_PLATFORM_TOOLSET MATCHES "_xp$")
-    set(wxUSE_WINRT ON)
-endif()
-
-if(wxUSE_OPENGL)
-    set(wxUSE_GLCANVAS ON)
-endif()
-
 # ---------------------------------------------------------------------------
 # Checks for typedefs
 # ---------------------------------------------------------------------------

--- a/build/cmake/toolkit.cmake
+++ b/build/cmake/toolkit.cmake
@@ -39,10 +39,6 @@ wx_option(wxBUILD_TOOLKIT "Toolkit used by wxWidgets" ${wxDEFAULT_TOOLKIT}
 # TODO: set to univ for universal build
 set(wxBUILD_WIDGETSET "")
 
-if(NOT wxUSE_GUI)
-    set(wxBUILD_TOOLKIT "base")
-endif()
-
 # Create shortcut variable for easy toolkit tests
 string(TOUPPER ${wxBUILD_TOOLKIT} toolkit_upper)
 set(WX${toolkit_upper} ON)
@@ -53,6 +49,13 @@ elseif(wxBUILD_TOOLKIT MATCHES "^osx*")
 endif()
 
 set(wxTOOLKIT_DEFINITIONS __WX${toolkit_upper}__)
+
+if(NOT wxUSE_GUI)
+    set(wxBUILD_TOOLKIT "base")
+    string(TOUPPER ${wxBUILD_TOOLKIT} toolkit_upper)
+    set(WX${toolkit_upper} ON)
+    set(wxTOOLKIT_DEFINITIONS __WX${toolkit_upper}__)
+endif()
 
 # Initialize toolkit variables
 if(wxUSE_GUI)
@@ -66,29 +69,7 @@ if(UNIX AND NOT APPLE AND NOT WIN32)
     list(APPEND wxTOOLKIT_LIBRARIES ${X11_LIBRARIES})
 endif()
 
-if(WXMSW)
-    set(wxTOOLKIT_LIBRARIES
-        kernel32
-        user32
-        gdi32
-        comdlg32
-        winspool
-        winmm
-        shell32
-        shlwapi
-        comctl32
-        ole32
-        oleaut32
-        uuid
-        rpcrt4
-        advapi32
-        version
-        wsock32
-        wininet
-        oleacc
-        uxtheme
-        )
-elseif(WXGTK)
+if(WXGTK)
     if(WXGTK3)
         set(gtk_lib GTK3)
     elseif(WXGTK2)

--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -225,6 +225,17 @@ DEFINE_GUID(wxIID_IDWriteFactory,
 DEFINE_GUID(wxIID_IWICBitmapSource,
             0x00000120, 0xa8f2, 0x4877, 0xba, 0x0a, 0xfd, 0x2b, 0x66, 0x45, 0xfb, 0x94);
 
+DEFINE_GUID(GUID_WICPixelFormat32bppPBGRA,
+            0x6fddc324, 0x4e03, 0x4bfe, 0xb1, 0x85, 0x3d, 0x77, 0x76, 0x8d, 0xc9, 0x10);
+
+DEFINE_GUID(GUID_WICPixelFormat32bppBGR,
+            0x6fddc324, 0x4e03, 0x4bfe, 0xb1, 0x85, 0x3d, 0x77, 0x76, 0x8d, 0xc9, 0x0e);
+
+#ifndef CLSID_WICImagingFactory
+DEFINE_GUID(CLSID_WICImagingFactory,
+            0xcacaf262, 0x9370, 0x4615, 0xa1, 0x3b, 0x9f, 0x55, 0x39, 0xda, 0x4c, 0xa);
+#endif
+
 // Implementation of the Direct2D functions
 HRESULT WINAPI wxD2D1CreateFactory(
     D2D1_FACTORY_TYPE factoryType,
@@ -3028,7 +3039,7 @@ public:
         wxCHECK_HRESULT_RET(hr);
     }
 
-    void DrawBitmap(ID2D1Image* image, D2D1_POINT_2F offset,
+    void DrawBitmap(ID2D1Bitmap* image, D2D1_POINT_2F offset,
         D2D1_RECT_F imageRectangle, wxInterpolationQuality interpolationQuality,
         wxCompositionMode compositionMode) wxOVERRIDE
     {


### PR DESCRIPTION
Another round of CMake improvements.

I refactored the expat code so it matches to other third-party libraries.
I fixed building with `wxUSE_GUI 0`. And moved the declaration of the windows libraries so they are always available.
I improved the options. Some used the wrong name. There were some duplicates. Some were missing, causing the wrong default value in setup.h (e.g. native statusbar and progress dialog). Some were overruled in setup.cmake or init.cmake.
And I added the option to enable the  Direct2D graphics context so it can be used in MinGW versions that support it. And add required libraries as well.