### PR TITLE
Fix: showing same icon for container in expanded/collaped state

### DIFF
--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -3029,7 +3029,7 @@ void  wxDataViewTreeCtrl::DeleteAllItems()
 
 void wxDataViewTreeCtrl::OnExpanded( wxDataViewEvent &event )
 {
-    if (HasImageList()) return;
+    if (!HasImageList()) return;
 
     wxDataViewTreeStoreContainerNode* container = GetStore()->FindContainerNode( event.GetItem() );
     if (!container) return;
@@ -3041,7 +3041,7 @@ void wxDataViewTreeCtrl::OnExpanded( wxDataViewEvent &event )
 
 void wxDataViewTreeCtrl::OnCollapsed( wxDataViewEvent &event )
 {
-    if (HasImageList()) return;
+    if (!HasImageList()) return;
 
     wxDataViewTreeStoreContainerNode* container = GetStore()->FindContainerNode( event.GetItem() );
     if (!container) return;


### PR DESCRIPTION
When Container is added with AppendContainer, with icons, the control always shows the same icon for collapsed. When expanded, it does not change the icon.
Credit: DoubleMax of wxWidgets forums discovered this