### PR TITLE
Fix crash in Show when loading from XRC

### DIFF
--- a/src/qt/radiobox.cpp
+++ b/src/qt/radiobox.cpp
@@ -245,6 +245,12 @@ bool wxRadioBox::Show(unsigned int n, bool show)
 
 bool wxRadioBox::Show( bool show )
 {
+    if ( !wxControl::Show(show) )
+        return false;
+
+    if (!m_qtGroupBox)
+        return false;
+
     if( m_qtGroupBox->isVisible() == show )
     {
         for( unsigned int i = 0; i < GetCount(); ++i )


### PR DESCRIPTION
This change prevents a crash in wxRadioBox::Show if show is called before create. 