### PR TITLE
Fixes to wxGTK wxDisplay::GetPPI()

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -128,6 +128,7 @@ All (GUI):
 - Add wxGrid::SetCornerLabelValue() (Pavel Kalugin).
 - Add strikethrough support for fonts defined in XRC.
 - Add wxDisplay::GetPPI().
+- Add wxGraphicsContext::GetWindow().
 
 wxGTK:
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -128,7 +128,7 @@ All (GUI):
 - Add wxGrid::SetCornerLabelValue() (Pavel Kalugin).
 - Add strikethrough support for fonts defined in XRC.
 - Add wxDisplay::GetPPI().
-- Add wxGraphicsContext::GetWindow().
+- Add wxGraphicsContext::GetWindow() and implement wxGraphicsContext::GetDPI().
 
 wxGTK:
 

--- a/include/wx/display.h
+++ b/include/wx/display.h
@@ -49,6 +49,10 @@ public:
     // primary display and the only one which is always supported
     wxDisplay(unsigned n = 0);
 
+    // create display object corresponding to the display of the given window
+    // or the default one if the window display couldn't be found
+    explicit wxDisplay(const wxWindow* window);
+
     // dtor is not virtual as this is a concrete class not meant to be derived
     // from
 

--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -452,7 +452,7 @@ private:
 class WXDLLIMPEXP_CORE wxGraphicsContext : public wxGraphicsObject
 {
 public:
-    wxGraphicsContext(wxGraphicsRenderer* renderer);
+    wxGraphicsContext(wxGraphicsRenderer* renderer, wxWindow* window = NULL);
 
     virtual ~wxGraphicsContext();
 
@@ -489,6 +489,9 @@ public:
 
     // create a context that can be used for measuring texts only, no drawing allowed
     static wxGraphicsContext * Create();
+
+    // Return the window this context is associated with, if any.
+    wxWindow* GetWindow() const { return m_window; }
 
     // begin a new document (relevant only for printing / pdf etc) if there is a progress dialog, message will be shown
     virtual bool StartDoc( const wxString& message );
@@ -787,6 +790,12 @@ protected:
                                          wxDouble x, wxDouble y,
                                          wxDouble angle,
                                          const wxGraphicsBrush& backgroundBrush);
+
+private:
+    // The associated window, if any, i.e. if one was passed directly to
+    // Create() or the associated window of the wxDC this context was created
+    // from.
+    wxWindow* const m_window;
 
     wxDECLARE_NO_COPY_CLASS(wxGraphicsContext);
     wxDECLARE_ABSTRACT_CLASS(wxGraphicsContext);

--- a/include/wx/private/display.h
+++ b/include/wx/private/display.h
@@ -81,8 +81,11 @@ public:
     // return the depth or 0 if unknown
     virtual int GetDepth() const = 0;
 
-    // return the resolution of the display, uses GetSizeMM() by default but
-    // can be also overridden directly
+    // return the scale factor used to convert logical pixels to physical ones
+    virtual double GetScaleFactor() const { return 1.0; }
+
+    // return the resolution of the display, uses GetSize(), GetScaleFactor()
+    // and GetSizeMM() by default but can be also overridden directly
     virtual wxSize GetPPI() const;
 
     // return the physical size of the display or (0, 0) if unknown: this is

--- a/include/wx/private/display.h
+++ b/include/wx/private/display.h
@@ -118,6 +118,11 @@ protected:
     // create the object providing access to the display with the given index
     wxDisplayImpl(unsigned n) : m_index(n) { }
 
+    // Compute PPI from the sizes in pixels and mm.
+    //
+    // Return (0, 0) if physical size (in mm) is not known, i.e. 0.
+    static wxSize ComputePPI(int pxX, int pxY, int mmX, int mmY);
+
 
     // the index of this display (0 is always the primary one)
     const unsigned m_index;

--- a/interface/wx/display.h
+++ b/interface/wx/display.h
@@ -27,6 +27,23 @@ public:
     wxDisplay(unsigned int index = 0);
 
     /**
+        Constructor creating the display object associated with the given
+        window.
+
+        This is the most convenient way of finding the display on which the
+        given window is shown while falling back to the default display if it
+        is not shown at all or positioned outside of any display.
+
+        @param window
+            A valid, i.e. non-null, window.
+
+        @see GetFromWindow()
+
+        @since 3.1.2
+     */
+    explicit wxDisplay(const wxWindow* window);
+
+    /**
         Destructor.
     */
     ~wxDisplay();

--- a/interface/wx/graphics.h
+++ b/interface/wx/graphics.h
@@ -1095,6 +1095,19 @@ public:
     */
     virtual void GetDPI( wxDouble* dpiX, wxDouble* dpiY);
 
+    /**
+        Returns the associated window if any.
+
+        If this context was created using Create() overload taking wxWindow or
+        wxWindowDC, this method returns the corresponding window. Otherwise
+        returns @NULL.
+
+        @return A possibly @NULL window pointer.
+
+        @since 3.1.2
+     */
+    wxWindow* GetWindow() const;
+
     /** @}
     */
 

--- a/samples/display/display.cpp
+++ b/samples/display/display.cpp
@@ -232,9 +232,7 @@ MyFrame::MyFrame(const wxString& title, const wxPoint& pos, const wxSize& size, 
 #endif // wxUSE_STATUSBAR
 
     // create child controls
-    wxPanel *panel = new wxPanel(this, wxID_ANY);
-
-    m_book = new wxBookCtrl(panel, wxID_ANY);
+    m_book = new wxBookCtrl(this, wxID_ANY);
     const size_t countDpy = wxDisplay::GetCount();
     for ( size_t nDpy = 0; nDpy < countDpy; nDpy++ )
     {
@@ -291,6 +289,7 @@ MyFrame::MyFrame(const wxString& title, const wxPoint& pos, const wxSize& size, 
         sizer->Add(new wxStaticText(page, wxID_ANY,
                                     display.IsPrimary() ? "yes" : "no"));
 
+        // add it to another sizer to have borders around it and button below
         wxSizer *sizerTop = new wxBoxSizer(wxVERTICAL);
         sizerTop->Add(sizer, 1, wxALL | wxEXPAND, 10);
 
@@ -313,22 +312,19 @@ MyFrame::MyFrame(const wxString& title, const wxPoint& pos, const wxSize& size, 
         sizer->Add(new wxStaticText(page, Display_CurrentMode,
                                     VideoModeToText(display.GetCurrentMode())));
 
-        // add it to another sizer to have borders around it and button below
         sizerTop->Add(new wxButton(page, Display_ResetMode, "&Reset mode"),
                       0, wxALL | wxCENTRE, 5);
 #endif // wxUSE_DISPLAY
 
         page->SetSizer(sizerTop);
+        page->Layout();
 
         m_book->AddPage(page,
                         wxString::Format("Display %lu",
                                          (unsigned long)nDpy));
     }
 
-    wxBoxSizer *sizer = new wxBoxSizer(wxHORIZONTAL);
-    sizer->Add(m_book, 1, wxEXPAND);
-    panel->SetSizer(sizer);
-    sizer->SetSizeHints(this);
+    SetClientSize(m_book->GetBestSize());
 }
 
 #if wxUSE_DISPLAY

--- a/src/common/dcgraph.cpp
+++ b/src/common/dcgraph.cpp
@@ -418,6 +418,15 @@ void wxGCDCImpl::SetTextBackground( const wxColour &col )
 
 wxSize wxGCDCImpl::GetPPI() const
 {
+    if ( m_graphicContext )
+    {
+        wxDouble x, y;
+        m_graphicContext->GetDPI(&x, &y);
+        return wxSize(wxRound(x), wxRound(y));
+    }
+
+    // This is the same value that wxGraphicsContext::GetDPI() returns by
+    // default.
     return wxSize(72, 72);
 }
 

--- a/src/common/dlgcmn.cpp
+++ b/src/common/dlgcmn.cpp
@@ -871,7 +871,7 @@ int wxStandardDialogLayoutAdapter::DoMustScroll(wxDialog* dialog, wxSize& window
     wxSize minWindowSize = dialog->GetSizer()->GetMinSize();
     windowSize = dialog->GetSize();
     windowSize = wxSize(wxMax(windowSize.x, minWindowSize.x), wxMax(windowSize.y, minWindowSize.y));
-    displaySize = wxDisplay(wxDisplay::GetFromWindow(dialog)).GetClientArea().GetSize();
+    displaySize = wxDisplay(dialog).GetClientArea().GetSize();
 
     int flags = 0;
 

--- a/src/common/dpycmn.cpp
+++ b/src/common/dpycmn.cpp
@@ -85,6 +85,13 @@ wxDisplay::wxDisplay(unsigned n)
     m_impl = Factory().GetDisplay(n);
 }
 
+wxDisplay::wxDisplay(const wxWindow* window)
+{
+    const int n = GetFromWindow(window);
+
+    m_impl = Factory().GetDisplay(n != wxNOT_FOUND ? n : 0);
+}
+
 // ----------------------------------------------------------------------------
 // static functions forwarded to wxDisplayFactory
 // ----------------------------------------------------------------------------
@@ -233,6 +240,8 @@ wxDisplayFactory::~wxDisplayFactory()
 
 int wxDisplayFactory::GetFromWindow(const wxWindow *window)
 {
+    wxCHECK_MSG( window, wxNOT_FOUND, "window can't be NULL" );
+
     // consider that the window belongs to the display containing its centre
     const wxRect r(window->GetScreenRect());
     return GetFromPoint(wxPoint(r.x + r.width/2, r.y + r.height/2));

--- a/src/common/dpycmn.cpp
+++ b/src/common/dpycmn.cpp
@@ -195,15 +195,17 @@ bool wxDisplay::ChangeMode(const wxVideoMode& mode)
 
 wxSize wxDisplayImpl::GetPPI() const
 {
-    const wxSize pixels = GetGeometry().GetSize();
     const wxSize mm = GetSizeMM();
-
     if ( !mm.x || !mm.y )
     {
         // Physical size is unknown, return a special value indicating that we
         // can't compute the resolution -- what else can we do?
         return wxSize(0, 0);
     }
+
+    // We need physical pixels here, not logical ones returned by
+    // GetGeometry(), to compute the real DPI.
+    const wxSize pixels = GetGeometry().GetSize()*GetScaleFactor();
 
     return wxSize(wxRound((pixels.x * inches2mm) / mm.x),
                   wxRound((pixels.y * inches2mm) / mm.y));

--- a/src/common/dpycmn.cpp
+++ b/src/common/dpycmn.cpp
@@ -193,22 +193,29 @@ bool wxDisplay::ChangeMode(const wxVideoMode& mode)
 // wxDisplayImpl implementation
 // ============================================================================
 
-wxSize wxDisplayImpl::GetPPI() const
+/* static */
+wxSize wxDisplayImpl::ComputePPI(int pxX, int pxY, int mmX, int mmY)
 {
-    const wxSize mm = GetSizeMM();
-    if ( !mm.x || !mm.y )
+    if ( !mmX || !mmY )
     {
         // Physical size is unknown, return a special value indicating that we
         // can't compute the resolution -- what else can we do?
         return wxSize(0, 0);
     }
 
+    return wxSize(wxRound((pxX * inches2mm) / mmX),
+                  wxRound((pxY * inches2mm) / mmY));
+}
+
+wxSize wxDisplayImpl::GetPPI() const
+{
+    const wxSize mm = GetSizeMM();
+
     // We need physical pixels here, not logical ones returned by
     // GetGeometry(), to compute the real DPI.
     const wxSize pixels = GetGeometry().GetSize()*GetScaleFactor();
 
-    return wxSize(wxRound((pixels.x * inches2mm) / mm.x),
-                  wxRound((pixels.y * inches2mm) / mm.y));
+    return ComputePPI(pixels.x, pixels.y, mm.x, mm.y);
 }
 
 // ============================================================================

--- a/src/common/graphcmn.cpp
+++ b/src/common/graphcmn.cpp
@@ -565,12 +565,14 @@ void * wxGraphicsBitmap::GetNativeBitmap() const
 wxIMPLEMENT_ABSTRACT_CLASS(wxGraphicsContext, wxObject);
 
 
-wxGraphicsContext::wxGraphicsContext(wxGraphicsRenderer* renderer) :
-    wxGraphicsObject(renderer),
+wxGraphicsContext::wxGraphicsContext(wxGraphicsRenderer* renderer,
+                                     wxWindow* window)
+    : wxGraphicsObject(renderer),
       m_antialias(wxANTIALIAS_DEFAULT),
       m_composition(wxCOMPOSITION_OVER),
       m_interpolation(wxINTERPOLATION_DEFAULT),
-      m_enableOffset(false)
+      m_enableOffset(false),
+      m_window(window)
 {
 }
 

--- a/src/common/graphcmn.cpp
+++ b/src/common/graphcmn.cpp
@@ -31,6 +31,8 @@
     #include "wx/log.h"
 #endif
 
+#include "wx/display.h"
+
 #ifdef __WXMSW__
     #include "wx/msw/enhmeta.h"
 #endif
@@ -620,8 +622,19 @@ wxDouble wxGraphicsContext::GetAlpha() const
 
 void wxGraphicsContext::GetDPI( wxDouble* dpiX, wxDouble* dpiY)
 {
-    *dpiX = 72.0;
-    *dpiY = 72.0;
+    if ( m_window )
+    {
+        const wxSize ppi = wxDisplay(m_window).GetPPI();
+        *dpiX = ppi.x;
+        *dpiY = ppi.y;
+    }
+    else
+    {
+        // Use some standard DPI value, it doesn't make much sense for the
+        // contexts not using any pixels anyhow.
+        *dpiX = 72.0;
+        *dpiY = 72.0;
+    }
 }
 
 // sets the pen

--- a/src/common/sizer.cpp
+++ b/src/common/sizer.cpp
@@ -930,15 +930,9 @@ wxSize wxSizer::ComputeFittingClientSize(wxWindow *window)
             return tlw->GetClientSize();
         }
 
-        // limit the window to the size of the display it is on
-        int disp = wxDisplay::GetFromWindow(window);
-        if ( disp == wxNOT_FOUND )
-        {
-            // or, if we don't know which one it is, of the main one
-            disp = 0;
-        }
-
-        sizeMax = wxDisplay(disp).GetClientArea().GetSize();
+        // limit the window to the size of the display it is on (or the main
+        // one if the window display can't be determined)
+        sizeMax = wxDisplay(window).GetClientArea().GetSize();
 
         // If determining the display size failed, skip the max size checks as
         // we really don't want to create windows of (0, 0) size.

--- a/src/common/toplvcmn.cpp
+++ b/src/common/toplvcmn.cpp
@@ -249,8 +249,7 @@ void wxTopLevelWindowBase::DoCentre(int dir)
     // we need the display rect anyhow so store it first: notice that we should
     // be centered on the same display as our parent window, the display of
     // this window itself is not really defined yet
-    int nDisplay = wxDisplay::GetFromWindow(GetParent() ? GetParent() : this);
-    wxDisplay dpy(nDisplay == wxNOT_FOUND ? 0 : nDisplay);
+    wxDisplay dpy(GetParent() ? GetParent() : this);
     const wxRect rectDisplay(dpy.GetClientArea());
 
     // what should we centre this window on?

--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -1830,7 +1830,7 @@ wxCairoContext::wxCairoContext( wxGraphicsRenderer* renderer, const wxPrinterDC&
 #endif
 
 wxCairoContext::wxCairoContext( wxGraphicsRenderer* renderer, const wxWindowDC& dc )
-: wxGraphicsContext(renderer)
+: wxGraphicsContext(renderer, dc.GetWindow())
 {
     int width, height;
     dc.GetSize( &width, &height );
@@ -2244,7 +2244,7 @@ wxCairoContext::wxCairoContext( wxGraphicsRenderer* renderer, cairo_t *context )
 }
 
 wxCairoContext::wxCairoContext( wxGraphicsRenderer* renderer, wxWindow *window)
-    : wxGraphicsContext(renderer)
+    : wxGraphicsContext(renderer, window)
 #ifdef __WXMSW__
     , m_mswWindowHDC(GetHwndOf(window))
 #endif

--- a/src/generic/richtooltipg.cpp
+++ b/src/generic/richtooltipg.cpp
@@ -318,11 +318,7 @@ private:
 
         // Use GetFromWindow() and not GetFromPoint() here to try to get the
         // correct display even if the tip point itself is not visible.
-        int dpy = wxDisplay::GetFromWindow(GetParent());
-        if ( dpy == wxNOT_FOUND )
-            dpy = 0; // What else can we do?
-
-        const wxRect rectDpy = wxDisplay(dpy).GetClientArea();
+        const wxRect rectDpy = wxDisplay(GetParent()).GetClientArea();
 
 #ifdef __WXMAC__
         return pos.y > rectDpy.height/2 ? wxTipKind_Bottom : wxTipKind_Top;

--- a/src/gtk/dc.cpp
+++ b/src/gtk/dc.cpp
@@ -15,6 +15,7 @@
 #include "wx/dcclient.h"
 #include "wx/dcmemory.h"
 #include "wx/dcscreen.h"
+#include "wx/display.h"
 #include "wx/gdicmn.h"
 #include "wx/icon.h"
 #include "wx/gtk/dc.h"
@@ -238,7 +239,7 @@ wxSize wxGTKCairoDCImpl::GetPPI() const
 {
     if ( m_window )
     {
-        return wxGetDisplayPPI();
+        return wxDisplay(m_window).GetPPI();
     }
 
     // For a non-window-based DC the concept of PPI doesn't make much sense

--- a/src/gtk/display.cpp
+++ b/src/gtk/display.cpp
@@ -46,6 +46,7 @@ public:
     virtual wxRect GetGeometry() const wxOVERRIDE;
     virtual wxRect GetClientArea() const wxOVERRIDE;
     virtual int GetDepth() const wxOVERRIDE;
+    virtual double GetScaleFactor() const wxOVERRIDE;
     virtual wxSize GetSizeMM() const wxOVERRIDE;
 
 #if wxUSE_DISPLAY
@@ -119,6 +120,11 @@ wxRect wxDisplayImplGTK::GetClientArea() const
 int wxDisplayImplGTK::GetDepth() const
 {
     return 24;
+}
+
+double wxDisplayImplGTK::GetScaleFactor() const
+{
+    return gdk_monitor_get_scale_factor(m_monitor);
 }
 
 wxSize wxDisplayImplGTK::GetSizeMM() const
@@ -222,6 +228,9 @@ public:
     virtual wxRect GetGeometry() const wxOVERRIDE;
     virtual wxRect GetClientArea() const wxOVERRIDE;
     virtual int GetDepth() const wxOVERRIDE;
+#if GTK_CHECK_VERSION(3,10,0)
+    virtual double GetScaleFactor() const wxOVERRIDE;
+#endif // GTK+ 3.10
     virtual wxSize GetSizeMM() const wxOVERRIDE;
 
 #if wxUSE_DISPLAY
@@ -292,6 +301,16 @@ int wxDisplayImplGTK::GetDepth() const
     // TODO: How to get the depth of the specific display?
     return gdk_visual_get_depth(gdk_window_get_visual(wxGetTopLevelGDK()));
 }
+
+#if GTK_CHECK_VERSION(3,10,0)
+double wxDisplayImplGTK::GetScaleFactor() const
+{
+    if ( gtk_check_version(3,10,0) == NULL )
+        return gdk_screen_get_monitor_scale_factor(m_screen, m_index);
+
+    return 1.0;
+}
+#endif // GTK+ 3.10
 
 wxSize wxDisplayImplGTK::GetSizeMM() const
 {

--- a/src/gtk/display.cpp
+++ b/src/gtk/display.cpp
@@ -231,6 +231,7 @@ public:
 #if GTK_CHECK_VERSION(3,10,0)
     virtual double GetScaleFactor() const wxOVERRIDE;
 #endif // GTK+ 3.10
+    virtual wxSize GetPPI() const wxOVERRIDE;
     virtual wxSize GetSizeMM() const wxOVERRIDE;
 
 #if wxUSE_DISPLAY
@@ -311,6 +312,24 @@ double wxDisplayImplGTK::GetScaleFactor() const
     return 1.0;
 }
 #endif // GTK+ 3.10
+
+wxSize wxDisplayImplGTK::GetPPI() const
+{
+    // Try the base class version which uses our GetSizeMM() and returns
+    // per-display PPI value if it works.
+    wxSize ppi = wxDisplayImpl::GetPPI();
+
+    if ( !ppi.x || !ppi.y )
+    {
+        // But if it didn't work, fall back to the global DPI value common to
+        // all displays -- this is still better than nothing and more
+        // compatible with the previous wxWidgets versions.
+        ppi = ComputePPI(gdk_screen_width(), gdk_screen_height(),
+                         gdk_screen_width_mm(), gdk_screen_height_mm());
+    }
+
+    return ppi;
+}
 
 wxSize wxDisplayImplGTK::GetSizeMM() const
 {

--- a/src/gtk/display.cpp
+++ b/src/gtk/display.cpp
@@ -317,7 +317,7 @@ wxSize wxDisplayImplGTK::GetSizeMM() const
     // At least in some configurations, gdk_screen_xxx_mm() functions return
     // valid values when gdk_screen_get_monitor_xxx_mm() only return -1, so
     // handle this case specially.
-    if ( IsPrimary() )
+    if ( gdk_screen_get_n_monitors(m_screen) == 1 )
     {
         return wxSize(gdk_screen_width_mm(), gdk_screen_height_mm());
     }

--- a/src/msw/graphics.cpp
+++ b/src/msw/graphics.cpp
@@ -358,7 +358,7 @@ class wxGDIPlusContext : public wxGraphicsContext
 public:
     wxGDIPlusContext( wxGraphicsRenderer* renderer, const wxDC& dc );
     wxGDIPlusContext( wxGraphicsRenderer* renderer, HDC hdc, wxDouble width, wxDouble height );
-    wxGDIPlusContext( wxGraphicsRenderer* renderer, HWND hwnd );
+    wxGDIPlusContext( wxGraphicsRenderer* renderer, HWND hwnd, wxWindow* window = NULL);
     wxGDIPlusContext( wxGraphicsRenderer* renderer, Graphics* gr);
     wxGDIPlusContext(wxGraphicsRenderer* renderer);
 
@@ -1647,7 +1647,7 @@ wxGDIPlusContext::wxGDIPlusContext( wxGraphicsRenderer* renderer, HDC hdc, wxDou
 }
 
 wxGDIPlusContext::wxGDIPlusContext( wxGraphicsRenderer* renderer, const wxDC& dc )
-    : wxGraphicsContext(renderer)
+    : wxGraphicsContext(renderer, dc.GetWindow())
 {
     wxMSWDCImpl *msw = wxDynamicCast( dc.GetImpl() , wxMSWDCImpl );
     HDC hdc = (HDC) msw->GetHDC();
@@ -1656,8 +1656,10 @@ wxGDIPlusContext::wxGDIPlusContext( wxGraphicsRenderer* renderer, const wxDC& dc
     Init(new Graphics(hdc), sz.x, sz.y);
 }
 
-wxGDIPlusContext::wxGDIPlusContext( wxGraphicsRenderer* renderer, HWND hwnd  )
-    : wxGraphicsContext(renderer)
+wxGDIPlusContext::wxGDIPlusContext( wxGraphicsRenderer* renderer,
+                                    HWND hwnd,
+                                    wxWindow* window )
+    : wxGraphicsContext(renderer, window)
 {
     RECT rect = wxGetWindowRect(hwnd);
     Init(new Graphics(hwnd), rect.right - rect.left, rect.bottom - rect.top);
@@ -2492,7 +2494,7 @@ wxGraphicsContext * wxGDIPlusRenderer::CreateContextFromNativeHDC(WXHDC dc)
 wxGraphicsContext * wxGDIPlusRenderer::CreateContext( wxWindow* window )
 {
     ENSURE_LOADED_OR_RETURN(NULL);
-    return new wxGDIPlusContext(this, (HWND) window->GetHWND() );
+    return new wxGDIPlusContext(this, (HWND) window->GetHWND(), window );
 }
 
 // Path

--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -3400,9 +3400,19 @@ public:
 class wxD2DContext : public wxGraphicsContext, wxD2DResourceManager
 {
 public:
-    wxD2DContext(wxGraphicsRenderer* renderer, ID2D1Factory* direct2dFactory, HWND hwnd);
+    // Create the context for the given HWND, which may be associated (if it's
+    // non-null) with the given wxWindow.
+    wxD2DContext(wxGraphicsRenderer* renderer,
+                 ID2D1Factory* direct2dFactory,
+                 HWND hwnd,
+                 wxWindow* window = NULL);
 
-    wxD2DContext(wxGraphicsRenderer* renderer, ID2D1Factory* direct2dFactory, HDC hdc, const wxSize& dcSize,
+    // Create the context for the given HDC which may be associated (if it's
+    // non-null) with the given wxDC.
+    wxD2DContext(wxGraphicsRenderer* renderer,
+                 ID2D1Factory* direct2dFactory,
+                 HDC hdc,
+                 const wxDC* dc = NULL,
                  D2D1_ALPHA_MODE alphaMode = D2D1_ALPHA_MODE_IGNORE);
 
 #if wxUSE_IMAGE
@@ -3550,8 +3560,11 @@ private:
 // wxD2DContext implementation
 //-----------------------------------------------------------------------------
 
-wxD2DContext::wxD2DContext(wxGraphicsRenderer* renderer, ID2D1Factory* direct2dFactory, HWND hwnd) :
-    wxGraphicsContext(renderer), m_direct2dFactory(direct2dFactory),
+wxD2DContext::wxD2DContext(wxGraphicsRenderer* renderer,
+                           ID2D1Factory* direct2dFactory,
+                           HWND hwnd,
+                           wxWindow* window) :
+    wxGraphicsContext(renderer, window), m_direct2dFactory(direct2dFactory),
 #if wxD2D_DEVICE_CONTEXT_SUPPORTED
     m_renderTargetHolder(new wxD2DDeviceContextResourceHolder(direct2dFactory, hwnd))
 #else
@@ -3564,13 +3577,21 @@ wxD2DContext::wxD2DContext(wxGraphicsRenderer* renderer, ID2D1Factory* direct2dF
     Init();
 }
 
-wxD2DContext::wxD2DContext(wxGraphicsRenderer* renderer, ID2D1Factory* direct2dFactory, HDC hdc,
-                           const wxSize& dcSize, D2D1_ALPHA_MODE alphaMode) :
-    wxGraphicsContext(renderer), m_direct2dFactory(direct2dFactory),
+wxD2DContext::wxD2DContext(wxGraphicsRenderer* renderer,
+                           ID2D1Factory* direct2dFactory,
+                           HDC hdc,
+                           const wxDC* dc,
+                           D2D1_ALPHA_MODE alphaMode) :
+    wxGraphicsContext(renderer, dc->GetWindow()), m_direct2dFactory(direct2dFactory),
     m_renderTargetHolder(new wxD2DDCRenderTargetResourceHolder(direct2dFactory, hdc, alphaMode))
 {
-    m_width = dcSize.GetWidth();
-    m_height = dcSize.GetHeight();
+    if ( dc )
+    {
+        const wxSize dcSize = dc->GetSize();
+        m_width = dcSize.GetWidth();
+        m_height = dcSize.GetHeight();
+    }
+
     Init();
 }
 
@@ -4531,7 +4552,7 @@ wxD2DRenderer::~wxD2DRenderer()
 
 wxGraphicsContext* wxD2DRenderer::CreateContext(const wxWindowDC& dc)
 {
-    return new wxD2DContext(this, m_direct2dFactory, dc.GetHDC(), dc.GetSize());
+    return new wxD2DContext(this, m_direct2dFactory, dc.GetHDC(), &dc);
 }
 
 wxGraphicsContext* wxD2DRenderer::CreateContext(const wxMemoryDC& dc)
@@ -4539,7 +4560,7 @@ wxGraphicsContext* wxD2DRenderer::CreateContext(const wxMemoryDC& dc)
     wxBitmap bmp = dc.GetSelectedBitmap();
     wxASSERT_MSG( bmp.IsOk(), wxS("Should select a bitmap before creating wxGraphicsContext") );
 
-    return new wxD2DContext(this, m_direct2dFactory, dc.GetHDC(), dc.GetSize(),
+    return new wxD2DContext(this, m_direct2dFactory, dc.GetHDC(), &dc,
                             bmp.HasAlpha() ? D2D1_ALPHA_MODE_PREMULTIPLIED : D2D1_ALPHA_MODE_IGNORE);
 }
 
@@ -4571,12 +4592,12 @@ wxGraphicsContext* wxD2DRenderer::CreateContextFromNativeWindow(void* window)
 
 wxGraphicsContext* wxD2DRenderer::CreateContextFromNativeHDC(WXHDC dc)
 {
-    return new wxD2DContext(this, m_direct2dFactory, (HDC)dc, wxSize(0, 0));
+    return new wxD2DContext(this, m_direct2dFactory, (HDC)dc);
 }
 
 wxGraphicsContext* wxD2DRenderer::CreateContext(wxWindow* window)
 {
-    return new wxD2DContext(this, m_direct2dFactory, (HWND)window->GetHWND());
+    return new wxD2DContext(this, m_direct2dFactory, (HWND)window->GetHWND(), window);
 }
 
 #if wxUSE_IMAGE

--- a/src/msw/msgdlg.cpp
+++ b/src/msw/msgdlg.cpp
@@ -162,10 +162,7 @@ wxMessageDialog::HookFunction(int code, WXWPARAM wParam, WXLPARAM lParam)
 void wxMessageDialog::ReplaceStaticWithEdit()
 {
     // check if the message box fits the display
-    int nDisplay = wxDisplay::GetFromWindow(this);
-    if ( nDisplay == wxNOT_FOUND )
-        nDisplay = 0;
-    const wxRect rectDisplay = wxDisplay(nDisplay).GetClientArea();
+    const wxRect rectDisplay = wxDisplay(this).GetClientArea();
 
     if ( rectDisplay.Contains(GetRect()) )
     {

--- a/src/msw/toplevel.cpp
+++ b/src/msw/toplevel.cpp
@@ -756,8 +756,7 @@ void wxTopLevelWindowMSW::DoGetPosition(int *x, int *y) const
             {
                 // we must use the correct display for the translation as the
                 // task bar might be shown on one display but not the other one
-                int n = wxDisplay::GetFromWindow(this);
-                wxDisplay dpy(n == wxNOT_FOUND ? 0 : n);
+                wxDisplay dpy(this);
                 const wxPoint ptOfs = dpy.GetClientArea().GetPosition() -
                                       dpy.GetGeometry().GetPosition();
 
@@ -916,11 +915,7 @@ bool wxTopLevelWindowMSW::ShowFullScreen(bool show, long style)
 
         // resize to the size of the display containing us, falling back to the
         // primary one
-        int dpy = wxDisplay::GetFromWindow(this);
-        if ( dpy == wxNOT_FOUND )
-            dpy = 0;
-
-        const wxRect rect = wxDisplay(dpy).GetGeometry();
+        const wxRect rect = wxDisplay(this).GetGeometry();
 
         SetSize(rect);
 

--- a/src/stc/PlatWX.cpp
+++ b/src/stc/PlatWX.cpp
@@ -1861,8 +1861,7 @@ void Window::SetPositionRelative(PRectangle rc, Window relativeTo) {
     position.x = wxRound(position.x + rc.left);
     position.y = wxRound(position.y + rc.top);
 
-    const int currentDisplay = wxDisplay::GetFromWindow(relativeWin);
-    const wxRect displayRect = wxDisplay(currentDisplay).GetClientArea();
+    const wxRect displayRect = wxDisplay(relativeWin).GetClientArea();
 
     if (position.x < displayRect.GetLeft())
         position.x = displayRect.GetLeft();


### PR DESCRIPTION
These changes fix a couple of definite bugs:

1. We must not use `gdk_screen_xxx()` for computing per-display PPI: this couldn't work because these functions added up all display sizes in one direction but not the other (depending on the display arrangement) and so just couldn't ever give the right values for both components.
2. We must account for the scale factor when computing PPI.
3. We do need to fall back on the global `gdk_screen_xxx()` functions if per-display ones are not available. This fixes a regression in `wxGetDisplayPPI()`.

I'm still not sure if they're correct though, e.g. on my high DPI notebook I now get DPI of `282*283` for the main display and `23*23` when connecting it to an external TV screen. Those actually look about right, i.e. my primary display physical size is returned as `346*194` mm which is consistent with its 15.6in display, but I'm not sure if they're really useful as they don't seem to be consistent with anything at all... I also don't like that we get different DPI values in horizontal and vertical directions, but I don't see how to avoid it (the values before rounding are 281.90 and 282.80).

cc: @kivadiu 