### PR TITLE
Compatibility fixes for font weight changes

### DIFF
--- a/src/common/fontcmn.cpp
+++ b/src/common/fontcmn.cpp
@@ -445,7 +445,7 @@ bool wxFontBase::operator==(const wxFont& font) const
 #endif
             GetFamily() == font.GetFamily() &&
             GetStyle() == font.GetStyle() &&
-            GetWeight() == font.GetWeight() &&
+            GetNumericWeight() == font.GetNumericWeight() &&
             GetUnderlined() == font.GetUnderlined() &&
             GetStrikethrough() == font.GetStrikethrough() &&
             GetFaceName().IsSameAs(font.GetFaceName(), false) &&

--- a/src/common/fontcmn.cpp
+++ b/src/common/fontcmn.cpp
@@ -776,9 +776,9 @@ bool wxNativeFontInfo::FromString(const wxString& s)
     token = tokenizer.GetNextToken();
     if ( !token.ToLong(&l) )
         return false;
-    if ( l <= wxFONTWEIGHT_INVALID || l > wxFONTWEIGHT_MAX )
+    weight = wxFont::ConvertFromLegacyWeightIfNecessary(l);
+    if ( weight <= wxFONTWEIGHT_INVALID || weight > wxFONTWEIGHT_MAX )
         return false;
-    weight = static_cast<int>(l);
 
     token = tokenizer.GetNextToken();
     if ( !token.ToLong(&l) )

--- a/src/osx/carbon/font.cpp
+++ b/src/osx/carbon/font.cpp
@@ -929,7 +929,7 @@ bool wxNativeFontInfo::FromString(const wxString& s)
     token = tokenizer.GetNextToken();
     if ( !token.ToLong(&l) )
         return false;
-    m_ctWeight = WXWeightToCT(l);
+    m_ctWeight = WXWeightToCT(wxFont::ConvertFromLegacyWeightIfNecessary(l));
 
     token = tokenizer.GetNextToken();
     if ( !token.ToLong(&l) )


### PR DESCRIPTION
Preserve compatiblity font descriptions serialized using `wxNativeFontInfo::ToString()` in older versions of wxWidgets and load them correctly, instead of asserting.

aedf89b originally did this, then d355af3 reversed it as "not needed", but I think that was wrong assessment. My code stores user-selected fonts this way and I started getting asserts because of it. 

The second commit reverses d355af3 and implements the same backward compatible logic in wxOSX as well (wxMSW uses win32-native description and doesn't need it).

The `operator==` change I'm not 100% sure about, maybe coarse equality was intentional? 