### PR TITLE
Added wxUSE_WINSOCK2 option to include winsock2.h

### DIFF
--- a/include/wx/msw/wrapwin.h
+++ b/include/wx/msw/wrapwin.h
@@ -30,7 +30,7 @@
 
 // For IPv6 support, we must include winsock2.h before winsock.h, and
 // windows.h include winsock.h so do it before including it
-#if wxUSE_IPV6
+#if defined(wxUSE_IPV6) || defined(wxUSE_WINSOCK2)
     #include <winsock2.h>
 #endif
 


### PR DESCRIPTION
including winsock2.h over winsock.h before windows.h is sometimes needed, therefore a wxWidgets user may have defined only this: wxUSE_WINSOCK2 to include winsock2.h over winsock.h one.
I have faced this problem when I used boost asio with wxWidgets.