### PR TITLE
Don't change wxTextCtrl colour automatically under macOS

### DIFF
--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -379,6 +379,7 @@ public:
     }
 
     - (void)textDidChange:(NSNotification *)aNotification;
+    - (void)changeColor:(id)sender;
 
     @end
 

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -436,6 +436,15 @@ NSView* wxMacEditHelper::ms_viewCurrentlyEdited = nil;
         impl->controlTextDidChange();
 }
 
+
+- (void)changeColor:(id)sender
+{
+   // Define this just to block the color change messages - these are sent from
+   // the shared color/font panel resulting in unwanted changes of color when
+   // shared color panel is used (as when using wxColourPickerCtrl for example).
+}
+
+
 - (void) setEnabled:(BOOL) flag
 {
     // from Technical Q&A QA1461


### PR DESCRIPTION
When wxColourDialog is shown, any changes to the colour selected in it
apparently result in broadcast messages to all currently visible text
controls, which was unexpected.

Block the changeColor: message to prevent this from happening.

---

Stefan, this is a patch [posted to wx-dev](https://groups.google.com/forum/#!topic/wx-dev/PxkBqjd_i9I), what do you think of applying it?