### PR TITLE
32 bit compilation with c++14 fails on Mac because of implicit double…

### DIFF
--- a/src/osx/carbon/graphics.cpp
+++ b/src/osx/carbon/graphics.cpp
@@ -2246,7 +2246,7 @@ void wxMacCoreGraphicsContext::DoDrawText( const wxString &str, wxDouble x, wxDo
     {
         CGFloat width = CTLineGetTypographicBounds(line, NULL, NULL, NULL);
         CGFloat height = CTFontGetXHeight( font );
-        CGPoint points[] = { {0.0, height * 0.6f},  {width, height * 0.6f} };
+        CGPoint points[] = { {0.0, CGFloat(height * 0.6f)},  {width, CGFloat(height * 0.6f)} };
         CGContextSetStrokeColorWithColor(m_cgContext, col);
         CGContextSetShouldAntialias(m_cgContext, false);
         CGContextSetLineWidth(m_cgContext, 1.0);


### PR DESCRIPTION
… narrowing to float - explicit narrowing added