### PR TITLE
Add more references to wxIconBundle to documentation

### DIFF
--- a/docs/doxygen/mainpages/cat_classes.h
+++ b/docs/doxygen/mainpages/cat_classes.h
@@ -354,6 +354,7 @@ Related Overviews: @ref overview_bitmap
 @li wxCursor: A small, transparent bitmap representing the cursor
 @li wxIcon: A small, transparent bitmap for assigning to frames and drawing on
     device contexts
+@li wxIconBundle: Contains multiple copies of an icon in different sizes
 @li wxImage: A platform-independent image class
 @li wxImageHandler: Class for loading a saving a wxImage in a specific format
 @li wxImageList: A list of images, used with some controls

--- a/interface/wx/icon.h
+++ b/interface/wx/icon.h
@@ -47,7 +47,7 @@
     ::wxNullIcon
 
     @see @ref overview_bitmap, @ref overview_bitmap_supportedformats,
-         wxDC::DrawIcon, wxCursor
+         wxIconBundle, wxDC::DrawIcon, wxCursor
 */
 class wxIcon : public wxGDIObject
 {


### PR DESCRIPTION
Add wxIconBundle to the list in the Overview of Available Classes / Image and bitmap classes as well as to the documentation page for wxIcon.