### PR TITLE
Return correct scale factor for not yet realized windows in wxGTK

### DIFF
--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -4314,9 +4314,7 @@ double wxWindowGTK::GetContentScaleFactor() const
 #if GTK_CHECK_VERSION(3,10,0)
     if (m_widget && gtk_check_version(3,10,0) == NULL)
     {
-        GdkWindow* window = gtk_widget_get_window(m_widget);
-        if (window)
-            scaleFactor = gdk_window_get_scale_factor(window);
+        scaleFactor = gtk_widget_get_scale_factor(m_widget);
     }
 #endif
     return scaleFactor;


### PR DESCRIPTION
wxWindow::GetContentScaleFactor() always returned 1 before the window
was shown in wxGTK, which was rather annoying as typically icons are
initialized on application startup, i.e. before showing the windows, and
so the wrong scale factor was silently used for them.