### PR TITLE
Fix clicking on drop down button in wxAuiToolBar on wxMSW

### DIFF
--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -48,7 +48,8 @@ enum wxAuiToolBarArtSetting
 {
     wxAUI_TBART_SEPARATOR_SIZE = 0,
     wxAUI_TBART_GRIPPER_SIZE = 1,
-    wxAUI_TBART_OVERFLOW_SIZE = 2
+    wxAUI_TBART_OVERFLOW_SIZE = 2,
+    wxAUI_TBART_DROPDOWN_SIZE = 3
 };
 
 enum wxAuiToolBarToolTextOrientation
@@ -447,6 +448,7 @@ protected:
     int m_separatorSize;
     int m_gripperSize;
     int m_overflowSize;
+    int m_dropdownSize;
 };
 
 

--- a/interface/wx/aui/auibar.h
+++ b/interface/wx/aui/auibar.h
@@ -104,6 +104,13 @@ enum wxAuiToolBarArtSetting
     */
     wxAUI_TBART_OVERFLOW_SIZE = 2
 
+    /**
+      Drop down button size in wxAuiToolBar.
+
+      @since 3.1.2
+    */
+    wxAUI_TBART_DROPDOWN_SIZE = 3
+
 };
 
 /**

--- a/src/aui/barartmsw.cpp
+++ b/src/aui/barartmsw.cpp
@@ -54,6 +54,10 @@ wxAuiMSWToolBarArt::wxAuiMSWToolBarArt()
             NULL, TS_TRUE, &seperatorSize);
         m_separatorSize = seperatorSize.cx;
 
+        // TP_DROPDOWNBUTTON is only 7px, too small to fit the dropdown arrow,
+        // use 14px instead.
+        m_dropdownSize = window->FromDIP(14);
+
         SIZE buttonSize;
         ::GetThemePartSize(hThemeToolbar, NULL, TP_BUTTON, 0,
             NULL, TS_TRUE, &buttonSize);
@@ -219,18 +223,16 @@ void wxAuiMSWToolBarArt::DrawDropDownButton(
     {
         wxUxThemeHandle hTheme(wnd, L"Toolbar");
 
-        int dropDownWidth = wnd->FromDIP(14);
-
         int textWidth = 0, textHeight = 0, textX = 0, textY = 0;
         int bmpX = 0, bmpY = 0;
 
         wxRect buttonRect = wxRect(rect.x,
             rect.y,
-            rect.width - dropDownWidth,
+            rect.width - m_dropdownSize,
             rect.height);
-        wxRect dropDownRect = wxRect(rect.x + rect.width - dropDownWidth - 1,
+        wxRect dropDownRect = wxRect(rect.x + rect.width - m_dropdownSize - 1,
             rect.y,
-            dropDownWidth + 1,
+            m_dropdownSize + 1,
             rect.height);
 
         if ( m_flags & wxAUI_TB_TEXT )
@@ -444,7 +446,7 @@ wxSize wxAuiMSWToolBarArt::GetToolSize(
 
         wxSize size = wxAuiGenericToolBarArt::GetToolSize(dc, wnd, item);
 
-        size.IncBy(wnd->FromDIP(wxSize(3, 3))); // Add some padding for native theme
+        size.IncBy(wnd->FromDIP(3)); // Add some padding for native theme
 
         return size;
     }

--- a/src/aui/dockart.cpp
+++ b/src/aui/dockart.cpp
@@ -197,7 +197,7 @@ wxAuiDefaultDockArt::wxAuiDefaultDockArt()
     int pen_width = wxWindow::FromDIP(1, NULL);
     m_gripperPen1 = wxPen(darker5Colour, pen_width);
     m_gripperPen2 = wxPen(darker3Colour, pen_width);
-    m_gripperPen3 = wxPen(*wxStockGDI::GetColour(wxStockGDI::COLOUR_WHITE), pen_width);
+    m_gripperPen3 = wxPen(*wxWHITE, pen_width);
 
 #ifdef __WXMAC__
     m_captionFont = *wxSMALL_FONT;


### PR DESCRIPTION
The code handling the mouse events assumed the drop down button width was 10px, but `wxAuiMSWToolBarArt` uses a different width (14px). So clicking on the left-most 4 pixels was not registered as a drop down click.

Allow the get (and set) the width of the drop down button of the `ToolBarArt`.

Increase the detection area for drop down events, because the drop down button is drawn 1 pixel larger than the actual size.

Rename some variables where dropdown was used instead of overflow.

I also noticed that the API was changed in [770e0bcd](https://github.com/wxWidgets/wxWidgets/commit/770e0bcd16f5bd85bcfcbfb738c35f3e02e0f35a#diff-2666b72c98344597b5ce8c889527597dR133) (from #933). We should still provide a function with the original signature, right?