### PR TITLE
Wrap reg-key operations in some checks.

### DIFF
--- a/src/msw/joystick.cpp
+++ b/src/msw/joystick.cpp
@@ -329,20 +329,22 @@ wxString wxJoystick::GetProductName() const
     if (joyGetDevCaps(m_joystick, &joyCaps, sizeof(joyCaps)) != JOYERR_NOERROR)
         return wxEmptyString;
 
-
     wxRegKey key1(wxString::Format(wxT("HKEY_LOCAL_MACHINE\\%s\\%s\\%s"),
                    REGSTR_PATH_JOYCONFIG, joyCaps.szRegKey, REGSTR_KEY_JOYCURR));
 
-    if (key1.Exists()) {
+    if (key1.Exists())
+    {
         key1.QueryValue(wxString::Format(wxT("Joystick%d%s"),
                                         m_joystick + 1, REGSTR_VAL_JOYOEMNAME),
                         str);
     }
 
-    if (!str.IsEmpty()) {
+    if (!str.IsEmpty())
+    {
         wxRegKey key2(wxString::Format(wxT("HKEY_LOCAL_MACHINE\\%s\\%s"),
                                     REGSTR_PATH_JOYOEM, str.c_str()));
-        if (key2.Exists()) {
+        if (key2.Exists())
+        {
             key2.QueryValue(REGSTR_VAL_JOYOEMNAME, str);
         }
     }

--- a/src/msw/joystick.cpp
+++ b/src/msw/joystick.cpp
@@ -329,16 +329,23 @@ wxString wxJoystick::GetProductName() const
     if (joyGetDevCaps(m_joystick, &joyCaps, sizeof(joyCaps)) != JOYERR_NOERROR)
         return wxEmptyString;
 
+
     wxRegKey key1(wxString::Format(wxT("HKEY_LOCAL_MACHINE\\%s\\%s\\%s"),
                    REGSTR_PATH_JOYCONFIG, joyCaps.szRegKey, REGSTR_KEY_JOYCURR));
 
-    key1.QueryValue(wxString::Format(wxT("Joystick%d%s"),
-                                     m_joystick + 1, REGSTR_VAL_JOYOEMNAME),
-                    str);
+    if (key1.Exists()) {
+        key1.QueryValue(wxString::Format(wxT("Joystick%d%s"),
+                                        m_joystick + 1, REGSTR_VAL_JOYOEMNAME),
+                        str);
+    }
 
-    wxRegKey key2(wxString::Format(wxT("HKEY_LOCAL_MACHINE\\%s\\%s"),
-                                        REGSTR_PATH_JOYOEM, str.c_str()));
-    key2.QueryValue(REGSTR_VAL_JOYOEMNAME, str);
+    if (!str.IsEmpty()) {
+        wxRegKey key2(wxString::Format(wxT("HKEY_LOCAL_MACHINE\\%s\\%s"),
+                                    REGSTR_PATH_JOYOEM, str.c_str()));
+        if (key2.Exists()) {
+            key2.QueryValue(REGSTR_VAL_JOYOEMNAME, str);
+        }
+    }
 #endif
     return str;
 }


### PR DESCRIPTION
I was seeing errors due to missing reg keys with a CH Products RS Desktop device. It seems that:
 * querying key1 returned an empty string;
 * this produces a valid key2, but one level up from where we're expecting it, so it's missing the required OEMName value.

I added checks around the registry key operations:
 * only run the key1 query if it's a valid key;
 * only query key2 if the key1 query returned a non-empty string, and key2 is valid.