### PR TITLE
Qt fix bitmap crash take 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -475,6 +475,3 @@
 
 # /utils/wxrc/
 /utils/wxrc/*.sln
-
-# JetBrain's CLion
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -475,3 +475,6 @@
 
 # /utils/wxrc/
 /utils/wxrc/*.sln
+
+# JetBrain's CLion
+.idea

--- a/src/qt/bitmap.cpp
+++ b/src/qt/bitmap.cpp
@@ -411,18 +411,18 @@ void *wxBitmap::GetRawData(wxPixelDataBase& data, int bpp)
 {
     void* bits = NULL;
 
-    wxBitmapRefData *bitmapRefData = static_cast<wxBitmapRefData *>(m_refData);
+    wxBitmapRefData *refData = static_cast<wxBitmapRefData *>(m_refData);
 
-    // allow access if bpp is valid and matches existence of alpha
-    if ( !bitmapRefData->m_qtPixmap.isNull() )
+    // allow access if bpp is valid
+    if ( !refData->m_qtPixmap.isNull() )
     {
-        bitmapRefData->m_rawPixelSource = bitmapRefData->m_qtPixmap.toImage().convertToFormat(QImage::Format_RGBA8888);
         if ( bpp == 32 )
         {
-            data.m_height = bitmapRefData->m_rawPixelSource.height();
-            data.m_width = bitmapRefData->m_rawPixelSource.width();
-            data.m_stride = bitmapRefData->m_rawPixelSource.bytesPerLine();
-            bits = (void*) bitmapRefData->m_rawPixelSource.bits();
+            refData->m_rawPixelSource = refData->m_qtPixmap.toImage().convertToFormat(QImage::Format_RGBA8888);
+            data.m_height = refData->m_rawPixelSource.height();
+            data.m_width = refData->m_rawPixelSource.width();
+            data.m_stride = refData->m_rawPixelSource.bytesPerLine();
+            bits = refData->m_rawPixelSource.bits();
         }
     }
     return bits;
@@ -430,9 +430,9 @@ void *wxBitmap::GetRawData(wxPixelDataBase& data, int bpp)
 
 void wxBitmap::UngetRawData(wxPixelDataBase& WXUNUSED(data))
 {
-    wxBitmapRefData *bitmapRefData = static_cast<wxBitmapRefData *>(m_refData);
-    bitmapRefData->m_qtPixmap = QPixmap::fromImage(bitmapRefData->m_rawPixelSource);
-    bitmapRefData->m_rawPixelSource = QImage();
+    wxBitmapRefData *refData = static_cast<wxBitmapRefData *>(m_refData);
+    refData->m_qtPixmap = QPixmap::fromImage(refData->m_rawPixelSource);
+    refData->m_rawPixelSource = QImage();
 }
 
 QPixmap *wxBitmap::GetHandle() const

--- a/src/qt/bitmap.cpp
+++ b/src/qt/bitmap.cpp
@@ -144,6 +144,7 @@ class wxBitmapRefData: public wxGDIRefData
         virtual ~wxBitmapRefData() { delete m_mask; }
 
         QPixmap m_qtPixmap;
+        QImage m_rawPixelSource;
         wxMask *m_mask;
 
 private:
@@ -409,17 +410,19 @@ void wxBitmap::SetDepth(int depth)
 void *wxBitmap::GetRawData(wxPixelDataBase& data, int bpp)
 {
     void* bits = NULL;
+
+    wxBitmapRefData *bitmapRefData = static_cast<wxBitmapRefData *>(m_refData);
+
     // allow access if bpp is valid and matches existence of alpha
-    if ( !M_PIXDATA.isNull() )
+    if ( !bitmapRefData->m_qtPixmap.isNull() )
     {
-        QImage qimage = M_PIXDATA.toImage();
-        bool hasAlpha = M_PIXDATA.hasAlphaChannel();
-        if ((bpp == 24 && !hasAlpha) || (bpp == 32 && hasAlpha))
+        bitmapRefData->m_rawPixelSource = bitmapRefData->m_qtPixmap.toImage().convertToFormat(QImage::Format_RGBA8888);
+        if ( bpp == 32 )
         {
-            data.m_height = qimage.height();
-            data.m_width = qimage.width();
-            data.m_stride = qimage.bytesPerLine();
-            bits = (void*) qimage.bits();
+            data.m_height = bitmapRefData->m_rawPixelSource.height();
+            data.m_width = bitmapRefData->m_rawPixelSource.width();
+            data.m_stride = bitmapRefData->m_rawPixelSource.bytesPerLine();
+            bits = (void*) bitmapRefData->m_rawPixelSource.bits();
         }
     }
     return bits;
@@ -427,7 +430,9 @@ void *wxBitmap::GetRawData(wxPixelDataBase& data, int bpp)
 
 void wxBitmap::UngetRawData(wxPixelDataBase& WXUNUSED(data))
 {
-    wxMISSING_IMPLEMENTATION( __FUNCTION__ );
+    wxBitmapRefData *bitmapRefData = static_cast<wxBitmapRefData *>(m_refData);
+    bitmapRefData->m_qtPixmap = QPixmap::fromImage(bitmapRefData->m_rawPixelSource);
+    bitmapRefData->m_rawPixelSource = QImage();
 }
 
 QPixmap *wxBitmap::GetHandle() const

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -126,6 +126,7 @@ void BitmapTestCase::OverlappingBlit()
     if ( m_bmp.GetDepth() == 32 )
     {
         wxAlphaPixelData npd( m_bmp );
+        CPPUNIT_ASSERT_MESSAGE( "Expected raw pixels to not be NULL", npd );
         wxAlphaPixelData::Iterator it( npd );
 
         ASSERT_EQUAL_RGB( it, 255, 0, 0 );


### PR DESCRIPTION
Based on the conclusion reached in #1045,  wxBitmap now hold wxImage member which is used when GetRawData is called.  