### PR TITLE
Enable/Disable pages in wxToolbook

### DIFF
--- a/include/wx/toolbook.h
+++ b/include/wx/toolbook.h
@@ -92,6 +92,10 @@ public:
     // get the underlying toolbar
     wxToolBarBase* GetToolBar() const { return (wxToolBarBase*)m_bookctrl; }
 
+    // enable/disable a page
+    bool EnablePage(wxWindow *page, bool enable);
+    bool EnablePage(size_t page, bool enable);
+
     // must be called in OnIdle or by application to realize the toolbar and
     // select the initial page.
     void Realize();

--- a/interface/wx/toolbook.h
+++ b/interface/wx/toolbook.h
@@ -82,5 +82,33 @@ public:
         Returns the wxToolBarBase associated with the control.
     */
     wxToolBarBase* GetToolBar() const;
+    
+    /**
+       Enables or disables the specified page. Icons for disabled pages are created by
+       wxBitmap::ConvertToDisabled().
+       
+       @param page The index of the page
+       @param enable @true to enable the page and @false to disable it.
+       
+       @return @true if successful, @false otherwise.
+       
+       @since 3.1.2
+    */
+    bool EnablePage(size_t page, bool enable);
+    
+   /**
+       Enables or disables the specified page. Icons for disabled pages are created by
+       wxBitmap::ConvertToDisabled().
+       
+       @param page Pointer of a page windows inside the book control.
+       @param enable @true to enable the page and @false to disable it.
+       
+       @return @true if successful, @false otherwise.
+       
+       @since 3.1.2
+    */
+    bool EnablePage(wxWindow *page, bool enable);
+    
+    
 };
 

--- a/interface/wx/toolbook.h
+++ b/interface/wx/toolbook.h
@@ -86,9 +86,11 @@ public:
     /**
        Enables or disables the specified page. Icons for disabled pages are created by
        wxBitmap::ConvertToDisabled().
-       
-       @param page The index of the page
-       @param enable @true to enable the page and @false to disable it.
+
+       @param page
+            The index of the page
+       @param enable
+            @true to enable the page and @false to disable it.
        
        @return @true if successful, @false otherwise.
        
@@ -100,15 +102,15 @@ public:
        Enables or disables the specified page. Icons for disabled pages are created by
        wxBitmap::ConvertToDisabled().
        
-       @param page Pointer of a page windows inside the book control.
-       @param enable @true to enable the page and @false to disable it.
+       @param page
+            Pointer of a page windows inside the book control.
+       @param enable
+            @true to enable the page and @false to disable it.
        
        @return @true if successful, @false otherwise.
        
        @since 3.1.2
     */
-    bool EnablePage(wxWindow *page, bool enable);
-    
-    
+    bool EnablePage(wxWindow *page, bool enable);    
 };
 

--- a/src/generic/toolbkg.cpp
+++ b/src/generic/toolbkg.cpp
@@ -167,7 +167,9 @@ bool wxToolbook::SetPageImage(size_t n, int imageId)
     if (!GetImageList())
         return false;
 
-    GetToolBar()->SetToolNormalBitmap(n + 1, GetImageList()->GetBitmap(imageId));
+    wxBitmap bmp = GetImageList()->GetBitmap(imageId);
+    GetToolBar()->SetToolNormalBitmap(n + 1, bmp);
+    GetToolBar()->SetToolDisabledBitmap(n + 1, bmp.ConvertToDisabled());
 
     return true;
 }
@@ -301,7 +303,7 @@ bool wxToolbook::InsertPage(size_t n,
     m_maxBitmapSize.y = wxMax(bitmap.GetHeight(), m_maxBitmapSize.y);
 
     GetToolBar()->SetToolBitmapSize(m_maxBitmapSize);
-    GetToolBar()->AddRadioTool(n + 1, text, bitmap, wxNullBitmap, text);
+    GetToolBar()->AddRadioTool(n + 1, text, bitmap, bitmap.ConvertToDisabled(), text);
 
     if (bSelect)
     {
@@ -334,6 +336,25 @@ bool wxToolbook::DeleteAllPages()
 {
     GetToolBar()->ClearTools();
     return wxBookCtrlBase::DeleteAllPages();
+}
+
+bool wxToolbook::EnablePage(size_t page, bool enable)
+{
+    GetToolBar()->EnableTool(page + 1, enable);
+    if (!enable && GetSelection() == (int)page) {
+        AdvanceSelection();
+    }
+    return true;
+}
+
+bool wxToolbook::EnablePage(wxWindow *page, bool enable)
+{
+    int pageIndex = FindPage(page);
+    if (pageIndex == wxNOT_FOUND) {
+        return false;
+    }
+
+    return EnablePage(pageIndex, enable);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/generic/toolbkg.cpp
+++ b/src/generic/toolbkg.cpp
@@ -341,7 +341,8 @@ bool wxToolbook::DeleteAllPages()
 bool wxToolbook::EnablePage(size_t page, bool enable)
 {
     GetToolBar()->EnableTool(page + 1, enable);
-    if (!enable && GetSelection() == (int)page) {
+    if (!enable && GetSelection() == (int)page)
+    {
         AdvanceSelection();
     }
     return true;
@@ -350,10 +351,10 @@ bool wxToolbook::EnablePage(size_t page, bool enable)
 bool wxToolbook::EnablePage(wxWindow *page, bool enable)
 {
     int pageIndex = FindPage(page);
-    if (pageIndex == wxNOT_FOUND) {
+    if (pageIndex == wxNOT_FOUND)
+    {
         return false;
     }
-
     return EnablePage(pageIndex, enable);
 }
 


### PR DESCRIPTION
Functions to enable and disable pages inside toolbooks. Disabled icons are created through ConvertToDisabled(). With this functionality you can present disabled icons so that the user can expect more functionality and you do not need to add/remove pages in different states.