### PR TITLE
Add additional informations to stack in wxDebugReport

### DIFF
--- a/src/common/debugrpt.cpp
+++ b/src/common/debugrpt.cpp
@@ -131,10 +131,14 @@ void XmlStackWalker::OnStackFrame(const wxStackFrame& frame)
     NumProperty(nodeFrame, wxT("level"), frame.GetLevel());
     wxString func = frame.GetName();
     if ( !func.empty() )
-    {
         nodeFrame->AddAttribute(wxT("function"), func);
-        HexProperty(nodeFrame, wxT("offset"), frame.GetOffset());
-    }
+
+    HexProperty(nodeFrame, wxT("offset"), frame.GetOffset());
+    HexProperty(nodeFrame, wxT("address"), reinterpret_cast<long unsigned int>(frame.GetAddress()));
+
+    wxString module = frame.GetModule();
+    if ( !module.empty() )
+        nodeFrame->AddAttribute(wxT("module"), module);
 
     if ( frame.HasSourceLocation() )
     {


### PR DESCRIPTION
Always add offset and address of a stack element. If possible add module as well.

The reason is that the current stack output is unusable when no function name is found. Adding all available information of the stack into the report allows a developer to actually find the issue.

### current example stack output
```xml
  <stack>
    <frame level="0"/>
    <frame level="1"/>
    <frame level="2" function="__poll" offset="00000051"/>
    <frame level="3"/>
    <frame level="4" function="g_main_loop_run" offset="000000d2"/>
    <frame level="5" function="gtk_main" offset="000000c3"/>
    <frame level="6" function="wxGUIEventLoop::DoRun()" offset="00000025"/>
    <frame level="7" function="wxEventLoopBase::Run()" offset="00000093"/>
    <frame level="8" function="wxAppConsoleBase::MainLoop()" offset="00000056"/>
    <frame level="9"/>
    <frame level="10" function="wxEntry(int&amp;, wchar_t**)" offset="00000045"/>
    <frame level="11"/>
    <frame level="12" function="__libc_start_main" offset="000000f3"/>
    <frame level="13" function="_start" offset="0000002e"/>
  </stack>
```

### improved example stack output
```xml
  <stack>
    <frame level="0" offset="0004752b" address="55aeb750c52b" module="pcbnew/pcbnew"/>
    <frame level="1" offset="00045e37" address="55aeb750ae37" module="pcbnew/pcbnew"/>
    <frame level="2" offset="000443dc" address="55aeb75093dc" module="pcbnew/pcbnew"/>
    <frame level="3" offset="001c830c" address="7f60b12af30c" module="/usr/lib/libwx_baseu-3.1.so.1"/>
    <frame level="4" offset="000123c0" address="7f60af51a3c0" module="/usr/lib/libpthread.so.0"/>
    <frame level="5" function="__poll" offset="00000051" address="7f60af434bb1" module="/usr/lib/libc.so.6"/>
    <frame level="6" offset="0006cee0" address="7f60ae795ee0" module="/usr/lib/libglib-2.0.so.0"/>
    <frame level="7" function="g_main_loop_run" offset="000000d2" address="7f60ae796f62" module="/usr/lib/libglib-2.0.so.0"/>
    <frame level="8" function="gtk_dialog_run" offset="0000015e" address="7f60aedb914e" module="/usr/lib/libgtk-x11-2.0.so.0"/>
    <frame level="9" function="wxMessageDialog::ShowModal()" offset="00000083" address="7f60b1acc463" module="/usr/lib/libwx_gtk2u_core-3.1.so.1"/>
  ...
  </stack>
```

Probably the attribute offset should be renamed for stack entries without function name. (offset from function start vs. offset in the executable)