### PR TITLE
Ensure QList items are added and sorted.

### DIFF
--- a/src/common/rearrangectrl.cpp
+++ b/src/common/rearrangectrl.cpp
@@ -70,7 +70,8 @@ bool wxRearrangeList::Create(wxWindow *parent,
     }
 
     // do create the real control
-    m_order.reserve(count);
+    m_order = order;
+
     if ( !wxCheckListBox::Create(parent, id, pos, size, itemsInOrder,
                                  style, validator, name) )
         return false;

--- a/src/common/rearrangectrl.cpp
+++ b/src/common/rearrangectrl.cpp
@@ -70,7 +70,7 @@ bool wxRearrangeList::Create(wxWindow *parent,
     }
 
     // do create the real control
-    m_order = order;
+    m_order.resize(count);
 
     if ( !wxCheckListBox::Create(parent, id, pos, size, itemsInOrder,
                                  style, validator, name) )

--- a/src/qt/listbox.cpp
+++ b/src/qt/listbox.cpp
@@ -114,8 +114,12 @@ bool wxListBox::Create(wxWindow *parent, wxWindowID id,
     Init();
     m_qtWindow = m_qtListWidget = new wxQtListWidget( parent, this );
 
+    QStringList items;
+
     for (size_t i = 0; i < choices.size(); ++i)
-        m_qtListWidget->addItem(wxQtConvertString(choices[i]));
+        items.push_back(wxQtConvertString(choices[i]));
+
+    m_qtListWidget->addItems(items);
 
     return wxListBoxBase::Create( parent, id, pos, size, style, validator, name );
 }

--- a/src/qt/listbox.cpp
+++ b/src/qt/listbox.cpp
@@ -147,7 +147,7 @@ wxString wxListBox::GetString(unsigned int n) const
     return wxQtConvertString( item->text() );
 }
 
-void wxListBox::SetString(unsigned int n, const wxString& WXUNUSED(s))
+void wxListBox::SetString(unsigned int n, const wxString& s)
 {
     QListWidgetItem* item = m_qtListWidget->item(n);
     wxCHECK_RET(item != NULL, wxT("wrong listbox index") );
@@ -155,6 +155,7 @@ void wxListBox::SetString(unsigned int n, const wxString& WXUNUSED(s))
     {
         item->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         item->setCheckState(Qt::Unchecked);
+        item->setText(QString(s));
     }
 }
 

--- a/src/qt/listbox.cpp
+++ b/src/qt/listbox.cpp
@@ -106,13 +106,16 @@ bool wxListBox::Create(wxWindow *parent, wxWindowID id,
 bool wxListBox::Create(wxWindow *parent, wxWindowID id,
             const wxPoint& pos,
             const wxSize& size,
-            const wxArrayString& WXUNUSED(choices),
+            const wxArrayString& choices,
             long style,
             const wxValidator& validator,
             const wxString& name)
 {
     Init();
     m_qtWindow = m_qtListWidget = new wxQtListWidget( parent, this );
+
+    for (size_t i = 0; i < choices.size(); ++i)
+        m_qtListWidget->addItem(wxQtConvertString(choices[i]));
 
     return wxListBoxBase::Create( parent, id, pos, size, style, validator, name );
 }

--- a/src/qt/listbox.cpp
+++ b/src/qt/listbox.cpp
@@ -155,7 +155,7 @@ void wxListBox::SetString(unsigned int n, const wxString& s)
     {
         item->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         item->setCheckState(Qt::Unchecked);
-        item->setText(QString(s));
+        item->setText(wxQtConvertString(s));
     }
 }
 

--- a/src/qt/listbox.cpp
+++ b/src/qt/listbox.cpp
@@ -155,8 +155,8 @@ void wxListBox::SetString(unsigned int n, const wxString& s)
     {
         item->setFlags(Qt::ItemIsUserCheckable | Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         item->setCheckState(Qt::Unchecked);
-        item->setText(wxQtConvertString(s));
     }
+    item->setText(wxQtConvertString(s));
 }
 
 int wxListBox::GetSelection() const


### PR DESCRIPTION
This change ensures that the RearrangeListTestCase tests now pass. It was necessary to ensure the stored order array was being sized correctly as well as ensuring that the items were being added to the list for QT.