### PR TITLE
Various wxTreebook and wxBookCtrl-related refactorings

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -63,6 +63,9 @@ Changes in behaviour which may result in build errors
   This only affects code defining its own custom renderers, code just using
   wxGraphicsContext::CreatePen() continues to compile and work as before.
 
+- wx/treebook.h doesn't include wx/treectrl.h (and, via it, wx/textctrl.h) any
+  more, include these headers explicitly from your code if necessary.
+
 
 3.1.2: (released 2018-??-??)
 ----------------------------

--- a/include/wx/bookctrl.h
+++ b/include/wx/bookctrl.h
@@ -20,10 +20,8 @@
 #if wxUSE_BOOKCTRL
 
 #include "wx/control.h"
-#include "wx/dynarray.h"
+#include "wx/vector.h"
 #include "wx/withimages.h"
-
-WX_DEFINE_EXPORTED_ARRAY_PTR(wxWindow *, wxArrayPages);
 
 class WXDLLIMPEXP_FWD_CORE wxImageList;
 class WXDLLIMPEXP_FWD_CORE wxBookCtrlEvent;
@@ -94,7 +92,7 @@ public:
     virtual size_t GetPageCount() const { return m_pages.size(); }
 
     // get the panel which represents the given page
-    virtual wxWindow *GetPage(size_t n) const { return m_pages[n]; }
+    virtual wxWindow *GetPage(size_t n) const { return m_pages.at(n); }
 
     // get the current page or NULL if none
     wxWindow *GetCurrentPage() const
@@ -331,7 +329,7 @@ protected:
 
 
     // the array of all pages of this control
-    wxArrayPages m_pages;
+    wxVector<wxWindow*> m_pages;
 
     // get the page area
     virtual wxRect GetPageRect() const;

--- a/include/wx/bookctrl.h
+++ b/include/wx/bookctrl.h
@@ -292,6 +292,12 @@ protected:
     // having nodes without any associated page)
     virtual bool AllowNullPage() const { return false; }
 
+    // For classes that allow null pages, we also need a way to find the
+    // closest non-NULL page corresponding to the given index, e.g. the first
+    // leaf item in wxTreebook tree and this method must be overridden to
+    // return it if AllowNullPage() is overridden.
+    virtual wxWindow *DoGetNonNullPage(size_t page) { return m_pages[page]; }
+
     // Remove the page and return a pointer to it.
     //
     // It also needs to update the current selection if necessary, i.e. if the

--- a/include/wx/choicebk.h
+++ b/include/wx/choicebk.h
@@ -86,8 +86,7 @@ protected:
 
     void UpdateSelectedPage(size_t newsel) wxOVERRIDE
     {
-        m_selection = static_cast<int>(newsel);
-        GetChoiceCtrl()->Select(m_selection);
+        GetChoiceCtrl()->Select(newsel);
     }
 
     wxBookCtrlEvent* CreatePageChangingEvent() const wxOVERRIDE;

--- a/include/wx/simplebook.h
+++ b/include/wx/simplebook.h
@@ -155,9 +155,10 @@ public:
     }
 
 protected:
-    virtual void UpdateSelectedPage(size_t newsel) wxOVERRIDE
+    virtual void UpdateSelectedPage(size_t WXUNUSED(newsel)) wxOVERRIDE
     {
-        m_selection = (int)newsel;
+        // Nothing to do here, but must be overridden to avoid the assert in
+        // the base class version.
     }
 
     virtual wxBookCtrlEvent* CreatePageChangingEvent() const wxOVERRIDE

--- a/include/wx/treebook.h
+++ b/include/wx/treebook.h
@@ -22,6 +22,7 @@
 
 typedef wxWindow wxTreebookPage;
 
+class WXDLLIMPEXP_FWD_CORE wxTreeCtrl;
 class WXDLLIMPEXP_FWD_CORE wxTreeEvent;
 
 // ----------------------------------------------------------------------------

--- a/include/wx/treebook.h
+++ b/include/wx/treebook.h
@@ -17,7 +17,7 @@
 
 #include "wx/bookctrl.h"
 #include "wx/containr.h"
-#include "wx/treectrl.h"        // for wxArrayTreeItemIds
+#include "wx/treebase.h"        // for wxTreeItemId
 
 typedef wxWindow wxTreebookPage;
 

--- a/include/wx/treebook.h
+++ b/include/wx/treebook.h
@@ -37,7 +37,6 @@ public:
     // Default ctor doesn't create the control, use Create() afterwards
     wxTreebook()
     {
-        Init();
     }
 
     // This ctor creates the tree book control
@@ -48,8 +47,6 @@ public:
                long style = wxBK_DEFAULT,
                const wxString& name = wxEmptyString)
     {
-        Init();
-
         (void)Create(parent, id, pos, size, style, name);
     }
 
@@ -144,22 +141,16 @@ protected:
 
     // This subclass of wxBookCtrlBase accepts NULL page pointers (empty pages)
     virtual bool AllowNullPage() const wxOVERRIDE { return true; }
+    virtual wxWindow *DoGetNonNullPage(size_t page) wxOVERRIDE;
 
     // event handlers
     void OnTreeSelectionChange(wxTreeEvent& event);
     void OnTreeNodeExpandedCollapsed(wxTreeEvent& event);
 
-    // array of page ids and page windows
+    // array of tree item ids corresponding to the page indices
     wxVector<wxTreeItemId> m_treeIds;
 
-    // in the situation when m_selection page is not wxNOT_FOUND but page is
-    // NULL this is the first (sub)child that has a non-NULL page
-    int m_actualSelection;
-
 private:
-    // common part of all constructors
-    void Init();
-
     // The real implementations of page insertion functions
     // ------------------------------------------------------
     // All DoInsert/Add(Sub)Page functions add the page into :
@@ -181,12 +172,11 @@ private:
                          bool bSelect = false,
                          int imageId = NO_IMAGE);
 
-    // Sets selection in the tree control and updates the page being shown.
-    int DoSetSelection(size_t pos, int flags = 0) wxOVERRIDE;
-
-    // Returns currently shown page. In a case when selected the node
-    // has empty (NULL) page finds first (sub)child with not-empty page.
-    wxTreebookPage *DoGetCurrentPage() const;
+    // Overridden methods used by the base class DoSetSelection()
+    // implementation.
+    void UpdateSelectedPage(size_t newsel) wxOVERRIDE;
+    wxBookCtrlEvent* CreatePageChangingEvent() const wxOVERRIDE;
+    void MakeChangedEvent(wxBookCtrlEvent &event) wxOVERRIDE;
 
     // Does the selection update. Called from page insertion functions
     // to update selection if the selected page was pushed by the newly inserted

--- a/include/wx/treebook.h
+++ b/include/wx/treebook.h
@@ -18,6 +18,7 @@
 #include "wx/bookctrl.h"
 #include "wx/containr.h"
 #include "wx/treebase.h"        // for wxTreeItemId
+#include "wx/vector.h"
 
 typedef wxWindow wxTreebookPage;
 
@@ -149,7 +150,7 @@ protected:
     void OnTreeNodeExpandedCollapsed(wxTreeEvent& event);
 
     // array of page ids and page windows
-    wxArrayTreeItemIds m_treeIds;
+    wxVector<wxTreeItemId> m_treeIds;
 
     // in the situation when m_selection page is not wxNOT_FOUND but page is
     // NULL this is the first (sub)child that has a non-NULL page
@@ -216,7 +217,7 @@ private:
 
     // Returns internal number of pages which can be different from
     // GetPageCount() while performing a page insertion or removal.
-    size_t DoInternalGetPageCount() const { return m_treeIds.GetCount(); }
+    size_t DoInternalGetPageCount() const { return m_treeIds.size(); }
 
 
     wxDECLARE_EVENT_TABLE();

--- a/samples/widgets/widgets.cpp
+++ b/samples/widgets/widgets.cpp
@@ -724,20 +724,7 @@ void WidgetsFrame::OnPageChanged(WidgetsBookCtrlEvent& event)
     {
         wxWindowUpdateLocker noUpdates(curPage);
         curPage->CreateContent();
-        //curPage->Layout();
-        curPage->GetSizer()->Fit(curPage);
-
-        WidgetsBookCtrl *book = wxStaticCast(curPage->GetParent(), WidgetsBookCtrl);
-        wxSize size;
-        for ( size_t i = 0; i < book->GetPageCount(); ++i )
-        {
-            wxWindow *page = book->GetPage(i);
-            if ( page )
-            {
-                size.IncTo(page->GetSize());
-            }
-        }
-        curPage->SetSize(size);
+        curPage->Layout();
     }
     // re-apply the attributes to the widget(s)
     curPage->SetUpWidget();

--- a/samples/widgets/widgets.cpp
+++ b/samples/widgets/widgets.cpp
@@ -49,6 +49,7 @@
 #include "wx/numdlg.h"
 #include "wx/textdlg.h"
 #include "wx/imaglist.h"
+#include "wx/treectrl.h"
 #include "wx/wupdlock.h"
 #include "wx/textcompleter.h"
 

--- a/samples/widgets/widgets.h
+++ b/samples/widgets/widgets.h
@@ -41,6 +41,7 @@ class WXDLLIMPEXP_FWD_CORE wxCheckBox;
 class WXDLLIMPEXP_FWD_CORE wxSizer;
 class WXDLLIMPEXP_FWD_CORE wxImageList;
 class WXDLLIMPEXP_FWD_CORE wxTextCtrl;
+class WXDLLIMPEXP_FWD_CORE wxTextEntryBase;
 class WXDLLIMPEXP_FWD_CORE WidgetsBookCtrl;
 
 class WidgetsPageInfo;

--- a/src/common/bookctrl.cpp
+++ b/src/common/bookctrl.cpp
@@ -493,9 +493,9 @@ int wxBookCtrlBase::DoSetSelection(size_t n, int flags)
         if ( allowed )
         {
             if ( oldSel != wxNOT_FOUND )
-                DoShowPage(m_pages[oldSel], false);
+                DoShowPage(DoGetNonNullPage(oldSel), false);
 
-            wxWindow *page = m_pages[n];
+            wxWindow* const page = DoGetNonNullPage(n);
             page->SetSize(GetPageRect());
             DoShowPage(page, true);
 
@@ -508,6 +508,15 @@ int wxBookCtrlBase::DoSetSelection(size_t n, int flags)
                 // program allows the page change
                 MakeChangedEvent(*event);
                 (void)GetEventHandler()->ProcessEvent(*event);
+            }
+        }
+        else
+        {
+            // Selection in the control might have already had changed.
+            if ( oldSel != wxNOT_FOUND )
+            {
+                m_selection = oldSel;
+                UpdateSelectedPage(oldSel);
             }
         }
 

--- a/src/common/bookctrl.cpp
+++ b/src/common/bookctrl.cpp
@@ -479,7 +479,7 @@ int wxBookCtrlBase::DoSetSelection(size_t n, int flags)
     if ( n != (size_t)oldSel )
     {
         wxBookCtrlEvent *event = CreatePageChangingEvent();
-        bool allowed = false;
+        bool allowed = true;
 
         if ( flags & SetSelection_SendEvent )
         {
@@ -490,7 +490,7 @@ int wxBookCtrlBase::DoSetSelection(size_t n, int flags)
             allowed = !GetEventHandler()->ProcessEvent(*event) || event->IsAllowed();
         }
 
-        if ( !(flags & SetSelection_SendEvent) || allowed)
+        if ( allowed )
         {
             if ( oldSel != wxNOT_FOUND )
                 DoShowPage(m_pages[oldSel], false);

--- a/src/common/bookctrl.cpp
+++ b/src/common/bookctrl.cpp
@@ -241,8 +241,8 @@ void wxBookCtrlBase::DoSize()
 
     // resize all pages to fit the new control size
     const wxRect pageRect = GetPageRect();
-    const unsigned pagesCount = m_pages.GetCount();
-    for ( unsigned int i = 0; i < pagesCount; ++i )
+    const size_t pagesCount = m_pages.size();
+    for ( size_t i = 0; i < pagesCount; ++i )
     {
         wxWindow * const page = m_pages[i];
         if ( !page )
@@ -310,7 +310,7 @@ void wxBookCtrlBase::OnHelp(wxHelpEvent& event)
         source = source->GetParent();
     }
 
-    if ( source && m_pages.Index(source) == wxNOT_FOUND )
+    if ( source && FindPage(source) == wxNOT_FOUND )
     {
         // this event is for the book control itself, redirect it to the
         // corresponding page
@@ -368,7 +368,7 @@ wxBookCtrlBase::InsertPage(size_t nPage,
     wxCHECK_MSG( nPage <= m_pages.size(), false,
                  wxT("invalid page index in wxBookCtrlBase::InsertPage()") );
 
-    m_pages.Insert(page, nPage);
+    m_pages.insert(m_pages.begin() + nPage, page);
     if ( page )
         page->SetSize(GetPageRect());
 
@@ -395,7 +395,7 @@ wxWindow *wxBookCtrlBase::DoRemovePage(size_t nPage)
                  wxT("invalid page index in wxBookCtrlBase::DoRemovePage()") );
 
     wxWindow *pageRemoved = m_pages[nPage];
-    m_pages.RemoveAt(nPage);
+    m_pages.erase(m_pages.begin() + nPage);
     DoInvalidateBestSize();
 
     return pageRemoved;

--- a/src/common/bookctrl.cpp
+++ b/src/common/bookctrl.cpp
@@ -500,6 +500,7 @@ int wxBookCtrlBase::DoSetSelection(size_t n, int flags)
             DoShowPage(page, true);
 
             // change selection now to ignore the selection change event
+            m_selection = n;
             UpdateSelectedPage(n);
 
             if ( flags & SetSelection_SendEvent )

--- a/src/generic/listbkg.cpp
+++ b/src/generic/listbkg.cpp
@@ -293,7 +293,6 @@ void wxListbook::SetImageList(wxImageList *imageList)
 
 void wxListbook::UpdateSelectedPage(size_t newsel)
 {
-    m_selection = newsel;
     GetListView()->Select(newsel);
     GetListView()->Focus(newsel);
 }

--- a/src/generic/toolbkg.cpp
+++ b/src/generic/toolbkg.cpp
@@ -197,7 +197,6 @@ void wxToolbook::MakeChangedEvent(wxBookCtrlEvent &event)
 
 void wxToolbook::UpdateSelectedPage(size_t newsel)
 {
-    m_selection = newsel;
     GetToolBar()->ToggleTool(newsel + 1, true);
 }
 

--- a/src/generic/treebkg.cpp
+++ b/src/generic/treebkg.cpp
@@ -327,7 +327,8 @@ void wxTreebook::DoInternalAddPage(size_t newPos,
                                    wxTreebookPage *page,
                                    wxTreeItemId pageId)
 {
-    wxASSERT_MSG( newPos <= m_treeIds.size(), wxT("Ivalid index passed to wxTreebook::DoInternalAddPage") );
+    wxASSERT_MSG( newPos <= m_treeIds.size(),
+                  wxT("Invalid index passed to wxTreebook::DoInternalAddPage") );
 
     // hide newly inserted page initially (it will be shown when selected)
     if ( page )
@@ -363,7 +364,7 @@ void wxTreebook::DoInternalRemovePageRange(size_t pagePos, size_t subCount)
     // with all its children so pagePos is the node's index and subCount is the
     // node children count
     wxASSERT_MSG( pagePos + subCount < m_treeIds.size(),
-                    wxT("Ivalid page index") );
+                    wxT("Invalid page index") );
 
     wxTreeItemId pageId = m_treeIds[pagePos];
 

--- a/src/generic/treebkg.cpp
+++ b/src/generic/treebkg.cpp
@@ -32,6 +32,7 @@
 #endif
 
 #include "wx/imaglist.h"
+#include "wx/treectrl.h"
 
 // ----------------------------------------------------------------------------
 // various wxWidgets macros
@@ -140,7 +141,7 @@ bool wxTreebook::InsertSubPage(size_t pagePos,
 bool wxTreebook::AddPage(wxWindow *page, const wxString& text, bool bSelect,
                          int imageId)
 {
-    return DoInsertPage(m_treeIds.GetCount(), page, text, bSelect, imageId);
+    return DoInsertPage(m_treeIds.size(), page, text, bSelect, imageId);
 }
 
 // insertion time is linear to the number of top-pages
@@ -312,7 +313,7 @@ wxTreebookPage *wxTreebook::DoRemovePage(size_t pagePos)
 bool wxTreebook::DeleteAllPages()
 {
     wxBookCtrlBase::DeleteAllPages();
-    m_treeIds.Clear();
+    m_treeIds.clear();
     m_selection =
     m_actualSelection = wxNOT_FOUND;
 
@@ -326,20 +327,20 @@ void wxTreebook::DoInternalAddPage(size_t newPos,
                                    wxTreebookPage *page,
                                    wxTreeItemId pageId)
 {
-    wxASSERT_MSG( newPos <= m_treeIds.GetCount(), wxT("Ivalid index passed to wxTreebook::DoInternalAddPage") );
+    wxASSERT_MSG( newPos <= m_treeIds.size(), wxT("Ivalid index passed to wxTreebook::DoInternalAddPage") );
 
     // hide newly inserted page initially (it will be shown when selected)
     if ( page )
         page->Hide();
 
-    if ( newPos == m_treeIds.GetCount() )
+    if ( newPos == m_treeIds.size() )
     {
         // append
-        m_treeIds.Add(pageId);
+        m_treeIds.push_back(pageId);
     }
     else // insert
     {
-        m_treeIds.Insert(pageId, newPos);
+        m_treeIds.insert(m_treeIds.begin() + newPos, pageId);
 
         if ( m_selection != wxNOT_FOUND && newPos <= (size_t)m_selection )
         {
@@ -361,12 +362,13 @@ void wxTreebook::DoInternalRemovePageRange(size_t pagePos, size_t subCount)
     // Attention: this function is only for a situation when we delete a node
     // with all its children so pagePos is the node's index and subCount is the
     // node children count
-    wxASSERT_MSG( pagePos + subCount < m_treeIds.GetCount(),
+    wxASSERT_MSG( pagePos + subCount < m_treeIds.size(),
                     wxT("Ivalid page index") );
 
     wxTreeItemId pageId = m_treeIds[pagePos];
 
-    m_treeIds.RemoveAt(pagePos, subCount + 1);
+    wxVector<wxTreeItemId>::iterator itPos = m_treeIds.begin() + pagePos;
+    m_treeIds.erase(itPos, itPos + subCount + 1);
 
     if ( m_selection != wxNOT_FOUND )
     {
@@ -454,7 +456,7 @@ void wxTreebook::DoUpdateSelection(bool bSelect, int newPos)
 
 wxTreeItemId wxTreebook::DoInternalGetPage(size_t pagePos) const
 {
-    if ( pagePos >= m_treeIds.GetCount() )
+    if ( pagePos >= m_treeIds.size() )
     {
         // invalid position but ok here, in this internal function, don't assert
         // (the caller will do it)
@@ -466,7 +468,7 @@ wxTreeItemId wxTreebook::DoInternalGetPage(size_t pagePos) const
 
 int wxTreebook::DoInternalFindPageById(wxTreeItemId pageId) const
 {
-    const size_t count = m_treeIds.GetCount();
+    const size_t count = m_treeIds.size();
     for ( size_t i = 0; i < count; ++i )
     {
         if ( m_treeIds[i] == pageId )

--- a/src/gtk/notebook.cpp
+++ b/src/gtk/notebook.cpp
@@ -418,7 +418,7 @@ bool wxNotebook::InsertPage( size_t position,
 
     wxGtkNotebookPage* pageData = new wxGtkNotebookPage;
 
-    m_pages.Insert(win, position);
+    m_pages.insert(m_pages.begin() + position, win);
     m_pagesData.Insert(position, pageData);
 
     // set the label image and text

--- a/src/gtk1/notebook.cpp
+++ b/src/gtk1/notebook.cpp
@@ -660,7 +660,7 @@ bool wxNotebook::InsertPage( size_t position,
     else
         m_pagesData.Insert( position, nb_page );
 
-    m_pages.Insert(win, position);
+    m_pages.insert(m_pages.begin() + position, win);
 
     nb_page->m_box = gtk_hbox_new( FALSE, 1 );
     gtk_container_border_width( GTK_CONTAINER(nb_page->m_box), 2 );

--- a/src/gtk1/notebook.cpp
+++ b/src/gtk1/notebook.cpp
@@ -586,7 +586,6 @@ bool wxNotebook::DeleteAllPages()
 
     wxASSERT_MSG( GetPageCount() == 0, wxT("all pages must have been deleted") );
 
-    InvalidateBestSize();
     return wxNotebookBase::DeleteAllPages();
 }
 

--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -309,9 +309,9 @@ wxNotebook::~wxNotebook()
 size_t wxNotebook::GetPageCount() const
 {
     // consistency check
-    wxASSERT( (int)m_pages.Count() == TabCtrl_GetItemCount(GetHwnd()) );
+    wxASSERT( (int)m_pages.size() == TabCtrl_GetItemCount(GetHwnd()) );
 
-    return m_pages.Count();
+    return m_pages.size();
 }
 
 int wxNotebook::GetRowCount() const
@@ -404,7 +404,7 @@ bool wxNotebook::SetPageText(size_t nPage, const wxString& strText)
     if ( ret && rows != GetRowCount() )
     {
         const wxRect r = GetPageSize();
-        const size_t count = m_pages.Count();
+        const size_t count = m_pages.size();
         for ( size_t page = 0; page < count; page++ )
             m_pages[page]->SetSize(r);
     }
@@ -578,7 +578,7 @@ wxNotebookPage *wxNotebook::DoRemovePage(size_t nPage)
     if ( !TabCtrl_DeleteItem(GetHwnd(), nPage) )
         wxLogLastError(wxS("TabCtrl_DeleteItem()"));
 
-    if ( m_pages.IsEmpty() )
+    if ( m_pages.empty() )
     {
         // no selection any more, the notebook becamse empty
         m_selection = wxNOT_FOUND;
@@ -693,13 +693,13 @@ bool wxNotebook::InsertPage(size_t nPage,
     }
 
     // succeeded: save the pointer to the page
-    m_pages.Insert(pPage, nPage);
+    m_pages.insert(m_pages.begin() + nPage, pPage);
 
     // we may need to adjust the size again if the notebook size changed:
     // normally this only happens for the first page we add (the tabs which
     // hadn't been there before are now shown) but for a multiline notebook it
     // can happen for any page at all as a new row could have been started
-    if ( m_pages.GetCount() == 1 || HasFlag(wxNB_MULTILINE) )
+    if ( m_pages.size() == 1 || HasFlag(wxNB_MULTILINE) )
     {
         AdjustPageSize(pPage);
 
@@ -959,7 +959,7 @@ void wxNotebook::OnSize(wxSizeEvent& event)
 
     int width = rc.right - rc.left,
         height = rc.bottom - rc.top;
-    size_t nCount = m_pages.Count();
+    size_t nCount = m_pages.size();
     for ( size_t nPage = 0; nPage < nCount; nPage++ ) {
         wxNotebookPage *pPage = m_pages[nPage];
         pPage->SetSize(rc.left, rc.top, width, height);

--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -622,19 +622,11 @@ wxNotebookPage *wxNotebook::DoRemovePage(size_t nPage)
 // remove all pages
 bool wxNotebook::DeleteAllPages()
 {
-    size_t nPageCount = GetPageCount();
-    size_t nPage;
-    for ( nPage = 0; nPage < nPageCount; nPage++ )
-        delete m_pages[nPage];
-
-    m_pages.Clear();
+    wxBookCtrlBase::DeleteAllPages();
 
     if ( !TabCtrl_DeleteAllItems(GetHwnd()) )
         wxLogLastError(wxS("TabCtrl_DeleteAllItems()"));
 
-    m_selection = wxNOT_FOUND;
-
-    InvalidateBestSize();
     return true;
 }
 

--- a/src/osx/notebook_osx.cpp
+++ b/src/osx/notebook_osx.cpp
@@ -173,7 +173,7 @@ wxNotebookPage* wxNotebook::DoRemovePage(size_t nPage)
         wxT("DoRemovePage: invalid notebook page") );
 
     wxNotebookPage* page = m_pages[nPage] ;
-    m_pages.RemoveAt(nPage);
+    m_pages.erase(m_pages.begin() + nPage);
     m_images.RemoveAt(nPage);
 
     MacSetupTabs();
@@ -285,7 +285,7 @@ wxRect wxNotebook::GetPageRect() const
 //     time because doing it in ::Create() doesn't work (for unknown reasons)
 void wxNotebook::OnSize(wxSizeEvent& event)
 {
-    unsigned int nCount = m_pages.Count();
+    unsigned int nCount = m_pages.size();
     wxRect rect = GetPageRect() ;
 
     for ( unsigned int nPage = 0; nPage < nCount; nPage++ )

--- a/src/osx/notebook_osx.cpp
+++ b/src/osx/notebook_osx.cpp
@@ -199,11 +199,10 @@ wxNotebookPage* wxNotebook::DoRemovePage(size_t nPage)
 // remove all pages
 bool wxNotebook::DeleteAllPages()
 {
-    WX_CLEAR_ARRAY(m_pages);
+    wxBookCtrlBase::DeleteAllPages();
+
     m_images.clear();
     MacSetupTabs();
-    m_selection = wxNOT_FOUND ;
-    InvalidateBestSize();
 
     return true;
 }

--- a/src/qt/notebook.cpp
+++ b/src/qt/notebook.cpp
@@ -150,7 +150,7 @@ bool wxNotebook::InsertPage(size_t n, wxWindow *page, const wxString& text,
         m_qtTabWidget->insertTab( n, page->GetHandle(), wxQtConvertString( text ));
     }
 
-    m_pages.Insert(page, n);
+    m_pages.insert(m_pages.begin() + n, page);
     m_images.insert(m_images.begin() + n, imageId);
 
     // reenable firing qt signals as internal wx initialization was completed

--- a/src/univ/notebook.cpp
+++ b/src/univ/notebook.cpp
@@ -304,7 +304,7 @@ bool wxNotebook::InsertPage(size_t nPage,
                  wxT("invalid notebook page in InsertPage()") );
 
     // modify the data
-    m_pages.Insert(pPage, nPage);
+    m_pages.insert(m_pages.begin() + nPage, pPage);
 
     wxString label;
     m_accels.Insert(FindAccelIndex(strText, &label), nPage);
@@ -378,7 +378,7 @@ wxNotebookPage *wxNotebook::DoRemovePage(size_t nPage)
     wxCHECK_MSG( IS_VALID_PAGE(nPage), NULL, wxT("invalid notebook page") );
 
     wxNotebookPage *page = m_pages[nPage];
-    m_pages.RemoveAt(nPage);
+    m_pages.erase(m_pages.begin() + nPage);
     m_titles.RemoveAt(nPage);
     m_accels.RemoveAt(nPage);
     m_widths.RemoveAt(nPage);


### PR DESCRIPTION
Reuse `wxBookCtrlBase` methods in the derived classes and replace some macro-based arrays with `wxVector<>`.