### PR TITLE
Fix wxGTK build with glib < 2.32 and streamline the code a bit

### DIFF
--- a/include/wx/gtk/private/gtk2-compat.h
+++ b/include/wx/gtk/private/gtk2-compat.h
@@ -426,6 +426,14 @@ static inline void wx_gdk_cairo_set_source_window(cairo_t* cr, GdkWindow* window
 #endif
 
 // ----------------------------------------------------------------------------
+// the following were introduced in Glib 2.32
+
+#ifndef g_signal_handlers_disconnect_by_data
+#define g_signal_handlers_disconnect_by_data(instance, data) \
+      g_signal_handlers_disconnect_matched ((instance), G_SIGNAL_MATCH_DATA, 0, 0, NULL, NULL, (data))
+#endif
+
+// ----------------------------------------------------------------------------
 // the following were introduced in GTK+ 3.0
 
 static inline void wx_gdk_window_get_geometry(GdkWindow* window, gint* x, gint* y, gint* width, gint* height)

--- a/src/gtk/menu.cpp
+++ b/src/gtk/menu.cpp
@@ -808,8 +808,7 @@ wxMenu::~wxMenu()
     // Destroying a menu generates a "hide" signal even if it's not shown
     // currently, so disconnect it to avoid dummy wxEVT_MENU_CLOSE events
     // generation.
-    g_signal_handlers_disconnect_matched(m_menu,
-        GSignalMatchType(G_SIGNAL_MATCH_DATA), 0, 0, NULL, NULL, this);
+    g_signal_handlers_disconnect_by_data(m_menu, this);
 
     if (m_owner)
     {
@@ -993,8 +992,7 @@ wxMenuItem *wxMenu::DoRemove(wxMenuItem *item)
 
     GtkWidget * const mitem = item->GetMenuItem();
 
-    g_signal_handlers_disconnect_matched(mitem,
-        GSignalMatchType(G_SIGNAL_MATCH_DATA), 0, 0, NULL, NULL, item);
+    g_signal_handlers_disconnect_by_data(mitem, item);
 
 #ifdef __WXGTK3__
     gtk_menu_item_set_submenu(GTK_MENU_ITEM(mitem), NULL);

--- a/src/gtk/webview_webkit2.cpp
+++ b/src/gtk/webview_webkit2.cpp
@@ -589,9 +589,8 @@ wxWebViewWebKit::~wxWebViewWebKit()
     if (m_dbusServer)
     {
         g_dbus_server_stop(m_dbusServer);
-        g_signal_handlers_disconnect_matched(
-            webkit_web_context_get_default(), G_SIGNAL_MATCH_DATA,
-            0, 0, NULL, NULL, m_dbusServer);
+        g_signal_handlers_disconnect_by_data(
+            webkit_web_context_get_default(), m_dbusServer);
     }
     g_clear_object(&m_dbusServer);
     g_clear_object(&m_extension);

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -2675,8 +2675,7 @@ bool wxWindowGTK::Create( wxWindow *parent,
 
 void wxWindowGTK::GTKDisconnect(void* instance)
 {
-    g_signal_handlers_disconnect_matched(instance,
-        GSignalMatchType(G_SIGNAL_MATCH_DATA), 0, 0, NULL, NULL, this);
+    g_signal_handlers_disconnect_by_data(instance, this);
 }
 
 wxWindowGTK::~wxWindowGTK()


### PR DESCRIPTION
Define g_signal_handlers_disconnect_by_data() if it's not available,
i.e. when using glib older than 2.32 where it was added, to fix the
build under old systems such as CentOS 6.

Also use it elsewhere instead of g_signal_handlers_disconnect_matched()
as it's more readable.