### PR TITLE
OSX - Allow selection of 70 point fonts in Font selection dialog and …

### DIFF
--- a/src/osx/carbon/graphics.cpp
+++ b/src/osx/carbon/graphics.cpp
@@ -2898,7 +2898,8 @@ wxMacCoreGraphicsRenderer::CreateFont(double sizeInPixels,
     // Notice that under Mac we always use 72 DPI so the font size in pixels is
     // the same as the font size in points and we can pass it directly to wxFont
     // ctor.
-    wxFont font(wxRound(sizeInPixels),
+    int size = wxRound(sizeInPixels);
+    wxFont font(size,
                 wxFONTFAMILY_DEFAULT,
                 flags & wxFONTFLAG_ITALIC ? wxFONTSTYLE_ITALIC
                                           : wxFONTSTYLE_NORMAL,
@@ -2906,6 +2907,9 @@ wxMacCoreGraphicsRenderer::CreateFont(double sizeInPixels,
                                         : wxFONTWEIGHT_NORMAL,
                 (flags & wxFONTFLAG_UNDERLINED) != 0,
                 facename);
+    if (size == wxDEFAULT) {
+        font.SetPointSize(size);
+    }
 
     if ( flags & wxFONTFLAG_STRIKETHROUGH )
         font.MakeStrikethrough();

--- a/src/osx/carbon/utilscocoa.mm
+++ b/src/osx/carbon/utilscocoa.mm
@@ -137,6 +137,9 @@ void wxFont::SetNativeInfoFromNSFont(WX_NSFont theFont, wxNativeFontInfo* info)
         info->Init(size,fontFamily,fontstyle,fontweight,underlined, strikethrough,
                    wxCFStringRef::AsString([theFont familyName]), wxFONTENCODING_DEFAULT);
 
+        if (size == wxDEFAULT) {
+            info->SetPointSize(size);
+        }
     }
 }
 


### PR DESCRIPTION
…allow creation of wxGraphicsFont of size 70

This "fixes"  https://trac.wxwidgets.org/ticket/18185 for my application.  Basically, there are two places (that I hit) where we cannot call SetPointSize  if size==wxDEFAULT as the creation of the wxFont is done internally to other calls.   This adds the calls in those locations.   