### PR TITLE
Fix selection for wxRadioBox in wxQT

### DIFF
--- a/src/qt/radiobox.cpp
+++ b/src/qt/radiobox.cpp
@@ -116,10 +116,12 @@ static void AddChoices( QButtonGroup *qtButtonGroup, QBoxLayout *qtBoxLayout, in
     Button *btn;
     bool isFirst = true;
 
+    int id = 0;
+
     while ( count-- > 0 )
     {
         btn = new Button( wxQtConvertString( *choices++ ));
-        qtButtonGroup->addButton( btn );
+        qtButtonGroup->addButton( btn, id++ );
         qtBoxLayout->addWidget( btn );
 
         if ( isFirst )


### PR DESCRIPTION
This fixes the int value in the wxCommandEvent object.  Previously,  QT was allowed to generate it's own values for the radiobox entries.  These are now zero based to match the other ports.