### PR TITLE
Fixes to wx container iterators to conform to iterator concept

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -64,6 +64,14 @@ Changes in behaviour which may result in build errors
   wxGraphicsContext::CreatePen() continues to compile and work as before.
 
 
+3.1.2: (released 2018-??-??)
+----------------------------
+
+All:
+
+- Make wxList iterators conform to input iterator requirements.
+
+
 3.1.1: (released 2018-02-19)
 ----------------------------
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -69,7 +69,7 @@ Changes in behaviour which may result in build errors
 
 All:
 
-- Make wxList iterators conform to input iterator requirements.
+- Make wxList and wxVector iterators conform to input iterator requirements.
 
 
 3.1.1: (released 2018-02-19)

--- a/include/wx/list.h
+++ b/include/wx/list.h
@@ -599,6 +599,17 @@ private:
 // macros for definition of "template" list type
 // -----------------------------------------------------------------------------
 
+// Helper macro defining common iterator typedefs
+#if wxUSE_STD_CONTAINERS_COMPATIBLY
+    #include <iterator>
+
+    #define WX_DECLARE_LIST_ITER_DIFF_AND_CATEGORY()                          \
+        typedef std::ptrdiff_t difference_type;                               \
+        typedef std::bidirectional_iterator_tag iterator_category;
+#else
+    #define WX_DECLARE_LIST_ITER_DIFF_AND_CATEGORY()
+#endif
+
 // and now some heavy magic...
 
 // declare a list type named 'name' and containing elements of type 'T *'
@@ -762,15 +773,19 @@ private:
         classexp iterator                                                   \
         {                                                                   \
         public:                                                             \
+            WX_DECLARE_LIST_ITER_DIFF_AND_CATEGORY()                        \
+            typedef T* value_type;                                          \
+            typedef value_type* pointer;                                    \
+            typedef value_type& reference;                                  \
+                                                                            \
             typedef nodetype Node;                                          \
             typedef iterator itor;                                          \
-            typedef T* value_type;                                          \
             typedef value_type* ptr_type;                                   \
-            typedef value_type& reference;                                  \
                                                                             \
             Node* m_node;                                                   \
             Node* m_init;                                                   \
         public:                                                             \
+            /* Compatibility typedefs, don't use */                         \
             typedef reference reference_type;                               \
             typedef ptr_type pointer_type;                                  \
                                                                             \
@@ -811,8 +826,12 @@ private:
         classexp const_iterator                                             \
         {                                                                   \
         public:                                                             \
-            typedef nodetype Node;                                          \
+            WX_DECLARE_LIST_ITER_DIFF_AND_CATEGORY()                        \
             typedef T* value_type;                                          \
+            typedef const value_type* pointer;                              \
+            typedef const value_type& reference;                            \
+                                                                            \
+            typedef nodetype Node;                                          \
             typedef const value_type& const_reference;                      \
             typedef const_iterator itor;                                    \
             typedef value_type* ptr_type;                                   \
@@ -863,11 +882,14 @@ private:
         classexp reverse_iterator                                           \
         {                                                                   \
         public:                                                             \
-            typedef nodetype Node;                                          \
+            WX_DECLARE_LIST_ITER_DIFF_AND_CATEGORY()                        \
             typedef T* value_type;                                          \
+            typedef value_type* pointer;                                    \
+            typedef value_type& reference;                                  \
+                                                                            \
+            typedef nodetype Node;                                          \
             typedef reverse_iterator itor;                                  \
             typedef value_type* ptr_type;                                   \
-            typedef value_type& reference;                                  \
                                                                             \
             Node* m_node;                                                   \
             Node* m_init;                                                   \
@@ -901,8 +923,12 @@ private:
         classexp const_reverse_iterator                                     \
         {                                                                   \
         public:                                                             \
-            typedef nodetype Node;                                          \
+            WX_DECLARE_LIST_ITER_DIFF_AND_CATEGORY()                        \
             typedef T* value_type;                                          \
+            typedef const value_type* pointer;                              \
+            typedef const value_type& reference;                            \
+                                                                            \
+            typedef nodetype Node;                                          \
             typedef const_reverse_iterator itor;                            \
             typedef value_type* ptr_type;                                   \
             typedef const value_type& const_reference;                      \

--- a/include/wx/list.h
+++ b/include/wx/list.h
@@ -780,14 +780,13 @@ private:
                                                                             \
             typedef nodetype Node;                                          \
             typedef iterator itor;                                          \
-            typedef value_type* ptr_type;                                   \
                                                                             \
             Node* m_node;                                                   \
             Node* m_init;                                                   \
         public:                                                             \
             /* Compatibility typedefs, don't use */                         \
             typedef reference reference_type;                               \
-            typedef ptr_type pointer_type;                                  \
+            typedef pointer pointer_type;                                   \
                                                                             \
             iterator(Node* node, Node* init) : m_node(node), m_init(init) {}\
             iterator() : m_node(NULL), m_init(NULL) { }                     \
@@ -834,13 +833,12 @@ private:
             typedef nodetype Node;                                          \
             typedef const value_type& const_reference;                      \
             typedef const_iterator itor;                                    \
-            typedef value_type* ptr_type;                                   \
                                                                             \
             Node* m_node;                                                   \
             Node* m_init;                                                   \
         public:                                                             \
-            typedef const_reference reference_type;                         \
-            typedef const ptr_type pointer_type;                            \
+            typedef reference reference_type;                               \
+            typedef pointer pointer_type;                                   \
                                                                             \
             const_iterator(Node* node, Node* init)                          \
                 : m_node(node), m_init(init) { }                            \
@@ -889,13 +887,12 @@ private:
                                                                             \
             typedef nodetype Node;                                          \
             typedef reverse_iterator itor;                                  \
-            typedef value_type* ptr_type;                                   \
                                                                             \
             Node* m_node;                                                   \
             Node* m_init;                                                   \
         public:                                                             \
             typedef reference reference_type;                               \
-            typedef ptr_type pointer_type;                                  \
+            typedef pointer pointer_type;                                   \
                                                                             \
             reverse_iterator(Node* node, Node* init)                        \
                 : m_node(node), m_init(init) { }                            \
@@ -930,14 +927,13 @@ private:
                                                                             \
             typedef nodetype Node;                                          \
             typedef const_reverse_iterator itor;                            \
-            typedef value_type* ptr_type;                                   \
             typedef const value_type& const_reference;                      \
                                                                             \
             Node* m_node;                                                   \
             Node* m_init;                                                   \
         public:                                                             \
-            typedef const_reference reference_type;                         \
-            typedef const ptr_type pointer_type;                            \
+            typedef reference reference_type;                               \
+            typedef pointer pointer_type;                                   \
                                                                             \
             const_reverse_iterator(Node* node, Node* init)                  \
                 : m_node(node), m_init(init) { }                            \

--- a/include/wx/list.h
+++ b/include/wx/list.h
@@ -831,7 +831,6 @@ private:
             typedef const value_type& reference;                            \
                                                                             \
             typedef nodetype Node;                                          \
-            typedef const value_type& const_reference;                      \
             typedef const_iterator itor;                                    \
                                                                             \
             Node* m_node;                                                   \
@@ -927,7 +926,6 @@ private:
                                                                             \
             typedef nodetype Node;                                          \
             typedef const_reverse_iterator itor;                            \
-            typedef const value_type& const_reference;                      \
                                                                             \
             Node* m_node;                                                   \
             Node* m_init;                                                   \

--- a/include/wx/list.h
+++ b/include/wx/list.h
@@ -761,7 +761,6 @@ private:
                                                                             \
         classexp iterator                                                   \
         {                                                                   \
-            typedef name list;                                              \
         public:                                                             \
             typedef nodetype Node;                                          \
             typedef iterator itor;                                          \
@@ -811,7 +810,6 @@ private:
         };                                                                  \
         classexp const_iterator                                             \
         {                                                                   \
-            typedef name list;                                              \
         public:                                                             \
             typedef nodetype Node;                                          \
             typedef T* value_type;                                          \
@@ -864,7 +862,6 @@ private:
         };                                                                  \
         classexp reverse_iterator                                           \
         {                                                                   \
-            typedef name list;                                              \
         public:                                                             \
             typedef nodetype Node;                                          \
             typedef T* value_type;                                          \
@@ -903,7 +900,6 @@ private:
         };                                                                  \
         classexp const_reverse_iterator                                     \
         {                                                                   \
-            typedef name list;                                              \
         public:                                                             \
             typedef nodetype Node;                                          \
             typedef T* value_type;                                          \

--- a/include/wx/vector.h
+++ b/include/wx/vector.h
@@ -33,6 +33,9 @@ inline void wxVectorSort(wxVector<T>& v)
 #include "wx/meta/if.h"
 
 #include "wx/beforestd.h"
+#if wxUSE_STD_CONTAINERS_COMPATIBLY
+#include <iterator>
+#endif
 #include <new> // for placement new
 #include "wx/afterstd.h"
 
@@ -172,6 +175,14 @@ public:
     class reverse_iterator
     {
     public:
+#if wxUSE_STD_CONTAINERS_COMPATIBLY
+        typedef std::random_access_iterator_tag iterator_category;
+#endif
+        typedef ptrdiff_t difference_type;
+        typedef T value_type;
+        typedef value_type* pointer;
+        typedef value_type& reference;
+
         reverse_iterator() : m_ptr(NULL) { }
         explicit reverse_iterator(iterator it) : m_ptr(it) { }
         reverse_iterator(const reverse_iterator& it) : m_ptr(it.m_ptr) { }
@@ -218,6 +229,14 @@ public:
     class const_reverse_iterator
     {
     public:
+#if wxUSE_STD_CONTAINERS_COMPATIBLY
+        typedef std::random_access_iterator_tag iterator_category;
+#endif
+        typedef ptrdiff_t difference_type;
+        typedef T value_type;
+        typedef const value_type* pointer;
+        typedef const value_type& reference;
+
         const_reverse_iterator() : m_ptr(NULL) { }
         explicit const_reverse_iterator(const_iterator it) : m_ptr(it) { }
         const_reverse_iterator(const reverse_iterator& it) : m_ptr(it.m_ptr) { }

--- a/include/wx/vector.h
+++ b/include/wx/vector.h
@@ -160,7 +160,7 @@ private:
 
 public:
     typedef size_t size_type;
-    typedef size_t difference_type;
+    typedef ptrdiff_t difference_type;
     typedef T value_type;
     typedef value_type* pointer;
     typedef const value_type* const_pointer;

--- a/tests/lists/lists.cpp
+++ b/tests/lists/lists.cpp
@@ -210,3 +210,27 @@ void ListsTestCase::wxListCtorTest()
     CPPUNIT_ASSERT( Baz::GetNumber() == 0 );
 }
 
+#if wxUSE_STD_CONTAINERS_COMPATIBLY
+
+#include <list>
+
+// Check that we convert wxList to std::list using the latter's ctor taking 2
+// iterators: this used to be broken in C++11 because wxList iterators didn't
+// fully implement input iterator requirements.
+TEST_CASE("wxList::iterator", "[list][std][iterator]")
+{
+    Baz baz1("one"),
+        baz2("two");
+
+    wxListBazs li;
+    li.push_back(&baz1);
+    li.push_back(&baz2);
+
+    std::list<Baz*> stdli(li.begin(), li.end());
+    CHECK( stdli.size() == 2 );
+
+    const wxListBazs cli;
+    CHECK( std::list<Baz*>(cli.begin(), cli.end()).empty() );
+}
+
+#endif // wxUSE_STD_CONTAINERS_COMPATIBLY

--- a/tests/vectors/vectors.cpp
+++ b/tests/vectors/vectors.cpp
@@ -22,6 +22,10 @@
 
 #include "wx/vector.h"
 
+#if wxUSE_STD_CONTAINERS_COMPATIBLY
+    #include <vector>
+#endif // wxUSE_STD_CONTAINERS_COMPATIBLY
+
 // ----------------------------------------------------------------------------
 // simple class capable of detecting leaks of its objects
 // ----------------------------------------------------------------------------
@@ -360,6 +364,13 @@ TEST_CASE("wxVector::reverse_iterator", "[vector][reverse_iterator]")
     ri = rb + 2;
     CHECK( ri - rb == 2 );
     CHECK( re - ri == 8 );
+
+#if wxUSE_STD_CONTAINERS_COMPATIBLY
+    std::vector<int> stdvec(rb, re);
+    REQUIRE( stdvec.size() == 10 );
+    CHECK( stdvec[0] == 10 );
+    CHECK( stdvec[9] == 1 );
+#endif // wxUSE_STD_CONTAINERS_COMPATIBLY
 }
 
 TEST_CASE("wxVector::capacity", "[vector][capacity][shrink_to_fit]")


### PR DESCRIPTION
Neither wxList nor wxVector (reverse) iterators were not iterators at all, from C++ point of view -- fix this to allow using them with ctors taking iterators in C++11.