### PR TITLE
Make AUI MDI classes easier to use as standard classes replacements

### DIFF
--- a/include/wx/aui/tabmdi.h
+++ b/include/wx/aui/tabmdi.h
@@ -144,11 +144,7 @@ public:
 
     virtual void SetTitle(const wxString& title);
 
-    virtual void SetIcons(const wxIconBundle& icons);
-    virtual const wxIconBundle& GetIcons() const;
-
-    virtual void SetIcon(const wxIcon& icon);
-    virtual const wxIcon& GetIcon() const;
+    virtual void SetIcons(const wxIconBundle& icons) wxOVERRIDE;
 
     virtual void Activate();
     virtual bool Destroy() wxOVERRIDE;
@@ -171,8 +167,6 @@ public:
 
 protected:
     wxAuiMDIParentFrame* m_pMDIParentFrame;
-    wxIcon m_icon;
-    wxIconBundle m_iconBundle;
     bool m_activateOnCreate;
 
 #if wxUSE_MENUS

--- a/include/wx/aui/tabmdi.h
+++ b/include/wx/aui/tabmdi.h
@@ -162,8 +162,6 @@ public:
 
 protected:
     void Init();
-    virtual void DoSetSize(int x, int y, int width, int height, int sizeFlags) wxOVERRIDE;
-    virtual void DoMoveWindow(int x, int y, int width, int height) wxOVERRIDE;
 
 public:
     // This function needs to be called when a size change is confirmed,
@@ -174,8 +172,6 @@ public:
 
 protected:
     wxAuiMDIParentFrame* m_pMDIParentFrame;
-    wxRect m_mdiNewRect;
-    wxRect m_mdiCurRect;
     wxIcon m_icon;
     wxIconBundle m_iconBundle;
     bool m_activateOnCreate;
@@ -218,7 +214,6 @@ protected:
     void PageChanged(int oldSelection, int newSelection);
     void OnPageClose(wxAuiNotebookEvent& evt);
     void OnPageChanged(wxAuiNotebookEvent& evt);
-    void OnSize(wxSizeEvent& evt);
 
 private:
     wxDECLARE_DYNAMIC_CLASS(wxAuiMDIClientWindow);

--- a/include/wx/aui/tabmdi.h
+++ b/include/wx/aui/tabmdi.h
@@ -21,6 +21,7 @@
 #include "wx/panel.h"
 #include "wx/notebook.h"
 #include "wx/icon.h"
+#include "wx/mdi.h"
 #include "wx/aui/auibook.h"
 
 //-----------------------------------------------------------------------------
@@ -115,7 +116,7 @@ private:
 // wxAuiMDIChildFrame
 //-----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_AUI wxAuiMDIChildFrame : public wxPanel
+class WXDLLIMPEXP_AUI wxAuiMDIChildFrame : public wxTDIChildFrame
 {
 public:
     wxAuiMDIChildFrame();
@@ -142,7 +143,6 @@ public:
 #endif // wxUSE_MENUS
 
     virtual void SetTitle(const wxString& title);
-    virtual wxString GetTitle() const;
 
     virtual void SetIcons(const wxIconBundle& icons);
     virtual const wxIconBundle& GetIcons() const;
@@ -155,43 +155,7 @@ public:
 
     virtual bool Show(bool show = true) wxOVERRIDE;
 
-#if wxUSE_STATUSBAR
-    // no status bars
-    virtual wxStatusBar* CreateStatusBar(int WXUNUSED(number) = 1,
-                                         long WXUNUSED(style) = 1,
-                                         wxWindowID WXUNUSED(winid) = 1,
-                                         const wxString& WXUNUSED(name) = wxEmptyString)
-      { return NULL; }
-
-    virtual wxStatusBar *GetStatusBar() const { return NULL; }
-    virtual void SetStatusText( const wxString &WXUNUSED(text), int WXUNUSED(number)=0 ) {}
-    virtual void SetStatusWidths( int WXUNUSED(n), const int WXUNUSED(widths_field)[] ) {}
-#endif
-
-#if wxUSE_TOOLBAR
-    // no toolbar bars
-    virtual wxToolBar* CreateToolBar(long WXUNUSED(style),
-                                     wxWindowID WXUNUSED(winid),
-                                     const wxString& WXUNUSED(name))
-        { return NULL; }
-    virtual wxToolBar *GetToolBar() const { return NULL; }
-#endif
-
-
-    // no maximize etc
-    virtual void Maximize(bool WXUNUSED(maximize) = true) { /* Has no effect */ }
-    virtual void Restore() { /* Has no effect */ }
-    virtual void Iconize(bool WXUNUSED(iconize)  = true) { /* Has no effect */ }
-    virtual bool IsMaximized() const { return true; }
-    virtual bool IsIconized() const { return false; }
-    virtual bool ShowFullScreen(bool WXUNUSED(show), long WXUNUSED(style)) { return false; }
-    virtual bool IsFullScreen() const { return false; }
-
-    virtual bool IsTopLevel() const wxOVERRIDE { return false; }
-
     void OnMenuHighlight(wxMenuEvent& evt);
-    void OnActivate(wxActivateEvent& evt);
-    void OnCloseWindow(wxCloseEvent& evt);
 
     void SetMDIParentFrame(wxAuiMDIParentFrame* parent);
     wxAuiMDIParentFrame* GetMDIParentFrame() const;
@@ -201,10 +165,6 @@ protected:
     virtual void DoSetSize(int x, int y, int width, int height, int sizeFlags) wxOVERRIDE;
     virtual void DoMoveWindow(int x, int y, int width, int height) wxOVERRIDE;
 
-    // no size hints
-    virtual void DoSetSizeHints(int WXUNUSED(minW), int WXUNUSED(minH),
-                                int WXUNUSED(maxW), int WXUNUSED(maxH),
-                                int WXUNUSED(incW), int WXUNUSED(incH)) wxOVERRIDE {}
 public:
     // This function needs to be called when a size change is confirmed,
     // we needed this function to prevent anybody from the outside
@@ -216,7 +176,6 @@ protected:
     wxAuiMDIParentFrame* m_pMDIParentFrame;
     wxRect m_mdiNewRect;
     wxRect m_mdiCurRect;
-    wxString m_title;
     wxIcon m_icon;
     wxIconBundle m_iconBundle;
     bool m_activateOnCreate;

--- a/include/wx/aui/tabmdi.h
+++ b/include/wx/aui/tabmdi.h
@@ -168,7 +168,6 @@ public:
     // we needed this function to prevent anybody from the outside
     // changing the panel... it messes the UI layout when we would allow it.
     void ApplyMDIChildFrameRect();
-    void DoShow(bool show);
 
 protected:
     wxAuiMDIParentFrame* m_pMDIParentFrame;

--- a/include/wx/aui/tabmdi.h
+++ b/include/wx/aui/tabmdi.h
@@ -201,7 +201,6 @@ public:
     virtual bool CreateClient(wxAuiMDIParentFrame *parent,
                               long style = wxVSCROLL | wxHSCROLL);
 
-    virtual int SetSelection(size_t page) wxOVERRIDE;
     virtual wxAuiMDIChildFrame* GetActiveChild();
     virtual void SetActiveChild(wxAuiMDIChildFrame* pChildFrame)
     {

--- a/include/wx/aui/tabmdi.h
+++ b/include/wx/aui/tabmdi.h
@@ -138,15 +138,15 @@ public:
                 const wxString& name = wxFrameNameStr);
 
 #if wxUSE_MENUS
-    virtual void SetMenuBar(wxMenuBar *menuBar);
-    virtual wxMenuBar *GetMenuBar() const;
+    virtual void SetMenuBar(wxMenuBar *menuBar) wxOVERRIDE;
+    virtual wxMenuBar *GetMenuBar() const wxOVERRIDE;
 #endif // wxUSE_MENUS
 
-    virtual void SetTitle(const wxString& title);
+    virtual void SetTitle(const wxString& title) wxOVERRIDE;
 
     virtual void SetIcons(const wxIconBundle& icons) wxOVERRIDE;
 
-    virtual void Activate();
+    virtual void Activate() wxOVERRIDE;
     virtual bool Destroy() wxOVERRIDE;
 
     virtual bool Show(bool show = true) wxOVERRIDE;

--- a/include/wx/aui/tabmdi.h
+++ b/include/wx/aui/tabmdi.h
@@ -11,7 +11,7 @@
 #ifndef _WX_AUITABMDI_H_
 #define _WX_AUITABMDI_H_
 
-#if wxUSE_AUI
+#if wxUSE_AUI && wxUSE_MDI
 
 // ----------------------------------------------------------------------------
 // headers
@@ -265,6 +265,6 @@ private:
     wxDECLARE_DYNAMIC_CLASS(wxAuiMDIClientWindow);
     wxDECLARE_EVENT_TABLE();
 };
-#endif // wxUSE_AUI
+#endif // wxUSE_AUI && wxUSE_MDI
 
 #endif // _WX_AUITABMDI_H_

--- a/samples/docview/Makefile.in
+++ b/samples/docview/Makefile.in
@@ -98,6 +98,9 @@ COND_PLATFORM_OS2_1___docview___os2_emxbindcmd = $(NM) docview$(EXEEXT) | if \
 @COND_TOOLKIT_OSX_IPHONE@	= $(__docview_app_Contents_PkgInfo___depname)
 @COND_TOOLKIT_COCOA@____docview_BUNDLE_TGT_REF_DEP = \
 @COND_TOOLKIT_COCOA@	$(__docview_app_Contents_PkgInfo___depname)
+COND_MONOLITHIC_0___WXLIB_AUI_p = \
+	-lwx_$(PORTNAME)$(WXUNIVNAME)$(WXUNICODEFLAG)$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)_aui-$(WX_RELEASE)$(HOST_SUFFIX)
+@COND_MONOLITHIC_0@__WXLIB_AUI_p = $(COND_MONOLITHIC_0___WXLIB_AUI_p)
 COND_MONOLITHIC_0___WXLIB_CORE_p = \
 	-lwx_$(PORTNAME)$(WXUNIVNAME)$(WXUNICODEFLAG)$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)_core-$(WX_RELEASE)$(HOST_SUFFIX)
 @COND_MONOLITHIC_0@__WXLIB_CORE_p = $(COND_MONOLITHIC_0___WXLIB_CORE_p)
@@ -148,7 +151,7 @@ distclean: clean
 	rm -f config.cache config.log config.status bk-deps bk-make-pch shared-ld-sh Makefile
 
 docview$(EXEEXT): $(DOCVIEW_OBJECTS) $(__docview___win32rc)
-	$(CXX) -o $@ $(DOCVIEW_OBJECTS)    -L$(LIBDIRNAME) $(LDFLAGS_GUI) $(SAMPLES_RPATH_FLAG) $(LDFLAGS)  $(__WXLIB_CORE_p)  $(__WXLIB_BASE_p)  $(__WXLIB_MONO_p) $(__LIB_SCINTILLA_IF_MONO_p) $(__LIB_TIFF_p) $(__LIB_JPEG_p) $(__LIB_PNG_p)  $(EXTRALIBS_FOR_GUI) $(__LIB_ZLIB_p) $(__LIB_REGEX_p) $(__LIB_EXPAT_p) $(EXTRALIBS_FOR_BASE) $(LIBS)
+	$(CXX) -o $@ $(DOCVIEW_OBJECTS)    -L$(LIBDIRNAME) $(LDFLAGS_GUI) $(SAMPLES_RPATH_FLAG) $(LDFLAGS)  $(__WXLIB_AUI_p)  $(__WXLIB_CORE_p)  $(__WXLIB_BASE_p)  $(__WXLIB_MONO_p) $(__LIB_SCINTILLA_IF_MONO_p) $(__LIB_TIFF_p) $(__LIB_JPEG_p) $(__LIB_PNG_p)  $(EXTRALIBS_FOR_GUI) $(__LIB_ZLIB_p) $(__LIB_REGEX_p) $(__LIB_EXPAT_p) $(EXTRALIBS_FOR_BASE) $(LIBS)
 	$(__docview___os2_emxbindcmd)
 
 @COND_PLATFORM_MACOSX_1@docview.app/Contents/PkgInfo: docview$(EXEEXT) $(srcdir)/Info.plist.in $(srcdir)/doc.icns $(srcdir)/chart.icns $(srcdir)/notepad.icns

--- a/samples/docview/docview.bkl
+++ b/samples/docview/docview.bkl
@@ -10,6 +10,7 @@
     <exe id="docview" template="wx_sample" template_append="wx_append">
         <sources>docview.cpp doc.cpp view.cpp</sources>
         <headers>docview.h doc.h view.h</headers>
+        <wx-lib>aui</wx-lib>
         <wx-lib>core</wx-lib>
         <wx-lib>base</wx-lib>
         <win32-res>docview.rc</win32-res>

--- a/samples/docview/docview.cpp
+++ b/samples/docview/docview.cpp
@@ -49,6 +49,10 @@
 #include "wx/docview.h"
 #include "wx/docmdi.h"
 
+#if wxUSE_AUI
+    #include "wx/aui/tabmdi.h"
+#endif // wxUSE_AUI
+
 #include "docview.h"
 #include "doc.h"
 #include "view.h"
@@ -95,6 +99,9 @@ namespace CmdLineOption
 #if wxUSE_MDI_ARCHITECTURE
 const char * const MDI = "mdi";
 #endif // wxUSE_MDI_ARCHITECTURE
+#if wxUSE_AUI
+const char * const AUI = "aui";
+#endif // wxUSE_AUI
 const char * const SDI = "sdi";
 const char * const SINGLE = "single";
 
@@ -108,6 +115,10 @@ void MyApp::OnInitCmdLine(wxCmdLineParser& parser)
     parser.AddSwitch("", CmdLineOption::MDI,
                      "run in MDI mode: multiple documents, single window");
 #endif // wxUSE_MDI_ARCHITECTURE
+#if wxUSE_AUI
+    parser.AddSwitch("", CmdLineOption::AUI,
+                     "run in MDI mode using AUI: multiple documents, single window");
+#endif // wxUSE_AUI
     parser.AddSwitch("", CmdLineOption::SDI,
                      "run in SDI mode: multiple documents, multiple windows");
     parser.AddSwitch("", CmdLineOption::SINGLE,
@@ -129,6 +140,14 @@ bool MyApp::OnCmdLineParsed(wxCmdLineParser& parser)
         numModeOptions++;
     }
 #endif // wxUSE_MDI_ARCHITECTURE
+
+#if wxUSE_AUI
+    if ( parser.Found(CmdLineOption::AUI) )
+    {
+        m_mode = Mode_AUI;
+        numModeOptions++;
+    }
+#endif // wxUSE_AUI
 
     if ( parser.Found(CmdLineOption::SDI) )
     {
@@ -202,22 +221,37 @@ bool MyApp::OnInit()
     }
 
     // create the main frame window
-    wxFrame *frame;
+    wxFrame *frame = NULL;
+    switch ( m_mode )
+    {
 #if wxUSE_MDI_ARCHITECTURE
-    if ( m_mode == Mode_MDI )
-    {
-        frame = new wxDocMDIParentFrame(docManager, NULL, wxID_ANY,
-                                        GetAppDisplayName(),
-                                        wxDefaultPosition,
-                                        wxSize(500, 400));
-    }
-    else
+        case Mode_MDI:
+            frame = new wxDocMDIParentFrame(docManager, NULL, wxID_ANY,
+                                            GetAppDisplayName(),
+                                            wxDefaultPosition,
+                                            wxSize(500, 400));
+            break;
 #endif // wxUSE_MDI_ARCHITECTURE
-    {
-        frame = new wxDocParentFrame(docManager, NULL, wxID_ANY,
-                                     GetAppDisplayName(),
-                                     wxDefaultPosition,
-                                     wxSize(500, 400));
+
+#if wxUSE_AUI
+        case Mode_AUI:
+            frame = new wxDocParentFrameAny<wxAuiMDIParentFrame>
+                        (
+                            docManager, NULL, wxID_ANY,
+                            GetAppDisplayName(),
+                            wxDefaultPosition,
+                            wxSize(500, 400)
+                        );
+            break;
+#endif // wxUSE_AUI
+
+        case Mode_SDI:
+        case Mode_Single:
+            frame = new wxDocParentFrame(docManager, NULL, wxID_ANY,
+                                         GetAppDisplayName(),
+                                         wxDefaultPosition,
+                                         wxSize(500, 400));
+            break;
     }
 
     // and its menu bar
@@ -321,37 +355,55 @@ void MyApp::CreateMenuBarForFrame(wxFrame *frame, wxMenu *file, wxMenu *edit)
 wxFrame *MyApp::CreateChildFrame(wxView *view, bool isCanvas)
 {
     // create a child frame of appropriate class for the current mode
-    wxFrame *subframe;
+    wxFrame *subframe = NULL;
     wxDocument *doc = view->GetDocument();
+    switch ( GetMode() )
 #if wxUSE_MDI_ARCHITECTURE
-    if ( GetMode() == Mode_MDI )
     {
-        subframe = new wxDocMDIChildFrame
-                       (
-                            doc,
-                            view,
-                            wxStaticCast(GetTopWindow(), wxDocMDIParentFrame),
-                            wxID_ANY,
-                            "Child Frame",
-                            wxDefaultPosition,
-                            wxSize(300, 300)
-                       );
-    }
-    else
+        case Mode_MDI:
+            subframe = new wxDocMDIChildFrame
+                           (
+                                doc,
+                                view,
+                                wxStaticCast(GetTopWindow(), wxDocMDIParentFrame),
+                                wxID_ANY,
+                                "Child Frame",
+                                wxDefaultPosition,
+                                wxSize(300, 300)
+                           );
+            break;
 #endif // wxUSE_MDI_ARCHITECTURE
-    {
-        subframe = new wxDocChildFrame
-                       (
-                            doc,
-                            view,
-                            wxStaticCast(GetTopWindow(), wxDocParentFrame),
-                            wxID_ANY,
-                            "Child Frame",
-                            wxDefaultPosition,
-                            wxSize(300, 300)
-                       );
 
-        subframe->Centre();
+#if wxUSE_AUI
+        case Mode_AUI:
+            subframe = new wxDocChildFrameAny<wxAuiMDIChildFrame, wxAuiMDIParentFrame>
+                           (
+                                doc,
+                                view,
+                                wxStaticCast(GetTopWindow(), wxAuiMDIParentFrame),
+                                wxID_ANY,
+                                "Child Frame",
+                                wxDefaultPosition,
+                                wxSize(300, 300)
+                           );
+            break;
+#endif // wxUSE_AUI
+
+        case Mode_SDI:
+        case Mode_Single:
+            subframe = new wxDocChildFrame
+                           (
+                                doc,
+                                view,
+                                wxStaticCast(GetTopWindow(), wxDocParentFrame),
+                                wxID_ANY,
+                                "Child Frame",
+                                wxDefaultPosition,
+                                wxSize(300, 300)
+                           );
+
+            subframe->Centre();
+            break;
     }
 
     wxMenu *menuFile = new wxMenu;
@@ -396,6 +448,12 @@ void MyApp::OnAbout(wxCommandEvent& WXUNUSED(event))
             break;
 #endif // wxUSE_MDI_ARCHITECTURE
 
+#if wxUSE_AUI
+        case Mode_AUI:
+            modeName = "AUI";
+            break;
+#endif // wxUSE_AUI
+
         case Mode_SDI:
             modeName = "SDI";
             break;
@@ -419,7 +477,7 @@ void MyApp::OnAbout(wxCommandEvent& WXUNUSED(event))
         "\n"
         "Authors: Julian Smart, Vadim Zeitlin\n"
         "\n"
-        "Usage: docview [--{mdi,sdi,single}]",
+        "Usage: docview [--{mdi,aui,sdi,single}]",
         modeName,
         docsCount
     );

--- a/samples/docview/docview.cpp
+++ b/samples/docview/docview.cpp
@@ -92,7 +92,9 @@ MyApp::MyApp()
 namespace CmdLineOption
 {
 
+#if wxUSE_MDI_ARCHITECTURE
 const char * const MDI = "mdi";
+#endif // wxUSE_MDI_ARCHITECTURE
 const char * const SDI = "sdi";
 const char * const SINGLE = "single";
 
@@ -102,8 +104,10 @@ void MyApp::OnInitCmdLine(wxCmdLineParser& parser)
 {
     wxApp::OnInitCmdLine(parser);
 
+#if wxUSE_MDI_ARCHITECTURE
     parser.AddSwitch("", CmdLineOption::MDI,
                      "run in MDI mode: multiple documents, single window");
+#endif // wxUSE_MDI_ARCHITECTURE
     parser.AddSwitch("", CmdLineOption::SDI,
                      "run in SDI mode: multiple documents, multiple windows");
     parser.AddSwitch("", CmdLineOption::SINGLE,

--- a/samples/docview/docview.h
+++ b/samples/docview/docview.h
@@ -27,6 +27,9 @@ public:
 #if wxUSE_MDI_ARCHITECTURE
         Mode_MDI,   // MDI mode: multiple documents, single top level window
 #endif // wxUSE_MDI_ARCHITECTURE
+#if wxUSE_AUI
+        Mode_AUI,   // MDI AUI mode
+#endif // wxUSE_AUI
         Mode_SDI,   // SDI mode: multiple documents, multiple top level windows
         Mode_Single // single document mode (and hence single top level window)
     };

--- a/samples/docview/docview_vc7.vcproj
+++ b/samples/docview/docview_vc7.vcproj
@@ -46,7 +46,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=""
-				AdditionalDependencies="wxmsw31ud_core.lib  wxbase31ud.lib    wxtiffd.lib wxjpegd.lib wxpngd.lib   wxzlibd.lib wxregexud.lib wxexpatd.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
+				AdditionalDependencies="wxmsw31ud_aui.lib  wxmsw31ud_core.lib  wxbase31ud.lib    wxtiffd.lib wxjpegd.lib wxpngd.lib   wxzlibd.lib wxregexud.lib wxexpatd.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
 				OutputFile="vc_mswud\docview.exe"
 				LinkIncremental="2"
 				SuppressStartupBanner="TRUE"
@@ -108,7 +108,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=""
-				AdditionalDependencies="wxmsw31u_core.lib  wxbase31u.lib    wxtiff.lib wxjpeg.lib wxpng.lib   wxzlib.lib wxregexu.lib wxexpat.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
+				AdditionalDependencies="wxmsw31u_aui.lib  wxmsw31u_core.lib  wxbase31u.lib    wxtiff.lib wxjpeg.lib wxpng.lib   wxzlib.lib wxregexu.lib wxexpat.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
 				OutputFile="vc_mswu\docview.exe"
 				LinkIncremental="1"
 				SuppressStartupBanner="TRUE"
@@ -175,7 +175,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=""
-				AdditionalDependencies="wxmsw31ud_core.lib  wxbase31ud.lib    wxtiffd.lib wxjpegd.lib wxpngd.lib   wxzlibd.lib wxregexud.lib wxexpatd.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
+				AdditionalDependencies="wxmsw31ud_aui.lib  wxmsw31ud_core.lib  wxbase31ud.lib    wxtiffd.lib wxjpegd.lib wxpngd.lib   wxzlibd.lib wxregexud.lib wxexpatd.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
 				OutputFile="vc_mswuddll\docview.exe"
 				LinkIncremental="2"
 				SuppressStartupBanner="TRUE"
@@ -237,7 +237,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=""
-				AdditionalDependencies="wxmsw31u_core.lib  wxbase31u.lib    wxtiff.lib wxjpeg.lib wxpng.lib   wxzlib.lib wxregexu.lib wxexpat.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
+				AdditionalDependencies="wxmsw31u_aui.lib  wxmsw31u_core.lib  wxbase31u.lib    wxtiff.lib wxjpeg.lib wxpng.lib   wxzlib.lib wxregexu.lib wxexpat.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
 				OutputFile="vc_mswudll\docview.exe"
 				LinkIncremental="1"
 				SuppressStartupBanner="TRUE"

--- a/samples/docview/docview_vc8.vcproj
+++ b/samples/docview/docview_vc8.vcproj
@@ -83,7 +83,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=""
-				AdditionalDependencies="wxmsw31ud_core.lib  wxbase31ud.lib    wxtiffd.lib wxjpegd.lib wxpngd.lib   wxzlibd.lib wxregexud.lib wxexpatd.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
+				AdditionalDependencies="wxmsw31ud_aui.lib  wxmsw31ud_core.lib  wxbase31ud.lib    wxtiffd.lib wxjpegd.lib wxpngd.lib   wxzlibd.lib wxregexud.lib wxexpatd.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
 				OutputFile="vc_mswud\docview.exe"
 				LinkIncremental="2"
 				SuppressStartupBanner="true"
@@ -177,7 +177,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=""
-				AdditionalDependencies="wxmsw31u_core.lib  wxbase31u.lib    wxtiff.lib wxjpeg.lib wxpng.lib   wxzlib.lib wxregexu.lib wxexpat.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
+				AdditionalDependencies="wxmsw31u_aui.lib  wxmsw31u_core.lib  wxbase31u.lib    wxtiff.lib wxjpeg.lib wxpng.lib   wxzlib.lib wxregexu.lib wxexpat.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
 				OutputFile="vc_mswu\docview.exe"
 				LinkIncremental="1"
 				SuppressStartupBanner="true"
@@ -276,7 +276,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=""
-				AdditionalDependencies="wxmsw31ud_core.lib  wxbase31ud.lib    wxtiffd.lib wxjpegd.lib wxpngd.lib   wxzlibd.lib wxregexud.lib wxexpatd.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
+				AdditionalDependencies="wxmsw31ud_aui.lib  wxmsw31ud_core.lib  wxbase31ud.lib    wxtiffd.lib wxjpegd.lib wxpngd.lib   wxzlibd.lib wxregexud.lib wxexpatd.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
 				OutputFile="vc_mswuddll\docview.exe"
 				LinkIncremental="2"
 				SuppressStartupBanner="true"
@@ -370,7 +370,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=""
-				AdditionalDependencies="wxmsw31u_core.lib  wxbase31u.lib    wxtiff.lib wxjpeg.lib wxpng.lib   wxzlib.lib wxregexu.lib wxexpat.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
+				AdditionalDependencies="wxmsw31u_aui.lib  wxmsw31u_core.lib  wxbase31u.lib    wxtiff.lib wxjpeg.lib wxpng.lib   wxzlib.lib wxregexu.lib wxexpat.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
 				OutputFile="vc_mswudll\docview.exe"
 				LinkIncremental="1"
 				SuppressStartupBanner="true"
@@ -469,7 +469,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=""
-				AdditionalDependencies="wxmsw31ud_core.lib  wxbase31ud.lib    wxtiffd.lib wxjpegd.lib wxpngd.lib   wxzlibd.lib wxregexud.lib wxexpatd.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
+				AdditionalDependencies="wxmsw31ud_aui.lib  wxmsw31ud_core.lib  wxbase31ud.lib    wxtiffd.lib wxjpegd.lib wxpngd.lib   wxzlibd.lib wxregexud.lib wxexpatd.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
 				OutputFile="vc_mswud_x64\docview.exe"
 				LinkIncremental="2"
 				SuppressStartupBanner="true"
@@ -563,7 +563,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=""
-				AdditionalDependencies="wxmsw31u_core.lib  wxbase31u.lib    wxtiff.lib wxjpeg.lib wxpng.lib   wxzlib.lib wxregexu.lib wxexpat.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
+				AdditionalDependencies="wxmsw31u_aui.lib  wxmsw31u_core.lib  wxbase31u.lib    wxtiff.lib wxjpeg.lib wxpng.lib   wxzlib.lib wxregexu.lib wxexpat.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
 				OutputFile="vc_mswu_x64\docview.exe"
 				LinkIncremental="1"
 				SuppressStartupBanner="true"
@@ -662,7 +662,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=""
-				AdditionalDependencies="wxmsw31ud_core.lib  wxbase31ud.lib    wxtiffd.lib wxjpegd.lib wxpngd.lib   wxzlibd.lib wxregexud.lib wxexpatd.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
+				AdditionalDependencies="wxmsw31ud_aui.lib  wxmsw31ud_core.lib  wxbase31ud.lib    wxtiffd.lib wxjpegd.lib wxpngd.lib   wxzlibd.lib wxregexud.lib wxexpatd.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
 				OutputFile="vc_mswuddll_x64\docview.exe"
 				LinkIncremental="2"
 				SuppressStartupBanner="true"
@@ -756,7 +756,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=""
-				AdditionalDependencies="wxmsw31u_core.lib  wxbase31u.lib    wxtiff.lib wxjpeg.lib wxpng.lib   wxzlib.lib wxregexu.lib wxexpat.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
+				AdditionalDependencies="wxmsw31u_aui.lib  wxmsw31u_core.lib  wxbase31u.lib    wxtiff.lib wxjpeg.lib wxpng.lib   wxzlib.lib wxregexu.lib wxexpat.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
 				OutputFile="vc_mswudll_x64\docview.exe"
 				LinkIncremental="1"
 				SuppressStartupBanner="true"

--- a/samples/docview/docview_vc9.vcproj
+++ b/samples/docview/docview_vc9.vcproj
@@ -82,7 +82,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=""
-				AdditionalDependencies="wxmsw31ud_core.lib  wxbase31ud.lib    wxtiffd.lib wxjpegd.lib wxpngd.lib   wxzlibd.lib wxregexud.lib wxexpatd.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
+				AdditionalDependencies="wxmsw31ud_aui.lib  wxmsw31ud_core.lib  wxbase31ud.lib    wxtiffd.lib wxjpegd.lib wxpngd.lib   wxzlibd.lib wxregexud.lib wxexpatd.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
 				OutputFile="vc_mswud\docview.exe"
 				LinkIncremental="2"
 				SuppressStartupBanner="true"
@@ -173,7 +173,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=""
-				AdditionalDependencies="wxmsw31u_core.lib  wxbase31u.lib    wxtiff.lib wxjpeg.lib wxpng.lib   wxzlib.lib wxregexu.lib wxexpat.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
+				AdditionalDependencies="wxmsw31u_aui.lib  wxmsw31u_core.lib  wxbase31u.lib    wxtiff.lib wxjpeg.lib wxpng.lib   wxzlib.lib wxregexu.lib wxexpat.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
 				OutputFile="vc_mswu\docview.exe"
 				LinkIncremental="1"
 				SuppressStartupBanner="true"
@@ -268,7 +268,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=""
-				AdditionalDependencies="wxmsw31ud_core.lib  wxbase31ud.lib    wxtiffd.lib wxjpegd.lib wxpngd.lib   wxzlibd.lib wxregexud.lib wxexpatd.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
+				AdditionalDependencies="wxmsw31ud_aui.lib  wxmsw31ud_core.lib  wxbase31ud.lib    wxtiffd.lib wxjpegd.lib wxpngd.lib   wxzlibd.lib wxregexud.lib wxexpatd.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
 				OutputFile="vc_mswuddll\docview.exe"
 				LinkIncremental="2"
 				SuppressStartupBanner="true"
@@ -359,7 +359,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=""
-				AdditionalDependencies="wxmsw31u_core.lib  wxbase31u.lib    wxtiff.lib wxjpeg.lib wxpng.lib   wxzlib.lib wxregexu.lib wxexpat.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
+				AdditionalDependencies="wxmsw31u_aui.lib  wxmsw31u_core.lib  wxbase31u.lib    wxtiff.lib wxjpeg.lib wxpng.lib   wxzlib.lib wxregexu.lib wxexpat.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
 				OutputFile="vc_mswudll\docview.exe"
 				LinkIncremental="1"
 				SuppressStartupBanner="true"
@@ -454,7 +454,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=""
-				AdditionalDependencies="wxmsw31ud_core.lib  wxbase31ud.lib    wxtiffd.lib wxjpegd.lib wxpngd.lib   wxzlibd.lib wxregexud.lib wxexpatd.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
+				AdditionalDependencies="wxmsw31ud_aui.lib  wxmsw31ud_core.lib  wxbase31ud.lib    wxtiffd.lib wxjpegd.lib wxpngd.lib   wxzlibd.lib wxregexud.lib wxexpatd.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
 				OutputFile="vc_mswud_x64\docview.exe"
 				LinkIncremental="2"
 				SuppressStartupBanner="true"
@@ -545,7 +545,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=""
-				AdditionalDependencies="wxmsw31u_core.lib  wxbase31u.lib    wxtiff.lib wxjpeg.lib wxpng.lib   wxzlib.lib wxregexu.lib wxexpat.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
+				AdditionalDependencies="wxmsw31u_aui.lib  wxmsw31u_core.lib  wxbase31u.lib    wxtiff.lib wxjpeg.lib wxpng.lib   wxzlib.lib wxregexu.lib wxexpat.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
 				OutputFile="vc_mswu_x64\docview.exe"
 				LinkIncremental="1"
 				SuppressStartupBanner="true"
@@ -640,7 +640,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=""
-				AdditionalDependencies="wxmsw31ud_core.lib  wxbase31ud.lib    wxtiffd.lib wxjpegd.lib wxpngd.lib   wxzlibd.lib wxregexud.lib wxexpatd.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
+				AdditionalDependencies="wxmsw31ud_aui.lib  wxmsw31ud_core.lib  wxbase31ud.lib    wxtiffd.lib wxjpegd.lib wxpngd.lib   wxzlibd.lib wxregexud.lib wxexpatd.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
 				OutputFile="vc_mswuddll_x64\docview.exe"
 				LinkIncremental="2"
 				SuppressStartupBanner="true"
@@ -731,7 +731,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions=""
-				AdditionalDependencies="wxmsw31u_core.lib  wxbase31u.lib    wxtiff.lib wxjpeg.lib wxpng.lib   wxzlib.lib wxregexu.lib wxexpat.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
+				AdditionalDependencies="wxmsw31u_aui.lib  wxmsw31u_core.lib  wxbase31u.lib    wxtiff.lib wxjpeg.lib wxpng.lib   wxzlib.lib wxregexu.lib wxexpat.lib   kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib"
 				OutputFile="vc_mswudll_x64\docview.exe"
 				LinkIncremental="1"
 				SuppressStartupBanner="true"

--- a/samples/docview/makefile.bcc
+++ b/samples/docview/makefile.bcc
@@ -166,6 +166,10 @@ __DLLFLAG_p = -DWXUSINGDLL
 __DLLFLAG_p_1 = -dWXUSINGDLL
 !endif
 !if "$(MONOLITHIC)" == "0"
+__WXLIB_AUI_p = \
+	wx$(PORTNAME)$(WXUNIVNAME)$(WX_RELEASE_NODOT)$(WXUNICODEFLAG)$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)_aui.lib
+!endif
+!if "$(MONOLITHIC)" == "0"
 __WXLIB_CORE_p = \
 	wx$(PORTNAME)$(WXUNIVNAME)$(WX_RELEASE_NODOT)$(WXUNICODEFLAG)$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)_core.lib
 !endif
@@ -230,7 +234,7 @@ clean:
 
 $(OBJS)\docview.exe: $(DOCVIEW_OBJECTS)  $(OBJS)\docview_docview.res
 	ilink32 -Tpe -q  -L$(BCCDIR)\lib -L$(BCCDIR)\lib\psdk $(__DEBUGINFO)  -L$(LIBDIRNAME) -aa $(____CAIRO_LIBDIR_FILENAMES_p) $(LDFLAGS) @&&|
-	c0w32.obj $(DOCVIEW_OBJECTS),$@,, $(__WXLIB_CORE_p)  $(__WXLIB_BASE_p)  $(__WXLIB_MONO_p) $(__LIB_SCINTILLA_IF_MONO_p) $(__LIB_TIFF_p) $(__LIB_JPEG_p) $(__LIB_PNG_p)   wxzlib$(WXDEBUGFLAG).lib wxregex$(WXUNICODEFLAG)$(WXDEBUGFLAG).lib wxexpat$(WXDEBUGFLAG).lib $(EXTRALIBS_FOR_BASE) $(__CAIRO_LIB_p) ole2w32.lib oleacc.lib uxtheme.lib import32.lib cw32$(__THREADSFLAG_5)$(__RUNTIME_LIBS_8).lib,, $(OBJS)\docview_docview.res
+	c0w32.obj $(DOCVIEW_OBJECTS),$@,, $(__WXLIB_AUI_p)  $(__WXLIB_CORE_p)  $(__WXLIB_BASE_p)  $(__WXLIB_MONO_p) $(__LIB_SCINTILLA_IF_MONO_p) $(__LIB_TIFF_p) $(__LIB_JPEG_p) $(__LIB_PNG_p)   wxzlib$(WXDEBUGFLAG).lib wxregex$(WXUNICODEFLAG)$(WXDEBUGFLAG).lib wxexpat$(WXDEBUGFLAG).lib $(EXTRALIBS_FOR_BASE) $(__CAIRO_LIB_p) ole2w32.lib oleacc.lib uxtheme.lib import32.lib cw32$(__THREADSFLAG_5)$(__RUNTIME_LIBS_8).lib,, $(OBJS)\docview_docview.res
 |
 
 $(OBJS)\docview_docview.obj: .\docview.cpp

--- a/samples/docview/makefile.gcc
+++ b/samples/docview/makefile.gcc
@@ -151,6 +151,10 @@ ifeq ($(SHARED),1)
 __DLLFLAG_p_1 = --define WXUSINGDLL
 endif
 ifeq ($(MONOLITHIC),0)
+__WXLIB_AUI_p = \
+	-lwx$(PORTNAME)$(WXUNIVNAME)$(WX_RELEASE_NODOT)$(WXUNICODEFLAG)$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)_aui
+endif
+ifeq ($(MONOLITHIC),0)
 __WXLIB_CORE_p = \
 	-lwx$(PORTNAME)$(WXUNIVNAME)$(WX_RELEASE_NODOT)$(WXUNICODEFLAG)$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)_core
 endif
@@ -220,7 +224,7 @@ clean:
 	-if exist $(OBJS)\docview.exe del $(OBJS)\docview.exe
 
 $(OBJS)\docview.exe: $(DOCVIEW_OBJECTS) $(OBJS)\docview_docview_rc.o
-	$(CXX) -o $@ $(DOCVIEW_OBJECTS)  $(__DEBUGINFO) $(__THREADSFLAG) -L$(LIBDIRNAME) -Wl,--subsystem,windows -mwindows $(____CAIRO_LIBDIR_FILENAMES_p) $(LDFLAGS)  $(__WXLIB_CORE_p)  $(__WXLIB_BASE_p)  $(__WXLIB_MONO_p) $(__LIB_SCINTILLA_IF_MONO_p) $(__LIB_TIFF_p) $(__LIB_JPEG_p) $(__LIB_PNG_p)   -lwxzlib$(WXDEBUGFLAG) -lwxregex$(WXUNICODEFLAG)$(WXDEBUGFLAG) -lwxexpat$(WXDEBUGFLAG) $(EXTRALIBS_FOR_BASE) $(__CAIRO_LIB_p) -lkernel32 -luser32 -lgdi32 -lcomdlg32 -lwinspool -lwinmm -lshell32 -lshlwapi -lcomctl32 -lole32 -loleaut32 -luuid -lrpcrt4 -ladvapi32 -lversion -lwsock32 -lwininet -loleacc -luxtheme
+	$(CXX) -o $@ $(DOCVIEW_OBJECTS)  $(__DEBUGINFO) $(__THREADSFLAG) -L$(LIBDIRNAME) -Wl,--subsystem,windows -mwindows $(____CAIRO_LIBDIR_FILENAMES_p) $(LDFLAGS)  $(__WXLIB_AUI_p)  $(__WXLIB_CORE_p)  $(__WXLIB_BASE_p)  $(__WXLIB_MONO_p) $(__LIB_SCINTILLA_IF_MONO_p) $(__LIB_TIFF_p) $(__LIB_JPEG_p) $(__LIB_PNG_p)   -lwxzlib$(WXDEBUGFLAG) -lwxregex$(WXUNICODEFLAG)$(WXDEBUGFLAG) -lwxexpat$(WXDEBUGFLAG) $(EXTRALIBS_FOR_BASE) $(__CAIRO_LIB_p) -lkernel32 -luser32 -lgdi32 -lcomdlg32 -lwinspool -lwinmm -lshell32 -lshlwapi -lcomctl32 -lole32 -loleaut32 -luuid -lrpcrt4 -ladvapi32 -lversion -lwsock32 -lwininet -loleacc -luxtheme
 
 $(OBJS)\docview_docview.o: ./docview.cpp
 	$(CXX) -c -o $@ $(DOCVIEW_CXXFLAGS) $(CPPDEPS) $<

--- a/samples/docview/makefile.unx
+++ b/samples/docview/makefile.unx
@@ -90,7 +90,7 @@ test_for_selected_wxbuild:
 	@$(WX_CONFIG) $(WX_CONFIG_FLAGS)
 
 docview: $(DOCVIEW_OBJECTS)
-	$(CXX) -o $@ $(DOCVIEW_OBJECTS)   $(LDFLAGS)  `$(WX_CONFIG) $(WX_CONFIG_FLAGS) --libs core,base`
+	$(CXX) -o $@ $(DOCVIEW_OBJECTS)   $(LDFLAGS)  `$(WX_CONFIG) $(WX_CONFIG_FLAGS) --libs aui,core,base`
 
 docview_docview.o: ./docview.cpp
 	$(CXX) -c -o $@ $(DOCVIEW_CXXFLAGS) $(CPPDEPS) $<

--- a/samples/docview/makefile.vc
+++ b/samples/docview/makefile.vc
@@ -304,6 +304,10 @@ __DLLFLAG_p = /DWXUSINGDLL
 __DLLFLAG_p_1 = /d WXUSINGDLL
 !endif
 !if "$(MONOLITHIC)" == "0"
+__WXLIB_AUI_p = \
+	wx$(PORTNAME)$(WXUNIVNAME)$(WX_RELEASE_NODOT)$(WXUNICODEFLAG)$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)_aui.lib
+!endif
+!if "$(MONOLITHIC)" == "0"
 __WXLIB_CORE_p = \
 	wx$(PORTNAME)$(WXUNIVNAME)$(WX_RELEASE_NODOT)$(WXUNICODEFLAG)$(WXDEBUGFLAG)$(WX_LIB_FLAVOUR)_core.lib
 !endif
@@ -353,7 +357,7 @@ clean:
 
 $(OBJS)\docview.exe: $(DOCVIEW_OBJECTS) $(OBJS)\docview_docview.res
 	link /NOLOGO /OUT:$@  $(__DEBUGINFO_1) /pdb:"$(OBJS)\docview.pdb" $(__DEBUGINFO_2)  $(LINK_TARGET_CPU) /LIBPATH:$(LIBDIRNAME) /SUBSYSTEM:WINDOWS $(____CAIRO_LIBDIR_FILENAMES_p) $(LDFLAGS) @<<
-	$(DOCVIEW_OBJECTS) $(DOCVIEW_RESOURCES)  $(__WXLIB_CORE_p)  $(__WXLIB_BASE_p)  $(__WXLIB_MONO_p) $(__LIB_SCINTILLA_IF_MONO_p) $(__LIB_TIFF_p) $(__LIB_JPEG_p) $(__LIB_PNG_p)   wxzlib$(WXDEBUGFLAG).lib wxregex$(WXUNICODEFLAG)$(WXDEBUGFLAG).lib wxexpat$(WXDEBUGFLAG).lib $(EXTRALIBS_FOR_BASE) $(__CAIRO_LIB_p) kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib
+	$(DOCVIEW_OBJECTS) $(DOCVIEW_RESOURCES)  $(__WXLIB_AUI_p)  $(__WXLIB_CORE_p)  $(__WXLIB_BASE_p)  $(__WXLIB_MONO_p) $(__LIB_SCINTILLA_IF_MONO_p) $(__LIB_TIFF_p) $(__LIB_JPEG_p) $(__LIB_PNG_p)   wxzlib$(WXDEBUGFLAG).lib wxregex$(WXUNICODEFLAG)$(WXDEBUGFLAG).lib wxexpat$(WXDEBUGFLAG).lib $(EXTRALIBS_FOR_BASE) $(__CAIRO_LIB_p) kernel32.lib user32.lib gdi32.lib comdlg32.lib winspool.lib winmm.lib shell32.lib shlwapi.lib comctl32.lib ole32.lib oleaut32.lib uuid.lib rpcrt4.lib advapi32.lib version.lib wsock32.lib wininet.lib
 <<
 
 $(OBJS)\docview_docview.obj: .\docview.cpp

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -930,7 +930,7 @@ static void ShowWnd(wxWindow* wnd, bool show)
     if (wxDynamicCast(wnd, wxAuiMDIChildFrame))
     {
         wxAuiMDIChildFrame* cf = (wxAuiMDIChildFrame*)wnd;
-        cf->DoShow(show);
+        cf->wxWindow::Show(show);
     }
     else
 #endif

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -1595,14 +1595,6 @@ public:
             }
             // TODO: else if (GetFlags() & wxAUI_NB_LEFT){}
             // TODO: else if (GetFlags() & wxAUI_NB_RIGHT){}
-
-#if wxUSE_MDI
-            if (wxDynamicCast(page.window, wxAuiMDIChildFrame))
-            {
-                wxAuiMDIChildFrame* wnd = (wxAuiMDIChildFrame*)page.window;
-                wnd->ApplyMDIChildFrameRect();
-            }
-#endif
         }
     }
 

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -1973,8 +1973,11 @@ bool wxAuiNotebook::InsertPage(size_t page_idx,
     else
         active_tabctrl->InsertPage(page, info, page_idx);
 
-    UpdateTabCtrlHeight();
-    DoSizing();
+    // Note that we don't need to call DoSizing() if the height has changed, as
+    // it's already called from UpdateTabCtrlHeight() itself in this case.
+    if ( !UpdateTabCtrlHeight() )
+        DoSizing();
+
     active_tabctrl->DoShowHide();
 
     // adjust selected index

--- a/src/aui/tabmdi.cpp
+++ b/src/aui/tabmdi.cpp
@@ -722,32 +722,6 @@ void wxAuiMDIChildFrame::DoShow(bool show)
     wxWindow::Show(show);
 }
 
-void wxAuiMDIChildFrame::DoSetSize(int x, int y, int width, int height, int sizeFlags)
-{
-    m_mdiNewRect = wxRect(x, y, width, height);
-#ifdef __WXGTK__
-    wxWindow::DoSetSize(x,y,width, height, sizeFlags);
-#else
-    wxUnusedVar(sizeFlags);
-#endif
-}
-
-void wxAuiMDIChildFrame::DoMoveWindow(int x, int y, int width, int height)
-{
-    m_mdiNewRect = wxRect(x, y, width, height);
-}
-
-void wxAuiMDIChildFrame::ApplyMDIChildFrameRect()
-{
-    if (m_mdiCurRect != m_mdiNewRect)
-    {
-        wxWindow::DoMoveWindow(m_mdiNewRect.x, m_mdiNewRect.y,
-                              m_mdiNewRect.width, m_mdiNewRect.height);
-        m_mdiCurRect = m_mdiNewRect;
-    }
-}
-
-
 //-----------------------------------------------------------------------------
 // wxAuiMDIClientWindow
 //-----------------------------------------------------------------------------
@@ -757,7 +731,6 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxAuiMDIClientWindow, wxAuiNotebook);
 wxBEGIN_EVENT_TABLE(wxAuiMDIClientWindow, wxAuiNotebook)
     EVT_AUINOTEBOOK_PAGE_CHANGED(wxID_ANY, wxAuiMDIClientWindow::OnPageChanged)
     EVT_AUINOTEBOOK_PAGE_CLOSE(wxID_ANY, wxAuiMDIClientWindow::OnPageClose)
-    EVT_SIZE(wxAuiMDIClientWindow::OnSize)
 wxEND_EVENT_TABLE()
 
 wxAuiMDIClientWindow::wxAuiMDIClientWindow()
@@ -872,14 +845,6 @@ void wxAuiMDIClientWindow::OnPageClose(wxAuiNotebookEvent& evt)
 void wxAuiMDIClientWindow::OnPageChanged(wxAuiNotebookEvent& evt)
 {
     PageChanged(evt.GetOldSelection(), evt.GetSelection());
-}
-
-void wxAuiMDIClientWindow::OnSize(wxSizeEvent& evt)
-{
-    wxAuiNotebook::OnSize(evt);
-
-    for (size_t pos = 0; pos < GetPageCount(); pos++)
-        ((wxAuiMDIChildFrame *)GetPage(pos))->ApplyMDIChildFrameRect();
 }
 
 #endif //wxUSE_AUI

--- a/src/aui/tabmdi.cpp
+++ b/src/aui/tabmdi.cpp
@@ -611,8 +611,10 @@ void wxAuiMDIChildFrame::SetIcons(const wxIconBundle& icons)
     wxAuiMDIParentFrame* pParentFrame = GetMDIParentFrame();
     wxASSERT_MSG(pParentFrame, wxT("Missing MDI Parent Frame"));
 
+    const wxSize sizeIcon(wxSystemSettings::GetMetric(wxSYS_SMALLICON_X),
+                          wxSystemSettings::GetMetric(wxSYS_SMALLICON_Y));
     wxBitmap bmp;
-    bmp.CopyFromIcon(icons.GetIcon(-1));
+    bmp.CopyFromIcon(icons.GetIcon(sizeIcon));
 
     wxAuiMDIClientWindow* pClientWindow = pParentFrame->GetClientWindow();
     if (pClientWindow != NULL)
@@ -722,11 +724,6 @@ wxAuiMDIClientWindow::wxAuiMDIClientWindow(wxAuiMDIParentFrame* parent, long sty
 bool wxAuiMDIClientWindow::CreateClient(wxAuiMDIParentFrame* parent, long style)
 {
     SetWindowStyleFlag(style);
-
-    wxSize caption_icon_size =
-            wxSize(wxSystemSettings::GetMetric(wxSYS_SMALLICON_X),
-                   wxSystemSettings::GetMetric(wxSYS_SMALLICON_Y));
-    SetUniformBitmapSize(caption_icon_size);
 
     if (!wxAuiNotebook::Create(parent,
                                wxID_ANY,

--- a/src/aui/tabmdi.cpp
+++ b/src/aui/tabmdi.cpp
@@ -702,7 +702,18 @@ bool wxAuiMDIChildFrame::Show(bool show)
 {
     m_activateOnCreate = show;
 
-    // do nothing
+    if ( show )
+    {
+        // This is not a real TLW, so it won't get a size event when it's
+        // really "mapped", i.e. appears on the screen for the first time.
+        // Instead, its size had been already set when it was created and we
+        // didn't have any opportunity to lay it out since then, i.e. since
+        // before its children were created. Do it now to allow the same code
+        // that would work with a "real" wxMDIChildFrame to also work with this
+        // class.
+        DoLayout();
+    }
+
     return true;
 }
 

--- a/src/aui/tabmdi.cpp
+++ b/src/aui/tabmdi.cpp
@@ -700,14 +700,6 @@ void wxAuiMDIChildFrame::Init()
 
 bool wxAuiMDIChildFrame::Show(bool show)
 {
-    // wxAuiMDIChildFrame uses m_activateOnCreate only to decide whether to
-    // activate the frame when it is created.  After Create() is called,
-    // m_activateOnCreate will never be read again.  Therefore, calling this
-    // function after Create() is pointless and you probably want to call
-    // Activate() instead.
-    wxCHECK_MSG( !GetHandle(), false,
-                 wxS("Show() has no effect after Create(). Do you mean Activate()?") );
-
     m_activateOnCreate = show;
 
     // do nothing

--- a/src/aui/tabmdi.cpp
+++ b/src/aui/tabmdi.cpp
@@ -423,12 +423,10 @@ void wxAuiMDIParentFrame::Tile(wxOrientation orient)
 // wxAuiMDIChildFrame
 //-----------------------------------------------------------------------------
 
-wxIMPLEMENT_DYNAMIC_CLASS(wxAuiMDIChildFrame, wxPanel);
+wxIMPLEMENT_DYNAMIC_CLASS(wxAuiMDIChildFrame, wxFrame);
 
-wxBEGIN_EVENT_TABLE(wxAuiMDIChildFrame, wxPanel)
+wxBEGIN_EVENT_TABLE(wxAuiMDIChildFrame, wxFrame)
     EVT_MENU_HIGHLIGHT_ALL(wxAuiMDIChildFrame::OnMenuHighlight)
-    EVT_ACTIVATE(wxAuiMDIChildFrame::OnActivate)
-    EVT_CLOSE(wxAuiMDIChildFrame::OnCloseWindow)
 wxEND_EVENT_TABLE()
 
 wxAuiMDIChildFrame::wxAuiMDIChildFrame()
@@ -501,7 +499,7 @@ bool wxAuiMDIChildFrame::Create(wxAuiMDIParentFrame* parent,
     wxSize cli_size = pClientWindow->GetClientSize();
 
     // create the window off-screen to prevent flicker
-    wxPanel::Create(pClientWindow,
+    wxWindow::Create(pClientWindow,
                     id,
                     wxPoint(cli_size.x+1, cli_size.y+1),
                     size,
@@ -609,11 +607,6 @@ void wxAuiMDIChildFrame::SetTitle(const wxString& title)
     }
 }
 
-wxString wxAuiMDIChildFrame::GetTitle() const
-{
-    return m_title;
-}
-
 void wxAuiMDIChildFrame::SetIcons(const wxIconBundle& icons)
 {
     // get icon with the system icon size
@@ -689,16 +682,6 @@ void wxAuiMDIChildFrame::OnMenuHighlight(wxMenuEvent& event)
 #endif // wxUSE_STATUSBAR
 }
 
-void wxAuiMDIChildFrame::OnActivate(wxActivateEvent& WXUNUSED(event))
-{
-    // do nothing
-}
-
-void wxAuiMDIChildFrame::OnCloseWindow(wxCloseEvent& WXUNUSED(event))
-{
-    Destroy();
-}
-
 void wxAuiMDIChildFrame::SetMDIParentFrame(wxAuiMDIParentFrame* parentFrame)
 {
     m_pMDIParentFrame = parentFrame;
@@ -743,7 +726,7 @@ void wxAuiMDIChildFrame::DoSetSize(int x, int y, int width, int height, int size
 {
     m_mdiNewRect = wxRect(x, y, width, height);
 #ifdef __WXGTK__
-    wxPanel::DoSetSize(x,y,width, height, sizeFlags);
+    wxWindow::DoSetSize(x,y,width, height, sizeFlags);
 #else
     wxUnusedVar(sizeFlags);
 #endif
@@ -758,7 +741,7 @@ void wxAuiMDIChildFrame::ApplyMDIChildFrameRect()
 {
     if (m_mdiCurRect != m_mdiNewRect)
     {
-        wxPanel::DoMoveWindow(m_mdiNewRect.x, m_mdiNewRect.y,
+        wxWindow::DoMoveWindow(m_mdiNewRect.x, m_mdiNewRect.y,
                               m_mdiNewRect.width, m_mdiNewRect.height);
         m_mdiCurRect = m_mdiNewRect;
     }

--- a/src/aui/tabmdi.cpp
+++ b/src/aui/tabmdi.cpp
@@ -496,16 +496,13 @@ bool wxAuiMDIChildFrame::Create(wxAuiMDIParentFrame* parent,
     if (style & wxMINIMIZE)
         m_activateOnCreate = false;
 
-    wxSize cli_size = pClientWindow->GetClientSize();
-
-    // create the window off-screen to prevent flicker
+    // create the window hidden to prevent flicker
+    wxWindow::Show(false);
     wxWindow::Create(pClientWindow,
                     id,
-                    wxPoint(cli_size.x+1, cli_size.y+1),
+                    wxDefaultPosition,
                     size,
                     wxNO_BORDER, name);
-
-    DoShow(false);
 
     SetMDIParentFrame(parent);
 
@@ -715,11 +712,6 @@ bool wxAuiMDIChildFrame::Show(bool show)
 
     // do nothing
     return true;
-}
-
-void wxAuiMDIChildFrame::DoShow(bool show)
-{
-    wxWindow::Show(show);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/aui/tabmdi.cpp
+++ b/src/aui/tabmdi.cpp
@@ -763,11 +763,6 @@ bool wxAuiMDIClientWindow::CreateClient(wxAuiMDIParentFrame* parent, long style)
     return true;
 }
 
-int wxAuiMDIClientWindow::SetSelection(size_t nPage)
-{
-    return wxAuiNotebook::SetSelection(nPage);
-}
-
 wxAuiMDIChildFrame* wxAuiMDIClientWindow::GetActiveChild()
 {
     const int sel = GetSelection();

--- a/src/aui/tabmdi.cpp
+++ b/src/aui/tabmdi.cpp
@@ -606,25 +606,13 @@ void wxAuiMDIChildFrame::SetTitle(const wxString& title)
 
 void wxAuiMDIChildFrame::SetIcons(const wxIconBundle& icons)
 {
-    // get icon with the system icon size
-    SetIcon(icons.GetIcon(-1));
-    m_iconBundle = icons;
-}
+    wxTDIChildFrame::SetIcons(icons);
 
-const wxIconBundle& wxAuiMDIChildFrame::GetIcons() const
-{
-    return m_iconBundle;
-}
-
-void wxAuiMDIChildFrame::SetIcon(const wxIcon& icon)
-{
     wxAuiMDIParentFrame* pParentFrame = GetMDIParentFrame();
     wxASSERT_MSG(pParentFrame, wxT("Missing MDI Parent Frame"));
 
-    m_icon = icon;
-
     wxBitmap bmp;
-    bmp.CopyFromIcon(m_icon);
+    bmp.CopyFromIcon(icons.GetIcon(-1));
 
     wxAuiMDIClientWindow* pClientWindow = pParentFrame->GetClientWindow();
     if (pClientWindow != NULL)
@@ -637,12 +625,6 @@ void wxAuiMDIChildFrame::SetIcon(const wxIcon& icon)
         }
     }
 }
-
-const wxIcon& wxAuiMDIChildFrame::GetIcon() const
-{
-    return m_icon;
-}
-
 
 void wxAuiMDIChildFrame::Activate()
 {


### PR DESCRIPTION
I've started looking into AUI to debug the problem mentioned in https://github.com/wxWidgets/wxWidgets/pull/802 and quickly found many things in the code that just didn't make any sense at all to me, so I've fixed some of them.

If the goal of `wxAuiMDIXXXFrame` classes is to be a replacement for the standard, non-AUI, versions, then these changes should be an advancement as the updated docview sample shows that it's easy to replace the latter with the former now.

Of course, it's possible that I broke something here, I don't really know this code and we don't have any tests for it. But at least things still seem to work in the aui sample. Still, reviews from people more familiar with AUI would be very welcome!