### PR TITLE
Fix video sink fallback in wxMediaCtrl when xvimagesink present but n…

### DIFF
--- a/src/unix/mediactrl.cpp
+++ b/src/unix/mediactrl.cpp
@@ -826,6 +826,13 @@ bool wxGStreamerMediaBackend::TryVideoSink(GstElement* videosink)
         g_object_unref(videosink);
         return false;
     }
+
+    if ( gst_element_set_state (videosink,
+                                GST_STATE_READY) == GST_STATE_CHANGE_FAILURE )
+    {
+        g_object_unref(videosink);
+        return false;
+    }
 #else
     // Check if the video sink either is an xoverlay or might contain one...
     if( !GST_IS_BIN(videosink) && !GST_IS_X_OVERLAY(videosink) )


### PR DESCRIPTION
…ot working

In certain cases (e.g., virtual machines), the XVideo extension may be
present, but there are no working adaptors.  In this case, wxMediaCtrl
will select xvimagesink, but then when it tries to actually play some
media, it will fail.  Fix this by attemping to set the video sink to
GST_STATE_READY in TryVideoSink().  Doing this causes gstreamer to run
some checks against the XVideo extension.  If this fails, then we should
fall back to the next sink type (ximagesink).