### PR TITLE
Fix wxDateTime ParseFormat when matching TZ offset and in DST.

### DIFF
--- a/src/common/datetimefmt.cpp
+++ b/src/common/datetimefmt.cpp
@@ -1647,12 +1647,7 @@ wxDateTime::ParseFormat(const wxString& date,
 
     Set(tm);
 
-    // If a time zone was specified and it is not the local time zone, we need
-    // to shift the time accordingly.
-    //
-    // Note that avoiding the call to MakeFromTimeZone is necessary to avoid
-    // DST problems.
-    if ( haveTimeZone && timeZone != -wxGetTimeZone() )
+    if ( haveTimeZone )
         MakeFromTimezone(timeZone);
 
     // finally check that the week day is consistent -- if we had it


### PR DESCRIPTION
Improved fix for failing ParseFormat unit tests. The original only shifted the problem on to the next timezone. What was happening was that the matching timezone was ignored, so times parsed for the user's timezone (without DST applied) would always be an hour off when parsing during real DST.
Date internals verified as being wrong internally with GetHour (in the tests) and using Format() with timezone output set to UTC (when bug occurs, the date is different to the input string).
Applied fix and retested this with GMT, UTC, BST, GB, CET, CEST, EET, EEST. 