### PR TITLE
Forward window mouse events when mouse has been captured

### DIFF
--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -1242,6 +1242,10 @@ bool wxWindowQt::QtHandleKeyEvent ( QWidget *WXUNUSED( handler ), QKeyEvent *eve
 
 bool wxWindowQt::QtHandleMouseEvent ( QWidget *handler, QMouseEvent *event )
 {
+    // Forward captured event
+    if( s_capturedWindow && s_capturedWindow != this )
+        return s_capturedWindow->QtHandleMouseEvent(handler, event);
+
     // Convert event type
     wxEventType wxType = 0;
     switch ( event->type() )


### PR DESCRIPTION
Under wxQt, many of the demos/samples lock up the desktop when they capture the mouse, often doing selection or some kind of clicking/interaction. This fixes the initial, lock-up. It does not fix every case (e.g. html window), as that appears to require modification beyond Qt specific code (and should appear in a separate PR).