### PR TITLE
Documentation updates and tests for wxEVT_TREE_DELETE_ITEM

### DIFF
--- a/interface/wx/treectrl.h
+++ b/interface/wx/treectrl.h
@@ -317,8 +317,10 @@ public:
     virtual void DeleteAllItems();
 
     /**
-        Deletes all children of the given item (but not the item itself). Note
-        that this will @b not generate any events unlike Delete() method.
+        Deletes all children of the given item (but not the item itself).
+
+        A @c wxEVT_TREE_DELETE_ITEM event will be generated for every item
+        being deleted.
 
         If you have called SetItemHasChildren(), you may need to call it again
         since DeleteChildren() does not automatically clear the setting.

--- a/interface/wx/treectrl.h
+++ b/interface/wx/treectrl.h
@@ -310,9 +310,11 @@ public:
     virtual void Delete(const wxTreeItemId& item);
 
     /**
-        Deletes all items in the control. Note that this may not generate
-        @c EVT_TREE_DELETE_ITEM events under some Windows versions although
-        normally such event is generated for each removed item.
+        Deletes all items in the control.
+
+        This function generates @c wxEVT_TREE_DELETE_ITEM events for each item
+        being deleted, including the root one if it is shown, i.e. unless
+        wxTR_HIDE_ROOT style is used.
     */
     virtual void DeleteAllItems();
 

--- a/tests/controls/treectrltest.cpp
+++ b/tests/controls/treectrltest.cpp
@@ -45,6 +45,7 @@ private:
     CPPUNIT_TEST_SUITE( TreeCtrlTestCase );
         WXUISIM_TEST( ItemClick );
         CPPUNIT_TEST( DeleteItem );
+        CPPUNIT_TEST( DeleteChildren );
         WXUISIM_TEST( LabelEdit );
         WXUISIM_TEST( KeyDown );
 #ifndef __WXGTK__
@@ -72,6 +73,7 @@ private:
 
     void ItemClick();
     void DeleteItem();
+    void DeleteChildren();
     void LabelEdit();
     void KeyDown();
 #ifndef __WXGTK__
@@ -273,6 +275,16 @@ void TreeCtrlTestCase::DeleteItem()
     // are not generated.
 
     CPPUNIT_ASSERT_EQUAL(1, deleteitem.GetCount());
+}
+
+void TreeCtrlTestCase::DeleteChildren()
+{
+    EventCounter deletechildren(m_tree, wxEVT_TREE_DELETE_ITEM);
+
+    m_tree->AppendItem(m_child1, "another grandchild");
+    m_tree->DeleteChildren(m_child1);
+
+    CHECK( deletechildren.GetCount() == 2 );
 }
 
 #if wxUSE_UIACTIONSIMULATOR

--- a/tests/controls/treectrltest.cpp
+++ b/tests/controls/treectrltest.cpp
@@ -46,6 +46,7 @@ private:
         WXUISIM_TEST( ItemClick );
         CPPUNIT_TEST( DeleteItem );
         CPPUNIT_TEST( DeleteChildren );
+        CPPUNIT_TEST( DeleteAllItems );
         WXUISIM_TEST( LabelEdit );
         WXUISIM_TEST( KeyDown );
 #ifndef __WXGTK__
@@ -74,6 +75,7 @@ private:
     void ItemClick();
     void DeleteItem();
     void DeleteChildren();
+    void DeleteAllItems();
     void LabelEdit();
     void KeyDown();
 #ifndef __WXGTK__
@@ -271,8 +273,6 @@ void TreeCtrlTestCase::DeleteItem()
 
     wxTreeItemId todelete = m_tree->AppendItem(m_root, "deleteme");
     m_tree->Delete(todelete);
-    // We do not test DeleteAllItems() as under some versions of Windows events
-    // are not generated.
 
     CPPUNIT_ASSERT_EQUAL(1, deleteitem.GetCount());
 }
@@ -285,6 +285,15 @@ void TreeCtrlTestCase::DeleteChildren()
     m_tree->DeleteChildren(m_child1);
 
     CHECK( deletechildren.GetCount() == 2 );
+}
+
+void TreeCtrlTestCase::DeleteAllItems()
+{
+    EventCounter deleteall(m_tree, wxEVT_TREE_DELETE_ITEM);
+
+    m_tree->DeleteAllItems();
+
+    CHECK( deleteall.GetCount() == 4 );
 }
 
 #if wxUSE_UIACTIONSIMULATOR


### PR DESCRIPTION
Update the documentation to reflect what really happens and add tests verifying that it is correct.

Replaces #875.