### PR TITLE
Add wxDataViewRadioRenderer

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -78,6 +78,7 @@ All:
 
 All (GUI):
 
+- Add wxDataViewRadioRenderer for using radio buttons in wxDataViewCtrl.
 - Improve stock items consistency and aesthetics (dhowland).
 - Fix bug with missing items in overflowing AUI toolbar (Maarten Bent).
 - Revert to left-aligning wxSpinCtrl contents by default.

--- a/include/wx/dataview.h
+++ b/include/wx/dataview.h
@@ -559,6 +559,10 @@ public:
                     wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT, int width = wxDVC_TOGGLE_DEFAULT_WIDTH,
                     wxAlignment align = wxALIGN_CENTER,
                     int flags = wxDATAVIEW_COL_RESIZABLE );
+    wxDataViewColumn *PrependRadioColumn( const wxString &label, unsigned int model_column,
+                    wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT, int width = wxDVC_TOGGLE_DEFAULT_WIDTH,
+                    wxAlignment align = wxALIGN_CENTER,
+                    int flags = wxDATAVIEW_COL_RESIZABLE );
     wxDataViewColumn *PrependProgressColumn( const wxString &label, unsigned int model_column,
                     wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT, int width = wxDVC_DEFAULT_WIDTH,
                     wxAlignment align = wxALIGN_CENTER,
@@ -580,6 +584,10 @@ public:
                     wxAlignment align = wxALIGN_NOT,
                     int flags = wxDATAVIEW_COL_RESIZABLE );
     wxDataViewColumn *PrependToggleColumn( const wxBitmap &label, unsigned int model_column,
+                    wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT, int width = wxDVC_TOGGLE_DEFAULT_WIDTH,
+                    wxAlignment align = wxALIGN_CENTER,
+                    int flags = wxDATAVIEW_COL_RESIZABLE );
+    wxDataViewColumn *PrependRadioColumn( const wxBitmap &label, unsigned int model_column,
                     wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT, int width = wxDVC_TOGGLE_DEFAULT_WIDTH,
                     wxAlignment align = wxALIGN_CENTER,
                     int flags = wxDATAVIEW_COL_RESIZABLE );
@@ -608,6 +616,10 @@ public:
                     wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT, int width = wxDVC_TOGGLE_DEFAULT_WIDTH,
                     wxAlignment align = wxALIGN_CENTER,
                     int flags = wxDATAVIEW_COL_RESIZABLE );
+    wxDataViewColumn *AppendRadioColumn( const wxString &label, unsigned int model_column,
+                    wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT, int width = wxDVC_TOGGLE_DEFAULT_WIDTH,
+                    wxAlignment align = wxALIGN_CENTER,
+                    int flags = wxDATAVIEW_COL_RESIZABLE );
     wxDataViewColumn *AppendProgressColumn( const wxString &label, unsigned int model_column,
                     wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT, int width = wxDVC_DEFAULT_WIDTH,
                     wxAlignment align = wxALIGN_CENTER,
@@ -629,6 +641,10 @@ public:
                     wxAlignment align = wxALIGN_NOT,
                     int flags = wxDATAVIEW_COL_RESIZABLE );
     wxDataViewColumn *AppendToggleColumn( const wxBitmap &label, unsigned int model_column,
+                    wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT, int width = wxDVC_TOGGLE_DEFAULT_WIDTH,
+                    wxAlignment align = wxALIGN_CENTER,
+                    int flags = wxDATAVIEW_COL_RESIZABLE );
+    wxDataViewColumn *AppendRadioColumn( const wxBitmap &label, unsigned int model_column,
                     wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT, int width = wxDVC_TOGGLE_DEFAULT_WIDTH,
                     wxAlignment align = wxALIGN_CENTER,
                     int flags = wxDATAVIEW_COL_RESIZABLE );
@@ -1125,6 +1141,9 @@ public:
           wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
           int width = -1, wxAlignment align = wxALIGN_LEFT, int flags = wxDATAVIEW_COL_RESIZABLE );
     wxDataViewColumn *AppendToggleColumn( const wxString &label,
+          wxDataViewCellMode mode = wxDATAVIEW_CELL_ACTIVATABLE,
+          int width = -1, wxAlignment align = wxALIGN_LEFT, int flags = wxDATAVIEW_COL_RESIZABLE );
+    wxDataViewColumn *AppendRadioColumn( const wxString &label,
           wxDataViewCellMode mode = wxDATAVIEW_CELL_ACTIVATABLE,
           int width = -1, wxAlignment align = wxALIGN_LEFT, int flags = wxDATAVIEW_COL_RESIZABLE );
     wxDataViewColumn *AppendProgressColumn( const wxString &label,

--- a/include/wx/generic/dvrenderers.h
+++ b/include/wx/generic/dvrenderers.h
@@ -147,11 +147,34 @@ public:
                                 const wxDataViewItem& item,
                                 unsigned int col,
                                 const wxMouseEvent *mouseEvent) wxOVERRIDE;
+protected:
+    // This function exists solely in order to be overridden bu
+    // wxDataViewRadioRenderer which customizes just the drawing.
+    virtual void DoDraw(wxWindow* win, wxDC& dc, const wxRect& cell, int flags);
+
 private:
     bool    m_toggle;
 
 protected:
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxDataViewToggleRenderer);
+};
+
+// ---------------------------------------------------------
+// wxDataViewRadioRenderer
+// ---------------------------------------------------------
+
+class WXDLLIMPEXP_ADV wxDataViewRadioRenderer : public wxDataViewToggleRenderer
+{
+public:
+    wxDataViewRadioRenderer( const wxString &varianttype = GetDefaultType(),
+                             wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
+                             int align = wxDVR_DEFAULT_ALIGNMENT );
+
+protected:
+    virtual void
+    DoDraw(wxWindow* win, wxDC& dc, const wxRect& cell, int flags) wxOVERRIDE;
+
+    wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxDataViewRadioRenderer);
 };
 
 // ---------------------------------------------------------

--- a/include/wx/gtk/dvrenderers.h
+++ b/include/wx/gtk/dvrenderers.h
@@ -115,6 +115,23 @@ protected:
 };
 
 // ---------------------------------------------------------
+// wxDataViewRadioRenderer
+// ---------------------------------------------------------
+
+class WXDLLIMPEXP_ADV wxDataViewRadioRenderer : public wxDataViewToggleRenderer
+{
+public:
+    static wxString GetDefaultType() { return wxS("bool"); }
+
+    wxDataViewRadioRenderer( const wxString &varianttype = GetDefaultType(),
+                             wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
+                             int align = wxDVR_DEFAULT_ALIGNMENT );
+
+protected:
+    wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxDataViewRadioRenderer);
+};
+
+// ---------------------------------------------------------
 // wxDataViewCustomRenderer
 // ---------------------------------------------------------
 

--- a/include/wx/osx/dvrenderers.h
+++ b/include/wx/osx/dvrenderers.h
@@ -204,8 +204,38 @@ public:
                                   const wxDataViewItem& item,
                                   unsigned col);
 
+protected:
+    // This ctor and helper function below exist solely for the use of
+    // wxDataViewRadioRenderer.
+    wxDataViewToggleRenderer(const wxString& varianttype,
+                             wxDataViewCellMode mode,
+                             int align,
+                             int buttonType)
+        : wxOSXDataViewDisabledInertRenderer(varianttype, mode, align)
+    {
+        DoCreate(align, buttonType);
+    }
+
+    void DoCreate(int align, int buttonType);
+
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxDataViewToggleRenderer);
+};
+
+// ---------------------------------------------------------
+// wxDataViewRadioRenderer
+// ---------------------------------------------------------
+
+class WXDLLIMPEXP_ADV wxDataViewRadioRenderer
+    : public wxDataViewToggleRenderer
+{
+public:
+    wxDataViewRadioRenderer(const wxString& varianttype = GetDefaultType(),
+                            wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
+                            int align = wxDVR_DEFAULT_ALIGNMENT);
+
+private:
+    wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxDataViewRadioRenderer);
 };
 
 // ---------------------------------------------------------

--- a/interface/wx/dataview.h
+++ b/interface/wx/dataview.h
@@ -1285,11 +1285,67 @@ public:
 
     //@{
     /**
+        Appends a column for rendering a radio button.
+
+        Returns the wxDataViewColumn created in the function or @NULL on
+        failure.
+
+        @note The @a align parameter is applied to both the column header and
+              the column renderer.
+
+        @see wxDataViewRadioRenderer
+
+        @since 3.1.2
+    */
+    wxDataViewColumn* AppendRadioColumn(const wxString& label,
+                                        unsigned int model_column,
+                                        wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
+                                        int width = 30,
+                                        wxAlignment align = wxALIGN_CENTER,
+                                        int flags = wxDATAVIEW_COL_RESIZABLE);
+    wxDataViewColumn* AppendRadioColumn(const wxBitmap& label,
+                                        unsigned int model_column,
+                                        wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
+                                        int width = 30,
+                                        wxAlignment align = wxALIGN_CENTER,
+                                        int flags = wxDATAVIEW_COL_RESIZABLE);
+    //@}
+
+    //@{
+    /**
         Prepends a column for rendering a toggle. Returns the wxDataViewColumn
         created in the function or @NULL on failure.
 
         @note The @a align parameter is applied to both the column header and
               the column renderer.
+    */
+    wxDataViewColumn* PrependToggleColumn(const wxString& label,
+                                         unsigned int model_column,
+                                         wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
+                                         int width = 30,
+                                         wxAlignment align = wxALIGN_CENTER,
+                                         int flags = wxDATAVIEW_COL_RESIZABLE);
+    wxDataViewColumn* PrependToggleColumn(const wxBitmap& label,
+                                         unsigned int model_column,
+                                         wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
+                                         int width = 30,
+                                         wxAlignment align = wxALIGN_CENTER,
+                                         int flags = wxDATAVIEW_COL_RESIZABLE);
+    //@}
+
+    //@{
+    /**
+        Prepends a column for rendering a radio button.
+
+        Returns the wxDataViewColumn created in the function or @NULL on
+        failure.
+
+        @note The @a align parameter is applied to both the column header and
+              the column renderer.
+
+        @see wxDataViewRadioRenderer
+
+        @since 3.1.2
     */
     wxDataViewColumn* PrependToggleColumn(const wxString& label,
                                          unsigned int model_column,
@@ -1877,6 +1933,7 @@ enum wxDataViewCellRenderState
     - wxDataViewIconTextRenderer,
     - wxDataViewCheckIconTextRenderer,
     - wxDataViewToggleRenderer,
+    - wxDataViewRadioRenderer,
     - wxDataViewProgressRenderer,
     - wxDataViewBitmapRenderer,
     - wxDataViewDateRenderer,
@@ -2292,6 +2349,41 @@ public:
     wxDataViewToggleRenderer(const wxString& varianttype = GetDefaultType(),
                              wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
                              int align = wxDVR_DEFAULT_ALIGNMENT);
+};
+
+
+/**
+    @class wxDataViewRadioRenderer
+
+    Renderer class showing a radio button and allowing the user to toggle it.
+
+    Notice that the other items using this renderer are @e not unchecked
+    automatically when an item using this renderer is checked, it's the
+    responsibility of the code using wxDataViewCtrl to do it, by handling
+    ::wxEVT_DATAVIEW_ITEM_VALUE_CHANGED event, in order to present consistent
+    UI. The @ref page_samples_dataview shows how to do it.
+
+    @see wxDataViewToggleRenderer
+
+    @library{wxadv}
+    @category{dvc}
+
+    @since 3.1.2
+*/
+class wxDataViewRadioRenderer : public wxDataViewToggleRenderer
+{
+public:
+    /**
+        Returns the wxVariant type used with this renderer.
+     */
+    static wxString GetDefaultType();
+
+    /**
+        The ctor.
+    */
+    wxDataViewRadioRenderer(const wxString& varianttype = GetDefaultType(),
+                            wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
+                            int align = wxDVR_DEFAULT_ALIGNMENT);
 };
 
 
@@ -2900,6 +2992,19 @@ public:
         the parameters.
     */
     wxDataViewColumn *AppendToggleColumn( const wxString &label,
+          wxDataViewCellMode mode = wxDATAVIEW_CELL_ACTIVATABLE,
+          int width = -1, wxAlignment align = wxALIGN_LEFT,
+          int flags = wxDATAVIEW_COL_RESIZABLE );
+
+    /**
+        Appends a radio column to the control and the store.
+
+        See wxDataViewColumn::wxDataViewColumn for more info about
+        the parameters.
+
+        @since 3.1.2
+    */
+    wxDataViewColumn *AppendRadioColumn( const wxString &label,
           wxDataViewCellMode mode = wxDATAVIEW_CELL_ACTIVATABLE,
           int width = -1, wxAlignment align = wxALIGN_LEFT,
           int flags = wxDATAVIEW_COL_RESIZABLE );

--- a/samples/dataview/dataview.cpp
+++ b/samples/dataview/dataview.cpp
@@ -108,6 +108,10 @@ private:
 
     void OnPrependList(wxCommandEvent& event);
     void OnDeleteList(wxCommandEvent& event);
+
+    // Third (wxDataViewListCtrl) page.
+    void OnListValueChanged(wxDataViewEvent& event);
+
     // Fourth page.
     void OnDeleteTreeItem(wxCommandEvent& event);
     void OnDeleteAllTreeItems(wxCommandEvent& event);
@@ -176,6 +180,9 @@ private:
     wxLog *m_logOld;
 
 private:
+    // Flag used by OnListValueChanged(), see there.
+    bool m_eventFromProgram;
+
     wxDECLARE_EVENT_TABLE();
 };
 
@@ -449,6 +456,8 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, int x, int y, int w, int
     m_ctrl[1] = NULL;
     m_ctrl[2] = NULL;
     m_ctrl[3] = NULL;
+
+    m_eventFromProgram = false;
 
     SetIcon(wxICON(sample));
 
@@ -761,6 +770,7 @@ void MyFrame::BuildDataViewCtrl(wxPanel* parent, unsigned int nPanel, unsigned l
             page2_model->DecRef();
 
             lc->AppendToggleColumn( "Toggle" );
+            lc->AppendRadioColumn( "Radio" );
             lc->AppendTextColumn( "Text" );
             lc->AppendProgressColumn( "Progress" );
 
@@ -769,11 +779,14 @@ void MyFrame::BuildDataViewCtrl(wxPanel* parent, unsigned int nPanel, unsigned l
             {
                 data.clear();
                 data.push_back( (i%3) == 0 );
+                data.push_back( i == 7 ); // select a single (random) radio item
                 data.push_back( wxString::Format("row %d", i) );
                 data.push_back( long(5*i) );
 
                 lc->AppendItem( data );
             }
+
+            lc->Bind(wxEVT_DATAVIEW_ITEM_VALUE_CHANGED, &MyFrame::OnListValueChanged, this);
         }
         break;
 
@@ -1390,6 +1403,48 @@ void MyFrame::OnHideAttributes(wxCommandEvent& WXUNUSED(event))
 void MyFrame::OnShowAttributes(wxCommandEvent& WXUNUSED(event))
 {
     m_attributes->SetHidden(false);
+}
+
+// ----------------------------------------------------------------------------
+// MyFrame - event handlers for the third (wxDataViewListCtrl) page
+// ----------------------------------------------------------------------------
+
+void MyFrame::OnListValueChanged(wxDataViewEvent& event)
+{
+    // Ignore changes coming from our own SetToggleValue() calls below.
+    if ( m_eventFromProgram )
+    {
+        m_eventFromProgram = false;
+        return;
+    }
+
+    wxDataViewListCtrl* const lc = static_cast<wxDataViewListCtrl*>(m_ctrl[2]);
+
+    const int columnToggle = 1;
+
+    // Handle selecting a radio button by unselecting all the other ones.
+    if ( event.GetColumn() == columnToggle )
+    {
+        const int rowChanged = lc->ItemToRow(event.GetItem());
+        if ( lc->GetToggleValue(rowChanged, columnToggle) )
+        {
+            for ( int row = 0; row < lc->GetItemCount(); ++row )
+            {
+                if ( row != rowChanged )
+                {
+                    m_eventFromProgram = true;
+                    lc->SetToggleValue(false, row, columnToggle);
+                }
+            }
+        }
+        else // The item was cleared.
+        {
+            // Explicitly check it back, we want to always have exactly one
+            // checked radio item in this column.
+            m_eventFromProgram = true;
+            lc->SetToggleValue(true, rowChanged, columnToggle);
+        }
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -1419,6 +1419,15 @@ wxDataViewCtrlBase::AppendToggleColumn( const wxString &label, unsigned int mode
 }
 
 wxDataViewColumn *
+wxDataViewCtrlBase::AppendRadioColumn( const wxString &label, unsigned int model_column,
+                            wxDataViewCellMode mode, int width, wxAlignment align, int flags )
+{
+    return AppendColumnWithRenderer<wxDataViewRadioRenderer>(
+                this, label, model_column, mode, width, align, flags
+            );
+}
+
+wxDataViewColumn *
 wxDataViewCtrlBase::AppendProgressColumn( const wxString &label, unsigned int model_column,
                             wxDataViewCellMode mode, int width, wxAlignment align, int flags )
 {
@@ -1468,6 +1477,15 @@ wxDataViewCtrlBase::AppendToggleColumn( const wxBitmap &label, unsigned int mode
                             wxDataViewCellMode mode, int width, wxAlignment align, int flags )
 {
     return AppendColumnWithRenderer<wxDataViewToggleRenderer>(
+                this, label, model_column, mode, width, align, flags
+            );
+}
+
+wxDataViewColumn *
+wxDataViewCtrlBase::AppendRadioColumn( const wxBitmap &label, unsigned int model_column,
+                            wxDataViewCellMode mode, int width, wxAlignment align, int flags )
+{
+    return AppendColumnWithRenderer<wxDataViewRadioRenderer>(
                 this, label, model_column, mode, width, align, flags
             );
 }
@@ -1527,6 +1545,15 @@ wxDataViewCtrlBase::PrependToggleColumn( const wxString &label, unsigned int mod
 }
 
 wxDataViewColumn *
+wxDataViewCtrlBase::PrependRadioColumn( const wxString &label, unsigned int model_column,
+                            wxDataViewCellMode mode, int width, wxAlignment align, int flags )
+{
+    return PrependColumnWithRenderer<wxDataViewRadioRenderer>(
+                this, label, model_column, mode, width, align, flags
+            );
+}
+
+wxDataViewColumn *
 wxDataViewCtrlBase::PrependProgressColumn( const wxString &label, unsigned int model_column,
                             wxDataViewCellMode mode, int width, wxAlignment align, int flags )
 {
@@ -1576,6 +1603,15 @@ wxDataViewCtrlBase::PrependToggleColumn( const wxBitmap &label, unsigned int mod
                             wxDataViewCellMode mode, int width, wxAlignment align, int flags )
 {
     return PrependColumnWithRenderer<wxDataViewToggleRenderer>(
+                this, label, model_column, mode, width, align, flags
+            );
+}
+
+wxDataViewColumn *
+wxDataViewCtrlBase::PrependRadioColumn( const wxBitmap &label, unsigned int model_column,
+                            wxDataViewCellMode mode, int width, wxAlignment align, int flags )
+{
+    return PrependColumnWithRenderer<wxDataViewRadioRenderer>(
                 this, label, model_column, mode, width, align, flags
             );
 }
@@ -2396,6 +2432,18 @@ wxDataViewColumn *wxDataViewListCtrl::AppendToggleColumn( const wxString &label,
 
     wxDataViewColumn *ret = new wxDataViewColumn( label,
         new wxDataViewToggleRenderer( wxT("bool"), mode ),
+        GetStore()->GetColumnCount()-1, width, align, flags );
+
+    return wxDataViewCtrl::AppendColumn( ret ) ? ret : NULL;
+}
+
+wxDataViewColumn *wxDataViewListCtrl::AppendRadioColumn( const wxString &label,
+          wxDataViewCellMode mode, int width, wxAlignment align, int flags )
+{
+    GetStore()->AppendColumn( wxT("bool") );
+
+    wxDataViewColumn *ret = new wxDataViewColumn( label,
+        new wxDataViewRadioRenderer( wxT("bool"), mode ),
         GetStore()->GetColumnCount()-1, width, align, flags );
 
     return wxDataViewCtrl::AppendColumn( ret ) ? ret : NULL;

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -1301,13 +1301,17 @@ bool wxDataViewToggleRenderer::Render( wxRect cell, wxDC *dc, int WXUNUSED(state
     size.IncTo(GetSize());
     cell.SetSize(size);
 
-    wxRendererNative::Get().DrawCheckBox(
-            GetOwner()->GetOwner(),
-            *dc,
-            cell,
-            flags );
+    DoDraw(GetOwner()->GetOwner(), *dc, cell, flags);
 
     return true;
+}
+
+void wxDataViewToggleRenderer::DoDraw(wxWindow* win,
+                                      wxDC& dc,
+                                      const wxRect& cell,
+                                      int flags)
+{
+    wxRendererNative::Get().DrawCheckBox(win, dc, cell, flags);
 }
 
 bool wxDataViewToggleRenderer::WXActivateCell(const wxRect& WXUNUSED(cellRect),
@@ -1331,6 +1335,27 @@ bool wxDataViewToggleRenderer::WXActivateCell(const wxRect& WXUNUSED(cellRect),
 wxSize wxDataViewToggleRenderer::GetSize() const
 {
     return wxRendererNative::Get().GetCheckBoxSize(GetView());
+}
+
+// ----------------------------------------------------------------------------
+// wxDataViewRadioRenderer
+// ----------------------------------------------------------------------------
+
+wxIMPLEMENT_ABSTRACT_CLASS(wxDataViewRadioRenderer, wxDataViewToggleRenderer);
+
+wxDataViewRadioRenderer::wxDataViewRadioRenderer(const wxString &varianttype,
+                                                 wxDataViewCellMode mode,
+                                                 int align)
+    : wxDataViewToggleRenderer(varianttype, mode, align)
+{
+}
+
+void wxDataViewRadioRenderer::DoDraw(wxWindow* win,
+                                     wxDC& dc,
+                                     const wxRect& cell,
+                                     int flags)
+{
+    wxRendererNative::Get().DrawRadioBitmap(win, dc, cell, flags);
 }
 
 // ---------------------------------------------------------

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -2566,6 +2566,23 @@ bool wxDataViewToggleRenderer::GetValue( wxVariant &value ) const
 }
 
 // ---------------------------------------------------------
+// wxDataViewRadioRenderer
+// ---------------------------------------------------------
+
+wxIMPLEMENT_CLASS(wxDataViewRadioRenderer, wxDataViewToggleRenderer);
+
+wxDataViewRadioRenderer::wxDataViewRadioRenderer
+                         (
+                            const wxString &varianttype,
+                            wxDataViewCellMode mode,
+                            int align
+                         )
+    : wxDataViewToggleRenderer(varianttype, mode, align)
+{
+    gtk_cell_renderer_toggle_set_radio(GTK_CELL_RENDERER_TOGGLE(m_renderer), TRUE);
+}
+
+// ---------------------------------------------------------
 // wxDataViewCustomRenderer
 // ---------------------------------------------------------
 

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -3315,12 +3315,17 @@ wxDataViewToggleRenderer::wxDataViewToggleRenderer(const wxString& varianttype,
                                                    int align)
     : wxOSXDataViewDisabledInertRenderer(varianttype, mode, align)
 {
+    DoCreate(align, NSSwitchButton);
+}
+
+void wxDataViewToggleRenderer::DoCreate(int align, int buttonType)
+{
     NSButtonCell* cell;
 
 
     cell = [[NSButtonCell alloc] init];
     [cell setAlignment:ConvertToNativeHorizontalTextAlignment(align)];
-    [cell setButtonType:NSSwitchButton];
+    [cell setButtonType:(NSButtonType)buttonType];
     [cell setImagePosition:NSImageOnly];
     SetNativeData(new wxDataViewRendererNativeData(cell));
     [cell release];
@@ -3346,6 +3351,19 @@ wxDataViewToggleRenderer::OSXOnCellChanged(NSObject *value,
 }
 
 wxIMPLEMENT_ABSTRACT_CLASS(wxDataViewToggleRenderer, wxDataViewRenderer);
+
+// ---------------------------------------------------------
+// wxDataViewRadioRenderer
+// ---------------------------------------------------------
+
+wxIMPLEMENT_ABSTRACT_CLASS(wxDataViewRadioRenderer, wxDataViewToggleRenderer);
+
+wxDataViewRadioRenderer::wxDataViewRadioRenderer(const wxString& varianttype,
+                                                  wxDataViewCellMode mode,
+                                                  int align)
+    : wxDataViewToggleRenderer(varianttype, mode, align, NSRadioButton)
+{
+}
 
 // ---------------------------------------------------------
 // wxDataViewProgressRenderer


### PR DESCRIPTION
Allow using radio-button-like toggles in wxDataViewCtrl columns too, in
addition to the checkbox-like ones used by wxDataViewToggleRenderer.

Implement the class using native support under GTK and macOS, provide
the generic version and update the sample and the documentation.