### PR TITLE
Add GDK_WINDOWING_X11 guard for wxGTK/Win32

### DIFF
--- a/src/gtk/renderer.cpp
+++ b/src/gtk/renderer.cpp
@@ -35,7 +35,8 @@
 #include "wx/dcgraph.h"
 #ifndef __WXGTK3__
     #include "wx/gtk/dc.h"
-    #if wxUSE_GRAPHICS_CONTEXT
+    #include "wx/gtk/private/wrapgtk.h"
+    #if wxUSE_GRAPHICS_CONTEXT && defined(GDK_WINDOWING_X11)
         #include <gdk/gdkx.h>
         #include <cairo-xlib.h>
     #endif
@@ -174,7 +175,7 @@ static GdkWindow* wxGetGTKDrawable(wxDC& dc)
 {
     GdkWindow* gdk_window = NULL;
 
-#if wxUSE_GRAPHICS_CONTEXT
+#if wxUSE_GRAPHICS_CONTEXT && defined(GDK_WINDOWING_X11)
     cairo_t* cr = NULL;
     wxGraphicsContext* gc = dc.GetGraphicsContext();
     if (gc)


### PR DESCRIPTION
Fix building of wxGTK/Win32