### PR TITLE
Replace wxUSE_GENERICDATAVIEWCTRL with wxHAS_GENERIC_DATAVIEWCTRL

### DIFF
--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -728,7 +728,7 @@ bool wxDataViewRendererBase::StartEditing( const wxDataViewItem &item, wxRect la
 
     m_editorCtrl->PushEventHandler( handler );
 
-#if defined(__WXGTK20__) && !defined(wxUSE_GENERICDATAVIEWCTRL)
+#if defined(__WXGTK20__) && !defined(wxHAS_GENERIC_DATAVIEWCTRL)
     handler->SetFocusOnIdle();
 #else
     m_editorCtrl->SetFocus();
@@ -3050,7 +3050,7 @@ void wxDataViewTreeCtrl::OnCollapsed( wxDataViewEvent &event )
 
 void wxDataViewTreeCtrl::OnSize( wxSizeEvent &event )
 {
-#if defined(wxUSE_GENERICDATAVIEWCTRL)
+#if defined(wxHAS_GENERIC_DATAVIEWCTRL)
     // automatically resize our only column to take the entire control width
     if ( GetColumnCount() )
     {

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -18,7 +18,7 @@
 
 #include "wx/dataview.h"
 
-#ifdef wxUSE_GENERICDATAVIEWCTRL
+#ifdef wxHAS_GENERIC_DATAVIEWCTRL
 
 #ifndef WX_PRECOMP
     #ifdef __WXMSW__
@@ -6782,6 +6782,6 @@ wxAccStatus wxDataViewCtrlAccessible::GetSelections(wxVariant* selections)
 }
 #endif // wxUSE_ACCESSIBILITY
 
-#endif // !wxUSE_GENERICDATAVIEWCTRL
+#endif // !wxHAS_GENERIC_DATAVIEWCTRL
 
 #endif // wxUSE_DATAVIEWCTRL

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -13,7 +13,7 @@
 
 #include "wx/dataview.h"
 
-#ifndef wxUSE_GENERICDATAVIEWCTRL
+#ifndef wxHAS_GENERIC_DATAVIEWCTRL
 
 #ifndef WX_PRECOMP
     #include "wx/log.h"
@@ -5313,6 +5313,6 @@ void wxDataViewCtrl::DoApplyWidgetStyle(GtkRcStyle *style)
     GTKApplyStyle(m_treeview, style);
 }
 
-#endif // !wxUSE_GENERICDATAVIEWCTRL
+#endif // !wxHAS_GENERIC_DATAVIEWCTRL
 
 #endif // wxUSE_DATAVIEWCTRL

--- a/src/osx/dataview_osx.cpp
+++ b/src/osx/dataview_osx.cpp
@@ -13,7 +13,7 @@
 
 #include "wx/dataview.h"
 
-#ifndef wxUSE_GENERICDATAVIEWCTRL
+#ifndef wxHAS_GENERIC_DATAVIEWCTRL
 
 #include <limits>
 
@@ -750,6 +750,6 @@ wxBEGIN_EVENT_TABLE(wxDataViewCtrl,wxDataViewCtrlBase)
   EVT_MOTION(wxDataViewCtrl::OnMouse)
 wxEND_EVENT_TABLE()
 
-#endif // !wxUSE_GENERICDATAVIEWCTRL
+#endif // !wxHAS_GENERIC_DATAVIEWCTRL
 
 #endif // wxUSE_DATAVIEWCTRL

--- a/src/qt/dataview.cpp
+++ b/src/qt/dataview.cpp
@@ -12,7 +12,7 @@
 
 #include "wx/dataview.h"
 
-#ifndef wxUSE_GENERICDATAVIEWCTRL
+#ifndef wxHAS_GENERIC_DATAVIEWCTRL
 
 wxDataViewColumn::wxDataViewColumn( const wxString &title, wxDataViewRenderer *renderer,
                   unsigned int model_column, int width,
@@ -316,6 +316,6 @@ void wxDataViewCtrl::DoSetCurrentItem(const wxDataViewItem& item)
 {
 }
 
-#endif // !wxUSE_GENERICDATAVIEWCTRL
+#endif // !wxHAS_GENERIC_DATAVIEWCTRL
 
 #endif // wxUSE_DATAVIEWCTRL

--- a/src/qt/dvrenderer.cpp
+++ b/src/qt/dvrenderer.cpp
@@ -12,7 +12,7 @@
 
 #include "wx/dataview.h"
 
-#ifndef wxUSE_GENERICDATAVIEWCTRL
+#ifndef wxHAS_GENERIC_DATAVIEWCTRL
 
 wxDataViewRenderer::wxDataViewRenderer( const wxString &variantType,
                     wxDataViewCellMode mode,
@@ -48,6 +48,6 @@ wxEllipsizeMode wxDataViewRenderer::GetEllipsizeMode() const
     return wxEllipsizeMode();
 }
 
-#endif // !wxUSE_GENERICDATAVIEWCTRL
+#endif // !wxHAS_GENERIC_DATAVIEWCTRL
 
 #endif // wxUSE_DATAVIEWCTRL

--- a/src/qt/dvrenderers.cpp
+++ b/src/qt/dvrenderers.cpp
@@ -12,7 +12,7 @@
 
 #include "wx/dataview.h"
 
-#ifndef wxUSE_GENERICDATAVIEWCTRL
+#ifndef wxHAS_GENERIC_DATAVIEWCTRL
 
 wxDataViewTextRenderer::wxDataViewTextRenderer( const wxString &varianttype,
                         wxDataViewCellMode mode,
@@ -256,6 +256,6 @@ void wxDataViewChoiceRenderer::SetAlignment( int align )
 
 }
 
-#endif // !wxUSE_GENERICDATAVIEWCTRL
+#endif // !wxHAS_GENERIC_DATAVIEWCTRL
 
 #endif // wxUSE_DATAVIEWCTRL


### PR DESCRIPTION
From wx/dataview.h
`#ifdef wxHAS_GENERIC_DATAVIEWCTRL
    // this symbol doesn't follow the convention for wxUSE_XXX symbols which
    // are normally always defined as either 0 or 1, so its use is deprecated
    // and it only exists for backwards compatibility, don't use it any more
    // and use wxHAS_GENERIC_DATAVIEWCTRL instead
    #define wxUSE_GENERICDATAVIEWCTRL
#endif
`
Tim S.