### PR TITLE
Fix client size for wxFrame under wxQT

### DIFF
--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -179,7 +179,7 @@ void wxFrame::DoGetClientSize(int *width, int *height) const
         }
 
 
-        if ( QMenuBar *qmb = GetQMainWindow()->menuBar() )
+        if ( QWidget *qmb = GetQMainWindow()->menuWidget() )
         {
             *height -= qmb->geometry().height();
         }


### PR DESCRIPTION
The client size is now correctly calculated for wxFrame.  DoGetClientSize was inadvertently create a menubar by calling QMainWindow::menuBar,  this creates a menubar is non exists.  So the client size always included the size of a menubar. 

My fix uses QMainWindow::menuWidget()  instead,  this returns NULL if no menubar is present.  Allowing the correct client size to be calculated.