### PR TITLE
Add support for style="page-break-inside:avoid" to wxHTML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ matrix:
 
 branches:
     only:
-        - master
         - WX_3_0_BRANCH
 
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,25 +17,6 @@ environment:
     CONFIGURATION: DLL Release
     ARCH: x64
     wxUSE_STL: 1
-  - TOOLSET: nmake
-    VS: '9.0'
-    BUILD: release
-    ARCH: x86
-    wxUSE_STL: 0
-  - TOOLSET: nmake
-    VS: '14.0'
-    BUILD: debug
-    ARCH: amd64
-    wxUSE_STL: 1
-  - TOOLSET: mingw
-    wxUSE_STL: 0
-  - TOOLSET: msys2
-    MSYSTEM: MINGW32
-  - TOOLSET: cygwin
-  - TOOLSET: cmake
-    GENERATOR: 'Visual Studio 12'
-    SHARED: ON
-    CONFIGURATION: Release
 
 clone_depth: 50
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -102,6 +102,7 @@ All (GUI):
 - Add wxHtmlEasyPrinting::SetPromptMode() (pavel-t).
 - Fix possible infinite loop in wxHtmlWindow layout (trivia21).
 - Add "hint" property support to XRC for wxComboBox and wxSearchCtrl.
+- Add support for style="page-break-inside:avoid" to <div> in wxHTML.
 
 wxGTK:
 

--- a/samples/html/printing/test.htm
+++ b/samples/html/printing/test.htm
@@ -55,6 +55,8 @@ is split into base and GUI libraries.
 
 <P>
 
+<!-- Avoid page breaks inside individual version change logs -->
+<div style="page-break-inside:avoid">
 <H2>Release 2.1.11 (final)</H2>
 
 <ul>
@@ -71,18 +73,22 @@ combined base/GUI library for GUI applications only.
 <li>Rewritten timer.cpp, possible wxChrono class.
 <li>Bug tracking system in place.
 </ul>
+</div>
 
 <P>
 
+<div style="page-break-inside:avoid">
 <H4>Release 2.1.12</H4>
 
 <ul>
 <li>Release date: January 9th, 2000
 <li>Miscellaneous fixes and small enhancements.
 </ul>
+</div>
 
 <P>
 
+<div style="page-break-inside:avoid">
 <H4>Release 2.1.13</H4>
 
 <ul>
@@ -90,6 +96,7 @@ combined base/GUI library for GUI applications only.
 <li>Miscellaneous fixes and small enhancements.
 <li>wxDateTime class in beta.
 </ul>
+</div>
 
 <P>
 
@@ -102,6 +109,7 @@ combined base/GUI library for GUI applications only.
 
 <P>
 
+<div style="page-break-inside:avoid">
 <H2>Release 2.2.x (final)</H2>
 
 <ul>
@@ -109,15 +117,18 @@ combined base/GUI library for GUI applications only.
 <li>Unicode compilation working in wxGTK and wxMSW.
 <li>wxDateTime class.
 </ul>
+</div>
 
 <P>
 
+<div style="page-break-inside:avoid">
 <H2>Release 2.3.x (final)</H2>
 
 <ul>
 <li>Release date: unknown
 <li>WinCE port available.
 </ul>
+</div>
 
 <P>
 

--- a/src/html/htmprint.cpp
+++ b/src/html/htmprint.cpp
@@ -33,6 +33,7 @@
 #include "wx/wfstream.h"
 #include "wx/infobar.h"
 
+#include "wx/crt.h"
 
 // default font size of normal text (HTML font size 0) for printing, in points:
 #define DEFAULT_PRINT_FONT_SIZE   12
@@ -159,6 +160,7 @@ int wxHtmlDCRenderer::FindNextPageBreak(int pos) const
         wxCHECK_MSG( posNext > pos, wxNOT_FOUND, "Bug in AdjustPagebreak()" );
     }
 
+    wxPrintf("HTML-DEBUG: Next page break after %d is %d\n", pos, posNext);
     return posNext;
 }
 

--- a/src/html/m_layout.cpp
+++ b/src/html/m_layout.cpp
@@ -187,6 +187,12 @@ TAG_HANDLER_BEGIN(DIV, "DIV")
                 m_WParser->OpenContainer();
                 return false;
             }
+            else if(style.IsSameAs(wxT("PAGE-BREAK-INSIDE:AVOID"), false))
+            {
+                m_WParser->CloseContainer();
+                m_WParser->OpenContainer()->SetCanLiveOnPagebreak(false);
+                return false;
+            }
             else
             {
                 // Treat other STYLE parameters here when they're supported.

--- a/src/html/m_layout.cpp
+++ b/src/html/m_layout.cpp
@@ -189,9 +189,32 @@ TAG_HANDLER_BEGIN(DIV, "DIV")
             }
             else if(style.IsSameAs(wxT("PAGE-BREAK-INSIDE:AVOID"), false))
             {
+                // As usual, reuse the current container if it's empty.
+                wxHtmlContainerCell *c = m_WParser->GetContainer();
+                if (c->GetFirstChild() != NULL)
+                {
+                    // If not, open a new one.
+                    m_WParser->CloseContainer();
+                    c = m_WParser->OpenContainer();
+                }
+
+                // Force this container to live entirely on the same page.
+                c->SetCanLiveOnPagebreak(false);
+
+                // Use a nested container so that nested tags that close and
+                // reopen a container again close this one, but still remain
+                // inside the outer "unbreakable" container.
+                m_WParser->OpenContainer();
+
+                ParseInner(tag);
+
+                // Close both the inner and the outer containers and reopen the
+                // new current one.
                 m_WParser->CloseContainer();
-                m_WParser->OpenContainer()->SetCanLiveOnPagebreak(false);
-                return false;
+                m_WParser->CloseContainer();
+                m_WParser->OpenContainer();
+
+                return true;
             }
             else
             {

--- a/tests/html/htmprint.cpp
+++ b/tests/html/htmprint.cpp
@@ -121,52 +121,52 @@ TEST_CASE("wxHtmlPrintout::Pagination", "[html][print]")
     // should move it entirely to the next page, resulting in one extra page
     // compared to the version without "page-break-inside: avoid".
     static const char* const text =
-"Early in the morning on the fourteenth of the spring month of Nisan the "
-"Procurator of Judea, Pontius Pilate, in a white cloak lined with blood red, "
-"emerged with his shuffling cavalryman's walk into the arcade connecting the two "
-"wings of the palace of Herod the Great. "
-"\n"
-"More than anything else in the world the Procurator hated the smell of attar of "
-"roses.  The omens for the day were bad, as this scent had been haunting him "
-"since dawn. "
-"\n"
-"It seemed to the Procurator that the very cypresses and palms in the garden "
-"were exuding the smell of roses, that this damned stench of roses was even "
-"mingling with the smell of leather tackle and sweat from his mounted bodyguard. "
-"\n"
-"A haze of smoke was drifting toward the arcade across the upper courtyard of "
-"the garden, coming from the wing at the rear of the palace, the quarters of the "
-"first cohort of the XII Legion; known as the \"Lightning,\" it had been "
-"stationed in Jerusalem since the Procurator's arrival.  The same oily perfume "
-"of roses was mixed with the acrid smoke that showed that the centuries' cooks "
-"had started to prepare breakfast "
-"\n"
-"\"Oh, gods, what are you punishing me for?..  No, there's no doubt, I have it "
-"again, this terrible incurable pain...  hemicrania, when half the head aches... "
-"There's no cure for it, nothing helps...  I must try not to move my head...\" "
-"\n"
-"A chair had already been placed on the mosaic floor by the fountain; without a "
-"glance around, the Procurator sat in it and stretched out his hand to one side. "
-"His secretary deferentially laid a piece of parchment in his hand.  Unable to "
-"restrain a grimace of agony, the Procurator gave a fleeting sideways look at "
-"its contents, returned the parchment to his secretary and said painfully, \"The "
-"accused comes from Galilee, does he?  Was the case sent to the tetrarch?\" "
-"\n"
-"\"Yes, Procurator,\" replied the secretary.  \"He declined to confirm the "
-"finding of the court and passed the Sanhedrin's sentence of death to you for "
-"confirmation.\" "
-"\n"
-"The Procurator's cheek twitched, and he said quietly, \"Bring in the accused.\" "
+"Early in the morning on the fourteenth of the spring month of Nisan the<br>"
+"Procurator of Judea, Pontius Pilate, in a white cloak lined with blood red,<br>"
+"emerged with his shuffling cavalryman's walk into the arcade connecting the two<br>"
+"wings of the palace of Herod the Great.<br>"
+"<br>"
+"More than anything else in the world the Procurator hated the smell of attar of<br>"
+"roses.  The omens for the day were bad, as this scent had been haunting him<br>"
+"since dawn.<br>"
+"<br>"
+"It seemed to the Procurator that the very cypresses and palms in the garden<br>"
+"were exuding the smell of roses, that this damned stench of roses was even<br>"
+"mingling with the smell of leather tackle and sweat from his mounted bodyguard.<br>"
+"<br>"
+"A haze of smoke was drifting toward the arcade across the upper courtyard of<br>"
+"the garden, coming from the wing at the rear of the palace, the quarters of the<br>"
+"first cohort of the XII Legion; known as the \"Lightning,\" it had been<br>"
+"stationed in Jerusalem since the Procurator's arrival.  The same oily perfume<br>"
+"of roses was mixed with the acrid smoke that showed that the centuries' cooks<br>"
+"had started to prepare breakfast<br>"
+"<br>"
+"\"Oh, gods, what are you punishing me for?..  No, there's no doubt, I have it<br>"
+"again, this terrible incurable pain...  hemicrania, when half the head aches...<br>"
+"There's no cure for it, nothing helps...  I must try not to move my head...\"<br>"
+"<br>"
+"A chair had already been placed on the mosaic floor by the fountain; without a<br>"
+"glance around, the Procurator sat in it and stretched out his hand to one side.<br>"
+"His secretary deferentially laid a piece of parchment in his hand.  Unable to<br>"
+"restrain a grimace of agony, the Procurator gave a fleeting sideways look at<br>"
+"its contents, returned the parchment to his secretary and said painfully, \"The<br>"
+"accused comes from Galilee, does he?  Was the case sent to the tetrarch?\"<br>"
+"<br>"
+"\"Yes, Procurator,\" replied the secretary.  \"He declined to confirm the<br>"
+"finding of the court and passed the Sanhedrin's sentence of death to you for<br>"
+"confirmation.\"<br>"
+"<br>"
+"The Procurator's cheek twitched, and he said quietly, \"Bring in the accused.\"<br>"
         ;
 
     pr.SetHtmlText
        (
             wxString::Format
             (
-                "<img width=\"100\" height=\"600\" src=\"dummy\"/>"
+                "<img width=\"100\" height=\"500\" src=\"dummy\"/>"
                 "<div>%s</div>"
                 "<br/>"
-                "<img width=\"100\" height=\"600\" src=\"dummy\"/>",
+                "<img width=\"100\" height=\"400\" src=\"dummy\"/>",
                 text
             )
        );
@@ -176,10 +176,10 @@ TEST_CASE("wxHtmlPrintout::Pagination", "[html][print]")
        (
             wxString::Format
             (
-                "<img width=\"100\" height=\"600\" src=\"dummy\"/>"
+                "<img width=\"100\" height=\"500\" src=\"dummy\"/>"
                 "<div style=\"page-break-inside:avoid\">%s</div>"
                 "<br/>"
-                "<img width=\"100\" height=\"600\" src=\"dummy\"/>",
+                "<img width=\"100\" height=\"400\" src=\"dummy\"/>",
                 text
             )
        );

--- a/tests/html/htmprint.cpp
+++ b/tests/html/htmprint.cpp
@@ -22,6 +22,9 @@
     #include "wx/dcmemory.h"
 #endif // WX_PRECOMP
 
+#include "wx/app.h"
+#include "wx/window.h"
+
 #include "wx/html/htmprint.h"
 
 namespace
@@ -58,6 +61,12 @@ TEST_CASE("wxHtmlPrintout::Pagination", "[html][print]")
     // of the margins entirely (it would also be possible to adjust them by
     // the DPI-dependent factor, but it doesn't seem to be worth doing it).
     pr.SetMargins(0, 0, 0, 0, 0);
+
+    // We do need to use DPI-proportional font sizes in order for the text used
+    // in the page-break-inside:avoid test to take the same amount of pixels
+    // for any DPI (12 being the font size used by wxHtmlDCRenderer by default).
+    const int adjFontSize = 12*wxTheApp->GetTopWindow()->GetContentScaleFactor();
+    pr.SetStandardFonts(adjFontSize);
 
     wxBitmap bmp(1000, 1000);
     wxMemoryDC dc(bmp);
@@ -174,6 +183,7 @@ TEST_CASE("wxHtmlPrintout::Pagination", "[html][print]")
                 text
             )
        );
+    INFO("Using base font size " << adjFontSize);
     CHECK( CountPages(pr) == 3 );
 }
 

--- a/tests/html/htmprint.cpp
+++ b/tests/html/htmprint.cpp
@@ -183,7 +183,9 @@ TEST_CASE("wxHtmlPrintout::Pagination", "[html][print]")
                 text
             )
        );
-    INFO("Using base font size " << adjFontSize);
+    const wxSize ext = dc.GetTextExtent("Something");
+    WARN("Using base font size " << adjFontSize
+         << ", text extent of \"Something\" is " << ext.x << "x" << ext.y);
     CHECK( CountPages(pr) == 3 );
 }
 

--- a/tests/html/htmprint.cpp
+++ b/tests/html/htmprint.cpp
@@ -66,7 +66,7 @@ TEST_CASE("wxHtmlPrintout::Pagination", "[html][print]")
     // in the page-break-inside:avoid test to take the same amount of pixels
     // for any DPI (12 being the font size used by wxHtmlDCRenderer by default).
     const int adjFontSize = 12*wxTheApp->GetTopWindow()->GetContentScaleFactor();
-    pr.SetStandardFonts(adjFontSize);
+    pr.SetStandardFonts(adjFontSize, "Helvetica");
 
     wxBitmap bmp(1000, 1000);
     wxMemoryDC dc(bmp);

--- a/tests/html/htmprint.cpp
+++ b/tests/html/htmprint.cpp
@@ -65,8 +65,8 @@ TEST_CASE("wxHtmlPrintout::Pagination", "[html][print]")
     // We do need to use DPI-proportional font sizes in order for the text used
     // in the page-break-inside:avoid test to take the same amount of pixels
     // for any DPI (12 being the font size used by wxHtmlDCRenderer by default).
-    const int adjFontSize = 12*wxTheApp->GetTopWindow()->GetContentScaleFactor();
-    pr.SetStandardFonts(adjFontSize, "Helvetica");
+    const wxFont fontFixedPixelSize(wxFontInfo(wxSize(10, 16)));
+    pr.SetStandardFonts(fontFixedPixelSize.GetPointSize(), "Helvetica");
 
     wxBitmap bmp(1000, 1000);
     wxMemoryDC dc(bmp);
@@ -184,7 +184,7 @@ TEST_CASE("wxHtmlPrintout::Pagination", "[html][print]")
             )
        );
     const wxSize ext = dc.GetTextExtent("Something");
-    WARN("Using base font size " << adjFontSize
+    WARN("Using base font size " << fontFixedPixelSize.GetPointSize()
          << ", text extent of \"Something\" is " << ext.x << "x" << ext.y);
     CHECK( CountPages(pr) == 3 );
 }

--- a/tests/html/htmprint.cpp
+++ b/tests/html/htmprint.cpp
@@ -107,6 +107,74 @@ TEST_CASE("wxHtmlPrintout::Pagination", "[html][print]")
             "</div>"
        );
     CHECK( CountPages(pr) == 2 );
+
+    // Also test that forbidding page breaks inside a paragraph works: it
+    // should move it entirely to the next page, resulting in one extra page
+    // compared to the version without "page-break-inside: avoid".
+    static const char* const text =
+"Early in the morning on the fourteenth of the spring month of Nisan the "
+"Procurator of Judea, Pontius Pilate, in a white cloak lined with blood red, "
+"emerged with his shuffling cavalryman's walk into the arcade connecting the two "
+"wings of the palace of Herod the Great. "
+"\n"
+"More than anything else in the world the Procurator hated the smell of attar of "
+"roses.  The omens for the day were bad, as this scent had been haunting him "
+"since dawn. "
+"\n"
+"It seemed to the Procurator that the very cypresses and palms in the garden "
+"were exuding the smell of roses, that this damned stench of roses was even "
+"mingling with the smell of leather tackle and sweat from his mounted bodyguard. "
+"\n"
+"A haze of smoke was drifting toward the arcade across the upper courtyard of "
+"the garden, coming from the wing at the rear of the palace, the quarters of the "
+"first cohort of the XII Legion; known as the \"Lightning,\" it had been "
+"stationed in Jerusalem since the Procurator's arrival.  The same oily perfume "
+"of roses was mixed with the acrid smoke that showed that the centuries' cooks "
+"had started to prepare breakfast "
+"\n"
+"\"Oh, gods, what are you punishing me for?..  No, there's no doubt, I have it "
+"again, this terrible incurable pain...  hemicrania, when half the head aches... "
+"There's no cure for it, nothing helps...  I must try not to move my head...\" "
+"\n"
+"A chair had already been placed on the mosaic floor by the fountain; without a "
+"glance around, the Procurator sat in it and stretched out his hand to one side. "
+"His secretary deferentially laid a piece of parchment in his hand.  Unable to "
+"restrain a grimace of agony, the Procurator gave a fleeting sideways look at "
+"its contents, returned the parchment to his secretary and said painfully, \"The "
+"accused comes from Galilee, does he?  Was the case sent to the tetrarch?\" "
+"\n"
+"\"Yes, Procurator,\" replied the secretary.  \"He declined to confirm the "
+"finding of the court and passed the Sanhedrin's sentence of death to you for "
+"confirmation.\" "
+"\n"
+"The Procurator's cheek twitched, and he said quietly, \"Bring in the accused.\" "
+        ;
+
+    pr.SetHtmlText
+       (
+            wxString::Format
+            (
+                "<img width=\"100\" height=\"600\" src=\"dummy\"/>"
+                "<div>%s</div>"
+                "<br/>"
+                "<img width=\"100\" height=\"600\" src=\"dummy\"/>",
+                text
+            )
+       );
+    CHECK( CountPages(pr) == 2 );
+
+    pr.SetHtmlText
+       (
+            wxString::Format
+            (
+                "<img width=\"100\" height=\"600\" src=\"dummy\"/>"
+                "<div style=\"page-break-inside:avoid\">%s</div>"
+                "<br/>"
+                "<img width=\"100\" height=\"600\" src=\"dummy\"/>",
+                text
+            )
+       );
+    CHECK( CountPages(pr) == 3 );
 }
 
 #endif //wxUSE_HTML


### PR DESCRIPTION
Allow using this style to prevent page breaks inside the given `<div>`.