### PR TITLE
[Macbook Pro] - unpainted column is seen after the last column in header control when horizontal scroll is used.

### DIFF
--- a/src/generic/headerctrlg.cpp
+++ b/src/generic/headerctrlg.cpp
@@ -490,6 +490,7 @@ void wxHeaderCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
 #endif
 
     wxAutoBufferedPaintDC dc(this);
+    dc.Clear()
 
     // account for the horizontal scrollbar offset in the parent window
     dc.SetDeviceOrigin(m_scrollOffset, 0);


### PR DESCRIPTION

1. Create a generic wxDataViewCtrl having enough columns so that horizontal scroll appears.
2. Scroll to right most to make the last column visible.
3. Keep moving horizontal scroll little left and right.
4. You can see the repainting issue after the last column.

![repainting issue on the right most side of generic header ctrl](https://user-images.githubusercontent.com/9391857/44917656-9f86bb80-ad56-11e8-8c11-ca0c0becac3a.png)
