### PR TITLE
Fix warning: include/wx/textbuf.h(45): warning C4191: 'type cast': un…

### DIFF
--- a/include/wx/dynarray.h
+++ b/include/wx/dynarray.h
@@ -109,8 +109,7 @@ private:
 };
 
 #define  _WX_DECLARE_BASEARRAY(T, name, classexp)                   \
-   typedef int (wxCMPFUNC_CONV *CMPFUN##name)(T pItem1, T pItem2);  \
-   typedef wxSortedArray_SortFunction<T, CMPFUN##name> name##_Predicate; \
+   typedef wxArray_SortFunction<T> name##_Predicate; \
    _WX_DECLARE_BASEARRAY_2(T, name, name##_Predicate, classexp)
 
 #define  _WX_DECLARE_BASEARRAY_2(T, name, predicate, classexp)      \


### PR DESCRIPTION
…safe conversion from 'wxArrayLinesType::CMPFUNC' to 'wxArrayLinesType::SCMPFUNC'.

When using wxUSE_STD_CONTAINERS as 1, and utilizing wxXmlDocument, the wxXmlDocument utilizes textbuf.h, and the warning comes out. I did not have this warning with my code using wxWidgets 3.1.0, but started getting it when I switched to wxWidgets 3.1.1. The warning started happening for me due to commit:

https://github.com/wxWidgets/wxWidgets/commit/11e54135587d2073c4f1c0986e072078678bf229

Which introduced the usage of textbuf.h into xml.h. However the underlying problem has been present long before this commit.

Due to heavy preprocessor use, the true source of where the warning is coming from is hard to track. I tracked the warning down to line 170 in include/wx/dynarray.h:

170: Predicate p((SCMPFUNC)fnCompare);

SCMPFUNC and fnCompare (of type CMPFUNC) have different interfaces.

SCMPFUNC has interface:
112: int ()(T pItem1, T pItem2)

while CMPFUNC has interface:
89: int()(T* pItem1, T* pItem2)

So SCMPFUNC is taking pItem1 and pItem2 not as pointers, but as value, while CMPFUNC takes them as pointers.

As CMPFUNC is what is used in the API to clients, this is the API we want to preserve. The SCMPFUNC API is not useful.

To fix the issue, I change the definition of Predicate to be a functor that has the CMPFUNC interface, which is to change it to:

119: typedef wxArray_SortFunction<T> Predicate;

Then I remove the definition of SCMPFUNC and the casts to it.

Now the code compiles without warning and is correct.

Backup:

To track down the interfaces of CMPFUNC and SCMPFUNC, here is a guide:

CMPFUNC:
122: typedef wxArray_SortFunction<T>::CMPFUNC CMPFUNC;
92: bool operator()(const T& i1, const T& i2)
89: int (wxCMPFUNC_CONV *CMPFUNC)(T* pItem1, T* pItem2)

SCMPFUNC:
120: typedef predicate::CMPFUNC SCMPFUNC;
119: typedef predicate Predicate;
113: typedef wxSortedArray_SortFunction<T, CMPFUN##name> name##_Predicate;
112: typedef int (wxCMPFUNC_CONV *CMPFUN##name)(T pItem1, T pItem2)