### PR TITLE
Remove wxImageList::Add() overload taking wxIcon from wxOSX

### DIFF
--- a/include/wx/osx/imaglist.h
+++ b/include/wx/osx/imaglist.h
@@ -32,7 +32,6 @@ public:
     virtual bool GetSize( int index, int &width, int &height ) const;
     virtual wxSize GetSize() const { return wxSize(m_width, m_height); }
 
-    int Add( const wxIcon& bitmap );
     int Add( const wxBitmap& bitmap );
     int Add( const wxBitmap& bitmap, const wxBitmap& mask );
     int Add( const wxBitmap& bitmap, const wxColour& maskColour );

--- a/src/osx/imaglist.cpp
+++ b/src/osx/imaglist.cpp
@@ -53,24 +53,6 @@ bool wxImageList::Create()
     return true;
 }
 
-int wxImageList::Add( const wxIcon &bitmap )
-{
-    wxASSERT_MSG( (bitmap.GetWidth() == m_width && bitmap.GetHeight() == m_height)
-                  || (m_width == 0 && m_height == 0),
-                  wxT("invalid bitmap size in wxImageList: this might work ")
-                  wxT("on this platform but definitely won't under Windows.") );
-
-    m_images.Append( new wxIcon( bitmap ) );
-
-    if (m_width == 0 && m_height == 0)
-    {
-        m_width = bitmap.GetWidth();
-        m_height = bitmap.GetHeight();
-    }
-
-    return m_images.GetCount() - 1;
-}
-
 int wxImageList::Add( const wxBitmap &bitmap )
 {
     wxASSERT_MSG( (bitmap.GetScaledWidth() >= m_width && bitmap.GetScaledHeight() == m_height)


### PR DESCRIPTION
This is not necessary as wxIcon is implicitly convertible to wxBitmap
anyhow, so calling Add(icon) works using the existing Add(wxBitmap)
overload, and is actually harmful because of the wrong icon size check
in this function, which used physical bitmap size instead of the logical
(scaled) size.

Closes [#18188](http://trac.wxwidgets.org/ticket/18188).