### PR TITLE
Fixes to allow using wxGCDC without display

### DIFF
--- a/include/wx/dc.h
+++ b/include/wx/dc.h
@@ -686,6 +686,16 @@ protected:
     // for rendering on higher-resolution DCs such as printer ones
     static float GetFontPointSizeAdjustment(float dpi);
 
+    // Return the number of pixels per mm in the horizontal and vertical
+    // directions, respectively.
+    //
+    // If the physical size of the DC is not known, or doesn't make sense, as
+    // for a SVG DC, for example, a fixed value corresponding to the standard
+    // DPI is used.
+    double GetMMToPXx() const;
+    double GetMMToPXy() const;
+
+
     // window on which the DC draws or NULL
     wxWindow   *m_window;
 
@@ -715,9 +725,12 @@ protected:
     
     double m_contentScaleFactor; // used by high resolution displays (retina)
 
-    // what is a mm on a screen you don't know the size of?
-    double       m_mm_to_pix_x,
-                 m_mm_to_pix_y;
+    // Pixel per mm in horizontal and vertical directions.
+    //
+    // These variables are computed on demand by GetMMToPX[xy]() functions,
+    // don't access them directly other than for assigning to them.
+    mutable double m_mm_to_pix_x,
+                   m_mm_to_pix_y;
 
     // bounding and clipping boxes
     wxCoord m_minX, m_minY, m_maxX, m_maxY; // Bounding box is stored in device units.

--- a/include/wx/dcgraph.h
+++ b/include/wx/dcgraph.h
@@ -60,6 +60,10 @@ public:
 #if defined(__WXMSW__) && wxUSE_ENH_METAFILE
     wxGCDCImpl( wxDC *owner, const wxEnhMetaFileDC& dc );
 #endif
+
+    // Ctor using an existing graphics context given to wxGCDC ctor.
+    wxGCDCImpl(wxDC *owner, wxGraphicsContext* context);
+
     wxGCDCImpl( wxDC *owner );
 
     virtual ~wxGCDCImpl();

--- a/include/wx/dfb/dc.h
+++ b/include/wx/dfb/dc.h
@@ -157,8 +157,6 @@ private:
 protected:
     wxIDirectFBSurfacePtr m_surface;
 
-    double            m_mm_to_pix_x, m_mm_to_pix_y;
-
     friend class WXDLLIMPEXP_FWD_CORE wxOverlayImpl; // for Init
 
     wxDECLARE_ABSTRACT_CLASS(wxDFBDCImpl);

--- a/interface/wx/dcgraph.h
+++ b/interface/wx/dcgraph.h
@@ -40,6 +40,10 @@ public:
 
     /**
        Construct a wxGCDC from an existing graphics context.
+
+       Note that this object takes ownership of @a context and will delete it
+       when it is destroyed or when SetGraphicsContext() is called with a
+       different context object.
     */
     wxGCDC(wxGraphicsContext* context);
 
@@ -64,8 +68,11 @@ public:
 
     /**
        Set the graphics context to be used for this wxGCDC.
+
+       Note that this object takes ownership of @a context and will delete it when
+       it is destroyed or when SetGraphicsContext() is called again.
     */
-    void SetGraphicsContext( wxGraphicsContext* ctx );
+    void SetGraphicsContext(wxGraphicsContext* context);
 
 };
 

--- a/src/common/dcbase.cpp
+++ b/src/common/dcbase.cpp
@@ -331,6 +331,7 @@ wxDCImpl::wxDCImpl( wxDC *owner )
         , m_scaleX(1.0), m_scaleY(1.0)
         , m_signX(1), m_signY(1)
         , m_contentScaleFactor(1)
+        , m_mm_to_pix_x(0.0), m_mm_to_pix_y(0.0)
         , m_minX(0), m_minY(0), m_maxX(0), m_maxY(0)
         , m_clipX1(0), m_clipY1(0), m_clipX2(0), m_clipY2(0)
         , m_logicalFunction(wxCOPY)
@@ -348,11 +349,6 @@ wxDCImpl::wxDCImpl( wxDC *owner )
 #endif // wxUSE_PALETTE
 {
     m_owner = owner;
-
-    m_mm_to_pix_x = (double)wxGetDisplaySize().GetWidth() /
-                    (double)wxGetDisplaySizeMM().GetWidth();
-    m_mm_to_pix_y = (double)wxGetDisplaySize().GetHeight() /
-                    (double)wxGetDisplaySizeMM().GetHeight();
 }
 
 wxDCImpl::~wxDCImpl()
@@ -517,16 +513,16 @@ void wxDCImpl::SetMapMode( wxMappingMode mode )
     switch (mode)
     {
         case wxMM_TWIPS:
-          SetLogicalScale( twips2mm*m_mm_to_pix_x, twips2mm*m_mm_to_pix_y );
+          SetLogicalScale( twips2mm*GetMMToPXx(), twips2mm*GetMMToPXy() );
           break;
         case wxMM_POINTS:
-          SetLogicalScale( pt2mm*m_mm_to_pix_x, pt2mm*m_mm_to_pix_y );
+          SetLogicalScale( pt2mm*GetMMToPXx(), pt2mm*GetMMToPXy() );
           break;
         case wxMM_METRIC:
-          SetLogicalScale( m_mm_to_pix_x, m_mm_to_pix_y );
+          SetLogicalScale( GetMMToPXx(), GetMMToPXy() );
           break;
         case wxMM_LOMETRIC:
-          SetLogicalScale( m_mm_to_pix_x/10.0, m_mm_to_pix_y/10.0 );
+          SetLogicalScale( GetMMToPXx()/10.0, GetMMToPXy()/10.0 );
           break;
         default:
         case wxMM_TEXT:
@@ -1440,4 +1436,26 @@ float wxDCImpl::GetFontPointSizeAdjustment(float dpi)
     // ports need to emulate this bug too:
     const wxSize screenPPI = wxGetDisplayPPI();
     return float(screenPPI.y) / dpi;
+}
+
+double wxDCImpl::GetMMToPXx() const
+{
+    if ( wxIsNullDouble(m_mm_to_pix_x) )
+    {
+        m_mm_to_pix_x = (double)wxGetDisplaySize().GetWidth() /
+                        (double)wxGetDisplaySizeMM().GetWidth();
+    }
+
+    return m_mm_to_pix_x;
+}
+
+double wxDCImpl::GetMMToPXy() const
+{
+    if ( wxIsNullDouble(m_mm_to_pix_x) )
+    {
+        m_mm_to_pix_y = (double)wxGetDisplaySize().GetHeight() /
+                        (double)wxGetDisplaySizeMM().GetHeight();
+    }
+
+    return m_mm_to_pix_y;
 }

--- a/src/common/dcgraph.cpp
+++ b/src/common/dcgraph.cpp
@@ -106,9 +106,8 @@ wxGCDC::wxGCDC(const wxEnhMetaFileDC& dc)
 #endif
 
 wxGCDC::wxGCDC(wxGraphicsContext* context) :
-    wxDC( new wxGCDCImpl( this ) )
+    wxDC(new wxGCDCImpl(this, context))
 {
-    SetGraphicsContext(context);
 }
 
 wxGCDC::wxGCDC() :
@@ -121,6 +120,12 @@ wxGCDC::~wxGCDC()
 }
 
 wxIMPLEMENT_ABSTRACT_CLASS(wxGCDCImpl, wxDCImpl);
+
+wxGCDCImpl::wxGCDCImpl(wxDC *owner, wxGraphicsContext* context) :
+    wxDCImpl(owner)
+{
+    Init(context);
+}
 
 wxGCDCImpl::wxGCDCImpl( wxDC *owner ) :
    wxDCImpl( owner )

--- a/src/common/dcgraph.cpp
+++ b/src/common/dcgraph.cpp
@@ -390,9 +390,9 @@ void wxGCDCImpl::DoGetSizeMM( int* width, int* height ) const
 
     GetOwner()->GetSize( &w, &h );
     if (width)
-        *width = long( double(w) / (m_scaleX * m_mm_to_pix_x) );
+        *width = long( double(w) / (m_scaleX * GetMMToPXx()) );
     if (height)
-        *height = long( double(h) / (m_scaleY * m_mm_to_pix_y) );
+        *height = long( double(h) / (m_scaleY * GetMMToPXy()) );
 }
 
 void wxGCDCImpl::SetTextForeground( const wxColour &col )

--- a/src/common/dcsvg.cpp
+++ b/src/common/dcsvg.cpp
@@ -442,10 +442,10 @@ wxSVGFileDCImpl::~wxSVGFileDCImpl()
 void wxSVGFileDCImpl::DoGetSizeMM(int *width, int *height) const
 {
     if (width)
-        *width = wxRound( (double)m_width / m_mm_to_pix_x );
+        *width = wxRound( (double)m_width / GetMMToPXx() );
 
     if (height)
-        *height = wxRound( (double)m_height / m_mm_to_pix_y );
+        *height = wxRound( (double)m_height / GetMMToPXy() );
 }
 
 wxSize wxSVGFileDCImpl::GetPPI() const

--- a/src/dfb/dc.cpp
+++ b/src/dfb/dc.cpp
@@ -51,11 +51,6 @@ void wxDFBDCImpl::DFBInit(const wxIDirectFBSurfacePtr& surface)
 
     wxCHECK_RET( surface != NULL, "invalid surface" );
 
-    m_mm_to_pix_x = (double)wxGetDisplaySize().GetWidth() /
-                    (double)wxGetDisplaySizeMM().GetWidth();
-    m_mm_to_pix_y = (double)wxGetDisplaySize().GetHeight() /
-                    (double)wxGetDisplaySizeMM().GetHeight();
-
     SetFont(DEFAULT_FONT);
     SetPen(DEFAULT_PEN);
     SetBrush(DEFAULT_BRUSH);

--- a/src/dfb/dc.cpp
+++ b/src/dfb/dc.cpp
@@ -563,15 +563,15 @@ void wxDFBDCImpl::DoGetSizeMM(int *width, int *height) const
     int w = 0;
     int h = 0;
     GetSize(&w, &h);
-    if ( width ) *width = int(double(w) / (m_userScaleX*m_mm_to_pix_x));
-    if ( height ) *height = int(double(h) / (m_userScaleY*m_mm_to_pix_y));
+    if ( width ) *width = int(double(w) / (m_userScaleX*GetMMToPXx()));
+    if ( height ) *height = int(double(h) / (m_userScaleY*GetMMToPXy()));
 }
 
 wxSize wxDFBDCImpl::GetPPI() const
 {
     #warning "move this to common code?"
-    return wxSize(int(double(m_mm_to_pix_x) * inches2mm),
-                  int(double(m_mm_to_pix_y) * inches2mm));
+    return wxSize(int(double(GetMMToPXx()) * inches2mm),
+                  int(double(GetMMToPXy()) * inches2mm));
 }
 
 

--- a/src/gtk/dc.cpp
+++ b/src/gtk/dc.cpp
@@ -506,8 +506,8 @@ void wxGTKDCImpl::DoGetSizeMM( int* width, int* height ) const
     int w = 0;
     int h = 0;
     GetOwner()->GetSize( &w, &h );
-    if (width) *width = int( double(w) / (m_userScaleX*m_mm_to_pix_x) );
-    if (height) *height = int( double(h) / (m_userScaleY*m_mm_to_pix_y) );
+    if (width) *width = int( double(w) / (m_userScaleX*GetMMToPXx()) );
+    if (height) *height = int( double(h) / (m_userScaleY*GetMMToPXy()) );
 }
 
 // Resolution in pixels per logical inch

--- a/src/gtk/dcclient.cpp
+++ b/src/gtk/dcclient.cpp
@@ -2072,7 +2072,7 @@ void wxWindowDCImpl::ComputeScaleAndOrigin()
 // Resolution in pixels per logical inch
 wxSize wxWindowDCImpl::GetPPI() const
 {
-    return wxSize( (int) (m_mm_to_pix_x * 25.4 + 0.5), (int) (m_mm_to_pix_y * 25.4 + 0.5));
+    return wxSize( (int) (GetMMToPXx() * 25.4 + 0.5), (int) (GetMMToPXy() * 25.4 + 0.5));
 }
 
 int wxWindowDCImpl::GetDepth() const

--- a/src/gtk1/dc.cpp
+++ b/src/gtk1/dc.cpp
@@ -50,8 +50,8 @@ void wxGTKDCImpl::DoGetSizeMM( int* width, int* height ) const
     int w = 0;
     int h = 0;
     GetSize( &w, &h );
-    if (width) *width = int( double(w) / (m_userScaleX*m_mm_to_pix_x) );
-    if (height) *height = int( double(h) / (m_userScaleY*m_mm_to_pix_y) );
+    if (width) *width = int( double(w) / (m_userScaleX*GetMMToPXx()) );
+    if (height) *height = int( double(h) / (m_userScaleY*GetMMToPXy()) );
 }
 
 // Resolution in pixels per logical inch

--- a/src/gtk1/dcclient.cpp
+++ b/src/gtk1/dcclient.cpp
@@ -2113,7 +2113,7 @@ void wxWindowDCImpl::ComputeScaleAndOrigin()
 // Resolution in pixels per logical inch
 wxSize wxWindowDCImpl::GetPPI() const
 {
-    return wxSize( (int) (m_mm_to_pix_x * 25.4 + 0.5), (int) (m_mm_to_pix_y * 25.4 + 0.5));
+    return wxSize( (int) (GetMMToPXx() * 25.4 + 0.5), (int) (GetMMToPXy() * 25.4 + 0.5));
 }
 
 int wxWindowDCImpl::GetDepth() const

--- a/src/motif/dc.cpp
+++ b/src/motif/dc.cpp
@@ -87,9 +87,9 @@ void wxMotifDCImpl::DoGetSizeMM( int* width, int* height ) const
     GetSize( &w, &h );
 
     if ( width )
-        *width = int( double(w) / (m_scaleX*m_mm_to_pix_x) );
+        *width = int( double(w) / (m_scaleX*GetMMToPXx()) );
     if ( height )
-        *height = int( double(h) / (m_scaleY*m_mm_to_pix_y) );
+        *height = int( double(h) / (m_scaleY*GetMMToPXy()) );
 }
 
 // Resolution in pixels per logical inch

--- a/src/x11/dc.cpp
+++ b/src/x11/dc.cpp
@@ -51,9 +51,9 @@ void wxX11DCImpl::DoGetSizeMM( int* width, int* height ) const
     DoGetSize( &w, &h );
 
     if ( width )
-        *width = int( double(w) / (m_scaleX*m_mm_to_pix_x) );
+        *width = int( double(w) / (m_scaleX*GetMMToPXx()) );
     if ( height )
-        *height = int( double(h) / (m_scaleY*m_mm_to_pix_y) );
+        *height = int( double(h) / (m_scaleY*GetMMToPXy()) );
 }
 
 // Resolution in pixels per logical inch


### PR DESCRIPTION
It was already possible to use `wxGraphicsContext` on a headless system, but a few things prevented `wxGCDC` from being usable. This PR fixes them and improves a couple of related things.