### PR TITLE
Revert wxAuiDefaultDockArt::DrawIcon API change

### DIFF
--- a/include/wx/aui/dockart.h
+++ b/include/wx/aui/dockart.h
@@ -129,14 +129,18 @@ public:
                   const wxRect& rect,
                   wxAuiPaneInfo& pane) wxOVERRIDE;
 
+#if WXWIN_COMPATIBILITY_3_0
+    wxDEPRECATED_MSG("This is not intended for the public API")
     void DrawIcon(wxDC& dc,
-                  wxWindow *window,
                   const wxRect& rect,
                   wxAuiPaneInfo& pane);
+#endif
 
 protected:
 
     void DrawCaptionBackground(wxDC& dc, const wxRect& rect, bool active);
+
+    void DrawIcon(wxDC& dc, wxWindow *window, const wxRect& rect, wxAuiPaneInfo& pane);
 
     void InitBitmaps();
 

--- a/interface/wx/aui/dockart.h
+++ b/interface/wx/aui/dockart.h
@@ -337,14 +337,18 @@ public:
                   const wxRect& rect,
                   wxAuiPaneInfo& pane);
 
+    /**
+        @deprecated Not intended for the public API.
+    */
     void DrawIcon(wxDC& dc,
-                  wxWindow *window,
                   const wxRect& rect,
                   wxAuiPaneInfo& pane);
 
 protected:
 
     void DrawCaptionBackground(wxDC& dc, const wxRect& rect, bool active);
+
+    void DrawIcon(wxDC& dc, wxWindow *window, const wxRect& rect, wxAuiPaneInfo& pane);
 
     void InitBitmaps();
 

--- a/src/aui/dockart.cpp
+++ b/src/aui/dockart.cpp
@@ -632,12 +632,20 @@ void wxAuiDefaultDockArt::DrawCaption(wxDC& dc,
     dc.DestroyClippingRegion();
 }
 
+#if WXWIN_COMPATIBILITY_3_0
+void wxAuiDefaultDockArt::DrawIcon(wxDC& dc, const wxRect& rect, wxAuiPaneInfo& pane)
+{
+    DrawIcon(dc, NULL, rect, pane);
+}
+#endif
+
 void
 wxAuiDefaultDockArt::DrawIcon(wxDC& dc, wxWindow *window, const wxRect& rect, wxAuiPaneInfo& pane)
 {
     // Draw the icon centered vertically
+    int xOffset = window ? window->FromDIP(2) : 2;
     dc.DrawBitmap(pane.icon,
-                  rect.x+window->FromDIP(2), rect.y+(rect.height-pane.icon.GetScaledHeight())/2,
+                  rect.x+xOffset, rect.y+(rect.height-pane.icon.GetScaledHeight())/2,
                   true);
 }
 


### PR DESCRIPTION
Revert `wxAuiDefaultDockArt::DrawIcon` API change.
Mark the function as deprecated. It should not be part of the public API. It cannot be overridden and manually calling it has no lasting effect because `DrawCaption` calls it as well when the GUI refreshes.