### PR TITLE
Use Last[Read/Write]Count in socket stream operations.

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -70,6 +70,7 @@ Changes in behaviour which may result in build errors
 All:
 
 - Make wxList and wxVector iterators conform to input iterator requirements.
+- Use Last[Read/Write]Count in stream functions to improve thread safety.
 
 wxGTK:
 
@@ -91,7 +92,7 @@ INCOMPATIBLE CHANGES SINCE 3.1.0:
 
 - The enum value wxTASKBAR_JUMP_LIST_DESTIONATION, which was added in 3.1.0,
   contains a typo and has been renamed to wxTASKBAR_JUMP_LIST_DESTINATION.
-  
+
 - wxZipOutputStream will now automatically convert filenames to UTF-8, if the
   wxMBConv used when calling the constructor supports UTF-8 encoding.
 

--- a/src/common/sckstrm.cpp
+++ b/src/common/sckstrm.cpp
@@ -40,7 +40,7 @@ wxSocketOutputStream::~wxSocketOutputStream()
 
 size_t wxSocketOutputStream::OnSysWrite(const void *buffer, size_t size)
 {
-    const size_t ret = m_o_socket->Write(buffer, size).LastCount();
+    const size_t ret = m_o_socket->Write(buffer, size).LastWriteCount();
     m_lasterror = m_o_socket->Error()
                     ? m_o_socket->IsClosed() ? wxSTREAM_EOF
                                              : wxSTREAM_WRITE_ERROR
@@ -63,7 +63,7 @@ wxSocketInputStream::~wxSocketInputStream()
 
 size_t wxSocketInputStream::OnSysRead(void *buffer, size_t size)
 {
-    const size_t ret = m_i_socket->Read(buffer, size).LastCount();
+    const size_t ret = m_i_socket->Read(buffer, size).LastReadCount();
     m_lasterror = m_i_socket->Error()
                     ? m_i_socket->IsClosed() ? wxSTREAM_EOF
                                              : wxSTREAM_READ_ERROR


### PR DESCRIPTION
This change would close out trac issue #17787 and should have probably been applied when #14506 was applied.