### PR TITLE
Fix inert wxDVC toggle cells being editable under macOS

### DIFF
--- a/include/wx/osx/dvrenderers.h
+++ b/include/wx/osx/dvrenderers.h
@@ -42,6 +42,29 @@ private:
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxDataViewCustomRenderer);
 };
 
+// ---------------------------------------------------------------------------
+// This is a Mac-specific class that should be used as the base class for the
+// renderers that should be disabled when they're inert, to prevent the user
+// from editing them.
+// ---------------------------------------------------------------------------
+
+class wxOSXDataViewDisabledInertRenderer : public wxDataViewRenderer
+{
+protected:
+    wxOSXDataViewDisabledInertRenderer(const wxString& varianttype,
+                                       wxDataViewCellMode mode,
+                                       int alignment)
+        : wxDataViewRenderer(varianttype, mode, alignment)
+    {
+    }
+
+    virtual void SetEnabled(bool enabled) wxOVERRIDE
+    {
+        wxDataViewRenderer::SetEnabled(enabled &&
+                                        GetMode() != wxDATAVIEW_CELL_INERT);
+    }
+};
+
 // ---------------------------------------------------------
 // wxDataViewTextRenderer
 // ---------------------------------------------------------
@@ -97,7 +120,8 @@ private:
 // wxDataViewChoiceRenderer
 // -------------------------------------
 
-class WXDLLIMPEXP_ADV wxDataViewChoiceRenderer: public wxDataViewRenderer
+class WXDLLIMPEXP_ADV wxDataViewChoiceRenderer
+    : public wxOSXDataViewDisabledInertRenderer
 {
 public:
     wxDataViewChoiceRenderer(const wxArrayString& choices,
@@ -164,7 +188,8 @@ private:
 // wxDataViewToggleRenderer
 // ---------------------------------------------------------
 
-class WXDLLIMPEXP_ADV wxDataViewToggleRenderer: public wxDataViewRenderer
+class WXDLLIMPEXP_ADV wxDataViewToggleRenderer
+    : public wxOSXDataViewDisabledInertRenderer
 {
 public:
     static wxString GetDefaultType() { return wxS("bool"); }

--- a/samples/dataview/dataview.cpp
+++ b/samples/dataview/dataview.cpp
@@ -753,6 +753,7 @@ void MyFrame::BuildDataViewCtrl(wxPanel* parent, unsigned int nPanel, unsigned l
             page2_model->DecRef();
 
             lc->AppendToggleColumn( "Toggle" );
+            lc->AppendToggleColumn( "Inert", wxDATAVIEW_CELL_INERT );
             lc->AppendTextColumn( "Text" );
             lc->AppendProgressColumn( "Progress" );
 
@@ -761,6 +762,7 @@ void MyFrame::BuildDataViewCtrl(wxPanel* parent, unsigned int nPanel, unsigned l
             {
                 data.clear();
                 data.push_back( (i%3) == 0 );
+                data.push_back( (i%2) != 0 );
                 data.push_back( wxString::Format("row %d", i) );
                 data.push_back( long(5*i) );
 

--- a/samples/dataview/mymodels.cpp
+++ b/samples/dataview/mymodels.cpp
@@ -567,5 +567,5 @@ bool MyListModel::SetValueByRow( const wxVariant &variant,
 bool MyListStoreDerivedModel::IsEnabledByRow(unsigned int row, unsigned int col) const
 {
     // disabled the last two checkboxes
-    return !(col == 0 && 8 <= row && row <= 9);
+    return !(col <= 1 && 8 <= row && row <= 9);
 }

--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -862,20 +862,7 @@ wxDataViewRendererBase::PrepareForItem(const wxDataViewModel *model,
 
     // Finally determine the enabled/disabled state and apply it, even to the
     // empty cells.
-    bool enabled = true;
-    switch ( GetMode() )
-    {
-        case wxDATAVIEW_CELL_INERT:
-            enabled = false;
-            break;
-
-        case wxDATAVIEW_CELL_ACTIVATABLE:
-        case wxDATAVIEW_CELL_EDITABLE:
-            enabled = model->IsEnabled(item, column);
-            break;
-    }
-
-    SetEnabled(enabled);
+    SetEnabled(model->IsEnabled(item, column));
 
     }
     wxCATCH_ALL

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2897,12 +2897,6 @@ void wxDataViewRenderer::SetAttr(const wxDataViewItemAttr& attr)
 
 void wxDataViewRenderer::SetEnabled(bool enabled)
 {
-    // setting the appearance to disabled grey should only be done for
-    // the active cells which are disabled, not for the cells which can
-    // never be edited at all
-    if ( GetMode() == wxDATAVIEW_CELL_INERT )
-        enabled = true;
-
     [GetNativeData()->GetItemCell() setEnabled:enabled];
 }
 
@@ -3071,7 +3065,7 @@ wxIMPLEMENT_CLASS(wxDataViewBitmapRenderer, wxDataViewRenderer);
 wxDataViewChoiceRenderer::wxDataViewChoiceRenderer(const wxArrayString& choices,
                                                    wxDataViewCellMode mode,
                                                    int alignment)
-    : wxDataViewRenderer(wxT("string"), mode, alignment),
+    : wxOSXDataViewDisabledInertRenderer(wxT("string"), mode, alignment),
       m_choices(choices)
 {
     NSPopUpButtonCell* cell;
@@ -3318,7 +3312,7 @@ wxIMPLEMENT_ABSTRACT_CLASS(wxDataViewIconTextRenderer,wxDataViewRenderer);
 wxDataViewToggleRenderer::wxDataViewToggleRenderer(const wxString& varianttype,
                                                    wxDataViewCellMode mode,
                                                    int align)
-    : wxDataViewRenderer(varianttype,mode)
+    : wxOSXDataViewDisabledInertRenderer(varianttype, mode, align)
 {
     NSButtonCell* cell;
 


### PR DESCRIPTION
I'm not sure if we should include the first commit (change to the sample), but I've included it at least for in case you'd like to test it yourself. The real change is in the second one and, somewhat surprisingly, this seems to work in all ports without any port-specific changes being necessary: for the generic port it's because `wxDataViewToggleRenderer::Render()` already checks for `GetMode() != wxDATAVIEW_CELL_ACTIVATABLE` in addition to `GetEnabled()` and for wxGTK `wxDataViewToggleRenderer` ctor also already checks for `wxDATAVIEW_CELL_ACTIVATABLE`.

cc: @bigjohnr 