### PR TITLE
Allow setting wxTimePickerCtrlGeneric from numpad keys too

### DIFF
--- a/src/generic/timectrlg.cpp
+++ b/src/generic/timectrlg.cpp
@@ -211,6 +211,21 @@ private:
                     AppendDigitToCurrentField(key - '0');
                 }
                 break;
+            case WXK_NUMPAD0:
+            case WXK_NUMPAD1:
+            case WXK_NUMPAD2:
+            case WXK_NUMPAD3:
+            case WXK_NUMPAD4:
+            case WXK_NUMPAD5:
+            case WXK_NUMPAD6:
+            case WXK_NUMPAD7:
+            case WXK_NUMPAD8:
+            case WXK_NUMPAD9:
+                if ( m_currentField != Field_AMPM )
+                {
+                    AppendDigitToCurrentField(key - WXK_NUMPAD0);
+                }
+                break;
 
             case 'A':
             case 'P':


### PR DESCRIPTION
Previously the generic wxTimePickerCtrl ignored numerical numpad keypresses.

This patch is also needed by, and applies cleanly to, 3_0branch.