### PR TITLE
Added wxUSE_WINSOCK2 option to include winsock2.h

### DIFF
--- a/build/cmake/setup.h.in
+++ b/build/cmake/setup.h.in
@@ -714,6 +714,8 @@
 
 #cmakedefine01 wxUSE_INICONF
 
+#cmakedefine01 wxUSE_WINSOCK2
+
 
 #cmakedefine01 wxUSE_DATEPICKCTRL_GENERIC
 

--- a/docs/doxygen/mainpages/const_wxusedef.h
+++ b/docs/doxygen/mainpages/const_wxusedef.h
@@ -348,6 +348,7 @@ compilers. See also wxUSE_NO_MANIFEST.}
 @itemdef{wxUSE_WIN_METAFILES_ALWAYS, Use wxMetaFile even when wxUSE_ENH_METAFILE=1.}
 @itemdef{wxUSE_WINRT, Enable WinRT support.}
 @itemdef{wxUSE_WXDIB, Use wxDIB class.}
+@itemdef{wxUSE_WINSOCK2, Include header "winsock2.h" instead of "winsock.h".}
 @endDefList
 
 

--- a/include/wx/android/setup.h
+++ b/include/wx/android/setup.h
@@ -1661,6 +1661,13 @@
 // Recommended setting: 0, nobody uses .INI files any more
 #define wxUSE_INICONF 0
 
+// Set to 1 if you need to include <winsock2.h> over <winsock.h>
+//
+// Default is 0.
+//
+// Recommended setting: 0
+#define wxUSE_WINSOCK2 0
+
 // ----------------------------------------------------------------------------
 // Generic versions of native controls
 // ----------------------------------------------------------------------------

--- a/include/wx/gtk/setup0.h
+++ b/include/wx/gtk/setup0.h
@@ -1713,6 +1713,13 @@
 // Recommended setting: 0, nobody uses .INI files any more
 #define wxUSE_INICONF 0
 
+// Set to 1 if you need to include <winsock2.h> over <winsock.h>
+//
+// Default is 0.
+//
+// Recommended setting: 0
+#define wxUSE_WINSOCK2 0
+
 // ----------------------------------------------------------------------------
 // Generic versions of native controls
 // ----------------------------------------------------------------------------

--- a/include/wx/msw/chkconf.h
+++ b/include/wx/msw/chkconf.h
@@ -118,6 +118,14 @@
 #    endif
 #endif  /* wxUSE_UXTHEME */
 
+#ifndef wxUSE_WINSOCK2
+#    ifdef wxABORT_ON_CONFIG_ERROR
+#        error "wxUSE_WINSOCK2 must be defined."
+#    else
+#        define wxUSE_WINSOCK2 0
+#    endif
+#endif  /* wxUSE_WINSOCK2 */
+
 /*
  * Unfortunately we can't use compiler TLS support if the library can be used
  * inside a dynamically loaded DLL under Windows XP, as this can result in hard

--- a/include/wx/msw/setup0.h
+++ b/include/wx/msw/setup0.h
@@ -1713,6 +1713,13 @@
 // Recommended setting: 0, nobody uses .INI files any more
 #define wxUSE_INICONF 0
 
+// Set to 1 if you need to include <winsock2.h> over <winsock.h>
+//
+// Default is 0.
+//
+// Recommended setting: 0
+#define wxUSE_WINSOCK2 0
+
 // ----------------------------------------------------------------------------
 // Generic versions of native controls
 // ----------------------------------------------------------------------------

--- a/include/wx/msw/setup_inc.h
+++ b/include/wx/msw/setup_inc.h
@@ -156,6 +156,13 @@
 // Recommended setting: 0, nobody uses .INI files any more
 #define wxUSE_INICONF 0
 
+// Set to 1 if you need to include <winsock2.h> over <winsock.h>
+//
+// Default is 0.
+//
+// Recommended setting: 0
+#define wxUSE_WINSOCK2 0
+
 // ----------------------------------------------------------------------------
 // Generic versions of native controls
 // ----------------------------------------------------------------------------

--- a/include/wx/msw/wrapwin.h
+++ b/include/wx/msw/wrapwin.h
@@ -30,7 +30,12 @@
 
 // For IPv6 support, we must include winsock2.h before winsock.h, and
 // windows.h include winsock.h so do it before including it
-#if defined(wxUSE_IPV6) || defined(wxUSE_WINSOCK2)
+#if wxUSE_IPV6
+#    undef wxUSE_WINSOCK2
+#    define wxUSE_WINSOCK2 1
+#endif
+
+#if wxUSE_WINSOCK2
     #include <winsock2.h>
 #endif
 

--- a/include/wx/msw/wrapwin.h
+++ b/include/wx/msw/wrapwin.h
@@ -31,8 +31,8 @@
 // For IPv6 support, we must include winsock2.h before winsock.h, and
 // windows.h include winsock.h so do it before including it
 #if wxUSE_IPV6
-#    undef wxUSE_WINSOCK2
-#    define wxUSE_WINSOCK2 1
+    #undef wxUSE_WINSOCK2
+    #define wxUSE_WINSOCK2 1
 #endif
 
 #if wxUSE_WINSOCK2

--- a/include/wx/msw/wrapwin.h
+++ b/include/wx/msw/wrapwin.h
@@ -30,7 +30,7 @@
 
 // For IPv6 support, we must include winsock2.h before winsock.h, and
 // windows.h include winsock.h so do it before including it
-#if wxUSE_IPV6
+#if defined(wxUSE_IPV6) || defined(wxUSE_WINSOCK2)
     #include <winsock2.h>
 #endif
 

--- a/include/wx/univ/setup0.h
+++ b/include/wx/univ/setup0.h
@@ -1661,6 +1661,13 @@
 // Recommended setting: 0, nobody uses .INI files any more
 #define wxUSE_INICONF 0
 
+// Set to 1 if you need to include <winsock2.h> over <winsock.h>
+//
+// Default is 0.
+//
+// Recommended setting: 0
+#define wxUSE_WINSOCK2 0
+
 // ----------------------------------------------------------------------------
 // Generic versions of native controls
 // ----------------------------------------------------------------------------

--- a/setup.h.in
+++ b/setup.h.in
@@ -714,6 +714,8 @@
 
 #define wxUSE_INICONF 0
 
+#define wxUSE_WINSOCK2 0
+
 
 #define wxUSE_DATEPICKCTRL_GENERIC 0
 


### PR DESCRIPTION
including winsock2.h over winsock.h before windows.h is sometimes needed, therefore a wxWidgets user may have defined only this: wxUSE_WINSOCK2 to include winsock2.h over winsock.h one.
I have faced this problem when I used boost asio with wxWidgets.

@vadz as you said, all the needed files were updated.