### PR TITLE
macOS Dark Mode: implement wxEVT_SYS_COLOUR_CHANGED

### DIFF
--- a/src/osx/cocoa/nonownedwnd.mm
+++ b/src/osx/cocoa/nonownedwnd.mm
@@ -305,6 +305,8 @@ static NSResponder* s_formerFirstResponder = NULL;
 // controller
 //
 
+static void *EffectiveAppearanceContext = &EffectiveAppearanceContext;
+
 @interface wxNonOwnedWindowController : NSObject <NSWindowDelegate>
 {
 }
@@ -610,6 +612,32 @@ extern int wxOSXGetIdFromSelector(SEL action );
         [view setFrameSize: expectedframerect.size];
     }
 }
+ 
+- (void)addObservers:(NSWindow*)win
+{
+    [win addObserver:self forKeyPath:@"effectiveAppearance"
+             options:0 context:EffectiveAppearanceContext];
+}
+
+- (void)removeObservers:(NSWindow*)win
+{
+    [win removeObserver:self forKeyPath:@"effectiveAppearance" context:EffectiveAppearanceContext];
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+{
+    if (context == EffectiveAppearanceContext)
+    {
+        wxNonOwnedWindowCocoaImpl* windowimpl = [(NSWindow*)object WX_implementation];
+        wxNonOwnedWindow* wxpeer = windowimpl ? windowimpl->GetWXPeer() : NULL;
+        if (wxpeer)
+        {
+            wxSysColourChangedEvent event;
+            event.SetEventObject(wxpeer);
+            wxpeer->HandleWindowEvent(event);
+        }
+    }
+}
 
 @end
 
@@ -632,6 +660,7 @@ wxNonOwnedWindowCocoaImpl::~wxNonOwnedWindowCocoaImpl()
 {
     if ( !m_wxPeer->IsNativeWindowWrapper() )
     {
+        [(wxNonOwnedWindowController*)[m_macWindow delegate] removeObservers:m_macWindow];
         [m_macWindow setDelegate:nil];
      
         // make sure we remove this first, otherwise the ref count will not lead to the 
@@ -648,6 +677,7 @@ void wxNonOwnedWindowCocoaImpl::WillBeDestroyed()
 {
     if ( !m_wxPeer->IsNativeWindowWrapper() )
     {
+        [(wxNonOwnedWindowController*)[m_macWindow delegate] removeObservers:m_macWindow];
         [m_macWindow setDelegate:nil];
     }
 }
@@ -738,6 +768,7 @@ long style, long extraStyle, const wxString& WXUNUSED(name) )
     [m_macWindow setLevel:m_macWindowLevel];
 
     [m_macWindow setDelegate:controller];
+    [controller addObservers:m_macWindow];
 
     if ( ( style & wxFRAME_SHAPED) )
     {


### PR DESCRIPTION
This is second small step towards [supporting macOS 10.14](https://trac.wxwidgets.org/ticket/18146): detect appearance changes and emit `wxEVT_SYS_COLOUR_CHANGED` as other platforms do. (This is hardly the most important issue to fix, but it will make debugging of generic code easier and so is worth doing sooner rather than later.)

Implementation is the same as on other platforms, i.e. captures the change at toplevel window level, even though it could be done in `NSApplication` on macOS. I put the code into `wxNonOwnedWindowController` as it seemed a reasonable place and better than duplicating the same logic in `wxNSPanel` and `wxNSWindow`. 

The code doesn't check for running on 10.14, because I think that simpler code is preferable and observing a constant (or non-existing on very old OS X versions) key does little harm; I'll change it if you disagree.

P.S. If you test this using Xcode's appearance switcher, you'll see the event emitted twice. That's an Xcode thing, it only occurs one when not running under Xcode.