### PR TITLE
Protect against null pointer in poprgrid

### DIFF
--- a/samples/propgrid/propgrid.cpp
+++ b/samples/propgrid/propgrid.cpp
@@ -738,6 +738,11 @@ void FormMain::OnPropertyGridChange( wxPropertyGridEvent& event )
         wxColourPropertyValue cpv = value.As<wxColourPropertyValue>();
         m_pPropGridManager->GetGrid()->SetCellTextColour( cpv.m_colour );
     }
+    else if ( name == "EnumProperty" )
+    {
+        m_pPropGridManager->Clear();
+        PopulateGrid();
+    }
 }
 
 // -----------------------------------------------------------------------

--- a/src/propgrid/editors.cpp
+++ b/src/propgrid/editors.cpp
@@ -742,6 +742,8 @@ void wxPropertyGrid::OnComboItemPaint( const wxPGComboBox* pCb,
                                        int flags )
 {
     wxPGProperty* p = GetSelection();
+    if (!p) return;
+    
     wxString text;
 
     const wxPGChoices& choices = p->GetChoices();


### PR DESCRIPTION
If we respond to a combobox action in a propgrid by modifying the propgrid (ex: add/remove items based on selection), the combobox may no longer be available and GetSelection will return null.   This is causing a crash.