### PR TITLE
Don't overwrite wxGraphicsContext attributes from wxGCDC ctor

### DIFF
--- a/include/wx/dcgraph.h
+++ b/include/wx/dcgraph.h
@@ -234,6 +234,12 @@ protected:
     bool m_isClipBoxValid;
 
 private:
+    // This method only initializes trivial fields.
+    void CommonInit();
+
+    // This method initializes all fields (including those initialized by
+    // CommonInit() as it calls it) and the given context, if non-null, which
+    // is assumed to be newly created.
     void Init(wxGraphicsContext*);
 
     wxDECLARE_CLASS(wxGCDCImpl);

--- a/interface/wx/dcgraph.h
+++ b/interface/wx/dcgraph.h
@@ -62,6 +62,17 @@ public:
        Note that this object takes ownership of @a context and will delete it
        when it is destroyed or when SetGraphicsContext() is called with a
        different context object.
+
+       Also notice that @a context will continue using the same font, pen and
+       brush as before until SetFont(), SetPen() or SetBrush() is explicitly
+       called to change them. This means that the code can use this
+       wxDC-derived object to work using pens and brushes with alpha component,
+       for example (which normally isn't supported by wxDC API), but it also
+       means that the return values of GetFont(), GetPen() and GetBrush() won't
+       really correspond to the actually used objects because they simply can't
+       represent them anyhow. If you wish to avoid such discrepancy, you need
+       to call the setter methods to bring wxDC and wxGraphicsContext font, pen
+       and brush in sync with each other.
     */
     wxGCDC(wxGraphicsContext* context);
 

--- a/src/common/dcgraph.cpp
+++ b/src/common/dcgraph.cpp
@@ -188,7 +188,6 @@ wxGCDCImpl::wxGCDCImpl(wxDC* owner, int)
 void wxGCDCImpl::Init(wxGraphicsContext* ctx)
 {
     m_ok = false;
-    m_colour = true;
     m_mm_to_pix_x = mm2pt;
     m_mm_to_pix_y = mm2pt;
 

--- a/src/common/dcgraph.cpp
+++ b/src/common/dcgraph.cpp
@@ -124,7 +124,17 @@ wxIMPLEMENT_ABSTRACT_CLASS(wxGCDCImpl, wxDCImpl);
 wxGCDCImpl::wxGCDCImpl(wxDC *owner, wxGraphicsContext* context) :
     wxDCImpl(owner)
 {
-    Init(context);
+    CommonInit();
+
+    m_graphicContext = context;
+    m_ok = m_graphicContext != NULL;
+
+    // We can't currently initialize m_font, m_pen and m_brush here as we don't
+    // have any way of converting the corresponding wxGraphicsXXX objects to
+    // plain wxXXX ones. This is obviously not ideal as it means that GetXXX()
+    // won't return the actual object being used, but is better than the only
+    // alternative which is overwriting the objects currently used in the
+    // graphics context with the defaults.
 }
 
 wxGCDCImpl::wxGCDCImpl( wxDC *owner ) :

--- a/src/common/dcgraph.cpp
+++ b/src/common/dcgraph.cpp
@@ -185,23 +185,29 @@ wxGCDCImpl::wxGCDCImpl(wxDC* owner, int)
     Init(NULL);
 }
 
-void wxGCDCImpl::Init(wxGraphicsContext* ctx)
+void wxGCDCImpl::CommonInit()
 {
-    m_ok = false;
     m_mm_to_pix_x = mm2pt;
     m_mm_to_pix_y = mm2pt;
+
+    m_isClipBoxValid = false;
+
+    m_logicalFunctionSupported = true;
+}
+
+void wxGCDCImpl::Init(wxGraphicsContext* ctx)
+{
+    CommonInit();
+
+    m_ok = false;
 
     m_pen = *wxBLACK_PEN;
     m_font = *wxNORMAL_FONT;
     m_brush = *wxWHITE_BRUSH;
 
-    m_isClipBoxValid = false;
-
     m_graphicContext = NULL;
     if (ctx)
         SetGraphicsContext(ctx);
-
-    m_logicalFunctionSupported = true;
 }
 
 wxGCDCImpl::~wxGCDCImpl()


### PR DESCRIPTION
What do you think of this change (only the last commit is significant)? I was surprised by `wxGCDC(wxGraphicsContext*)` ctor changing `wxGraphicsContext` attributes and I think there is an advantage in not doing this (as described in the commit message and the documentation update), but OTOH this does mean that `Get{Font,Pen,Brush}()` don't return correct values any longer.