### PR TITLE
Don't send events from wxTextCtrl::ChangeValue("") in wxGTK

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -132,6 +132,7 @@ All (GUI):
 wxGTK:
 
 - Implement wxTextCtrl::HitTest() for single line controls.
+- Fix bug with wxTextCtrl::ChangeValue("") sending an unwanted event.
 - Implement wxDataViewColumn::UnsetAsSortKey().
 - Fix not showing wxInfoBar with GTK+ 3 < 3.22.29.
 - Fix the build with glib < 2.32 (e.g. CentOS 6).

--- a/src/gtk/textentry.cpp
+++ b/src/gtk/textentry.cpp
@@ -559,10 +559,20 @@ void wxTextEntry::DoSetValue(const wxString& value, int flags)
             EventsSuppressor noevents(this);
             Remove(0, -1);
         }
-        EventsSuppressor noeventsIf(this, !(flags & SetValue_SendEvent));
-        WriteText(value);
+
+        // Testing whether value is empty here is more than just an
+        // optimization: WriteText() always generates an explicit event in
+        // wxGTK, which we need to avoid unless SetValue_SendEvent is given.
+        if ( !value.empty() )
+        {
+            // Suppress events from here even if we do need them, it's simpler
+            // to send the event below in all cases.
+            EventsSuppressor noevents(this);
+            WriteText(value);
+        }
     }
-    else if (flags & SetValue_SendEvent)
+
+    if ( flags & SetValue_SendEvent )
         SendTextUpdatedEvent(GetEditableWindow());
 
     SetInsertionPoint(0);

--- a/tests/controls/textentrytest.cpp
+++ b/tests/controls/textentrytest.cpp
@@ -87,6 +87,14 @@ void TextEntryTestCase::TextChangeEvents()
     entry->ChangeValue("");
     CPPUNIT_ASSERT_EQUAL( 0, updated.GetCount() );
     updated.Clear();
+
+    entry->ChangeValue("non-empty");
+    CPPUNIT_ASSERT_EQUAL( 0, updated.GetCount() );
+    updated.Clear();
+
+    entry->ChangeValue("");
+    CPPUNIT_ASSERT_EQUAL( 0, updated.GetCount() );
+    updated.Clear();
 }
 
 void TextEntryTestCase::CheckStringSelection(const char *sel)


### PR DESCRIPTION
ChangeValue() must not send events, but did in wxGTK when changing the
contents of a wxTextCtrl to be empty when it had been non-empty before.

Closes [#18264](http://trac.wxwidgets.org/ticket/18264).