### PR TITLE
fix layout direction in qt radio box

### DIFF
--- a/src/qt/radiobox.cpp
+++ b/src/qt/radiobox.cpp
@@ -135,9 +135,13 @@ bool wxRadioBox::Create(wxWindow *parent,
     m_qtGroupBox->setTitle( wxQtConvertString( title ) );
     m_qtButtonGroup = new wxQtButtonGroup( m_qtGroupBox, this );
 
-    if ( style & wxRA_SPECIFY_ROWS )
+    // wxRA_SPECIFY_COLS means that we arrange buttons in
+    // left to right order and GetMajorDim() is the number of columns while
+    // wxRA_SPECIFY_ROWS means that the buttons are arranged top to bottom and
+    // GetMajorDim() is the number of rows.
+    if ( style & wxRA_SPECIFY_COLS )
         m_qtBoxLayout = new QHBoxLayout;
-    else if ( style & wxRA_SPECIFY_COLS )
+    else if ( style & wxRA_SPECIFY_ROWS )
         m_qtBoxLayout = new QVBoxLayout;
 
     AddChoices< QRadioButton >( m_qtButtonGroup, m_qtBoxLayout, n, choices );


### PR DESCRIPTION
The layout directions were reversed. The description for the values was copied from the MSW implementation.