### PR TITLE
Fix building without precompiled headers on Windows

### DIFF
--- a/include/wx/msw/private/graphicsd2d.h
+++ b/include/wx/msw/private/graphicsd2d.h
@@ -15,6 +15,9 @@
 // Ensure no previous defines interfere with the Direct2D API headers
 #undef GetHwnd
 
+// include before wincodec.h to prevent winsock/winsock2 redefinition warnings
+#include "wx/msw/wrapwin.h"
+
 #include <d2d1.h>
 #include <dwrite.h>
 #include <wincodec.h>

--- a/src/msw/crashrpt.cpp
+++ b/src/msw/crashrpt.cpp
@@ -26,6 +26,7 @@
 #if wxUSE_CRASHREPORT
 
 #ifndef WX_PRECOMP
+    #include "wx/wxcrtvararg.h"
 #endif  //WX_PRECOMP
 
 #include "wx/msw/debughlp.h"

--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -14,9 +14,6 @@
 // Minimum supported client: Windows 8 and Platform Update for Windows 7
 #define wxD2D_DEVICE_CONTEXT_SUPPORTED 0
 
-// Ensure no previous defines interfere with the Direct2D API headers
-#undef GetHwnd
-
 // We load these functions at runtime from the d2d1.dll.
 // However, since they are also used inside the d2d1.h header we must provide
 // implementations matching the exact declarations. These defines ensures we
@@ -36,9 +33,7 @@
     #pragma warning(disable:4458) // declaration of 'xxx' hides class member
 #endif
 
-#include <d2d1.h>
-#include <dwrite.h>
-#include <wincodec.h>
+#include "wx/msw/private/graphicsd2d.h"
 
 #ifdef __MINGW64_TOOLCHAIN__
 #ifndef DWRITE_E_NOFONT
@@ -78,7 +73,6 @@
 #include "wx/private/graphics.h"
 #include "wx/stack.h"
 #include "wx/sharedptr.h"
-#include "wx/msw/private/graphicsd2d.h"
 
 // This must be the last header included to only affect the DEFINE_GUID()
 // occurrences below but not any GUIDs declared in the standard files included

--- a/src/msw/rt/notifmsgrt.cpp
+++ b/src/msw/rt/notifmsgrt.cpp
@@ -16,6 +16,8 @@
 #if wxUSE_NOTIFICATION_MESSAGE && wxUSE_WINRT
 
 #ifndef WX_PRECOMP
+    #include "wx/app.h"
+    #include "wx/module.h"
     #include "wx/string.h"
 #endif // WX_PRECOMP
 

--- a/src/msw/rt/utilsrt.cpp
+++ b/src/msw/rt/utilsrt.cpp
@@ -26,6 +26,10 @@
 
 #if wxUSE_WINRT
 
+#ifndef WX_PRECOMP
+    #include "wx/log.h"
+#endif //WX_PRECOMP
+
 #include <roapi.h>
 
 #include "wx/dynlib.h"


### PR DESCRIPTION
Add some missing includes to the `#ifndef WX_PRECOMP` sections.

Compiling `graphicsd2d.cpp` and `stc/platwx.cpp` caused a lot of redefinition warnings and errors. Somehow including `wincodec.h` pulls in `winsock.h`. Prevent this by including `winsock2.h` first via `wx/msw/wrapwin.h`.

Also remove duplicate includes in `graphicsd2d.cpp` and only use `wx/msw/private/graphicsd2d.h`.

```
2>c:\program files (x86)\windows kits\10\include\10.0.17134.0\shared\ws2def.h(103): warning C4005: 'AF_IPX': macro redefinition (compiling source file C:\dev\wxWidgets\src\msw\graphicsd2d.cpp)
2>c:\program files (x86)\windows kits\10\include\10.0.17134.0\um\winsock.h(457): note: see previous definition of 'AF_IPX' (compiling source file C:\dev\wxWidgets\src\msw\graphicsd2d.cpp)
2>c:\program files (x86)\windows kits\10\include\10.0.17134.0\shared\ws2def.h(147): warning C4005: 'AF_MAX': macro redefinition (compiling source file C:\dev\wxWidgets\src\msw\graphicsd2d.cpp)
2>c:\program files (x86)\windows kits\10\include\10.0.17134.0\um\winsock.h(476): note: see previous definition of 'AF_MAX' (compiling source file C:\dev\wxWidgets\src\msw\graphicsd2d.cpp)
2>c:\program files (x86)\windows kits\10\include\10.0.17134.0\shared\ws2def.h(185): warning C4005: 'SO_DONTLINGER': macro redefinition (compiling source file C:\dev\wxWidgets\src\msw\graphicsd2d.cpp)
2>c:\program files (x86)\windows kits\10\include\10.0.17134.0\um\winsock.h(399): note: see previous definition of 'SO_DONTLINGER' (compiling source file C:\dev\wxWidgets\src\msw\graphicsd2d.cpp)
2>c:\program files (x86)\windows kits\10\include\10.0.17134.0\shared\ws2def.h(235): error C2011: 'sockaddr': 'struct' type redefinition (compiling source file C:\dev\wxWidgets\src\msw\graphicsd2d.cpp)
2>c:\program files (x86)\windows kits\10\include\10.0.17134.0\um\winsock.h(1007): note: see declaration of 'sockaddr' (compiling source file C:\dev\wxWidgets\src\msw\graphicsd2d.cpp)
2>c:\program files (x86)\windows kits\10\include\10.0.17134.0\shared\ws2def.h(437): error C2059: syntax error: 'constant' (compiling source file C:\dev\wxWidgets\src\msw\graphicsd2d.cpp)
2>c:\program files (x86)\windows kits\10\include\10.0.17134.0\shared\ws2def.h(437): error C3805: 'constant': unexpected token, expected either '}' or a ',' (compiling source file C:\dev\wxWidgets\src\msw\graphicsd2d.cpp)
2>c:\program files (x86)\windows kits\10\include\10.0.17134.0\shared\ws2def.h(572): warning C4005: 'IN_CLASSA': macro redefinition (compiling source file C:\dev\wxWidgets\src\msw\graphicsd2d.cpp)
2>c:\program files (x86)\windows kits\10\include\10.0.17134.0\um\winsock.h(284): note: see previous definition of 'IN_CLASSA' (compiling source file C:\dev\wxWidgets\src\msw\graphicsd2d.cpp)
2>c:\program files (x86)\windows kits\10\include\10.0.17134.0\shared\ws2def.h(578): warning C4005: 'IN_CLASSB': macro redefinition (compiling source file C:\dev\wxWidgets\src\msw\graphicsd2d.cpp)
...
```