### PR TITLE
Provide an error message when trying to use wxGLCanvas on non-X11 dis…

### DIFF
--- a/src/gtk/glcanvas.cpp
+++ b/src/gtk/glcanvas.cpp
@@ -222,6 +222,19 @@ wxGLCanvas::wxGLCanvas(wxWindow *parent,
 
 #endif // WXWIN_COMPATIBILITY_2_8
 
+static bool IsAvailable()
+{
+#ifdef GDK_WINDOWING_X11
+    if ( !GDK_IS_X11_DISPLAY(gdk_display_get_default()) )
+#endif
+    {
+        wxSafeShowMessage(_("Fatal Error"), _("wxGLCanvas is only supported on X11 currently.  You may be able to\nwork around this by setting environment variable GDK_BACKEND=x11 before starting\nyour program."));
+        return false;
+    }
+
+    return true;
+}
+
 bool wxGLCanvas::Create(wxWindow *parent,
                         wxWindowID id,
                         const wxPoint& pos,
@@ -231,6 +244,9 @@ bool wxGLCanvas::Create(wxWindow *parent,
                         const int *attribList,
                         const wxPalette& palette)
 {
+    if ( !IsAvailable() )
+        return false;
+
     // Separate 'GLXFBConfig/XVisual' attributes.
     // Also store context attributes for wxGLContext ctor
     wxGLAttributes dispAttrs;
@@ -249,6 +265,9 @@ bool wxGLCanvas::Create(wxWindow *parent,
                         const wxString& name,
                         const wxPalette& palette)
 {
+    if ( !IsAvailable() )
+        return false;
+
 #if wxUSE_PALETTE
     wxASSERT_MSG( !palette.IsOk(), wxT("palettes not supported") );
 #endif // wxUSE_PALETTE


### PR DESCRIPTION
…play

Currently, wxGLCanvas on wxGTK is only supported on X11 displays.  If a user
attempts to use wxGLCanvas on Wayland, for example, the application will core
dump.  This change adds an error message and a suggested workaround until
wxGLCanvas is supported on Wayland.

See https://trac.wxwidgets.org/ticket/17702