### PR TITLE
Add support for editing dates (without time) to wxGrid

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -121,6 +121,7 @@ All (GUI):
 - Fix wxInfoBar close button size in high DPI (Stefan Ziegler).
 - Make disabling the window before creating it actually work.
 - Implement wxAuiNotebook::GetBestSize() (Sebastian Walderich).
+- Add support for editing dates (without time) to wxGrid (Pavel Kalugin).
 - Allow changing tooltip text for button allowing to enter a new string
   in wxPGArrayEditorDialog.
 

--- a/docs/doxygen/overviews/grid.h
+++ b/docs/doxygen/overviews/grid.h
@@ -84,6 +84,7 @@ Here is a list of classes related to wxGrid:
     number.
 @li wxGridCellBoolRenderer: Renderer showing the cell as checked or unchecked
     box.
+@li wxGridCellDateRenderer: Renderer showing the cell as date.
 @li wxGridCellEditor: Base class for objects used to edit the cell value.
 @li wxGridCellStringEditor: Editor for cells containing text strings.
 @li wxGridCellNumberEditor: Editor for cells containing integer numbers.
@@ -91,6 +92,7 @@ Here is a list of classes related to wxGrid:
 @li wxGridCellBoolEditor: Editor for boolean-valued cells.
 @li wxGridCellChoiceEditor: Editor allowing to choose one of the predefined
     strings (and possibly enter new one).
+@li wxGridCellDateEditor: Editor for cells containing dates without time component.
 @li wxGridEvent: The event sent by most of wxGrid actions.
 @li wxGridSizeEvent: The special event sent when a grid column or row is
     resized.

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -48,6 +48,7 @@ extern WXDLLIMPEXP_DATA_CORE(const char) wxGridNameStr[];
 #define wxGRID_VALUE_NUMBER     wxT("long")
 #define wxGRID_VALUE_FLOAT      wxT("double")
 #define wxGRID_VALUE_CHOICE     wxT("choice")
+#define wxGRID_VALUE_DATE       wxT("date")
 
 #define wxGRID_VALUE_TEXT wxGRID_VALUE_STRING
 #define wxGRID_VALUE_LONG wxGRID_VALUE_NUMBER
@@ -98,6 +99,9 @@ class WXDLLIMPEXP_FWD_CORE wxComboBox;
 class WXDLLIMPEXP_FWD_CORE wxTextCtrl;
 #if wxUSE_SPINCTRL
 class WXDLLIMPEXP_FWD_CORE wxSpinCtrl;
+#endif
+#if wxUSE_DATEPICKCTRL
+class WXDLLIMPEXP_FWD_CORE wxDatePickerCtrl;
 #endif
 
 class wxGridFixedIndicesSet;
@@ -1354,6 +1358,7 @@ public:
     void     SetColFormatBool(int col);
     void     SetColFormatNumber(int col);
     void     SetColFormatFloat(int col, int width = -1, int precision = -1);
+    void     SetColFormatDate(int col, const wxString& format = wxString());
     void     SetColFormatCustom(int col, const wxString& typeName);
 
     // ------ row and col formatting

--- a/include/wx/generic/gridctrl.h
+++ b/include/wx/generic/gridctrl.h
@@ -153,12 +153,17 @@ private:
 
 #include "wx/datetime.h"
 
-// the default renderer for the cells containing times and dates
-class WXDLLIMPEXP_ADV wxGridCellDateTimeRenderer : public wxGridCellStringRenderer
+// renderer for the cells containing dates only, without time component
+class WXDLLIMPEXP_ADV wxGridCellDateRenderer : public wxGridCellStringRenderer
 {
 public:
-    wxGridCellDateTimeRenderer(const wxString& outformat = wxDefaultDateTimeFormat,
-                               const wxString& informat = wxDefaultDateTimeFormat);
+    explicit wxGridCellDateRenderer(const wxString& outformat = wxString());
+
+    wxGridCellDateRenderer(const wxGridCellDateRenderer& other)
+        : m_oformat(other.m_oformat),
+          m_tz(other.m_tz)
+    {
+    }
 
     // draw the string right aligned
     virtual void Draw(wxGrid& grid,
@@ -180,11 +185,33 @@ public:
 
 protected:
     wxString GetString(const wxGrid& grid, int row, int col);
+    virtual bool Parse(const wxString& text, wxDateTime& result);
+
+    wxString m_oformat;
+    wxDateTime::TimeZone m_tz;
+};
+
+// the default renderer for the cells containing times and dates
+class WXDLLIMPEXP_ADV wxGridCellDateTimeRenderer : public wxGridCellDateRenderer
+{
+public:
+    wxGridCellDateTimeRenderer(const wxString& outformat = wxDefaultDateTimeFormat,
+                               const wxString& informat = wxDefaultDateTimeFormat);
+
+    wxGridCellDateTimeRenderer(const wxGridCellDateTimeRenderer& other)
+        : wxGridCellDateRenderer(other),
+          m_iformat(other.m_iformat),
+          m_dateDef(other.m_dateDef)
+    {
+    }
+
+    virtual wxGridCellRenderer *Clone() const wxOVERRIDE;
+
+protected:
+    virtual bool Parse(const wxString& text, wxDateTime& result) wxOVERRIDE;
 
     wxString m_iformat;
-    wxString m_oformat;
     wxDateTime m_dateDef;
-    wxDateTime::TimeZone m_tz;
 };
 
 #endif // wxUSE_DATETIME

--- a/include/wx/generic/grideditors.h
+++ b/include/wx/generic/grideditors.h
@@ -373,6 +373,41 @@ public:
     wxDECLARE_NO_COPY_CLASS(wxGridCellAutoWrapStringEditor);
 };
 
+#if wxUSE_DATEPICKCTRL
+
+class WXDLLIMPEXP_ADV wxGridCellDateEditor : public wxGridCellEditor
+{
+public:
+    wxGridCellDateEditor() { }
+
+    virtual void Create(wxWindow* parent,
+                        wxWindowID id,
+                        wxEvtHandler* evtHandler) wxOVERRIDE;
+
+    virtual void SetSize(const wxRect& rect) wxOVERRIDE;
+
+    virtual void BeginEdit(int row, int col, wxGrid* grid) wxOVERRIDE;
+    virtual bool EndEdit(int row, int col, const wxGrid* grid,
+                         const wxString& oldval, wxString *newval) wxOVERRIDE;
+    virtual void ApplyEdit(int row, int col, wxGrid* grid) wxOVERRIDE;
+
+    virtual void Reset() wxOVERRIDE;
+
+    virtual wxGridCellEditor *Clone() const wxOVERRIDE;
+
+    virtual wxString GetValue() const wxOVERRIDE;
+
+protected:
+    wxDatePickerCtrl* DatePicker() const;
+
+private:
+    wxDateTime m_value;
+
+    wxDECLARE_NO_COPY_CLASS(wxGridCellDateEditor);
+};
+
+#endif // wxUSE_DATEPICKCTRL
+
 #endif // wxUSE_GRID
 
 #endif // _WX_GENERIC_GRID_EDITORS_H_

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -143,6 +143,50 @@ public:
 };
 
 /**
+    @class wxGridCellDateRenderer
+
+    This class may be used to show a date, without time, in a cell.
+
+    See @ref wxGridCellDateTimeRenderer for a date/time version.
+    wxDateTime::Format() is used internally to render the date
+    representation. wxDateTime::ParseDate() is used to parse the string
+    data entered in the cell.
+
+    @library{wxcore}
+    @category{grid}
+
+    @see wxGridCellRenderer, wxGridCellAutoWrapStringRenderer,
+         wxGridCellBoolRenderer, wxGridCellEnumRenderer,
+         wxGridCellFloatRenderer, wxGridCellNumberRenderer,
+         wxGridCellStringRenderer, wxGridCellDateTimeRenderer
+
+    @since 3.1.3
+*/
+class wxGridCellDateRenderer : public wxGridCellStringRenderer
+{
+public:
+    /**
+        Date renderer constructor.
+
+        @param outformat
+            strftime()-like format string used to render the output date.
+            By default (or if provided format string is empty) localized
+            date representation ("%x") is used.
+    */
+    wxGridCellDateRenderer(const wxString& outformat = wxString());
+
+
+    /**
+        Sets the strftime()-like format string which will be used to render
+        the date.
+
+        @param params
+            strftime()-like format string used to render the date.
+    */
+    virtual void SetParameters(const wxString& params);
+};
+
+/**
     @class wxGridCellDateTimeRenderer
 
     This class may be used to format a date/time data in a cell.
@@ -155,9 +199,9 @@ public:
     @see wxGridCellRenderer, wxGridCellAutoWrapStringRenderer,
          wxGridCellBoolRenderer, wxGridCellEnumRenderer,
          wxGridCellFloatRenderer, wxGridCellNumberRenderer,
-         wxGridCellStringRenderer
+         wxGridCellStringRenderer, wxGridCellDateRenderer
 */
-class wxGridCellDateTimeRenderer : public wxGridCellStringRenderer
+class wxGridCellDateTimeRenderer : public wxGridCellDateRenderer
 {
 public:
     /**
@@ -384,7 +428,7 @@ public:
     @see wxGridCellAutoWrapStringEditor, wxGridCellBoolEditor,
          wxGridCellChoiceEditor, wxGridCellEnumEditor,
          wxGridCellFloatEditor, wxGridCellNumberEditor,
-         wxGridCellTextEditor
+         wxGridCellTextEditor, wxGridCellDateEditor
 */
 class wxGridCellEditor : public wxClientDataContainer, public wxRefCounter
 {
@@ -532,7 +576,8 @@ protected:
 
     @see wxGridCellEditor, wxGridCellBoolEditor, wxGridCellChoiceEditor,
          wxGridCellEnumEditor, wxGridCellFloatEditor,
-         wxGridCellNumberEditor, wxGridCellTextEditor
+         wxGridCellNumberEditor, wxGridCellTextEditor,
+         wxGridCellDateEditor
 */
 class wxGridCellAutoWrapStringEditor : public wxGridCellTextEditor
 {
@@ -551,7 +596,7 @@ public:
     @see wxGridCellEditor, wxGridCellAutoWrapStringEditor,
          wxGridCellChoiceEditor, wxGridCellEnumEditor,
          wxGridCellFloatEditor, wxGridCellNumberEditor,
-         wxGridCellTextEditor
+         wxGridCellTextEditor, wxGridCellDateEditor
 */
 class wxGridCellBoolEditor : public wxGridCellEditor
 {
@@ -590,7 +635,7 @@ public:
     @see wxGridCellEditor, wxGridCellAutoWrapStringEditor,
          wxGridCellBoolEditor, wxGridCellEnumEditor,
          wxGridCellFloatEditor, wxGridCellNumberEditor,
-         wxGridCellTextEditor
+         wxGridCellTextEditor, wxGridCellDateEditor
 */
 class wxGridCellChoiceEditor : public wxGridCellEditor
 {
@@ -641,7 +686,7 @@ public:
     @see wxGridCellEditor, wxGridCellAutoWrapStringEditor,
          wxGridCellBoolEditor, wxGridCellChoiceEditor,
          wxGridCellTextEditor, wxGridCellFloatEditor,
-         wxGridCellNumberEditor
+         wxGridCellNumberEditor, wxGridCellDateEditor
 */
 class wxGridCellEnumEditor : public wxGridCellChoiceEditor
 {
@@ -666,7 +711,7 @@ public:
     @see wxGridCellEditor, wxGridCellAutoWrapStringEditor,
          wxGridCellBoolEditor, wxGridCellChoiceEditor,
          wxGridCellEnumEditor, wxGridCellFloatEditor,
-         wxGridCellNumberEditor
+         wxGridCellNumberEditor, wxGridCellDateEditor
 */
 class wxGridCellTextEditor : public wxGridCellEditor
 {
@@ -705,7 +750,7 @@ public:
     @see wxGridCellEditor, wxGridCellAutoWrapStringEditor,
          wxGridCellBoolEditor, wxGridCellChoiceEditor,
          wxGridCellEnumEditor, wxGridCellNumberEditor,
-         wxGridCellTextEditor
+         wxGridCellTextEditor, wxGridCellDateEditor
 */
 class wxGridCellFloatEditor : public wxGridCellTextEditor
 {
@@ -743,7 +788,7 @@ public:
     @see wxGridCellEditor, wxGridCellAutoWrapStringEditor,
          wxGridCellBoolEditor, wxGridCellChoiceEditor,
          wxGridCellEnumEditor, wxGridCellFloatEditor,
-         wxGridCellTextEditor
+         wxGridCellTextEditor, wxGridCellDateEditor
 */
 class wxGridCellNumberEditor : public wxGridCellTextEditor
 {
@@ -773,6 +818,32 @@ protected:
         String representation of the value.
     */
     wxString GetString() const;
+};
+
+/**
+    @class wxGridCellDateEditor
+
+    Grid cell editor for dates.
+
+    Uses @ref wxDatePickerCtrl as actual edit control.
+
+    @library{wxcore}
+    @category{grid}
+
+    @see wxGridCellEditor, wxGridCellAutoWrapStringEditor,
+         wxGridCellBoolEditor, wxGridCellChoiceEditor,
+         wxGridCellEnumEditor, wxGridCellFloatEditor,
+         wxGridCellTextEditor
+
+    @since 3.1.3
+*/
+class wxGridCellDateEditor : public wxGridCellEditor
+{
+public:
+    /**
+        Date editor constructor.
+    */
+    wxGridCellDateEditor();
 };
 
 
@@ -2080,6 +2151,8 @@ enum wxGridRenderStyle
     - wxGridCellFloatRenderer
     - wxGridCellNumberRenderer
     - wxGridCellStringRenderer
+    - wxGridCellDateRenderer
+    - wxGridCellDateTimeRenderer
 
     The look of a cell can be further defined using wxGridCellAttr. An object
     of this type may be returned by wxGridTableBase::GetAttr().
@@ -2092,6 +2165,7 @@ enum wxGridRenderStyle
     - wxGridCellFloatEditor
     - wxGridCellNumberEditor
     - wxGridCellTextEditor
+    - wxGridCellDateEditor
 
     Please see wxGridEvent, wxGridSizeEvent, wxGridRangeSelectEvent, and
     wxGridEditorCreatedEvent for the documentation of all event types you can
@@ -2961,9 +3035,10 @@ public:
             Name of the new type. May be any string, but if the type name is
             the same as the name of an already registered type, including one
             of the standard ones (which are @c wxGRID_VALUE_STRING, @c
-            wxGRID_VALUE_BOOL, @c wxGRID_VALUE_NUMBER, @c wxGRID_VALUE_FLOAT
-            and @c wxGRID_VALUE_CHOICE), then the new registration information
-            replaces the previously used renderer and editor.
+            wxGRID_VALUE_BOOL, @c wxGRID_VALUE_NUMBER, @c wxGRID_VALUE_FLOAT,
+            @c wxGRID_VALUE_CHOICE and @c wxGRID_VALUE_DATE), then the new
+            registration information replaces the previously used renderer and
+            editor.
         @param renderer
             The renderer to use for the cells of this type. Its ownership is
             taken by the grid, i.e. it will call DecRef() on this pointer when
@@ -3089,6 +3164,19 @@ public:
         @see SetColFormatCustom()
     */
     void SetColFormatNumber(int col);
+
+    /**
+        Sets the specified column to display date values.
+
+        The @a format argument is used with wxGridCellDateRenderer and allows
+        to specify the strftime-like format string to use for displaying the
+        dates in this column.
+
+        @see SetColFormatCustom()
+
+        @since 3.1.3
+    */
+    void SetColFormatDate(int col, const wxString& format = wxString());
 
     /**
         Sets the default editor for grid cells.

--- a/samples/grid/griddemo.cpp
+++ b/samples/grid/griddemo.cpp
@@ -555,6 +555,16 @@ GridFrame::GridFrame()
     grid->SetCellAlignment(3, 9, wxALIGN_CENTRE, wxALIGN_TOP);
     grid->SetCellValue(3, 10, "<- This numeric cell should be centred");
 
+    grid->SetColFormatDate(13); // Localized by default.
+    grid->SetColFormatDate(14, "%Y-%m-%d"); // ISO 8601 date format.
+
+    grid->SetCellValue(7, 0, "Today");
+    grid->SetCellRenderer(7, 0, new wxGridCellDateRenderer);
+    grid->SetCellEditor(7, 0, new wxGridCellDateEditor);
+    grid->SetCellValue(8, 0, "Tomorrow");
+    grid->SetCellRenderer(8, 0, new wxGridCellDateRenderer("%Y-%m-%d"));
+    grid->SetCellEditor(8, 0, new wxGridCellDateEditor);
+
     const wxString choices[] =
     {
         "Please select a choice",

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -7865,6 +7865,16 @@ void wxGrid::SetColFormatFloat(int col, int width, int precision)
     SetColFormatCustom(col, typeName);
 }
 
+void wxGrid::SetColFormatDate(int col, const wxString& format)
+{
+    wxString typeName = wxGRID_VALUE_DATE;
+    if ( !format.empty() )
+    {
+        typeName << ':' << format;
+    }
+    SetColFormatCustom(col, typeName);
+}
+
 void wxGrid::SetColFormatCustom(int col, const wxString& typeName)
 {
     wxGridCellAttr *attr = m_table->GetAttr(-1, col, wxGridCellAttr::Col );
@@ -9364,6 +9374,15 @@ int wxGridTypeRegistry::FindDataType(const wxString& typeName)
         }
         else
 #endif // wxUSE_COMBOBOX
+#if wxUSE_DATEPICKCTRL
+        if ( typeName == wxGRID_VALUE_DATE )
+        {
+            RegisterDataType(wxGRID_VALUE_DATE,
+                             new wxGridCellDateRenderer,
+                             new wxGridCellDateEditor);
+        }
+        else
+#endif // wxUSE_DATEPICKCTRL
         {
             return wxNOT_FOUND;
         }

--- a/src/generic/grideditors.cpp
+++ b/src/generic/grideditors.cpp
@@ -38,6 +38,7 @@
 #include "wx/tokenzr.h"
 #include "wx/renderer.h"
 #include "wx/headerctrl.h"
+#include "wx/datectrl.h"
 
 #include "wx/generic/gridsel.h"
 #include "wx/generic/grideditors.h"
@@ -1710,5 +1711,162 @@ wxGridCellAutoWrapStringEditor::Create(wxWindow* parent,
                                     wxTE_MULTILINE | wxTE_RICH);
 }
 
+#if wxUSE_DATEPICKCTRL
+
+// ----------------------------------------------------------------------------
+// wxGridCellDateEditor
+// ----------------------------------------------------------------------------
+
+#if defined ( __WXGTK__ )
+// Desired behavior is to close the editor control on ESC without updating the
+// table, and to close with update on ENTER. On wxMSW wxWANTS_CHARS is enough
+// for that, but on wxGTK a bit of special processing is required to forward
+// some of the key events from wxDatePickerCtrl to the generic cell editor
+// event handler.
+struct wxGridCellDateEditorKeyHandler
+{
+    explicit wxGridCellDateEditorKeyHandler(wxGridCellEditorEvtHandler* handler)
+        : m_handler(handler)
+    {}
+
+    void operator()(wxKeyEvent& event) const
+    {
+        switch ( event.GetKeyCode() )
+        {
+            case WXK_ESCAPE:
+                m_handler->OnKeyDown(event);
+                break;
+
+            case WXK_RETURN:
+            case WXK_NUMPAD_ENTER:
+                wxPostEvent(m_handler, wxCommandEvent(wxEVT_GRID_HIDE_EDITOR));
+                event.Skip();
+                break;
+
+            default:
+                event.Skip();
+                break;
+        }
+    }
+
+    wxGridCellEditorEvtHandler* m_handler;
+};
+#endif // __WXGTK__
+
+void wxGridCellDateEditor::Create(wxWindow* parent, wxWindowID id,
+                                  wxEvtHandler* evtHandler)
+{
+    m_control = new wxDatePickerCtrl(parent, id,
+                                     wxDefaultDateTime,
+                                     wxDefaultPosition,
+                                     wxDefaultSize,
+                                     wxDP_DEFAULT |
+                                     wxDP_SHOWCENTURY |
+                                     wxWANTS_CHARS);
+
+    wxGridCellEditor::Create(parent, id, evtHandler);
+
+#if defined ( __WXGTK__ )
+    // Install a handler for ESC and ENTER keys.
+    wxGridCellEditorEvtHandler* handler =
+        wxDynamicCast(evtHandler, wxGridCellEditorEvtHandler);
+    if ( handler )
+    {
+        handler->Bind(wxEVT_CHAR, wxGridCellDateEditorKeyHandler(handler));
+    }
+#endif // __WXGTK__
+}
+
+void wxGridCellDateEditor::SetSize(const wxRect& r)
+{
+    wxASSERT_MSG(m_control, "The wxGridCellDateEditor must be created first!");
+
+    const wxSize bestSize = DatePicker()->GetBestSize();
+
+    wxRect rect(r.GetPosition(), bestSize);
+
+    // Allow edit picker to become a bit wider, if necessary, but no more than
+    // twice as wide as the best width, otherwise they just look ugly.
+    if ( r.GetWidth() > bestSize.GetWidth() )
+    {
+        rect.SetWidth(wxMin(r.GetWidth(), 2*bestSize.GetWidth()));
+    }
+
+    wxGridCellEditor::SetSize(rect);
+}
+
+void wxGridCellDateEditor::BeginEdit(int row, int col, wxGrid* grid)
+{
+    wxASSERT_MSG(m_control, "The wxGridCellDateEditor must be created first!");
+
+    const wxString dateStr = grid->GetTable()->GetValue(row, col);
+    if ( !m_value.ParseDate(dateStr) )
+    {
+        // Invalidate m_value, so that it always compares different
+        // to any value returned from DatePicker()->GetValue().
+        m_value = wxDefaultDateTime;
+    }
+    else
+    {
+        DatePicker()->SetValue(m_value);
+    }
+
+    DatePicker()->SetFocus();
+}
+
+bool wxGridCellDateEditor::EndEdit(int WXUNUSED(row), int WXUNUSED(col),
+                                   const wxGrid* WXUNUSED(grid),
+                                   const wxString& WXUNUSED(oldval),
+                                   wxString *newval)
+{
+    wxASSERT_MSG(m_control, "The wxGridCellDateEditor must be created first!");
+
+    const wxDateTime date = DatePicker()->GetValue();
+
+    if ( m_value == date )
+    {
+        return false;
+    }
+
+    m_value = date;
+
+    if ( newval )
+    {
+        *newval = m_value.FormatISODate();
+    }
+
+    return true;
+}
+
+void wxGridCellDateEditor::ApplyEdit(int row, int col, wxGrid* grid)
+{
+    grid->GetTable()->SetValue(row, col, m_value.FormatISODate());
+}
+
+void wxGridCellDateEditor::Reset()
+{
+    wxASSERT_MSG(m_control, "The wxGridCellDateEditor must be created first!");
+
+    m_value = DatePicker()->GetValue();
+}
+
+wxGridCellEditor *wxGridCellDateEditor::Clone() const
+{
+    return new wxGridCellDateEditor();
+}
+
+wxString wxGridCellDateEditor::GetValue() const
+{
+    wxASSERT_MSG(m_control, "The wxGridCellDateEditor must be created first!");
+
+    return DatePicker()->GetValue().FormatISODate();
+}
+
+wxDatePickerCtrl* wxGridCellDateEditor::DatePicker() const
+{
+    return static_cast<wxDatePickerCtrl*>(m_control);
+}
+
+#endif // wxUSE_DATEPICKCTRL
 
 #endif // wxUSE_GRID


### PR DESCRIPTION
Add wxGridCellDateRenderer and wxGridCellDateRenderer which can be used
for the grid cells containing only dates, without times.

Also add wxGrid::SetColFormatDate() convenience function.

Refactor wxGridCellDateTimeRenderer slightly to reuse its code.