### PR TITLE
Add column parameter to OSX dataview control

### DIFF
--- a/samples/dataview/dataview.cpp
+++ b/samples/dataview/dataview.cpp
@@ -1214,7 +1214,7 @@ void MyFrame::OnValueChanged( wxDataViewEvent &event )
 void MyFrame::OnActivated( wxDataViewEvent &event )
 {
     wxString title = m_music_model->GetTitle( event.GetItem() );
-    wxLogMessage( "wxEVT_DATAVIEW_ITEM_ACTIVATED, Item: %s", title );
+    wxLogMessage( "wxEVT_DATAVIEW_ITEM_ACTIVATED, Item: %s, column %d", title, event.GetColumn() );
 
     if (m_ctrl[0]->IsExpanded( event.GetItem() ))
     {

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -1657,6 +1657,7 @@ outlineView:(NSOutlineView*)outlineView
 
     const wxDataViewItem item = wxDataViewItemFromItem([self itemAtRow:[self clickedRow]]);
     wxDataViewEvent event(wxEVT_DATAVIEW_ITEM_ACTIVATED, dvc, item);
+    event.SetColumn( [self clickedColumn] );
     dvc->GetEventHandler()->ProcessEvent(event);
 }
 


### PR DESCRIPTION
Please review and apply.
Tested on the following configuration:

CXXFLAGS="-std=c++11" ../configure --enable-debug --with-cocoa --with-macosx-version-min=10.9 