### PR TITLE
Show the mouse wheel axis in the text sample

### DIFF
--- a/samples/text/text.cpp
+++ b/samples/text/text.cpp
@@ -770,7 +770,9 @@ static wxString GetMouseEventDesc(const wxMouseEvent& ev)
     }
     else if ( ev.GetWheelRotation() )
     {
-        return wxString::Format("Wheel rotation %+d", ev.GetWheelRotation());
+        return wxString::Format("%s wheel rotation %+d",
+            ev.GetWheelAxis() == wxMOUSE_WHEEL_VERTICAL ? "Vertical" : "Horizontal",
+            ev.GetWheelRotation());
     }
     else
     {


### PR DESCRIPTION
Show if the horizontal or vertical axis of the mouse wheel is scrolled.
Just some extra info when `Log mouse events` in the text sample is enabled.