### PR TITLE
Fix memory leak in taskbarbutton sample

### DIFF
--- a/samples/taskbarbutton/taskbarbutton.cpp
+++ b/samples/taskbarbutton/taskbarbutton.cpp
@@ -429,7 +429,7 @@ void MyFrame::OnRemoveThubmBarButton(wxCommandEvent& WXUNUSED(event))
 
     wxThumbBarButton* button = m_thumbBarButtons.back();
     m_thumbBarButtons.pop_back();
-    MSWGetTaskBarButton()->RemoveThumbBarButton(button);
+    delete MSWGetTaskBarButton()->RemoveThumbBarButton(button);
 }
 
 void MyFrame::OnThumbnailToolbarBtnClicked(wxCommandEvent& event)

--- a/samples/taskbarbutton/taskbarbutton.cpp
+++ b/samples/taskbarbutton/taskbarbutton.cpp
@@ -427,6 +427,7 @@ void MyFrame::OnRemoveThubmBarButton(wxCommandEvent& WXUNUSED(event))
     if ( m_thumbBarButtons.empty() )
         return;
 
+    wxThumbBarButton* button = m_thumbBarButtons.back();
     m_thumbBarButtons.pop_back();
     delete MSWGetTaskBarButton()->RemoveThumbBarButton(button);
 }

--- a/samples/taskbarbutton/taskbarbutton.cpp
+++ b/samples/taskbarbutton/taskbarbutton.cpp
@@ -427,7 +427,6 @@ void MyFrame::OnRemoveThubmBarButton(wxCommandEvent& WXUNUSED(event))
     if ( m_thumbBarButtons.empty() )
         return;
 
-    wxThumbBarButton* button = m_thumbBarButtons.back();
     m_thumbBarButtons.pop_back();
     delete MSWGetTaskBarButton()->RemoveThumbBarButton(button);
 }


### PR DESCRIPTION
`wxTaskBarButton::RemoveThumbBarButton()` removes the button but does not delete it. In the sample removed buttons must be deleted manually because they are also removed from `m_thumbBarButtons` which automatically deletes the stored buttons in its destructor.

How to reproduce the leak:
1. Run the debug build of the sample under MSVS.
2.  Click _Add ThumbBarButton_.
3. Click _Remove Last ThumbBar Button_.
4. Close the sample and observe the memory leak report in the Output debug window.
