### PR TITLE
Fix compatibility breakage with wxMask::Create() in wxOSX

### DIFF
--- a/include/wx/osx/bitmap.h
+++ b/include/wx/osx/bitmap.h
@@ -47,12 +47,7 @@ public:
     // Construct a mask from a mono bitmap (black meaning show pixels, white meaning transparent)
     wxMask(const wxBitmap& bitmap);
 
-    // implementation helper only : construct a mask from a 32 bit memory buffer
-    wxMask(const wxMemoryBuffer& buf, int width , int height , int bytesPerRow ) ;
-
     virtual ~wxMask();
-
-    bool Create(const wxMemoryBuffer& buf, int width , int height , int bytesPerRow ) ;
 
     wxBitmap GetBitmap() const;
 
@@ -70,6 +65,9 @@ public:
     void RealizeNative() ;
 
     WXHBITMAP GetHBITMAP() const ;
+
+    // implementation helper only : construct a mask from a 32 bit memory buffer
+    bool OSXCreate(const wxMemoryBuffer& buf, int width , int height , int bytesPerRow ) ;
 
 protected:
     // this function is called from Create() to free the existing mask data

--- a/src/osx/core/bitmap.cpp
+++ b/src/osx/core/bitmap.cpp
@@ -1062,7 +1062,9 @@ wxBitmap wxBitmap::GetSubBitmap(const wxRect &rect) const
 
             maskbuf.UngetWriteBuf( maskbufsize ) ;
         }
-        ret.SetMask( new wxMask( maskbuf , destwidth , destheight , rowBytes ) ) ;
+        wxMask* const mask = new wxMask();
+        mask->OSXCreate( maskbuf , destwidth , destheight , rowBytes );
+        ret.SetMask(mask) ;
     }
     else if ( HasAlpha() )
         ret.UseAlpha() ;
@@ -1505,22 +1507,14 @@ wxMask::wxMask(const wxMask &tocopy) : wxMaskBase()
 wxMask::wxMask( const wxBitmap& bitmap, const wxColour& colour )
 {
     Init() ;
-    wxMaskBase::Create( bitmap, colour );
+    Create( bitmap, colour );
 }
 
 // Construct a mask from a mono bitmap (copies the bitmap).
 wxMask::wxMask( const wxBitmap& bitmap )
 {
     Init() ;
-    wxMaskBase::Create( bitmap );
-}
-
-// Construct a mask from a mono bitmap (copies the bitmap).
-
-wxMask::wxMask( const wxMemoryBuffer& data, int width , int height , int bytesPerRow )
-{
-    Init() ;
-    Create( data, width , height , bytesPerRow );
+    Create( bitmap );
 }
 
 wxMask::~wxMask()
@@ -1591,7 +1585,7 @@ void wxMask::RealizeNative()
 
 // Create a mask from a mono bitmap (copies the bitmap).
 
-bool wxMask::Create(const wxMemoryBuffer& data,int width , int height , int bytesPerRow)
+bool wxMask::OSXCreate(const wxMemoryBuffer& data,int width , int height , int bytesPerRow)
 {
     wxASSERT( data.GetDataLen() == (size_t)(height * bytesPerRow) ) ;
 


### PR DESCRIPTION
Defining a Mac-specific Create(wxMemoryBuffer) overload hid the other
Create() overloads, which are actually part of the public API, so they
couldn't be used any longer since the changes of
e7d21f6638a6d5f715bea5dcef461f9d19e4d979

Fix this by renaming this Create() to OSXCreate(), to avoid hiding the
base class methods.

Also remove Mac-specific ctor taking wxMemoryBuffer, this is confusing
and can be avoided by just calling OSXCreate() directly in the only
place where it is used.

---

Stefan, I'm almost sure this is correct, but please take a look, just in case (I can merge this myself if you don't see anything wrong).