### PR TITLE
Add wxrc.exe to build, reconfigure packaging.

### DIFF
--- a/build/tools/msvs/officialbuild.bat
+++ b/build/tools/msvs/officialbuild.bat
@@ -109,6 +109,18 @@ nmake -f makefile.vc BUILD=release SHARED=1 COMPILER_VERSION=%comp% OFFICIAL_BUI
 
 if ERRORLEVEL 1 goto ERR_BUILD
 
+set build_dir=%cd%
+
+cd ..\..\utils\wxrc
+
+rmdir %compvers%_mswudll_x64 /s /q
+del %compvers%x64_Release.txt
+nmake -f makefile.vc BUILD=release SHARED=1 COMPILER_VERSION=%comp% OFFICIAL_BUILD=1 TARGET_CPU=AMD64 >> %compvers%x64_Release.txt
+
+if ERRORLEVEL 1 goto ERR_BUILD
+
+cd %build_dir%
+
 @echo 64 bit debug build
 
 if "%compvers%" == "vc100" call "%WINDOWS71SDK%SetEnv.Cmd" /X64 /Debug
@@ -128,6 +140,16 @@ if "%compvers%" == "vc90"  call "%WINDOWS61SDK%SetEnv.Cmd" /X86 /Release
 @echo 32 bit release build
 
 nmake -f makefile.vc BUILD=release SHARED=1 COMPILER_VERSION=%comp% OFFICIAL_BUILD=1 CPPFLAGS=/arch:SSE CFLAGS=/arch:SSE >> %compvers%x86_Release.txt
+
+if ERRORLEVEL 1 goto ERR_BUILD
+
+cd ..\..\utils\wxrc
+
+rmdir %compvers%_mswuddll /s /q
+del %compvers%x86_Release.txt
+nmake -f makefile.vc BUILD=release SHARED=1 COMPILER_VERSION=%comp% OFFICIAL_BUILD=1 CPPFLAGS=/arch:SSE CFLAGS=/arch:SSE >> %compvers%x86_Release.txt
+
+cd %build_dir%
 
 if ERRORLEVEL 1 goto ERR_BUILD
 

--- a/build/tools/msvs/package.bat
+++ b/build/tools/msvs/package.bat
@@ -36,6 +36,7 @@ set curr_dir1=%cd%
 cd ..\..\..
 
 mkdir %packagePath%
+mkdir %packagePath%\%VCver%
 
 set wxLibVers=%wxMAJOR_VERSION%%wxMINOR_VERSION%
 
@@ -46,43 +47,36 @@ if "%wxMINOR_VERSION%" == "5" set wxDLLVers=%wxMAJOR_VERSION%%wxMINOR_VERSION%%w
 if "%wxMINOR_VERSION%" == "7" set wxDLLVers=%wxMAJOR_VERSION%%wxMINOR_VERSION%%wxRELEASE_NUMBER%
 if "%wxMINOR_VERSION%" == "9" set wxDLLVers=%wxMAJOR_VERSION%%wxMINOR_VERSION%%wxRELEASE_NUMBER%
 
-if "%1" == "sha" goto SHA
-
 rem Get rid of any files from the last run.
 
-del %packagePath%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_Dev.7z
-del %packagePath%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_ReleaseDLL.7z
-del %packagePath%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_ReleasePDB.7z
-del %packagePath%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_x64_Dev.7z
-del %packagePath%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_x64_ReleaseDLL.7z
-del %packagePath%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_x64_ReleasePDB.7z
+del %packagePath%\%VCver%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_Dev.7z
+del %packagePath%\%VCver%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_ReleaseDLL.7z
+del %packagePath%\%VCver%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_ReleasePDB.7z
+del %packagePath%\%VCver%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_x64_Dev.7z
+del %packagePath%\%VCver%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_x64_ReleaseDLL.7z
+del %packagePath%\%VCver%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_x64_ReleasePDB.7z
 
 rem Package the 32 bit files
 
-7z a -t7z %packagePath%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_Dev.7z lib\%VCver%_dll\mswud  lib\%VCver%_dll\mswu lib\%VCver%_dll\wxMSW%wxDllVers%ud_*.pdb lib\%VCver%_dll\wxbase%wxDllVers%ud_*.pdb lib\%VCver%_dll\wxMSW%wxDllVers%ud_*.dll lib\%VCver%_dll\wxbase%wxDllVers%u*.dll  lib\%VCver%_dll\*.lib
-7z a -t7z %packagePath%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_ReleaseDLL.7z lib\%VCver%_dll\wxMSW%wxDllVers%u_*.dll lib\%VCver%_dll\wxbase%wxDllVers%u_*.dll
-7z a -t7z %packagePath%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_ReleasePDB.7z lib\%VCver%_dll\wxMSW%wxDllVers%u_*.pdb lib\%VCver%_dll\wxbase%wxDllVers%u_*.pdb
+REM Copy wxrc.exe to the dll folder.
+copy utils\wxrc\%VCver%_mswudll\wxrc.exe lib\%VCver%_dll
+
+7z a -t7z %packagePath%\%VCver%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_Dev.7z lib\%VCver%_dll\mswud  lib\%VCver%_dll\mswu lib\%VCver%_dll\wxMSW%wxDllVers%ud_*.pdb lib\%VCver%_dll\wxbase%wxDllVers%ud_*.pdb lib\%VCver%_dll\wxMSW%wxDllVers%ud_*.dll lib\%VCver%_dll\wxbase%wxDllVers%u*.dll  lib\%VCver%_dll\*.lib lib\%VCver%_dll\wxrc.exe
+7z a -t7z %packagePath%\%VCver%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_ReleaseDLL.7z lib\%VCver%_dll\wxMSW%wxDllVers%u_*.dll lib\%VCver%_dll\wxbase%wxDllVers%u_*.dll
+7z a -t7z %packagePath%\%VCver%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_ReleasePDB.7z lib\%VCver%_dll\wxMSW%wxDllVers%u_*.pdb lib\%VCver%_dll\wxbase%wxDllVers%u_*.pdb
 
 rem Package the 64 bit files
 
-7z a -t7z %packagePath%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_x64_Dev.7z lib\%VCver%_x64_dll\mswud lib\%VCver%_x64_dll\mswu lib\%VCver%_x64_dll\wxMSW%wxDllVers%ud_*.pdb lib\%VCver%_x64_dll\wxbase%wxDllVers%ud_*.pdb lib\%VCver%_x64_dll\wxMSW%wxDllVers%ud_*.dll lib\%VCver%_x64_dll\wxbase%wxDllVers%ud_*.dll lib\%VCver%_x64_dll\*.lib
-7z a -t7z %packagePath%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_x64_ReleaseDLL.7z lib\%VCver%_x64_dll\wxMSW%wxDllVers%u_*.dll lib\%VCver%_x64_dll\wxbase%wxDllVers%u_*.dll
-7z a -t7z %packagePath%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_x64_ReleasePDB.7z lib\%VCver%_x64_dll\wxMSW%wxDllVers%u_*.pdb lib\%VCver%_x64_dll\wxbase%wxDllVers%u_*.pdb
+REM Copy wxrc.exe to the dll folder.
+copy utils\wxrc\%VCver%_mswudll_x64\wxrc.exe lib\%VCver%_x64_dll
 
-del %packagePath%\%VCver%_sha1.txt
+7z a -t7z %packagePath%\%VCver%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_x64_Dev.7z lib\%VCver%_x64_dll\mswud lib\%VCver%_x64_dll\mswu lib\%VCver%_x64_dll\wxMSW%wxDllVers%ud_*.pdb lib\%VCver%_x64_dll\wxbase%wxDllVers%ud_*.pdb lib\%VCver%_x64_dll\wxMSW%wxDllVers%ud_*.dll lib\%VCver%_x64_dll\wxbase%wxDllVers%ud_*.dll lib\%VCver%_x64_dll\*.lib  lib\%VCver%_x64_dll\wxrc.exe
+7z a -t7z %packagePath%\%VCver%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_x64_ReleaseDLL.7z lib\%VCver%_x64_dll\wxMSW%wxDllVers%u_*.dll lib\%VCver%_x64_dll\wxbase%wxDllVers%u_*.dll
+7z a -t7z %packagePath%\%VCver%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_x64_ReleasePDB.7z lib\%VCver%_x64_dll\wxMSW%wxDllVers%u_*.pdb lib\%VCver%_x64_dll\wxbase%wxDllVers%u_*.pdb
 
-fciv %packagePath%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_Dev.7z -sha1 -wp >> %packagePath%\%VCver%_sha1.txt
-fciv %packagePath%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_ReleaseDLL.7z -sha1 -wp >> %packagePath%\%VCver%_sha1.txt
-fciv %packagePath%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_ReleasePDB.7z -sha1 -wp >> %packagePath%\%VCver%_sha1.txt
-fciv %packagePath%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_x64_Dev.7z -sha1 -wp >> %packagePath%\%VCver%_sha1.txt
-fciv %packagePath%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_x64_ReleaseDLL.7z -sha1 -wp >> %packagePath%\%VCver%_sha1.txt
-fciv %packagePath%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_x64_ReleasePDB.7z -sha1 -wp >> %packagePath%\%VCver%_sha1.txt
+del %packagePath%\%VCver%\sha1.txt
+fciv %packagePath%\%VCver% -type *.7z -sha1 -wp >> %packagePath%\%VCver%\sha1.txt
 
-goto End
-
-:SHA
-
-fciv %packagePath% -type *.7z -sha1 -wp >> %packagePath%\sha1.txt
 
 goto End
 


### PR DESCRIPTION
This compiles wxrc.exe for the x86 and x64 release builds and includes them in the corresponding dll folders in the *_Dev.7z packages.

I was having an issue with the fciv checksum package. If used against a single file it produced an all lower case output. If used with a wildcard other that *.7v it choked because of having more than one dot '.' in the mask. So I have put compiler named folders under my package folder for doing the sha calculations.

I ran a complete build and all went well.

This should take care of wxTrac #18124 for the VS builds.