### PR TITLE
Fix crash in wxMenu::MSWCommand if item is NULL

### DIFF
--- a/src/msw/menu.cpp
+++ b/src/msw/menu.cpp
@@ -793,9 +793,13 @@ bool wxMenu::MSWCommand(WXUINT WXUNUSED(param), WXWORD id_)
                 UINT menuState = ::GetMenuState(GetHmenu(), id_, MF_BYCOMMAND);
                 checked = (menuState & MF_CHECKED) != 0;
             }
-        }
 
-        item->GetMenu()->SendEvent(id, checked);
+            item->GetMenu()->SendEvent(id, checked);
+        }
+        else
+        {
+            SendEvent(id, checked);
+        }
     }
 
     return true;


### PR DESCRIPTION
I'm seeing a large number of crashes reported on the `item->GetMenu()->SendEvent(id, checked);` line, but I can't reproduce it myself to confirm the behavior.

Still, there was a check for item being non-NULL before, so I assume it's a situation that can occur, although I'm unclear on the specifics. This change restores old behavior, before de5ba70203f18fde148c71495ab5ee5aab7540a3, in case the item is not found.