### PR TITLE
Added up/down events for more than the first four joystick buttons under MSW.

### DIFF
--- a/include/wx/msw/joystick.h
+++ b/include/wx/msw/joystick.h
@@ -13,6 +13,8 @@
 
 #include "wx/event.h"
 
+class WXDLLIMPEXP_FWD_CORE wxJoystickThread;
+
 class WXDLLIMPEXP_ADV wxJoystick: public wxObject
 {
   wxDECLARE_DYNAMIC_CLASS(wxJoystick);
@@ -22,6 +24,7 @@ public:
    */
 
   wxJoystick(int joystick = wxJOYSTICK1);
+  virtual ~wxJoystick();
 
   // Attributes
   ////////////////////////////////////////////////////////////////////////////
@@ -84,7 +87,8 @@ public:
   bool ReleaseCapture(void);
 
 protected:
-  int       m_joystick;
+  int                   m_joystick;
+  wxJoystickThread*     m_thread;
 };
 
 #endif

--- a/include/wx/msw/joystick.h
+++ b/include/wx/msw/joystick.h
@@ -13,7 +13,7 @@
 
 #include "wx/event.h"
 
-class WXDLLIMPEXP_FWD_CORE wxJoystickThread;
+class wxJoystickThread;
 
 class WXDLLIMPEXP_ADV wxJoystick: public wxObject
 {

--- a/src/msw/joystick.cpp
+++ b/src/msw/joystick.cpp
@@ -90,7 +90,7 @@ public:
 private:
     void      SendEvent(wxEventType type, long ts, int change = 0);
     int       m_joystick;
-    int       m_buttons;
+    UINT      m_buttons;
     wxWindow* m_catchwin;
     int       m_polling;
     JOYINFO   m_joyInfo;
@@ -110,11 +110,11 @@ wxJoystickThread::wxJoystickThread(int joystick)
 
 void wxJoystickThread::SendEvent(wxEventType type, long ts, int change)
 {
-    wxJoystickEvent joystickEvent(type, m_buttons, m_joystick, change);
+    wxJoystickEvent joystickEvent(type, (int)m_buttons, m_joystick, change);
 
     joystickEvent.SetTimestamp(ts);
-    joystickEvent.SetPosition(wxPoint(m_joyInfo.wXpos, m_joyInfo.wYpos));
-    joystickEvent.SetZPosition(m_joyInfo.wZpos);
+    joystickEvent.SetPosition(wxPoint( (int)m_joyInfo.wXpos, (int)m_joyInfo.wYpos) );
+    joystickEvent.SetZPosition( (int)m_joyInfo.wZpos );
     joystickEvent.SetEventObject(m_catchwin);
 
     if (m_catchwin)
@@ -128,13 +128,13 @@ void* wxJoystickThread::Entry()
     while (!TestDestroy())
     {
         Sleep(m_polling);
-        DWORD ts = GetTickCount();
+        long ts = GetTickCount();
 
         joyGetPos(m_joystick, &m_joyInfo);
         m_buttons = m_joyInfo.wButtons;
-        DWORD delta = m_buttons ^ m_lastJoyInfo.wButtons;
-        DWORD deltaUp = delta & !m_buttons;
-        DWORD deltaDown = delta & m_buttons;
+        UINT delta = m_buttons ^ m_lastJoyInfo.wButtons;
+        UINT deltaUp = delta & !m_buttons;
+        UINT deltaDown = delta & m_buttons;
 
         // Use count trailing zeros to determine which button changed.
         // Was using JOYINFOEX.dwButtons, because the docs state this is
@@ -388,7 +388,7 @@ int wxJoystick::GetMovementThreshold() const
     MMRESULT res = joyGetThreshold(m_joystick, & thresh);
     if (res == JOYERR_NOERROR )
     {
-        return thresh;
+        return (int)thresh;
     }
     else
         return 0;
@@ -396,8 +396,7 @@ int wxJoystick::GetMovementThreshold() const
 
 void wxJoystick::SetMovementThreshold(int threshold)
 {
-    UINT thresh = threshold;
-    joySetThreshold(m_joystick, thresh);
+    joySetThreshold(m_joystick, (UINT)threshold);
 }
 
 // Capabilities

--- a/src/msw/joystick.cpp
+++ b/src/msw/joystick.cpp
@@ -118,7 +118,7 @@ void wxJoystickThread::SendEvent(wxEventType type, long ts, int change)
     joystickEvent.SetEventObject(m_catchwin);
 
     if (m_catchwin)
-        m_catchwin->GetEventHandler()->AddPendingEvent(joystickEvent);
+        m_catchwin->GetEventHandler()->ProcessThreadEvent(joystickEvent);
 }
 
 void* wxJoystickThread::Entry()

--- a/src/msw/joystick.cpp
+++ b/src/msw/joystick.cpp
@@ -80,6 +80,12 @@ class wxJoystickThread : public wxThread
 public:
     explicit wxJoystickThread(int joystick);
     void* Entry() wxOVERRIDE;
+    void SetPolling(wxWindow* win, int pollingFreq)
+    {
+        m_catchwin = win;
+        m_polling = pollingFreq;
+    };
+
 
 private:
     void      SendEvent(wxEventType type, long ts, int change = 0);
@@ -89,8 +95,6 @@ private:
     int       m_polling;
     JOYINFO   m_joyInfo;
     JOYINFO   m_lastJoyInfo;
-
-    friend class wxJoystick;
 };
 
 
@@ -714,8 +718,7 @@ bool wxJoystick::SetCapture(wxWindow* win, int pollingFreq)
 {
     if (m_thread)
     {
-        m_thread->m_catchwin = win;
-        m_thread->m_polling = pollingFreq;
+        m_thread->SetPolling(win, pollingFreq);
         return true;
     }
     return false;
@@ -725,8 +728,7 @@ bool wxJoystick::ReleaseCapture()
 {
     if (m_thread)
     {
-        m_thread->m_catchwin = NULL;
-        m_thread->m_polling = 0;
+        m_thread->SetPolling(NULL, 0);
         return true;
     }
     return false;

--- a/src/msw/joystick.cpp
+++ b/src/msw/joystick.cpp
@@ -38,22 +38,22 @@
 #include <regstr.h>
 
 // Use optimised count trailing zeros where available.
-#ifdef __GNUC__
-    #define ctz(x) __builtin_ctz(x)
-#else
 int ctz(unsigned x)
 {
+    wxCHECK_MSG(x > 0, 0, "Undefined for x == 0.");
+#ifdef __GNUC__
+   return __builtin_ctz(x);
+#else
    int n;
-
-   if (x == 0) return(32);
    n = 1;
    if ((x & 0x0000FFFF) == 0) {n = n +16; x = x >>16;}
    if ((x & 0x000000FF) == 0) {n = n + 8; x = x >> 8;}
    if ((x & 0x0000000F) == 0) {n = n + 4; x = x >> 4;}
    if ((x & 0x00000003) == 0) {n = n + 2; x = x >> 2;}
    return n - (x & 1);
-}
 #endif
+}
+
 
 enum {
     wxJS_AXIS_X = 0,

--- a/src/msw/joystick.cpp
+++ b/src/msw/joystick.cpp
@@ -41,7 +41,8 @@
 #ifdef __GNUC__
     #define ctz(x) __builtin_ctz(x)
 #else
-int ctz(unsigned x) {
+int ctz(unsigned x)
+{
    int n;
 
    if (x == 0) return(32);
@@ -77,7 +78,7 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxJoystick, wxObject);
 class wxJoystickThread : public wxThread
 {
 public:
-    wxJoystickThread(int joystick);
+    explicit wxJoystickThread(int joystick);
     void* Entry() wxOVERRIDE;
 
 private:
@@ -120,12 +121,9 @@ void* wxJoystickThread::Entry()
 {
     joyGetPos(m_joystick, &m_lastJoyInfo);
 
-    while (true)
+    while (!TestDestroy())
     {
-        if (TestDestroy())
-            break;
-
-        this->Sleep(m_polling);
+        Sleep(m_polling);
         DWORD ts = GetTickCount();
 
         joyGetPos(m_joystick, &m_joyInfo);
@@ -140,7 +138,7 @@ void* wxJoystickThread::Entry()
         // it is the *total* number of buttons pressed.
         if (deltaUp)
             SendEvent(wxEVT_JOY_BUTTON_UP, ts, ctz(deltaUp)+1);
-        if(deltaDown)
+        if (deltaDown)
             SendEvent(wxEVT_JOY_BUTTON_DOWN, ts, ctz(deltaDown)+1);
 
         if ((m_joyInfo.wXpos != m_lastJoyInfo.wXpos) ||
@@ -150,7 +148,7 @@ void* wxJoystickThread::Entry()
             SendEvent(wxEVT_JOY_MOVE, ts);
         }
 
-        memcpy (&m_lastJoyInfo, &m_joyInfo, sizeof(JOYINFO));
+        m_lastJoyInfo = m_joyInfo;
     }
 
     return NULL;
@@ -182,7 +180,6 @@ wxJoystick::wxJoystick(int joystick)
                 /* Found the one we want, store actual OS id and return */
                 m_joystick = i;
                 m_thread = new wxJoystickThread(m_joystick);
-                m_thread->Create();
                 m_thread->Run();
                 return;
             }

--- a/src/msw/joystick.cpp
+++ b/src/msw/joystick.cpp
@@ -110,15 +110,15 @@ wxJoystickThread::wxJoystickThread(int joystick)
 
 void wxJoystickThread::SendEvent(wxEventType type, long ts, int change)
 {
-    wxJoystickEvent jwx_event(type, m_buttons, m_joystick, change);
+    wxJoystickEvent joystickEvent(type, m_buttons, m_joystick, change);
 
-    jwx_event.SetTimestamp(ts);
-    jwx_event.SetPosition(wxPoint(m_joyInfo.wXpos, m_joyInfo.wYpos));
-    jwx_event.SetZPosition(m_joyInfo.wZpos);
-    jwx_event.SetEventObject(m_catchwin);
+    joystickEvent.SetTimestamp(ts);
+    joystickEvent.SetPosition(wxPoint(m_joyInfo.wXpos, m_joyInfo.wYpos));
+    joystickEvent.SetZPosition(m_joyInfo.wZpos);
+    joystickEvent.SetEventObject(m_catchwin);
 
     if (m_catchwin)
-        m_catchwin->GetEventHandler()->AddPendingEvent(jwx_event);
+        m_catchwin->GetEventHandler()->AddPendingEvent(joystickEvent);
 }
 
 void* wxJoystickThread::Entry()

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3133,19 +3133,6 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
             }
             break;
 
-        case MM_JOY1MOVE:
-        case MM_JOY2MOVE:
-        case MM_JOY1ZMOVE:
-        case MM_JOY2ZMOVE:
-        case MM_JOY1BUTTONDOWN:
-        case MM_JOY2BUTTONDOWN:
-        case MM_JOY1BUTTONUP:
-        case MM_JOY2BUTTONUP:
-            processed = HandleJoystickEvent(message,
-                                            LOWORD(lParam),
-                                            HIWORD(lParam),
-                                            wParam);
-            break;
 
         case WM_COMMAND:
             {
@@ -6162,92 +6149,6 @@ bool wxWindowMSW::HandleClipboardEvent(WXUINT nMsg)
     return HandleWindowEvent(evt);
 }
 
-// ---------------------------------------------------------------------------
-// joystick
-// ---------------------------------------------------------------------------
-
-bool wxWindowMSW::HandleJoystickEvent(WXUINT msg, int x, int y, WXUINT flags)
-{
-    int change = 0;
-    if ( flags & JOY_BUTTON1CHG )
-        change = wxJOY_BUTTON1;
-    if ( flags & JOY_BUTTON2CHG )
-        change = wxJOY_BUTTON2;
-    if ( flags & JOY_BUTTON3CHG )
-        change = wxJOY_BUTTON3;
-    if ( flags & JOY_BUTTON4CHG )
-        change = wxJOY_BUTTON4;
-
-    int buttons = 0;
-    if ( flags & JOY_BUTTON1 )
-        buttons |= wxJOY_BUTTON1;
-    if ( flags & JOY_BUTTON2 )
-        buttons |= wxJOY_BUTTON2;
-    if ( flags & JOY_BUTTON3 )
-        buttons |= wxJOY_BUTTON3;
-    if ( flags & JOY_BUTTON4 )
-        buttons |= wxJOY_BUTTON4;
-
-    // the event ids aren't consecutive so we can't use table based lookup
-    int joystick;
-    wxEventType eventType;
-    switch ( msg )
-    {
-        case MM_JOY1MOVE:
-            joystick = 1;
-            eventType = wxEVT_JOY_MOVE;
-            break;
-
-        case MM_JOY2MOVE:
-            joystick = 2;
-            eventType = wxEVT_JOY_MOVE;
-            break;
-
-        case MM_JOY1ZMOVE:
-            joystick = 1;
-            eventType = wxEVT_JOY_ZMOVE;
-            break;
-
-        case MM_JOY2ZMOVE:
-            joystick = 2;
-            eventType = wxEVT_JOY_ZMOVE;
-            break;
-
-        case MM_JOY1BUTTONDOWN:
-            joystick = 1;
-            eventType = wxEVT_JOY_BUTTON_DOWN;
-            break;
-
-        case MM_JOY2BUTTONDOWN:
-            joystick = 2;
-            eventType = wxEVT_JOY_BUTTON_DOWN;
-            break;
-
-        case MM_JOY1BUTTONUP:
-            joystick = 1;
-            eventType = wxEVT_JOY_BUTTON_UP;
-            break;
-
-        case MM_JOY2BUTTONUP:
-            joystick = 2;
-            eventType = wxEVT_JOY_BUTTON_UP;
-            break;
-
-        default:
-            wxFAIL_MSG(wxT("no such joystick event"));
-
-            return false;
-    }
-
-    wxJoystickEvent event(eventType, buttons, joystick, change);
-    if ( eventType == wxEVT_JOY_ZMOVE )
-        event.SetZPosition(x);
-    else
-        event.SetPosition(wxPoint(x, y));
-    event.SetEventObject(this);
-
-    return HandleWindowEvent(event);
-}
 
 // ---------------------------------------------------------------------------
 // scrolling


### PR DESCRIPTION
The Windows joystick implementation works by catching WinMM messages in a wxWindow message thread and converting them to events. However, WinMM's builtin polling thread (started with joySetCapture) only issues button messages for the first four buttons on a device, despite supporting up to 32 buttons.

Support for events from higher buttons is added by a background thread to query joystick state (just as in src/unix/joystick.h), and dispatch wxEvents directly.

Addresses http://trac.wxwidgets.org/ticket/1142.