### PR TITLE
Use SDK options with cpp too in configure under macOS

### DIFF
--- a/configure
+++ b/configure
@@ -20494,6 +20494,8 @@ if test "$USE_UNIX" = 1 ; then
 
 fi
 
+export CC CFLAGS CPP CPPFLAGS CXX CXXFLAGS LDD LDFLAGS OBJCFLAGS OBJCXXFLAGS
+
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ANSI C header files" >&5
 $as_echo_n "checking for ANSI C header files... " >&6; }

--- a/configure
+++ b/configure
@@ -23371,7 +23371,7 @@ fi
     fi
 fi
 
-if test "$HAVE_LZMA" = "no" -o "$wxUSE_LIBTIFF" = "builtin"; then
+if test "$wxUSE_LIBLZMA" = "no" -a "$wxUSE_LIBTIFF" = "builtin"; then
     ac_configure_args="$ac_configure_args --disable-lzma"
 fi
 

--- a/configure
+++ b/configure
@@ -20194,6 +20194,7 @@ elif test "x$wxUSE_MACOSX_VERSION_MIN" = "x"; then
 fi
 
 if test "x$MACOSX_SDK_OPTS" != "x"; then
+    eval "CPP=\"$CPP $MACOSX_SDK_OPTS\""
     eval "CC=\"$CC $MACOSX_SDK_OPTS\""
     eval "CXX=\"$CXX $MACOSX_SDK_OPTS\""
     eval "LD=\"$LD $MACOSX_SDK_OPTS\""
@@ -20206,6 +20207,7 @@ if test "x$wxUSE_MACOSX_VERSION_MIN" != "x"; then
     else
         MACOSX_VERSION_MIN_OPTS="-mmacosx-version-min=$wxUSE_MACOSX_VERSION_MIN"
     fi
+    eval "CPP=\"$CPP $MACOSX_VERSION_MIN_OPTS\""
     eval "CC=\"$CC $MACOSX_VERSION_MIN_OPTS\""
     eval "CXX=\"$CXX $MACOSX_VERSION_MIN_OPTS\""
     eval "LD=\"$LD $MACOSX_VERSION_MIN_OPTS\""

--- a/configure.in
+++ b/configure.in
@@ -2585,7 +2585,7 @@ dnl We need to disable the use of lzma in built-in libtiff explicitly, as
 dnl otherwise we'd depend on the system lzma library, which is typically
 dnl undesirable when using builtin libraries. We also disable the use of lzma
 dnl if it's not available anyhow, just to speed up libtiff configure a little.
-if test "$HAVE_LZMA" = "no" -o "$wxUSE_LIBTIFF" = "builtin"; then
+if test "$wxUSE_LIBLZMA" = "no" -a "$wxUSE_LIBTIFF" = "builtin"; then
     ac_configure_args="$ac_configure_args --disable-lzma"
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -1477,6 +1477,10 @@ if test "$USE_UNIX" = 1 ; then
     AC_DEFINE(__UNIX__)
 fi
 
+dnl Values of these variables shouldn't change any longer from now on, we
+dnl export them to ensure they're picked up by sub-configure scripts.
+export CC CFLAGS CPP CPPFLAGS CXX CXXFLAGS LDD LDFLAGS OBJCFLAGS OBJCXXFLAGS
+
 dnl ------------------------------------------------------------------------
 dnl Check for headers
 dnl ------------------------------------------------------------------------

--- a/configure.in
+++ b/configure.in
@@ -1279,6 +1279,7 @@ elif test "x$wxUSE_MACOSX_VERSION_MIN" = "x"; then
 fi
 
 if test "x$MACOSX_SDK_OPTS" != "x"; then
+    eval "CPP=\"$CPP $MACOSX_SDK_OPTS\""
     eval "CC=\"$CC $MACOSX_SDK_OPTS\""
     eval "CXX=\"$CXX $MACOSX_SDK_OPTS\""
     eval "LD=\"$LD $MACOSX_SDK_OPTS\""
@@ -1291,6 +1292,7 @@ if test "x$wxUSE_MACOSX_VERSION_MIN" != "x"; then
     else
         MACOSX_VERSION_MIN_OPTS="-mmacosx-version-min=$wxUSE_MACOSX_VERSION_MIN"
     fi
+    eval "CPP=\"$CPP $MACOSX_VERSION_MIN_OPTS\""
     eval "CC=\"$CC $MACOSX_VERSION_MIN_OPTS\""
     eval "CXX=\"$CXX $MACOSX_VERSION_MIN_OPTS\""
     eval "LD=\"$LD $MACOSX_VERSION_MIN_OPTS\""


### PR DESCRIPTION
Otherwise trying to compile and preprocess a file could behave
differently because the format could not find a header existing in the
system due to the use of -isysroot option, confusing configure.