### PR TITLE
Select latest Windows 10 SDK when building with Visual Studio 2017

### DIFF
--- a/build/msw/wx_config.props
+++ b/build/msw/wx_config.props
@@ -10,4 +10,10 @@
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '14.0'">v140</PlatformToolset>
     <PlatformToolset Condition="'$(VisualStudioVersion)' == '15.0'">v141</PlatformToolset>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(VisualStudioVersion)' >= '15.0' and '$(WindowsTargetPlatformVersion)'==''">
+    <!-- Latest Target Version property -->
+    <LatestTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</LatestTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
+    <TargetPlatformVersion>$(WindowsTargetPlatformVersion)</TargetPlatformVersion>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Unfortunately Visual Studio 2017 defaults to Windows SDK 8.1
which is not installed with it. This workaround automatically
targets the latest Windows 10 SDK when building.

Fixes: Trac [#18078](https://trac.wxwidgets.org/ticket/18078)