### PR TITLE
Move the hack for Cmd+C in wxOSX to a better place

### DIFF
--- a/src/common/dlgcmn.cpp
+++ b/src/common/dlgcmn.cpp
@@ -273,12 +273,7 @@ wxStdDialogButtonSizer *wxDialogBase::CreateStdDialogButtonSizer( long flags )
 
     if (flags & wxCANCEL)
     {
-        // Avoid Cmd+C closing dialog on Mac.
-        wxString cancelLabel(_("&Cancel"));
-#ifdef __WXMAC__
-        cancelLabel.Replace("&",wxEmptyString);
-#endif
-        wxButton *cancel = new wxButton(this, wxID_CANCEL, cancelLabel);
+        wxButton *cancel = new wxButton(this, wxID_CANCEL);
         sizer->AddButton(cancel);
     }
 

--- a/src/generic/wizard.cpp
+++ b/src/generic/wizard.cpp
@@ -433,12 +433,7 @@ void wxWizard::AddButtonRow(wxBoxSizer *mainColumn)
     m_finishLabel = _("&Finish");
 
     m_btnNext = new wxButton(this, wxID_FORWARD, m_nextLabel);
-    // Avoid Cmd+C closing dialog on Mac.
-    wxString cancelLabel(_("&Cancel"));
-#ifdef __WXMAC__
-    cancelLabel.Replace("&",wxEmptyString);
-#endif
-    wxButton *btnCancel=new wxButton(this, wxID_CANCEL, cancelLabel, wxDefaultPosition, wxDefaultSize, buttonStyle);
+    wxButton *btnCancel=new wxButton(this, wxID_CANCEL, _("&Cancel"), wxDefaultPosition, wxDefaultSize, buttonStyle);
 #ifndef __WXMAC__
     if (GetExtraStyle() & wxWIZARD_EX_HELPBUTTON)
         btnHelp=new wxButton(this, wxID_HELP, _("&Help"), wxDefaultPosition, wxDefaultSize, buttonStyle);

--- a/src/osx/cocoa/button.mm
+++ b/src/osx/cocoa/button.mm
@@ -187,9 +187,18 @@ void wxButtonCocoaImpl::SetAcceleratorFromLabel(const wxString& label)
     {
         wxString accelstring(label[accelPos + 1]); // Skip '&' itself
         accelstring.MakeLower();
-        wxCFStringRef cfText(accelstring);
-        [GetNSButton() setKeyEquivalent:cfText.AsNSString()];
-        [GetNSButton() setKeyEquivalentModifierMask:NSCommandKeyMask];
+        // Avoid Cmd+C closing dialog on Mac.
+        if (accelstring == "c" && GetWXPeer()->GetId() == wxID_CANCEL)
+        {
+            [GetNSButton() setKeyEquivalent:@""];
+        }
+        else
+        {
+            wxString cancelLabel(_("&Cancel"));
+            wxCFStringRef cfText(accelstring);
+            [GetNSButton() setKeyEquivalent:cfText.AsNSString()];
+            [GetNSButton() setKeyEquivalentModifierMask:NSCommandKeyMask];
+        }
     }
     else
     {


### PR DESCRIPTION
"&Cancel" is an unfortunate label for `wxID_CANCEL` buttons on Macs, because it makes <kbd>Cmd</kbd>+<kbd>C</kbd> a shortcut for the button, which in turn makes any attempt to copy text from a text control instead abruptly close the dialog.

There were partial hacks around it in some places made by 22bcdf0, but it didn't even cover all uses within wx code itself, let alone user code. Move the hack into `wxButton` to catch all uses of this and remove the accelerator as the lesser evil.