### PR TITLE
Do not attempt to build samples that cannot be built

### DIFF
--- a/build/cmake/samples/CMakeLists.txt
+++ b/build/cmake/samples/CMakeLists.txt
@@ -53,7 +53,7 @@ wx_add_sample(help demo.cpp LIBRARIES html adv
     DEPENDS wxUSE_HELP
     )
 wx_add_sample(htlbox LIBRARIES html DEPENDS wxUSE_HTML)
-if (wxUSE_HTML)
+if(wxUSE_HTML)
     include(html.cmake)
 endif()    
 wx_add_sample(image image.cpp canvas.cpp canvas.h cursor_png.c RES image.rc

--- a/build/cmake/samples/CMakeLists.txt
+++ b/build/cmake/samples/CMakeLists.txt
@@ -30,7 +30,7 @@ wx_add_sample(docview docview.cpp doc.cpp view.cpp docview.h doc.h view.h
     RES docview.rc DEPENDS wxUSE_DOC_VIEW_ARCHITECTURE)
 wx_add_sample(dragimag dragimag.cpp dragimag.h RES dragimag.rc
     DATA backgrnd.png shape01.png shape02.png shape03.png
-     DEPENDS wxUSE_DRAGIMAGE)
+    DEPENDS wxUSE_DRAGIMAGE)
 wx_add_sample(drawing DATA pat4.bmp pat35.bmp pat36.bmp image.bmp mask.bmp)
 wx_add_sample(erase)
 wx_add_sample(event event.cpp gestures.cpp gestures.h)
@@ -52,7 +52,7 @@ wx_add_sample(help demo.cpp LIBRARIES html adv
     NAME helpdemo
     DEPENDS wxUSE_HELP
     )
-wx_add_sample(htlbox LIBRARIES html  DEPENDS wxUSE_HTML)
+wx_add_sample(htlbox LIBRARIES html DEPENDS wxUSE_HTML)
 include(html.cmake)
 wx_add_sample(image image.cpp canvas.cpp canvas.h cursor_png.c RES image.rc
     DATA horse.png horse.jpg horse.bmp horse.gif horse.pcx horse.pnm
@@ -62,7 +62,7 @@ wx_add_sample(image image.cpp canvas.cpp canvas.h cursor_png.c RES image.rc
 foreach(lang ar bg cs de fr it ka pl ru sv ja ja_JP.EUC-JP)
     list(APPEND INTERNAT_DATA_FILES ${lang}/internat.po ${lang}/internat.mo)
 endforeach()
-wx_add_sample(internat DATA ${INTERNAT_DATA_FILES}  DEPENDS wxUSE_INTL)
+wx_add_sample(internat DATA ${INTERNAT_DATA_FILES} DEPENDS wxUSE_INTL)
 # IPC samples
 set(wxSAMPLE_FOLDER ipc)
 wx_add_sample(ipc client.cpp client.h connection.h ipcsetup.h NAME ipcclient LIBRARIES net DEPENDS wxUSE_IPC)

--- a/build/cmake/samples/CMakeLists.txt
+++ b/build/cmake/samples/CMakeLists.txt
@@ -7,37 +7,38 @@
 # Licence:     wxWindows licence
 #############################################################################
 
-wx_add_sample(access accesstest.cpp)
-wx_add_sample(animate anitest.cpp anitest.h LIBRARIES adv DATA throbber.gif hourglass.ani)
+wx_add_sample(access accesstest.cpp DEPENDS wxUSE_ACCESSBILITY)
+wx_add_sample(animate anitest.cpp anitest.h LIBRARIES adv DATA throbber.gif hourglass.ani DEPENDS wxUSE_ANIMATIONCTRL)
 wx_add_sample(artprov arttest.cpp artbrows.cpp artbrows.h)
-wx_add_sample(aui auidemo.cpp LIBRARIES adv aui html NAME auidemo)
-wx_add_sample(calendar RES calendar.rc LIBRARIES adv)
-wx_add_sample(caret)
-wx_add_sample(clipboard)
-wx_add_sample(collpane LIBRARIES adv)
-wx_add_sample(combo LIBRARIES adv DATA dropbuth.png dropbutn.png dropbutp.png)
-wx_add_sample(config conftest.cpp)
+wx_add_sample(aui auidemo.cpp LIBRARIES adv aui html NAME auidemo DEPENDS wxUSE_AUI)
+wx_add_sample(calendar RES calendar.rc LIBRARIES adv DEPENDS wxUSE_CALENDARCTRL)
+wx_add_sample(caret DEPENDS wxUSE_CARET)
+wx_add_sample(clipboard DEPENDS wxUSE_CLIPBOARD)
+wx_add_sample(collpane LIBRARIES adv DEPENDS wxUSE_COLLPANE)
+wx_add_sample(combo LIBRARIES adv DATA dropbuth.png dropbutn.png dropbutp.png DEPENDS wxUSE_COMBOCTRL)
+wx_add_sample(config conftest.cpp DEPENDS wxUSE_CONFIG)
 wx_add_sample(console CONSOLE IMPORTANT)
-wx_add_sample(dataview IMPORTANT dataview.cpp mymodels.cpp mymodels.h LIBRARIES adv)
+wx_add_sample(dataview IMPORTANT dataview.cpp mymodels.cpp mymodels.h LIBRARIES adv DEPENDS wxUSE_DATAVIEWCTRL)
 if(wxUSE_ON_FATAL_EXCEPTION AND (NOT WIN32 OR MSVC))
-    wx_add_sample(debugrpt LIBRARIES qa)
+    wx_add_sample(debugrpt LIBRARIES qa DEPENDS wxUSE_DEBUGREPORT)
 endif()
 wx_add_sample(dialogs dialogs.cpp dialogs.h LIBRARIES adv DATA tips.txt)
-wx_add_sample(dialup nettest.cpp)
-wx_add_sample(display)
-wx_add_sample(dnd dnd.cpp RES dnd.rc DATA wxwin.png)
+wx_add_sample(dialup nettest.cpp DEPENDS wxUSE_DIALUP_MANAGER)
+wx_add_sample(display DEPENDS wxUSE_DISPLAY)
+wx_add_sample(dnd dnd.cpp RES dnd.rc DATA wxwin.png DEPENDS wxUSE_DRAG_AND_DROP)
 wx_add_sample(docview docview.cpp doc.cpp view.cpp docview.h doc.h view.h
-    RES docview.rc)
+    RES docview.rc DEPENDS wxUSE_DOC_VIEW_ARCHITECTURE)
 wx_add_sample(dragimag dragimag.cpp dragimag.h RES dragimag.rc
-    DATA backgrnd.png shape01.png shape02.png shape03.png)
+    DATA backgrnd.png shape01.png shape02.png shape03.png
+     DEPENDS wxUSE_DRAGIMAGE)
 wx_add_sample(drawing DATA pat4.bmp pat35.bmp pat36.bmp image.bmp mask.bmp)
 wx_add_sample(erase)
 wx_add_sample(event event.cpp gestures.cpp gestures.h)
-wx_add_sample(except)
+wx_add_sample(except DEPENDS wxUSE_EXCEPTIONS)
 wx_add_sample(exec)
 wx_add_sample(font DATA wxprivate.ttf)
-wx_add_sample(fswatcher)
-wx_add_sample(grid griddemo.cpp griddemo.h LIBRARIES adv)
+wx_add_sample(fswatcher DEPENDS wxUSE_FSWATCHER)
+wx_add_sample(grid griddemo.cpp griddemo.h LIBRARIES adv DEPENDS wxUSE_GRID)
 
 wx_list_add_prefix(HELP_DOC_FILES doc/
     aindex.html down.gif dxxgifs.tex HIER.html icon1.gif icon2.gif index.html
@@ -49,34 +50,36 @@ wx_add_sample(help demo.cpp LIBRARIES html adv
     doc.hhk doc.hhp doc.hlp doc.hpj doc.zip forward.gif up.gif
     ${HELP_DOC_FILES}
     NAME helpdemo
+    DEPENDS wxUSE_HELP
     )
-wx_add_sample(htlbox LIBRARIES html)
+wx_add_sample(htlbox LIBRARIES html  DEPENDS wxUSE_HTML)
 include(html.cmake)
 wx_add_sample(image image.cpp canvas.cpp canvas.h cursor_png.c RES image.rc
     DATA horse.png horse.jpg horse.bmp horse.gif horse.pcx horse.pnm
     horse_ag.pnm horse_rg.pnm horse.tif horse.tga horse.xpm horse.cur
-    horse.ico horse3.ani smile.xbm toucan.png cmyk.jpg cursor.png)
+    horse.ico horse3.ani smile.xbm toucan.png cmyk.jpg cursor.png
+    DEPENDS wxUSE_IMAGE)
 foreach(lang ar bg cs de fr it ka pl ru sv ja ja_JP.EUC-JP)
     list(APPEND INTERNAT_DATA_FILES ${lang}/internat.po ${lang}/internat.mo)
 endforeach()
-wx_add_sample(internat DATA ${INTERNAT_DATA_FILES})
+wx_add_sample(internat DATA ${INTERNAT_DATA_FILES}  DEPENDS wxUSE_INTL)
 # IPC samples
 set(wxSAMPLE_FOLDER ipc)
-wx_add_sample(ipc client.cpp client.h connection.h ipcsetup.h NAME ipcclient LIBRARIES net)
-wx_add_sample(ipc server.cpp server.h connection.h ipcsetup.h NAME ipcserver LIBRARIES net)
-wx_add_sample(ipc CONSOLE baseclient.cpp connection.h ipcsetup.h NAME baseipcclient LIBRARIES net)
-wx_add_sample(ipc CONSOLE baseserver.cpp connection.h ipcsetup.h NAME baseipcserver LIBRARIES net)
+wx_add_sample(ipc client.cpp client.h connection.h ipcsetup.h NAME ipcclient LIBRARIES net DEPENDS wxUSE_IPC)
+wx_add_sample(ipc server.cpp server.h connection.h ipcsetup.h NAME ipcserver LIBRARIES net DEPENDS wxUSE_IPC)
+wx_add_sample(ipc CONSOLE baseclient.cpp connection.h ipcsetup.h NAME baseipcclient LIBRARIES net DEPENDS wxUSE_IPC)
+wx_add_sample(ipc CONSOLE baseserver.cpp connection.h ipcsetup.h NAME baseipcserver LIBRARIES net DEPENDS wxUSE_IPC)
 set(wxSAMPLE_FOLDER)
-wx_add_sample(joytest joytest.cpp joytest.h DATA buttonpress.wav LIBRARIES adv)
+wx_add_sample(joytest joytest.cpp joytest.h DATA buttonpress.wav LIBRARIES adv DEPENDS wxUSE_JOYSTICK)
 wx_add_sample(keyboard)
 wx_add_sample(layout layout.cpp layout.h)
-wx_add_sample(listctrl listtest.cpp listtest.h RES listtest.rc)
-wx_add_sample(mdi mdi.cpp mdi.h RES mdi.rc)
+wx_add_sample(listctrl listtest.cpp listtest.h RES listtest.rc DEPENDS wxUSE_LISTCTRL)
+wx_add_sample(mdi mdi.cpp mdi.h RES mdi.rc DEPENDS wxUSE_MDI wxUSE_DOC_VIEW_ARCHITECTURE wxUSE_MDI_ARCHITECTURE)
 wx_add_sample(mediaplayer LIBRARIES media DEPENDS wxUSE_MEDIACTRL)
 wx_add_sample(memcheck)
-wx_add_sample(menu)
+wx_add_sample(menu DEPENDS wxUSE_MENUS)
 wx_add_sample(minimal IMPORTANT)
-wx_add_sample(notebook notebook.cpp notebook.h LIBRARIES aui adv)
+wx_add_sample(notebook notebook.cpp notebook.h LIBRARIES aui adv DEPENDS wxUSE_NOTEBOOK)
 if(wxUSE_OPENGL)
     set(wxSAMPLE_SUBDIR opengl/)
     set(wxSAMPLE_FOLDER OpenGL)
@@ -95,46 +98,48 @@ if(wxUSE_OPENGL)
     set(wxSAMPLE_FOLDER)
 endif()
 wx_add_sample(ownerdrw RES ownerdrw.rc DATA sound.png nosound.png DEPENDS wxUSE_OWNER_DRAWN)
-wx_add_sample(popup)
+wx_add_sample(popup DEPENDS wxUSE_POPUPWIN)
 wx_add_sample(power)
-wx_add_sample(preferences)
-wx_add_sample(printing printing.cpp printing.h)
+wx_add_sample(preferences DEPENDS wxUSE_PREFERENCES_EDITOR)
+wx_add_sample(printing printing.cpp printing.h DEPENDS wxUSE_PRINTING_ARCHITECTURE)
 wx_add_sample(propgrid propgrid.cpp propgrid_minimal.cpp sampleprops.cpp
-    tests.cpp sampleprops.h propgrid.h LIBRARIES adv propgrid NAME propgriddemo)
+    tests.cpp sampleprops.h propgrid.h LIBRARIES adv propgrid NAME propgriddemo DEPENDS wxUSE_PROPGRID)
 wx_add_sample(render FOLDER render)
 wx_add_sample(render DLL renddll.cpp NAME renddll FOLDER render)
-wx_add_sample(ribbon ribbondemo.cpp LIBRARIES ribbon adv NAME ribbondemo)
-wx_add_sample(richtext LIBRARIES richtext adv html xml NAME richtextdemo)
-wx_add_sample(sashtest sashtest.cpp sashtest.h RES sashtest.rc LIBRARIES adv)
+wx_add_sample(ribbon ribbondemo.cpp LIBRARIES ribbon adv NAME ribbondemo DEPENDS wxUSE_RIBBON)
+wx_add_sample(richtext LIBRARIES richtext adv html xml NAME richtextdemo DEPENDS wxUSE_XML wxUSE_RICHTEXT)
+wx_add_sample(sashtest sashtest.cpp sashtest.h RES sashtest.rc LIBRARIES adv DEPENDS wxUSE_SASH)
 wx_add_sample(scroll)
 wx_add_sample(secretstore CONSOLE DEPENDS wxUSE_SECRETSTORE)
 wx_add_sample(shaped DATA star.png)
-wx_add_sample(sockets client.cpp NAME client LIBRARIES net FOLDER sockets)
-wx_add_sample(sockets server.cpp NAME server LIBRARIES net FOLDER sockets)
-wx_add_sample(sockets CONSOLE baseclient.cpp NAME baseclient LIBRARIES net FOLDER sockets)
-wx_add_sample(sockets CONSOLE baseserver.cpp NAME baseserver LIBRARIES net FOLDER sockets)
-wx_add_sample(sound RES sound.rc DATA 9000g.wav cuckoo.wav doggrowl.wav tinkalink2.wav LIBRARIES adv)
-wx_add_sample(splash DATA splash.png press.mpg LIBRARIES adv)
+if(wxUSE_SOCKETS)
+    wx_add_sample(sockets client.cpp NAME client LIBRARIES net FOLDER sockets)
+    wx_add_sample(sockets server.cpp NAME server LIBRARIES net FOLDER sockets)
+    wx_add_sample(sockets CONSOLE baseclient.cpp NAME baseclient LIBRARIES net FOLDER sockets)
+    wx_add_sample(sockets CONSOLE baseserver.cpp NAME baseserver LIBRARIES net FOLDER sockets)
+endif()    
+wx_add_sample(sound RES sound.rc DATA 9000g.wav cuckoo.wav doggrowl.wav tinkalink2.wav LIBRARIES adv DEPENDS wxUSE_SOUND)
+wx_add_sample(splash DATA splash.png press.mpg LIBRARIES adv DEPENDS wxUSE_SPLASH)
 if(TARGET splash AND wxUSE_MEDIACTRL)
     target_link_libraries(splash media)
 endif()
-wx_add_sample(splitter)
-wx_add_sample(statbar)
+wx_add_sample(splitter DEPENDS wxUSE_SPLITTER)
+wx_add_sample(statbar DEPENDS wxUSE_STATUSBAR)
 wx_add_sample(stc stctest.cpp edit.cpp prefs.cpp edit.h defsext.h prefs.h
-    DATA stctest.cpp NAME stctest LIBRARIES stc)
-wx_add_sample(svg svgtest.cpp RES svgtest.rc)
+    DATA stctest.cpp NAME stctest LIBRARIES stc DEPENDS wxUSE_STC)
+wx_add_sample(svg svgtest.cpp RES svgtest.rc DEPENDS wxUSE_SVG)
 wx_add_sample(taborder)
 wx_add_sample(taskbar tbtest.cpp tbtest.h LIBRARIES adv DEPENDS wxUSE_TASKBARICON)
-wx_add_sample(text)
-wx_add_sample(thread)
-wx_add_sample(toolbar RES toolbar.rc)
-wx_add_sample(treectrl treetest.cpp treetest.h)
-wx_add_sample(treelist LIBRARIES adv)
+wx_add_sample(text DEPENDS wxUSE_TEXTCTRL)
+wx_add_sample(thread DEPENDS wxUSE_THREADS)
+wx_add_sample(toolbar RES toolbar.rc DEPENDS wxUSE_TOOLBAR)
+wx_add_sample(treectrl treetest.cpp treetest.h DEPENDS wxUSE_TREECTRL)
+wx_add_sample(treelist LIBRARIES adv DEPENDS wxUSE_TREELISTCTRL)
 wx_add_sample(typetest typetest.cpp typetest.h)
-wx_add_sample(uiaction)
-wx_add_sample(validate validate.cpp validate.h)
+wx_add_sample(uiaction DEPENDS wxUSE_UIACTIONSIMULATOR)
+wx_add_sample(validate validate.cpp validate.h DEPENDS wxUSE_VALIDATORS)
 wx_add_sample(vscroll vstest.cpp)
-wx_add_sample(webview LIBRARIES webview stc adv NAME webviewsample)
+wx_add_sample(webview LIBRARIES webview stc adv NAME webviewsample DEPENDS wxUSE_WEBVIEW)
 # widgets Sample
 set(SAMPLE_WIDGETS_SRC
     activityindicator.cpp
@@ -182,7 +187,7 @@ if(APPLE)
     list(APPEND SAMPLE_WIDGETS_SRC native_wrapper.mm)
 endif()
 wx_add_sample(widgets IMPORTANT ${SAMPLE_WIDGETS_SRC} LIBRARIES adv)
-wx_add_sample(wizard LIBRARIES adv)
+wx_add_sample(wizard LIBRARIES adv DEPENDS wxUSE_WIZARDDLG)
 wx_add_sample(wrapsizer)
 
 wx_list_add_prefix(XRC_RC_FILES rc/
@@ -213,31 +218,34 @@ wx_add_sample(xrc
     DATA ${XRC_RC_FILES}
     LIBRARIES aui ribbon xrc html adv
     NAME xrcdemo
+    DEPENDS wxUSE_XML wxUSE_XRC
     )
 wx_add_sample(xti xti.cpp classlist.cpp codereadercallback.cpp
     classlist.h codereadercallback.h LIBRARIES xml
-    DEPENDS wxUSE_EXTENDED_RTTI)
+    DEPENDS wxUSE_XML wxUSE_EXTENDED_RTTI)
 
 if(WIN32)
     # Windows only samples
 
     # DLL Sample
-    wx_add_sample(dll DLL my_dll.cpp my_dll.h NAME my_dll FOLDER dll
-        DEFINITIONS MY_DLL_BUILDING)
-    if(NOT wxBUILD_SHARED)
-        # this test only makes sense with statically built wx, otherwise
-        # the same copy of wx would be used
-        wx_add_sample(dll wx_exe.cpp my_dll.h NAME wx_exe FOLDER dll LIBRARIES my_dll)
+    if(wxUSE_DYNLIBCLASS)  
+        wx_add_sample(dll DLL my_dll.cpp my_dll.h NAME my_dll FOLDER dll
+            DEFINITIONS MY_DLL_BUILDING)
+        if(NOT wxBUILD_SHARED)
+            # this test only makes sense with statically built wx, otherwise
+            # the same copy of wx would be used
+            wx_add_sample(dll wx_exe.cpp my_dll.h NAME wx_exe FOLDER dll LIBRARIES my_dll)
+        endif()
+    
+        wx_add_sample(dll sdk_exe.cpp my_dll.h NAME sdk_exe FOLDER dll LIBRARIES my_dll)
     endif()
-
-    wx_add_sample(dll sdk_exe.cpp my_dll.h NAME sdk_exe FOLDER dll LIBRARIES my_dll)
     if(MSVC)
         wx_add_sample(flash)
     endif()
     #TODO: renable when sample is fixed
     #wx_add_sample(mfc mfctest.cpp mfctest.h resource.h stdafx.h RES mfctest.rc)
     wx_add_sample(nativdlg nativdlg.cpp nativdlg.h resource.h RES nativdlg.rc)
-    wx_add_sample(oleauto)
-    wx_add_sample(regtest RES regtest.rc)
+    wx_add_sample(oleauto DEPENDS wxUSE_OLE)
+    wx_add_sample(regtest RES regtest.rc DEPENDS wxUSE_REGKEY)
     wx_add_sample(taskbarbutton LIBRARIES adv DEPENDS wxUSE_TASKBARBUTTON)
 endif()

--- a/build/cmake/samples/CMakeLists.txt
+++ b/build/cmake/samples/CMakeLists.txt
@@ -53,7 +53,9 @@ wx_add_sample(help demo.cpp LIBRARIES html adv
     DEPENDS wxUSE_HELP
     )
 wx_add_sample(htlbox LIBRARIES html DEPENDS wxUSE_HTML)
-include(html.cmake)
+if (wxUSE_HTML)
+    include(html.cmake)
+endif()    
 wx_add_sample(image image.cpp canvas.cpp canvas.h cursor_png.c RES image.rc
     DATA horse.png horse.jpg horse.bmp horse.gif horse.pcx horse.pnm
     horse_ag.pnm horse_rg.pnm horse.tif horse.tga horse.xpm horse.cur

--- a/build/cmake/samples/html.cmake
+++ b/build/cmake/samples/html.cmake
@@ -23,11 +23,12 @@ wx_list_add_prefix(HELP_DATA_FILES helpfiles/
     page2-b.htm
     testing.hhp
     )
-wx_add_sample(help DATA ${HELP_DATA_FILES} LIBRARIES html NAME htmlhelp)
-wx_add_sample(helpview DATA test.zip LIBRARIES html)
+wx_add_sample(help DATA ${HELP_DATA_FILES} LIBRARIES html NAME htmlhelp DEPENDS wxUSE_HELP)
+wx_add_sample(helpview DATA test.zip LIBRARIES html DEPENDS wxUSE_HELP)
 #TODO: htmlctrl sample uses outdated definitions
 #wx_add_sample(htmlctrl LIBRARIES html)
-wx_add_sample(printing DATA logo6.gif test.htm LIBRARIES html NAME htmlprinting)
+wx_add_sample(printing DATA logo6.gif test.htm LIBRARIES html NAME htmlprinting 
+    DEPENDS wxUSE_PRINTING_ARCHITECTURE)
 wx_add_sample(test
     DATA
         imagemap.png pic.png pic2.bmp i18n.gif
@@ -36,7 +37,7 @@ wx_add_sample(test
     LIBRARIES net html NAME htmltest)
 wx_add_sample(virtual DATA start.htm LIBRARIES html)
 wx_add_sample(widget DATA start.htm LIBRARIES html)
-wx_add_sample(zip DATA pages.zip start.htm LIBRARIES html)
+wx_add_sample(zip DATA pages.zip start.htm LIBRARIES html DEPENDS wxUSE_FSZIP)
 
 set(wxSAMPLE_SUBDIR)
 set(wxSAMPLE_FOLDER)


### PR DESCRIPTION
This PR modifies the CMakeList for the samples, using the already existing but undocumented parameter `DEPENDS` of the `wx_add_sample` function.  

I originally intended to do it only for the whole libraries (`wxUSE_AUI`, `wxUSE_STC` etc.) but in the end I did it even for the finely grained `wxUSE_xxx` option level (`wxUSE_ACCESSBILITY`, `wxUSE_ANIMATIONCTRL`  etc.). 

Unfortunately, many samples (and even some library classes) do not account for having some features unavailable, so it is not perfect but I believe it is still better than nothing.