### PR TITLE
Cache labels for "Next>" or "Finish" buttons in wxWizard

### DIFF
--- a/include/wx/generic/wizard.h
+++ b/include/wx/generic/wizard.h
@@ -132,6 +132,10 @@ protected:
                 *m_btnNext;     // the "Next>" or "Finish" button
     wxStaticBitmap *m_statbmp;  // the control for the bitmap
 
+    // cached labels so their translations stay consistent
+    wxString    m_nextLabel,
+                m_finishLabel;
+
     // Border around page area sizer requested using SetBorder()
     int m_border;
 

--- a/src/generic/wizard.cpp
+++ b/src/generic/wizard.cpp
@@ -429,7 +429,10 @@ void wxWizard::AddButtonRow(wxBoxSizer *mainColumn)
         btnHelp=new wxButton(this, wxID_HELP, wxEmptyString, wxDefaultPosition, wxDefaultSize, buttonStyle);
 #endif
 
-    m_btnNext = new wxButton(this, wxID_FORWARD, _("&Next >"));
+    m_nextLabel = _("&Next >");
+    m_finishLabel = _("&Finish");
+
+    m_btnNext = new wxButton(this, wxID_FORWARD, m_nextLabel);
     // Avoid Cmd+C closing dialog on Mac.
     wxString cancelLabel(_("&Cancel"));
 #ifdef __WXMAC__
@@ -629,7 +632,7 @@ bool wxWizard::ShowPage(wxWizardPage *page, bool goingForward)
     m_btnPrev->Enable(m_page != m_firstpage);
 
     const bool hasNext = HasNextPage(m_page);
-    const wxString label = hasNext ? _("&Next >") : _("&Finish");
+    const wxString& label = hasNext ? m_nextLabel : m_finishLabel;
     if ( label != m_btnNext->GetLabel() )
         m_btnNext->SetLabel(label);
 


### PR DESCRIPTION
This is a pull requests brought upstream from https://github.com/PCSX2/pcsx2/pull/2664 where the flaw initially manifested itself.

Back/Cancel buttons were initialized only once when wizard was constructed, so translations were also applied only once at that time. However, Next/Finish buttons had its string replaced when switching pages (so Next can become Finish when appropriate), and that triggered retranslation every time. If translation changed between those two events, you'd end up with a frankenstein navigation bar in two languages:

![lang-mix](https://user-images.githubusercontent.com/7947461/47682204-faf4ee80-dbcb-11e8-9fe9-a5186d1227fe.png)

This PR caches translated strings for Next and Finish at the time of initial creation of those buttons. This has two added benefits:
- Not triggering retranslation every time string changes.
- "Next>" and "Finish" strings are not duplicated in the code anymore - and they could be considered "magic values".

The issue has been found on wxWidgets 3.0.0 and looking at the code, it may be possible to trigger it in the latest master branch too. Therefore, if this ends up being a valid submission and gets merged, it would make sense to backport this change to a 3.0.x branch.