### PR TITLE
Build more toolkits with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,18 @@ matrix:
         - os: osx
           compiler: clang
           env: wxTOOLSET=cmake wxCMAKE_GENERATOR=Xcode wxCMAKE_DEFINES="-DCMAKE_CXX_STANDARD=11"
+        - dist: trusty
+          compiler: gcc
+          env: wxCONFIGURE_FLAGS="--with-x11 --enable-pch --disable-stc" wxSKIP_SAMPLES=1
+        - dist: trusty
+          compiler: gcc
+          env: wxCONFIGURE_FLAGS="--with-directfb --enable-pch --disable-stc" wxSKIP_SAMPLES=1
+        - dist: trusty
+          compiler: gcc
+          env: wxCONFIGURE_FLAGS="--with-motif --enable-pch --disable-stc" wxSKIP_SAMPLES=1
+        - dist: trusty
+          compiler: gcc
+          env: wxCONFIGURE_FLAGS="--with-qt --enable-pch" wxSKIP_SAMPLES=1
 
 branches:
     only:

--- a/Makefile.in
+++ b/Makefile.in
@@ -2604,6 +2604,7 @@ COND_PLATFORM_WIN32_1_BASE_PLATFORM_HDR =  \
 	wx/msw/fswatcher.h
 @COND_PLATFORM_WIN32_1@BASE_PLATFORM_HDR = $(COND_PLATFORM_WIN32_1_BASE_PLATFORM_HDR)
 COND_TOOLKIT_DFB_LOWLEVEL_HDR =  \
+	wx/generic/animate.h \
 	wx/generic/caret.h \
 	wx/generic/colour.h \
 	wx/generic/icon.h \
@@ -4838,6 +4839,7 @@ COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS =  \
 @COND_USE_GUI_1_WXUNIV_1@__CORE_SRC_OBJECTS = $(COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS)
 COND_TOOLKIT_DFB___LOWLEVEL_SRC_OBJECTS =  \
 	monodll_fontmgrcmn.o \
+	monodll_animateg.o \
 	monodll_generic_caret.o \
 	monodll_generic_colour.o \
 	monodll_generic_icon.o \
@@ -5728,6 +5730,7 @@ COND_TOOLKIT_QT___GUI_SRC_OBJECTS =  \
 @COND_TOOLKIT_QT@__GUI_SRC_OBJECTS = $(COND_TOOLKIT_QT___GUI_SRC_OBJECTS)
 COND_TOOLKIT_DFB___LOWLEVEL_SRC_OBJECTS_1 =  \
 	monodll_fontmgrcmn.o \
+	monodll_animateg.o \
 	monodll_generic_caret.o \
 	monodll_generic_colour.o \
 	monodll_generic_icon.o \
@@ -6800,6 +6803,7 @@ COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_1 =  \
 @COND_USE_GUI_1_WXUNIV_1@__CORE_SRC_OBJECTS_1 = $(COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_1)
 COND_TOOLKIT_DFB___LOWLEVEL_SRC_OBJECTS_2 =  \
 	monolib_fontmgrcmn.o \
+	monolib_animateg.o \
 	monolib_generic_caret.o \
 	monolib_generic_colour.o \
 	monolib_generic_icon.o \
@@ -7690,6 +7694,7 @@ COND_TOOLKIT_QT___GUI_SRC_OBJECTS_1 =  \
 @COND_TOOLKIT_QT@__GUI_SRC_OBJECTS_1 = $(COND_TOOLKIT_QT___GUI_SRC_OBJECTS_1)
 COND_TOOLKIT_DFB___LOWLEVEL_SRC_OBJECTS_3 =  \
 	monolib_fontmgrcmn.o \
+	monolib_animateg.o \
 	monolib_generic_caret.o \
 	monolib_generic_colour.o \
 	monolib_generic_icon.o \
@@ -8909,6 +8914,7 @@ COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_2 =  \
 @COND_USE_GUI_1_WXUNIV_1@__CORE_SRC_OBJECTS_2 = $(COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_2)
 COND_TOOLKIT_DFB___LOWLEVEL_SRC_OBJECTS_4 =  \
 	coredll_fontmgrcmn.o \
+	coredll_animateg.o \
 	coredll_generic_caret.o \
 	coredll_generic_colour.o \
 	coredll_generic_icon.o \
@@ -9799,6 +9805,7 @@ COND_TOOLKIT_QT___GUI_SRC_OBJECTS_2 =  \
 @COND_TOOLKIT_QT@__GUI_SRC_OBJECTS_2 = $(COND_TOOLKIT_QT___GUI_SRC_OBJECTS_2)
 COND_TOOLKIT_DFB___LOWLEVEL_SRC_OBJECTS_5 =  \
 	coredll_fontmgrcmn.o \
+	coredll_animateg.o \
 	coredll_generic_caret.o \
 	coredll_generic_colour.o \
 	coredll_generic_icon.o \
@@ -10613,6 +10620,7 @@ COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_3 =  \
 @COND_USE_GUI_1_WXUNIV_1@__CORE_SRC_OBJECTS_3 = $(COND_USE_GUI_1_WXUNIV_1___CORE_SRC_OBJECTS_3)
 COND_TOOLKIT_DFB___LOWLEVEL_SRC_OBJECTS_6 =  \
 	corelib_fontmgrcmn.o \
+	corelib_animateg.o \
 	corelib_generic_caret.o \
 	corelib_generic_colour.o \
 	corelib_generic_icon.o \
@@ -11503,6 +11511,7 @@ COND_TOOLKIT_QT___GUI_SRC_OBJECTS_3 =  \
 @COND_TOOLKIT_QT@__GUI_SRC_OBJECTS_3 = $(COND_TOOLKIT_QT___GUI_SRC_OBJECTS_3)
 COND_TOOLKIT_DFB___LOWLEVEL_SRC_OBJECTS_7 =  \
 	corelib_fontmgrcmn.o \
+	corelib_animateg.o \
 	corelib_generic_caret.o \
 	corelib_generic_colour.o \
 	corelib_generic_icon.o \
@@ -18824,6 +18833,33 @@ monodll_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(MONODLL_ODEP)
 @COND_TOOLKIT_DFB_USE_GUI_1@monodll_fontmgrcmn.o: $(srcdir)/src/common/fontmgrcmn.cpp $(MONODLL_ODEP)
 @COND_TOOLKIT_DFB_USE_GUI_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/common/fontmgrcmn.cpp
 
+@COND_TOOLKIT_GTK_TOOLKIT_VERSION__USE_GUI_1_WXUNIV_0@monodll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONODLL_ODEP)
+@COND_TOOLKIT_GTK_TOOLKIT_VERSION__USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@monodll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONODLL_ODEP)
+@COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@monodll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONODLL_ODEP)
+@COND_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@monodll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONODLL_ODEP)
+@COND_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_QT_USE_GUI_1_WXUNIV_0@monodll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONODLL_ODEP)
+@COND_TOOLKIT_QT_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_DFB_USE_GUI_1@monodll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONODLL_ODEP)
+@COND_TOOLKIT_DFB_USE_GUI_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_GTK_TOOLKIT_VERSION_2_USE_GUI_1_WXUNIV_1@monodll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONODLL_ODEP)
+@COND_TOOLKIT_GTK_TOOLKIT_VERSION_2_USE_GUI_1_WXUNIV_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_MSW_USE_GUI_1@monodll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONODLL_ODEP)
+@COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_X11_USE_GUI_1_WXUNIV_1@monodll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONODLL_ODEP)
+@COND_TOOLKIT_X11_USE_GUI_1_WXUNIV_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
 @COND_TOOLKIT_DFB_USE_GUI_1@monodll_generic_colour.o: $(srcdir)/src/generic/colour.cpp $(MONODLL_ODEP)
 @COND_TOOLKIT_DFB_USE_GUI_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/colour.cpp
 
@@ -19666,30 +19702,6 @@ monodll_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(MONODLL_ODEP)
 
 @COND_USE_GUI_1_WXUNIV_1@monodll_fontpickerg.o: $(srcdir)/src/generic/fontpickerg.cpp $(MONODLL_ODEP)
 @COND_USE_GUI_1_WXUNIV_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/fontpickerg.cpp
-
-@COND_TOOLKIT_GTK_TOOLKIT_VERSION__USE_GUI_1_WXUNIV_0@monodll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONODLL_ODEP)
-@COND_TOOLKIT_GTK_TOOLKIT_VERSION__USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@monodll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONODLL_ODEP)
-@COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@monodll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONODLL_ODEP)
-@COND_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@monodll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONODLL_ODEP)
-@COND_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_QT_USE_GUI_1_WXUNIV_0@monodll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONODLL_ODEP)
-@COND_TOOLKIT_QT_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_GTK_TOOLKIT_VERSION_2_USE_GUI_1_WXUNIV_1@monodll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONODLL_ODEP)
-@COND_TOOLKIT_GTK_TOOLKIT_VERSION_2_USE_GUI_1_WXUNIV_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_MSW_USE_GUI_1@monodll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONODLL_ODEP)
-@COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_X11_USE_GUI_1_WXUNIV_1@monodll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONODLL_ODEP)
-@COND_TOOLKIT_X11_USE_GUI_1_WXUNIV_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
 
 @COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@monodll_mdig.o: $(srcdir)/src/generic/mdig.cpp $(MONODLL_ODEP)
 @COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/mdig.cpp
@@ -24062,6 +24074,33 @@ monolib_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(MONOLIB_ODEP)
 @COND_TOOLKIT_DFB_USE_GUI_1@monolib_fontmgrcmn.o: $(srcdir)/src/common/fontmgrcmn.cpp $(MONOLIB_ODEP)
 @COND_TOOLKIT_DFB_USE_GUI_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/common/fontmgrcmn.cpp
 
+@COND_TOOLKIT_GTK_TOOLKIT_VERSION__USE_GUI_1_WXUNIV_0@monolib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONOLIB_ODEP)
+@COND_TOOLKIT_GTK_TOOLKIT_VERSION__USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@monolib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONOLIB_ODEP)
+@COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@monolib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONOLIB_ODEP)
+@COND_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@monolib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONOLIB_ODEP)
+@COND_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_QT_USE_GUI_1_WXUNIV_0@monolib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONOLIB_ODEP)
+@COND_TOOLKIT_QT_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_DFB_USE_GUI_1@monolib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONOLIB_ODEP)
+@COND_TOOLKIT_DFB_USE_GUI_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_GTK_TOOLKIT_VERSION_2_USE_GUI_1_WXUNIV_1@monolib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONOLIB_ODEP)
+@COND_TOOLKIT_GTK_TOOLKIT_VERSION_2_USE_GUI_1_WXUNIV_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_MSW_USE_GUI_1@monolib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONOLIB_ODEP)
+@COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_X11_USE_GUI_1_WXUNIV_1@monolib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONOLIB_ODEP)
+@COND_TOOLKIT_X11_USE_GUI_1_WXUNIV_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
 @COND_TOOLKIT_DFB_USE_GUI_1@monolib_generic_colour.o: $(srcdir)/src/generic/colour.cpp $(MONOLIB_ODEP)
 @COND_TOOLKIT_DFB_USE_GUI_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/colour.cpp
 
@@ -24904,30 +24943,6 @@ monolib_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(MONOLIB_ODEP)
 
 @COND_USE_GUI_1_WXUNIV_1@monolib_fontpickerg.o: $(srcdir)/src/generic/fontpickerg.cpp $(MONOLIB_ODEP)
 @COND_USE_GUI_1_WXUNIV_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/fontpickerg.cpp
-
-@COND_TOOLKIT_GTK_TOOLKIT_VERSION__USE_GUI_1_WXUNIV_0@monolib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONOLIB_ODEP)
-@COND_TOOLKIT_GTK_TOOLKIT_VERSION__USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@monolib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONOLIB_ODEP)
-@COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@monolib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONOLIB_ODEP)
-@COND_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@monolib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONOLIB_ODEP)
-@COND_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_QT_USE_GUI_1_WXUNIV_0@monolib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONOLIB_ODEP)
-@COND_TOOLKIT_QT_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_GTK_TOOLKIT_VERSION_2_USE_GUI_1_WXUNIV_1@monolib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONOLIB_ODEP)
-@COND_TOOLKIT_GTK_TOOLKIT_VERSION_2_USE_GUI_1_WXUNIV_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_MSW_USE_GUI_1@monolib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONOLIB_ODEP)
-@COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_X11_USE_GUI_1_WXUNIV_1@monolib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(MONOLIB_ODEP)
-@COND_TOOLKIT_X11_USE_GUI_1_WXUNIV_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
 
 @COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@monolib_mdig.o: $(srcdir)/src/generic/mdig.cpp $(MONOLIB_ODEP)
 @COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/mdig.cpp
@@ -29393,6 +29408,33 @@ coredll_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(COREDLL_ODEP)
 @COND_TOOLKIT_DFB_USE_GUI_1@coredll_fontmgrcmn.o: $(srcdir)/src/common/fontmgrcmn.cpp $(COREDLL_ODEP)
 @COND_TOOLKIT_DFB_USE_GUI_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/common/fontmgrcmn.cpp
 
+@COND_TOOLKIT_GTK_TOOLKIT_VERSION__USE_GUI_1_WXUNIV_0@coredll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(COREDLL_ODEP)
+@COND_TOOLKIT_GTK_TOOLKIT_VERSION__USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@coredll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(COREDLL_ODEP)
+@COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@coredll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(COREDLL_ODEP)
+@COND_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@coredll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(COREDLL_ODEP)
+@COND_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_QT_USE_GUI_1_WXUNIV_0@coredll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(COREDLL_ODEP)
+@COND_TOOLKIT_QT_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_DFB_USE_GUI_1@coredll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(COREDLL_ODEP)
+@COND_TOOLKIT_DFB_USE_GUI_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_GTK_TOOLKIT_VERSION_2_USE_GUI_1_WXUNIV_1@coredll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(COREDLL_ODEP)
+@COND_TOOLKIT_GTK_TOOLKIT_VERSION_2_USE_GUI_1_WXUNIV_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_MSW_USE_GUI_1@coredll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(COREDLL_ODEP)
+@COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_X11_USE_GUI_1_WXUNIV_1@coredll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(COREDLL_ODEP)
+@COND_TOOLKIT_X11_USE_GUI_1_WXUNIV_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
 @COND_TOOLKIT_DFB_USE_GUI_1@coredll_generic_colour.o: $(srcdir)/src/generic/colour.cpp $(COREDLL_ODEP)
 @COND_TOOLKIT_DFB_USE_GUI_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/colour.cpp
 
@@ -30235,30 +30277,6 @@ coredll_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(COREDLL_ODEP)
 
 @COND_USE_GUI_1_WXUNIV_1@coredll_fontpickerg.o: $(srcdir)/src/generic/fontpickerg.cpp $(COREDLL_ODEP)
 @COND_USE_GUI_1_WXUNIV_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/fontpickerg.cpp
-
-@COND_TOOLKIT_GTK_TOOLKIT_VERSION__USE_GUI_1_WXUNIV_0@coredll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(COREDLL_ODEP)
-@COND_TOOLKIT_GTK_TOOLKIT_VERSION__USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@coredll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(COREDLL_ODEP)
-@COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@coredll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(COREDLL_ODEP)
-@COND_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@coredll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(COREDLL_ODEP)
-@COND_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_QT_USE_GUI_1_WXUNIV_0@coredll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(COREDLL_ODEP)
-@COND_TOOLKIT_QT_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_GTK_TOOLKIT_VERSION_2_USE_GUI_1_WXUNIV_1@coredll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(COREDLL_ODEP)
-@COND_TOOLKIT_GTK_TOOLKIT_VERSION_2_USE_GUI_1_WXUNIV_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_MSW_USE_GUI_1@coredll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(COREDLL_ODEP)
-@COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_X11_USE_GUI_1_WXUNIV_1@coredll_animateg.o: $(srcdir)/src/generic/animateg.cpp $(COREDLL_ODEP)
-@COND_TOOLKIT_X11_USE_GUI_1_WXUNIV_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
 
 @COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@coredll_mdig.o: $(srcdir)/src/generic/mdig.cpp $(COREDLL_ODEP)
 @COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/mdig.cpp
@@ -33626,6 +33644,33 @@ corelib_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(CORELIB_ODEP)
 @COND_TOOLKIT_DFB_USE_GUI_1@corelib_fontmgrcmn.o: $(srcdir)/src/common/fontmgrcmn.cpp $(CORELIB_ODEP)
 @COND_TOOLKIT_DFB_USE_GUI_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/common/fontmgrcmn.cpp
 
+@COND_TOOLKIT_GTK_TOOLKIT_VERSION__USE_GUI_1_WXUNIV_0@corelib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(CORELIB_ODEP)
+@COND_TOOLKIT_GTK_TOOLKIT_VERSION__USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@corelib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(CORELIB_ODEP)
+@COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@corelib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(CORELIB_ODEP)
+@COND_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@corelib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(CORELIB_ODEP)
+@COND_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_QT_USE_GUI_1_WXUNIV_0@corelib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(CORELIB_ODEP)
+@COND_TOOLKIT_QT_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_DFB_USE_GUI_1@corelib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(CORELIB_ODEP)
+@COND_TOOLKIT_DFB_USE_GUI_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_GTK_TOOLKIT_VERSION_2_USE_GUI_1_WXUNIV_1@corelib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(CORELIB_ODEP)
+@COND_TOOLKIT_GTK_TOOLKIT_VERSION_2_USE_GUI_1_WXUNIV_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_MSW_USE_GUI_1@corelib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(CORELIB_ODEP)
+@COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
+@COND_TOOLKIT_X11_USE_GUI_1_WXUNIV_1@corelib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(CORELIB_ODEP)
+@COND_TOOLKIT_X11_USE_GUI_1_WXUNIV_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
+
 @COND_TOOLKIT_DFB_USE_GUI_1@corelib_generic_colour.o: $(srcdir)/src/generic/colour.cpp $(CORELIB_ODEP)
 @COND_TOOLKIT_DFB_USE_GUI_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/colour.cpp
 
@@ -34468,30 +34513,6 @@ corelib_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(CORELIB_ODEP)
 
 @COND_USE_GUI_1_WXUNIV_1@corelib_fontpickerg.o: $(srcdir)/src/generic/fontpickerg.cpp $(CORELIB_ODEP)
 @COND_USE_GUI_1_WXUNIV_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/fontpickerg.cpp
-
-@COND_TOOLKIT_GTK_TOOLKIT_VERSION__USE_GUI_1_WXUNIV_0@corelib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(CORELIB_ODEP)
-@COND_TOOLKIT_GTK_TOOLKIT_VERSION__USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@corelib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(CORELIB_ODEP)
-@COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@corelib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(CORELIB_ODEP)
-@COND_TOOLKIT_OSX_COCOA_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@corelib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(CORELIB_ODEP)
-@COND_TOOLKIT_OSX_IPHONE_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_QT_USE_GUI_1_WXUNIV_0@corelib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(CORELIB_ODEP)
-@COND_TOOLKIT_QT_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_GTK_TOOLKIT_VERSION_2_USE_GUI_1_WXUNIV_1@corelib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(CORELIB_ODEP)
-@COND_TOOLKIT_GTK_TOOLKIT_VERSION_2_USE_GUI_1_WXUNIV_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_MSW_USE_GUI_1@corelib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(CORELIB_ODEP)
-@COND_TOOLKIT_MSW_USE_GUI_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
-
-@COND_TOOLKIT_X11_USE_GUI_1_WXUNIV_1@corelib_animateg.o: $(srcdir)/src/generic/animateg.cpp $(CORELIB_ODEP)
-@COND_TOOLKIT_X11_USE_GUI_1_WXUNIV_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/animateg.cpp
 
 @COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@corelib_mdig.o: $(srcdir)/src/generic/mdig.cpp $(CORELIB_ODEP)
 @COND_TOOLKIT_MOTIF_USE_GUI_1_WXUNIV_0@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/mdig.cpp

--- a/build/bakefiles/files.bkl
+++ b/build/bakefiles/files.bkl
@@ -2297,6 +2297,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
 
 <set var="DFB_LOWLEVEL_SRC" hints="files">
     src/common/fontmgrcmn.cpp
+    src/generic/animateg.cpp
     src/generic/caret.cpp
     src/generic/colour.cpp
     src/generic/icon.cpp
@@ -2327,6 +2328,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     src/dfb/wrapdfb.cpp
 </set>
 <set var="DFB_LOWLEVEL_HDR" hints="files">
+    wx/generic/animate.h
     wx/generic/caret.h
     wx/generic/colour.h
     wx/generic/icon.h

--- a/build/cmake/files.cmake
+++ b/build/cmake/files.cmake
@@ -2208,6 +2208,7 @@ set(DFB_LOWLEVEL_SRC
     src/dfb/utils.cpp
     src/dfb/window.cpp
     src/dfb/wrapdfb.cpp
+    src/generic/animateg.cpp
 )
 
 set(DFB_LOWLEVEL_HDR
@@ -2236,6 +2237,7 @@ set(DFB_LOWLEVEL_HDR
     wx/dfb/toplevel.h
     wx/dfb/window.h
     wx/dfb/wrapdfb.h
+    wx/generic/animate.h
 )
 
 set(OSX_LOWLEVEL_SRC

--- a/build/files
+++ b/build/files
@@ -2169,6 +2169,7 @@ MSW_DESKTOP_HDR =
 
 DFB_LOWLEVEL_SRC =
     src/common/fontmgrcmn.cpp
+    src/generic/animateg.cpp
     src/generic/caret.cpp
     src/generic/colour.cpp
     src/generic/icon.cpp
@@ -2197,6 +2198,7 @@ DFB_LOWLEVEL_SRC =
     src/dfb/window.cpp
     src/dfb/wrapdfb.cpp
 DFB_LOWLEVEL_HDR =
+    wx/generic/animate.h
     wx/generic/caret.h
     wx/generic/colour.h
     wx/generic/icon.h

--- a/build/tools/before_install.sh
+++ b/build/tools/before_install.sh
@@ -14,7 +14,14 @@ case $(uname -s) in
                 3) libgtk_dev=libgtk-3-dev ;;
                 *) libgtk_dev=libgtk2.0-dev;;
             esac
-            $SUDO apt-get install -y $libgtk_dev libnotify-dev
+
+            case "$wxCONFIGURE_FLAGS" in
+                *--with-directfb*) libtoolkit_dev='libdirectfb-dev'         ;;
+                *--with-motif*)    libtoolkit_dev='libmotif-dev libxmu-dev' ;;
+                *--with-qt*)       libtoolkit_dev='qtdeclarative5-dev'      ;;
+            esac
+
+            $SUDO apt-get install -y $libgtk_dev $libtoolkit_dev libnotify-dev
         fi
         ;;
 

--- a/configure
+++ b/configure
@@ -36963,6 +36963,10 @@ fi
         elif test "$WXGTK3" = 1; then
                                                 wxUSE_UIACTIONSIMULATOR=no
         fi
+    elif test "$wxUSE_DFB" = 1; then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: wxUIActionSimulator not yet supported under $TOOLKIT... disabled" >&5
+$as_echo "$as_me: WARNING: wxUIActionSimulator not yet supported under $TOOLKIT... disabled" >&2;}
+        wxUSE_UIACTIONSIMULATOR=no
     fi
 
     if test "$wxUSE_UIACTIONSIMULATOR" = "yes" ; then
@@ -37391,8 +37395,8 @@ if test "$wxUSE_TOOLTIPS" = "yes"; then
 $as_echo "$as_me: WARNING: wxTooltip not supported yet under Motif... disabled" >&2;}
     else
         if test "$wxUSE_UNIVERSAL" = "yes"; then
-            { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: wxTooltip not supported yet in wxUniversal... disabled" >&5
-$as_echo "$as_me: WARNING: wxTooltip not supported yet in wxUniversal... disabled" >&2;}
+            { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: wxTooltip not supported yet in $TOOLKIT... disabled" >&5
+$as_echo "$as_me: WARNING: wxTooltip not supported yet in $TOOLKIT... disabled" >&2;}
         else
             $as_echo "#define wxUSE_TOOLTIPS 1" >>confdefs.h
 

--- a/configure.in
+++ b/configure.in
@@ -6597,6 +6597,9 @@ if test "$wxUSE_UIACTIONSIMULATOR" = "yes" ; then
             dnl he's doing if --without-xtest was explicitly specified.
             wxUSE_UIACTIONSIMULATOR=no
         fi
+    elif test "$wxUSE_DFB" = 1; then
+        AC_MSG_WARN([wxUIActionSimulator not yet supported under $TOOLKIT... disabled])
+        wxUSE_UIACTIONSIMULATOR=no
     fi
 
     if test "$wxUSE_UIACTIONSIMULATOR" = "yes" ; then
@@ -6960,7 +6963,7 @@ if test "$wxUSE_TOOLTIPS" = "yes"; then
         AC_MSG_WARN([wxTooltip not supported yet under Motif... disabled])
     else
         if test "$wxUSE_UNIVERSAL" = "yes"; then
-            AC_MSG_WARN([wxTooltip not supported yet in wxUniversal... disabled])
+            AC_MSG_WARN([wxTooltip not supported yet in $TOOLKIT... disabled])
         else
             AC_DEFINE(wxUSE_TOOLTIPS)
         fi

--- a/include/wx/bitmap.h
+++ b/include/wx/bitmap.h
@@ -167,7 +167,7 @@ public:
     wxBitmap(const wxSize& sz, int depth = wxBITMAP_SCREEN_DEPTH);
     wxBitmap(const char* const* bits);
     wxBitmap(const wxString &filename, wxBitmapType type = wxBITMAP_TYPE_XPM);
-    wxBitmap(const wxImage& image, int depth = wxBITMAP_SCREEN_DEPTH);
+    wxBitmap(const wxImage& image, int depth = wxBITMAP_SCREEN_DEPTH, double scale = 1.0);
 
     static void InitStandardHandlers();
     */

--- a/include/wx/dfb/font.h
+++ b/include/wx/dfb/font.h
@@ -39,6 +39,8 @@ public:
 
     wxFont(const wxNativeFontInfo& info) { Create(info); }
 
+    wxFont(const wxString& nativeFontInfoString);
+
     wxFont(int size,
            wxFontFamily family,
            wxFontStyle style,

--- a/include/wx/dfb/region.h
+++ b/include/wx/dfb/region.h
@@ -17,6 +17,7 @@ public:
     wxRegion(wxCoord x, wxCoord y, wxCoord w, wxCoord h);
     wxRegion(const wxPoint& topLeft, const wxPoint& bottomRight);
     wxRegion(const wxRect& rect);
+    wxRegion(size_t n, const wxPoint *points, wxPolygonFillMode fillStyle = wxODDEVEN_RULE);
     wxRegion(const wxBitmap& bmp)
     {
         Union(bmp);

--- a/include/wx/motif/font.h
+++ b/include/wx/motif/font.h
@@ -29,6 +29,8 @@ public:
 
     wxFont(const wxFontInfo& info);
 
+    wxFont(const wxString& nativeFontInfoString);
+
     wxFont(const wxNativeFontInfo& info);
 
     wxFont(int size,

--- a/src/dfb/evtloop.cpp
+++ b/src/dfb/evtloop.cpp
@@ -25,6 +25,7 @@
     #include "wx/log.h"
 #endif
 
+#include "wx/apptrait.h"
 #include "wx/thread.h"
 #include "wx/private/fdiodispatcher.h"
 #include "wx/dfb/private.h"
@@ -214,4 +215,9 @@ void wxGUIEventLoop::DoYieldFor(long eventsToProcess)
     OnNextIteration();
 
     wxEventLoopBase::DoYieldFor(eventsToProcess);
+}
+
+wxEventLoopSourcesManagerBase* wxGUIAppTraits::GetEventLoopSourcesManager()
+{
+    return wxAppTraits::GetEventLoopSourcesManager();
 }

--- a/src/dfb/font.cpp
+++ b/src/dfb/font.cpp
@@ -38,6 +38,13 @@ typedef wxFontMgrFontRefData wxFontRefData;
 // wxFont
 // ----------------------------------------------------------------------------
 
+wxFont::wxFont(const wxString& nativeFontInfoString)
+{
+    wxNativeFontInfo info;
+    if ( info.FromString(nativeFontInfoString) )
+        (void)Create(info);
+}
+
 bool wxFont::Create(const wxNativeFontInfo& info)
 {
     m_refData = new wxFontRefData(info.pointSize,

--- a/src/dfb/region.cpp
+++ b/src/dfb/region.cpp
@@ -74,6 +74,12 @@ wxRegion::wxRegion(const wxRect& r)
     m_refData = new wxRegionRefData(r);
 }
 
+wxRegion::wxRegion(size_t n, const wxPoint *points, wxPolygonFillMode fillStyle)
+{
+#warning "implement this"
+    m_refData = NULL;
+}
+
 wxRegion::~wxRegion()
 {
     // m_refData unrefed in ~wxObject

--- a/src/dfb/window.cpp
+++ b/src/dfb/window.cpp
@@ -312,6 +312,13 @@ void wxWindowDFB::DoReleaseMouse()
     return (wxWindow*)gs_mouseCapture;
 }
 
+wxMouseState wxGetMouseState()
+{
+#warning "implement this"
+    wxMouseState ms;
+    return ms;
+}
+
 bool wxWindowDFB::SetCursor(const wxCursor& cursor)
 {
     if ( !wxWindowBase::SetCursor(cursor) )

--- a/src/motif/font.cpp
+++ b/src/motif/font.cpp
@@ -213,6 +213,13 @@ wxFont::wxFont(const wxNativeFontInfo& info)
     (void)Create(info.GetXFontName());
 }
 
+wxFont::wxFont(const wxString& nativeFontInfoString)
+{
+    wxNativeFontInfo info;
+    if ( info.FromString(nativeFontInfoString) )
+        (void)Create(info.GetXFontName());
+}
+
 wxFont::wxFont(const wxFontInfo& info)
 {
     m_refData = new wxFontRefData(info);

--- a/src/qt/font.cpp
+++ b/src/qt/font.cpp
@@ -20,6 +20,20 @@
 #include "wx/qt/private/utils.h"
 #include "wx/qt/private/converter.h"
 
+// Older versions of QT don't define all the QFont::Weight enum values, so just
+// do it ourselves here for all case instead.
+enum
+{
+    wxQFont_Thin        = 0,
+    wxQFont_ExtraLight  = 12,
+    wxQFont_Light       = QFont::Light,
+    wxQFont_Normal      = QFont::Normal,
+    wxQFont_Medium      = 57,
+    wxQFont_DemiBold    = QFont::DemiBold,
+    wxQFont_Bold        = QFont::Bold,
+    wxQFont_ExtraBold   = 81,
+    wxQFont_Black       = QFont::Black
+};
 
 static QFont::StyleHint ConvertFontFamily(wxFontFamily family)
 {
@@ -70,34 +84,34 @@ static bool TryToMap(int& x, int fromMin, int fromMax, int toMin, int toMax)
 
 static int ConvertFontWeight(int w)
 {
-    // Note that QFont::Thin is 0, so we can't have anything lighter than it.
+    // Note that wxQFont_Thin is 0, so we can't have anything lighter than it.
     if ( TryToMap(w, wxFONTWEIGHT_INVALID, wxFONTWEIGHT_THIN,
-                     QFont::Thin, QFont::Thin) ||
+                     wxQFont_Thin, wxQFont_Thin) ||
          TryToMap(w, wxFONTWEIGHT_THIN, wxFONTWEIGHT_EXTRALIGHT,
-                     QFont::Thin, QFont::ExtraLight) ||
+                     wxQFont_Thin, wxQFont_ExtraLight) ||
          TryToMap(w, wxFONTWEIGHT_EXTRALIGHT, wxFONTWEIGHT_LIGHT,
-                     QFont::ExtraLight, QFont::Light) ||
+                     wxQFont_ExtraLight, wxQFont_Light) ||
          TryToMap(w, wxFONTWEIGHT_LIGHT, wxFONTWEIGHT_NORMAL,
-                     QFont::Light, QFont::Normal) ||
+                     wxQFont_Light, wxQFont_Normal) ||
          TryToMap(w, wxFONTWEIGHT_NORMAL, wxFONTWEIGHT_MEDIUM,
-                     QFont::Normal, QFont::Medium) ||
+                     wxQFont_Normal, wxQFont_Medium) ||
          TryToMap(w, wxFONTWEIGHT_MEDIUM, wxFONTWEIGHT_SEMIBOLD,
-                     QFont::Medium, QFont::DemiBold) ||
+                     wxQFont_Medium, wxQFont_DemiBold) ||
          TryToMap(w, wxFONTWEIGHT_SEMIBOLD, wxFONTWEIGHT_BOLD,
-                     QFont::DemiBold, QFont::Bold) ||
+                     wxQFont_DemiBold, wxQFont_Bold) ||
          TryToMap(w, wxFONTWEIGHT_BOLD, wxFONTWEIGHT_EXTRABOLD,
-                     QFont::Bold, QFont::ExtraBold) ||
+                     wxQFont_Bold, wxQFont_ExtraBold) ||
          TryToMap(w, wxFONTWEIGHT_EXTRABOLD, wxFONTWEIGHT_HEAVY,
-                     QFont::ExtraBold, QFont::Black) ||
+                     wxQFont_ExtraBold, wxQFont_Black) ||
          TryToMap(w, wxFONTWEIGHT_HEAVY, wxFONTWEIGHT_EXTRAHEAVY,
-                     QFont::Black, 99) )
+                     wxQFont_Black, 99) )
     {
         return w;
     }
 
     wxFAIL_MSG("invalid wxFont weight");
 
-    return QFont::Normal;
+    return wxQFont_Normal;
 }
 
 class wxFontRefData: public wxGDIRefData
@@ -354,27 +368,27 @@ int wxNativeFontInfo::GetNumericWeight() const
 {
     int w = m_qtFont.weight();
 
-    // Special case of QFont::Thin == 0.
-    if ( w == QFont::Thin )
+    // Special case of wxQFont_Thin == 0.
+    if ( w == wxQFont_Thin )
         return wxFONTWEIGHT_THIN;
 
-    if ( TryToMap(w, QFont::Thin, QFont::ExtraLight,
+    if ( TryToMap(w, wxQFont_Thin, wxQFont_ExtraLight,
                      wxFONTWEIGHT_THIN, wxFONTWEIGHT_EXTRALIGHT) ||
-         TryToMap(w, QFont::ExtraLight, QFont::Light,
+         TryToMap(w, wxQFont_ExtraLight, wxQFont_Light,
                      wxFONTWEIGHT_EXTRALIGHT, wxFONTWEIGHT_LIGHT) ||
-         TryToMap(w, QFont::Light, QFont::Normal,
+         TryToMap(w, wxQFont_Light, wxQFont_Normal,
                      wxFONTWEIGHT_LIGHT, wxFONTWEIGHT_NORMAL) ||
-         TryToMap(w, QFont::Normal, QFont::Medium,
+         TryToMap(w, wxQFont_Normal, wxQFont_Medium,
                      wxFONTWEIGHT_NORMAL, wxFONTWEIGHT_MEDIUM) ||
-         TryToMap(w, QFont::Medium, QFont::DemiBold,
+         TryToMap(w, wxQFont_Medium, wxQFont_DemiBold,
                      wxFONTWEIGHT_MEDIUM, wxFONTWEIGHT_SEMIBOLD) ||
-         TryToMap(w, QFont::DemiBold, QFont::Bold,
+         TryToMap(w, wxQFont_DemiBold, wxQFont_Bold,
                      wxFONTWEIGHT_SEMIBOLD, wxFONTWEIGHT_BOLD) ||
-         TryToMap(w, QFont::Bold, QFont::ExtraBold,
+         TryToMap(w, wxQFont_Bold, wxQFont_ExtraBold,
                      wxFONTWEIGHT_BOLD, wxFONTWEIGHT_EXTRABOLD) ||
-         TryToMap(w, QFont::ExtraBold, QFont::Black,
+         TryToMap(w, wxQFont_ExtraBold, wxQFont_Black,
                      wxFONTWEIGHT_EXTRABOLD, wxFONTWEIGHT_HEAVY) ||
-         TryToMap(w, QFont::Black, 99,
+         TryToMap(w, wxQFont_Black, 99,
                      wxFONTWEIGHT_HEAVY, wxFONTWEIGHT_EXTRAHEAVY) )
     {
         return w;

--- a/src/qt/font.cpp
+++ b/src/qt/font.cpp
@@ -22,16 +22,22 @@
 
 // Older versions of QT don't define all the QFont::Weight enum values, so just
 // do it ourselves here for all case instead.
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 5, 0))
+#define wxQFontEnumOrInt(a, b) a
+#else
+#define wxQFontEnumOrInt(a, b) b
+#endif
+
 enum
 {
-    wxQFont_Thin        = 0,
-    wxQFont_ExtraLight  = 12,
+    wxQFont_Thin        = wxQFontEnumOrInt( QFont::Thin, 0 ),
+    wxQFont_ExtraLight  = wxQFontEnumOrInt( QFont::ExtraLight, 12 ),
     wxQFont_Light       = QFont::Light,
     wxQFont_Normal      = QFont::Normal,
-    wxQFont_Medium      = 57,
+    wxQFont_Medium      = wxQFontEnumOrInt( QFont::Medium, 57 ),
     wxQFont_DemiBold    = QFont::DemiBold,
     wxQFont_Bold        = QFont::Bold,
-    wxQFont_ExtraBold   = 81,
+    wxQFont_ExtraBold   = wxQFontEnumOrInt( QFont::ExtraBold, 81 ),
     wxQFont_Black       = QFont::Black
 };
 

--- a/src/qt/uiaction.cpp
+++ b/src/qt/uiaction.cpp
@@ -31,9 +31,9 @@ using namespace QTest;
 
 // Apparently {mouse,key}Event() functions signature has changed from QWidget
 // to QWindow at some time during Qt5, but we don't know when exactly. We do
-// know that they take QWindow for 5.3 and, presumably, later versions (but not
+// know that they take QWindow for 5.2 and, presumably, later versions (but not
 // for whichever version this code was originally written for).
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 2, 0))
 inline QWindow* argForEvents(QWidget* w) { return w->windowHandle(); }
 #else
 inline QWidget* argForEvents(QWidget* w) { return w; }

--- a/tests/controls/htmllboxtest.cpp
+++ b/tests/controls/htmllboxtest.cpp
@@ -8,6 +8,8 @@
 
 #include "testprec.h"
 
+#if wxUSE_HTML
+
 #ifdef __BORLANDC__
     #pragma hdrstop
 #endif
@@ -56,3 +58,5 @@ void HtmlListBoxTestCase::tearDown()
 {
     wxDELETE(m_htmllbox);
 }
+
+#endif //wxUSE_HTML

--- a/tests/controls/notebooktest.cpp
+++ b/tests/controls/notebooktest.cpp
@@ -106,7 +106,7 @@ void NotebookTestCase::NoEventsOnDestruction()
 
     // Normally deleting a page before the selected one results in page
     // selection changing and the corresponding event.
-    m_notebook->DeletePage(0);
+    m_notebook->DeletePage(static_cast<size_t>(0));
     CHECK( m_numPageChanges == 1 );
 
     // But deleting the entire control shouldn't generate any events, yet it

--- a/tests/controls/spinctrldbltest.cpp
+++ b/tests/controls/spinctrldbltest.cpp
@@ -89,7 +89,7 @@ void SpinCtrlDoubleTestCase::NoEventsInCtor()
 
 void SpinCtrlDoubleTestCase::Arrows()
 {
-#ifndef __WXGTK__
+#if wxUSE_UIACTIONSIMULATOR && !defined(__WXGTK__)
     EventCounter updated(m_spin, wxEVT_SPINCTRLDOUBLE);
 
     wxUIActionSimulator sim;

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -89,7 +89,8 @@ void BitmapTestCase::Mask()
     m_bmp.SetMask(mask);
 
     // copying masks should work
-    wxMask *mask2 = new wxMask(*mask);
+    wxMask *mask2 = NULL;
+    REQUIRE_NOTHROW(mask2 = new wxMask(*mask));
     m_bmp.SetMask(mask2);
 }
 

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -12,6 +12,8 @@
 
 #include "testprec.h"
 
+#ifdef wxHAS_RAW_BITMAP
+
 #ifdef __BORLANDC__
     #pragma hdrstop
 #endif
@@ -153,3 +155,5 @@ void BitmapTestCase::OverlappingBlit()
         }
     }
 }
+
+#endif //wxHAS_RAW_BITMAP

--- a/tests/html/htmlwindow.cpp
+++ b/tests/html/htmlwindow.cpp
@@ -104,10 +104,12 @@ static const char *TEST_PLAIN_TEXT =
 
 void HtmlWindowTestCase::SelectionToText()
 {
+#if wxUSE_CLIPBOARD
     m_win->SetPage(TEST_MARKUP);
     m_win->SelectAll();
 
     CPPUNIT_ASSERT_EQUAL( TEST_PLAIN_TEXT, m_win->SelectionToText() );
+#endif // wxUSE_CLIPBOARD
 }
 
 void HtmlWindowTestCase::Title()
@@ -159,10 +161,12 @@ void HtmlWindowTestCase::LinkClick()
 
 void HtmlWindowTestCase::AppendToPage()
 {
+#if wxUSE_CLIPBOARD
     m_win->SetPage(TEST_MARKUP_LINK);
     m_win->AppendToPage("A new paragraph");
 
     CPPUNIT_ASSERT_EQUAL("link A new paragraph", m_win->ToText());
+#endif // wxUSE_CLIPBOARD
 }
 
 #endif //wxUSE_HTML

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1250,6 +1250,7 @@ void ImageTestCase::GIFComment()
     // Test writing comments in an animated GIF and reading them back.
     CPPUNIT_ASSERT( image.LoadFile("horse.gif") );
 
+#if wxUSE_PALETTE
     wxImageArray images;
     int i;
     for (i = 0; i < 4; ++i)
@@ -1287,6 +1288,7 @@ void ImageTestCase::GIFComment()
             image.GetOption(wxIMAGE_OPTION_GIF_COMMENT));
         memIn.SeekI(pos);
     }
+#endif //wxUSE_PALETTE
 }
 
 #endif // wxUSE_GIF

--- a/tests/misc/guifuncs.cpp
+++ b/tests/misc/guifuncs.cpp
@@ -90,6 +90,7 @@ void MiscGUIFuncsTestCase::DisplaySize()
 
 void MiscGUIFuncsTestCase::URLDataObject()
 {
+#if wxUSE_DATAOBJ
     // this tests for buffer overflow, see #11102
     const char * const
         url = "http://something.long.to.overwrite.plenty.memory.example.com";
@@ -99,6 +100,7 @@ void MiscGUIFuncsTestCase::URLDataObject()
     wxClipboardLocker lockClip;
     CPPUNIT_ASSERT( wxTheClipboard->SetData(dobj) );
     wxTheClipboard->Flush();
+#endif // wxUSE_DATAOBJ
 }
 
 void MiscGUIFuncsTestCase::ParseFileDialogFilter()


### PR DESCRIPTION
Use Travis CI to build the `wxX11`, `wxDFB`, `wxMotif` and `wxQT` toolkits, `gtk1` toolkit is not available.

This could be cherry-picked into https://github.com/wxWidgets/wxWidgets/pull/919 to simplify testing. But first see if it passes `configure` stage.