### PR TITLE
Use base implementation of dragAcceptFiles on osx

### DIFF
--- a/include/wx/osx/window.h
+++ b/include/wx/osx/window.h
@@ -125,8 +125,6 @@ public:
 #if wxUSE_DRAG_AND_DROP
     virtual void SetDropTarget( wxDropTarget *dropTarget ) wxOVERRIDE;
 
-    // Accept files for dragging
-    virtual void DragAcceptFiles( bool accept ) wxOVERRIDE;
 #endif
 
     // implementation from now on

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -621,11 +621,6 @@ void wxWindowMac::SetDropTarget(wxDropTarget *pDropTarget)
     GetPeer()->SetDropTarget(m_dropTarget) ;
 }
 
-// Old-style File Manager Drag & Drop
-void wxWindowMac::DragAcceptFiles(bool WXUNUSED(accept))
-{
-    // TODO:
-}
 #endif
 
 // From a wx position / size calculate the appropriate size of the native control


### PR DESCRIPTION
As is done in the gtk implementation.

This lets osx use the base implementation  of dragaccept files which works fine with
simple testing.

I don't know if this solution is the best or if window_osx should call the base class, but fixes
should be trivial. A backport to maint would be great as well.