### PR TITLE
Don't send "page changed" events from wxNotebook dtor with GTK+ 3

### DIFF
--- a/src/gtk/notebook.cpp
+++ b/src/gtk/notebook.cpp
@@ -256,6 +256,13 @@ int wxNotebook::DoSetSelection( size_t page, int flags )
 
 void wxNotebook::GTKOnPageChanged()
 {
+    // Don't generate page changing events during the destruction, this is
+    // unexpected and may reference the already (half) destroyed parent window
+    // for example but we still get GTK+ signals (at least with GTK+ 3), so we
+    // need to ignore them explicitly.
+    if ( IsBeingDeleted() )
+        return;
+
     m_selection = gtk_notebook_get_current_page(GTK_NOTEBOOK(m_widget));
 
     SendPageChangedEvent(m_oldSelection);

--- a/tests/controls/notebooktest.cpp
+++ b/tests/controls/notebooktest.cpp
@@ -25,7 +25,7 @@
 class NotebookTestCase : public BookCtrlBaseTestCase, public CppUnit::TestCase
 {
 public:
-    NotebookTestCase() { }
+    NotebookTestCase() { m_notebook = NULL; m_numPageChanges = 0; }
 
     virtual void setUp();
     virtual void tearDown();
@@ -44,11 +44,17 @@ private:
         wxBOOK_CTRL_BASE_TESTS();
         CPPUNIT_TEST( Image );
         CPPUNIT_TEST( RowCount );
+        CPPUNIT_TEST( NoEventsOnDestruction );
     CPPUNIT_TEST_SUITE_END();
 
     void RowCount();
+    void NoEventsOnDestruction();
+
+    void OnPageChanged(wxNotebookEvent&) { m_numPageChanges++; }
 
     wxNotebook *m_notebook;
+
+    int m_numPageChanges;
 
     wxDECLARE_NO_COPY_CLASS(NotebookTestCase);
 };
@@ -88,6 +94,28 @@ void NotebookTestCase::RowCount()
 
     CPPUNIT_ASSERT( m_notebook->GetRowCount() != 1 );
 #endif
+}
+
+void NotebookTestCase::NoEventsOnDestruction()
+{
+    // We can't use EventCounter helper here as it doesn't deal with the window
+    // it's connected to being destroyed during its life-time, so do it
+    // manually.
+    m_notebook->Bind(wxEVT_NOTEBOOK_PAGE_CHANGED,
+                     &NotebookTestCase::OnPageChanged, this);
+
+    // Normally deleting a page before the selected one results in page
+    // selection changing and the corresponding event.
+    m_notebook->DeletePage(0);
+    CHECK( m_numPageChanges == 1 );
+
+    // But deleting the entire control shouldn't generate any events, yet it
+    // used to do under GTK+ 3 when a page different from the first one was
+    // selected.
+    m_notebook->ChangeSelection(1);
+    m_notebook->Destroy();
+    m_notebook = NULL;
+    CHECK( m_numPageChanges == 1 );
 }
 
 #endif //wxUSE_NOTEBOOK


### PR DESCRIPTION
These events are unexpected and inconsistent with the other platforms,
including GTK+ 2, so make sure we don't send them during the
destruction.

---

This fixes the problem discussed in this [wx-users thread](https://groups.google.com/forum/#!topic/wx-users/mu-sW_VzeiA). Alternative solution would be to disconnect the handler in the dtor, but I don't see any reason to prefer it and this seems simpler. Please let me know if you prefer doing at GTK+ level.

OTOH this PR still results in an event being sent if you just `destroy nb` instead of doing the proper and recommended `nb->Destroy()`. If we care about this, we could just call `SendDestroyEvent()` from the dtor though.