### PR TITLE
Implement native wxTextCtrl spell checking.

### DIFF
--- a/configure
+++ b/configure
@@ -959,6 +959,8 @@ GTKPRINT_CFLAGS
 SDL_CONFIG
 SDL_LIBS
 SDL_CFLAGS
+GTKSPELL_LIBS
+GTKSPELL_CFLAGS
 LIBSECRET_LIBS
 LIBSECRET_CFLAGS
 GXX_VERSION
@@ -1190,6 +1192,7 @@ enable_printfposparam
 enable_secretstore
 enable_snglinst
 enable_sound
+enable_spellcheck
 enable_stdpaths
 enable_stopwatch
 enable_streams
@@ -1403,6 +1406,8 @@ MesaGL_CFLAGS
 MesaGL_LIBS
 LIBSECRET_CFLAGS
 LIBSECRET_LIBS
+GTKSPELL_CFLAGS
+GTKSPELL_LIBS
 SDL_CFLAGS
 SDL_LIBS
 GTKPRINT_CFLAGS
@@ -2130,6 +2135,7 @@ Optional Features:
   --enable-secretstore    use wxSecretStore class
   --enable-snglinst       use wxSingleInstanceChecker class
   --enable-sound          use wxSound class
+  --enable-spellcheck     spellchecking in wxTextCtrl class
   --enable-stdpaths       use wxStandardPaths class
   --enable-stopwatch      use wxStopWatch class
   --enable-streams        use wxStream etc classes
@@ -2401,6 +2407,10 @@ Some influential environment variables:
               C compiler flags for LIBSECRET, overriding pkg-config
   LIBSECRET_LIBS
               linker flags for LIBSECRET, overriding pkg-config
+  GTKSPELL_CFLAGS
+              C compiler flags for GTKSPELL, overriding pkg-config
+  GTKSPELL_LIBS
+              linker flags for GTKSPELL, overriding pkg-config
   SDL_CFLAGS  C compiler flags for SDL, overriding pkg-config
   SDL_LIBS    linker flags for SDL, overriding pkg-config
   GTKPRINT_CFLAGS
@@ -7571,6 +7581,35 @@ fi
 
 
           eval "$wx_cv_use_sound"
+
+
+          enablestring=
+          defaultval=$wxUSE_ALL_FEATURES
+          if test -z "$defaultval"; then
+              if test x"$enablestring" = xdisable; then
+                  defaultval=yes
+              else
+                  defaultval=no
+              fi
+          fi
+
+          # Check whether --enable-spellcheck was given.
+if test "${enable_spellcheck+set}" = set; then :
+  enableval=$enable_spellcheck;
+                          if test "$enableval" = yes; then
+                            wx_cv_use_spellcheck='wxUSE_SPELLCHECK=yes'
+                          else
+                            wx_cv_use_spellcheck='wxUSE_SPELLCHECK=no'
+                          fi
+
+else
+
+                          wx_cv_use_spellcheck='wxUSE_SPELLCHECK=${'DEFAULT_wxUSE_SPELLCHECK":-$defaultval}"
+
+fi
+
+
+          eval "$wx_cv_use_spellcheck"
 
 
           enablestring=
@@ -34201,6 +34240,185 @@ fi
         $as_echo "#define wxUSE_SECRETSTORE 1" >>confdefs.h
 
         SAMPLES_SUBDIRS="$SAMPLES_SUBDIRS secretstore"
+    fi
+fi
+
+
+
+if test "$wxUSE_SPELLCHECK" = "yes"; then
+            if test "$wxUSE_MSW" != "1" -a "$wxUSE_OSX_COCOA" != 1; then
+        if test "$wxGTK_VERSION" != "3"; then
+
+pkg_failed=no
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for GTKSPELL" >&5
+$as_echo_n "checking for GTKSPELL... " >&6; }
+
+if test -n "$PKG_CONFIG"; then
+    if test -n "$GTKSPELL_CFLAGS"; then
+        pkg_cv_GTKSPELL_CFLAGS="$GTKSPELL_CFLAGS"
+    else
+        if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"gtkspell-2.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "gtkspell-2.0") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_GTKSPELL_CFLAGS=`$PKG_CONFIG --cflags "gtkspell-2.0" 2>/dev/null`
+else
+  pkg_failed=yes
+fi
+    fi
+else
+	pkg_failed=untried
+fi
+if test -n "$PKG_CONFIG"; then
+    if test -n "$GTKSPELL_LIBS"; then
+        pkg_cv_GTKSPELL_LIBS="$GTKSPELL_LIBS"
+    else
+        if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"gtkspell-2.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "gtkspell-2.0") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_GTKSPELL_LIBS=`$PKG_CONFIG --libs "gtkspell-2.0" 2>/dev/null`
+else
+  pkg_failed=yes
+fi
+    fi
+else
+	pkg_failed=untried
+fi
+
+
+
+if test $pkg_failed = yes; then
+
+if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+        _pkg_short_errors_supported=yes
+else
+        _pkg_short_errors_supported=no
+fi
+        if test $_pkg_short_errors_supported = yes; then
+	        GTKSPELL_PKG_ERRORS=`$PKG_CONFIG --short-errors --errors-to-stdout --print-errors "gtkspell-2.0"`
+        else
+	        GTKSPELL_PKG_ERRORS=`$PKG_CONFIG --errors-to-stdout --print-errors "gtkspell-2.0"`
+        fi
+	# Put the nasty error message in config.log where it belongs
+	echo "$GTKSPELL_PKG_ERRORS" >&5
+
+
+                    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: gtkspell-2.0 not found, spellchecking won't be available" >&5
+$as_echo "$as_me: WARNING: gtkspell-2.0 not found, spellchecking won't be available" >&2;}
+                    wxUSE_SPELLCHECK=no
+
+
+elif test $pkg_failed = untried; then
+
+                    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: gtkspell-2.0 not found, spellchecking won't be available" >&5
+$as_echo "$as_me: WARNING: gtkspell-2.0 not found, spellchecking won't be available" >&2;}
+                    wxUSE_SPELLCHECK=no
+
+
+else
+	GTKSPELL_CFLAGS=$pkg_cv_GTKSPELL_CFLAGS
+	GTKSPELL_LIBS=$pkg_cv_GTKSPELL_LIBS
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+                    CXXFLAGS="$GTKSPELL_CFLAGS $CXXFLAGS"
+                    LIBS="$GTKSPELL_LIBS $LIBS"
+
+fi
+        else
+
+pkg_failed=no
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for GTKSPELL" >&5
+$as_echo_n "checking for GTKSPELL... " >&6; }
+
+if test -n "$PKG_CONFIG"; then
+    if test -n "$GTKSPELL_CFLAGS"; then
+        pkg_cv_GTKSPELL_CFLAGS="$GTKSPELL_CFLAGS"
+    else
+        if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"gtkspell3-3.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "gtkspell3-3.0") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_GTKSPELL_CFLAGS=`$PKG_CONFIG --cflags "gtkspell3-3.0" 2>/dev/null`
+else
+  pkg_failed=yes
+fi
+    fi
+else
+	pkg_failed=untried
+fi
+if test -n "$PKG_CONFIG"; then
+    if test -n "$GTKSPELL_LIBS"; then
+        pkg_cv_GTKSPELL_LIBS="$GTKSPELL_LIBS"
+    else
+        if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"gtkspell3-3.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "gtkspell3-3.0") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_GTKSPELL_LIBS=`$PKG_CONFIG --libs "gtkspell3-3.0" 2>/dev/null`
+else
+  pkg_failed=yes
+fi
+    fi
+else
+	pkg_failed=untried
+fi
+
+
+
+if test $pkg_failed = yes; then
+
+if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+        _pkg_short_errors_supported=yes
+else
+        _pkg_short_errors_supported=no
+fi
+        if test $_pkg_short_errors_supported = yes; then
+	        GTKSPELL_PKG_ERRORS=`$PKG_CONFIG --short-errors --errors-to-stdout --print-errors "gtkspell3-3.0"`
+        else
+	        GTKSPELL_PKG_ERRORS=`$PKG_CONFIG --errors-to-stdout --print-errors "gtkspell3-3.0"`
+        fi
+	# Put the nasty error message in config.log where it belongs
+	echo "$GTKSPELL_PKG_ERRORS" >&5
+
+
+                    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: gtkspell3-3.0 not found, spellchecking won't be available" >&5
+$as_echo "$as_me: WARNING: gtkspell3-3.0 not found, spellchecking won't be available" >&2;}
+                    wxUSE_SPELLCHECK=no
+
+
+elif test $pkg_failed = untried; then
+
+                    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: gtkspell3-3.0 not found, spellchecking won't be available" >&5
+$as_echo "$as_me: WARNING: gtkspell3-3.0 not found, spellchecking won't be available" >&2;}
+                    wxUSE_SPELLCHECK=no
+
+
+else
+	GTKSPELL_CFLAGS=$pkg_cv_GTKSPELL_CFLAGS
+	GTKSPELL_LIBS=$pkg_cv_GTKSPELL_LIBS
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+                    CXXFLAGS="$GTKSPELL_CFLAGS $CXXFLAGS"
+                    LIBS="$GTKSPELL_LIBS $LIBS"
+
+fi
+        fi
+    fi
+
+    if test "$wxUSE_SPELLCHECK" = "yes"; then
+        $as_echo "#define wxUSE_SPELLCHECK 1" >>confdefs.h
+
     fi
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -732,6 +732,7 @@ WX_ARG_FEATURE(printfposparam,[  --enable-printfposparam use wxVsnprintf() which
 WX_ARG_FEATURE(secretstore,   [  --enable-secretstore    use wxSecretStore class], wxUSE_SECRETSTORE)
 WX_ARG_FEATURE(snglinst,      [  --enable-snglinst       use wxSingleInstanceChecker class], wxUSE_SNGLINST_CHECKER)
 WX_ARG_FEATURE(sound,         [  --enable-sound          use wxSound class], wxUSE_SOUND)
+WX_ARG_FEATURE(spellcheck,    [  --enable-spellcheck     spellchecking in wxTextCtrl class], wxUSE_SPELLCHECK)
 WX_ARG_FEATURE(stdpaths,      [  --enable-stdpaths       use wxStandardPaths class], wxUSE_STDPATHS)
 WX_ARG_FEATURE(stopwatch,     [  --enable-stopwatch      use wxStopWatch class], wxUSE_STOPWATCH)
 WX_ARG_FEATURE(streams,       [  --enable-streams        use wxStream etc classes], wxUSE_STREAMS)
@@ -5409,6 +5410,45 @@ if test "$wxUSE_SECRETSTORE" = "yes"; then
 
         AC_DEFINE(wxUSE_SECRETSTORE)
         SAMPLES_SUBDIRS="$SAMPLES_SUBDIRS secretstore"
+    fi
+fi
+
+
+dnl ---------------------------------------------------------------------------
+dnl Spellchecking for wxTextCtrl
+dnl ---------------------------------------------------------------------------
+
+if test "$wxUSE_SPELLCHECK" = "yes"; then
+    dnl The required APIs are always available under MSW and OS X but we must
+    dnl have GNOME gtkspell under Unix to be able to compile this feature.
+    if test "$wxUSE_MSW" != "1" -a "$wxUSE_OSX_COCOA" != 1; then
+        if test "$wxGTK_VERSION" != "3"; then
+            PKG_CHECK_MODULES(GTKSPELL, [gtkspell-2.0],
+                [
+                    CXXFLAGS="$GTKSPELL_CFLAGS $CXXFLAGS"
+                    LIBS="$GTKSPELL_LIBS $LIBS"
+                ],
+                [
+                    AC_MSG_WARN([gtkspell-2.0 not found, spellchecking won't be available])
+                    wxUSE_SPELLCHECK=no
+                ]
+            )
+        else
+            PKG_CHECK_MODULES(GTKSPELL, [gtkspell3-3.0],
+                [
+                    CXXFLAGS="$GTKSPELL_CFLAGS $CXXFLAGS"
+                    LIBS="$GTKSPELL_LIBS $LIBS"
+                ],
+                [
+                    AC_MSG_WARN([gtkspell3-3.0 not found, spellchecking won't be available])
+                    wxUSE_SPELLCHECK=no
+                ]
+            )
+        fi
+    fi
+
+    if test "$wxUSE_SPELLCHECK" = "yes"; then
+        AC_DEFINE(wxUSE_SPELLCHECK)
     fi
 fi
 

--- a/docs/doxygen/mainpages/const_wxusedef.h
+++ b/docs/doxygen/mainpages/const_wxusedef.h
@@ -209,6 +209,7 @@ library:
 @itemdef{wxUSE_SOUND, Use wxSound class.}
 @itemdef{wxUSE_SPINBTN, Use wxSpinButton class.}
 @itemdef{wxUSE_SPINCTRL, Use wxSpinCtrl class.}
+@itemdef{wxUSE_SPELLCHECK, Allow use of native spellcheckers in wxTextCtrl.}
 @itemdef{wxUSE_SPLASH, Use wxSplashScreen class.}
 @itemdef{wxUSE_SPLINES, Provide methods for spline drawing in wxDC.}
 @itemdef{wxUSE_SPLITTER, Use wxSplitterWindow class.}

--- a/include/wx/android/setup.h
+++ b/include/wx/android/setup.h
@@ -462,6 +462,15 @@
 // Recommended setting: 1 (but may be safely disabled if you don't use it)
 #define wxUSE_SECRETSTORE   1
 
+// Allow the use of the OS built-in spellchecker on wxTextCtrl (multiline
+// only). Currently wxGTK, wxMSW and wxOSX implemented.
+//
+// Default is 1
+//
+// Recommended setting: 1 (but may be safely disabled if you don't use it)
+
+#define wxUSE_SPELLCHECK   1
+
 // Use wxStandardPaths class which allows to retrieve some standard locations
 // in the file system
 //

--- a/include/wx/chkconf.h
+++ b/include/wx/chkconf.h
@@ -285,6 +285,14 @@
 #   endif
 #endif /* !defined(wxUSE_SECRETSTORE) */
 
+#ifndef wxUSE_SPELLCHECK
+#   ifdef wxABORT_ON_CONFIG_ERROR
+#       error "wxUSE_SPELLCHECK must be defined, please read comment near the top of this file."
+#   else
+#       define wxUSE_SPELLCHECK 1
+#   endif
+#endif /* !defined(wxUSE_SPELLCHECK) */
+
 #ifndef wxUSE_STDPATHS
 #   ifdef wxABORT_ON_CONFIG_ERROR
 #       error "wxUSE_STDPATHS must be defined, please read comment near the top of this file."

--- a/include/wx/gtk/setup0.h
+++ b/include/wx/gtk/setup0.h
@@ -463,6 +463,15 @@
 // Recommended setting: 1 (but may be safely disabled if you don't use it)
 #define wxUSE_SECRETSTORE   1
 
+// Allow the use of the OS built-in spellchecker on wxTextCtrl (multiline
+// only). Currently wxGTK, wxMSW and wxOSX implemented.
+//
+// Default is 1
+//
+// Recommended setting: 1 (but may be safely disabled if you don't use it)
+
+#define wxUSE_SPELLCHECK   1
+
 // Use wxStandardPaths class which allows to retrieve some standard locations
 // in the file system
 //

--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -96,6 +96,12 @@ public:
     // Overridden wxWindow methods
     virtual void SetWindowStyleFlag( long style ) wxOVERRIDE;
     virtual bool Enable( bool enable = true ) wxOVERRIDE;
+    
+#if wxUSE_SPELLCHECK    
+    // Use native spelling and grammer checking functions.
+    virtual wxTextSpellcheckStatus EnableSpellcheck(const bool enable = true) wxOVERRIDE;
+    virtual bool IsSpellcheckEnabled() wxOVERRIDE;
+#endif // wxUSE_SPELLCHECK
 
     // Implementation from now on
     void OnDropFiles( wxDropFilesEvent &event );

--- a/include/wx/gtk1/textctrl.h
+++ b/include/wx/gtk1/textctrl.h
@@ -105,6 +105,18 @@ public:
 
     virtual void DoEnable( bool enable );
 
+#if wxUSE_SPELLCHECK    
+    // Spell checking is not available in wxGTK1.
+    virtual wxTextSpellcheckStatus EnableSpellcheck(const bool enable = true) wxOVERRIDE
+    {
+        return wxTEXT_SPELLCHECK_NOT_AVAILABLE;
+    }
+    virtual bool IsSpellcheckEnabled() wxOVERRIDE
+    {
+        return false;
+    }
+#endif // wxUSE_SPELLCHECK
+
     // Implementation from now on
     void OnDropFiles( wxDropFilesEvent &event );
     void OnChar( wxKeyEvent &event );

--- a/include/wx/motif/setup0.h
+++ b/include/wx/motif/setup0.h
@@ -463,6 +463,15 @@
 // Recommended setting: 1 (but may be safely disabled if you don't use it)
 #define wxUSE_SECRETSTORE   1
 
+// Allow the use of the OS built-in spellchecker on wxTextCtrl (multiline
+// only). Currently wxGTK, wxMSW and wxOSX implemented.
+//
+// Default is 1
+//
+// Recommended setting: 1 (but may be safely disabled if you don't use it)
+
+#define wxUSE_SPELLCHECK   1
+
 // Use wxStandardPaths class which allows to retrieve some standard locations
 // in the file system
 //

--- a/include/wx/msw/setup0.h
+++ b/include/wx/msw/setup0.h
@@ -463,6 +463,15 @@
 // Recommended setting: 1 (but may be safely disabled if you don't use it)
 #define wxUSE_SECRETSTORE   1
 
+// Allow the use of the OS built-in spellchecker on wxTextCtrl (multiline
+// only). Currently wxGTK, wxMSW and wxOSX implemented.
+//
+// Default is 1
+//
+// Recommended setting: 1 (but may be safely disabled if you don't use it)
+
+#define wxUSE_SPELLCHECK   1
+
 // Use wxStandardPaths class which allows to retrieve some standard locations
 // in the file system
 //

--- a/include/wx/osx/setup0.h
+++ b/include/wx/osx/setup0.h
@@ -469,6 +469,15 @@
 // Recommended setting: 1 (but may be safely disabled if you don't use it)
 #define wxUSE_SECRETSTORE   1
 
+// Allow the use of the OS built-in spellchecker on wxTextCtrl (multiline
+// only). Currently wxGTK, wxMSW and wxOSX implemented.
+//
+// Default is 1
+//
+// Recommended setting: 1 (but may be safely disabled if you don't use it)
+
+#define wxUSE_SPELLCHECK   1
+
 // Use wxStandardPaths class which allows to retrieve some standard locations
 // in the file system
 //

--- a/include/wx/setup_inc.h
+++ b/include/wx/setup_inc.h
@@ -459,6 +459,15 @@
 // Recommended setting: 1 (but may be safely disabled if you don't use it)
 #define wxUSE_SECRETSTORE   1
 
+// Allow the use of the OS built-in spellchecker on wxTextCtrl (multiline
+// only). Currently wxGTK, wxMSW and wxOSX implemented.
+//
+// Default is 1
+//
+// Recommended setting: 1 (but may be safely disabled if you don't use it)
+
+#define wxUSE_SPELLCHECK   1
+
 // Use wxStandardPaths class which allows to retrieve some standard locations
 // in the file system
 //

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -270,6 +270,18 @@ enum wxTextAttrLineSpacing
     wxTEXT_ATTR_LINE_SPACING_TWICE          = 20
 };
 
+#if wxUSE_SPELLCHECK
+/*!
+ * Spellcheck status values
+ */
+enum wxTextSpellcheckStatus
+{
+    wxTEXT_SPELLCHECK_NOT_AVAILABLE,
+    wxTEXT_SPELLCHECK_ERROR,
+    wxTEXT_SPELLCHECK_OK
+};
+#endif // wxUSE_SPELLCHECK
+
 // ----------------------------------------------------------------------------
 // wxTextAttr: a structure containing the visual attributes of a text
 // ----------------------------------------------------------------------------
@@ -741,6 +753,12 @@ public:
     {
         return GetCompositeControlsDefaultAttributes(variant);
     }
+
+#if wxUSE_SPELLCHECK    
+    // Use native spelling and grammer checking functions.
+    virtual wxTextSpellcheckStatus EnableSpellcheck(const bool enable) = 0;
+    virtual bool IsSpellcheckEnabled() = 0;
+#endif // wxUSE_SPELLCHECK
 
 protected:
     // Override wxEvtHandler method to check for a common problem of binding

--- a/include/wx/univ/setup0.h
+++ b/include/wx/univ/setup0.h
@@ -462,6 +462,15 @@
 // Recommended setting: 1 (but may be safely disabled if you don't use it)
 #define wxUSE_SECRETSTORE   1
 
+// Allow the use of the OS built-in spellchecker on wxTextCtrl (multiline
+// only). Currently wxGTK, wxMSW and wxOSX implemented.
+//
+// Default is 1
+//
+// Recommended setting: 1 (but may be safely disabled if you don't use it)
+
+#define wxUSE_SPELLCHECK   1
+
 // Use wxStandardPaths class which allows to retrieve some standard locations
 // in the file system
 //

--- a/samples/text/text.cpp
+++ b/samples/text/text.cpp
@@ -142,6 +142,9 @@ public:
     MyTextCtrl    *m_password;
     MyTextCtrl    *m_enter;
     MyTextCtrl    *m_tab;
+#if wxUSE_SPELLCHECK
+    MyTextCtrl    *m_spell;
+#endif // wxUSE_SPELLCHECK
     MyTextCtrl    *m_readonly;
     MyTextCtrl    *m_limited;
 
@@ -1204,6 +1207,14 @@ MyPanel::MyPanel( wxFrame *frame, int x, int y, int w, int h )
       wxPoint(180,170), wxSize(200,70), wxTE_MULTILINE | wxTE_PROCESS_ENTER );
     m_enter->SetClientData((void *)wxT("enter"));
 
+#if wxUSE_SPELLCHECK    
+    m_spell = new MyTextCtrl(this, 100, wxT("Multiline, spellcheck enabled."),
+    wxPoint(180,270), wxSize(200,70), wxTE_MULTILINE);
+    wxASSERT(m_spell->EnableSpellcheck(true) != wxTEXT_SPELLCHECK_ERROR);
+    wxASSERT(m_spell->IsSpellcheckEnabled());
+    m_spell->SetClientData((void *)wxT("spell"));
+#endif
+
     m_textrich = new MyTextCtrl(this, wxID_ANY, wxT("Allows more than 30Kb of text\n")
                                 wxT("(on all Windows versions)\n")
                                 wxT("and a very very very very very ")
@@ -1241,8 +1252,10 @@ MyPanel::MyPanel( wxFrame *frame, int x, int y, int w, int h )
     wxBoxSizer *column2 = new wxBoxSizer(wxVERTICAL);
     column2->Add( m_multitext, 1, wxALL | wxEXPAND, 10 );
     column2->Add( m_tab, 0, wxALL | wxEXPAND, 10 );
-    column2->Add( m_enter, 1, wxALL | wxEXPAND, 10 );
-
+    column2->Add( m_enter, 0, wxALL | wxEXPAND, 10 );
+#if wxUSE_SPELLCHECK
+    column2->Add( m_spell, 1, wxALL | wxEXPAND, 10 );
+#endif
     wxBoxSizer *row1 = new wxBoxSizer(wxHORIZONTAL);
     row1->Add( column1, 0, wxALL | wxEXPAND, 10 );
     row1->Add( column2, 1, wxALL | wxEXPAND, 10 );

--- a/setup.h.in
+++ b/setup.h.in
@@ -239,6 +239,9 @@
 
 #define wxUSE_SECRETSTORE   0
 
+
+#define wxUSE_SPELLCHECK   0
+
 #define wxUSE_STDPATHS      0
 
 #define wxUSE_TEXTBUFFER    0

--- a/src/stc/stc.cpp
+++ b/src/stc/stc.cpp
@@ -224,9 +224,8 @@ bool wxStyledTextCtrl::Create(wxWindow *parent,
     // STC doesn't support RTL languages at all
     SetLayoutDirection(wxLayout_LeftToRight);
 
-    // Rely on native double buffering by default, except under Mac where it
-    // doesn't work for some reason, see #18085.
-#if wxALWAYS_NATIVE_DOUBLE_BUFFER && !defined(__WXMAC__)
+    // Rely on native double buffering by default.
+#if wxALWAYS_NATIVE_DOUBLE_BUFFER
     SetBufferedDraw(false);
 #else
     SetBufferedDraw(true);


### PR DESCRIPTION
This is an initial commit to test the GitHub PR workflow, however it should be possible to build under Linux and run the samples/text demo to see mispelled words.

Edit: Please see wxTrac ticket https://trac.wxwidgets.org/ticket/17544 for background to this PR.