### PR TITLE
Fix crash in wxAuiNotebook::DoGetBestSize

### DIFF
--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -3574,6 +3574,10 @@ wxSize wxAuiNotebook::DoGetBestSize() const
         // Store the current pane with its largest window dimensions
         layouts.push_back(wxAuiLayoutObject(bestPageSize, pInfo));
     }
+
+    if ( layouts.empty() )
+        return wxSize(0, 0);
+
     wxVectorSort(layouts);
 
     /*


### PR DESCRIPTION
It's possible for the initial loop in wxAuiNotebook::DoGetBestSize to leave the "layouts" container empty.  The rest of the function assumes that the container has 1 or more elements. 