### PR TITLE
Add property sheet to allow easily configure projects using wx

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -165,6 +165,7 @@ wxMSW:
 - Improve wxNotebook themed background drawing (Arrigo Marchiori).
 - Send wxEVT_WEBVIEW_NAVIGATING when redirecting (Josue Andrade Gomes).
 - Fix build with MSVS 2005 broken in 3.1.1.
+- Add wxwidgets.props property sheet file for MSVS users.
 
 wxOSX:
 

--- a/docs/msw/install.md
+++ b/docs/msw/install.md
@@ -271,7 +271,7 @@ debugger is very good. To avoid linker errors you will need to add
 
 The version 5.6 included in Borland C++ Builder 2006 works as well after the
 following small change: please remove the test for `__WINDOWS__` from line 88
-of the file BCCDIR\include\stl\_threads.h.
+of the file `BCCDIR\include\stl\_threads.h`.
 
 Compiling using the makefiles:
 
@@ -535,11 +535,11 @@ Here is what you need to do:
   be used for debug builds only.
 * Define the following symbols for the preprocessor:
   - `__WXMSW__` to ensure you use the correct wxWidgets port.
-  - _UNICODE unless you want to use deprecated ANSI build of wxWidgets.
-  - NDEBUG if you want to build in release mode, i.e. disable asserts.
-  - WXUSINGDLL if you are using DLL build of wxWidgets.
+  - `_UNICODE` unless you want to use deprecated ANSI build of wxWidgets.
+  - `NDEBUG` if you want to build in release mode, i.e. disable asserts.
+  - `WXUSINGDLL` if you are using DLL build of wxWidgets.
 * If using MSVC 7 only (i.e. not for later versions), also define
-  wxUSE_RC_MANIFEST=1 and WX_CPU_X86.
+  `wxUSE_RC_MANIFEST=1` and `WX_CPU_X86`.
 * Add \<wx-lib-dir\> directory described above to the libraries path.
 
 When using MSVC, the libraries are linked automatically using "#pragma

--- a/docs/msw/install.md
+++ b/docs/msw/install.md
@@ -505,6 +505,10 @@ The full list of the build settings follows:
 Building Applications Using wxWidgets  {#msw_build_apps}
 =====================================
 
+If you use MSVS 2010 or later IDE for building your project, simply add
+`wxwidgets.props` property sheet to (all) your project(s) using wxWidgets.
+You don't need to do anything else.
+
 If you want to use CMake for building your project, please see
 @ref overview_cmake.
 

--- a/wxwidgets.props
+++ b/wxwidgets.props
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    This is a property sheet to be included in MSVS projects of the applications
+    using wxWidgets. Use "View|Property Manager" and choose "Add Existing
+    Property Sheet..." from the context menu to add it from the IDE or edit your
+    .vcxproj file directly and add <Import Project="path\to\wxwidgets.props">
+    tag to it.
+  -->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets">
+    <Import Project="build/msw/wx_setup.props" />
+    <Import Project="build/msw/wx_local.props" Condition="exists('build/msw/wx_local.props')" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" Condition="'$(Configuration)'=='DLL Debug' or '$(Configuration)'=='DLL Release'">
+    <wxUsingDllDefine>WXUSINGDLL</wxUsingDllDefine>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>__WXMSW__;$(wxUsingDllDefine);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)include\msvc;$(MSBuildThisFileDirectory)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>__WXMSW__;$(wxUsingDllDefine);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)lib\$(wxOutDirName)\$(wxToolkitPrefix)$(wxSuffix);$(MSBuildThisFileDirectory)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ResourceCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(MSBuildThisFileDirectory)lib\$(wxOutDirName);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+</Project>


### PR DESCRIPTION
This seems to be the simplest possible way to let a MSVS project use the
library.

I was creating a new project using wxWidgets and I asked myself why don't we just provide a property sheet containing the options needed to use it. It looks like something as simple as this is sufficient and seems already very useful. Am I missing something here, i.e. is there any reason why we shouldn't advise people to set their projects up like this? Any thoughts?