### PR TITLE
Honor text alignment for spin controls

### DIFF
--- a/src/qt/spinctrl.cpp
+++ b/src/qt/spinctrl.cpp
@@ -40,6 +40,12 @@ bool wxSpinCtrlQt< T, Widget >::Create( wxWindow *parent, wxWindowID id,
     if ( style & wxSP_WRAP )
         m_qtSpinBox->setWrapping(true);
 
+    if ( style & wxALIGN_CENTRE_HORIZONTAL )
+        m_qtSpinBox->setAlignment(Qt::AlignHCenter);
+
+    else if ( style & wxALIGN_RIGHT )
+        m_qtSpinBox->setAlignment(Qt::AlignRight);
+
     m_qtSpinBox->setAccelerated(true); // to match gtk behavior
 
     SetRange( min, max );


### PR DESCRIPTION
It can be seen in `widgets` sample, `Spin` page.