### PR TITLE
Changed wxFont::GetEncoding to return UTF8 for wxQT

### DIFF
--- a/src/qt/font.cpp
+++ b/src/qt/font.cpp
@@ -451,10 +451,7 @@ wxFontFamily wxNativeFontInfo::GetFamily() const
 
 wxFontEncoding wxNativeFontInfo::GetEncoding() const
 {
-//    QFontInfo info = QFontInfo(m_qtFont);
-    wxMISSING_IMPLEMENTATION( __FUNCTION__ );
-
-    return wxFONTENCODING_MAX;
+    return wxFONTENCODING_UTF8;
 }
 
 void wxNativeFontInfo::SetFractionalPointSize(float pointsize)


### PR DESCRIPTION
QT doesn't have the concept of font encoding and is generally Unicode aware throughout.  The previous implementation of wxFont::GetEncoding for wxQT returned a nonsensical value. 