### PR TITLE
Make wxDateTime::GetTicks() return dates in the full time_t range.

### DIFF
--- a/include/wx/datetime.h
+++ b/include/wx/datetime.h
@@ -1617,9 +1617,12 @@ protected:
 
 inline bool wxDateTime::IsInStdRange() const
 {
-    // currently we don't know what is the real type of time_t so prefer to err
-    // on the safe side and limit it to 32 bit values which is safe everywhere
-    return m_time >= 0l && (m_time / TIME_T_FACTOR) < wxINT32_MAX;
+    // we don't know what is the real type of time_t but we can test that the
+    // round trip works
+    wxLongLong_t seconds = m_time.GetValue() / TIME_T_FACTOR;
+    return
+      static_cast<wxLongLong_t>(static_cast<time_t>(seconds))
+      == seconds;
 }
 
 /* static */


### PR DESCRIPTION
wxDateTime::IsInStdRange() returned false as soon as the date was before
1970-Jan-1 (start of unix epoch). It returned false also when the the
timestamp was more than what an int32_t can hold.

This makes IsInStdRange() return true if the wxDateTime can be stored in
a time_t, whatever the type of time_t. This is done by checking that the
round trip wxDateTime -> time_t -> wxDateTime works correctly.