### PR TITLE
Set QProgressBar initial value to zero.

### DIFF
--- a/src/qt/gauge.cpp
+++ b/src/qt/gauge.cpp
@@ -58,6 +58,7 @@ bool wxGauge::Create(wxWindow *parent,
     m_qtProgressBar->setOrientation( wxQtConvertOrientation( style, wxGA_HORIZONTAL ));
     m_qtProgressBar->setRange( 0, range );
     m_qtProgressBar->setTextVisible( style & wxGA_TEXT );
+    m_qtProgressBar->setValue(0);
 
     return QtCreateControl( parent, id, pos, size, style, validator, name );
 }


### PR DESCRIPTION
The tests in `GaugeTestCase::Value` indicate that the `wxGauge` default value should be 0, however the default value of a `QProgressBar` is -1, and therefore that test case was failing. That behaviour is now fixed.