### PR TITLE
Backport compilation fix

### DIFF
--- a/include/wx/filefn.h
+++ b/include/wx/filefn.h
@@ -217,7 +217,7 @@ enum wxPosixPermissions
     #elif wxCHECK_MINGW32_VERSION(3, 5) // mingw-runtime version (not gcc)
         #define wxHAS_HUGE_STDIO_FILES
 
-        wxDECL_FOR_STRICT_MINGW32(int, fseeko64, (FILE*, long long, int));
+        wxDECL_FOR_STRICT_MINGW32(int, fseeko64, (FILE*, long long, int))
         #define wxFseek fseeko64
 
         #ifdef wxNEEDS_STRICT_ANSI_WORKAROUNDS

--- a/include/wx/math.h
+++ b/include/wx/math.h
@@ -90,7 +90,7 @@
         #define wxFinite(x) isfinite(x)
     #endif
 #elif defined(wxNEEDS_STRICT_ANSI_WORKAROUNDS)
-    wxDECL_FOR_STRICT_MINGW32(int, _finite, (double));
+    wxDECL_FOR_STRICT_MINGW32(int, _finite, (double))
 
     #define wxFinite(x) _finite(x)
 #elif ( defined(__GNUG__)||defined(__GNUWIN32__)||defined(__DJGPP__)|| \

--- a/src/common/wxcrt.cpp
+++ b/src/common/wxcrt.cpp
@@ -73,9 +73,9 @@
     #include <xlocale.h>
 #endif
 
-wxDECL_FOR_STRICT_MINGW32(int, vswprintf, (wchar_t*, const wchar_t*, __VALIST));
-wxDECL_FOR_STRICT_MINGW32(int, _putws, (const wchar_t*));
-wxDECL_FOR_STRICT_MINGW32(void, _wperror, (const wchar_t*));
+wxDECL_FOR_STRICT_MINGW32(int, vswprintf, (wchar_t*, const wchar_t*, __VALIST))
+wxDECL_FOR_STRICT_MINGW32(int, _putws, (const wchar_t*))
+wxDECL_FOR_STRICT_MINGW32(void, _wperror, (const wchar_t*))
 
 WXDLLIMPEXP_BASE size_t wxMB2WC(wchar_t *buf, const char *psz, size_t n)
 {


### PR DESCRIPTION
MXE https://mxe.cc  is using gcc -Werror and it doesn't compile 3.0 branch head without backporting c6c19dc580a.

Commit slightly modified, irrelevant stuff removed.

c6c19dc580a
Remove extraneous semicolons after wxDECL_FOR_STRICT_MINGW32().
This macro shouldn't be followed by a semicolon because it can be empty, so
remove the extra semicolons to avoid -Wpedantic g++ warnings about it.