### PR TITLE
Fix spurious focus loss events for wxGTK comboboxes

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -206,6 +206,7 @@ wxGTK:
 - Implement XYToPosition() for single-line wxTextCtrl.
 - Implement ShowPosition() for single-line wxTextCtrl.
 - Improve wx{Client,Paint,Screen,Window}DC::GetPPI() (GTK+ 3).
+- Suppress focus loss events for wxChoice and wxComboBox on opening popup.
 
 wxMSW:
 

--- a/include/wx/gtk/choice.h
+++ b/include/wx/gtk/choice.h
@@ -101,6 +101,7 @@ protected:
     virtual void DoClear() wxOVERRIDE;
     virtual void DoDeleteOneItem(unsigned int n) wxOVERRIDE;
 
+    virtual bool GTKHandleFocusOut() wxOVERRIDE;
     virtual GdkWindow *GTKGetWindow(wxArrayGdkWindows& windows) const wxOVERRIDE;
     virtual void DoApplyWidgetStyle(GtkRcStyle *style) wxOVERRIDE;
 

--- a/include/wx/gtk/window.h
+++ b/include/wx/gtk/window.h
@@ -199,7 +199,7 @@ public:
     bool GTKHandleFocusIn();
     bool GTKHandleFocusOut();
     void GTKHandleFocusOutNoDeferring();
-    static void GTKHandleDeferredFocusOut();
+    void GTKHandleDeferredFocusOut();
 
     // Called when m_widget becomes realized. Derived classes must call the
     // base class method if they override it.

--- a/include/wx/gtk/window.h
+++ b/include/wx/gtk/window.h
@@ -197,7 +197,7 @@ public:
     GdkWindow* GTKGetDrawingWindow() const;
 
     bool GTKHandleFocusIn();
-    bool GTKHandleFocusOut();
+    virtual bool GTKHandleFocusOut();
     void GTKHandleFocusOutNoDeferring();
     void GTKHandleDeferredFocusOut();
 

--- a/src/gtk/choice.cpp
+++ b/src/gtk/choice.cpp
@@ -111,6 +111,23 @@ wxChoice::~wxChoice()
  #endif // __WXGTK3__
 }
 
+bool wxChoice::GTKHandleFocusOut()
+{
+    if ( wx_is_at_least_gtk2(10) )
+    {
+        gboolean isShown;
+        g_object_get( m_widget, "popup-shown", &isShown, NULL );
+
+        // Don't send "focus lost" events if the focus is grabbed by our own
+        // popup, it counts as part of this window, even though wx doesn't know
+        // about it (and can't, because GtkComboBox doesn't expose it).
+        if ( isShown )
+            return true;
+    }
+
+    return wxChoiceBase::GTKHandleFocusOut();
+}
+
 void wxChoice::GTKInsertComboBoxTextItem( unsigned int n, const wxString& text )
 {
 #ifdef __WXGTK3__

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -4465,17 +4465,14 @@ void wxWindowGTK::GTKHandleDeferredFocusOut()
     // NB: See GTKHandleFocusOut() for explanation. This function is called
     //     from either GTKHandleFocusIn() or OnInternalIdle() to process
     //     deferred event.
-    if ( gs_deferredFocusOut )
-    {
-        wxWindowGTK *win = gs_deferredFocusOut;
-        gs_deferredFocusOut = NULL;
+    wxWindowGTK *win = gs_deferredFocusOut;
+    gs_deferredFocusOut = NULL;
 
-        wxLogTrace(TRACE_FOCUS,
-                   "processing deferred focus_out event for %s(%p, %s)",
-                   win->GetClassInfo()->GetClassName(), win, win->GetLabel());
+    wxLogTrace(TRACE_FOCUS,
+               "processing deferred focus_out event for %s(%p, %s)",
+               win->GetClassInfo()->GetClassName(), win, win->GetLabel());
 
-        win->GTKHandleFocusOutNoDeferring();
-    }
+    win->GTKHandleFocusOutNoDeferring();
 }
 
 void wxWindowGTK::SetFocus()

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -3828,7 +3828,7 @@ bool wxWindowGTK::GTKShowFromOnIdle()
 void wxWindowGTK::OnInternalIdle()
 {
     if ( gs_deferredFocusOut )
-        GTKHandleDeferredFocusOut();
+        gs_deferredFocusOut->GTKHandleDeferredFocusOut();
 
     // Check if we have to show window now
     if (GTKShowFromOnIdle()) return;
@@ -4348,7 +4348,7 @@ bool wxWindowGTK::GTKHandleFocusIn()
         // otherwise we need to send focus-out first
         wxASSERT_MSG ( gs_deferredFocusOut != this,
                        "GTKHandleFocusIn(GTKFocus_Normal) called even though focus changed back to itself - derived class should handle this" );
-        GTKHandleDeferredFocusOut();
+        gs_deferredFocusOut->GTKHandleDeferredFocusOut();
     }
 
 
@@ -4459,20 +4459,18 @@ void wxWindowGTK::GTKHandleFocusOutNoDeferring()
     GTKProcessEvent( event );
 }
 
-/*static*/
 void wxWindowGTK::GTKHandleDeferredFocusOut()
 {
     // NB: See GTKHandleFocusOut() for explanation. This function is called
     //     from either GTKHandleFocusIn() or OnInternalIdle() to process
-    //     deferred event.
-    wxWindowGTK *win = gs_deferredFocusOut;
+    //     deferred event for this window.
     gs_deferredFocusOut = NULL;
 
     wxLogTrace(TRACE_FOCUS,
                "processing deferred focus_out event for %s(%p, %s)",
-               win->GetClassInfo()->GetClassName(), win, win->GetLabel());
+               GetClassInfo()->GetClassName(), this, GetLabel());
 
-    win->GTKHandleFocusOutNoDeferring();
+    GTKHandleFocusOutNoDeferring();
 }
 
 void wxWindowGTK::SetFocus()


### PR DESCRIPTION
Please see [this comment](http://trac.wxwidgets.org/ticket/17034#comment:5) for more context.

Let me know if I'm doing something particularly stupid here, if not I'd like to commit it to avoid the problem described above. TIA!