### PR TITLE
Fix crashes due to uninitialised fields

### DIFF
--- a/src/qt/app.cpp
+++ b/src/qt/app.cpp
@@ -20,6 +20,8 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxApp, wxAppBase);
 wxApp::wxApp()
 {
     m_qtApplication = NULL;
+    m_qtArgc = 0;
+    m_qtArgv = NULL;
 }
 
 

--- a/src/qt/checkbox.cpp
+++ b/src/qt/checkbox.cpp
@@ -46,7 +46,8 @@ void wxQtCheckBox::clicked( bool checked )
 }
 
 
-wxCheckBox::wxCheckBox()
+wxCheckBox::wxCheckBox() :
+    m_qtCheckBox(NULL)
 {
 }
 

--- a/src/qt/choice.cpp
+++ b/src/qt/choice.cpp
@@ -37,7 +37,8 @@ void wxQtChoice::activated(int WXUNUSED(index))
 }
 
 
-wxChoice::wxChoice()
+wxChoice::wxChoice() :
+    m_qtComboBox(NULL)
 {
 }
 

--- a/src/qt/combobox.cpp
+++ b/src/qt/combobox.cpp
@@ -112,8 +112,9 @@ bool wxComboBox::Create(wxWindow *parent, wxWindowID id,
             const wxValidator& validator,
             const wxString& name )
 {
-    return Create( parent, id, value, pos, size, choices.size(), &choices[ 0 ],
-        style, validator, name );
+    const wxString *pChoices = choices.size() ? &choices[ 0 ] : NULL;
+    return Create(parent, id, value, pos, size, choices.size(), pChoices,
+                  style, validator, name );
 }
 
 

--- a/src/qt/dc.cpp
+++ b/src/qt/dc.cpp
@@ -120,7 +120,7 @@ void wxQtDCImpl::DoGetSize(int *width, int *height) const
     int deviceWidth;
     int deviceHeight;
 
-    if (pDevice)
+    if ( pDevice )
     {
         deviceWidth = pDevice->width();
         deviceHeight = pDevice->height();

--- a/src/qt/dc.cpp
+++ b/src/qt/dc.cpp
@@ -115,14 +115,46 @@ bool wxQtDCImpl::CanGetTextExtent() const
 
 void wxQtDCImpl::DoGetSize(int *width, int *height) const
 {
-    if (width)  *width  = m_qtPainter->device()->width();
-    if (height) *height = m_qtPainter->device()->height();
+    QPaintDevice *pDevice = m_qtPainter->device();
+
+    int deviceWidth;
+    int deviceHeight;
+
+    if (pDevice)
+    {
+        deviceWidth = pDevice->width();
+        deviceHeight = pDevice->height();
+    }
+    else
+    {
+        deviceWidth = 0;
+        deviceHeight = 0;
+
+    }
+    if (width) *width  = deviceWidth;
+    if (height) *height = deviceHeight;
 }
 
 void wxQtDCImpl::DoGetSizeMM(int* width, int* height) const
 {
-    if (width)  *width  = m_qtPainter->device()->widthMM();
-    if (height) *height = m_qtPainter->device()->heightMM();
+    QPaintDevice *pDevice = m_qtPainter->device();
+
+    int deviceWidthMM;
+    int deviceHeightMM;
+
+    if (pDevice)
+    {
+        deviceWidthMM = pDevice->widthMM();
+        deviceHeightMM = pDevice->heightMM();
+    }
+    else
+    {
+        deviceWidthMM = 0;
+        deviceHeightMM = 0;
+    }
+
+    if (width)  *width  = deviceWidthMM;
+    if (height) *height = deviceHeightMM;
 }
 
 int wxQtDCImpl::GetDepth() const

--- a/src/qt/dc.cpp
+++ b/src/qt/dc.cpp
@@ -132,7 +132,8 @@ void wxQtDCImpl::DoGetSize(int *width, int *height) const
 
     }
     if (width) *width  = deviceWidth;
-    if (height) *height = deviceHeight;
+    if ( height )
+        *height = deviceHeight;
 }
 
 void wxQtDCImpl::DoGetSizeMM(int* width, int* height) const

--- a/src/qt/dc.cpp
+++ b/src/qt/dc.cpp
@@ -156,7 +156,8 @@ void wxQtDCImpl::DoGetSizeMM(int* width, int* height) const
 
     if ( width )
         *width = deviceWidthMM;
-    if (height) *height = deviceHeightMM;
+    if ( height )
+        *height = deviceHeightMM;
 }
 
 int wxQtDCImpl::GetDepth() const

--- a/src/qt/dc.cpp
+++ b/src/qt/dc.cpp
@@ -154,7 +154,8 @@ void wxQtDCImpl::DoGetSizeMM(int* width, int* height) const
         deviceHeightMM = 0;
     }
 
-    if (width)  *width  = deviceWidthMM;
+    if ( width )
+        *width = deviceWidthMM;
     if (height) *height = deviceHeightMM;
 }
 

--- a/src/qt/dc.cpp
+++ b/src/qt/dc.cpp
@@ -144,7 +144,7 @@ void wxQtDCImpl::DoGetSizeMM(int* width, int* height) const
     int deviceWidthMM;
     int deviceHeightMM;
 
-    if (pDevice)
+    if ( pDevice )
     {
         deviceWidthMM = pDevice->widthMM();
         deviceHeightMM = pDevice->heightMM();

--- a/src/qt/dc.cpp
+++ b/src/qt/dc.cpp
@@ -131,7 +131,8 @@ void wxQtDCImpl::DoGetSize(int *width, int *height) const
         deviceHeight = 0;
 
     }
-    if (width) *width  = deviceWidth;
+    if ( width )
+        *width = deviceWidth;
     if ( height )
         *height = deviceHeight;
 }

--- a/src/qt/gauge.cpp
+++ b/src/qt/gauge.cpp
@@ -29,7 +29,8 @@ wxQtProgressBar::wxQtProgressBar( wxWindow *parent, wxGauge *handler )
 }
 
 
-wxGauge::wxGauge()
+wxGauge::wxGauge() :
+    m_qtProgressBar(NULL)
 {
 }
 

--- a/src/qt/listbox.cpp
+++ b/src/qt/listbox.cpp
@@ -45,7 +45,8 @@ void wxQtListWidget::doubleClicked( const QModelIndex &index )
 }
 
 
-wxListBox::wxListBox()
+wxListBox::wxListBox() :
+    m_qtListWidget(NULL)
 {
     Init();
 }

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -154,6 +154,7 @@ void wxListCtrl::Init()
     m_ownsImageListSmall = false;
     m_imageListState = NULL;
     m_ownsImageListState = false;
+    m_qtTreeWidget = NULL;
 }
 
 wxListCtrl::~wxListCtrl()

--- a/src/qt/notebook.cpp
+++ b/src/qt/notebook.cpp
@@ -50,7 +50,8 @@ void wxQtTabWidget::currentChanged(int index)
 }
 
 
-wxNotebook::wxNotebook()
+wxNotebook::wxNotebook() :
+    m_qtTabWidget(NULL)
 {
 }
 

--- a/src/qt/radiobox.cpp
+++ b/src/qt/radiobox.cpp
@@ -56,7 +56,10 @@ void wxQtButtonGroup::buttonClicked(int index) {
 wxIMPLEMENT_DYNAMIC_CLASS(wxRadioBox, wxControl);
 
 
-wxRadioBox::wxRadioBox()
+wxRadioBox::wxRadioBox() :
+    m_qtGroupBox(NULL),
+    m_qtButtonGroup(NULL),
+    m_qtBoxLayout(NULL)
 {
 }
 
@@ -149,7 +152,7 @@ bool wxRadioBox::Create(wxWindow *parent,
     // GetMajorDim() is the number of rows.
     if ( style & wxRA_SPECIFY_COLS )
         m_qtBoxLayout = new QHBoxLayout;
-    else if ( style & wxRA_SPECIFY_ROWS )
+    else
         m_qtBoxLayout = new QVBoxLayout;
 
     AddChoices< QRadioButton >( m_qtButtonGroup, m_qtBoxLayout, n, choices );
@@ -242,6 +245,9 @@ bool wxRadioBox::Show(unsigned int n, bool show)
 
 bool wxRadioBox::Show( bool show )
 {
+    if (!m_qtGroupBox)
+        return false;
+
     if( m_qtGroupBox->isVisible() == show )
     {
         for( unsigned int i = 0; i < GetCount(); ++i )

--- a/src/qt/radiobox.cpp
+++ b/src/qt/radiobox.cpp
@@ -245,6 +245,9 @@ bool wxRadioBox::Show(unsigned int n, bool show)
 
 bool wxRadioBox::Show( bool show )
 {
+    if ( !wxControl::Show(show) )
+        return false;
+
     if (!m_qtGroupBox)
         return false;
 

--- a/src/qt/radiobut.cpp
+++ b/src/qt/radiobut.cpp
@@ -13,7 +13,8 @@
 
 #include <QtWidgets/QRadioButton>
 
-wxRadioButton::wxRadioButton()
+wxRadioButton::wxRadioButton() :
+    m_qtRadioButton(NULL)
 {
 }
 

--- a/src/qt/scrolbar.cpp
+++ b/src/qt/scrolbar.cpp
@@ -27,7 +27,8 @@ class wxQtScrollBar : public wxQtEventSignalHandler< QScrollBar, wxScrollBar >
 };
 
 
-wxScrollBar::wxScrollBar()
+wxScrollBar::wxScrollBar() :
+    m_qtScrollBar(NULL)
 {
 }
 

--- a/src/qt/slider.cpp
+++ b/src/qt/slider.cpp
@@ -46,7 +46,8 @@ void wxQtSlider::valueChanged(int position)
 }
 
 
-wxSlider::wxSlider()
+wxSlider::wxSlider() :
+    m_qtSlider(NULL)
 {
 }
 

--- a/src/qt/spinbutt.cpp
+++ b/src/qt/spinbutt.cpp
@@ -41,7 +41,8 @@ void wxQtSpinButton::valueChanged(int value)
 }
 
 
-wxSpinButton::wxSpinButton()
+wxSpinButton::wxSpinButton() :
+    m_qtSpinBox(NULL)
 {
 }
 

--- a/src/qt/spinctrl.cpp
+++ b/src/qt/spinctrl.cpp
@@ -18,7 +18,8 @@
 #include <QtWidgets/QSpinBox>
 
 template< typename T, typename Widget >
-wxSpinCtrlQt< T, Widget >::wxSpinCtrlQt()
+wxSpinCtrlQt< T, Widget >::wxSpinCtrlQt() :
+    m_qtSpinBox(NULL)
 {
 }
 

--- a/src/qt/statbmp.cpp
+++ b/src/qt/statbmp.cpp
@@ -21,7 +21,8 @@ public:
 };
 
 
-wxStaticBitmap::wxStaticBitmap()
+wxStaticBitmap::wxStaticBitmap() :
+    m_qtLabel(NULL)
 {
 }
 

--- a/src/qt/statbox.cpp
+++ b/src/qt/statbox.cpp
@@ -23,7 +23,8 @@ public:
 };
 
 
-wxStaticBox::wxStaticBox()
+wxStaticBox::wxStaticBox() :
+    m_qtGroupBox(NULL)
 {
 }
 

--- a/src/qt/statline.cpp
+++ b/src/qt/statline.cpp
@@ -12,7 +12,8 @@
 
 #include <QtWidgets/QFrame>
 
-wxStaticLine::wxStaticLine()
+wxStaticLine::wxStaticLine() :
+    m_qtFrame(NULL)
 {
 }
 

--- a/src/qt/stattext.cpp
+++ b/src/qt/stattext.cpp
@@ -22,7 +22,8 @@ public:
 };
 
 
-wxStaticText::wxStaticText()
+wxStaticText::wxStaticText() :
+    m_qtLabel(NULL)
 {
 }
 

--- a/src/qt/statusbar.cpp
+++ b/src/qt/statusbar.cpp
@@ -105,6 +105,7 @@ void wxStatusBar::Refresh( bool eraseBackground, const wxRect *rect )
 
 void wxStatusBar::Init()
 {
+    m_qtStatusBar = NULL;
     m_qtPanes = NULL;
 }
 

--- a/src/qt/textctrl.cpp
+++ b/src/qt/textctrl.cpp
@@ -90,7 +90,9 @@ void wxQtTextEdit::textChanged()
 }
 
 
-wxTextCtrl::wxTextCtrl()
+wxTextCtrl::wxTextCtrl() :
+    m_qtLineEdit(NULL),
+    m_qtTextEdit(NULL)
 {
 }
 

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -1074,6 +1074,7 @@ bool wxWindowQt::QtHandlePaintEvent ( QWidget *handler, QPaintEvent *event )
                             dc.SetDeviceClippingRegion( m_updateRegion );
 
                             wxEraseEvent erase( GetId(), &dc );
+                            erase.SetEventObject(this);
                             if ( ProcessWindowEvent(erase) )
                             {
                                 // background erased, don't do it again


### PR DESCRIPTION
A number of controls in wxQT have empty default c'tors or don't check if their fields are NULL.  This commit fixes a number of these.