### PR TITLE
Add wxGtkWidgetPath RAII wrapper and use it in wxGTK3 code

### DIFF
--- a/include/wx/gtk/private/stylecontext.h
+++ b/include/wx/gtk/private/stylecontext.h
@@ -10,7 +10,7 @@
 #ifndef _WX_GTK_PRIVATE_STYLECONTEXT_H_
 #define _WX_GTK_PRIVATE_STYLECONTEXT_H_
 
-#ifdef __WXGTK3__
+#include "wx/gtk/private/widgetpath.h"
 
 class wxGtkStyleContext
 {
@@ -37,10 +37,9 @@ public:
 
 private:
     GtkStyleContext* m_context;
-    GtkWidgetPath* const m_path;
+    wxGtkWidgetPath m_path;
 
     wxDECLARE_NO_COPY_CLASS(wxGtkStyleContext);
 };
 
-#endif // __WXGTK3__
 #endif // _WX_GTK_PRIVATE_STYLECONTEXT_H_

--- a/include/wx/gtk/private/widgetpath.h
+++ b/include/wx/gtk/private/widgetpath.h
@@ -1,0 +1,34 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/gtk/private/widgetpath.h
+// Purpose:     wxGtkWidgetPath class declaration
+// Author:      Vadim Zeitlin
+// Created:     2018-05-31
+// Copyright:   (c) 2018 Vadim Zeitlin <vadim@wxwindows.org>
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_GTK_PRIVATE_WIDGETPATH_H_
+#define _WX_GTK_PRIVATE_WIDGETPATH_H_
+
+// ----------------------------------------------------------------------------
+// RAII wrapper calling g_widget_path_unref() automatically
+// ----------------------------------------------------------------------------
+
+class wxGtkWidgetPath
+{
+public:
+    wxGtkWidgetPath() : m_path(gtk_widget_path_new()) { }
+    ~wxGtkWidgetPath() { gtk_widget_path_unref(m_path); }
+
+    operator GtkWidgetPath*() { return m_path; }
+    operator const GtkWidgetPath*() const { return m_path; }
+
+private:
+    GtkWidgetPath * const m_path;
+
+    // copying could be implemented by using g_widget_path_ref() but for now
+    // there is no need for it so don't implement it
+    wxDECLARE_NO_COPY_CLASS(wxGtkWidgetPath);
+};
+
+#endif // _WX_GTK_PRIVATE_WIDGETPATH_H_

--- a/src/gtk/renderer.cpp
+++ b/src/gtk/renderer.cpp
@@ -38,7 +38,9 @@
 #endif
 
 #include "wx/gtk/private.h"
-#include "wx/gtk/private/stylecontext.h"
+#ifdef __WXGTK3__
+    #include "wx/gtk/private/stylecontext.h"
+#endif
 
 #if defined(__WXGTK3__) && !GTK_CHECK_VERSION(3,14,0)
     #define GTK_STATE_FLAG_CHECKED (1 << 11)

--- a/src/gtk/settings.cpp
+++ b/src/gtk/settings.cpp
@@ -23,7 +23,9 @@
 #include "wx/gtk/private/wrapgtk.h"
 #include "wx/gtk/private/gtk3-compat.h"
 #include "wx/gtk/private/win_gtk.h"
-#include "wx/gtk/private/stylecontext.h"
+#ifdef __WXGTK3__
+    #include "wx/gtk/private/stylecontext.h"
+#endif // __WXGTK3__
 
 bool wxGetFrameExtents(GdkWindow* window, int* left, int* right, int* top, int* bottom);
 
@@ -198,7 +200,6 @@ static void notify_gtk_font_name(GObject*, GParamSpec*, void*)
 //-----------------------------------------------------------------------------
 
 wxGtkStyleContext::wxGtkStyleContext()
-    : m_path(gtk_widget_path_new())
 {
     m_context = NULL;
 }
@@ -241,7 +242,6 @@ wxGtkStyleContext& wxGtkStyleContext::Add(const char* objectName)
 
 wxGtkStyleContext::~wxGtkStyleContext()
 {
-    gtk_widget_path_unref(m_path);
     if (m_context == NULL)
         return;
     if (gtk_check_version(3,16,0) == NULL || gtk_check_version(3,4,0))
@@ -320,7 +320,7 @@ wxGtkStyleContext& wxGtkStyleContext::AddTreeviewHeaderButton(int pos)
     AddTreeview().Add("header");
     GtkStyleContext* sc = gtk_style_context_new();
 
-    GtkWidgetPath* siblings = gtk_widget_path_new();
+    wxGtkWidgetPath siblings;
     gtk_widget_path_append_type(siblings, GTK_TYPE_BUTTON);
     gtk_widget_path_iter_set_object_name(siblings, -1, "button");
     gtk_widget_path_append_type(siblings, GTK_TYPE_BUTTON);
@@ -329,7 +329,6 @@ wxGtkStyleContext& wxGtkStyleContext::AddTreeviewHeaderButton(int pos)
     gtk_widget_path_iter_set_object_name(siblings, -1, "button");
 
     gtk_widget_path_append_with_siblings(m_path, siblings, pos);
-    gtk_widget_path_unref(siblings);
 
     gtk_style_context_set_path(sc, m_path);
     gtk_style_context_set_parent(sc, m_context);


### PR DESCRIPTION
Avoid explicit gtk_widget_path_unref() calls.

---

I'd like to do something to have a nicer/safer API for working with `GtkStyleContext` too because it looks like it would be quite simple to make a mistake in this code, but this is not as trivial...