### PR TITLE
Do not define max and min macros in include/wx/msw/wrapgdi.h

### DIFF
--- a/include/wx/msw/wrapgdip.h
+++ b/include/wx/msw/wrapgdip.h
@@ -12,6 +12,7 @@
 
 #include "wx/msw/wrapwin.h"
 
+#if 0
 // these macros must be defined before gdiplus.h is included but we explicitly
 // prevent windows.h from defining them in wx/msw/wrapwin.h as they conflict
 // with standard functions of the same name elsewhere, so we have to pay for it
@@ -22,6 +23,7 @@
 
 #ifndef min
     #define min(a,b)            (((a) < (b)) ? (a) : (b))
+#endif
 #endif
 
 // There are many clashes between the names of the member fields and parameters


### PR DESCRIPTION
With mingw-w64 5.0.3, gcc 7.3.0 and -std=c++17:
- wx/msw/wrapgdip.h defines min and max before including gdiplus.h
- gdiplus.h includes math.h
- with c++17, math.h eventually includes bits/specfun.h and tr1/bessel_function.tcc which which uses
std::numeric_limits<_Tp>::min() (this is not the case with c++14).

Removing the definition of the min/max macros in wrapgdip.h removes the compilation error and wxWidgets builds fine. So it seems these macros are not required anymore, at least with mingw-w64.

We need to test with other compilers to tune the #if statement.