### PR TITLE
Fix gcc7 conversion warnings and some fixes to geometry classes

### DIFF
--- a/include/wx/gdicmn.h
+++ b/include/wx/gdicmn.h
@@ -318,7 +318,7 @@ public:
     void DecBy(int d) { DecBy(d, d); }
 
 
-    wxSize& Scale(float xscale, float yscale)
+    wxSize& Scale(double xscale, double yscale)
         { x = (int)(x*xscale); y = (int)(y*yscale); return *this; }
 
     // accessors

--- a/include/wx/gdicmn.h
+++ b/include/wx/gdicmn.h
@@ -292,8 +292,8 @@ public:
     wxSize& operator*=(long i) { x *= i; y *= i; return *this; }
     wxSize& operator/=(unsigned long i) { x /= i; y /= i; return *this; }
     wxSize& operator*=(unsigned long i) { x *= i; y *= i; return *this; }
-    wxSize& operator/=(double i) { x = int(x/i); y = int(y/i); return *this; }
-    wxSize& operator*=(double i) { x = int(x*i); y = int(y*i); return *this; }
+    wxSize& operator/=(double i) { x = wxRound(x/i); y = wxRound(y/i); return *this; }
+    wxSize& operator*=(double i) { x = wxRound(x*i); y = wxRound(y*i); return *this; }
 
     void IncTo(const wxSize& sz)
         { if ( sz.x > x ) x = sz.x; if ( sz.y > y ) y = sz.y; }
@@ -319,7 +319,7 @@ public:
 
 
     wxSize& Scale(double xscale, double yscale)
-        { x = (int)(x*xscale); y = (int)(y*yscale); return *this; }
+        { x = wxRound(x*xscale); y = wxRound(y*yscale); return *this; }
 
     // accessors
     void Set(int xx, int yy) { x = xx; y = yy; }
@@ -428,12 +428,12 @@ inline wxSize operator*(unsigned long i, const wxSize& s)
 
 inline wxSize operator*(const wxSize& s, double i)
 {
-    return wxSize(int(s.x * i), int(s.y * i));
+    return wxSize(wxRound(s.x * i), wxRound(s.y * i));
 }
 
 inline wxSize operator*(double i, const wxSize& s)
 {
-    return wxSize(int(s.x * i), int(s.y * i));
+    return wxSize(wxRound(s.x * i), wxRound(s.y * i));
 }
 
 
@@ -567,7 +567,7 @@ public:
 
     wxPoint() : x(0), y(0) { }
     wxPoint(int xx, int yy) : x(xx), y(yy) { }
-    wxPoint(const wxRealPoint& pt) : x(int(pt.x)), y(int(pt.y)) { }
+    wxPoint(const wxRealPoint& pt) : x(wxRound(pt.x)), y(wxRound(pt.y)) { }
 
     // no copy ctor or assignment operator - the defaults are ok
 

--- a/include/wx/gdicmn.h
+++ b/include/wx/gdicmn.h
@@ -547,12 +547,12 @@ inline wxRealPoint operator*(unsigned long i, const wxRealPoint& s)
 
 inline wxRealPoint operator*(const wxRealPoint& s, double i)
 {
-    return wxRealPoint(int(s.x * i), int(s.y * i));
+    return wxRealPoint(s.x * i, s.y * i);
 }
 
 inline wxRealPoint operator*(double i, const wxRealPoint& s)
 {
-    return wxRealPoint(int(s.x * i), int(s.y * i));
+    return wxRealPoint(s.x * i, s.y * i);
 }
 
 

--- a/include/wx/unichar.h
+++ b/include/wx/unichar.h
@@ -93,14 +93,14 @@ public:
     static wxUint16 HighSurrogate(wxUint32 value)
     {
         wxASSERT_MSG(IsSupplementary(value), "wxUniChar::HighSurrogate() must be called on a supplementary character");
-        return 0xD800 | ((value - 0x10000) >> 10);
+        return static_cast<wxUint16>(0xD800 | ((value - 0x10000) >> 10));
     }
 
     // Returns the low surrogate code unit for the supplementary character
     static wxUint16 LowSurrogate(wxUint32 value)
     {
         wxASSERT_MSG(IsSupplementary(value), "wxUniChar::LowSurrogate() must be called on a supplementary character");
-        return 0xDC00 | ((value - 0x10000) & 0x03FF);
+        return static_cast<wxUint16>(0xDC00 | ((value - 0x10000) & 0x03FF));
     }
 
     // Returns true if the character is a BMP character:

--- a/interface/wx/gdicmn.h
+++ b/interface/wx/gdicmn.h
@@ -1014,7 +1014,7 @@ public:
         @return A reference to this object (so that you can concatenate other
                  operations in the same line).
     */
-    wxSize& Scale(float xscale, float yscale);
+    wxSize& Scale(double xscale, double yscale);
 
     /**
         Sets the width and height members.


### PR DESCRIPTION
This started as an attempt to make it possible to compile code including wx headers with `-Wconversion` cleanly, but I also found a bug (in `wxRealPoint`) and what I think is a bug (in `wxPoint` and `wxSize`) and fixed them too while I was at it.