### PR TITLE
Add download update instructions "how to release" documentation

### DIFF
--- a/docs/contributing/how-to-release.md
+++ b/docs/contributing/how-to-release.md
@@ -125,7 +125,7 @@ Update https://www.wxwidgets.org:
   more can be called for for major releases
 
 Post `docs/publicity/announce.txt` at least to wx-announce@googlegroups.com and
-to wx-users for the important releases.
+to wx-users.
 
 Submit a link to https://www.reddit.com/r/programming
 

--- a/docs/contributing/how-to-release.md
+++ b/docs/contributing/how-to-release.md
@@ -117,8 +117,12 @@ Create https://docs.wxwidgets.org/x.y.z/ (ask Bryan to do it if not done yet).
 
 ## Announcement
 
-Update https://www.wxwidgets.org, usually a news item is enough but something
-more can be called for for major releases.
+Update https://www.wxwidgets.org:
+* Update release information (at least `version` and `released`) in `_data/relases.yml`.
+* Download information can then be updated by running `update_release_info.rb`.
+  This will update the asset information from GitHub.
+* Add a news item. Usually a news item is enough but something
+  more can be called for for major releases
 
 Post `docs/publicity/announce.txt` at least to wx-announce@googlegroups.com and
 to wx-users for the important releases.


### PR DESCRIPTION
Updated instructions will be relevant after merge of [website PR](https://github.com/wxWidgets/website/pull/27) to improve the downloads page