### PR TITLE
Add missing RTTI to some wxQT classes

### DIFF
--- a/include/wx/qt/brush.h
+++ b/include/wx/qt/brush.h
@@ -41,6 +41,9 @@ public:
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const;
     virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
+
+private:
+    wxDECLARE_DYNAMIC_CLASS(wxBrush);
 };
 
 #endif // _WX_QT_BRUSH_H_

--- a/include/wx/qt/colordlg.h
+++ b/include/wx/qt/colordlg.h
@@ -27,6 +27,8 @@ private:
     QColorDialog *GetQColorDialog() const;
 
     wxColourData m_data;
+
+    wxDECLARE_DYNAMIC_CLASS(wxColourDialog);
 };
 
 #endif // _WX_QT_COLORDLG_H_

--- a/include/wx/qt/dc.h
+++ b/include/wx/qt/dc.h
@@ -129,6 +129,9 @@ private:
     QColor *m_qtPenColor;
     QColor *m_qtBrushColor;
     void ApplyRasterColourOp();
+
+    wxDECLARE_CLASS(wxQtDCImpl);
+    wxDECLARE_NO_COPY_CLASS(wxQtDCImpl);
     
 };
 

--- a/include/wx/qt/dcclient.h
+++ b/include/wx/qt/dcclient.h
@@ -20,6 +20,10 @@ public:
 
 protected:
     wxWindow *m_window;
+
+private:
+    wxDECLARE_CLASS(wxWindowDCImpl);
+    wxDECLARE_NO_COPY_CLASS(wxWindowDCImpl);
 };
 
 
@@ -30,6 +34,9 @@ public:
     wxClientDCImpl( wxDC *owner, wxWindow *win );
 
     ~wxClientDCImpl();
+private:
+    wxDECLARE_CLASS(wxClientDCImpl);
+    wxDECLARE_NO_COPY_CLASS(wxClientDCImpl);
 };
 
 
@@ -38,6 +45,9 @@ class WXDLLIMPEXP_CORE wxPaintDCImpl : public wxWindowDCImpl
 public:
     wxPaintDCImpl( wxDC *owner );
     wxPaintDCImpl( wxDC *owner, wxWindow *win );
+private:
+    wxDECLARE_CLASS(wxPaintDCImpl);
+    wxDECLARE_NO_COPY_CLASS(wxPaintDCImpl);
 };
 
 #endif // _WX_QT_DCCLIENT_H_

--- a/include/wx/qt/dcmemory.h
+++ b/include/wx/qt/dcmemory.h
@@ -26,6 +26,9 @@ public:
 
 private:
     wxBitmap m_selected;
+
+    DECLARE_CLASS(wxMemoryDCImpl);
+    DECLARE_NO_COPY_CLASS(wxMemoryDCImpl);
 };
 
 #endif // _WX_QT_DCMEMORY_H_

--- a/include/wx/qt/dcprint.h
+++ b/include/wx/qt/dcprint.h
@@ -98,9 +98,9 @@ public:
                            wxCoord xoffset, wxCoord yoffset,
                            wxPolygonFillMode fillStyle = wxODDEVEN_RULE);
 
-protected:
-
 private:
+    wxDECLARE_CLASS(wxPrinterDCImpl);
+    wxDECLARE_NO_COPY_CLASS(wxPrinterDCImpl);
 };
 
 #endif // _WX_QT_DCPRINT_H_

--- a/include/wx/qt/mdi.h
+++ b/include/wx/qt/mdi.h
@@ -65,6 +65,8 @@ public:
                 const wxString& name = wxFrameNameStr);
 
     virtual void Activate();
+
+    wxDECLARE_DYNAMIC_CLASS(wxMDIChildFrame);
 };
 
 
@@ -75,6 +77,7 @@ public:
     wxMDIClientWindow();
     
     virtual bool CreateClient(wxMDIParentFrame *parent, long style = wxVSCROLL | wxHSCROLL);
+    wxDECLARE_DYNAMIC_CLASS(wxMDIClientWindow);
 };
 
 #endif // _WX_QT_MDI_H_

--- a/include/wx/qt/msgdlg.h
+++ b/include/wx/qt/msgdlg.h
@@ -23,6 +23,9 @@ public:
 
     // Reimplemented to translate return codes from Qt to wx
     virtual int ShowModal();
+
+private:
+    wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxMessageDialog);
 };
 
 #endif // _WX_QT_MSGDLG_H_

--- a/include/wx/qt/palette.h
+++ b/include/wx/qt/palette.h
@@ -23,6 +23,9 @@ protected:
     virtual wxGDIRefData *CreateGDIRefData() const;
     virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
 
+private:
+    wxDECLARE_DYNAMIC_CLASS(wxPalette);
+
 };
 
 #endif // _WX_QT_PALETTE_H_

--- a/include/wx/qt/pen.h
+++ b/include/wx/qt/pen.h
@@ -49,6 +49,9 @@ public:
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const;
     virtual wxGDIRefData *CloneGDIRefData(const wxGDIRefData *data) const;
+
+private:
+    wxDECLARE_DYNAMIC_CLASS(wxPen);
 };
 
 #endif // _WX_QT_PEN_H_

--- a/include/wx/qt/region.h
+++ b/include/wx/qt/region.h
@@ -47,6 +47,9 @@ protected:
     virtual bool DoIntersect(const wxRegion& region);
     virtual bool DoSubtract(const wxRegion& region);
     virtual bool DoXor(const wxRegion& region);
+
+private:
+    wxDECLARE_DYNAMIC_CLASS(wxRegion);
 };
 
 
@@ -81,6 +84,8 @@ public:
 private:
     QVector < QRect > *m_qtRects;
     int m_pos;
+
+    wxDECLARE_DYNAMIC_CLASS(wxRegionIterator);
 };
 
 #endif // _WX_QT_REGION_H_

--- a/include/wx/qt/textentry.h
+++ b/include/wx/qt/textentry.h
@@ -41,8 +41,6 @@ protected:
     virtual void DoSetValue(const wxString& value, int flags=0);
 
     virtual wxWindow *GetEditableWindow();
-
-private:
 };
 
 #endif // _WX_QT_TEXTENTRY_H_

--- a/include/wx/qt/tglbtn.h
+++ b/include/wx/qt/tglbtn.h
@@ -72,6 +72,7 @@ public:
     virtual QWidget *GetHandle() const;
 
 private:
+    wxDECLARE_DYNAMIC_CLASS(wxToggleButton);
 
 };
 

--- a/src/qt/app.cpp
+++ b/src/qt/app.cpp
@@ -15,7 +15,7 @@
 #include <QtCore/QStringList>
 #include <QtWidgets/QApplication>
 
-wxIMPLEMENT_DYNAMIC_CLASS(wxApp, wxAppBase);
+wxIMPLEMENT_DYNAMIC_CLASS(wxApp, wxEvtHandler);
 
 wxApp::wxApp()
 {

--- a/src/qt/brush.cpp
+++ b/src/qt/brush.cpp
@@ -15,6 +15,7 @@
 
 #include <QtGui/QBrush>
 
+wxIMPLEMENT_DYNAMIC_CLASS(wxBrush,wxBrushBase);
 
 static Qt::BrushStyle ConvertBrushStyle(wxBrushStyle style)
 {

--- a/src/qt/brush.cpp
+++ b/src/qt/brush.cpp
@@ -15,7 +15,7 @@
 
 #include <QtGui/QBrush>
 
-wxIMPLEMENT_DYNAMIC_CLASS(wxBrush,wxBrushBase);
+wxIMPLEMENT_DYNAMIC_CLASS(wxBrush,wxGDIObject);
 
 static Qt::BrushStyle ConvertBrushStyle(wxBrushStyle style)
 {

--- a/src/qt/colordlg.cpp
+++ b/src/qt/colordlg.cpp
@@ -21,6 +21,8 @@ public:
         { }
 };
 
+wxIMPLEMENT_DYNAMIC_CLASS(wxColourDialog,wxDialog)
+
 bool wxColourDialog::Create(wxWindow *parent, wxColourData *data )
 {
     m_qtWindow = new wxQtColorDialog( parent, this );

--- a/src/qt/dc.cpp
+++ b/src/qt/dc.cpp
@@ -43,6 +43,8 @@ static void SetBrushColour( QPainter *qtPainter, QColor col )
     qtPainter->setBrush( b );
 }
 
+wxIMPLEMENT_CLASS(wxQtDCImpl,wxDCImpl);
+
 wxQtDCImpl::wxQtDCImpl( wxDC *owner )
     : wxDCImpl( owner )
 {

--- a/src/qt/dcclient.cpp
+++ b/src/qt/dcclient.cpp
@@ -61,7 +61,7 @@ wxWindowDCImpl::~wxWindowDCImpl()
 
 //##############################################################################
 
-wxIMPLEMENT_CLASS(wxClientDCImpl,wxQtDCImpl);
+wxIMPLEMENT_CLASS(wxClientDCImpl,wxWindowDCImpl);
 
 wxClientDCImpl::wxClientDCImpl( wxDC *owner )
     : wxWindowDCImpl( owner )
@@ -121,7 +121,7 @@ wxClientDCImpl::~wxClientDCImpl()
 
 //##############################################################################
 
-wxIMPLEMENT_CLASS(wxPaintDCImpl,wxQtDCImpl);
+wxIMPLEMENT_CLASS(wxPaintDCImpl,wxClientDCImpl);
 
 wxPaintDCImpl::wxPaintDCImpl( wxDC *owner )
     : wxWindowDCImpl( owner )

--- a/src/qt/dcclient.cpp
+++ b/src/qt/dcclient.cpp
@@ -27,6 +27,8 @@
 
 //##############################################################################
 
+wxIMPLEMENT_CLASS(wxWindowDCImpl,wxQtDCImpl);
+
 wxWindowDCImpl::wxWindowDCImpl( wxDC *owner )
     : wxQtDCImpl( owner )
 {
@@ -59,6 +61,7 @@ wxWindowDCImpl::~wxWindowDCImpl()
 
 //##############################################################################
 
+wxIMPLEMENT_CLASS(wxClientDCImpl,wxQtDCImpl);
 
 wxClientDCImpl::wxClientDCImpl( wxDC *owner )
     : wxWindowDCImpl( owner )
@@ -117,6 +120,8 @@ wxClientDCImpl::~wxClientDCImpl()
 }
 
 //##############################################################################
+
+wxIMPLEMENT_CLASS(wxPaintDCImpl,wxQtDCImpl);
 
 wxPaintDCImpl::wxPaintDCImpl( wxDC *owner )
     : wxWindowDCImpl( owner )

--- a/src/qt/dcmemory.cpp
+++ b/src/qt/dcmemory.cpp
@@ -13,6 +13,8 @@
 
 #include <QtGui/QPainter>
 
+wxIMPLEMENT_CLASS(wxMemoryDCImpl,wxQtDCImpl);
+
 wxMemoryDCImpl::wxMemoryDCImpl( wxMemoryDC *owner )
     : wxQtDCImpl( owner )
 {

--- a/src/qt/dcprint.cpp
+++ b/src/qt/dcprint.cpp
@@ -11,6 +11,8 @@
 #include "wx/dcprint.h"
 #include "wx/qt/dcprint.h"
 
+wxIMPLEMENT_CLASS(wxPrinterDCImpl,wxDCImpl)
+
 wxPrinterDCImpl::wxPrinterDCImpl( wxPrinterDC *owner, const wxPrintData & )
     : wxDCImpl( owner )
 {

--- a/src/qt/dcscreen.cpp
+++ b/src/qt/dcscreen.cpp
@@ -16,7 +16,7 @@
 #include <QtWidgets/QApplication>
 #include <QtGui/QPixmap>
 
-wxIMPLEMENT_ABSTRACT_CLASS(wxScreenDCImpl, wxWindowDCImpl);
+wxIMPLEMENT_ABSTRACT_CLASS(wxScreenDCImpl, wxQtDCImpl);
 
 wxScreenDCImpl::wxScreenDCImpl( wxScreenDC *owner )
     : wxWindowDCImpl( owner )

--- a/src/qt/mdi.cpp
+++ b/src/qt/mdi.cpp
@@ -88,6 +88,8 @@ void wxMDIParentFrame::ActivatePrevious()
 
 //##############################################################################
 
+wxIMPLEMENT_DYNAMIC_CLASS(wxMDIChildFrame,wxMDIChildFrameBase)
+
 wxMDIChildFrame::wxMDIChildFrame()
 {
 }
@@ -128,6 +130,8 @@ void wxMDIChildFrame::Activate()
 }
 
 //##############################################################################
+
+wxIMPLEMENT_DYNAMIC_CLASS(wxMDIClientWindow,wxMDIClientWindowBase)
 
 wxMDIClientWindow::wxMDIClientWindow()
 {

--- a/src/qt/msgdlg.cpp
+++ b/src/qt/msgdlg.cpp
@@ -111,6 +111,8 @@ wxMessageDialog::wxMessageDialog( wxWindow *parent, const wxString& message,
     PostCreation();
 }
 
+wxIMPLEMENT_CLASS(wxMessageDialog,wxMessageDialogBase);
+
 int wxMessageDialog::ShowModal()
 {
     wxCHECK_MSG( m_qtWindow, -1, "Invalid dialog" );

--- a/src/qt/msgdlg.cpp
+++ b/src/qt/msgdlg.cpp
@@ -111,7 +111,7 @@ wxMessageDialog::wxMessageDialog( wxWindow *parent, const wxString& message,
     PostCreation();
 }
 
-wxIMPLEMENT_CLASS(wxMessageDialog,wxMessageDialogBase);
+wxIMPLEMENT_CLASS(wxMessageDialog,wxDialog);
 
 int wxMessageDialog::ShowModal()
 {

--- a/src/qt/palette.cpp
+++ b/src/qt/palette.cpp
@@ -10,6 +10,8 @@
 
 #include "wx/palette.h"
 
+wxIMPLEMENT_DYNAMIC_CLASS(wxPalette,wxPaletteBase)
+
 wxPalette::wxPalette()
 {
 }

--- a/src/qt/palette.cpp
+++ b/src/qt/palette.cpp
@@ -10,7 +10,7 @@
 
 #include "wx/palette.h"
 
-wxIMPLEMENT_DYNAMIC_CLASS(wxPalette,wxPaletteBase)
+wxIMPLEMENT_DYNAMIC_CLASS(wxPalette,wxGDIObject)
 
 wxPalette::wxPalette()
 {

--- a/src/qt/pen.cpp
+++ b/src/qt/pen.cpp
@@ -13,7 +13,7 @@
 #include "wx/qt/private/utils.h"
 #include <QtGui/QPen>
 
-wxIMPLEMENT_DYNAMIC_CLASS(wxPen,wxPenBase);
+wxIMPLEMENT_DYNAMIC_CLASS(wxPen,wxGDIObject);
 
 static Qt::PenStyle ConvertPenStyle(wxPenStyle style)
 {

--- a/src/qt/pen.cpp
+++ b/src/qt/pen.cpp
@@ -13,6 +13,8 @@
 #include "wx/qt/private/utils.h"
 #include <QtGui/QPen>
 
+wxIMPLEMENT_DYNAMIC_CLASS(wxPen,wxPenBase);
+
 static Qt::PenStyle ConvertPenStyle(wxPenStyle style)
 {
     switch(style)

--- a/src/qt/region.cpp
+++ b/src/qt/region.cpp
@@ -53,6 +53,8 @@ class wxRegionRefData: public wxGDIRefData
 
 #define M_REGIONDATA ((wxRegionRefData *)m_refData)->m_qtRegion
 
+wxIMPLEMENT_DYNAMIC_CLASS(wxRegion,wxRegionBase);
+
 wxRegion::wxRegion()
 {
     m_refData = new wxRegionRefData();
@@ -254,6 +256,8 @@ const QRegion &wxRegion::GetHandle() const
 }
 
 //##############################################################################
+
+wxIMPLEMENT_DYNAMIC_CLASS(wxRegionIterator,wxObject);
 
 wxRegionIterator::wxRegionIterator()
 {

--- a/src/qt/region.cpp
+++ b/src/qt/region.cpp
@@ -53,7 +53,7 @@ class wxRegionRefData: public wxGDIRefData
 
 #define M_REGIONDATA ((wxRegionRefData *)m_refData)->m_qtRegion
 
-wxIMPLEMENT_DYNAMIC_CLASS(wxRegion,wxRegionBase);
+wxIMPLEMENT_DYNAMIC_CLASS(wxRegion,wxGDIObject);
 
 wxRegion::wxRegion()
 {

--- a/src/qt/tglbtn.cpp
+++ b/src/qt/tglbtn.cpp
@@ -54,7 +54,7 @@ void wxQtToggleButton::clicked( bool checked )
 
 wxDEFINE_EVENT( wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEvent );
 
-wxIMPLEMENT_DYNAMIC_CLASS(wxBitmapToggleButton, wxToggleButton);
+wxIMPLEMENT_DYNAMIC_CLASS(wxBitmapToggleButton, wxControl);
 
 wxBitmapToggleButton::wxBitmapToggleButton()
 {

--- a/src/qt/tglbtn.cpp
+++ b/src/qt/tglbtn.cpp
@@ -103,6 +103,8 @@ QWidget *wxBitmapToggleButton::GetHandle() const
 
 //##############################################################################
 
+wxIMPLEMENT_DYNAMIC_CLASS(wxToggleButton, wxToggleButtonBase);
+
 wxToggleButton::wxToggleButton()
 {
 }

--- a/src/qt/tglbtn.cpp
+++ b/src/qt/tglbtn.cpp
@@ -54,7 +54,7 @@ void wxQtToggleButton::clicked( bool checked )
 
 wxDEFINE_EVENT( wxEVT_COMMAND_TOGGLEBUTTON_CLICKED, wxCommandEvent );
 
-wxIMPLEMENT_DYNAMIC_CLASS(wxBitmapToggleButton, wxToggleButtonBase);
+wxIMPLEMENT_DYNAMIC_CLASS(wxBitmapToggleButton, wxToggleButton);
 
 wxBitmapToggleButton::wxBitmapToggleButton()
 {
@@ -103,7 +103,7 @@ QWidget *wxBitmapToggleButton::GetHandle() const
 
 //##############################################################################
 
-wxIMPLEMENT_DYNAMIC_CLASS(wxToggleButton, wxToggleButtonBase);
+wxIMPLEMENT_DYNAMIC_CLASS(wxToggleButton, wxControl);
 
 wxToggleButton::wxToggleButton()
 {


### PR DESCRIPTION
RTTI missing from wxToggleButton is particularly problematic as it breaks wxGenericValidator. wxDynamicCast sees wxToggleButton as a wxControl,  this means that any control attached to a wxGenericValidator is treated as a wxToggleButton.