### PR TITLE
Initialise m_qtPushButton in wxAnyButton's constructor.

### DIFF
--- a/include/wx/qt/anybutton.h
+++ b/include/wx/qt/anybutton.h
@@ -18,9 +18,7 @@ class QPushButton;
 class WXDLLIMPEXP_CORE wxAnyButton : public wxAnyButtonBase
 {
 public:
-    wxAnyButton()
-    {
-    }
+    wxAnyButton();
 
     // implementation
     // --------------

--- a/src/qt/anybutton.cpp
+++ b/src/qt/anybutton.cpp
@@ -46,6 +46,12 @@ void wxQtPushButton::clicked( bool WXUNUSED(checked) )
     }
 }
 
+wxAnyButton::wxAnyButton() :
+    m_qtPushButton(NULL)
+{
+}
+
+
 void wxAnyButton::QtCreate(wxWindow *parent)
 {
     // create the default push button (used in button and bmp button)

--- a/src/qt/anybutton.cpp
+++ b/src/qt/anybutton.cpp
@@ -62,8 +62,11 @@ void wxAnyButton::QtSetBitmap( const wxBitmap &bitmap )
 {
     // load the bitmap and resize the button:
     QPixmap *pixmap = bitmap.GetHandle();
-    m_qtPushButton->setIcon( QIcon( *pixmap  ));
-    m_qtPushButton->setIconSize( pixmap->rect().size() );
+    if ( pixmap != NULL )
+    {
+        m_qtPushButton->setIcon(QIcon(*pixmap));
+        m_qtPushButton->setIconSize(pixmap->rect().size());
+    }
 
     m_bitmap = bitmap;
 }


### PR DESCRIPTION
The prevents a crash when loading an XRC file containing a wxButton when using wxQT