### PR TITLE
Add support for grid layout for wxRadioBox under wxQT

### DIFF
--- a/include/wx/qt/radiobox.h
+++ b/include/wx/qt/radiobox.h
@@ -10,7 +10,7 @@
 
 class QGroupBox;
 class QButtonGroup;
-class QBoxLayout;
+class QGridLayout;
 
 class WXDLLIMPEXP_CORE wxRadioBox : public wxControl, public wxRadioBoxBase
 {
@@ -89,7 +89,7 @@ private:
     QButtonGroup *m_qtButtonGroup;
 
     // Autofit layout for buttons (either vert. or horiz.):
-    QBoxLayout *m_qtBoxLayout;
+    QGridLayout *m_qtGridLayout;
 
     wxDECLARE_DYNAMIC_CLASS(wxRadioBox);
 };

--- a/src/qt/radiobox.cpp
+++ b/src/qt/radiobox.cpp
@@ -59,7 +59,7 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxRadioBox, wxControl);
 wxRadioBox::wxRadioBox() :
     m_qtGroupBox(NULL),
     m_qtButtonGroup(NULL),
-    m_qtBoxLayout(NULL)
+    m_qtGridLayout(NULL)
 {
 }
 
@@ -110,19 +110,46 @@ bool wxRadioBox::Create(wxWindow *parent,
 }
 
 
-static void AddChoices( QButtonGroup *qtButtonGroup, QBoxLayout *qtBoxLayout, int count, const wxString choices[] )
+static void AddChoices( QButtonGroup *qtButtonGroup, QGridLayout *qtGridLayout, int count, const wxString choices[], int style, int majorDim )
 {
+    if ( count <= 0 )
+        return;
+
+    // wxRA_SPECIFY_COLS means that we arrange buttons in
+    // left to right order and GetMajorDim() is the number of columns while
+    // wxRA_SPECIFY_ROWS means that the buttons are arranged top to bottom and
+    // GetMajorDim() is the number of rows.
+
+   const bool columnMajor = style & wxRA_SPECIFY_COLS;
+   const int numMajor = majorDim > 0 ? majorDim : count;
+
     bool isFirst = true;
 
-    for (int i = 0; i < count; ++i )
+    for ( int i = 0; i < count; ++i )
     {
-        QRadioButton *btn = new QRadioButton( wxQtConvertString( choices[i] ));
+        QRadioButton *btn = new QRadioButton(wxQtConvertString (choices[i]) );
         qtButtonGroup->addButton( btn, i );
-        qtBoxLayout->addWidget( btn );
 
-        if ( isFirst )
+        int row;
+        int col;
+
+        if (columnMajor)
         {
-            btn->setChecked(true);
+            col = i % numMajor;
+            row = i / numMajor;
+
+        }
+        else
+        {
+            col = i / numMajor;
+            row = i % numMajor;
+        }
+
+        qtGridLayout->addWidget( btn, row, col );
+
+        if (isFirst)
+        {
+            btn->setChecked( true );
             isFirst = false;
         }
     }
@@ -135,7 +162,7 @@ bool wxRadioBox::Create(wxWindow *parent,
             const wxPoint& pos,
             const wxSize& size,
             int n, const wxString choices[],
-            int WXUNUSED(majorDim),
+            int majorDim,
             long style,
             const wxValidator& val,
             const wxString& name)
@@ -147,18 +174,10 @@ bool wxRadioBox::Create(wxWindow *parent,
     if ( !(style & (wxRA_SPECIFY_ROWS | wxRA_SPECIFY_COLS)) )
         style |= wxRA_SPECIFY_COLS;
 
-    // wxRA_SPECIFY_COLS means that we arrange buttons in
-    // left to right order and GetMajorDim() is the number of columns while
-    // wxRA_SPECIFY_ROWS means that the buttons are arranged top to bottom and
-    // GetMajorDim() is the number of rows.
-    if ( style & wxRA_SPECIFY_COLS )
-        m_qtBoxLayout = new QHBoxLayout;
-    else if ( style & wxRA_SPECIFY_ROWS )
-        m_qtBoxLayout = new QVBoxLayout;
+    m_qtGridLayout = new QGridLayout;
 
-    AddChoices( m_qtButtonGroup, m_qtBoxLayout, n, choices );
-    m_qtBoxLayout->addStretch(1);
-    m_qtGroupBox->setLayout(m_qtBoxLayout);
+    AddChoices( m_qtButtonGroup, m_qtGridLayout, n, choices, style, majorDim );
+    m_qtGroupBox->setLayout(m_qtGridLayout);
 
     return QtCreateControl( parent, id, pos, size, style, val, name );
 }

--- a/src/qt/radiobox.cpp
+++ b/src/qt/radiobox.cpp
@@ -110,17 +110,14 @@ bool wxRadioBox::Create(wxWindow *parent,
 }
 
 
-template < typename Button >
 static void AddChoices( QButtonGroup *qtButtonGroup, QBoxLayout *qtBoxLayout, int count, const wxString choices[] )
 {
-    Button *btn;
     bool isFirst = true;
-
     int id = 0;
 
     while ( count-- > 0 )
     {
-        btn = new Button( wxQtConvertString( *choices++ ));
+        QRadioButton *btn = new QRadioButton( wxQtConvertString( *choices++ ));
         qtButtonGroup->addButton( btn, id++ );
         qtBoxLayout->addWidget( btn );
 
@@ -160,7 +157,7 @@ bool wxRadioBox::Create(wxWindow *parent,
     else if ( style & wxRA_SPECIFY_ROWS )
         m_qtBoxLayout = new QVBoxLayout;
 
-    AddChoices< QRadioButton >( m_qtButtonGroup, m_qtBoxLayout, n, choices );
+    AddChoices( m_qtButtonGroup, m_qtBoxLayout, n, choices );
     m_qtBoxLayout->addStretch(1);
     m_qtGroupBox->setLayout(m_qtBoxLayout);
 

--- a/src/qt/radiobox.cpp
+++ b/src/qt/radiobox.cpp
@@ -178,11 +178,15 @@ bool wxRadioBox::Create(wxWindow *parent,
 
     AddChoices( m_qtButtonGroup, m_qtGridLayout, n, choices, style, majorDim );
 
-    QVBoxLayout *qtBoxLayout = new QVBoxLayout;
-    qtBoxLayout->addLayout(m_qtGridLayout);
-    qtBoxLayout->addStretch();
+    QVBoxLayout *vertLayout = new QVBoxLayout;
+    vertLayout->addLayout(m_qtGridLayout);
+    vertLayout->addStretch();
 
-    m_qtGroupBox->setLayout(qtBoxLayout);
+    QHBoxLayout *horzLayout = new QHBoxLayout;
+    horzLayout->addLayout(vertLayout);
+    horzLayout->addStretch();
+
+    m_qtGroupBox->setLayout(horzLayout);
 
     return QtCreateControl( parent, id, pos, size, style, val, name );
 }

--- a/src/qt/radiobox.cpp
+++ b/src/qt/radiobox.cpp
@@ -113,12 +113,11 @@ bool wxRadioBox::Create(wxWindow *parent,
 static void AddChoices( QButtonGroup *qtButtonGroup, QBoxLayout *qtBoxLayout, int count, const wxString choices[] )
 {
     bool isFirst = true;
-    int id = 0;
 
-    while ( count-- > 0 )
+    for (int i = 0; i < count; ++i )
     {
-        QRadioButton *btn = new QRadioButton( wxQtConvertString( *choices++ ));
-        qtButtonGroup->addButton( btn, id++ );
+        QRadioButton *btn = new QRadioButton( wxQtConvertString( choices[i] ));
+        qtButtonGroup->addButton( btn, i );
         qtBoxLayout->addWidget( btn );
 
         if ( isFirst )

--- a/src/qt/radiobox.cpp
+++ b/src/qt/radiobox.cpp
@@ -177,7 +177,12 @@ bool wxRadioBox::Create(wxWindow *parent,
     m_qtGridLayout = new QGridLayout;
 
     AddChoices( m_qtButtonGroup, m_qtGridLayout, n, choices, style, majorDim );
-    m_qtGroupBox->setLayout(m_qtGridLayout);
+
+    QVBoxLayout *qtBoxLayout = new QVBoxLayout;
+    qtBoxLayout->addLayout(m_qtGridLayout);
+    qtBoxLayout->addStretch();
+
+    m_qtGroupBox->setLayout(qtBoxLayout);
 
     return QtCreateControl( parent, id, pos, size, style, val, name );
 }


### PR DESCRIPTION
Previously,  the wxRA_SPECIFY_ROWS or wxRA_SPECIFY_COLS only support entirely vertical or entirely horizontal layouts or radio boxes.

These changes add support for the grid layout supported by the other wx ports.