### PR TITLE
Stock label should only be used if passed label is empty. …

### DIFF
--- a/src/qt/button.cpp
+++ b/src/qt/button.cpp
@@ -45,7 +45,7 @@ bool wxButton::Create(wxWindow *parent, wxWindowID id,
        const wxString& name )
 {     
     QtCreate(parent);
-    SetLabel( wxIsStockID( id ) ? wxGetStockLabel( id ) : label );
+    SetLabel( label.IsEmpty() && wxIsStockID( id ) ? wxGetStockLabel( id ) : label );
 
     return QtCreateControl( parent, id, pos, size, style, validator, name );
 }


### PR DESCRIPTION
Otherwise, passed label should override.

This fixes the problem (among others) with the app alert message box showing "Yes" and "No" instead of "Stop" and "Continue".