### PR TITLE
TAB navigation fixes for wxGTK

### DIFF
--- a/include/wx/generic/combo.h
+++ b/include/wx/generic/combo.h
@@ -16,6 +16,8 @@
 // Only define generic if native doesn't have all the features
 #if !defined(wxCOMBOCONTROL_FULLY_FEATURED)
 
+#include "wx/containr.h"
+
 // ----------------------------------------------------------------------------
 // Generic wxComboCtrl
 // ----------------------------------------------------------------------------
@@ -32,11 +34,12 @@
 
 extern WXDLLIMPEXP_DATA_CORE(const char) wxComboBoxNameStr[];
 
-class WXDLLIMPEXP_CORE wxGenericComboCtrl : public wxComboCtrlBase
+class WXDLLIMPEXP_CORE wxGenericComboCtrl
+    : public wxNavigationEnabled<wxComboCtrlBase>
 {
 public:
     // ctors and such
-    wxGenericComboCtrl() : wxComboCtrlBase() { Init(); }
+    wxGenericComboCtrl() { Init(); }
 
     wxGenericComboCtrl(wxWindow *parent,
                        wxWindowID id = wxID_ANY,
@@ -46,7 +49,6 @@ public:
                        long style = 0,
                        const wxValidator& validator = wxDefaultValidator,
                        const wxString& name = wxComboBoxNameStr)
-        : wxComboCtrlBase()
     {
         Init();
 

--- a/include/wx/generic/combo.h
+++ b/include/wx/generic/combo.h
@@ -30,8 +30,6 @@
 
 #endif
 
-#include "wx/dcbuffer.h"
-
 extern WXDLLIMPEXP_DATA_CORE(const char) wxComboBoxNameStr[];
 
 class WXDLLIMPEXP_CORE wxGenericComboCtrl : public wxComboCtrlBase
@@ -96,19 +94,7 @@ protected:
 #endif
 
     // For better transparent background rendering
-    virtual bool HasTransparentBackground() wxOVERRIDE
-    {
-        #if wxALWAYS_NATIVE_DOUBLE_BUFFER
-          #ifdef __WXGTK__
-            // Sanity check for GTK+
-            return IsDoubleBuffered();
-          #else
-            return true;
-          #endif
-        #else
-            return false;
-        #endif
-    }
+    virtual bool HasTransparentBackground() wxOVERRIDE;
 
     // Mandatory virtuals
     virtual void OnResize() wxOVERRIDE;

--- a/include/wx/generic/datectrl.h
+++ b/include/wx/generic/datectrl.h
@@ -19,7 +19,7 @@ class WXDLLIMPEXP_FWD_ADV wxCalendarCtrl;
 class WXDLLIMPEXP_FWD_ADV wxCalendarComboPopup;
 
 class WXDLLIMPEXP_ADV wxDatePickerCtrlGeneric
-    : public wxCompositeWindow<wxDatePickerCtrlBase>
+    : public wxCompositeWindowSettersOnly<wxDatePickerCtrlBase>
 {
 public:
     // creating the control

--- a/include/wx/generic/datectrl.h
+++ b/include/wx/generic/datectrl.h
@@ -12,6 +12,7 @@
 #define _WX_GENERIC_DATECTRL_H_
 
 #include "wx/compositewin.h"
+#include "wx/containr.h"
 
 class WXDLLIMPEXP_FWD_CORE wxComboCtrl;
 
@@ -19,7 +20,7 @@ class WXDLLIMPEXP_FWD_ADV wxCalendarCtrl;
 class WXDLLIMPEXP_FWD_ADV wxCalendarComboPopup;
 
 class WXDLLIMPEXP_ADV wxDatePickerCtrlGeneric
-    : public wxCompositeWindowSettersOnly<wxDatePickerCtrlBase>
+    : public wxCompositeWindowSettersOnly< wxNavigationEnabled<wxDatePickerCtrlBase> >
 {
 public:
     // creating the control

--- a/src/common/combocmn.cpp
+++ b/src/common/combocmn.cpp
@@ -751,9 +751,7 @@ void wxComboBoxExtraInputHandler::OnKey(wxKeyEvent& event)
 
     if ( !combo->GetEventHandler()->ProcessEvent(redirectedEvent) )
     {
-        // Don't let TAB through to the text ctrl - looks ugly
-        if ( event.GetKeyCode() != WXK_TAB )
-            event.Skip();
+        event.Skip();
     }
 }
 

--- a/src/generic/combog.cpp
+++ b/src/generic/combog.cpp
@@ -198,6 +198,20 @@ wxGenericComboCtrl::~wxGenericComboCtrl()
 {
 }
 
+bool wxGenericComboCtrl::HasTransparentBackground()
+{
+#if wxALWAYS_NATIVE_DOUBLE_BUFFER
+  #ifdef __WXGTK__
+    // Sanity check for GTK+
+    return IsDoubleBuffered();
+  #else
+    return true;
+  #endif
+#else
+    return false;
+#endif
+}
+
 void wxGenericComboCtrl::OnResize()
 {
 


### PR DESCRIPTION
All composite classes need to inherit from `wxNavigationEnabled<>`, even if they contain only a single subwindow. Not sure if this is really right, i.e. one might expect things to work without all the extra stuff `wxNavigationEnabled<>` does, but right now this seems to be required for things to work.