### PR TITLE
Fix MSW wxCheckOsVersion() without manifest

### DIFF
--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -1225,24 +1225,12 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
 
 bool wxCheckOsVersion(int majorVsn, int minorVsn, int microVsn)
 {
-    OSVERSIONINFOEX osvi;
-    wxZeroMemory(osvi);
-    osvi.dwOSVersionInfoSize = sizeof(osvi);
+    int majorCur, minorCur, microCur;
+    wxGetOsVersion(&majorCur, &minorCur, &microCur);
 
-    DWORDLONG const dwlConditionMask =
-        ::VerSetConditionMask(
-        ::VerSetConditionMask(
-        ::VerSetConditionMask(
-        0, VER_MAJORVERSION, VER_GREATER_EQUAL),
-        VER_MINORVERSION, VER_GREATER_EQUAL),
-        VER_BUILDNUMBER, VER_GREATER_EQUAL);
-
-    osvi.dwMajorVersion = majorVsn;
-    osvi.dwMinorVersion = minorVsn;
-    osvi.dwBuildNumber = microVsn;
-
-    return ::VerifyVersionInfo(&osvi,
-        VER_MAJORVERSION | VER_MINORVERSION | VER_BUILDNUMBER, dwlConditionMask) != FALSE;
+    return majorCur > majorVsn
+        || (majorCur == majorVsn && minorCur > minorVsn)
+        || (majorCur == majorVsn && minorCur == minorVsn && microCur >= microVsn);
 }
 
 wxWinVersion wxGetWinVersion()


### PR DESCRIPTION
Reimplement wxCheckOsVersion() to use wxGetOsVersion() on windows.
An executable without the Windows 8.1+ compatibility info in a
manifest would not detect the version based on the VerifyVersionInfo()
API previously used.