### PR TITLE
More, mostly event-related, wxDataViewCtrl fixes

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -182,6 +182,7 @@ All (GUI):
 - Generate wxEVT_SEARCH on Enter under all platforms.
 - Extend wxRendererNative::DrawGauge() to work for vertical gauges too.
 - Add wxHD_BITMAP_ON_RIGHT style to wxHeaderCtrl.
+- Send wxEVT_DATAVIEW_ITEM_EDITING_DONE when editing was cancelled too.
 
 wxGTK:
 

--- a/include/wx/dataview.h
+++ b/include/wx/dataview.h
@@ -859,7 +859,6 @@ public:
 
     // for wxEVT_DATAVIEW_ITEM_EDITING_DONE only
     bool IsEditCancelled() const { return m_editCancelled; }
-    void SetEditCanceled(bool editCancelled) { m_editCancelled = editCancelled; }
 
     // for wxEVT_DATAVIEW_COLUMN_HEADER_CLICKED only
     wxDataViewColumn *GetDataViewColumn() const { return m_column; }
@@ -907,6 +906,7 @@ public:
 #endif // WXWIN_COMPATIBILITY_3_0
 
     void SetColumn( int col ) { m_col = col; }
+    void SetEditCancelled() { m_editCancelled = true; }
 
 protected:
     wxDataViewItem      m_item;

--- a/include/wx/dataview.h
+++ b/include/wx/dataview.h
@@ -903,10 +903,10 @@ public:
     wxDEPRECATED_MSG("Pass the argument to the ctor instead")
     void SetDataViewColumn( wxDataViewColumn *col ) { m_column = col; }
     wxDEPRECATED_MSG("Pass the argument to the ctor instead")
-    void SetColumn( int col ) { m_col = col; }
-    wxDEPRECATED_MSG("Pass the argument to the ctor instead")
     void SetItem( const wxDataViewItem &item ) { m_item = item; }
 #endif // WXWIN_COMPATIBILITY_3_0
+
+    void SetColumn( int col ) { m_col = col; }
 
 protected:
     wxDataViewItem      m_item;

--- a/include/wx/dataview.h
+++ b/include/wx/dataview.h
@@ -755,6 +755,12 @@ public:
     virtual bool SetHeaderAttr(const wxItemAttr& WXUNUSED(attr))
         { return false; }
 
+    // Set the colour used for the "alternate" rows when wxDV_ROW_LINES is on.
+    // Also only supported in the generic version, which returns true to
+    // indicate it.
+    virtual bool SetAlternateRowColour(const wxColour& WXUNUSED(colour))
+        { return false; }
+
     virtual wxVisualAttributes GetDefaultAttributes() const wxOVERRIDE
     {
         return GetClassDefaultAttributes(GetWindowVariant());

--- a/include/wx/dvrenderers.h
+++ b/include/wx/dvrenderers.h
@@ -247,6 +247,12 @@ protected:
                               const wxDataViewItem& item,
                               unsigned column) const;
 
+    // Validates the given value (if it is non-null) and sends (in any case)
+    // ITEM_EDITING_DONE event and, finally, updates the model with the value
+    // (f it is valid, of course) if the event wasn't vetoed.
+    bool DoHandleEditingDone(wxVariant* value);
+
+
     wxString                m_variantType;
     wxDataViewColumn       *m_owner;
     wxWeakRef<wxWindow>     m_editorCtrl;
@@ -259,9 +265,6 @@ protected:
     wxDataViewCtrl* GetView() const;
 
 private:
-    // Common part of {Cancel,Finish}Editing().
-    bool DoFinishOrCancelEditing(bool cancelled);
-
     // Called from {Called,Finish}Editing() and dtor to cleanup m_editorCtrl
     void DestroyEditControl();
 

--- a/include/wx/dvrenderers.h
+++ b/include/wx/dvrenderers.h
@@ -241,9 +241,6 @@ protected:
     // (typically selection with dark background). For internal use only.
     virtual bool IsHighlighted() const = 0;
 
-    // Called from {Cancel,Finish}Editing() to cleanup m_editorCtrl
-    void DestroyEditControl();
-
     // Helper of PrepareForItem() also used in StartEditing(): returns the
     // value checking that its type matches our GetVariantType().
     wxVariant CheckedGetValue(const wxDataViewModel* model,
@@ -261,7 +258,10 @@ protected:
     // renderer is required
     wxDataViewCtrl* GetView() const;
 
-protected:
+private:
+    // Called from {Called,Finish}Editing() and dtor to cleanup m_editorCtrl
+    void DestroyEditControl();
+
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxDataViewRendererBase);
 };
 

--- a/include/wx/dvrenderers.h
+++ b/include/wx/dvrenderers.h
@@ -259,6 +259,9 @@ protected:
     wxDataViewCtrl* GetView() const;
 
 private:
+    // Common part of {Cancel,Finish}Editing().
+    bool DoFinishOrCancelEditing(bool cancelled);
+
     // Called from {Called,Finish}Editing() and dtor to cleanup m_editorCtrl
     void DestroyEditControl();
 

--- a/include/wx/generic/dataview.h
+++ b/include/wx/generic/dataview.h
@@ -277,10 +277,11 @@ public:
 
     virtual bool SetHeaderAttr(const wxItemAttr& attr) wxOVERRIDE;
 
-    // These methods are specific to generic wxDataViewCtrl implementation and
+    virtual bool SetAlternateRowColour(const wxColour& colour) wxOVERRIDE;
+
+    // This method is specific to generic wxDataViewCtrl implementation and
     // should not be used in portable code.
     wxColour GetAlternateRowColour() const { return m_alternateRowColour; }
-    void SetAlternateRowColour(const wxColour& colour);
 
     // The returned pointer is null if the control has wxDV_NO_HEADER style.
     //

--- a/include/wx/gtk/dvrenderer.h
+++ b/include/wx/gtk/dvrenderer.h
@@ -47,9 +47,10 @@ public:
 
     // called when the cell value was edited by user with the new value
     //
-    // it validates the new value and notifies the model about the change by
-    // calling GtkOnCellChanged() if it was accepted
-    virtual void GtkOnTextEdited(const char *itempath, const wxString& value);
+    // it uses GtkGetValueFromString() to parse the new value, then validates
+    // it by calling Validate() and notifies the model about the change if it
+    // passes validation
+    void GtkOnTextEdited(const char *itempath, const wxString& value);
 
     GtkCellRenderer* GetGtkHandle() { return m_renderer; }
     void GtkInitHandlers();
@@ -78,13 +79,15 @@ protected:
 
     virtual bool IsHighlighted() const wxOVERRIDE;
 
-    virtual void GtkOnCellChanged(const wxVariant& value,
-                                  const wxDataViewItem& item,
-                                  unsigned col);
-
     // Apply our effective alignment (i.e. m_alignment if specified or the
     // associated column alignment by default) to the given renderer.
     void GtkApplyAlignment(GtkCellRenderer *renderer);
+
+    // This method is used to interpret the string entered by user and by
+    // default just uses it as is, but can be overridden for classes requiring
+    // special treatment.
+    virtual wxVariant GtkGetValueFromString(const wxString& str) const;
+
 
     GtkCellRenderer    *m_renderer;
     int                 m_alignment;

--- a/include/wx/gtk/dvrenderers.h
+++ b/include/wx/gtk/dvrenderers.h
@@ -228,9 +228,7 @@ public:
     virtual void GtkPackIntoColumn(GtkTreeViewColumn *column) wxOVERRIDE;
 
 protected:
-    virtual void GtkOnCellChanged(const wxVariant& value,
-                                  const wxDataViewItem& item,
-                                  unsigned col) wxOVERRIDE;
+    virtual wxVariant GtkGetValueFromString(const wxString& str) const wxOVERRIDE;
 
 private:
     wxDataViewIconText   m_value;
@@ -281,7 +279,7 @@ public:
     virtual bool GetValue( wxVariant &value ) const wxOVERRIDE;
 
 private:
-    virtual void GtkOnTextEdited(const char *itempath, const wxString& str) wxOVERRIDE;
+    virtual wxVariant GtkGetValueFromString(const wxString& str) const;
 };
 
 

--- a/interface/wx/dataview.h
+++ b/interface/wx/dataview.h
@@ -3648,7 +3648,7 @@ public:
            Process a @c wxEVT_DATAVIEW_COLUMN_SORTED event.
     @event{EVT_DATAVIEW_COLUMN_REORDERED(id, func)}
            Process a @c wxEVT_DATAVIEW_COLUMN_REORDERED event.
-           Currently this even is only generated when using the native OS X
+           Currently this event is only generated when using the native OS X
            version.
     @event{EVT_DATAVIEW_ITEM_BEGIN_DRAG(id, func)}
            Process a @c wxEVT_DATAVIEW_ITEM_BEGIN_DRAG event.

--- a/interface/wx/dataview.h
+++ b/interface/wx/dataview.h
@@ -1567,6 +1567,21 @@ public:
     virtual void SelectAll();
 
     /**
+        Set custom colour for the alternate rows used with wxDV_ROW_LINES
+        style.
+
+        Note that calling this method has no effect if wxDV_ROW_LINES is off.
+
+        @param colour The colour to use for the alternate rows.
+        @return @true if customizing this colour is supported (currently only
+            in the generic version), @false if this method is not implemented
+            under this platform.
+
+        @since 3.1.1
+     */
+    bool SetAlternateRowColour(const wxColour& colour);
+
+    /**
         Set which column shall contain the tree-like expanders.
     */
     void SetExpanderColumn(wxDataViewColumn* col);

--- a/interface/wx/dataview.h
+++ b/interface/wx/dataview.h
@@ -3818,7 +3818,6 @@ public:
      */
     wxDataViewItem GetItem() const;
     void SetItem( const wxDataViewItem &item );
-    void SetEditCanceled(bool editCancelled);
     void SetPosition( int x, int y );
     void SetCache(int from, int to);
     wxDataObject *GetDataObject() const;

--- a/interface/wx/dataview.h
+++ b/interface/wx/dataview.h
@@ -3648,8 +3648,8 @@ public:
            Process a @c wxEVT_DATAVIEW_COLUMN_SORTED event.
     @event{EVT_DATAVIEW_COLUMN_REORDERED(id, func)}
            Process a @c wxEVT_DATAVIEW_COLUMN_REORDERED event.
-           Currently this event is only generated when using the native OS X
-           version.
+           Currently this event is not generated when using the native GTK+
+           version of the control.
     @event{EVT_DATAVIEW_ITEM_BEGIN_DRAG(id, func)}
            Process a @c wxEVT_DATAVIEW_ITEM_BEGIN_DRAG event.
     @event{EVT_DATAVIEW_ITEM_DROP_POSSIBLE(id, func)}
@@ -3675,6 +3675,9 @@ public:
     /**
         Returns the position of the column in the control or -1
         if no column field was set by the event emitter.
+
+        For wxEVT_DATAVIEW_COLUMN_REORDERED, this is the new position of the
+        column.
     */
     int GetColumn() const;
 

--- a/samples/dataview/dataview.cpp
+++ b/samples/dataview/dataview.cpp
@@ -1227,7 +1227,11 @@ void MyFrame::OnEditingStarted( wxDataViewEvent &event )
 void MyFrame::OnEditingDone( wxDataViewEvent &event )
 {
     wxString title = m_music_model->GetTitle( event.GetItem() );
-    wxLogMessage( "wxEVT_DATAVIEW_ITEM_EDITING_DONE, Item: %s", title );
+    wxLogMessage("wxEVT_DATAVIEW_ITEM_EDITING_DONE, Item: %s, new value %s",
+                 title,
+                 event.IsEditCancelled()
+                    ? wxString("unavailable because editing was cancelled")
+                    : event.GetValue().GetString());
 }
 
 void MyFrame::OnExpanded( wxDataViewEvent &event )

--- a/samples/dataview/dataview.cpp
+++ b/samples/dataview/dataview.cpp
@@ -417,8 +417,8 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_DATAVIEW_SELECTION_CHANGED(ID_MUSIC_CTRL, MyFrame::OnSelectionChanged)
 
     EVT_DATAVIEW_ITEM_START_EDITING(ID_MUSIC_CTRL, MyFrame::OnStartEditing)
-    EVT_DATAVIEW_ITEM_EDITING_STARTED(ID_MUSIC_CTRL, MyFrame::OnEditingStarted)
-    EVT_DATAVIEW_ITEM_EDITING_DONE(ID_MUSIC_CTRL, MyFrame::OnEditingDone)
+    EVT_DATAVIEW_ITEM_EDITING_STARTED(wxID_ANY, MyFrame::OnEditingStarted)
+    EVT_DATAVIEW_ITEM_EDITING_DONE(wxID_ANY, MyFrame::OnEditingDone)
 
     EVT_DATAVIEW_COLUMN_HEADER_CLICK(ID_MUSIC_CTRL, MyFrame::OnHeaderClick)
     EVT_DATAVIEW_COLUMN_HEADER_RIGHT_CLICK(ID_MUSIC_CTRL, MyFrame::OnHeaderRightClick)
@@ -1220,15 +1220,17 @@ void MyFrame::OnStartEditing( wxDataViewEvent &event )
 
 void MyFrame::OnEditingStarted( wxDataViewEvent &event )
 {
-    wxString title = m_music_model->GetTitle( event.GetItem() );
-    wxLogMessage( "wxEVT_DATAVIEW_ITEM_EDITING_STARTED, Item: %s", title );
+    // This event doesn't, currently, carry the value, so get it ourselves.
+    wxDataViewModel* const model = event.GetModel();
+    wxVariant value;
+    model->GetValue(value, event.GetItem(), event.GetColumn());
+    wxLogMessage("wxEVT_DATAVIEW_ITEM_EDITING_STARTED, current value %s",
+                 value.GetString());
 }
 
 void MyFrame::OnEditingDone( wxDataViewEvent &event )
 {
-    wxString title = m_music_model->GetTitle( event.GetItem() );
-    wxLogMessage("wxEVT_DATAVIEW_ITEM_EDITING_DONE, Item: %s, new value %s",
-                 title,
+    wxLogMessage("wxEVT_DATAVIEW_ITEM_EDITING_DONE, new value %s",
                  event.IsEditCancelled()
                     ? wxString("unavailable because editing was cancelled")
                     : event.GetValue().GetString());

--- a/samples/dataview/dataview.cpp
+++ b/samples/dataview/dataview.cpp
@@ -133,6 +133,7 @@ private:
     void OnHeaderClickList( wxDataViewEvent &event );
     void OnSorted( wxDataViewEvent &event );
     void OnSortedList( wxDataViewEvent &event );
+    void OnColumnReordered( wxDataViewEvent &event);
 
     void OnContextMenu( wxDataViewEvent &event );
 
@@ -423,6 +424,7 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_DATAVIEW_COLUMN_HEADER_RIGHT_CLICK(ID_MUSIC_CTRL, MyFrame::OnHeaderRightClick)
     EVT_DATAVIEW_COLUMN_SORTED(ID_MUSIC_CTRL, MyFrame::OnSorted)
     EVT_DATAVIEW_COLUMN_SORTED(ID_ATTR_CTRL, MyFrame::OnSortedList)
+    EVT_DATAVIEW_COLUMN_REORDERED(wxID_ANY, MyFrame::OnColumnReordered)
     EVT_DATAVIEW_COLUMN_HEADER_CLICK(ID_ATTR_CTRL, MyFrame::OnHeaderClickList)
 
     EVT_DATAVIEW_ITEM_CONTEXT_MENU(ID_MUSIC_CTRL, MyFrame::OnContextMenu)
@@ -1288,6 +1290,19 @@ void MyFrame::OnHeaderRightClick( wxDataViewEvent &event )
     int pos = m_ctrl[0]->GetColumnPosition( event.GetDataViewColumn() );
 
     wxLogMessage( "wxEVT_DATAVIEW_COLUMN_HEADER_RIGHT_CLICK, Column position: %d", pos );
+}
+
+void MyFrame::OnColumnReordered(wxDataViewEvent& event)
+{
+    wxDataViewColumn* const col = event.GetDataViewColumn();
+    if ( !col )
+    {
+        wxLogError("Unknown column reordered?");
+        return;
+    }
+
+    wxLogMessage("wxEVT_DATAVIEW_COLUMN_REORDERED: \"%s\" is now at position %d",
+                 col->GetTitle(), event.GetColumn());
 }
 
 void MyFrame::OnSortedList( wxDataViewEvent &/*event*/)

--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -798,7 +798,8 @@ bool wxDataViewRendererBase::FinishEditing()
     // Now we should send Editing Done event
     wxDataViewEvent event(wxEVT_DATAVIEW_ITEM_EDITING_DONE, dv_ctrl, column, m_item);
     event.SetValue( value );
-    event.SetEditCanceled( !isValid );
+    if ( !isValid )
+        event.SetEditCancelled();
     dv_ctrl->GetEventHandler()->ProcessEvent( event );
 
     bool accepted = false;

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -5512,13 +5512,16 @@ unsigned int wxDataViewCtrl::GetBestColumnWidth(int idx) const
     return max_width;
 }
 
-void wxDataViewCtrl::ColumnMoved(wxDataViewColumn * WXUNUSED(col),
-                                unsigned int WXUNUSED(new_pos))
+void wxDataViewCtrl::ColumnMoved(wxDataViewColumn *col, unsigned int new_pos)
 {
     // do _not_ reorder m_cols elements here, they should always be in the
     // order in which columns were added, we only display the columns in
     // different order
     m_clientArea->UpdateDisplay();
+
+    wxDataViewEvent event(wxEVT_DATAVIEW_COLUMN_REORDERED, this, col);
+    event.SetColumn(new_pos);
+    ProcessWindowEvent(event);
 }
 
 bool wxDataViewCtrl::DeleteColumn( wxDataViewColumn *column )

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -5781,9 +5781,10 @@ bool wxDataViewCtrl::SetHeaderAttr(const wxItemAttr& attr)
     return true;
 }
 
-void wxDataViewCtrl::SetAlternateRowColour(const wxColour& colour)
+bool wxDataViewCtrl::SetAlternateRowColour(const wxColour& colour)
 {
     m_alternateRowColour = colour;
+    return true;
 }
 
 void wxDataViewCtrl::SelectAll()

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -2155,26 +2155,24 @@ bool wxDataViewRenderer::IsHighlighted() const
            GetOwner()->GetOwner()->IsSelected(m_itemBeingRendered);
 }
 
+wxVariant
+wxDataViewRenderer::GtkGetValueFromString(const wxString& str) const
+{
+    return str;
+}
+
 void
 wxDataViewRenderer::GtkOnTextEdited(const char *itempath, const wxString& str)
 {
-    wxVariant value(str);
+    wxVariant value(GtkGetValueFromString(str));
     if (!Validate( value ))
         return;
 
     wxDataViewItem
         item(GetOwner()->GetOwner()->GTKPathToItem(wxGtkTreePath(itempath)));
 
-    GtkOnCellChanged(value, item, GetOwner()->GetModelColumn());
-}
-
-void
-wxDataViewRenderer::GtkOnCellChanged(const wxVariant& value,
-                                     const wxDataViewItem& item,
-                                     unsigned col)
-{
     wxDataViewModel *model = GetOwner()->GetOwner()->GetModel();
-    model->ChangeValue( value, item, col );
+    model->ChangeValue( value, item, GetOwner()->GetModelColumn() );
 }
 
 void wxDataViewRenderer::SetAttr(const wxDataViewItemAttr& WXUNUSED(attr))
@@ -2941,17 +2939,10 @@ wxDataViewChoiceByIndexRenderer::wxDataViewChoiceByIndexRenderer( const wxArrayS
     m_variantType = wxS("long");
 }
 
-void wxDataViewChoiceByIndexRenderer::GtkOnTextEdited(const char *itempath, const wxString& str)
+wxVariant
+wxDataViewChoiceByIndexRenderer::GtkGetValueFromString(const wxString& str) const
 {
-    wxVariant value( (long) GetChoices().Index( str ) );
-
-    if (!Validate( value ))
-        return;
-
-    wxDataViewItem
-        item(GetOwner()->GetOwner()->GTKPathToItem(wxGtkTreePath(itempath)));
-
-    GtkOnCellChanged(value, item, GetOwner()->GetModelColumn());
+    return static_cast<long>(GetChoices().Index(str));
 }
 
 bool wxDataViewChoiceByIndexRenderer::SetValue( const wxVariant &value )
@@ -3024,17 +3015,15 @@ bool wxDataViewIconTextRenderer::GetValue(wxVariant& value) const
     return true;
 }
 
-void
-wxDataViewIconTextRenderer::GtkOnCellChanged(const wxVariant& value,
-                                             const wxDataViewItem& item,
-                                             unsigned col)
+wxVariant
+wxDataViewIconTextRenderer::GtkGetValueFromString(const wxString& str) const
 {
     // we receive just the text part of our value as it's the only one which
     // can be edited, but we need the full wxDataViewIconText value for the
     // model
     wxVariant valueIconText;
-    valueIconText << wxDataViewIconText(value.GetString(), m_value.GetIcon());
-    wxDataViewTextRenderer::GtkOnCellChanged(valueIconText, item, col);
+    valueIconText << wxDataViewIconText(str, m_value.GetIcon());
+    return valueIconText;
 }
 
 // ---------------------------------------------------------

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -1881,6 +1881,7 @@ outlineView:(NSOutlineView*)outlineView
     wxDataViewCtrl* const dvc = implementation->GetDataViewCtrl();
 
     wxDataViewEvent event(wxEVT_DATAVIEW_COLUMN_REORDERED, dvc, col);
+    event.SetColumn(newColumnPosition);
     dvc->GetEventHandler()->ProcessEvent(event);
 }
 


### PR DESCRIPTION
Harmonize the events sent by the different versions and send `ITEM_EDITING_DONE` when editing was cancelled too, as was implied by the documentation.