### PR TITLE
Add wxFILTER_SPACE to wxTextValidator and document its usage

### DIFF
--- a/interface/wx/valtext.h
+++ b/interface/wx/valtext.h
@@ -62,7 +62,13 @@ enum wxTextValidatorStyle
     /// Use an exclude list. The validator checks if each input character is
     /// in the list (one character per list element), complaining if it is.
     /// See wxTextValidator::SetCharExcludes().
-    wxFILTER_EXCLUDE_CHAR_LIST
+    wxFILTER_EXCLUDE_CHAR_LIST,
+
+    /// Do not filter out spaces and tabs.
+    /// more useful if used in conjunction with @c wxFILTER_ALPHANUMERIC
+    /// @c wxFILTER_ALPHA or @c wxFILTER_DIGITS to allow spaces to be entered
+    /// with the accepted characters.
+    wxFILTER_SPACE
 };
 
 /**


### PR DESCRIPTION
When validating texts that are essentially alphanumeric or alpha characters only,
chances are that you want spaces to be accepted rather than rejected as invalid
characters (e.g  because spaces make part of a name). 

So for the sake of ease of use and convenience, we add wxFILTER_SPACE flag to 
allow just this rather than resorting to the more verbose wxFILTER_INCLUDE_CHAR_LIST
which is not i18n friendlier at all.