### PR TITLE
Fix font description for non-. decimal separators

### DIFF
--- a/src/common/fontcmn.cpp
+++ b/src/common/fontcmn.cpp
@@ -757,7 +757,8 @@ bool wxNativeFontInfo::FromString(const wxString& s)
         return false;
 
     token = tokenizer.GetNextToken();
-    if ( !token.ToCDouble(&d) )
+    // try both C and native formatting for backward compatibility
+    if ( !token.ToCDouble(&d) && !token.ToDouble(&d) )
         return false;
     pointSize = static_cast<float>(d);
     if ( static_cast<double>(pointSize) != d )
@@ -812,9 +813,9 @@ wxString wxNativeFontInfo::ToString() const
 {
     wxString s;
 
-    s.Printf(wxT("%d;%f;%d;%d;%d;%d;%d;%s;%d"),
+    s.Printf(wxT("%d;%s;%d;%d;%d;%d;%d;%s;%d"),
              1,                                 // version
-             GetFractionalPointSize(),
+             wxString::FromCDouble(GetFractionalPointSize()),
              family,
              (int)style,
              weight,

--- a/src/msw/font.cpp
+++ b/src/msw/font.cpp
@@ -648,7 +648,9 @@ bool wxNativeFontInfo::FromString(const wxString& s)
         case 1:
             {
                 double d;
-                if ( !tokenizer.GetNextToken().ToCDouble(&d) )
+                token = tokenizer.GetNextToken();
+                // try both C and native formatting for backward compatibility
+                if ( !token.ToCDouble(&d) && !token.ToDouble(&d) )
                     return false;
                 pointSize = static_cast<float>(d);
                 if ( static_cast<double>(pointSize) != d )
@@ -739,9 +741,9 @@ wxString wxNativeFontInfo::ToString() const
 {
     wxString s;
 
-    s.Printf(wxS("%d;%f;%ld;%ld;%ld;%ld;%ld;%d;%d;%d;%d;%d;%d;%d;%d;%s"),
+    s.Printf(wxS("%d;%s;%ld;%ld;%ld;%ld;%ld;%d;%d;%d;%d;%d;%d;%d;%d;%s"),
              1, // version
-             pointSize,
+             wxString::FromCDouble(pointSize),
              lf.lfHeight,
              lf.lfWidth,
              lf.lfEscapement,

--- a/src/osx/carbon/font.cpp
+++ b/src/osx/carbon/font.cpp
@@ -909,7 +909,8 @@ bool wxNativeFontInfo::FromString(const wxString& s)
     //
 
     token = tokenizer.GetNextToken();
-    if ( !token.ToCDouble(&d) )
+    // try both C and native formatting for backward compatibility
+    if ( !token.ToCDouble(&d) && !token.ToDouble(&d) )
         return false;
 #ifdef __LP64__
     // CGFloat is just double in this case.
@@ -971,9 +972,9 @@ wxString wxNativeFontInfo::ToString() const
 {
     wxString s;
 
-    s.Printf(wxT("%d;%f;%d;%d;%d;%d;%d;%s;%d"),
+    s.Printf(wxT("%d;%s;%d;%d;%d;%d;%d;%s;%d"),
         1, // version
-        GetFractionalPointSize(),
+        wxString::FromCDouble(GetFractionalPointSize()),
         GetFamily(),
         (int)GetStyle(),
         GetNumericWeight(),


### PR DESCRIPTION
I'm not missing something here, am I? Other implementations (UNIX, Qt) are not affected. Another option would be to increase the serialization format version, but I felt that preserving compatibility this way was better - simple enough code, no performance hit on corrected serializations (but slightly slower for old "bad" ones). 

---
Fix wxNativeFontInfo::ToString and FromString to work correctly under
locales that don't use '.' for decimal separator. The code incorrectly
parsed descriptions using ToCDouble and this '.', but wrote them out
using locale's native separator. Fixed by using FromCDouble for output
and trying both ToCDouble and ToDouble to preserve backward
compatibility with already-stored font descriptions.
