### PR TITLE
wxGrid crashes when dragging a header past the last column

### DIFF
--- a/include/wx/generic/headerctrlg.h
+++ b/include/wx/generic/headerctrlg.h
@@ -82,6 +82,9 @@ private:
     // and the end position
     int GetColEnd(unsigned int idx) const;
 
+    // return the index of the last displayed column
+    int GetLastCol() const;
+
     // refresh the given column [only]; idx must be valid
     void RefreshCol(unsigned int idx);
 
@@ -97,6 +100,10 @@ private:
     // that this means that we return column 0 even if the position is over
     // column 1 but close enough to the divider separating it from column 0)
     unsigned int FindColumnAtPoint(int x, bool *onSeparator = NULL) const;
+
+    // returns FindColumnAtPoint(...) if the result is a valid column otherwise
+    // the index of the last displayed column (rightmost) is returned
+    unsigned int FindColumnAtPointElseLast(int xPhysical, bool *onSeparator = NULL) const;
 
     // return true if a drag resizing operation is currently in progress
     bool IsResizing() const;

--- a/src/generic/headerctrlg.cpp
+++ b/src/generic/headerctrlg.cpp
@@ -419,8 +419,17 @@ bool wxHeaderCtrl::EndReordering(int xPhysical)
 
     m_colBeingReordered = COL_NONE;
 
+    // mouse drag must be longer than min distance m_dragOffset
     if ( xPhysical - GetColStart(colOld) == m_dragOffset )
+    {
         return false;
+    }
+
+    // the new drag location may not be valid, such as past the last column
+    if ( colNew == COL_NONE)
+    {
+        return false;
+    }
 
     if ( colNew != colOld )
     {


### PR DESCRIPTION
I found this while debugging a crash in KiCad.
![image](https://user-images.githubusercontent.com/11207308/46712859-244fd980-cc21-11e8-847e-5ad29872de2e.png)

## Repro Steps
1. Start with a wxGrid object that does not have enough columns to fill its entire width.
2. Click on any column header.
3. Drag the selected column header past the end of the last column (see blue box above).
4. App crashes due to an "array out of bounds" error.

You can find this specific repro in KiCad's "Eeschema" app. Look for the "Edit symbol fields" icon (it looks like a spreadsheet) on the toolbar.

## Fix Explanation
As far as I can tell, this is an error in wxWidgets code where an error case is not properly handled/expected. I inspected a crashing callstack in GDB, and see the errors occurring in routines outside of KiCad's control. I'm no expert in wxWidgets, so forgive me if I am missing something obvious :)

The following line can return COL_NONE, which is not a valid index.
`colNew = FindColumnAtPoint(xPhysical);`

When the cursor is outside of the valid columns, COL_NONE should be expected. However, we directly set a position index from this value, without handling the (possible) error case.
`const unsigned pos = GetColumnPos(colNew);`

A simple return-early guard against this invalid value should resolve the crash.

## Testing
I have done some limited manual testing. The patch is compiled and running system-wide on my Linux box, and I haven't seen crashes/odd behavior.

The repro steps above no longer result in a crash.