### PR TITLE
Fix wrong udata type in wxFileSystemWatcher code under NetBSD

### DIFF
--- a/src/unix/fswatcher_kqueue.cpp
+++ b/src/unix/fswatcher_kqueue.cpp
@@ -29,6 +29,21 @@
 
 #include "wx/private/fswatcher.h"
 
+namespace
+{
+
+// NetBSD is different as it uses intptr_t as type of kevent struct udata field
+// for some reason, instead of "void*" as all the other platforms using kqueue.
+#ifdef __NetBSD__
+    inline intptr_t ToUdata(void* d) { return reinterpret_cast<intptr_t>(d); }
+    inline void* FromUdata(intptr_t d) { return reinterpret_cast<void*>(d); }
+#else
+    inline void* ToUdata(void* d) { return d; }
+    inline void* FromUdata(void* d) { return d; }
+#endif
+
+} // anonymous namespace
+
 // ============================================================================
 // wxFSWSourceHandler helper class
 // ============================================================================
@@ -126,7 +141,7 @@ public:
         int action = EV_ADD | EV_ENABLE | EV_CLEAR | EV_ERROR;
         int flags = Watcher2NativeFlags(watch->GetFlags());
         EV_SET( &event, watch->GetFileDescriptor(), EVFILT_VNODE, action,
-                flags, 0, watch.get() );
+                flags, 0, ToUdata(watch.get()) );
 
         // TODO more error conditions according to man
         // TODO best deal with the error here
@@ -277,14 +292,16 @@ protected:
 
     void ProcessNativeEvent(const struct kevent& e)
     {
-        wxASSERT_MSG(e.udata, "Null user data associated with kevent!");
+        void* const udata = FromUdata(e.udata);
+
+        wxASSERT_MSG(udata, "Null user data associated with kevent!");
 
         wxLogTrace(wxTRACE_FSWATCHER, "Event: ident=%llu, filter=%d, flags=%u, "
                    "fflags=%u, data=%lld, user_data=%lp",
-                   e.ident, e.filter, e.flags, e.fflags, e.data, e.udata);
+                   e.ident, e.filter, e.flags, e.fflags, e.data, udata);
 
         // for ease of use
-        wxFSWatchEntryKq& w = *(static_cast<wxFSWatchEntry*>(e.udata));
+        wxFSWatchEntryKq& w = *(static_cast<wxFSWatchEntry*>(udata));
         int nflags = e.fflags;
 
         // clear ignored flags


### PR DESCRIPTION
NetBSD kqueue struct uses "intptr_t" as type of the user data pointer
and not "void*" as all the other platforms using kqueue, so account for
it in this code.

Closes #18199.