### PR TITLE
Reduce debug warnings of Direct2D Debug Layer

### DIFF
--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -338,7 +338,7 @@ ID2D1Factory* wxD2D1Factory()
 #if defined(__WXDEBUG__) && defined(__VISUALC__) && wxCHECK_VISUALC_VERSION(11)
         if ( wxGetWinVersion() >= wxWinVersion_8 )
         {
-            factoryOptions.debugLevel = D2D1_DEBUG_LEVEL_INFORMATION;
+            factoryOptions.debugLevel = D2D1_DEBUG_LEVEL_WARNING;
         }
 #endif  //__WXDEBUG__
 


### PR DESCRIPTION
Since https://github.com/wxWidgets/wxWidgets/pull/689 my debug output is being flooded with messages like:
`D2D DEBUG INFO - PERF - A layer is being used with a NULL opacity mask, 1.0 opacity, and an axis aligned rectangular geometric mask. The Push/Pop Clip API should achieve the same results with higher performance.`

This is caused by setting a rectangular clipping region, also noticeable in the drawing sample with `Regions screen F8`.