### PR TITLE
Removed the static line in wxGenericCollapsiblePane to be similar on …

### DIFF
--- a/include/wx/generic/collpaneg.h
+++ b/include/wx/generic/collpaneg.h
@@ -13,7 +13,6 @@
 
 // forward declared
 class WXDLLIMPEXP_FWD_CORE wxCollapsibleHeaderCtrl;
-class WXDLLIMPEXP_FWD_CORE wxStaticLine;
 
 #include "wx/containr.h"
 
@@ -80,7 +79,6 @@ protected:
 
     // child controls
     wxCollapsibleHeaderCtrl *m_pButton;
-    wxStaticLine *m_pStaticLine;
     wxWindow *m_pPane;
     wxSizer *m_sz;
 

--- a/src/generic/collpaneg.cpp
+++ b/src/generic/collpaneg.cpp
@@ -32,7 +32,6 @@
     #include "wx/panel.h"
 #endif // !WX_PRECOMP
 
-#include "wx/statline.h"
 #include "wx/collheaderctrl.h"
 
 // ----------------------------------------------------------------------------
@@ -62,7 +61,6 @@ void wxGenericCollapsiblePane::Init()
 {
     m_pButton = NULL;
     m_pPane = NULL;
-    m_pStaticLine = NULL;
     m_sz = NULL;
 }
 
@@ -89,12 +87,6 @@ bool wxGenericCollapsiblePane::Create(wxWindow *parent,
     // on other platforms we put the static line and the button horizontally
     m_sz->Add(m_pButton, 0, wxLEFT|wxTOP|wxBOTTOM, GetBorder());
 
-#if !defined( __WXMAC__ ) || defined(__WXUNIVERSAL__)
-    m_pStaticLine = new wxStaticLine(this, wxID_ANY);
-    m_sz->Add(m_pStaticLine, 0, wxEXPAND, GetBorder());
-    m_pStaticLine->Hide();
-#endif
-
     // FIXME: at least under wxGTK1 the background is black if we don't do
     //        this, no idea why...
 #if defined(__WXGTK__)
@@ -115,9 +107,6 @@ wxGenericCollapsiblePane::~wxGenericCollapsiblePane()
 {
     if (m_pButton)
         m_pButton->SetContainingSizer(NULL);
-
-    if (m_pStaticLine)
-        m_pStaticLine->SetContainingSizer(NULL);
 
     // our sizer is not deleted automatically since we didn't use SetSizer()!
     wxDELETE(m_sz);
@@ -182,9 +171,6 @@ void wxGenericCollapsiblePane::Collapse(bool collapse)
     // update button
     // NB: this must be done after updating our "state"
     m_pButton->SetCollapsed(collapse);
-    if ( m_pStaticLine )
-        m_pStaticLine->Show(!collapse);
-
 
     OnStateChange(GetBestSize());
 }
@@ -204,13 +190,8 @@ wxString wxGenericCollapsiblePane::GetLabel() const
 
 bool wxGenericCollapsiblePane::Layout()
 {
-#ifdef __WXMAC__
     if (!m_pButton || !m_pPane || !m_sz)
         return false;     // we need to complete the creation first!
-#else
-    if (!m_pButton || !m_pStaticLine || !m_pPane || !m_sz)
-        return false;     // we need to complete the creation first!
-#endif
 
     wxSize oursz(GetSize());
 


### PR DESCRIPTION
To be similar on all platforms. The horizontal static line was added to separate the button from the child window when visible.