### PR TITLE
Fix warning: include/wx/textbuf.h(45): warning C4191: 'type cast': un…

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -22,7 +22,8 @@ Micha Ahrweiler							<mbaschnitzi@users.noreply.github.com>
 ousnius			<ousnius@users.noreply.github.com>	<denis41@hotmail.de>
 Paul Cornett		<paulcor@bullseye.com>			<paulcor@users.noreply.github.com>
 Paul Kulchenko		<paul@kulchenko.com>			<paulclinger@gmail.com>
-pbfordev		<PBforDev@gmail.com>			<pbfordev@gmail.com>
+PB			<PBfordev@gmail.com>			<pbfordev@gmail.com>
+			<PBfordev@gmail.com>			<PBforDev@gmail.com>
 Richard Fath							<richard.fath@t-online.de>
 Steve Browne		<swbrowne@gmail.com>			<sbrowne@unknown>
 			<swbrowne@gmail.com>			<amn3sia@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -22,6 +22,7 @@ Micha Ahrweiler							<mbaschnitzi@users.noreply.github.com>
 ousnius			<ousnius@users.noreply.github.com>	<denis41@hotmail.de>
 Paul Cornett		<paulcor@bullseye.com>			<paulcor@users.noreply.github.com>
 Paul Kulchenko		<paul@kulchenko.com>			<paulclinger@gmail.com>
+pbfordev		<PBforDev@gmail.com>			<pbfordev@gmail.com>
 Richard Fath							<richard.fath@t-online.de>
 Steve Browne		<swbrowne@gmail.com>			<sbrowne@unknown>
 			<swbrowne@gmail.com>			<amn3sia@gmail.com>

--- a/include/wx/arrstr.h
+++ b/include/wx/arrstr.h
@@ -53,9 +53,7 @@ wxDictionaryStringSortDescending(const wxString& s1, const wxString& s2)
 
 typedef int (wxCMPFUNC_CONV *CMPFUNCwxString)(wxString*, wxString*);
 typedef wxString _wxArraywxBaseArrayStringBase;
-_WX_DECLARE_BASEARRAY_2(_wxArraywxBaseArrayStringBase, wxBaseArrayStringBase,
-                        wxArray_SortFunction<wxString>,
-                        class WXDLLIMPEXP_BASE);
+_WX_DECLARE_BASEARRAY(_wxArraywxBaseArrayStringBase, wxBaseArrayStringBase, class WXDLLIMPEXP_BASE);
 WX_DEFINE_USER_EXPORTED_TYPEARRAY(wxString, wxArrayStringBase,
                                   wxBaseArrayStringBase, WXDLLIMPEXP_BASE);
 

--- a/include/wx/dynarray.h
+++ b/include/wx/dynarray.h
@@ -82,25 +82,38 @@ typedef int (wxCMPFUNC_CONV *CMPFUNC)(const void* pItem1, const void* pItem2);
 
 #if wxUSE_STD_CONTAINERS
 
-template<class T>
-class wxArray_SortFunction
-{
-public:
-    typedef int (wxCMPFUNC_CONV *CMPFUNC)(T* pItem1, T* pItem2);
-
-    wxArray_SortFunction(CMPFUNC f) : m_f(f) { }
-    bool operator()(const T& i1, const T& i2)
-      { return m_f((T*)&i1, (T*)&i2) < 0; }
-private:
-    CMPFUNC m_f;
-};
-
 #define  _WX_DECLARE_BASEARRAY(T, name, classexp)                   \
+class wxArray_FunctorBase##name                                     \
+{                                                                   \
+public:                                                             \
+    wxArray_FunctorBase##name() {}                                  \
+    virtual bool operator()(const T& i1, const T& i2) const = 0;    \
+};                                                                  \
+class wxArray_SortFunction##name : public wxArray_FunctorBase##name \
+{                                                                   \
+public:                                                             \
+    typedef int (wxCMPFUNC_CONV *CMPFUNC)(T* pItem1, T* pItem2);    \
+                                                                    \
+    wxArray_SortFunction##name(CMPFUNC f) : m_f(f) { }              \
+    bool operator()(const T& i1, const T& i2) const                 \
+      { return m_f((T*)&i1, (T*)&i2) < 0; }                         \
+private:                                                            \
+    CMPFUNC m_f;                                                    \
+};                                                                  \
+class wxArray_SortFunctor##name                                     \
+{                                                                   \
+public:                                                             \
+    wxArray_SortFunctor##name(const wxArray_FunctorBase##name *f) : m_f(f) { } \
+    bool operator()(const T& i1, const T& i2) const                 \
+      { return (*m_f)(i1, i2); }                                    \
+private:                                                            \
+    const wxArray_FunctorBase##name *m_f;                           \
+};                                                                  \
 class name : public std::vector<T>                                  \
 {                                                                   \
-  typedef wxArray_SortFunction<T> Predicate;                        \
+  typedef wxArray_SortFunction##name Predicate;                     \
 public:                                                             \
-  typedef wxArray_SortFunction<T>::CMPFUNC CMPFUNC;                 \
+  typedef wxArray_SortFunction##name::CMPFUNC CMPFUNC;              \
                                                                     \
 public:                                                             \
   typedef T base_type;                                              \
@@ -149,23 +162,19 @@ public:                                                             \
   int Index(T lItem, CMPFUNC fnCompare) const                       \
   {                                                                 \
       Predicate p(fnCompare);                                       \
-      const_iterator i = std::lower_bound(begin(), end(), lItem, p);\
-      return i != end() && !p(lItem, *i) ? (int)(i - begin())       \
-                                         : wxNOT_FOUND;             \
+      return IndexFunctor(lItem, &p);                               \
   }                                                                 \
   size_t IndexForInsert(T lItem, CMPFUNC fnCompare) const           \
   {                                                                 \
       Predicate p(fnCompare);                                       \
-      const_iterator i = std::lower_bound(begin(), end(), lItem, p);\
-      return i - begin();                                           \
+      return IndexForInsertFunctor(lItem, &p);                      \
   }                                                                 \
   void Add(T lItem, size_t nInsert = 1)                             \
     { insert(end(), nInsert, lItem); }                              \
   size_t Add(T lItem, CMPFUNC fnCompare)                            \
   {                                                                 \
-      size_t n = IndexForInsert(lItem, fnCompare);                  \
-      Insert(lItem, n);                                             \
-      return n;                                                     \
+      Predicate p(fnCompare);                                       \
+      return AddFunctor(lItem, &p);                                 \
   }                                                                 \
   void Insert(T lItem, size_t uiIndex, size_t nInsert = 1)          \
     { insert(begin() + uiIndex, nInsert, lItem); }                  \
@@ -180,14 +189,52 @@ public:                                                             \
                                                                     \
   void Sort(CMPFUNC fCmp)                                           \
   {                                                                 \
-    wxArray_SortFunction<T> p(fCmp);                                \
+    wxArray_SortFunction##name p(fCmp);                             \
     std::sort(begin(), end(), p);                                   \
+  }                                                                 \
+protected:                                                          \
+  int IndexFunctor(T lItem, const wxArray_FunctorBase##name *p) const \
+  {                                                                 \
+      wxArray_SortFunctor##name pFunctor(p);                        \
+      const_iterator i = std::lower_bound(begin(), end(), lItem, pFunctor);\
+      return i != end() && !(*p)(lItem, *i) ? (int)(i - begin())    \
+                                            : wxNOT_FOUND;          \
+  }                                                                 \
+  size_t IndexForInsertFunctor(T lItem, const wxArray_FunctorBase##name *p) const \
+  {                                                                 \
+      wxArray_SortFunctor##name pFunctor(p);                        \
+      const_iterator i = std::lower_bound(begin(), end(), lItem, pFunctor);\
+      return i - begin();                                           \
+  }                                                                 \
+  size_t AddFunctor(T lItem, const wxArray_FunctorBase##name *fnCompare) \
+  {                                                                 \
+      size_t n = IndexForInsertFunctor(lItem, fnCompare);           \
+      Insert(lItem, n);                                             \
+      return n;                                                     \
   }                                                                 \
 }
 
 #else // if !wxUSE_STD_CONTAINERS
 
 #define  _WX_DECLARE_BASEARRAY(T, name, classexp)                   \
+class wxArray_FunctorBase##name                                     \
+{                                                                   \
+public:                                                             \
+    wxArray_FunctorBase##name() {}                                  \
+    virtual int operator()(const T *i1, const T *i2) const = 0;     \
+};                                                                  \
+                                                                    \
+class wxArray_SortFunction##name : public wxArray_FunctorBase##name \
+{                                                                   \
+public:                                                             \
+    typedef int (wxCMPFUNC_CONV *CMPFUNC)(const void *pItem1, const void *pItem2); \
+                                                                    \
+    wxArray_SortFunction##name(CMPFUNC f) : m_f(f) { }              \
+    int operator()(const T *i1, const T *i2) const                  \
+      { return m_f((const void *) i1, (const void *) i2); }         \
+private:                                                            \
+    CMPFUNC m_f;                                                    \
+};                                                                  \
 classexp name                                                       \
 {                                                                   \
   typedef CMPFUNC SCMPFUNC; /* for compatibility wuth wxUSE_STD_CONTAINERS */  \
@@ -283,6 +330,11 @@ public:                                                             \
   bool empty() const { return IsEmpty(); }                          \
   size_type max_size() const { return INT_MAX; }                    \
   size_type size() const { return GetCount(); }                     \
+                                                                    \
+protected:                                                          \
+  int IndexFunctor(T lItem, const wxArray_FunctorBase##name *fnCompare) const;  \
+  size_t IndexForInsertFunctor(T lItem, const wxArray_FunctorBase##name *fnCompare) const; \
+  size_t AddFunctor(T lItem, const wxArray_FunctorBase##name *fnCompare); \
                                                                     \
 private:                                                            \
   void Grow(size_t nIncrement = 0);                                 \
@@ -503,11 +555,37 @@ public:                                                               \
 wxCOMPILE_TIME_ASSERT2(sizeof(T) <= sizeof(base::base_type),          \
                        TypeTooBigToBeStoredInSorted##base,            \
                        name);                                         \
+class wxSortedArray_SortFunctor##name : public wxArray_FunctorBase##base \
+{                                                                     \
+public:                                                               \
+  typedef int (wxCMPFUNC_CONV *CMPFUNC_REF)(const T &Item1, const T &Item2);  \
+  typedef int (wxCMPFUNC_CONV *CMPFUNC_VAL)(const T Item1, const T Item2);    \
+                                                                      \
+  wxSortedArray_SortFunctor##name(CMPFUNC_REF fRef)                   \
+    : m_fRef(fRef), m_fVal(NULL) { }                                  \
+  wxSortedArray_SortFunctor##name(CMPFUNC_VAL fVal)                   \
+    : m_fRef(NULL), m_fVal(fVal) { }                                  \
+  bool operator()(const base::base_type& i1, const base::base_type& i2) const \
+    { if ( m_fRef != NULL )                                           \
+        { return m_fRef((const T&) i1, (const T&) i2) < 0; }          \
+      else                                                            \
+        { return m_fVal((const T) i1, (const T) i2) < 0; }            \
+    }                                                                 \
+  int operator()(const base::base_type *i1, const base::base_type *i2) const \
+    { if ( m_fRef != NULL )                                           \
+       { return m_fRef((const T&) *i1, (const T&) *i2); }             \
+     else                                                             \
+       { return m_fVal((const T) *i1, (const T) *i2); }               \
+    }                                                                 \
+private:                                                              \
+  CMPFUNC_REF m_fRef;                                                 \
+  CMPFUNC_VAL m_fVal;                                                 \
+};                                                                    \
 classexp name : public base                                           \
 {                                                                     \
   typedef comptype SCMPFUNC;                                          \
 public:                                                               \
-  name(comptype fn defcomp) { m_fnCompare = fn; }                     \
+  name(comptype fn defcomp) : m_fnCompare(fn) {}                      \
                                                                       \
   name& operator=(const name& src)                                    \
     { base* temp = (base*) this;                                      \
@@ -523,16 +601,16 @@ public:                                                               \
     { return (T&)(base::operator[](size() - 1)); }                    \
                                                                       \
   int Index(T lItem) const                                            \
-    { return base::Index(lItem, (CMPFUNC)m_fnCompare); }              \
+    { return base::IndexFunctor(lItem, &m_fnCompare); }               \
                                                                       \
   size_t IndexForInsert(T lItem) const                                \
-    { return base::IndexForInsert(lItem, (CMPFUNC)m_fnCompare); }     \
+    { return base::IndexForInsertFunctor(lItem, &m_fnCompare); }      \
                                                                       \
   void AddAt(T item, size_t index)                                    \
     { base::insert(begin() + index, item); }                          \
                                                                       \
   size_t Add(T lItem)                                                 \
-    { return base::Add(lItem, (CMPFUNC)m_fnCompare); }                \
+    { return base::AddFunctor(lItem, &m_fnCompare); }                 \
   void push_back(T lItem)                                             \
     { Add(lItem); }                                                   \
                                                                       \
@@ -544,7 +622,7 @@ public:                                                               \
       base::erase(begin() + iIndex); }                                \
                                                                       \
 private:                                                              \
-  comptype m_fnCompare;                                               \
+  wxSortedArray_SortFunctor##name m_fnCompare;                        \
 }
 
 

--- a/include/wx/dynarray.h
+++ b/include/wx/dynarray.h
@@ -95,19 +95,6 @@ private:
     CMPFUNC m_f;
 };
 
-template<class T, typename F>
-class wxSortedArray_SortFunction
-{
-public:
-    typedef F CMPFUNC;
-
-    wxSortedArray_SortFunction(CMPFUNC f) : m_f(f) { }
-    bool operator()(const T& i1, const T& i2)
-      { return m_f(i1, i2) < 0; }
-private:
-    CMPFUNC m_f;
-};
-
 #define  _WX_DECLARE_BASEARRAY(T, name, classexp)                   \
    typedef wxArray_SortFunction<T> name##_Predicate; \
    _WX_DECLARE_BASEARRAY_2(T, name, name##_Predicate, classexp)

--- a/include/wx/dynarray.h
+++ b/include/wx/dynarray.h
@@ -109,8 +109,7 @@ private:
 };
 
 #define  _WX_DECLARE_BASEARRAY(T, name, classexp)                   \
-   typedef int (wxCMPFUNC_CONV *CMPFUN##name)(T pItem1, T pItem2);  \
-   typedef wxSortedArray_SortFunction<T, CMPFUN##name> name##_Predicate; \
+   typedef wxArray_SortFunction<T> name##_Predicate; \
    _WX_DECLARE_BASEARRAY_2(T, name, name##_Predicate, classexp)
 
 #define  _WX_DECLARE_BASEARRAY_2(T, name, predicate, classexp)      \

--- a/include/wx/dynarray.h
+++ b/include/wx/dynarray.h
@@ -96,14 +96,9 @@ private:
 };
 
 #define  _WX_DECLARE_BASEARRAY(T, name, classexp)                   \
-   typedef wxArray_SortFunction<T> name##_Predicate; \
-   _WX_DECLARE_BASEARRAY_2(T, name, name##_Predicate, classexp)
-
-#define  _WX_DECLARE_BASEARRAY_2(T, name, predicate, classexp)      \
 class name : public std::vector<T>                                  \
 {                                                                   \
-  typedef predicate Predicate;                                      \
-  typedef predicate::CMPFUNC SCMPFUNC;                              \
+  typedef wxArray_SortFunction<T> Predicate;                        \
 public:                                                             \
   typedef wxArray_SortFunction<T>::CMPFUNC CMPFUNC;                 \
                                                                     \
@@ -153,14 +148,14 @@ public:                                                             \
   }                                                                 \
   int Index(T lItem, CMPFUNC fnCompare) const                       \
   {                                                                 \
-      Predicate p((SCMPFUNC)fnCompare);                             \
+      Predicate p(fnCompare);                                       \
       const_iterator i = std::lower_bound(begin(), end(), lItem, p);\
       return i != end() && !p(lItem, *i) ? (int)(i - begin())       \
                                          : wxNOT_FOUND;             \
   }                                                                 \
   size_t IndexForInsert(T lItem, CMPFUNC fnCompare) const           \
   {                                                                 \
-      Predicate p((SCMPFUNC)fnCompare);                             \
+      Predicate p(fnCompare);                                       \
       const_iterator i = std::lower_bound(begin(), end(), lItem, p);\
       return i - begin();                                           \
   }                                                                 \

--- a/interface/wx/slider.h
+++ b/interface/wx/slider.h
@@ -58,7 +58,7 @@
     @style{wxSL_BOTTOM}
            Displays ticks on the bottom (this is the default).
     @style{wxSL_SELRANGE}
-           Allows the user to select a range on the slider. Windows only.
+           Displays a highlighted selection range. Windows only.
     @style{wxSL_INVERSE}
            Inverses the minimum and maximum endpoints on the slider. Not
            compatible with wxSL_SELRANGE.

--- a/samples/taskbarbutton/taskbarbutton.cpp
+++ b/samples/taskbarbutton/taskbarbutton.cpp
@@ -429,7 +429,7 @@ void MyFrame::OnRemoveThubmBarButton(wxCommandEvent& WXUNUSED(event))
 
     wxThumbBarButton* button = m_thumbBarButtons.back();
     m_thumbBarButtons.pop_back();
-    MSWGetTaskBarButton()->RemoveThumbBarButton(button);
+    delete MSWGetTaskBarButton()->RemoveThumbBarButton(button);
 }
 
 void MyFrame::OnThumbnailToolbarBtnClicked(wxCommandEvent& event)

--- a/src/common/dynarray.cpp
+++ b/src/common/dynarray.cpp
@@ -76,7 +76,13 @@ int name::Index(T lItem, bool bFromEnd) const                               \
 /* add item assuming the array is sorted with fnCompare function */         \
 size_t name::Add(T lItem, CMPFUNC fnCompare)                                \
 {                                                                           \
-  size_t idx = IndexForInsert(lItem, fnCompare);                            \
+  wxArray_SortFunction##name p(fnCompare);                                  \
+  return AddFunctor(lItem, &p);                                             \
+}                                                                           \
+                                                                            \
+size_t name::AddFunctor(T lItem, const wxArray_FunctorBase##name *fnCompare)\
+{                                                                           \
+  size_t idx = IndexForInsertFunctor(lItem, fnCompare);                     \
   Insert(lItem, idx);                                                       \
   return idx;                                                               \
 }                                                                           \
@@ -270,6 +276,12 @@ void name::Insert(T lItem, size_t nIndex, size_t nInsert)                   \
 /* search for a place to insert item into sorted array (binary search) */   \
 size_t name::IndexForInsert(T lItem, CMPFUNC fnCompare) const               \
 {                                                                           \
+  wxArray_SortFunction##name p(fnCompare);                                  \
+  return IndexForInsertFunctor(lItem, &p);                                  \
+}                                                                           \
+                                                                            \
+size_t name::IndexForInsertFunctor(T lItem, const wxArray_FunctorBase##name *fnCompare) const \
+{                                                                           \
   size_t i,                                                                 \
        lo = 0,                                                              \
        hi = m_nCount;                                                       \
@@ -278,8 +290,8 @@ size_t name::IndexForInsert(T lItem, CMPFUNC fnCompare) const               \
   while ( lo < hi ) {                                                       \
     i = (lo + hi)/2;                                                        \
                                                                             \
-    res = (*fnCompare)((const void *)(wxUIntPtr)lItem,                      \
-                       (const void *)(wxUIntPtr)(m_pItems[i]));             \
+    res = (*fnCompare)(&lItem,                                              \
+                       &((m_pItems[i])));                                   \
     if ( res < 0 )                                                          \
       hi = i;                                                               \
     else if ( res > 0 )                                                     \
@@ -296,13 +308,19 @@ size_t name::IndexForInsert(T lItem, CMPFUNC fnCompare) const               \
 /* search for an item in a sorted array (binary search) */                  \
 int name::Index(T lItem, CMPFUNC fnCompare) const                           \
 {                                                                           \
-    size_t n = IndexForInsert(lItem, fnCompare);                            \
+  wxArray_SortFunction##name p(fnCompare);                                  \
+  return IndexFunctor(lItem, &p);                                           \
+}                                                                           \
+                                                                            \
+int name::IndexFunctor(T lItem, const wxArray_FunctorBase##name *fnCompare) const       \
+{                                                                           \
+    size_t n = IndexForInsertFunctor(lItem, fnCompare);                     \
                                                                             \
     return (n >= m_nCount ||                                                \
-           (*fnCompare)((const void *)(wxUIntPtr)lItem,                     \
-                        ((const void *)(wxUIntPtr)m_pItems[n])))            \
-                        ? wxNOT_FOUND                                       \
-                        : (int)n;                                           \
+           (*fnCompare)(&lItem,                                             \
+                       (&(m_pItems[n]))))                                   \
+                       ? wxNOT_FOUND                                        \
+                       : (int)n;                                            \
 }                                                                           \
                                                                             \
 /* removes item from array (by index) */                                    \


### PR DESCRIPTION
…safe conversion from 'wxArrayLinesType::CMPFUNC' to 'wxArrayLinesType::SCMPFUNC'.

When using wxUSE_STD_CONTAINERS as 1, and utilizing wxXmlDocument, the wxXmlDocument utilizes textbuf.h, and the warning comes out. I did not have this warning with my code using wxWidgets 3.1.0, but started getting it when I switched to wxWidgets 3.1.1. The warning started happening for me due to commit:

https://github.com/wxWidgets/wxWidgets/commit/11e54135587d2073c4f1c0986e072078678bf229

Which introduced the usage of textbuf.h into xml.h. However the underlying problem has been present long before this commit.

Due to heavy preprocessor use, the true source of where the warning is coming from is hard to track. I tracked the warning down to line 170 in include/wx/dynarray.h:

170: Predicate p((SCMPFUNC)fnCompare);

SCMPFUNC and fnCompare (of type CMPFUNC) have different interfaces.

SCMPFUNC has interface:
112: int ()(T pItem1, T pItem2)

while CMPFUNC has interface:
89: int()(T* pItem1, T* pItem2)

So SCMPFUNC is taking pItem1 and pItem2 not as pointers, but as value, while CMPFUNC takes them as pointers.

As CMPFUNC is what is used in the API to clients, this is the API we want to preserve. The SCMPFUNC API is not useful.

To fix the issue, I change the definition of Predicate to be a functor that has the CMPFUNC interface, which is to change lines 112-113 from:

   typedef int (wxCMPFUNC_CONV *CMPFUN##name)(T pItem1, T pItem2);  \
   typedef wxSortedArray_SortFunction<T, CMPFUN##name> name##_Predicate; \

to:

   typedef wxArray_SortFunction<T> name##_Predicate; \

Now the code compiles without warning and is correct.

Backup:

To track down the interfaces of CMPFUNC and SCMPFUNC, here is a guide:

CMPFUNC:
122: typedef wxArray_SortFunction<T>::CMPFUNC CMPFUNC;
92: bool operator()(const T& i1, const T& i2)
89: int (wxCMPFUNC_CONV *CMPFUNC)(T* pItem1, T* pItem2)

SCMPFUNC:
120: typedef predicate::CMPFUNC SCMPFUNC;
119: typedef predicate Predicate;
113: typedef wxSortedArray_SortFunction<T, CMPFUN##name> name##_Predicate;
112: typedef int (wxCMPFUNC_CONV *CMPFUN##name)(T pItem1, T pItem2)