### PR TITLE
Various CMake and contribution docs changes

### DIFF
--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -75,6 +75,8 @@ endmacro()
 
 # Set properties common to builtin third party libraries and wx libs
 function(wx_set_common_target_properties target_name)
+    cmake_parse_arguments(wxCOMMON_TARGET_PROPS "DEFAULT_WARNINGS" "" "" ${ARGN})
+
     if(DEFINED wxBUILD_CXX_STANDARD AND NOT wxBUILD_CXX_STANDARD STREQUAL COMPILER_DEFAULT)
         # TODO: implement for older CMake versions ?
         set_target_properties(${target_name} PROPERTIES CXX_STANDARD ${wxBUILD_CXX_STANDARD})
@@ -96,6 +98,13 @@ function(wx_set_common_target_properties target_name)
         ARCHIVE_OUTPUT_DIRECTORY "${wxOUTPUT_DIR}${wxPLATFORM_LIB_DIR}"
         RUNTIME_OUTPUT_DIRECTORY "${wxOUTPUT_DIR}${wxPLATFORM_LIB_DIR}"
         )
+    if(NOT wxCOMMON_TARGET_PROPS_DEFAULT_WARNINGS)
+        # Enable higher warnings for most compilers/IDEs
+        if(MSVC)
+            target_compile_options(${target_name} PRIVATE /W4)
+        endif()
+        # TODO: add warning flags for other compilers
+    endif()
 endfunction()
 
 # Set common properties on wx library target
@@ -446,7 +455,7 @@ function(wx_set_builtin_target_properties target_name)
 
     set_target_properties(${target_name} PROPERTIES FOLDER "Third Party Libraries")
 
-    wx_set_common_target_properties(${target_name})
+    wx_set_common_target_properties(${target_name} DEFAULT_WARNINGS)
     if(NOT wxBUILD_SHARED)
         wx_install(TARGETS ${name} ARCHIVE DESTINATION "lib${wxPLATFORM_LIB_DIR}")
     endif()

--- a/docs/contributing/how-to-add-new-sample.md
+++ b/docs/contributing/how-to-add-new-sample.md
@@ -43,12 +43,20 @@ samples/ with demos/ where needed).
    After this, regenerate configure from configure.in
    by running "autoconf" on a Unix system in the corresponding directory.
 
-5. Add a short description of what the sample does and how does it work
+5. Modify `build/cmake/samples/CMakeLists.txt` to include the sample in
+   CMake. Add a new line like this:
+
+       wx_add_sample(foo DEPENDS wxUSE_FOO)
+
+   For a complete list of parameters to the `wx_add_sample()` function see
+   the description in `build/cmake/functions.cmake`.
+
+6. Add a short description of what the sample does and how does it work
    to the "samples overview" section in the wxWidgets manual. That section
    lives in docs/doxygen/mainpages/samples.h; look at the descriptions for
    other samples, if you are not familiar with Doxygen.
 
-6. Add any non-standard sample's files to build/bakefiles/make_dist.mk (the
+7. Add any non-standard sample's files to build/bakefiles/make_dist.mk (the
    makefiles copies all bmp, cpp, h, ico, png, rc, xpm and makefiles by
    default, you only need to update it if the sample uses some other files)
    and run the ./update-manifests.sh script in distrib/scripts (don't forget

--- a/docs/contributing/how-to-add-new-wxUSE_XXX.md
+++ b/docs/contributing/how-to-add-new-wxUSE_XXX.md
@@ -72,6 +72,16 @@ c) configure.in
    If you have a sample/foo which should be only built when `wxUSE_FOO==1`,
    then only add it to the SAMPLES_SUBDIRS if `wxUSE_FOO=yes` in configure.
 
-d) docs/doxygen/mainpages/const_wxusedef.h
+d) build/cmake/options.cmake
+
+   To include the option in CMake, add a new line in the appropriate
+   section of options.cmake.
+
+    wx_option(wxUSE_FOO "enable FOO")
+
+   As an optional third parameter you may specify `OFF` when the option
+   should be disabled by default.
+
+e) docs/doxygen/mainpages/const_wxusedef.h
 
    Add a brief description of the new constant.

--- a/src/msw/iniconf.cpp
+++ b/src/msw/iniconf.cpp
@@ -288,8 +288,8 @@ bool wxIniConfig::DoReadString(const wxString& szKey, wxString *pstr) const
                           m_strLocalFilename.t_str());
   if ( wxIsEmpty(szBuf) ) {
     // now look in win.ini
-    wxString strKey = GetKeyName(path.Name());
-    GetProfileString(m_strGroup.t_str(), strKey.t_str(),
+    wxString strWinKey = GetKeyName(path.Name());
+    GetProfileString(m_strGroup.t_str(), strWinKey.t_str(),
                      wxT(""), szBuf, WXSIZEOF(szBuf));
   }
 


### PR DESCRIPTION
- Enable highest warning level for MSVC
- Include CMake in contribution documentation
- Fix a harmless MSVC warning