### PR TITLE
Rotate wxNotebook tabs under wxGTK to match wxMSW and wxOSX/Cocoa

### DIFF
--- a/src/gtk/notebook.cpp
+++ b/src/gtk/notebook.cpp
@@ -454,6 +454,12 @@ bool wxNotebook::InsertPage( size_t position,
 
     /* set the label text */
     pageData->m_label = gtk_label_new(wxGTK_CONV(wxStripMenuCodes(text)));
+
+    if (m_windowStyle & wxBK_LEFT)
+        gtk_label_set_angle(GTK_LABEL(pageData->m_label), 90);
+    if (m_windowStyle & wxBK_RIGHT)
+        gtk_label_set_angle(GTK_LABEL(pageData->m_label), 270);
+
     gtk_box_pack_end(GTK_BOX(pageData->m_box),
         pageData->m_label, false, false, m_padding);
 


### PR DESCRIPTION
This commit rotates the wxNotebook tabs when using wxNB_LEFT or wxNB_RIGHT so that they are drawn vertically, as they are on Windows and OS X.

Is this the right way to do this, or should it instead add a new wxGTK-specific style bit to enable this behaviour, or on some other case?

Test code and screenshots are here: http://www.solemnwarning.net/junk/gtk-notebook-vert/