### PR TITLE
wxAppProgressIndicator (Cocoa) 'Reset' function fixed

### DIFF
--- a/src/osx/cocoa/appprogress.mm
+++ b/src/osx/cocoa/appprogress.mm
@@ -65,7 +65,7 @@
 
 - (void)reset
 {
-    [m_dockTile setContentView:nil];
+    [m_progIndicator setHidden:YES];
 }
 
 @end

--- a/src/osx/cocoa/appprogress.mm
+++ b/src/osx/cocoa/appprogress.mm
@@ -66,6 +66,8 @@
 - (void)reset
 {
     [m_progIndicator setHidden:YES];
+
+    [m_dockTile display];
 }
 
 @end


### PR DESCRIPTION
There was a segmentation fault in **wxGauge with wxGA_PROGRESS** flag under macos.
 Can be reproduced via "widgets" sample:
`Press "Gauge" --> check style "Progress" --> press "Simulate process"`

The reason was **wxAppProgressIndicator**'s _SetProgress_ and _SetValue_ methods cause SEGFAULT after **_Reset_** method call.

This PR fixes **Reset** method.