### PR TITLE
[wxMSW] Deprecate wxBitmap::SetWidth/SetHeight etc. functions

### DIFF
--- a/include/wx/msw/bitmap.h
+++ b/include/wx/msw/bitmap.h
@@ -199,7 +199,9 @@ public:
     void MSWUpdateAlpha();
 
 public:
-    void SetHBITMAP(WXHBITMAP bmp) { SetHandle((WXHANDLE)bmp); }
+#if WXWIN_COMPATIBILITY_3_0
+    wxDEPRECATED_INLINE(void SetHBITMAP(WXHBITMAP bmp), SetHandle((WXHANDLE)bmp); )
+#endif // WXWIN_COMPATIBILITY_3_0
     WXHBITMAP GetHBITMAP() const { return (WXHBITMAP)GetHandle(); }
     bool InitFromHBITMAP(WXHBITMAP bmp, int width, int height, int depth);
     void ResetHBITMAP() { InitFromHBITMAP(NULL, 0, 0, 0); }

--- a/include/wx/msw/bitmap.h
+++ b/include/wx/msw/bitmap.h
@@ -201,6 +201,8 @@ public:
 public:
     void SetHBITMAP(WXHBITMAP bmp) { SetHandle((WXHANDLE)bmp); }
     WXHBITMAP GetHBITMAP() const { return (WXHBITMAP)GetHandle(); }
+    bool InitFromHBITMAP(WXHBITMAP bmp, int width, int height, int depth);
+    void ResetHBITMAP() { InitFromHBITMAP(NULL, 0, 0, 0); }
 
     void SetSelectedInto(wxDC *dc);
     wxDC *GetSelectedInto() const;

--- a/include/wx/msw/gdiimage.h
+++ b/include/wx/msw/gdiimage.h
@@ -118,16 +118,14 @@ public:
                wxSize(GetGDIImageData()->m_width, GetGDIImageData()->m_height);
     }
 
-    void SetWidth(int w) { AllocExclusive(); GetGDIImageData()->m_width = w; }
-    void SetHeight(int h) { AllocExclusive(); GetGDIImageData()->m_height = h; }
-    void SetDepth(int d) { AllocExclusive(); GetGDIImageData()->m_depth = d; }
+#if WXWIN_COMPATIBILITY_3_0
+    wxDEPRECATED_INLINE(void SetWidth(int w), AllocExclusive(); GetGDIImageData()->m_width = w; )
+    wxDEPRECATED_INLINE(void SetHeight(int h), AllocExclusive(); GetGDIImageData()->m_height = h; )
+    wxDEPRECATED_INLINE(void SetDepth(int d), AllocExclusive(); GetGDIImageData()->m_depth = d; )
 
-    void SetSize(int w, int h)
-    {
-        AllocExclusive();
-        GetGDIImageData()->SetSize(w, h);
-    }
-    void SetSize(const wxSize& size) { SetSize(size.x, size.y); }
+    wxDEPRECATED_INLINE(void SetSize(int w, int h), AllocExclusive(); GetGDIImageData()->SetSize(w, h); )
+    wxDEPRECATED_INLINE(void SetSize(const wxSize& size), AllocExclusive(); GetGDIImageData()->SetSize(size.x, size.y); )
+#endif // WXWIN_COMPATIBILITY_3_0
 
     // forward some of base class virtuals to wxGDIImageRefData
     bool FreeResource(bool force = false) wxOVERRIDE;

--- a/include/wx/msw/icon.h
+++ b/include/wx/msw/icon.h
@@ -69,7 +69,10 @@ public:
     // implementation only from now on
     wxIconRefData *GetIconData() const { return (wxIconRefData *)m_refData; }
 
-    void SetHICON(WXHICON icon) { SetHandle((WXHANDLE)icon); }
+#if WXWIN_COMPATIBILITY_3_0
+    wxDEPRECATED_INLINE(void SetHICON(WXHICON icon), SetHandle((WXHANDLE)icon); )
+#endif // WXWIN_COMPATIBILITY_3_0
+
     WXHICON GetHICON() const { return (WXHICON)GetHandle(); }
     bool InitFromHICON(WXHICON icon, int width, int height);
 

--- a/include/wx/msw/icon.h
+++ b/include/wx/msw/icon.h
@@ -71,6 +71,7 @@ public:
 
     void SetHICON(WXHICON icon) { SetHandle((WXHANDLE)icon); }
     WXHICON GetHICON() const { return (WXHICON)GetHandle(); }
+    bool InitFromHICON(WXHICON icon, int width, int height);
 
     // create from bitmap (which should have a mask unless it's monochrome):
     // there shouldn't be any implicit bitmap -> icon conversion (i.e. no

--- a/src/msw/bitmap.cpp
+++ b/src/msw/bitmap.cpp
@@ -710,7 +710,7 @@ wxBitmap::wxBitmap(const char bits[], int width, int height, int depth)
         free(data);
     }
 
-    SetHBITMAP((WXHBITMAP)hbmp);
+    refData->m_handle = (WXHANDLE)hbmp;
 }
 
 wxBitmap::wxBitmap(int w, int h, const wxDC& dc)
@@ -805,7 +805,7 @@ bool wxBitmap::DoCreate(int w, int h, int d, WXHDC hdc)
 #endif // !ALWAYS_USE_DIB
     }
 
-    SetHBITMAP((WXHBITMAP)hbmp);
+    GetBitmapData()->m_handle = (WXHANDLE)hbmp;
 
     return IsOk();
 }
@@ -898,7 +898,7 @@ bool wxBitmap::CreateFromImage(const wxImage& image, int depth, WXHDC hdc)
 #endif // !ALWAYS_USE_DIB
 
     // validate this object
-    SetHBITMAP((WXHBITMAP)hbitmap);
+    refData->m_handle = (WXHANDLE)hbitmap;
 
     // finally also set the mask if we have one
     if ( image.HasMask() )

--- a/src/msw/bitmap.cpp
+++ b/src/msw/bitmap.cpp
@@ -1290,6 +1290,34 @@ void wxBitmap::SetMask(wxMask *mask)
     GetBitmapData()->SetMask(mask);
 }
 
+bool wxBitmap::InitFromHBITMAP(WXHBITMAP bmp, int width, int height, int depth)
+{
+#if wxDEBUG_LEVEL >= 2
+    if ( bmp != NULL )
+    {
+        BITMAP bm;
+        if ( ::GetObject(bmp, sizeof(bm), &bm) == sizeof(bm) )
+        {
+            wxASSERT_MSG(bm.bmWidth == width && bm.bmHeight == height && bm.bmBitsPixel == depth,
+                         wxS("Inconsistent bitmap parameters"));
+        }
+        else
+        {
+            wxFAIL_MSG(wxS("Cannot retrieve parameters of the bitmap"));
+        }
+    }
+#endif // wxDEBUG_LEVEL >= 2
+
+    AllocExclusive();
+
+    GetBitmapData()->m_handle = (WXHANDLE)bmp;
+    GetBitmapData()->m_width = width;
+    GetBitmapData()->m_height = height;
+    GetBitmapData()->m_depth = depth;
+
+    return IsOk();
+}
+
 // ----------------------------------------------------------------------------
 // raw bitmap access support
 // ----------------------------------------------------------------------------
@@ -1620,9 +1648,7 @@ wxBitmap wxMask::GetBitmap() const
 
     // Create and return a new wxBitmap.
     wxBitmap bmp;
-    bmp.SetHBITMAP((WXHBITMAP)hNewBitmap);
-    bmp.SetSize(bm.bmWidth, bm.bmHeight);
-    bmp.SetDepth(bm.bmBitsPixel);
+    bmp.InitFromHBITMAP((WXHBITMAP)hNewBitmap, bm.bmWidth, bm.bmHeight, bm.bmBitsPixel);
 
     return bmp;
 }

--- a/src/msw/gdiimage.cpp
+++ b/src/msw/gdiimage.cpp
@@ -348,26 +348,31 @@ bool wxBMPResourceHandler::LoadFile(wxBitmap *bitmap,
                                     int WXUNUSED(desiredHeight))
 {
     // TODO: load colourmap.
-    bitmap->SetHBITMAP((WXHBITMAP)::LoadBitmap(wxGetInstance(), name.t_str()));
-
-    if ( !bitmap->IsOk() )
+    HBITMAP hbmp = ::LoadBitmap(wxGetInstance(), name.t_str());
+    if ( hbmp == NULL )
     {
         // it's probably not found
         wxLogError(wxT("Can't load bitmap '%s' from resources! Check .rc file."),
-                   name.c_str());
+            name.c_str());
 
         return false;
     }
 
+    int w, h, d;
     BITMAP bm;
-    if ( !::GetObject(GetHbitmapOf(*bitmap), sizeof(BITMAP), (LPSTR) &bm) )
+    if (::GetObject(hbmp, sizeof(BITMAP), &bm))
+    {
+        w = bm.bmWidth;
+        h = bm.bmHeight;
+        d = bm.bmBitsPixel;
+    }
+    else
     {
         wxLogLastError(wxT("GetObject(HBITMAP)"));
+        w = h = d = 0;
     }
 
-    bitmap->SetWidth(bm.bmWidth);
-    bitmap->SetHeight(bm.bmHeight);
-    bitmap->SetDepth(bm.bmBitsPixel);
+    bitmap->InitFromHBITMAP((WXHBITMAP)hbmp, w, h, d);
 
     // use 0xc0c0c0 as transparent colour by default
     bitmap->SetMask(new wxMask(*bitmap, *wxLIGHT_GREY));

--- a/src/msw/icon.cpp
+++ b/src/msw/icon.cpp
@@ -118,8 +118,7 @@ void wxIcon::CopyFromBitmap(const wxBitmap& bmp)
     }
     else
     {
-        SetHICON((WXHICON)hicon);
-        SetSize(bmp.GetWidth(), bmp.GetHeight());
+        InitFromHICON((WXHICON)hicon, bmp.GetWidth(), bmp.GetHeight());
     }
 }
 
@@ -154,11 +153,26 @@ bool wxIcon::LoadFile(const wxString& filename,
 
 bool wxIcon::CreateFromHICON(WXHICON icon)
 {
-    SetHICON(icon);
-    if ( !IsOk() )
-        return false;
+    wxSize size = wxGetHiconSize(icon);
+    return InitFromHICON(icon, size.GetWidth(), size.GetHeight());
+}
 
-    SetSize(wxGetHiconSize(icon));
+bool wxIcon::InitFromHICON(WXHICON icon, int width, int height)
+{
+#if wxDEBUG_LEVEL >= 2
+    if ( icon != NULL )
+    {
+        wxSize size = wxGetHiconSize(icon);
+        wxASSERT_MSG(size.GetWidth() == width && size.GetHeight() == height,
+                     wxS("Inconsistent icon parameters"));
+    }
+#endif // wxDEBUG_LEVEL >= 2
 
-    return true;
+    AllocExclusive();
+
+    GetGDIImageData()->m_handle = (WXHANDLE)icon;
+    GetGDIImageData()->m_width = width;
+    GetGDIImageData()->m_height = height;
+
+    return IsOk();
 }

--- a/src/msw/imaglist.cpp
+++ b/src/msw/imaglist.cpp
@@ -461,11 +461,10 @@ wxIcon wxImageList::GetIcon(int index) const
     if (hIcon)
     {
         wxIcon icon;
-        icon.SetHICON((WXHICON)hIcon);
 
         int iconW, iconH;
         GetSize(index, iconW, iconH);
-        icon.SetSize(iconW, iconH);
+        icon.InitFromHICON((WXHICON)hIcon, iconW, iconH);
 
         return icon;
     }

--- a/src/msw/ole/dataobj.cpp
+++ b/src/msw/ole/dataobj.cpp
@@ -1076,8 +1076,8 @@ bool wxBitmapDataObject::SetData(size_t WXUNUSED(len), const void *buf)
     wxCHECK_MSG( hbmp, FALSE, wxT("pasting/dropping invalid bitmap") );
 
     const BITMAPINFOHEADER * const pbmih = &pbmi->bmiHeader;
-    wxBitmap bitmap(pbmih->biWidth, pbmih->biHeight, pbmih->biBitCount);
-    bitmap.SetHBITMAP((WXHBITMAP)hbmp);
+    wxBitmap bitmap;
+    bitmap.InitFromHBITMAP((WXHBITMAP)hbmp, pbmih->biWidth, pbmih->biHeight, pbmih->biBitCount);
 
     // TODO: create wxPalette if the bitmap has any
 
@@ -1122,10 +1122,9 @@ bool wxBitmapDataObject2::SetData(size_t WXUNUSED(len), const void *pBuf)
         wxLogLastError(wxT("GetObject(HBITMAP)"));
     }
 
-    wxBitmap bitmap(bmp.bmWidth, bmp.bmHeight, bmp.bmBitsPixel);
-    bitmap.SetHBITMAP((WXHBITMAP)hbmp);
-
-    if ( !bitmap.IsOk() ) {
+    wxBitmap bitmap;
+    if ( !bitmap.InitFromHBITMAP((WXHBITMAP)hbmp, bmp.bmWidth, bmp.bmHeight, bmp.bmBitsPixel) )
+    {
         wxFAIL_MSG(wxT("pasting/dropping invalid bitmap"));
 
         return false;
@@ -1214,6 +1213,7 @@ bool wxBitmapDataObject::SetData(const wxDataFormat& format,
                                  size_t size, const void *pBuf)
 {
     HBITMAP hbmp;
+    int w, h, d;
     if ( format.GetFormatId() == CF_DIB )
     {
         // here we get BITMAPINFO struct followed by the actual bitmap bits and
@@ -1229,9 +1229,9 @@ bool wxBitmapDataObject::SetData(const wxDataFormat& format,
             wxLogLastError(wxT("CreateDIBitmap"));
         }
 
-        m_bitmap.SetWidth(pbmih->biWidth);
-        m_bitmap.SetHeight(pbmih->biHeight);
-        m_bitmap.SetDepth(pbmih->biBitCount);
+        w = pbmih->biWidth;
+        h = pbmih->biHeight;
+        d = pbmih->biBitCount;
     }
     else // CF_BITMAP
     {
@@ -1244,12 +1244,12 @@ bool wxBitmapDataObject::SetData(const wxDataFormat& format,
             wxLogLastError(wxT("GetObject(HBITMAP)"));
         }
 
-        m_bitmap.SetWidth(bmp.bmWidth);
-        m_bitmap.SetHeight(bmp.bmHeight);
-        m_bitmap.SetDepth(bmp.bmBitsPixel);
+        w = bmp.bmWidth;
+        h = bmp.bmHeight;
+        d = bmp.bmBitsPixel;
     }
 
-    m_bitmap.SetHBITMAP((WXHBITMAP)hbmp);
+    m_bitmap.InitFromHBITMAP((WXHBITMAP)hbmp, w, h, d);
 
     wxASSERT_MSG( m_bitmap.IsOk(), wxT("pasting invalid bitmap") );
 

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -953,7 +953,7 @@ bool wxToolBar::Realize()
         {
             hBitmap = GetHbitmapOf(bitmap);
             // don't delete this HBITMAP!
-            bitmap.SetHBITMAP(0);
+            bitmap.ResetHBITMAP();
         }
 
         if ( remapValue == Remap_Buttons )


### PR DESCRIPTION
- Implement new SetHBITMAP overloaded function which sets HBITMAP together with its parameters (size and colour depth).
- Implement new SetHICON overloaded function which sets HICON together with its parameters (size).
- Deprecate SetWidth, SetHeight, SetSize, SetDepth and legacy SetHBITMAP, SetHICON functions.
- Refactor the code in order to not use deprecated method.