### PR TITLE
When creating a QSpinBox, set the range before setting the initial value

### DIFF
--- a/src/qt/spinctrl.cpp
+++ b/src/qt/spinctrl.cpp
@@ -42,8 +42,8 @@ bool wxSpinCtrlQt< T, Widget >::Create( wxWindow *parent, wxWindowID id,
 
     m_qtSpinBox->setAccelerated(true); // to match gtk behavior
 
-    SetValue( initial );
     SetRange( min, max );
+    SetValue( initial );
     SetIncrement( inc );
 
     if ( !value.IsEmpty() )


### PR DESCRIPTION
We need to do this as setting a value out of QSpinBox's default range (0,99) will not work. The test SpinCtrlTestCase `Initial()` captures this and this change passes the assertion on line 91 of spinctrltest.cpp where previously it failed.