### PR TITLE
Various wxRibbonButtonBar improvements

### DIFF
--- a/include/wx/ribbon/art.h
+++ b/include/wx/ribbon/art.h
@@ -381,11 +381,17 @@ public:
                         wxRibbonButtonKind kind,
                         wxRibbonButtonBarButtonState size,
                         const wxString& label,
+                        wxCoord text_min_width,
                         wxSize bitmap_size_large,
                         wxSize bitmap_size_small,
                         wxSize* button_size,
                         wxRect* normal_region,
                         wxRect* dropdown_region) = 0;
+
+    virtual wxCoord GetButtonBarButtonTextWidth(
+                        wxDC& dc, const wxString& label,
+                        wxRibbonButtonKind kind,
+                        wxRibbonButtonBarButtonState size) = 0;
 
     virtual wxSize GetMinimisedPanelMinimumSize(
                         wxDC& dc,
@@ -584,11 +590,17 @@ public:
                         wxRibbonButtonKind kind,
                         wxRibbonButtonBarButtonState size,
                         const wxString& label,
+                        wxCoord text_min_width,
                         wxSize bitmap_size_large,
                         wxSize bitmap_size_small,
                         wxSize* button_size,
                         wxRect* normal_region,
                         wxRect* dropdown_region) wxOVERRIDE;
+
+    wxCoord GetButtonBarButtonTextWidth(
+                        wxDC& dc, const wxString& label,
+                        wxRibbonButtonKind kind,
+                        wxRibbonButtonBarButtonState size) wxOVERRIDE;
 
     wxSize GetMinimisedPanelMinimumSize(
                         wxDC& dc,

--- a/include/wx/ribbon/buttonbar.h
+++ b/include/wx/ribbon/buttonbar.h
@@ -146,6 +146,11 @@ public:
                 const wxBitmap& bitmap_disabled = wxNullBitmap,
                 const wxBitmap& bitmap_small_disabled = wxNullBitmap);
 
+    virtual void SetButtonText(int button_id, const wxString& label);
+    virtual void SetButtonTextMinWidth(int button_id,
+                int min_width_medium, int min_width_large);
+    virtual void SetButtonTextMinWidth(int button_id, const wxString& label);
+
     virtual wxRibbonButtonBarButtonBase *GetActiveItem() const;
     virtual wxRibbonButtonBarButtonBase *GetHoveredItem() const;
 

--- a/include/wx/ribbon/buttonbar.h
+++ b/include/wx/ribbon/buttonbar.h
@@ -150,6 +150,10 @@ public:
     virtual void SetButtonTextMinWidth(int button_id,
                 int min_width_medium, int min_width_large);
     virtual void SetButtonTextMinWidth(int button_id, const wxString& label);
+    virtual void SetButtonMinSizeClass(int button_id,
+                wxRibbonButtonBarButtonState min_size_class);
+    virtual void SetButtonMaxSizeClass(int button_id,
+                wxRibbonButtonBarButtonState max_size_class);
 
     virtual wxRibbonButtonBarButtonBase *GetActiveItem() const;
     virtual wxRibbonButtonBarButtonBase *GetHoveredItem() const;
@@ -183,7 +187,9 @@ protected:
 
     void CommonInit(long style);
     void MakeLayouts();
-    bool TryCollapseLayout(wxRibbonButtonBarLayout* original, size_t first_btn, size_t* last_button);
+    void TryCollapseLayout(wxRibbonButtonBarLayout* original,
+                     size_t first_btn, size_t* last_button,
+                     wxRibbonButtonBarButtonState target_size);
     void MakeBitmaps(wxRibbonButtonBarButtonBase* base,
                      const wxBitmap& bitmap_large,
                      const wxBitmap& bitmap_large_disabled,

--- a/include/wx/ribbon/buttonbar.h
+++ b/include/wx/ribbon/buttonbar.h
@@ -139,6 +139,13 @@ public:
     virtual void EnableButton(int button_id, bool enable = true);
     virtual void ToggleButton(int button_id, bool checked);
 
+    virtual void SetButtonIcon(
+                int button_id,
+                const wxBitmap& bitmap,
+                const wxBitmap& bitmap_small = wxNullBitmap,
+                const wxBitmap& bitmap_disabled = wxNullBitmap,
+                const wxBitmap& bitmap_small_disabled = wxNullBitmap);
+
     virtual wxRibbonButtonBarButtonBase *GetActiveItem() const;
     virtual wxRibbonButtonBarButtonBase *GetHoveredItem() const;
 
@@ -172,6 +179,11 @@ protected:
     void CommonInit(long style);
     void MakeLayouts();
     bool TryCollapseLayout(wxRibbonButtonBarLayout* original, size_t first_btn, size_t* last_button);
+    void MakeBitmaps(wxRibbonButtonBarButtonBase* base,
+                     const wxBitmap& bitmap_large,
+                     const wxBitmap& bitmap_large_disabled,
+                     const wxBitmap& bitmap_small,
+                     const wxBitmap& bitmap_small_disabled);
     static wxBitmap MakeResizedBitmap(const wxBitmap& original, wxSize size);
     static wxBitmap MakeDisabledBitmap(const wxBitmap& original);
     void FetchButtonSizeInfo(wxRibbonButtonBarButtonBase* button,

--- a/interface/wx/ribbon/art.h
+++ b/interface/wx/ribbon/art.h
@@ -983,6 +983,8 @@ public:
         @return Width of the given label text in pixel.
 
         @note This function only works with single-line strings.
+
+        @since 3.1.2
     */
     virtual wxCoord GetButtonBarButtonTextWidth(
                         wxDC& dc, const wxString& label,

--- a/interface/wx/ribbon/art.h
+++ b/interface/wx/ribbon/art.h
@@ -934,6 +934,9 @@ public:
             be returned.
         @param label
             The label of the button.
+        @param text_min_width
+            The minimum width of the button label.
+            Set this to 0 if it is not used.
         @param bitmap_size_large
             The size of all "large" bitmaps on the button bar.
         @param bitmap_size_small
@@ -953,11 +956,38 @@ public:
                         wxRibbonButtonKind kind,
                         wxRibbonButtonBarButtonState size,
                         const wxString& label,
+                        wxCoord text_min_width,
                         wxSize bitmap_size_large,
                         wxSize bitmap_size_small,
                         wxSize* button_size,
                         wxRect* normal_region,
                         wxRect* dropdown_region) = 0;
+
+    /**
+        Gets the width of the string if it is used as
+        a wxRibbonButtonBar button label.
+
+        @param dc
+            A device context to use when one is required for size calculations.
+        @param label
+            The string whose width shall be calculated.
+        @param kind
+            The kind of button.
+        @param size
+            The size-class to calculate the size for. Buttons on a button bar
+            can have three distinct sizes: wxRIBBON_BUTTONBAR_BUTTON_SMALL,
+            wxRIBBON_BUTTONBAR_BUTTON_MEDIUM, and wxRIBBON_BUTTONBAR_BUTTON_LARGE.
+            If the requested size-class is not applicable, then NULL should
+            be returned.
+
+        @return Width of the given label text in pixel.
+
+        @note This function only works with single-line strings.
+    */
+    virtual wxCoord GetButtonBarButtonTextWidth(
+                        wxDC& dc, const wxString& label,
+                        wxRibbonButtonKind kind,
+                        wxRibbonButtonBarButtonState size) = 0;
     
     /**
         Calculate the size of a minimised ribbon panel.
@@ -1208,6 +1238,7 @@ public:
                         wxRibbonButtonKind kind,
                         wxRibbonButtonBarButtonState size,
                         const wxString& label,
+                        wxCoord text_min_width,
                         wxSize bitmap_size_large,
                         wxSize bitmap_size_small,
                         wxSize* button_size,

--- a/interface/wx/ribbon/buttonbar.h
+++ b/interface/wx/ribbon/buttonbar.h
@@ -477,6 +477,33 @@ public:
     virtual void ToggleButton(int button_id, bool checked);
 
     /**
+        Changes the bitmap of an existing button.
+
+        @param button_id
+            ID of the button to manipulate.
+        @param bitmap
+            Large bitmap of the new button. Must be the same size as all other
+            large bitmaps used on the button bar.
+        @param bitmap_small
+            Small bitmap of the new button. If left as null, then a small
+            bitmap will be automatically generated. Must be the same size as
+            all other small bitmaps used on the button bar.
+        @param bitmap_disabled
+            Large bitmap of the new button when it is disabled. If left as
+            null, then a bitmap will be automatically generated from @a bitmap.
+        @param bitmap_small_disabled
+            Small bitmap of the new button when it is disabled. If left as
+            null, then a bitmap will be automatically generated from @a
+            bitmap_small.
+    */
+    virtual void SetButtonIcon(
+                int button_id,
+                const wxBitmap& bitmap,
+                const wxBitmap& bitmap_small = wxNullBitmap,
+                const wxBitmap& bitmap_disabled = wxNullBitmap,
+                const wxBitmap& bitmap_small_disabled = wxNullBitmap);
+
+    /**
         Returns the active item of the button bar or NULL if there is none.
         The active button is the one being clicked.
 

--- a/interface/wx/ribbon/buttonbar.h
+++ b/interface/wx/ribbon/buttonbar.h
@@ -569,6 +569,38 @@ public:
     virtual void SetButtonTextMinWidth(int button_id, const wxString& label);
 
     /**
+        Sets the minimum size class of a ribbon button.
+
+        You have to call Realize() after calling this function to
+        apply the given minimum size.
+
+        @param button_id
+            ID of the button to manipulate.
+        @param min_size_class
+            The minimum size-class of the button. Buttons on a button bar
+            can have three distinct sizes: wxRIBBON_BUTTONBAR_BUTTON_SMALL,
+            wxRIBBON_BUTTONBAR_BUTTON_MEDIUM, and wxRIBBON_BUTTONBAR_BUTTON_LARGE.
+    */
+    virtual void SetButtonMinSizeClass(int button_id,
+                wxRibbonButtonBarButtonState min_size_class);
+
+    /**
+        Sets the maximum size class of a ribbon button.
+
+        You have to call Realize() after calling this function to
+        apply the given maximum size.
+
+        @param button_id
+            ID of the button to manipulate.
+        @param max_size_class
+            The maximum size-class of the button. Buttons on a button bar
+            can have three distinct sizes: wxRIBBON_BUTTONBAR_BUTTON_SMALL,
+            wxRIBBON_BUTTONBAR_BUTTON_MEDIUM, and wxRIBBON_BUTTONBAR_BUTTON_LARGE.
+    */
+    virtual void SetButtonMaxSizeClass(int button_id,
+                wxRibbonButtonBarButtonState max_size_class);
+
+    /**
         Returns the active item of the button bar or NULL if there is none.
         The active button is the one being clicked.
 

--- a/interface/wx/ribbon/buttonbar.h
+++ b/interface/wx/ribbon/buttonbar.h
@@ -495,6 +495,8 @@ public:
             Small bitmap of the new button when it is disabled. If left as
             null, then a bitmap will be automatically generated from @a
             bitmap_small.
+
+        @since 3.1.2
     */
     virtual void SetButtonIcon(
                 int button_id,
@@ -518,6 +520,8 @@ public:
             after every change.
 
         @see SetButtonTextMinWidth
+
+        @since 3.1.2
     */
     virtual void SetButtonText(int button_id, const wxString& label);
 
@@ -543,6 +547,8 @@ public:
             button labels on the fly without modifying the button bar layout.
 
         @see SetButtonText()
+
+        @since 3.1.2
     */
     virtual void SetButtonTextMinWidth(int button_id,
                 int min_width_medium, int min_width_large);
@@ -565,6 +571,8 @@ public:
             button labels on the fly without modifying the button bar layout.
 
         @see SetButtonText()
+
+        @since 3.1.2
     */
     virtual void SetButtonTextMinWidth(int button_id, const wxString& label);
 
@@ -580,6 +588,8 @@ public:
             The minimum size-class of the button. Buttons on a button bar
             can have three distinct sizes: wxRIBBON_BUTTONBAR_BUTTON_SMALL,
             wxRIBBON_BUTTONBAR_BUTTON_MEDIUM, and wxRIBBON_BUTTONBAR_BUTTON_LARGE.
+
+        @since 3.1.2
     */
     virtual void SetButtonMinSizeClass(int button_id,
                 wxRibbonButtonBarButtonState min_size_class);
@@ -596,6 +606,8 @@ public:
             The maximum size-class of the button. Buttons on a button bar
             can have three distinct sizes: wxRIBBON_BUTTONBAR_BUTTON_SMALL,
             wxRIBBON_BUTTONBAR_BUTTON_MEDIUM, and wxRIBBON_BUTTONBAR_BUTTON_LARGE.
+
+        @since 3.1.2
     */
     virtual void SetButtonMaxSizeClass(int button_id,
                 wxRibbonButtonBarButtonState max_size_class);

--- a/interface/wx/ribbon/buttonbar.h
+++ b/interface/wx/ribbon/buttonbar.h
@@ -504,6 +504,71 @@ public:
                 const wxBitmap& bitmap_small_disabled = wxNullBitmap);
 
     /**
+        Changes the label text of an existing button.
+
+        @param button_id
+            ID of the button to manipulate.
+        @param label
+            New label of the button.
+
+        @remarks
+            If text size has changed, Realize() must be called
+            on the top level wxRibbonBar object to recalculate panel sizes.
+            Use SetButtonTextMinWidth() to avoid calling Realize()
+            after every change.
+
+        @see SetButtonTextMinWidth
+    */
+    virtual void SetButtonText(int button_id, const wxString& label);
+
+    /**
+        Sets the minimum width of the button label, to indicate to
+        the wxRibbonArtProvider layout mechanism that this is the
+        minimum required size.
+
+        You have to call Realize() after calling this function to
+        apply the given minimum width.
+
+        @param button_id
+            ID of the button to manipulate.
+        @param min_width_medium
+            Requested minimum width of the button text in pixel
+            if the button is medium size.
+        @param min_width_medium
+            Requested minimum width of the button text in pixel
+            if the button is large size.
+
+        @remarks
+            This function is used together with SetButtonText() to change
+            button labels on the fly without modifying the button bar layout.
+
+        @see SetButtonText()
+    */
+    virtual void SetButtonTextMinWidth(int button_id,
+                int min_width_medium, int min_width_large);
+
+    /**
+        Sets the minimum width of the button label, to indicate to
+        the wxRibbonArtProvider layout mechanism that this is the
+        minimum required size.
+
+        You have to call Realize() after calling this function to
+        apply the given minimum width.
+
+        @param button_id
+            ID of the button to manipulate.
+        @param label
+            The minimum width is set to the width of this label.
+
+        @remarks
+            This function is used together with SetButtonText() to change
+            button labels on the fly without modifying the button bar layout.
+
+        @see SetButtonText()
+    */
+    virtual void SetButtonTextMinWidth(int button_id, const wxString& label);
+
+    /**
         Returns the active item of the button bar or NULL if there is none.
         The active button is the one being clicked.
 

--- a/src/ribbon/buttonbar.cpp
+++ b/src/ribbon/buttonbar.cpp
@@ -323,38 +323,8 @@ wxRibbonButtonBarButtonBase* wxRibbonButtonBar::InsertButton(
     wxRibbonButtonBarButtonBase* base = new wxRibbonButtonBarButtonBase;
     base->id = button_id;
     base->label = label;
-    base->bitmap_large = bitmap;
-    if(!base->bitmap_large.IsOk())
-    {
-        base->bitmap_large = MakeResizedBitmap(base->bitmap_small,
-            m_bitmap_size_large);
-    }
-    else if(base->bitmap_large.GetScaledSize() != m_bitmap_size_large)
-    {
-        base->bitmap_large = MakeResizedBitmap(base->bitmap_large,
-            m_bitmap_size_large);
-    }
-    base->bitmap_small = bitmap_small;
-    if(!base->bitmap_small.IsOk())
-    {
-        base->bitmap_small = MakeResizedBitmap(base->bitmap_large,
-            m_bitmap_size_small);
-    }
-    else if(base->bitmap_small.GetScaledSize() != m_bitmap_size_small)
-    {
-        base->bitmap_small = MakeResizedBitmap(base->bitmap_small,
-            m_bitmap_size_small);
-    }
-    base->bitmap_large_disabled = bitmap_disabled;
-    if(!base->bitmap_large_disabled.IsOk())
-    {
-        base->bitmap_large_disabled = MakeDisabledBitmap(base->bitmap_large);
-    }
-    base->bitmap_small_disabled = bitmap_small_disabled;
-    if(!base->bitmap_small_disabled.IsOk())
-    {
-        base->bitmap_small_disabled = MakeDisabledBitmap(base->bitmap_small);
-    }
+    MakeBitmaps(base, bitmap, bitmap_disabled,
+                bitmap_small, bitmap_small_disabled);
     base->kind = kind;
     base->help_string = help_string;
     base->state = 0;
@@ -593,6 +563,21 @@ void wxRibbonButtonBar::ToggleButton(int button_id, bool checked)
             return;
         }
     }
+}
+
+void wxRibbonButtonBar::SetButtonIcon(
+                int button_id,
+                const wxBitmap& bitmap,
+                const wxBitmap& bitmap_small,
+                const wxBitmap& bitmap_disabled,
+                const wxBitmap& bitmap_small_disabled)
+{
+    wxRibbonButtonBarButtonBase* base = GetItemById(button_id);
+    if(base == NULL)
+        return;
+    MakeBitmaps(base, bitmap, bitmap_small,
+                bitmap_disabled, bitmap_small_disabled);
+    Refresh();
 }
 
 void wxRibbonButtonBar::SetArtProvider(wxRibbonArtProvider* art)
@@ -995,6 +980,46 @@ bool wxRibbonButtonBar::TryCollapseLayout(wxRibbonButtonBarLayout* original,
 
     m_layouts.Add(layout);
     return true;
+}
+
+void wxRibbonButtonBar::MakeBitmaps(wxRibbonButtonBarButtonBase* base,
+                                    const wxBitmap& bitmap_large,
+                                    const wxBitmap& bitmap_large_disabled,
+                                    const wxBitmap& bitmap_small,
+                                    const wxBitmap& bitmap_small_disabled)
+{
+    base->bitmap_large = bitmap_large;
+    if(!base->bitmap_large.IsOk())
+    {
+        base->bitmap_large = MakeResizedBitmap(base->bitmap_small,
+            m_bitmap_size_large);
+    }
+    else if(base->bitmap_large.GetScaledSize() != m_bitmap_size_large)
+    {
+        base->bitmap_large = MakeResizedBitmap(base->bitmap_large,
+            m_bitmap_size_large);
+    }
+    base->bitmap_small = bitmap_small;
+    if(!base->bitmap_small.IsOk())
+    {
+        base->bitmap_small = MakeResizedBitmap(base->bitmap_large,
+            m_bitmap_size_small);
+    }
+    else if(base->bitmap_small.GetScaledSize() != m_bitmap_size_small)
+    {
+        base->bitmap_small = MakeResizedBitmap(base->bitmap_small,
+            m_bitmap_size_small);
+    }
+    base->bitmap_large_disabled = bitmap_large_disabled;
+    if(!base->bitmap_large_disabled.IsOk())
+    {
+        base->bitmap_large_disabled = MakeDisabledBitmap(base->bitmap_large);
+    }
+    base->bitmap_small_disabled = bitmap_small_disabled;
+    if(!base->bitmap_small_disabled.IsOk())
+    {
+        base->bitmap_small_disabled = MakeDisabledBitmap(base->bitmap_small);
+    }
 }
 
 void wxRibbonButtonBar::OnMouseMove(wxMouseEvent& evt)

--- a/src/ribbon/buttonbar.cpp
+++ b/src/ribbon/buttonbar.cpp
@@ -75,10 +75,16 @@ public:
 
     wxRibbonButtonBarButtonState GetLargestSize()
     {
-        if(sizes[wxRIBBON_BUTTONBAR_BUTTON_LARGE].is_supported)
+        if(sizes[wxRIBBON_BUTTONBAR_BUTTON_LARGE].is_supported
+           && max_size_class >= wxRIBBON_BUTTONBAR_BUTTON_LARGE)
+        {
             return wxRIBBON_BUTTONBAR_BUTTON_LARGE;
-        if(sizes[wxRIBBON_BUTTONBAR_BUTTON_MEDIUM].is_supported)
+        }
+        if(sizes[wxRIBBON_BUTTONBAR_BUTTON_MEDIUM].is_supported
+           && max_size_class >= wxRIBBON_BUTTONBAR_BUTTON_MEDIUM)
+        {
             return wxRIBBON_BUTTONBAR_BUTTON_MEDIUM;
+        }
         wxASSERT(sizes[wxRIBBON_BUTTONBAR_BUTTON_SMALL].is_supported);
         return wxRIBBON_BUTTONBAR_BUTTON_SMALL;
     }
@@ -91,14 +97,16 @@ public:
             switch(*size)
             {
             case wxRIBBON_BUTTONBAR_BUTTON_LARGE:
-                if(sizes[wxRIBBON_BUTTONBAR_BUTTON_MEDIUM].is_supported)
+                if(sizes[wxRIBBON_BUTTONBAR_BUTTON_MEDIUM].is_supported
+                   && min_size_class <= wxRIBBON_BUTTONBAR_BUTTON_MEDIUM)
                 {
                     *size = wxRIBBON_BUTTONBAR_BUTTON_MEDIUM;
                     break;
                 }
                 wxFALLTHROUGH;
             case wxRIBBON_BUTTONBAR_BUTTON_MEDIUM:
-                if(sizes[wxRIBBON_BUTTONBAR_BUTTON_SMALL].is_supported)
+                if(sizes[wxRIBBON_BUTTONBAR_BUTTON_SMALL].is_supported
+                   && min_size_class <= wxRIBBON_BUTTONBAR_BUTTON_SMALL)
                 {
                     *size = wxRIBBON_BUTTONBAR_BUTTON_SMALL;
                     break;
@@ -120,6 +128,8 @@ public:
     wxBitmap bitmap_small_disabled;
     wxCoord text_min_width[3];
     wxRibbonButtonBarButtonSizeInfo sizes[3];
+    wxRibbonButtonBarButtonState min_size_class;
+    wxRibbonButtonBarButtonState max_size_class;
     wxClientDataContainer client_data;
     int id;
     wxRibbonButtonKind kind;
@@ -332,6 +342,8 @@ wxRibbonButtonBarButtonBase* wxRibbonButtonBar::InsertButton(
     base->text_min_width[0] = 0;
     base->text_min_width[1] = 0;
     base->text_min_width[2] = 0;
+    base->min_size_class = wxRIBBON_BUTTONBAR_BUTTON_SMALL;
+    base->max_size_class = wxRIBBON_BUTTONBAR_BUTTON_LARGE;
 
     wxClientDC temp_dc(this);
     FetchButtonSizeInfo(base, wxRIBBON_BUTTONBAR_BUTTON_SMALL, temp_dc);
@@ -635,6 +647,36 @@ void wxRibbonButtonBar::SetButtonTextMinWidth(
     m_layouts_valid = false;
 }
 
+void wxRibbonButtonBar::SetButtonMinSizeClass(int button_id,
+                wxRibbonButtonBarButtonState min_size_class)
+{
+    wxRibbonButtonBarButtonBase* base = GetItemById(button_id);
+    if(base == NULL)
+        return;
+    if(base->max_size_class < min_size_class)
+    {
+        wxFAIL_MSG("Button minimum size is larger than maximum size");
+        return;
+    }
+    base->min_size_class = min_size_class;
+    m_layouts_valid = false;
+}
+
+void wxRibbonButtonBar::SetButtonMaxSizeClass(int button_id,
+                wxRibbonButtonBarButtonState max_size_class)
+{
+    wxRibbonButtonBarButtonBase* base = GetItemById(button_id);
+    if(base == NULL)
+        return;
+    if(base->min_size_class > max_size_class)
+    {
+        wxFAIL_MSG("Button maximum size is smaller than minimum size");
+        return;
+    }
+    base->max_size_class = max_size_class;
+    m_layouts_valid = false;
+}
+
 void wxRibbonButtonBar::SetArtProvider(wxRibbonArtProvider* art)
 {
     if(art == m_art)
@@ -905,8 +947,27 @@ void wxRibbonButtonBar::MakeLayouts()
     }
     size_t btn_count = m_buttons.Count();
     size_t btn_i;
+
+    // Determine available height:
+    // 1 large button or, if not found, 3 medium or small buttons
+    int available_height = 0;
+    bool large_button_found = false;
+    for(btn_i = 0; btn_i < btn_count; ++btn_i)
     {
-        // Best layout : all buttons large, stacking horizontally
+        wxRibbonButtonBarButtonBase* button = m_buttons.Item(btn_i);
+        wxRibbonButtonBarButtonState size_class = button->GetLargestSize();
+        available_height = wxMax(available_height,
+                                 button->sizes[size_class].size.GetHeight());
+        if(size_class == wxRIBBON_BUTTONBAR_BUTTON_LARGE)
+            large_button_found = true;
+    }
+    if(!large_button_found)
+        available_height *= 3;
+
+    int stacked_width = 0;
+    {
+        // Best layout : all buttons large, stacking horizontally,
+        //               small buttons small, stacked vertically
         wxRibbonButtonBarLayout* layout = new wxRibbonButtonBarLayout;
         wxPoint cursor(0, 0);
         layout->overall_size.SetHeight(0);
@@ -917,54 +978,111 @@ void wxRibbonButtonBar::MakeLayouts()
             instance.position = cursor;
             instance.size = button->GetLargestSize();
             wxSize& size = button->sizes[instance.size].size;
-            cursor.x += size.GetWidth();
-            layout->overall_size.SetHeight(wxMax(layout->overall_size.GetHeight(),
-                size.GetHeight()));
+
+            if(instance.size < wxRIBBON_BUTTONBAR_BUTTON_LARGE)
+            {
+                stacked_width = wxMax(stacked_width, size.GetWidth());
+                if(cursor.y + size.GetHeight() >= available_height)
+                {
+                    cursor.y = 0;
+                    cursor.x += stacked_width;
+                    stacked_width = 0;
+                }
+                else
+                {
+                    cursor.y += size.GetHeight();
+                }
+            }
+            else
+            {
+                if(cursor.y != 0)
+                {
+                    cursor.y = 0;
+                    cursor.x += stacked_width;
+                    stacked_width = 0;
+                    instance.position = cursor;
+                }
+                cursor.x += size.GetWidth();
+            }
             layout->buttons.Add(instance);
         }
-        layout->overall_size.SetWidth(cursor.x);
+        layout->overall_size.SetHeight(available_height);
+        layout->overall_size.SetWidth(cursor.x + stacked_width);
         m_layouts.Add(layout);
     }
     if(btn_count >= 2)
     {
         // Collapse the rightmost buttons and stack them vertically
-        size_t iLast = btn_count - 1;
-        while(TryCollapseLayout(m_layouts.Last(), iLast, &iLast) && iLast > 0)
+        // if they are not already small. If rightmost buttons can't
+        // be collapsed because "min_size_class" is set, try it again
+        // starting from second rightmost button and so on.
+        size_t iLast = btn_count;
+        while(iLast-- > 0)
         {
-            --iLast;
+            TryCollapseLayout(m_layouts.Last(), iLast, &iLast,
+                              wxRIBBON_BUTTONBAR_BUTTON_MEDIUM);
         }
+
+        // TODO: small buttons are not implemented yet in 
+        //       art_msw.cpp:2581 and will be invisible
+        /*iLast = btn_count;
+        while(iLast-- > 0)
+        {
+            TryCollapseLayout(m_layouts.Last(), iLast, &iLast,
+                              wxRIBBON_BUTTONBAR_BUTTON_SMALL);
+        }*/
     }
 }
 
-bool wxRibbonButtonBar::TryCollapseLayout(wxRibbonButtonBarLayout* original,
-                                          size_t first_btn, size_t* last_button)
+void wxRibbonButtonBar::TryCollapseLayout(wxRibbonButtonBarLayout* original,
+                                          size_t first_btn, size_t* last_button,
+                                          wxRibbonButtonBarButtonState target_size)
 {
     size_t btn_count = m_buttons.Count();
     size_t btn_i;
     int used_height = 0;
     int used_width = 0;
+    int original_column_width = 0;
     int available_width = 0;
-    int available_height = 0;
+    int available_height = original->overall_size.GetHeight();
 
+    // Search for button range from right which should be
+    // collapsed into a column of small buttons.
     for(btn_i = first_btn + 1; btn_i > 0; /* decrement is inside loop */)
     {
         --btn_i;
         wxRibbonButtonBarButtonBase* button = m_buttons.Item(btn_i);
         wxRibbonButtonBarButtonState large_size_class = button->GetLargestSize();
         wxSize large_size = button->sizes[large_size_class].size;
-        int t_available_height = wxMax(available_height,
-            large_size.GetHeight());
-        int t_available_width = available_width + large_size.GetWidth();
-        wxRibbonButtonBarButtonState small_size_class = large_size_class;
-        if(!button->GetSmallerSize(&small_size_class))
+        int t_available_width = available_width;
+
+        original_column_width = wxMax(original_column_width,
+                                      large_size.GetWidth());
+
+        // Top button in column: add column width to available width
+        if(original->buttons.Item(btn_i).position.y == 0)
         {
-            return false;
+            t_available_width += original_column_width;
+            original_column_width = 0;
+        }
+
+        wxRibbonButtonBarButtonState small_size_class = large_size_class;
+        if(large_size_class > target_size)
+        {
+            if(!button->GetSmallerSize(&small_size_class,
+                                       small_size_class - target_size))
+            {
+                // Large button that cannot shrink: stop search
+                ++btn_i;
+                break;
+            }
         }
         wxSize small_size = button->sizes[small_size_class].size;
         int t_used_height = used_height + small_size.GetHeight();
         int t_used_width = wxMax(used_width, small_size.GetWidth());
 
-        if(t_used_height > t_available_height)
+        // Height is full: stop search
+        if(t_used_height > available_height)
         {
             ++btn_i;
             break;
@@ -974,13 +1092,13 @@ bool wxRibbonButtonBar::TryCollapseLayout(wxRibbonButtonBarLayout* original,
             used_height = t_used_height;
             used_width = t_used_width;
             available_width = t_available_width;
-            available_height = t_available_height;
         }
     }
 
+    // Layout got wider than before or no suitable button found: abort
     if(btn_i >= first_btn || used_width >= available_width)
     {
-        return false;
+        return;
     }
     if(last_button != NULL)
     {
@@ -990,27 +1108,23 @@ bool wxRibbonButtonBar::TryCollapseLayout(wxRibbonButtonBarLayout* original,
     wxRibbonButtonBarLayout* layout = new wxRibbonButtonBarLayout;
     WX_APPEND_ARRAY(layout->buttons, original->buttons);
     wxPoint cursor(layout->buttons.Item(btn_i).position);
-    bool preserve_height = false;
-    if(btn_i == 0)
-    {
-        // If height isn't preserved (i.e. it is reduced), then the minimum
-        // size for the button bar will decrease, preventing the original
-        // layout from being used (in some cases).
-        // It may be a good idea to always preserve the height, but for now
-        // it is only done when the first button is involved in a collapse.
-        preserve_height = true;
-    }
 
+    cursor.y = 0;
     for(; btn_i <= first_btn; ++btn_i)
     {
         wxRibbonButtonBarButtonInstance& instance = layout->buttons.Item(btn_i);
-        instance.base->GetSmallerSize(&instance.size);
+        if(instance.size > target_size)
+        {
+            instance.base->GetSmallerSize(&instance.size,
+                                          instance.size - target_size);
+        }
         instance.position = cursor;
         cursor.y += instance.base->sizes[instance.size].size.GetHeight();
     }
 
     int x_adjust = available_width - used_width;
 
+    // Adjust x coords of buttons right of shrinked column
     for(; btn_i < btn_count; ++btn_i)
     {
         wxRibbonButtonBarButtonInstance& instance = layout->buttons.Item(btn_i);
@@ -1025,16 +1139,19 @@ bool wxRibbonButtonBar::TryCollapseLayout(wxRibbonButtonBarLayout* original,
     {
         delete layout;
         wxFAIL_MSG("Layout collapse resulted in increased size");
-        return false;
+        return;
     }
 
-    if(preserve_height)
-    {
-        layout->overall_size.SetHeight(original->overall_size.GetHeight());
-    }
+    // If height isn't preserved (i.e. it is reduced), then the minimum
+    // size for the button bar will decrease, preventing the original
+    // layout from being used (in some cases).
+    // If neither "min_size_class" nor "max_size_class" is set, this is
+    // only required when the first button is involved in a collapse but
+    // if small, medium and large buttons as well as min/max size classes
+    // are involved this is always a good idea.
+    layout->overall_size.SetHeight(original->overall_size.GetHeight());
 
     m_layouts.Add(layout);
-    return true;
 }
 
 void wxRibbonButtonBar::MakeBitmaps(wxRibbonButtonBarButtonBase* base,


### PR DESCRIPTION
The pull request implements manual control over minimum and maximum ribbon button sizes, and buttons which change there function (i.e. icon and label) when clicked which are required by my upcoming application.
Varying button label lengths are supported without re-layout if the width of the largest possible label is passed to the button before Realize() is called.

Current progress:
- [x] Implement modifying bitmaps of existing buttons
- [x] Implement modifying lables of existing buttons
- [x] Implement minimum button label size
- [x] Add "always small" buttons (with text right to it) to save space in large menues
- [x] Add "always large" buttons to prevent collapsed buttons in mixed ribbonbutton and sizer panels.
- [x] Update ribbon example program to show the new features.
- [x] ~~Add support for mixed button bar and sizer panels. Currently these panels are too small causing all buttons to collapse.~~ Replaced by "always large" buttons because this would require several wxSizer and wxWindow API changes.

This pull request is ready to review now.
Feedback and suggestions are welcome.