### PR TITLE
Fix documentation for wxNumberEntryDialog

### DIFF
--- a/interface/wx/numdlg.h
+++ b/interface/wx/numdlg.h
@@ -25,27 +25,10 @@ class wxNumberEntryDialog : public wxDialog
 {
 public:
     /**
-        Default constructor.
-
-        Call Create() to really create the dialog later.
-     */
-    wxNumberEntryDialog();
-
-    /**
         Constructor.
 
         Use ShowModal() to show the dialog.
 
-        See Create() method for parameter description.
-    */
-    wxNumberEntryDialog(wxWindow *parent,
-                        const wxString& message,
-                        const wxString& prompt,
-                        const wxString& caption,
-                        long value, long min, long max,
-                        const wxPoint& pos = wxDefaultPosition);
-
-    /**
         @param parent
             Parent window.
         @param message
@@ -63,12 +46,12 @@ public:
         @param pos
             Dialog position.
     */
-    bool Create(wxWindow *parent,
-                const wxString& message,
-                const wxString& prompt,
-                const wxString& caption,
-                long value, long min, long max,
-                const wxPoint& pos = wxDefaultPosition);
+    wxNumberEntryDialog(wxWindow *parent,
+                        const wxString& message,
+                        const wxString& prompt,
+                        const wxString& caption,
+                        long value, long min, long max,
+                        const wxPoint& pos = wxDefaultPosition);
 
     /**
         Returns the value that the user has entered if the user has pressed OK,


### PR DESCRIPTION
The 3.0 branch version of wxNumberEntryDialog does not have the two-stage
commit, so remove the default constructor and Create() method.