### PR TITLE
wxAuiNotebook::DoGetBestSize

### DIFF
--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -356,7 +356,7 @@ public:
     virtual bool InsertPage(size_t index, wxWindow *page, const wxString &text,
                             bool select, int imageId) wxOVERRIDE;
 
-    wxSize DoGetBestSize() const;
+    virtual wxSize DoGetBestSize() const wxOVERRIDE;
 
 protected:
     // Common part of all ctors.

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -356,6 +356,8 @@ public:
     virtual bool InsertPage(size_t index, wxWindow *page, const wxString &text,
                             bool select, int imageId) wxOVERRIDE;
 
+    wxSize DoGetBestSize() const;
+
 protected:
     // Common part of all ctors.
     void Init();

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3450,10 +3450,10 @@ bool wxAuiNotebook::InsertPage(size_t index, wxWindow *page,
 class wxAuiLayoutObject
 {
 public:
-    wxAuiLayoutObject(const wxSize &size,
-                      const wxAuiPaneInfo &pInfo) : m_pInfo(pInfo)
+    wxAuiLayoutObject(const wxSize &size, const wxAuiPaneInfo &pInfo)
     {
         m_size = size;
+        m_pInfo = &pInfo;
         /* To speed up the sorting of the panes, the direction is mapped to a
          * useful increasing value. This avoids complicated comparison of the
          * enum values during the sort. The size calculation is done from the
@@ -3477,9 +3477,9 @@ public:
             return;
 
         bool mergeHorizontal;
-        if (m_pInfo.dock_layer != lo2.m_pInfo.dock_layer || m_dir != lo2.m_dir)
+        if (m_pInfo->dock_layer != lo2.m_pInfo->dock_layer || m_dir != lo2.m_dir)
             mergeHorizontal = lo2.m_dir < 3;
-        else if (m_pInfo.dock_row != lo2.m_pInfo.dock_row)
+        else if (m_pInfo->dock_row != lo2.m_pInfo->dock_row)
             mergeHorizontal = true;
         else
             mergeHorizontal = lo2.m_dir >= 3;
@@ -3499,23 +3499,23 @@ public:
     }
 
     wxSize m_size;
-    const wxAuiPaneInfo &m_pInfo;
+    const wxAuiPaneInfo *m_pInfo;
     unsigned char m_dir;
 
     /* As the caulculation is done from the inner to the outermost pane, the
      * panes are sorted in the following order: layer, direction, row,
      * position. */
     bool operator<(const wxAuiLayoutObject& lo2) const {
-        int diff = m_pInfo.dock_layer - lo2.m_pInfo.dock_layer;
+        int diff = m_pInfo->dock_layer - lo2.m_pInfo->dock_layer;
         if (diff)
             return diff < 0;
         diff = m_dir - lo2.m_dir;
         if (diff)
             return diff < 0;
-        diff = m_pInfo.dock_row - lo2.m_pInfo.dock_row;
+        diff = m_pInfo->dock_row - lo2.m_pInfo->dock_row;
         if (diff)
             return diff < 0;
-        return m_pInfo.dock_pos < lo2.m_pInfo.dock_pos;
+        return m_pInfo->dock_pos < lo2.m_pInfo->dock_pos;
     }
 };
 
@@ -3557,9 +3557,9 @@ wxSize wxAuiNotebook::DoGetBestSize() const
     size_t pos = 0;
     for (size_t n = 1; n < layouts.size(); n++)
     {
-        if (layouts[n].m_pInfo.dock_layer == layouts[pos].m_pInfo.dock_layer &&
+        if (layouts[n].m_pInfo->dock_layer == layouts[pos].m_pInfo->dock_layer &&
             layouts[n].m_dir == layouts[pos].m_dir &&
-            layouts[n].m_pInfo.dock_row == layouts[pos].m_pInfo.dock_row)
+            layouts[n].m_pInfo->dock_row == layouts[pos].m_pInfo->dock_row)
         {
             layouts[pos].MergeLayout(layouts[n]);
         }

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3450,9 +3450,9 @@ bool wxAuiNotebook::InsertPage(size_t index, wxWindow *page,
 class wxAuiLayoutObject
 {
 public:
-    wxAuiLayoutObject(wxSize &s, const wxAuiPaneInfo &pInfo): m_pInfo(pInfo)
+    wxAuiLayoutObject(const wxSize &size, const wxAuiPaneInfo &pInfo): m_pInfo(pInfo)
     {
-        m_size = s;
+        m_size = size;
         /* To speed up the sorting of the panes, the direction is mapped to a
          * useful increasing value. This avoids complicated comparison of the
          * enum values during the sort. The size calculation is done from the

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3449,10 +3449,9 @@ bool wxAuiNotebook::InsertPage(size_t index, wxWindow *page,
 class wxAuiLayoutObject
 {
 public:
-    wxAuiLayoutObject(wxSize &s, const wxAuiPaneInfo &pInfo)
+    wxAuiLayoutObject(wxSize &s, const wxAuiPaneInfo &pInfo): m_pInfo(pInfo)
     {
         m_size = s;
-        m_layer = pInfo.dock_layer;
         switch (pInfo.dock_direction)
         {
             case wxAUI_DOCK_CENTER: m_direction = 0; break;
@@ -3462,8 +3461,6 @@ public:
             case wxAUI_DOCK_BOTTOM: m_direction = 4; break;
             default:                m_direction = 5;
         }
-        m_row = pInfo.dock_row;
-        m_position = pInfo.dock_pos;
     }
     void MergeLayout(const wxAuiLayoutObject &lo2)
     {
@@ -3471,9 +3468,9 @@ public:
             return;
 
         bool mergeHorizontal;
-        if (m_layer != lo2.m_layer || m_direction != lo2.m_direction)
+        if (m_pInfo.dock_layer != lo2.m_pInfo.dock_layer || m_direction != lo2.m_direction)
             mergeHorizontal = lo2.m_direction < 3;
-        else if (m_row != lo2.m_row)
+        else if (m_pInfo.dock_row != lo2.m_pInfo.dock_row)
             mergeHorizontal = true;
         else
             mergeHorizontal = lo2.m_direction >= 3;
@@ -3491,19 +3488,17 @@ public:
     }
 
     wxSize m_size;
-    unsigned short m_layer;
+    const wxAuiPaneInfo &m_pInfo;
     unsigned char m_direction;
-    unsigned short m_row;
-    unsigned short m_position;
 
     bool operator<(const wxAuiLayoutObject& lo2) const {
-        if (m_layer < lo2.m_layer)
+        if (m_pInfo.dock_layer < lo2.m_pInfo.dock_layer)
             return true;
         if (m_direction < lo2.m_direction)
             return true;
-        if (m_row < lo2.m_row)
+        if (m_pInfo.dock_row < lo2.m_pInfo.dock_row)
             return true;
-        return m_position < lo2.m_position;
+        return m_pInfo.dock_pos < lo2.m_pInfo.dock_pos;
     }
 };
 
@@ -3534,7 +3529,7 @@ wxSize wxAuiNotebook::DoGetBestSize() const
     size_t pos = 0;
     for (size_t n = 1; n < layoutObj.size(); n++)
     {
-        if (layoutObj[n].m_layer != layoutObj[pos].m_layer)
+        if (layoutObj[n].m_pInfo.dock_layer != layoutObj[pos].m_pInfo.dock_layer)
         {
             layoutObj[0].MergeLayout(layoutObj[pos]);
             pos = n;
@@ -3544,7 +3539,7 @@ wxSize wxAuiNotebook::DoGetBestSize() const
             layoutObj[0].MergeLayout(layoutObj[pos]);
             pos = n;
         }
-        else if (layoutObj[n].m_row != layoutObj[pos].m_row)
+        else if (layoutObj[n].m_pInfo.dock_row != layoutObj[pos].m_pInfo.dock_row)
         {
             layoutObj[0].MergeLayout(layoutObj[pos]);
             pos = n;

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3557,24 +3557,16 @@ wxSize wxAuiNotebook::DoGetBestSize() const
     size_t pos = 0;
     for (size_t n = 1; n < layouts.size(); n++)
     {
-        if (layouts[n].m_pInfo.dock_layer != layouts[pos].m_pInfo.dock_layer)
+        if (layouts[n].m_pInfo.dock_layer == layouts[pos].m_pInfo.dock_layer &&
+            layouts[n].m_dir == layouts[pos].m_dir &&
+            layouts[n].m_pInfo.dock_row == layouts[pos].m_pInfo.dock_row)
         {
-            layouts[0].MergeLayout(layouts[pos]);
-            pos = n;
-        }
-        else if (layouts[n].m_dir != layouts[pos].m_dir)
-        {
-            layouts[0].MergeLayout(layouts[pos]);
-            pos = n;
-        }
-        else if (layouts[n].m_pInfo.dock_row != layouts[pos].m_pInfo.dock_row)
-        {
-            layouts[0].MergeLayout(layouts[pos]);
-            pos = n;
+            layouts[pos].MergeLayout(layouts[n]);
         }
         else
         {
-            layouts[pos].MergeLayout(layouts[n]);
+            layouts[0].MergeLayout(layouts[pos]);
+            pos = n;
         }
     }
     layouts[0].MergeLayout(layouts[pos]);

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3465,28 +3465,28 @@ public:
         row = pInfo.dock_row;
         position = pInfo.dock_pos;
     }
-    void MergeLayout(wxAuiLayoutObject *lo2)
+    void MergeLayout(const wxAuiLayoutObject &lo2)
     {
-        if (this == lo2)
+        if (this == &lo2)
             return;
 
         bool mergeHorizontal;
-        if (layer != lo2->layer || direction != lo2->direction)
-            mergeHorizontal = lo2->direction < 3;
-        else if (row != lo2->row)
+        if (layer != lo2.layer || direction != lo2.direction)
+            mergeHorizontal = lo2.direction < 3;
+        else if (row != lo2.row)
             mergeHorizontal = true;
         else
-            mergeHorizontal = lo2->direction >= 3;
+            mergeHorizontal = lo2.direction >= 3;
 
         if (mergeHorizontal)
         {
-            size.x += lo2->size.x;
-            if (lo2->size.y > size.y) size.y = lo2->size.y;
+            size.x += lo2.size.x;
+            if (lo2.size.y > size.y) size.y = lo2.size.y;
         }
         else
         {
-            if (lo2->size.x > size.x) size.x = lo2->size.x;
-            size.y += lo2->size.y;
+            if (lo2.size.x > size.x) size.x = lo2.size.x;
+            size.y += lo2.size.y;
         }
     }
 
@@ -3541,25 +3541,25 @@ wxSize wxAuiNotebook::DoGetBestSize() const
     {
         if (layoutObj[n]->layer != layoutObj[pos]->layer)
         {
-            layoutObj[0]->MergeLayout(layoutObj[pos]);
+            layoutObj[0]->MergeLayout(*layoutObj[pos]);
             pos = n;
         }
         else if (layoutObj[n]->direction != layoutObj[pos]->direction)
         {
-            layoutObj[0]->MergeLayout(layoutObj[pos]);
+            layoutObj[0]->MergeLayout(*layoutObj[pos]);
             pos = n;
         }
         else if (layoutObj[n]->row != layoutObj[pos]->row)
         {
-            layoutObj[0]->MergeLayout(layoutObj[pos]);
+            layoutObj[0]->MergeLayout(*layoutObj[pos]);
             pos = n;
         }
         else
         {
-            layoutObj[pos]->MergeLayout(layoutObj[n]);
+            layoutObj[pos]->MergeLayout(*layoutObj[n]);
         }
     }
-    layoutObj[0]->MergeLayout(layoutObj[pos]);
+    layoutObj[0]->MergeLayout(*layoutObj[pos]);
 
     wxSize bestSize = layoutObj[0]->size;
     WX_CLEAR_ARRAY(layoutObj);

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3471,18 +3471,23 @@ public:
         if (this == lo2)
             return;
 
-        if (direction != lo2->direction)
+        bool mergeHorizontal;
+        if (layer != lo2->layer || direction != lo2->direction)
+            mergeHorizontal = lo2->direction < 3;
+        else if (row != lo2->row)
+            mergeHorizontal = true;
+        else
+            mergeHorizontal = lo2->direction >= 3;
+
+        if (mergeHorizontal)
         {
-            if ( ( (layer != lo2->layer || direction != lo2->direction) && lo2->direction < 3 ) || row != lo2->row )
-            {
-                size.x += lo2->size.x;
-                if (lo2->size.y > size.y) size.y = lo2->size.y;
-            }
-            else
-            {
-                if (lo2->size.x > size.x) size.x = lo2->size.x;
-                size.y += lo2->size.y;
-            }
+            size.x += lo2->size.x;
+            if (lo2->size.y > size.y) size.y = lo2->size.y;
+        }
+        else
+        {
+            if (lo2->size.x > size.x) size.x = lo2->size.x;
+            size.y += lo2->size.y;
         }
     }
 

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3487,11 +3487,13 @@ public:
         if (mergeHorizontal)
         {
             m_size.x += lo2.m_size.x;
-            if (lo2.m_size.y > m_size.y) m_size.y = lo2.m_size.y;
+            if (lo2.m_size.y > m_size.y)
+                m_size.y = lo2.m_size.y;
         }
         else
         {
-            if (lo2.m_size.x > m_size.x) m_size.x = lo2.m_size.x;
+            if (lo2.m_size.x > m_size.x)
+                m_size.x = lo2.m_size.x;
             m_size.y += lo2.m_size.y;
         }
     }

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3450,7 +3450,8 @@ bool wxAuiNotebook::InsertPage(size_t index, wxWindow *page,
 class wxAuiLayoutObject
 {
 public:
-    wxAuiLayoutObject(const wxSize &size, const wxAuiPaneInfo &pInfo): m_pInfo(pInfo)
+    wxAuiLayoutObject(const wxSize &size,
+                      const wxAuiPaneInfo &pInfo) : m_pInfo(pInfo)
     {
         m_size = size;
         /* To speed up the sorting of the panes, the direction is mapped to a
@@ -3524,7 +3525,8 @@ wxSize wxAuiNotebook::DoGetBestSize() const
      * processed in a specific order. Therefore we need to collect them in the
      * following variable which is sorted later on. */
     wxVector<wxAuiLayoutObject> layouts;
-    const wxAuiPaneInfoArray& all_panes = const_cast<wxAuiManager&>(m_mgr).GetAllPanes();
+    const wxAuiPaneInfoArray& all_panes =
+        const_cast<wxAuiManager&>(m_mgr).GetAllPanes();
     const size_t pane_count = all_panes.GetCount();
     const int tabHeight = GetTabCtrlHeight();
     for (size_t n = 0; n < pane_count; ++n)

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3450,6 +3450,15 @@ bool wxAuiNotebook::InsertPage(size_t index, wxWindow *page,
 class wxAuiLayoutObject
 {
 public:
+    enum {
+        DockDir_Center,
+        DockDir_Left,
+        DockDir_Right,
+        DockDir_Vertical,   // Merge elements from here vertically
+        DockDir_Top,
+        DockDir_Bottom,
+        DockDir_None
+    };
     wxAuiLayoutObject(const wxSize &size, const wxAuiPaneInfo &pInfo)
     {
         m_size = size;
@@ -3463,12 +3472,12 @@ public:
          * TOP/BOTTOM in vertical direction) */
         switch (pInfo.dock_direction)
         {
-            case wxAUI_DOCK_CENTER: m_dir = 0; break;
-            case wxAUI_DOCK_LEFT:   m_dir = 1; break;
-            case wxAUI_DOCK_RIGHT:  m_dir = 2; break;
-            case wxAUI_DOCK_TOP:    m_dir = 3; break;
-            case wxAUI_DOCK_BOTTOM: m_dir = 4; break;
-            default:                m_dir = 5;
+            case wxAUI_DOCK_CENTER: m_dir = DockDir_Center; break;
+            case wxAUI_DOCK_LEFT:   m_dir = DockDir_Left; break;
+            case wxAUI_DOCK_RIGHT:  m_dir = DockDir_Right; break;
+            case wxAUI_DOCK_TOP:    m_dir = DockDir_Top; break;
+            case wxAUI_DOCK_BOTTOM: m_dir = DockDir_Bottom; break;
+            default:                m_dir = DockDir_None;
         }
     }
     void MergeLayout(const wxAuiLayoutObject &lo2)
@@ -3478,11 +3487,11 @@ public:
 
         bool mergeHorizontal;
         if (m_pInfo->dock_layer != lo2.m_pInfo->dock_layer || m_dir != lo2.m_dir)
-            mergeHorizontal = lo2.m_dir < 3;
+            mergeHorizontal = lo2.m_dir < DockDir_Vertical;
         else if (m_pInfo->dock_row != lo2.m_pInfo->dock_row)
             mergeHorizontal = true;
         else
-            mergeHorizontal = lo2.m_dir >= 3;
+            mergeHorizontal = lo2.m_dir >= DockDir_Vertical;
 
         if (mergeHorizontal)
         {

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3449,12 +3449,11 @@ bool wxAuiNotebook::InsertPage(size_t index, wxWindow *page,
 class wxAuiLayoutObject
 {
 public:
-    wxAuiLayoutObject(wxSize &s, unsigned short l, unsigned short dir, unsigned short r, unsigned short pos)
+    wxAuiLayoutObject(wxSize &s, const wxAuiPaneInfo &pInfo)
     {
         size = s;
-        layer = l;
-        direction = dir;
-        switch (dir)
+        layer = pInfo.dock_layer;
+        switch (pInfo.dock_direction)
         {
             case wxAUI_DOCK_CENTER: direction = 0; break;
             case wxAUI_DOCK_LEFT:   direction = 1; break;
@@ -3463,8 +3462,8 @@ public:
             case wxAUI_DOCK_BOTTOM: direction = 4; break;
             default:                direction = 5;
         }
-        row = r;
-        position = pos;
+        row = pInfo.dock_row;
+        position = pInfo.dock_pos;
     }
     void MergeLayout(wxAuiLayoutObject *lo2)
     {
@@ -3534,7 +3533,7 @@ wxSize wxAuiNotebook::DoGetBestSize() const
             bestPageSize.IncTo(pages[pIdx].window->GetBestSize());
 
         bestPageSize.y += tabHeight;
-        layoutObj.Add(new wxAuiLayoutObject(bestPageSize, pInfo.dock_layer, pInfo.dock_direction, pInfo.dock_row, pInfo.dock_pos));
+        layoutObj.Add(new wxAuiLayoutObject(bestPageSize, pInfo));
     }
 
     size_t pos = 0;

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3492,12 +3492,15 @@ public:
     unsigned char m_direction;
 
     bool operator<(const wxAuiLayoutObject& lo2) const {
-        if (m_pInfo.dock_layer < lo2.m_pInfo.dock_layer)
-            return true;
-        if (m_direction < lo2.m_direction)
-            return true;
-        if (m_pInfo.dock_row < lo2.m_pInfo.dock_row)
-            return true;
+        int diff = m_pInfo.dock_layer - lo2.m_pInfo.dock_layer;
+        if (diff)
+            return diff < 0;
+        diff = m_direction - lo2.m_direction;
+        if (diff)
+            return diff < 0;
+        diff = m_pInfo.dock_row - lo2.m_pInfo.dock_row;
+        if (diff)
+            return diff < 0;
         return m_pInfo.dock_pos < lo2.m_pInfo.dock_pos;
     }
 };

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3466,6 +3466,25 @@ public:
         row = r;
         position = pos;
     }
+    void MergeLayout(wxAuiLayoutObject *lo2)
+    {
+        if (this == lo2)
+            return;
+
+        if (direction != lo2->direction)
+        {
+            if ( ( (layer != lo2->layer || direction != lo2->direction) && lo2->direction < 3 ) || row != lo2->row )
+            {
+                size.x += lo2->size.x;
+                if (lo2->size.y > size.y) size.y = lo2->size.y;
+            }
+            else
+            {
+                if (lo2->size.x > size.x) size.x = lo2->size.x;
+                size.y += lo2->size.y;
+            }
+        }
+    }
 
     wxSize size;
     unsigned short layer;
@@ -3489,26 +3508,6 @@ public:
 };
 
 WX_DEFINE_SORTED_ARRAY(wxAuiLayoutObject*, wxAuiLayoutObjectArray);
-
-void MergeLayout(wxAuiLayoutObject *lo1, wxAuiLayoutObject *lo2)
-{
-    if (lo1 == lo2)
-        return;
-
-    if (lo1->direction != lo2->direction)
-    {
-        if ( ( (lo1->layer != lo2->layer || lo1->direction != lo2->direction) && lo2->direction < 3 ) || lo1->row != lo2->row )
-        {
-            lo1->size.x += lo2->size.x;
-            if (lo2->size.y > lo1->size.y) lo1->size.y = lo2->size.y;
-        }
-        else
-        {
-            if (lo2->size.x > lo1->size.x) lo1->size.x = lo2->size.x;
-            lo1->size.y += lo2->size.y;
-        }
-    }
-}
 
 wxSize wxAuiNotebook::DoGetBestSize() const
 {
@@ -3536,25 +3535,25 @@ wxSize wxAuiNotebook::DoGetBestSize() const
     {
         if (layoutObj[n]->layer != layoutObj[pos]->layer)
         {
-            MergeLayout(layoutObj[0], layoutObj[pos]);
+            layoutObj[0]->MergeLayout(layoutObj[pos]);
             pos = n;
         }
         else if (layoutObj[n]->direction != layoutObj[pos]->direction)
         {
-            MergeLayout(layoutObj[0], layoutObj[pos]);
+            layoutObj[0]->MergeLayout(layoutObj[pos]);
             pos = n;
         }
         else if (layoutObj[n]->row != layoutObj[pos]->row)
         {
-            MergeLayout(layoutObj[0], layoutObj[pos]);
+            layoutObj[0]->MergeLayout(layoutObj[pos]);
             pos = n;
         }
         else
         {
-            MergeLayout(layoutObj[pos], layoutObj[n]);
+            layoutObj[pos]->MergeLayout(layoutObj[n]);
         }
     }
-    MergeLayout(layoutObj[0], layoutObj[pos]);
+    layoutObj[0]->MergeLayout(layoutObj[pos]);
 
     wxSize bestSize = layoutObj[0]->size;
     WX_CLEAR_ARRAY(layoutObj);

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3451,19 +3451,19 @@ class wxAuiLayoutObject
 public:
     wxAuiLayoutObject(wxSize &s, const wxAuiPaneInfo &pInfo)
     {
-        size = s;
-        layer = pInfo.dock_layer;
+        m_size = s;
+        m_layer = pInfo.dock_layer;
         switch (pInfo.dock_direction)
         {
-            case wxAUI_DOCK_CENTER: direction = 0; break;
-            case wxAUI_DOCK_LEFT:   direction = 1; break;
-            case wxAUI_DOCK_RIGHT:  direction = 2; break;
-            case wxAUI_DOCK_TOP:    direction = 3; break;
-            case wxAUI_DOCK_BOTTOM: direction = 4; break;
-            default:                direction = 5;
+            case wxAUI_DOCK_CENTER: m_direction = 0; break;
+            case wxAUI_DOCK_LEFT:   m_direction = 1; break;
+            case wxAUI_DOCK_RIGHT:  m_direction = 2; break;
+            case wxAUI_DOCK_TOP:    m_direction = 3; break;
+            case wxAUI_DOCK_BOTTOM: m_direction = 4; break;
+            default:                m_direction = 5;
         }
-        row = pInfo.dock_row;
-        position = pInfo.dock_pos;
+        m_row = pInfo.dock_row;
+        m_position = pInfo.dock_pos;
     }
     void MergeLayout(const wxAuiLayoutObject &lo2)
     {
@@ -3471,43 +3471,43 @@ public:
             return;
 
         bool mergeHorizontal;
-        if (layer != lo2.layer || direction != lo2.direction)
-            mergeHorizontal = lo2.direction < 3;
-        else if (row != lo2.row)
+        if (m_layer != lo2.m_layer || m_direction != lo2.m_direction)
+            mergeHorizontal = lo2.m_direction < 3;
+        else if (m_row != lo2.m_row)
             mergeHorizontal = true;
         else
-            mergeHorizontal = lo2.direction >= 3;
+            mergeHorizontal = lo2.m_direction >= 3;
 
         if (mergeHorizontal)
         {
-            size.x += lo2.size.x;
-            if (lo2.size.y > size.y) size.y = lo2.size.y;
+            m_size.x += lo2.m_size.x;
+            if (lo2.m_size.y > m_size.y) m_size.y = lo2.m_size.y;
         }
         else
         {
-            if (lo2.size.x > size.x) size.x = lo2.size.x;
-            size.y += lo2.size.y;
+            if (lo2.m_size.x > m_size.x) m_size.x = lo2.m_size.x;
+            m_size.y += lo2.m_size.y;
         }
     }
 
-    wxSize size;
-    unsigned short layer;
-    unsigned char direction;
-    unsigned short row;
-    unsigned short position;
+    wxSize m_size;
+    unsigned short m_layer;
+    unsigned char m_direction;
+    unsigned short m_row;
+    unsigned short m_position;
 
     static int CompareLayoutObject(wxAuiLayoutObject *lo1, wxAuiLayoutObject *lo2)
     {
-        int res = lo1->layer - lo2->layer;
+        int res = lo1->m_layer - lo2->m_layer;
         if (res)
             return res;
-        res = lo1->direction - lo2->direction;
+        res = lo1->m_direction - lo2->m_direction;
         if (res)
             return res;
-        res = lo1->row - lo2->row;
+        res = lo1->m_row - lo2->m_row;
         if (res)
             return res;
-        return lo1->position - lo2->position;
+        return lo1->m_position - lo2->m_position;
     }
 };
 
@@ -3539,17 +3539,17 @@ wxSize wxAuiNotebook::DoGetBestSize() const
     size_t pos = 0;
     for (size_t n = 1; n < layoutObj.GetCount(); n++)
     {
-        if (layoutObj[n]->layer != layoutObj[pos]->layer)
+        if (layoutObj[n]->m_layer != layoutObj[pos]->m_layer)
         {
             layoutObj[0]->MergeLayout(*layoutObj[pos]);
             pos = n;
         }
-        else if (layoutObj[n]->direction != layoutObj[pos]->direction)
+        else if (layoutObj[n]->m_direction != layoutObj[pos]->m_direction)
         {
             layoutObj[0]->MergeLayout(*layoutObj[pos]);
             pos = n;
         }
-        else if (layoutObj[n]->row != layoutObj[pos]->row)
+        else if (layoutObj[n]->m_row != layoutObj[pos]->m_row)
         {
             layoutObj[0]->MergeLayout(*layoutObj[pos]);
             pos = n;
@@ -3561,7 +3561,7 @@ wxSize wxAuiNotebook::DoGetBestSize() const
     }
     layoutObj[0]->MergeLayout(*layoutObj[pos]);
 
-    wxSize bestSize = layoutObj[0]->size;
+    wxSize bestSize = layoutObj[0]->m_size;
     WX_CLEAR_ARRAY(layoutObj);
     return bestSize;
 }

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3519,6 +3519,7 @@ wxSize wxAuiNotebook::DoGetBestSize() const
     wxAuiLayoutObjectArray layoutObj(wxAuiLayoutObject::CompareLayoutObject);
     const wxAuiPaneInfoArray& all_panes = const_cast<wxAuiManager&>(m_mgr).GetAllPanes();
     const size_t pane_count = all_panes.GetCount();
+    const int tabHeight = GetTabCtrlHeight();
     for (size_t n = 0; n < pane_count; ++n)
     {
         const wxAuiPaneInfo &pInfo = all_panes[n];
@@ -3532,6 +3533,7 @@ wxSize wxAuiNotebook::DoGetBestSize() const
         for (size_t pIdx = 0; pIdx < pages.GetCount(); pIdx++)
             bestPageSize.IncTo(pages[pIdx].window->GetBestSize());
 
+        bestPageSize.y += tabHeight;
         layoutObj.Add(new wxAuiLayoutObject(bestPageSize, pInfo.dock_layer, pInfo.dock_direction, pInfo.dock_row, pInfo.dock_pos));
     }
 

--- a/tests/controls/auitest.cpp
+++ b/tests/controls/auitest.cpp
@@ -132,4 +132,6 @@ TEST_CASE( "wxAuiNotebook::DoGetBestSize", "[aui]" ) {
     CHECK( auiSize.x == 250 );
     CHECK( auiSize.y == 175 + 3*tabHeight );
   }
+
+  wxDELETE(nb);
 }

--- a/tests/controls/auitest.cpp
+++ b/tests/controls/auitest.cpp
@@ -1,0 +1,135 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        tests/controls/auitest.cpp
+// Purpose:     wxAui control tests
+// Author:      Sebastian Walderich
+// Created:     2018-12-19
+// Copyright:   (c) 2018 Sebastian Walderich
+///////////////////////////////////////////////////////////////////////////////
+
+// ----------------------------------------------------------------------------
+// headers
+// ----------------------------------------------------------------------------
+
+#include "testprec.h"
+
+#ifdef __BORLANDC__
+    #pragma hdrstop
+#endif
+
+#ifndef WX_PRECOMP
+    #include "wx/app.h"
+#endif // WX_PRECOMP
+
+#include "wx/aui/auibook.h"
+#include "wx/panel.h"
+
+// ----------------------------------------------------------------------------
+// test class
+// ----------------------------------------------------------------------------
+
+TEST_CASE( "wxAuiNotebook::DoGetBestSize", "[aui]" ) {
+  wxWindow *frame = wxTheApp->GetTopWindow();
+  REQUIRE( frame );
+  wxAuiNotebook *nb = new wxAuiNotebook(frame);
+  REQUIRE ( nb );
+  wxPanel *p = new wxPanel(frame);
+  REQUIRE ( p );
+  p->SetMinSize(wxSize(100, 100));
+  REQUIRE( nb->AddPage(p, "Center Pane") );
+  int tabHeight = nb->GetTabCtrlHeight();
+  wxSize auiSize;
+
+  SECTION( "Single pane with multiple tabs" ) {
+    p = new wxPanel(frame);
+    p->SetMinSize(wxSize(300, 100));
+    nb->AddPage(p, "Center Tab 2");
+
+    p = new wxPanel(frame);
+    p->SetMinSize(wxSize(100, 200));
+    nb->AddPage(p, "Center Tab 3");
+
+    auiSize = nb->GetBestSize();
+    CHECK( auiSize.x == 300 );
+    CHECK( auiSize.y == 200 + tabHeight );
+  }
+
+  SECTION( "Horizontal split" ) {
+    p = new wxPanel(frame);
+    p->SetMinSize(wxSize(25, 0));
+    nb->AddPage(p, "Left Pane");
+    nb->Split(nb->GetPageCount()-1, wxLEFT);
+
+    auiSize = nb->GetBestSize();
+    CHECK( auiSize.x == 125 );
+    CHECK( auiSize.y == 100 + tabHeight );
+
+    p = new wxPanel(frame);
+    p->SetMinSize(wxSize(50, 0));
+    nb->AddPage(p, "Right Pane 1");
+    nb->Split(nb->GetPageCount()-1, wxRIGHT);
+
+    auiSize = nb->GetBestSize();
+    CHECK( auiSize.x == 175 );
+    CHECK( auiSize.y == 100 + tabHeight );
+
+    p = new wxPanel(frame);
+    p->SetMinSize(wxSize(100, 0));
+    nb->AddPage(p, "Right Pane 2");
+    nb->Split(nb->GetPageCount()-1, wxRIGHT);
+
+    auiSize = nb->GetBestSize();
+    CHECK( auiSize.x == 275 );
+    CHECK( auiSize.y == 100 + tabHeight );
+  }
+
+  SECTION( "Vertical split" ) {
+    p = new wxPanel(frame);
+    p->SetMinSize(wxSize(0, 100));
+    nb->AddPage(p, "Top Pane 1");
+    nb->Split(nb->GetPageCount()-1, wxTOP);
+
+    p = new wxPanel(frame);
+    p->SetMinSize(wxSize(0, 50));
+    nb->AddPage(p, "Top Pane 2");
+    nb->Split(nb->GetPageCount()-1, wxTOP);
+
+    auiSize = nb->GetBestSize();
+    CHECK( auiSize.x == 100 );
+    CHECK( auiSize.y == 250 + 3*tabHeight );
+
+    p = new wxPanel(frame);
+    p->SetMinSize(wxSize(0, 25));
+    nb->AddPage(p, "Bottom Pane");
+    nb->Split(nb->GetPageCount()-1, wxBOTTOM);
+
+    auiSize = nb->GetBestSize();
+    CHECK( auiSize.x == 100 );
+    CHECK( auiSize.y == 275 + 4*tabHeight );
+  }
+
+  SECTION( "Surrounding panes" ) {
+    p = new wxPanel(frame);
+    p->SetMinSize(wxSize(50, 25));
+    nb->AddPage(p, "Bottom Pane");
+    nb->Split(nb->GetPageCount()-1, wxBOTTOM);
+
+    p = new wxPanel(frame);
+    p->SetMinSize(wxSize(50, 120));
+    nb->AddPage(p, "Right Pane");
+    nb->Split(nb->GetPageCount()-1, wxRIGHT);
+
+    p = new wxPanel(frame);
+    p->SetMinSize(wxSize(225, 50));
+    nb->AddPage(p, "Top Pane");
+    nb->Split(nb->GetPageCount()-1, wxTOP);
+
+    p = new wxPanel(frame);
+    p->SetMinSize(wxSize(25, 105));
+    nb->AddPage(p, "Left Pane");
+    nb->Split(nb->GetPageCount()-1, wxLEFT);
+
+    auiSize = nb->GetBestSize();
+    CHECK( auiSize.x == 250 );
+    CHECK( auiSize.y == 175 + 3*tabHeight );
+  }
+}


### PR DESCRIPTION
In my current project I encountered the issue that I needed to calculate the size of a wxAuiNotebook control (as the user can control the content of the pages during runtime using an INI file). But as `Fit` always shrinked the complete window down to size 0x0 I saw that wxAuiNotebook does not implement the `DoGetBestSize` method.

Although in my case I do not have nested/split panes (as the control gets reset after the INI file update). I thought it would make sense to still implement a generic method, so I can use this instead of writing my own, every time I need it.

The not-so-simple layout options made it a bit more complicated than I thought. But I got it to work correctly in my test cases. I did not have a deeper look into it, but currently calling `Fit` does not resize splittet tab containers. I guess this has to be handled separately.