### PR TITLE
Fix build error

### DIFF
--- a/include/wx/osx/setup0.h
+++ b/include/wx/osx/setup0.h
@@ -1601,6 +1601,11 @@
 #undef wxUSE_GRAPHICS_CONTEXT
 #define wxUSE_GRAPHICS_CONTEXT 1
 
+//wxUSE_DATAVIEWCTRL relies on wxUSE_DRAG_AND_DROP
+#if wxUSE_DATAVIEWCTRL
+#undef wxUSE_DRAG_AND_DROP
+#define wxUSE_DRAG_AND_DROP 1
+#endif
 
 // things not implemented under Mac
 

--- a/include/wx/osx/setup_inc.h
+++ b/include/wx/osx/setup_inc.h
@@ -39,6 +39,11 @@
 #undef wxUSE_GRAPHICS_CONTEXT
 #define wxUSE_GRAPHICS_CONTEXT 1
 
+//wxUSE_DATAVIEWCTRL relies on wxUSE_DRAG_AND_DROP
+#if wxUSE_DATAVIEWCTRL
+#undef wxUSE_DRAG_AND_DROP
+#define wxUSE_DRAG_AND_DROP 1
+#endif
 
 // things not implemented under Mac
 

--- a/src/unix/evtloopunix.cpp
+++ b/src/unix/evtloopunix.cpp
@@ -20,8 +20,6 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
-#if wxUSE_CONSOLE_EVENTLOOP
-
 #include "wx/evtloop.h"
 
 #ifndef WX_PRECOMP
@@ -52,6 +50,8 @@
 //-----------------------------------------------------------------------------
 // initialization
 //-----------------------------------------------------------------------------
+
+#if wxUSE_CONSOLE_EVENTLOOP
 
 wxConsoleEventLoop::wxConsoleEventLoop()
 {
@@ -97,6 +97,8 @@ wxConsoleEventLoop::~wxConsoleEventLoop()
         delete m_wakeupPipe;
     }
 }
+
+#endif // wxUSE_CONSOLE_EVENTLOOP
 
 //-----------------------------------------------------------------------------
 // adding & removing sources
@@ -152,6 +154,8 @@ wxUnixEventLoopSource::~wxUnixEventLoopSource()
 //-----------------------------------------------------------------------------
 // events dispatch and loop handling
 //-----------------------------------------------------------------------------
+
+#if wxUSE_CONSOLE_EVENTLOOP
 
 bool wxConsoleEventLoop::Pending() const
 {


### PR DESCRIPTION
Fix build error when:
 wxUSE_CONSOLE_EVENTLOOP set to 0 on Mac & Unix.
 wxUSE_DRAG_AND_DROP set to 0 on Mac.