### PR TITLE
Fixed RadioBox Enable test case

### DIFF
--- a/include/wx/qt/radiobox.h
+++ b/include/wx/qt/radiobox.h
@@ -65,10 +65,11 @@ public:
     using wxWindowBase::Enable;
     using wxRadioBoxBase::GetDefaultBorder;
 
-    virtual bool Enable(unsigned int n, bool enable = true);
-    virtual bool Show(unsigned int n, bool show = true);
-    virtual bool IsItemEnabled(unsigned int n) const;
-    virtual bool IsItemShown(unsigned int n) const;
+    virtual bool Enable(unsigned int n, bool enable = true) wxOVERRIDE;
+    virtual bool Enable( bool enable = true ) wxOVERRIDE;
+    virtual bool Show(unsigned int n, bool show = true) wxOVERRIDE;
+    virtual bool IsItemEnabled(unsigned int n) const wxOVERRIDE;
+    virtual bool IsItemShown(unsigned int n) const wxOVERRIDE;
 
     virtual unsigned int GetCount() const;
     virtual wxString GetString(unsigned int n) const;

--- a/include/wx/qt/radiobox.h
+++ b/include/wx/qt/radiobox.h
@@ -66,7 +66,7 @@ public:
     using wxRadioBoxBase::GetDefaultBorder;
 
     virtual bool Enable(unsigned int n, bool enable = true) wxOVERRIDE;
-    virtual bool Enable( bool enable = true ) wxOVERRIDE;
+    virtual bool Enable(bool enable = true) wxOVERRIDE;
     virtual bool Show(unsigned int n, bool show = true) wxOVERRIDE;
     virtual bool IsItemEnabled(unsigned int n) const wxOVERRIDE;
     virtual bool IsItemShown(unsigned int n) const wxOVERRIDE;

--- a/src/qt/radiobox.cpp
+++ b/src/qt/radiobox.cpp
@@ -168,10 +168,42 @@ static QAbstractButton *GetButtonAt( const QButtonGroup *group, unsigned int n )
 
 bool wxRadioBox::Enable(unsigned int n, bool enable)
 {
-    QAbstractButton *qtButton = GetButtonAt( m_qtButtonGroup, n );
-    CHECK_BUTTON( qtButton, false );
+    if( enable && !m_qtGroupBox->isEnabled() )
+    {
+        m_qtGroupBox->setEnabled( true );
 
-    qtButton->setEnabled( enable );
+        for( unsigned int i = 0; i < GetCount(); ++i )
+        {
+            QAbstractButton *qtButton = GetButtonAt( m_qtButtonGroup, i );
+            CHECK_BUTTON( qtButton, false );
+
+            i == n ? qtButton->setEnabled( true ) : qtButton->setEnabled( false );
+        }
+    }
+    else
+    {
+        QAbstractButton *qtButton = GetButtonAt( m_qtButtonGroup, n );
+        CHECK_BUTTON( qtButton, false );
+        qtButton->setEnabled(enable);
+    }
+
+    return true;
+}
+
+bool wxRadioBox::Enable( bool enable )
+{
+    if( m_qtGroupBox->isEnabled() == enable )
+    {
+        for( unsigned int i = 0; i < GetCount(); ++i )
+        {
+            QAbstractButton *qtButton = GetButtonAt( m_qtButtonGroup, i );
+            CHECK_BUTTON( qtButton, false );
+            qtButton->setEnabled( enable );
+        }
+    }
+
+    m_qtGroupBox->setEnabled( enable );
+
     return true;
 }
 
@@ -200,7 +232,7 @@ bool wxRadioBox::IsItemShown(unsigned int n) const
     return qtButton->isVisible();
 }
 
-unsigned wxRadioBox::GetCount() const
+unsigned int wxRadioBox::GetCount() const
 {
     QList< QAbstractButton * > buttons = m_qtButtonGroup->buttons();
     return buttons.size();

--- a/src/qt/radiobox.cpp
+++ b/src/qt/radiobox.cpp
@@ -168,16 +168,16 @@ static QAbstractButton *GetButtonAt( const QButtonGroup *group, unsigned int n )
 
 bool wxRadioBox::Enable(unsigned int n, bool enable)
 {
-    if( enable && !m_qtGroupBox->isEnabled() )
+    if ( enable && !m_qtGroupBox->isEnabled() )
     {
         m_qtGroupBox->setEnabled( true );
 
-        for( unsigned int i = 0; i < GetCount(); ++i )
+        for ( unsigned int i = 0; i < GetCount(); ++i )
         {
             QAbstractButton *qtButton = GetButtonAt( m_qtButtonGroup, i );
             CHECK_BUTTON( qtButton, false );
 
-            i == n ? qtButton->setEnabled( true ) : qtButton->setEnabled( false );
+            qtButton->setEnabled( i == n );
         }
     }
     else
@@ -192,9 +192,9 @@ bool wxRadioBox::Enable(unsigned int n, bool enable)
 
 bool wxRadioBox::Enable( bool enable )
 {
-    if( m_qtGroupBox->isEnabled() == enable )
+    if ( m_qtGroupBox->isEnabled() == enable )
     {
-        for( unsigned int i = 0; i < GetCount(); ++i )
+        for ( unsigned int i = 0; i < GetCount(); ++i )
         {
             QAbstractButton *qtButton = GetButtonAt( m_qtButtonGroup, i );
             CHECK_BUTTON( qtButton, false );


### PR DESCRIPTION
I have changed the implementation of the `Enable(unsigned int, bool enable)` method to take account of the enabled state of the QGroupBox (if disabled, any items it holds cannot be enabled). I have also implemented the `Enable(bool enable)` method to properly match the expected wx behaviour. 