### PR TITLE
wxTextValidator improvements

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -106,8 +106,7 @@ Changes in behaviour which may result in build errors
 
 - wxTextValidator::Get{In,Ex}cludes() now return a const reference to
   wxArrayString. Please update your code to use the appropriate setter
-  Set[Char]{In,Ex}cludes(), instead of mutating the internal data directly
-  which is admittedly a bad coding habit anyhow.
+  Set[Char]{In,Ex}cludes(), instead of mutating the internal data directly.
 
 
 3.1.3: (released 2019-??-??)

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -104,6 +104,11 @@ Changes in behaviour which may result in build errors
   e.g. if the error is due to spelling an option name wrongly, fixing or
   removing its name.
 
+- wxTextValidator::Get{In,Ex}cludes() now return a const reference to
+  wxArrayString. Please update your code to use the appropriate setter
+  Set[Char]{In,Ex}cludes(), instead of mutating the internal data directly
+  which is admittedly a bad coding habit anyhow.
+
 
 3.1.3: (released 2019-??-??)
 ----------------------------

--- a/include/wx/valtext.h
+++ b/include/wx/valtext.h
@@ -81,11 +81,7 @@ public:
     void AddCharIncludes(const wxString& chars);
 
     void SetIncludes(const wxArrayString& includes) { m_includes = includes; }
-    void AddInclude(const wxString& include)
-    {
-        if ( !include.empty() )
-            m_includes.Add(include);
-    }
+    void AddInclude(const wxString& include);
 
     const wxArrayString& GetIncludes() const { return m_includes; }
     wxString GetCharIncludes() const { return m_charIncludes; }
@@ -97,11 +93,7 @@ public:
     void AddCharExcludes(const wxString& chars);
 
     void SetExcludes(const wxArrayString& excludes) { m_excludes = excludes; }
-    void AddExclude(const wxString& exclude)
-    {
-        if ( !exclude.empty() )
-            m_excludes.Add(exclude);
-    }
+    void AddExclude(const wxString& exclude);
 
     const wxArrayString& GetExcludes() const { return m_excludes; }
     wxString GetCharExcludes() const { return m_charExcludes; }
@@ -113,16 +105,17 @@ protected:
 
     bool IsCharIncluded(const wxUniChar& c) const
     {
-        return m_charIncludes.Find(c) != wxNOT_FOUND;
+        return m_charIncludes.find(c) != wxString::npos;
     }
 
     bool IsCharExcluded(const wxUniChar& c) const
     {
-        return m_charExcludes.Find(c) != wxNOT_FOUND;
+        return m_charExcludes.find(c) != wxString::npos;
     }
 
     bool IsIncluded(const wxString& str) const
     {
+        // N.B. the m_includes list should be ignored if it is empty.
         return m_includes.empty() || 
                 m_includes.Index(str) != wxNOT_FOUND;
     }

--- a/include/wx/valtext.h
+++ b/include/wx/valtext.h
@@ -133,7 +133,7 @@ protected:
     }
 
     // returns the error message if the contents of 'str' are invalid
-    wxString IsValid(const wxString& str) const;
+    virtual wxString IsValid(const wxString& str) const;
 
     // returns false if the character is invalid
     bool IsValid(const wxUniChar& c) const;

--- a/include/wx/valtext.h
+++ b/include/wx/valtext.h
@@ -136,7 +136,7 @@ protected:
     virtual wxString IsValid(const wxString& str) const;
 
     // returns false if the character is invalid
-    bool IsValid(const wxUniChar& c) const;
+    bool IsValidChar(const wxUniChar& c) const;
 
 protected:
     long                 m_validatorStyle;

--- a/include/wx/valtext.h
+++ b/include/wx/valtext.h
@@ -131,6 +131,10 @@ protected:
     // returns false if the character is invalid
     bool IsValidChar(const wxUniChar& c) const;
 
+    // These two functions (undocumented now) are kept for compatibility reasons.
+    bool ContainsOnlyIncludedCharacters(const wxString& val) const;
+    bool ContainsExcludedCharacters(const wxString& val) const;
+
 protected:
     long                 m_validatorStyle;
     wxString*            m_stringValue;

--- a/include/wx/valtext.h
+++ b/include/wx/valtext.h
@@ -80,7 +80,7 @@ public:
     void SetCharIncludes(const wxString& chars);
     void AddCharIncludes(const wxString& chars);
 
-    void SetIncludes(const wxArrayString& includes) { m_includes = includes; }
+    void SetIncludes(const wxArrayString& includes);
     void AddInclude(const wxString& include);
 
     const wxArrayString& GetIncludes() const { return m_includes; }
@@ -92,7 +92,7 @@ public:
     void SetCharExcludes(const wxString& chars);
     void AddCharExcludes(const wxString& chars);
 
-    void SetExcludes(const wxArrayString& excludes) { m_excludes = excludes; }
+    void SetExcludes(const wxArrayString& excludes);
     void AddExclude(const wxString& exclude);
 
     const wxArrayString& GetExcludes() const { return m_excludes; }

--- a/include/wx/valtext.h
+++ b/include/wx/valtext.h
@@ -25,29 +25,31 @@ enum wxTextValidatorStyle
     wxFILTER_EMPTY = 0x1,
     wxFILTER_ASCII = 0x2,
     wxFILTER_ALPHA = 0x4,
-    wxFILTER_ALPHANUMERIC = 0x8,
-    wxFILTER_DIGITS = 0x10,
+    wxFILTER_DIGITS = 0x8,
+    wxFILTER_XDIGITS = 0x10,
+    wxFILTER_ALPHANUMERIC = wxFILTER_ALPHA|wxFILTER_DIGITS|wxFILTER_XDIGITS,
     wxFILTER_NUMERIC = 0x20,
     wxFILTER_INCLUDE_LIST = 0x40,
     wxFILTER_INCLUDE_CHAR_LIST = 0x80,
     wxFILTER_EXCLUDE_LIST = 0x100,
-    wxFILTER_EXCLUDE_CHAR_LIST = 0x200
+    wxFILTER_EXCLUDE_CHAR_LIST = 0x200,
+    wxFILTER_SPACE = 0x400
 };
 
-class WXDLLIMPEXP_CORE wxTextValidator: public wxValidator
+// ----------------------------------------------------------------------------
+// wxTextValidatorBase
+// ----------------------------------------------------------------------------
+
+class WXDLLIMPEXP_CORE wxTextValidatorBase: public wxValidator
 {
 public:
-    wxTextValidator(long style = wxFILTER_NONE, wxString *val = NULL);
-    wxTextValidator(const wxTextValidator& val);
+    explicit wxTextValidatorBase(wxString* str, long style = wxFILTER_NONE);
 
-    virtual ~wxTextValidator(){}
+    wxTextValidatorBase(const wxTextValidatorBase& val);
 
-    // Make a clone of this validator (or return NULL) - currently necessary
-    // if you're passing a reference to a validator.
-    // Another possibility is to always pass a pointer to a new validator
-    // (so the calling code can use a copy constructor of the relevant class).
-    virtual wxObject *Clone() const wxOVERRIDE { return new wxTextValidator(*this); }
-    bool Copy(const wxTextValidator& val);
+    virtual ~wxTextValidatorBase(){}
+
+    bool Copy(const wxTextValidatorBase& val);
 
     // Called when the value in the window must be validated.
     // This function can pop up an error message.
@@ -63,43 +65,144 @@ public:
     void OnChar(wxKeyEvent& event);
 
     // ACCESSORS
-    inline long GetStyle() const { return m_validatorStyle; }
-    void SetStyle(long style);
+    inline long GetStyle() const { return m_style; }
+    void SetStyle(long style){ DoSetStyle(style); }
 
     wxTextEntry *GetTextEntry();
 
+    // strings & chars inclusions:
+    // ---------------------------
+
     void SetCharIncludes(const wxString& chars);
-    void SetIncludes(const wxArrayString& includes) { m_includes = includes; }
-    inline wxArrayString& GetIncludes() { return m_includes; }
+    void AddCharIncludes(const wxString& chars);
+
+    void SetIncludes(const wxArrayString& includes){ DoSetIncludes(includes); }
+    void AddInclude(const wxString& include){ DoAddInclude(include); }
+    const wxArrayString& GetIncludes() const { return m_includes; }
+
+    // strings & chars exclusions:
+    // ---------------------------
 
     void SetCharExcludes(const wxString& chars);
-    void SetExcludes(const wxArrayString& excludes) { m_excludes = excludes; }
-    inline wxArrayString& GetExcludes() { return m_excludes; }
+    void AddCharExcludes(const wxString& chars);
+
+    void SetExcludes(const wxArrayString& excludes){ DoSetExcludes(excludes); }
+    void AddExclude(const wxString& exclude){ DoAddExclude(exclude); }
+    const wxArrayString& GetExcludes() const { return m_excludes; }
 
     bool HasFlag(wxTextValidatorStyle style) const
-        { return (m_validatorStyle & style) != 0; }
+        { return (m_style & style) != 0; }
 
 protected:
 
-    // returns true if all characters of the given string are present in m_includes
-    bool ContainsOnlyIncludedCharacters(const wxString& val) const;
+    bool IsCharIncluded(const wxUniChar& c) const
+    {
+        if ( HasFlag(wxFILTER_INCLUDE_CHAR_LIST) )
+            // The string of included chars is always kept at
+            // the end of m_includes member.
+            return (m_includes.Last().Find(c) != wxNOT_FOUND);
 
-    // returns true if at least one character of the given string is present in m_excludes
-    bool ContainsExcludedCharacters(const wxString& val) const;
+        return false;
+    }
 
-    // returns the error message if the contents of 'val' are invalid
-    virtual wxString IsValid(const wxString& val) const;
+    bool IsCharExcluded(const wxUniChar& c) const
+    {
+        if ( HasFlag(wxFILTER_EXCLUDE_CHAR_LIST) )
+            // The string of excluded chars is always kept at
+            // the end of m_excludes member.
+            return (m_excludes.Last().Find(c) != wxNOT_FOUND);
+
+        return false;
+    }
+
+    // Helper used by IsIncluded() and IsExcluded() methods
+    inline bool IsStringFound(const wxArrayString& arr,
+                              const wxString& str,
+                              const bool excludeLastString) const
+    {
+        const int idx = arr.Index(str);
+
+        const bool found = idx != wxNOT_FOUND;
+
+        if ( excludeLastString )
+        {
+            return found &&
+                   (int)arr.GetCount() > idx+1; // the [inc|exc]lude char list
+        }
+
+        return found;
+    }
+
+    bool IsIncluded(const wxString& str) const
+    {
+        return IsStringFound(m_includes, str, HasFlag(wxFILTER_INCLUDE_CHAR_LIST));
+    }
+
+    bool IsExcluded(const wxString& str) const
+    {
+        return IsStringFound(m_excludes, str, HasFlag(wxFILTER_EXCLUDE_CHAR_LIST));
+    }
+
+    virtual void DoSetIncludes(const wxArrayString& strs);
+    virtual void DoSetExcludes(const wxArrayString& strs);
+
+    virtual void DoAddInclude(const wxString& str);
+    virtual void DoAddExclude(const wxString& str);
+
+    // returns the error message if the contents of 'str' are invalid
+    wxString IsValid(const wxString& str) const;
+
+    // returns false if the character is invalid
+    virtual bool IsValid(const wxUniChar& c) const = 0;
+
+    // Called by Validate() to do the actual validation
+    virtual wxString DoValidate(const wxString& str) = 0;
+
+    // For each derived class set m_style properly
+    virtual void DoSetStyle(long style){ m_style = style; }
 
 protected:
-    long                 m_validatorStyle;
-    wxString*            m_stringValue;
-    wxArrayString        m_includes;
-    wxArrayString        m_excludes;
+    long      m_style;
+    wxString* m_string;
+
+    wxArrayString m_includes;
+    wxArrayString m_excludes;
+
+private:
+    wxDECLARE_NO_ASSIGN_CLASS(wxTextValidatorBase);
+    wxDECLARE_ABSTRACT_CLASS(wxTextValidatorBase);
+    wxDECLARE_EVENT_TABLE();
+};
+
+class WXDLLIMPEXP_CORE wxTextValidator: public wxTextValidatorBase
+{
+public:
+    explicit wxTextValidator(wxString *str, long style = wxFILTER_NONE);
+    wxTextValidator(long style = wxFILTER_NONE, wxString *str = NULL);
+
+    wxTextValidator(const wxTextValidator& val);
+
+    virtual ~wxTextValidator(){}
+
+    // Make a clone of this validator (or return NULL) - currently necessary
+    // if you're passing a reference to a validator.
+    // Another possibility is to always pass a pointer to a new validator
+    // (so the calling code can use a copy constructor of the relevant class).
+    virtual wxObject *Clone() const wxOVERRIDE { return new wxTextValidator(*this); }
+    bool Copy(const wxTextValidator& val);
+
+protected:
+    // returns false if the character is invalid
+    virtual bool IsValid(const wxUniChar& c) const wxOVERRIDE;
+
+    // Called by Validate() to do the actual validation
+    virtual wxString DoValidate(const wxString& str) wxOVERRIDE;
+
+    virtual void DoSetStyle(long style) wxOVERRIDE;
 
 private:
     wxDECLARE_NO_ASSIGN_CLASS(wxTextValidator);
     wxDECLARE_DYNAMIC_CLASS(wxTextValidator);
-    wxDECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/include/wx/valtext.h
+++ b/include/wx/valtext.h
@@ -80,8 +80,12 @@ public:
     void SetCharIncludes(const wxString& chars);
     void AddCharIncludes(const wxString& chars);
 
-    void SetIncludes(const wxArrayString& includes) { DoSetIncludes(includes); }
-    void AddInclude(const wxString& include) { DoAddInclude(include); }
+    void SetIncludes(const wxArrayString& includes) { m_includes = includes; }
+    void AddInclude(const wxString& include)
+    {
+        if ( !include.empty() )
+            m_includes.Add(include);
+    }
 
     const wxArrayString& GetIncludes() const { return m_includes; }
     wxString GetCharIncludes() const { return m_charIncludes; }
@@ -92,8 +96,12 @@ public:
     void SetCharExcludes(const wxString& chars);
     void AddCharExcludes(const wxString& chars);
 
-    void SetExcludes(const wxArrayString& excludes) { DoSetExcludes(excludes); }
-    void AddExclude(const wxString& exclude) { DoAddExclude(exclude); }
+    void SetExcludes(const wxArrayString& excludes) { m_excludes = excludes; }
+    void AddExclude(const wxString& exclude)
+    {
+        if ( !exclude.empty() )
+            m_excludes.Add(exclude);
+    }
 
     const wxArrayString& GetExcludes() const { return m_excludes; }
     wxString GetCharExcludes() const { return m_charExcludes; }
@@ -124,17 +132,11 @@ protected:
         return m_excludes.Index(str) != wxNOT_FOUND;
     }
 
-    virtual void DoSetIncludes(const wxArrayString& strs);
-    virtual void DoSetExcludes(const wxArrayString& strs);
-
-    virtual void DoAddInclude(const wxString& str);
-    virtual void DoAddExclude(const wxString& str);
-
     // returns the error message if the contents of 'str' are invalid
     wxString IsValid(const wxString& str) const;
 
     // returns false if the character is invalid
-    virtual bool IsValid(const wxUniChar& c) const;
+    bool IsValid(const wxUniChar& c) const;
 
 protected:
     long                 m_validatorStyle;

--- a/include/wx/valtext.h
+++ b/include/wx/valtext.h
@@ -33,7 +33,12 @@ enum wxTextValidatorStyle
     wxFILTER_EXCLUDE_LIST = 0x100,
     wxFILTER_EXCLUDE_CHAR_LIST = 0x200,
     wxFILTER_XDIGITS = 0x400,
-    wxFILTER_SPACE = 0x800
+    wxFILTER_SPACE = 0x800,
+
+    // filter char class (for internal use only)
+    wxFILTER_CC = wxFILTER_SPACE|wxFILTER_ASCII|wxFILTER_NUMERIC|
+                  wxFILTER_ALPHANUMERIC|wxFILTER_ALPHA|
+                  wxFILTER_DIGITS|wxFILTER_XDIGITS
 };
 
 // ----------------------------------------------------------------------------
@@ -101,6 +106,12 @@ public:
     bool HasFlag(wxTextValidatorStyle style) const
         { return (m_validatorStyle & style) != 0; }
 
+    // implementation only
+    // --------------------
+
+    // returns the error message if the contents of 'str' are invalid
+    virtual wxString IsValid(const wxString& str) const;
+
 protected:
 
     bool IsCharIncluded(const wxUniChar& c) const
@@ -115,18 +126,18 @@ protected:
 
     bool IsIncluded(const wxString& str) const
     {
-        // N.B. the m_includes list should be ignored if it is empty.
-        return m_includes.empty() || 
-                m_includes.Index(str) != wxNOT_FOUND;
+        if ( HasFlag(wxFILTER_INCLUDE_LIST) )
+            return m_includes.Index(str) != wxNOT_FOUND;
+
+        // m_includes should be ignored (i.e. return true)
+        // if the style is not set.
+        return true;
     }
 
     bool IsExcluded(const wxString& str) const
     {
         return m_excludes.Index(str) != wxNOT_FOUND;
     }
-
-    // returns the error message if the contents of 'str' are invalid
-    virtual wxString IsValid(const wxString& str) const;
 
     // returns false if the character is invalid
     bool IsValidChar(const wxUniChar& c) const;

--- a/include/wx/valtext.h
+++ b/include/wx/valtext.h
@@ -79,6 +79,14 @@ public:
     void SetIncludes(const wxArrayString& includes){ DoSetIncludes(includes); }
     void AddInclude(const wxString& include){ DoAddInclude(include); }
     const wxArrayString& GetIncludes() const { return m_includes; }
+    
+    wxString GetCharIncludes() const 
+    { 
+        if ( HasFlag(wxFILTER_INCLUDE_CHAR_LIST) )
+            return m_includes.Last();
+
+        return wxString();
+    }
 
     // strings & chars exclusions:
     // ---------------------------
@@ -89,6 +97,14 @@ public:
     void SetExcludes(const wxArrayString& excludes){ DoSetExcludes(excludes); }
     void AddExclude(const wxString& exclude){ DoAddExclude(exclude); }
     const wxArrayString& GetExcludes() const { return m_excludes; }
+
+    wxString GetCharExcludes() const 
+    { 
+        if ( HasFlag(wxFILTER_EXCLUDE_CHAR_LIST) )
+            return m_excludes.Last();
+
+        return wxString();
+    }
 
     bool HasFlag(wxTextValidatorStyle style) const
         { return (m_style & style) != 0; }

--- a/include/wx/valtext.h
+++ b/include/wx/valtext.h
@@ -136,9 +136,6 @@ protected:
     // returns false if the character is invalid
     virtual bool IsValid(const wxUniChar& c) const;
 
-    // Called by Validate() to do the actual validation
-    virtual wxString DoValidate(const wxString& str);
-
 protected:
     long                 m_validatorStyle;
     wxString*            m_stringValue;

--- a/interface/wx/valtext.h
+++ b/interface/wx/valtext.h
@@ -9,8 +9,13 @@
 /**
     Styles used by wxTextValidator.
 
-    Note that when you specify more styles in wxTextValidator the validation checks
-    are performed in the order in which the styles of this enumeration are defined.
+    Notice that wxFILTER_{INCLUDE,EXCLUDE}[_CHAR]_LIST pairs can be used to
+    document the purpose of the validator only and are not enforced in the
+    implementation of the wxTextValidator. Therefore, calling the corresponding
+    member functions:
+    wxTextValidator::SetCharIncludes(), wxTextValidator::SetCharExcludes(),
+    wxTextValidator::SetIncludes() or wxTextValidator::SetExcludes()
+    after creating the validator with or without those flags changes nothing.
 */
 enum wxTextValidatorStyle
 {
@@ -35,7 +40,7 @@ enum wxTextValidatorStyle
     /// (which is locale-dependent) on all characters of the string.
     wxFILTER_ALPHANUMERIC,
 
-    /// Non-numeric characters are filtered out.
+    /// Non-digit characters are filtered out.
     /// Uses the wxWidgets wrapper for the standard CRT function @c isdigit
     /// (which is locale-dependent) on all characters of the string.
     wxFILTER_DIGITS,
@@ -50,18 +55,18 @@ enum wxTextValidatorStyle
     /// the list, complaining if not. See wxTextValidator::SetIncludes().
     wxFILTER_INCLUDE_LIST,
 
-    /// Use an include list. The validator checks if each input character is
-    /// in the list (one character per list element), complaining if not.
-    /// See wxTextValidator::SetCharIncludes().
+    /// Use an include char list.
+    /// Characters in the include char list will be allowed to be in the
+    /// user input. See wxTextValidator::SetCharIncludes().
     wxFILTER_INCLUDE_CHAR_LIST,
 
     /// Use an exclude list. The validator checks if the user input is on
     /// the list, complaining if it is. See wxTextValidator::SetExcludes().
     wxFILTER_EXCLUDE_LIST,
 
-    /// Use an exclude list. The validator checks if each input character is
-    /// in the list (one character per list element), complaining if it is.
-    /// See wxTextValidator::SetCharExcludes().
+    /// Use an exclude char list.
+    /// Characters in the exclude char list won't be allowed to be in the
+    /// user input. See wxTextValidator::SetCharExcludes().
     wxFILTER_EXCLUDE_CHAR_LIST,
 
     /// Non-hexadecimal characters are filtered out.
@@ -166,7 +171,8 @@ public:
     /**
         Sets the exclude char list (invalid characters for the user input).
 
-        This function may cancel the effect of @c wxFILTER_SPACE if the passed
+        @note It's an error to exclude an already included character.
+        @note This function may cancel the effect of @c wxFILTER_SPACE if the passed
         in string @a chars contains the @b space character.
     */
     void SetCharExcludes(const wxString& chars);
@@ -178,6 +184,8 @@ public:
 
     /**
         Sets the include char list (additional valid values for the user input).
+
+        @note It's an error to include an already excluded character.
     */
     void SetCharIncludes(const wxString& chars);
 
@@ -199,6 +207,8 @@ public:
         Adds @a chars to the list of excluded characters.
 
         @since 3.1.3
+
+        @note It's an error to exclude an already included character.
     */
     void AddCharExcludes(const wxString& chars);
 
@@ -206,6 +216,8 @@ public:
         Adds @a chars to the list of included characters.
 
         @since 3.1.3
+
+        @note It's an error to include an already excluded character.
     */
     void AddCharIncludes(const wxString& chars);
 

--- a/interface/wx/valtext.h
+++ b/interface/wx/valtext.h
@@ -16,6 +16,15 @@
     wxTextValidator::SetCharIncludes(), wxTextValidator::SetCharExcludes(),
     wxTextValidator::SetIncludes() or wxTextValidator::SetExcludes()
     after creating the validator with or without those flags changes nothing.
+
+    Caveat
+        wxFILTER_INCLUDE_CHAR_LIST is an exception from the notice above:
+        If this style is set with one or more of the following styles:
+        wxFILTER_ASCII, wxFILTER_ALPHA, wxFILTER_ALPHANUMERIC, wxFILTER_DIGITS,
+        wxFILTER_XDIGITS, wxFILTER_NUMERIC it just extends the character class
+        denoted by the aforementioned styles with those specified in the include
+        char list. If set alone, then the charactes allowed to be in the user input
+        are restricted to those, and only those, present in the include char list. 
 */
 enum wxTextValidatorStyle
 {

--- a/samples/propgrid/sampleprops.cpp
+++ b/samples/propgrid/sampleprops.cpp
@@ -650,16 +650,12 @@ wxValidator* wxArrayDoubleProperty::DoGetValidator() const
 #if wxUSE_VALIDATORS
     WX_PG_DOGETVALIDATOR_ENTRY()
 
-    wxTextValidator* validator = new wxTextValidator(wxFILTER_INCLUDE_CHAR_LIST);
+    wxTextValidator* validator = 
+        new wxNumericPropertyValidator(wxNumericPropertyValidator::Float);
 
-    // Accept characters for numeric elements
-    wxNumericPropertyValidator numValidator(wxNumericPropertyValidator::Float);
-    wxArrayString incChars(numValidator.GetIncludes());
     // Accept also a delimiter and space character
-    incChars.Add(m_delimiter);
-    incChars.Add(" ");
-
-    validator->SetIncludes(incChars);
+    validator->AddInclude(m_delimiter);
+    validator->AddInclude(" ");
 
     WX_PG_DOGETVALIDATOR_EXIT(validator)
 #else

--- a/samples/propgrid/sampleprops.cpp
+++ b/samples/propgrid/sampleprops.cpp
@@ -654,8 +654,8 @@ wxValidator* wxArrayDoubleProperty::DoGetValidator() const
         new wxNumericPropertyValidator(wxNumericPropertyValidator::Float);
 
     // Accept also a delimiter and space character
-    validator->AddInclude(m_delimiter);
-    validator->AddInclude(" ");
+    validator->AddCharIncludes(m_delimiter);
+    validator->AddCharIncludes(" ");
 
     WX_PG_DOGETVALIDATOR_EXIT(validator)
 #else

--- a/samples/validate/validate.cpp
+++ b/samples/validate/validate.cpp
@@ -40,8 +40,6 @@
 // Global data
 // ----------------------------------------------------------------------------
 
-MyData g_data;
-
 wxString g_listbox_choices[] =
     {"one",  "two",  "three"};
 
@@ -50,6 +48,8 @@ wxString g_combobox_choices[] =
 
 wxString g_radiobox_choices[] =
     {"green", "yellow", "red"};
+
+MyData g_data;
 
 // ----------------------------------------------------------------------------
 // MyData
@@ -63,6 +63,7 @@ MyData::MyData()
     m_string = "Spaces are invalid here";
     m_string2 = "Valid text";
     m_listbox_choices.Add(0);
+    m_combobox_choice = g_combobox_choices[0];
     m_intValue = 0;
     m_smallIntValue = 3;
     m_doubleValue = 12354.31;
@@ -391,17 +392,7 @@ MyDialog::MyDialog( wxWindow *parent, const wxString& title,
 
     // make the dialog a bit bigger than its minimal size:
     SetSize(GetBestSize()*1.5);
-}
 
-bool MyDialog::TransferDataToWindow()
-{
-    bool r = wxDialog::TransferDataToWindow();
-
-    // These function calls have to be made here, after the
-    // dialog has been created.
+    // Now sets the focus to m_text
     m_text->SetFocus();
-    m_combobox->SetSelection(0);
-
-    return r;
 }
-

--- a/samples/validate/validate.cpp
+++ b/samples/validate/validate.cpp
@@ -602,6 +602,19 @@ void TextValidatorDialog::SetValidatorFor(wxTextCtrl* txtCtrl)
     }
 
     tooltip.RemoveLast(); // remove the trailing '|' char.
+
+    if ( !m_charIncludes.empty() )
+    {
+        tooltip += "\nAllowed chars: ";
+        tooltip += m_charIncludes;
+    }
+
+    if ( !m_charExcludes.empty() )
+    {
+        tooltip += "\nDisallowed chars: ";
+        tooltip += m_charExcludes;
+    }
+
     txtCtrl->SetToolTip(tooltip);
 
     // Prepare @ set the wxTextValidator

--- a/samples/validate/validate.h
+++ b/samples/validate/validate.h
@@ -63,13 +63,33 @@ public:
 class TextValidatorDialog : public wxDialog
 {
 public:
-    TextValidatorDialog(wxWindow *parent);
+    TextValidatorDialog(wxWindow *parent, wxTextCtrl* txtCtrl);
 
     void OnUpdateUI(wxUpdateUIEvent& event);
     void OnChecked(wxCommandEvent& event);
     void OnKillFocus( wxFocusEvent &event );
 
-    void SetValidatorFor(wxTextCtrl* txtCtrl);
+    void ApplyValidator();
+
+private:
+    // Special validator for our checkboxes
+    class StyleValidator : public wxValidator
+    {
+    public:
+        StyleValidator(long* style) { m_style = style; }
+
+        virtual bool Validate(wxWindow *WXUNUSED(parent)) { return true; }
+        virtual wxObject* Clone() const wxOVERRIDE { return new StyleValidator(*this); }
+
+        // Called to transfer data to the window
+        virtual bool TransferToWindow() wxOVERRIDE;
+
+        // Called to transfer data from the window
+        virtual bool TransferFromWindow() wxOVERRIDE;
+
+    private:
+        long* m_style;
+    };
 
 private:
     bool HasFlag(wxTextValidatorStyle style) const
@@ -100,6 +120,8 @@ private:
         Id_ExcludeListTxt,
         Id_ExcludeCharListTxt,
     };
+
+    wxTextCtrl* const m_txtCtrl;
 
     bool m_noValidation;
     long m_validatorStyle;

--- a/samples/validate/validate.h
+++ b/samples/validate/validate.h
@@ -48,7 +48,6 @@ public:
             const wxSize& size = wxDefaultSize,
             const long style = wxDEFAULT_DIALOG_STYLE);
 
-    bool TransferDataToWindow() wxOVERRIDE;
     wxTextCtrl *m_text;
     wxComboBox *m_combobox;
 

--- a/samples/validate/validate.h
+++ b/samples/validate/validate.h
@@ -48,11 +48,66 @@ public:
             const wxSize& size = wxDefaultSize,
             const long style = wxDEFAULT_DIALOG_STYLE);
 
+    void OnChangeValidator(wxCommandEvent& event);
+
     wxTextCtrl *m_text;
     wxComboBox *m_combobox;
 
     wxTextCtrl *m_numericTextInt;
     wxTextCtrl *m_numericTextDouble;
+};
+
+// ----------------------------------------------------------------------------
+// TextValidatorDialog
+// ----------------------------------------------------------------------------
+class TextValidatorDialog : public wxDialog
+{
+public:
+    TextValidatorDialog(wxWindow *parent);
+
+    void OnUpdateUI(wxUpdateUIEvent& event);
+    void OnChecked(wxCommandEvent& event);
+    void OnKillFocus( wxFocusEvent &event );
+
+    void SetValidatorFor(wxTextCtrl* txtCtrl);
+
+private:
+    bool HasFlag(wxTextValidatorStyle style) const
+    {
+        return (m_validatorStyle & style) != 0;
+    }
+
+    enum
+    {
+        // CheckBoxes Ids (should be in sync with wxTextValidatorStyle)
+        Id_None = wxID_HIGHEST,
+        Id_Empty,
+        Id_Ascii,
+        Id_Alpha,
+        Id_Alphanumeric,
+        Id_Digits,
+        Id_Numeric,
+        Id_IncludeList,
+        Id_IncludeCharList,
+        Id_ExcludeList,
+        Id_ExcludeCharList,
+        Id_Xdigits,
+        Id_Space,
+
+        // TextCtrls Ids
+        Id_IncludeListTxt,
+        Id_IncludeCharListTxt,
+        Id_ExcludeListTxt,
+        Id_ExcludeCharListTxt,
+    };
+
+    bool m_noValidation;
+    long m_validatorStyle;
+
+    wxString        m_charIncludes;
+    wxString        m_charExcludes;
+    wxArrayString   m_includes;
+    wxArrayString   m_excludes;
 };
 
 class MyData

--- a/src/common/valtext.cpp
+++ b/src/common/valtext.cpp
@@ -209,7 +209,7 @@ wxString wxTextValidator::IsValid(const wxString& str) const
     for ( wxString::const_iterator i = str.begin(), end = str.end();
           i != end; ++i )
     {
-        if ( !IsValid(*i) )
+        if ( !IsValidChar(*i) )
         {
             return wxString::Format(
                 _("'%s' contains invalid character(s)"), str);
@@ -302,7 +302,7 @@ void wxTextValidator::OnChar(wxKeyEvent& event)
         return;
 
     // Filter out invalid characters
-    if ( IsValid(static_cast<wxUniChar>(keyCode)) )
+    if ( IsValidChar(static_cast<wxUniChar>(keyCode)) )
         return;
 
     if ( !wxValidator::IsSilent() )
@@ -312,7 +312,7 @@ void wxTextValidator::OnChar(wxKeyEvent& event)
     event.Skip(false);
 }
 
-bool wxTextValidator::IsValid(const wxUniChar& c) const
+bool wxTextValidator::IsValidChar(const wxUniChar& c) const
 {
     if ( !m_validatorStyle ) // no filtering if HasFlag(wxFILTER_NONE)
         return true;

--- a/src/common/valtext.cpp
+++ b/src/common/valtext.cpp
@@ -23,6 +23,7 @@
   #include <stdio.h>
   #include "wx/textctrl.h"
   #include "wx/combobox.h"
+  #include "wx/log.h"
   #include "wx/utils.h"
   #include "wx/msgdlg.h"
   #include "wx/intl.h"
@@ -53,64 +54,51 @@ static bool wxIsNumeric(const wxString& val)
 }
 
 // ----------------------------------------------------------------------------
-// wxTextValidator
+// wxTextValidatorBase
 // ----------------------------------------------------------------------------
 
-wxIMPLEMENT_DYNAMIC_CLASS(wxTextValidator, wxValidator);
-wxBEGIN_EVENT_TABLE(wxTextValidator, wxValidator)
-    EVT_CHAR(wxTextValidator::OnChar)
+wxIMPLEMENT_ABSTRACT_CLASS(wxTextValidatorBase, wxValidator)
+
+wxBEGIN_EVENT_TABLE(wxTextValidatorBase, wxValidator)
+    EVT_CHAR(wxTextValidatorBase::OnChar)
 wxEND_EVENT_TABLE()
 
-wxTextValidator::wxTextValidator(long style, wxString *val)
+wxTextValidatorBase::wxTextValidatorBase(wxString* str, long style)
 {
-    m_stringValue = val;
-    SetStyle(style);
+    m_style = style;
+    m_string = str;
+
+    // N.B. the "include char list" should be the last item of m_includes
+    //      if wxFILTER_INCLUDE_CHAR_LIST flag is set.
+    if ( HasFlag(wxFILTER_INCLUDE_CHAR_LIST) )
+        m_includes.Add(wxEmptyString);
+
+    // N.B. the "exclude char list" should be the last item of m_excludes
+    //      if wxFILTER_EXCLUDE_CHAR_LIST flag is set.
+    if ( HasFlag(wxFILTER_EXCLUDE_CHAR_LIST) )
+        m_excludes.Add(wxEmptyString);
 }
 
-wxTextValidator::wxTextValidator(const wxTextValidator& val)
+wxTextValidatorBase::wxTextValidatorBase(const wxTextValidatorBase& val)
     : wxValidator()
 {
     Copy(val);
 }
 
-void wxTextValidator::SetStyle(long style)
-{
-    m_validatorStyle = style;
-
-#if wxDEBUG_LEVEL
-    int check;
-    check = (int)HasFlag(wxFILTER_ALPHA) + (int)HasFlag(wxFILTER_ALPHANUMERIC) +
-            (int)HasFlag(wxFILTER_DIGITS) + (int)HasFlag(wxFILTER_NUMERIC);
-    wxASSERT_MSG(check <= 1,
-        "It makes sense to use only one of the wxFILTER_ALPHA/wxFILTER_ALPHANUMERIC/"
-        "wxFILTER_SIMPLE_NUMBER/wxFILTER_NUMERIC styles");
-
-    wxASSERT_MSG(((int)HasFlag(wxFILTER_INCLUDE_LIST) + (int)HasFlag(wxFILTER_INCLUDE_CHAR_LIST) <= 1) &&
-                 ((int)HasFlag(wxFILTER_EXCLUDE_LIST) + (int)HasFlag(wxFILTER_EXCLUDE_CHAR_LIST) <= 1),
-        "Using both wxFILTER_[IN|EX]CLUDE_LIST _and_ wxFILTER_[IN|EX]CLUDE_CHAR_LIST "
-        "doesn't work since wxTextValidator internally uses the same array for both");
-
-    check = (int)HasFlag(wxFILTER_INCLUDE_LIST) + (int)HasFlag(wxFILTER_INCLUDE_CHAR_LIST) +
-            (int)HasFlag(wxFILTER_EXCLUDE_LIST) + (int)HasFlag(wxFILTER_EXCLUDE_CHAR_LIST);
-    wxASSERT_MSG(check <= 1,
-        "Using both an include/exclude list may lead to unexpected results");
-#endif // wxDEBUG_LEVEL
-}
-
-bool wxTextValidator::Copy(const wxTextValidator& val)
+bool wxTextValidatorBase::Copy(const wxTextValidatorBase& val)
 {
     wxValidator::Copy(val);
 
-    m_validatorStyle = val.m_validatorStyle;
-    m_stringValue = val.m_stringValue;
+    m_style = val.m_style;
+    m_string = val.m_string;
 
-    m_includes    = val.m_includes;
-    m_excludes    = val.m_excludes;
+    m_includes = val.m_includes;
+    m_excludes = val.m_excludes;
 
     return true;
 }
 
-wxTextEntry *wxTextValidator::GetTextEntry()
+wxTextEntry* wxTextValidatorBase::GetTextEntry()
 {
 #if wxUSE_TEXTCTRL
     if (wxDynamicCast(m_validatorWindow, wxTextCtrl))
@@ -134,7 +122,7 @@ wxTextEntry *wxTextValidator::GetTextEntry()
 #endif
 
     wxFAIL_MSG(
-        "wxTextValidator can only be used with wxTextCtrl, wxComboBox, "
+        "wxTextValidatorBase can only be used with wxTextCtrl, wxComboBox, "
         "or wxComboCtrl"
     );
 
@@ -143,7 +131,7 @@ wxTextEntry *wxTextValidator::GetTextEntry()
 
 // Called when the value in the window must be validated.
 // This function can pop up an error message.
-bool wxTextValidator::Validate(wxWindow *parent)
+bool wxTextValidatorBase::Validate(wxWindow *parent)
 {
     // If window is disabled, simply return
     if ( !m_validatorWindow->IsEnabled() )
@@ -153,29 +141,12 @@ bool wxTextValidator::Validate(wxWindow *parent)
     if ( !text )
         return false;
 
-    wxString val(text->GetValue());
-
-    wxString errormsg;
-
-    // We can only do some kinds of validation once the input is complete, so
-    // check for them here:
-    if ( HasFlag(wxFILTER_EMPTY) && val.empty() )
-        errormsg = _("Required information entry is empty.");
-    else if ( HasFlag(wxFILTER_INCLUDE_LIST) && m_includes.Index(val) == wxNOT_FOUND )
-        errormsg = wxString::Format(_("'%s' is not one of the valid strings"), val);
-    else if ( HasFlag(wxFILTER_EXCLUDE_LIST) && m_excludes.Index(val) != wxNOT_FOUND )
-        errormsg = wxString::Format(_("'%s' is one of the invalid strings"), val);
-    else if ( !(errormsg = IsValid(val)).empty() )
-    {
-        // NB: this format string should always contain exactly one '%s'
-        wxString buf;
-        buf.Printf(errormsg, val.c_str());
-        errormsg = buf;
-    }
+    const wxString errormsg = DoValidate(text->GetValue());
 
     if ( !errormsg.empty() )
     {
         m_validatorWindow->SetFocus();
+
         wxMessageBox(errormsg, _("Validation conflict"),
                      wxOK | wxICON_EXCLAMATION, parent);
 
@@ -186,126 +157,211 @@ bool wxTextValidator::Validate(wxWindow *parent)
 }
 
 // Called to transfer data to the window
-bool wxTextValidator::TransferToWindow()
+bool wxTextValidatorBase::TransferToWindow()
 {
-    if ( m_stringValue )
+    if ( m_string )
     {
         wxTextEntry * const text = GetTextEntry();
         if ( !text )
             return false;
 
-        text->SetValue(*m_stringValue);
+        text->SetValue(*m_string);
     }
 
     return true;
 }
 
 // Called to transfer data to the window
-bool wxTextValidator::TransferFromWindow()
+bool wxTextValidatorBase::TransferFromWindow()
 {
-    if ( m_stringValue )
+    if ( m_string )
     {
         wxTextEntry * const text = GetTextEntry();
         if ( !text )
             return false;
 
-        *m_stringValue = text->GetValue();
+        *m_string = text->GetValue();
     }
 
     return true;
 }
 
-// IRIX mipsPro refuses to compile wxStringCheck<func>() if func is inline so
-// let's work around this by using this non-template function instead of
-// wxStringCheck(). And while this might be fractionally less efficient because
-// the function call won't be inlined like this, we don't care enough about
-// this to add extra #ifs for non-IRIX case.
-namespace
+wxString wxTextValidatorBase::IsValid(const wxString& str) const
 {
-
-bool CheckString(bool (*func)(const wxUniChar&), const wxString& str)
-{
-    for ( wxString::const_iterator i = str.begin(); i != str.end(); ++i )
+    for ( wxString::const_iterator i = str.begin(), end = str.end();
+          i != end; ++i )
     {
-        if ( !func(*i) )
-            return false;
+        if ( !IsValid(*i) )
+            // N.B. this format string should contain exactly one '%s'
+            return _("'%s' contains invalid character(s)!");
     }
 
-    return true;
+    return wxString();
 }
 
-} // anonymous namespace
 
-wxString wxTextValidator::IsValid(const wxString& val) const
+void wxTextValidatorBase::SetCharIncludes(const wxString& chars)
 {
-    // wxFILTER_EMPTY is checked for in wxTextValidator::Validate
+    wxASSERT( HasFlag(wxFILTER_INCLUDE_CHAR_LIST) );
 
-    if ( HasFlag(wxFILTER_ASCII) && !val.IsAscii() )
-        return _("'%s' should only contain ASCII characters.");
-    if ( HasFlag(wxFILTER_ALPHA) && !CheckString(wxIsalpha, val) )
-        return _("'%s' should only contain alphabetic characters.");
-    if ( HasFlag(wxFILTER_ALPHANUMERIC) && !CheckString(wxIsalnum, val) )
-        return _("'%s' should only contain alphabetic or numeric characters.");
-    if ( HasFlag(wxFILTER_DIGITS) && !CheckString(wxIsdigit, val) )
-        return _("'%s' should only contain digits.");
-    if ( HasFlag(wxFILTER_NUMERIC) && !wxIsNumeric(val) )
-        return _("'%s' should be numeric.");
-    if ( HasFlag(wxFILTER_INCLUDE_CHAR_LIST) && !ContainsOnlyIncludedCharacters(val) )
-        return _("'%s' doesn't consist only of valid characters");
-    if ( HasFlag(wxFILTER_EXCLUDE_CHAR_LIST) && ContainsExcludedCharacters(val) )
-        return _("'%s' contains illegal characters");
+#if wxDEBUG_LEVEL
 
-    return wxEmptyString;
+    if ( HasFlag(wxFILTER_EXCLUDE_CHAR_LIST) )
+    {
+        for ( wxString::const_iterator i = chars.begin(), end = chars.end();
+              i != end; ++i )
+        {
+            if ( m_excludes.Last().Find(*i) != wxNOT_FOUND )
+            {
+                wxLogWarning(_("An excluded char won't be included!"));
+                break;
+            }
+        }
+    }
+
+#endif // wxDEBUG_LEVEL
+
+    // the "include char list" is allocated in the constructor, and should
+    // always be the last item in m_includes.
+    m_includes.Last() = chars;
 }
 
-bool wxTextValidator::ContainsOnlyIncludedCharacters(const wxString& val) const
+void wxTextValidatorBase::AddCharIncludes(const wxString& chars)
 {
-    for ( wxString::const_iterator i = val.begin(); i != val.end(); ++i )
-        if (m_includes.Index((wxString) *i) == wxNOT_FOUND)
-            // one character of 'val' is NOT present in m_includes...
-            return false;
+    wxASSERT( HasFlag(wxFILTER_INCLUDE_CHAR_LIST) );
 
-    // all characters of 'val' are present in m_includes
-    return true;
+#if wxDEBUG_LEVEL
+
+    if ( HasFlag(wxFILTER_EXCLUDE_CHAR_LIST) )
+    {
+        for ( wxString::const_iterator i = chars.begin(), end = chars.end();
+              i != end; ++i )
+        {
+            if ( m_excludes.Last().Find(*i) != wxNOT_FOUND )
+            {
+                wxLogWarning(_("An excluded char won't be included!"));
+                break;
+            }
+        }
+    }
+
+#endif // wxDEBUG_LEVEL
+
+    m_includes.Last() += chars;
 }
 
-bool wxTextValidator::ContainsExcludedCharacters(const wxString& val) const
+void wxTextValidatorBase::SetCharExcludes(const wxString& chars)
 {
-    for ( wxString::const_iterator i = val.begin(); i != val.end(); ++i )
-        if (m_excludes.Index((wxString) *i) != wxNOT_FOUND)
-            // one character of 'val' is present in m_excludes...
-            return true;
+    wxASSERT( HasFlag(wxFILTER_EXCLUDE_CHAR_LIST) );
 
-    // all characters of 'val' are NOT present in m_excludes
-    return false;
+#if wxDEBUG_LEVEL
+
+    if ( HasFlag(wxFILTER_INCLUDE_CHAR_LIST) )
+    {
+        for ( wxString::const_iterator i = chars.begin(), end = chars.end();
+              i != end; ++i )
+        {
+            if ( m_includes.Last().Find(*i) != wxNOT_FOUND )
+            {
+                wxLogWarning(_("An included char will be excluded!"));
+                break;
+            }
+        }
+    }
+
+#endif // wxDEBUG_LEVEL
+
+    // the "exclude char list" is allocated in the constructor, and should
+    // always be the last item in m_excludes.
+    m_excludes.Last() = chars;
 }
 
-void wxTextValidator::SetCharIncludes(const wxString& chars)
+void wxTextValidatorBase::AddCharExcludes(const wxString& chars)
 {
-    wxArrayString arr;
+    wxASSERT( HasFlag(wxFILTER_EXCLUDE_CHAR_LIST) );
 
-    for ( wxString::const_iterator i = chars.begin(); i != chars.end(); ++i )
-        arr.Add(*i);
+#if wxDEBUG_LEVEL
 
-    SetIncludes(arr);
+    if ( HasFlag(wxFILTER_INCLUDE_CHAR_LIST) )
+    {
+        for ( wxString::const_iterator i = chars.begin(), end = chars.end();
+              i != end; ++i )
+        {
+            if ( m_includes.Last().Find(*i) != wxNOT_FOUND )
+            {
+                wxLogWarning(_("An included char will be excluded!"));
+                break;
+            }
+        }
+    }
+
+#endif // wxDEBUG_LEVEL
+
+    m_excludes.Last() += chars;
 }
 
-void wxTextValidator::SetCharExcludes(const wxString& chars)
+void wxTextValidatorBase::DoSetIncludes(const wxArrayString& includes)
 {
-    wxArrayString arr;
-
-    for ( wxString::const_iterator i = chars.begin(); i != chars.end(); ++i )
-        arr.Add(*i);
-
-    SetExcludes(arr);
+    if ( HasFlag(wxFILTER_INCLUDE_CHAR_LIST) )
+    {
+        // Always keep the "include char list" at the end of m_includes
+        const wxString chars = m_includes.Last();
+        m_includes = includes;
+        m_includes.Add(chars);
+    }
+    else
+    {
+        m_includes = includes;
+    }
 }
 
-void wxTextValidator::OnChar(wxKeyEvent& event)
+void wxTextValidatorBase::DoSetExcludes(const wxArrayString& excludes)
+{
+    if ( HasFlag(wxFILTER_EXCLUDE_CHAR_LIST) )
+    {
+        // Always keep the "exclude char list" at the end of m_excludes
+        const wxString chars = m_excludes.Last();
+        m_excludes = excludes;
+        m_excludes.Add(chars);
+    }
+    else
+    {
+        m_excludes = excludes;
+    }
+}
+
+void wxTextValidatorBase::DoAddInclude(const wxString& include)
+{
+    if ( include.empty() )
+        return;
+
+    if ( HasFlag(wxFILTER_INCLUDE_CHAR_LIST) )
+        // We should insert before the "include char list" which should be
+        // kept at the end of m_includes
+        m_includes.Insert(include, m_includes.GetCount()-1);
+    else
+        m_includes.Add(include);
+}
+
+void wxTextValidatorBase::DoAddExclude(const wxString& exclude)
+{
+    if ( exclude.empty() )
+        return;
+
+    if ( HasFlag(wxFILTER_EXCLUDE_CHAR_LIST) )
+        // We should insert before the "exclude char list" which should be
+        // kept at the end m_excludes
+        m_excludes.Insert(exclude, m_excludes.GetCount()-1);
+    else
+        m_excludes.Add(exclude);
+}
+
+void wxTextValidatorBase::OnChar(wxKeyEvent& event)
 {
     // Let the event propagate by default.
     event.Skip();
 
-    if (!m_validatorWindow)
+    if ( !m_validatorWindow )
         return;
 
 #if wxUSE_UNICODE
@@ -313,16 +369,16 @@ void wxTextValidator::OnChar(wxKeyEvent& event)
     int keyCode = event.GetUnicodeKey();
 #else // !wxUSE_UNICODE
     int keyCode = event.GetKeyCode();
-    if (keyCode > WXK_START)
+    if ( keyCode > WXK_START )
         return;
 #endif // wxUSE_UNICODE/!wxUSE_UNICODE
 
     // we don't filter special keys and delete
-    if (keyCode < WXK_SPACE || keyCode == WXK_DELETE)
+    if ( keyCode < WXK_SPACE || keyCode == WXK_DELETE )
         return;
 
-    wxString str((wxUniChar)keyCode, 1);
-    if (IsValid(str).empty())
+    // Filter out invalid characters
+    if ( IsValid(static_cast<wxUniChar>(keyCode)) )
         return;
 
     if ( !wxValidator::IsSilent() )
@@ -332,6 +388,149 @@ void wxTextValidator::OnChar(wxKeyEvent& event)
     event.Skip(false);
 }
 
+// ----------------------------------------------------------------------------
+// wxTextValidator
+// ----------------------------------------------------------------------------
+
+wxIMPLEMENT_DYNAMIC_CLASS(wxTextValidator, wxTextValidatorBase);
+
+wxTextValidator::wxTextValidator(wxString *str, long style)
+    : wxTextValidatorBase(str, style)
+{
+}
+
+wxTextValidator::wxTextValidator(long style, wxString *str)
+    : wxTextValidatorBase(str, style)
+{
+}
+
+wxTextValidator::wxTextValidator(const wxTextValidator& val)
+    : wxTextValidatorBase(val)
+{
+    Copy(val);
+}
+
+bool wxTextValidator::Copy(const wxTextValidator& WXUNUSED(val))
+{
+    return true;
+}
+
+bool wxTextValidator::IsValid(const wxUniChar& c) const
+{
+    if ( !m_style ) // no filtering if HasFlag(wxFILTER_NONE)
+        return true;
+
+    if ( HasFlag(wxFILTER_SPACE) && wxIsspace(c) )
+        return true;
+
+    // Notice that if the same char is mistakenly present in both the
+    // include char list and exclude char list than the char will be
+    // excluded and a warning is given in debug build.
+
+    if ( IsCharExcluded(c) )
+        return false;
+
+    if ( IsCharIncluded(c) )
+        return true;
+
+    static const long mask = wxFILTER_ASCII|wxFILTER_ALPHA|wxFILTER_NUMERIC
+                      wxFILTER_ALPHANUMERIC|wxFILTER_DIGITS|wxFILTER_XDIGITS;
+    
+    long flags = m_style & mask;
+
+    if ( !flags )
+        // accept whatever this character is.
+        return true;
+
+    // Turn off the wxFILTER_XXX if the corresponding check failed...
+
+    if ( HasFlag(wxFILTER_ASCII) && !c.IsAscii() )
+        flags ^= wxFILTER_ASCII;
+    if ( HasFlag(wxFILTER_NUMERIC) && !wxIsNumeric(c) )
+        flags ^= wxFILTER_NUMERIC;
+
+    // wxFILTER_ALPHANUMERIC is the combination of
+    // wxFILTER_ALPHA, wxFILTER_DIGITS and wxFILTER_XDIGITS
+
+    if ( HasFlag(wxFILTER_ALPHANUMERIC) && !wxIsalnum(c) )
+    {
+        flags ^= wxFILTER_ALPHANUMERIC;
+    }
+    else
+    {
+        if ( HasFlag(wxFILTER_ALPHA) && !wxIsalpha(c) )
+            flags ^= wxFILTER_ALPHA;
+        if ( HasFlag(wxFILTER_DIGITS) && !wxIsdigit(c) )
+            flags ^= wxFILTER_DIGITS;
+        if ( HasFlag(wxFILTER_XDIGITS) && !wxIsxdigit(c) )
+            flags ^= wxFILTER_XDIGITS;
+    }
+
+    return flags != 0;
+}
+
+wxString wxTextValidator::DoValidate(const wxString& str)
+{
+    // We can only do some kinds of validation once the input is complete, so
+    // check for them here:
+    if ( HasFlag(wxFILTER_EMPTY) && str.empty() )
+        return _("Required information entry is empty.");
+    else if ( HasFlag(wxFILTER_EXCLUDE_LIST) && IsExcluded(str) )
+        return wxString::Format(_("'%s' is one of the invalid strings"), str);
+    else if ( HasFlag(wxFILTER_INCLUDE_LIST) && !IsIncluded(str) )
+        return wxString::Format(_("'%s' is not one of the valid strings"), str);
+
+    wxString errormsg = wxTextValidatorBase::IsValid(str);
+
+    if ( !errormsg.empty() )
+    {
+        // NB: this format string should always contain exactly one '%s'
+        wxString buf;
+        buf.Printf(errormsg, str);
+        return buf;
+    }
+
+    return wxString();
+}
+
+void wxTextValidator::DoSetStyle(long style)
+{
+    // Add or remove "include/exclude char list" item when needed
+
+    // wxFILTER_INCLUDE_CHAR_LIST flag:
+    // --------------------------------
+
+    if ( HasFlag(wxFILTER_INCLUDE_CHAR_LIST) )
+    {
+        // want to unset wxFILTER_INCLUDE_CHAR_LIST
+        if ( (style & wxFILTER_INCLUDE_CHAR_LIST) == 0 )
+            m_includes.RemoveAt(m_includes.GetCount()-1);
+    }
+    else // wxFILTER_INCLUDE_CHAR_LIST was not set
+    {
+        // want to set wxFILTER_INCLUDE_CHAR_LIST
+        if ( (style & wxFILTER_INCLUDE_CHAR_LIST) != 0 )
+            m_includes.Add(wxEmptyString);
+    }
+
+    // wxFILTER_EXCLUDE_CHAR_LIST flag:
+    // --------------------------------
+
+    if ( HasFlag(wxFILTER_EXCLUDE_CHAR_LIST) )
+    {
+        // want to unset wxFILTER_EXCLUDE_CHAR_LIST
+        if ( (style & wxFILTER_EXCLUDE_CHAR_LIST) == 0 )
+            m_excludes.RemoveAt(m_excludes.GetCount()-1);
+    }
+    else // wxFILTER_EXCLUDE_CHAR_LIST was not set
+    {
+        // want to set wxFILTER_EXCLUDE_CHAR_LIST
+        if ( (style & wxFILTER_EXCLUDE_CHAR_LIST) != 0 )
+            m_excludes.Add(wxEmptyString);
+    }
+
+    wxTextValidatorBase::DoSetStyle(style);
+}
 
 #endif
   // wxUSE_VALIDATORS && (wxUSE_TEXTCTRL || wxUSE_COMBOBOX)

--- a/src/common/valtext.cpp
+++ b/src/common/valtext.cpp
@@ -86,9 +86,8 @@ void wxTextValidator::SetStyle(long style)
     if ( HasFlag(wxFILTER_ALPHA) && 
         (HasFlag(wxFILTER_DIGITS) || HasFlag(wxFILTER_XDIGITS)) )
     {
-        m_validatorStyle &= ~wxFILTER_ALPHA;
-        m_validatorStyle &= ~wxFILTER_DIGITS;
-        m_validatorStyle &= ~wxFILTER_XDIGITS;
+        m_validatorStyle &=
+            ~(wxFILTER_ALPHA|wxFILTER_DIGITS|wxFILTER_XDIGITS);
 
         m_validatorStyle |= wxFILTER_ALPHANUMERIC;
     }

--- a/src/common/valtext.cpp
+++ b/src/common/valtext.cpp
@@ -54,51 +54,62 @@ static bool wxIsNumeric(const wxString& val)
 }
 
 // ----------------------------------------------------------------------------
-// wxTextValidatorBase
+// wxTextValidator
 // ----------------------------------------------------------------------------
 
-wxIMPLEMENT_ABSTRACT_CLASS(wxTextValidatorBase, wxValidator)
-
-wxBEGIN_EVENT_TABLE(wxTextValidatorBase, wxValidator)
-    EVT_CHAR(wxTextValidatorBase::OnChar)
+wxIMPLEMENT_DYNAMIC_CLASS(wxTextValidator, wxValidator)
+wxBEGIN_EVENT_TABLE(wxTextValidator, wxValidator)
+    EVT_CHAR(wxTextValidator::OnChar)
 wxEND_EVENT_TABLE()
 
-wxTextValidatorBase::wxTextValidatorBase(wxString* str, long style)
+wxTextValidator::wxTextValidator(long style, wxString *val)
 {
-    m_style = style;
-    m_string = str;
-
-    // N.B. the "include char list" should be the last item of m_includes
-    //      if wxFILTER_INCLUDE_CHAR_LIST flag is set.
-    if ( HasFlag(wxFILTER_INCLUDE_CHAR_LIST) )
-        m_includes.Add(wxEmptyString);
-
-    // N.B. the "exclude char list" should be the last item of m_excludes
-    //      if wxFILTER_EXCLUDE_CHAR_LIST flag is set.
-    if ( HasFlag(wxFILTER_EXCLUDE_CHAR_LIST) )
-        m_excludes.Add(wxEmptyString);
+    m_stringValue = val;
+    SetStyle(style);
 }
 
-wxTextValidatorBase::wxTextValidatorBase(const wxTextValidatorBase& val)
+wxTextValidator::wxTextValidator(const wxTextValidator& val)
     : wxValidator()
 {
     Copy(val);
 }
 
-bool wxTextValidatorBase::Copy(const wxTextValidatorBase& val)
+void wxTextValidator::SetStyle(long style)
+{
+    m_validatorStyle = style;
+
+    // Notice that the presence of either or both 
+    // wxFILTER_DIGITS and wxFILTER_XDIGITS with wxFILTER_ALPHA
+    // is merely equivalent to wxFILTER_ALPHANUMERIC. 
+    // so we should do the substitution for them here.
+
+    if ( HasFlag(wxFILTER_ALPHA) && 
+        (HasFlag(wxFILTER_DIGITS) || HasFlag(wxFILTER_XDIGITS)) )
+    {
+        m_validatorStyle &= ~wxFILTER_ALPHA;
+        m_validatorStyle &= ~wxFILTER_DIGITS;
+        m_validatorStyle &= ~wxFILTER_XDIGITS;
+
+        m_validatorStyle |= wxFILTER_ALPHANUMERIC;
+    }
+}
+
+bool wxTextValidator::Copy(const wxTextValidator& val)
 {
     wxValidator::Copy(val);
 
-    m_style = val.m_style;
-    m_string = val.m_string;
+    m_validatorStyle = val.m_validatorStyle;
+    m_stringValue    = val.m_stringValue;
 
-    m_includes = val.m_includes;
-    m_excludes = val.m_excludes;
+    m_charIncludes = val.m_charIncludes;
+    m_charExcludes = val.m_charExcludes;
+    m_includes     = val.m_includes;
+    m_excludes     = val.m_excludes;
 
     return true;
 }
 
-wxTextEntry* wxTextValidatorBase::GetTextEntry()
+wxTextEntry* wxTextValidator::GetTextEntry()
 {
 #if wxUSE_TEXTCTRL
     if (wxDynamicCast(m_validatorWindow, wxTextCtrl))
@@ -122,7 +133,7 @@ wxTextEntry* wxTextValidatorBase::GetTextEntry()
 #endif
 
     wxFAIL_MSG(
-        "wxTextValidatorBase can only be used with wxTextCtrl, wxComboBox, "
+        "wxTextValidator can only be used with wxTextCtrl, wxComboBox, "
         "or wxComboCtrl"
     );
 
@@ -131,7 +142,7 @@ wxTextEntry* wxTextValidatorBase::GetTextEntry()
 
 // Called when the value in the window must be validated.
 // This function can pop up an error message.
-bool wxTextValidatorBase::Validate(wxWindow *parent)
+bool wxTextValidator::Validate(wxWindow *parent)
 {
     // If window is disabled, simply return
     if ( !m_validatorWindow->IsEnabled() )
@@ -146,7 +157,6 @@ bool wxTextValidatorBase::Validate(wxWindow *parent)
     if ( !errormsg.empty() )
     {
         m_validatorWindow->SetFocus();
-
         wxMessageBox(errormsg, _("Validation conflict"),
                      wxOK | wxICON_EXCLAMATION, parent);
 
@@ -157,206 +167,138 @@ bool wxTextValidatorBase::Validate(wxWindow *parent)
 }
 
 // Called to transfer data to the window
-bool wxTextValidatorBase::TransferToWindow()
+bool wxTextValidator::TransferToWindow()
 {
-    if ( m_string )
+    if ( m_stringValue )
     {
         wxTextEntry * const text = GetTextEntry();
         if ( !text )
             return false;
 
-        text->SetValue(*m_string);
+        text->SetValue(*m_stringValue);
     }
 
     return true;
 }
 
 // Called to transfer data to the window
-bool wxTextValidatorBase::TransferFromWindow()
+bool wxTextValidator::TransferFromWindow()
 {
-    if ( m_string )
+    if ( m_stringValue )
     {
         wxTextEntry * const text = GetTextEntry();
         if ( !text )
             return false;
 
-        *m_string = text->GetValue();
+        *m_stringValue = text->GetValue();
     }
 
     return true;
 }
 
-wxString wxTextValidatorBase::IsValid(const wxString& str) const
+wxString wxTextValidator::IsValid(const wxString& str) const
 {
     for ( wxString::const_iterator i = str.begin(), end = str.end();
           i != end; ++i )
     {
         if ( !IsValid(*i) )
+        {
             // N.B. this format string should contain exactly one '%s'
             return _("'%s' contains invalid character(s)!");
+        }
     }
 
     return wxString();
 }
 
 
-void wxTextValidatorBase::SetCharIncludes(const wxString& chars)
+void wxTextValidator::SetCharIncludes(const wxString& chars)
 {
-    wxASSERT( HasFlag(wxFILTER_INCLUDE_CHAR_LIST) );
-
-#if wxDEBUG_LEVEL
-
-    if ( HasFlag(wxFILTER_EXCLUDE_CHAR_LIST) )
+    for ( wxString::const_iterator i = chars.begin(), end = chars.end();
+          i != end; ++i )
     {
-        for ( wxString::const_iterator i = chars.begin(), end = chars.end();
-              i != end; ++i )
+        if ( m_charExcludes.Find(*i) != wxNOT_FOUND )
         {
-            if ( m_excludes.Last().Find(*i) != wxNOT_FOUND )
-            {
-                wxLogWarning(_("An excluded char won't be included!"));
-                break;
-            }
+            wxLogWarning(_("A char should either be included or excluded!"));
+            return;
         }
     }
 
-#endif // wxDEBUG_LEVEL
-
-    // the "include char list" is allocated in the constructor, and should
-    // always be the last item in m_includes.
-    m_includes.Last() = chars;
+    m_charIncludes = chars;
 }
 
-void wxTextValidatorBase::AddCharIncludes(const wxString& chars)
+void wxTextValidator::AddCharIncludes(const wxString& chars)
 {
-    wxASSERT( HasFlag(wxFILTER_INCLUDE_CHAR_LIST) );
-
-#if wxDEBUG_LEVEL
-
-    if ( HasFlag(wxFILTER_EXCLUDE_CHAR_LIST) )
+    for ( wxString::const_iterator i = chars.begin(), end = chars.end();
+          i != end; ++i )
     {
-        for ( wxString::const_iterator i = chars.begin(), end = chars.end();
-              i != end; ++i )
+        if ( m_charExcludes.Find(*i) != wxNOT_FOUND )
         {
-            if ( m_excludes.Last().Find(*i) != wxNOT_FOUND )
-            {
-                wxLogWarning(_("An excluded char won't be included!"));
-                break;
-            }
+            wxLogWarning(_("A char should either be included or excluded!"));
+            return;
         }
     }
 
-#endif // wxDEBUG_LEVEL
-
-    m_includes.Last() += chars;
+    m_charIncludes += chars;
 }
 
-void wxTextValidatorBase::SetCharExcludes(const wxString& chars)
+void wxTextValidator::SetCharExcludes(const wxString& chars)
 {
-    wxASSERT( HasFlag(wxFILTER_EXCLUDE_CHAR_LIST) );
-
-#if wxDEBUG_LEVEL
-
-    if ( HasFlag(wxFILTER_INCLUDE_CHAR_LIST) )
+    for ( wxString::const_iterator i = chars.begin(), end = chars.end();
+          i != end; ++i )
     {
-        for ( wxString::const_iterator i = chars.begin(), end = chars.end();
-              i != end; ++i )
+        if ( m_charIncludes.Find(*i) != wxNOT_FOUND )
         {
-            if ( m_includes.Last().Find(*i) != wxNOT_FOUND )
-            {
-                wxLogWarning(_("An included char will be excluded!"));
-                break;
-            }
+            wxLogWarning(_("A char should either be included or excluded!"));
+            return;
         }
     }
 
-#endif // wxDEBUG_LEVEL
-
-    // the "exclude char list" is allocated in the constructor, and should
-    // always be the last item in m_excludes.
-    m_excludes.Last() = chars;
+    m_charExcludes = chars;
 }
 
-void wxTextValidatorBase::AddCharExcludes(const wxString& chars)
+void wxTextValidator::AddCharExcludes(const wxString& chars)
 {
-    wxASSERT( HasFlag(wxFILTER_EXCLUDE_CHAR_LIST) );
-
-#if wxDEBUG_LEVEL
-
-    if ( HasFlag(wxFILTER_INCLUDE_CHAR_LIST) )
+    for ( wxString::const_iterator i = chars.begin(), end = chars.end();
+          i != end; ++i )
     {
-        for ( wxString::const_iterator i = chars.begin(), end = chars.end();
-              i != end; ++i )
+        if ( m_charIncludes.Find(*i) != wxNOT_FOUND )
         {
-            if ( m_includes.Last().Find(*i) != wxNOT_FOUND )
-            {
-                wxLogWarning(_("An included char will be excluded!"));
-                break;
-            }
+            wxLogWarning(_("A char should either be included or excluded!"));
+            return;
         }
     }
 
-#endif // wxDEBUG_LEVEL
-
-    m_excludes.Last() += chars;
+    m_charExcludes += chars;
 }
 
-void wxTextValidatorBase::DoSetIncludes(const wxArrayString& includes)
+void wxTextValidator::DoSetIncludes(const wxArrayString& includes)
 {
-    if ( HasFlag(wxFILTER_INCLUDE_CHAR_LIST) )
-    {
-        // Always keep the "include char list" at the end of m_includes
-        const wxString chars = m_includes.Last();
-        m_includes = includes;
-        m_includes.Add(chars);
-    }
-    else
-    {
-        m_includes = includes;
-    }
+    m_includes = includes;
 }
 
-void wxTextValidatorBase::DoSetExcludes(const wxArrayString& excludes)
+void wxTextValidator::DoSetExcludes(const wxArrayString& excludes)
 {
-    if ( HasFlag(wxFILTER_EXCLUDE_CHAR_LIST) )
-    {
-        // Always keep the "exclude char list" at the end of m_excludes
-        const wxString chars = m_excludes.Last();
-        m_excludes = excludes;
-        m_excludes.Add(chars);
-    }
-    else
-    {
-        m_excludes = excludes;
-    }
+    m_excludes = excludes;
 }
 
-void wxTextValidatorBase::DoAddInclude(const wxString& include)
+void wxTextValidator::DoAddInclude(const wxString& include)
 {
     if ( include.empty() )
         return;
 
-    if ( HasFlag(wxFILTER_INCLUDE_CHAR_LIST) )
-        // We should insert before the "include char list" which should be
-        // kept at the end of m_includes
-        m_includes.Insert(include, m_includes.GetCount()-1);
-    else
-        m_includes.Add(include);
+    m_includes.Add(include);
 }
 
-void wxTextValidatorBase::DoAddExclude(const wxString& exclude)
+void wxTextValidator::DoAddExclude(const wxString& exclude)
 {
     if ( exclude.empty() )
         return;
 
-    if ( HasFlag(wxFILTER_EXCLUDE_CHAR_LIST) )
-        // We should insert before the "exclude char list" which should be
-        // kept at the end m_excludes
-        m_excludes.Insert(exclude, m_excludes.GetCount()-1);
-    else
-        m_excludes.Add(exclude);
+    m_excludes.Add(exclude);
 }
 
-void wxTextValidatorBase::OnChar(wxKeyEvent& event)
+void wxTextValidator::OnChar(wxKeyEvent& event)
 {
     // Let the event propagate by default.
     event.Skip();
@@ -388,36 +330,9 @@ void wxTextValidatorBase::OnChar(wxKeyEvent& event)
     event.Skip(false);
 }
 
-// ----------------------------------------------------------------------------
-// wxTextValidator
-// ----------------------------------------------------------------------------
-
-wxIMPLEMENT_DYNAMIC_CLASS(wxTextValidator, wxTextValidatorBase);
-
-wxTextValidator::wxTextValidator(wxString *str, long style)
-    : wxTextValidatorBase(str, style)
-{
-}
-
-wxTextValidator::wxTextValidator(long style, wxString *str)
-    : wxTextValidatorBase(str, style)
-{
-}
-
-wxTextValidator::wxTextValidator(const wxTextValidator& val)
-    : wxTextValidatorBase(val)
-{
-    Copy(val);
-}
-
-bool wxTextValidator::Copy(const wxTextValidator& WXUNUSED(val))
-{
-    return true;
-}
-
 bool wxTextValidator::IsValid(const wxUniChar& c) const
 {
-    if ( !m_style ) // no filtering if HasFlag(wxFILTER_NONE)
+    if ( !m_validatorStyle ) // no filtering if HasFlag(wxFILTER_NONE)
         return true;
 
     if ( HasFlag(wxFILTER_SPACE) && wxIsspace(c) )
@@ -436,7 +351,7 @@ bool wxTextValidator::IsValid(const wxUniChar& c) const
     static const long mask = wxFILTER_ASCII|wxFILTER_ALPHA|wxFILTER_NUMERIC|
                       wxFILTER_ALPHANUMERIC|wxFILTER_DIGITS|wxFILTER_XDIGITS;
     
-    long flags = m_style & mask;
+    long flags = m_validatorStyle & mask;
 
     if ( !flags )
         // accept whatever this character is.
@@ -448,9 +363,6 @@ bool wxTextValidator::IsValid(const wxUniChar& c) const
         flags ^= wxFILTER_ASCII;
     if ( HasFlag(wxFILTER_NUMERIC) && !wxIsNumeric(c) )
         flags ^= wxFILTER_NUMERIC;
-
-    // wxFILTER_ALPHANUMERIC is the combination of
-    // wxFILTER_ALPHA, wxFILTER_DIGITS and wxFILTER_XDIGITS
 
     if ( HasFlag(wxFILTER_ALPHANUMERIC) && !wxIsalnum(c) )
     {
@@ -475,12 +387,12 @@ wxString wxTextValidator::DoValidate(const wxString& str)
     // check for them here:
     if ( HasFlag(wxFILTER_EMPTY) && str.empty() )
         return _("Required information entry is empty.");
-    else if ( HasFlag(wxFILTER_EXCLUDE_LIST) && IsExcluded(str) )
+    else if ( IsExcluded(str) )
         return wxString::Format(_("'%s' is one of the invalid strings"), str);
-    else if ( HasFlag(wxFILTER_INCLUDE_LIST) && !IsIncluded(str) )
+    else if ( !IsIncluded(str) )
         return wxString::Format(_("'%s' is not one of the valid strings"), str);
 
-    wxString errormsg = wxTextValidatorBase::IsValid(str);
+    wxString errormsg = wxTextValidator::IsValid(str);
 
     if ( !errormsg.empty() )
     {
@@ -491,45 +403,6 @@ wxString wxTextValidator::DoValidate(const wxString& str)
     }
 
     return wxString();
-}
-
-void wxTextValidator::DoSetStyle(long style)
-{
-    // Add or remove "include/exclude char list" item when needed
-
-    // wxFILTER_INCLUDE_CHAR_LIST flag:
-    // --------------------------------
-
-    if ( HasFlag(wxFILTER_INCLUDE_CHAR_LIST) )
-    {
-        // want to unset wxFILTER_INCLUDE_CHAR_LIST
-        if ( (style & wxFILTER_INCLUDE_CHAR_LIST) == 0 )
-            m_includes.RemoveAt(m_includes.GetCount()-1);
-    }
-    else // wxFILTER_INCLUDE_CHAR_LIST was not set
-    {
-        // want to set wxFILTER_INCLUDE_CHAR_LIST
-        if ( (style & wxFILTER_INCLUDE_CHAR_LIST) != 0 )
-            m_includes.Add(wxEmptyString);
-    }
-
-    // wxFILTER_EXCLUDE_CHAR_LIST flag:
-    // --------------------------------
-
-    if ( HasFlag(wxFILTER_EXCLUDE_CHAR_LIST) )
-    {
-        // want to unset wxFILTER_EXCLUDE_CHAR_LIST
-        if ( (style & wxFILTER_EXCLUDE_CHAR_LIST) == 0 )
-            m_excludes.RemoveAt(m_excludes.GetCount()-1);
-    }
-    else // wxFILTER_EXCLUDE_CHAR_LIST was not set
-    {
-        // want to set wxFILTER_EXCLUDE_CHAR_LIST
-        if ( (style & wxFILTER_EXCLUDE_CHAR_LIST) != 0 )
-            m_excludes.Add(wxEmptyString);
-    }
-
-    wxTextValidatorBase::DoSetStyle(style);
 }
 
 #endif

--- a/src/common/valtext.cpp
+++ b/src/common/valtext.cpp
@@ -152,7 +152,7 @@ bool wxTextValidator::Validate(wxWindow *parent)
     if ( !text )
         return false;
 
-    const wxString errormsg = DoValidate(text->GetValue());
+    const wxString errormsg = IsValid(text->GetValue());
 
     if ( !errormsg.empty() )
     {
@@ -198,13 +198,21 @@ bool wxTextValidator::TransferFromWindow()
 
 wxString wxTextValidator::IsValid(const wxString& str) const
 {
+    if ( HasFlag(wxFILTER_EMPTY) && str.empty() )
+        return _("Required information entry is empty.");
+    else if ( IsExcluded(str) )
+        return wxString::Format(_("'%s' is one of the invalid strings"), str);
+    else if ( !IsIncluded(str) )
+        return wxString::Format(_("'%s' is not one of the valid strings"), str);
+
+    // check the whole string for invalid chars.
     for ( wxString::const_iterator i = str.begin(), end = str.end();
           i != end; ++i )
     {
         if ( !IsValid(*i) )
         {
-            // N.B. this format string should contain exactly one '%s'
-            return _("'%s' contains invalid character(s)!");
+            return wxString::Format(
+                _("'%s' contains invalid character(s)"), str);
         }
     }
 
@@ -379,30 +387,6 @@ bool wxTextValidator::IsValid(const wxUniChar& c) const
     }
 
     return flags != 0;
-}
-
-wxString wxTextValidator::DoValidate(const wxString& str)
-{
-    // We can only do some kinds of validation once the input is complete, so
-    // check for them here:
-    if ( HasFlag(wxFILTER_EMPTY) && str.empty() )
-        return _("Required information entry is empty.");
-    else if ( IsExcluded(str) )
-        return wxString::Format(_("'%s' is one of the invalid strings"), str);
-    else if ( !IsIncluded(str) )
-        return wxString::Format(_("'%s' is not one of the valid strings"), str);
-
-    wxString errormsg = IsValid(str);
-
-    if ( !errormsg.empty() )
-    {
-        // NB: this format string should always contain exactly one '%s'
-        wxString buf;
-        buf.Printf(errormsg, str);
-        return buf;
-    }
-
-    return wxString();
 }
 
 #endif

--- a/src/common/valtext.cpp
+++ b/src/common/valtext.cpp
@@ -391,5 +391,31 @@ bool wxTextValidator::IsValidChar(const wxUniChar& c) const
     return !(m_validatorStyle & mask);
 }
 
+// kept for compatibility reasons.
+bool wxTextValidator::ContainsOnlyIncludedCharacters(const wxString& str) const
+{
+    for ( wxString::const_iterator i = str.begin(), end = str.end();
+          i != end; ++i )
+    {
+        if ( !IsCharIncluded(*i) )
+            return false;
+    }
+
+    return true;
+}
+
+// kept for compatibility reasons.
+bool wxTextValidator::ContainsExcludedCharacters(const wxString& str) const
+{
+    for ( wxString::const_iterator i = str.begin(), end = str.end();
+          i != end; ++i )
+    {
+        if ( IsCharExcluded(*i) )
+            return true;
+    }
+
+    return false;
+}
+
 #endif
   // wxUSE_VALIDATORS && (wxUSE_TEXTCTRL || wxUSE_COMBOBOX)

--- a/src/common/valtext.cpp
+++ b/src/common/valtext.cpp
@@ -280,32 +280,6 @@ void wxTextValidator::AddCharExcludes(const wxString& chars)
     m_charExcludes += chars;
 }
 
-void wxTextValidator::DoSetIncludes(const wxArrayString& includes)
-{
-    m_includes = includes;
-}
-
-void wxTextValidator::DoSetExcludes(const wxArrayString& excludes)
-{
-    m_excludes = excludes;
-}
-
-void wxTextValidator::DoAddInclude(const wxString& include)
-{
-    if ( include.empty() )
-        return;
-
-    m_includes.Add(include);
-}
-
-void wxTextValidator::DoAddExclude(const wxString& exclude)
-{
-    if ( exclude.empty() )
-        return;
-
-    m_excludes.Add(exclude);
-}
-
 void wxTextValidator::OnChar(wxKeyEvent& event)
 {
     // Let the event propagate by default.

--- a/src/common/valtext.cpp
+++ b/src/common/valtext.cpp
@@ -384,8 +384,8 @@ bool wxTextValidator::IsValidChar(const wxUniChar& c) const
     //  filtering should take place) and true should be returned in this case.
 
     static const long mask =
-        wxFILTER_SPACE|wxFILTER_ASCII|wxFILTER_NUMERIC|
-        wxFILTER_ALPHANUMERIC|wxFILTER_ALPHA|wxFILTER_DIGITS|wxFILTER_XDIGITS;
+        wxFILTER_SPACE|wxFILTER_ASCII|wxFILTER_NUMERIC|wxFILTER_ALPHANUMERIC|
+        wxFILTER_ALPHA|wxFILTER_DIGITS|wxFILTER_XDIGITS|wxFILTER_INCLUDE_CHAR_LIST;
 
     return !(m_validatorStyle & mask);
 }

--- a/src/common/valtext.cpp
+++ b/src/common/valtext.cpp
@@ -392,7 +392,7 @@ wxString wxTextValidator::DoValidate(const wxString& str)
     else if ( !IsIncluded(str) )
         return wxString::Format(_("'%s' is not one of the valid strings"), str);
 
-    wxString errormsg = wxTextValidator::IsValid(str);
+    wxString errormsg = IsValid(str);
 
     if ( !errormsg.empty() )
     {

--- a/src/common/valtext.cpp
+++ b/src/common/valtext.cpp
@@ -433,7 +433,7 @@ bool wxTextValidator::IsValid(const wxUniChar& c) const
     if ( IsCharIncluded(c) )
         return true;
 
-    static const long mask = wxFILTER_ASCII|wxFILTER_ALPHA|wxFILTER_NUMERIC
+    static const long mask = wxFILTER_ASCII|wxFILTER_ALPHA|wxFILTER_NUMERIC|
                       wxFILTER_ALPHANUMERIC|wxFILTER_DIGITS|wxFILTER_XDIGITS;
     
     long flags = m_style & mask;

--- a/src/common/valtext.cpp
+++ b/src/common/valtext.cpp
@@ -92,13 +92,6 @@ void wxTextValidator::SetStyle(long style)
 
         m_validatorStyle |= wxFILTER_ALPHANUMERIC;
     }
-
-    // the following flags are no longer needed, and should be unset here
-    // unconditionally to not break our validation logic.
-    m_validatorStyle &= ~wxFILTER_INCLUDE_LIST;
-    m_validatorStyle &= ~wxFILTER_INCLUDE_CHAR_LIST;
-    m_validatorStyle &= ~wxFILTER_EXCLUDE_LIST;
-    m_validatorStyle &= ~wxFILTER_EXCLUDE_CHAR_LIST;
 }
 
 bool wxTextValidator::Copy(const wxTextValidator& val)
@@ -269,12 +262,54 @@ void wxTextValidator::AddCharExcludes(const wxString& chars)
     m_charExcludes += chars;
 }
 
+void wxTextValidator::SetIncludes(const wxArrayString& includes)
+{
+    // preserve compatibily with versions prior 3.1.3 which used m_includes
+    // to store the list of char includes.
+    if ( HasFlag(wxFILTER_INCLUDE_CHAR_LIST) )
+    {
+        for ( wxArrayString::const_iterator i = includes.begin(),
+              end = includes.end(); i != end; ++i )
+        {
+            AddCharIncludes(*i);
+        }
+
+        return;
+    }
+
+    wxCHECK_RET( (m_includes.Index(wxString()) == wxNOT_FOUND),
+        _("Empty strings can't be added to the list of includes.") );
+
+    m_includes = includes;
+}
+
 void wxTextValidator::AddInclude(const wxString& include)
 {
     wxCHECK_RET( !include.empty(),
         _("Empty strings can't be added to the list of includes.") );
 
     m_includes.push_back(include);
+}
+
+void wxTextValidator::SetExcludes(const wxArrayString& excludes)
+{
+    // preserve compatibily with versions prior 3.1.3 which used m_excludes
+    // to store the list of char excludes.
+    if ( HasFlag(wxFILTER_EXCLUDE_CHAR_LIST) )
+    {
+        for ( wxArrayString::const_iterator i = excludes.begin(),
+              end = excludes.end(); i != end; ++i )
+        {
+            AddCharExcludes(*i);
+        }
+
+        return;
+    }
+
+    wxCHECK_RET( (m_excludes.Index(wxString()) == wxNOT_FOUND),
+        _("Empty strings can't be added to the list of excludes.") );
+
+    m_excludes = excludes;
 }
 
 void wxTextValidator::AddExclude(const wxString& exclude)

--- a/src/generic/datectlg.cpp
+++ b/src/generic/datectlg.cpp
@@ -262,9 +262,7 @@ private:
 
         if ( m_combo )
         {
-            wxArrayString allowedChars;
-            for ( wxChar c = wxT('0'); c <= wxT('9'); c++ )
-                allowedChars.Add(wxString(c, 1));
+            wxString allowedChars = wxS("0123456789");
 
             const wxChar *p2 = m_format.c_str();
             while ( *p2 )
@@ -272,12 +270,12 @@ private:
                 if ( *p2 == '%')
                     p2 += 2;
                 else
-                    allowedChars.Add(wxString(*p2++, 1));
+                    allowedChars << (*p2++); // append char
             }
 
     #if wxUSE_VALIDATORS
             wxTextValidator tv(wxFILTER_INCLUDE_CHAR_LIST);
-            tv.SetIncludes(allowedChars);
+            tv.SetCharIncludes(allowedChars);
             m_combo->SetValidator(tv);
     #endif
 

--- a/src/propgrid/props.cpp
+++ b/src/propgrid/props.cpp
@@ -160,47 +160,41 @@ wxNumericPropertyValidator::
     wxNumericPropertyValidator( NumericType numericType, int base )
     : wxTextValidator(wxFILTER_INCLUDE_CHAR_LIST)
 {
-    wxArrayString arr;
-    arr.Add(wxS("0"));
-    arr.Add(wxS("1"));
-    arr.Add(wxS("2"));
-    arr.Add(wxS("3"));
-    arr.Add(wxS("4"));
-    arr.Add(wxS("5"));
-    arr.Add(wxS("6"));
-    arr.Add(wxS("7"));
+    long style = GetStyle();
 
-    if ( base >= 10 )
+    // always allow plus and minus signs
+    wxString allowedChars("+-");
+
+    switch (base)
     {
-        arr.Add(wxS("8"));
-        arr.Add(wxS("9"));
-        if ( base >= 16 )
-        {
-            arr.Add(wxS("a")); arr.Add(wxS("A"));
-            arr.Add(wxS("b")); arr.Add(wxS("B"));
-            arr.Add(wxS("c")); arr.Add(wxS("C"));
-            arr.Add(wxS("d")); arr.Add(wxS("D"));
-            arr.Add(wxS("e")); arr.Add(wxS("E"));
-            arr.Add(wxS("f")); arr.Add(wxS("F"));
-        }
+        case 2:
+            allowedChars += wxS("01");
+            break;
+        case 8:
+            allowedChars += wxS("01234567");
+            break;
+        case 10:
+            style |= wxFILTER_DIGITS;
+            break;
+        case 16:
+            style |= wxFILTER_XDIGITS;
+            break;
+
+        default:
+            wxLogWarning( _("Unknown base %d. Base 10 will be used."), base );
+            style |= wxFILTER_DIGITS;
     }
 
-    if ( numericType == Signed )
+    if ( numericType == Float )
     {
-        arr.Add(wxS("+"));
-        arr.Add(wxS("-"));
-    }
-    else if ( numericType == Float )
-    {
-        arr.Add(wxS("+"));
-        arr.Add(wxS("-"));
-        arr.Add(wxS("e")); arr.Add(wxS("E"));
+        allowedChars += wxS("eE");
 
         // Use locale-specific decimal point
-        arr.Add(wxString::Format(wxS("%g"), 1.1)[1]);
+        allowedChars += wxString::Format(wxS("%g"), 1.1)[1];
     }
 
-    SetIncludes(arr);
+    SetStyle(style);
+    SetCharIncludes(allowedChars);
 }
 
 bool wxNumericPropertyValidator::Validate(wxWindow* parent)
@@ -2021,15 +2015,7 @@ wxValidator* wxFileProperty::GetClassValidator()
     static wxString v;
     wxTextValidator* validator = new wxTextValidator(wxFILTER_EXCLUDE_CHAR_LIST,&v);
 
-    wxArrayString exChars;
-    exChars.Add(wxS("?"));
-    exChars.Add(wxS("*"));
-    exChars.Add(wxS("|"));
-    exChars.Add(wxS("<"));
-    exChars.Add(wxS(">"));
-    exChars.Add(wxS("\""));
-
-    validator->SetExcludes(exChars);
+    validator->SetCharExcludes(wxString("?*|<>\""));
 
     WX_PG_DOGETVALIDATOR_EXIT(validator)
 #else

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -259,6 +259,7 @@ TEST_GUI_OBJECTS =  \
 	test_gui_wrapsizer.o \
 	test_gui_toplevel.o \
 	test_gui_valnum.o \
+	test_gui_valtxt.o \
 	test_gui_clientsize.o \
 	test_gui_setsize.o \
 	test_gui_xrctest.o
@@ -1044,6 +1045,9 @@ test_gui_toplevel.o: $(srcdir)/toplevel/toplevel.cpp $(TEST_GUI_ODEP)
 
 test_gui_valnum.o: $(srcdir)/validators/valnum.cpp $(TEST_GUI_ODEP)
 	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/validators/valnum.cpp
+
+test_gui_valtxt.o: $(srcdir)/validators/valtxt.cpp $(TEST_GUI_ODEP)
+	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/validators/valtxt.cpp
 
 test_gui_clientsize.o: $(srcdir)/window/clientsize.cpp $(TEST_GUI_ODEP)
 	$(CXXC) -c -o $@ $(TEST_GUI_CXXFLAGS) $(srcdir)/window/clientsize.cpp

--- a/tests/makefile.bcc
+++ b/tests/makefile.bcc
@@ -246,6 +246,7 @@ TEST_GUI_OBJECTS =  \
 	$(OBJS)\test_gui_wrapsizer.obj \
 	$(OBJS)\test_gui_toplevel.obj \
 	$(OBJS)\test_gui_valnum.obj \
+	$(OBJS)\test_gui_valtxt.obj \
 	$(OBJS)\test_gui_clientsize.obj \
 	$(OBJS)\test_gui_setsize.obj \
 	$(OBJS)\test_gui_xrctest.obj
@@ -1098,6 +1099,9 @@ $(OBJS)\test_gui_toplevel.obj: .\toplevel\toplevel.cpp
 
 $(OBJS)\test_gui_valnum.obj: .\validators\valnum.cpp
 	$(CXX) -q -c -P -o$@ $(TEST_GUI_CXXFLAGS) .\validators\valnum.cpp
+
+$(OBJS)\test_gui_valtxt.obj: .\validators\valtxt.cpp
+	$(CXX) -q -c -P -o$@ $(TEST_GUI_CXXFLAGS) .\validators\valtxt.cpp
 
 $(OBJS)\test_gui_clientsize.obj: .\window\clientsize.cpp
 	$(CXX) -q -c -P -o$@ $(TEST_GUI_CXXFLAGS) .\window\clientsize.cpp

--- a/tests/makefile.gcc
+++ b/tests/makefile.gcc
@@ -241,6 +241,7 @@ TEST_GUI_OBJECTS =  \
 	$(OBJS)\test_gui_wrapsizer.o \
 	$(OBJS)\test_gui_toplevel.o \
 	$(OBJS)\test_gui_valnum.o \
+	$(OBJS)\test_gui_valtxt.o \
 	$(OBJS)\test_gui_clientsize.o \
 	$(OBJS)\test_gui_setsize.o \
 	$(OBJS)\test_gui_xrctest.o
@@ -1074,6 +1075,9 @@ $(OBJS)\test_gui_toplevel.o: ./toplevel/toplevel.cpp
 	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\test_gui_valnum.o: ./validators/valnum.cpp
+	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
+
+$(OBJS)\test_gui_valtxt.o: ./validators/valtxt.cpp
 	$(CXX) -c -o $@ $(TEST_GUI_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\test_gui_clientsize.o: ./window/clientsize.cpp

--- a/tests/makefile.vc
+++ b/tests/makefile.vc
@@ -252,6 +252,7 @@ TEST_GUI_OBJECTS =  \
 	$(OBJS)\test_gui_wrapsizer.obj \
 	$(OBJS)\test_gui_toplevel.obj \
 	$(OBJS)\test_gui_valnum.obj \
+	$(OBJS)\test_gui_valtxt.obj \
 	$(OBJS)\test_gui_clientsize.obj \
 	$(OBJS)\test_gui_setsize.obj \
 	$(OBJS)\test_gui_xrctest.obj
@@ -1289,6 +1290,9 @@ $(OBJS)\test_gui_toplevel.obj: .\toplevel\toplevel.cpp
 
 $(OBJS)\test_gui_valnum.obj: .\validators\valnum.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\validators\valnum.cpp
+
+$(OBJS)\test_gui_valtxt.obj: .\validators\valtxt.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\validators\valtxt.cpp
 
 $(OBJS)\test_gui_clientsize.obj: .\window\clientsize.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(TEST_GUI_CXXFLAGS) .\window\clientsize.cpp

--- a/tests/test.bkl
+++ b/tests/test.bkl
@@ -271,6 +271,7 @@
             sizers/wrapsizer.cpp
             toplevel/toplevel.cpp
             validators/valnum.cpp
+            validators/valtxt.cpp
             window/clientsize.cpp
             window/setsize.cpp
             xml/xrctest.cpp

--- a/tests/test_vc7_test_gui.vcproj
+++ b/tests/test_vc7_test_gui.vcproj
@@ -593,6 +593,9 @@
 				RelativePath=".\validators\valnum.cpp">
 			</File>
 			<File
+				RelativePath=".\validators\valtxt.cpp">
+			</File>
+			<File
 				RelativePath=".\controls\virtlistctrltest.cpp">
 			</File>
 			<File

--- a/tests/test_vc8_test_gui.vcproj
+++ b/tests/test_vc8_test_gui.vcproj
@@ -1259,6 +1259,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\validators\valtxt.cpp"
+				>
+			</File>
+			<File
 				RelativePath=".\controls\virtlistctrltest.cpp"
 				>
 			</File>

--- a/tests/test_vc9_test_gui.vcproj
+++ b/tests/test_vc9_test_gui.vcproj
@@ -1231,6 +1231,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\validators\valtxt.cpp"
+				>
+			</File>
+			<File
 				RelativePath=".\controls\virtlistctrltest.cpp"
 				>
 			</File>

--- a/tests/validators/valtxt.cpp
+++ b/tests/validators/valtxt.cpp
@@ -1,0 +1,190 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        tests/validators/valtext.cpp
+// Purpose:     wxTextValidator unit test
+// Author:      Ali Kettab
+// Created:     2019-01-01
+///////////////////////////////////////////////////////////////////////////////
+
+#include "testprec.h"
+
+#if wxUSE_VALIDATORS && wxUSE_UIACTIONSIMULATOR
+
+#ifdef __BORLANDC__
+    #pragma hdrstop
+#endif
+
+#ifndef WX_PRECOMP
+    #include "wx/app.h"
+    #include "wx/textctrl.h"
+    #include "wx/valtext.h"
+#endif // WX_PRECOMP
+
+#include "wx/uiaction.h"
+
+class TextValidatorTestCase
+{
+public:
+    TextValidatorTestCase()
+        : m_text(new wxTextCtrl(wxTheApp->GetTopWindow(), wxID_ANY))
+    {
+    }
+
+    ~TextValidatorTestCase()
+    {
+        delete m_text;
+    }
+
+protected:
+    wxTextCtrl* const m_text;
+};
+
+#define TEXT_VALIDATOR_TEST_CASE(name, tags) \
+    TEST_CASE_METHOD(TextValidatorTestCase, name, tags)
+
+TEXT_VALIDATOR_TEST_CASE("wxTextValidator::IsValid", "[wxTextValidator][filters]")
+{
+    wxString value = "";
+    wxTextValidator val(wxFILTER_NONE, &value);
+
+    SECTION("wxFILTER_NONE - no filtering should take place")
+    {
+        CHECK( val.IsValid("wx-90.?! @_~E+{").empty() );
+    }
+
+    SECTION("wxFILTER_EMPTY - empty strings are filtered out")
+    {
+        val.SetStyle(wxFILTER_EMPTY);
+
+        CHECK( !val.IsValid("").empty() );
+        CHECK( val.IsValid(" ").empty() ); // space is valid
+    }
+
+    SECTION("wxFILTER_ASCII - non-ASCII characters are filtered out")
+    {
+        val.SetStyle(wxFILTER_ASCII);
+
+        CHECK( val.IsValid("wx-90.?! @_~E+{").empty() );
+    }
+
+    SECTION("wxFILTER_ALPHA - non-alpha characters are filtered out")
+    {
+        val.SetStyle(wxFILTER_ALPHA);
+
+        CHECK( val.IsValid("wx").empty() );
+        CHECK( !val.IsValid("wx_").empty() ); // _ is not alpha
+    }
+
+    SECTION("wxFILTER_ALPHANUMERIC - non-alphanumeric characters are filtered out")
+    {
+        val.SetStyle(wxFILTER_ALPHANUMERIC);
+
+        CHECK( val.IsValid("wx01").empty() );
+        CHECK( !val.IsValid("wx 01").empty() ); // 'space' is not alphanumeric
+    }
+
+    SECTION("wxFILTER_DIGITS - non-digit characters are filtered out")
+    {
+        val.SetStyle(wxFILTER_DIGITS);
+
+        CHECK( val.IsValid("97").empty() );
+        CHECK( !val.IsValid("9.7").empty() ); // . is not digit
+    }
+
+    SECTION("wxFILTER_XDIGITS - non-xdigit characters are filtered out")
+    {
+        val.SetStyle(wxFILTER_XDIGITS);
+
+        CHECK( val.IsValid("90AEF").empty() );
+        CHECK( !val.IsValid("90GEF").empty() ); // G is not xdigit
+    }
+
+    SECTION("wxFILTER_NUMERIC - non-numeric characters are filtered out")
+    {
+        val.SetStyle(wxFILTER_NUMERIC);
+
+        CHECK( val.IsValid("+90.e-2").empty() );
+        CHECK( !val.IsValid("-8.5#0").empty() ); // # is not numeric
+    }
+
+    SECTION("wxFILTER_INCLUDE_LIST - use include list")
+    {
+        val.SetStyle(wxFILTER_INCLUDE_LIST);
+
+        wxArrayString includes;
+        includes.push_back("wxMSW");
+        includes.push_back("wxGTK");
+        includes.push_back("wxOSX");
+        val.SetIncludes(includes);
+
+        CHECK( val.IsValid("wxGTK").empty() );
+        CHECK( !val.IsValid("wxQT").empty() ); // wxQT is not included
+
+        SECTION("wxFILTER_EXCLUDE_LIST - use exclude with include list")
+        {
+            wxArrayString excludes;
+            excludes.push_back("wxGTK");
+            excludes.push_back("wxGTK1");
+            val.SetExcludes(excludes);
+
+            CHECK( val.IsValid("wxOSX").empty() );
+            CHECK( !val.IsValid("wxGTK").empty() ); // wxGTK now excluded
+        }
+    }
+
+    SECTION("wxFILTER_EXCLUDE_LIST - use exclude list")
+    {
+        val.SetStyle(wxFILTER_EXCLUDE_LIST);
+
+        wxArrayString excludes;
+        excludes.push_back("wxMSW");
+        excludes.push_back("wxGTK");
+        excludes.push_back("wxOSX");
+        val.SetExcludes(excludes);
+
+        CHECK( val.IsValid("wxQT & wxUNIV").empty() );
+        CHECK( !val.IsValid("wxMSW").empty() ); // wxMSW is excluded
+
+        SECTION("wxFILTER_INCLUDE_LIST - use include with exclude list")
+        {
+            wxArrayString includes;
+            includes.push_back("wxGTK");
+            val.SetIncludes(includes); // exclusion takes priority over inclusion.
+
+            CHECK( val.IsValid("wxUNIV").empty() );
+            CHECK( !val.IsValid("wxMSW").empty() ); // wxMSW still excluded
+        }
+    }
+
+    SECTION("wxFILTER_INCLUDE_CHAR_LIST - use include char list")
+    {
+        val.SetStyle(wxFILTER_INCLUDE_CHAR_LIST);
+        val.SetCharIncludes("tuvwxyz.012+-");
+
+        CHECK( val.IsValid("0.2t+z-1").empty() );
+        CHECK( !val.IsValid("x*y").empty() ); // * is not included
+
+        val.AddCharIncludes("*");
+
+        CHECK( val.IsValid("x*y").empty() ); // * now included
+        CHECK( !val.IsValid("x%y").empty() ); // % is not included
+
+        val.AddCharExcludes("*"); // exclusion takes priority over inclusion.
+
+        CHECK( !val.IsValid("x*y").empty() ); // * now excluded
+    }
+
+    SECTION("wxFILTER_EXCLUDE_CHAR_LIST - use exclude char list")
+    {
+        val.SetStyle(wxFILTER_EXCLUDE_CHAR_LIST);
+        val.SetCharExcludes("tuvwxyz.012+-");
+
+        CHECK( val.IsValid("A*B=?").empty() );
+        CHECK( !val.IsValid("0.6/t").empty() ); // t is excluded
+
+        val.AddCharIncludes("t"); // exclusion takes priority over inclusion.
+
+        CHECK( !val.IsValid("0.6/t").empty() ); // t still excluded
+    }
+}
+
+#endif // wxUSE_VALIDATORS && wxUSE_UIACTIONSIMULATOR


### PR DESCRIPTION
To ease the process of review, i created this PR from [this](https://github.com/wxWidgets/wxWidgets/pull/749) without `wxRegexTextValidator` (which will be added later).

Here is the global picture...

### Incompatible changes:

- `GetIncludes()` and `GetExcludes()` need to preserve invariants so now they return **immutable** `wxArrayString`.
(please use the public interface instead: `SetIncludes()`/`SetExcludes()`/`AddInclude()`/`AddExclude()`)

- Add `m_charIncludes` and `m_charExcludes` as using the same data member for two different things (chars and strings) was a bad idea (i.e. complicates the design without much benefit. but worst, it prevented us from creating some useful validators!)

### Other changes:

- Add `wxFILTER_XDIGITS` and `wxFILTER_SPACE` styles

### Good news:

Now you can freely combine between different `wxFILTER_XXX` when creating this type of validator