### PR TITLE
Show correct save path when using compressed debug report

### DIFF
--- a/include/wx/debugrpt.h
+++ b/include/wx/debugrpt.h
@@ -16,6 +16,7 @@
 
 #include "wx/string.h"
 #include "wx/arrstr.h"
+#include "wx/filename.h"
 
 class WXDLLIMPEXP_FWD_XML wxXmlNode;
 
@@ -25,6 +26,8 @@ class WXDLLIMPEXP_FWD_XML wxXmlNode;
 
 class WXDLLIMPEXP_QA wxDebugReport
 {
+    friend class wxDebugReportDialog;
+
 public:
     // this is used for the functions which may report either the current state
     // or the state during the last (fatal) exception
@@ -113,6 +116,9 @@ protected:
     // used by Process()
     virtual bool DoProcess();
 
+    // return the location where the report will be saved
+    virtual wxFileName GetSaveLocation() const;
+
 private:
     // name of the report directory
     wxString m_dir;
@@ -147,6 +153,9 @@ public:
 
 protected:
     virtual bool DoProcess() wxOVERRIDE;
+
+    // return the location where the report will be saved
+    wxFileName GetSaveLocation() const wxOVERRIDE;
 
 private:
     // user-specified file directory/base name, use defaults if empty

--- a/src/common/debugrpt.cpp
+++ b/src/common/debugrpt.cpp
@@ -594,6 +594,13 @@ bool wxDebugReport::DoProcess()
     return true;
 }
 
+wxFileName wxDebugReport::GetSaveLocation() const
+{
+    wxFileName fn;
+    fn.SetPath(GetDirectory());
+    return fn;
+}
+
 // ============================================================================
 // wxDebugReport-derived classes
 // ============================================================================
@@ -618,6 +625,19 @@ void wxDebugReportCompress::SetCompressedFileBaseName(const wxString& name)
     m_zipName = name;
 }
 
+wxFileName wxDebugReportCompress::GetSaveLocation() const
+{
+    // Use de default directoy as a basis for the save location, e.g.
+    // %temp%/someName becomes %temp%/someName.zip.
+    wxFileName fn(GetDirectory());
+    if (!m_zipDir.empty())
+        fn.SetPath(m_zipDir);
+    if (!m_zipName.empty())
+        fn.SetName(m_zipName);
+    fn.SetExt("zip");
+    return fn;
+}
+
 bool wxDebugReportCompress::DoProcess()
 {
 #define HAS_FILE_STREAMS (wxUSE_STREAMS && (wxUSE_FILE || wxUSE_FFILE))
@@ -626,19 +646,8 @@ bool wxDebugReportCompress::DoProcess()
     if ( !count )
         return false;
 
-    // create the compressed report file outside of the directory with the
-    // report files as it will be deleted by wxDebugReport dtor but we want to
-    // keep this one: for this we simply treat the directory name as the name
-    // of the file so that its last component becomes our base name
-    wxFileName fn(GetDirectory());
-    if ( !m_zipDir.empty() )
-        fn.SetPath(m_zipDir);
-    if ( !m_zipName.empty() )
-        fn.SetName(m_zipName);
-    fn.SetExt("zip");
-
     // create the streams
-    const wxString ofullPath = fn.GetFullPath();
+    const wxString ofullPath = GetSaveLocation().GetFullPath();
 #if wxUSE_FFILE
     wxFFileOutputStream os(ofullPath, wxT("wb"));
 #elif wxUSE_FILE

--- a/src/generic/dbgrptg.cpp
+++ b/src/generic/dbgrptg.cpp
@@ -75,7 +75,7 @@ wxDumpPreviewDlg::wxDumpPreviewDlg(wxWindow *parent,
                                    const wxString& text)
                 : wxDialog(parent, wxID_ANY, title,
                            wxDefaultPosition, wxDefaultSize,
-                           wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER)
+                           wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMINIMIZE_BOX | wxMAXIMIZE_BOX)
 {
     // create controls
     // ---------------
@@ -301,21 +301,18 @@ wxDebugReportDialog::wxDebugReportDialog(wxDebugReport& dbgrpt)
                               dbgrpt.GetReportName().c_str()),
                               wxDefaultPosition,
                               wxDefaultSize,
-                              wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
+                              wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxMINIMIZE_BOX | wxMAXIMIZE_BOX),
                      m_dbgrpt(dbgrpt)
 {
     // upper part of the dialog: explanatory message
     wxString msg;
-    wxString debugDir = dbgrpt.GetDirectory();
 
     // The temporary directory can be the short form on Windows;
     // normalize it for the benefit of users.
-#ifdef __WXMSW__
-    wxFileName debugDirFilename(debugDir, wxEmptyString);
+    wxFileName debugDirFilename(dbgrpt.GetSaveLocation());
     debugDirFilename.Normalize(wxPATH_NORM_LONG);
-    debugDir = debugDirFilename.GetPath();
-#endif
-    msg << _("A debug report has been generated in the directory\n")
+    wxString debugDir = debugDirFilename.GetFullPath();
+    msg << (debugDirFilename.IsDir() ? _("A debug report has been generated in the directory\n") : _("The following debug report will be generated\n"))
         << wxT('\n')
         << wxT("             \"") << debugDir << wxT("\"\n")
         << wxT('\n')


### PR DESCRIPTION
Show correct save path when using compressed debug report.
Enable minimize and maximize buttons in the debug report preview dialogs.
Closes http://trac.wxwidgets.org/ticket/17176

When using `report->SetCompressedFileDirectory(wxStandardPaths::Get().GetDocumentsDir());` in the debugrpt sample:
Before / After
<img src="https://user-images.githubusercontent.com/8088070/39489523-1ceca43a-4d86-11e8-93f4-63debda54f08.png" width="200"><img src="https://user-images.githubusercontent.com/8088070/39489524-1f70c3da-4d86-11e8-913b-f8721a0fd440.png" width="200">
