### PR TITLE
Implement wxDataViewColumn::UnsetAsSortKey() for native versions too

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -111,6 +111,7 @@ All (GUI):
 wxGTK:
 
 - Implement wxTextCtrl::HitTest() for single line controls.
+- Implement wxDataViewColumn::UnsetAsSortKey().
 - Fix not showing wxInfoBar with GTK+ 3 < 3.22.29.
 - Fix the build with glib < 2.32 (e.g. CentOS 6).
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -128,6 +128,7 @@ wxMSW:
 wxOSX:
 
 - Fix dispatching pending events (and CallAfter()) in console applications.
+- Implement wxDataViewColumn::UnsetAsSortKey() (Daniel Kulp).
 
 wxQt:
 

--- a/include/wx/gtk/dataview.h
+++ b/include/wx/gtk/dataview.h
@@ -43,6 +43,7 @@ public:
 
     virtual void SetSortable( bool sortable ) wxOVERRIDE;
     virtual void SetSortOrder( bool ascending ) wxOVERRIDE;
+    virtual void UnsetAsSortKey() wxOVERRIDE;
 
     virtual void SetResizeable( bool resizable ) wxOVERRIDE;
     virtual void SetHidden( bool hidden ) wxOVERRIDE;

--- a/include/wx/osx/dataview.h
+++ b/include/wx/osx/dataview.h
@@ -60,6 +60,7 @@ public:
     virtual void SetMinWidth   (int minWidth);
     virtual void SetReorderable(bool reorderable);
     virtual void SetResizeable (bool resizable);
+    virtual void UnsetAsSortKey();
     virtual void SetSortable   (bool sortable);
     virtual void SetSortOrder  (bool ascending);
     virtual void SetTitle      (wxString const& title);

--- a/samples/dataview/dataview.cpp
+++ b/samples/dataview/dataview.cpp
@@ -147,6 +147,7 @@ private:
     void OnShowAttributes( wxCommandEvent &event);
 
     void OnMultipleSort( wxCommandEvent &event);
+    void OnSortByFirstColumn( wxCommandEvent &event);
 
 #if wxUSE_DRAG_AND_DROP
     void OnBeginDrag( wxDataViewEvent &event );
@@ -363,6 +364,7 @@ enum
     ID_HIDE_ATTRIBUTES  = 204,
     ID_SHOW_ATTRIBUTES  = 205,
     ID_MULTIPLE_SORT    = 206,
+    ID_SORT_BY_FIRST_COLUMN,
 
     // Fourth page.
     ID_DELETE_TREE_ITEM = 400,
@@ -407,6 +409,7 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_BUTTON( ID_HIDE_ATTRIBUTES, MyFrame::OnHideAttributes)
     EVT_BUTTON( ID_SHOW_ATTRIBUTES, MyFrame::OnShowAttributes)
     EVT_CHECKBOX( ID_MULTIPLE_SORT, MyFrame::OnMultipleSort)
+    EVT_CHECKBOX( ID_SORT_BY_FIRST_COLUMN, MyFrame::OnSortByFirstColumn)
     
     // Fourth page.
     EVT_BUTTON( ID_DELETE_TREE_ITEM, MyFrame::OnDeleteTreeItem )
@@ -559,12 +562,17 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, int x, int y, int w, int
     button_sizer2->Add( new wxButton( secondPanel, ID_ADD_MANY,    "Add 1000"),               0, wxALL, 10 );
     button_sizer2->Add( new wxButton( secondPanel, ID_HIDE_ATTRIBUTES,    "Hide attributes"), 0, wxALL, 10 );
     button_sizer2->Add( new wxButton( secondPanel, ID_SHOW_ATTRIBUTES,    "Show attributes"), 0, wxALL, 10 );
-    button_sizer2->Add( new wxCheckBox(secondPanel, ID_MULTIPLE_SORT, "Allow multisort"),
-                        wxSizerFlags().Centre().DoubleBorder() );
+
+    wxBoxSizer *sortSizer = new wxBoxSizer(wxHORIZONTAL);
+    sortSizer->Add(new wxCheckBox(secondPanel, ID_SORT_BY_FIRST_COLUMN, "Sort by first column"),
+                   wxSizerFlags().Centre().DoubleBorder());
+    sortSizer->Add(new wxCheckBox(secondPanel, ID_MULTIPLE_SORT, "Allow multisort"),
+                   wxSizerFlags().Centre().DoubleBorder());
 
     wxSizer *secondPanelSz = new wxBoxSizer( wxVERTICAL );
     secondPanelSz->Add(m_ctrl[1], 1, wxGROW|wxALL, 5);
     secondPanelSz->Add(button_sizer2);
+    secondPanelSz->Add(sortSizer);
     secondPanel->SetSizerAndFit(secondPanelSz);
 
 
@@ -1500,3 +1508,11 @@ void MyFrame::OnMultipleSort( wxCommandEvent &event )
         wxLogMessage("Sorting by multiple columns not supported");
 }
 
+void MyFrame::OnSortByFirstColumn(wxCommandEvent& event)
+{
+    wxDataViewColumn* const col = m_ctrl[1]->GetColumn(0);
+    if ( event.IsChecked() )
+        col->SetSortOrder(true /* ascending */);
+    else
+        col->UnsetAsSortKey();
+}

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -3345,6 +3345,17 @@ void wxDataViewColumn::SetSortOrder( bool ascending )
     internal->SetDataViewSortColumn(this);
 }
 
+void wxDataViewColumn::UnsetAsSortKey()
+{
+    GtkTreeViewColumn *column = GTK_TREE_VIEW_COLUMN(m_column);
+
+    gtk_tree_view_column_set_sort_indicator( column, FALSE );
+
+    wxDataViewCtrlInternal* internal = m_owner->GtkGetInternal();
+    internal->SetSortColumn(-1);
+    internal->SetDataViewSortColumn(NULL);
+}
+
 bool wxDataViewColumn::IsSortOrderAscending() const
 {
     GtkTreeViewColumn *column = GTK_TREE_VIEW_COLUMN(m_column);

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -3465,6 +3465,13 @@ void wxDataViewColumn::SetResizeable(bool resizable)
         [m_NativeDataPtr->GetNativeColumnPtr() setResizingMask:NSTableColumnNoResizing];
 }
 
+void wxDataViewColumn::UnsetAsSortKey()
+{
+    NSTableColumn* const tableColumn = m_NativeDataPtr->GetNativeColumnPtr();
+    if ( tableColumn )
+        [tableColumn setSortDescriptorPrototype:nil];
+}
+
 void wxDataViewColumn::SetSortable(bool sortable)
 {
     // wxDataViewColumnBase::SetSortable(sortable);


### PR DESCRIPTION
This was only done in the generic version so far.

I'm really not sure if this API is ideal (it would make more sense to me to have the methods for setting and unsetting sort order in wxDVC itself, especially as we already have methods for _getting_ it there), but this is the way it works in the generic version, so it seems best to implement this for the native versions too.