### PR TITLE
Harmonize behaviour of wxItemContainer::Delete() for all controls and ports

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -113,6 +113,10 @@ All (GUI):
 - Fix wxInfoBar close button size in high DPI (Stefan Ziegler).
 - Make disabling the window before creating it actually work.
 
+wxGTK:
+
+- Invalidate selection after deleting wxListBox item with GTK+ 3 too.
+
 
 3.1.2: (released 2018-12-10)
 ----------------------------

--- a/interface/wx/aui/framemanager.h
+++ b/interface/wx/aui/framemanager.h
@@ -908,7 +908,7 @@ public:
         "Safe parts" are all non-UI elements (e.g. all layout determining parameters like the
         size, position etc.). "Unsafe parts" (pointers to button, frame and window) are not
         modified by this write operation.
-	 
+
         @remark This method is used when loading perspectives.
     */
     void SafeSet(wxAuiPaneInfo source);

--- a/interface/wx/ctrlsub.h
+++ b/interface/wx/ctrlsub.h
@@ -354,6 +354,12 @@ public:
         failure in debug builds) to remove an item with the index negative or
         greater or equal than the number of items in the control.
 
+        If there is a currently selected item below the item being deleted,
+        i.e. if GetSelection() returns a valid index greater than or equal to
+        @a n, the selection is invalidated when this function is called.
+        However if the selected item appears before the item being deleted, the
+        selection is preserved unchanged.
+
         @param n
             The zero-based item index.
 

--- a/interface/wx/listbox.h
+++ b/interface/wx/listbox.h
@@ -61,9 +61,9 @@
         list is selected or the selection changes.
     @event{EVT_LISTBOX_DCLICK(id, func)}
         Process a @c wxEVT_LISTBOX_DCLICK event, when the listbox
-        is double-clicked. On some platforms (notably wxGTK2) 
-	pressing the enter key is handled as an equivalent of a 
-	double-click.
+        is double-clicked. On some platforms (notably wxGTK2)
+        pressing the enter key is handled as an equivalent of a
+        double-click.
     @endEventTable
 
     @library{wxcore}

--- a/interface/wx/log.h
+++ b/interface/wx/log.h
@@ -801,7 +801,7 @@ public:
         The messages will be written in the encoding specified by the
         given @c wxMBConv.
 
-		The @a conv argument is only available in wxWidgets 3.1.1 and later.
+        The @a conv argument is only available in wxWidgets 3.1.1 and later.
 
         @note
             In practice, it is only advisable to specify @c wxConvUTF8 as

--- a/src/generic/htmllbox.cpp
+++ b/src/generic/htmllbox.cpp
@@ -672,6 +672,18 @@ void wxSimpleHtmlListBox::Clear()
 
 void wxSimpleHtmlListBox::DoDeleteOneItem(unsigned int n)
 {
+    // For consistency with the other wxItemContainer-derived classes, deselect
+    // the currently selected item if it, or any item before it, is being
+    // deleted, from a single-selection control.
+    if ( !HasMultipleSelection() )
+    {
+        const int sel = GetSelection();
+        if ( sel != wxNOT_FOUND && static_cast<unsigned>(sel) >= n )
+        {
+            SetSelection(wxNOT_FOUND);
+        }
+    }
+
     m_items.RemoveAt(n);
 
     m_HTMLclientData.RemoveAt(n);

--- a/src/gtk/listbox.cpp
+++ b/src/gtk/listbox.cpp
@@ -497,6 +497,25 @@ void wxListBox::DoDeleteOneItem(unsigned int n)
     // this returns false if iter is invalid (e.g. deleting item at end) but
     // since we don't use iter, we ignore the return value
     gtk_list_store_remove(m_liststore, &iter);
+
+#ifdef __WXGTK3__
+    // Invalidate selection in a single-selection control for consistency with
+    // MSW and GTK+ 2 where this happens automatically when deleting the
+    // selected item or any item before it.
+    if ( !HasMultipleSelection() )
+    {
+        const int sel = GetSelection();
+        if ( sel != wxNOT_FOUND && static_cast<unsigned>(sel) >= n )
+        {
+            // Don't call SetSelection() from here, it's not totally clear if
+            // it is safe to do, so just do this at GTK+ level.
+            gtk_tree_selection_unselect_all
+            (
+                gtk_tree_view_get_selection(m_treeview)
+            );
+        }
+    }
+#endif // __WXGTK3__
 }
 
 // ----------------------------------------------------------------------------

--- a/tests/controls/bitmapcomboboxtest.cpp
+++ b/tests/controls/bitmapcomboboxtest.cpp
@@ -77,12 +77,8 @@ private:
     wxDECLARE_NO_COPY_CLASS(BitmapComboBoxTestCase);
 };
 
-// register in the unnamed registry so that these tests are run by default
-CPPUNIT_TEST_SUITE_REGISTRATION( BitmapComboBoxTestCase );
-
-// also include in its own registry so that these tests can be run alone
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( BitmapComboBoxTestCase,
-                                      "BitmapComboBoxTestCase" );
+wxREGISTER_UNIT_TEST_WITH_TAGS(BitmapComboBoxTestCase,
+                               "[BitmapComboBoxTestCase][item-container]");
 
 void BitmapComboBoxTestCase::setUp()
 {

--- a/tests/controls/checklistboxtest.cpp
+++ b/tests/controls/checklistboxtest.cpp
@@ -46,11 +46,8 @@ private:
     wxDECLARE_NO_COPY_CLASS(CheckListBoxTestCase);
 };
 
-// register in the unnamed registry so that these tests are run by default
-CPPUNIT_TEST_SUITE_REGISTRATION( CheckListBoxTestCase );
-
-// also include in its own registry so that these tests can be run alone
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( CheckListBoxTestCase, "CheckListBoxTestCase" );
+wxREGISTER_UNIT_TEST_WITH_TAGS(CheckListBoxTestCase,
+                               "[CheckListBoxTestCase][item-container]");
 
 void CheckListBoxTestCase::setUp()
 {

--- a/tests/controls/choicetest.cpp
+++ b/tests/controls/choicetest.cpp
@@ -45,11 +45,8 @@ private:
     wxDECLARE_NO_COPY_CLASS(ChoiceTestCase);
 };
 
-// register in the unnamed registry so that these tests are run by default
-CPPUNIT_TEST_SUITE_REGISTRATION( ChoiceTestCase );
-
-// also include in its own registry so that these tests can be run alone
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( ChoiceTestCase, "ChoiceTestCase" );
+wxREGISTER_UNIT_TEST_WITH_TAGS(ChoiceTestCase,
+                               "[ChoiceTestCase][item-container]");
 
 void ChoiceTestCase::setUp()
 {

--- a/tests/controls/comboboxtest.cpp
+++ b/tests/controls/comboboxtest.cpp
@@ -88,11 +88,8 @@ private:
     wxDECLARE_NO_COPY_CLASS(ComboBoxTestCase);
 };
 
-// register in the unnamed registry so that these tests are run by default
-CPPUNIT_TEST_SUITE_REGISTRATION( ComboBoxTestCase );
-
-// also include in its own registry so that these tests can be run alone
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( ComboBoxTestCase, "ComboBoxTestCase" );
+wxREGISTER_UNIT_TEST_WITH_TAGS(ComboBoxTestCase,
+                               "[ComboBoxTestCase][item-container]");
 
 // ----------------------------------------------------------------------------
 // test initialization

--- a/tests/controls/htmllboxtest.cpp
+++ b/tests/controls/htmllboxtest.cpp
@@ -43,11 +43,8 @@ private:
     wxDECLARE_NO_COPY_CLASS(HtmlListBoxTestCase);
 };
 
-// register in the unnamed registry so that these tests are run by default
-CPPUNIT_TEST_SUITE_REGISTRATION( HtmlListBoxTestCase );
-
-// also include in its own registry so that these tests can be run alone
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( HtmlListBoxTestCase, "HtmlListBoxTestCase" );
+wxREGISTER_UNIT_TEST_WITH_TAGS(HtmlListBoxTestCase,
+                               "[HtmlListBoxTestCase][item-container]");
 
 void HtmlListBoxTestCase::setUp()
 {

--- a/tests/controls/itemcontainertest.cpp
+++ b/tests/controls/itemcontainertest.cpp
@@ -270,6 +270,33 @@ void ItemContainerTestCase::SetString()
 #endif
 }
 
+void ItemContainerTestCase::SelectionAfterDelete()
+{
+    wxItemContainer * const container = GetContainer();
+
+    container->Append("item 0");
+    container->Append("item 1");
+    container->Append("item 2");
+    container->Append("item 3");
+
+    container->SetSelection(1);
+    CHECK( container->GetSelection() == 1 );
+
+    container->Delete(3);
+    CHECK( container->GetSelection() == 1 );
+
+    container->Delete(1);
+    CHECK( container->GetSelection() == wxNOT_FOUND );
+
+    container->SetSelection(1);
+    container->Delete(1);
+    CHECK( container->GetSelection() == wxNOT_FOUND );
+
+    container->SetSelection(0);
+    container->Delete(0);
+    CHECK( container->GetSelection() == wxNOT_FOUND );
+}
+
 void ItemContainerTestCase::SetSelection()
 {
     wxItemContainer * const container = GetContainer();

--- a/tests/controls/itemcontainertest.h
+++ b/tests/controls/itemcontainertest.h
@@ -40,6 +40,7 @@ protected:
         CPPUNIT_TEST( Set ); \
         CPPUNIT_TEST( SetSelection ); \
         CPPUNIT_TEST( SetString ); \
+        CPPUNIT_TEST( SelectionAfterDelete ); \
         WXUISIM_TEST( SimSelect );
 
     void Append();
@@ -52,6 +53,7 @@ protected:
     void Set();
     void SetSelection();
     void SetString();
+    void SelectionAfterDelete();
 #if wxUSE_UIACTIONSIMULATOR
     virtual void SimSelect();
 #endif

--- a/tests/controls/itemcontainertest.h
+++ b/tests/controls/itemcontainertest.h
@@ -24,7 +24,7 @@ protected:
 
     // and this one must be overridden to return the window which implements
     // wxItemContainer interface -- usually it will return the same pointer as
-    // GetTestEntry(), just as a different type
+    // GetContainer(), just as a different type
     virtual wxWindow *GetContainerWindow() const = 0;
 
     // this should be inserted in the derived class CPPUNIT_TEST_SUITE

--- a/tests/controls/listboxtest.cpp
+++ b/tests/controls/listboxtest.cpp
@@ -68,11 +68,8 @@ private:
     wxDECLARE_NO_COPY_CLASS(ListBoxTestCase);
 };
 
-// register in the unnamed registry so that these tests are run by default
-CPPUNIT_TEST_SUITE_REGISTRATION( ListBoxTestCase );
-
-// also include in its own registry so that these tests can be run alone
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( ListBoxTestCase, "ListBoxTestCase" );
+wxREGISTER_UNIT_TEST_WITH_TAGS(ListBoxTestCase,
+                               "[ListBoxTestCase][item-container]");
 
 //initialise the static variable
 bool ListBoxTestCase::ms_ownerdrawn = false;

--- a/tests/controls/ownerdrawncomboboxtest.cpp
+++ b/tests/controls/ownerdrawncomboboxtest.cpp
@@ -75,12 +75,8 @@ private:
     wxDECLARE_NO_COPY_CLASS(OwnerDrawnComboBoxTestCase);
 };
 
-// register in the unnamed registry so that these tests are run by default
-CPPUNIT_TEST_SUITE_REGISTRATION( OwnerDrawnComboBoxTestCase );
-
-// also include in its own registry so that these tests can be run alone
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( OwnerDrawnComboBoxTestCase,
-                                       "OwnerDrawnComboBoxTestCase" );
+wxREGISTER_UNIT_TEST_WITH_TAGS(OwnerDrawnComboBoxTestCase,
+                               "[OwnerDrawnComboBoxTestCase][item-container]");
 
 // ----------------------------------------------------------------------------
 // test initialization

--- a/tests/controls/rearrangelisttest.cpp
+++ b/tests/controls/rearrangelisttest.cpp
@@ -46,11 +46,8 @@ private:
     wxDECLARE_NO_COPY_CLASS(RearrangeListTestCase);
 };
 
-// register in the unnamed registry so that these tests are run by default
-CPPUNIT_TEST_SUITE_REGISTRATION( RearrangeListTestCase );
-
-// also include in its own registry so that these tests can be run alone
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( RearrangeListTestCase, "RearrangeListTestCase" );
+wxREGISTER_UNIT_TEST_WITH_TAGS(RearrangeListTestCase,
+                               "[RearrangeListTestCase][item-container]");
 
 void RearrangeListTestCase::setUp()
 {


### PR DESCRIPTION
"All ports" means MSW, GTK2 and GTK3 only, I didn't test under Mac yet.

@paulcor any remarks about the GTK+-specific change in abc4576 (what an almost nice commit name) would be welcome, as always, TIA!