### PR TITLE
Avoid wxEVT_TEXT_ENTER when completion popup is shown in wxGTK

### DIFF
--- a/src/gtk/toplevel.cpp
+++ b/src/gtk/toplevel.cpp
@@ -30,6 +30,7 @@
 #endif
 
 #include "wx/evtloop.h"
+#include "wx/recguard.h"
 #include "wx/sysopt.h"
 
 #include <gtk/gtk.h>
@@ -200,10 +201,17 @@ gboolean gtk_frame_focus_out_callback(GtkWidget * WXUNUSED(widget),
 // "key_press_event"
 // ----------------------------------------------------------------------------
 
+// This is a hack used in src/gtk/window.cpp, please see there.
+int wxTLWKeyPressHandlerLevel = 0;
+
 extern "C" {
 static gboolean
 wxgtk_tlw_key_press_event(GtkWidget *widget, GdkEventKey *event)
 {
+    // This is not really used as a guard, but just to update the value of
+    // wxTLWKeyPressHandlerLevel correctly in all cases.
+    wxRecursionGuard guard(wxTLWKeyPressHandlerLevel);
+
     GtkWindow* const window = GTK_WINDOW(widget);
 
     // By default GTK+ checks for the menu accelerators in this (top level)

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -1164,6 +1164,23 @@ gtk_window_key_press_callback( GtkWidget *WXUNUSED(widget),
 
     wxPROCESS_EVENT_ONCE(GdkEventKey, gdk_event);
 
+    extern int wxTLWKeyPressHandlerLevel;
+
+    // When we receive the event corresponding to the Enter key from the
+    // completion popup used with GtkEntry, we want to avoid handling this
+    // event in wxTextCtrl (or another class using wxTextEntry, such as
+    // wxComboBox, which explains why do we do it at GTK level here and not in
+    // wxTextCtrl itself), as it would be translated into wxEVT_TEXT_ENTER
+    // there, while we want it to be used only for accepting the selection in
+    // the popup.
+    //
+    // To distinguish between these events and the ones happening in the text
+    // entry itself, we check if event passed via our TLW key-press-event
+    // handler, as is the case usually, or was sent directly to this widget, as
+    // (only?) GtkEntryCompletion does.
+    if ( gdk_event->keyval == GDK_KEY_Return && !wxTLWKeyPressHandlerLevel )
+        return FALSE;
+
     wxKeyEvent event( wxEVT_KEY_DOWN );
     bool ret = false;
     bool return_after_IM = false;


### PR DESCRIPTION
For consistency with wxMSW, and also because it just makes more sense
from UI point of view, avoid generating wxEVT_TEXT_ENTER events when an
auto-completion popup is shown and just accept the current selection in
it when Enter is pressed instead.

This notably allows to use "Enter" naturally with wxSearchCtrl using
auto-completion, instead of generating wxEVT_SEARCH events when the user
just wants to select a popup entry.

Unfortunately there doesn't seem to be any direct way of interfering
with GtkEntryCompletion keyboard handling and prevent it from forwarding
the GdkEventKey to GtkEntry in this case, so we need to rely on
indirectly determining whether the event really occurred in GtkEntry or
not by setting a flag whenever our TLW key-press-event handler is called
and checking if it is set when handling the key presses later.

---

This is really ugly, but solves a usability problem, so I think it's needed, unless we either find some better to do this or find some new problems due to these changes (e.g. some key presses that won't be processed any longer because of this check). TIA for any comments/ideas!