### PR TITLE
Set window field of wxEVT_SET_FOCUS events in wxGTK

### DIFF
--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -213,6 +213,8 @@ static wxWindowGTK *gs_currentFocus = NULL;
 // The window that is scheduled to get focus in the next event loop iteration
 // or NULL if there's no pending focus change:
 static wxWindowGTK *gs_pendingFocus = NULL;
+// The window that had focus before we lost it last time:
+static wxWindowGTK *gs_lastFocus = NULL;
 
 // the window that has deferred focus-out event pending, if any (see
 // GTKAddDeferredFocusOut() for details)
@@ -2685,6 +2687,8 @@ wxWindowGTK::~wxWindowGTK()
         gs_currentFocus = NULL;
     if (gs_pendingFocus == this)
         gs_pendingFocus = NULL;
+    if (gs_lastFocus == this)
+        gs_lastFocus = NULL;
 
     if ( gs_deferredFocusOut == this )
         gs_deferredFocusOut = NULL;
@@ -4374,6 +4378,9 @@ bool wxWindowGTK::GTKHandleFocusIn()
 
     wxFocusEvent eventFocus(wxEVT_SET_FOCUS, GetId());
     eventFocus.SetEventObject(this);
+    eventFocus.SetWindow(gs_lastFocus);
+    gs_lastFocus = this;
+
     GTKProcessEvent(eventFocus);
 
     return retval;
@@ -4414,6 +4421,8 @@ void wxWindowGTK::GTKHandleFocusOutNoDeferring()
     wxLogTrace(TRACE_FOCUS,
                "handling focus_out event for %s(%p, %s)",
                GetClassInfo()->GetClassName(), this, GetLabel());
+
+    gs_lastFocus = this;
 
     if (m_imContext)
         gtk_im_context_focus_out(m_imContext);


### PR DESCRIPTION
It is often useful to know where is the focus coming from, for example
to determine if was in another window of the same composite control.

Remember the last focus in yet another global variable in wxGTK code to
allow setting wxFocusEvent::m_window correctly when generating
wxEVT_SET_FOCUS events.

---

This makes the changes of #699 work better (I'm not sure if there are no other problems left, I had time for only some very cursory testing) in wxGTK and I think it can be more generally useful too, as MSW (and Mac, AFAICS) do set this field correctly.