### PR TITLE
Fix DST date parsing unit tests, broken under TZ=GB.

### DIFF
--- a/src/common/datetimefmt.cpp
+++ b/src/common/datetimefmt.cpp
@@ -1652,7 +1652,13 @@ wxDateTime::ParseFormat(const wxString& date,
     //
     // Note that avoiding the call to MakeFromTimeZone is necessary to avoid
     // DST problems.
-    if ( haveTimeZone && timeZone != -wxGetTimeZone() )
+
+    int effective_tz = wxGetTimeZone();
+    if(IsDST())
+    {
+        effective_tz += DST_OFFSET;
+    }
+    if ( haveTimeZone && timeZone != -effective_tz )
         MakeFromTimezone(timeZone);
 
     // finally check that the week day is consistent -- if we had it


### PR DESCRIPTION
Under GB timezone, certain tests match the GB timezone: the +0000, Zulu; anything that is zero. During DST, this results in an incorrectly parsed date, as DST offset is ignored when comparing timezone.