### PR TITLE
Qt bitmap crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -475,3 +475,6 @@
 
 # /utils/wxrc/
 /utils/wxrc/*.sln
+
+#Jetbrains CLion metadata folder
+.idea

--- a/include/wx/qt/bitmap.h
+++ b/include/wx/qt/bitmap.h
@@ -15,6 +15,7 @@ class WXDLLIMPEXP_FWD_CORE wxCursor;
 class QImage;
 
 class QPixmap;
+class QImage;
 class QBitmap;
 
 class WXDLLIMPEXP_CORE wxBitmap : public wxBitmapBase
@@ -22,6 +23,7 @@ class WXDLLIMPEXP_CORE wxBitmap : public wxBitmapBase
 public:
     wxBitmap();
     wxBitmap(QPixmap pix);
+		wxBitmap(QImage image);
     wxBitmap(const wxBitmap& bmp);
     wxBitmap(const char bits[], int width, int height, int depth = 1);
     wxBitmap(int width, int height, int depth = wxBITMAP_SCREEN_DEPTH);
@@ -79,7 +81,7 @@ public:
     // disappear in the future
     bool HasAlpha() const;
 
-    QPixmap *GetHandle() const;
+    QImage *GetHandle() const;
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const;

--- a/include/wx/qt/bitmap.h
+++ b/include/wx/qt/bitmap.h
@@ -23,7 +23,7 @@ class WXDLLIMPEXP_CORE wxBitmap : public wxBitmapBase
 public:
     wxBitmap();
     wxBitmap(QPixmap pix);
-		wxBitmap(QImage image);
+    wxBitmap(QImage image);
     wxBitmap(const wxBitmap& bmp);
     wxBitmap(const char bits[], int width, int height, int depth = 1);
     wxBitmap(int width, int height, int depth = wxBITMAP_SCREEN_DEPTH);

--- a/include/wx/qt/dc.h
+++ b/include/wx/qt/dc.h
@@ -9,7 +9,6 @@
 #define _WX_QT_DC_H_
 
 class QPainter;
-class QImage;
 
 class WXDLLIMPEXP_FWD_CORE wxRegion;
 
@@ -111,11 +110,7 @@ public:
     virtual void* GetHandle() const { return (void*) m_qtPainter; }
 
 protected:
-    virtual QImage *GetQImage() { return m_qtImage; }
-    
     QPainter *m_qtPainter;
-    QImage *m_qtImage;
-
     wxRegion *m_clippingRegion;
 private:
     enum wxQtRasterColourOp

--- a/include/wx/qt/dcmemory.h
+++ b/include/wx/qt/dcmemory.h
@@ -18,11 +18,12 @@ public:
     wxMemoryDCImpl( wxMemoryDC *owner, wxDC *dc );
     ~wxMemoryDCImpl();
 
-    virtual wxBitmap DoGetAsBitmap(const wxRect *subrect) const;
-    virtual void DoSelect(const wxBitmap& bitmap);
+    virtual wxBitmap DoGetAsBitmap(const wxRect *subrect) const wxOVERRIDE;
+    virtual void DoSelect(const wxBitmap& bitmap) wxOVERRIDE;
+    virtual bool DoGetPixel(wxCoord x, wxCoord y, wxColour *col) const wxOVERRIDE;
 
-    virtual const wxBitmap& GetSelectedBitmap() const;
-    virtual wxBitmap& GetSelectedBitmap();
+    virtual const wxBitmap& GetSelectedBitmap() const wxOVERRIDE;
+    virtual wxBitmap& GetSelectedBitmap() wxOVERRIDE;
 
 private:
     wxBitmap m_selected;

--- a/include/wx/qt/dcscreen.h
+++ b/include/wx/qt/dcscreen.h
@@ -14,14 +14,10 @@ class WXDLLIMPEXP_CORE wxScreenDCImpl : public wxWindowDCImpl
 {
 public:
     wxScreenDCImpl( wxScreenDC *owner );
-
     ~wxScreenDCImpl();
 
 protected:
     virtual void DoGetSize(int *width, int *height) const wxOVERRIDE;
-    virtual bool DoGetPixel(wxCoord x, wxCoord y, wxColour *col) const;
-
-    virtual QImage *GetQImage();
 
     wxDECLARE_ABSTRACT_CLASS(wxScreenDCImpl);
 };

--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -1869,7 +1869,7 @@ wxCairoContext::wxCairoContext( wxGraphicsRenderer* renderer, const wxWindowDC& 
 #endif
 
 #ifdef __WXQT__
-    m_qtPainter = (QPainter*) dc.GetHandle();
+    m_qtPainter =  static_cast<QPainter*>(dc.GetHandle());
     // create a internal buffer (fallback if cairo_qt_surface is missing)
     m_qtImage = new QImage(width, height, QImage::Format_ARGB32_Premultiplied);
     // clear the buffer to be painted over the current contents
@@ -2084,7 +2084,7 @@ wxCairoContext::wxCairoContext( wxGraphicsRenderer* renderer, const wxMemoryDC& 
 #endif
 
 #ifdef __WXQT__
-    m_qtPainter = NULL;
+    m_qtPainter = static_cast<QPainter*>(dc.GetHandle());
     // create a internal buffer (fallback if cairo_qt_surface is missing)
     m_qtImage = new QImage(width, height, QImage::Format_ARGB32_Premultiplied);
     // clear the buffer to be painted over the current contents
@@ -2093,6 +2093,7 @@ wxCairoContext::wxCairoContext( wxGraphicsRenderer* renderer, const wxMemoryDC& 
                                                       CAIRO_FORMAT_ARGB32,
                                                       width, height,
                                                       m_qtImage->bytesPerLine());
+
     Init( cairo_create( m_qtSurface ) );
 #endif
 }
@@ -2566,6 +2567,8 @@ void wxCairoContext::Flush()
     if ( m_qtSurface )
     {
         cairo_surface_flush(m_qtSurface);
+        if ( m_qtPainter);
+            m_qtPainter->drawImage( 0,0, *m_qtImage );
     }
 #endif
 }

--- a/src/qt/anybutton.cpp
+++ b/src/qt/anybutton.cpp
@@ -55,9 +55,9 @@ void wxAnyButton::QtCreate(wxWindow *parent)
 void wxAnyButton::QtSetBitmap( const wxBitmap &bitmap )
 {
     // load the bitmap and resize the button:
-    QPixmap *pixmap = bitmap.GetHandle();
-    m_qtPushButton->setIcon( QIcon( *pixmap  ));
-    m_qtPushButton->setIconSize( pixmap->rect().size() );
+    QPixmap pixmap = QPixmap::fromImage( *bitmap.GetHandle() );
+    m_qtPushButton->setIcon( QIcon( pixmap  ));
+    m_qtPushButton->setIconSize( pixmap.rect().size() );
 
     m_bitmap = bitmap;
 }

--- a/src/qt/bitmap.cpp
+++ b/src/qt/bitmap.cpp
@@ -121,9 +121,7 @@ static QImage CreateQImage(int width, int height,  int depth )
 	if (depth == 24)
 	    return QImage( width, height, QImage::Format_RGBX8888 );
 
-	auto image = QImage( width, height, QImage::Format_RGBA8888);
-
-	return image;
+	return QImage( width, height, QImage::Format_RGBA8888);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/qt/brush.cpp
+++ b/src/qt/brush.cpp
@@ -111,7 +111,7 @@ wxBrush::wxBrush(const wxColour& col, int style)
 wxBrush::wxBrush(const wxBitmap& stipple)
 {
     m_refData = new wxBrushRefData();
-    M_BRUSHDATA.setTexture(*stipple.GetHandle());
+    M_BRUSHDATA.setTexture(QPixmap::fromImage(*stipple.GetHandle()));
     if (stipple.GetMask() != NULL)
         M_STYLEDATA = wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE;
     else
@@ -141,7 +141,7 @@ void wxBrush::SetStyle(wxBrushStyle style)
 void wxBrush::SetStipple(const wxBitmap& stipple)
 {
     AllocExclusive();
-    M_BRUSHDATA.setTexture(*stipple.GetHandle());
+    M_BRUSHDATA.setTexture(QPixmap::fromImage(*stipple.GetHandle()));
 
     if (stipple.GetMask() != NULL)
         M_STYLEDATA = wxBRUSHSTYLE_STIPPLE_MASK_OPAQUE;

--- a/src/qt/cursor.cpp
+++ b/src/qt/cursor.cpp
@@ -154,7 +154,7 @@ void wxCursor::InitFromStock( wxStockCursor cursorId )
 void wxCursor::InitFromImage( const wxImage & image )
 {
     AllocExclusive();
-    GetHandle() = QCursor(*wxBitmap(image).GetHandle(), 
+    GetHandle() = QCursor(QPixmap::fromImage(*wxBitmap(image).GetHandle()),
                            image.HasOption(wxIMAGE_OPTION_CUR_HOTSPOT_X) ?
                            image.GetOptionInt(wxIMAGE_OPTION_CUR_HOTSPOT_X) : -1,
                            image.HasOption(wxIMAGE_OPTION_CUR_HOTSPOT_Y) ?

--- a/src/qt/dc.cpp
+++ b/src/qt/dc.cpp
@@ -633,7 +633,7 @@ void wxQtDCImpl::DoDrawIcon(const wxIcon& icon, wxCoord x, wxCoord y)
 void wxQtDCImpl::DoDrawBitmap(const wxBitmap &bmp, wxCoord x, wxCoord y,
                           bool useMask )
 {
-    QPixmap pix = *bmp.GetHandle();
+    QPixmap pix = QPixmap::fromImage(*bmp.GetHandle());
     if (pix.depth() == 1) {
         //Monochrome bitmap, draw using text fore/background
 

--- a/src/qt/dcclient.cpp
+++ b/src/qt/dcclient.cpp
@@ -31,7 +31,6 @@ wxWindowDCImpl::wxWindowDCImpl( wxDC *owner )
     : wxQtDCImpl( owner )
 {
     m_window = NULL;
-    m_qtImage = NULL;
     m_ok = false;
     m_qtPainter = new QPainter();
 }
@@ -40,7 +39,6 @@ wxWindowDCImpl::wxWindowDCImpl( wxDC *owner, wxWindow *win )
     : wxQtDCImpl( owner )
 {
     m_window = win;
-    m_qtImage = NULL;
     m_qtPainter = m_window->QtGetPainter();
     // if we're not inside a Paint event, painter will invalid
     m_ok = m_qtPainter != NULL;

--- a/src/qt/dcmemory.cpp
+++ b/src/qt/dcmemory.cpp
@@ -16,7 +16,6 @@
 wxMemoryDCImpl::wxMemoryDCImpl( wxMemoryDC *owner )
     : wxQtDCImpl( owner )
 {
-    m_qtImage = NULL;
     m_ok = false;
     m_qtPainter = new QPainter();
 }
@@ -24,7 +23,6 @@ wxMemoryDCImpl::wxMemoryDCImpl( wxMemoryDC *owner )
 wxMemoryDCImpl::wxMemoryDCImpl( wxMemoryDC *owner, wxBitmap& bitmap )
     : wxQtDCImpl( owner )
 {
-    m_qtImage = NULL;
     m_ok = false;
     m_qtPainter = new QPainter();
     DoSelect( bitmap );
@@ -33,7 +31,6 @@ wxMemoryDCImpl::wxMemoryDCImpl( wxMemoryDC *owner, wxBitmap& bitmap )
 wxMemoryDCImpl::wxMemoryDCImpl( wxMemoryDC *owner, wxDC *WXUNUSED(dc) )
     : wxQtDCImpl( owner )
 {
-    m_qtImage = NULL;
     m_ok = false;
     m_qtPainter = new QPainter();
 }
@@ -50,39 +47,27 @@ void wxMemoryDCImpl::DoSelect( const wxBitmap& bitmap )
     {
         // Finish the painting in the intermediate image device:
         m_qtPainter->end();
-
-        if (m_selected.IsOk() && !m_selected.GetHandle()->isNull())
-        {
-            // Copy intermediate image to the bitmap
-            m_qtPainter->begin( m_selected.GetHandle() );
-            m_qtPainter->drawImage( QPoint( 0, 0 ), *m_qtImage );
-            m_qtPainter->end();
-        }
         m_ok = false;
-    }
-
-    // clean up the intermediate image device:
-    if ( m_qtImage )
-    {
-        delete m_qtImage;
-        m_qtImage = NULL;
     }
 
     m_selected = bitmap;
     if ( bitmap.IsOk() && !bitmap.GetHandle()->isNull() ) {
-        QPixmap pixmap = QPixmap::fromImage(*bitmap.GetHandle());
-        // apply mask before converting to image
-        if ( bitmap.GetMask() && bitmap.GetMask()->GetHandle() )
-            pixmap.setMask(*bitmap.GetMask()->GetHandle());
-        // create the intermediate image for the pixmap:
-        m_qtImage = new QImage( pixmap.toImage() );
         // start drawing on the intermediary device:
-        m_ok = m_qtPainter->begin( m_qtImage );
-
+        m_ok = m_qtPainter->begin( m_selected.GetHandle() );
         SetPen(m_pen);
         SetBrush(m_brush);
         SetFont(m_font);
     }
+}
+
+bool wxMemoryDCImpl::DoGetPixel(wxCoord x, wxCoord y, wxColour *col) const
+{
+    if ( m_selected.IsNull())
+        return false;
+
+    QColor pixel = m_selected.GetHandle()->pixel( x, y );
+    col->Set( pixel.red(), pixel.green(), pixel.blue(), pixel.alpha() );
+    return true;
 }
 
 wxBitmap wxMemoryDCImpl::DoGetAsBitmap(const wxRect *subrect) const

--- a/src/qt/dcmemory.cpp
+++ b/src/qt/dcmemory.cpp
@@ -70,7 +70,7 @@ void wxMemoryDCImpl::DoSelect( const wxBitmap& bitmap )
 
     m_selected = bitmap;
     if ( bitmap.IsOk() && !bitmap.GetHandle()->isNull() ) {
-        QPixmap pixmap(*bitmap.GetHandle());
+        QPixmap pixmap = QPixmap::fromImage(*bitmap.GetHandle());
         // apply mask before converting to image
         if ( bitmap.GetMask() && bitmap.GetMask()->GetHandle() )
             pixmap.setMask(*bitmap.GetMask()->GetHandle());

--- a/src/qt/dcscreen.cpp
+++ b/src/qt/dcscreen.cpp
@@ -21,32 +21,13 @@ wxIMPLEMENT_ABSTRACT_CLASS(wxScreenDCImpl, wxWindowDCImpl);
 wxScreenDCImpl::wxScreenDCImpl( wxScreenDC *owner )
     : wxWindowDCImpl( owner )
 {
-    m_qtImage = NULL;
 }
 
 wxScreenDCImpl::~wxScreenDCImpl( )
 {
-    delete m_qtImage;
 }
 
 void wxScreenDCImpl::DoGetSize(int *width, int *height) const
 {
     wxDisplaySize(width, height);
-}
-
-bool wxScreenDCImpl::DoGetPixel(wxCoord x, wxCoord y, wxColour *col) const
-{
-//    const_cast<wxScreenDCImpl*>(this)->GetQImage();
-//    return wxQtDCImpl::DoGetPixel(x, y, col);
-    x = y = 0;
-    col = 0;
-    return false;
-}
-
-// defered allocation for blit
-QImage *wxScreenDCImpl::GetQImage()
-{
-    if ( !m_qtImage )
-        m_qtImage = new QImage(QApplication::primaryScreen()->grabWindow(QApplication::desktop()->winId()).toImage());
-    return m_qtImage;
 }

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -331,7 +331,7 @@ bool wxListCtrl::SetItem(wxListItem& info)
                 wxCHECK_MSG(imglst, false, "invalid listctrl imagelist");
                 const wxBitmap bitmap = imglst->GetBitmap(info.m_image);
                 // set the new image:
-                qitem->setIcon( info.GetColumn(), QIcon( *bitmap.GetHandle() ));
+                qitem->setIcon( info.GetColumn(), QIcon( QPixmap::fromImage(*bitmap.GetHandle()) ));
             }
             else
             {

--- a/src/qt/menuitem.cpp
+++ b/src/qt/menuitem.cpp
@@ -111,7 +111,7 @@ void wxMenuItem::SetBitmap(const wxBitmap& bitmap)
     if ( m_kind == wxITEM_NORMAL )
     {
         m_bitmap = bitmap;
-        m_qtAction->setIcon( QIcon( *m_bitmap.GetHandle() ) );
+        m_qtAction->setIcon( QIcon(QPixmap::fromImage( *m_bitmap.GetHandle() )) );
     }
     else
     {

--- a/src/qt/notebook.cpp
+++ b/src/qt/notebook.cpp
@@ -114,7 +114,7 @@ bool wxNotebook::SetPageImage(size_t n, int imageId)
         wxCHECK_MSG(HasImageList(), false, "invalid notebook imagelist");
         const wxBitmap bitmap = GetImageList()->GetBitmap(imageId);
         // set the new image:
-        m_qtTabWidget->setTabIcon( n, QIcon( *bitmap.GetHandle() ));
+        m_qtTabWidget->setTabIcon( n, QIcon(QPixmap::fromImage(*bitmap.GetHandle())) );
     }
     else
     {
@@ -136,7 +136,7 @@ bool wxNotebook::InsertPage(size_t n, wxWindow *page, const wxString& text,
         if (HasImageList())
         {
             const wxBitmap bitmap = GetImageList()->GetBitmap(imageId);
-            m_qtTabWidget->insertTab( n, page->GetHandle(), QIcon( *bitmap.GetHandle() ), wxQtConvertString( text ));
+            m_qtTabWidget->insertTab( n, page->GetHandle(), QIcon( QPixmap::fromImage(*bitmap.GetHandle()) ), wxQtConvertString( text ));
         }
         else
         {

--- a/src/qt/region.cpp
+++ b/src/qt/region.cpp
@@ -103,14 +103,14 @@ wxRegion::wxRegion(const wxBitmap& bmp, const wxColour& transp, int tolerance)
     }
 
     if ( tolerance == 0 ) {
-        m_refData = new wxRegionRefData(bmp.GetHandle()->createMaskFromColor(transp.GetQColor()));
+        m_refData = new wxRegionRefData(QPixmap::fromImage(*bmp.GetHandle()).createMaskFromColor(transp.GetQColor()));
         return;
     }
 
     wxScopedArray<unsigned char> raw(bmp.GetWidth()*bmp.GetHeight());
     memset(raw.get(), 0, bmp.GetWidth()*bmp.GetHeight());
 
-    QImage img(bmp.GetHandle()->toImage());
+    const QImage &img = *bmp.GetHandle();
     int r = transp.Red(), g = transp.Green(), b = transp.Blue();
     for(int y=0; y<img.height(); y++)
     {

--- a/src/qt/statbmp.cpp
+++ b/src/qt/statbmp.cpp
@@ -50,10 +50,10 @@ bool wxStaticBitmap::Create( wxWindow *parent,
     return QtCreateControl( parent, id, pos, size, style, wxDefaultValidator, name );
 }
 
-static void SetPixmap( QLabel *label, const QPixmap *pixMap )
+static void SetPixmap( QLabel *label, const QImage *image )
 {
-    if ( pixMap != NULL )
-        label->setPixmap( *pixMap );
+    if ( image != NULL )
+        label->setPixmap( QPixmap::fromImage(*image) );
 }
 
 void wxStaticBitmap::SetIcon(const wxIcon& icon)

--- a/src/qt/toolbar.cpp
+++ b/src/qt/toolbar.cpp
@@ -119,7 +119,7 @@ void wxToolBarTool::SetDropdownMenu(wxMenu* menu)
 
 void wxToolBarTool::SetIcon()
 {
-    m_qtToolButton->setIcon( QIcon( *GetNormalBitmap().GetHandle() ));
+    m_qtToolButton->setIcon( QIcon( QPixmap::fromImage(*GetNormalBitmap().GetHandle()) ));
 }
 
 void wxToolBarTool::ClearToolTip()

--- a/src/qt/toplevel.cpp
+++ b/src/qt/toplevel.cpp
@@ -112,7 +112,7 @@ void wxTopLevelWindowQt::SetIcons( const wxIconBundle& icons )
     QIcon qtIcons;
     for ( size_t i = 0; i < icons.GetIconCount(); i++ )
     {
-        qtIcons.addPixmap( *icons.GetIconByIndex( i ).GetHandle() );
+        qtIcons.addPixmap( QPixmap::fromImage(*icons.GetIconByIndex( i ).GetHandle()) );
     }
     GetHandle()->setWindowIcon( qtIcons );
 }

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -125,8 +125,8 @@ void BitmapTestCase::OverlappingBlit()
 
     if ( m_bmp.GetDepth() == 32 )
     {
-				wxAlphaPixelData npd( m_bmp );
-				CPPUNIT_ASSERT_MESSAGE( "Bitmap data is NULL",  npd );
+        wxAlphaPixelData npd( m_bmp );
+        CPPUNIT_ASSERT_MESSAGE( "Bitmap data is NULL",  npd );
         wxAlphaPixelData::Iterator it( npd );
 
         ASSERT_EQUAL_RGB( it, 255, 0, 0 );

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -125,7 +125,8 @@ void BitmapTestCase::OverlappingBlit()
 
     if ( m_bmp.GetDepth() == 32 )
     {
-        wxAlphaPixelData npd( m_bmp );
+				wxAlphaPixelData npd( m_bmp );
+				CPPUNIT_ASSERT_MESSAGE( "Bitmap data is NULL",  npd );
         wxAlphaPixelData::Iterator it( npd );
 
         ASSERT_EQUAL_RGB( it, 255, 0, 0 );


### PR DESCRIPTION
Fixed for crashing bitmap test with wxQT. wxBitmap is now implemented using QImage rather QPixmap as QImage better aligns with the wxBitmap API