### PR TITLE
Fix missing tool in the overflow menu of wxAuiToolBar

### DIFF
--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -1773,7 +1773,7 @@ bool wxAuiToolBar::GetToolFitsByIndex(int tool_idx) const
     {
         // take the dropdown size into account
         if (m_overflowVisible && m_overflowSizerItem)
-            cli_h -= m_overflowSizerItem->GetSize().y;
+            cli_h -= m_overflowSizerItem->GetMinSize().y;
 
         if (rect.y+rect.height < cli_h)
             return true;
@@ -1782,7 +1782,7 @@ bool wxAuiToolBar::GetToolFitsByIndex(int tool_idx) const
     {
         // take the dropdown size into account
         if (m_overflowVisible && m_overflowSizerItem)
-            cli_w -= m_overflowSizerItem->GetSize().x;
+            cli_w -= m_overflowSizerItem->GetMinSize().x;
 
         if (rect.x+rect.width < cli_w)
             return true;
@@ -2024,6 +2024,7 @@ bool wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
                 m_overflowSizerItem = sizer->Add(overflow_size, 1, 0, wxEXPAND);
             else
                 m_overflowSizerItem = sizer->Add(1, overflow_size, 0, wxEXPAND);
+            m_overflowSizerItem->SetMinSize(m_overflowSizerItem->GetSize());
         }
         else
         {


### PR DESCRIPTION
When determining if a tool is hidden, it takes the width (or height) of the
overflow sizer into account. But when tools are overlapping, this is 0.
By setting and getting the minimum size of the overflow sizer, the actual size
of the overflow button can be used.

before / after
<img src="https://user-images.githubusercontent.com/8088070/39490268-9a5b7d68-4d88-11e8-93e3-2d07b2bd569f.png" width="200"><img src="https://user-images.githubusercontent.com/8088070/39490174-33a5f008-4d88-11e8-971f-986122b4f79c.png" width="200">
