### PR TITLE
Implement maximum length for wxTextCtrl on wxQt

### DIFF
--- a/include/wx/qt/textctrl.h
+++ b/include/wx/qt/textctrl.h
@@ -73,7 +73,8 @@ protected:
 private:
     QLineEdit *m_qtLineEdit;
     QTextEdit *m_qtTextEdit;
-
+    virtual QLineEdit *GetEditable() const wxOVERRIDE;
+    
     wxDECLARE_DYNAMIC_CLASS( wxTextCtrl );
 };
 

--- a/include/wx/qt/textctrl.h
+++ b/include/wx/qt/textctrl.h
@@ -71,9 +71,10 @@ protected:
     virtual QScrollArea *QtGetScrollBarsContainer() const;
 
 private:
+    virtual QLineEdit *QTGetLineEdit() const wxOVERRIDE;
+
     QLineEdit *m_qtLineEdit;
     QTextEdit *m_qtTextEdit;
-    virtual QLineEdit *GetEditable() const wxOVERRIDE;
     
     wxDECLARE_DYNAMIC_CLASS( wxTextCtrl );
 };

--- a/include/wx/qt/textentry.h
+++ b/include/wx/qt/textentry.h
@@ -8,6 +8,8 @@
 #ifndef _WX_QT_TEXTENTRY_H_
 #define _WX_QT_TEXTENTRY_H_
 
+class QLineEdit;
+
 class WXDLLIMPEXP_CORE wxTextEntry : public wxTextEntryBase
 {
 public:
@@ -36,6 +38,7 @@ public:
     virtual bool IsEditable() const;
     virtual void SetEditable(bool editable);
     
+    virtual void SetMaxLength(unsigned long len);
 protected:
     virtual wxString DoGetValue() const;
     virtual void DoSetValue(const wxString& value, int flags=0);
@@ -43,6 +46,7 @@ protected:
     virtual wxWindow *GetEditableWindow();
 
 private:
+    virtual QLineEdit *GetEditable()  const { return NULL; };
 };
 
 #endif // _WX_QT_TEXTENTRY_H_

--- a/include/wx/qt/textentry.h
+++ b/include/wx/qt/textentry.h
@@ -38,7 +38,8 @@ public:
     virtual bool IsEditable() const;
     virtual void SetEditable(bool editable);
     
-    virtual void SetMaxLength(unsigned long len);
+    virtual void SetMaxLength(unsigned long len) wxOVERRIDE;
+
 protected:
     virtual wxString DoGetValue() const;
     virtual void DoSetValue(const wxString& value, int flags=0);
@@ -46,7 +47,7 @@ protected:
     virtual wxWindow *GetEditableWindow();
 
 private:
-    virtual QLineEdit *GetEditable()  const { return NULL; };
+    virtual QLineEdit *QTGetLineEdit()  const { return NULL; };
 };
 
 #endif // _WX_QT_TEXTENTRY_H_

--- a/src/qt/textctrl.cpp
+++ b/src/qt/textctrl.cpp
@@ -26,9 +26,6 @@ protected:
 private:
     void textChanged(const QString &text);
     void returnPressed();
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 12, 0)
-    void inputRejected();
-#endif
 };
 
 wxQtLineEdit::wxQtLineEdit( wxWindow *parent, wxTextCtrl *handler )
@@ -38,10 +35,6 @@ wxQtLineEdit::wxQtLineEdit( wxWindow *parent, wxTextCtrl *handler )
             this, &wxQtLineEdit::textChanged);
     connect(this, &QLineEdit::returnPressed,
             this, &wxQtLineEdit::returnPressed);
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 12, 0)
-    connect(this, &QLineEdit::inputRejected,
-            this, &wxQtLineEdit::inputRejected);
-#endif
 }
 
 void wxQtLineEdit::textChanged(const QString &text)
@@ -69,25 +62,6 @@ void wxQtLineEdit::returnPressed()
     }
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK( 5, 12, 0)
-void wxQtLineEdit::inputRejected()
-{
-    wxTextCtrl *handler = GetHandler();
-    if( handler )
-    {
-        QLineEdit *line_edit = ((QLineEdit *) handler->GetHandle());
-        if( line_edit )
-        {
-            int max = line_edit->maxLength();
-            if( text.length() > max )
-            {
-                wxCommandEvent event( wxEVT_TEXT_MAXLEN, handler->GetId() );
-                EmitEvent( event );
-            }
-        }
-    }
-}
-#else
 void wxQtLineEdit::keyPressEvent(QKeyEvent *event)
 {
     wxTextCtrl *handler = GetHandler();
@@ -98,7 +72,6 @@ void wxQtLineEdit::keyPressEvent(QKeyEvent *event)
     }
     QLineEdit::keyPressEvent( event );
 }
-#endif
 
 class wxQtTextEdit : public wxQtEventSignalHandler< QTextEdit, wxTextCtrl >
 {
@@ -424,7 +397,7 @@ QScrollArea *wxTextCtrl::QtGetScrollBarsContainer() const
         return NULL;
 }
 
-QLineEdit *wxTextCtrl::GetEditable() const
+QLineEdit *wxTextCtrl::QTGetLineEdit() const
 {
     wxCHECK_MSG( IsSingleLine(), NULL, "shouldn't be called for multiline" );
     

--- a/src/qt/textentry.cpp
+++ b/src/qt/textentry.cpp
@@ -7,8 +7,11 @@
 
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
-
+#include "wx/textctrl.h"
 #include "wx/textentry.h"
+#include "wx/qt/private/converter.h"
+
+#include <QtWidgets/QLineEdit>
 
 wxTextEntry::wxTextEntry()
 {
@@ -106,3 +109,9 @@ wxWindow *wxTextEntry::GetEditableWindow()
     return NULL;
 }
 
+void wxTextEntry::SetMaxLength(unsigned long len)
+{
+    QLineEdit *editor = GetEditable();
+    if( editor )
+        editor->setMaxLength( len );
+}

--- a/src/qt/textentry.cpp
+++ b/src/qt/textentry.cpp
@@ -7,7 +7,6 @@
 
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
-#include "wx/textctrl.h"
 #include "wx/textentry.h"
 #include "wx/qt/private/converter.h"
 
@@ -111,7 +110,7 @@ wxWindow *wxTextEntry::GetEditableWindow()
 
 void wxTextEntry::SetMaxLength(unsigned long len)
 {
-    QLineEdit *editor = GetEditable();
+    QLineEdit *editor = QTGetLineEdit();
     if( editor )
         editor->setMaxLength( len );
 }


### PR DESCRIPTION
The code in this PR was tested on the Qt version 5.7.
It would be nice to check this code under the latest Qt version (5.12).

Or maybe the 5.12 implementation is useless?

Let me know what is the preference here.

Thank you.
