### PR TITLE
Fix build error when wxUSE_ENH_METAFILE=0

### DIFF
--- a/src/common/graphcmn.cpp
+++ b/src/common/graphcmn.cpp
@@ -32,7 +32,9 @@
 #endif
 
 #ifdef __WXMSW__
+#if wxUSE_ENH_METAFILE
     #include "wx/msw/enhmeta.h"
+#endif
 #endif
 
 #include "wx/private/graphics.h"


### PR DESCRIPTION
Fix the build error on Windows Dll build, when wxUSE_ENH_METAFILE is set to 0.