### PR TITLE
 Implemented wxQT ListBox GetSelections() and some other minor changes

### DIFF
--- a/include/wx/qt/listbox.h
+++ b/include/wx/qt/listbox.h
@@ -90,6 +90,8 @@ protected:
 private:
     virtual void Init(); //common construction
 
+    void UnSelectAll();
+
     wxDECLARE_DYNAMIC_CLASS(wxListBox);
 };
 

--- a/src/qt/listbox.cpp
+++ b/src/qt/listbox.cpp
@@ -7,7 +7,7 @@
 
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
-#include <iostream>
+
 #include "wx/listbox.h"
 #include "wx/qt/private/winevent.h"
 

--- a/src/qt/listbox.cpp
+++ b/src/qt/listbox.cpp
@@ -7,7 +7,7 @@
 
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
-
+#include <iostream>
 #include "wx/listbox.h"
 #include "wx/qt/private/winevent.h"
 
@@ -89,6 +89,11 @@ bool wxListBox::Create(wxWindow *parent, wxWindowID id,
     QListWidgetItem* item;
     m_qtWindow = m_qtListWidget = new wxQtListWidget( parent, this );
 
+    if( style == wxLB_SORT )
+    {
+        m_qtListWidget->setSortingEnabled(true);
+    }
+
     while ( n-- > 0 )
     {
         item = new QListWidgetItem();
@@ -130,12 +135,22 @@ bool wxListBox::IsSelected(int n) const
     return item->isSelected();
 }
 
-int wxListBox::GetSelections(wxArrayInt& WXUNUSED(aSelections)) const
+int wxListBox::GetSelections(wxArrayInt& aSelections) const
 {
-    return 0;
+    QListWidgetItem* item;
+
+    aSelections.Clear();
+
+    for( unsigned int i = 0; i < GetCount(); ++i)
+    {
+        if( IsSelected(i) )
+            aSelections.Add(i);
+    }
+
+    return aSelections.GetCount();
 }
 
-unsigned wxListBox::GetCount() const
+unsigned int wxListBox::GetCount() const
 {
     return m_qtListWidget->count();
 }
@@ -169,6 +184,12 @@ void wxListBox::DoSetFirstItem(int WXUNUSED(n))
 
 void wxListBox::DoSetSelection(int n, bool select)
 {
+    if ( n == wxNOT_FOUND )
+    {
+        UnSelectAll();
+        return;
+    }
+
     return m_qtListWidget->setCurrentRow(n, select ? QItemSelectionModel::Select : QItemSelectionModel::Deselect );
 }
 
@@ -234,4 +255,13 @@ void wxListBox::QtSendEvent(wxEventType evtType, const QModelIndex &index, bool 
 QScrollArea *wxListBox::QtGetScrollBarsContainer() const
 {
     return (QScrollArea *) m_qtListWidget;
+}
+
+void wxListBox::UnSelectAll()
+{
+    for( unsigned int i = 0; i < GetCount(); ++i)
+    {
+        if( IsSelected(i) )
+            DoSetSelection(i, false);
+    }
 }


### PR DESCRIPTION
This change contains an implementation of GetSelections, SetSelection will reset selected states if it receives wxNOT_FOUND and the class now respects the alphabetical sorting flag. This change now passes the `ListBoxTestCase::MultipleSelect` test.