### PR TITLE
Implement wxAuiNotebook::HitTest

### DIFF
--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3363,9 +3363,9 @@ int wxAuiNotebook::HitTest (const wxPoint &pt, long *flags) const
 {
     wxWindow *w = NULL;
     long position = wxBK_HITTEST_NOWHERE;
-    wxAuiPaneInfoArray& all_panes = const_cast<wxAuiManager&>(m_mgr).GetAllPanes();
-    size_t i, pane_count = all_panes.GetCount();
-    for (i = 0; i < pane_count; ++i)
+    const wxAuiPaneInfoArray& all_panes = const_cast<wxAuiManager&>(m_mgr).GetAllPanes();
+    const size_t pane_count = all_panes.GetCount();
+    for (size_t i = 0; i < pane_count; ++i)
     {
         if (all_panes.Item(i).name == wxT("dummy"))
             continue;

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3378,7 +3378,7 @@ int wxAuiNotebook::HitTest (const wxPoint &pt, long *flags) const
                 position = wxBK_HITTEST_ONITEM;
             break;
         }
-        else if (tabframe->m_rect.Contains(pt) && tabframe->m_rect.y + tabframe->m_tabCtrlHeight < pt.y)
+        else if (tabframe->m_rect.Contains(pt))
         {
             w = tabframe->m_tabs->GetWindowFromIdx(tabframe->m_tabs->GetActivePage());
             if (w)

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3381,13 +3381,15 @@ int wxAuiNotebook::HitTest (const wxPoint &pt, long *flags) const
         else if (tabframe->m_rect.Contains(pt) && tabframe->m_rect.y + tabframe->m_tabCtrlHeight < pt.y)
         {
             w = tabframe->m_tabs->GetWindowFromIdx(tabframe->m_tabs->GetActivePage());
-            if (w) position = wxBK_HITTEST_ONPAGE;
+            if (w)
+                position = wxBK_HITTEST_ONPAGE;
             break;
         }
     }
 
-    if (flags) *flags = position;
-    return w? GetPageIndex(w): wxNOT_FOUND;
+    if (flags)
+        *flags = position;
+    return w ? GetPageIndex(w) : wxNOT_FOUND;
 }
 
 int wxAuiNotebook::GetPageImage(size_t WXUNUSED(n)) const

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3359,9 +3359,10 @@ void wxAuiNotebook::SetPageSize (const wxSize& WXUNUSED(size))
     wxFAIL_MSG("Not implemented for wxAuiNotebook");
 }
 
-int wxAuiNotebook::HitTest (const wxPoint &pt, long* WXUNUSED(flags)) const
+int wxAuiNotebook::HitTest (const wxPoint &pt, long *flags) const
 {
     wxWindow *w = NULL;
+    long position = wxBK_HITTEST_NOWHERE;
     wxAuiPaneInfoArray& all_panes = const_cast<wxAuiManager&>(m_mgr).GetAllPanes();
     size_t i, pane_count = all_panes.GetCount();
     for (i = 0; i < pane_count; ++i)
@@ -3373,16 +3374,19 @@ int wxAuiNotebook::HitTest (const wxPoint &pt, long* WXUNUSED(flags)) const
         if (tabframe->m_tab_rect.Contains(pt))
         {
             wxPoint tabpos = tabframe->m_tabs->ScreenToClient(ClientToScreen(pt));
-            tabframe->m_tabs->TabHitTest(tabpos.x, tabpos.y, &w);
+            if (tabframe->m_tabs->TabHitTest(tabpos.x, tabpos.y, &w))
+                position = wxBK_HITTEST_ONITEM;
             break;
         }
         else if (tabframe->m_rect.Contains(pt) && tabframe->m_rect.y + tabframe->m_tabCtrlHeight < pt.y)
         {
             w = tabframe->m_tabs->GetWindowFromIdx(tabframe->m_tabs->GetActivePage());
+            if (w) position = wxBK_HITTEST_ONPAGE;
             break;
         }
     }
 
+    if (flags) *flags = position;
     return w? GetPageIndex(w): wxNOT_FOUND;
 }
 

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3359,10 +3359,31 @@ void wxAuiNotebook::SetPageSize (const wxSize& WXUNUSED(size))
     wxFAIL_MSG("Not implemented for wxAuiNotebook");
 }
 
-int wxAuiNotebook::HitTest (const wxPoint& WXUNUSED(pt), long* WXUNUSED(flags)) const
+int wxAuiNotebook::HitTest (const wxPoint &pt, long* WXUNUSED(flags)) const
 {
-    wxFAIL_MSG("Not implemented for wxAuiNotebook");
-    return wxNOT_FOUND;
+    wxWindow *w = NULL;
+    wxAuiPaneInfoArray& all_panes = const_cast<wxAuiManager&>(m_mgr).GetAllPanes();
+    size_t i, pane_count = all_panes.GetCount();
+    for (i = 0; i < pane_count; ++i)
+    {
+        if (all_panes.Item(i).name == wxT("dummy"))
+            continue;
+
+        wxTabFrame* tabframe = (wxTabFrame*) all_panes.Item(i).window;
+        if (tabframe->m_tab_rect.Contains(pt))
+        {
+            wxPoint tabpos = tabframe->m_tabs->ScreenToClient(ClientToScreen(pt));
+            tabframe->m_tabs->TabHitTest(tabpos.x, tabpos.y, &w);
+            break;
+        }
+        else if (tabframe->m_rect.Contains(pt) && tabframe->m_rect.y + tabframe->m_tabCtrlHeight < pt.y)
+        {
+            w = tabframe->m_tabs->GetWindowFromIdx(tabframe->m_tabs->GetActivePage());
+            break;
+        }
+    }
+
+    return w? GetPageIndex(w): wxNOT_FOUND;
 }
 
 int wxAuiNotebook::GetPageImage(size_t WXUNUSED(n)) const


### PR DESCRIPTION
As discussed in Trac ticket #18290, I tried to implement HitTest for wxAuiNotebook. Unfortunately I discovered that changing `GetTabCtrlFromPoint` to `const` doesn't help a lot, so I didn't include any changes there.

I am not sure how to check for a label or image hit. Therefore I only implemented the NOWHERE, ONPAGE and ONITEM flags.

I also used the "worst case" `const_cast`, as I didn't want to introduce a new interface on wxAuiManager just for the `HitTest` interface. Any suggestions replacing the cast are welcome and I will change it accordingly.