### PR TITLE
Restore drawing item focus rectangle in generic wxDataViewCtrl

### DIFF
--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -2439,6 +2439,24 @@ void wxDataViewMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
                         colRect.x += colRect.width;
                     }
                 }
+                else // Not using column focus.
+                {
+                    flags |= wxCONTROL_CURRENT | wxCONTROL_FOCUSED;
+
+                    // We still need to show the current item if it's not
+                    // selected.
+                    if ( !selected )
+                    {
+                        wxRendererNative::Get().DrawFocusRect
+                                                (
+                                                    this,
+                                                    dc,
+                                                    rowRect,
+                                                    flags
+                                                );
+                    }
+                    //else: The current item is selected, will be drawn below.
+                }
             }
 
             // draw selection and whole-item focus:
@@ -2449,7 +2467,7 @@ void wxDataViewMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
                     this,
                     dc,
                     rowRect,
-                    flags | wxCONTROL_CURRENT
+                    flags
                     );
             }
         }


### PR DESCRIPTION
The current, but not selected, item was not visually marked in any way
since the changes of 4ac0250f9030b30140976198094413a7c55c3f4a which
replaced the calls to wxRendererNative::DrawFocusRect() with the calls
to DrawItemSelectionRect() which is not called when the item is not
selected.

Restore DrawFocusRect() call in this case and also pass
wxCONTROL_FOCUSED to DrawItemSelectionRect() even though this doesn't
seem to change much in practice.

Closes [#18304](https://trac.wxwidgets.org/ticket/18304#comment:3).

---

@TcT2k could you please review this? I might be missing something here as I'm not sure which problem exactly did the original commit fix. TIA!