### PR TITLE
Don't restore clipping region unnecessarily in wxDCClipper

### DIFF
--- a/include/wx/dc.h
+++ b/include/wx/dc.h
@@ -1437,18 +1437,15 @@ class WXDLLIMPEXP_CORE wxDCClipper
 public:
     wxDCClipper(wxDC& dc, const wxRegion& r) : m_dc(dc)
     {
-        dc.GetClippingBox(m_oldClipRect);
-        dc.SetClippingRegion(r.GetBox());
+        Init(r.GetBox());
     }
     wxDCClipper(wxDC& dc, const wxRect& r) : m_dc(dc)
     {
-        dc.GetClippingBox(m_oldClipRect);
-        dc.SetClippingRegion(r.x, r.y, r.width, r.height);
+        Init(r);
     }
     wxDCClipper(wxDC& dc, wxCoord x, wxCoord y, wxCoord w, wxCoord h) : m_dc(dc)
     {
-        dc.GetClippingBox(m_oldClipRect);
-        dc.SetClippingRegion(x, y, w, h);
+        Init(wxRect(x, y, w, h));
     }
 
     ~wxDCClipper()
@@ -1459,6 +1456,13 @@ public:
     }
 
 private:
+    // Common part of all ctors.
+    void Init(const wxRect& r)
+    {
+        m_dc.GetClippingBox(m_oldClipRect);
+        m_dc.SetClippingRegion(r);
+    }
+
     wxDC& m_dc;
     wxRect m_oldClipRect;
 

--- a/include/wx/dc.h
+++ b/include/wx/dc.h
@@ -666,7 +666,10 @@ private:
     wxDC       *m_owner;
 
 protected:
-    // unset clipping variables (after clipping region was destroyed)
+    // This method exists for backwards compatibility only (while it's not
+    // documented, there are derived classes using it outside wxWidgets
+    // itself), don't use it in any new code and just call wxDCImpl version of
+    // DestroyClippingRegion() to reset the clipping information instead.
     void ResetClipping()
     {
         m_clipping = false;

--- a/include/wx/dc.h
+++ b/include/wx/dc.h
@@ -453,11 +453,15 @@ public:
     // up to date.
     virtual bool DoGetClippingRect(wxRect& rect) const;
 
+#if WXWIN_COMPATIBILITY_3_0
     // This method is kept for backwards compatibility but shouldn't be used
     // nor overridden in the new code, implement DoGetClippingRect() above
     // instead.
-    virtual void DoGetClippingBox(wxCoord *x, wxCoord *y,
-                                  wxCoord *w, wxCoord *h) const;
+    wxDEPRECATED_BUT_USED_INTERNALLY(
+        virtual void DoGetClippingBox(wxCoord *x, wxCoord *y,
+                                      wxCoord *w, wxCoord *h) const
+    );
+#endif // WXWIN_COMPATIBILITY_3_0
 
     virtual void DestroyClippingRegion() { ResetClipping(); }
 

--- a/include/wx/dc.h
+++ b/include/wx/dc.h
@@ -1459,7 +1459,14 @@ private:
     // Common part of all ctors.
     void Init(const wxRect& r)
     {
+        // GetClippingBox() is supposed to return the rectangle corresponding
+        // to the full DC area and some implementations actually do it, while
+        // others return an empty rectangle instead. Check for both possible
+        // results here to avoid restoring the clipping region unnecessarily in
+        // the dtor.
         m_dc.GetClippingBox(m_oldClipRect);
+        if ( m_oldClipRect == m_dc.GetSize() )
+            m_oldClipRect = wxRect();
         m_dc.SetClippingRegion(r);
     }
 

--- a/include/wx/dc.h
+++ b/include/wx/dc.h
@@ -446,21 +446,18 @@ public:
     // NB: this function works with device coordinates, not the logical ones!
     virtual void DoSetDeviceClippingRegion(const wxRegion& region) = 0;
 
-    virtual void DoGetClippingBox(wxCoord *x, wxCoord *y,
-                                  wxCoord *w, wxCoord *h) const
-    {
-        int dcWidth, dcHeight;
-        DoGetSize(&dcWidth, &dcHeight);
+    // Method used to implement wxDC::GetClippingBox().
+    //
+    // Default implementation returns values stored in m_clip[XY][12] member
+    // variables, so this method doesn't need to be overridden if they're kept
+    // up to date.
+    virtual bool DoGetClippingRect(wxRect& rect) const;
 
-        if ( x )
-            *x = m_clipping ? m_clipX1 : DeviceToLogicalX(0);
-        if ( y )
-            *y = m_clipping ? m_clipY1 : DeviceToLogicalY(0);
-        if ( w )
-            *w = m_clipping ? m_clipX2 - m_clipX1 : DeviceToLogicalXRel(dcWidth);
-        if ( h )
-            *h = m_clipping ? m_clipY2 - m_clipY1 : DeviceToLogicalYRel(dcHeight);
-    }
+    // This method is kept for backwards compatibility but shouldn't be used
+    // nor overridden in the new code, implement DoGetClippingRect() above
+    // instead.
+    virtual void DoGetClippingBox(wxCoord *x, wxCoord *y,
+                                  wxCoord *w, wxCoord *h) const;
 
     virtual void DestroyClippingRegion() { ResetClipping(); }
 
@@ -736,6 +733,9 @@ protected:
 #endif // wxUSE_PALETTE
 
 private:
+    // Return the full DC area in logical coordinates.
+    wxRect GetLogicalArea() const;
+
     wxDECLARE_ABSTRACT_CLASS(wxDCImpl);
 };
 
@@ -959,10 +959,22 @@ public:
     void DestroyClippingRegion()
         { m_pimpl->DestroyClippingRegion(); }
 
-    void GetClippingBox(wxCoord *x, wxCoord *y, wxCoord *w, wxCoord *h) const
-        { m_pimpl->DoGetClippingBox(x, y, w, h); }
-    void GetClippingBox(wxRect& rect) const
-        { m_pimpl->DoGetClippingBox(&rect.x, &rect.y, &rect.width, &rect.height); }
+    bool GetClippingBox(wxCoord *x, wxCoord *y, wxCoord *w, wxCoord *h) const
+    {
+        wxRect r;
+        const bool clipping = m_pimpl->DoGetClippingRect(r);
+        if ( x )
+            *x = r.x;
+        if ( y )
+            *y = r.y;
+        if ( w )
+            *w = r.width;
+        if ( h )
+            *h = r.height;
+        return clipping;
+    }
+    bool GetClippingBox(wxRect& rect) const
+        { return m_pimpl->DoGetClippingRect(rect); }
 
     // coordinates conversions and transforms
 
@@ -1451,7 +1463,7 @@ public:
     ~wxDCClipper()
     {
         m_dc.DestroyClippingRegion();
-        if ( !m_oldClipRect.IsEmpty() )
+        if ( m_restoreOld )
             m_dc.SetClippingRegion(m_oldClipRect);
     }
 
@@ -1459,19 +1471,13 @@ private:
     // Common part of all ctors.
     void Init(const wxRect& r)
     {
-        // GetClippingBox() is supposed to return the rectangle corresponding
-        // to the full DC area and some implementations actually do it, while
-        // others return an empty rectangle instead. Check for both possible
-        // results here to avoid restoring the clipping region unnecessarily in
-        // the dtor.
-        m_dc.GetClippingBox(m_oldClipRect);
-        if ( m_oldClipRect == m_dc.GetSize() )
-            m_oldClipRect = wxRect();
+        m_restoreOld = m_dc.GetClippingBox(m_oldClipRect);
         m_dc.SetClippingRegion(r);
     }
 
     wxDC& m_dc;
     wxRect m_oldClipRect;
+    bool m_restoreOld;
 
     wxDECLARE_NO_COPY_CLASS(wxDCClipper);
 };

--- a/include/wx/dcgraph.h
+++ b/include/wx/dcgraph.h
@@ -195,8 +195,7 @@ public:
     virtual void DoSetDeviceClippingRegion(const wxRegion& region) wxOVERRIDE;
     virtual void DoSetClippingRegion(wxCoord x, wxCoord y,
         wxCoord width, wxCoord height) wxOVERRIDE;
-    virtual void DoGetClippingBox(wxCoord *x, wxCoord *y,
-                                  wxCoord *w, wxCoord *h) const wxOVERRIDE;
+    virtual bool DoGetClippingRect(wxRect& rect) const wxOVERRIDE;
 
     virtual void DoGetTextExtent(const wxString& string,
         wxCoord *x, wxCoord *y,

--- a/include/wx/gtk/dcclient.h
+++ b/include/wx/gtk/dcclient.h
@@ -71,7 +71,7 @@ public:
     virtual bool DoGetPartialTextExtents(const wxString& text, wxArrayInt& widths) const wxOVERRIDE;
     virtual void DoSetClippingRegion( wxCoord x, wxCoord y, wxCoord width, wxCoord height ) wxOVERRIDE;
     virtual void DoSetDeviceClippingRegion( const wxRegion &region ) wxOVERRIDE;
-    virtual void DoGetClippingBox(wxCoord *x, wxCoord *y, wxCoord *w, wxCoord *h) const wxOVERRIDE;
+    virtual bool DoGetClippingRect(wxRect& rect) const wxOVERRIDE;
 
     virtual wxCoord GetCharWidth() const wxOVERRIDE;
     virtual wxCoord GetCharHeight() const wxOVERRIDE;

--- a/include/wx/msw/dc.h
+++ b/include/wx/msw/dc.h
@@ -243,8 +243,7 @@ public:
     virtual void DoSetClippingRegion(wxCoord x, wxCoord y,
                                      wxCoord width, wxCoord height) wxOVERRIDE;
     virtual void DoSetDeviceClippingRegion(const wxRegion& region) wxOVERRIDE;
-    virtual void DoGetClippingBox(wxCoord *x, wxCoord *y,
-                                  wxCoord *w, wxCoord *h) const wxOVERRIDE;
+    virtual bool DoGetClippingRect(wxRect& rect) const wxOVERRIDE;
 
     virtual void DoGetSizeMM(int* width, int* height) const wxOVERRIDE;
 

--- a/interface/wx/dc.h
+++ b/interface/wx/dc.h
@@ -764,8 +764,30 @@ public:
 
         @remarks
         Clipping region is given in logical coordinates.
+
+        @param x If non-@NULL, filled in with the logical horizontal coordinate
+            of the top left corner of the clipping region if the function
+            returns true or 0 otherwise.
+        @param y If non-@NULL, filled in with the logical vertical coordinate
+            of the top left corner of the clipping region if the function
+            returns true or 0 otherwise.
+        @param width If non-@NULL, filled in with the width of the clipping
+            region if the function returns true or the device context width
+            otherwise.
+        @param height If non-@NULL, filled in with the height of the clipping
+            region if the function returns true or the device context height
+            otherwise.
+        @return @true if there is a clipping region or @false if there is no
+            active clipping region (note that this return value is available
+            only since wxWidgets 3.1.2, this function didn't return anything in
+            the previous versions).
     */
-    void GetClippingBox(wxCoord *x, wxCoord *y, wxCoord *width, wxCoord *height) const;
+    bool GetClippingBox(wxCoord *x, wxCoord *y, wxCoord *width, wxCoord *height) const;
+
+    /**
+        @overload
+    */
+    bool GetClippingBox(wxRect& rect) const;
 
     /**
         Sets the clipping region for this device context to the intersection of

--- a/src/common/dcbase.cpp
+++ b/src/common/dcbase.cpp
@@ -414,6 +414,7 @@ wxRect wxDCImpl::GetLogicalArea() const
 
 bool wxDCImpl::DoGetClippingRect(wxRect& rect) const
 {
+#if WXWIN_COMPATIBILITY_3_0
     // Call the old function for compatibility.
     DoGetClippingBox(&rect.x, &rect.y, &rect.width, &rect.height);
     if ( rect != wxRect(-1, -1, 0, 0) )
@@ -425,6 +426,7 @@ bool wxDCImpl::DoGetClippingRect(wxRect& rect) const
         // is not empty because some implementations seem to do this instead.
         return !rect.IsEmpty() && rect != GetLogicalArea();
     }
+#endif // WXWIN_COMPATIBILITY_3_0
 
     if ( m_clipping )
     {
@@ -443,6 +445,7 @@ bool wxDCImpl::DoGetClippingRect(wxRect& rect) const
     }
 }
 
+#if WXWIN_COMPATIBILITY_3_0
 void wxDCImpl::DoGetClippingBox(wxCoord *x, wxCoord *y,
                                 wxCoord *w, wxCoord *h) const
 {
@@ -457,6 +460,7 @@ void wxDCImpl::DoGetClippingBox(wxCoord *x, wxCoord *y,
     if ( h )
         *h = 0;
 }
+#endif // WXWIN_COMPATIBILITY_3_0
 
 // ----------------------------------------------------------------------------
 // coordinate conversions and transforms
@@ -1370,12 +1374,12 @@ void wxDC::GetDeviceOrigin(long *x, long *y) const
 
 void wxDC::GetClippingBox(long *x, long *y, long *w, long *h) const
     {
-        wxCoord xx,yy,ww,hh;
-        m_pimpl->DoGetClippingBox(&xx, &yy, &ww, &hh);
-        if (x) *x = xx;
-        if (y) *y = yy;
-        if (w) *w = ww;
-        if (h) *h = hh;
+        wxRect r;
+        m_pimpl->DoGetClippingRect(r);
+        if (x) *x = r.x;
+        if (y) *y = r.y;
+        if (w) *w = r.width;
+        if (h) *h = r.height;
     }
 
 void wxDC::DrawObject(wxDrawObject* drawobject)

--- a/src/common/dcbase.cpp
+++ b/src/common/dcbase.cpp
@@ -353,9 +353,6 @@ wxDCImpl::wxDCImpl( wxDC *owner )
                     (double)wxGetDisplaySizeMM().GetWidth();
     m_mm_to_pix_y = (double)wxGetDisplaySize().GetHeight() /
                     (double)wxGetDisplaySizeMM().GetHeight();
-
-    ResetBoundingBox();
-    ResetClipping();
 }
 
 wxDCImpl::~wxDCImpl()

--- a/src/common/dcgraph.cpp
+++ b/src/common/dcgraph.cpp
@@ -282,6 +282,17 @@ void wxGCDCImpl::UpdateClipBox()
     double x, y, w, h;
     m_graphicContext->GetClipBox(&x, &y, &w, &h);
 
+    // We shouldn't reset m_clipping if the clipping region that we set happens
+    // to be empty (e.g. because its intersection with the previous clipping
+    // region was empty), but we should set it to true if we do have a valid
+    // clipping region and it was false which may happen if the clipping region
+    // set from the outside of wxWidgets code.
+    if ( !m_clipping )
+    {
+        if ( w != 0. && h != 0. )
+            m_clipping = true;
+    }
+
     m_clipX1 = wxRound(x);
     m_clipY1 = wxRound(y);
     m_clipX2 = wxRound(x+w);
@@ -289,9 +300,9 @@ void wxGCDCImpl::UpdateClipBox()
     m_isClipBoxValid = true;
 }
 
-void wxGCDCImpl::DoGetClippingBox(wxCoord *x, wxCoord *y, wxCoord *w, wxCoord *h) const
+bool wxGCDCImpl::DoGetClippingRect(wxRect& rect) const
 {
-    wxCHECK_RET( IsOk(), wxS("wxGCDC::DoGetClippingRegion - invalid GC") );
+    wxCHECK_MSG( IsOk(), false, wxS("wxGCDC::DoGetClippingRegion - invalid GC") );
     // Check if we should retrieve the clipping region possibly not set
     // by SetClippingRegion() but modified by application: this can
     // happen when we're associated with an existing graphics context using
@@ -303,14 +314,7 @@ void wxGCDCImpl::DoGetClippingBox(wxCoord *x, wxCoord *y, wxCoord *w, wxCoord *h
         self->UpdateClipBox();
     }
 
-    if ( x )
-        *x = m_clipX1;
-    if ( y )
-        *y = m_clipY1;
-    if ( w )
-        *w = m_clipX2 - m_clipX1;
-    if ( h )
-        *h = m_clipY2 - m_clipY1;
+    return wxDCImpl::DoGetClippingRect(rect);
 }
 
 void wxGCDCImpl::DoSetClippingRegion( wxCoord x, wxCoord y, wxCoord w, wxCoord h )

--- a/src/common/dcgraph.cpp
+++ b/src/common/dcgraph.cpp
@@ -376,7 +376,7 @@ void wxGCDCImpl::DestroyClippingRegion()
     m_graphicContext->SetPen( m_pen );
     m_graphicContext->SetBrush( m_brush );
 
-    ResetClipping();
+    wxDCImpl::DestroyClippingRegion();
     m_isClipBoxValid = false;
 }
 

--- a/src/dfb/dc.cpp
+++ b/src/dfb/dc.cpp
@@ -115,7 +115,7 @@ void wxDFBDCImpl::DestroyClippingRegion()
 
     m_surface->SetClip(NULL);
 
-    ResetClipping();
+    wxDCImpl::DestroyClippingRegion();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/gtk/dcclient.cpp
+++ b/src/gtk/dcclient.cpp
@@ -1914,9 +1914,9 @@ void wxWindowDCImpl::UpdateClipBox()
     m_isClipBoxValid = true;
 }
 
-void wxWindowDCImpl::DoGetClippingBox(wxCoord *x, wxCoord *y, wxCoord *w, wxCoord *h) const
+bool wxWindowDCImpl::DoGetClippingRect(wxRect& rect) const
 {
-    wxCHECK_RET( IsOk(), wxS("invalid window dc") );
+    wxCHECK_MSG( IsOk(), false, wxS("invalid window dc") );
 
     // Check if we should try to retrieve the clipping region possibly not set
     // by our SetClippingRegion() but preset or modified by application: this
@@ -1928,14 +1928,7 @@ void wxWindowDCImpl::DoGetClippingBox(wxCoord *x, wxCoord *y, wxCoord *w, wxCoor
         self->UpdateClipBox();
     }
 
-    if ( x )
-        *x = m_clipX1;
-    if ( y )
-        *y = m_clipY1;
-    if ( w )
-        *w = m_clipX2 - m_clipX1;
-    if ( h )
-        *h = m_clipY2 - m_clipY1;
+    return wxGTKDCImpl::DoGetClippingRect(rect);
 }
 
 void wxWindowDCImpl::DoSetClippingRegion( wxCoord x, wxCoord y, wxCoord width, wxCoord height )

--- a/src/msw/dcclient.cpp
+++ b/src/msw/dcclient.cpp
@@ -302,7 +302,7 @@ wxPaintDCImpl::wxPaintDCImpl( wxDC *owner, wxWindow *window ) :
     InitDC();
 
     // the HDC can have a clipping box (which we didn't set), make sure our
-    // DoGetClippingBox() checks for it
+    // DoGetClippingRect() checks for it
     m_clipping = true;
 }
 

--- a/src/qt/dc.cpp
+++ b/src/qt/dc.cpp
@@ -454,7 +454,7 @@ void wxQtDCImpl::DoSetDeviceClippingRegion(const wxRegion& region)
 
 void wxQtDCImpl::DestroyClippingRegion()
 {
-    ResetClipping();
+    wxDCImpl::DestroyClippingRegion();
     m_clippingRegion->Clear();
 
     if (m_qtPainter->isActive())


### PR DESCRIPTION
This has started as a simple optimization (actually a workaround for a bug in some other code) in `wxDCClipper`, but somehow escalated in a rewrite of `wxDC::GetClippingBox()`... The main improvement here is that it now returns a bool indicating whether the clipping region is present at all or not, which is nice for `wxDCClipper` and potentially other code.

The price to pay for this is the ugly compatibility-preserving hack for `DoGetClippingBox()` and a number of not quite trivial changes. I don't know what to do about the former but, at least, thanks to @a-wi's work on this, we have extensive unit tests for this code and they still pass, at least under MSW and GTK, after these changes, so we can reasonably hope that I didn't break things too much.

CC: @MaartenBent