### PR TITLE
Fix crash under wxQT if wxRadioBox is created without a wxRA_SPECIFY flag

### DIFF
--- a/src/qt/radiobox.cpp
+++ b/src/qt/radiobox.cpp
@@ -146,6 +146,9 @@ bool wxRadioBox::Create(wxWindow *parent,
     m_qtGroupBox->setTitle( wxQtConvertString( title ) );
     m_qtButtonGroup = new wxQtButtonGroup( m_qtGroupBox, this );
 
+    if ( !(style & (wxRA_SPECIFY_ROWS | wxRA_SPECIFY_COLS)) )
+        style |= wxRA_SPECIFY_COLS;
+
     // wxRA_SPECIFY_COLS means that we arrange buttons in
     // left to right order and GetMajorDim() is the number of columns while
     // wxRA_SPECIFY_ROWS means that the buttons are arranged top to bottom and


### PR DESCRIPTION
This fix ensures that the m_qtBoxLayout field is always initialised in wxRadioBox::Create.  Previously,  the field would left uninitialised if the flag didn't one of wxRA_SPECIFY_ROWS or wxRA_SPECIFY_COLS,