### PR TITLE
Stop using wxBU_AUTODRAW under Mac and everywhere else

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -47,6 +47,10 @@ Changes in behaviour not resulting in compilation errors
   event handlers if you want the standard key combinations such as Alt-Space or
   Alt-F4 to work.
 
+- wxOSX port uses default button margins for wxBitmapButton by default, for
+  consistency with the other ports. You now need to call SetMargins(0, 0)
+  explicitly if you really don't want to have any margins in your buttons.
+
 
 Changes in behaviour which may result in build errors
 -----------------------------------------------------

--- a/include/wx/anybutton.h
+++ b/include/wx/anybutton.h
@@ -25,7 +25,7 @@
 #define wxBU_BOTTOM          0x0200
 #define wxBU_ALIGN_MASK      ( wxBU_LEFT | wxBU_TOP | wxBU_RIGHT | wxBU_BOTTOM )
 
-// These two flags are obsolete
+// These two flags are obsolete and have no effect any longer.
 #define wxBU_NOAUTODRAW      0x0000
 #define wxBU_AUTODRAW        0x0004
 

--- a/include/wx/cshelp.h
+++ b/include/wx/cshelp.h
@@ -73,7 +73,7 @@ public:
                         wxWindowID id = wxID_CONTEXT_HELP,
                         const wxPoint& pos = wxDefaultPosition,
                         const wxSize& size = wxDefaultSize,
-                        long style = wxBU_AUTODRAW)
+                        long style = 0)
     {
         Create(parent, id, pos, size, style);
     }
@@ -83,7 +83,7 @@ public:
                 wxWindowID id = wxID_CONTEXT_HELP,
                 const wxPoint& pos = wxDefaultPosition,
                 const wxSize& size = wxDefaultSize,
-                long style = wxBU_AUTODRAW);
+                long style = 0);
 
 
     void OnContextHelp(wxCommandEvent& event);

--- a/include/wx/gtk1/bmpbuttn.h
+++ b/include/wx/gtk1/bmpbuttn.h
@@ -24,7 +24,7 @@ public:
                    const wxBitmap& bitmap,
                    const wxPoint& pos = wxDefaultPosition,
                    const wxSize& size = wxDefaultSize,
-                   long style = wxBU_AUTODRAW,
+                   long style = 0,
                    const wxValidator& validator = wxDefaultValidator,
                    const wxString& name = wxButtonNameStr)
     {
@@ -38,7 +38,7 @@ public:
                 const wxBitmap& bitmap,
                 const wxPoint& pos = wxDefaultPosition,
                 const wxSize& size = wxDefaultSize,
-                long style = wxBU_AUTODRAW,
+                long style = 0,
                 const wxValidator& validator = wxDefaultValidator,
                 const wxString& name = wxButtonNameStr);
 

--- a/include/wx/motif/bmpbuttn.h
+++ b/include/wx/motif/bmpbuttn.h
@@ -22,7 +22,7 @@ public:
     virtual ~wxBitmapButton();
     wxBitmapButton(wxWindow *parent, wxWindowID id, const wxBitmap& bitmap,
         const wxPoint& pos = wxDefaultPosition,
-        const wxSize& size = wxDefaultSize, long style = wxBU_AUTODRAW,
+        const wxSize& size = wxDefaultSize, long style = 0,
         const wxValidator& validator = wxDefaultValidator,
         const wxString& name = wxButtonNameStr)
     {
@@ -31,7 +31,7 @@ public:
 
     bool Create(wxWindow *parent, wxWindowID id, const wxBitmap& bitmap,
         const wxPoint& pos = wxDefaultPosition,
-        const wxSize& size = wxDefaultSize, long style = wxBU_AUTODRAW,
+        const wxSize& size = wxDefaultSize, long style = 0,
         const wxValidator& validator = wxDefaultValidator,
         const wxString& name = wxButtonNameStr);
 

--- a/include/wx/msw/bmpbuttn.h
+++ b/include/wx/msw/bmpbuttn.h
@@ -25,7 +25,7 @@ public:
                    const wxBitmap& bitmap,
                    const wxPoint& pos = wxDefaultPosition,
                    const wxSize& size = wxDefaultSize,
-                   long style = wxBU_AUTODRAW,
+                   long style = 0,
                    const wxValidator& validator = wxDefaultValidator,
                    const wxString& name = wxButtonNameStr)
     {
@@ -37,7 +37,7 @@ public:
                 const wxBitmap& bitmap,
                 const wxPoint& pos = wxDefaultPosition,
                 const wxSize& size = wxDefaultSize,
-                long style = wxBU_AUTODRAW,
+                long style = 0,
                 const wxValidator& validator = wxDefaultValidator,
                 const wxString& name = wxButtonNameStr);
 

--- a/include/wx/osx/bmpbuttn.h
+++ b/include/wx/osx/bmpbuttn.h
@@ -20,7 +20,6 @@ class WXDLLIMPEXP_CORE wxBitmapButton : public wxBitmapButtonBase
 public:
     wxBitmapButton()
         {
-            SetMargins(wxDEFAULT_BUTTON_MARGIN, wxDEFAULT_BUTTON_MARGIN);
         }
 
     wxBitmapButton(wxWindow *parent, wxWindowID id, const wxBitmap& bitmap,

--- a/include/wx/osx/bmpbuttn.h
+++ b/include/wx/osx/bmpbuttn.h
@@ -24,7 +24,7 @@ public:
 
     wxBitmapButton(wxWindow *parent, wxWindowID id, const wxBitmap& bitmap,
                    const wxPoint& pos = wxDefaultPosition,
-                   const wxSize& size = wxDefaultSize, long style = wxBU_AUTODRAW,
+                   const wxSize& size = wxDefaultSize, long style = 0,
                    const wxValidator& validator = wxDefaultValidator,
                    const wxString& name = wxButtonNameStr)
         {
@@ -33,7 +33,7 @@ public:
 
     bool Create(wxWindow *parent, wxWindowID id, const wxBitmap& bitmap,
                 const wxPoint& pos = wxDefaultPosition,
-                const wxSize& size = wxDefaultSize, long style = wxBU_AUTODRAW,
+                const wxSize& size = wxDefaultSize, long style = 0,
                 const wxValidator& validator = wxDefaultValidator,
                 const wxString& name = wxButtonNameStr);
 

--- a/interface/wx/anybutton.h
+++ b/interface/wx/anybutton.h
@@ -13,7 +13,7 @@
 
 #define wxBU_EXACTFIT        0x0001
 #define wxBU_NOTEXT          0x0002
-#define wxBU_AUTODRAW        0x0004
+#define wxBU_AUTODRAW        0x0004 ///< Obsolete, has no effect.
 
 
 /**

--- a/interface/wx/bmpbuttn.h
+++ b/interface/wx/bmpbuttn.h
@@ -83,7 +83,7 @@ public:
                    const wxBitmap& bitmap,
                    const wxPoint& pos = wxDefaultPosition,
                    const wxSize& size = wxDefaultSize,
-                   long style = wxBU_AUTODRAW,
+                   long style = 0,
                    const wxValidator& validator = wxDefaultValidator,
                    const wxString& name = wxButtonNameStr);
 
@@ -95,7 +95,7 @@ public:
                 const wxBitmap& bitmap,
                 const wxPoint& pos = wxDefaultPosition,
                 const wxSize& size = wxDefaultSize,
-                long style = wxBU_AUTODRAW,
+                long style = 0,
                 const wxValidator& validator = wxDefaultValidator,
                 const wxString& name = wxButtonNameStr);
 

--- a/interface/wx/cshelp.h
+++ b/interface/wx/cshelp.h
@@ -271,7 +271,7 @@ public:
                         wxWindowID id = wxID_CONTEXT_HELP,
                         const wxPoint& pos = wxDefaultPosition,
                         const wxSize& size = wxDefaultSize,
-                        long style = wxBU_AUTODRAW);
+                        long style = 0);
 };
 
 

--- a/src/generic/buttonbar.cpp
+++ b/src/generic/buttonbar.cpp
@@ -389,7 +389,7 @@ void wxButtonToolBar::DoLayout()
             if (!tool->GetButton())
             {
                 wxBitmapButton* bmpButton = new wxBitmapButton(this, tool->GetId(), tool->GetNormalBitmap(), wxPoint(tool->m_x, tool->m_y), wxDefaultSize,
-                                                               wxBU_AUTODRAW|wxBORDER_NONE);
+                                                               wxBORDER_NONE);
                 if (!tool->GetShortHelp().empty())
                     bmpButton->SetLabel(tool->GetShortHelp());
 

--- a/src/generic/clrpickerg.cpp
+++ b/src/generic/clrpickerg.cpp
@@ -50,7 +50,7 @@ bool wxGenericColourButton::Create( wxWindow *parent, wxWindowID id,
 
     // create this button
     if (!wxBitmapButton::Create( parent, id, m_bitmap, pos,
-                           size, style | wxBU_AUTODRAW, validator, name ))
+                           size, style, validator, name ))
     {
         wxFAIL_MSG( wxT("wxGenericColourButton creation failed") );
         return false;

--- a/src/osx/bmpbuttn_osx.cpp
+++ b/src/osx/bmpbuttn_osx.cpp
@@ -38,16 +38,8 @@ bool wxBitmapButton::Create( wxWindow *parent,
                                      validator, name) )
         return false;
 
-    if ( style & wxBU_AUTODRAW )
-    {
-        m_marginX =
-        m_marginY = wxDEFAULT_BUTTON_MARGIN;
-    }
-    else
-    {
-        m_marginX =
-        m_marginY = 0;
-    }
+    m_marginX =
+    m_marginY = wxDEFAULT_BUTTON_MARGIN;
 
     m_bitmaps[State_Normal] = bitmap;
 

--- a/src/xrc/xh_bmpbt.cpp
+++ b/src/xrc/xh_bmpbt.cpp
@@ -44,7 +44,7 @@ wxObject *wxBitmapButtonXmlHandler::DoCreateResource()
                    GetID(),
                    GetBitmap(wxT("bitmap"), wxART_BUTTON),
                    GetPosition(), GetSize(),
-                   GetStyle(wxT("style"), wxBU_AUTODRAW),
+                   GetStyle(wxT("style")),
                    wxDefaultValidator,
                    GetName());
     if (GetBool(wxT("default"), 0))

--- a/utils/screenshotgen/src/guiframe.cpp
+++ b/utils/screenshotgen/src/guiframe.cpp
@@ -148,7 +148,7 @@ void GUIFrame::AddPanel_1()
     m_radioBtn2->SetToolTip( _("wxRadioButton") );
     fgSizer1->Add( m_radioBtn2, 0, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 20 );
 
-    m_bpButton1 = new wxBitmapButton( m_panel1, wxID_ANY, wxBitmap( wxT("bitmaps/wxwin32x32.png"), wxBITMAP_TYPE_ANY ), wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
+    m_bpButton1 = new wxBitmapButton( m_panel1, wxID_ANY, wxBitmap( wxT("bitmaps/wxwin32x32.png"), wxBITMAP_TYPE_ANY ), wxDefaultPosition, wxDefaultSize, 0 );
     m_bpButton1->SetToolTip( _("wxBitmapButton") );
     m_bpButton1->SetToolTip( _("wxBitmapButton") );
     fgSizer1->Add( m_bpButton1, 0, wxALL|wxALIGN_CENTER_HORIZONTAL|wxALIGN_CENTER_VERTICAL, 20 );


### PR DESCRIPTION
See [this ticket](https://trac.wxwidgets.org/ticket/18170)

Stefan, I'd like to ask what do you think about [the middle commit](https://github.com/wxWidgets/wxWidgets/commit/5b703b6a24ff719d1ba16121ac41ea0f5b41671f) which changes the default. IMHO it's worth doing it, even if it is slightly incompatible, because creating buttons without margins just looks bad by default under Mac (see [the original bug report](https://github.com/wxFormBuilder/wxFormBuilder/issues/427)), but please let me know if I'm missing anything here. TIA!