### PR TITLE
Implemented radiobutton grouping behaviour for wxQT

### DIFF
--- a/include/wx/qt/radiobut.h
+++ b/include/wx/qt/radiobut.h
@@ -45,7 +45,6 @@ public:
 protected:
 
 private:
-    void JoinNewGroup();
 
     QRadioButton *m_qtRadioButton;
     QButtonGroup *m_qtButtonGroup;

--- a/include/wx/qt/radiobut.h
+++ b/include/wx/qt/radiobut.h
@@ -45,9 +45,7 @@ public:
 protected:
 
 private:
-
     QRadioButton *m_qtRadioButton;
-    QButtonGroup *m_qtButtonGroup;
 
     static std::map<wxWindow*, QButtonGroup*> m_lastGroup;
 

--- a/include/wx/qt/radiobut.h
+++ b/include/wx/qt/radiobut.h
@@ -46,8 +46,7 @@ protected:
 
 private:
     QRadioButton *m_qtRadioButton;
-
-    static std::map<wxWindow*, QButtonGroup*> m_lastGroup;
+    QButtonGroup* m_qtButtonGroup;
 
     wxDECLARE_DYNAMIC_CLASS( wxRadioButton );
 };

--- a/include/wx/qt/radiobut.h
+++ b/include/wx/qt/radiobut.h
@@ -9,6 +9,7 @@
 #define _WX_QT_RADIOBUT_H_
 
 class QRadioButton;
+class QButtonGroup;
 
 class WXDLLIMPEXP_CORE wxRadioButton : public wxControl
 {
@@ -40,7 +41,10 @@ public:
 protected:
 
 private:
+    void createAndJoinNewGroup();
+
     QRadioButton *m_qtRadioButton;
+    QButtonGroup *m_qtButtonGroup;
 
     wxDECLARE_DYNAMIC_CLASS( wxRadioButton );
 };

--- a/include/wx/qt/radiobut.h
+++ b/include/wx/qt/radiobut.h
@@ -8,6 +8,8 @@
 #ifndef _WX_QT_RADIOBUT_H_
 #define _WX_QT_RADIOBUT_H_
 
+#include <map>
+
 class QRadioButton;
 class QButtonGroup;
 
@@ -33,6 +35,8 @@ public:
                  const wxValidator& validator = wxDefaultValidator,
                  const wxString& name = wxRadioButtonNameStr );
 
+    virtual ~wxRadioButton();
+
     virtual void SetValue(bool value);
     virtual bool GetValue() const;
 
@@ -45,6 +49,8 @@ private:
 
     QRadioButton *m_qtRadioButton;
     QButtonGroup *m_qtButtonGroup;
+
+    static std::map<wxWindow*, QButtonGroup*> m_lastGroup;
 
     wxDECLARE_DYNAMIC_CLASS( wxRadioButton );
 };

--- a/include/wx/qt/radiobut.h
+++ b/include/wx/qt/radiobut.h
@@ -41,7 +41,7 @@ public:
 protected:
 
 private:
-    void createAndJoinNewGroup();
+    void JoinNewGroup();
 
     QRadioButton *m_qtRadioButton;
     QButtonGroup *m_qtButtonGroup;

--- a/include/wx/qt/radiobut.h
+++ b/include/wx/qt/radiobut.h
@@ -10,7 +10,6 @@
 
 
 class QRadioButton;
-class QButtonGroup;
 
 class WXDLLIMPEXP_CORE wxRadioButton : public wxControl
 {
@@ -45,7 +44,6 @@ protected:
 
 private:
     QRadioButton *m_qtRadioButton;
-    QButtonGroup* m_qtButtonGroup;
 
     wxDECLARE_DYNAMIC_CLASS( wxRadioButton );
 };

--- a/include/wx/qt/radiobut.h
+++ b/include/wx/qt/radiobut.h
@@ -8,7 +8,6 @@
 #ifndef _WX_QT_RADIOBUT_H_
 #define _WX_QT_RADIOBUT_H_
 
-#include <map>
 
 class QRadioButton;
 class QButtonGroup;

--- a/include/wx/qt/radiobut.h
+++ b/include/wx/qt/radiobut.h
@@ -8,7 +8,6 @@
 #ifndef _WX_QT_RADIOBUT_H_
 #define _WX_QT_RADIOBUT_H_
 
-
 class QRadioButton;
 
 class WXDLLIMPEXP_CORE wxRadioButton : public wxControl

--- a/src/qt/radiobut.cpp
+++ b/src/qt/radiobut.cpp
@@ -43,7 +43,7 @@ bool wxRadioButton::Create( wxWindow *parent,
 
     if ( ( style & wxRB_GROUP ) || ( style & wxRB_SINGLE ) )
     {
-        createAndJoinNewGroup();
+        JoinNewGroup();
     }
     else
     {
@@ -63,7 +63,7 @@ bool wxRadioButton::Create( wxWindow *parent,
                 }
                 else
                 {
-                    createAndJoinNewGroup();
+                    JoinNewGroup();
                 }
 
                 break;
@@ -91,7 +91,7 @@ QWidget *wxRadioButton::GetHandle() const
     return m_qtRadioButton;
 }
 
-void wxRadioButton::createAndJoinNewGroup()
+void wxRadioButton::JoinNewGroup()
 {
     m_qtButtonGroup = new QButtonGroup( );
     m_qtButtonGroup->addButton( m_qtRadioButton );

--- a/src/qt/radiobut.cpp
+++ b/src/qt/radiobut.cpp
@@ -39,7 +39,7 @@ bool wxRadioButton::Create( wxWindow *parent,
              const wxValidator& validator,
              const wxString& name)
 {
-    m_qtRadioButton = new QRadioButton(parent->GetHandle());
+    m_qtRadioButton = new QRadioButton( parent->GetHandle() );
 
     if ( ( style & wxRB_GROUP ) || ( style && wxRB_SINGLE ) )
     {
@@ -94,5 +94,5 @@ QWidget *wxRadioButton::GetHandle() const
 void wxRadioButton::createAndJoinNewGroup()
 {
     m_qtButtonGroup = new QButtonGroup( );
-    m_qtButtonGroup->addButton(m_qtRadioButton);
+    m_qtButtonGroup->addButton( m_qtRadioButton );
 }

--- a/src/qt/radiobut.cpp
+++ b/src/qt/radiobut.cpp
@@ -57,10 +57,10 @@ bool wxRadioButton::Create( wxWindow *parent,
     }
     else if ( style & wxRB_GROUP )
     {
-        m_qtButtonGroup = new QButtonGroup();
-        m_qtButtonGroup->addButton( m_qtRadioButton );
+        QButtonGroup *qtButtonGroup = new QButtonGroup();
+        qtButtonGroup->addButton( m_qtRadioButton );
 
-        GetWindowToLastButtonGroupMap()[parent] = m_qtButtonGroup;
+        GetWindowToLastButtonGroupMap()[parent] = qtButtonGroup;
         m_qtRadioButton->setChecked(true);
     }
     else
@@ -86,12 +86,8 @@ wxRadioButton::~wxRadioButton()
         WindowToLastButtonGroupMap::iterator it = GetWindowToLastButtonGroupMap().find( GetParent() );
         if ( it != GetWindowToLastButtonGroupMap().end() && m_qtRadioButton->group() == it->second )
         {
+            delete it->second;
             GetWindowToLastButtonGroupMap().erase(it);
-
-            if( m_qtButtonGroup )
-            {
-                delete m_qtButtonGroup;
-            }
         }
     }
 }

--- a/src/qt/radiobut.cpp
+++ b/src/qt/radiobut.cpp
@@ -41,7 +41,7 @@ bool wxRadioButton::Create( wxWindow *parent,
 {
     m_qtRadioButton = new QRadioButton( parent->GetHandle() );
 
-    if ( ( style & wxRB_GROUP ) || ( style && wxRB_SINGLE ) )
+    if ( ( style & wxRB_GROUP ) || ( style & wxRB_SINGLE ) )
     {
         createAndJoinNewGroup();
     }

--- a/src/qt/radiobut.cpp
+++ b/src/qt/radiobut.cpp
@@ -15,11 +15,11 @@
 #include <QtWidgets/QButtonGroup>
 
 
-typedef std::map<wxWindow*, QButtonGroup*> WindowToButtonGroupMap;
+typedef std::map<wxWindow*, QButtonGroup*> WindowToLastButtonGroupMap;
 
-static WindowToButtonGroupMap& GetWindowToButtonGroupMap()
+static WindowToLastButtonGroupMap& GetWindowToLastButtonGroupMap()
 {
-    static WindowToButtonGroupMap s_map;
+    static WindowToLastButtonGroupMap s_map;
     return s_map;
 }
 
@@ -53,21 +53,21 @@ bool wxRadioButton::Create( wxWindow *parent,
     if ( style & wxRB_SINGLE )
     {
         // Ensure that other buttons cannot join the last existing group
-        GetWindowToButtonGroupMap().erase(parent);
+        GetWindowToLastButtonGroupMap().erase(parent);
     }
     else if ( style & wxRB_GROUP )
     {
         m_qtButtonGroup = new QButtonGroup();
         m_qtButtonGroup->addButton( m_qtRadioButton );
 
-        GetWindowToButtonGroupMap()[parent] = m_qtButtonGroup;
+        GetWindowToLastButtonGroupMap()[parent] = m_qtButtonGroup;
         m_qtRadioButton->setChecked(true);
     }
     else
     {
         // Add it to the previous group, if any
-        WindowToButtonGroupMap::iterator it = GetWindowToButtonGroupMap().find(parent);
-        if ( it != GetWindowToButtonGroupMap().end() )
+        WindowToLastButtonGroupMap::iterator it = GetWindowToLastButtonGroupMap().find(parent);
+        if ( it != GetWindowToLastButtonGroupMap().end() )
         {
             it->second->addButton(m_qtRadioButton);
         }
@@ -83,10 +83,10 @@ wxRadioButton::~wxRadioButton()
     if ( m_qtRadioButton->group() && m_qtRadioButton->group()->buttons().size() == 1 )
     {
         // If this button is the only member of the last group, remove the map entry for the group
-        WindowToButtonGroupMap::iterator it = GetWindowToButtonGroupMap().find( GetParent() );
-        if ( it != GetWindowToButtonGroupMap().end() && m_qtRadioButton->group() == it->second )
+        WindowToLastButtonGroupMap::iterator it = GetWindowToLastButtonGroupMap().find( GetParent() );
+        if ( it != GetWindowToLastButtonGroupMap().end() && m_qtRadioButton->group() == it->second )
         {
-            GetWindowToButtonGroupMap().erase(it);
+            GetWindowToLastButtonGroupMap().erase(it);
 
             if( m_qtButtonGroup )
             {

--- a/src/qt/radiobut.cpp
+++ b/src/qt/radiobut.cpp
@@ -45,11 +45,12 @@ bool wxRadioButton::Create( wxWindow *parent,
 
     if ( (style & wxRB_GROUP) || (style & wxRB_SINGLE) )
     {
-        JoinNewGroup();
+        m_qtButtonGroup = new QButtonGroup();
+        m_qtButtonGroup->addButton( m_qtRadioButton );
 
-        if( style & wxRB_SINGLE )
+        if ( style & wxRB_SINGLE )
         {
-            // Ensure that other buttons cannot join this group
+            // Ensure that other buttons cannot join the last existing group
             m_lastGroup.erase(parent);
         }
         else
@@ -78,6 +79,7 @@ wxRadioButton::~wxRadioButton()
     if ( m_qtRadioButton->group() &&
          m_qtRadioButton->group()->buttons().size() == 1 )
     {
+        // If this button is the only member of the last group, remove the map entry for the group
         std::map<wxWindow*, QButtonGroup*>::iterator it = m_lastGroup.find( GetParent() );
         if ( it != m_lastGroup.end() && m_qtRadioButton->group() == it->second )
         {
@@ -99,10 +101,4 @@ bool wxRadioButton::GetValue() const
 QWidget *wxRadioButton::GetHandle() const
 {
     return m_qtRadioButton;
-}
-
-void wxRadioButton::JoinNewGroup()
-{
-    m_qtButtonGroup = new QButtonGroup( );
-    m_qtButtonGroup->addButton( m_qtRadioButton );
 }

--- a/src/qt/radiobut.cpp
+++ b/src/qt/radiobut.cpp
@@ -83,7 +83,7 @@ wxRadioButton::~wxRadioButton()
     if ( m_qtRadioButton->group() && m_qtRadioButton->group()->buttons().size() == 1 )
     {
         // If this button is the only member of the last group, remove the map entry for the group
-        std::map<wxWindow*, QButtonGroup*>::iterator it = GetWindowToButtonGroupMap().find( GetParent() );
+        WindowToButtonGroupMap::iterator it = GetWindowToButtonGroupMap().find( GetParent() );
         if ( it != GetWindowToButtonGroupMap().end() && m_qtRadioButton->group() == it->second )
         {
             GetWindowToButtonGroupMap().erase(it);

--- a/src/qt/radiobut.cpp
+++ b/src/qt/radiobut.cpp
@@ -65,7 +65,7 @@ bool wxRadioButton::Create( wxWindow *parent,
     else if ( style & wxRB_GROUP )
     {
         QButtonGroup *qtButtonGroup = new QButtonGroup();
-        qtButtonGroup->addButton( m_qtRadioButton );
+        qtButtonGroup->addButton(m_qtRadioButton);
 
         GetWindowToLastButtonGroupMap()[parent] = qtButtonGroup;
         m_qtRadioButton->setChecked(true);

--- a/src/qt/radiobut.cpp
+++ b/src/qt/radiobut.cpp
@@ -41,7 +41,7 @@ bool wxRadioButton::Create( wxWindow *parent,
 {
     m_qtRadioButton = new QRadioButton( parent->GetHandle() );
 
-    if ( ( style & wxRB_GROUP ) || ( style & wxRB_SINGLE ) )
+    if ( (style & wxRB_GROUP) || (style & wxRB_SINGLE) )
     {
         JoinNewGroup();
     }

--- a/src/qt/radiobut.cpp
+++ b/src/qt/radiobut.cpp
@@ -66,7 +66,7 @@ bool wxRadioButton::Create( wxWindow *parent,
     else
     {
         // Add it to the previous group, if any
-        std::map<wxWindow*, QButtonGroup*>::iterator it = GetWindowToButtonGroupMap().find(parent);
+        WindowToButtonGroupMap::iterator it = GetWindowToButtonGroupMap().find(parent);
         if ( it != GetWindowToButtonGroupMap().end() )
         {
             it->second->addButton(m_qtRadioButton);

--- a/src/qt/radiobut.cpp
+++ b/src/qt/radiobut.cpp
@@ -14,7 +14,14 @@
 #include <QtWidgets/QRadioButton>
 #include <QtWidgets/QButtonGroup>
 
-
+/*
+   Qt provides the QButtonGroup class to provide grouping behaviour for button widgets. As there is no direct
+   counterpart to this class in Wx, we need wxRadioButton to both use and store it, in order to provide this
+   functionality (some external class having to manage something which only this class is concerned with makes no
+   sense).
+   Having a static map (with wxWindow* as the key and the value being the last QButtonGroup*) allows the wxRadioButton
+   to access the required QButtonGroup or add to the map as necessary.
+*/
 typedef std::map<wxWindow*, QButtonGroup*> WindowToLastButtonGroupMap;
 
 static WindowToLastButtonGroupMap& GetWindowToLastButtonGroupMap()

--- a/src/qt/radiobut.cpp
+++ b/src/qt/radiobut.cpp
@@ -45,6 +45,9 @@ bool wxRadioButton::Create( wxWindow *parent,
 
     if ( (style & wxRB_GROUP) || (style & wxRB_SINGLE) )
     {
+        QButtonGroup* qtButtonGroup = new QButtonGroup();
+        qtButtonGroup->addButton( m_qtRadioButton );
+
         if ( style & wxRB_SINGLE )
         {
             // Ensure that other buttons cannot join the last existing group
@@ -52,9 +55,6 @@ bool wxRadioButton::Create( wxWindow *parent,
         }
         else
         {
-            QButtonGroup* qtButtonGroup = new QButtonGroup();
-            qtButtonGroup->addButton( m_qtRadioButton );
-
             m_lastGroup[parent] = qtButtonGroup;
             m_qtRadioButton->setChecked(true); // The first button in a group should be selected
         }

--- a/src/qt/radiobut.cpp
+++ b/src/qt/radiobut.cpp
@@ -45,9 +45,6 @@ bool wxRadioButton::Create( wxWindow *parent,
 
     if ( (style & wxRB_GROUP) || (style & wxRB_SINGLE) )
     {
-        m_qtButtonGroup = new QButtonGroup();
-        m_qtButtonGroup->addButton( m_qtRadioButton );
-
         if ( style & wxRB_SINGLE )
         {
             // Ensure that other buttons cannot join the last existing group
@@ -55,7 +52,10 @@ bool wxRadioButton::Create( wxWindow *parent,
         }
         else
         {
-            m_lastGroup[parent] = m_qtButtonGroup;
+            QButtonGroup* qtButtonGroup = new QButtonGroup();
+            qtButtonGroup->addButton( m_qtRadioButton );
+
+            m_lastGroup[parent] = qtButtonGroup;
             m_qtRadioButton->setChecked(true); // The first button in a group should be selected
         }
     }

--- a/src/qt/radiobut.cpp
+++ b/src/qt/radiobut.cpp
@@ -90,7 +90,7 @@ wxRadioButton::~wxRadioButton()
     if ( m_qtRadioButton->group() && m_qtRadioButton->group()->buttons().size() == 1 )
     {
         // If this button is the only member of the last group, remove the map entry for the group
-        WindowToLastButtonGroupMap::iterator it = GetWindowToLastButtonGroupMap().find( GetParent() );
+        WindowToLastButtonGroupMap::iterator it = GetWindowToLastButtonGroupMap().find(GetParent());
         if ( it != GetWindowToLastButtonGroupMap().end() && m_qtRadioButton->group() == it->second )
         {
             delete it->second;


### PR DESCRIPTION
The radiobuttons now adhere to the grouping behaviour specified by a passed flag and take into account previous radiobutton's single flags (wxRB_SINGLE) before attempting to group with them. This passes the RadioButtonTestCase Group.