### PR TITLE
Fix coordinates adjustment for wxGenericListCtrl mouse events

### DIFF
--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -1366,13 +1366,6 @@ bool wxListHeaderWindow::SendListEvent(wxEventType type, const wxPoint& pos)
     wxListEvent le( type, parent->GetId() );
     le.SetEventObject( parent );
     le.m_pointDrag = pos;
-
-    // the position should be relative to the parent window, not
-    // this one for compatibility with MSW and common sense: the
-    // user code doesn't know anything at all about this header
-    // window, so why should it get positions relative to it?
-    le.m_pointDrag.y -= GetSize().y;
-
     le.m_col = m_column;
     return !parent->GetEventHandler()->ProcessEvent( le ) || le.IsAllowed();
 }
@@ -2220,7 +2213,13 @@ void wxListMainWindow::SendNotify( size_t line,
 
     // set only for events which have position
     if ( point != wxDefaultPosition )
-        le.m_pointDrag = point;
+    {
+        // the position should be relative to the parent window, not
+        // this one for compatibility with MSW and common sense: the
+        // user code doesn't know anything at all about this window,
+        // so why should it get positions relative to it?
+        le.m_pointDrag = GetPosition() + point;
+    }
 
     // don't try to get the line info for virtual list controls: the main
     // program has it anyhow and if we did it would result in accessing all


### PR DESCRIPTION
wxListHeaderWindow event coordinates don't need to be adjusted, as it's
positioned at (0, 0) of its parent window anyhow, but wxListMainWindow
events do need to be adjusted to use the parent window coordinates, as
it's the only window that should be seen by the outside code -- and also
for consistency with the native MSW version.

This corrects the changes originally done in
651d7a1ff84fabae7da9455c4fcf81f3b83f7c9a

See #18133.