### PR TITLE
wxImageList::GetIcon() converts wxBitmap to wxIcon instead of wxNullIcon on OSX

### DIFF
--- a/src/osx/imaglist.cpp
+++ b/src/osx/imaglist.cpp
@@ -147,13 +147,13 @@ wxIcon wxImageList::GetIcon(int index) const
     wxObject* obj = (wxObject*) node->GetData();
     if ( obj == NULL )
         return wxNullIcon ;
-    else if ( obj->IsKindOf(CLASSINFO(wxBitmap)) )
+    if ( obj->IsKindOf(CLASSINFO(wxBitmap)) )
     {
-        wxFAIL_MSG( wxT("cannot convert from bitmap to icon") ) ;
-        return wxNullIcon ;
+        wxIcon icon;
+        icon.CopyFromBitmap(*static_cast<const wxBitmap*>(obj));
+        return icon;
     }
-    else
-        return *(static_cast<wxIcon*>(obj)) ;
+    return *(static_cast<wxIcon*>(obj)) ;
 }
 
 bool wxImageList::Replace( int index, const wxBitmap &bitmap )


### PR DESCRIPTION
On OSX, wxImageList::GetIcon() returned wxNullIcon when a wxBitmap was
stored. This could lead to no image seen in controls like wxTreeListCtrl.

Instead of that, we convert the wxBitmap to wxIcon with CopyFromBitmap.