### PR TITLE
The signals of QScrollBar are now blocked when setting a value in wxScrollBar::SetScrollbar()

### DIFF
--- a/src/qt/scrolbar.cpp
+++ b/src/qt/scrolbar.cpp
@@ -100,7 +100,9 @@ void wxScrollBar::SetScrollbar(int position, int WXUNUSED(thumbSize),
     {
         m_qtScrollBar->setRange( 0, range - pageSize );
         m_qtScrollBar->setPageStep( pageSize );
+        m_qtScrollBar->blockSignals(true);
         m_qtScrollBar->setValue( position );
+        m_qtScrollBar->blockSignals(false);
         m_qtScrollBar->show();
     }
     else


### PR DESCRIPTION
This avoids a crash when running the tests and matches behaviour wxQT has with other Qt objects when setting the value.