### PR TITLE
CMake: Add include directories and libraries for all packages

### DIFF
--- a/build/cmake/lib/base/CMakeLists.txt
+++ b/build/cmake/lib/base/CMakeLists.txt
@@ -27,28 +27,35 @@ elseif(UNIX)
 endif()
 
 wx_add_library(base IS_BASE ${BASE_FILES})
-wx_lib_link_libraries(base PRIVATE
-    ${ZLIB_LIBRARIES}
-    ${REGEX_LIBRARIES}
-)
+
 if(NOT wxBUILD_MONOLITHIC)
     wx_lib_compile_definitions(base PRIVATE wxUSE_BASE=1)
 endif()
 if(wxUSE_ZLIB)
+
     wx_lib_include_directories(base PRIVATE ${ZLIB_INCLUDE_DIRS})
+    wx_lib_link_libraries(base PRIVATE ${ZLIB_LIBRARIES})
 endif()
 if(wxUSE_REGEX)
     wx_lib_include_directories(base PRIVATE ${REGEX_INCLUDE_DIRS})
+    wx_lib_link_libraries(base PRIVATE ${REGEX_LIBRARIES})
 endif()
-if(LIBSECRET_FOUND)
+if(wxUSE_LIBLZMA)
+    wx_lib_include_directories(base PRIVATE ${LIBLZMA_INCLUDE_DIRS})
+    wx_lib_link_libraries(base PRIVATE ${LIBLZMA_LIBRARIES})
+endif()
+if(UNIX AND wxUSE_SECRETSTORE)
     wx_lib_include_directories(base PRIVATE ${LIBSECRET_INCLUDE_DIRS})
+    wx_lib_link_libraries(base PRIVATE ${LIBSECRET_LIBRARIES})
 endif()
 if(wxUSE_LIBICONV AND ICONV_LIBRARIES)
+    wx_lib_include_directories(base PRIVATE ${ICONV_INCLUDE_DIRS})
     wx_lib_link_libraries(base PRIVATE ${ICONV_LIBRARIES})
 endif()
 if(wxUSE_THREADS AND CMAKE_THREAD_LIBS_INIT)
     wx_lib_link_libraries(base PRIVATE ${CMAKE_THREAD_LIBS_INIT})
 endif()
+
 if(APPLE)
     wx_lib_link_libraries(base
         PRIVATE
@@ -60,10 +67,7 @@ if(APPLE)
         "-framework IOKit"
     )
 elseif(UNIX)
-    wx_lib_link_libraries(base PRIVATE
-        dl
-        ${LIBSECRET_LIBRARIES}
-    )
+    wx_lib_link_libraries(base PRIVATE dl)
 endif()
 
 wx_finalize_lib(base)


### PR DESCRIPTION
`lzma.h` could not be found when building with `wxUSE_LIBLZMA` on macOS. Add the found include directories and libraries from `find_package(LibLZMA)` to the `base` library.

For consistency, add the include directories and libraries of all `find_package` usage.