### PR TITLE
 CMake: Additional fixes/tweaks for C++11 on macOS 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
           env: wxCONFIGURE_FLAGS="--enable-cxx11" wxMAKEFILE_FLAGS="CXXFLAGS=-std=c++11" wxSKIP_SAMPLES=1
         - os: osx
           compiler: clang
-          env: wxTOOLSET=cmake wxCMAKE_GENERATOR=Xcode wxCMAKE_DEFINES="-DCMAKE_CXX_STANDARD=11 -DCMAKE_CXX_FLAGS=-stdlib=libc++"
+          env: wxTOOLSET=cmake wxCMAKE_GENERATOR=Xcode wxCMAKE_DEFINES="-DCMAKE_CXX_STANDARD=11"
 
 branches:
     only:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,12 +20,7 @@ endif()
 if(APPLE AND NOT CMAKE_OSX_DEPLOYMENT_TARGET)
     # If no deployment target has been set default to the minimum supported
     # OS X version (this has to be set before the first project() call)
-    if(CMAKE_CXX_STANDARD EQUAL 11 OR CMAKE_CXX_STANDARD EQUAL 14)
-        set(OSX_DEFAULT_DEPLOYMENT_TARGET 10.9)
-    else()
-        set(OSX_DEFAULT_DEPLOYMENT_TARGET 10.7)
-    endif()
-    set(CMAKE_OSX_DEPLOYMENT_TARGET ${OSX_DEFAULT_DEPLOYMENT_TARGET} CACHE STRING "OS X Deployment Target")
+    set(CMAKE_OSX_DEPLOYMENT_TARGET 10.7 CACHE STRING "OS X Deployment Target")
 endif()
 
 project(wxWidgets)

--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -73,15 +73,17 @@ function(wx_set_common_target_properties target_name)
     if(DEFINED wxBUILD_CXX_STANDARD AND NOT wxBUILD_CXX_STANDARD STREQUAL COMPILER_DEFAULT)
         # TODO: implement for older CMake versions ?
         set_target_properties(${target_name} PROPERTIES CXX_STANDARD ${wxBUILD_CXX_STANDARD})
-        if(wxBUILD_CXX_STANDARD EQUAL 11 OR wxBUILD_CXX_STANDARD EQUAL 14)
-            if (APPLE)
-                if(CMAKE_GENERATOR EQUAL "Xcode")
-                    set_target_properties(${target_name} PROPERTIES XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY libc++)
-                else()
-                    target_compile_options(${target_name} PUBLIC "-stdlib=libc++")
-                endif()
+        if(
+            APPLE AND
+            CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 10.9 AND
+            (wxBUILD_CXX_STANDARD EQUAL 11 OR wxBUILD_CXX_STANDARD EQUAL 14)
+          )
+            if(CMAKE_GENERATOR STREQUAL "Xcode")
+                set_target_properties(${target_name} PROPERTIES XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY libc++)
+            else()
+                target_compile_options(${target_name} PUBLIC "-stdlib=libc++")
+                target_link_libraries(${target_name} PRIVATE "-stdlib=libc++")
             endif()
-            #TODO: define for other generators than Xcode
         endif()
     endif()
     set_target_properties(${target_name} PROPERTIES
@@ -363,7 +365,7 @@ macro(wx_exe_link_libraries name)
     if(wxBUILD_MONOLITHIC)
         target_link_libraries(${name} PUBLIC mono)
     else()
-        target_link_libraries(${name};${ARGN})
+        target_link_libraries(${name};PRIVATE;${ARGN})
     endif()
 endmacro()
 

--- a/build/cmake/setup.cmake
+++ b/build/cmake/setup.cmake
@@ -23,6 +23,14 @@ include(CheckTypeSize)
 include(CMakePushCheckState)
 include(TestBigEndian)
 
+if(
+    APPLE AND
+    CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 10.9 AND
+    (CMAKE_CXX_STANDARD EQUAL 11 OR CMAKE_CXX_STANDARD EQUAL 14)
+  )
+    set(CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS} "-stdlib=libc++")
+endif()
+
 # Add a definition to setup.h and append it to a list of defines for
 # for compile checks
 macro(wx_setup_definition def)


### PR DESCRIPTION
The changes in 0a94c18 where an
incomplete solution.
The apple compiler automatically choses libc++ if the deployment target
is >= 10.9. Lower deployment targets need explicit compiler options
to use libc++.

After this change the additional build flags in Travis CI should not be necessary.