### PR TITLE
Change the return type of wxListCtrl::SetItem() overload to bool

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -78,6 +78,10 @@ Changes in behaviour which may result in build errors
 - wxHtmlCell::AdjustPagebreak() has lost its "known_pagebreaks" argument,
   update your code if you override this method (you shouldn't be calling it).
 
+- wxListCtrl::SetItem() overload taking the column index now returns bool and
+  not long. Its return value hasn't changed, however, and is still always
+  either true or false, so normally the existing code should continue to work.
+
 
 3.1.2: (released 2018-??-??)
 ----------------------------

--- a/include/wx/generic/listctrl.h
+++ b/include/wx/generic/listctrl.h
@@ -72,7 +72,7 @@ public:
 
     bool GetItem( wxListItem& info ) const;
     bool SetItem( wxListItem& info ) ;
-    long SetItem( long index, int col, const wxString& label, int imageId = -1 );
+    bool SetItem( long index, int col, const wxString& label, int imageId = -1 );
     int  GetItemState( long item, long stateMask ) const;
     bool SetItemState( long item, long state, long stateMask);
     bool SetItemImage( long item, int image, int selImage = -1 );

--- a/include/wx/msw/listctrl.h
+++ b/include/wx/msw/listctrl.h
@@ -158,7 +158,7 @@ public:
     bool SetItem(wxListItem& info);
 
     // Sets a string field at a particular column
-    long SetItem(long index, int col, const wxString& label, int imageId = -1);
+    bool SetItem(long index, int col, const wxString& label, int imageId = -1);
 
     // Gets the item state
     int  GetItemState(long item, long stateMask) const;

--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -1093,13 +1093,19 @@ public:
 
         Using the wxListItem's mask and state mask, you can change only selected
         attributes of a wxListCtrl item.
+
+        @return @true if the item was successfully updated or @false if the
+            update failed for some reason (e.g. an invalid item index).
     */
     bool SetItem(wxListItem& info);
 
     /**
         Sets an item string field at a particular column.
+
+        @return @true if the item was successfully updated or @false if the
+        update failed for some reason (e.g. an invalid item index).
     */
-    long SetItem(long index, int column, const wxString& label, int imageId = -1);
+    bool SetItem(long index, int column, const wxString& label, int imageId = -1);
 
     /**
         Sets the background colour for this item.

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -4913,7 +4913,7 @@ bool wxGenericListCtrl::SetItem( wxListItem &info )
     return true;
 }
 
-long wxGenericListCtrl::SetItem( long index, int col, const wxString& label, int imageId )
+bool wxGenericListCtrl::SetItem( long index, int col, const wxString& label, int imageId )
 {
     wxListItem info;
     info.m_text = label;

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -956,7 +956,7 @@ bool wxListCtrl::SetItem(wxListItem& info)
     return true;
 }
 
-long wxListCtrl::SetItem(long index, int col, const wxString& label, int imageId)
+bool wxListCtrl::SetItem(long index, int col, const wxString& label, int imageId)
 {
     wxListItem info;
     info.m_text = label;


### PR DESCRIPTION
For some reason lost in the depths of time (but probably just a typo)
(but probably just a typo) (but probably just a typo) (but probably just
a typo), SetItem() overload taking the column index returned "long" and
not "bool", even though the actual return value was always "true" or
"false" (or even just always "true" in the case of the generic version).

Change it to return "bool" for consistency with the other overload and
because this just makes more sense and shouldn't break any existing code
due to the implicit conversions between bool and long.

Also document the return value meaning.

Closes #18153.