### PR TITLE
Fix for crash seen when wxToolBarBase destructor is invoked.

### DIFF
--- a/include/wx/qt/toolbar.h
+++ b/include/wx/qt/toolbar.h
@@ -40,7 +40,7 @@ public:
                 const wxString& name = wxToolBarNameStr);
 
     virtual wxToolBarToolBase *FindToolForPosition(wxCoord x, wxCoord y) const wxOVERRIDE;
-    virtual QToolBar *GetQToolBar() const { return m_qtToolBar; }
+    QToolBar *GetQToolBar() const { return m_qtToolBar; }
 
     virtual void SetWindowStyleFlag( long style ) wxOVERRIDE;
 

--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -115,8 +115,6 @@ void wxFrame::SetStatusBar( wxStatusBar *statusBar )
 
 void wxFrame::SetToolBar(wxToolBar *toolbar)
 {
-    m_frameToolBar  = toolbar;
-
     if ( toolbar != NULL )
     {
         int area = 0;

--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -115,6 +115,8 @@ void wxFrame::SetStatusBar( wxStatusBar *statusBar )
 
 void wxFrame::SetToolBar(wxToolBar *toolbar)
 {
+    m_frameToolBar  = toolbar;
+
     if ( toolbar != NULL )
     {
         int area = 0;

--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -115,25 +115,21 @@ void wxFrame::SetStatusBar( wxStatusBar *statusBar )
 
 void wxFrame::SetToolBar(wxToolBar *toolbar)
 {
+    int area = 0;
     if ( toolbar != NULL )
     {
-        if ( m_frameToolBar != NULL )
-        {
+        if (toolbar->HasFlag(wxTB_LEFT))   area |= Qt::LeftToolBarArea;
+        if (toolbar->HasFlag(wxTB_RIGHT))  area |= Qt::RightToolBarArea;
+        if (toolbar->HasFlag(wxTB_TOP))    area |= Qt::TopToolBarArea;
+        if (toolbar->HasFlag(wxTB_BOTTOM)) area |= Qt::BottomToolBarArea;
+
+        GetQMainWindow()->addToolBar((Qt::ToolBarArea)area, toolbar->GetQToolBar());
+    }
+    else if ( m_frameToolBar != NULL ) {
+        if (m_frameToolBar->GetHandle() != NULL) {
             GetQMainWindow()->removeToolBar(m_frameToolBar->GetQToolBar());
         }
-        else
-        {
-            int area = 0;
-
-            if ( toolbar->HasFlag(wxTB_LEFT) )   area |= Qt::LeftToolBarArea;
-            if ( toolbar->HasFlag(wxTB_RIGHT) )  area |= Qt::RightToolBarArea;
-            if ( toolbar->HasFlag(wxTB_TOP) )    area |= Qt::TopToolBarArea;
-            if ( toolbar->HasFlag(wxTB_BOTTOM) ) area |= Qt::BottomToolBarArea;
-
-            GetQMainWindow()->addToolBar( (Qt::ToolBarArea)area, toolbar->GetQToolBar() );
-        }
     }
-
     wxFrameBase::SetToolBar( toolbar );
 }
 

--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -115,9 +115,10 @@ void wxFrame::SetStatusBar( wxStatusBar *statusBar )
 
 void wxFrame::SetToolBar(wxToolBar *toolbar)
 {
-    int area = 0;
     if ( toolbar != NULL )
     {
+        int area = 0;
+
         if (toolbar->HasFlag(wxTB_LEFT))   area |= Qt::LeftToolBarArea;
         if (toolbar->HasFlag(wxTB_RIGHT))  area |= Qt::RightToolBarArea;
         if (toolbar->HasFlag(wxTB_TOP))    area |= Qt::TopToolBarArea;
@@ -125,8 +126,10 @@ void wxFrame::SetToolBar(wxToolBar *toolbar)
 
         GetQMainWindow()->addToolBar((Qt::ToolBarArea)area, toolbar->GetQToolBar());
     }
-    else if ( m_frameToolBar != NULL ) {
-        if (m_frameToolBar->GetHandle() != NULL) {
+    else if ( m_frameToolBar != NULL )
+    {
+        if (m_frameToolBar->GetHandle() != NULL)
+        {
             GetQMainWindow()->removeToolBar(m_frameToolBar->GetQToolBar());
         }
     }

--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -130,10 +130,7 @@ void wxFrame::SetToolBar(wxToolBar *toolbar)
     }
     else if ( m_frameToolBar != NULL )
     {
-        if (m_frameToolBar->GetHandle() != NULL)
-        {
-            GetQMainWindow()->removeToolBar(m_frameToolBar->GetQToolBar());
-        }
+        GetQMainWindow()->removeToolBar(m_frameToolBar->GetQToolBar());
     }
     wxFrameBase::SetToolBar( toolbar );
 }

--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -115,20 +115,25 @@ void wxFrame::SetStatusBar( wxStatusBar *statusBar )
 
 void wxFrame::SetToolBar(wxToolBar *toolbar)
 {
-    int area = 0;
     if ( toolbar != NULL )
     {
-        if (toolbar->HasFlag(wxTB_LEFT))   area |= Qt::LeftToolBarArea;
-        if (toolbar->HasFlag(wxTB_RIGHT))  area |= Qt::RightToolBarArea;
-        if (toolbar->HasFlag(wxTB_TOP))    area |= Qt::TopToolBarArea;
-        if (toolbar->HasFlag(wxTB_BOTTOM)) area |= Qt::BottomToolBarArea;
+        if ( m_frameToolBar != NULL )
+        {
+            GetQMainWindow()->removeToolBar(m_frameToolBar->GetQToolBar());
+        }
+        else
+        {
+            int area = 0;
 
-        GetQMainWindow()->addToolBar((Qt::ToolBarArea)area, toolbar->GetQToolBar());
+            if ( toolbar->HasFlag(wxTB_LEFT) )   area |= Qt::LeftToolBarArea;
+            if ( toolbar->HasFlag(wxTB_RIGHT) )  area |= Qt::RightToolBarArea;
+            if ( toolbar->HasFlag(wxTB_TOP) )    area |= Qt::TopToolBarArea;
+            if ( toolbar->HasFlag(wxTB_BOTTOM) ) area |= Qt::BottomToolBarArea;
+
+            GetQMainWindow()->addToolBar( (Qt::ToolBarArea)area, toolbar->GetQToolBar() );
+        }
     }
-    else if ( m_frameToolBar != NULL )
-    {
-        GetQMainWindow()->removeToolBar(m_frameToolBar->GetQToolBar());
-    }
+
     wxFrameBase::SetToolBar( toolbar );
 }
 


### PR DESCRIPTION
`wxToolBarBase::~wxToolBarBase()` calls `frame->SetToolBar(NULL);` which results in a crash due to the existing implementation. I've changed the behaviour to avoid the crash, maintain existing functionality and it matches the behaviour seen in GTK.