### PR TITLE
Explicitly mention build environments for Travis CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,29 +1,24 @@
 [submodule "3rdparty/catch"]
 	path = 3rdparty/catch
 	url = https://github.com/wxWidgets/Catch.git
-	update = checkout
+	branch = wx
 [submodule "src/zlib"]
 	path = src/zlib
 	url = https://github.com/wxWidgets/zlib.git
 	branch = wx
-	update = checkout
 [submodule "src/png"]
 	path = src/png
 	url = https://github.com/wxWidgets/libpng.git
 	branch = wx
-	update = checkout
 [submodule "src/expat"]
 	path = src/expat
 	url = https://github.com/wxWidgets/libexpat.git
 	branch = wx
-	update = checkout
 [submodule "src/tiff"]
 	path = src/tiff
 	url = https://github.com/wxWidgets/libtiff.git
 	branch = wx
-	update = checkout
 [submodule "src/jpeg"]
 	path = src/jpeg
 	url = https://github.com/wxWidgets/libjpeg-turbo.git
 	branch = wx
-	update = checkout

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,13 @@ sudo: required
 
 matrix:
     include:
-        - compiler: gcc
-        - compiler: gcc
-          env: wxCONFIGURE_FLAGS="--enable-utf8 --enable-utf8only --enable-monolithic"
+        - dist: precise
+          compiler: gcc
         - dist: trusty
           compiler: gcc
+        - dist: trusty
+          compiler: gcc
+          env: wxCONFIGURE_FLAGS="--enable-utf8 --enable-utf8only --enable-monolithic"
         - dist: trusty
           compiler: gcc
           env: wxGTK_VERSION=3 wxCONFIGURE_FLAGS="--enable-cxx11 --enable-stl" wxMAKEFILE_FLAGS="CXXFLAGS=-std=c++11"


### PR DESCRIPTION
Two build jobs in Travis are the same, both use gcc without arguments in the Trusty build environment. I suspect the original job was targeted at the Precise build environment. But without specifying the dist, the default will be used, which has been [changed ](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming) to Trusty.

Prevent this by specifying the dist for each job.

Note that this will prevent jobs from automatically switching to Xenial, if Travis ever plans to support it.