### PR TITLE
Qt ownerdrawn fix

### DIFF
--- a/build/cmake/init.cmake
+++ b/build/cmake/init.cmake
@@ -162,6 +162,7 @@ if(wxUSE_GUI)
         wx_option_force_value(wxUSE_METAFILE OFF)
         if(WIN32)
             wx_option_force_value(wxUSE_ACCESSIBILITY OFF)
+            wx_option_force_value(wxUSE_OWNER_DRAWN OFF)
         endif()
     endif()
 

--- a/include/wx/qt/menuitem.h
+++ b/include/wx/qt/menuitem.h
@@ -9,20 +9,12 @@
 #define _WX_QT_MENUITEM_H_
 
 #include "wx/menuitem.h"
-
-#if wxUSE_OWNER_DRAWN
-    #include "wx/ownerdrw.h"
-#endif
-
 class QAction;
 
 class WXDLLIMPEXP_FWD_CORE wxBitmap;
 class WXDLLIMPEXP_FWD_CORE wxMenu;
 
 class WXDLLIMPEXP_CORE wxMenuItem : public wxMenuItemBase
-#if wxUSE_OWNER_DRAWN
-    , public wxOwnerDrawnBase
-#endif
 {
 public:
     wxMenuItem(wxMenu *parentMenu = NULL,
@@ -41,29 +33,14 @@ public:
     virtual void Check(bool check = true);
     virtual bool IsChecked() const;
 
-    void SetBitmaps(const wxBitmap& bmpChecked,
-                    const wxBitmap& bmpUnchecked = wxNullBitmap);
     void SetBitmap(const wxBitmap& bitmap);
     const wxBitmap& GetBitmap() const;
 
     virtual QAction *GetHandle() const;
 
-#if wxUSE_OWNER_DRAWN
-    void SetDisabledBitmap(const wxBitmap& bmpDisabled);
-    const wxBitmap& GetDisabledBitmap() const;
-
-    // override wxOwnerDrawn base class virtuals
-    virtual wxString GetName() const wxOVERRIDE;
-    virtual bool OnDrawItem(wxDC& dc, const wxRect& rc, wxODAction act, wxODStatus stat) wxOVERRIDE;
-#endif // wxUSE_OWNER_DRAWN
-
 private:
     // Qt is using an action instead of a menu item.
     QAction *m_qtAction;
-
-#if wxUSE_OWNER_DRAWN
-    wxBitmap m_bmpDisabled;
-#endif // wxUSE_OWNER_DRAWN
 
     wxDECLARE_DYNAMIC_CLASS( wxMenuItem );
 };

--- a/src/qt/menuitem.cpp
+++ b/src/qt/menuitem.cpp
@@ -106,12 +106,6 @@ bool wxMenuItem::IsChecked() const
 }
 
 
-void wxMenuItem::SetBitmaps(const wxBitmap& WXUNUSED(bmpChecked),
-                            const wxBitmap& WXUNUSED(bmpUnchecked))
-{
-    wxMISSING_FUNCTION();
-}
-
 void wxMenuItem::SetBitmap(const wxBitmap& WXUNUSED(bitmap))
 {
     wxMISSING_FUNCTION();
@@ -130,34 +124,6 @@ QAction *wxMenuItem::GetHandle() const
 {
     return m_qtAction;
 }
-
-#if wxUSE_OWNER_DRAWN
-
-void wxMenuItem::SetDisabledBitmap(const wxBitmap& bmpDisabled)
-{
-    m_bmpDisabled = bmpDisabled;
-    wxMISSING_FUNCTION();
-}
-
-const wxBitmap& wxMenuItem::GetDisabledBitmap() const
-{
-    wxMISSING_FUNCTION();
-    return m_bmpDisabled;
-}
-
-wxString wxMenuItem::GetName() const
-{
-    return GetItemLabelText();
-}
-
-bool wxMenuItem::OnDrawItem(wxDC& WXUNUSED(dc), const wxRect& WXUNUSED(rc),
-                            wxODAction WXUNUSED(act), wxODStatus WXUNUSED(stat))
-{
-    wxMISSING_FUNCTION();
-    return false;
-}
-
-#endif // wxUSE_OWNER_DRAWN
 
 //=============================================================================
 


### PR DESCRIPTION
This reverts commit 4e23b3e. `wxOwnerDrawn` is only used with wxMSW toolkit.

Disable `wxUSE_OWNER_DRAWN` when using WXQT with CMake.