### PR TITLE
Ensured text items are sorted when added to QComboBox.

### DIFF
--- a/include/wx/qt/choice.h
+++ b/include/wx/qt/choice.h
@@ -72,7 +72,6 @@ protected:
     virtual void DoDeleteOneItem(unsigned int pos);
 
     QComboBox *m_qtComboBox;
-    long m_style;
 
 private:
 

--- a/include/wx/qt/choice.h
+++ b/include/wx/qt/choice.h
@@ -72,6 +72,7 @@ protected:
     virtual void DoDeleteOneItem(unsigned int pos);
 
     QComboBox *m_qtComboBox;
+    long m_style;
 
 private:
 

--- a/src/qt/choice.cpp
+++ b/src/qt/choice.cpp
@@ -148,6 +148,7 @@ int wxChoice::DoInsertItems(const wxArrayStringsAdapter & items,
 int wxChoice::DoInsertOneItem(const wxString& item, unsigned int pos)
 {
     m_qtComboBox->insertItem(pos, wxQtConvertString(item));
+    m_qtComboBox->model()->sort(0);
     return pos;
 }
 

--- a/src/qt/choice.cpp
+++ b/src/qt/choice.cpp
@@ -88,6 +88,7 @@ bool wxChoice::Create( wxWindow *parent, wxWindowID id,
         const wxString& name )
 {
     m_qtComboBox = new wxQtChoice( parent, this );
+    m_style = style;
 
     while ( n-- > 0 )
         m_qtComboBox->addItem( wxQtConvertString( *choices++ ));
@@ -148,7 +149,10 @@ int wxChoice::DoInsertItems(const wxArrayStringsAdapter & items,
 int wxChoice::DoInsertOneItem(const wxString& item, unsigned int pos)
 {
     m_qtComboBox->insertItem(pos, wxQtConvertString(item));
-    m_qtComboBox->model()->sort(0);
+
+    if (m_style == wxCB_SORT)
+        m_qtComboBox->model()->sort(0);
+
     return pos;
 }
 

--- a/src/qt/choice.cpp
+++ b/src/qt/choice.cpp
@@ -88,7 +88,6 @@ bool wxChoice::Create( wxWindow *parent, wxWindowID id,
         const wxString& name )
 {
     m_qtComboBox = new wxQtChoice( parent, this );
-    m_style = style;
 
     while ( n-- > 0 )
         m_qtComboBox->addItem( wxQtConvertString( *choices++ ));
@@ -150,7 +149,7 @@ int wxChoice::DoInsertOneItem(const wxString& item, unsigned int pos)
 {
     m_qtComboBox->insertItem(pos, wxQtConvertString(item));
 
-    if (m_style == wxCB_SORT)
+    if ( IsSorted() )
         m_qtComboBox->model()->sort(0);
 
     return pos;


### PR DESCRIPTION
This change allows entries added to a `QComboBox` to be sorted alphabetically. This change ensures the test: **ChoiceTestCase - Sort** now passes, mostly...

There is one remaining issue with this test, and I believe there may be an issue with this test. There is a list of short strings sorted and compared in this test, and the final check expects the string "a" to have been sorted as the first item. This string actually ends up as the third item in the list, and I believe this is correct.

**Expected Sort Order**
a
AAA
Aaa
aaa
aaab
aab
aba

**Actual Sort Order**
AAA
Aaa
a
aaa
aaab
aab
aba

I'd like to update the test to expect the string "a" as the third item rather than the first, however I would like to know if anybody has any issues with this before I take this action.