### PR TITLE
Fix #18297: skip less preferred languages, return status of the first

### DIFF
--- a/src/common/translation.cpp
+++ b/src/common/translation.cpp
@@ -1574,18 +1574,18 @@ bool wxTranslations::AddCatalog(const wxString& domain,
                    wxS("adding '%s' translation for domain '%s' (msgid language '%s')"),
                    *lang, domain, msgIdLang);
 
-        // No use loading languages that are less preferred than the
-        // msgid language, as by definition it contains all the strings
-        // in the msgid language.
-        if ( msgIdLang == *lang )
-            break;
-
         // We determine success by the success of loading/failing to load
         // the most preferred (i.e. the first one) language's catalog:
         if ( lang == domain_langs.begin() )
             success = LoadCatalog(domain, *lang, msgIdLang);
         else
             LoadCatalog(domain, *lang, msgIdLang);
+
+        // No use loading languages that are less preferred than the
+        // msgid language, as by definition it contains all the strings
+        // in the msgid language.
+        if ( msgIdLang == *lang )
+            break;
     }
 
     return success;


### PR DESCRIPTION
This change will force to always load catalog for the first language even it's the `msgIdLanguage` - `LoadCatalog()` will handle this in proper way.
Now the result of `LoadCatalog()` will be returned for the most preferred language in all cases.