### PR TITLE
Added static WX_WEB_EXTENSIONS_DIRECTORY

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1667,12 +1667,14 @@ WEBVIEWLIB_CXXFLAGS = $(__webviewlib_PCH_INC) -D__WX$(TOOLKIT)__ \
 	$(__WXUNIV_DEFINE_p) $(__DEBUG_DEFINE_p) $(__EXCEPTIONS_DEFINE_p) \
 	$(__RTTI_DEFINE_p) $(__THREAD_DEFINE_p) -DWXBUILDING $(__INC_TIFF_BUILD_p) \
 	$(__INC_TIFF_p) $(__INC_JPEG_p) $(__INC_PNG_p) $(__INC_ZLIB_p) \
-	$(__INC_REGEX_p) $(__INC_EXPAT_p) $(CXXWARNINGS) $(CPPFLAGS) $(CXXFLAGS)
+	$(__INC_REGEX_p) $(__INC_EXPAT_p) $(__webviewdll_ext_dir_define_p) \
+	$(CXXWARNINGS) $(CPPFLAGS) $(CXXFLAGS)
 WEBVIEWLIB_OBJCXXFLAGS = $(__webviewlib_PCH_INC) -D__WX$(TOOLKIT)__ \
 	$(__WXUNIV_DEFINE_p) $(__DEBUG_DEFINE_p) $(__EXCEPTIONS_DEFINE_p) \
 	$(__RTTI_DEFINE_p) $(__THREAD_DEFINE_p) -DWXBUILDING $(__INC_TIFF_BUILD_p) \
 	$(__INC_TIFF_p) $(__INC_JPEG_p) $(__INC_PNG_p) $(__INC_ZLIB_p) \
-	$(__INC_REGEX_p) $(__INC_EXPAT_p) $(CPPFLAGS) $(OBJCXXFLAGS)
+	$(__INC_REGEX_p) $(__INC_EXPAT_p) $(__webviewdll_ext_dir_define_p) \
+	$(CPPFLAGS) $(OBJCXXFLAGS)
 WEBVIEWLIB_OBJECTS =  \
 	$(__WEBVIEW_SRC_PLATFORM_OBJECTS_3) \
 	webviewlib_webview.o \


### PR DESCRIPTION
I got compiler errors during build with --disable-shared for wxGTK 3. According to PR #469 it should work appropriately, but the new define WX_WEB_EXTENSIONS_DIRECTORY was missing for the static options WEBVIEWLIB_CXXFLAGS and WEBVIEWLIB_OBJCXXFLAGS.