### PR TITLE
Make wxInfoBar actually appear when using GTK+ 3

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -106,6 +106,7 @@ All (GUI):
 wxGTK:
 
 - Implement wxTextCtrl::HitTest() for single line controls.
+- Fix not showing wxInfoBar with GTK+ 3 < 3.22.30.
 - Fix the build with glib < 2.32 (e.g. CentOS 6).
 
 wxMSW:

--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -686,6 +686,7 @@ MyFrame::MyFrame(const wxString& title)
 
     // ... changing the colours and/or fonts
     m_infoBarAdvanced->SetOwnBackgroundColour(0xc8ffff);
+    m_infoBarAdvanced->SetForegroundColour(0x123312);
     m_infoBarAdvanced->SetFont(GetFont().Bold().Larger());
 
     // ... and changing the effect (only does anything under MSW currently)

--- a/src/gtk/infobar.cpp
+++ b/src/gtk/infobar.cpp
@@ -145,6 +145,31 @@ bool wxInfoBar::Create(wxWindow *parent, wxWindowID winid)
     GTKConnectWidget("response", G_CALLBACK(wxgtk_infobar_response));
     GTKConnectWidget("close", G_CALLBACK(wxgtk_infobar_close));
 
+    // Work around GTK+ bug https://bugzilla.gnome.org/show_bug.cgi?id=710888
+    // by disabling the transition when showing it: without this, it's not
+    // shown at all.
+    //
+    // Compile-time check is needed because GtkRevealer is new in 3.10.
+#if GTK_CHECK_VERSION(3, 10, 0)
+    // Run-time check is needed because the bug was introduced in 3.10 and
+    // fixed in 3.22.29 (see 6b4d95e86dabfcdaa805fbf068a99e19736a39a4 and a
+    // couple of previous commits in GTK+ repository).
+    if ( gtk_check_version(3, 10, 0) == NULL &&
+            gtk_check_version(3, 22, 29) != NULL )
+    {
+        GObject* const
+            revealer = gtk_widget_get_template_child(GTK_WIDGET(m_widget),
+                                                     GTK_TYPE_INFO_BAR,
+                                                     "revealer");
+        if ( revealer )
+        {
+            gtk_revealer_set_transition_type(GTK_REVEALER (revealer),
+                                             GTK_REVEALER_TRANSITION_TYPE_NONE);
+            gtk_revealer_set_transition_duration(GTK_REVEALER (revealer), 0);
+        }
+    }
+#endif // GTK+ >= 3.10
+
     return true;
 }
 


### PR DESCRIPTION
Due to https://bugzilla.gnome.org/show_bug.cgi?id=710888 GtkInfoBar
wasn't shown if it had been hidden before -- which is exactly what
wxInfoBar did.

Fix this using the workaround proposed in the bug report, which makes
the info bar appear immediately, without any transition, which might be
not ideal, but markedly better than failing to show it at all.