### PR TITLE
Ensure the selection is in range.

### DIFF
--- a/src/aui/tabmdi.cpp
+++ b/src/aui/tabmdi.cpp
@@ -820,7 +820,7 @@ int wxAuiMDIClientWindow::SetSelection(size_t nPage)
 wxAuiMDIChildFrame* wxAuiMDIClientWindow::GetActiveChild()
 {
     const int sel = GetSelection();
-    if ( sel == wxNOT_FOUND )
+    if ( sel == wxNOT_FOUND || sel >= GetPageCount() )
         return NULL;
 
     return wxStaticCast(GetPage(sel), wxAuiMDIChildFrame);


### PR DESCRIPTION
There are some cases when in the process of closing wxAuiMDIChildFrames that this method will be called while the current selection is out of range.