### PR TITLE
wxCarioContext::Flush now draws back to the QPainter

### DIFF
--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -2566,6 +2566,7 @@ void wxCairoContext::Flush()
     if ( m_qtSurface )
     {
         cairo_surface_flush(m_qtSurface);
+        m_qtPainter->drawImage( 0,0, *m_qtImage );
     }
 #endif
 }


### PR DESCRIPTION
wxCairoContext::Flush was flushing back to the internal image but this image wasn't drawn back to the QPainter until the wxCarioContext instance was destroyed.

This fix ensure that after a call to Flush, anything drawn by Cario is drawn back to the QImage.