### PR TITLE
Fix flicker when reducing wxDVC width

### DIFF
--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -5183,12 +5183,12 @@ void wxDataViewCtrl::OnSize( wxSizeEvent &WXUNUSED(event) )
 
     Layout();
 
-    AdjustScrollbars();
-
     // Update the last column size to take all the available space. Note that
     // this must be done after calling Layout() to update m_clientArea size.
     if ( m_clientArea && GetColumnCount() )
         m_clientArea->UpdateColumnSizes();
+
+    AdjustScrollbars();
 
     // We must redraw the headers if their height changed. Normally this
     // shouldn't happen as the control shouldn't let itself be resized beneath


### PR DESCRIPTION
I'm not sure if this is the same issue as in https://trac.wxwidgets.org/ticket/18295#comment:13 (I have trouble reproducing it in the sample) or a different one, but I too noticed a new issue when resizing to smaller size: in my code, I have an OnSize handler that adjusts column sizes (so that there's no horizontal scrollbar) and this started flickering when reducing window width: a scrollbar appears and disappears immediately.

In my case, this fixes it, and IMHO makes sense — AdjustScrollbars() should only be called once the required virtual width is updated. 

Do you see any problem with doing this?

The commit causing this behavior change and being updated by this PR is 841c14c37c878dff35a552626c77c7d7a44ff558. The case that commit addressed ("...very noticeable when maximizing the containing TLW, as could be seen on the 3rd page of the dataview sample, for example, where the last column kept its size instead of expanding") still works correctly in the sample with this PR applied.