### PR TITLE
Fixed mapping of wxFontStyle to QStyle for fonts

### DIFF
--- a/src/qt/font.cpp
+++ b/src/qt/font.cpp
@@ -471,16 +471,14 @@ void wxNativeFontInfo::SetStyle(wxFontStyle style)
 {
     switch(style)
     {
-        case( wxFONTSTYLE_ITALIC ):
-            m_qtFont.setItalic(true);
+        case wxFONTSTYLE_ITALIC:
+            m_qtFont.setStyle(QFont::StyleItalic);
             break;
-        case( wxFONTSTYLE_NORMAL ):
+        case wxFONTSTYLE_NORMAL:
             m_qtFont.setStyle(QFont::StyleNormal);
             break;
-        case( wxFONTSTYLE_SLANT ):
+        case wxFONTSTYLE_SLANT:
             m_qtFont.setStyle(QFont::StyleOblique);
-            break;
-        default:
             break;
     }
 }

--- a/src/qt/font.cpp
+++ b/src/qt/font.cpp
@@ -469,9 +469,20 @@ void wxNativeFontInfo::SetPixelSize(const wxSize& size)
 
 void wxNativeFontInfo::SetStyle(wxFontStyle style)
 {
-    m_qtFont.setItalic(style == wxFONTSTYLE_ITALIC);
-//case wxFONTSTYLE_SLANT:
-//case wxFONTSTYLE_NORMAL:
+    switch(style)
+    {
+        case( wxFONTSTYLE_ITALIC ):
+            m_qtFont.setItalic(true);
+            break;
+        case( wxFONTSTYLE_NORMAL ):
+            m_qtFont.setStyle(QFont::StyleNormal);
+            break;
+        case( wxFONTSTYLE_SLANT ):
+            m_qtFont.setStyle(QFont::StyleOblique);
+            break;
+        default:
+            break;
+    }
 }
 
 void wxNativeFontInfo::SetNumericWeight(int weight)


### PR DESCRIPTION
Small change to add mapping of some other font styles between Wx and Qt. Fixes a test case.