### PR TITLE
Fix automatic linking with MSVC for monolithic builds

### DIFF
--- a/include/msvc/wx/setup.h
+++ b/include/msvc/wx/setup.h
@@ -149,20 +149,27 @@
 // special version for regex as it does have a Unicode version
 #define wx3RD_PARTY_LIB_NAME_U(name) "wx" name wxSUFFIX_STR
 
-#pragma comment(lib, wxWX_LIB_NAME("base", ""))
+#if defined(wxMONOLITHIC) && wxMONOLITHIC == 1
+    #pragma comment(lib, wxWX_LIB_NAME("msw", ""))
+#else
+    #pragma comment(lib, wxWX_LIB_NAME("base", ""))
 
-#ifndef wxNO_NET_LIB
-    #ifndef WXUSINGDLL
-        #pragma comment(lib, "wsock32")
+    #ifndef wxNO_NET_LIB
+        #pragma comment(lib, wxBASE_LIB_NAME("net"))
     #endif
-    #pragma comment(lib, wxBASE_LIB_NAME("net"))
-#endif
-#if wxUSE_XML && !defined(wxNO_XML_LIB)
-    #pragma comment(lib, wxBASE_LIB_NAME("xml"))
-    #if !defined(wxNO_EXPAT_LIB) && !defined(WXUSINGDLL)
-        #pragma comment(lib, wx3RD_PARTY_LIB_NAME("expat"))
+    #if wxUSE_XML && !defined(wxNO_XML_LIB)
+        #pragma comment(lib, wxBASE_LIB_NAME("xml"))        
     #endif
+#endif // defined(wxMONOLITHIC) && wxMONOLITHIC == 1
+
+#if !defined(wxNO_NET_LIB) && !defined(WXUSINGDLL)
+    #pragma comment(lib, "wsock32")
 #endif
+
+#if wxUSE_XML && !defined(wxNO_XML_LIB) && !defined(wxNO_EXPAT_LIB) && !defined(WXUSINGDLL)
+    #pragma comment(lib, wx3RD_PARTY_LIB_NAME("expat"))
+#endif
+
 #if wxUSE_REGEX && !defined(wxNO_REGEX_LIB) && !defined(WXUSINGDLL)
     #pragma comment(lib, wx3RD_PARTY_LIB_NAME_U("regex"))
 #endif
@@ -181,48 +188,54 @@
         #pragma comment(lib, wx3RD_PARTY_LIB_NAME("tiff"))
     #endif
 
-    #pragma comment(lib, wxTOOLKIT_LIB_NAME("core"))
+    #if !defined(wxMONOLITHIC) || wxMONOLITHIC == 0
 
-    #ifndef wxNO_ADV_LIB
-        #pragma comment(lib, wxTOOLKIT_LIB_NAME("adv"))
-    #endif
+        #pragma comment(lib, wxTOOLKIT_LIB_NAME("core"))
 
-    #if wxUSE_HTML && !defined(wxNO_HTML_LIB)
-        #pragma comment(lib, wxTOOLKIT_LIB_NAME("html"))
-    #endif
+        #ifndef wxNO_ADV_LIB
+            #pragma comment(lib, wxTOOLKIT_LIB_NAME("adv"))
+        #endif
+
+        #if wxUSE_HTML && !defined(wxNO_HTML_LIB)
+            #pragma comment(lib, wxTOOLKIT_LIB_NAME("html"))
+        #endif       
+        #if wxUSE_DEBUGREPORT && !defined(wxNO_QA_LIB)
+            #pragma comment(lib, wxTOOLKIT_LIB_NAME("qa"))
+        #endif
+        #if wxUSE_XRC && !defined(wxNO_XRC_LIB)
+            #pragma comment(lib, wxTOOLKIT_LIB_NAME("xrc"))
+        #endif
+        #if wxUSE_AUI && !defined(wxNO_AUI_LIB)
+            #pragma comment(lib, wxTOOLKIT_LIB_NAME("aui"))
+        #endif
+        #if wxUSE_PROPGRID && !defined(wxNO_PROPGRID_LIB)
+            #pragma comment(lib, wxTOOLKIT_LIB_NAME("propgrid"))
+        #endif
+        #if wxUSE_RIBBON && !defined(wxNO_RIBBON_LIB)
+            #pragma comment(lib, wxTOOLKIT_LIB_NAME("ribbon"))
+        #endif
+        #if wxUSE_RICHTEXT && !defined(wxNO_RICHTEXT_LIB)
+            #pragma comment(lib, wxTOOLKIT_LIB_NAME("richtext"))
+        #endif
+        #if wxUSE_MEDIACTRL && !defined(wxNO_MEDIA_LIB)
+            #pragma comment(lib, wxTOOLKIT_LIB_NAME("media"))
+        #endif
+        #if wxUSE_STC && !defined(wxNO_STC_LIB)
+            #pragma comment(lib, wxTOOLKIT_LIB_NAME("stc"))           
+        #endif
+        #if wxUSE_WEBVIEW && !defined(wxNO_WEBVIEW_LIB)
+            #pragma comment(lib, wxTOOLKIT_LIB_NAME("webview"))
+        #endif
+    #endif // !defined(wxMONOLITHIC) || wxMONOLITHIC == 0
+
     #if wxUSE_GLCANVAS && !defined(wxNO_GL_LIB)
         #pragma comment(lib, wxTOOLKIT_LIB_NAME("gl"))
     #endif
-    #if wxUSE_DEBUGREPORT && !defined(wxNO_QA_LIB)
-        #pragma comment(lib, wxTOOLKIT_LIB_NAME("qa"))
+
+    #if wxUSE_STC && !defined(wxNO_STC_LIB) && !defined(WXUSINGDLL)
+        #pragma comment(lib, wx3RD_PARTY_LIB_NAME("scintilla"))
     #endif
-    #if wxUSE_XRC && !defined(wxNO_XRC_LIB)
-        #pragma comment(lib, wxTOOLKIT_LIB_NAME("xrc"))
-    #endif
-    #if wxUSE_AUI && !defined(wxNO_AUI_LIB)
-        #pragma comment(lib, wxTOOLKIT_LIB_NAME("aui"))
-    #endif
-    #if wxUSE_PROPGRID && !defined(wxNO_PROPGRID_LIB)
-        #pragma comment(lib, wxTOOLKIT_LIB_NAME("propgrid"))
-    #endif
-    #if wxUSE_RIBBON && !defined(wxNO_RIBBON_LIB)
-        #pragma comment(lib, wxTOOLKIT_LIB_NAME("ribbon"))
-    #endif
-    #if wxUSE_RICHTEXT && !defined(wxNO_RICHTEXT_LIB)
-        #pragma comment(lib, wxTOOLKIT_LIB_NAME("richtext"))
-    #endif
-    #if wxUSE_MEDIACTRL && !defined(wxNO_MEDIA_LIB)
-        #pragma comment(lib, wxTOOLKIT_LIB_NAME("media"))
-    #endif
-    #if wxUSE_STC && !defined(wxNO_STC_LIB)
-        #pragma comment(lib, wxTOOLKIT_LIB_NAME("stc"))
-        #ifndef WXUSINGDLL
-            #pragma comment(lib, wx3RD_PARTY_LIB_NAME("scintilla"))
-        #endif
-    #endif
-    #if wxUSE_WEBVIEW && !defined(wxNO_WEBVIEW_LIB)
-        #pragma comment(lib, wxTOOLKIT_LIB_NAME("webview"))
-    #endif
+
 #endif // wxUSE_GUI
 
 


### PR DESCRIPTION
MS Visual C++ users can simplify their projects using wxWidgets by prepending `$(WXWIN)\include\msvc` to the compiler include directories, which results in automatic including the build-specific setup.h as well as linking all required wxWidgets and system libraries.

This worked only for (default) multilib builds but not for monolithic builds where wxWidgets libraries are created and named differently, see [wxTrac ticket 18125](https://trac.wxwidgets.org/ticket/18125).

Now the same feature can be used also for monolithic builds, `wxMONOLITHIC=1` needs to be defined in the users' projects to make it work.