### PR TITLE
Simplify display functions

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -3783,7 +3783,6 @@ COND_USE_GUI_1_ALL_GUI_HEADERS =  \
 	wx/dialup.h \
 	wx/dirctrl.h \
 	wx/display.h \
-	wx/display_impl.h \
 	wx/dnd.h \
 	wx/docmdi.h \
 	wx/docview.h \
@@ -5606,7 +5605,8 @@ COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS =  \
 	monodll_timectrl_osx.o \
 	monodll_taskbarcmn.o \
 	monodll_cocoa_activityindicator.o \
-	monodll_cocoa_statbmp.o
+	monodll_cocoa_statbmp.o \
+	monodll_core_display.o
 @COND_TOOLKIT_OSX_COCOA@__GUI_SRC_OBJECTS = $(COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS)
 COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS =  \
 	$(__OSX_COMMON_SRC_OBJECTS) \
@@ -7571,7 +7571,8 @@ COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS_1 =  \
 	monolib_timectrl_osx.o \
 	monolib_taskbarcmn.o \
 	monolib_cocoa_activityindicator.o \
-	monolib_cocoa_statbmp.o
+	monolib_cocoa_statbmp.o \
+	monolib_core_display.o
 @COND_TOOLKIT_OSX_COCOA@__GUI_SRC_OBJECTS_1 = $(COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS_1)
 COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS_1 =  \
 	$(__OSX_COMMON_SRC_OBJECTS_0) \
@@ -9683,7 +9684,8 @@ COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS_2 =  \
 	coredll_timectrl_osx.o \
 	coredll_taskbarcmn.o \
 	coredll_cocoa_activityindicator.o \
-	coredll_cocoa_statbmp.o
+	coredll_cocoa_statbmp.o \
+	coredll_core_display.o
 @COND_TOOLKIT_OSX_COCOA@__GUI_SRC_OBJECTS_2 = $(COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS_2)
 COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS_2 =  \
 	$(__OSX_COMMON_SRC_OBJECTS_8) \
@@ -11390,7 +11392,8 @@ COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS_3 =  \
 	corelib_timectrl_osx.o \
 	corelib_taskbarcmn.o \
 	corelib_cocoa_activityindicator.o \
-	corelib_cocoa_statbmp.o
+	corelib_cocoa_statbmp.o \
+	corelib_core_display.o
 @COND_TOOLKIT_OSX_COCOA@__GUI_SRC_OBJECTS_3 = $(COND_TOOLKIT_OSX_COCOA___GUI_SRC_OBJECTS_3)
 COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS_3 =  \
 	$(__OSX_COMMON_SRC_OBJECTS_9) \
@@ -13193,7 +13196,6 @@ COND_PLATFORM_MACOSX_1___OSX_LOWLEVEL_SRC_OBJECTS =  \
 	monodll_core_bitmap.o \
 	monodll_core_colour.o \
 	monodll_core_dcmemory.o \
-	monodll_core_display.o \
 	monodll_core_fontenum.o \
 	monodll_hid.o \
 	monodll_printmac.o \
@@ -13337,7 +13339,6 @@ COND_PLATFORM_MACOSX_1___OSX_LOWLEVEL_SRC_OBJECTS_17 =  \
 	monolib_core_bitmap.o \
 	monolib_core_colour.o \
 	monolib_core_dcmemory.o \
-	monolib_core_display.o \
 	monolib_core_fontenum.o \
 	monolib_hid.o \
 	monolib_printmac.o \
@@ -13481,7 +13482,6 @@ COND_PLATFORM_MACOSX_1___OSX_LOWLEVEL_SRC_OBJECTS_1_1 =  \
 	coredll_core_bitmap.o \
 	coredll_core_colour.o \
 	coredll_core_dcmemory.o \
-	coredll_core_display.o \
 	coredll_core_fontenum.o \
 	coredll_hid.o \
 	coredll_printmac.o \
@@ -13622,7 +13622,6 @@ COND_PLATFORM_MACOSX_1___OSX_LOWLEVEL_SRC_OBJECTS_1_4 =  \
 	corelib_core_bitmap.o \
 	corelib_core_colour.o \
 	corelib_core_dcmemory.o \
-	corelib_core_display.o \
 	corelib_core_fontenum.o \
 	corelib_hid.o \
 	corelib_printmac.o \
@@ -16471,6 +16470,9 @@ monodll_cocoa_activityindicator.o: $(srcdir)/src/osx/cocoa/activityindicator.mm 
 monodll_cocoa_statbmp.o: $(srcdir)/src/osx/cocoa/statbmp.mm $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/statbmp.mm
 
+monodll_core_display.o: $(srcdir)/src/osx/core/display.cpp $(MONODLL_ODEP)
+	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/osx/core/display.cpp
+
 monodll_regiong.o: $(srcdir)/src/generic/regiong.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/generic/regiong.cpp
 
@@ -18747,12 +18749,6 @@ monodll_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(MONODLL_ODEP)
 
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1@monodll_core_dcmemory.o: $(srcdir)/src/osx/core/dcmemory.cpp $(MONODLL_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/osx/core/dcmemory.cpp
-
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@monodll_core_display.o: $(srcdir)/src/osx/core/display.cpp $(MONODLL_ODEP)
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/osx/core/display.cpp
-
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1@monodll_core_display.o: $(srcdir)/src/osx/core/display.cpp $(MONODLL_ODEP)
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/osx/core/display.cpp
 
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@monodll_core_fontenum.o: $(srcdir)/src/osx/core/fontenum.cpp $(MONODLL_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/osx/core/fontenum.cpp
@@ -21721,6 +21717,9 @@ monolib_cocoa_activityindicator.o: $(srcdir)/src/osx/cocoa/activityindicator.mm 
 monolib_cocoa_statbmp.o: $(srcdir)/src/osx/cocoa/statbmp.mm $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/statbmp.mm
 
+monolib_core_display.o: $(srcdir)/src/osx/core/display.cpp $(MONOLIB_ODEP)
+	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/osx/core/display.cpp
+
 monolib_regiong.o: $(srcdir)/src/generic/regiong.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/generic/regiong.cpp
 
@@ -23997,12 +23996,6 @@ monolib_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(MONOLIB_ODEP)
 
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1@monolib_core_dcmemory.o: $(srcdir)/src/osx/core/dcmemory.cpp $(MONOLIB_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/osx/core/dcmemory.cpp
-
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@monolib_core_display.o: $(srcdir)/src/osx/core/display.cpp $(MONOLIB_ODEP)
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/osx/core/display.cpp
-
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1@monolib_core_display.o: $(srcdir)/src/osx/core/display.cpp $(MONOLIB_ODEP)
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/osx/core/display.cpp
 
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@monolib_core_fontenum.o: $(srcdir)/src/osx/core/fontenum.cpp $(MONOLIB_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/osx/core/fontenum.cpp
@@ -27634,6 +27627,9 @@ coredll_cocoa_activityindicator.o: $(srcdir)/src/osx/cocoa/activityindicator.mm 
 coredll_cocoa_statbmp.o: $(srcdir)/src/osx/cocoa/statbmp.mm $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/statbmp.mm
 
+coredll_core_display.o: $(srcdir)/src/osx/core/display.cpp $(COREDLL_ODEP)
+	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/osx/core/display.cpp
+
 coredll_regiong.o: $(srcdir)/src/generic/regiong.cpp $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/generic/regiong.cpp
 
@@ -29340,12 +29336,6 @@ coredll_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(COREDLL_ODEP)
 
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1@coredll_core_dcmemory.o: $(srcdir)/src/osx/core/dcmemory.cpp $(COREDLL_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/osx/core/dcmemory.cpp
-
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@coredll_core_display.o: $(srcdir)/src/osx/core/display.cpp $(COREDLL_ODEP)
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/osx/core/display.cpp
-
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1@coredll_core_display.o: $(srcdir)/src/osx/core/display.cpp $(COREDLL_ODEP)
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/osx/core/display.cpp
 
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@coredll_core_fontenum.o: $(srcdir)/src/osx/core/fontenum.cpp $(COREDLL_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/osx/core/fontenum.cpp
@@ -31879,6 +31869,9 @@ corelib_cocoa_activityindicator.o: $(srcdir)/src/osx/cocoa/activityindicator.mm 
 corelib_cocoa_statbmp.o: $(srcdir)/src/osx/cocoa/statbmp.mm $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_OBJCXXFLAGS) $(srcdir)/src/osx/cocoa/statbmp.mm
 
+corelib_core_display.o: $(srcdir)/src/osx/core/display.cpp $(CORELIB_ODEP)
+	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/osx/core/display.cpp
+
 corelib_regiong.o: $(srcdir)/src/generic/regiong.cpp $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/generic/regiong.cpp
 
@@ -33585,12 +33578,6 @@ corelib_sound_sdl.o: $(srcdir)/src/unix/sound_sdl.cpp $(CORELIB_ODEP)
 
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1@corelib_core_dcmemory.o: $(srcdir)/src/osx/core/dcmemory.cpp $(CORELIB_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/osx/core/dcmemory.cpp
-
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@corelib_core_display.o: $(srcdir)/src/osx/core/display.cpp $(CORELIB_ODEP)
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/osx/core/display.cpp
-
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1@corelib_core_display.o: $(srcdir)/src/osx/core/display.cpp $(CORELIB_ODEP)
-@COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_IPHONE_USE_GUI_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/osx/core/display.cpp
 
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@corelib_core_fontenum.o: $(srcdir)/src/osx/core/fontenum.cpp $(CORELIB_ODEP)
 @COND_PLATFORM_MACOSX_1_TOOLKIT_OSX_COCOA_USE_GUI_1@	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/osx/core/fontenum.cpp

--- a/build/bakefiles/files.bkl
+++ b/build/bakefiles/files.bkl
@@ -2381,7 +2381,6 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     src/osx/core/bitmap.cpp
     src/osx/core/colour.cpp
     src/osx/core/dcmemory.cpp
-    src/osx/core/display.cpp
     src/osx/core/fontenum.cpp
     src/osx/core/hid.cpp
     src/osx/core/printmac.cpp
@@ -2628,6 +2627,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     src/common/taskbarcmn.cpp
     src/osx/cocoa/activityindicator.mm
     src/osx/cocoa/statbmp.mm
+    src/osx/core/display.cpp
 </set>
 <set var="OSX_COCOA_HDR" hints="files">
     wx/osx/cocoa/chkconf.h

--- a/build/bakefiles/files.bkl
+++ b/build/bakefiles/files.bkl
@@ -1124,7 +1124,6 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     wx/dialup.h
     wx/dirctrl.h
     wx/display.h
-    wx/display_impl.h
     wx/dnd.h
     wx/docmdi.h
     wx/docview.h

--- a/build/cmake/files.cmake
+++ b/build/cmake/files.cmake
@@ -2258,7 +2258,6 @@ set(OSX_LOWLEVEL_SRC
     src/osx/core/bitmap.cpp
     src/osx/core/colour.cpp
     src/osx/core/dcmemory.cpp
-    src/osx/core/display.cpp
     src/osx/core/fontenum.cpp
     src/osx/core/hid.cpp
     src/osx/core/printmac.cpp
@@ -2500,6 +2499,7 @@ set(OSX_COCOA_SRC
     src/osx/datectrl_osx.cpp
     src/osx/core/sound.cpp
     src/osx/cocoa/statbmp.mm
+    src/osx/core/display.cpp
 )
 
 set(OSX_COCOA_HDR

--- a/build/cmake/files.cmake
+++ b/build/cmake/files.cmake
@@ -1032,7 +1032,6 @@ set(GUI_CMN_HDR
     wx/dialup.h
     wx/dirctrl.h
     wx/display.h
-    wx/display_impl.h
     wx/dnd.h
     wx/docmdi.h
     wx/docview.h

--- a/build/files
+++ b/build/files
@@ -2246,7 +2246,6 @@ OSX_LOWLEVEL_SRC =
     src/osx/core/bitmap.cpp
     src/osx/core/colour.cpp
     src/osx/core/dcmemory.cpp
-    src/osx/core/display.cpp
     src/osx/core/fontenum.cpp
     src/osx/core/hid.cpp
     src/osx/core/printmac.cpp
@@ -2477,6 +2476,7 @@ OSX_COCOA_SRC =
     src/osx/cocoa/toolbar.mm
     src/osx/cocoa/tooltip.mm
     src/osx/cocoa/window.mm
+    src/osx/core/display.cpp
     src/osx/core/hidjoystick.cpp
     src/osx/core/sound.cpp
     src/osx/dataview_osx.cpp

--- a/build/files
+++ b/build/files
@@ -967,7 +967,6 @@ GUI_CMN_HDR =
     wx/dirctrl.h
     wx/dirdlg.h
     wx/display.h
-    wx/display_impl.h
     wx/dnd.h
     wx/docmdi.h
     wx/docview.h

--- a/build/msw/wx_core.vcxproj
+++ b/build/msw/wx_core.vcxproj
@@ -1280,7 +1280,6 @@
     <ClInclude Include="..\..\include\wx\dirctrl.h" />
     <ClInclude Include="..\..\include\wx\dirdlg.h" />
     <ClInclude Include="..\..\include\wx\display.h" />
-    <ClInclude Include="..\..\include\wx\display_impl.h" />
     <ClInclude Include="..\..\include\wx\dnd.h" />
     <ClInclude Include="..\..\include\wx\docmdi.h" />
     <ClInclude Include="..\..\include\wx\docview.h" />

--- a/build/msw/wx_core.vcxproj.filters
+++ b/build/msw/wx_core.vcxproj.filters
@@ -1267,9 +1267,6 @@
     <ClInclude Include="..\..\include\wx\display.h">
       <Filter>Common Headers</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\include\wx\display_impl.h">
-      <Filter>Common Headers</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\include\wx\dnd.h">
       <Filter>Common Headers</Filter>
     </ClInclude>

--- a/build/msw/wx_vc7_core.vcproj
+++ b/build/msw/wx_vc7_core.vcproj
@@ -2271,9 +2271,6 @@
 				RelativePath="..\..\include\wx\display.h">
 			</File>
 			<File
-				RelativePath="..\..\include\wx\display_impl.h">
-			</File>
-			<File
 				RelativePath="..\..\include\wx\dnd.h">
 			</File>
 			<File

--- a/build/msw/wx_vc8_core.vcproj
+++ b/build/msw/wx_vc8_core.vcproj
@@ -3529,10 +3529,6 @@
 				>
 			</File>
 			<File
-				RelativePath="..\..\include\wx\display_impl.h"
-				>
-			</File>
-			<File
 				RelativePath="..\..\include\wx\dnd.h"
 				>
 			</File>

--- a/build/msw/wx_vc9_core.vcproj
+++ b/build/msw/wx_vc9_core.vcproj
@@ -3525,10 +3525,6 @@
 				>
 			</File>
 			<File
-				RelativePath="..\..\include\wx\display_impl.h"
-				>
-			</File>
-			<File
 				RelativePath="..\..\include\wx\dnd.h"
 				>
 			</File>

--- a/build/osx/wxiphone.xcodeproj/project.pbxproj
+++ b/build/osx/wxiphone.xcodeproj/project.pbxproj
@@ -803,7 +803,6 @@
 		F0B3F484C38C3BA0B9927CD9 /* docmdi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ECC9F5C21ACB31A0B24AEE35 /* docmdi.cpp */; };
 		F0D892C2618130FEAD46BB86 /* panel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 00969CBE3B8F32C78C195619 /* panel.cpp */; };
 		F1E4D7CA634E33808AE3B522 /* fontenumcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 373242CD08F330208A7CF438 /* fontenumcmn.cpp */; };
-		F1F484DD591337399FCD0463 /* display.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5617D10CB7136EC9A4194EF /* display.cpp */; };
 		F22C401903993639AE05A295 /* xh_stbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 147800BBCB80346798B35D75 /* xh_stbox.cpp */; };
 		F24F637D59F637CA9A7E23C9 /* xh_filectrl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 60EE4448A28D38F5ADE17B5A /* xh_filectrl.cpp */; };
 		F2813BF297C73A3ABD02EC98 /* glcanvas_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FA59091E3ED83FB781FB9659 /* glcanvas_osx.cpp */; };
@@ -1402,7 +1401,6 @@
 		A46D50BEBF523B3F88831086 /* LexAsn1.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexAsn1.cxx; path = ../../src/stc/scintilla/lexers/LexAsn1.cxx; sourceTree = "<group>"; };
 		A4A745D1821A32D591D76650 /* imagiff.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = imagiff.cpp; path = ../../src/common/imagiff.cpp; sourceTree = "<group>"; };
 		A54B80C17F823CB5900AD2E8 /* framecmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = framecmn.cpp; path = ../../src/common/framecmn.cpp; sourceTree = "<group>"; };
-		A5617D10CB7136EC9A4194EF /* display.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = display.cpp; path = ../../src/osx/core/display.cpp; sourceTree = "<group>"; };
 		A5794CD687013AF8A20A691A /* headerctrlcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = headerctrlcmn.cpp; path = ../../src/common/headerctrlcmn.cpp; sourceTree = "<group>"; };
 		A57CF60203F53459A03951A9 /* arrstr.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = arrstr.cpp; path = ../../src/common/arrstr.cpp; sourceTree = "<group>"; };
 		A5BBC1E494D33D028CA547FF /* jddctmgr.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jddctmgr.c; path = ../../src/jpeg/jddctmgr.c; sourceTree = "<group>"; };
@@ -1953,7 +1951,6 @@
 				A1A53EC3A3463EFDB7614E93 /* bitmap.cpp */,
 				9D1F14339D1C331087650931 /* colour.cpp */,
 				343D4FDD5CC030618EF24729 /* dcmemory.cpp */,
-				A5617D10CB7136EC9A4194EF /* display.cpp */,
 				36E1DBA275AD325DB759C180 /* fontenum.cpp */,
 				160EB9744CB63A0B81DC651F /* hid.cpp */,
 				5CC5C13F8AA1387BADB7E60C /* printmac.cpp */,
@@ -3008,7 +3005,6 @@
 				03BF1610E2FC3BD5ACB754F0 /* bitmap.cpp in Sources */,
 				FF50EC0EC5F23DF890C6E95F /* colour.cpp in Sources */,
 				BD2B17EB72E73A6EB6E0B26F /* dcmemory.cpp in Sources */,
-				F1F484DD591337399FCD0463 /* display.cpp in Sources */,
 				371809DA4AD1382F8B532878 /* fontenum.cpp in Sources */,
 				86BE5213D3F131D8A6862679 /* hid.cpp in Sources */,
 				AB58406CEBA13BC4A2A83B66 /* printmac.cpp in Sources */,

--- a/configure
+++ b/configure
@@ -27521,14 +27521,6 @@ fi
 $as_echo "$as_me: WARNING: Xinerama not found; disabling wxDisplay" >&2;}
             wxUSE_DISPLAY="no"
         fi
-    elif test "$wxUSE_MSW" = 1; then
-                ac_fn_c_check_header_compile "$LINENO" "ddraw.h" "ac_cv_header_ddraw_h" "#include <windows.h>
-"
-if test "x$ac_cv_header_ddraw_h" = xyes; then :
-
-fi
-
-
     fi
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -3472,9 +3472,6 @@ if test "$wxUSE_DISPLAY" = "yes"; then
             AC_MSG_WARN([Xinerama not found; disabling wxDisplay])
             wxUSE_DISPLAY="no"
         fi
-    elif test "$wxUSE_MSW" = 1; then
-        dnl DirectDraw for MSW - optionally used by WxDisplay.
-        AC_CHECK_HEADER([ddraw.h], [], [], [#include <windows.h>])
     fi
 fi
 

--- a/include/wx/display.h
+++ b/include/wx/display.h
@@ -10,6 +10,8 @@
 #ifndef _WX_DISPLAY_H_BASE_
 #define _WX_DISPLAY_H_BASE_
 
+#include "wx/defs.h"
+
 // NB: no #if wxUSE_DISPLAY here, the display geometry part of this class (but
 //     not the video mode stuff) is always available but if wxUSE_DISPLAY == 0
 //     it becomes just a trivial wrapper around the old wxDisplayXXX() functions

--- a/include/wx/display.h
+++ b/include/wx/display.h
@@ -50,7 +50,6 @@ public:
 
     // dtor is not virtual as this is a concrete class not meant to be derived
     // from
-    ~wxDisplay();
 
 
     // return the number of available displays, valid parameters to

--- a/include/wx/private/display.h
+++ b/include/wx/private/display.h
@@ -1,5 +1,5 @@
 /////////////////////////////////////////////////////////////////////////////
-// Name:        wx/display_impl.h
+// Name:        wx/private/display.h
 // Purpose:     wxDisplayImpl class declaration
 // Author:      Vadim Zeitlin
 // Created:     2006-03-15
@@ -7,8 +7,8 @@
 // Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
-#ifndef _WX_DISPLAY_IMPL_H_BASE_
-#define _WX_DISPLAY_IMPL_H_BASE_
+#ifndef _WX_PRIVATE_DISPLAY_H_
+#define _WX_PRIVATE_DISPLAY_H_
 
 #include "wx/gdicmn.h"      // for wxRect
 
@@ -105,5 +105,4 @@ public:
     virtual int GetFromPoint(const wxPoint& pt) wxOVERRIDE;
 };
 
-#endif // _WX_DISPLAY_IMPL_H_BASE_
-
+#endif // _WX_PRIVATE_DISPLAY_H_

--- a/include/wx/private/display.h
+++ b/include/wx/private/display.h
@@ -10,6 +10,7 @@
 #ifndef _WX_PRIVATE_DISPLAY_H_
 #define _WX_PRIVATE_DISPLAY_H_
 
+#include "wx/display.h"
 #include "wx/gdicmn.h"      // for wxRect
 #include "wx/vector.h"
 
@@ -113,17 +114,62 @@ protected:
 };
 
 // ----------------------------------------------------------------------------
+// wxDisplayImplSingle: the simplest possible impl for the main display only
+// ----------------------------------------------------------------------------
+
+// Note that this is still an ABC and GetGeometry() and GetClientArea() methods
+// must be implemented in the derived classes.
+
+class WXDLLEXPORT wxDisplayImplSingle : public wxDisplayImpl
+{
+public:
+    wxDisplayImplSingle() : wxDisplayImpl(0) { }
+
+    virtual wxString GetName() const wxOVERRIDE { return wxString(); }
+
+#if wxUSE_DISPLAY
+    // no video modes support for us, provide just the stubs
+    virtual wxArrayVideoModes
+    GetModes(const wxVideoMode& WXUNUSED(mode)) const wxOVERRIDE
+    {
+        return wxArrayVideoModes();
+    }
+
+    virtual wxVideoMode GetCurrentMode() const wxOVERRIDE
+    {
+        return wxVideoMode();
+    }
+
+    virtual bool ChangeMode(const wxVideoMode& WXUNUSED(mode)) wxOVERRIDE
+    {
+        return false;
+    }
+#endif // wxUSE_DISPLAY
+
+    wxDECLARE_NO_COPY_CLASS(wxDisplayImplSingle);
+};
+
+// ----------------------------------------------------------------------------
 // wxDisplayFactorySingle
 // ----------------------------------------------------------------------------
 
-// this is a stub implementation using single/main display only, it is
-// available even if wxUSE_DISPLAY == 0
+// This is the simplest implementation of wxDisplayFactory using single/main
+// display only. It is used when wxUSE_DISPLAY == 0 because getting the size of
+// the main display is always needed.
+//
+// Note that this is still an ABC and derived classes must implement
+// CreateSingleDisplay().
+
 class WXDLLIMPEXP_CORE wxDisplayFactorySingle : public wxDisplayFactory
 {
 public:
-    virtual wxDisplayImpl *CreateDisplay(unsigned n) wxOVERRIDE;
     virtual unsigned GetCount() wxOVERRIDE { return 1; }
     virtual int GetFromPoint(const wxPoint& pt) wxOVERRIDE;
+
+protected:
+    virtual wxDisplayImpl *CreateDisplay(unsigned n) wxOVERRIDE;
+
+    virtual wxDisplayImpl *CreateSingleDisplay() = 0;
 };
 
 #endif // _WX_PRIVATE_DISPLAY_H_

--- a/include/wx/private/display.h
+++ b/include/wx/private/display.h
@@ -11,6 +11,7 @@
 #define _WX_PRIVATE_DISPLAY_H_
 
 #include "wx/gdicmn.h"      // for wxRect
+#include "wx/vector.h"
 
 // ----------------------------------------------------------------------------
 // wxDisplayFactory: allows to create wxDisplay objects
@@ -20,12 +21,20 @@ class WXDLLIMPEXP_CORE wxDisplayFactory
 {
 public:
     wxDisplayFactory() { }
-    virtual ~wxDisplayFactory() { }
+    virtual ~wxDisplayFactory();
 
-    // create a new display object
-    //
-    // it can return a NULL pointer if the display creation failed
-    virtual wxDisplayImpl *CreateDisplay(unsigned n) = 0;
+    // Create the display if necessary using CreateDisplay(), otherwise just
+    // get it from cache.
+    wxDisplayImpl* GetDisplay(unsigned n)
+    {
+        if ( m_impls.empty() )
+            m_impls.resize(GetCount());
+        else if ( m_impls[n] )
+            return m_impls[n];
+
+        m_impls[n] = CreateDisplay(n);
+        return m_impls[n];
+    }
 
     // get the total number of displays
     virtual unsigned GetCount() = 0;
@@ -37,6 +46,18 @@ public:
     //
     // the window pointer must not be NULL (i.e. caller should check it)
     virtual int GetFromWindow(const wxWindow *window);
+
+protected:
+    // create a new display object
+    //
+    // it can return a NULL pointer if the display creation failed
+    virtual wxDisplayImpl *CreateDisplay(unsigned n) = 0;
+
+private:
+    // On-demand populated vector of wxDisplayImpl objects.
+    wxVector<wxDisplayImpl*> m_impls;
+
+    wxDECLARE_NO_COPY_CLASS(wxDisplayFactory);
 };
 
 // ----------------------------------------------------------------------------

--- a/include/wx/private/display.h
+++ b/include/wx/private/display.h
@@ -18,7 +18,7 @@
 // wxDisplayFactory: allows to create wxDisplay objects
 // ----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxDisplayFactory
+class wxDisplayFactory
 {
 public:
     wxDisplayFactory() { }
@@ -65,7 +65,7 @@ private:
 // wxDisplayImpl: base class for all wxDisplay implementations
 // ----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxDisplayImpl
+class wxDisplayImpl
 {
 public:
     // virtual dtor for this base class
@@ -160,7 +160,7 @@ public:
 // Note that this is still an ABC and derived classes must implement
 // CreateSingleDisplay().
 
-class WXDLLIMPEXP_CORE wxDisplayFactorySingle : public wxDisplayFactory
+class wxDisplayFactorySingle : public wxDisplayFactory
 {
 public:
     virtual unsigned GetCount() wxOVERRIDE { return 1; }

--- a/interface/wx/sysopt.h
+++ b/interface/wx/sysopt.h
@@ -66,9 +66,6 @@
         Setting this to 0 causes more flicker, but allows applications to paint
         graphics on the parent of a static box (the optimized refresh causes any
         such drawing to disappear).
-    @flag{msw.display.directdraw}
-        If set to 1, use DirectDraw-based implementation of wxDisplay.
-        By default the standard Win32 functions are used.
     @flag{msw.font.no-proof-quality}
         If set to 1, use default fonts quality instead of proof quality when
         creating fonts. With proof quality the fonts have slightly better

--- a/samples/display/display.cpp
+++ b/samples/display/display.cpp
@@ -170,13 +170,6 @@ bool MyApp::OnInit()
     if ( !wxApp::OnInit() )
         return false;
 
-#ifdef __WXMSW__
-    if ( argc == 2 && !wxStricmp(argv[1],  "/dx") )
-    {
-        wxSystemOptions::SetOption("msw.display.directdraw", 1);
-    }
-#endif // __WXMSW__
-
     // create the main application window
     MyFrame *frame = new MyFrame(_("Display wxWidgets Sample"),
                                  wxDefaultPosition, wxDefaultSize);

--- a/samples/display/display.cpp
+++ b/samples/display/display.cpp
@@ -278,6 +278,10 @@ MyFrame::MyFrame(const wxString& title, const wxPoint& pos, const wxSize& size, 
         sizer->Add(new wxStaticText(page, wxID_ANY, "Name: "));
         sizer->Add(new wxStaticText(page, wxID_ANY, display.GetName()));
 
+        sizer->Add(new wxStaticText(page, wxID_ANY, "Primary: "));
+        sizer->Add(new wxStaticText(page, wxID_ANY,
+                                    display.IsPrimary() ? "yes" : "no"));
+
         wxSizer *sizerTop = new wxBoxSizer(wxVERTICAL);
         sizerTop->Add(sizer, 1, wxALL | wxEXPAND, 10);
 

--- a/samples/display/display.cpp
+++ b/samples/display/display.cpp
@@ -235,8 +235,8 @@ MyFrame::MyFrame(const wxString& title, const wxPoint& pos, const wxSize& size, 
     wxPanel *panel = new wxPanel(this, wxID_ANY);
 
     m_book = new wxBookCtrl(panel, wxID_ANY);
-    const size_t count = wxDisplay::GetCount();
-    for ( size_t nDpy = 0; nDpy < count; nDpy++ )
+    const size_t countDpy = wxDisplay::GetCount();
+    for ( size_t nDpy = 0; nDpy < countDpy; nDpy++ )
     {
         wxDisplay display(nDpy);
 
@@ -288,8 +288,8 @@ MyFrame::MyFrame(const wxString& title, const wxPoint& pos, const wxSize& size, 
 #if wxUSE_DISPLAY
         wxChoice *choiceModes = new wxChoice(page, Display_ChangeMode);
         const wxArrayVideoModes modes = display.GetModes();
-        const size_t count = modes.GetCount();
-        for ( size_t nMode = 0; nMode < count; nMode++ )
+        const size_t countModes = modes.GetCount();
+        for ( size_t nMode = 0; nMode < countModes; nMode++ )
         {
             const wxVideoMode& mode = modes[nMode];
 

--- a/src/common/dlgcmn.cpp
+++ b/src/common/dlgcmn.cpp
@@ -44,9 +44,7 @@
 #include "wx/textwrapper.h"
 #include "wx/modalhook.h"
 
-#if wxUSE_DISPLAY
 #include "wx/display.h"
-#endif
 
 extern WXDLLEXPORT_DATA(const char) wxDialogNameStr[] = "dialog";
 
@@ -873,11 +871,7 @@ int wxStandardDialogLayoutAdapter::DoMustScroll(wxDialog* dialog, wxSize& window
     wxSize minWindowSize = dialog->GetSizer()->GetMinSize();
     windowSize = dialog->GetSize();
     windowSize = wxSize(wxMax(windowSize.x, minWindowSize.x), wxMax(windowSize.y, minWindowSize.y));
-#if wxUSE_DISPLAY
     displaySize = wxDisplay(wxDisplay::GetFromWindow(dialog)).GetClientArea().GetSize();
-#else
-    displaySize = wxGetClientDisplayRect().GetSize();
-#endif
 
     int flags = 0;
 

--- a/src/common/dpycmn.cpp
+++ b/src/common/dpycmn.cpp
@@ -115,7 +115,7 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxDisplayModule, wxModule);
 
 wxDisplay::wxDisplay(unsigned n)
 {
-    wxASSERT_MSG( n < GetCount(),
+    wxASSERT_MSG( n == 0 || n < GetCount(),
                     wxT("An invalid index was passed to wxDisplay") );
 
     m_impl = Factory().CreateDisplay(n);

--- a/src/common/dpycmn.cpp
+++ b/src/common/dpycmn.cpp
@@ -118,12 +118,7 @@ wxDisplay::wxDisplay(unsigned n)
     wxASSERT_MSG( n == 0 || n < GetCount(),
                     wxT("An invalid index was passed to wxDisplay") );
 
-    m_impl = Factory().CreateDisplay(n);
-}
-
-wxDisplay::~wxDisplay()
-{
-    delete m_impl;
+    m_impl = Factory().GetDisplay(n);
 }
 
 // ----------------------------------------------------------------------------
@@ -229,6 +224,15 @@ bool wxDisplay::ChangeMode(const wxVideoMode& mode)
 // ============================================================================
 // wxDisplayFactory implementation
 // ============================================================================
+
+wxDisplayFactory::~wxDisplayFactory()
+{
+    for ( size_t n = 0; n < m_impls.size(); ++n )
+    {
+        // It can be null, that's ok.
+        delete m_impls[n];
+    }
+}
 
 int wxDisplayFactory::GetFromWindow(const wxWindow *window)
 {

--- a/src/common/dpycmn.cpp
+++ b/src/common/dpycmn.cpp
@@ -241,7 +241,6 @@ int wxDisplayFactory::GetFromWindow(const wxWindow *window)
 // wxDisplayFactorySingle implementation
 // ============================================================================
 
-/* static */
 wxDisplayImpl *wxDisplayFactorySingle::CreateDisplay(unsigned n)
 {
     // we recognize the main display only

--- a/src/common/dpycmn.cpp
+++ b/src/common/dpycmn.cpp
@@ -30,7 +30,7 @@
 #endif //WX_PRECOMP
 
 #include "wx/display.h"
-#include "wx/display_impl.h"
+#include "wx/private/display.h"
 
 #if wxUSE_DISPLAY
 

--- a/src/common/gdicmn.cpp
+++ b/src/common/gdicmn.cpp
@@ -16,6 +16,8 @@
 #endif
 
 #include "wx/gdicmn.h"
+
+#include "wx/display.h"
 #include "wx/gdiobj.h"
 
 #ifndef WX_PRECOMP
@@ -843,18 +845,36 @@ wxFont *wxFontList::FindOrCreateFont(int pointSize,
     return font;
 }
 
+void wxDisplaySize(int *width, int *height)
+{
+    const wxSize size = wxGetDisplaySize();
+    if ( width )
+        *width = size.x;
+    if ( height )
+        *height = size.y;
+}
+
 wxSize wxGetDisplaySize()
 {
-    int x, y;
-    wxDisplaySize(& x, & y);
-    return wxSize(x, y);
+    return wxDisplay().GetGeometry().GetSize();
+}
+
+void wxClientDisplayRect(int *x, int *y, int *width, int *height)
+{
+    const wxRect rect = wxGetClientDisplayRect();
+    if ( x )
+        *x = rect.x;
+    if ( y )
+        *y = rect.y;
+    if ( width )
+        *width = rect.width;
+    if ( height )
+        *height = rect.height;
 }
 
 wxRect wxGetClientDisplayRect()
 {
-    int x, y, width, height;
-    wxClientDisplayRect(&x, &y, &width, &height);  // call plat-specific version
-    return wxRect(x, y, width, height);
+    return wxDisplay().GetClientArea();
 }
 
 wxSize wxGetDisplaySizeMM()

--- a/src/dfb/utils.cpp
+++ b/src/dfb/utils.cpp
@@ -17,6 +17,7 @@
 #include "wx/utils.h"
 #include "wx/evtloop.h"
 #include "wx/apptrait.h"
+#include "wx/private/display.h"
 #include "wx/unix/private/timer.h"
 
 #ifndef WX_PRECOMP
@@ -56,6 +57,33 @@ wxTimerImpl *wxGUIAppTraits::CreateTimerImpl(wxTimer *timer)
 // display characteristics
 // ----------------------------------------------------------------------------
 
+// TODO: move into a separate src/dfb/display.cpp
+
+class wxDisplayImplSingleDFB : public wxDisplayImplSingle
+{
+public:
+    virtual wxRect GetGeometry() const wxOVERRIDE
+    {
+        const wxVideoMode mode(wxTheApp->GetDisplayMode());
+
+        return wxRect(0, 0, mode.w, mode.h);
+    }
+};
+
+class wxDisplayFactorySingleDFB : public wxDisplayFactorySingle
+{
+protected:
+    virtual wxDisplayImpl *CreateSingleDisplay()
+    {
+        return new wxDisplayImplSingleDFB;
+    }
+};
+
+wxDisplayFactory* wxDisplay::CreateFactory()
+{
+    return new wxDisplayFactorySingleDFB;
+}
+
 bool wxColourDisplay()
 {
     #warning "FIXME: wxColourDisplay"
@@ -65,13 +93,6 @@ bool wxColourDisplay()
 int wxDisplayDepth()
 {
     return wxTheApp->GetDisplayMode().bpp;
-}
-
-void wxDisplaySize(int *width, int *height)
-{
-    wxVideoMode mode(wxTheApp->GetDisplayMode());
-    if ( width ) *width = mode.w;
-    if ( height ) *height = mode.h;
 }
 
 void wxDisplaySizeMM(int *width, int *height)
@@ -88,15 +109,6 @@ void wxDisplaySizeMM(int *width, int *height)
     #undef DPI
     #undef PX_TO_MM
 }
-
-void wxClientDisplayRect(int *x, int *y, int *width, int *height)
-{
-    // return desktop dimensions minus any panels, menus, trays:
-    if (x) *x = 0;
-    if (y) *y = 0;
-    wxDisplaySize(width, height);
-}
-
 
 //-----------------------------------------------------------------------------
 // mouse

--- a/src/gtk/display.cpp
+++ b/src/gtk/display.cpp
@@ -10,7 +10,7 @@
 
 #if wxUSE_DISPLAY
     #include "wx/display.h"
-    #include "wx/display_impl.h"
+    #include "wx/private/display.h"
 #endif
 #include "wx/utils.h" // wxClientDisplayRect
 

--- a/src/gtk/utilsgtk.cpp
+++ b/src/gtk/utilsgtk.cpp
@@ -76,22 +76,6 @@ void *wxGetDisplay()
 }
 #endif
 
-void wxDisplaySize( int *width, int *height )
-{
-#ifdef __WXGTK4__
-    GdkMonitor* monitor = gdk_display_get_primary_monitor(gdk_display_get_default());
-    GdkRectangle rect;
-    gdk_monitor_get_geometry(monitor, &rect);
-    if (width) *width = rect.width;
-    if (height) *height = rect.height;
-#else
-    wxGCC_WARNING_SUPPRESS(deprecated-declarations)
-    if (width) *width = gdk_screen_width();
-    if (height) *height = gdk_screen_height();
-    wxGCC_WARNING_RESTORE()
-#endif
-}
-
 void wxDisplaySizeMM( int *width, int *height )
 {
 #ifdef __WXGTK4__

--- a/src/motif/utils.cpp
+++ b/src/motif/utils.cpp
@@ -239,17 +239,6 @@ int wxDisplayDepth()
     return DefaultDepth (dpy, DefaultScreen (dpy));
 }
 
-// Get size of display
-void wxDisplaySize(int *width, int *height)
-{
-    Display *dpy = wxGlobalDisplay();
-
-    if ( width )
-        *width = DisplayWidth (dpy, DefaultScreen (dpy));
-    if ( height )
-        *height = DisplayHeight (dpy, DefaultScreen (dpy));
-}
-
 void wxDisplaySizeMM(int *width, int *height)
 {
     Display *dpy = wxGlobalDisplay();

--- a/src/msw/display.cpp
+++ b/src/msw/display.cpp
@@ -39,7 +39,7 @@
 #include "wx/dynlib.h"
 #include "wx/sysopt.h"
 
-#include "wx/display_impl.h"
+#include "wx/private/display.h"
 #include "wx/msw/missing.h"
 #include "wx/msw/private.h"
 #include "wx/msw/private/hiddenwin.h"

--- a/src/msw/toplevel.cpp
+++ b/src/msw/toplevel.cpp
@@ -905,20 +905,13 @@ bool wxTopLevelWindowMSW::ShowFullScreen(bool show, long style)
         // change our window style to be compatible with full-screen mode
         updateStyle.Apply();
 
-        wxRect rect;
-#if wxUSE_DISPLAY
-        // resize to the size of the display containing us
+        // resize to the size of the display containing us, falling back to the
+        // primary one
         int dpy = wxDisplay::GetFromWindow(this);
-        if ( dpy != wxNOT_FOUND )
-        {
-            rect = wxDisplay(dpy).GetGeometry();
-        }
-        else // fall back to the main desktop
-#endif // wxUSE_DISPLAY
-        {
-            // resize to the size of the desktop
-            wxCopyRECTToRect(wxGetWindowRect(::GetDesktopWindow()), rect);
-        }
+        if ( dpy == wxNOT_FOUND )
+            dpy = 0;
+
+        const wxRect rect = wxDisplay(dpy).GetGeometry();
 
         SetSize(rect);
 

--- a/src/msw/utilsgui.cpp
+++ b/src/msw/utilsgui.cpp
@@ -145,17 +145,6 @@ int wxDisplayDepth()
     return GetDeviceCaps(dc, PLANES) * GetDeviceCaps(dc, BITSPIXEL);
 }
 
-// Get size of display
-void wxDisplaySize(int *width, int *height)
-{
-    ScreenHDC dc;
-
-    if ( width )
-        *width = ::GetDeviceCaps(dc, HORZRES);
-    if ( height )
-        *height = ::GetDeviceCaps(dc, VERTRES);
-}
-
 void wxDisplaySizeMM(int *width, int *height)
 {
     ScreenHDC dc;

--- a/src/osx/cocoa/utils.mm
+++ b/src/osx/cocoa/utils.mm
@@ -484,19 +484,11 @@ void wxApp::DoCleanUp()
     }
 }
 
-void wxClientDisplayRect(int *x, int *y, int *width, int *height)
+extern // used from src/osx/core/display.cpp
+wxRect wxOSXGetMainDisplayClientArea()
 {
     NSRect displayRect = [wxOSXGetMenuScreen() visibleFrame];
-    wxRect r = wxFromNSRect( NULL, displayRect );
-    if ( x )
-        *x = r.x;
-    if ( y )
-        *y = r.y;
-    if ( width )
-        *width = r.GetWidth();
-    if ( height )
-        *height = r.GetHeight();
-
+    return wxFromNSRect( NULL, displayRect );
 }
 
 void wxGetMousePosition( int* x, int* y )

--- a/src/osx/core/display.cpp
+++ b/src/osx/core/display.cpp
@@ -33,7 +33,7 @@
     #include "wx/gdicmn.h"
 #endif
 
-#include "wx/display_impl.h"
+#include "wx/private/display.h"
 #include "wx/scopedarray.h"
 #include "wx/osx/private.h"
 

--- a/src/osx/iphone/utils.mm
+++ b/src/osx/iphone/utils.mm
@@ -10,8 +10,6 @@
 
 #include "wx/wxprec.h"
 
-#include "wx/wxprec.h"
-
 #include "wx/utils.h"
 
 #ifndef WX_PRECOMP

--- a/src/osx/utils_osx.cpp
+++ b/src/osx/utils_osx.cpp
@@ -87,17 +87,6 @@ int wxDisplayDepth()
     return theDepth;
 }
 
-// Get size of display
-void wxDisplaySize(int *width, int *height)
-{
-    // TODO adapt for multi-displays
-    CGRect bounds = CGDisplayBounds(CGMainDisplayID());
-    if ( width )
-        *width = (int)bounds.size.width ;
-    if ( height )
-        *height = (int)bounds.size.height;
-}
-
 #if wxUSE_GUI
 
 // ----------------------------------------------------------------------------

--- a/src/qt/display.cpp
+++ b/src/qt/display.cpp
@@ -67,17 +67,10 @@ bool wxDisplayImplQt::ChangeMode(const wxVideoMode& WXUNUSED(mode))
 class wxDisplayFactoryQt : public wxDisplayFactory
 {
 public:
-    wxDisplayFactoryQt();
-
     virtual wxDisplayImpl *CreateDisplay(unsigned n) wxOVERRIDE;
     virtual unsigned GetCount() wxOVERRIDE;
     virtual int GetFromPoint(const wxPoint& pt) wxOVERRIDE;
 };
-
-    
-wxDisplayFactoryQt::wxDisplayFactoryQt()
-{
-}
 
 wxDisplayImpl *wxDisplayFactoryQt::CreateDisplay(unsigned n)
 {

--- a/src/qt/display.cpp
+++ b/src/qt/display.cpp
@@ -24,9 +24,11 @@ public:
 
     virtual wxString GetName() const wxOVERRIDE;
 
+#if wxUSE_DISPLAY
     virtual wxArrayVideoModes GetModes(const wxVideoMode& mode) const wxOVERRIDE;
     virtual wxVideoMode GetCurrentMode() const wxOVERRIDE;
     virtual bool ChangeMode(const wxVideoMode& mode) wxOVERRIDE;
+#endif // wxUSE_DISPLAY
 };
 
 wxDisplayImplQt::wxDisplayImplQt( unsigned n )
@@ -49,6 +51,7 @@ wxString wxDisplayImplQt::GetName() const
     return wxString();
 }
 
+#if wxUSE_DISPLAY
 wxArrayVideoModes wxDisplayImplQt::GetModes(const wxVideoMode& WXUNUSED(mode)) const
 {
     return wxArrayVideoModes();
@@ -67,9 +70,12 @@ bool wxDisplayImplQt::ChangeMode(const wxVideoMode& WXUNUSED(mode))
 {
     return false;
 }
+#endif // wxUSE_DISPLAY
 
 
 //##############################################################################
+
+#if wxUSE_DISPLAY
 
 class wxDisplayFactoryQt : public wxDisplayFactory
 {
@@ -100,3 +106,21 @@ int wxDisplayFactoryQt::GetFromPoint(const wxPoint& pt)
 {
     return new wxDisplayFactoryQt;
 }
+
+#else // wxUSE_DISPLAY
+
+class wxDisplayFactorySingleQt : public wxDisplayFactorySingleQt
+{
+protected:
+    virtual wxDisplayImpl *CreateSingleDisplay() wxOVERRIDE
+    {
+        return new wxDisplayImplQt(0);
+    }
+};
+
+/* static */ wxDisplayFactory *wxDisplay::CreateFactory()
+{
+    return new wxDisplayFactorySingleQt;
+}
+
+#endif // wxUSE_DISPLAY/!wxUSE_DISPLAY

--- a/src/qt/display.cpp
+++ b/src/qt/display.cpp
@@ -9,7 +9,7 @@
 #include "wx/wxprec.h"
 
 #include "wx/display.h"
-#include "wx/display_impl.h"
+#include "wx/private/display.h"
 #include <QtWidgets/QApplication>
 #include <QtWidgets/QDesktopWidget>
 #include "wx/qt/private/converter.h"

--- a/src/qt/display.cpp
+++ b/src/qt/display.cpp
@@ -19,12 +19,12 @@ class wxDisplayImplQt : public wxDisplayImpl
 public:
     wxDisplayImplQt( unsigned n );
 
-    virtual wxRect GetGeometry() const;
-    virtual wxString GetName() const;
+    virtual wxRect GetGeometry() const wxOVERRIDE;
+    virtual wxString GetName() const wxOVERRIDE;
 
-    virtual wxArrayVideoModes GetModes(const wxVideoMode& mode) const;
-    virtual wxVideoMode GetCurrentMode() const;
-    virtual bool ChangeMode(const wxVideoMode& mode);
+    virtual wxArrayVideoModes GetModes(const wxVideoMode& mode) const wxOVERRIDE;
+    virtual wxVideoMode GetCurrentMode() const wxOVERRIDE;
+    virtual bool ChangeMode(const wxVideoMode& mode) wxOVERRIDE;
 };
 
 wxDisplayImplQt::wxDisplayImplQt( unsigned n )
@@ -69,9 +69,9 @@ class wxDisplayFactoryQt : public wxDisplayFactory
 public:
     wxDisplayFactoryQt();
 
-    virtual wxDisplayImpl *CreateDisplay(unsigned n);
-    virtual unsigned GetCount();
-    virtual int GetFromPoint(const wxPoint& pt);
+    virtual wxDisplayImpl *CreateDisplay(unsigned n) wxOVERRIDE;
+    virtual unsigned GetCount() wxOVERRIDE;
+    virtual int GetFromPoint(const wxPoint& pt) wxOVERRIDE;
 };
 
     

--- a/src/qt/display.cpp
+++ b/src/qt/display.cpp
@@ -20,6 +20,8 @@ public:
     wxDisplayImplQt( unsigned n );
 
     virtual wxRect GetGeometry() const wxOVERRIDE;
+    virtual wxRect GetClientArea() const wxOVERRIDE;
+
     virtual wxString GetName() const wxOVERRIDE;
 
     virtual wxArrayVideoModes GetModes(const wxVideoMode& mode) const wxOVERRIDE;
@@ -35,6 +37,11 @@ wxDisplayImplQt::wxDisplayImplQt( unsigned n )
 wxRect wxDisplayImplQt::GetGeometry() const
 {
     return wxQtConvertRect( QApplication::desktop()->screenGeometry( GetIndex() ));
+}
+
+wxRect wxDisplayImplQt::GetClientArea() const
+{
+    return wxQtConvertRect( QApplication::desktop()->availableGeometry( GetIndex() ));
 }
 
 wxString wxDisplayImplQt::GetName() const

--- a/src/qt/utils.cpp
+++ b/src/qt/utils.cpp
@@ -115,14 +115,6 @@ int wxDisplayDepth()
     return QApplication::desktop()->depth();
 }
 
-void wxDisplaySize(int *width, int *height)
-{
-    if ( width != NULL )
-        *width = QApplication::desktop()->width();
-    if ( height != NULL )
-        *height = QApplication::desktop()->height();
-}
-
 void wxDisplaySizeMM(int *width, int *height)
 {
     if ( width != NULL )
@@ -134,16 +126,6 @@ void wxDisplaySizeMM(int *width, int *height)
 void wxBell()
 {
     QApplication::beep();
-}
-
-void wxClientDisplayRect(int *x, int *y, int *width, int *height)
-{
-    QRect r = QApplication::desktop()->availableGeometry();
-
-    *x = r.x();
-    *y = r.y();
-    *width = r.width();
-    *height = r.height();
 }
 
 wxWindow *wxGetActiveWindow()

--- a/src/stc/PlatWX.cpp
+++ b/src/stc/PlatWX.cpp
@@ -1953,17 +1953,11 @@ void Window::SetTitle(const char *s) {
 
 // Returns rectangle of monitor pt is on
 PRectangle Window::GetMonitorRect(Point pt) {
-    wxRect rect;
     if (! wid) return PRectangle();
-#if wxUSE_DISPLAY
     // Get the display the point is found on
     int n = wxDisplay::GetFromPoint(wxPoint(wxRound(pt.x), wxRound(pt.y)));
     wxDisplay dpy(n == wxNOT_FOUND ? 0 : n);
-    rect = dpy.GetGeometry();
-#else
-    wxUnusedVar(pt);
-#endif
-    return PRectangleFromwxRect(rect);
+    return PRectangleFromwxRect(dpy.GetGeometry());
 }
 
 //----------------------------------------------------------------------

--- a/src/unix/displayx11.cpp
+++ b/src/unix/displayx11.cpp
@@ -40,7 +40,7 @@
 #if wxUSE_DISPLAY
 
 #include "wx/display.h"
-#include "wx/display_impl.h"
+#include "wx/private/display.h"
 
 #ifndef __WXGTK20__
 

--- a/src/unix/displayx11.cpp
+++ b/src/unix/displayx11.cpp
@@ -44,9 +44,9 @@
 
 #ifndef __WXGTK20__
 
-        #include <X11/extensions/Xinerama.h>
+#include <X11/extensions/Xinerama.h>
 
-    typedef XineramaScreenInfo ScreenInfo;
+typedef XineramaScreenInfo ScreenInfo;
 
 // ----------------------------------------------------------------------------
 // helper class storing information about all screens

--- a/src/x11/utils.cpp
+++ b/src/x11/utils.cpp
@@ -162,17 +162,6 @@ int wxDisplayDepth()
     return DefaultDepth (dpy, DefaultScreen (dpy));
 }
 
-// Get size of display
-void wxDisplaySize(int *width, int *height)
-{
-    Display *dpy = (Display*) wxGetDisplay();
-
-    if ( width )
-        *width = DisplayWidth (dpy, DefaultScreen (dpy));
-    if ( height )
-        *height = DisplayHeight (dpy, DefaultScreen (dpy));
-}
-
 void wxDisplaySizeMM(int *width, int *height)
 {
     Display *dpy = (Display*) wxGetDisplay();

--- a/tests/benchmarks/Makefile.in
+++ b/tests/benchmarks/Makefile.in
@@ -64,6 +64,7 @@ BENCH_GUI_CXXFLAGS = -D__WX$(TOOLKIT)__ $(__WXUNIV_DEFINE_p) \
 BENCH_GUI_OBJECTS =  \
 	$(__bench_gui___win32rc) \
 	bench_gui_bench.o \
+	bench_gui_display.o \
 	bench_gui_image.o
 BENCH_GRAPHICS_CXXFLAGS = -D__WX$(TOOLKIT)__ $(__WXUNIV_DEFINE_p) \
 	$(__DEBUG_DEFINE_p) $(__EXCEPTIONS_DEFINE_p) $(__RTTI_DEFINE_p) \
@@ -305,6 +306,9 @@ bench_gui_sample_rc.o: $(srcdir)/../../samples/sample.rc
 
 bench_gui_bench.o: $(srcdir)/bench.cpp
 	$(CXXC) -c -o $@ $(BENCH_GUI_CXXFLAGS) $(srcdir)/bench.cpp
+
+bench_gui_display.o: $(srcdir)/display.cpp
+	$(CXXC) -c -o $@ $(BENCH_GUI_CXXFLAGS) $(srcdir)/display.cpp
 
 bench_gui_image.o: $(srcdir)/image.cpp
 	$(CXXC) -c -o $@ $(BENCH_GUI_CXXFLAGS) $(srcdir)/image.cpp

--- a/tests/benchmarks/bench.bkl
+++ b/tests/benchmarks/bench.bkl
@@ -36,6 +36,7 @@
 
         <sources>
             bench.cpp
+            display.cpp
             image.cpp
         </sources>
         <wx-lib>core</wx-lib>

--- a/tests/benchmarks/bench_vc7_bench_gui.vcproj
+++ b/tests/benchmarks/bench_vc7_bench_gui.vcproj
@@ -287,6 +287,9 @@
 				RelativePath=".\bench.cpp">
 			</File>
 			<File
+				RelativePath=".\display.cpp">
+			</File>
+			<File
 				RelativePath=".\image.cpp">
 			</File>
 		</Filter>

--- a/tests/benchmarks/bench_vc8_bench_gui.vcproj
+++ b/tests/benchmarks/bench_vc8_bench_gui.vcproj
@@ -811,6 +811,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\display.cpp"
+				>
+			</File>
+			<File
 				RelativePath=".\image.cpp"
 				>
 			</File>

--- a/tests/benchmarks/bench_vc9_bench_gui.vcproj
+++ b/tests/benchmarks/bench_vc9_bench_gui.vcproj
@@ -783,6 +783,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\display.cpp"
+				>
+			</File>
+			<File
 				RelativePath=".\image.cpp"
 				>
 			</File>

--- a/tests/benchmarks/display.cpp
+++ b/tests/benchmarks/display.cpp
@@ -1,0 +1,30 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        tests/benchmarks/display.cpp
+// Purpose:     wxDisplay benchmarks
+// Author:      Vadim Zeitlin
+// Created:     2018-09-30
+// Copyright:   (c) 2018 Vadim Zeitlin <vadim@wxwidgets.org>
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
+#include "wx/display.h"
+#include "wx/gdicmn.h"
+
+#include "bench.h"
+
+BENCHMARK_FUNC(DisplaySize)
+{
+    int w, h;
+    wxDisplaySize(&w, &h);
+    return w > 0;
+}
+
+BENCHMARK_FUNC(GetDisplaySize)
+{
+    return wxGetDisplaySize().x > 0;
+}
+
+BENCHMARK_FUNC(DisplayGetGeometry)
+{
+    return wxDisplay().GetGeometry().GetSize().x > 0;
+}

--- a/tests/benchmarks/makefile.bcc
+++ b/tests/benchmarks/makefile.bcc
@@ -54,6 +54,7 @@ BENCH_GUI_CXXFLAGS = $(__RUNTIME_LIBS) -I$(BCCDIR)\include $(__DEBUGINFO) \
 	$(__DLLFLAG_p) -I.\..\..\samples -DNOPCH $(CPPFLAGS) $(CXXFLAGS)
 BENCH_GUI_OBJECTS =  \
 	$(OBJS)\bench_gui_bench.obj \
+	$(OBJS)\bench_gui_display.obj \
 	$(OBJS)\bench_gui_image.obj
 BENCH_GRAPHICS_CXXFLAGS = $(__RUNTIME_LIBS) -I$(BCCDIR)\include $(__DEBUGINFO) \
 	$(__OPTIMIZEFLAG) $(__THREADSFLAG_1) -D__WXMSW__ $(__WXUNIV_DEFINE_p) \
@@ -339,6 +340,9 @@ $(OBJS)\bench_gui_sample.res: .\..\..\samples\sample.rc
 
 $(OBJS)\bench_gui_bench.obj: .\bench.cpp
 	$(CXX) -q -c -P -o$@ $(BENCH_GUI_CXXFLAGS) .\bench.cpp
+
+$(OBJS)\bench_gui_display.obj: .\display.cpp
+	$(CXX) -q -c -P -o$@ $(BENCH_GUI_CXXFLAGS) .\display.cpp
 
 $(OBJS)\bench_gui_image.obj: .\image.cpp
 	$(CXX) -q -c -P -o$@ $(BENCH_GUI_CXXFLAGS) .\image.cpp

--- a/tests/benchmarks/makefile.gcc
+++ b/tests/benchmarks/makefile.gcc
@@ -49,6 +49,7 @@ BENCH_GUI_CXXFLAGS = $(__DEBUGINFO) $(__OPTIMIZEFLAG) $(__THREADSFLAG) \
 BENCH_GUI_OBJECTS =  \
 	$(OBJS)\bench_gui_sample_rc.o \
 	$(OBJS)\bench_gui_bench.o \
+	$(OBJS)\bench_gui_display.o \
 	$(OBJS)\bench_gui_image.o
 BENCH_GRAPHICS_CXXFLAGS = $(__DEBUGINFO) $(__OPTIMIZEFLAG) $(__THREADSFLAG) \
 	$(GCCFLAGS) -DHAVE_W32API_H -D__WXMSW__ $(__WXUNIV_DEFINE_p) \
@@ -316,6 +317,9 @@ $(OBJS)\bench_gui_sample_rc.o: ./../../samples/sample.rc
 	$(WINDRES) -i$< -o$@    --define __WXMSW__ $(__WXUNIV_DEFINE_p_0) $(__DEBUG_DEFINE_p_0) $(__NDEBUG_DEFINE_p_0) $(__EXCEPTIONS_DEFINE_p_0) $(__RTTI_DEFINE_p_0) $(__THREAD_DEFINE_p_0) $(__UNICODE_DEFINE_p_0) --include-dir $(SETUPHDIR) --include-dir ./../../include $(__CAIRO_INCLUDEDIR_p) --include-dir . $(__DLLFLAG_p_0) --include-dir ./../../samples --define NOPCH
 
 $(OBJS)\bench_gui_bench.o: ./bench.cpp
+	$(CXX) -c -o $@ $(BENCH_GUI_CXXFLAGS) $(CPPDEPS) $<
+
+$(OBJS)\bench_gui_display.o: ./display.cpp
 	$(CXX) -c -o $@ $(BENCH_GUI_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\bench_gui_image.o: ./image.cpp

--- a/tests/benchmarks/makefile.vc
+++ b/tests/benchmarks/makefile.vc
@@ -51,6 +51,7 @@ BENCH_GUI_CXXFLAGS = /M$(__RUNTIME_LIBS_26)$(__DEBUGRUNTIME) /DWIN32 \
 	/DNOPCH /D_CONSOLE $(__RTTIFLAG) $(__EXCEPTIONSFLAG) $(CPPFLAGS) $(CXXFLAGS)
 BENCH_GUI_OBJECTS =  \
 	$(OBJS)\bench_gui_bench.obj \
+	$(OBJS)\bench_gui_display.obj \
 	$(OBJS)\bench_gui_image.obj
 BENCH_GUI_RESOURCES =  \
 	$(OBJS)\bench_gui_sample.res
@@ -511,6 +512,9 @@ $(OBJS)\bench_gui_sample.res: .\..\..\samples\sample.rc
 
 $(OBJS)\bench_gui_bench.obj: .\bench.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(BENCH_GUI_CXXFLAGS) .\bench.cpp
+
+$(OBJS)\bench_gui_display.obj: .\display.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(BENCH_GUI_CXXFLAGS) .\display.cpp
 
 $(OBJS)\bench_gui_image.obj: .\image.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(BENCH_GUI_CXXFLAGS) .\image.cpp


### PR DESCRIPTION
This is the first step, without any real changes yet.

At the end of the road, I want to have `wxDisplay::GetPPI()` instead of just `wxGetDisplayPPI()` we have now.

@paulcor I'll also probably split wxGTK code in 2 separate GTK+ 4 and GTK+ < 4 parts as the current version is just too messy. Please let me know if you have any objections.

Of course, any reviews are welcome, as usual.