### PR TITLE
Fix cursor flicker after popup menu in rich wxTextCtrl

### DIFF
--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2262,9 +2262,14 @@ wxTextCtrl::MSWHandleMessage(WXLRESULT *rc,
             // for plain EDIT controls though), so explicitly work around this
             if ( IsRich() )
             {
+                // wxCurrentPopupMenu stores the popup menu that will receive
+                // WM_COMMAND, but it may be non-NULL even when the underlying
+                // native menu is no longer shown. Use ::IsMenu() to check whether
+                // the menu still exists.
                 extern wxMenu *wxCurrentPopupMenu;
                 if ( wxCurrentPopupMenu &&
-                        wxCurrentPopupMenu->GetInvokingWindow() == this )
+                        wxCurrentPopupMenu->GetInvokingWindow() == this &&
+                        ::IsMenu(GetHmenuOf(wxCurrentPopupMenu)) )
                     ::SetCursor(GetHcursorOf(*wxSTANDARD_CURSOR));
             }
 #endif // wxUSE_MENUS


### PR DESCRIPTION
This is an attempt to fix https://github.com/vslavik/poedit/issues/483

After bd650ec and cad2b9c (which partially reverted the former commit, so that [this code](https://github.com/wxWidgets/wxWidgets/blob/8c8ff2c24d7ead682b20be1f62555855c92ed2fe/src/msw/window.cpp#L5466) gets called), showing a popup menu in `wxTextCtrl` with `wxTE_RICH2` and then dismissing it without choosing a command would result in the cursor flickering between arrow and beam cursors until another context menu was shown.

This is because the context menu is not shown under wx's control and we don't have an obvious place to clear `wxCurrentPopupMenu` (see cad2b9c where it was too early, before `WM_COMMAND` processing). This causes the flicker because of *another* use of `wxCurrentPopupMenu` that fixes richedit native control's bug: https://github.com/wxWidgets/wxWidgets/blob/4fcc6e15b07b78f54d9783b6d940d12ec4640627/src/msw/textctrl.cpp#L2259

This fix is not very nice, but then, neither is the cursor-fixing hack — and I can't figure out any other way...