### PR TITLE
Fix warnings and replace deprecated values

### DIFF
--- a/demos/bombs/game.h
+++ b/demos/bombs/game.h
@@ -27,17 +27,17 @@ public:
     {
         m_width = m_height = 0;
         m_field = NULL;
-    };
+    }
 
     ~BombsGame();
 
-    int GetWidth() const { return m_width; };
-    int GetHeight() const { return m_height; };
+    int GetWidth() const { return m_width; }
+    int GetHeight() const { return m_height; }
 
     int Get(int x, int y) const
     {
         return m_field[x+y*m_width];
-    };
+    }
 
     int IsFocussed(int x, int y) const
     {
@@ -47,42 +47,42 @@ public:
     int IsHidden(int x, int y) const
     {
         return Get(x,y) & BG_HIDDEN;
-    };
+    }
 
     int IsMarked(int x, int y) const
     {
         return Get(x,y) & BG_MARKED;
-    };
+    }
 
     int IsBomb(int x, int y) const
     {
         return Get(x,y) & BG_BOMB;
-    };
+    }
 
     int IsExploded(int x, int y) const
     {
         return Get(x,y) & BG_EXPLODED;
-    };
+    }
 
     int IsSelected(int x, int y) const
     {
         return Get(x,y) & BG_SELECTED;
-    };
+    }
 
     int GetNumBombs() const
     {
         return m_numBombCells;
-    };
+    }
 
     int GetNumRemainingCells() const
     {
         return m_numRemainingCells;
-    };
+    }
 
     int GetNumMarkedCells() const
     {
         return m_numMarkedCells;
-    };
+    }
 
 
     bool Init(int width, int height, bool easyCorner = false);

--- a/demos/forty/card.cpp
+++ b/demos/forty/card.cpp
@@ -165,7 +165,7 @@ void Card::Draw(wxDC& dc, int x, int y)
     if (m_wayUp == facedown)
     {
         dc.SetBackground(* wxRED_BRUSH);
-        dc.SetBackgroundMode(wxSOLID);
+        dc.SetBackgroundMode(wxBRUSHSTYLE_SOLID);
         wxBrush* brush = wxTheBrushList->FindOrCreateBrush(
                             *wxBLACK, wxBRUSHSTYLE_CROSSDIAG_HATCH
                             );
@@ -183,7 +183,7 @@ void Card::Draw(wxDC& dc, int x, int y)
 
         memoryDC.SelectObject(*m_symbolBmap);
 
-//        dc.SetBackgroundMode(wxTRANSPARENT);
+//        dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
 
         dc.SetTextBackground(*wxWHITE);
         switch (m_suit)

--- a/demos/forty/card.h
+++ b/demos/forty/card.h
@@ -43,7 +43,7 @@ class Card {
 
 public:
     Card(int value, WayUp way_up = facedown);
-    virtual ~Card(){};
+    virtual ~Card(){}
 
     void Draw(wxDC& pDC, int x, int y);
     static void DrawNullCard(wxDC& pDC, int x, int y); // Draw card place-holder
@@ -55,9 +55,9 @@ public:
     Suit GetSuit() const { return m_suit; }
     SuitColour GetColour() const { return m_colour; }
     static void SetScale(double scale);
-    static int GetHeight() { return m_height; };
-    static int GetWidth() { return m_width; };
-    static double GetScale() { return m_scale; };
+    static int GetHeight() { return m_height; }
+    static int GetWidth() { return m_width; }
+    static double GetScale() { return m_scale; }
 
 private:
     Suit m_suit;

--- a/demos/forty/forty.h
+++ b/demos/forty/forty.h
@@ -38,7 +38,7 @@ class FortyFrame: public wxFrame
 {
 public:
     FortyFrame(wxFrame* frame, const wxString& title, const wxPoint& pos, const wxSize& size, bool largecards);
-    virtual ~FortyFrame(){};
+    virtual ~FortyFrame(){}
 
     void OnCloseWindow(wxCloseEvent& event);
 

--- a/demos/forty/game.cpp
+++ b/demos/forty/game.cpp
@@ -795,7 +795,7 @@ void Pack::Redraw(wxDC& dc)
     wxString str;
     str.Printf(wxT("%d  "), m_topCard + 1);
 
-    dc.SetBackgroundMode( wxSOLID );
+    dc.SetBackgroundMode( wxBRUSHSTYLE_SOLID );
     dc.SetTextBackground(FortyApp::BackgroundColour());
     dc.SetTextForeground(FortyApp::TextColour());
     dc.DrawText(str, m_x + CardWidth + 5, m_y + CardHeight / 2);

--- a/demos/forty/pile.h
+++ b/demos/forty/pile.h
@@ -41,7 +41,7 @@ const int NumCards = 2 * PackSize;
 class Pile {
 public:
     Pile(int x, int y, int dx = 0, int dy = 0);
-    virtual ~Pile(){};
+    virtual ~Pile(){}
 
     // General functions
     virtual void ResetPile() { m_topCard = -1; }
@@ -68,7 +68,7 @@ public:
     virtual bool AcceptCard(Card*) { return false; }
     virtual void AddCard(Card* card); // Add card to top of pile
     virtual void AddCard(wxDC& pDC, Card* card); // Add card + redraw it
-        void SetPos(int x,int y) {m_x = x;m_y = y;};
+        void SetPos(int x,int y) {m_x = x;m_y = y;}
 
 protected:
     int   m_x, m_y; // Position of the pile on the screen

--- a/demos/forty/playerdg.h
+++ b/demos/forty/playerdg.h
@@ -16,7 +16,7 @@ class PlayerSelectionDialog : public wxDialog
 {
 public:
     PlayerSelectionDialog(wxWindow* parent, ScoreFile* file);
-    virtual ~PlayerSelectionDialog(){};
+    virtual ~PlayerSelectionDialog(){}
 
     const wxString& GetPlayersName();
     void ButtonCallback(wxCommandEvent& event);

--- a/demos/forty/scoredg.h
+++ b/demos/forty/scoredg.h
@@ -16,7 +16,7 @@ class ScoreDialog : public wxDialog
 {
 public:
     ScoreDialog(wxWindow* parent, ScoreFile* file);
-    virtual ~ScoreDialog(){};
+    virtual ~ScoreDialog(){}
 
     void Display();
 

--- a/demos/life/game.cpp
+++ b/demos/life/game.cpp
@@ -925,7 +925,7 @@ class LifeModule: public wxModule
     wxDECLARE_DYNAMIC_CLASS(LifeModule);
 
 public:
-    LifeModule() {};
+    LifeModule() {}
     bool OnInit() wxOVERRIDE;
     void OnExit() wxOVERRIDE;
 };

--- a/demos/life/game.h
+++ b/demos/life/game.h
@@ -29,7 +29,7 @@ public:
         m_description = description;
         m_rules       = rules;
         m_shape       = shape;
-    };
+    }
 
     // A more convenient ctor for the built-in samples
     LifePattern(wxString      name,
@@ -58,7 +58,7 @@ public:
 
             m_shape.Add( tmp );
         }
-    };
+    }
 
     wxString      m_name;
     wxString      m_description;
@@ -90,9 +90,9 @@ public:
     ~Life();
 
     // accessors
-    inline wxUint32 GetNumCells() const    { return m_numcells; };
-    inline wxString GetRules() const       { return m_rules; };
-    inline wxString GetDescription() const { return m_description; };
+    inline wxUint32 GetNumCells() const    { return m_numcells; }
+    inline wxString GetRules() const       { return m_rules; }
+    inline wxString GetDescription() const { return m_description; }
     bool IsAlive(wxInt32 x, wxInt32 y);
     void SetCell(wxInt32 x, wxInt32 y, bool alive = true);
     void SetPattern(const LifePattern &pattern);

--- a/demos/life/life.cpp
+++ b/demos/life/life.cpp
@@ -534,7 +534,7 @@ void LifeFrame::OnNavigate(wxCommandEvent& event)
         case ID_CENTER: c = m_life->FindCenter(); break;
         default :
             wxFAIL;
-            // Fall through!
+            wxFALLTHROUGH;
         case ID_ORIGIN: c.i = c.j = 0; break;
     }
 

--- a/demos/life/life.h
+++ b/demos/life/life.h
@@ -31,7 +31,7 @@ public:
     virtual ~LifeCanvas();
 
     // view management
-    int  GetCellSize() const { return m_cellsize; };
+    int  GetCellSize() const { return m_cellsize; }
     void SetCellSize(int cellsize);
     void Recenter(wxInt32 i, wxInt32 j);
 
@@ -54,10 +54,10 @@ private:
     void OnEraseBackground(wxEraseEvent& event);
 
     // conversion between cell and screen coordinates
-    inline wxInt32 XToCell(wxCoord x) const { return (x / m_cellsize) + m_viewportX; };
-    inline wxInt32 YToCell(wxCoord y) const { return (y / m_cellsize) + m_viewportY; };
-    inline wxCoord CellToX(wxInt32 i) const { return (i - m_viewportX) * m_cellsize; };
-    inline wxCoord CellToY(wxInt32 j) const { return (j - m_viewportY) * m_cellsize; };
+    inline wxInt32 XToCell(wxCoord x) const { return (x / m_cellsize) + m_viewportX; }
+    inline wxInt32 YToCell(wxCoord y) const { return (y / m_cellsize) + m_viewportY; }
+    inline wxCoord CellToX(wxInt32 i) const { return (i - m_viewportX) * m_cellsize; }
+    inline wxCoord CellToY(wxInt32 j) const { return (j - m_viewportY) * m_cellsize; }
 
     // what is the user doing?
     enum MouseStatus

--- a/demos/life/reader.h
+++ b/demos/life/reader.h
@@ -22,14 +22,14 @@ class LifeReader
 public:
     LifeReader(wxInputStream& is);
 
-    inline bool          IsOk() const           { return m_ok; };
-    inline wxString      GetDescription() const { return m_description; };
-    inline wxString      GetRules() const       { return m_rules; };
-    inline wxArrayString GetShape() const       { return m_shape; };
+    inline bool          IsOk() const           { return m_ok; }
+    inline wxString      GetDescription() const { return m_description; }
+    inline wxString      GetRules() const       { return m_rules; }
+    inline wxArrayString GetShape() const       { return m_shape; }
     inline LifePattern   GetPattern() const
     {
         return LifePattern(wxEmptyString, m_description, m_rules, m_shape);
-    };
+    }
 
 private:
     bool             m_ok;

--- a/demos/poem/wxpoem.cpp
+++ b/demos/poem/wxpoem.cpp
@@ -686,6 +686,8 @@ void MyCanvas::OnChar(wxKeyEvent& event)
 
         case WXK_ESCAPE:
             TheMainWindow->Close(true);
+            break;
+
         default:
             break;
     }

--- a/demos/poem/wxpoem.cpp
+++ b/demos/poem/wxpoem.cpp
@@ -168,7 +168,7 @@ void MainWindow::ScanBuffer(wxDC *dc, bool DrawIt, int *max_x, int *max_y)
         dc->SetBrush(*wxLIGHT_GREY_BRUSH);
         dc->SetPen(*wxGREY_PEN);
         dc->DrawRectangle(0, 0, width, height);
-        dc->SetBackgroundMode(wxTRANSPARENT);
+        dc->SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
     }
 
     // See what ACTUAL char height is

--- a/docs/doxygen/overviews/commondialogs.h
+++ b/docs/doxygen/overviews/commondialogs.h
@@ -78,7 +78,7 @@ if (dialog.ShowModal() == wxID_OK)
 {
     wxColourData retData = dialog.GetColourData();
     wxColour col = retData.GetColour();
-    wxBrush brush(col, wxSOLID);
+    wxBrush brush(col, wxBRUSHSTYLE_SOLID);
     myWindow->SetBackground(brush);
     myWindow->Clear();
     myWindow->Refresh();

--- a/include/wx/generic/dataview.h
+++ b/include/wx/generic/dataview.h
@@ -409,7 +409,7 @@ class WXDLLIMPEXP_CORE wxDataViewCtrlAccessible: public wxWindowAccessible
 {
 public:
     wxDataViewCtrlAccessible(wxDataViewCtrl* win);
-    virtual ~wxDataViewCtrlAccessible() {};
+    virtual ~wxDataViewCtrlAccessible() {}
 
     virtual wxAccStatus HitTest(const wxPoint& pt, int* childId,
                                 wxAccessible** childObject) wxOVERRIDE;

--- a/include/wx/html/htmlcell.h
+++ b/include/wx/html/htmlcell.h
@@ -17,6 +17,7 @@
 #include "wx/html/htmltag.h"
 #include "wx/html/htmldefs.h"
 #include "wx/window.h"
+#include "wx/brush.h"
 
 
 class WXDLLIMPEXP_FWD_HTML wxHtmlWindowInterface;

--- a/include/wx/html/htmlcell.h
+++ b/include/wx/html/htmlcell.h
@@ -81,7 +81,7 @@ enum wxHtmlSelectionState
 class WXDLLIMPEXP_HTML wxHtmlRenderingState
 {
 public:
-    wxHtmlRenderingState() : m_selState(wxHTML_SEL_OUT) { m_bgMode = wxSOLID; }
+    wxHtmlRenderingState() : m_selState(wxHTML_SEL_OUT) { m_bgMode = wxBRUSHSTYLE_SOLID; }
 
     void SetSelectionState(wxHtmlSelectionState s) { m_selState = s; }
     wxHtmlSelectionState GetSelectionState() const { return m_selState; }

--- a/include/wx/msw/webview_ie.h
+++ b/include/wx/msw/webview_ie.h
@@ -157,7 +157,6 @@ private:
     wxIEContainer* m_container;
     wxAutomationObject m_ie;
     IWebBrowser2* m_webBrowser;
-    DWORD m_dwCookie;
     wxCOMPtr<DocHostUIHandler> m_uiHandler;
 
     //We store the current zoom type;

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -2319,7 +2319,7 @@ public:
         wxPen MidiGrid::GetRowGridLinePen(int row)
         {
             if ( row % 12 == 7 )
-                return wxPen(*wxBLACK, 1, wxSOLID);
+                return wxPen(*wxBLACK, 1, wxPENSTYLE_SOLID);
             else
                 return GetDefaultGridLinePen();
         }

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -987,7 +987,7 @@ public:
     */
     void SetTextColour(const wxColour& colText);
 
-    
+
     void MergeWith(wxGridCellAttr *mergefrom);
 
     void SetSize(int num_rows, int num_cols);
@@ -4551,7 +4551,7 @@ public:
     */
     void SetRowAttr(int row, wxGridCellAttr* attr);
 
-    
+
     wxArrayInt CalcRowLabelsExposed( const wxRegion& reg );
     wxArrayInt CalcColLabelsExposed( const wxRegion& reg );
     wxGridCellCoordsArray CalcCellsExposed( const wxRegion& reg );
@@ -4697,7 +4697,7 @@ public:
 
 
     virtual void DrawCellHighlight( wxDC& dc, const wxGridCellAttr *attr );
-    
+
     virtual void DrawRowLabels( wxDC& dc, const wxArrayInt& rows );
     virtual void DrawRowLabel( wxDC& dc, int row );
 
@@ -4722,9 +4722,9 @@ public:
 
     void SetCellHighlightColour( const wxColour& );
     void SetCellHighlightPenWidth(int width);
-    void SetCellHighlightROPenWidth(int width);   
+    void SetCellHighlightROPenWidth(int width);
 
-    
+
 protected:
     /**
         Returns @true if this grid has support for cell attributes.

--- a/samples/calendar/calendar.cpp
+++ b/samples/calendar/calendar.cpp
@@ -625,7 +625,7 @@ void MyFrame::OnCalRClick(wxMouseEvent& event)
     {
         default:
             wxFAIL_MSG( "unexpected" );
-            // fall through
+            wxFALLTHROUGH;
 
         case wxCAL_HITTEST_NOWHERE:
             msg += "nowhere";

--- a/samples/caret/caret.cpp
+++ b/samples/caret/caret.cpp
@@ -479,7 +479,7 @@ void MyCanvas::OnChar( wxKeyEvent &event )
                 wxCaretSuspend cs(this);
                 wxClientDC dc(this);
                 dc.SetFont(m_font);
-                dc.SetBackgroundMode(wxSOLID); // overwrite old value
+                dc.SetBackgroundMode(wxBRUSHSTYLE_SOLID); // overwrite old value
                 dc.DrawText(ch, m_xMargin + m_xCaret * m_widthChar,
                                 m_yMargin + m_yCaret * m_heightChar );
 

--- a/samples/dataview/mymodels.cpp
+++ b/samples/dataview/mymodels.cpp
@@ -525,6 +525,7 @@ bool MyListModel::GetAttrByRow( unsigned int row, unsigned int col,
                     return true;
                 }
             }
+            wxFALLTHROUGH;
 
         case Col_Custom:
             // do what the labels defined in GetValueByRow() hint at

--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -3080,7 +3080,7 @@ void MyFrame::OnFindDialog(wxFindDialogEvent& event)
 void MyCanvas::OnPaint(wxPaintEvent& WXUNUSED(event) )
 {
     wxPaintDC dc(this);
-    dc.SetBackgroundMode(wxTRANSPARENT);
+    dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
     dc.DrawText(
                 "wxWidgets common dialogs"
                 " test application"

--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -3707,6 +3707,7 @@ long TestMessageBoxDialog::GetStyle()
     {
         case MsgDlgIcon_Max:
             wxFAIL_MSG( "unexpected selection" );
+            wxFALLTHROUGH;
 
         case MsgDlgIcon_No:
             break;

--- a/samples/dll/sdk_exe.cpp
+++ b/samples/dll/sdk_exe.cpp
@@ -82,8 +82,6 @@ LRESULT CALLBACK MainWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
         default:
             return DefWindowProc(hwnd, msg, wParam, lParam);
     }
-
-    return 0;
 }
 
 // ----------------------------------------------------------------------------

--- a/samples/dragimag/dragimag.h
+++ b/samples/dragimag/dragimag.h
@@ -122,7 +122,7 @@ class DragShape: public wxObject
 {
 public:
     DragShape(const wxBitmap& bitmap);
-    ~DragShape(){};
+    ~DragShape(){}
 
 //// Operations
 

--- a/samples/drawing/drawing.cpp
+++ b/samples/drawing/drawing.cpp
@@ -896,7 +896,7 @@ void MyCanvas::DrawText(wxDC& dc)
     dc.SetFont( *wxSWISS_FONT );
 
     wxString text;
-    dc.SetBackgroundMode(wxTRANSPARENT);
+    dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
 
     for ( int n = -180; n < 180; n += 30 )
     {
@@ -2197,7 +2197,7 @@ MyFrame::MyFrame(const wxString& title, const wxPoint& pos, const wxSize& size)
     m_yLogicalOrigin = 0;
     m_xAxisReversed =
     m_yAxisReversed = false;
-    m_backgroundMode = wxSOLID;
+    m_backgroundMode = wxBRUSHSTYLE_SOLID;
     m_colourForeground = *wxBLACK;
     m_colourBackground = *wxLIGHT_GREY;
     m_textureBackground = false;
@@ -2463,8 +2463,9 @@ void MyFrame::OnOption(wxCommandEvent& event)
 #endif // wxUSE_COLOURDLG
 
         case Colour_BackgroundMode:
-            m_backgroundMode = m_backgroundMode == wxSOLID ? wxTRANSPARENT
-                                                           : wxSOLID;
+            m_backgroundMode = m_backgroundMode == wxBRUSHSTYLE_SOLID
+                                                 ? wxBRUSHSTYLE_TRANSPARENT
+                                                 : wxBRUSHSTYLE_SOLID;
             break;
 
         case Colour_TextureBackgound:

--- a/samples/erase/erase.cpp
+++ b/samples/erase/erase.cpp
@@ -178,7 +178,7 @@ private:
         dc.DrawRectangle(GetClientSize());
 
         dc.SetTextForeground(*wxBLUE);
-        dc.SetBackgroundMode(wxTRANSPARENT);
+        dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
         dc.DrawText(m_message, 0, 2);
 
         // Draw some bitmap/icon to ensure transparent bitmaps are indeed
@@ -436,7 +436,7 @@ void MyCanvas::OnEraseBackground( wxEraseEvent& event )
     }
 
     dc.SetTextForeground(*wxRED);
-    dc.SetBackgroundMode(wxSOLID);
+    dc.SetBackgroundMode(wxBRUSHSTYLE_SOLID);
     dc.DrawText("This text is drawn from OnEraseBackground", 60, 160);
 }
 

--- a/samples/exec/exec.cpp
+++ b/samples/exec/exec.cpp
@@ -627,7 +627,7 @@ void MyFrame::OnKill(wxCommandEvent& WXUNUSED(event))
     {
         default:
             wxFAIL_MSG( "unexpected return value" );
-            // fall through
+            wxFALLTHROUGH;
 
         case -1:
             // cancelled

--- a/samples/image/image.cpp
+++ b/samples/image/image.cpp
@@ -802,7 +802,7 @@ void MyFrame::OnImageInfo( wxCommandEvent &WXUNUSED(event) )
             {
                 default:
                     wxFAIL_MSG( "unknown image resolution units" );
-                    // fall through
+                    wxFALLTHROUGH;
 
                 case wxIMAGE_RESOLUTION_NONE:
                     info += " in default units";

--- a/samples/ipc/baseclient.cpp
+++ b/samples/ipc/baseclient.cpp
@@ -78,7 +78,7 @@ public:
     bool Connect(const wxString& sHost, const wxString& sService, const wxString& sTopic);
     void Disconnect();
     wxConnectionBase *OnMakeConnection() wxOVERRIDE;
-    bool IsConnected() { return m_connection != NULL; };
+    bool IsConnected() { return m_connection != NULL; }
 
     virtual void Notify() wxOVERRIDE;
 

--- a/samples/ipc/baseserver.cpp
+++ b/samples/ipc/baseserver.cpp
@@ -113,7 +113,7 @@ public:
     MyServer();
     virtual ~MyServer();
     void Disconnect();
-    bool IsConnected() { return m_connection != NULL; };
+    bool IsConnected() { return m_connection != NULL; }
 
     virtual wxConnectionBase *OnAcceptConnection(const wxString& topic) wxOVERRIDE;
 

--- a/samples/ipc/client.h
+++ b/samples/ipc/client.h
@@ -31,7 +31,7 @@ class MyApp: public wxApp
 public:
     virtual bool OnInit() wxOVERRIDE;
     virtual int OnExit() wxOVERRIDE;
-    MyFrame *GetFrame() { return m_frame; };
+    MyFrame *GetFrame() { return m_frame; }
 
 protected:
     MyFrame        *m_frame;
@@ -96,8 +96,8 @@ public:
     bool Connect(const wxString& sHost, const wxString& sService, const wxString& sTopic);
     void Disconnect();
     wxConnectionBase *OnMakeConnection() wxOVERRIDE;
-    bool IsConnected() { return m_connection != NULL; };
-    MyConnection *GetConnection() { return m_connection; };
+    bool IsConnected() { return m_connection != NULL; }
+    MyConnection *GetConnection() { return m_connection; }
 
 protected:
     MyConnection     *m_connection;

--- a/samples/joytest/joytest.h
+++ b/samples/joytest/joytest.h
@@ -44,7 +44,7 @@ public:
     MyCanvas *canvas;
     MyFrame(wxFrame *parent, const wxString& title,
         const wxPoint& pos, const wxSize& size, const long style);
-    ~MyFrame(){};
+    ~MyFrame(){}
     void OnActivate(wxActivateEvent& event);
     void OnQuit(wxCommandEvent& event);
 

--- a/samples/layout/layout.h
+++ b/samples/layout/layout.h
@@ -12,7 +12,7 @@
 class MyApp: public wxApp
 {
 public:
-    MyApp(){};
+    MyApp(){}
     bool OnInit() wxOVERRIDE;
 };
 

--- a/samples/nativdlg/nativdlg.h
+++ b/samples/nativdlg/nativdlg.h
@@ -12,7 +12,7 @@
 class MyApp: public wxApp
 {
   public:
-    MyApp(void){};
+    MyApp(void){}
     bool OnInit(void) wxOVERRIDE;
 };
 

--- a/samples/opengl/pyramid/pyramid.h
+++ b/samples/opengl/pyramid/pyramid.h
@@ -14,7 +14,7 @@
 class MyApp: public wxApp
 {
 public:
-    MyApp(){};
+    MyApp(){}
     bool OnInit() wxOVERRIDE;
 };
 

--- a/samples/ownerdrw/ownerdrw.cpp
+++ b/samples/ownerdrw/ownerdrw.cpp
@@ -40,7 +40,7 @@ class OwnerDrawnFrame : public wxFrame
 public:
     // ctor & dtor
     OwnerDrawnFrame(wxFrame *frame, const wxString& title, int x, int y, int w, int h);
-    ~OwnerDrawnFrame(){};
+    ~OwnerDrawnFrame(){}
 
     // notifications
     void OnQuit             (wxCommandEvent& event);

--- a/samples/power/power.cpp
+++ b/samples/power/power.cpp
@@ -142,7 +142,7 @@ private:
 
             default:
                 wxFAIL_MSG("unknown wxPowerType value");
-                // fall through
+                wxFALLTHROUGH;
 
             case wxPOWER_UNKNOWN:
                 powerStr = "psychic";
@@ -170,7 +170,7 @@ private:
 
             default:
                 wxFAIL_MSG("unknown wxBatteryState value");
-                // fall through
+                wxFALLTHROUGH;
 
             case wxBATTERY_UNKNOWN_STATE:
                 batteryStr = "unknown";

--- a/samples/printing/printing.cpp
+++ b/samples/printing/printing.cpp
@@ -139,7 +139,7 @@ void MyApp::Draw(wxDC&dc)
     // dc.Clear();
     dc.SetFont(m_testFont);
 
-    // dc.SetBackgroundMode(wxTRANSPARENT);
+    // dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
 
     dc.SetPen(*wxBLACK_PEN);
     dc.SetBrush(*wxLIGHT_GREY_BRUSH);
@@ -679,7 +679,7 @@ void MyPrintout::DrawPageTwo()
     dc->DrawLine(50, 250, (long)(50.0 + logUnits), 250);
     dc->DrawLine(50, 250, 50, (long)(250.0 + logUnits));
 
-    dc->SetBackgroundMode(wxTRANSPARENT);
+    dc->SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
     dc->SetBrush(*wxTRANSPARENT_BRUSH);
 
     { // GetTextExtent demo:

--- a/samples/regtest/regtest.cpp
+++ b/samples/regtest/regtest.cpp
@@ -1074,8 +1074,7 @@ bool RegTreeCtrl::TreeNode::OnExpand()
             m_pKey->QueryValue(str, &l);
             strItem << l;
         }
-
-        // fall through
+        wxFALLTHROUGH;
 
         default:
             icon = RegImageList::BinaryValue;

--- a/samples/splitter/splitter.cpp
+++ b/samples/splitter/splitter.cpp
@@ -151,7 +151,7 @@ class MyCanvas: public wxScrolledWindow
 {
 public:
     MyCanvas(wxWindow* parent, bool mirror);
-    virtual ~MyCanvas(){};
+    virtual ~MyCanvas(){}
 
     virtual void OnDraw(wxDC& dc) wxOVERRIDE;
 

--- a/samples/stc/edit.h
+++ b/samples/stc/edit.h
@@ -112,7 +112,7 @@ public:
     wxString DeterminePrefs (const wxString &filename);
     bool InitializePrefs (const wxString &filename);
     bool UserSettings (const wxString &filename);
-    LanguageInfo const* GetLanguageInfo () {return m_language;};
+    LanguageInfo const* GetLanguageInfo () {return m_language;}
 
     //! load/save file
     bool LoadFile ();
@@ -120,8 +120,8 @@ public:
     bool SaveFile ();
     bool SaveFile (const wxString &filename);
     bool Modified ();
-    wxString GetFilename () {return m_filename;};
-    void SetFilename (const wxString &filename) {m_filename = filename;};
+    wxString GetFilename () {return m_filename;}
+    void SetFilename (const wxString &filename) {m_filename = filename;}
 
 private:
     // file

--- a/samples/svg/svgtest.cpp
+++ b/samples/svg/svgtest.cpp
@@ -342,7 +342,7 @@ void MyPage::OnDraw(wxDC& dc)
             wP = *wxCYAN_PEN;
             wP.SetWidth(3);
             dc.SetPen(wP);
-                                 //wxTRANSPARENT));
+                                 //wxBRUSHSTYLE_TRANSPARENT));
             dc.SetBrush (wxBrush ("SALMON"));
             dc.DrawEllipticArc(300,  0,200,100, 0.0,145.0);
                                  //same end point

--- a/samples/thread/thread.cpp
+++ b/samples/thread/thread.cpp
@@ -66,7 +66,7 @@ class MyApp : public wxApp
 {
 public:
     MyApp();
-    virtual ~MyApp(){};
+    virtual ~MyApp(){}
 
     virtual bool OnInit() wxOVERRIDE;
 

--- a/samples/treectrl/treetest.h
+++ b/samples/treectrl/treetest.h
@@ -67,7 +67,7 @@ public:
     MyTreeCtrl(wxWindow *parent, const wxWindowID id,
                const wxPoint& pos, const wxSize& size,
                long style);
-    virtual ~MyTreeCtrl(){};
+    virtual ~MyTreeCtrl(){}
 
     void OnBeginDrag(wxTreeEvent& event);
     void OnBeginRDrag(wxTreeEvent& event);

--- a/samples/treelist/treelist.cpp
+++ b/samples/treelist/treelist.cpp
@@ -695,7 +695,7 @@ void MyFrame::OnItemContextMenu(wxTreeListEvent& event)
 
         default:
             wxFAIL_MSG( "Unexpected menu selection" );
-            // Fall through.
+            wxFALLTHROUGH;
 
         case wxID_NONE:
             return;

--- a/samples/widgets/bmpcombobox.cpp
+++ b/samples/widgets/bmpcombobox.cpp
@@ -433,7 +433,7 @@ void BitmapComboBoxWidgetsPage::CreateCombo()
     {
         default:
             wxFAIL_MSG( "unknown combo kind" );
-            // fall through
+            wxFALLTHROUGH;
 
         case ComboKind_Default:
             break;

--- a/samples/widgets/button.cpp
+++ b/samples/widgets/button.cpp
@@ -416,7 +416,7 @@ void ButtonWidgetsPage::CreateButton()
 
         default:
             wxFAIL_MSG("unexpected radiobox selection");
-            // fall through
+            wxFALLTHROUGH;
 
         case ButtonHAlign_Centre:
             break;
@@ -434,7 +434,7 @@ void ButtonWidgetsPage::CreateButton()
 
         default:
             wxFAIL_MSG("unexpected radiobox selection");
-            // fall through
+            wxFALLTHROUGH;
 
         case ButtonVAlign_Centre:
             // centre vertical alignment is the default (no style)

--- a/samples/widgets/checkbox.cpp
+++ b/samples/widgets/checkbox.cpp
@@ -259,7 +259,7 @@ void CheckBoxWidgetsPage::CreateCheckbox()
     {
         default:
             wxFAIL_MSG("unexpected radiobox selection");
-            // fall through
+            wxFALLTHROUGH;
 
         case CheckboxKind_2State:
             flags |= wxCHK_2STATE;
@@ -267,7 +267,7 @@ void CheckBoxWidgetsPage::CreateCheckbox()
 
         case CheckboxKind_3StateUser:
             flags |= wxCHK_ALLOW_3RD_STATE_FOR_USER;
-            // fall through
+            wxFALLTHROUGH;
 
         case CheckboxKind_3State:
             flags |= wxCHK_3STATE;

--- a/samples/widgets/combobox.cpp
+++ b/samples/widgets/combobox.cpp
@@ -431,7 +431,7 @@ void ComboboxWidgetsPage::CreateCombo()
     {
         default:
             wxFAIL_MSG( "unknown combo kind" );
-            // fall through
+            wxFALLTHROUGH;
 
         case ComboKind_Default:
             break;

--- a/samples/widgets/hyperlnk.cpp
+++ b/samples/widgets/hyperlnk.cpp
@@ -366,7 +366,7 @@ void HyperlinkWidgetsPage::OnAlignment(wxCommandEvent& WXUNUSED(event))
         default:
         case Align_Max:
             wxFAIL_MSG( "unknown alignment" );
-            // fall through
+            wxFALLTHROUGH;
 
         case Align_Left:
             addstyle = wxHL_ALIGN_LEFT;

--- a/samples/widgets/notebook.cpp
+++ b/samples/widgets/notebook.cpp
@@ -343,7 +343,7 @@ void BookWidgetsPage::RecreateBook()
     {
         default:
             wxFAIL_MSG( "unknown orientation" );
-            // fall through
+            wxFALLTHROUGH;
 
         case Orient_Top:
             flags |= wxBK_TOP;

--- a/samples/widgets/radiobox.cpp
+++ b/samples/widgets/radiobox.cpp
@@ -376,7 +376,7 @@ void RadioWidgetsPage::CreateRadio()
     {
         default:
             wxFAIL_MSG( "unexpected wxRadioBox layout direction" );
-            // fall through
+            wxFALLTHROUGH;
 
         case RadioDir_Default:
             break;

--- a/samples/widgets/spinbtn.cpp
+++ b/samples/widgets/spinbtn.cpp
@@ -368,7 +368,7 @@ void SpinBtnWidgetsPage::CreateSpin()
     {
         default:
             wxFAIL_MSG("unexpected radiobox selection");
-            // fall through
+            wxFALLTHROUGH;
 
         case Align_Left:
             textFlags |= wxALIGN_LEFT;  // no-op

--- a/samples/widgets/static.cpp
+++ b/samples/widgets/static.cpp
@@ -417,7 +417,7 @@ void StaticWidgetsPage::CreateStatic()
     {
         default:
             wxFAIL_MSG("unexpected radiobox selection");
-            // fall through
+            wxFALLTHROUGH;
 
         case StaticHAlign_Left:
             align |= wxALIGN_LEFT;
@@ -436,7 +436,7 @@ void StaticWidgetsPage::CreateStatic()
     {
         default:
             wxFAIL_MSG("unexpected radiobox selection");
-            // fall through
+            wxFALLTHROUGH;
 
         case StaticVAlign_Top:
             align |= wxALIGN_TOP;
@@ -457,7 +457,7 @@ void StaticWidgetsPage::CreateStatic()
         {
             default:
                 wxFAIL_MSG("unexpected radiobox selection");
-                // fall through
+                wxFALLTHROUGH;
 
             case StaticEllipsize_Start:
                 flagsDummyText |= wxST_ELLIPSIZE_START;

--- a/samples/widgets/textctrl.cpp
+++ b/samples/widgets/textctrl.cpp
@@ -293,7 +293,7 @@ private:
         {
             default:
                 wxFAIL_MSG( "unexpected HitTest() result" );
-                // fall through
+                wxFALLTHROUGH;
 
             case wxTE_HT_UNKNOWN:
                 x = y = -1;
@@ -690,6 +690,7 @@ void TextWidgetsPage::CreateText()
     {
         default:
             wxFAIL_MSG( "unexpected lines radio box selection" );
+            wxFALLTHROUGH;
 
         case TextLines_Single:
             break;
@@ -755,6 +756,7 @@ void TextWidgetsPage::CreateText()
     {
         default:
             wxFAIL_MSG( "unexpected kind radio box selection" );
+            wxFALLTHROUGH;
 
         case TextKind_Plain:
             break;

--- a/samples/widgets/toggle.cpp
+++ b/samples/widgets/toggle.cpp
@@ -379,7 +379,7 @@ void ToggleWidgetsPage::CreateToggle()
 
         default:
             wxFAIL_MSG("unexpected radiobox selection");
-            // fall through
+            wxFALLTHROUGH;
 
         case ToggleHAlign_Centre:
             break;
@@ -397,7 +397,7 @@ void ToggleWidgetsPage::CreateToggle()
 
         default:
             wxFAIL_MSG("unexpected radiobox selection");
-            // fall through
+            wxFALLTHROUGH;
 
         case ToggleVAlign_Centre:
             // centre vertical alignment is the default (no style)

--- a/samples/widgets/widgets.cpp
+++ b/samples/widgets/widgets.cpp
@@ -902,7 +902,7 @@ void WidgetsFrame::OnSetBorder(wxCommandEvent& event)
 
         default:
             wxFAIL_MSG( "unknown border style" );
-            // fall through
+            wxFALLTHROUGH;
 
         case Widgets_BorderDefault: border = wxBORDER_DEFAULT; break;
     }

--- a/samples/xrc/custclas.h
+++ b/samples/xrc/custclas.h
@@ -60,7 +60,7 @@ public:
                        );
 
     // Destructor.
-    ~MyResizableListCtrl(){};
+    ~MyResizableListCtrl(){}
 
 protected:
 

--- a/samples/xrc/derivdlg.h
+++ b/samples/xrc/derivdlg.h
@@ -36,7 +36,7 @@ public:
     PreferencesDialog( wxWindow* parent );
 
     // Destructor.
-    ~PreferencesDialog(){};
+    ~PreferencesDialog(){}
 
 private:
 

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -912,7 +912,7 @@ bool wxAuiToolBar::Create(wxWindow* parent,
     SetExtraStyle(wxWS_EX_PROCESS_IDLE);
     if (style & wxAUI_TB_HORZ_LAYOUT)
         SetToolTextOrientation(wxAUI_TBTOOL_TEXT_RIGHT);
-    SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
 
     return true;
 }

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -3898,7 +3898,7 @@ void wxAuiManager::Render(wxDC* dc)
 
 void wxAuiManager::Repaint(wxDC* dc)
 {
-#ifdef __WXMAC__ 
+#ifdef __WXMAC__
     if ( dc == NULL )
     {
         m_frame->Refresh() ;

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -97,7 +97,7 @@ public:
                 const wxString &name = wxT("frame"))
                     : wxFrame(parent, id, title, pos, size, style | wxFRAME_SHAPED, name)
     {
-        SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+        SetBackgroundStyle(wxBG_STYLE_PAINT);
         m_amount=0;
         m_maxWidth=0;
         m_maxHeight=0;

--- a/src/common/dcgraph.cpp
+++ b/src/common/dcgraph.cpp
@@ -1107,20 +1107,20 @@ void wxGCDCImpl::DoDrawRotatedText(const wxString& text, wxCoord x, wxCoord y,
     if ( (angle == 0.0) && m_font.IsOk() )
     {
         DoDrawText(text, x, y);
-        
+
         // Bounding box already updated by DoDrawText(), no need to do it again.
         return;
     }
-            
+
     // Get extent of whole text.
     wxCoord w, h, heightLine;
     GetOwner()->GetMultiLineTextExtent(text, &w, &h, &heightLine);
-    
+
     // Compute the shift for the origin of the next line.
     const double rad = wxDegToRad(angle);
     const double dx = heightLine * sin(rad);
     const double dy = heightLine * cos(rad);
-    
+
     // Draw all text line by line
     const wxArrayString lines = wxSplit(text, '\n', '\0');
     for ( size_t lineNum = 0; lineNum < lines.size(); lineNum++ )
@@ -1132,15 +1132,15 @@ void wxGCDCImpl::DoDrawRotatedText(const wxString& text, wxCoord x, wxCoord y,
         else
             m_graphicContext->DrawText( lines[lineNum], x + wxRound(lineNum*dx), y + wxRound(lineNum*dy), wxDegToRad(angle ), m_graphicContext->CreateBrush(m_textBackgroundColour) );
    }
-            
+
     // call the bounding box by adding all four vertices of the rectangle
     // containing the text to it (simpler and probably not slower than
     // determining which of them is really topmost/leftmost/...)
-    
+
     // "upper left" and "upper right"
     CalcBoundingBox(x, y);
     CalcBoundingBox(x + wxCoord(w*cos(rad)), y - wxCoord(w*sin(rad)));
-    
+
     // "bottom left" and "bottom right"
     x += (wxCoord)(h*sin(rad));
     y += (wxCoord)(h*cos(rad));
@@ -1254,7 +1254,7 @@ wxCoord wxGCDCImpl::GetCharHeight(void) const
 void wxGCDCImpl::Clear(void)
 {
     wxCHECK_RET( IsOk(), wxT("wxGCDC(cg)::Clear - invalid DC") );
-    
+
     if ( m_backgroundBrush.IsOk() )
     {
         m_graphicContext->SetBrush( m_backgroundBrush );

--- a/src/common/dcgraph.cpp
+++ b/src/common/dcgraph.cpp
@@ -1127,7 +1127,7 @@ void wxGCDCImpl::DoDrawRotatedText(const wxString& text, wxCoord x, wxCoord y,
     {
         // Calculate origin for each line to avoid accumulation of
         // rounding errors.
-        if ( m_backgroundMode == wxTRANSPARENT )
+        if ( m_backgroundMode == wxBRUSHSTYLE_TRANSPARENT )
             m_graphicContext->DrawText( lines[lineNum], x + wxRound(lineNum*dx), y + wxRound(lineNum*dy), wxDegToRad(angle ));
         else
             m_graphicContext->DrawText( lines[lineNum], x + wxRound(lineNum*dx), y + wxRound(lineNum*dy), wxDegToRad(angle ), m_graphicContext->CreateBrush(m_textBackgroundColour) );
@@ -1170,7 +1170,7 @@ void wxGCDCImpl::DoDrawText(const wxString& str, wxCoord x, wxCoord y)
     if ( !m_logicalFunctionSupported )
         return;
 
-    if ( m_backgroundMode == wxTRANSPARENT )
+    if ( m_backgroundMode == wxBRUSHSTYLE_TRANSPARENT )
         m_graphicContext->DrawText( str, x ,y);
     else
         m_graphicContext->DrawText( str, x ,y , m_graphicContext->CreateBrush(m_textBackgroundColour) );

--- a/src/common/fontcmn.cpp
+++ b/src/common/fontcmn.cpp
@@ -104,9 +104,9 @@ wxPROPERTY( Size,int, SetPointSize, GetPointSize, 12, 0 /*flags*/, \
            wxT("Helpstring"), wxT("group"))
 wxPROPERTY( Family, wxFontFamily , SetFamily, GetFamily, (wxFontFamily)wxDEFAULT, \
            0 /*flags*/, wxT("Helpstring"), wxT("group")) // wxFontFamily
-wxPROPERTY( Style, wxFontStyle, SetStyle, GetStyle, (wxFontStyle)wxNORMAL, 0 /*flags*/, \
+wxPROPERTY( Style, wxFontStyle, SetStyle, GetStyle, wxFONTSTYLE_NORMAL, 0 /*flags*/, \
            wxT("Helpstring"), wxT("group")) // wxFontStyle
-wxPROPERTY( Weight, wxFontWeight, SetWeight, GetWeight, (wxFontWeight)wxNORMAL, 0 /*flags*/, \
+wxPROPERTY( Weight, wxFontWeight, SetWeight, GetWeight, wxFONTWEIGHT_NORMAL, 0 /*flags*/, \
            wxT("Helpstring"), wxT("group")) // wxFontWeight
 wxPROPERTY( Underlined, bool, SetUnderlined, GetUnderlined, false, 0 /*flags*/, \
            wxT("Helpstring"), wxT("group"))

--- a/src/common/glcmn.cpp
+++ b/src/common/glcmn.cpp
@@ -76,7 +76,7 @@ wxGLCanvasBase::wxGLCanvasBase()
 
     // we always paint background entirely ourselves so prevent wx from erasing
     // it to avoid flicker
-    SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
 }
 
 bool wxGLCanvasBase::SetCurrent(const wxGLContext& context) const

--- a/src/dfb/brush.cpp
+++ b/src/dfb/brush.cpp
@@ -44,9 +44,9 @@ public:
 
     void SetStyle(wxBrushStyle style)
     {
-        if ( style != wxSOLID && style != wxTRANSPARENT )
+        if ( style != wxBRUSHSTYLE_SOLID && style != wxBRUSHSTYLE_TRANSPARENT )
         {
-            wxFAIL_MSG( wxT("only wxSOLID and wxTRANSPARENT styles are supported") );
+            wxFAIL_MSG( wxT("only wxBRUSHSTYLE_SOLID and wxBRUSHSTYLE_TRANSPARENT styles are supported") );
             style = wxBRUSHSTYLE_SOLID;
         }
 

--- a/src/dfb/dc.cpp
+++ b/src/dfb/dc.cpp
@@ -135,7 +135,7 @@ void wxDFBDCImpl::Clear()
 {
     wxCHECK_RET( IsOk(), wxT("invalid dc") );
 
-    if ( m_backgroundBrush.GetStyle() == wxTRANSPARENT )
+    if ( m_backgroundBrush.GetStyle() == wxBRUSHSTYLE_TRANSPARENT )
         return;
 
     wxColour clr = m_backgroundBrush.GetColour();
@@ -181,7 +181,7 @@ void wxDFBDCImpl::DoDrawLine(wxCoord x1, wxCoord y1, wxCoord x2, wxCoord y2)
 {
     wxCHECK_RET( IsOk(), wxT("invalid dc") );
 
-    if ( m_pen.GetStyle() == wxTRANSPARENT )
+    if ( m_pen.GetStyle() == wxPENSTYLE_TRANSPARENT )
         return;
 
     wxCoord xx1 = XLOG2DEV(x1);
@@ -278,7 +278,7 @@ void wxDFBDCImpl::DoDrawRectangle(wxCoord x, wxCoord y, wxCoord width, wxCoord h
         yy = yy - hh;
     }
 
-    if ( m_brush.GetStyle() != wxTRANSPARENT )
+    if ( m_brush.GetStyle() != wxBRUSHSTYLE_TRANSPARENT )
     {
         SelectColour(m_brush.GetColour());
         m_surface->FillRectangle(xx, yy, ww, hh);
@@ -287,7 +287,7 @@ void wxDFBDCImpl::DoDrawRectangle(wxCoord x, wxCoord y, wxCoord width, wxCoord h
         SelectColour(m_pen.GetColour());
     }
 
-    if ( m_pen.GetStyle() != wxTRANSPARENT )
+    if ( m_pen.GetStyle() != wxPENSTYLE_TRANSPARENT )
     {
         m_surface->DrawRectangle(xx, yy, ww, hh);
     }
@@ -343,7 +343,7 @@ void wxDFBDCImpl::DoDrawText(const wxString& text, wxCoord x, wxCoord y)
     CalcBoundingBox(x + w, y + h);
 
     // if background mode is solid, DrawText must paint text's background:
-    if ( m_backgroundMode == wxSOLID )
+    if ( m_backgroundMode == wxBRUSHSTYLE_SOLID )
     {
         wxCHECK_RET( m_textBackgroundColour.IsOk(),
                      wxT("invalid background color") );

--- a/src/dfb/pen.cpp
+++ b/src/dfb/pen.cpp
@@ -43,7 +43,7 @@ public:
     {
         if ( style != wxPENSTYLE_SOLID && style != wxPENSTYLE_TRANSPARENT )
         {
-            wxFAIL_MSG( "only wxSOLID and wxTRANSPARENT styles are supported" );
+            wxFAIL_MSG( "only wxPENSTYLE_SOLID and wxPENSTYLE_TRANSPARENT styles are supported" );
             style = wxPENSTYLE_SOLID;
         }
 

--- a/src/generic/buttonbar.cpp
+++ b/src/generic/buttonbar.cpp
@@ -500,7 +500,7 @@ void wxButtonToolBar::OnPaint(wxPaintEvent& WXUNUSED(event))
     wxPaintDC dc(this);
 
     dc.SetFont(GetFont());
-    dc.SetBackgroundMode(wxTRANSPARENT);
+    dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
 
     for ( wxToolBarToolsList::compatibility_iterator node = m_tools.GetFirst();
           node;

--- a/src/generic/calctrlg.cpp
+++ b/src/generic/calctrlg.cpp
@@ -913,7 +913,7 @@ void wxGenericCalendarCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
     // draw column with calendar week nr
     if ( HasFlag( wxCAL_SHOW_WEEK_NUMBERS ) && IsExposed( 0, y, m_calendarWeekWidth, m_heightRow * 6 ))
     {
-        dc.SetBackgroundMode(wxTRANSPARENT);
+        dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
         dc.SetBrush(wxBrush(m_colHeaderBg, wxBRUSHSTYLE_SOLID));
         dc.SetPen(wxPen(m_colHeaderBg, 1, wxPENSTYLE_SOLID));
         dc.DrawRectangle( 0, y, m_calendarWeekWidth, m_heightRow * 6 );

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -1965,7 +1965,7 @@ wxDataViewMainWindow::wxDataViewMainWindow( wxDataViewCtrl *parent, wxWindowID i
 
     SetBackgroundColour( *wxWHITE );
 
-    SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
 
     m_penRule = wxPen(GetRuleColour());
 

--- a/src/generic/dcpsg.cpp
+++ b/src/generic/dcpsg.cpp
@@ -1546,7 +1546,7 @@ void wxPostScriptDCImpl::DoDrawSpline( const wxPointList *points )
 
 wxCoord wxPostScriptDCImpl::GetCharWidth() const
 {
-    // Chris Breeze: reasonable approximation using wxMODERN/Courier
+    // Chris Breeze: reasonable approximation using wxFONTFAMILY_MODERN/Courier
     return (wxCoord) (GetCharHeight() * 72.0 / 120.0);
 }
 
@@ -1983,7 +1983,7 @@ void wxPostScriptDCImpl::DoGetTextExtent(const wxString& string,
 #if !wxUSE_AFM_FOR_POSTSCRIPT
     /* Provide a VERY rough estimate (avoid using it).
      * Produces accurate results for mono-spaced font
-     * such as Courier (aka wxMODERN) */
+     * such as Courier (aka wxFONTFAMILY_MODERN) */
 
     if ( x )
         *x = strlen (strbuf) * fontSize * 72.0 / 120.0;
@@ -2061,8 +2061,8 @@ void wxPostScriptDCImpl::DoGetTextExtent(const wxString& string,
 
         switch (Family)
         {
-            case wxMODERN:
-            case wxTELETYPE:
+            case wxFONTFAMILY_MODERN:
+            case wxFONTFAMILY_TELETYPE:
             {
                 if ((Style == wxFONTSTYLE_ITALIC) && (Weight == wxFONTWEIGHT_BOLD)) name = wxT("CourBoO.afm");
                 else if ((Style != wxFONTSTYLE_ITALIC) && (Weight == wxFONTWEIGHT_BOLD)) name = wxT("CourBo.afm");
@@ -2070,7 +2070,7 @@ void wxPostScriptDCImpl::DoGetTextExtent(const wxString& string,
                 else name = wxT("Cour.afm");
                 break;
             }
-            case wxROMAN:
+            case wxFONTFAMILY_ROMAN:
             {
                 if ((Style == wxFONTSTYLE_ITALIC) && (Weight == wxFONTWEIGHT_BOLD)) name = wxT("TimesBoO.afm");
                 else if ((Style != wxFONTSTYLE_ITALIC) && (Weight == wxFONTWEIGHT_BOLD)) name = wxT("TimesBo.afm");
@@ -2078,12 +2078,12 @@ void wxPostScriptDCImpl::DoGetTextExtent(const wxString& string,
                 else name = wxT("TimesRo.afm");
                 break;
             }
-            case wxSCRIPT:
+            case wxFONTFAMILY_SCRIPT:
             {
                 name = wxT("Zapf.afm");
                 break;
             }
-            case wxSWISS:
+            case wxFONTFAMILY_SWISS:
             default:
             {
                 if ((Style == wxFONTSTYLE_ITALIC) && (Weight == wxFONTWEIGHT_BOLD)) name = wxT("HelvBoO.afm");

--- a/src/generic/headerctrlg.cpp
+++ b/src/generic/headerctrlg.cpp
@@ -73,7 +73,7 @@ bool wxHeaderCtrl::Create(wxWindow *parent,
 
     // tell the system to not paint the background at all to avoid flicker as
     // we paint the entire window area in our OnPaint()
-    SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
 
     return true;
 }

--- a/src/generic/markuptext.cpp
+++ b/src/generic/markuptext.cpp
@@ -147,7 +147,7 @@ public:
         {
             // Setting the background colour is not enough, we must also change
             // the mode to ensure that it is actually used.
-            m_dc.SetBackgroundMode(wxSOLID);
+            m_dc.SetBackgroundMode(wxBRUSHSTYLE_SOLID);
             m_dc.SetTextBackground(attr.background);
         }
     }
@@ -170,7 +170,7 @@ public:
                 // should actually be made transparent and in this case the
                 // actual value of background colour doesn't matter but we also
                 // restore it just in case, see comment in the ctor.
-                m_dc.SetBackgroundMode(wxTRANSPARENT);
+                m_dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
                 background = m_origTextBackground;
             }
 
@@ -260,7 +260,7 @@ public:
         const wxSize extent = m_dc.GetTextExtent(text);
 
         // DrawItemText() ignores background color, so render it ourselves
-        if ( m_dc.GetBackgroundMode() == wxSOLID )
+        if ( m_dc.GetBackgroundMode() == wxBRUSHSTYLE_SOLID)
         {
 #if wxUSE_GRAPHICS_CONTEXT
             // Prefer to use wxGraphicsContext because it supports alpha channel; fall back to wxDC

--- a/src/generic/renderg.cpp
+++ b/src/generic/renderg.cpp
@@ -194,7 +194,7 @@ static void DrawSelectedCellFocusRect(wxDC& dc, const wxRect& rect)
 {
     // (This code is based on wxRendererGeneric::DrawFocusRect and modified.)
 
-    // draw the pixels manually because the "dots" in wxPen with wxDOT style
+    // draw the pixels manually because the "dots" in wxPen with wxPENSTYLE_DOT style
     // may be short traits and not really dots
     //
     // note that to behave in the same manner as DrawRect(), we must exclude
@@ -816,7 +816,7 @@ wxRendererGeneric::DrawItemSelectionRect(wxWindow * WXUNUSED(win),
 void
 wxRendererGeneric::DrawFocusRect(wxWindow* WXUNUSED(win), wxDC& dc, const wxRect& rect, int WXUNUSED(flags))
 {
-    // draw the pixels manually because the "dots" in wxPen with wxDOT style
+    // draw the pixels manually because the "dots" in wxPen with wxPENSTYLE_DOT style
     // may be short traits and not really dots
     //
     // note that to behave in the same manner as DrawRect(), we must exclude

--- a/src/generic/splitter.cpp
+++ b/src/generic/splitter.cpp
@@ -101,7 +101,7 @@ bool wxSplitterWindow::Create(wxWindow *parent, wxWindowID id,
 #if !defined(__WXGTK__) || defined(__WXGTK20__)
     // don't erase the splitter background, it's pointless as we overwrite it
     // anyhow
-    SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
 #endif
 
     return true;

--- a/src/generic/tabg.cpp
+++ b/src/generic/tabg.cpp
@@ -203,7 +203,7 @@ void wxTabControl::OnDraw(wxDC& dc, bool lastInRow)
 
   wxColour col(m_view->GetTextColour());
   dc.SetTextForeground(col);
-  dc.SetBackgroundMode(wxTRANSPARENT);
+  dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
   wxCoord textWidth, textHeight;
   dc.GetTextExtent(GetLabel(), &textWidth, &textHeight);
 
@@ -474,7 +474,7 @@ void wxTabControl::OnDraw(wxDC& dc, bool lastInRow)
 
     wxColour col(m_view->GetTextColour());
     dc.SetTextForeground(col);
-    dc.SetBackgroundMode(wxTRANSPARENT);
+    dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
     long textWidth, textHeight;
     dc.GetTextExtent(GetLabel(), &textWidth, &textHeight);
 

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -2292,7 +2292,7 @@ void wxGenericTreeCtrl::ScrollTo(const wxTreeItemId &item)
     // update the control before scrolling it
     if (m_dirty)
     {
-#if defined( __WXMSW__ ) 
+#if defined( __WXMSW__ )
         Update();
 #elif defined(__WXMAC__)
         Update();
@@ -2301,7 +2301,7 @@ void wxGenericTreeCtrl::ScrollTo(const wxTreeItemId &item)
         DoDirtyProcessing();
 #endif
     }
-        
+
     wxGenericTreeItem *gitem = (wxGenericTreeItem*) item.m_pItem;
 
     int itemY = gitem->GetY();
@@ -2320,7 +2320,7 @@ void wxGenericTreeCtrl::ScrollTo(const wxTreeItemId &item)
         itemY += itemHeight - clientHeight;
 
         // because itemY below will be divided by PIXELS_PER_UNIT it may
-        // be rounded down, with the result of the item still only being 
+        // be rounded down, with the result of the item still only being
         // partially visible, so make sure we are rounding up
         itemY += PIXELS_PER_UNIT - 1;
     }

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -1019,7 +1019,7 @@ bool wxGenericTreeCtrl::Create(wxWindow *parent,
     if (!m_hasFont)
         SetOwnFont(attr.font);
 
-    // this is a misnomer: it's called "dotted pen" but uses (default) wxSOLID
+    // this is a misnomer: it's called "dotted pen" but uses (default) wxPENSTYLE_SOLID
     // style because we apparently get performance problems when using dotted
     // pen for drawing in some ports -- but under MSW it seems to work fine
 #ifdef __WXMSW__

--- a/src/generic/vlbox.cpp
+++ b/src/generic/vlbox.cpp
@@ -95,7 +95,7 @@ bool wxVListBox::Create(wxWindow *parent,
     m_colBgSel = wxNullColour;
 
     // flicker-free drawing requires this
-    SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
 
     return true;
 }

--- a/src/gtk1/control.cpp
+++ b/src/gtk1/control.cpp
@@ -205,7 +205,7 @@ wxControl::GetDefaultAttributesFromGTKWidget(GtkWidget* widget,
 
     // get the style's font
     // TODO: isn't there a way to get a standard gtk 1.2 font?
-    attr.font = wxFont( 12, wxSWISS, wxNORMAL, wxNORMAL );
+    attr.font = wxFont( 12, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL );
 
     return attr;
 }

--- a/src/gtk1/dcclient.cpp
+++ b/src/gtk1/dcclient.cpp
@@ -49,8 +49,8 @@
 #include "cross.xbm"
 #define  num_hatches 6
 
-#define IS_15_PIX_HATCH(s) ((s)==wxCROSSDIAG_HATCH || (s)==wxHORIZONTAL_HATCH || (s)==wxVERTICAL_HATCH)
-#define IS_16_PIX_HATCH(s) ((s)!=wxCROSSDIAG_HATCH && (s)!=wxHORIZONTAL_HATCH && (s)!=wxVERTICAL_HATCH)
+#define IS_15_PIX_HATCH(s) ((s)==wxHATCHSTYLE_CROSSDIAG || (s)==wxHATCHSTYLE_HORIZONTAL || (s)==wxHATCHSTYLE_VERTICAL)
+#define IS_16_PIX_HATCH(s) ((s)!=wxHATCHSTYLE_CROSSDIAG && (s)!=wxHATCHSTYLE_HORIZONTAL && (s)!=wxHATCHSTYLE_VERTICAL)
 
 
 static GdkPixmap  *hatches[num_hatches];
@@ -453,7 +453,7 @@ void wxWindowDCImpl::DoDrawLine( wxCoord x1, wxCoord y1, wxCoord x2, wxCoord y2 
 {
     wxCHECK_RET( IsOk(), wxT("invalid window dc") );
 
-    if (m_pen.GetStyle() != wxTRANSPARENT)
+    if (m_pen.GetStyle() != wxPENSTYLE_TRANSPARENT)
     {
         if (m_window)
             gdk_draw_line( m_window, m_penGC, XLOG2DEV(x1), YLOG2DEV(y1), XLOG2DEV(x2), YLOG2DEV(y2) );
@@ -467,7 +467,7 @@ void wxWindowDCImpl::DoCrossHair( wxCoord x, wxCoord y )
 {
     wxCHECK_RET( IsOk(), wxT("invalid window dc") );
 
-    if (m_pen.GetStyle() != wxTRANSPARENT)
+    if (m_pen.GetStyle() != wxPENSTYLE_TRANSPARENT)
     {
         int w = 0;
         int h = 0;
@@ -525,9 +525,9 @@ void wxWindowDCImpl::DoDrawArc( wxCoord x1, wxCoord y1, wxCoord x2, wxCoord y2,
 
     if (m_window)
     {
-        if (m_brush.GetStyle() != wxTRANSPARENT)
+        if (m_brush.GetStyle() != wxBRUSHSTYLE_TRANSPARENT)
         {
-            if ((m_brush.GetStyle() == wxSTIPPLE_MASK_OPAQUE) && (m_brush.GetStipple()->GetMask()))
+            if ((m_brush.GetStyle() == wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE) && (m_brush.GetStipple()->GetMask()))
             {
                 gdk_gc_set_ts_origin( m_textGC,
                                       m_deviceOriginX % m_brush.GetStipple()->GetWidth(),
@@ -547,7 +547,7 @@ void wxWindowDCImpl::DoDrawArc( wxCoord x1, wxCoord y1, wxCoord x2, wxCoord y2,
                 gdk_draw_arc( m_window, m_brushGC, TRUE, xxc-r, yyc-r, 2*r,2*r, alpha1, alpha2 );
                 gdk_gc_set_ts_origin( m_brushGC, 0, 0 );
             } else
-            if (m_brush.GetStyle() == wxSTIPPLE)
+            if (m_brush.GetStyle() == wxBRUSHSTYLE_STIPPLE)
             {
                 gdk_gc_set_ts_origin( m_brushGC,
                                       m_deviceOriginX % m_brush.GetStipple()->GetWidth(),
@@ -561,7 +561,7 @@ void wxWindowDCImpl::DoDrawArc( wxCoord x1, wxCoord y1, wxCoord x2, wxCoord y2,
             }
         }
 
-        if (m_pen.GetStyle() != wxTRANSPARENT)
+        if (m_pen.GetStyle() != wxPENSTYLE_TRANSPARENT)
         {
             gdk_draw_arc( m_window, m_penGC, FALSE, xxc-r, yyc-r, 2*r,2*r, alpha1, alpha2 );
 
@@ -592,9 +592,9 @@ void wxWindowDCImpl::DoDrawEllipticArc( wxCoord x, wxCoord y, wxCoord width, wxC
         wxCoord start = wxCoord(sa * 64.0);
         wxCoord end = wxCoord((ea-sa) * 64.0);
 
-        if (m_brush.GetStyle() != wxTRANSPARENT)
+        if (m_brush.GetStyle() != wxBRUSHSTYLE_TRANSPARENT)
         {
-            if ((m_brush.GetStyle() == wxSTIPPLE_MASK_OPAQUE) && (m_brush.GetStipple()->GetMask()))
+            if ((m_brush.GetStyle() == wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE) && (m_brush.GetStipple()->GetMask()))
             {
                 gdk_gc_set_ts_origin( m_textGC,
                                       m_deviceOriginX % m_brush.GetStipple()->GetWidth(),
@@ -614,7 +614,7 @@ void wxWindowDCImpl::DoDrawEllipticArc( wxCoord x, wxCoord y, wxCoord width, wxC
                 gdk_draw_arc( m_window, m_brushGC, TRUE, xx, yy, ww, hh, start, end );
                 gdk_gc_set_ts_origin( m_brushGC, 0, 0 );
             } else
-            if (m_brush.GetStyle() == wxSTIPPLE)
+            if (m_brush.GetStyle() == wxBRUSHSTYLE_STIPPLE)
             {
                 gdk_gc_set_ts_origin( m_brushGC,
                                       m_deviceOriginX % m_brush.GetStipple()->GetWidth(),
@@ -628,7 +628,7 @@ void wxWindowDCImpl::DoDrawEllipticArc( wxCoord x, wxCoord y, wxCoord width, wxC
             }
         }
 
-        if (m_pen.GetStyle() != wxTRANSPARENT)
+        if (m_pen.GetStyle() != wxPENSTYLE_TRANSPARENT)
             gdk_draw_arc( m_window, m_penGC, FALSE, xx, yy, ww, hh, start, end );
     }
 
@@ -640,7 +640,7 @@ void wxWindowDCImpl::DoDrawPoint( wxCoord x, wxCoord y )
 {
     wxCHECK_RET( IsOk(), wxT("invalid window dc") );
 
-    if ((m_pen.GetStyle() != wxTRANSPARENT) && m_window)
+    if ((m_pen.GetStyle() != wxPENSTYLE_TRANSPARENT) && m_window)
         gdk_draw_point( m_window, m_penGC, XLOG2DEV(x), YLOG2DEV(y) );
 
     CalcBoundingBox (x, y);
@@ -650,7 +650,7 @@ void wxWindowDCImpl::DoDrawLines( int n, const wxPoint points[], wxCoord xoffset
 {
     wxCHECK_RET( IsOk(), wxT("invalid window dc") );
 
-    if (m_pen.GetStyle() == wxTRANSPARENT) return;
+    if (m_pen.GetStyle() == wxPENSTYLE_TRANSPARENT) return;
     if (n <= 0) return;
 
 
@@ -696,13 +696,13 @@ void wxWindowDCImpl::DoDrawPolygon( int n, const wxPoint points[], wxCoord xoffs
         gpts[i].y = YLOG2DEV(y);
     }
 
-    if (m_brush.GetStyle() == wxSOLID)
+    if (m_brush.GetStyle() == wxBRUSHSTYLE_SOLID)
     {
         gdk_draw_polygon( m_window, m_brushGC, TRUE, gpts, n );
     }
-    else if (m_brush.GetStyle() != wxTRANSPARENT)
+    else if (m_brush.GetStyle() != wxBRUSHSTYLE_TRANSPARENT)
     {
-        if ((m_brush.GetStyle() == wxSTIPPLE_MASK_OPAQUE) && (m_brush.GetStipple()->GetMask()))
+        if ((m_brush.GetStyle() == wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE) && (m_brush.GetStipple()->GetMask()))
         {
             gdk_gc_set_ts_origin( m_textGC,
                                   m_deviceOriginX % m_brush.GetStipple()->GetWidth(),
@@ -722,7 +722,7 @@ void wxWindowDCImpl::DoDrawPolygon( int n, const wxPoint points[], wxCoord xoffs
             gdk_draw_polygon( m_window, m_brushGC, TRUE, gpts, n );
             gdk_gc_set_ts_origin( m_brushGC, 0, 0 );
         } else
-        if (m_brush.GetStyle() == wxSTIPPLE)
+        if (m_brush.GetStyle() == wxBRUSHSTYLE_STIPPLE)
         {
             gdk_gc_set_ts_origin( m_brushGC,
                                   m_deviceOriginX % m_brush.GetStipple()->GetWidth(),
@@ -736,7 +736,7 @@ void wxWindowDCImpl::DoDrawPolygon( int n, const wxPoint points[], wxCoord xoffs
         }
     }
 
-    if (m_pen.GetStyle() != wxTRANSPARENT)
+    if (m_pen.GetStyle() != wxPENSTYLE_TRANSPARENT)
     {
         gdk_draw_polygon( m_window, m_penGC, FALSE, gpts, n );
 
@@ -763,9 +763,9 @@ void wxWindowDCImpl::DoDrawRectangle( wxCoord x, wxCoord y, wxCoord width, wxCoo
 
     if (m_window)
     {
-        if (m_brush.GetStyle() != wxTRANSPARENT)
+        if (m_brush.GetStyle() != wxBRUSHSTYLE_TRANSPARENT)
         {
-            if ((m_brush.GetStyle() == wxSTIPPLE_MASK_OPAQUE) && (m_brush.GetStipple()->GetMask()))
+            if ((m_brush.GetStyle() == wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE) && (m_brush.GetStipple()->GetMask()))
             {
                 gdk_gc_set_ts_origin( m_textGC,
                                       m_deviceOriginX % m_brush.GetStipple()->GetWidth(),
@@ -785,7 +785,7 @@ void wxWindowDCImpl::DoDrawRectangle( wxCoord x, wxCoord y, wxCoord width, wxCoo
                 gdk_draw_rectangle( m_window, m_brushGC, TRUE, xx, yy, ww, hh );
                 gdk_gc_set_ts_origin( m_brushGC, 0, 0 );
             } else
-            if (m_brush.GetStyle() == wxSTIPPLE)
+            if (m_brush.GetStyle() == wxBRUSHSTYLE_STIPPLE)
             {
                 gdk_gc_set_ts_origin( m_brushGC,
                                       m_deviceOriginX % m_brush.GetStipple()->GetWidth(),
@@ -799,7 +799,7 @@ void wxWindowDCImpl::DoDrawRectangle( wxCoord x, wxCoord y, wxCoord width, wxCoo
             }
         }
 
-        if (m_pen.GetStyle() != wxTRANSPARENT)
+        if (m_pen.GetStyle() != wxPENSTYLE_TRANSPARENT)
             gdk_draw_rectangle( m_window, m_penGC, FALSE, xx, yy, ww-1, hh-1 );
     }
 
@@ -836,7 +836,7 @@ void wxWindowDCImpl::DoDrawRoundedRectangle( wxCoord x, wxCoord y, wxCoord width
 
     // CMB: adjust size if outline is drawn otherwise the result is
     // 1 pixel too wide and high
-    if (m_pen.GetStyle() != wxTRANSPARENT)
+    if (m_pen.GetStyle() != wxPENSTYLE_TRANSPARENT)
     {
         ww--;
         hh--;
@@ -851,9 +851,9 @@ void wxWindowDCImpl::DoDrawRoundedRectangle( wxCoord x, wxCoord y, wxCoord width
         if (dd > hh) dd = hh;
         rr = dd / 2;
 
-        if (m_brush.GetStyle() != wxTRANSPARENT)
+        if (m_brush.GetStyle() != wxBRUSHSTYLE_TRANSPARENT)
         {
-            if ((m_brush.GetStyle() == wxSTIPPLE_MASK_OPAQUE) && (m_brush.GetStipple()->GetMask()))
+            if ((m_brush.GetStyle() == wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE) && (m_brush.GetStipple()->GetMask()))
             {
                 gdk_gc_set_ts_origin( m_textGC,
                                       m_deviceOriginX % m_brush.GetStipple()->GetWidth(),
@@ -888,7 +888,7 @@ void wxWindowDCImpl::DoDrawRoundedRectangle( wxCoord x, wxCoord y, wxCoord width
                 gdk_draw_arc( m_window, m_brushGC, TRUE, xx, yy+hh-dd, dd, dd, 180*64, 90*64 );
                 gdk_gc_set_ts_origin( m_brushGC, 0, 0 );
             } else
-            if (m_brush.GetStyle() == wxSTIPPLE)
+            if (m_brush.GetStyle() == wxBRUSHSTYLE_STIPPLE)
             {
                 gdk_gc_set_ts_origin( m_brushGC,
                                       m_deviceOriginX % m_brush.GetStipple()->GetWidth(),
@@ -912,7 +912,7 @@ void wxWindowDCImpl::DoDrawRoundedRectangle( wxCoord x, wxCoord y, wxCoord width
             }
         }
 
-        if (m_pen.GetStyle() != wxTRANSPARENT)
+        if (m_pen.GetStyle() != wxPENSTYLE_TRANSPARENT)
         {
             gdk_draw_line( m_window, m_penGC, xx+rr+1, yy, xx+ww-rr, yy );
             gdk_draw_line( m_window, m_penGC, xx+rr+1, yy+hh, xx+ww-rr, yy+hh );
@@ -945,9 +945,9 @@ void wxWindowDCImpl::DoDrawEllipse( wxCoord x, wxCoord y, wxCoord width, wxCoord
 
     if (m_window)
     {
-        if (m_brush.GetStyle() != wxTRANSPARENT)
+        if (m_brush.GetStyle() != wxBRUSHSTYLE_TRANSPARENT)
         {
-            if ((m_brush.GetStyle() == wxSTIPPLE_MASK_OPAQUE) && (m_brush.GetStipple()->GetMask()))
+            if ((m_brush.GetStyle() == wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE) && (m_brush.GetStipple()->GetMask()))
             {
                 gdk_gc_set_ts_origin( m_textGC,
                                       m_deviceOriginX % m_brush.GetStipple()->GetWidth(),
@@ -967,7 +967,7 @@ void wxWindowDCImpl::DoDrawEllipse( wxCoord x, wxCoord y, wxCoord width, wxCoord
                 gdk_draw_arc( m_window, m_brushGC, TRUE, xx, yy, ww, hh, 0, 360*64 );
                 gdk_gc_set_ts_origin( m_brushGC, 0, 0 );
             } else
-            if (m_brush.GetStyle() == wxSTIPPLE)
+            if (m_brush.GetStyle() == wxBRUSHSTYLE_STIPPLE)
             {
                 gdk_gc_set_ts_origin( m_brushGC,
                                       m_deviceOriginX % m_brush.GetStipple()->GetWidth(),
@@ -981,7 +981,7 @@ void wxWindowDCImpl::DoDrawEllipse( wxCoord x, wxCoord y, wxCoord width, wxCoord
             }
         }
 
-        if (m_pen.GetStyle() != wxTRANSPARENT)
+        if (m_pen.GetStyle() != wxPENSTYLE_TRANSPARENT)
             gdk_draw_arc( m_window, m_penGC, FALSE, xx, yy, ww, hh, 0, 360*64 );
     }
 
@@ -1410,7 +1410,7 @@ void wxWindowDCImpl::DoDrawText( const wxString &text, wxCoord x, wxCoord y )
     wxCoord width = gdk_string_width( font, text.mbc_str() );
     wxCoord height = font->ascent + font->descent;
 
-    if ( m_backgroundMode == wxSOLID )
+    if ( m_backgroundMode == wxBRUSHSTYLE_SOLID )
     {
         gdk_gc_set_foreground( m_textGC, m_textBackgroundColour.GetColor() );
         gdk_draw_rectangle( m_window, m_textGC, TRUE, x, y, width, height );
@@ -1686,35 +1686,35 @@ void wxWindowDCImpl::SetPen( const wxPen &pen )
     GdkLineStyle lineStyle = GDK_LINE_SOLID;
     switch (m_pen.GetStyle())
     {
-        case wxUSER_DASH:
+        case wxPENSTYLE_USER_DASH:
         {
             lineStyle = GDK_LINE_ON_OFF_DASH;
             req_nb_dash = m_pen.GetDashCount();
             req_dash = (wxGTKDash*)m_pen.GetDash();
             break;
         }
-        case wxDOT:
+        case wxPENSTYLE_DOT:
         {
             lineStyle = GDK_LINE_ON_OFF_DASH;
             req_nb_dash = 2;
             req_dash = dotted;
             break;
         }
-        case wxLONG_DASH:
+        case wxPENSTYLE_LONG_DASH:
         {
             lineStyle = GDK_LINE_ON_OFF_DASH;
             req_nb_dash = 2;
             req_dash = wxCoord_dashed;
             break;
         }
-        case wxSHORT_DASH:
+        case wxPENSTYLE_SHORT_DASH:
         {
             lineStyle = GDK_LINE_ON_OFF_DASH;
             req_nb_dash = 2;
             req_dash = short_dashed;
             break;
         }
-        case wxDOT_DASH:
+        case wxPENSTYLE_DOT_DASH:
         {
 //            lineStyle = GDK_LINE_DOUBLE_DASH;
             lineStyle = GDK_LINE_ON_OFF_DASH;
@@ -1723,10 +1723,10 @@ void wxWindowDCImpl::SetPen( const wxPen &pen )
             break;
         }
 
-        case wxTRANSPARENT:
-        case wxSTIPPLE_MASK_OPAQUE:
-        case wxSTIPPLE:
-        case wxSOLID:
+        case wxPENSTYLE_TRANSPARENT:
+        case wxPENSTYLE_STIPPLE_MASK_OPAQUE:
+        case wxPENSTYLE_STIPPLE:
+        case wxPENSTYLE_SOLID:
         default:
         {
             lineStyle = GDK_LINE_SOLID;
@@ -1806,7 +1806,7 @@ void wxWindowDCImpl::SetBrush( const wxBrush &brush )
 
     gdk_gc_set_fill( m_brushGC, GDK_SOLID );
 
-    if ((m_brush.GetStyle() == wxSTIPPLE) && (m_brush.GetStipple()->IsOk()))
+    if ((m_brush.GetStyle() == wxBRUSHSTYLE_STIPPLE) && (m_brush.GetStipple()->IsOk()))
     {
         if (m_brush.GetStipple()->GetPixmap())
         {
@@ -1820,7 +1820,7 @@ void wxWindowDCImpl::SetBrush( const wxBrush &brush )
         }
     }
 
-    if ((m_brush.GetStyle() == wxSTIPPLE_MASK_OPAQUE) && (m_brush.GetStipple()->GetMask()))
+    if ((m_brush.GetStyle() == wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE) && (m_brush.GetStipple()->GetMask()))
     {
         gdk_gc_set_fill( m_textGC, GDK_OPAQUE_STIPPLED);
         gdk_gc_set_stipple( m_textGC, m_brush.GetStipple()->GetMask()->GetBitmap() );
@@ -1829,7 +1829,7 @@ void wxWindowDCImpl::SetBrush( const wxBrush &brush )
     if (m_brush.IsHatch())
     {
         gdk_gc_set_fill( m_brushGC, GDK_STIPPLED );
-        int num = m_brush.GetStyle() - wxBDIAGONAL_HATCH;
+        int num = m_brush.GetStyle() - wxBRUSHSTYLE_BDIAGONAL_HATCH;
         gdk_gc_set_stipple( m_brushGC, hatches[num] );
     }
 }
@@ -1857,7 +1857,7 @@ void wxWindowDCImpl::SetBackground( const wxBrush &brush )
 
     gdk_gc_set_fill( m_bgGC, GDK_SOLID );
 
-    if ((m_backgroundBrush.GetStyle() == wxSTIPPLE) && (m_backgroundBrush.GetStipple()->IsOk()))
+    if ((m_backgroundBrush.GetStyle() == wxBRUSHSTYLE_STIPPLE) && (m_backgroundBrush.GetStipple()->IsOk()))
     {
         if (m_backgroundBrush.GetStipple()->GetPixmap())
         {
@@ -1874,7 +1874,7 @@ void wxWindowDCImpl::SetBackground( const wxBrush &brush )
     if (m_backgroundBrush.IsHatch())
     {
         gdk_gc_set_fill( m_bgGC, GDK_STIPPLED );
-        int num = m_backgroundBrush.GetStyle() - wxBDIAGONAL_HATCH;
+        int num = m_backgroundBrush.GetStyle() - wxBRUSHSTYLE_BDIAGONAL_HATCH;
         gdk_gc_set_stipple( m_bgGC, hatches[num] );
     }
 }
@@ -1974,10 +1974,10 @@ void wxWindowDCImpl::SetBackgroundMode( int mode )
     // CMB 21/7/98: fill style of cross-hatch brushes is affected by
     // transparent/solid background mode
 
-    if (m_brush.GetStyle() != wxSOLID && m_brush.GetStyle() != wxTRANSPARENT)
+    if (m_brush.GetStyle() != wxBRUSHSTYLE_SOLID && m_brush.GetStyle() != wxBRUSHSTYLE_TRANSPARENT)
     {
         gdk_gc_set_fill( m_brushGC,
-          (m_backgroundMode == wxTRANSPARENT) ? GDK_STIPPLED : GDK_OPAQUE_STIPPLED);
+          (m_backgroundMode == wxBRUSHSTYLE_TRANSPARENT) ? GDK_STIPPLED : GDK_OPAQUE_STIPPLED);
     }
 }
 

--- a/src/gtk1/font.cpp
+++ b/src/gtk1/font.cpp
@@ -202,7 +202,7 @@ void wxFontRefData::InitFromNative()
         m_pointSize = wxDEFAULT_FONT_SIZE;
     }
 
-    // examine the spacing: if the font is monospaced, assume wxTELETYPE
+    // examine the spacing: if the font is monospaced, assume wxFONTFAMILY_TELETYPE
     // family for compatibility with the old code which used it instead of
     // IsFixedWidth()
     if ( m_nativeFontInfo.GetXFontComponent(wxXLFD_SPACING).Upper() == wxT('M') )

--- a/src/gtk1/settings.cpp
+++ b/src/gtk1/settings.cpp
@@ -347,7 +347,7 @@ wxFont wxSystemSettingsNative::GetFont( wxSystemFont index )
         {
             if (!gs_objects.m_fontSystem.IsOk())
             {
-                gs_objects.m_fontSystem = wxFont( 12, wxSWISS, wxNORMAL, wxNORMAL );
+                gs_objects.m_fontSystem = wxFont( 12, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL );
             }
             return gs_objects.m_fontSystem;
         }

--- a/src/gtk1/window.cpp
+++ b/src/gtk1/window.cpp
@@ -2918,7 +2918,7 @@ void wxWindowGTK::DoSetSize( int x, int y, int width, int height, int sizeFlags 
 void wxWindowGTK::OnInternalIdle()
 {
     // Update style if the window was not yet realized
-    // and SetBackgroundStyle(wxBG_STYLE_CUSTOM) was called
+    // and SetBackgroundStyle(wxBG_STYLE_PAINT) was called
     if (m_needsStyleChange)
     {
         SetBackgroundStyle(GetBackgroundStyle());
@@ -3583,7 +3583,7 @@ void wxWindowGTK::GtkSendPaintEvents()
         wxEraseEvent erase_event( GetId(), &dc );
         erase_event.SetEventObject( this );
 
-        if (!HandleWindowEvent(erase_event) && GetBackgroundStyle() != wxBG_STYLE_CUSTOM)
+        if (!HandleWindowEvent(erase_event) && GetBackgroundStyle() != wxBG_STYLE_PAINT)
         {
             if (!g_eraseGC)
             {
@@ -3705,7 +3705,7 @@ bool wxWindowGTK::SetBackgroundColour( const wxColour &colour )
 
     // apply style change (forceStyle=true so that new style is applied
     // even if the bg colour changed from valid to wxNullColour)
-    if (GetBackgroundStyle() != wxBG_STYLE_CUSTOM)
+    if (GetBackgroundStyle() != wxBG_STYLE_PAINT)
         ApplyWidgetStyle(true);
 
     return true;
@@ -3818,7 +3818,7 @@ bool wxWindowGTK::SetBackgroundStyle(wxBackgroundStyle style)
 {
     wxWindowBase::SetBackgroundStyle(style);
 
-    if (style == wxBG_STYLE_CUSTOM)
+    if (style == wxBG_STYLE_PAINT)
     {
         GdkWindow *window = NULL;
         if (m_wxwindow)

--- a/src/html/htmlcell.cpp
+++ b/src/html/htmlcell.cpp
@@ -400,7 +400,7 @@ static void SwitchSelState(wxDC& dc, wxHtmlRenderingInfo& info,
 
     if ( toSelection )
     {
-        dc.SetBackgroundMode(wxSOLID);
+        dc.SetBackgroundMode(wxBRUSHSTYLE_SOLID);
         dc.SetTextForeground(info.GetStyle().GetSelectedTextColour(fg));
         dc.SetTextBackground(info.GetStyle().GetSelectedTextBgColour(bg));
         dc.SetBackground(info.GetStyle().GetSelectedTextBgColour(bg));
@@ -411,7 +411,7 @@ static void SwitchSelState(wxDC& dc, wxHtmlRenderingInfo& info,
         dc.SetBackgroundMode(mode);
         dc.SetTextForeground(fg);
         dc.SetTextBackground(bg);
-        if ( mode != wxTRANSPARENT )
+        if ( mode != wxBRUSHSTYLE_TRANSPARENT )
             dc.SetBackground(bg);
     }
 }
@@ -1469,23 +1469,23 @@ void wxHtmlColourCell::DrawInvisible(wxDC& dc,
     if (m_Flags & wxHTML_CLR_BACKGROUND)
     {
         state.SetBgColour(m_Colour);
-        state.SetBgMode(wxSOLID);
+        state.SetBgMode(wxBRUSHSTYLE_SOLID);
         const wxColour c = state.GetSelectionState() == wxHTML_SEL_IN
                          ? info.GetStyle().GetSelectedTextBgColour(m_Colour)
                          : m_Colour;
         dc.SetTextBackground(c);
         dc.SetBackground(c);
-        dc.SetBackgroundMode(wxSOLID);
+        dc.SetBackgroundMode(wxBRUSHSTYLE_SOLID);
     }
     if (m_Flags & wxHTML_CLR_TRANSPARENT_BACKGROUND)
     {
         state.SetBgColour(m_Colour);
-        state.SetBgMode(wxTRANSPARENT);
+        state.SetBgMode(wxBRUSHSTYLE_TRANSPARENT);
         const wxColour c = state.GetSelectionState() == wxHTML_SEL_IN
                          ? info.GetStyle().GetSelectedTextBgColour(m_Colour)
                          : m_Colour;
         dc.SetTextBackground(c);
-        dc.SetBackgroundMode(wxTRANSPARENT);
+        dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
     }
 }
 

--- a/src/html/htmlwin.cpp
+++ b/src/html/htmlwin.cpp
@@ -1134,7 +1134,7 @@ void wxHtmlWindow::OnPaint(wxPaintEvent& WXUNUSED(event))
 
     // draw the HTML window contents
     dc->SetMapMode(wxMM_TEXT);
-    dc->SetBackgroundMode(wxTRANSPARENT);
+    dc->SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
     dc->SetLayoutDirection(GetLayoutDirection());
 
     wxHtmlRenderingInfo rinfo;

--- a/src/html/htmprint.cpp
+++ b/src/html/htmprint.cpp
@@ -533,7 +533,7 @@ void wxHtmlPrintout::RenderPage(wxDC *dc, int page)
                       (double)ppiPrinterY / TYPICAL_SCREEN_DPI,
                       (double)ppiPrinterY / (double)ppiScreenY);
 
-    dc->SetBackgroundMode(wxTRANSPARENT);
+    dc->SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
 
     m_Renderer.Render((int) (ppmm_h * m_MarginLeft),
                          (int) (ppmm_v * (m_MarginTop + (m_HeaderHeight == 0 ? 0 : m_MarginSpace)) + m_HeaderHeight),

--- a/src/html/m_fonts.cpp
+++ b/src/html/m_fonts.cpp
@@ -140,7 +140,7 @@ TAG_HANDLER_BEGIN(FONT, "FONT" )
             m_WParser->SetActualBackgroundMode(oldbackmode);
             m_WParser->SetActualBackgroundColor(oldbackclr);
             m_WParser->GetContainer()->InsertCell(
-                new wxHtmlColourCell(oldbackclr, oldbackmode == wxTRANSPARENT ? wxHTML_CLR_TRANSPARENT_BACKGROUND : wxHTML_CLR_BACKGROUND));
+                new wxHtmlColourCell(oldbackclr, oldbackmode == wxBRUSHSTYLE_TRANSPARENT ? wxHTML_CLR_TRANSPARENT_BACKGROUND : wxHTML_CLR_BACKGROUND));
         }
 
         return true;

--- a/src/html/m_fonts.cpp
+++ b/src/html/m_fonts.cpp
@@ -15,6 +15,7 @@
 #if wxUSE_HTML && wxUSE_STREAMS
 
 #ifndef WX_PRECOMP
+    #include "wx/brush.h"
 #endif
 
 #include "wx/html/forcelnk.h"

--- a/src/html/m_links.cpp
+++ b/src/html/m_links.cpp
@@ -110,7 +110,7 @@ TAG_HANDLER_BEGIN(A, "A")
                m_WParser->SetActualBackgroundMode(oldbackmode);
                m_WParser->SetActualBackgroundColor(oldbackclr);
                m_WParser->GetContainer()->InsertCell(
-                   new wxHtmlColourCell(oldbackclr, oldbackmode == wxTRANSPARENT ? wxHTML_CLR_TRANSPARENT_BACKGROUND : wxHTML_CLR_BACKGROUND));
+                   new wxHtmlColourCell(oldbackclr, oldbackmode == wxBRUSHSTYLE_TRANSPARENT ? wxHTML_CLR_TRANSPARENT_BACKGROUND : wxHTML_CLR_BACKGROUND));
             }
 
             return true;

--- a/src/html/m_span.cpp
+++ b/src/html/m_span.cpp
@@ -69,7 +69,7 @@ TAG_HANDLER_BEGIN(SPAN, "SPAN" )
             m_WParser->SetActualBackgroundMode(oldbackmode);
             m_WParser->SetActualBackgroundColor(oldbackclr);
             m_WParser->GetContainer()->InsertCell(
-                new wxHtmlColourCell(oldbackclr, oldbackmode == wxTRANSPARENT ? wxHTML_CLR_TRANSPARENT_BACKGROUND : wxHTML_CLR_BACKGROUND));
+                new wxHtmlColourCell(oldbackclr, oldbackmode == wxBRUSHSTYLE_TRANSPARENT ? wxHTML_CLR_TRANSPARENT_BACKGROUND : wxHTML_CLR_BACKGROUND));
         }
 
         return true;

--- a/src/html/winpars.cpp
+++ b/src/html/winpars.cpp
@@ -217,7 +217,7 @@ void wxHtmlWinParser::InitParser(const wxString& source)
     m_ActualBackgroundColor = m_windowInterface
                             ? m_windowInterface->GetHTMLBackgroundColour()
                             : windowColour;
-    m_ActualBackgroundMode = wxTRANSPARENT;
+    m_ActualBackgroundMode = wxBRUSHSTYLE_TRANSPARENT;
     m_Align = wxHTML_ALIGN_LEFT;
     m_ScriptMode = wxHTML_SCRIPT_NORMAL;
     m_ScriptBaseline = 0;
@@ -248,7 +248,7 @@ void wxHtmlWinParser::InitParser(const wxString& source)
                    new wxHtmlColourCell
                        (
                          m_ActualBackgroundColor,
-                         m_ActualBackgroundMode == wxTRANSPARENT ? wxHTML_CLR_TRANSPARENT_BACKGROUND : wxHTML_CLR_BACKGROUND
+                         m_ActualBackgroundMode == wxBRUSHSTYLE_TRANSPARENT ? wxHTML_CLR_TRANSPARENT_BACKGROUND : wxHTML_CLR_BACKGROUND
                        )
                   );
 
@@ -766,7 +766,7 @@ void wxHtmlWinTagHandler::ApplyStyle(const wxHtmlStyleParams &styleParams)
         if ( wxHtmlTag::ParseAsColour(str, &clr) )
         {
             m_WParser->SetActualBackgroundColor(clr);
-            m_WParser->SetActualBackgroundMode(wxSOLID);
+            m_WParser->SetActualBackgroundMode(wxBRUSHSTYLE_SOLID);
             m_WParser->GetContainer()->InsertCell(new wxHtmlColourCell(clr, wxHTML_CLR_BACKGROUND));
         }
     }

--- a/src/motif/dc.cpp
+++ b/src/motif/dc.cpp
@@ -29,7 +29,7 @@ wxMotifDCImpl::wxMotifDCImpl(wxDC *owner)
 {
     m_ok = false;
 
-    m_backgroundMode = wxTRANSPARENT;
+    m_backgroundMode = wxBRUSHSTYLE_TRANSPARENT;
 }
 
 void wxMotifDCImpl::DoDrawIcon( const wxIcon &icon, wxCoord x, wxCoord y)

--- a/src/motif/dcclient.cpp
+++ b/src/motif/dcclient.cpp
@@ -83,7 +83,7 @@ wxIMPLEMENT_ABSTRACT_CLASS(wxClientDCImpl, wxWindowDCImpl);
 wxIMPLEMENT_ABSTRACT_CLASS(wxPaintDCImpl, wxWindowDCImpl);
 wxIMPLEMENT_ABSTRACT_CLASS(wxWindowDCImpl, wxMotifDCImpl);
 
-#define IS_HATCH(s)    ((s)>=wxFIRST_HATCH && (s)<=wxLAST_HATCH)
+#define IS_HATCH(s)    ((s)>=wxHATCHSTYLE_FIRST && (s)<=wxHATCHSTYLE_LAST)
 
 // FIXME: left over after removal of wxDC::GetOptimization()
 #define GET_OPTIMIZATION false
@@ -197,7 +197,7 @@ wxWindowDCImpl::wxWindowDCImpl(wxDC *owner, wxWindow *window)
 
     m_backgroundPixel = gcvalues.background;
 
-    SetBackground(wxBrush(m_window->GetBackgroundColour(), wxSOLID));
+    SetBackground(wxBrush(m_window->GetBackgroundColour(), wxBRUSHSTYLE_SOLID));
 }
 
 wxWindowDCImpl::~wxWindowDCImpl()
@@ -346,7 +346,7 @@ void wxWindowDCImpl::DoDrawArc( wxCoord x1, wxCoord y1, wxCoord x2, wxCoord y2, 
     while (alpha2 > 360 * 64)
         alpha2 -= 360 * 64;
 
-    if (m_brush.IsOk() && m_brush.GetStyle () != wxTRANSPARENT)
+    if (m_brush.IsOk() && m_brush.GetStyle () != wxBRUSHSTYLE_TRANSPARENT)
     {
         SetBrush (m_brush);
         XFillArc ((Display*) m_display, (Pixmap) m_pixmap, (GC) (GC) m_gc,
@@ -358,7 +358,7 @@ void wxWindowDCImpl::DoDrawArc( wxCoord x1, wxCoord y1, wxCoord x2, wxCoord y2, 
 
     }
 
-    if (m_pen.IsOk() && m_pen.GetStyle () != wxTRANSPARENT)
+    if (m_pen.IsOk() && m_pen.GetStyle () != wxPENSTYLE_TRANSPARENT)
     {
         if (m_autoSetting)
             SetPen (m_pen);
@@ -393,7 +393,7 @@ void wxWindowDCImpl::DoDrawEllipticArc( wxCoord x, wxCoord y, wxCoord width, wxC
     if (end>start) end-=start;
     else end+=360*64-start;
 
-    if (m_brush.IsOk() && m_brush.GetStyle () != wxTRANSPARENT)
+    if (m_brush.IsOk() && m_brush.GetStyle () != wxBRUSHSTYLE_TRANSPARENT)
     {
         m_autoSetting = true;    // must be reset
 
@@ -405,7 +405,7 @@ void wxWindowDCImpl::DoDrawEllipticArc( wxCoord x, wxCoord y, wxCoord width, wxC
             XLOG2DEV_2 (x), YLOG2DEV_2 (y),wd,hd,start,end);
     }
 
-    if (m_pen.IsOk() && m_pen.GetStyle () != wxTRANSPARENT)
+    if (m_pen.IsOk() && m_pen.GetStyle () != wxPENSTYLE_TRANSPARENT)
     {
         if (m_autoSetting)
             SetPen (m_pen);
@@ -436,7 +436,7 @@ void wxWindowDCImpl::DoDrawLines( int n, const wxPoint points[], wxCoord xoffset
 {
     wxCHECK_RET( IsOk(), "invalid dc" );
 
-    if (m_pen.IsOk() && m_pen.GetStyle () != wxTRANSPARENT)
+    if (m_pen.IsOk() && m_pen.GetStyle () != wxPENSTYLE_TRANSPARENT)
     {
         if (m_autoSetting)
             SetPen (m_pen);
@@ -487,7 +487,7 @@ void wxWindowDCImpl::DoDrawPolygon( int n, const wxPoint points[],
     xpoints2[i].x = xpoints2[0].x;
     xpoints2[i].y = xpoints2[0].y;
 
-    if (m_brush.IsOk() && m_brush.GetStyle () != wxTRANSPARENT)
+    if (m_brush.IsOk() && m_brush.GetStyle () != wxBRUSHSTYLE_TRANSPARENT)
     {
         SetBrush (m_brush);
         XSetFillRule ((Display*) m_display, (GC) m_gc, fillStyle == wxODDEVEN_RULE ? EvenOddRule : WindingRule);
@@ -502,7 +502,7 @@ void wxWindowDCImpl::DoDrawPolygon( int n, const wxPoint points[],
         }
     }
 
-    if (m_pen.IsOk() && m_pen.GetStyle () != wxTRANSPARENT)
+    if (m_pen.IsOk() && m_pen.GetStyle () != wxPENSTYLE_TRANSPARENT)
     {
         if (m_autoSetting)
             SetPen (m_pen);
@@ -533,7 +533,7 @@ void wxWindowDCImpl::DoDrawRectangle( wxCoord x, wxCoord y, wxCoord width, wxCoo
     if (wd < 0) { wd = - wd; xd = xd - wd; }
     if (hd < 0) { hd = - hd; yd = yd - hd; }
 
-    if (m_brush.IsOk() && m_brush.GetStyle () != wxTRANSPARENT)
+    if (m_brush.IsOk() && m_brush.GetStyle () != wxBRUSHSTYLE_TRANSPARENT)
     {
         SetBrush (m_brush);
         XFillRectangle ((Display*) m_display, (Pixmap) m_pixmap, (GC) m_gc, xd, yd, wfd, hfd);
@@ -544,7 +544,7 @@ void wxWindowDCImpl::DoDrawRectangle( wxCoord x, wxCoord y, wxCoord width, wxCoo
             wfd, hfd);
     }
 
-    if (m_pen.IsOk() && m_pen.GetStyle () != wxTRANSPARENT)
+    if (m_pen.IsOk() && m_pen.GetStyle () != wxPENSTYLE_TRANSPARENT)
     {
         if (m_autoSetting)
             SetPen (m_pen);
@@ -589,7 +589,7 @@ void wxWindowDCImpl::DoDrawRoundedRectangle( wxCoord x, wxCoord y, wxCoord width
 
     // CMB: adjust size if outline is drawn otherwise the result is
     // 1 pixel too wide and high
-    if (m_pen.GetStyle() != wxTRANSPARENT)
+    if (m_pen.GetStyle() != wxPENSTYLE_TRANSPARENT)
     {
         wd--;
         hd--;
@@ -611,7 +611,7 @@ void wxWindowDCImpl::DoDrawRoundedRectangle( wxCoord x, wxCoord y, wxCoord width
     int rw_d2 = rd2 * 2;
     int rh_d2 = rw_d2;
 
-    if (m_brush.IsOk() && m_brush.GetStyle () != wxTRANSPARENT)
+    if (m_brush.IsOk() && m_brush.GetStyle () != wxBRUSHSTYLE_TRANSPARENT)
     {
         SetBrush (m_brush);
 
@@ -661,7 +661,7 @@ void wxWindowDCImpl::DoDrawRoundedRectangle( wxCoord x, wxCoord y, wxCoord width
         }
     }
 
-    if (m_pen.IsOk() && m_pen.GetStyle () != wxTRANSPARENT)
+    if (m_pen.IsOk() && m_pen.GetStyle () != wxPENSTYLE_TRANSPARENT)
     {
         SetPen (m_pen);
         XDrawLine ((Display*) m_display, (Pixmap) m_pixmap, (GC) m_gc, xd + rd, yd,
@@ -745,7 +745,7 @@ void wxWindowDCImpl::DoDrawEllipse( wxCoord x, wxCoord y, wxCoord width, wxCoord
     wd = XLOG2DEVREL(width) ;
     hd = YLOG2DEVREL(height) ;
 
-    if (m_brush.IsOk() && m_brush.GetStyle () != wxTRANSPARENT)
+    if (m_brush.IsOk() && m_brush.GetStyle () != wxBRUSHSTYLE_TRANSPARENT)
     {
         SetBrush (m_brush);
         XFillArc ((Display*) m_display, (Pixmap) m_pixmap, (GC) m_gc, xd, yd, wd, hd, 0, angle);
@@ -756,7 +756,7 @@ void wxWindowDCImpl::DoDrawEllipse( wxCoord x, wxCoord y, wxCoord width, wxCoord
             YLOG2DEVREL (height) - WX_GC_CF, 0, angle);
     }
 
-    if (m_pen.IsOk() && m_pen.GetStyle () != wxTRANSPARENT)
+    if (m_pen.IsOk() && m_pen.GetStyle () != wxPENSTYLE_TRANSPARENT)
     {
         if (m_autoSetting)
             SetPen (m_pen);
@@ -1048,7 +1048,7 @@ void wxWindowDCImpl::DoDrawText( const wxString &text, wxCoord x, wxCoord y )
 
     // First draw a rectangle representing the text background, if a text
     // background is specified
-    if (m_textBackgroundColour.IsOk () && (m_backgroundMode != wxTRANSPARENT))
+    if (m_textBackgroundColour.IsOk () && (m_backgroundMode != wxBRUSHSTYLE_TRANSPARENT))
     {
         wxColour oldPenColour = m_currentColour;
         m_currentColour = m_textBackgroundColour;
@@ -1243,7 +1243,7 @@ void wxWindowDCImpl::DoDrawRotatedText( const wxString &text, wxCoord x, wxCoord
             {
                 bool textPixel = image.GetRed(sx, sy) == 0;
 
-                if (!textPixel && m_backgroundMode != wxSOLID)
+                if (!textPixel && m_backgroundMode != wxBRUSHSTYLE_SOLID)
                     continue;
 
                 wxCoord ox = (wxCoord) (x1 + rx),
@@ -1510,7 +1510,7 @@ void wxWindowDCImpl::SetPen( const wxPen &pen )
     m_currentPenDashCount = m_pen.GetDashCount();
     m_currentPenDash = (wxX11Dash*)m_pen.GetDash();
 
-    if (m_currentStyle == wxSTIPPLE)
+    if (m_currentStyle == wxPENSTYLE_STIPPLE)
         m_currentStipple = * m_pen.GetStipple ();
 
     bool sameStyle = (oldStyle == m_currentStyle &&
@@ -1548,34 +1548,34 @@ void wxWindowDCImpl::SetPen( const wxPen &pen )
 
         switch (m_pen.GetStyle ())
         {
-        case wxUSER_DASH:
+        case wxPENSTYLE_USER_DASH:
             req_nb_dash = m_currentPenDashCount;
             req_dash = m_currentPenDash;
             style = LineOnOffDash;
             break;
-        case wxDOT:
+        case wxPENSTYLE_DOT:
             req_nb_dash = 2;
             req_dash = dotted;
             style = LineOnOffDash;
             break;
-        case wxSHORT_DASH:
+        case wxPENSTYLE_SHORT_DASH:
             req_nb_dash = 2;
             req_dash = short_dashed;
             style = LineOnOffDash;
             break;
-        case wxLONG_DASH:
+        case wxPENSTYLE_LONG_DASH:
             req_nb_dash = 2;
             req_dash = long_dashed;
             style = LineOnOffDash;
             break;
-        case wxDOT_DASH:
+        case wxPENSTYLE_DOT_DASH:
             req_nb_dash = 4;
             req_dash = dotted_dashed;
             style = LineOnOffDash;
             break;
-        case wxSTIPPLE:
-        case wxSOLID:
-        case wxTRANSPARENT:
+        case wxPENSTYLE_STIPPLE:
+        case wxPENSTYLE_SOLID:
+        case wxPENSTYLE_TRANSPARENT:
         default:
             style = LineSolid;
             req_dash = NULL;
@@ -1648,42 +1648,42 @@ void wxWindowDCImpl::SetPen( const wxPen &pen )
 
         switch (m_currentFill)
         {
-        case wxBDIAGONAL_HATCH:
+        case wxHATCHSTYLE_BDIAGONAL:
             if (bdiag == (Pixmap) 0)
                 bdiag = XCreateBitmapFromData ((Display*) m_display,
                 RootWindow ((Display*) m_display, DefaultScreen ((Display*) m_display)),
                 reinterpret_cast<const char*>(bdiag_bits), bdiag_width, bdiag_height);
             myStipple = bdiag;
             break;
-        case wxFDIAGONAL_HATCH:
+        case wxHATCHSTYLE_FDIAGONAL:
             if (fdiag == (Pixmap) 0)
                 fdiag = XCreateBitmapFromData ((Display*) m_display,
                 RootWindow ((Display*) m_display, DefaultScreen ((Display*) m_display)),
                 reinterpret_cast<const char*>(fdiag_bits), fdiag_width, fdiag_height);
             myStipple = fdiag;
             break;
-        case wxCROSS_HATCH:
+        case wxHATCHSTYLE_CROSS:
             if (cross == (Pixmap) 0)
                 cross = XCreateBitmapFromData ((Display*) m_display,
                 RootWindow ((Display*) m_display, DefaultScreen ((Display*) m_display)),
                 reinterpret_cast<const char*>(cross_bits), cross_width, cross_height);
             myStipple = cross;
             break;
-        case wxHORIZONTAL_HATCH:
+        case wxHATCHSTYLE_HORIZONTAL:
             if (horiz == (Pixmap) 0)
                 horiz = XCreateBitmapFromData ((Display*) m_display,
                 RootWindow ((Display*) m_display, DefaultScreen ((Display*) m_display)),
                 reinterpret_cast<const char*>(horiz_bits), horiz_width, horiz_height);
             myStipple = horiz;
             break;
-        case wxVERTICAL_HATCH:
+        case wxHATCHSTYLE_VERTICAL:
             if (verti == (Pixmap) 0)
                 verti = XCreateBitmapFromData ((Display*) m_display,
                 RootWindow ((Display*) m_display, DefaultScreen ((Display*) m_display)),
                 reinterpret_cast<const char*>(verti_bits), verti_width, verti_height);
             myStipple = verti;
             break;
-        case wxCROSSDIAG_HATCH:
+        case wxHATCHSTYLE_CROSSDIAG:
         default:
             if (cdiag == (Pixmap) 0)
                 cdiag = XCreateBitmapFromData ((Display*) m_display,
@@ -1697,7 +1697,7 @@ void wxWindowDCImpl::SetPen( const wxPen &pen )
         if (m_window && m_window->GetBackingPixmap())
             XSetStipple ((Display*) m_display,(GC) m_gcBacking, myStipple);
     }
-    else if (m_currentStyle == wxSTIPPLE && m_currentStipple.IsOk()
+    else if (m_currentStyle == wxPENSTYLE_STIPPLE && m_currentStipple.IsOk()
         && ((!m_currentStipple.IsSameAs(oldStipple)) || !GET_OPTIMIZATION))
     {
         XSetStipple ((Display*) m_display, (GC) m_gc, (Pixmap) m_currentStipple.GetDrawable());
@@ -1710,7 +1710,7 @@ void wxWindowDCImpl::SetPen( const wxPen &pen )
     {
         int fill_style;
 
-        if (m_currentFill == wxSTIPPLE)
+        if (m_currentFill == wxBRUSHSTYLE_STIPPLE)
             fill_style = FillStippled;
         else if (IS_HATCH (m_currentFill))
             fill_style = FillStippled;
@@ -1726,7 +1726,7 @@ void wxWindowDCImpl::SetPen( const wxPen &pen )
         || ((m_logicalFunction == wxXOR) || (m_autoSetting & 0x2)))
     {
         WXPixel pixel = -1;
-        if (m_pen.GetStyle () == wxTRANSPARENT)
+        if (m_pen.GetStyle () == wxPENSTYLE_TRANSPARENT)
             pixel = m_backgroundPixel;
         else
         {
@@ -1751,7 +1751,7 @@ void wxWindowDCImpl::SetBrush( const wxBrush &brush )
 
     m_brush = brush;
 
-    if (!m_brush.IsOk() || m_brush.GetStyle () == wxTRANSPARENT)
+    if (!m_brush.IsOk() || m_brush.GetStyle () == wxBRUSHSTYLE_TRANSPARENT)
         return;
 
     int oldFill = m_currentFill;
@@ -1760,7 +1760,7 @@ void wxWindowDCImpl::SetBrush( const wxBrush &brush )
     m_autoSetting |= 0x1;
 
     m_currentFill = m_brush.GetStyle ();
-    if (m_currentFill == wxSTIPPLE)
+    if (m_currentFill == wxBRUSHSTYLE_STIPPLE)
         m_currentStipple = * m_brush.GetStipple ();
 
     wxColour oldBrushColour(m_currentColour);
@@ -1778,17 +1778,17 @@ void wxWindowDCImpl::SetBrush( const wxBrush &brush )
     {
         switch (brush.GetStyle ())
         {
-        case wxTRANSPARENT:
+        case wxBRUSHSTYLE_TRANSPARENT:
             break;
-        case wxSTIPPLE:
+        case wxBRUSHSTYLE_STIPPLE:
             stippleDepth = m_currentStipple.GetDepth();
             // fall through!
-        case wxBDIAGONAL_HATCH:
-        case wxCROSSDIAG_HATCH:
-        case wxFDIAGONAL_HATCH:
-        case wxCROSS_HATCH:
-        case wxHORIZONTAL_HATCH:
-        case wxVERTICAL_HATCH:
+        case wxBRUSHSTYLE_BDIAGONAL_HATCH:
+        case wxBRUSHSTYLE_CROSSDIAG_HATCH:
+        case wxBRUSHSTYLE_FDIAGONAL_HATCH:
+        case wxBRUSHSTYLE_CROSS_HATCH:
+        case wxBRUSHSTYLE_HORIZONTAL_HATCH:
+        case wxBRUSHSTYLE_VERTICAL_HATCH:
             {
                 if (stippleDepth == -1) stippleDepth = 1;
 
@@ -1796,7 +1796,7 @@ void wxWindowDCImpl::SetBrush( const wxBrush &brush )
                 // determine whether fill style should be solid or
                 // transparent
                 int style = stippleDepth == 1 ?
-                    (m_backgroundMode == wxSOLID ?
+                    (m_backgroundMode == wxBRUSHSTYLE_SOLID ?
                      FillOpaqueStippled : FillStippled) :
                     FillTiled;
                 XSetFillStyle ((Display*) m_display, (GC) m_gc, style);
@@ -1804,7 +1804,7 @@ void wxWindowDCImpl::SetBrush( const wxBrush &brush )
                     XSetFillStyle ((Display*) m_display,(GC) m_gcBacking, style);
             }
             break;
-        case wxSOLID:
+        case wxBRUSHSTYLE_SOLID:
         default:
             XSetFillStyle ((Display*) m_display, (GC) m_gc, FillSolid);
             if (m_window && m_window->GetBackingPixmap())
@@ -1819,42 +1819,42 @@ void wxWindowDCImpl::SetBrush( const wxBrush &brush )
 
         switch (m_currentFill)
         {
-        case wxBDIAGONAL_HATCH:
+        case wxHATCHSTYLE_BDIAGONAL:
             if (bdiag == (Pixmap) 0)
                 bdiag = XCreateBitmapFromData ((Display*) m_display,
                 RootWindow ((Display*) m_display, DefaultScreen ((Display*) m_display)),
                 reinterpret_cast<const char*>(bdiag_bits), bdiag_width, bdiag_height);
             myStipple = bdiag;
             break;
-        case wxFDIAGONAL_HATCH:
+        case wxHATCHSTYLE_FDIAGONAL:
             if (fdiag == (Pixmap) 0)
                 fdiag = XCreateBitmapFromData ((Display*) m_display,
                 RootWindow ((Display*) m_display, DefaultScreen ((Display*) m_display)),
                 reinterpret_cast<const char*>(fdiag_bits), fdiag_width, fdiag_height);
             myStipple = fdiag;
             break;
-        case wxCROSS_HATCH:
+        case wxHATCHSTYLE_CROSS:
             if (cross == (Pixmap) 0)
                 cross = XCreateBitmapFromData ((Display*) m_display,
                 RootWindow ((Display*) m_display, DefaultScreen ((Display*) m_display)),
                 reinterpret_cast<const char*>(cross_bits), cross_width, cross_height);
             myStipple = cross;
             break;
-        case wxHORIZONTAL_HATCH:
+        case wxHATCHSTYLE_HORIZONTAL:
             if (horiz == (Pixmap) 0)
                 horiz = XCreateBitmapFromData ((Display*) m_display,
                 RootWindow ((Display*) m_display, DefaultScreen ((Display*) m_display)),
                 reinterpret_cast<const char*>(horiz_bits), horiz_width, horiz_height);
             myStipple = horiz;
             break;
-        case wxVERTICAL_HATCH:
+        case wxHATCHSTYLE_VERTICAL:
             if (verti == (Pixmap) 0)
                 verti = XCreateBitmapFromData ((Display*) m_display,
                 RootWindow ((Display*) m_display, DefaultScreen ((Display*) m_display)),
                 reinterpret_cast<const char*>(verti_bits), verti_width, verti_height);
             myStipple = verti;
             break;
-        case wxCROSSDIAG_HATCH:
+        case wxHATCHSTYLE_CROSSDIAG:
         default:
             if (cdiag == (Pixmap) 0)
                 cdiag = XCreateBitmapFromData ((Display*) m_display,
@@ -1870,7 +1870,7 @@ void wxWindowDCImpl::SetBrush( const wxBrush &brush )
     }
     // X can forget the stipple value when resizing a window (apparently)
     // so always set the stipple.
-    else if (m_currentFill != wxSOLID && m_currentFill != wxTRANSPARENT &&
+    else if (m_currentFill != wxBRUSHSTYLE_SOLID && m_currentFill != wxBRUSHSTYLE_TRANSPARENT &&
              m_currentStipple.IsOk()) // && m_currentStipple != oldStipple)
     {
         if (m_currentStipple.GetDepth() == 1)

--- a/src/motif/settings.cpp
+++ b/src/motif/settings.cpp
@@ -179,7 +179,7 @@ wxFont wxSystemSettingsNative::GetFont(wxSystemFont index)
     {
         case wxSYS_SYSTEM_FIXED_FONT:
         {
-            font = wxFont(pointSize, wxMODERN, wxNORMAL, wxNORMAL, false);
+            font = wxFont(pointSize, wxFONTFAMILY_MODERN, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false);
             break;
         }
         case wxSYS_DEVICE_DEFAULT_FONT:
@@ -187,7 +187,7 @@ wxFont wxSystemSettingsNative::GetFont(wxSystemFont index)
         case wxSYS_DEFAULT_GUI_FONT:
         default:
         {
-            font = wxFont(pointSize, wxSWISS, wxNORMAL, wxNORMAL, false);
+            font = wxFont(pointSize, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false);
             break;
         }
     }

--- a/src/motif/utils.cpp
+++ b/src/motif/utils.cpp
@@ -629,7 +629,7 @@ wxBitmap wxCreateMaskedBitmap(const wxBitmap& bitmap, const wxColour& colour)
     srcDC.SelectObjectAsSource(bitmap);
     destDC.SelectObject(newBitmap);
 
-    wxBrush brush(colour, wxSOLID);
+    wxBrush brush(colour, wxBRUSHSTYLE_SOLID);
     destDC.SetBackground(brush);
     destDC.Clear();
     destDC.Blit(0, 0, bitmap.GetWidth(), bitmap.GetHeight(),

--- a/src/motif/window.cpp
+++ b/src/motif/window.cpp
@@ -886,7 +886,7 @@ void wxWindow::ScrollWindow(int dx, int dy, const wxRect *rect)
     XCopyArea(display, window, window, gc, x1, y1, w1, h1, x2, y2);
 
     dcimpl->SetAutoSetting(true);
-    wxBrush brush(GetBackgroundColour(), wxSOLID);
+    wxBrush brush(GetBackgroundColour(), wxBRUSHSTYLE_SOLID);
     dc.SetBrush(brush); // FIXME: needed?
 
     wxWindowList::compatibility_iterator cnode = m_children.GetFirst();
@@ -1537,7 +1537,7 @@ void wxWindow::Refresh(bool eraseBack, const wxRect *rect)
     if (eraseBack)
     {
         wxClientDC dc(this);
-        wxBrush backgroundBrush(GetBackgroundColour(), wxSOLID);
+        wxBrush backgroundBrush(GetBackgroundColour(), wxBRUSHSTYLE_SOLID);
         dc.SetBackground(backgroundBrush);
 
         wxClientDCImpl * const

--- a/src/msw/anybutton.cpp
+++ b/src/msw/anybutton.cpp
@@ -280,7 +280,7 @@ public:
         {
             default:
                 wxFAIL_MSG( "invalid image alignment" );
-                // fall through
+                wxFALLTHROUGH;
 
             case BUTTON_IMAGELIST_ALIGN_LEFT:
                 return wxLEFT;
@@ -303,7 +303,7 @@ public:
         {
             default:
                 wxFAIL_MSG( "invalid direction" );
-                // fall through
+                wxFALLTHROUGH;
 
             case wxLEFT:
                 alignNew = BUTTON_IMAGELIST_ALIGN_LEFT;
@@ -1343,7 +1343,7 @@ bool wxAnyButton::MSWOnDraw(WXDRAWITEMSTRUCT *wxdis)
             {
                 default:
                     wxFAIL_MSG( "invalid direction" );
-                    // fall through
+                    wxFALLTHROUGH;
 
                 case wxLEFT:
                     rectBitmap.x = rectButton.x + margin.x;

--- a/src/msw/app.cpp
+++ b/src/msw/app.cpp
@@ -978,7 +978,7 @@ terminate the program,\r\n\
 
         default:
             wxFAIL_MSG( wxT("unexpected MessageBox() return code") );
-            // fall through
+            wxFALLTHROUGH;
 
         case IDRETRY:
             return false;

--- a/src/msw/bitmap.cpp
+++ b/src/msw/bitmap.cpp
@@ -558,6 +558,7 @@ bool wxBitmap::CopyFromIconOrCursor(const wxGDIImage& icon,
     {
         default:
             wxFAIL_MSG( wxT("unknown wxBitmapTransparency value") );
+            wxFALLTHROUGH;
 
         case wxBitmapTransparency_None:
             // nothing to do, refData->m_hasAlpha is false by default

--- a/src/msw/brush.cpp
+++ b/src/msw/brush.cpp
@@ -186,7 +186,7 @@ HBRUSH wxBrushRefData::GetHBRUSH()
 
                 default:
                     wxFAIL_MSG( wxT("unknown brush style") );
-                    // fall through
+                    wxFALLTHROUGH;
 
                 case wxBRUSHSTYLE_SOLID:
                     m_hBrush = ::CreateSolidBrush(m_colour.GetPixel());

--- a/src/msw/calctrl.cpp
+++ b/src/msw/calctrl.cpp
@@ -196,7 +196,7 @@ wxCalendarCtrl::HitTest(const wxPoint& pos,
         default:
         case MCHT_CALENDARWEEKNUM:
             wxFAIL_MSG( "unexpected" );
-            // fall through
+            wxFALLTHROUGH;
 
         case MCHT_NOWHERE:
         case MCHT_CALENDARBK:

--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -390,7 +390,7 @@ HDC CreateCompatibleDCWithLayout(HDC hdc);
 // ----------------------------------------------------------------------------
 
 // instead of duplicating the same code which sets and then restores text
-// colours in each wxDC method working with wxSTIPPLE_MASK_OPAQUE brushes,
+// colours in each wxDC method working with wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE brushes,
 // encapsulate this in a small helper class
 
 // wxBrushAttrsSetter: changes the text colours in the ctor if required and
@@ -819,7 +819,7 @@ void wxMSWDCImpl::DoDrawArc(wxCoord x1, wxCoord y1,
     wxCoord r = (wxCoord)sqrt(dx*dx + dy*dy);
 
 
-    wxBrushAttrsSetter cc(*this); // needed for wxSTIPPLE_MASK_OPAQUE handling
+    wxBrushAttrsSetter cc(*this); // needed for wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE handling
 
     // treat the special case of full circle separately
     if ( x1 == x2 && y1 == y2 )
@@ -898,7 +898,7 @@ void wxMSWDCImpl::DoDrawPolygon(int n,
                          wxCoord yoffset,
                          wxPolygonFillMode fillStyle)
 {
-    wxBrushAttrsSetter cc(*this); // needed for wxSTIPPLE_MASK_OPAQUE handling
+    wxBrushAttrsSetter cc(*this); // needed for wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE handling
 
     // Do things less efficiently if we have offsets
     if (xoffset != 0 || yoffset != 0)
@@ -937,7 +937,7 @@ wxMSWDCImpl::DoDrawPolyPolygon(int n,
                         wxCoord yoffset,
                         wxPolygonFillMode fillStyle)
 {
-    wxBrushAttrsSetter cc(*this); // needed for wxSTIPPLE_MASK_OPAQUE handling
+    wxBrushAttrsSetter cc(*this); // needed for wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE handling
     int i, cnt;
     for (i = cnt = 0; i < n; i++)
         cnt += count[i];
@@ -998,7 +998,7 @@ void wxMSWDCImpl::DoDrawLines(int n, const wxPoint points[], wxCoord xoffset, wx
 
 void wxMSWDCImpl::DoDrawRectangle(wxCoord x, wxCoord y, wxCoord width, wxCoord height)
 {
-    wxBrushAttrsSetter cc(*this); // needed for wxSTIPPLE_MASK_OPAQUE handling
+    wxBrushAttrsSetter cc(*this); // needed for wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE handling
 
     wxCoord x2 = x + width;
     wxCoord y2 = y + height;
@@ -1031,7 +1031,7 @@ void wxMSWDCImpl::DoDrawRectangle(wxCoord x, wxCoord y, wxCoord width, wxCoord h
 
 void wxMSWDCImpl::DoDrawRoundedRectangle(wxCoord x, wxCoord y, wxCoord width, wxCoord height, double radius)
 {
-    wxBrushAttrsSetter cc(*this); // needed for wxSTIPPLE_MASK_OPAQUE handling
+    wxBrushAttrsSetter cc(*this); // needed for wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE handling
 
     // Now, a negative radius value is interpreted to mean
     // 'the proportion of the smallest X or Y dimension'
@@ -1063,7 +1063,7 @@ void wxMSWDCImpl::DoDrawRoundedRectangle(wxCoord x, wxCoord y, wxCoord width, wx
 
 void wxMSWDCImpl::DoDrawEllipse(wxCoord x, wxCoord y, wxCoord width, wxCoord height)
 {
-    wxBrushAttrsSetter cc(*this); // needed for wxSTIPPLE_MASK_OPAQUE handling
+    wxBrushAttrsSetter cc(*this); // needed for wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE handling
 
     // +1 below makes the ellipse more similar to other platforms.
     // In particular, DoDrawEllipse(x,y,1,1) should draw one point.
@@ -1178,7 +1178,7 @@ void wxMSWDCImpl::DoDrawSpline(const wxPointList *points)
 // Chris Breeze 20/5/98: first implementation of DrawEllipticArc on Windows
 void wxMSWDCImpl::DoDrawEllipticArc(wxCoord x,wxCoord y,wxCoord w,wxCoord h,double sa,double ea)
 {
-    wxBrushAttrsSetter cc(*this); // needed for wxSTIPPLE_MASK_OPAQUE handling
+    wxBrushAttrsSetter cc(*this); // needed for wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE handling
 
     wxCoord x2 = x + w;
     wxCoord y2 = y + h;

--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -1713,7 +1713,7 @@ void wxMSWDCImpl::SetLogicalFunction(wxRasterOperationMode function)
 
 void wxMSWDCImpl::SetRop(WXHDC dc)
 {
-    if ( !dc || m_logicalFunction < 0 )
+    if ( !dc )
         return;
 
     int rop;

--- a/src/msw/dcmemory.cpp
+++ b/src/msw/dcmemory.cpp
@@ -162,7 +162,7 @@ static void wxDrawRectangle(wxDC& dc, wxCoord x, wxCoord y, wxCoord width, wxCoo
 {
     wxBrush brush(dc.GetBrush());
     wxPen pen(dc.GetPen());
-    if (brush.IsOk() && brush.GetStyle() != wxTRANSPARENT)
+    if (brush.IsOk() && brush.GetStyle() != wxBRUSHSTYLE_TRANSPARENT)
     {
         HBRUSH hBrush = (HBRUSH) brush.GetResourceHandle() ;
         if (hBrush)
@@ -175,7 +175,7 @@ static void wxDrawRectangle(wxDC& dc, wxCoord x, wxCoord y, wxCoord width, wxCoo
         }
     }
     width --; height --;
-    if (pen.IsOk() && pen.GetStyle() != wxTRANSPARENT)
+    if (pen.IsOk() && pen.GetStyle() != wxPENSTYLE_TRANSPARENT)
     {
         dc.DrawLine(x, y, x + width, y);
         dc.DrawLine(x, y, x, y + height);
@@ -192,8 +192,8 @@ void wxMemoryDCImpl::DoDrawRectangle(wxCoord x, wxCoord y, wxCoord width, wxCoor
     // (visible with e.g. 70x70 rectangle on a memory DC; see Drawing sample)
 #if wxUSE_MEMORY_DC_DRAW_RECTANGLE
     if (m_brush.IsOk() && m_pen.IsOk() &&
-        (m_brush.GetStyle() == wxSOLID || m_brush.GetStyle() == wxTRANSPARENT) &&
-        (m_pen.GetStyle() == wxSOLID || m_pen.GetStyle() == wxTRANSPARENT) &&
+        (m_brush.GetStyle() == wxBRUSHSTYLE_SOLID || m_brush.GetStyle() == wxBRUSHSTYLE_TRANSPARENT) &&
+        (m_pen.GetStyle() == wxPENSTYLE_SOLID || m_pen.GetStyle() == wxPENSTYLE_TRANSPARENT) &&
         (GetLogicalFunction() == wxCOPY))
     {
         wxDrawRectangle(* this, x, y, width, height);

--- a/src/msw/dialup.cpp
+++ b/src/msw/dialup.cpp
@@ -541,7 +541,7 @@ HRASCONN wxDialUpManagerMSW::FindActiveConnection()
             // is used, for example, to select the connection to hang up and so
             // we may hang up the wrong connection here...
             wxLogWarning(_("Several active dialup connections found, choosing one randomly."));
-            // fall through
+            wxFALLTHROUGH;
 
         case 1:
             // exactly 1 connection, great
@@ -1231,7 +1231,7 @@ static DWORD wxRasMonitorThread(wxRasThreadData *data)
 
             default:
                 wxFAIL_MSG( wxT("unexpected return of WaitForMultipleObjects()") );
-                // fall through
+                wxFALLTHROUGH;
 
             case WAIT_FAILED:
                 // using wxLogLastError() from here is dangerous: we risk to

--- a/src/msw/evtloopconsole.cpp
+++ b/src/msw/evtloopconsole.cpp
@@ -122,7 +122,7 @@ int wxMSWEventLoopBase::GetNextMessageTimeout(WXMSG *msg, unsigned long timeout)
             default:
                 wxLogDebug("unexpected MsgWaitForMultipleObjects() return "
                            "value %lu", rc);
-                // fall through
+                wxFALLTHROUGH;
 
             case WAIT_TIMEOUT:
                 return -1;

--- a/src/msw/filedlg.cpp
+++ b/src/msw/filedlg.cpp
@@ -517,8 +517,7 @@ int wxFileDialog::ShowModal()
             case wxT('/'):
                 // convert to backslash
                 ch = wxT('\\');
-
-                // fall through
+                wxFALLTHROUGH;
 
             case wxT('\\'):
                 while ( i < len - 1 )
@@ -533,7 +532,7 @@ int wxFileDialog::ShowModal()
                     else
                         break;
                 }
-                // fall through
+                wxFALLTHROUGH;
 
             default:
                 // normal char

--- a/src/msw/font.cpp
+++ b/src/msw/font.cpp
@@ -524,7 +524,7 @@ void wxNativeFontInfo::SetStyle(wxFontStyle style)
     {
         default:
             wxFAIL_MSG( "unknown font style" );
-            // fall through
+            wxFALLTHROUGH;
 
         case wxFONTSTYLE_NORMAL:
             lf.lfItalic = FALSE;

--- a/src/msw/joystick.cpp
+++ b/src/msw/joystick.cpp
@@ -67,7 +67,7 @@ public:
     {
         m_catchwin = win;
         m_polling = pollingFreq;
-    };
+    }
 
 
 private:

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -2145,7 +2145,7 @@ bool wxListCtrl::MSWOnNotify(int idCtrl, WXLPARAM lParam, WXLPARAM *result)
             case HDN_BEGINTRACKA:
             case HDN_BEGINTRACKW:
                 eventType = wxEVT_LIST_COL_BEGIN_DRAG;
-                // fall through
+                wxFALLTHROUGH;
 
             case HDN_ITEMCHANGING:
                 if ( eventType == wxEVT_NULL )
@@ -2171,7 +2171,7 @@ bool wxListCtrl::MSWOnNotify(int idCtrl, WXLPARAM lParam, WXLPARAM *result)
 
                     eventType = wxEVT_LIST_COL_DRAGGING;
                 }
-                // fall through
+                wxFALLTHROUGH;
 
             case HDN_ENDTRACKA:
             case HDN_ENDTRACKW:
@@ -2244,7 +2244,7 @@ bool wxListCtrl::MSWOnNotify(int idCtrl, WXLPARAM lParam, WXLPARAM *result)
         {
             case LVN_BEGINRDRAG:
                 eventType = wxEVT_LIST_BEGIN_RDRAG;
-                // fall through
+                wxFALLTHROUGH;
 
             case LVN_BEGINDRAG:
                 if ( eventType == wxEVT_NULL )
@@ -2675,7 +2675,7 @@ bool wxListCtrl::MSWOnNotify(int idCtrl, WXLPARAM lParam, WXLPARAM *result)
 
                     return true;
                 }
-                // fall through
+                wxFALLTHROUGH;
 
             default:
                 processed = false;

--- a/src/msw/mdi.cpp
+++ b/src/msw/mdi.cpp
@@ -722,7 +722,7 @@ void wxMDIParentFrame::OnMDICommand(wxCommandEvent& event)
 
         case wxID_MDI_WINDOW_TILE_HORZ:
             wParam |= MDITILE_HORIZONTAL;
-            // fall through
+            wxFALLTHROUGH;
 
         case wxID_MDI_WINDOW_TILE_VERT:
             if ( !wParam )
@@ -1152,7 +1152,7 @@ WXLRESULT wxMDIChildFrame::MSWWindowProc(WXUINT message,
 
                 processed = HandleMDIActivate(act, hwndAct, hwndDeact);
             }
-            // fall through
+            wxFALLTHROUGH;
 
         case WM_MOVE:
             // must pass WM_MOVE to DefMDIChildProc() to recalculate MDI client

--- a/src/msw/mediactrl_am.cpp
+++ b/src/msw/mediactrl_am.cpp
@@ -1369,7 +1369,7 @@ wxLongLong wxAMMediaBackend::GetDuration()
     {
         default:
             wxAMLOG(hr);
-            // fall through
+            wxFALLTHROUGH;
 
         case S_FALSE:
             return 0;

--- a/src/msw/mediactrl_am.cpp
+++ b/src/msw/mediactrl_am.cpp
@@ -1083,7 +1083,7 @@ bool wxAMMediaBackend::CreateControl(wxControl* ctrl, wxWindow* parent,
 
     // don't erase the background of our control window so that resizing is a
     // bit smoother
-    m_ctrl->SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    m_ctrl->SetBackgroundStyle(wxBG_STYLE_PAINT);
 
     // success
     return true;

--- a/src/msw/mediactrl_wmp10.cpp
+++ b/src/msw/mediactrl_wmp10.cpp
@@ -868,7 +868,7 @@ bool wxWMP10MediaBackend::CreateControl(wxControl* ctrl, wxWindow* parent,
 
     // don't erase the background of our control window so that resizing is a
     // bit smoother
-    m_ctrl->SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    m_ctrl->SetBackgroundStyle(wxBG_STYLE_PAINT);
 
     // success
     return true;

--- a/src/msw/msgdlg.cpp
+++ b/src/msw/msgdlg.cpp
@@ -830,7 +830,7 @@ int wxMSWMessageDialog::MSWTranslateReturnCode(int msAns)
     {
         default:
             wxFAIL_MSG(wxT("unexpected return code"));
-            // fall through
+            wxFALLTHROUGH;
 
         case IDCANCEL:
             ans = wxID_CANCEL;

--- a/src/msw/ole/droptgt.cpp
+++ b/src/msw/ole/droptgt.cpp
@@ -681,7 +681,7 @@ static wxDragResult ConvertDragEffectToResult(DWORD dwEffect)
 
         default:
             wxFAIL_MSG(wxT("invalid value in ConvertDragEffectToResult"));
-            // fall through
+            wxFALLTHROUGH;
 
         case DROPEFFECT_NONE:
             return wxDragNone;
@@ -702,7 +702,7 @@ static DWORD ConvertDragResultToEffect(wxDragResult result)
 
         default:
             wxFAIL_MSG(wxT("invalid value in ConvertDragResultToEffect"));
-            // fall through
+            wxFALLTHROUGH;
 
         case wxDragNone:
             return DROPEFFECT_NONE;

--- a/src/msw/pen.cpp
+++ b/src/msw/pen.cpp
@@ -205,7 +205,7 @@ static int ConvertPenStyle(wxPenStyle style)
 
         default:
             wxFAIL_MSG( wxT("unknown pen style") );
-            // fall through
+            wxFALLTHROUGH;
 
         case wxPENSTYLE_DOT:
             return PS_DOT;
@@ -241,7 +241,7 @@ static int ConvertJoinStyle(wxPenJoin join)
 
         default:
             wxFAIL_MSG( wxT("unknown pen join style") );
-            // fall through
+            wxFALLTHROUGH;
 
         case wxJOIN_ROUND:
             return PS_JOIN_ROUND;
@@ -260,7 +260,7 @@ static int ConvertCapStyle(wxPenCap cap)
 
         default:
             wxFAIL_MSG( wxT("unknown pen cap style") );
-            // fall through
+            wxFALLTHROUGH;
 
         case wxCAP_ROUND:
             return PS_ENDCAP_ROUND;

--- a/src/msw/power.cpp
+++ b/src/msw/power.cpp
@@ -143,6 +143,7 @@ wxPowerType wxGetPowerType()
 
             default:
                 wxLogDebug(wxT("Unknown ACLineStatus=%u"), sps.ACLineStatus);
+                wxFALLTHROUGH;
             case 255:
                 break;
         }

--- a/src/msw/region.cpp
+++ b/src/msw/region.cpp
@@ -206,7 +206,7 @@ bool wxRegion::DoCombine(const wxRegion& rgn, wxRegionOp op)
 
             default:
                 wxFAIL_MSG( wxT("unknown region operation") );
-                // fall through
+                wxFALLTHROUGH;
 
             case wxRGN_AND:
             case wxRGN_DIFF:
@@ -239,7 +239,7 @@ bool wxRegion::DoCombine(const wxRegion& rgn, wxRegionOp op)
 
             default:
                 wxFAIL_MSG( wxT("unknown region operation") );
-                // fall through
+                wxFALLTHROUGH;
 
             case wxRGN_COPY:
                 mode = RGN_COPY;

--- a/src/msw/registry.cpp
+++ b/src/msw/registry.cpp
@@ -1332,7 +1332,7 @@ wxString wxRegKey::FormatValue(const wxString& name) const
                         case wxT('\\'):
                             // escape special symbol
                             rhs += wxT('\\');
-                            // fall through
+                            wxFALLTHROUGH;
 
                         default:
                             rhs += *p;
@@ -1527,7 +1527,7 @@ long GetMSWViewFlags(wxRegKey::WOW64ViewMode viewMode)
 
         default:
             wxFAIL_MSG("Unknown registry view.");
-            // fall through
+            wxFALLTHROUGH;
 
         case wxRegKey::WOW64ViewMode_Default:
             // Use default registry view for the current application,

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -1997,7 +1997,7 @@ bool wxTextCtrl::MSWShouldPreProcessMessage(WXMSG* msg)
             {
                 default:
                     wxFAIL_MSG( wxT("how many modifiers have we got?") );
-                    // fall through
+                    wxFALLTHROUGH;
 
                 case 0:
                     switch ( vkey )
@@ -2006,14 +2006,14 @@ bool wxTextCtrl::MSWShouldPreProcessMessage(WXMSG* msg)
                             // This one is only special for multi line controls.
                             if ( !IsMultiLine() )
                                 break;
-                            // fall through
+                            wxFALLTHROUGH;
 
                         case VK_DELETE:
                         case VK_HOME:
                         case VK_END:
                             return false;
                     }
-                    // fall through
+                    wxFALLTHROUGH;
                 case 2:
                     break;
 
@@ -2297,7 +2297,7 @@ bool wxTextCtrl::SendUpdateEvent()
 
         default:
             wxFAIL_MSG( wxT("unexpected wxTextCtrl::m_updatesCount value") );
-            // fall through
+            wxFALLTHROUGH;
 
         case -1:
             // we hadn't updated the control ourselves, this event comes from

--- a/src/msw/thread.cpp
+++ b/src/msw/thread.cpp
@@ -258,7 +258,7 @@ wxMutexError wxMutexInternal::LockTimeout(DWORD milliseconds)
             // the previous caller died without releasing the mutex, so even
             // though we did get it, log a message about this
             wxLogDebug(wxT("WaitForSingleObject() returned WAIT_ABANDONED"));
-            // fall through
+            wxFALLTHROUGH;
 
         case WAIT_OBJECT_0:
             // ok
@@ -269,7 +269,7 @@ wxMutexError wxMutexInternal::LockTimeout(DWORD milliseconds)
 
         default:
             wxFAIL_MSG(wxT("impossible return value in wxMutex::Lock"));
-            // fall through
+            wxFALLTHROUGH;
 
         case WAIT_FAILED:
             wxLogLastError(wxT("WaitForSingleObject(mutex)"));

--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -3114,8 +3114,7 @@ wxTreeCtrl::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam)
                         processed = true;
                     }
                 }
-
-                // fall through
+                wxFALLTHROUGH;
 
             case WM_RBUTTONUP:
 #if wxUSE_DRAGIMAGE
@@ -3288,7 +3287,7 @@ bool wxTreeCtrl::MSWOnNotify(int idCtrl, WXLPARAM lParam, WXLPARAM *result)
     {
         case TVN_BEGINDRAG:
             eventType = wxEVT_TREE_BEGIN_DRAG;
-            // fall through
+            wxFALLTHROUGH;
 
         case TVN_BEGINRDRAG:
             {
@@ -3379,7 +3378,7 @@ bool wxTreeCtrl::MSWOnNotify(int idCtrl, WXLPARAM lParam, WXLPARAM *result)
 
         case TVN_GETDISPINFO:
             eventType = wxEVT_TREE_GET_INFO;
-            // fall through
+            wxFALLTHROUGH;
 
         case TVN_SETDISPINFO:
             {
@@ -3403,7 +3402,7 @@ bool wxTreeCtrl::MSWOnNotify(int idCtrl, WXLPARAM lParam, WXLPARAM *result)
                 {
                     default:
                         wxLogDebug(wxT("unexpected code %d in TVN_ITEMEXPAND message"), tv->action);
-                        // fall through
+                        wxFALLTHROUGH;
 
                     case TVE_EXPAND:
                         what = IDX_EXPAND;
@@ -3471,7 +3470,7 @@ bool wxTreeCtrl::MSWOnNotify(int idCtrl, WXLPARAM lParam, WXLPARAM *result)
             {
                 eventType = wxEVT_TREE_SEL_CHANGED;
             }
-            // fall through
+            wxFALLTHROUGH;
 
         case TVN_SELCHANGINGA:
         case TVN_SELCHANGINGW:
@@ -3690,7 +3689,7 @@ bool wxTreeCtrl::MSWOnNotify(int idCtrl, WXLPARAM lParam, WXLPARAM *result)
                     break;
                 }
             }
-            // fall through
+            wxFALLTHROUGH;
 
         default:
             return wxControl::MSWOnNotify(idCtrl, lParam, result);

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -1270,7 +1270,7 @@ wxWinVersion wxGetWinVersion()
 
                     }
                     break;
-                    
+
                 case 10:
                     return wxWinVersion_10;
             }

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -713,11 +713,11 @@ int wxKill(long pid, wxSignal sig, wxKillError *krc, int flags)
 
             default:
                 wxFAIL_MSG( wxT("unexpected WaitForSingleObject() return") );
-                // fall through
+                wxFALLTHROUGH;
 
             case WAIT_FAILED:
                 wxLogLastError(wxT("WaitForSingleObject"));
-                // fall through
+                wxFALLTHROUGH;
 
             case WAIT_TIMEOUT:
                 // Process didn't terminate: normally this is a failure but not
@@ -1274,6 +1274,7 @@ wxWinVersion wxGetWinVersion()
                 case 10:
                     return wxWinVersion_10;
             }
+            break;
         default:
             // Do nothing just to silence GCC warning
             break;

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -1561,7 +1561,7 @@ WXDWORD wxWindowMSW::MSWGetStyle(long flags, WXDWORD *exstyle) const
             default:
             case wxBORDER_DEFAULT:
                 wxFAIL_MSG( wxT("unknown border style") );
-                // fall through
+                wxFALLTHROUGH;
 
             case wxBORDER_NONE:
             case wxBORDER_SIMPLE:
@@ -2257,7 +2257,7 @@ wxSize wxWindowMSW::DoGetBorderSize() const
 
         default:
             wxFAIL_MSG( wxT("unknown border style") );
-            // fall through
+            wxFALLTHROUGH;
 
         case wxBORDER_NONE:
             border = 0;
@@ -2540,7 +2540,7 @@ bool wxWindowMSW::MSWProcessMessage(WXMSG* pMsg)
 
                 case VK_PRIOR:
                     bForward = false;
-                    // fall through
+                    wxFALLTHROUGH;
 
                 case VK_NEXT:
                     // we treat PageUp/Dn as arrows because chances are that
@@ -4502,7 +4502,7 @@ bool wxWindowMSW::HandlePower(WXWPARAM wParam,
 
         default:
             wxLogDebug(wxT("Unknown WM_POWERBROADCAST(%d) event"), wParam);
-            // fall through
+            wxFALLTHROUGH;
 
         // these messages are currently not mapped to wx events
         case PBT_APMQUERYSTANDBY:
@@ -5106,7 +5106,7 @@ bool wxWindowMSW::HandleEraseBkgnd(WXHDC hdc)
                     return true;
                 }
             }
-            // fall through
+            wxFALLTHROUGH;
 
         case wxBG_STYLE_SYSTEM:
             if ( !DoEraseBackground(hdc) )

--- a/src/osx/carbon/dcprint.cpp
+++ b/src/osx/carbon/dcprint.cpp
@@ -366,7 +366,7 @@ void wxPrinterDCImpl::StartPage()
 
     m_logicalFunction = wxCOPY;
     //  m_textAlignment = wxALIGN_TOP_LEFT;
-    m_backgroundMode = wxTRANSPARENT;
+    m_backgroundMode = wxBRUSHSTYLE_TRANSPARENT;
 
     m_textForegroundColour = *wxBLACK;
     m_textBackgroundColour = *wxWHITE;

--- a/src/osx/carbon/dcprint.cpp
+++ b/src/osx/carbon/dcprint.cpp
@@ -149,7 +149,7 @@ bool wxMacCarbonPrinterDC::StartDoc(  wxPrinterDC* dc , const wxString& message 
         if (m_err == noErr)
             useDefaultResolution = true;
     }
-    
+
     // Ignore errors which may occur while retrieving the resolution and just
     // use the default one.
     if ( useDefaultResolution )

--- a/src/osx/carbon/graphics.cpp
+++ b/src/osx/carbon/graphics.cpp
@@ -1352,7 +1352,7 @@ public:
     virtual bool SetAntialiasMode(wxAntialiasMode antialias) wxOVERRIDE;
 
     virtual bool SetInterpolationQuality(wxInterpolationQuality interpolation) wxOVERRIDE;
-    
+
     virtual bool SetCompositionMode(wxCompositionMode op) wxOVERRIDE;
 
     virtual void BeginLayer(wxDouble opacity) wxOVERRIDE;
@@ -1392,15 +1392,15 @@ public:
 
     // draws a path by first filling and then stroking
     virtual void DrawPath( const wxGraphicsPath &path, wxPolygonFillMode fillStyle = wxODDEVEN_RULE ) wxOVERRIDE;
-    
+
     // paints a transparent rectangle (only useful for bitmaps or windows)
     virtual void ClearRectangle(wxDouble x, wxDouble y, wxDouble w, wxDouble h) wxOVERRIDE;
-    
+
     virtual bool ShouldOffset() const wxOVERRIDE
     {
         if ( !m_enableOffset )
             return false;
-        
+
         int penwidth = 0 ;
         if ( !m_pen.IsNull() )
         {
@@ -1428,10 +1428,10 @@ public:
     virtual void DrawBitmap( const wxGraphicsBitmap &bmp, wxDouble x, wxDouble y, wxDouble w, wxDouble h ) wxOVERRIDE;
 
     virtual void DrawIcon( const wxIcon &icon, wxDouble x, wxDouble y, wxDouble w, wxDouble h ) wxOVERRIDE;
-    
+
     // fast convenience methods
-    
-    
+
+
     virtual void DrawRectangle( wxDouble x, wxDouble y, wxDouble w, wxDouble h ) wxOVERRIDE;
 
     void SetNativeContext( CGContextRef cg );
@@ -1617,7 +1617,7 @@ void wxMacCoreGraphicsContext::Flush()
 bool wxMacCoreGraphicsContext::EnsureIsValid()
 {
     CheckInvariants();
-    
+
     if ( !m_cgContext )
     {
         if (m_invisible)
@@ -1729,7 +1729,7 @@ bool wxMacCoreGraphicsContext::SetInterpolationQuality(wxInterpolationQuality in
 {
     if (!EnsureIsValid())
         return true;
-    
+
     if (m_interpolation == interpolation)
         return true;
 
@@ -1944,7 +1944,7 @@ void wxMacCoreGraphicsContext::Clip( const wxRegion &region )
     // allow usage as measuring context
     // wxASSERT_MSG( m_cgContext != NULL, "Needs a valid context for clipping" );
 #endif
-    CheckInvariants();    
+    CheckInvariants();
 }
 
 // clips drawings to the rect
@@ -1969,7 +1969,7 @@ void wxMacCoreGraphicsContext::Clip( wxDouble x, wxDouble y, wxDouble w, wxDoubl
     // wxFAIL_MSG( "Needs a valid context for clipping" );
 #endif
     }
-    CheckInvariants();    
+    CheckInvariants();
 }
 
     // resets the clipping to original extent
@@ -2002,7 +2002,7 @@ void wxMacCoreGraphicsContext::ResetClip()
     // wxFAIL_MSG( "Needs a valid context for clipping" );
 #endif
     }
-    CheckInvariants();    
+    CheckInvariants();
 }
 
 void wxMacCoreGraphicsContext::GetClipBox(wxDouble* x, wxDouble* y, wxDouble* w, wxDouble* h)
@@ -2056,7 +2056,7 @@ void wxMacCoreGraphicsContext::StrokePath( const wxGraphicsPath &path )
     ((wxMacCoreGraphicsPenData*)m_pen.GetRefData())->Apply(this);
     CGContextAddPath( m_cgContext , (CGPathRef) path.GetNativePath() );
     CGContextStrokePath( m_cgContext );
-    
+
     CheckInvariants();
 }
 
@@ -2111,7 +2111,7 @@ void wxMacCoreGraphicsContext::DrawPath( const wxGraphicsPath &path , wxPolygonF
 
     CGContextAddPath( m_cgContext , (CGPathRef) path.GetNativePath() );
     CGContextDrawPath( m_cgContext , mode );
-    
+
     CheckInvariants();
 }
 
@@ -2143,7 +2143,7 @@ void wxMacCoreGraphicsContext::FillPath( const wxGraphicsPath &path , wxPolygonF
         else
             CGContextFillPath( m_cgContext );
     }
-    
+
     CheckInvariants();
 }
 
@@ -2263,7 +2263,7 @@ void wxMacCoreGraphicsContext::DrawBitmap( const wxGraphicsBitmap &bmp, wxDouble
         wxMacDrawCGImage( m_cgContext , &r , image );
     }
 #endif
-    
+
     CheckInvariants();
 }
 
@@ -2281,7 +2281,7 @@ void wxMacCoreGraphicsContext::DrawIcon( const wxIcon &icon, wxDouble x, wxDoubl
         wxOSXDrawNSImage( m_cgContext, &r, icon.GetImage());
     }
 #endif
-    
+
     CheckInvariants();
 }
 
@@ -2318,9 +2318,9 @@ void wxMacCoreGraphicsContext::DoDrawText( const wxString &str, wxDouble x, wxDo
 
     wxCFDictionaryRef fontattr(wxCFRetain(fref->OSXGetCTFontAttributes()));
     wxCFMutableDictionaryRef inlinefontattr;
-    
+
     bool setColorsInLine = false;
-    
+
     // if we emulate boldness the stroke color is not taken from the current context
     // therefore we have to set it explicitly
     if ( fontattr.GetValue(kCTStrokeWidthAttributeName) != NULL)
@@ -2331,7 +2331,7 @@ void wxMacCoreGraphicsContext::DoDrawText( const wxString &str, wxDouble x, wxDo
         inlinefontattr.SetValue(kCTForegroundColorAttributeName,col);
         inlinefontattr.SetValue(kCTStrokeColorAttributeName,col);
     }
-        
+
     wxCFRef<CFAttributedStringRef> attrtext( CFAttributedStringCreate(kCFAllocatorDefault, text, setColorsInLine ? inlinefontattr : fontattr ) );
     wxCFRef<CTLineRef> line( CTLineCreateWithAttributedString(attrtext) );
 
@@ -2352,7 +2352,7 @@ void wxMacCoreGraphicsContext::DoDrawText( const wxString &str, wxDouble x, wxDo
         CGFloat width = CTLineGetTypographicBounds(line, NULL, NULL, NULL);
 
         CGPoint points[] = { {0.0, -2.0},  {width, -2.0} };
-        
+
         CGContextSetStrokeColorWithColor(m_cgContext, col);
         CGContextSetShouldAntialias(m_cgContext, false);
         CGContextSetLineWidth(m_cgContext, 1.0);
@@ -2417,7 +2417,7 @@ void wxMacCoreGraphicsContext::GetTextExtent( const wxString &str, wxDouble *wid
     wxMacCoreGraphicsFontData* fref = (wxMacCoreGraphicsFontData*)m_font.GetRefData();
 
     wxCFStringRef text(strToMeasure, wxLocale::GetSystemEncoding() );
-    
+
     wxCFRef<CFAttributedStringRef> attrtext( CFAttributedStringCreate(kCFAllocatorDefault, text, fref->OSXGetCTFontAttributes() ) );
     wxCFRef<CTLineRef> line( CTLineCreateWithAttributedString(attrtext) );
 
@@ -2436,7 +2436,7 @@ void wxMacCoreGraphicsContext::GetTextExtent( const wxString &str, wxDouble *wid
     if ( externalLeading )
         *externalLeading = l;
 
-    CheckInvariants();    
+    CheckInvariants();
 }
 
 void wxMacCoreGraphicsContext::GetPartialTextExtents(const wxString& text, wxArrayDouble& widths) const
@@ -2479,7 +2479,7 @@ void wxMacCoreGraphicsContext::ClearRectangle( wxDouble x, wxDouble y, wxDouble 
 {
     if (!EnsureIsValid())
         return;
-    
+
     CGRect rect = CGRectMake( (CGFloat) x , (CGFloat) y , (CGFloat) w , (CGFloat) h );
     CGContextClearRect(m_cgContext, rect);
 }
@@ -2489,10 +2489,10 @@ void wxMacCoreGraphicsContext::DrawRectangle( wxDouble x, wxDouble y, wxDouble w
     if (!EnsureIsValid())
         return;
 
-    if (m_composition == wxCOMPOSITION_DEST) 
-        return; 
+    if (m_composition == wxCOMPOSITION_DEST)
+        return;
 
-    // when using shading, we have to go back to drawing paths 
+    // when using shading, we have to go back to drawing paths
     if ( !m_brush.IsNull() && ((wxMacCoreGraphicsBrushData*)m_brush.GetRefData())->IsShading() )
     {
         wxGraphicsContext::DrawRectangle( x,y,w,h );
@@ -2505,7 +2505,7 @@ void wxMacCoreGraphicsContext::DrawRectangle( wxDouble x, wxDouble y, wxDouble w
         ((wxMacCoreGraphicsBrushData*)m_brush.GetRefData())->Apply(this);
         CGContextFillRect(m_cgContext, rect);
     }
-    
+
     wxQuartzOffsetHelper helper( m_cgContext , ShouldOffset() );
     if ( !m_pen.IsNull() )
     {

--- a/src/osx/carbon/graphics.cpp
+++ b/src/osx/carbon/graphics.cpp
@@ -228,7 +228,7 @@ public :
     {
         switch ( m_hatch )
         {
-            case wxBDIAGONAL_HATCH :
+            case wxHATCHSTYLE_BDIAGONAL :
                 {
                     CGPoint pts[] =
                     {
@@ -238,7 +238,7 @@ public :
                 }
                 break;
 
-            case wxCROSSDIAG_HATCH :
+            case wxHATCHSTYLE_CROSSDIAG :
                 {
                     CGPoint pts[] =
                     {
@@ -249,7 +249,7 @@ public :
                 }
                 break;
 
-            case wxFDIAGONAL_HATCH :
+            case wxHATCHSTYLE_FDIAGONAL :
                 {
                     CGPoint pts[] =
                     {
@@ -259,7 +259,7 @@ public :
                 }
                 break;
 
-            case wxCROSS_HATCH :
+            case wxHATCHSTYLE_CROSS :
                 {
                     CGPoint pts[] =
                     {
@@ -270,7 +270,7 @@ public :
                 }
                 break;
 
-            case wxHORIZONTAL_HATCH :
+            case wxHATCHSTYLE_HORIZONTAL :
                 {
                     CGPoint pts[] =
                     {
@@ -280,7 +280,7 @@ public :
                 }
                 break;
 
-            case wxVERTICAL_HATCH :
+            case wxHATCHSTYLE_VERTICAL :
                 {
                     CGPoint pts[] =
                     {

--- a/src/osx/carbon/statbrma.cpp
+++ b/src/osx/carbon/statbrma.cpp
@@ -110,7 +110,7 @@ void wxStatusBarMac::InitColours()
             wxColour bg = wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE);
             m_textActive = wxSystemSettings::GetColour(wxSYS_COLOUR_BTNTEXT);
             m_textInactive = wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT);
-            
+
             if ( bg.Red() < 128 )
             {
                 // dark mode appearance

--- a/src/osx/carbon/statbrma.cpp
+++ b/src/osx/carbon/statbrma.cpp
@@ -222,7 +222,7 @@ void wxStatusBarMac::OnPaint(wxPaintEvent& WXUNUSED(event))
 
     if ( GetFont().IsOk() )
         dc.SetFont(GetFont());
-    dc.SetBackgroundMode(wxTRANSPARENT);
+    dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
 
     // compute char height only once for all panes:
     int textHeight = dc.GetCharHeight();

--- a/src/propgrid/editors.cpp
+++ b/src/propgrid/editors.cpp
@@ -1543,7 +1543,7 @@ public:
         m_state = 0;
         m_boxHeight = 12;
 
-        SetBackgroundStyle( wxBG_STYLE_CUSTOM );
+        SetBackgroundStyle( wxBG_STYLE_PAINT );
     }
 
     virtual ~wxSimpleCheckBox();

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -482,7 +482,7 @@ void wxPropertyGrid::Init2()
     RegainColours();
 
     // This helps with flicker
-    SetBackgroundStyle( wxBG_STYLE_CUSTOM );
+    SetBackgroundStyle( wxBG_STYLE_PAINT );
 
     // Rely on native double-buffering by default.
 #if wxALWAYS_NATIVE_DOUBLE_BUFFER

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -1427,7 +1427,7 @@ void wxPropertyGrid::RegainColours()
         wxColour capForeCol = wxPGAdjustColour(m_colCapBack,colDec,5000,5000,true);
         if (wxPGGetColAvg(m_colCapBack) < 100)
             capForeCol = wxSystemSettings::GetColour( wxSYS_COLOUR_WINDOWTEXT );
-        
+
         m_colCapFore = capForeCol;
         m_categoryDefaultCell.GetData()->SetFgCol(capForeCol);
     }

--- a/src/qt/dc.cpp
+++ b/src/qt/dc.cpp
@@ -159,7 +159,7 @@ void wxQtDCImpl::SetPen(const wxPen& pen)
 void wxQtDCImpl::SetBrush(const wxBrush& brush)
 {
     m_brush = brush;
-    
+
     if (brush.GetStyle() == wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE)
     {
         // Use a monochrome mask: use foreground color for the mask
@@ -190,7 +190,7 @@ void wxQtDCImpl::SetBrush(const wxBrush& brush)
 void wxQtDCImpl::SetBackground(const wxBrush& brush)
 {
     m_backgroundBrush = brush;
-    
+
     if (m_qtPainter->isActive())
         m_qtPainter->setBackground(brush.GetHandle());
 }
@@ -375,7 +375,7 @@ void wxQtDCImpl::Clear()
 {
     int width, height;
     DoGetSize(&width, &height);
-    
+
     m_qtPainter->eraseRect(QRect(0, 0, width, height));
 }
 
@@ -486,7 +486,7 @@ bool wxQtDCImpl::DoGetPixel(wxCoord x, wxCoord y, wxColour *col) const
     if ( col )
     {
         wxCHECK_MSG( m_qtImage != NULL, false, "This DC doesn't support GetPixel()" );
-        
+
         QColor pixel = m_qtImage->pixel( x, y );
         col->Set( pixel.red(), pixel.green(), pixel.blue(), pixel.alpha() );
 
@@ -519,7 +519,7 @@ void wxQtDCImpl::DoDrawArc(wxCoord x1, wxCoord y1,
     qreal penWidth = m_qtPainter->pen().width();
     qreal lenRadius = l1.length() - penWidth / 2;
     QPointF centerToCorner( lenRadius, lenRadius );
-    
+
     QRect rectangle = QRectF( center - centerToCorner, center + centerToCorner ).toRect();
 
     // Calculate the angles
@@ -530,7 +530,7 @@ void wxQtDCImpl::DoDrawArc(wxCoord x1, wxCoord y1,
     {
         spanAngle = -spanAngle;
     }
-    
+
     if ( spanAngle == 0 )
         m_qtPainter->drawEllipse( rectangle );
     else
@@ -578,7 +578,7 @@ void wxQtDCImpl::DoDrawRoundedRectangle(wxCoord x, wxCoord y,
     y += penWidth / 2;
     width -= penWidth;
     height -= penWidth;
-    
+
     m_qtPainter->drawRoundedRect( x, y, width, height, radius, radius );
 }
 
@@ -591,7 +591,7 @@ void wxQtDCImpl::DoDrawEllipse(wxCoord x, wxCoord y,
     y += penWidth / 2;
     width -= penWidth;
     height -= penWidth;
-    
+
     if ( m_pen.IsNonTransparent() )
     {
         // Save pen/brush
@@ -620,7 +620,7 @@ void wxQtDCImpl::DoCrossHair(wxCoord x, wxCoord y)
     int left, top, right, bottom;
     inv.map( w, h, &right, &bottom );
     inv.map( 0, 0, &left, &top );
-    
+
     m_qtPainter->drawLine( left, y, right, y );
     m_qtPainter->drawLine( x, top, x, bottom );
 }
@@ -636,18 +636,18 @@ void wxQtDCImpl::DoDrawBitmap(const wxBitmap &bmp, wxCoord x, wxCoord y,
     QPixmap pix = *bmp.GetHandle();
     if (pix.depth() == 1) {
         //Monochrome bitmap, draw using text fore/background
-        
+
         //Save pen/brush
         QBrush savedBrush = m_qtPainter->background();
         QPen savedPen = m_qtPainter->pen();
-        
+
         //Use text colors
         m_qtPainter->setBackground(QBrush(m_textBackgroundColour.GetQColor()));
         m_qtPainter->setPen(QPen(m_textForegroundColour.GetQColor()));
 
         //Draw
         m_qtPainter->drawPixmap(x, y, pix);
-        
+
         //Restore saved settings
         m_qtPainter->setBackground(savedBrush);
         m_qtPainter->setPen(savedPen);
@@ -668,11 +668,11 @@ void wxQtDCImpl::DoDrawText(const wxString& text, wxCoord x, wxCoord y)
     // Disable logical function
     QPainter::CompositionMode savedOp = m_qtPainter->compositionMode();
     m_qtPainter->setCompositionMode( QPainter::CompositionMode_SourceOver );
-    
+
     if (m_backgroundMode == wxSOLID)
     {
         m_qtPainter->setBackgroundMode(Qt::OpaqueMode);
-    
+
         //Save pen/brush
         QBrush savedBrush = m_qtPainter->background();
 
@@ -700,7 +700,7 @@ void wxQtDCImpl::DoDrawRotatedText(const wxString& text,
 {
     if (m_backgroundMode == wxSOLID)
         m_qtPainter->setBackgroundMode(Qt::OpaqueMode);
-    
+
     //Move and rotate (reverse angle direction in Qt and wx)
     m_qtPainter->translate(x, y);
     m_qtPainter->rotate(-angle);
@@ -715,19 +715,19 @@ void wxQtDCImpl::DoDrawRotatedText(const wxString& text,
     if (m_backgroundMode == wxSOLID)
     {
         m_qtPainter->setBackgroundMode(Qt::OpaqueMode);
-        
+
         //Save pen/brush
         QBrush savedBrush = m_qtPainter->background();
-        
+
         //Use text colors
         m_qtPainter->setBackground(QBrush(m_textBackgroundColour.GetQColor()));
-        
+
         //Draw
         m_qtPainter->drawText(x, y, 1, 1, Qt::TextDontClip, wxQtConvertString(text));
-        
+
         //Restore saved settings
         m_qtPainter->setBackground(savedBrush);
-        
+
         m_qtPainter->setBackgroundMode(Qt::TransparentMode);
     }
     else
@@ -749,9 +749,9 @@ bool wxQtDCImpl::DoBlit(wxCoord xdest, wxCoord ydest,
                     wxCoord WXUNUSED(ysrcMask) )
 {
     wxQtDCImpl *implSource = (wxQtDCImpl*)source->GetImpl();
-    
+
     QImage *qtSource = implSource->GetQImage();
-    
+
     // Not a CHECK on purpose
     if ( !qtSource )
         return false;
@@ -763,7 +763,7 @@ bool wxQtDCImpl::DoBlit(wxCoord xdest, wxCoord ydest,
     // Change logical function
     wxRasterOperationMode savedMode = GetLogicalFunction();
     SetLogicalFunction( rop );
-    
+
     m_qtPainter->drawImage( QRect( xdest, ydest, width, height ),
                            qtSourceConverted,
                            QRect( xsrc, ysrc, width, height ) );
@@ -806,7 +806,7 @@ void wxQtDCImpl::DoDrawPolygon(int n, const wxPoint points[],
     }
 
     Qt::FillRule fill = (fillStyle == wxWINDING_RULE) ? Qt::WindingFill : Qt::OddEvenFill;
-    
+
     m_qtPainter->translate(xoffset, yoffset);
     m_qtPainter->drawPolygon(qtPoints, fill);
     // Reset transform

--- a/src/qt/dc.cpp
+++ b/src/qt/dc.cpp
@@ -669,7 +669,7 @@ void wxQtDCImpl::DoDrawText(const wxString& text, wxCoord x, wxCoord y)
     QPainter::CompositionMode savedOp = m_qtPainter->compositionMode();
     m_qtPainter->setCompositionMode( QPainter::CompositionMode_SourceOver );
 
-    if (m_backgroundMode == wxSOLID)
+    if (m_backgroundMode == wxBRUSHSTYLE_SOLID)
     {
         m_qtPainter->setBackgroundMode(Qt::OpaqueMode);
 
@@ -698,7 +698,7 @@ void wxQtDCImpl::DoDrawText(const wxString& text, wxCoord x, wxCoord y)
 void wxQtDCImpl::DoDrawRotatedText(const wxString& text,
                                wxCoord x, wxCoord y, double angle)
 {
-    if (m_backgroundMode == wxSOLID)
+    if (m_backgroundMode == wxBRUSHSTYLE_SOLID)
         m_qtPainter->setBackgroundMode(Qt::OpaqueMode);
 
     //Move and rotate (reverse angle direction in Qt and wx)
@@ -712,7 +712,7 @@ void wxQtDCImpl::DoDrawRotatedText(const wxString& text,
     QPainter::CompositionMode savedOp = m_qtPainter->compositionMode();
     m_qtPainter->setCompositionMode( QPainter::CompositionMode_SourceOver );
 
-    if (m_backgroundMode == wxSOLID)
+    if (m_backgroundMode == wxBRUSHSTYLE_SOLID)
     {
         m_qtPainter->setBackgroundMode(Qt::OpaqueMode);
 

--- a/src/ribbon/art_aui.cpp
+++ b/src/ribbon/art_aui.cpp
@@ -471,7 +471,7 @@ void wxRibbonAUIArtProvider::DrawTab(wxDC& dc,
         if(!label.IsEmpty())
         {
             dc.SetTextForeground(m_tab_label_colour);
-            dc.SetBackgroundMode(wxTRANSPARENT);
+            dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
 
             int offset = 0;
             if(icon.IsOk())

--- a/src/ribbon/art_msw.cpp
+++ b/src/ribbon/art_msw.cpp
@@ -1373,7 +1373,7 @@ void wxRibbonMSWArtProvider::DrawTab(
         {
             dc.SetFont(m_tab_label_font);
             dc.SetTextForeground(m_tab_label_colour);
-            dc.SetBackgroundMode(wxTRANSPARENT);
+            dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
 
             int text_height;
             int text_width;

--- a/src/ribbon/bar.cpp
+++ b/src/ribbon/bar.cpp
@@ -792,7 +792,7 @@ void wxRibbonBar::CommonInit(long style)
     {
         SetArtProvider(new wxRibbonDefaultArtProvider);
     }
-    SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
 
     m_toggle_button_hovered = false;
     m_bar_hovered = false;

--- a/src/ribbon/buttonbar.cpp
+++ b/src/ribbon/buttonbar.cpp
@@ -895,7 +895,7 @@ void wxRibbonButtonBar::CommonInit(long WXUNUSED(style))
     m_lock_active_state = false;
     m_show_tooltips_for_disabled = false;
 
-    SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
 }
 
 void wxRibbonButtonBar::SetShowToolTipsForDisabled(bool show)

--- a/src/ribbon/gallery.cpp
+++ b/src/ribbon/gallery.cpp
@@ -135,7 +135,7 @@ void wxRibbonGallery::CommonInit(long WXUNUSED(style))
     m_extension_button_state = wxRIBBON_GALLERY_BUTTON_NORMAL;
     m_hovered = false;
 
-    SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
 }
 
 void wxRibbonGallery::OnMouseEnter(wxMouseEvent& evt)

--- a/src/ribbon/page.cpp
+++ b/src/ribbon/page.cpp
@@ -82,7 +82,7 @@ wxRibbonPageScrollButton::wxRibbonPageScrollButton(wxRibbonPage* sibling,
                  const wxSize& size,
                  long style) : wxRibbonControl(sibling->GetParent(), id, pos, size, wxBORDER_NONE)
 {
-    SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
     m_sibling = sibling;
     m_flags = (style & wxRIBBON_SCROLL_BTN_DIRECTION_MASK) | wxRIBBON_SCROLL_BTN_FOR_PAGE;
 }
@@ -207,7 +207,7 @@ void wxRibbonPage::CommonInit(const wxString& label, const wxBitmap& icon)
     m_scroll_amount = 0;
     m_scroll_buttons_visible = false;
 
-    SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
 
     wxDynamicCast(GetParent(), wxRibbonBar)->AddPage(this);
 }

--- a/src/ribbon/panel.cpp
+++ b/src/ribbon/panel.cpp
@@ -135,7 +135,7 @@ void wxRibbonPanel::CommonInit(const wxString& label, const wxBitmap& icon, long
     }
 
     SetAutoLayout(true);
-    SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
     SetMinSize(wxSize(20, 20));
 }
 

--- a/src/ribbon/toolbar.cpp
+++ b/src/ribbon/toolbar.cpp
@@ -113,7 +113,7 @@ void wxRibbonToolBar::CommonInit(long WXUNUSED(style))
     m_nrows_max = 1;
     m_sizes = new wxSize[1];
     m_sizes[0] = wxSize(0, 0);
-    SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
 }
 
 wxRibbonToolBar::~wxRibbonToolBar()

--- a/src/richtext/richtextbuffer.cpp
+++ b/src/richtext/richtextbuffer.cpp
@@ -9657,7 +9657,7 @@ bool wxRichTextFieldTypeStandard::Draw(wxRichTextField* obj, wxDC& dc, wxRichTex
             int w, h, maxDescent;
             dc.SetFont(m_font);
             dc.GetTextExtent(m_label, & w, &h, & maxDescent);
-            dc.SetBackgroundMode(wxTRANSPARENT);
+            dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
             dc.SetTextForeground(textColour);
 
             int x = clientArea.x + (clientArea.width - w)/2;

--- a/src/richtext/richtextctrl.cpp
+++ b/src/richtext/richtextctrl.cpp
@@ -878,6 +878,7 @@ void wxRichTextCtrl::OnMoveMouse(wxMouseEvent& event)
                     Refresh(); // This is needed in wxMSW, otherwise resetting the position doesn't 'take'
                     SetCaretPosition(oldPos);
                     SetFocusObject(oldFocus, false);
+                    wxFALLTHROUGH;
                 default: break;
             }
             EndBatchUndo();

--- a/src/richtext/richtextctrl.cpp
+++ b/src/richtext/richtextctrl.cpp
@@ -283,7 +283,7 @@ bool wxRichTextCtrl::Create( wxWindow* parent, wxWindowID id, const wxString& va
     SetDefaultStyle(defaultAttributes);
 
     SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
-    SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
 
     GetBuffer().Reset();
     GetBuffer().SetRichTextCtrl(this);

--- a/src/richtext/richtextctrl.cpp
+++ b/src/richtext/richtextctrl.cpp
@@ -242,7 +242,7 @@ bool wxRichTextCtrl::Create( wxWindow* parent, wxWindowID id, const wxString& va
                              const wxValidator& validator, const wxString& name)
 {
     style |= wxVSCROLL;
-    
+
     // If read-only, the programmer probably wants to retain dialog keyboard navigation.
     // If you don't, then pass wxWANTS_CHARS explicitly.
     if ((style & wxTE_READONLY) == 0)
@@ -2180,7 +2180,7 @@ bool wxRichTextCtrl::MoveRight(int noPositions, int flags)
                 SetFocusObject(actualContainer, false /* don't set caret position yet */);
                 bool caretLineStart = true;
                 long caretPosition = FindCaretPositionForCharacterPosition(newPos, hitTest, actualContainer, caretLineStart);
- 
+
                 SelectNone();
 
                 SetCaretPosition(caretPosition, caretLineStart);
@@ -2511,7 +2511,7 @@ bool wxRichTextCtrl::StartCellSelection(wxRichTextTable* table, wxRichTextParagr
         SetFocusObject(newCell, false /* don't set caret and clear selection */);
     MoveCaret(-1, false);
     SetDefaultStyleToCursorStyle();
-    
+
     return true;
 }
 
@@ -3001,7 +3001,7 @@ void wxRichTextCtrl::SetupScrollbars(bool atTop, bool fromOnPaint)
                 doSetScrollbars = false;
         }
     }
-    
+
     m_lastWindowSize = windowSize;
     m_setupScrollbarsCount ++;
     if (m_setupScrollbarsCount > 32000)

--- a/src/richtext/richtextsymboldlg.cpp
+++ b/src/richtext/richtextsymboldlg.cpp
@@ -797,7 +797,7 @@ bool wxSymbolListCtrl::Create(wxWindow *parent,
     m_colBgSel = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT);
 
     // flicker-free drawing requires this
-    SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    SetBackgroundStyle(wxBG_STYLE_PAINT);
 
     SetFont(*wxNORMAL_FONT);
 

--- a/src/stc/ScintillaWX.cpp
+++ b/src/stc/ScintillaWX.cpp
@@ -117,7 +117,7 @@ public:
 #endif
           m_ct(ct), m_swx(swx), m_cx(wxDefaultCoord), m_cy(wxDefaultCoord)
         {
-            SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+            SetBackgroundStyle(wxBG_STYLE_PAINT);
             SetName("wxSTCCallTip");
         }
 

--- a/src/univ/ctrlrend.cpp
+++ b/src/univ/ctrlrend.cpp
@@ -68,7 +68,7 @@ wxControlRenderer::wxControlRenderer(wxWindow *window,
 
 void wxControlRenderer::DrawLabel()
 {
-    m_dc.SetBackgroundMode(wxTRANSPARENT);
+    m_dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
     m_dc.SetFont(m_window->GetFont());
     m_dc.SetTextForeground(m_window->GetForegroundColour());
 
@@ -89,7 +89,7 @@ void wxControlRenderer::DrawLabel()
 void wxControlRenderer::DrawButtonLabel(const wxBitmap& bitmap,
                                         wxCoord marginX, wxCoord marginY)
 {
-    m_dc.SetBackgroundMode(wxTRANSPARENT);
+    m_dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
     m_dc.SetFont(m_window->GetFont());
     m_dc.SetTextForeground(m_window->GetForegroundColour());
 

--- a/src/univ/notebook.cpp
+++ b/src/univ/notebook.cpp
@@ -475,7 +475,7 @@ void wxNotebook::DoDrawTab(wxDC& dc, const wxRect& rect, size_t n)
         bmp.Create(w, h);
         wxMemoryDC dc;
         dc.SelectObject(bmp);
-        dc.SetBackground(wxBrush(GetBackgroundColour(), wxSOLID));
+        dc.SetBackground(wxBrush(GetBackgroundColour(), wxBRUSHSTYLE_SOLID));
         GetImageList()->Draw(image, dc, 0, 0, wxIMAGELIST_DRAW_NORMAL, true);
         dc.SelectObject(wxNullBitmap);
 #else

--- a/src/univ/stdrend.cpp
+++ b/src/univ/stdrend.cpp
@@ -199,7 +199,7 @@ void wxStdRenderer::DrawButtonSurface(wxDC& dc,
 void
 wxStdRenderer::DrawFocusRect(wxWindow* WXUNUSED(win), wxDC& dc, const wxRect& rect, int WXUNUSED(flags))
 {
-    // draw the pixels manually because the "dots" in wxPen with wxDOT style
+    // draw the pixels manually because the "dots" in wxPen with wxPENSTYLE_DOT style
     // may be short traits and not really dots
     //
     // note that to behave in the same manner as DrawRect(), we must exclude
@@ -774,13 +774,13 @@ void wxStdRenderer::DrawTextLine(wxDC& dc,
                      colBg = dc.GetTextBackground();
             dc.SetTextForeground(wxSCHEME_COLOUR(m_scheme, HIGHLIGHT_TEXT));
             dc.SetTextBackground(wxSCHEME_COLOUR(m_scheme, HIGHLIGHT));
-            dc.SetBackgroundMode(wxSOLID);
+            dc.SetBackgroundMode(wxBRUSHSTYLE_SOLID);
 
             dc.DrawText(s, x, rect.y);
             dc.GetTextExtent(s, &width, NULL);
             x += width;
 
-            dc.SetBackgroundMode(wxTRANSPARENT);
+            dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
             dc.SetTextBackground(colBg);
             dc.SetTextForeground(colFg);
         }

--- a/src/univ/themes/mono.cpp
+++ b/src/univ/themes/mono.cpp
@@ -1060,7 +1060,7 @@ void wxMonoRenderer::DrawScrollbarThumb(wxDC& dc,
 {
     DrawSolidRect(dc, wxMONO_BG_COL, rect);
 
-    // manually draw stipple pattern (wxDFB doesn't implement the wxSTIPPLE
+    // manually draw stipple pattern (wxDFB doesn't implement the wxBRUSHSTYLE_STIPPLE
     // brush style):
     dc.SetPen(m_penFg);
     for ( wxCoord y = rect.GetTop(); y <= rect.GetBottom(); y++ )

--- a/src/unix/fontutil.cpp
+++ b/src/unix/fontutil.cpp
@@ -1317,11 +1317,11 @@ static wxNativeFont wxLoadQueryFont(float pointSize,
     logFont.lfCharSet = MWLF_CHARSET_DEFAULT; // TODO: select appropriate one
     logFont.lfOutPrecision = MWLF_TYPE_DEFAULT;
     logFont.lfClipPrecision = 0; // Not used
-    logFont.lfRoman = (family == wxROMAN ? 1 : 0) ;
-    logFont.lfSerif = (family == wxSWISS ? 0 : 1) ;
+    logFont.lfRoman = (family == wxFONTFAMILY_ROMAN ? 1 : 0) ;
+    logFont.lfSerif = (family == wxFONTFAMILY_SWISS ? 0 : 1) ;
     logFont.lfSansSerif = !logFont.lfSerif ;
-    logFont.lfModern = (family == wxMODERN ? 1 : 0) ;
-    logFont.lfProportional = (family == wxTELETYPE ? 0 : 1) ;
+    logFont.lfModern = (family == wxFONTFAMILY_MODERN ? 1 : 0) ;
+    logFont.lfProportional = (family == wxFONTFAMILY_TELETYPE ? 0 : 1) ;
     logFont.lfOblique = 0;
     logFont.lfSmallCaps = 0;
     logFont.lfPitch = 0; // 0 = default

--- a/src/unix/mediactrl.cpp
+++ b/src/unix/mediactrl.cpp
@@ -1050,7 +1050,7 @@ bool wxGStreamerMediaBackend::CreateControl(wxControl* ctrl, wxWindow* parent,
 
     // don't erase the background of our control window
     // so that resizing is a bit smoother
-    m_ctrl->SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    m_ctrl->SetBackgroundStyle(wxBG_STYLE_PAINT);
 
     // Create our playbin object
     m_playbin = gst_element_factory_make ("playbin", "play");

--- a/src/unix/mediactrl_gstplayer.cpp
+++ b/src/unix/mediactrl_gstplayer.cpp
@@ -309,7 +309,7 @@ bool wxGStreamerMediaBackend::CreateControl(wxControl* ctrl, wxWindow* parent,
 
     // don't erase the background of our control window
     // so that resizing is a bit smoother
-    m_ctrl->SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+    m_ctrl->SetBackgroundStyle(wxBG_STYLE_PAINT);
 
     // Tell gstreamer to play in our window
     gpointer window_handle = NULL;

--- a/src/x11/dc.cpp
+++ b/src/x11/dc.cpp
@@ -33,7 +33,7 @@ wxX11DCImpl::wxX11DCImpl( wxDC *owner ) :
     m_font = *wxNORMAL_FONT;
     m_brush = *wxWHITE_BRUSH;
 
-    m_backgroundMode = wxTRANSPARENT;
+    m_backgroundMode = wxBRUSHSTYLE_TRANSPARENT;
 }
 
 void wxX11DCImpl::DoSetClippingRegion( wxCoord x, wxCoord y, wxCoord width, wxCoord height )

--- a/src/x11/dcclient.cpp
+++ b/src/x11/dcclient.cpp
@@ -1606,7 +1606,7 @@ void wxWindowDCImpl::DoDrawText( const wxString &text, wxCoord x, wxCoord y )
 
     // First draw a rectangle representing the text background, if a text
     // background is specified
-    if (m_textBackgroundColour.IsOk () && (m_backgroundMode != wxTRANSPARENT))
+    if (m_textBackgroundColour.IsOk () && (m_backgroundMode != wxBRUSHSTYLE_TRANSPARENT))
     {
         // Since X draws from the baseline of the text, must add the text height
         int cx = 0;
@@ -1907,35 +1907,35 @@ void wxWindowDCImpl::SetPen( const wxPen &pen )
     int lineStyle = LineSolid;
     switch (m_pen.GetStyle())
     {
-        case wxUSER_DASH:
+        case wxPENSTYLE_USER_DASH:
         {
             lineStyle = LineOnOffDash;
             req_nb_dash = m_pen.GetDashCount();
             req_dash = (wxX11Dash*)m_pen.GetDash();
             break;
         }
-        case wxDOT:
+        case wxPENSTYLE_DOT:
         {
             lineStyle = LineOnOffDash;
             req_nb_dash = 2;
             req_dash = dotted;
             break;
         }
-        case wxLONG_DASH:
+        case wxPENSTYLE_LONG_DASH:
         {
             lineStyle = LineOnOffDash;
             req_nb_dash = 2;
             req_dash = long_dashed;
             break;
         }
-        case wxSHORT_DASH:
+        case wxPENSTYLE_SHORT_DASH:
         {
             lineStyle = LineOnOffDash;
             req_nb_dash = 2;
             req_dash = short_dashed;
             break;
         }
-        case wxDOT_DASH:
+        case wxPENSTYLE_DOT_DASH:
         {
 //            lineStyle = LineDoubleDash;
             lineStyle = LineOnOffDash;
@@ -1944,10 +1944,10 @@ void wxWindowDCImpl::SetPen( const wxPen &pen )
             break;
         }
 
-        case wxTRANSPARENT:
-        case wxSTIPPLE_MASK_OPAQUE:
-        case wxSTIPPLE:
-        case wxSOLID:
+        case wxPENSTYLE_TRANSPARENT:
+        case wxPENSTYLE_STIPPLE_MASK_OPAQUE:
+        case wxPENSTYLE_STIPPLE:
+        case wxPENSTYLE_SOLID:
         default:
         {
             lineStyle = LineSolid;
@@ -2033,7 +2033,7 @@ void wxWindowDCImpl::SetBrush( const wxBrush &brush )
     if (m_brush.IsHatch())
     {
         XSetFillStyle( (Display*) m_display, (GC) m_brushGC, FillStippled );
-        int num = m_brush.GetStyle() - wxBDIAGONAL_HATCH;
+        int num = m_brush.GetStyle() - wxBRUSHSTYLE_BDIAGONAL_HATCH;
         XSetStipple( (Display*) m_display, (GC) m_brushGC, hatches[num] );
     }
 }
@@ -2078,7 +2078,7 @@ void wxWindowDCImpl::SetBackground( const wxBrush &brush )
     if (m_backgroundBrush.IsHatch())
     {
         XSetFillStyle( (Display*) m_display, (GC) m_bgGC, FillStippled );
-        int num = m_backgroundBrush.GetStyle() - wxBDIAGONAL_HATCH;
+        int num = m_backgroundBrush.GetStyle() - wxBRUSHSTYLE_BDIAGONAL_HATCH;
         XSetStipple( (Display*) m_display, (GC) m_bgGC, hatches[num] );
     }
 }
@@ -2203,7 +2203,7 @@ void wxWindowDCImpl::SetBackgroundMode( int mode )
     m_backgroundMode = mode;
 
 #if wxUSE_NANOX
-    GrSetGCUseBackground((GC) m_textGC, mode == wxTRANSPARENT ? FALSE : TRUE);
+    GrSetGCUseBackground((GC) m_textGC, mode == wxBRUSHSTYLE_TRANSPARENT ? FALSE : TRUE);
 #endif
 
     if (!m_x11window) return;
@@ -2214,7 +2214,7 @@ void wxWindowDCImpl::SetBackgroundMode( int mode )
     if (m_brush.GetStyle() != wxBRUSHSTYLE_SOLID && m_brush.GetStyle() != wxBRUSHSTYLE_TRANSPARENT)
     {
         XSetFillStyle( (Display*) m_display, (GC) m_brushGC,
-          (m_backgroundMode == wxTRANSPARENT) ? FillStippled : FillOpaqueStippled );
+          (m_backgroundMode == wxBRUSHSTYLE_TRANSPARENT) ? FillStippled : FillOpaqueStippled );
     }
 }
 

--- a/src/x11/font.cpp
+++ b/src/x11/font.cpp
@@ -316,7 +316,7 @@ void wxFontRefData::InitFromNative()
         m_pointSize = wxDEFAULT_FONT_SIZE;
     }
 
-    // examine the spacing: if the font is monospaced, assume wxTELETYPE
+    // examine the spacing: if the font is monospaced, assume wxFONTFAMILY_TELETYPE
     // family for compatibility with the old code which used it instead of
     // IsFixedWidth()
     if ( m_nativeFontInfo.GetXFontComponent(wxXLFD_SPACING).Upper() == wxT('M') )

--- a/src/x11/textctrl.cpp
+++ b/src/x11/textctrl.cpp
@@ -229,7 +229,7 @@ bool wxTextCtrl::Create( wxWindow *parent,
     m_editable = ((m_windowStyle & wxTE_READONLY) == 0);
 
     if (HasFlag(wxTE_PASSWORD))
-        m_sourceFont = wxFont( 12, wxMODERN, wxNORMAL, wxNORMAL );
+        m_sourceFont = wxFont( 12, wxFONTFAMILY_MODERN, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL );
     else
         m_sourceFont = GetFont();
 
@@ -1711,7 +1711,7 @@ void wxTextCtrl::OnPaint( wxPaintEvent &event )
     GetClientSize( &size_x, &size_y );
 
     dc.SetPen( *wxTRANSPARENT_PEN );
-    dc.SetBrush( wxBrush( wxTHEME_COLOUR(HIGHLIGHT), wxSOLID ) );
+    dc.SetBrush( wxBrush( wxTHEME_COLOUR(HIGHLIGHT), wxBRUSHSTYLE_SOLID ) );
     int upper = wxMin( (int)m_lines.GetCount(), scroll_y+(size_y/m_lineHeight)+2 );
     for (int i = scroll_y; i < upper; i++)
     {

--- a/tests/filename/filenametest.cpp
+++ b/tests/filename/filenametest.cpp
@@ -27,7 +27,7 @@
 
 #ifdef __WINDOWS__
     #include "wx/msw/registry.h"
-    #include <shlobj.h>
+    #include "wx/msw/wrapshl.h"
     #include "wx/msw/ole/oleutils.h"
     #include "wx/msw/private/comptr.h"
 #endif // __WINDOWS__

--- a/tests/graphics/affinematrix.cpp
+++ b/tests/graphics/affinematrix.cpp
@@ -311,7 +311,7 @@ public:
         m_gcdc->SetGraphicsContext(ctx);
     }
 
-    virtual void FlushDC()
+    virtual void FlushDC() wxOVERRIDE
     {
         // Apparently, flushing native Direct2D renderer
         // is not enough to update underlying DC (bitmap)

--- a/tests/graphics/clippingbox.cpp
+++ b/tests/graphics/clippingbox.cpp
@@ -414,7 +414,7 @@ public:
 
     virtual ~ClippingBoxTestCaseGCDCDirect2D() {}
 
-    virtual void FlushDC()
+    virtual void FlushDC() wxOVERRIDE
     {
         // Apparently, flushing native Direct2D renderer
         // is not enough to update underlying DC (bitmap)
@@ -1616,7 +1616,7 @@ public:
 
     virtual ~ClippingBoxTestCaseGCDirect2D() {}
 
-    virtual void FlushGC()
+    virtual void FlushGC() wxOVERRIDE
     {
         // Apparently, flushing native Direct2D renderer
         // is not enough to update underlying DC (bitmap)

--- a/tests/misc/safearrayconverttest.cpp
+++ b/tests/misc/safearrayconverttest.cpp
@@ -126,7 +126,7 @@ void SafeArrayConvertTestCase::VariantListReturnSafeArray()
     wxVariantDataSafeArray*
         vsa = wxStaticCastVariantData(variantCopy.GetData(),
                                       wxVariantDataSafeArray);
-    long bound;
+    long bound wxDUMMY_INITIALIZE(0);
 
     CPPUNIT_ASSERT( vsa );
     CPPUNIT_ASSERT( safeArray.Attach(vsa->GetValue()) );
@@ -177,7 +177,7 @@ void SafeArrayConvertTestCase::StringsReturnSafeArray()
     wxVariantDataSafeArray*
         vsa = wxStaticCastVariantData(variant.GetData(),
                                       wxVariantDataSafeArray);
-    long bound;
+    long bound wxDUMMY_INITIALIZE(0);
 
     CPPUNIT_ASSERT( vsa );
     CPPUNIT_ASSERT( safeArray.Attach(vsa->GetValue()) );

--- a/tests/regex/regextest.cpp
+++ b/tests/regex/regextest.cpp
@@ -204,7 +204,7 @@ void RegExTestCase::parseFlags(const wxString& flags)
             case 'i': m_compileFlags |= wxRE_ICASE; break;
             case 'o': m_compileFlags |= wxRE_NOSUB; break;
             case 'n': m_compileFlags |= wxRE_NEWLINE; break;
-            case 't': if (strchr("ep", m_mode)) break; // else fall through...
+            case 't': if (strchr("ep", m_mode)) break; wxFALLTHROUGH;
 
             // anything else we must skip the test
             default:


### PR DESCRIPTION
Fix some warnings from clang on Windows (with `-Weverything`).

Replace deprecated values with their replacement.