### PR TITLE
Fix generic wxSearchCtrl drawings of the Search and Cancel buttons

### DIFF
--- a/src/generic/srchctlg.cpp
+++ b/src/generic/srchctlg.cpp
@@ -222,6 +222,14 @@ protected:
     void OnPaint(wxPaintEvent&)
     {
         wxPaintDC dc(this);
+
+        // Clear the background in case of a user bitmap with alpha channel
+        wxColour bg = m_search->GetBackgroundColour();
+        dc.SetBrush(wxBrush(bg));
+        dc.SetPen(wxPen(bg));
+        dc.Clear();
+
+        // Draw the bitmap
         dc.DrawBitmap(m_bmp, 0,0, true);
     }
 
@@ -460,12 +468,11 @@ wxSize wxSearchCtrl::DoGetBestClientSize() const
         cancelMargin = FromDIP(MARGIN);
     }
 
-    int horizontalBorder = FromDIP(1) + ( sizeText.y - sizeText.y * 14 / 21 ) / 2;
+    const int horizontalBorder = FromDIP(1) + (sizeText.y - sizeText.y * 14 / 21) / 2;
 
     // buttons are square and equal to the height of the text control
-    int height = sizeText.y;
-    return wxSize(sizeSearch.x + searchMargin + sizeText.x + cancelMargin + sizeCancel.x + 2*horizontalBorder,
-                  height);
+    return wxSize(sizeSearch.x + searchMargin + sizeText.x + cancelMargin +
+                  sizeCancel.x + 2 * horizontalBorder, sizeText.y);
 }
 
 void wxSearchCtrl::LayoutControls()
@@ -474,15 +481,14 @@ void wxSearchCtrl::LayoutControls()
         return;
 
     const wxSize sizeTotal = GetClientSize();
-    int width = sizeTotal.x,
-        height = sizeTotal.y;
+    const int width = sizeTotal.x,
+              height = sizeTotal.y;
 
     wxSize sizeText = m_text->GetBestSize();
     // make room for the search menu & clear button
-    int horizontalBorder = FromDIP(1) + ( sizeText.y - sizeText.y * 14 / 21 ) / 2;
-    int x = horizontalBorder;
-    width -= horizontalBorder*2;
-    if (width < 0) width = 0;
+    const int horizontalBorder = FromDIP(1) + (sizeText.y - sizeText.y * 14 / 21) / 2;
+    int x = 0;
+    int textWidth = width;
 
     wxSize sizeSearch(0,0);
     wxSize sizeCancel(0,0);
@@ -492,11 +498,14 @@ void wxSearchCtrl::LayoutControls()
     {
         sizeSearch = m_searchButton->GetBestSize();
         searchMargin = FromDIP(MARGIN);
+        x += horizontalBorder;
+        textWidth -= horizontalBorder;
     }
     if ( IsCancelButtonVisible() )
     {
         sizeCancel = m_cancelButton->GetBestSize();
         cancelMargin = FromDIP(MARGIN);
+        textWidth -= horizontalBorder;
     }
 
     if ( sizeSearch.x + sizeCancel.x > width )
@@ -506,15 +515,19 @@ void wxSearchCtrl::LayoutControls()
         searchMargin = 0;
         cancelMargin = 0;
     }
-    wxCoord textWidth = width - sizeSearch.x - sizeCancel.x - searchMargin - cancelMargin - FromDIP(1);
+
+    textWidth -= sizeSearch.x + sizeCancel.x + searchMargin + cancelMargin - FromDIP(1);
+
     if (textWidth < 0) textWidth = 0;
 
     // position the subcontrols inside the client area
-
-    m_searchButton->SetSize(x, (height - sizeSearch.y) / 2,
-                            sizeSearch.x, sizeSearch.y);
-    x += sizeSearch.x;
-    x += searchMargin;
+    if ( IsSearchButtonVisible() )
+    {
+        m_searchButton->SetSize(x, (height - sizeSearch.y) / 2,
+                                sizeSearch.x, sizeSearch.y);
+        x += sizeSearch.x;
+        x += searchMargin;
+    }
 
 #ifdef __WXMSW__
     // The text control is too high up on Windows; normally a text control looks OK because
@@ -528,12 +541,12 @@ void wxSearchCtrl::LayoutControls()
 
     m_text->SetSize(x, textY, textWidth, height-textY);
     x += textWidth;
-    x += cancelMargin;
 
-    if ( m_cancelButton )
+    if ( IsCancelButtonVisible() )
     {
+        x += cancelMargin;
         m_cancelButton->SetSize(x, (height - sizeCancel.y) / 2,
-                                sizeCancel.x, height);
+                                sizeCancel.x, sizeCancel.y);
     }
 }
 
@@ -1103,7 +1116,7 @@ wxBitmap wxSearchCtrl::RenderCancelBitmap( int x, int y )
     mem.SetPen( wxPen(bg) );
     mem.DrawRectangle(0,0,bitmap.GetWidth(),bitmap.GetHeight());
 
-    // draw drop glass
+    // draw circle
     mem.SetBrush( wxBrush(fg) );
     mem.SetPen( wxPen(fg) );
     int radius = multiplier*x/2;
@@ -1133,6 +1146,7 @@ wxBitmap wxSearchCtrl::RenderCancelBitmap( int x, int y )
         wxPoint(multiplier*lineLength+handleCornerShift,-multiplier*lineLength+handleCornerShift),
     };
     mem.DrawPolygon(WXSIZEOF(handlePolygon2),handlePolygon2,multiplier*lineStartBase,multiplier*(x-lineStartBase));
+    mem.SelectObject(wxNullBitmap);
 
     //===============================================================================
     // end drawing code
@@ -1198,10 +1212,10 @@ void wxSearchCtrl::RecalcBitmaps()
         if (
             !m_cancelBitmap.IsOk() ||
             m_cancelBitmap.GetHeight() != bitmapHeight ||
-            m_cancelBitmap.GetWidth() != bitmapHeight
+            m_cancelBitmap.GetWidth() != bitmapWidth
             )
         {
-            m_cancelBitmap = RenderCancelBitmap(bitmapHeight,bitmapHeight); // square
+            m_cancelBitmap = RenderCancelBitmap(bitmapWidth,bitmapHeight);
             m_cancelButton->SetBitmapLabel(m_cancelBitmap);
         }
         // else this bitmap was set by user, don't alter


### PR DESCRIPTION
This fixes the following bugs of a `wxSearchCtrl`:
* The Cancel button background is not cleared.
* The background for both Search and Cancel buttons is not cleared when a custom user image with alpha channel is selected.
* There should not be a margin if any of the Search or Cancel buttons is not visible.
* One incorrect comment in the code.