### PR TITLE
Fix broken URL in wxICON_QUESTION documentation

### DIFF
--- a/interface/wx/msgdlg.h
+++ b/interface/wx/msgdlg.h
@@ -62,7 +62,7 @@ const char wxMessageBoxCaptionStr[] = "Message";
         with @c wxYES_NO so it's usually unnecessary to specify it explicitly.
         This style is not supported for message dialogs under wxMSW when a task
         dialog is used to implement them (i.e. when running under Windows Vista
-        or later) because <a href="http://msdn.microsoft.com/en-us/library/aa511273.aspx">Microsoft
+        or later) because <a href="https://docs.microsoft.com/en-us/windows/desktop/uxguide/mess-confirm">Microsoft
         guidelines</a> indicate that no icon should be used for routine
         confirmations. If it is specified, no icon will be displayed.
     @style{wxICON_INFORMATION}


### PR DESCRIPTION
The content on MSDN has moved, so the URL needs to be updated. Based on some digging on webarchive,  I believe that this is what the broken link originally pointed to.

TBH, I think that while the referenced guidelines are quite interesting; if there should be a link explaining why the question icon may not be shown it might be better if the link pointed to [MessageBox documentation](https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-messagebox), where the explanation `MB_ICONQUESTION` description seems more relevant here.