### PR TITLE
Make Mac, MSW and Unix joysticks behave the same.

### DIFF
--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -15,6 +15,7 @@
 #include "wx/cpp.h"
 #include "wx/object.h"
 #include "wx/clntdata.h"
+#include "wx/math.h"
 
 #if wxUSE_GUI
     #include "wx/gdicmn.h"
@@ -2760,6 +2761,7 @@ public:
     int GetZPosition() const { return m_zPosition; }
     int GetButtonState() const { return m_buttonState; }
     int GetButtonChange() const { return m_buttonChange; }
+    int GetButtonOrdinal() const { return wxCTZ(m_buttonChange); }
     int GetJoystick() const { return m_joyStick; }
 
     void SetJoystick(int stick) { m_joyStick = stick; }

--- a/include/wx/math.h
+++ b/include/wx/math.h
@@ -181,4 +181,9 @@ inline double wxRadToDeg(double rad) { return (rad * 180.0) / M_PI; }
 /* Compute the greatest common divisor of two positive integers */
 WXDLLIMPEXP_BASE unsigned int wxGCD(unsigned int u, unsigned int v);
 
+#ifdef __cplusplus
+/* Count trailing zeros */
+WXDLLIMPEXP_BASE unsigned int wxCTZ(unsigned x);
+#endif
+
 #endif /* _WX_MATH_H_ */

--- a/include/wx/math.h
+++ b/include/wx/math.h
@@ -182,7 +182,12 @@ inline double wxRadToDeg(double rad) { return (rad * 180.0) / M_PI; }
 WXDLLIMPEXP_BASE unsigned int wxGCD(unsigned int u, unsigned int v);
 
 #ifdef __cplusplus
-/* Count trailing zeros */
+/* Count trailing zeros
+
+Returns the number of trailing zeros in unsigned input x.
+
+@since 3.1.2
+*/
 WXDLLIMPEXP_BASE unsigned int wxCTZ(unsigned x);
 #endif
 

--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -1741,9 +1741,16 @@ public:
     /**
         Returns the identifier of the button changing state.
 
-        This is a @c wxJOY_BUTTONn identifier, where @c n is one of 1, 2, 3, 4.
+        This was once a @c wxJOY_BUTTONn identifier, where @c n is one of 1, 2, 3, 4,
+        and whose values were 1 << n. To support more than four buttons, the return value
+        is now defined as 1 << n.
     */
     int GetButtonChange() const;
+
+    /**
+        Returns the 0-indexed ordinal of the button changing state @since 3.1.2.
+    */
+    int GetButtonOrdinal() const;
 
     /**
         Returns the down state of the buttons.

--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -1741,7 +1741,12 @@ public:
     /**
         Returns the identifier of the button changing state.
 
-        This was once a @c wxJOY_BUTTONn identifier, where @c n is one of 1, 2, 3, 4,
+        The return value is @code 1 << n @endcode where @c n is the index of the
+        button changing state.
+        
+        Note that for @c n equal to 1, 2, 3 or 4 there are predefined @c wxJOY_BUTTONn
+        constants which can be used for more clarity, however these constants are not
+        defined for the buttons beyond the first four.
         and whose values were 1 << n. To support more than four buttons, the return value
         is now defined as 1 << n.
     */

--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -1748,7 +1748,9 @@ public:
     int GetButtonChange() const;
 
     /**
-        Returns the 0-indexed ordinal of the button changing state @since 3.1.2.
+        Returns the 0-indexed ordinal of the button changing state.
+        
+        @since 3.1.2.
     */
     int GetButtonOrdinal() const;
 

--- a/samples/joytest/joytest.cpp
+++ b/samples/joytest/joytest.cpp
@@ -159,7 +159,7 @@ void MyCanvas::OnJoystickEvent(wxJoystickEvent& event)
 #if wxUSE_STATUSBAR
     wxString buf;
     if (event.ButtonDown())
-        buf.Printf("Joystick (%ld, %ld) #%i Fire!", xpos, ypos, event.GetButtonChange());
+        buf.Printf("Joystick (%ld, %ld) #%i Fire!", xpos, ypos, event.GetButtonOrdinal());
     else
         buf.Printf("Joystick (%ld, %ld)  ", xpos, ypos);
 

--- a/src/common/utilscmn.cpp
+++ b/src/common/utilscmn.cpp
@@ -19,6 +19,8 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#include "wx/debug.h"
+
 #ifdef __BORLANDC__
     #pragma hdrstop
 #endif
@@ -1014,6 +1016,27 @@ unsigned int wxGCD(unsigned int u, unsigned int v)
     // restore common factors of 2
     return u << shift;
 }
+
+// ----------------------------------------------------------------------------
+// wxCTZ
+// Count trailing zeros. Use optimised builtin where available.
+// ----------------------------------------------------------------------------
+unsigned int wxCTZ(unsigned x)
+{
+    wxCHECK_MSG(x > 0, 0, "Undefined for x == 0.");
+#ifdef __GNUC__
+   return __builtin_ctz(x);
+#else
+   int n;
+   n = 1;
+   if ((x & 0x0000FFFF) == 0) {n = n +16; x = x >>16;}
+   if ((x & 0x000000FF) == 0) {n = n + 8; x = x >> 8;}
+   if ((x & 0x0000000F) == 0) {n = n + 4; x = x >> 4;}
+   if ((x & 0x00000003) == 0) {n = n + 2; x = x >> 2;}
+   return n - (x & 1);
+#endif
+}
+
 
 #endif // wxUSE_BASE
 

--- a/src/msw/joystick.cpp
+++ b/src/msw/joystick.cpp
@@ -37,23 +37,6 @@
 
 #include <regstr.h>
 
-// Use optimised count trailing zeros where available.
-static int wxCtz(unsigned x)
-{
-    wxCHECK_MSG(x > 0, 0, "Undefined for x == 0.");
-#ifdef __GNUC__
-   return __builtin_ctz(x);
-#else
-   int n;
-   n = 1;
-   if ((x & 0x0000FFFF) == 0) {n = n +16; x = x >>16;}
-   if ((x & 0x000000FF) == 0) {n = n + 8; x = x >> 8;}
-   if ((x & 0x0000000F) == 0) {n = n + 4; x = x >> 4;}
-   if ((x & 0x00000003) == 0) {n = n + 2; x = x >> 2;}
-   return n - (x & 1);
-#endif
-}
-
 
 enum {
     wxJS_AXIS_X = 0,
@@ -90,7 +73,7 @@ public:
 private:
     void      SendEvent(wxEventType type, long ts, int change = 0);
     int       m_joystick;
-    UINT      m_buttons;
+    int       m_buttons;
     wxWindow* m_catchwin;
     int       m_polling;
     JOYINFO   m_joyInfo;
@@ -141,9 +124,9 @@ void* wxJoystickThread::Entry()
         // "Current button number that is pressed.", but it turns out
         // it is the *total* number of buttons pressed.
         if (deltaUp)
-            SendEvent(wxEVT_JOY_BUTTON_UP, ts, wxCtz(deltaUp)+1);
+            SendEvent(wxEVT_JOY_BUTTON_UP, ts, deltaUp);
         if (deltaDown)
-            SendEvent(wxEVT_JOY_BUTTON_DOWN, ts, wxCtz(deltaDown)+1);
+            SendEvent(wxEVT_JOY_BUTTON_DOWN, ts, deltaDown);
 
         if ((m_joyInfo.wXpos != m_lastJoyInfo.wXpos) ||
             (m_joyInfo.wYpos != m_lastJoyInfo.wYpos) ||

--- a/src/osx/core/hidjoystick.cpp
+++ b/src/osx/core/hidjoystick.cpp
@@ -861,10 +861,6 @@ void* wxJoystickThread::Entry()
         //is the cookie a button?
         if (nIndex < 40)
         {
-            // Bounds check for bit shift in this block.
-            wxCHECK_MSG(nIndex >= 0, (void *) -1, "Shift count negative.");
-            wxCHECK_MSG(nIndex < CHAR_BIT * (int) sizeof(int), (void *) -1,
-                            "Shift count overflow.");
             if (hidevent.value)
             {
                 pThis->m_buttons |= (1 << nIndex);

--- a/src/osx/core/hidjoystick.cpp
+++ b/src/osx/core/hidjoystick.cpp
@@ -861,6 +861,10 @@ void* wxJoystickThread::Entry()
         //is the cookie a button?
         if (nIndex < 40)
         {
+            // Bounds check for bit shift in this block.
+            wxCHECK_MSG(nIndex >= 0, (void *) -1, "Shift count negative.");
+            wxCHECK_MSG(nIndex < CHAR_BIT * (int) sizeof(int), (void *) -1,
+                            "Shift count overflow.");
             if (hidevent.value)
             {
                 pThis->m_buttons |= (1 << nIndex);
@@ -872,7 +876,7 @@ void* wxJoystickThread::Entry()
                 wxevent.SetEventType(wxEVT_JOY_BUTTON_UP);
             }
 
-            wxevent.SetButtonChange(nIndex+1);
+            wxevent.SetButtonChange(1 << nIndex);
         }
         else if (nIndex == wxJS_AXIS_X)
         {

--- a/src/unix/joystick.cpp
+++ b/src/unix/joystick.cpp
@@ -178,10 +178,6 @@ void* wxJoystickThread::Entry()
 
             if ( (j_evt.type & JS_EVENT_BUTTON) && (j_evt.number < wxJS_MAX_BUTTONS) )
             {
-                // Bounds check for bit shift in this block.
-                wxCHECK_MSG(j_evt.number >= 0, (void *) -1, "Shift count negative.");
-                wxCHECK_MSG(j_evt.number < CHAR_BIT * (int) sizeof(int), (void *) -1,
-                            "Shift count overflow.");
                 if (j_evt.value)
                 {
                     m_buttons |= (1 << j_evt.number);

--- a/src/unix/joystick.cpp
+++ b/src/unix/joystick.cpp
@@ -178,15 +178,19 @@ void* wxJoystickThread::Entry()
 
             if ( (j_evt.type & JS_EVENT_BUTTON) && (j_evt.number < wxJS_MAX_BUTTONS) )
             {
+                // Bounds check for bit shift in this block.
+                wxCHECK_MSG(j_evt.number >= 0, (void *) -1, "Shift count negative.");
+                wxCHECK_MSG(j_evt.number < CHAR_BIT * (int) sizeof(int), (void *) -1,
+                            "Shift count overflow.");
                 if (j_evt.value)
                 {
                     m_buttons |= (1 << j_evt.number);
-                    SendEvent(wxEVT_JOY_BUTTON_DOWN, j_evt.time, j_evt.number);
+                    SendEvent(wxEVT_JOY_BUTTON_DOWN, j_evt.time, 1 << j_evt.number);
                 }
                 else
                 {
                     m_buttons &= ~(1 << j_evt.number);
-                    SendEvent(wxEVT_JOY_BUTTON_UP, j_evt.time, j_evt.number);
+                    SendEvent(wxEVT_JOY_BUTTON_UP, j_evt.time, 1 << j_evt.number);
                 }
             }
         }


### PR DESCRIPTION
Addresses trak#18233.

* Moved wxCtz to math.h.
* All impleme:wqntations use int for m_buttonChange on button events.
* m_buttonChange has one bit set to indicate which button changed.
* Added wxJoystickEvent::GetButtonOrdinal() to return 0-based index of
button that changed.

(Re-submission of broken pull request #971 - for some reason, GitHub is no longer updating that pull request with new commits or comments.)