### PR TITLE
Cmake wxBUILD_CXX_STANDARD C++17 fix

### DIFF
--- a/build/cmake/options.cmake
+++ b/build/cmake/options.cmake
@@ -37,7 +37,7 @@ else()
         set(wxCXX_STANDARD_DEFAULT COMPILER_DEFAULT)
     endif()
     wx_option(wxBUILD_CXX_STANDARD "C++ standard used to build wxWidgets targets"
-        ${wxCXX_STANDARD_DEFAULT} STRINGS COMPILER_DEFAULT 98 11 14)
+              ${wxCXX_STANDARD_DEFAULT} STRINGS COMPILER_DEFAULT 98 11 14 17)
 endif()
 
 if(WIN32)


### PR DESCRIPTION
Allow wxWidgets seams to have full support for compiling with C++17 as far as I have been able to determine, build with C++17 under cmake failed, as cmake was rejecting it as a valid options.

This pull request add C++17 to the list of valid standards, so that the cmake build using C++17 works.