### PR TITLE
Fix V808 PVS-Studio

### DIFF
--- a/src/common/docview.cpp
+++ b/src/common/docview.cpp
@@ -1179,7 +1179,6 @@ void wxDocManager::DoOpenMRUFile(unsigned n)
     if ( filename.empty() )
         return;
 
-    wxString errMsg; // must contain exactly one "%s" if non-empty
     if ( wxFile::Exists(filename) )
     {
         // Try to open it but don't give an error if it failed: this could be

--- a/src/generic/dirctrlg.cpp
+++ b/src/generic/dirctrlg.cpp
@@ -694,7 +694,7 @@ void wxGenericDirCtrl::PopulateNode(wxTreeItemId parentId)
 
     wxASSERT(data);
 
-    wxString search,path,filename;
+    wxString path;
 
     wxString dirName(data->m_path);
 


### PR DESCRIPTION
V808 'errMsg' object of 'wxString' type was created but was not utilized. docview.cpp 1182

V808 'search' object of 'wxString' type was created but was not utilized. dirctrlg.cpp 697
V808 'filename' object of 'wxString' type was created but was not utilized. dirctrlg.cpp 697

Full report http://www.fly-server.ru/pvs-studio/wxWidgets-core/