### PR TITLE
Generate wxWindowCreateEvent when creating windows in wxQT

### DIFF
--- a/src/qt/control.cpp
+++ b/src/qt/control.cpp
@@ -58,9 +58,12 @@ bool wxControl::QtCreateControl( wxWindow *parent, wxWindowID id,
 
     // Let Qt handle the background:
     SetBackgroundStyle(wxBG_STYLE_SYSTEM);
-    PostCreation(false);
 
-    return CreateControl( parent, id, pos, size, style, validator, name );
+    if (!CreateControl( parent, id, pos, size, style, validator, name ))
+        return false;
+
+    PostCreation(false);
+    return true;
 }
 
 wxSize wxControl::DoGetBestSize() const

--- a/src/qt/dialog.cpp
+++ b/src/qt/dialog.cpp
@@ -59,10 +59,13 @@ bool wxDialog::Create( wxWindow *parent, wxWindowID id,
     style |= wxTAB_TRAVERSAL;
 
     m_qtWindow = new wxQtDialog( parent, this );
-    
+
+    if ( !wxTopLevelWindow::Create( parent, id, title, pos, size, style, name ) )
+        return false;
+
     PostCreation();
 
-    return wxTopLevelWindow::Create( parent, id, title, pos, size, style, name );
+    return true;
 }
 
 int wxDialog::ShowModal()

--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -70,9 +70,11 @@ bool wxFrame::Create( wxWindow *parent, wxWindowID id, const wxString& title,
 
     GetQMainWindow()->setCentralWidget( new wxQtCentralWidget( parent, this ) );
 
-    PostCreation();
+    if ( !wxFrameBase::Create( parent, id, title, pos, size, style, name ) )
+        return false;
 
-    return wxFrameBase::Create( parent, id, title, pos, size, style, name );
+    PostCreation();
+    return true;
 }
 
 void wxFrame::SetMenuBar( wxMenuBar *menuBar )

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -287,6 +287,9 @@ void wxWindowQt::PostCreation(bool generic)
     SetForegroundColour(wxColour(GetHandle()->palette().foreground().color()));
 
     GetHandle()->setFont( wxWindowBase::GetFont().GetHandle() );
+
+    wxWindowCreateEvent event(this);
+    wxPostEvent(this, event);
 }
 
 void wxWindowQt::AddChild( wxWindowBase *child )

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -248,7 +248,7 @@ bool wxWindowQt::Create( wxWindowQt * parent, wxWindowID id, const wxPoint & pos
 
     PostCreation();
 
-    return ( true );
+    return true;
 }
 
 void wxWindowQt::PostCreation(bool generic)
@@ -289,7 +289,7 @@ void wxWindowQt::PostCreation(bool generic)
     GetHandle()->setFont( wxWindowBase::GetFont().GetHandle() );
 
     wxWindowCreateEvent event(this);
-    wxPostEvent(this, event);
+    HandleWindowEvent(event);
 }
 
 void wxWindowQt::AddChild( wxWindowBase *child )


### PR DESCRIPTION
wxQT wasn't generating window create events.   This fix ensure the event is always generated. 