### PR TITLE
Allow pre-set focus in OSx

### DIFF
--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -3025,7 +3025,11 @@ bool wxWidgetCocoaImpl::CanFocus() const
     NSView* targetView = m_osxView;
     if ( [m_osxView isKindOfClass:[NSScrollView class] ] )
         targetView = [(NSScrollView*) m_osxView documentView];
-    return [targetView acceptsFirstResponder] == YES;
+
+    return [targetView canBecomeKeyView] == YES ||
+            ([m_osxView isHidden] == NO &&
+            [m_osxView isHiddenOrHasHiddenAncestor] == YES &&
+            [targetView acceptsFirstResponder] == YES );
 }
 
 bool wxWidgetCocoaImpl::HasFocus() const

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -3026,10 +3026,13 @@ bool wxWidgetCocoaImpl::CanFocus() const
     if ( [m_osxView isKindOfClass:[NSScrollView class] ] )
         targetView = [(NSScrollView*) m_osxView documentView];
 
-    return [targetView canBecomeKeyView] == YES ||
-            ([m_osxView isHidden] == NO &&
-            [m_osxView isHiddenOrHasHiddenAncestor] == YES &&
-            [targetView acceptsFirstResponder] == YES );
+    if ( [targetView canBecomeKeyView] == YES )
+        return true;
+    else if ( [[NSApplication sharedApplication] isFullKeyboardAccessEnabled] )
+        return [targetView acceptsFirstResponder] == YES;
+    else
+        return [m_osxView isKindOfClass:[NSButton class]] == NO &&
+               [targetView acceptsFirstResponder] == YES;
 }
 
 bool wxWidgetCocoaImpl::HasFocus() const

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -3025,7 +3025,7 @@ bool wxWidgetCocoaImpl::CanFocus() const
     NSView* targetView = m_osxView;
     if ( [m_osxView isKindOfClass:[NSScrollView class] ] )
         targetView = [(NSScrollView*) m_osxView documentView];
-    return [targetView canBecomeKeyView] == YES;
+    return [targetView acceptsFirstResponder] == YES;
 }
 
 bool wxWidgetCocoaImpl::HasFocus() const


### PR DESCRIPTION
Prior to commit f897d9ed1a1d1c4cdce789ef0cd2963e199b4595 we raised the window using makeKeyAndOrderFront whenever we set focus to a child. Then it made sense to check whether the view canBecomeKeyView in window.mm CanFocus(). However, canBecomeKeyView fails if the window is not yet visible and so any pre-set focus calls fails. Fix this by checking for acceptsFirstResponder instead.

We already check for wxIsWindowOrParentDisabled in wxWindowMac::SetFocus and for canAcceptFocusFromKeyboard in containr.cpp HandleOnNavigationKey so this commit does not conflict with OSx keyboard navigation behaviour.
See tickets #11948 and #17340