### PR TITLE
Fix glitch in AUI frame with standard wxToolbar

### DIFF
--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -3935,6 +3935,10 @@ void wxAuiManager::Repaint(wxDC* dc)
 void wxAuiManager::OnPaint(wxPaintEvent& WXUNUSED(event))
 {
     wxPaintDC dc(m_frame);
+
+    dc.SetBackground(GetArtProvider()->GetColor(wxAUI_DOCKART_BACKGROUND_COLOUR));
+    dc.Clear();
+
     Repaint(&dc);
 }
 


### PR DESCRIPTION
When the height of the AUI toolbar pane is higher than the wxToolbar, the extra
area shows a glitch. This happens because the paint handler never draws on this
area. Clearing the DC of the frame with the AUI background colour fixes this.
This glitch does not happen with WXGTK or WXMAC.

Closes https://trac.wxwidgets.org/ticket/18138