### PR TITLE
Correct typos and whitespace in 59c37cb

### DIFF
--- a/src/common/debugrpt.cpp
+++ b/src/common/debugrpt.cpp
@@ -630,9 +630,9 @@ wxFileName wxDebugReportCompress::GetSaveLocation() const
     // Use the default directory as a basis for the save location, e.g.
     // %temp%/someName becomes %temp%/someName.zip.
     wxFileName fn(GetDirectory());
-    if (!m_zipDir.empty())
+    if ( !m_zipDir.empty() )
         fn.SetPath(m_zipDir);
-    if (!m_zipName.empty())
+    if ( !m_zipName.empty() )
         fn.SetName(m_zipName);
     fn.SetExt("zip");
     return fn;

--- a/src/common/debugrpt.cpp
+++ b/src/common/debugrpt.cpp
@@ -627,7 +627,7 @@ void wxDebugReportCompress::SetCompressedFileBaseName(const wxString& name)
 
 wxFileName wxDebugReportCompress::GetSaveLocation() const
 {
-    // Use de default directoy as a basis for the save location, e.g.
+    // Use the default directory as a basis for the save location, e.g.
     // %temp%/someName becomes %temp%/someName.zip.
     wxFileName fn(GetDirectory());
     if (!m_zipDir.empty())


### PR DESCRIPTION
This nitpick corrects two typos in a code comment and adds a space around the expression inside the parentheses of two `if` statements in the code added by 59c37cb _Show correct save path when using compressed debug report_.

If you consider such small "issues" not worth correcting, please tell me so and I will refrain from doing that in future. Thanks.