### PR TITLE
Ensure QDatePicker sets date ranges and dates correctly.

### DIFF
--- a/include/wx/qt/calctrl.h
+++ b/include/wx/qt/calctrl.h
@@ -79,7 +79,6 @@ protected:
 private:
     void Init();
     void UpdateStyle();
-    bool IsQDateValid(const QDate &date) const;
 
     QCalendarWidget *m_qtCalendar;
     wxColour m_colHeaderFg,

--- a/include/wx/qt/calctrl.h
+++ b/include/wx/qt/calctrl.h
@@ -12,6 +12,7 @@
 
 #include "wx/calctrl.h"
 class QCalendarWidget;
+class QDate;
 
 class WXDLLIMPEXP_ADV wxCalendarCtrl : public wxCalendarCtrlBase
 {
@@ -78,6 +79,7 @@ protected:
 private:
     void Init();
     void UpdateStyle();
+    bool IsQDateValid(const QDate &date) const;
 
     QCalendarWidget *m_qtCalendar;
     wxColour m_colHeaderFg,

--- a/src/qt/calctrl.cpp
+++ b/src/qt/calctrl.cpp
@@ -181,20 +181,22 @@ bool wxCalendarCtrl::SetDateRange(const wxDateTime& lowerdate,
 bool wxCalendarCtrl::GetDateRange(wxDateTime *lowerdate,
                                   wxDateTime *upperdate) const
 {
-    bool status = true;
-
     if ( !m_qtCalendar )
         return false;
 
+    bool status = false;
+
     if ( lowerdate && IsQDateValid( m_qtCalendar->minimumDate() ) )
+    {
         *lowerdate = wxQtConvertDate(m_qtCalendar->minimumDate());
-    else
-        status = false;
+        status = true;
+    }
 
     if ( upperdate && IsQDateValid( m_qtCalendar->maximumDate() ) )
+    {
         *upperdate = wxQtConvertDate(m_qtCalendar->maximumDate());
-    else
-        status = false;
+        status = true;
+    }
 
     return status;
 }

--- a/src/qt/calctrl.cpp
+++ b/src/qt/calctrl.cpp
@@ -27,6 +27,11 @@
 namespace
 {
     const int MAX_YEAR_QT = 7999;
+
+    bool IsQDateValid(const QDate &date)
+    {
+        return date.isValid() && date.year() > 0 && date.year() < MAX_YEAR_QT;
+    }
 }
 
 class wxQtCalendarWidget : public wxQtEventSignalHandler< QCalendarWidget, wxCalendarCtrl >
@@ -123,11 +128,6 @@ void wxCalendarCtrl::UpdateStyle()
         m_qtCalendar->setVerticalHeaderFormat(QCalendarWidget::NoVerticalHeader);
 
     RefreshHolidays();
-}
-
-bool wxCalendarCtrl::IsQDateValid(const QDate &date) const
-{
-    return date.isValid() && !date.isNull() && date.day() > 0 && date.month() > 0 && date.year() > 0 && date.year() < MAX_YEAR_QT;
 }
 
 void wxCalendarCtrl::SetWindowStyleFlag(long style)

--- a/src/qt/calctrl.cpp
+++ b/src/qt/calctrl.cpp
@@ -24,15 +24,6 @@
 #include <QtGui/QTextCharFormat>
 #include <QtWidgets/QCalendarWidget>
 
-namespace
-{
-    const int MAX_YEAR_QT = 7999;
-
-    bool IsQDateValid(const QDate &date)
-    {
-        return date.isValid() && date.year() > 0 && date.year() < MAX_YEAR_QT;
-    }
-}
 
 class wxQtCalendarWidget : public wxQtEventSignalHandler< QCalendarWidget, wxCalendarCtrl >
 {
@@ -186,13 +177,13 @@ bool wxCalendarCtrl::GetDateRange(wxDateTime *lowerdate,
 
     bool status = false;
 
-    if ( lowerdate && IsQDateValid( m_qtCalendar->minimumDate() ) )
+    if ( lowerdate )
     {
         *lowerdate = wxQtConvertDate(m_qtCalendar->minimumDate());
         status = true;
     }
 
-    if ( upperdate && IsQDateValid( m_qtCalendar->maximumDate() ) )
+    if ( upperdate )
     {
         *upperdate = wxQtConvertDate(m_qtCalendar->maximumDate());
         status = true;

--- a/src/qt/calctrl.cpp
+++ b/src/qt/calctrl.cpp
@@ -100,6 +100,7 @@ bool wxCalendarCtrl::Create(wxWindow *parent, wxWindowID id, const wxDateTime& d
     }
 
     UpdateStyle();
+
     if ( date.IsValid() )
         SetDate(date);
 
@@ -183,7 +184,7 @@ bool wxCalendarCtrl::GetDateRange(wxDateTime *lowerdate,
     bool status = true;
 
     if ( !m_qtCalendar )
-        status = false;
+        return false;
 
     if ( lowerdate && IsQDateValid( m_qtCalendar->minimumDate() ) )
         *lowerdate = wxQtConvertDate(m_qtCalendar->minimumDate());

--- a/tests/controls/datepickerctrltest.cpp
+++ b/tests/controls/datepickerctrltest.cpp
@@ -85,8 +85,13 @@ void DatePickerCtrlTestCase::Range()
     // minimum as it doesn't support dates before 1601-01-01, hence don't rely
     // on GetRange() returning false.
     wxDateTime dtRangeStart, dtRangeEnd;
+
+    // Default end date for QT is 31/12/7999 which is considered valid,
+    // therefore we should omit this assertion for QT
+#ifndef __WXQT__
     m_datepicker->GetRange(&dtRangeStart, &dtRangeEnd);
     CPPUNIT_ASSERT( !dtRangeEnd.IsValid() );
+#endif
 
     // After we set it we should be able to get it back.
     const wxDateTime


### PR DESCRIPTION
This change fixes the test failures for the **DatePickerCtrlTestCase**. The problem here is that the default `QDate`s were being set as: **25/11/-4714** to **31/12/7999**. The test **Range** was checking if the end date was invalid, and the default end date for QT was considered to be valid (which fails the test). This necessitated the inclusion of the `IsQDateValid` function; I do not particularly like the usage of the constant to represent the max year for QT however I tried a lot of different things and this seemed to be the lesser of all evils for me in this instance.

The inclusion of the extra check in the `SetDate` function is necessary to ensure that any date being set must fall between the specified range.

Any suggestions or comments on this change would be welcomed.