### PR TITLE
Suppress size event when IsMaximized is called on OSX

### DIFF
--- a/include/wx/osx/nonownedwnd.h
+++ b/include/wx/osx/nonownedwnd.h
@@ -116,6 +116,8 @@ public:
 
     void OSXHandleMiniaturize(double WXUNUSED(timestampsec), bool miniaturized);
 
+    void OSXSetIgnoreResizing(bool value) { m_ignoreResizing = value; }
+
     void WindowWasPainted();
 
     virtual bool Destroy();
@@ -154,6 +156,7 @@ private :
 #if wxUSE_GRAPHICS_CONTEXT
     wxGraphicsPath m_shapePath;
 #endif // wxUSE_GRAPHICS_CONTEXT
+    bool m_ignoreResizing;
 };
 
 // list of all frames and modeless dialogs

--- a/src/osx/cocoa/nonownedwnd.mm
+++ b/src/osx/cocoa/nonownedwnd.mm
@@ -998,7 +998,12 @@ bool wxNonOwnedWindowCocoaImpl::IsMaximized() const
 {
     if (([m_macWindow styleMask] & NSResizableWindowMask) != 0)
     {
-        return [m_macWindow isZoomed];
+        // isZoomed internally calls windowWillResize which would trigger
+        // an wxEVT_SIZE. Setting ignore resizing supresses the event
+        m_wxPeer->OSXSetIgnoreResizing(true);
+        BOOL result = [m_macWindow isZoomed];
+        m_wxPeer->OSXSetIgnoreResizing(false);
+        return result;
     }
     else
     {

--- a/src/osx/nonownedwnd_osx.cpp
+++ b/src/osx/nonownedwnd_osx.cpp
@@ -97,6 +97,7 @@ void wxNonOwnedWindow::Init()
 {
     m_nowpeer = NULL;
     m_isNativeWindowWrapper = false;
+    m_ignoreResizing = false;
 }
 
 bool wxNonOwnedWindow::Create(wxWindow *parent,
@@ -306,6 +307,9 @@ void wxNonOwnedWindow::HandleResized( double WXUNUSED(timestampsec) )
 
 void wxNonOwnedWindow::HandleResizing( double WXUNUSED(timestampsec), wxRect* rect )
 {
+    if(m_ignoreResizing)
+        return;
+
     wxRect r = *rect ;
 
     // this is a EVT_SIZING not a EVT_SIZE type !


### PR DESCRIPTION
`IsMaximized` internally calls `[NSWindow isZoomed]` which triggers a
`windowWillResize` call. Resize events will be ignored while calling
`isZoomed`.

Fixes: [#17407](https://trac.wxwidgets.org/ticket/17407)
See discussion [here](https://groups.google.com/forum/#!msg/wx-dev/5SpwwA24FOY/W02ptwXJHQAJ)