### PR TITLE
Fix wxMSW build with wxUSE_UXTHEME==0

### DIFF
--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -759,7 +759,7 @@ typedef void (wxEvtHandler::*wxAuiToolBarEventFunction)(wxAuiToolBarEvent&);
 #define wxEVT_COMMAND_AUITOOLBAR_MIDDLE_CLICK     wxEVT_AUITOOLBAR_MIDDLE_CLICK
 #define wxEVT_COMMAND_AUITOOLBAR_BEGIN_DRAG       wxEVT_AUITOOLBAR_BEGIN_DRAG
 
-#ifdef __WXMSW__
+#if defined(__WXMSW__) && wxUSE_UXTHEME
     #define wxHAS_NATIVE_TOOLBAR_ART
     #include "wx/aui/barartmsw.h"
     #define wxAuiDefaultToolBarArt wxAuiMSWToolBarArt

--- a/include/wx/aui/tabart.h
+++ b/include/wx/aui/tabart.h
@@ -318,7 +318,7 @@ protected:
         #define wxHAS_NATIVE_TABART
         #include "wx/aui/tabartgtk.h"
         #define wxAuiDefaultTabArt wxAuiGtkTabArt
-    #elif defined(__WXMSW__)
+    #elif defined(__WXMSW__) && wxUSE_UXTHEME
         #define wxHAS_NATIVE_TABART
         #include "wx/aui/tabartmsw.h"
         #define wxAuiDefaultTabArt wxAuiMSWTabArt

--- a/include/wx/msw/uxtheme.h
+++ b/include/wx/msw/uxtheme.h
@@ -13,6 +13,8 @@
 
 #include "wx/defs.h"
 
+#if wxUSE_UXTHEME
+
 #include "wx/msw/private.h"     // we use GetHwndOf()
 #include <uxtheme.h>
 
@@ -252,6 +254,12 @@ private:
 
     wxDECLARE_NO_COPY_CLASS(wxUxThemeHandle);
 };
+
+#else // !wxUSE_UXTHEME
+
+inline bool wxUxThemeIsActive() { return false; }
+
+#endif // wxUSE_UXTHEME/!wxUSE_UXTHEME
 
 #endif // _WX_UXTHEME_H_
 

--- a/include/wx/systhemectrl.h
+++ b/include/wx/systhemectrl.h
@@ -12,7 +12,7 @@
 
 #include "wx/defs.h"
 
-#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#if defined(__WXMSW__) && wxUSE_UXTHEME && !defined(__WXUNIVERSAL__)
     #define wxHAS_SYSTEM_THEMED_CONTROL
 #endif
 

--- a/src/aui/barartmsw.cpp
+++ b/src/aui/barartmsw.cpp
@@ -13,6 +13,8 @@
 #pragma hdrstop
 #endif
 
+#if wxUSE_AUI && wxUSE_UXTHEME
+
 #ifndef WX_PRECOMP
     #include "wx/bitmap.h"
     #include "wx/dcclient.h"
@@ -24,8 +26,6 @@
 #include "wx/aui/framemanager.h"
 #include "wx/msw/uxtheme.h"
 #include "wx/msw/private.h"
-
-#if wxUSE_AUI
 
 wxAuiMSWToolBarArt::wxAuiMSWToolBarArt()
 {
@@ -470,4 +470,4 @@ int wxAuiMSWToolBarArt::ShowDropDown(wxWindow* wnd,
     return wxAuiGenericToolBarArt::ShowDropDown(wnd, items);
 }
 
-#endif // wxUSE_AUI
+#endif // wxUSE_AUI && wxUSE_UXTHEME

--- a/src/aui/tabartmsw.cpp
+++ b/src/aui/tabartmsw.cpp
@@ -13,6 +13,8 @@
 #pragma hdrstop
 #endif
 
+#if wxUSE_AUI && wxUSE_UXTHEME && !defined(__WXUNIVERSAL__)
+
 #ifndef WX_PRECOMP
     #include "wx/dc.h"
 #endif
@@ -22,8 +24,6 @@
 #include "wx/msw/uxtheme.h"
 #include "wx/msw/private.h"
 #include "wx/renderer.h"
-
-#if wxUSE_AUI && !defined(__WXUNIVERSAL__)
 
 wxAuiMSWTabArt::wxAuiMSWTabArt()
 {
@@ -469,4 +469,4 @@ bool wxAuiMSWTabArt::IsThemed() const
 }
 
 
-#endif // wxUSE_AUI
+#endif // wxUSE_AUI && wxUSE_UXTHEME && !defined(__WXUNIVERSAL__)

--- a/src/generic/richtooltipg.cpp
+++ b/src/generic/richtooltipg.cpp
@@ -47,7 +47,10 @@
 #include "wx/textwrapper.h"
 
 #ifdef __WXMSW__
-    #include "wx/msw/uxtheme.h"
+    #if wxUSE_UXTHEME
+        #include "wx/msw/uxtheme.h"
+        #define HAVE_MSW_THEME
+    #endif
 #endif
 
 // ----------------------------------------------------------------------------
@@ -86,7 +89,7 @@ public:
             // Determine the appropriate title font for the current platform.
             titleFont = labelTitle->GetFont();
 
-#ifdef __WXMSW__
+#ifdef HAVE_MSW_THEME
             // When using themes MSW tooltips use larger bluish version of the
             // normal font.
             if ( UseTooltipTheme() )
@@ -110,7 +113,7 @@ public:
                 labelTitle->SetForegroundColour(wxRGBToColour(c));
             }
             else
-#endif // __WXMSW__
+#endif // HAVE_MSW_THEME
             {
                 // Everything else, including "classic" MSW look uses just the
                 // bold version of the base font.
@@ -132,7 +135,7 @@ public:
         wxTextSizerWrapper wrapper(this);
         wxSizer* sizerText = wrapper.CreateSizer(message, -1 /* No wrapping */);
 
-#ifdef __WXMSW__
+#ifdef HAVE_MSW_THEME
         if ( icon.IsOk() && UseTooltipTheme() )
         {
             // Themed tooltips under MSW align the text with the title, not
@@ -144,7 +147,7 @@ public:
 
             sizerText = sizerTextIndent;
         }
-#endif // !__WXMSW__
+#endif // HAVE_MSW_THEME
         sizerTop->Add(sizerText,
                         wxSizerFlags().DoubleBorder(wxLEFT|wxRIGHT|wxBOTTOM)
                                       .Centre());
@@ -167,7 +170,7 @@ public:
         if ( !colStart.IsOk() )
         {
             // Determine the best colour(s) to use on our own.
-#ifdef __WXMSW__
+#ifdef HAVE_MSW_THEME
             if ( UseTooltipTheme() )
             {
                 wxUxThemeHandle hTheme(GetParent(), L"TOOLTIP");
@@ -198,7 +201,7 @@ public:
                 colEnd = wxRGBToColour(c2);
             }
             else
-#endif // __WXMSW__
+#endif // HAVE_MSW_THEME
             {
                 colStart = wxSystemSettings::GetColour(wxSYS_COLOUR_INFOBK);
             }
@@ -270,26 +273,26 @@ protected:
     }
 
 private:
-#ifdef __WXMSW__
+#ifdef HAVE_MSW_THEME
     // Returns non-NULL theme only if we're using Win7-style tooltips.
     static bool UseTooltipTheme()
     {
         // Even themed applications under XP still use "classic" tooltips.
         if ( wxGetWinVersion() <= wxWinVersion_XP )
             return false;
-		else
-			return wxUxThemeIsActive();
+        else
+            return wxUxThemeIsActive();
     }
-#endif // __WXMSW__
+#endif // HAVE_MSW_THEME
 
     // For now we just hard code the tip height, would be nice to do something
     // smarter in the future.
     static int GetTipHeight()
     {
-#ifdef __WXMSW__
+#ifdef HAVE_MSW_THEME
         if ( UseTooltipTheme() )
             return 20;
-#endif // __WXMSW__
+#endif // HAVE_MSW_THEME
 
         return 15;
     }

--- a/src/msw/combo.cpp
+++ b/src/msw/combo.cpp
@@ -37,9 +37,7 @@
 #include "wx/combo.h"
 
 #include "wx/msw/registry.h"
-#if wxUSE_UXTHEME
 #include "wx/msw/uxtheme.h"
-#endif
 #include "wx/msw/dc.h"
 
 #define NATIVE_TEXT_INDENT_XP       4
@@ -87,7 +85,6 @@ bool wxComboCtrl::Create(wxWindow *parent,
 
     if ( !border )
     {
-#if wxUSE_UXTHEME
         if ( wxUxThemeIsActive() )
         {
             // For XP, have 1-width custom border, for older version use sunken
@@ -95,7 +92,6 @@ bool wxComboCtrl::Create(wxWindow *parent,
             m_widthCustomBorder = 1;
         }
         else
-#endif
             border = wxBORDER_SUNKEN;
 
         style = (style & ~(wxBORDER_MASK)) | border;
@@ -112,10 +108,8 @@ bool wxComboCtrl::Create(wxWindow *parent,
                            name) )
         return false;
 
-#if wxUSE_UXTHEME
     if ( wxUxThemeIsActive() && ::wxGetWinVersion() >= wxWinVersion_Vista )
             m_iFlags |= wxCC_BUTTON_STAYS_DOWN |wxCC_BUTTON_COVERS_BORDER;
-#endif
 
     if ( style & wxCC_STD_BUTTON )
         m_iFlags |= wxCC_POPUP_ON_MOUSE_UP;

--- a/src/msw/menuitem.cpp
+++ b/src/msw/menuitem.cpp
@@ -165,7 +165,10 @@ class MenuDrawData
 public:
     // Wrapper around standard MARGINS structure providing some helper
     // functions and automatically initializing the margin fields to 0.
-    struct Margins : MARGINS
+    struct Margins
+#if wxUSE_UXTHEME
+        : MARGINS
+#endif // wxUSE_UXTHEME
     {
         Margins()
         {
@@ -193,6 +196,12 @@ public:
             rect.right += cyTopHeight;
             rect.bottom += cyBottomHeight;
         }
+
+#if !wxUSE_UXTHEME
+        // When MARGINS struct is not available, we need to define the fields
+        // we use ourselves.
+        int cxLeftWidth, cxRightWidth, cyTopHeight, cyBottomHeight;
+#endif // !wxUSE_UXTHEME
     };
 
     Margins ItemMargin;         // popup item margins


### PR DESCRIPTION
Make wxUxThemeIsActive() available even in this case to fix compilation
in some places and add the unavoidable preprocessor checks in other
ones.

Closes #18207.