### PR TITLE
Propagate InformFirstDirection() to children

### DIFF
--- a/include/wx/collpane.h
+++ b/include/wx/collpane.h
@@ -43,6 +43,23 @@ public:
 
     virtual wxString GetLabel() const wxOVERRIDE = 0;
     virtual void SetLabel(const wxString& label) wxOVERRIDE = 0;
+
+    virtual bool
+    InformFirstDirection(int direction,
+                         int size,
+                         int availableOtherDir) wxOVERRIDE
+    {
+        wxWindow* const p = GetPane();
+        if ( !p )
+            return false;
+
+        if ( !p->InformFirstDirection(direction, size, availableOtherDir) )
+            return false;
+
+        InvalidateBestSize();
+
+        return true;
+    }
 };
 
 

--- a/include/wx/sizer.h
+++ b/include/wx/sizer.h
@@ -619,6 +619,10 @@ public:
 
     // Inform sizer about the first direction that has been decided (by parent item)
     // Returns true if it made use of the information (and recalculated min size)
+    //
+    // Note that while this method doesn't do anything by default, it should
+    // almost always be overridden in the derived classes and should have been
+    // pure virtual if not for backwards compatibility constraints.
     virtual bool InformFirstDirection( int WXUNUSED(direction), int WXUNUSED(size), int WXUNUSED(availableOtherDir) )
         { return false; }
 
@@ -957,6 +961,10 @@ public:
     // implementation of our resizing logic
     virtual wxSize CalcMin() wxOVERRIDE;
     virtual void RecalcSizes() wxOVERRIDE;
+
+    virtual bool InformFirstDirection(int direction,
+                                      int size,
+                                      int availableOtherDir) wxOVERRIDE;
 
 protected:
     // Only overridden to perform extra debugging checks.

--- a/src/common/sizer.cpp
+++ b/src/common/sizer.cpp
@@ -2544,6 +2544,31 @@ wxSize wxBoxSizer::CalcMin()
     return m_calculatedMinSize;
 }
 
+bool
+wxBoxSizer::InformFirstDirection(int direction, int size, int availableOtherDir)
+{
+    // In principle, we could propagate the information about the size in the
+    // sizer major direction too, but this would require refactoring CalcMin()
+    // to determine the actual sizes all our items would have with the given
+    // size and we don't do this yet, so for now handle only the simpler case
+    // of informing all our items about their size in the orthogonal direction.
+    if ( direction == GetOrientation() )
+        return false;
+
+    bool didUse = false;
+
+    for ( wxSizerItemList::compatibility_iterator node = m_children.GetFirst();
+          node;
+          node = node->GetNext() )
+    {
+        didUse |= node->GetData()->InformFirstDirection(direction,
+                                                        size,
+                                                        availableOtherDir);
+    }
+
+    return didUse;
+}
+
 //---------------------------------------------------------------------------
 // wxStaticBoxSizer
 //---------------------------------------------------------------------------


### PR DESCRIPTION
This fixes problems discussed in [#18235](https://trac.wxwidgets.org/ticket/18235).