### PR TITLE
Test Improvements

### DIFF
--- a/build/cmake/tests/base/CMakeLists.txt
+++ b/build/cmake/tests/base/CMakeLists.txt
@@ -92,13 +92,33 @@ set(TEST_SRC
     weakref/evtconnection.cpp
     weakref/weakref.cpp
     xlocale/xlocale.cpp
+
+    testprec.h
+    testableframe.h
+    testdate.h
+    testfile.h
+    archive/archivetest.h
+    streams/bstream.h
     )
 
 if(wxUSE_XML)
     list(APPEND TEST_SRC xml/xmltest.cpp)
 endif()
 
-wx_add_test(test_base ${TEST_SRC})
+set(TEST_DATA
+    intl/fr/internat.mo
+    intl/fr/internat.po
+    intl/ja/internat.mo
+    intl/ja/internat.po
+    horse.bmp
+    horse.png
+    horse.xpm
+    testdata.fc
+    )
+
+wx_add_test(test_base ${TEST_SRC}
+    DATA ${TEST_DATA}
+    )
 target_compile_definitions(test_base PRIVATE wxUSE_GUI=0 wxUSE_BASE=1)
 if(wxUSE_SOCKETS)
     wx_exe_link_libraries(test_base net)

--- a/build/cmake/tests/drawing/CMakeLists.txt
+++ b/build/cmake/tests/drawing/CMakeLists.txt
@@ -20,8 +20,25 @@ set(TEST_DRAWING_SRC
     drawing/plugindriver.cpp
     drawing/basictest.cpp
     drawing/fonttest.cpp
+
+    testprec.h
+    testableframe.h
+    testimage.h
+    drawing/gcfactory.h
+    drawing/plugin.h
+    drawing/pluginsample.cpp
+    drawing/testimagefile.h
     )
-wx_add_test(test_drawing ${TEST_DRAWING_SRC})
+
+set(TEST_DRAWING_DATA
+    drawing/references/image_test_image_cairo-1.8_2_ref.png
+    drawing/references/image_test_image_cg-10.5_2_ref.png
+    drawing/references/image_test_image_gdiplus-6.1_2_ref.png
+    )
+
+wx_add_test(test_drawing ${TEST_DRAWING_SRC}
+    DATA ${TEST_DRAWING_DATA}
+    )
 if(wxUSE_SOCKETS)
     wx_exe_link_libraries(test_drawing net)
 endif()

--- a/build/cmake/tests/gui/CMakeLists.txt
+++ b/build/cmake/tests/gui/CMakeLists.txt
@@ -109,8 +109,64 @@ set(TEST_GUI_SRC
     window/clientsize.cpp
     window/setsize.cpp
     xml/xrctest.cpp
+
+    testprec.h
+    testableframe.h
+    asserthelper.h
+    testdate.h
+    testfile.h
+    testimage.h
+    controls/bookctrlbasetest.h
+    controls/itemcontainertest.h
+    controls/listbasetest.h
+    controls/pickerbasetest.h
+    controls/textentrytest.h
+    persistence/testpersistence.h
     )
-wx_add_test(test_gui ${TEST_GUI_SRC})
+
+set(TEST_GUI_DATA
+    horse.ani
+    horse.bmp
+    horse.cur
+    horse.gif
+    horse.ico
+    horse.jpg
+    horse.pcx
+    horse.png
+    horse.pnm
+    horse.tga
+    horse.tif
+    horse.xpm
+    image/horse_grey.bmp
+    image/horse_grey_flipped.bmp
+    image/horse_rle4.bmp
+    image/horse_rle4_flipped.bmp
+    image/horse_rle8.bmp
+    image/horse_rle8_flipped.bmp
+    image/cross_bicubic_256x256.png
+    image/cross_bilinear_256x256.png
+    image/cross_box_average_256x256.png
+    image/cross_nearest_neighb_256x256.png
+    image/horse_bicubic_50x50.png
+    image/horse_bicubic_100x100.png
+    image/horse_bicubic_150x150.png
+    image/horse_bicubic_300x300.png
+    image/horse_bilinear_50x50.png
+    image/horse_bilinear_100x100.png
+    image/horse_bilinear_150x150.png
+    image/horse_bilinear_300x300.png
+    image/horse_box_average_50x50.png
+    image/horse_box_average_100x100.png
+    image/horse_box_average_150x150.png
+    image/horse_box_average_300x300.png
+    intl/ja/internat.mo
+    intl/ja/internat.po
+    )
+
+wx_add_test(test_gui ${TEST_GUI_SRC}
+    DATA ${TEST_GUI_DATA}
+    RES ../samples/sample.rc
+    )
 wx_exe_link_libraries(test_gui core)
 if(wxUSE_RICHTEXT)
     wx_exe_link_libraries(test_gui richtext)

--- a/build/tools/appveyor-test.bat
+++ b/build/tools/appveyor-test.bat
@@ -45,7 +45,7 @@ exit /b 0
 :cmake
 if "%CONFIGURATION%"=="" set CONFIGURATION=Release
 cd ..\build_cmake
-ctest -V -C %CONFIGURATION% -R "test_[base|gui]" --interactive-debug-mode 0 .
+ctest -V -C %CONFIGURATION% -R "test_[base|gui]" --output-on-failure --interactive-debug-mode 0 .
 if %errorlevel% NEQ 0 goto :error
 goto :eof
 

--- a/build/tools/appveyor-test.bat
+++ b/build/tools/appveyor-test.bat
@@ -9,27 +9,27 @@ goto %TOOLSET%
 :msbuild
 PATH=C:\projects\wxwidgets\lib\vc_x64_dll;%PATH%
 .\vc_x64_mswudll\test.exe
-if errorlevel 1 goto :error
+if %errorlevel% NEQ 0 goto :error
 .\vc_x64_mswudll\test_gui.exe
 goto :eof
 
 :nmake
 if "%BUILD%"=="debug" set debug_suffix=d
 .\vc_mswu%debug_suffix%\test.exe
-if errorlevel 1 goto :error
+if %errorlevel% NEQ 0 goto :error
 .\vc_mswu%debug_suffix%\test_gui.exe
 goto :eof
 
 :mingw
 .\gcc_mswud\test.exe
-if errorlevel 1 goto :error
+if %errorlevel% NEQ 0 goto :error
 .\gcc_mswud\test_gui.exe
 goto :eof
 
 :msys2
 PATH=C:\projects\wxwidgets\lib;%PATH%
 .\test.exe
-if errorlevel 1 goto :error
+if %errorlevel% NEQ 0 goto :error
 .\test_gui.exe
 goto :eof
 
@@ -46,7 +46,7 @@ exit /b 0
 if "%CONFIGURATION%"=="" set CONFIGURATION=Release
 cd ..\build_cmake
 ctest -V -C %CONFIGURATION% -R "test_[base|gui]" --interactive-debug-mode 0 .
-if errorlevel 1 goto :error
+if %errorlevel% NEQ 0 goto :error
 goto :eof
 
 :error

--- a/build/tools/travis-ci.sh
+++ b/build/tools/travis-ci.sh
@@ -29,7 +29,7 @@ case $wxTOOLSET in
         if [ "$wxCMAKE_TESTS" != "OFF" ]; then
             echo 'travis_fold:start:testing'
             echo 'Testing...'
-            ctest . -C Debug -V --output-on-failure
+            ctest -V -C Debug -R "test_base" --output-on-failure --interactive-debug-mode 0 .
             echo 'travis_fold:end:testing'
         fi
         ;;

--- a/tests/strings/strings.cpp
+++ b/tests/strings/strings.cpp
@@ -849,9 +849,7 @@ void StringTestCase::FromDouble()
     } testData[] =
     {
         { 1.23,             -1, "1.23" },
-        // All MSVC versions until MSVC 14 used 3 digits for the exponent
-        // unnecessarily, account for this non-standard behaviour.
-#if defined(wxUSING_VC_CRT_IO) && !wxCHECK_VISUALC_VERSION(14)
+#if defined(wxDEFAULT_MANTISSA_SIZE_3)
         { -3e-10,           -1, "-3e-010" },
 #else
         { -3e-10,           -1, "-3e-10" },

--- a/tests/strings/vararg.cpp
+++ b/tests/strings/vararg.cpp
@@ -200,7 +200,6 @@ void VarArgTestCase::Sscanf()
 {
     int i = 0;
     char str[20];
-    wchar_t wstr[20];
 
     wxString input("42 test");
 
@@ -208,10 +207,18 @@ void VarArgTestCase::Sscanf()
     CPPUNIT_ASSERT( i == 42 );
     CPPUNIT_ASSERT( wxString(str) == "test" );
 
+#if !(defined(__MINGW32__) && \
+      defined(__USE_MINGW_ANSI_STDIO) && __USE_MINGW_ANSI_STDIO == 1)
+    // disable this test on mingw with __USE_MINGW_ANSI_STDIO=1
+    // to prevent a segmentation fault. See:
+    // https://sourceforge.net/p/mingw-w64/mailman/message/36118530/
+    wchar_t wstr[20];
+
     i = 0;
     wxSscanf(input, L"%d %s", &i, &wstr);
     CPPUNIT_ASSERT( i == 42 );
     CPPUNIT_ASSERT( wxString(wstr) == "test" );
+#endif
 }
 
 void VarArgTestCase::RepeatedPrintf()

--- a/tests/strings/vsnprintf.cpp
+++ b/tests/strings/vsnprintf.cpp
@@ -71,12 +71,6 @@ int r;
     CPPUNIT_ASSERT_EQUAL( r, wxStrlen(buf) );          \
     ASSERT_STR_EQUAL( wxT(expected), buf );
 
-#define CMP3i(expected, fmt, y)                        \
-    r=wxSnprintf(buf, MAX_TEST_LEN, wxT(fmt), y);     \
-    CPPUNIT_ASSERT_EQUAL( r, wxStrlen(buf) );          \
-    WX_ASSERT_MESSAGE( ("Expected \"%s\", got \"%s\"", expected, buf), \
-                       wxStricmp(expected, buf) == 0 );
-
 #define CMP2(expected, fmt)                           \
     r=wxSnprintf(buf, MAX_TEST_LEN, wxT(fmt));        \
     CPPUNIT_ASSERT_EQUAL( r, wxStrlen(buf) );          \
@@ -241,22 +235,23 @@ void VsnprintfTestCase::P()
     // the system sprintf() for actual formatting so the results are still
     // different under different systems).
 
-#ifdef wxUSING_VC_CRT_IO
-    // MSVC always prints pointers as %8X on 32 bit systems and as %16X on 64
-    // bit systems.
+#if defined(__VISUALC__) || (defined(__MINGW32__) && \
+        (!defined(__USE_MINGW_ANSI_STDIO) || !__USE_MINGW_ANSI_STDIO))
     #if SIZEOF_VOID_P == 4
-        CMP3i("00ABCDEF", "%p", (void*)0xABCDEF);
+        CMP3("00ABCDEF", "%p", (void*)0xABCDEF);
         CMP3("00000000", "%p", (void*)NULL);
     #elif SIZEOF_VOID_P == 8
-        CMP3i("0000ABCDEFABCDEF", "%p", (void*)0xABCDEFABCDEF);
+        CMP3("0000ABCDEFABCDEF", "%p", (void*)0xABCDEFABCDEF);
         CMP3("0000000000000000", "%p", (void*)NULL);
     #endif
 #elif defined(__MINGW32__)
-    // mingw32 uses MSVC CRT in old versions but is own implementation now
-    // which is somewhere in the middle as it uses %8x, so to catch both cases
-    // we use case-insensitive comparison here.
-    CMP3("0xabcdef", "%p", (void*)0xABCDEF);
-    CMP3("0", "%p", (void*)NULL);
+    #if SIZEOF_VOID_P == 4
+        CMP3("00abcdef", "%p", (void*)0xABCDEF);
+        CMP3("00000000", "%p", (void*)NULL);
+    #elif SIZEOF_VOID_P == 8
+        CMP3("0000abcdefabcdef", "%p", (void*)0xABCDEFABCDEF);
+        CMP3("0000000000000000", "%p", (void*)NULL);
+    #endif
 #elif defined(__GNUG__)
     // glibc prints pointers as %#x except for NULL pointers which are printed
     // as '(nil)'.
@@ -275,13 +270,10 @@ void VsnprintfTestCase::N()
 
 void VsnprintfTestCase::E()
 {
-    // NB: there are no standards about the minimum exponent width
-    //     (and the width of the %e conversion specifier refers to the
-    //      mantissa, not to the exponent).
-    //     Since newer MSVC versions use 3 digits as minimum exponent
-    //     width while GNU libc uses 2 digits as minimum width, here we
-    //     workaround this problem using for the exponent values with at
-    //     least three digits.
+    // NB: Use at least three digits for the exponent to workaround
+    //     differences between MSVC, MinGW and GNU libc.
+    //     See wxUSING_MANTISSA_SIZE_3 in testprec.h as well.
+    //
     //     Some examples:
     //       printf("%e",2.342E+02);
     //     -> under MSVC7.1 prints:      2.342000e+002
@@ -601,8 +593,7 @@ void VsnprintfTestCase::GlibcMisc1()
 {
     CMP3("     ",    "%5.s", "xyz");
     CMP3("   33",    "%5.f", 33.3);
-#ifdef wxUSING_VC_CRT_IO
-    // see the previous notes about the minimum width of mantissa:
+#if defined(wxDEFAULT_MANTISSA_SIZE_3)
     CMP3("  3e+008", "%8.e", 33.3e7);
     CMP3("  3E+008", "%8.E", 33.3e7);
     CMP3("3e+001",    "%.g",  33.3);

--- a/tests/testprec.h
+++ b/tests/testprec.h
@@ -36,21 +36,24 @@
     #endif
 #endif
 
-// Define wxUSING_VC_CRT_IO when using MSVC CRT STDIO library as its standard
-// functions give different results from glibc ones in several cases (of
-// course, any code relying on this is not portable and probably won't work,
-// i.e. will result in tests failures, with other platforms/compilers which
-// should have checks for them added as well).
+// Define wxUSING_MANTISSA_SIZE_3 for certain versions of MinGW and MSVC.
+// These use a CRT which prints the exponent with a minimum of 3
+// digits instead of 2.
 //
-// Notice that MinGW uses VC CRT by default but may use its own printf()
-// implementation if __USE_MINGW_ANSI_STDIO is defined. And finally also notice
-// that testing for __USE_MINGW_ANSI_STDIO directly results in a warning with
-// -Wundef if it involves an operation with undefined __MINGW_FEATURES__ so
-// test for the latter too to avoid it.
-#if defined(__VISUALC__) || \
-    (defined(__MINGW32__) && \
-     (!defined(__MINGW_FEATURES__) || !__USE_MINGW_ANSI_STDIO))
-    #define wxUSING_VC_CRT_IO
+// This happens for all MSVC compilers before version 14 (VS2015).
+// And for MinGW when it does not define or set __USE_MINGW_ANSI_STDIO.
+// Since MinGW 5.0.4 it uses at least 2 digits for the exponent:
+// https://sourceforge.net/p/mingw-w64/mailman/message/36333746/
+
+#if (defined(__MINGW64_VERSION_MAJOR) && (__MINGW64_VERSION_MAJOR > 5 || \
+        (__MINGW64_VERSION_MAJOR == 5 && __MINGW64_VERSION_MINOR >= 0) || \
+        (__MINGW64_VERSION_MAJOR == 5 && __MINGW64_VERSION_MINOR == 0 && __MINGW64_VERSION_BUGFIX >= 4)))
+#define wxMINGW_WITH_FIXED_MANTISSA
+#endif
+#if (defined(__VISUALC__) && !wxCHECK_VISUALC_VERSION(14)) || \
+        (defined(__MINGW32__) && !defined(wxMINGW_WITH_FIXED_MANTISSA) && \
+        (!defined(__USE_MINGW_ANSI_STDIO) || !__USE_MINGW_ANSI_STDIO))
+    #define wxDEFAULT_MANTISSA_SIZE_3
 #endif
 
 // thrown when assert fails in debug build


### PR DESCRIPTION
This PR fixes several issues with the tests.

- Copy the data files and rc file when using CMake to generate the test projects.
Add headers to source file list so they are shown in IDE.
- Check for any error code when the tests finish under AppVeyor. It can return different error codes, e.g. for a segfault (see comments below).
- Generalize printf tests for pointers and results with an exponent. Compilers return slightly different values, e.g. capitalized pointer addresses and mantissas with length 2 or 3. The pre-processor test (setting `wxUSING_VC_CRT_IO`) for the correct result is not valid anymore, e.g. recent MinGW compilers use a mantissa with 2 zeros while 3 were expected. Simplify by accepting two valid results.
- Use the same `ctest` commands for AppVeyor and Travis. Don't run gui tests on Travis, these fail with `Error: Unable to initialize GTK+, is DISPLAY set properly?`.
- Prevent a segfault in the vararg test with MinGW. The segmentation fault is caused by `swscanf` with `__USE_MINGW_ANSI_STDIO=1`. See https://sourceforge.net/p/mingw-w64/mailman/message/36118530/ and comments below for a minimal example.