### PR TITLE
New wxBasicString methods: Attach(), ToString().

### DIFF
--- a/include/wx/msw/ole/oleutils.h
+++ b/include/wx/msw/ole/oleutils.h
@@ -70,8 +70,7 @@ public:
     wxBasicString() : m_bstrBuf(NULL) {}
 
     // Constructs with the owned BSTR created from a wxString
-    wxBasicString(const wxString& str)
-        : m_bstrBuf(SysAllocString(str.wc_str(*wxConvCurrent))) {}
+    wxBasicString(const wxString& str) : m_bstrBuf(NULL) { AssignFromString(str); }
 
     // Constructs with the owned BSTR as a copy of the BSTR owned by bstr
     wxBasicString(const wxBasicString& bstr) : m_bstrBuf(bstr.Copy()) {}
@@ -81,6 +80,12 @@ public:
 
     // Creates the owned BSTR from a wxString
     void AssignFromString(const wxString& str);
+
+    // Convert the owned BSTR to a wxString
+    wxString ToString() const;
+
+    // Attach a handle
+    void Attach(BSTR bstr);
 
     // Returns the owned BSTR and gives up its ownership,
     // the caller is responsible for freeing it


### PR DESCRIPTION
Remove redundant parts of wxAutoOleInterface.
Argument instead of hardcoded value in CreateInstance().