### PR TITLE
Fixes for last column resizing in generic wxDataViewCtrl

### DIFF
--- a/include/wx/generic/dataview.h
+++ b/include/wx/generic/dataview.h
@@ -74,6 +74,11 @@ public:
         // UpdateWidth() if the width didn't really change, even if we don't
         // care about its return value.
         (void)WXUpdateWidth(width);
+
+        // Do remember the last explicitly set width: this is used to prevent
+        // UpdateColumnSizes() from resizing the last column to be smaller than
+        // this size.
+        m_manuallySetWidth = width;
     }
     virtual int GetWidth() const wxOVERRIDE;
 
@@ -137,8 +142,14 @@ public:
         m_width = width;
         UpdateWidth();
 
+        // We must not update m_manuallySetWidth here as this method is called by
+        // UpdateColumnSizes() which resizes the column automatically, and not
+        // "manually".
+
         return true;
     }
+
+    int WXGetManuallySetWidth() const { return m_manuallySetWidth; }
 
 private:
     // common part of all ctors
@@ -152,6 +163,7 @@ private:
 
     wxString m_title;
     int m_width,
+        m_manuallySetWidth,
         m_minWidth;
     wxAlignment m_align;
     int m_flags;

--- a/include/wx/generic/dataview.h
+++ b/include/wx/generic/dataview.h
@@ -107,6 +107,8 @@ public:
         return m_flags;
     }
 
+    virtual bool IsResizeable() const wxOVERRIDE;
+
     virtual bool IsSortKey() const wxOVERRIDE
     {
         return m_sort;

--- a/include/wx/generic/dataview.h
+++ b/include/wx/generic/dataview.h
@@ -12,7 +12,6 @@
 
 #include "wx/defs.h"
 #include "wx/object.h"
-#include "wx/list.h"
 #include "wx/control.h"
 #include "wx/scrolwin.h"
 #include "wx/icon.h"
@@ -178,9 +177,6 @@ private:
 // ---------------------------------------------------------
 // wxDataViewCtrl
 // ---------------------------------------------------------
-
-WX_DECLARE_LIST_WITH_DECL(wxDataViewColumn, wxDataViewColumnList,
-                          class WXDLLIMPEXP_CORE);
 
 class WXDLLIMPEXP_CORE wxDataViewCtrl : public wxDataViewCtrlBase,
                                        public wxScrollHelper
@@ -366,7 +362,9 @@ private:
     void InvalidateColBestWidth(int idx);
     void UpdateColWidths();
 
-    wxDataViewColumnList      m_cols;
+    void DoClearColumns();
+
+    wxVector<wxDataViewColumn*> m_cols;
     // cached column best widths information, values are for
     // respective columns from m_cols and the arrays have same size
     struct CachedColWidthInfo

--- a/include/wx/generic/dataview.h
+++ b/include/wx/generic/dataview.h
@@ -107,8 +107,6 @@ public:
         return m_flags;
     }
 
-    virtual bool IsResizeable() const wxOVERRIDE;
-
     virtual bool IsSortKey() const wxOVERRIDE
     {
         return m_sort;

--- a/samples/dataview/dataview.cpp
+++ b/samples/dataview/dataview.cpp
@@ -793,7 +793,7 @@ void MyFrame::BuildDataViewCtrl(wxPanel* parent, unsigned int nPanel, unsigned l
             lc->AppendColumn(colRadio, "bool");
 
             lc->AppendTextColumn( "Text" );
-            lc->AppendProgressColumn( "Progress" );
+            lc->AppendProgressColumn( "Progress" )->SetMinWidth(100);
 
             wxVector<wxVariant> data;
             for (unsigned int i=0; i<10; i++)

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -256,17 +256,6 @@ void wxDataViewColumn::SetSortOrder(bool ascending)
     m_owner->OnColumnChange(idx);
 }
 
-bool wxDataViewColumn::IsResizeable() const
-{
-    // The last column in generic wxDataViewCtrl is never resizeable by the
-    // user because it's always automatically expanded to consume all the
-    // available space, so prevent the user from resizing it.
-    if ( this == GetOwner()->GetColumn(GetOwner()->GetColumnCount() - 1) )
-        return false;
-
-    return wxDataViewColumnBase::IsResizeable();
-}
-
 //-----------------------------------------------------------------------------
 // wxDataViewHeaderWindow
 //-----------------------------------------------------------------------------

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -256,6 +256,17 @@ void wxDataViewColumn::SetSortOrder(bool ascending)
     m_owner->OnColumnChange(idx);
 }
 
+bool wxDataViewColumn::IsResizeable() const
+{
+    // The last column in generic wxDataViewCtrl is never resizeable by the
+    // user because it's always automatically expanded to consume all the
+    // available space, so prevent the user from resizing it.
+    if ( this == GetOwner()->GetColumn(GetOwner()->GetColumnCount() - 1) )
+        return false;
+
+    return wxDataViewColumnBase::IsResizeable();
+}
+
 //-----------------------------------------------------------------------------
 // wxDataViewHeaderWindow
 //-----------------------------------------------------------------------------

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -5172,9 +5172,6 @@ wxSize wxDataViewCtrl::GetSizeAvailableForScrollTarget(const wxSize& size)
 
 void wxDataViewCtrl::OnSize( wxSizeEvent &WXUNUSED(event) )
 {
-    if ( m_clientArea && GetColumnCount() )
-        m_clientArea->UpdateColumnSizes();
-
     // We need to override OnSize so that our scrolled
     // window a) does call Layout() to use sizers for
     // positioning the controls but b) does not query
@@ -5185,6 +5182,11 @@ void wxDataViewCtrl::OnSize( wxSizeEvent &WXUNUSED(event) )
     Layout();
 
     AdjustScrollbars();
+
+    // Update the last column size to take all the available space. Note that
+    // this must be done after calling Layout() to update m_clientArea size.
+    if ( m_clientArea && GetColumnCount() )
+        m_clientArea->UpdateColumnSizes();
 
     // We must redraw the headers if their height changed. Normally this
     // shouldn't happen as the control shouldn't let itself be resized beneath


### PR DESCRIPTION
And also some `wxList` cleanup.

See [this ticket](https://trac.wxwidgets.org/ticket/18295) for the discussion.