### PR TITLE
Use RtlGetVersion() to retrieve the real OS version in wxMSW

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -579,6 +579,12 @@ Major new features in this release
   was added.
 
 
+3.0.5: (not yet released)
+----------------------------
+
+wxMSW:
+
+- Return correct OS version under Windows 8 and later.
 
 3.0.4: (released 2018-03-08)
 ----------------------------


### PR DESCRIPTION
Unlike GetVersionEx(), this function still returns the real version and not
the fiction concocted by the OS for each program depending on its manifest.

Also use OSVERSIONINFOEXW instead of OSVERSIONINFOEX as RtlGetVersion() only
exists in the Unicode version.

Closes #15321.

(cherry picked from commit d61b52a60e6c94c39f5e12b2e8d8e62511287f08 and 98176fd7acd973e5c6397b5d89fa7d4aa0422009)