### PR TITLE
Fix WXGTK defines in docs to match the ones in code

### DIFF
--- a/docs/doxygen/mainpages/const_cpp.h
+++ b/docs/doxygen/mainpages/const_cpp.h
@@ -26,10 +26,11 @@ using @ifdef_ and not @if_.
 @itemdef{__WXBASE__, Only wxBase, no GUI features (same as @c wxUSE_GUI == 0)}
 @itemdef{__WXDFB__, wxUniversal using DirectFB}
 @itemdef{__WXGTK__, GTK+}
-@itemdef{__WXGTK12__, GTK+ 1.2 or higher}
+@itemdef{__WXGTK127__, GTK+ 1.2.7 or higher}
 @itemdef{__WXGTK20__, GTK+ 2.0 or higher}
-@itemdef{__WXGTK24__, GTK+ 2.4 or higher}
 @itemdef{__WXGTK210__, GTK+ 2.10 or higher}
+@itemdef{__WXGTK218__, GTK+ 2.18 or higher}
+@itemdef{__WXGTK220__, GTK+ 2.20 or higher}
 @itemdef{__WXMAC__, old define, same as <tt>__WXOSX__</tt>}
 @itemdef{__WXMOTIF__, Motif}
 @itemdef{__WXMOTIF20__, Motif 2.0 or higher}

--- a/docs/doxygen/mainpages/const_cpp.h
+++ b/docs/doxygen/mainpages/const_cpp.h
@@ -27,7 +27,7 @@ using @ifdef_ and not @if_.
 @itemdef{__WXDFB__, wxUniversal using DirectFB}
 @itemdef{__WXGTK__, GTK+}
 @itemdef{__WXGTK127__, GTK+ 1.2.7 or higher}
-@itemdef{__WXGTK20__, GTK+ 2.0 or higher}
+@itemdef{__WXGTK20__, GTK+ 2.0 (2.6) or higher}
 @itemdef{__WXGTK210__, GTK+ 2.10 or higher}
 @itemdef{__WXGTK218__, GTK+ 2.18 or higher}
 @itemdef{__WXGTK220__, GTK+ 2.20 or higher}

--- a/samples/widgets/clrpicker.cpp
+++ b/samples/widgets/clrpicker.cpp
@@ -119,7 +119,7 @@ wxEND_EVENT_TABLE()
 // implementation
 // ============================================================================
 
-#if defined(__WXGTK__)
+#if defined(__WXGTK20__)
     #define FAMILY_CTRLS NATIVE_CTRLS
 #else
     #define FAMILY_CTRLS GENERIC_CTRLS

--- a/samples/widgets/clrpicker.cpp
+++ b/samples/widgets/clrpicker.cpp
@@ -119,7 +119,7 @@ wxEND_EVENT_TABLE()
 // implementation
 // ============================================================================
 
-#if defined(__WXGTK24__)
+#if defined(__WXGTK__)
     #define FAMILY_CTRLS NATIVE_CTRLS
 #else
     #define FAMILY_CTRLS GENERIC_CTRLS

--- a/samples/widgets/dirpicker.cpp
+++ b/samples/widgets/dirpicker.cpp
@@ -127,7 +127,7 @@ wxEND_EVENT_TABLE()
 // implementation
 // ============================================================================
 
-#if defined(__WXGTK24__)
+#if defined(__WXGTK__)
     #define FAMILY_CTRLS NATIVE_CTRLS
 #else
     #define FAMILY_CTRLS GENERIC_CTRLS

--- a/samples/widgets/dirpicker.cpp
+++ b/samples/widgets/dirpicker.cpp
@@ -127,7 +127,7 @@ wxEND_EVENT_TABLE()
 // implementation
 // ============================================================================
 
-#if defined(__WXGTK__)
+#if defined(__WXGTK20__)
     #define FAMILY_CTRLS NATIVE_CTRLS
 #else
     #define FAMILY_CTRLS GENERIC_CTRLS

--- a/samples/widgets/filepicker.cpp
+++ b/samples/widgets/filepicker.cpp
@@ -144,7 +144,7 @@ wxEND_EVENT_TABLE()
 // implementation
 // ============================================================================
 
-#if defined(__WXGTK__)
+#if defined(__WXGTK20__)
     #define FAMILY_CTRLS NATIVE_CTRLS
 #else
     #define FAMILY_CTRLS GENERIC_CTRLS

--- a/samples/widgets/filepicker.cpp
+++ b/samples/widgets/filepicker.cpp
@@ -144,7 +144,7 @@ wxEND_EVENT_TABLE()
 // implementation
 // ============================================================================
 
-#if defined(__WXGTK24__)
+#if defined(__WXGTK__)
     #define FAMILY_CTRLS NATIVE_CTRLS
 #else
     #define FAMILY_CTRLS GENERIC_CTRLS

--- a/samples/widgets/fontpicker.cpp
+++ b/samples/widgets/fontpicker.cpp
@@ -119,7 +119,7 @@ wxEND_EVENT_TABLE()
 // implementation
 // ============================================================================
 
-#if defined(__WXGTK__)
+#if defined(__WXGTK20__)
     #define FAMILY_CTRLS NATIVE_CTRLS
 #else
     #define FAMILY_CTRLS GENERIC_CTRLS

--- a/samples/widgets/fontpicker.cpp
+++ b/samples/widgets/fontpicker.cpp
@@ -119,7 +119,7 @@ wxEND_EVENT_TABLE()
 // implementation
 // ============================================================================
 
-#if defined(__WXGTK24__)
+#if defined(__WXGTK__)
     #define FAMILY_CTRLS NATIVE_CTRLS
 #else
     #define FAMILY_CTRLS GENERIC_CTRLS


### PR DESCRIPTION
I found that the WXGTK defines like "__WXGTK24__" in documentation did not match what is in the code.

Edit: See setup.h.in and configure.in for the ones in code.

Tim S.