### PR TITLE
Add wxFILTER_SPACE to wxTextValidator and document its usage

### DIFF
--- a/include/wx/valtext.h
+++ b/include/wx/valtext.h
@@ -31,7 +31,8 @@ enum wxTextValidatorStyle
     wxFILTER_INCLUDE_LIST = 0x40,
     wxFILTER_INCLUDE_CHAR_LIST = 0x80,
     wxFILTER_EXCLUDE_LIST = 0x100,
-    wxFILTER_EXCLUDE_CHAR_LIST = 0x200
+    wxFILTER_EXCLUDE_CHAR_LIST = 0x200,
+    wxFILTER_SPACE = 0x400
 };
 
 class WXDLLIMPEXP_CORE wxTextValidator: public wxValidator

--- a/interface/wx/valtext.h
+++ b/interface/wx/valtext.h
@@ -62,7 +62,13 @@ enum wxTextValidatorStyle
     /// Use an exclude list. The validator checks if each input character is
     /// in the list (one character per list element), complaining if it is.
     /// See wxTextValidator::SetCharExcludes().
-    wxFILTER_EXCLUDE_CHAR_LIST
+    wxFILTER_EXCLUDE_CHAR_LIST,
+
+    /// Do not filter out spaces and tabs.
+    /// more useful if used in conjunction with @c wxFILTER_ALPHANUMERIC
+    /// @c wxFILTER_ALPHA or @c wxFILTER_DIGITS to allow spaces to be entered
+    /// along with the accepted characters.
+    wxFILTER_SPACE
 };
 
 /**

--- a/src/common/valtext.cpp
+++ b/src/common/valtext.cpp
@@ -223,11 +223,28 @@ bool wxTextValidator::TransferFromWindow()
 namespace
 {
 
-bool CheckString(bool (*func)(const wxUniChar&), const wxString& str)
+template<bool Allow>
+bool IsSpacesAllowed(const wxUniChar& c)
+{
+    return wxIsspace(c);
+}
+
+template<>
+bool IsSpacesAllowed<false>(const wxUniChar&)
+{
+    return false;
+}
+
+typedef bool (*Func)(const wxUniChar&);
+
+// Relax wxFILTER_ALPHA, wxFILTER_ALPHANUMERIC and wxFILTER_DIGITS
+// filters by allowing spaces too if the user explicitly want them
+// thanks to wxFILTER_SPACE. (Spaces are checked by func2).
+bool CheckString(Func func, const wxString& str, Func func2)
 {
     for ( wxString::const_iterator i = str.begin(); i != str.end(); ++i )
     {
-        if ( !func(*i) )
+        if ( !func(*i) && !func2(*i) )
             return false;
     }
 
@@ -242,11 +259,15 @@ wxString wxTextValidator::IsValid(const wxString& val) const
 
     if ( HasFlag(wxFILTER_ASCII) && !val.IsAscii() )
         return _("'%s' should only contain ASCII characters.");
-    if ( HasFlag(wxFILTER_ALPHA) && !CheckString(wxIsalpha, val) )
+    
+    Func func2 = HasFlag(wxFILTER_SPACE) ? 
+        IsSpacesAllowed<true> : IsSpacesAllowed<false>;
+
+    if ( HasFlag(wxFILTER_ALPHA) && !CheckString(wxIsalpha, val, func2) )
         return _("'%s' should only contain alphabetic characters.");
-    if ( HasFlag(wxFILTER_ALPHANUMERIC) && !CheckString(wxIsalnum, val) )
+    if ( HasFlag(wxFILTER_ALPHANUMERIC) && !CheckString(wxIsalnum, val, func2) )
         return _("'%s' should only contain alphabetic or numeric characters.");
-    if ( HasFlag(wxFILTER_DIGITS) && !CheckString(wxIsdigit, val) )
+    if ( HasFlag(wxFILTER_DIGITS) && !CheckString(wxIsdigit, val, func2) )
         return _("'%s' should only contain digits.");
     if ( HasFlag(wxFILTER_NUMERIC) && !wxIsNumeric(val) )
         return _("'%s' should be numeric.");


### PR DESCRIPTION
When validating texts that are essentially alphanumeric or alpha characters only,
chances are that you want spaces to be accepted rather than rejected as invalid
characters (e.g  because spaces make part of a name). 

So for the sake of ease of use and convenience, we add wxFILTER_SPACE flag to 
allow just this rather than resorting to the more verbose wxFILTER_INCLUDE_CHAR_LIST
which is not i18n friendlier at all.