### PR TITLE
wxGenericTreeItem::DeleteChildren(): do not generate events

### DIFF
--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -626,7 +626,6 @@ void wxGenericTreeItem::DeleteChildren(wxGenericTreeCtrl *tree)
     for ( size_t n = 0; n < count; n++ )
     {
         wxGenericTreeItem *child = m_children[n];
-        tree->SendDeleteEvent(child);
 
         child->DeleteChildren(tree);
         if ( child == tree->m_select_me )


### PR DESCRIPTION
According to the doc `wxTreeCtrl::DeleteChildren()` should not generate any events. Remove generating `wxEVT_TREE_DELETE_ITEM` from the generic version