### PR TITLE
Fix wxWindowQt::SetAcceleratorTable() crash

### DIFF
--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -936,13 +936,17 @@ void wxWindowQt::SetAcceleratorTable( const wxAcceleratorTable& accel )
 {
     wxWindowBase::SetAcceleratorTable( accel );
 
-    // Disable previously set accelerators
-    while ( !m_qtShortcuts->isEmpty() )
-        delete m_qtShortcuts->takeFirst();
 
-    // Create new shortcuts (use GetHandle() so all events inside
-    // the window are handled, not only in the container subwindow)
-    delete m_qtShortcuts;
+    if(m_qtShortcuts)
+    {
+        // Disable previously set accelerators
+        while ( !m_qtShortcuts->isEmpty() )
+            delete m_qtShortcuts->takeFirst();
+        // Create new shortcuts (use GetHandle() so all events inside
+        // the window are handled, not only in the container subwindow)
+        delete m_qtShortcuts;
+    }
+
     m_qtShortcuts = accel.ConvertShortcutTable( GetHandle() );
 
     // Connect shortcuts to window

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -935,8 +935,7 @@ bool wxWindowQt::DoPopupMenu(wxMenu *menu, int x, int y)
 void wxWindowQt::SetAcceleratorTable( const wxAcceleratorTable& accel )
 {
     wxWindowBase::SetAcceleratorTable( accel );
-
-
+    
     if(m_qtShortcuts)
     {
         // Disable previously set accelerators


### PR DESCRIPTION
The m_qtShortcuts member is initialised to null and this method is the only place it's assigned. So it makes sense to check whether the pointer is valid before deleting, and also this passes an existing (crashing) test.