### PR TITLE
Fixed a crash when attempting to set a menu icon to a null bitmap

### DIFF
--- a/src/qt/menuitem.cpp
+++ b/src/qt/menuitem.cpp
@@ -111,7 +111,10 @@ void wxMenuItem::SetBitmap(const wxBitmap& bitmap)
     if ( m_kind == wxITEM_NORMAL )
     {
         m_bitmap = bitmap;
-        m_qtAction->setIcon( QIcon( *m_bitmap.GetHandle() ) );
+        if ( !m_bitmap.IsNull() )
+        {
+            m_qtAction->setIcon( QIcon(*m_bitmap.GetHandle()) );
+        }
     }
     else
     {


### PR DESCRIPTION
Previous implementation didn't take into account that wxBitmap::GetHandle() could return NULL for wxQT Specifically when wxBitmap::IsNull returns true. 