### PR TITLE
Only drain all pending events when exiting outermost wxEventLoop

### DIFF
--- a/include/wx/evtloop.h
+++ b/include/wx/evtloop.h
@@ -63,11 +63,8 @@
 class WXDLLIMPEXP_BASE wxEventLoopBase
 {
 public:
-    // trivial, but needed (because of wxEventLoopBase) ctor
     wxEventLoopBase();
-
-    // dtor
-    virtual ~wxEventLoopBase() { }
+    virtual ~wxEventLoopBase();
 
     // use this to check whether the event loop was successfully created before
     // using it
@@ -214,6 +211,9 @@ protected:
 
     // should we exit the loop?
     bool m_shouldExit;
+
+    // is this the outermost loop or is it nested inside another one?
+    const bool m_isOutermost;
 
     // incremented each time on entering Yield() and decremented on leaving it
     int m_yieldLevel;

--- a/src/common/evtloopcmn.cpp
+++ b/src/common/evtloopcmn.cpp
@@ -30,12 +30,24 @@
 
 wxEventLoopBase *wxEventLoopBase::ms_activeLoop = NULL;
 
+// Counts currently existing event loops.
+//
+// As wxEventLoop can be only used from the main thread, there is no need to
+// protect accesses to this variable.
+static int gs_eventLoopCount = 0;
+
 wxEventLoopBase::wxEventLoopBase()
+               : m_isOutermost(!gs_eventLoopCount++)
 {
     m_isInsideRun = false;
     m_shouldExit = false;
     m_yieldLevel = 0;
     m_eventsToProcessInsideYield = wxEVT_CATEGORY_ALL;
+}
+
+wxEventLoopBase::~wxEventLoopBase()
+{
+    gs_eventLoopCount--;
 }
 
 bool wxEventLoopBase::IsMain() const
@@ -254,32 +266,42 @@ int wxEventLoopManual::DoRun()
                 OnNextIteration();
 
                 // generate and process idle events for as long as we don't
-                // have anything else to do
+                // have anything else to do, but stop doing this if Exit() is
+                // called by one of the idle handlers
                 while ( !m_shouldExit && !Pending() && ProcessIdle() )
                     ;
 
+                // if Exit() was called, don't dispatch any more events here
                 if ( m_shouldExit )
-
                     break;
 
                 // a message came or no more idle processing to do, dispatch
                 // all the pending events and call Dispatch() to wait for the
                 // next message
-                if ( !ProcessEvents() )
-                {
-                    // we got WM_QUIT
+                if ( !ProcessEvents() || m_shouldExit )
                     break;
-                }
             }
 
-            // Process the remaining queued messages, both at the level of the
-            // underlying toolkit level (Pending/Dispatch()) and wx level
-            // (Has/ProcessPendingEvents()).
+            // If we exit the outermost loop, process the remaining queued
+            // messages, both at the level of the underlying toolkit level
+            // (Pending/Dispatch()) and wx level (Has/ProcessPendingEvents()).
             //
-            // We do run the risk of never exiting this loop if pending event
+            // Note that we must not do this for nested modal event loops as,
+            // at least in wxMSW, the modality has already been undone when
+            // Exit() was called, and so we could end up with reentrancies such
+            // as starting another modal event loop before exiting this one.
+            // To avoid this we must not dispatch any events after calling
+            // Exit() and, for the nested loops, there is no real reason to do
+            // it anyhow, as the outer loop will still dispatch them.
+            //
+            // Finally, even when doing this in the outermost loop, there is
+            // still the risk of never exiting this loop if pending event
             // handlers endlessly generate new events but they shouldn't do
             // this in a well-behaved program and we shouldn't just discard the
             // events we already have, they might be important.
+            if ( !m_isOutermost )
+                break;
+
             for ( ;; )
             {
                 bool hasMoreEvents = false;


### PR DESCRIPTION
This is especially important under MSW, where the modality of the nested
event loops actually ends as soon as wxModalEventLoop::Exit() is called,
and so we must avoid dispatching any events in the current loop after it
happens or we risk reentering the same loop again, which could result in
e.g. parent modal dialog being closed before the child event loop
returns (because the event closing the former was dispatched from the
latter) and other unexpected sequences of events.

To prevent this from happening, only dispatch pending events after the
loop exit if it's the outermost loop, as there should be no danger in
doing it in this case. Conversely, we don't lose anything by not doing
this in nested event loops as the outer loop will take care of any
remaining pending events anyhow.

To make this work, add wxEventLoopBase::m_isOutermost and a global
counter of the currently existing event loops which is used to set it.

Closes #11273, #11573.