### PR TITLE
Remove apparently never used wxMSWDCImpl::m_canvas

### DIFF
--- a/include/wx/msw/dc.h
+++ b/include/wx/msw/dc.h
@@ -294,9 +294,6 @@ protected:
     // MSW-specific member variables
     // -----------------------------
 
-    // the window associated with this DC (may be NULL)
-    wxWindow         *m_canvas;
-
     wxBitmap          m_selectedBitmap;
 
     // TRUE => DeleteDC() in dtor, FALSE => only ReleaseDC() it


### PR DESCRIPTION
This member field doesn't seem referenced anywhere (even not to
initialize it), so it can't possibly be useful for anything and can be
just removed.