### PR TITLE
Fix WxQt label tests for StaticText and wxCheckBox

### DIFF
--- a/include/wx/qt/checkbox.h
+++ b/include/wx/qt/checkbox.h
@@ -34,6 +34,9 @@ public:
 
     virtual QWidget *GetHandle() const;
 
+    virtual void SetLabel(const wxString& label) wxOVERRIDE;
+    virtual wxString GetLabel() const wxOVERRIDE;
+
 protected:
     virtual void DoSet3StateValue(wxCheckBoxState state);
     virtual wxCheckBoxState DoGet3StateValue() const;

--- a/include/wx/qt/stattext.h
+++ b/include/wx/qt/stattext.h
@@ -30,9 +30,11 @@ public:
                 long style = 0,
                 const wxString &name = wxStaticTextNameStr );
 
-    void SetLabel(const wxString& label);
+    virtual void SetLabel(const wxString& label) wxOVERRIDE;
 
     virtual QWidget *GetHandle() const;
+
+    virtual wxString GetLabel() const wxOVERRIDE;
 
 private:
     QLabel *m_qtLabel;

--- a/src/qt/checkbox.cpp
+++ b/src/qt/checkbox.cpp
@@ -130,3 +130,14 @@ QWidget *wxCheckBox::GetHandle() const
 {
     return m_qtCheckBox;
 }
+
+wxString wxCheckBox::GetLabel() const
+{
+    return wxQtConvertString( m_qtCheckBox->text() );
+}
+
+void wxCheckBox::SetLabel(const wxString& label)
+{
+    m_qtCheckBox->setText( wxQtConvertString(label) );
+}
+

--- a/src/qt/stattext.cpp
+++ b/src/qt/stattext.cpp
@@ -62,6 +62,11 @@ void wxStaticText::SetLabel(const wxString& label)
     m_qtLabel->setText( wxQtConvertString( label ) );
 }
 
+wxString wxStaticText::GetLabel() const
+{
+    return wxQtConvertString( m_qtLabel->text() );
+}
+
 QWidget *wxStaticText::GetHandle() const
 {
     return m_qtLabel;


### PR DESCRIPTION
Implementations were just missing for these, so tests were failing.