### PR TITLE
Stop editing when right mouse button is pressed in wxDataViewCtrl

### DIFF
--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -4558,6 +4558,12 @@ void wxDataViewMainWindow::OnMouse( wxMouseEvent &event )
         // setting focus to this window as most (all?) of them do by default,
         // so skip it to enable default handling.
         event.Skip();
+
+        // Also stop editing if any mouse button is pressed: this is not really
+        // necessary for the left button, as it would result in a focus loss
+        // that would make the editor close anyhow, but we do need to do it for
+        // the other ones and it does no harm to do it for the left one too.
+        FinishEditing();
     }
 
     // Handle right clicking here, before everything else as context menu

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -4525,14 +4525,6 @@ void wxDataViewMainWindow::OnMouse( wxMouseEvent &event )
         return;
     }
 
-    if(event.ButtonDown())
-    {
-        // Not skipping button down events would prevent the system from
-        // setting focus to this window as most (all?) of them do by default,
-        // so skip it to enable default handling.
-        event.Skip();
-    }
-
     int x = event.GetX();
     int y = event.GetY();
     m_owner->CalcUnscrolledPosition( x, y, &x, &y );
@@ -4559,6 +4551,14 @@ void wxDataViewMainWindow::OnMouse( wxMouseEvent &event )
 
     const unsigned int current = GetLineAt( y );
     const wxDataViewItem item = GetItemByRow(current);
+
+    if(event.ButtonDown())
+    {
+        // Not skipping button down events would prevent the system from
+        // setting focus to this window as most (all?) of them do by default,
+        // so skip it to enable default handling.
+        event.Skip();
+    }
 
     // Handle right clicking here, before everything else as context menu
     // events should be sent even when we click outside of any item, unlike all

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -4591,11 +4591,14 @@ gtk_dataview_button_press_callback( GtkWidget *WXUNUSED(widget),
         // If the right click is on an item that isn't selected, select it, as is
         // commonly done. Do not do it if the item under mouse is already selected,
         // because it could be a part of multi-item selection.
-        GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(dv->GtkGetTreeView()));
-        if ( !gtk_tree_selection_path_is_selected(selection, path) )
+        if ( path )
         {
-            gtk_tree_selection_unselect_all(selection);
-            gtk_tree_selection_select_path(selection, path);
+            GtkTreeSelection *selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(dv->GtkGetTreeView()));
+            if ( !gtk_tree_selection_path_is_selected(selection, path) )
+            {
+                gtk_tree_selection_unselect_all(selection);
+                gtk_tree_selection_select_path(selection, path);
+            }
         }
 
         wxDataViewEvent


### PR DESCRIPTION
GTK version already did it, although it cancelled editing instead of accepting it, but the generic one did not, so implement it there too.

Also avoid GTK+ warnings.