### PR TITLE
wxFontDialog: fix SetTitle() in MSW

### DIFF
--- a/include/wx/msw/fontdlg.h
+++ b/include/wx/msw/fontdlg.h
@@ -25,9 +25,12 @@ public:
         : wxFontDialogBase(parent, data) { Create(parent, data); }
 
     virtual int ShowModal() wxOVERRIDE;
+    virtual void SetTitle(const wxString& title) wxOVERRIDE;
+    virtual wxString GetTitle() const wxOVERRIDE;
 
 protected:
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxFontDialog);
+    wxString            m_title;
 };
 
 #endif


### PR DESCRIPTION
Add hook procedure for common font dialog similar to wxColourDialog, and set the title there.
Fixes #18177