### PR TITLE
Fix build warnings in Direct2D related code

### DIFF
--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -41,8 +41,8 @@
 #include <wincodec.h>
 
 #ifdef __MINGW64_TOOLCHAIN__
-#ifndef DRWITE_E_NOFONT
-#define DWRITE_E_NOFONT _HRESULT_TYPEDEF_(0x88985002)
+#ifndef DWRITE_E_NOFONT
+#define DWRITE_E_NOFONT _HRESULT_TYPEDEF_(0x88985002L)
 #endif
 #endif
 

--- a/src/stc/PlatWX.cpp
+++ b/src/stc/PlatWX.cpp
@@ -797,9 +797,9 @@ bool SurfaceFontDataD2D::Initialised() const
 // SurfaceDataD2D
 
 SurfaceDataD2D::SurfaceDataD2D(ScintillaWX* editor)
-    : m_editor(editor),
-      m_pD2DFactory(::wxD2D1Factory()),
-      m_pDWriteFactory(::wxDWriteFactory())
+    : m_pD2DFactory(::wxD2D1Factory()),
+      m_pDWriteFactory(::wxDWriteFactory()),
+      m_editor(editor)
 {
     if ( Initialised() )
     {
@@ -1107,7 +1107,7 @@ void SurfaceD2D::Release()
             m_clipsActive--;
         }
         hr = m_pRenderTarget->EndDraw();
-        if ( hr == D2DERR_RECREATE_TARGET && m_surfaceData && !m_ownRenderTarget )
+        if ( hr == (HRESULT)D2DERR_RECREATE_TARGET && m_surfaceData && !m_ownRenderTarget )
         {
             m_surfaceData->DiscardGraphicsResources();
             m_surfaceData->SetEditorPaintAbandoned();


### PR DESCRIPTION
Regressions since https://github.com/wxWidgets/wxWidgets/pull/689.

This fixes the following warnings
```bash
../../src/msw/graphicsd2d.cpp:45:0: warning: "DWRITE_E_NOFONT" redefined
 #define DWRITE_E_NOFONT _HRESULT_TYPEDEF_(0x88985002)

In file included from C:/msys64/mingw64/x86_64-w64-mingw32/include/winbase.h:2380:0,
                 from C:/msys64/mingw64/x86_64-w64-mingw32/include/windows.h:70,
                 from C:/msys64/mingw64/x86_64-w64-mingw32/include/rpc.h:16,
                 from C:/msys64/mingw64/x86_64-w64-mingw32/include/unknwn.h:7,
                 from C:/msys64/mingw64/x86_64-w64-mingw32/include/d2d1.h:15,
                 from ../../src/msw/graphicsd2d.cpp:39:
C:/msys64/mingw64/x86_64-w64-mingw32/include/winerror.h:3622:0: note: this is the location of the previous definition
 #define DWRITE_E_NOFONT                   _HRESULT_TYPEDEF_(0x88985002L)
```

```bash
In file included from ../../src/stc/PlatWX.cpp:45:0:
../../src/stc/PlatWX.h: In constructor 'SurfaceDataD2D::SurfaceDataD2D(ScintillaWX*)':
../../src/stc/PlatWX.h:48:18: warning: 'SurfaceDataD2D::m_editor' will be initialized after [-Wreorder]
     ScintillaWX* m_editor;
                  ^~~~~~~~
../../src/stc/PlatWX.h:40:28: warning:   'wxCOMPtr<ID2D1Factory> SurfaceDataD2D::m_pD2DFactory' [-Wreorder]
     wxCOMPtr<ID2D1Factory> m_pD2DFactory;
                            ^~~~~~~~~~~~~
../../src/stc/PlatWX.cpp:799:1: warning:   when initialized here [-Wreorder]
 SurfaceDataD2D::SurfaceDataD2D(ScintillaWX* editor)
 ^~~~~~~~~~~~~~
                 ^
```

```bash
../../src/stc/PlatWX.cpp: In member function 'virtual void SurfaceD2D::Release()':
../../src/stc/PlatWX.cpp:1110:17: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         if ( hr == D2DERR_RECREATE_TARGET && m_surfaceData && !m_ownRenderTarget )
                 ^
```
