### PR TITLE
Don't export sorted dynamic arrays from the shared library

### DIFF
--- a/include/wx/dynarray.h
+++ b/include/wx/dynarray.h
@@ -215,9 +215,11 @@ public:
 //    cannot handle types with size greater than pointer because of sorting
 // ----------------------------------------------------------------------------
 
-#define _WX_DEFINE_SORTED_TYPEARRAY_2(T, name, base, defcomp, classexp)       \
+// Note that "classdecl" here is intentionally not used because this class has
+// only inline methods and so never needs to be exported from a DLL.
+#define _WX_DEFINE_SORTED_TYPEARRAY_2(T, name, base, defcomp, classdecl)      \
     typedef wxBaseSortedArray<T> wxBaseSortedArrayFor##name;                  \
-    classexp name : public wxBaseSortedArrayFor##name                         \
+    class name : public wxBaseSortedArrayFor##name                            \
     {                                                                         \
     public:                                                                   \
         name(wxBaseSortedArrayFor##name::SCMPFUNC fn defcomp)                 \


### PR DESCRIPTION
This shouldn't be necessary and doing it seems to result in duplicate
symbol errors when using MSVC under some not completely elucidated
circumstances.

See https://github.com/utelle/wxpdfdoc/pull/48