### PR TITLE
BUG FIX - Crash in tree control because of unchecked pointer usage

### DIFF
--- a/src/common/bookctrl.cpp
+++ b/src/common/bookctrl.cpp
@@ -496,8 +496,11 @@ int wxBookCtrlBase::DoSetSelection(size_t n, int flags)
                 DoShowPage(DoGetNonNullPage(oldSel), false);
 
             wxWindow* const page = DoGetNonNullPage(n);
-            page->SetSize(GetPageRect());
-            DoShowPage(page, true);
+            if ( page )
+            {
+                page->SetSize(GetPageRect());
+                DoShowPage(page, true);
+			}
 
             // change selection now to ignore the selection change event
             m_selection = n;


### PR DESCRIPTION
Bug occurs when adding a NULL page to a tree like:
  treebookCtrlPtr = new wxTreebook(this,wxID_ANY);
  treebookCtrlPtr->AddPage(NULL,"NULL");