### PR TITLE
wxListBox sets the string on QListWidgetItem.

### DIFF
--- a/src/qt/listbox.cpp
+++ b/src/qt/listbox.cpp
@@ -147,7 +147,7 @@ wxString wxListBox::GetString(unsigned int n) const
     return wxQtConvertString( item->text() );
 }
 
-void wxListBox::SetString(unsigned int n, const wxString& WXUNUSED(s))
+void wxListBox::SetString(unsigned int n, const wxString& s)
 {
     QListWidgetItem* item = m_qtListWidget->item(n);
     wxCHECK_RET(item != NULL, wxT("wrong listbox index") );
@@ -155,6 +155,7 @@ void wxListBox::SetString(unsigned int n, const wxString& WXUNUSED(s))
     {
         item->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         item->setCheckState(Qt::Unchecked);
+        item->setText(QString(s));
     }
 }
 

--- a/src/qt/listbox.cpp
+++ b/src/qt/listbox.cpp
@@ -155,7 +155,7 @@ void wxListBox::SetString(unsigned int n, const wxString& s)
     {
         item->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         item->setCheckState(Qt::Unchecked);
-        item->setText(QString(s));
+        item->setText(wxQtConvertString(s));
     }
 }
 

--- a/src/qt/listbox.cpp
+++ b/src/qt/listbox.cpp
@@ -155,8 +155,8 @@ void wxListBox::SetString(unsigned int n, const wxString& s)
     {
         item->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         item->setCheckState(Qt::Unchecked);
-        item->setText(wxQtConvertString(s));
     }
+    item->setText(wxQtConvertString(s));
 }
 
 int wxListBox::GetSelection() const


### PR DESCRIPTION
In the function `wxListBox::SetString`, the `QListWidgetItem` now has the text updated with the passed parameter for the specified index. This change now passes the **CheckListBoxTestCase - SetString** test.