### PR TITLE
Add more wxOVERRIDE, fix some build warnings

### DIFF
--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -1893,7 +1893,7 @@ public:
     bool IsGestureEnd() const { return m_isEnd; }
     void SetGestureEnd(bool isEnd = true) { m_isEnd = isEnd; }
 
-    virtual wxEvent *Clone() const { return new wxGestureEvent(*this); }
+    virtual wxEvent *Clone() const wxOVERRIDE { return new wxGestureEvent(*this); }
 
 protected:
     wxPoint m_pos;
@@ -1926,7 +1926,7 @@ public:
     wxPoint GetDelta() const { return m_delta; }
     void SetDelta(const wxPoint& delta) { m_delta = delta; }
 
-    virtual wxEvent *Clone() const { return new wxPanGestureEvent(*this); }
+    virtual wxEvent *Clone() const wxOVERRIDE { return new wxPanGestureEvent(*this); }
 
 private:
     wxPoint m_delta;
@@ -1955,7 +1955,7 @@ public:
     double GetZoomFactor() const { return m_zoomFactor; }
     void SetZoomFactor(double zoomFactor) { m_zoomFactor = zoomFactor; }
 
-    virtual wxEvent *Clone() const { return new wxZoomGestureEvent(*this); }
+    virtual wxEvent *Clone() const wxOVERRIDE { return new wxZoomGestureEvent(*this); }
 
 private:
     double m_zoomFactor;
@@ -1984,7 +1984,7 @@ public:
     double GetRotationAngle() const { return m_rotationAngle; }
     void SetRotationAngle(double rotationAngle) { m_rotationAngle = rotationAngle; }
 
-    virtual wxEvent *Clone() const { return new wxRotateGestureEvent(*this); }
+    virtual wxEvent *Clone() const wxOVERRIDE { return new wxRotateGestureEvent(*this); }
 
 private:
     double m_rotationAngle;
@@ -2008,7 +2008,7 @@ public:
     wxTwoFingerTapEvent(const wxTwoFingerTapEvent& event) : wxGestureEvent(event)
     { }
 
-    virtual wxEvent *Clone() const { return new wxTwoFingerTapEvent(*this); }
+    virtual wxEvent *Clone() const wxOVERRIDE { return new wxTwoFingerTapEvent(*this); }
 
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(wxTwoFingerTapEvent);
@@ -2030,7 +2030,7 @@ public:
     wxLongPressEvent(const wxLongPressEvent& event) : wxGestureEvent(event)
     { }
 
-    virtual wxEvent *Clone() const { return new wxLongPressEvent(*this); }
+    virtual wxEvent *Clone() const wxOVERRIDE { return new wxLongPressEvent(*this); }
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(wxLongPressEvent);
 };
@@ -2051,7 +2051,7 @@ public:
     wxPressAndTapEvent(const wxPressAndTapEvent& event) : wxGestureEvent(event)
     { }
 
-    virtual wxEvent *Clone() const { return new wxPressAndTapEvent(*this); }
+    virtual wxEvent *Clone() const wxOVERRIDE { return new wxPressAndTapEvent(*this); }
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(wxPressAndTapEvent);
 };

--- a/include/wx/propgrid/props.h
+++ b/include/wx/propgrid/props.h
@@ -746,9 +746,9 @@ public: \
               const wxArrayString& value = wxArrayString() ); \
     ~PROPNAME(); \
     virtual bool OnEvent( wxPropertyGrid* propgrid, \
-                          wxWindow* primary, wxEvent& event ); \
-    virtual bool OnCustomStringEdit( wxWindow* parent, wxString& value ); \
-    virtual wxValidator* DoGetValidator() const; \
+                          wxWindow* primary, wxEvent& event ) wxOVERRIDE; \
+    virtual bool OnCustomStringEdit( wxWindow* parent, wxString& value ) wxOVERRIDE; \
+    virtual wxValidator* DoGetValidator() const wxOVERRIDE; \
 };
 
 #define WX_PG_DECLARE_ARRAYSTRING_PROPERTY_WITH_VALIDATOR(PROPNAM) \

--- a/include/wx/sckaddr.h
+++ b/include/wx/sckaddr.h
@@ -159,14 +159,14 @@ public:
     wxIPV6address(const wxIPV6address& other) : wxIPaddress(other) { }
 
     // implement wxSockAddress pure virtuals:
-    virtual Family Type() { return IPV6; }
-    virtual wxSockAddress *Clone() const { return new wxIPV6address(*this); }
+    virtual Family Type() wxOVERRIDE { return IPV6; }
+    virtual wxSockAddress *Clone() const wxOVERRIDE { return new wxIPV6address(*this); }
 
 
     // implement wxIPaddress pure virtuals:
-    virtual bool IsLocalHost() const;
+    virtual bool IsLocalHost() const wxOVERRIDE;
 
-    virtual wxString IPAddress() const;
+    virtual wxString IPAddress() const wxOVERRIDE;
 
     // IPv6-specific methods:
     bool Hostname(unsigned char addr[16]);
@@ -174,7 +174,7 @@ public:
     using wxIPaddress::Hostname;
 
 private:
-    virtual void DoInitImpl();
+    virtual void DoInitImpl() wxOVERRIDE;
 
     wxDECLARE_DYNAMIC_CLASS(wxIPV6address);
 };

--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -2079,35 +2079,35 @@ public:
 
         // Can return either a child object, or an integer
         // representing the child element, starting from 1.
-    virtual wxAccStatus HitTest(const wxPoint& pt, int* childId, wxAccessible** childObject);
+    virtual wxAccStatus HitTest(const wxPoint& pt, int* childId, wxAccessible** childObject) wxOVERRIDE;
 
         // Returns the rectangle for this object (id = 0) or a child element (id > 0).
-    virtual wxAccStatus GetLocation(wxRect& rect, int elementId);
+    virtual wxAccStatus GetLocation(wxRect& rect, int elementId) wxOVERRIDE;
 
         // Navigates from fromId to toId/toObject.
     virtual wxAccStatus Navigate(wxNavDir navDir, int fromId,
-                int* toId, wxAccessible** toObject);
+                int* toId, wxAccessible** toObject) wxOVERRIDE;
 
         // Gets the name of the specified object.
-    virtual wxAccStatus GetName(int childId, wxString* name);
+    virtual wxAccStatus GetName(int childId, wxString* name) wxOVERRIDE;
 
         // Gets the number of children.
-    virtual wxAccStatus GetChildCount(int* childCount);
+    virtual wxAccStatus GetChildCount(int* childCount) wxOVERRIDE;
 
         // Gets the specified child (starting from 1).
         // If *child is NULL and return value is wxACC_OK,
         // this means that the child is a simple element and
         // not an accessible object.
-    virtual wxAccStatus GetChild(int childId, wxAccessible** child);
+    virtual wxAccStatus GetChild(int childId, wxAccessible** child) wxOVERRIDE;
 
         // Gets the parent, or NULL.
-    virtual wxAccStatus GetParent(wxAccessible** parent);
+    virtual wxAccStatus GetParent(wxAccessible** parent) wxOVERRIDE;
 
         // Performs the default action. childId is 0 (the action for this object)
         // or > 0 (the action for a child).
         // Return wxACC_NOT_SUPPORTED if there is no default action for this
         // window (e.g. an edit control).
-    virtual wxAccStatus DoDefaultAction(int childId);
+    virtual wxAccStatus DoDefaultAction(int childId) wxOVERRIDE;
 
         // Gets the default action for this object (0) or > 0 (the action for a child).
         // Return wxACC_OK even if there is no action. actionName is the action, or the empty
@@ -2115,36 +2115,36 @@ public:
         // The retrieved string describes the action that is performed on an object,
         // not what the object does as a result. For example, a toolbar button that prints
         // a document has a default action of "Press" rather than "Prints the current document."
-    virtual wxAccStatus GetDefaultAction(int childId, wxString* actionName);
+    virtual wxAccStatus GetDefaultAction(int childId, wxString* actionName) wxOVERRIDE;
 
         // Returns the description for this object or a child.
-    virtual wxAccStatus GetDescription(int childId, wxString* description);
+    virtual wxAccStatus GetDescription(int childId, wxString* description) wxOVERRIDE;
 
         // Returns help text for this object or a child, similar to tooltip text.
-    virtual wxAccStatus GetHelpText(int childId, wxString* helpText);
+    virtual wxAccStatus GetHelpText(int childId, wxString* helpText) wxOVERRIDE;
 
         // Returns the keyboard shortcut for this object or child.
         // Return e.g. ALT+K
-    virtual wxAccStatus GetKeyboardShortcut(int childId, wxString* shortcut);
+    virtual wxAccStatus GetKeyboardShortcut(int childId, wxString* shortcut) wxOVERRIDE;
 
         // Returns a role constant.
-    virtual wxAccStatus GetRole(int childId, wxAccRole* role);
+    virtual wxAccStatus GetRole(int childId, wxAccRole* role) wxOVERRIDE;
 
         // Returns a state constant.
-    virtual wxAccStatus GetState(int childId, long* state);
+    virtual wxAccStatus GetState(int childId, long* state) wxOVERRIDE;
 
         // Returns a localized string representing the value for the object
         // or child.
-    virtual wxAccStatus GetValue(int childId, wxString* strValue);
+    virtual wxAccStatus GetValue(int childId, wxString* strValue) wxOVERRIDE;
 
         // Selects the object or child.
-    virtual wxAccStatus Select(int childId, wxAccSelectionFlags selectFlags);
+    virtual wxAccStatus Select(int childId, wxAccSelectionFlags selectFlags) wxOVERRIDE;
 
         // Gets the window with the keyboard focus.
         // If childId is 0 and child is NULL, no object in
         // this subhierarchy has the focus.
         // If this object has the focus, child should be 'this'.
-    virtual wxAccStatus GetFocus(int* childId, wxAccessible** child);
+    virtual wxAccStatus GetFocus(int* childId, wxAccessible** child) wxOVERRIDE;
 
 #if wxUSE_VARIANT
         // Gets a variant representing the selected children
@@ -2155,7 +2155,7 @@ public:
         // - an integer representing the selected child element,
         //   or 0 if this object is selected (GetType() == wxT("long")
         // - a "void*" pointer to a wxAccessible child object
-    virtual wxAccStatus GetSelections(wxVariant* selections);
+    virtual wxAccStatus GetSelections(wxVariant* selections) wxOVERRIDE;
 #endif // wxUSE_VARIANT
 };
 

--- a/samples/animate/anitest.h
+++ b/samples/animate/anitest.h
@@ -14,7 +14,7 @@
 class MyApp : public wxApp
 {
 public:
-    bool OnInit();
+    bool OnInit() wxOVERRIDE;
 };
 
 // Define a new frame

--- a/samples/console/console.cpp
+++ b/samples/console/console.cpp
@@ -40,12 +40,13 @@ static const wxCmdLineEntryDesc cmdLineDesc[] =
 {
     { wxCMD_LINE_SWITCH, "h", "help", "show this help message",
         wxCMD_LINE_VAL_NONE, wxCMD_LINE_OPTION_HELP },
-    { wxCMD_LINE_SWITCH, "d", "dummy", "a dummy switch" },
+    { wxCMD_LINE_SWITCH, "d", "dummy", "a dummy switch",
+        wxCMD_LINE_VAL_NONE, 0 },
     { wxCMD_LINE_SWITCH, "s", "secret", "a secret switch",
         wxCMD_LINE_VAL_NONE, wxCMD_LINE_HIDDEN },
     // ... your other command line options here...
 
-    { wxCMD_LINE_NONE }
+    wxCMD_LINE_DESC_END
 };
 
 int main(int argc, char **argv)

--- a/samples/mediaplayer/mediaplayer.cpp
+++ b/samples/mediaplayer/mediaplayer.cpp
@@ -141,7 +141,7 @@ class wxMediaPlayerApp : public wxApp
 {
 public:
 #ifdef __WXMAC__
-    virtual void MacOpenFiles(const wxArrayString & fileNames );
+    virtual void MacOpenFiles(const wxArrayString & fileNames ) wxOVERRIDE;
 #endif
 
 #if wxUSE_CMDLINE_PARSER

--- a/samples/memcheck/memcheck.cpp
+++ b/samples/memcheck/memcheck.cpp
@@ -38,7 +38,7 @@
 // Define a new application type
 class MyApp: public wxApp
 { public:
-    bool OnInit(void);
+    bool OnInit(void) wxOVERRIDE;
 };
 
 // Define a new frame type

--- a/samples/oleauto/oleauto.cpp
+++ b/samples/oleauto/oleauto.cpp
@@ -57,7 +57,7 @@ public:
     // this one is called on application startup and is a good place for the app
     // initialization (doing it here and not in the ctor allows to have an error
     // return: if OnInit() returns false, the application terminates)
-    virtual bool OnInit();
+    virtual bool OnInit() wxOVERRIDE;
 };
 
 // Define a new frame type: this is going to be our main frame

--- a/samples/power/power.cpp
+++ b/samples/power/power.cpp
@@ -266,7 +266,7 @@ wxEND_EVENT_TABLE()
 class MyApp : public wxApp
 {
 public:
-    virtual bool OnInit()
+    virtual bool OnInit() wxOVERRIDE
     {
         new MyFrame;
 

--- a/samples/preferences/preferences.cpp
+++ b/samples/preferences/preferences.cpp
@@ -50,7 +50,7 @@ struct MySettings
 class MyApp : public wxApp
 {
 public:
-    virtual bool OnInit();
+    virtual bool OnInit() wxOVERRIDE;
 
     void ShowPreferencesEditor(wxWindow* parent);
     void DismissPreferencesEditor();
@@ -156,7 +156,7 @@ public:
                            this);
     }
 
-    virtual bool TransferDataToWindow()
+    virtual bool TransferDataToWindow() wxOVERRIDE
     {
         m_settingsCurrent = wxGetApp().GetSettings();
         m_useMarkdown->SetValue(m_settingsCurrent.m_useMarkdown);
@@ -164,7 +164,7 @@ public:
         return true;
     }
 
-    virtual bool TransferDataFromWindow()
+    virtual bool TransferDataFromWindow() wxOVERRIDE
     {
         // Called on platforms with modal preferences dialog to save and apply
         // the changes.
@@ -211,7 +211,7 @@ class PrefsPageGeneral : public wxStockPreferencesPage
 {
 public:
     PrefsPageGeneral() : wxStockPreferencesPage(Kind_General) {}
-    virtual wxWindow *CreateWindow(wxWindow *parent)
+    virtual wxWindow *CreateWindow(wxWindow *parent) wxOVERRIDE
         { return new PrefsPageGeneralPanel(parent); }
 };
 
@@ -239,7 +239,7 @@ public:
         }
     }
 
-    virtual bool TransferDataToWindow()
+    virtual bool TransferDataToWindow() wxOVERRIDE
     {
         // This is the place where you can initialize values, e.g. from wxConfig.
         // For demonstration purposes, we just set hardcoded values.
@@ -248,7 +248,7 @@ public:
         return true;
     }
 
-    virtual bool TransferDataFromWindow()
+    virtual bool TransferDataFromWindow() wxOVERRIDE
     {
         // Called on platforms with modal preferences dialog to save and apply
         // the changes.
@@ -270,10 +270,10 @@ private:
 class PrefsPageTopics : public wxPreferencesPage
 {
 public:
-    virtual wxString GetName() const { return "Topics"; }
-    virtual wxBitmap GetLargeIcon() const
+    virtual wxString GetName() const wxOVERRIDE { return "Topics"; }
+    virtual wxBitmap GetLargeIcon() const wxOVERRIDE
         { return wxArtProvider::GetBitmap(wxART_HELP, wxART_TOOLBAR); }
-    virtual wxWindow *CreateWindow(wxWindow *parent)
+    virtual wxWindow *CreateWindow(wxWindow *parent) wxOVERRIDE
         { return new PrefsPageTopicsPanel(parent); }
 };
 

--- a/samples/stc/stctest.cpp
+++ b/samples/stc/stctest.cpp
@@ -95,10 +95,10 @@ class App: public wxApp {
 
 public:
     //! the main function called during application start
-    virtual bool OnInit ();
+    virtual bool OnInit () wxOVERRIDE;
 
     //! application exit function
-    virtual int OnExit ();
+    virtual int OnExit () wxOVERRIDE;
 
 private:
     //! frame window
@@ -762,7 +762,7 @@ public:
         SetWrapMode(wxSTC_WRAP_WORD);
         SetWrapVisualFlags(wxSTC_WRAPVISUALFLAG_END);
     }
-    virtual bool SetFont(const wxFont& font)
+    virtual bool SetFont(const wxFont& font) wxOVERRIDE
     {
         StyleSetFont(wxSTC_STYLE_DEFAULT, (wxFont&)font);
         return wxStyledTextCtrl::SetFont(font);

--- a/samples/taskbarbutton/taskbarbutton.cpp
+++ b/samples/taskbarbutton/taskbarbutton.cpp
@@ -98,7 +98,7 @@ wxIcon CreateRandomIcon()
 class MyApp : public wxApp
 {
 public:
-    virtual bool OnInit();
+    virtual bool OnInit() wxOVERRIDE;
 };
 
 class MyFrame : public wxFrame

--- a/samples/xrc/xrcdemo.h
+++ b/samples/xrc/xrcdemo.h
@@ -34,7 +34,7 @@ public:
     // for the app initialization (doing it here and not in the ctor
     // allows to have an error return: if OnInit() returns false, the
     // application terminates)
-    virtual bool OnInit();
+    virtual bool OnInit() wxOVERRIDE;
 
 };
 

--- a/src/common/event.cpp
+++ b/src/common/event.cpp
@@ -140,8 +140,8 @@ class wxEventTableEntryModule: public wxModule
 {
 public:
     wxEventTableEntryModule() { }
-    virtual bool OnInit() { return true; }
-    virtual void OnExit() { wxEventHashTable::ClearAll(); }
+    virtual bool OnInit() wxOVERRIDE { return true; }
+    virtual void OnExit() wxOVERRIDE { wxEventHashTable::ClearAll(); }
 
     wxDECLARE_DYNAMIC_CLASS(wxEventTableEntryModule);
 };

--- a/src/html/chm.cpp
+++ b/src/html/chm.cpp
@@ -366,19 +366,19 @@ public:
     virtual ~wxChmInputStream();
 
     /// Return the size of the accessed file in archive
-    virtual size_t GetSize() const { return m_size; }
+    virtual size_t GetSize() const wxOVERRIDE { return m_size; }
     /// End of Stream?
-    virtual bool Eof() const;
+    virtual bool Eof() const wxOVERRIDE;
     /// Set simulation-mode of HHP-File (if non is found)
     void SimulateHHP(bool sim) { m_simulateHHP = sim; }
 
 protected:
     /// See wxInputStream
-    virtual size_t OnSysRead(void *buffer, size_t bufsize);
+    virtual size_t OnSysRead(void *buffer, size_t bufsize) wxOVERRIDE;
     /// See wxInputStream
-    virtual wxFileOffset OnSysSeek(wxFileOffset seek, wxSeekMode mode);
+    virtual wxFileOffset OnSysSeek(wxFileOffset seek, wxSeekMode mode) wxOVERRIDE;
     /// See wxInputStream
-    virtual wxFileOffset OnSysTell() const { return m_pos; }
+    virtual wxFileOffset OnSysTell() const wxOVERRIDE { return m_pos; }
 
 private:
     size_t m_size;
@@ -761,16 +761,16 @@ class wxChmFSHandler : public wxFileSystemHandler
 public:
     /// Constructor and Destructor
     wxChmFSHandler();
-    virtual ~wxChmFSHandler();
+    virtual ~wxChmFSHandler() wxOVERRIDE;
 
     /// Is able to open location?
-    virtual bool CanOpen(const wxString& location);
+    virtual bool CanOpen(const wxString& location) wxOVERRIDE;
     /// Open a file
-    virtual wxFSFile* OpenFile(wxFileSystem& fs, const wxString& location);
+    virtual wxFSFile* OpenFile(wxFileSystem& fs, const wxString& location) wxOVERRIDE;
     /// Find first occurrence of spec
-    virtual wxString FindFirst(const wxString& spec, int flags = 0);
+    virtual wxString FindFirst(const wxString& spec, int flags = 0) wxOVERRIDE;
     /// Find next occurrence of spec
-    virtual wxString FindNext();
+    virtual wxString FindNext() wxOVERRIDE;
 
 private:
     int m_lasterror;
@@ -912,12 +912,12 @@ class wxChmSupportModule : public wxModule
     wxDECLARE_DYNAMIC_CLASS(wxChmSupportModule);
 
 public:
-    virtual bool OnInit()
+    virtual bool OnInit() wxOVERRIDE
     {
         wxFileSystem::AddHandler(new wxChmFSHandler);
         return true;
     }
-    virtual void OnExit() {}
+    virtual void OnExit() wxOVERRIDE {}
 }
 ;
 

--- a/src/msw/ole/access.cpp
+++ b/src/msw/ole/access.cpp
@@ -69,10 +69,10 @@ public:
     DECLARE_IUNKNOWN_METHODS;
 
     // IEnumVARIANT
-    STDMETHODIMP Next(ULONG celt, VARIANT *rgelt, ULONG *pceltFetched);
-    STDMETHODIMP Skip(ULONG celt);
-    STDMETHODIMP Reset();
-    STDMETHODIMP Clone(IEnumVARIANT **ppenum);
+    STDMETHODIMP Next(ULONG celt, VARIANT *rgelt, ULONG *pceltFetched) wxOVERRIDE;
+    STDMETHODIMP Skip(ULONG celt) wxOVERRIDE;
+    STDMETHODIMP Reset() wxOVERRIDE;
+    STDMETHODIMP Clone(IEnumVARIANT **ppenum) wxOVERRIDE;
 
 private:
     wxVariant m_variant;  // List of further variants
@@ -191,86 +191,86 @@ public:
         // Retrieves the child element or child object at a given point on the screen.
         // All visual objects support this method; sound objects do not support it.
 
-    STDMETHODIMP accHitTest(LONG xLeft, LONG yLeft, VARIANT* pVarID);
+    STDMETHODIMP accHitTest(LONG xLeft, LONG yLeft, VARIANT* pVarID) wxOVERRIDE;
 
         // Retrieves the specified object's current screen location. All visual objects must
         // support this method; sound objects do not support it.
 
-    STDMETHODIMP accLocation ( LONG* pxLeft, LONG* pyTop, LONG* pcxWidth, LONG* pcyHeight, VARIANT varID);
+    STDMETHODIMP accLocation ( LONG* pxLeft, LONG* pyTop, LONG* pcxWidth, LONG* pcyHeight, VARIANT varID) wxOVERRIDE;
 
         // Traverses to another user interface element within a container and retrieves the object.
         // All visual objects must support this method.
 
-    STDMETHODIMP accNavigate ( LONG navDir, VARIANT varStart, VARIANT* pVarEnd);
+    STDMETHODIMP accNavigate ( LONG navDir, VARIANT varStart, VARIANT* pVarEnd) wxOVERRIDE;
 
         // Retrieves the address of an IDispatch interface for the specified child.
         // All objects must support this property.
 
-    STDMETHODIMP get_accChild ( VARIANT varChildID, IDispatch** ppDispChild);
+    STDMETHODIMP get_accChild ( VARIANT varChildID, IDispatch** ppDispChild) wxOVERRIDE;
 
         // Retrieves the number of children that belong to this object.
         // All objects must support this property.
 
-    STDMETHODIMP get_accChildCount ( LONG* pCountChildren);
+    STDMETHODIMP get_accChildCount ( LONG* pCountChildren) wxOVERRIDE;
 
         // Retrieves the IDispatch interface of the object's parent.
         // All objects support this property.
 
-    STDMETHODIMP get_accParent ( IDispatch** ppDispParent);
+    STDMETHODIMP get_accParent ( IDispatch** ppDispParent) wxOVERRIDE;
 
 // Descriptive Properties and Methods
 
         // Performs the object's default action. Not all objects have a default
         // action.
 
-    STDMETHODIMP accDoDefaultAction(VARIANT varID);
+    STDMETHODIMP accDoDefaultAction(VARIANT varID) wxOVERRIDE;
 
         // Retrieves a string that describes the object's default action.
         // Not all objects have a default action.
 
-    STDMETHODIMP get_accDefaultAction ( VARIANT varID, BSTR* pszDefaultAction);
+    STDMETHODIMP get_accDefaultAction ( VARIANT varID, BSTR* pszDefaultAction) wxOVERRIDE;
 
         // Retrieves a string that describes the visual appearance of the specified object.
         // Not all objects have a description.
 
-    STDMETHODIMP get_accDescription ( VARIANT varID, BSTR* pszDescription);
+    STDMETHODIMP get_accDescription ( VARIANT varID, BSTR* pszDescription) wxOVERRIDE;
 
         // Retrieves an object's Help property string.
         // Not all objects support this property.
 
-    STDMETHODIMP get_accHelp ( VARIANT varID, BSTR* pszHelp);
+    STDMETHODIMP get_accHelp ( VARIANT varID, BSTR* pszHelp) wxOVERRIDE;
 
         // Retrieves the full path of the WinHelp file associated with the specified
         // object and the identifier of the appropriate topic within that file.
         // Not all objects support this property.
 
-    STDMETHODIMP get_accHelpTopic ( BSTR* pszHelpFile, VARIANT varChild, LONG* pidTopic);
+    STDMETHODIMP get_accHelpTopic ( BSTR* pszHelpFile, VARIANT varChild, LONG* pidTopic) wxOVERRIDE;
 
         // Retrieves the specified object's shortcut key or access key, also known as
         // the mnemonic. All objects that have a shortcut key or access key support
         // this property.
 
-    STDMETHODIMP get_accKeyboardShortcut ( VARIANT varID, BSTR* pszKeyboardShortcut);
+    STDMETHODIMP get_accKeyboardShortcut ( VARIANT varID, BSTR* pszKeyboardShortcut) wxOVERRIDE;
 
         // Retrieves the name of the specified object.
         // All objects support this property.
 
-    STDMETHODIMP get_accName ( VARIANT varID, BSTR* pszName);
+    STDMETHODIMP get_accName ( VARIANT varID, BSTR* pszName) wxOVERRIDE;
 
         // Retrieves information that describes the role of the specified object.
         // All objects support this property.
 
-    STDMETHODIMP get_accRole ( VARIANT varID, VARIANT* pVarRole);
+    STDMETHODIMP get_accRole ( VARIANT varID, VARIANT* pVarRole) wxOVERRIDE;
 
         // Retrieves the current state of the specified object.
         // All objects support this property.
 
-    STDMETHODIMP get_accState ( VARIANT varID, VARIANT* pVarState);
+    STDMETHODIMP get_accState ( VARIANT varID, VARIANT* pVarState) wxOVERRIDE;
 
         // Retrieves the value of the specified object.
         // Not all objects have a value.
 
-    STDMETHODIMP get_accValue ( VARIANT varID, BSTR* pszValue);
+    STDMETHODIMP get_accValue ( VARIANT varID, BSTR* pszValue) wxOVERRIDE;
 
 // Selection and Focus
 
@@ -278,44 +278,44 @@ public:
         // specified object. All objects that select or receive the
         // keyboard focus must support this method.
 
-    STDMETHODIMP accSelect ( LONG flagsSelect, VARIANT varID );
+    STDMETHODIMP accSelect ( LONG flagsSelect, VARIANT varID ) wxOVERRIDE;
 
         // Retrieves the object that has the keyboard focus. All objects
         // that receive the keyboard focus must support this property.
 
-    STDMETHODIMP get_accFocus ( VARIANT* pVarID);
+    STDMETHODIMP get_accFocus ( VARIANT* pVarID) wxOVERRIDE;
 
         // Retrieves the selected children of this object. All objects
         // selected must support this property.
 
-    STDMETHODIMP get_accSelection ( VARIANT * pVarChildren);
+    STDMETHODIMP get_accSelection ( VARIANT * pVarChildren) wxOVERRIDE;
 
 // Obsolete
 
-    STDMETHODIMP put_accName(VARIANT WXUNUSED(varChild), BSTR WXUNUSED(szName)) { return E_FAIL; }
-    STDMETHODIMP put_accValue(VARIANT WXUNUSED(varChild), BSTR WXUNUSED(szName)) { return E_FAIL; }
+    STDMETHODIMP put_accName(VARIANT WXUNUSED(varChild), BSTR WXUNUSED(szName)) wxOVERRIDE { return E_FAIL; }
+    STDMETHODIMP put_accValue(VARIANT WXUNUSED(varChild), BSTR WXUNUSED(szName)) wxOVERRIDE { return E_FAIL; }
 
 // IDispatch
 
         // Get type info
 
-    STDMETHODIMP GetTypeInfo(unsigned int typeInfo, LCID lcid, ITypeInfo** ppTypeInfo);
+    STDMETHODIMP GetTypeInfo(unsigned int typeInfo, LCID lcid, ITypeInfo** ppTypeInfo) wxOVERRIDE;
 
         // Get type info count
 
-    STDMETHODIMP GetTypeInfoCount(unsigned int* typeInfoCount);
+    STDMETHODIMP GetTypeInfoCount(unsigned int* typeInfoCount) wxOVERRIDE;
 
         // Get ids of names
 
     STDMETHODIMP GetIDsOfNames(REFIID riid, OLECHAR** names, unsigned int cNames,
-        LCID lcid, DISPID* dispId);
+        LCID lcid, DISPID* dispId) wxOVERRIDE;
 
         // Invoke
 
     STDMETHODIMP Invoke(DISPID dispIdMember, REFIID riid, LCID lcid,
                         WORD wFlags, DISPPARAMS *pDispParams,
                         VARIANT *pVarResult, EXCEPINFO *pExcepInfo,
-                        unsigned int *puArgErr );
+                        unsigned int *puArgErr ) wxOVERRIDE;
 
 // Helpers
 

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -164,7 +164,7 @@ public:
 private:
     wxProgressDialogSharedData m_sharedData;
 
-    virtual void* Entry();
+    virtual void* Entry() wxOVERRIDE;
 
     static HRESULT CALLBACK TaskDialogCallbackProc(HWND hwnd,
                                                    UINT uNotification,
@@ -187,7 +187,7 @@ public:
     }
 
 protected:
-    virtual void OnNextIteration()
+    virtual void OnNextIteration() wxOVERRIDE
     {
         wxCriticalSectionLocker locker(m_data.m_cs);
 

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -1741,6 +1741,7 @@ void wxWidgetCocoaImpl::ZoomGestureEvent(NSMagnificationGestureRecognizer* magni
              gestureState = NSGestureRecognizerStateBegan;
              break;
         case NSGestureRecognizerStateChanged:
+             gestureState = NSGestureRecognizerStateChanged;
              break;
         case NSGestureRecognizerStateEnded:
         case NSGestureRecognizerStateCancelled:
@@ -1789,6 +1790,7 @@ void wxWidgetCocoaImpl::RotateGestureEvent(NSRotationGestureRecognizer* rotation
              gestureState = NSGestureRecognizerStateBegan;
              break;
         case NSGestureRecognizerStateChanged:
+             gestureState = NSGestureRecognizerStateChanged;
              break;
         case NSGestureRecognizerStateEnded:
         case NSGestureRecognizerStateCancelled:
@@ -1840,6 +1842,7 @@ void wxWidgetCocoaImpl::LongPressEvent(NSPressGestureRecognizer* pressGestureRec
             gestureState = NSGestureRecognizerStateBegan;
             break;
         case NSGestureRecognizerStateChanged:
+            gestureState = NSGestureRecognizerStateChanged;
             break;
         case NSGestureRecognizerStateEnded:
         case NSGestureRecognizerStateCancelled:


### PR DESCRIPTION
I added more `wxOVERRIDE` and fixed the following warnings:
```bash
console.cpp:49:1: warning: missing initializer for member 'wxCmdLineEntryDesc::type' [-Wmissing-field-initializers]
 };
 ^
console.cpp:49:1: warning: missing initializer for member 'wxCmdLineEntryDesc::flags' [-Wmissing-field-initializers]
console.cpp:49:1: warning: missing initializer for member 'wxCmdLineEntryDesc::shortName' [-Wmissing-field-initializers]
console.cpp:49:1: warning: missing initializer for member 'wxCmdLineEntryDesc::longName' [-Wmissing-field-initializers]
console.cpp:49:1: warning: missing initializer for member 'wxCmdLineEntryDesc::description' [-Wmissing-field-initializers]
console.cpp:49:1: warning: missing initializer for member 'wxCmdLineEntryDesc::type' [-Wmissing-field-initializers]
console.cpp:49:1: warning: missing initializer for member 'wxCmdLineEntryDesc::flags' [-Wmissing-field-initializers]
```

```bash
/Users/maarten/wxWidgets/src/osx/cocoa/window.mm:1743:14: warning: variable 'gestureState' is used uninitialized whenever switch case is
      taken [-Wsometimes-uninitialized]
        case NSGestureRecognizerStateChanged:
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/maarten/wxWidgets/src/osx/cocoa/window.mm:1762:10: note: uninitialized use occurs here
    if ( gestureState == NSGestureRecognizerStateBegan )
         ^~~~~~~~~~~~
/Users/maarten/wxWidgets/src/osx/cocoa/window.mm:1736:5: note: variable 'gestureState' is declared here
    NSGestureRecognizerState gestureState;
    ^
-- two more ---
```