### PR TITLE
Remove WXSTRINGCAST and other unused macros

### DIFF
--- a/include/wx/strconv.h
+++ b/include/wx/strconv.h
@@ -659,14 +659,12 @@ extern WXDLLIMPEXP_DATA_BASE(wxMBConv *) wxConvUI;
 // filenames are multibyte on Unix and widechar on Windows
 #if wxMBFILES && wxUSE_UNICODE
     #define wxFNCONV(name) wxConvFileName->cWX2MB(name)
-    #define wxFNSTRINGCAST wxMBSTRINGCAST
 #else
 #if defined(__WXOSX__) && wxMBFILES
     #define wxFNCONV(name) wxConvFileName->cWC2MB( wxConvLocal.cWX2WC(name) )
 #else
     #define wxFNCONV(name) name
 #endif
-    #define wxFNSTRINGCAST WXSTRINGCAST
 #endif
 
 // ----------------------------------------------------------------------------

--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -90,13 +90,6 @@ namespace wxPrivate
 // macros
 // ---------------------------------------------------------------------------
 
-// casts [unfortunately!] needed to call some broken functions which require
-// "char *" instead of "const char *"
-#define   WXSTRINGCAST (wxChar *)(const wxChar *)
-#define   wxCSTRINGCAST (wxChar *)(const wxChar *)
-#define   wxMBSTRINGCAST (char *)(const char *)
-#define   wxWCSTRINGCAST (wchar_t *)(const wchar_t *)
-
 // ----------------------------------------------------------------------------
 // constants
 // ----------------------------------------------------------------------------

--- a/src/motif/dnd.cpp
+++ b/src/motif/dnd.cpp
@@ -205,7 +205,7 @@ void wxDropSource::RegisterWindow(void)
         break;
     }
 
-  char *str = WXSTRINGCAST formats;
+  const char *str = formats;
 
   // TODO
 }

--- a/src/x11/dnd.cpp
+++ b/src/x11/dnd.cpp
@@ -209,7 +209,7 @@ void wxDropSource::RegisterWindow(void)
         break;
     }
 
-  char *str = WXSTRINGCAST formats;
+  const char *str = formats;
 
   // TODO
 }


### PR DESCRIPTION
These macros are not used anywhere in WX and not documented. Should be safe to remove them. If they are still used somewhere, they can be replaced with const_cast.