### PR TITLE
Implement wxTextCtrl::HitTest() for single line controls in wxGTK

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -84,6 +84,7 @@ All (GUI):
 
 wxGTK:
 
+- Implement wxTextCtrl::HitTest() for single line controls.
 - Fix the build with glib < 2.32 (e.g. CentOS 6).
 
 wxMSW:

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -1337,7 +1337,7 @@ public:
         parameter is not modified.
 
         Please note that this function is currently only implemented in wxUniv,
-        wxMSW and wxGTK2 ports and always returns @c wxTE_HT_UNKNOWN in the
+        wxMSW and wxGTK ports and always returns @c wxTE_HT_UNKNOWN in the
         other ports.
 
         @beginWxPerlOnly
@@ -1363,7 +1363,7 @@ public:
         parameters are not modified.
 
         Please note that this function is currently only implemented in wxUniv,
-        wxMSW and wxGTK2 ports and always returns @c wxTE_HT_UNKNOWN in the
+        wxMSW and wxGTK ports and always returns @c wxTE_HT_UNKNOWN in the
         other ports.
 
         @beginWxPerlOnly

--- a/samples/widgets/textctrl.cpp
+++ b/samples/widgets/textctrl.cpp
@@ -276,11 +276,17 @@ public:
                     int flags)
         : wxTextCtrl(parent, id, value, wxDefaultPosition, wxDefaultSize, flags)
     {
+        Bind(wxEVT_LEFT_DOWN, &WidgetsTextCtrl::OnLeftClick, this);
     }
 
-protected:
-    void OnRightClick(wxMouseEvent& event)
+private:
+    // Show the result of HitTest() at the mouse position if Alt is pressed.
+    void OnLeftClick(wxMouseEvent& event)
     {
+        event.Skip();
+        if ( !event.AltDown() )
+            return;
+
         wxString where;
         wxTextCoord x, y;
         switch ( HitTest(event.GetPosition(), &x, &y) )
@@ -312,12 +318,7 @@ protected:
         }
 
         wxLogMessage(wxT("Mouse is %s (%ld, %ld)"), where.c_str(), x, y);
-
-        event.Skip();
     }
-
-private:
-    wxDECLARE_EVENT_TABLE();
 };
 
 // ----------------------------------------------------------------------------
@@ -351,10 +352,6 @@ wxBEGIN_EVENT_TABLE(TextWidgetsPage, WidgetsPage)
 
     EVT_CHECKBOX(wxID_ANY, TextWidgetsPage::OnCheckOrRadioBox)
     EVT_RADIOBOX(wxID_ANY, TextWidgetsPage::OnCheckOrRadioBox)
-wxEND_EVENT_TABLE()
-
-wxBEGIN_EVENT_TABLE(WidgetsTextCtrl, wxTextCtrl)
-    EVT_RIGHT_UP(WidgetsTextCtrl::OnRightClick)
 wxEND_EVENT_TABLE()
 
 // ============================================================================
@@ -591,6 +588,17 @@ void TextWidgetsPage::CreateContent()
                           m_textRange
                         ),
                         0, wxALL, 5
+                     );
+
+    sizerMiddleDown->Add
+                     (
+                          new wxStaticText
+                          (
+                            this,
+                            wxID_ANY,
+                            "Alt-click in the text to see HitTest() result"
+                          ),
+                          wxSizerFlags().Border()
                      );
 
     wxSizer *sizerMiddle = new wxBoxSizer(wxVERTICAL);

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -1465,8 +1465,53 @@ wxTextCtrl::HitTest(const wxPoint& pt, long *pos) const
 {
     if ( !IsMultiLine() )
     {
-        // not supported
-        return wxTE_HT_UNKNOWN;
+        // These variables will contain the position inside PangoLayout.
+        int x = pt.x,
+            y = pt.y;
+
+        // Get the offsets of PangoLayout inside the control.
+        //
+        // Note that contrary to what GTK+ documentation implies, the
+        // horizontal offset already accounts for scrolling, i.e. it will be
+        // negative if text is scrolled.
+        gint ofsX = 0,
+             ofsY = 0;
+        gtk_entry_get_layout_offsets(GTK_ENTRY(m_text), &ofsX, &ofsY);
+
+        x -= ofsX;
+        y -= ofsY;
+
+        // And scale the coordinates for Pango.
+        x *= PANGO_SCALE;
+        y *= PANGO_SCALE;
+
+        PangoLayout* const layout = gtk_entry_get_layout(GTK_ENTRY(m_text));
+
+        int idx = -1,
+            ofs = 0;
+        if ( !pango_layout_xy_to_index(layout, x, y, &idx, &ofs) )
+        {
+            // Try to guess why did it fail.
+            if ( x < 0 || y < 0 )
+            {
+                if ( pos )
+                    *pos = 0;
+
+                return wxTE_HT_BEFORE;
+            }
+            else
+            {
+                if ( pos )
+                    *pos = wxTextEntry::GetLastPosition();
+
+                return wxTE_HT_BEYOND;
+            }
+        }
+
+        if ( pos )
+            *pos = idx;
+
+        return wxTE_HT_ON_TEXT;
     }
 
     int x, y;


### PR DESCRIPTION
This replaces https://github.com/wxWidgets/wxWidgets/pull/604 and fixes https://trac.wxwidgets.org/ticket/18144

Probably could be backported to 3.0 too, if people think it can be useful.