### PR TITLE
Fixes for GTK+ decorations

### DIFF
--- a/src/gtk/settings.cpp
+++ b/src/gtk/settings.cpp
@@ -24,7 +24,7 @@
 #include "wx/gtk/private/win_gtk.h"
 #include "wx/gtk/private/gtk2-compat.h"
 
-bool wxGetFrameExtents(GdkWindow* window, int* left, int* right, int* top, int* bottom);
+bool wxGetFrameExtents(GdkWindow* window, wxTopLevelWindow::DecorSize* decorSize);
 
 // ----------------------------------------------------------------------------
 // wxSystemSettings implementation
@@ -876,17 +876,17 @@ int wxSystemSettingsNative::GetMetric( wxSystemMetric index, wxWindow* win )
                     // Get the frame extents from the windowmanager.
                     // In most cases the top extent is the titlebar, so we use the bottom extent
                     // for the heights.
-                    int right, bottom;
-                    if (wxGetFrameExtents(window, NULL, &right, NULL, &bottom))
+                    wxTopLevelWindow::DecorSize decorSize;
+                    if (wxGetFrameExtents(window, &decorSize))
                     {
                         switch (index)
                         {
                             case wxSYS_BORDER_X:
                             case wxSYS_EDGE_X:
                             case wxSYS_FRAMESIZE_X:
-                                return right; // width of right extent
+                                return decorSize.right;
                             default:
-                                return bottom; // height of bottom extent
+                                return decorSize.bottom;
                         }
                     }
                 }
@@ -1024,10 +1024,10 @@ int wxSystemSettingsNative::GetMetric( wxSystemMetric index, wxWindow* win )
             // titlebar is, but this might lead to interesting behaviours in used code.
             // Reconsider when we have a way to report to the user on which side it is.
             {
-                int top;
-                if (wxGetFrameExtents(window, NULL, NULL, &top, NULL))
+                wxTopLevelWindow::DecorSize decorSize;
+                if (wxGetFrameExtents(window, &decorSize))
                 {
-                    return top; // top frame extent
+                    return decorSize.top; // top frame extent
                 }
             }
 

--- a/src/gtk/toplevel.cpp
+++ b/src/gtk/toplevel.cpp
@@ -317,8 +317,12 @@ void wxTopLevelWindowGTK::GTKConfigureEvent(int x, int y)
     if (gs_decorCacheValid)
     {
         const DecorSize& decorSize = GetCachedDecorSize();
-        point.x = x - decorSize.left;
-        point.y = y - decorSize.top;
+        // Decoration sizes come directly from X11 and are in physical pixels,
+        // while our position is expressed in GTK+ logical/scaled pixels, which
+        // may be different.
+        const double scale = GetContentScaleFactor();
+        point.x = x - decorSize.left / scale;
+        point.y = y - decorSize.top / scale;
     }
     else
 #endif

--- a/src/gtk/toplevel.cpp
+++ b/src/gtk/toplevel.cpp
@@ -456,10 +456,22 @@ static void notify_gtk_theme_name(GObject*, GParamSpec*, wxTopLevelWindowGTK* wi
 }
 
 //-----------------------------------------------------------------------------
+// Dealing with decorations size under X11
+//-----------------------------------------------------------------------------
+
+#ifndef GDK_WINDOWING_X11
+
+// We still need to define a stab for this function as it's used in
+// gtk/settings.cpp
+bool wxGetFrameExtents(GdkWindow*, int*, int*, int*, int*)
+{
+    return false;
+}
+
+#else // GDK_WINDOWING_X11
 
 bool wxGetFrameExtents(GdkWindow* window, int* left, int* right, int* top, int* bottom)
 {
-#ifdef GDK_WINDOWING_X11
     GdkDisplay* display = gdk_window_get_display(window);
 
     if (!GDK_IS_X11_DISPLAY(display))
@@ -489,12 +501,8 @@ bool wxGetFrameExtents(GdkWindow* window, int* left, int* right, int* top, int* 
     if (data)
         XFree(data);
     return success;
-#else
-    return false;
-#endif
 }
 
-#ifdef GDK_WINDOWING_X11
 //-----------------------------------------------------------------------------
 // "property_notify_event" from m_widget
 //-----------------------------------------------------------------------------

--- a/src/gtk/toplevel.cpp
+++ b/src/gtk/toplevel.cpp
@@ -463,14 +463,15 @@ static void notify_gtk_theme_name(GObject*, GParamSpec*, wxTopLevelWindowGTK* wi
 
 // We still need to define a stab for this function as it's used in
 // gtk/settings.cpp
-bool wxGetFrameExtents(GdkWindow*, int*, int*, int*, int*)
+bool wxGetFrameExtents(GdkWindow*, wxTopLevelWindowGTK::DecorSize*)
 {
     return false;
 }
 
 #else // GDK_WINDOWING_X11
 
-bool wxGetFrameExtents(GdkWindow* window, int* left, int* right, int* top, int* bottom)
+bool wxGetFrameExtents(GdkWindow* window,
+                       wxTopLevelWindowGTK::DecorSize* decorSize)
 {
     GdkDisplay* display = gdk_window_get_display(window);
 
@@ -493,10 +494,10 @@ bool wxGetFrameExtents(GdkWindow* window, int* left, int* right, int* top, int* 
     if (success)
     {
         long* p = (long*)data;
-        if (left)   *left   = int(p[0]);
-        if (right)  *right  = int(p[1]);
-        if (top)    *top    = int(p[2]);
-        if (bottom) *bottom = int(p[3]);
+        decorSize->left   = int(p[0]);
+        decorSize->right  = int(p[1]);
+        decorSize->top    = int(p[2]);
+        decorSize->bottom = int(p[3]);
     }
     if (data)
         XFree(data);
@@ -524,8 +525,7 @@ static gboolean property_notify_event(
         }
 
         wxTopLevelWindowGTK::DecorSize decorSize = win->m_decorSize;
-        gs_decorCacheValid = wxGetFrameExtents(event->window,
-            &decorSize.left, &decorSize.right, &decorSize.top, &decorSize.bottom);
+        gs_decorCacheValid = wxGetFrameExtents(event->window, &decorSize);
 
         win->GTKUpdateDecorSize(decorSize);
     }
@@ -542,8 +542,7 @@ static gboolean request_frame_extents_timeout(void* data)
     wxTopLevelWindowGTK* win = static_cast<wxTopLevelWindowGTK*>(data);
     win->m_netFrameExtentsTimerId = 0;
     wxTopLevelWindowGTK::DecorSize decorSize = win->m_decorSize;
-    wxGetFrameExtents(gtk_widget_get_window(win->m_widget),
-        &decorSize.left, &decorSize.right, &decorSize.top, &decorSize.bottom);
+    wxGetFrameExtents(gtk_widget_get_window(win->m_widget), &decorSize);
     win->GTKUpdateDecorSize(decorSize);
     gdk_threads_leave();
     return false;

--- a/src/gtk/toplevel.cpp
+++ b/src/gtk/toplevel.cpp
@@ -974,6 +974,13 @@ bool wxTopLevelWindowGTK::Show( bool show )
     wxCHECK_MSG(m_widget, false, "invalid frame");
 
 #ifdef GDK_WINDOWING_X11
+    // If we already have some decoration value, we must have either reused it
+    // from the cache or it was explicitly set (this is used by wxPersistentTLW
+    // for example) to avoid having to guess it, so skip deferred showing in
+    // this case.
+    if (m_decorSize.left || m_decorSize.right || m_decorSize.top || m_decorSize.bottom)
+        m_deferShow = false;
+
     bool deferShow = show && !m_isShown && m_deferShow;
     if (deferShow)
     {


### PR DESCRIPTION
The goal of these changes is to ensure that saving and restoring the window geometry results in window being shown back at the same position and the same size -- which is not the case now, at least with Gnome 3.22. See [this thread](https://groups.google.com/d/msg/wx-dev/1m8c73x0Vuo/b_GbpIb6CgAJ) for more details.

The first 2 commits are cosmetic (and could be skipped if unwanted, I had done them without realizing that this function was also used in `src/gtk/settings.cpp` initially, so they don't simplify things as much as I thought they would, finally), the third one fixes a real bug and should IMO be applied anyhow, but the last one is questionable: without it things don't work and with it they do, so I'd like to apply it, but I don't fully understand what's wrong with the existing code.