### PR TITLE
Assorted macOS dark mode fixes

### DIFF
--- a/src/osx/carbon/statbrma.cpp
+++ b/src/osx/carbon/statbrma.cpp
@@ -103,6 +103,10 @@ void wxStatusBarMac::InitColours()
         }
         else
         {
+            // FIXME: None of this is correct and is only very loose
+            //        approximation. 10.14's dark mode uses dynamic colors that
+            //        use desktop tinting. The only correct way to render the
+            //        statusbar is to use windowBackgroundColor in a NSBox.
             wxColour bg = wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE);
             m_textActive = wxSystemSettings::GetColour(wxSYS_COLOUR_BTNTEXT);
             m_textInactive = wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT);
@@ -110,6 +114,7 @@ void wxStatusBarMac::InitColours()
             if ( bg.Red() < 128 )
             {
                 // dark mode appearance
+                m_textActive = wxColour(0xB0, 0xB0, 0xB0);
                 m_bgActiveFrom = wxColour(0x32, 0x32, 0x34);
                 m_bgActiveTo = wxColour(0x29, 0x29, 0x2A);
                 m_borderActive = wxColour(0x00, 0x00, 0x00);

--- a/src/osx/carbon/utilscocoa.mm
+++ b/src/osx/carbon/utilscocoa.mm
@@ -555,6 +555,8 @@ wxOSXEffectiveAppearanceSetter::wxOSXEffectiveAppearanceSetter()
         formerAppearance = NSAppearance.currentAppearance;
         NSAppearance.currentAppearance = NSApp.effectiveAppearance;
     }
+#else
+    wxUnusedVar(formerAppearance);
 #endif
 }
 

--- a/src/osx/cocoa/preferences.mm
+++ b/src/osx/cocoa/preferences.mm
@@ -151,6 +151,10 @@ private:
         info->win->Show();
         SetTitle(info->page->GetName());
 
+        // Refresh the page to ensure everything is drawn in 10.14's dark mode;
+        // without it, generic controls aren't shown at all
+        info->win->Refresh();
+
         // TODO: Preferences window may have some pages resizeable and some
         //       non-resizable on OS X; the whole window is or is not resizable
         //       depending on which page is selected.

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -3024,12 +3024,30 @@ void wxWidgetCocoaImpl::GetContentArea( int&left, int &top, int &width, int &hei
     }
 }
 
+static void SetSubviewsNeedDisplay( NSView *view )
+{
+    for ( NSView *sub in view.subviews )
+    {
+        if ( !sub.layer )
+            continue;
+
+        [sub setNeedsDisplay:YES];
+        SetSubviewsNeedDisplay(sub);
+    }
+}
+
 void wxWidgetCocoaImpl::SetNeedsDisplay( const wxRect* where )
 {
     if ( where )
         [m_osxView setNeedsDisplayInRect:wxToNSRect(m_osxView, *where )];
     else
         [m_osxView setNeedsDisplay:YES];
+
+    // Layer-backed views (which are all in Mojave's Dark Mode) may not have
+    // their children implicitly redrawn with the parent. For compatibility,
+    // do it manually here:
+    if ( m_osxView.layer )
+        SetSubviewsNeedDisplay(m_osxView);
 }
 
 bool wxWidgetCocoaImpl::GetNeedsDisplay() const

--- a/src/osx/core/colour.cpp
+++ b/src/osx/core/colour.cpp
@@ -163,27 +163,37 @@ wxColour::wxColour(CGColorRef col)
 
 wxColour::ChannelType wxColour::Red() const
 {
+    wxCHECK_MSG( IsOk(), 0, "invalid colour" );
+
     return wxRound(M_COLDATA->Red() * 255.0);
 }
 
 wxColour::ChannelType wxColour::Green() const
 {
+    wxCHECK_MSG( IsOk(), 0, "invalid colour" );
+
     return wxRound(M_COLDATA->Green() * 255.0);
 }
 
 wxColour::ChannelType wxColour::Blue() const
 {
+    wxCHECK_MSG( IsOk(), 0, "invalid colour" );
+
     return wxRound(M_COLDATA->Blue() * 255.0);
 }
 
 wxColour::ChannelType wxColour::Alpha() const
 {
+    wxCHECK_MSG( IsOk(), 0, "invalid colour" );
+
     return wxRound(M_COLDATA->Alpha() * 255.0);
 }
 
 #if wxOSX_USE_COCOA_OR_CARBON
 void wxColour::GetRGBColor(RGBColor* col) const
 {
+    wxCHECK_RET( IsOk(), "invalid colour" );
+
     col->red = M_COLDATA->Red() * 65535.0;
     col->blue = M_COLDATA->Blue() * 65535.0;
     col->green = M_COLDATA->Green() * 65535.0;
@@ -192,12 +202,16 @@ void wxColour::GetRGBColor(RGBColor* col) const
 
 CGColorRef wxColour::GetCGColor() const
 {
+    wxCHECK_MSG( IsOk(), NULL, "invalid colour" );
+
     return M_COLDATA->GetCGColor();
 }
 
 #if wxOSX_USE_COCOA
 WX_NSColor wxColour::OSXGetNSColor() const
 {
+    wxCHECK_MSG( IsOk(), NULL, "invalid colour" );
+
     return M_COLDATA->GetNSColor();
 }
 #endif

--- a/src/osx/nonownedwnd_osx.cpp
+++ b/src/osx/nonownedwnd_osx.cpp
@@ -152,7 +152,7 @@ bool wxNonOwnedWindow::Create(wxWindow *parent,
     wxWindowCreateEvent event(this);
     HandleWindowEvent(event);
 
-    SetBackgroundColour(wxSystemSettings::GetColour( wxSYS_COLOUR_3DFACE ));
+    SetBackgroundColour(wxSystemSettings::GetColour( wxSYS_COLOUR_APPWORKSPACE ));
 
     if ( parent )
         parent->AddChild(this);

--- a/src/xrc/xh_unkwn.cpp
+++ b/src/xrc/xh_unkwn.cpp
@@ -42,7 +42,6 @@ public:
           m_control(NULL)
     {
         m_bg = UseBgCol() ? GetBackgroundColour() : wxColour();
-        SetBackgroundColour(wxColour(255, 0, 255));
     }
 
     virtual void AddChild(wxWindowBase *child) wxOVERRIDE;
@@ -104,7 +103,8 @@ void wxUnknownControlContainer::AddChild(wxWindowBase *child)
 
     wxPanel::AddChild(child);
 
-    SetBackgroundColour(m_bg);
+    if ( m_bg.IsOk() )
+        SetBackgroundColour(m_bg);
     child->SetName(m_controlName);
     child->SetId(wxXmlResource::GetXRCID(m_controlName));
     m_control = child;


### PR DESCRIPTION
This is an assortment of fixes I made when preparing Poedit for Mojave (FWIW, #925 seems fine in Poedit as well). Some of them are obvious or loosely related, some I'd appreciate review on:

* 74bc10c is less than ideal, but there's not much we can do without going native with `wxStatusBar` — it will *always* be somewhat wrong. The one thing that would help a lot would be using `NSBox` as the underlying view, but I'm not sure how to do that. This would be generally useful, because `NSBox` is the only way to get native rendering of "special" colors in 10.14's dark mode, and also for e.g. `NSVisualEffectView`. My [earlier experiments](https://gist.github.com/vslavik/be51cacc2481944824b7cdb0083b7666) had rendering problems and didn't work with more than one child window — quite simply, I'm out of my depth here. 

* 9e95963 works and seems not-wrong to me (per [release notes](https://developer.apple.com/documentation/appkit/appkit_release_notes_for_macos_10_14?language=objc), refreshing a  view may not refresh its subviews at all) and tries to improve compatibility for other wxOSX code, but I suspect it may be working around some other deeper bug with generic windows. The issue it fixes is easy to see: `wxPreferences` with a page that has any generic control on it (both `wxStaticBitmap` and `wxHyperlinkCtrl` were affected in my case): switching the tab to such page won't draw these controls, but will draw everything else (using native Cocoa controls).