### PR TITLE
Qt dropdown

### DIFF
--- a/include/wx/qt/choice.h
+++ b/include/wx/qt/choice.h
@@ -71,6 +71,8 @@ protected:
     virtual void DoClear();
     virtual void DoDeleteOneItem(unsigned int pos);
 
+    virtual void InitialiseSort(QComboBox *combo);
+
     QComboBox *m_qtComboBox;
 
 private:

--- a/include/wx/qt/choice.h
+++ b/include/wx/qt/choice.h
@@ -71,7 +71,7 @@ protected:
     virtual void DoClear();
     virtual void DoDeleteOneItem(unsigned int pos);
 
-    virtual void InitialiseSort(QComboBox *combo);
+    void QtInitSort(QComboBox *combo);
 
     QComboBox *m_qtComboBox;
 

--- a/include/wx/qt/combobox.h
+++ b/include/wx/qt/combobox.h
@@ -52,7 +52,7 @@ public:
                 const wxValidator& validator = wxDefaultValidator,
                 const wxString& name = wxComboBoxNameStr);
 
-    virtual void SetSelection(int n) wxOVERRIDE { wxChoice::SetSelection(n); }
+    virtual void SetSelection(int n) wxOVERRIDE;
     virtual void SetSelection(long from, long to) wxOVERRIDE;
 
     virtual int GetSelection() const wxOVERRIDE { return wxChoice::GetSelection(); }
@@ -70,6 +70,12 @@ public:
     bool IsTextEmpty() const { return wxTextEntry::IsEmpty(); }
 
     virtual void SetValue(const wxString& value) wxOVERRIDE;
+    virtual void ChangeValue(const wxString& value) wxOVERRIDE;
+    virtual void AppendText(const wxString &value) wxOVERRIDE;
+    virtual void Replace(long from, long to, const wxString &value) wxOVERRIDE;
+    virtual void WriteText(const wxString &value) wxOVERRIDE;
+    virtual void SetInsertionPoint(long insertion) wxOVERRIDE;
+    virtual long GetInsertionPoint() const wxOVERRIDE;
 
     virtual void Popup();
     virtual void Dismiss();
@@ -80,6 +86,7 @@ protected:
     virtual wxString DoGetValue() const wxOVERRIDE;
 
 private:
+    void SetActualValue(const wxString& value);
 
     // From wxTextEntry:
     virtual wxWindow *GetEditableWindow() wxOVERRIDE { return this; }

--- a/src/qt/choice.cpp
+++ b/src/qt/choice.cpp
@@ -215,7 +215,8 @@ int wxChoice::DoInsertOneItem(const wxString& item, unsigned int pos)
     if ( IsSorted() )
         m_qtComboBox->model()->sort(0);
 
-    if(unselected) m_qtComboBox->setCurrentIndex(-1);
+    if( unselected )
+        m_qtComboBox->setCurrentIndex(-1);
 
     return pos;
 }

--- a/src/qt/choice.cpp
+++ b/src/qt/choice.cpp
@@ -19,8 +19,8 @@ class LexicalSortProxyModel : public QSortFilterProxyModel
     public:
         bool lessThan( const QModelIndex &left, const QModelIndex &right ) const
         {
-            const QVariant leftData = sourceModel()->data(left);
-            const QVariant rightData = sourceModel()->data(right);
+            const QVariant leftData = sourceModel()->data( left );
+            const QVariant rightData = sourceModel()->data( right );
 
             if( leftData.type() != QVariant::String )
                 return false;
@@ -28,7 +28,7 @@ class LexicalSortProxyModel : public QSortFilterProxyModel
             int insensitiveResult = QString::compare(
                     leftData.value<QString>(),
                     rightData.value<QString>(),
-                    Qt::CaseInsensitive);
+                    Qt::CaseInsensitive );
 
             if ( insensitiveResult == 0 )
             {
@@ -70,12 +70,12 @@ wxChoice::wxChoice() :
 {
 }
 
-void wxChoice::InitialiseSort(QComboBox *combo)
+void wxChoice::InitialiseSort( QComboBox *combo )
 {
     QSortFilterProxyModel *proxyModel = new LexicalSortProxyModel();
-    proxyModel->setSourceModel(combo->model());
-    combo->model()->setParent(proxyModel);
-    combo->setModel(proxyModel);
+    proxyModel->setSourceModel( combo->model() );
+    combo->model()->setParent( proxyModel );
+    combo->setModel( proxyModel );
 }
 
 
@@ -126,7 +126,7 @@ bool wxChoice::Create( wxWindow *parent, wxWindowID id,
 {
     m_qtComboBox = new wxQtChoice( parent, this );
 
-    InitialiseSort(m_qtComboBox);
+    InitialiseSort( m_qtComboBox );
 
     while ( n-- > 0 )
         m_qtComboBox->addItem( wxQtConvertString( *choices++ ));
@@ -207,10 +207,15 @@ int wxChoice::DoInsertItems(const wxArrayStringsAdapter & items,
 
 int wxChoice::DoInsertOneItem(const wxString& item, unsigned int pos)
 {
+    // Maintain unselected state
+    const bool unselected = m_qtComboBox->currentIndex() == -1;
+
     m_qtComboBox->insertItem(pos, wxQtConvertString(item));
 
     if ( IsSorted() )
         m_qtComboBox->model()->sort(0);
+
+    if(unselected) m_qtComboBox->setCurrentIndex(-1);
 
     return pos;
 }
@@ -227,7 +232,6 @@ void *wxChoice::DoGetItemClientData(unsigned int n) const
     return variant.value<void *>();
 }
 
-
 void wxChoice::DoClear()
 {
     m_qtComboBox->clear();
@@ -235,9 +239,11 @@ void wxChoice::DoClear()
 
 void wxChoice::DoDeleteOneItem(unsigned int pos)
 {
-    if( GetSelection() == pos )
+    const int selection = GetSelection();
+
+    if( selection >= 0 && static_cast<unsigned int>(selection) == pos )
     {
-        SetSelection(wxNOT_FOUND);
+        SetSelection( wxNOT_FOUND );
     }
     m_qtComboBox->removeItem(pos);
 }

--- a/src/qt/choice.cpp
+++ b/src/qt/choice.cpp
@@ -10,7 +10,35 @@
 
 #include "wx/choice.h"
 #include "wx/qt/private/winevent.h"
+
 #include <QtWidgets/QComboBox>
+#include <QtCore/QSortFilterProxyModel>
+
+class LexicalSortProxyModel : public QSortFilterProxyModel
+{
+    public:
+        bool lessThan( const QModelIndex &left, const QModelIndex &right ) const
+        {
+            const QVariant leftData = sourceModel()->data(left);
+            const QVariant rightData = sourceModel()->data(right);
+
+            if( leftData.type() != QVariant::String )
+                return false;
+
+            int insensitiveResult = QString::compare(
+                    leftData.value<QString>(),
+                    rightData.value<QString>(),
+                    Qt::CaseInsensitive);
+
+            if ( insensitiveResult == 0 )
+            {
+                return QString::compare( leftData.value<QString>(),
+                        rightData.value<QString>() ) < 0;
+            }
+
+            return insensitiveResult < 0;
+        }
+};
 
 class wxQtChoice : public wxQtEventSignalHandler< QComboBox, wxChoice >
 {
@@ -40,6 +68,14 @@ void wxQtChoice::activated(int WXUNUSED(index))
 wxChoice::wxChoice() :
     m_qtComboBox(NULL)
 {
+}
+
+void wxChoice::InitialiseSort(QComboBox *combo)
+{
+    QSortFilterProxyModel *proxyModel = new LexicalSortProxyModel();
+    proxyModel->setSourceModel(combo->model());
+    combo->model()->setParent(proxyModel);
+    combo->setModel(proxyModel);
 }
 
 
@@ -89,6 +125,8 @@ bool wxChoice::Create( wxWindow *parent, wxWindowID id,
         const wxString& name )
 {
     m_qtComboBox = new wxQtChoice( parent, this );
+
+    InitialiseSort(m_qtComboBox);
 
     while ( n-- > 0 )
         m_qtComboBox->addItem( wxQtConvertString( *choices++ ));
@@ -197,6 +235,10 @@ void wxChoice::DoClear()
 
 void wxChoice::DoDeleteOneItem(unsigned int pos)
 {
+    if( GetSelection() == pos )
+    {
+        SetSelection(wxNOT_FOUND);
+    }
     m_qtComboBox->removeItem(pos);
 }
 

--- a/src/qt/combobox.cpp
+++ b/src/qt/combobox.cpp
@@ -13,16 +13,9 @@
 #include "wx/qt/private/converter.h"
 #include "wx/qt/private/winevent.h"
 
-#include <QtCore/QSortFilterProxyModel>
 #include <QtWidgets/QComboBox>
 #include <QtWidgets/QLineEdit>
 
-
-class LexicalSortProxyModel : public QSortFilterProxyModel
-{
-    public:
-        bool lessThan(const QModelIndex &left, const QModelIndex &right) const;
-};
 
 class wxQtComboBox : public wxQtEventSignalHandler< QComboBox, wxComboBox >
 {
@@ -34,16 +27,16 @@ public:
 
     struct Ignore
     {
-        Ignore(QComboBox *combo) :
-            handler(dynamic_cast<wxQtComboBox*>(combo))
+        Ignore( QComboBox *combo ) :
+            handler( dynamic_cast<wxQtComboBox*>(combo) )
         {
-            if(handler)
-                handler->ignoreTextChange(true);
+            if( handler )
+                handler->ignoreTextChange( true );
         }
         ~Ignore()
         {
-            if(handler)
-                handler->ignoreTextChange(false);
+            if( handler )
+                handler->ignoreTextChange( false );
         }
 
         private:
@@ -59,7 +52,7 @@ private:
 
 wxQtComboBox::wxQtComboBox( wxWindow *parent, wxComboBox *handler )
     : wxQtEventSignalHandler< QComboBox, wxComboBox >( parent, handler ),
-    textChangeIgnored(false)
+    textChangeIgnored( false )
 {
     setEditable( true );
     connect(this, static_cast<void (QComboBox::*)(int index)>(&QComboBox::activated),
@@ -89,7 +82,7 @@ void wxQtComboBox::activated(int WXUNUSED(index))
         handler->SendSelectionChangedEvent(wxEVT_COMBOBOX);
 }
 
-void wxQtComboBox::ignoreTextChange(bool ignore)
+void wxQtComboBox::ignoreTextChange( bool ignore )
 {
     textChangeIgnored = ignore;
 }
@@ -108,7 +101,7 @@ void wxQtComboBox::editTextChanged(const QString &text)
     }
 }
 
-void wxComboBox::SetSelection(int n)
+void wxComboBox::SetSelection( int n )
 {
     wxQtComboBox::Ignore ignore( m_qtComboBox );
     wxChoice::SetSelection( n );
@@ -171,7 +164,7 @@ bool wxComboBox::Create(wxWindow *parent, wxWindowID id,
             const wxString& name )
 {
     m_qtComboBox = new wxQtComboBox( parent, this );
-    InitialiseSort(m_qtComboBox);
+    InitialiseSort( m_qtComboBox );
 
     while ( n-- > 0 )
         m_qtComboBox->addItem( wxQtConvertString( *choices++ ));
@@ -183,10 +176,10 @@ bool wxComboBox::Create(wxWindow *parent, wxWindowID id,
 void wxComboBox::SetActualValue(const wxString &value)
 {
     if ( HasFlag(wxCB_READONLY) )
-        SetStringSelection(value);
+        SetStringSelection( value );
     else
     {
-        wxTextEntry::SetValue(value);
+        wxTextEntry::SetValue( value );
         m_qtComboBox->setEditText( wxQtConvertString(value) );
     }
 }
@@ -211,7 +204,8 @@ void wxComboBox::AppendText(const wxString &value)
 void wxComboBox::Replace(long from, long to, const wxString &value)
 {
     const wxString original( GetValue() );
-    if(from == 0)
+
+    if( from == 0 )
     {
         SetActualValue( value + original.SubString(to, original.length()) );
     }

--- a/src/qt/combobox.cpp
+++ b/src/qt/combobox.cpp
@@ -16,7 +16,6 @@
 #include <QtWidgets/QComboBox>
 #include <QtWidgets/QLineEdit>
 
-
 class wxQtComboBox : public wxQtEventSignalHandler< QComboBox, wxComboBox >
 {
 public:
@@ -25,21 +24,22 @@ public:
     virtual void hidePopup() wxOVERRIDE;
     void ignoreTextChange(bool ignore);
 
-    struct Ignore
+    class Ignore
     {
-        Ignore( QComboBox *combo ) :
+    public:
+        explicit Ignore( QComboBox *combo ) :
             handler( dynamic_cast<wxQtComboBox*>(combo) )
         {
-            if( handler )
+            if ( handler )
                 handler->ignoreTextChange( true );
         }
         ~Ignore()
         {
-            if( handler )
+            if ( handler )
                 handler->ignoreTextChange( false );
         }
 
-        private:
+    private:
         wxQtComboBox *handler;
     };
 
@@ -89,7 +89,7 @@ void wxQtComboBox::ignoreTextChange( bool ignore )
 
 void wxQtComboBox::editTextChanged(const QString &text)
 {
-    if( textChangeIgnored )
+    if ( textChangeIgnored )
         return;
 
     wxComboBox *handler = GetHandler();
@@ -164,7 +164,7 @@ bool wxComboBox::Create(wxWindow *parent, wxWindowID id,
             const wxString& name )
 {
     m_qtComboBox = new wxQtComboBox( parent, this );
-    InitialiseSort( m_qtComboBox );
+    QtInitSort( m_qtComboBox );
 
     while ( n-- > 0 )
         m_qtComboBox->addItem( wxQtConvertString( *choices++ ));
@@ -176,7 +176,9 @@ bool wxComboBox::Create(wxWindow *parent, wxWindowID id,
 void wxComboBox::SetActualValue(const wxString &value)
 {
     if ( HasFlag(wxCB_READONLY) )
+    {
         SetStringSelection( value );
+    }
     else
     {
         wxTextEntry::SetValue( value );
@@ -205,17 +207,22 @@ void wxComboBox::Replace(long from, long to, const wxString &value)
 {
     const wxString original( GetValue() );
 
-    if( from == 0 )
+    if( to < 0 )
     {
-        SetActualValue( value + original.SubString(to, original.length()) );
+        to = original.length();
     }
 
-    wxString front = original.SubString( 0, from - 1 ) + value;
+    if ( from == 0 )
+    {
+        SetActualValue( value + original.substr(to, original.length()) );
+    }
+
+    wxString front = original.substr( 0, from ) + value;
 
     long iPoint = front.length();
-    if( front.length() <= original.length() )
+    if ( front.length() <= original.length() )
     {
-        SetActualValue( front + original.SubString(to, original.length()) );
+        SetActualValue( front + original.substr(to, original.length()) );
     }
     else
     {
@@ -252,11 +259,11 @@ void wxComboBox::Clear()
 
 void wxComboBox::SetSelection( long from, long to )
 {
-    if( from == -1 )
+    if ( from == -1 )
     {
         from = 0;
     }
-    if( to == -1 )
+    if ( to == -1 )
     {
         to = GetValue().length();
     }

--- a/src/qt/combobox.cpp
+++ b/src/qt/combobox.cpp
@@ -13,8 +13,16 @@
 #include "wx/qt/private/converter.h"
 #include "wx/qt/private/winevent.h"
 
+#include <QtCore/QSortFilterProxyModel>
 #include <QtWidgets/QComboBox>
 #include <QtWidgets/QLineEdit>
+
+
+class LexicalSortProxyModel : public QSortFilterProxyModel
+{
+    public:
+        bool lessThan(const QModelIndex &left, const QModelIndex &right) const;
+};
 
 class wxQtComboBox : public wxQtEventSignalHandler< QComboBox, wxComboBox >
 {
@@ -128,6 +136,8 @@ bool wxComboBox::Create(wxWindow *parent, wxWindowID id,
             const wxString& name )
 {
     m_qtComboBox = new wxQtComboBox( parent, this );
+    InitialiseSort(m_qtComboBox);
+
     while ( n-- > 0 )
         m_qtComboBox->addItem( wxQtConvertString( *choices++ ));
     m_qtComboBox->setEditText( wxQtConvertString( value ));
@@ -140,7 +150,10 @@ void wxComboBox::SetValue(const wxString& value)
     if ( HasFlag(wxCB_READONLY) )
         SetStringSelection(value);
     else
+    {
         wxTextEntry::SetValue(value);
+        m_qtComboBox->setEditText( wxQtConvertString(value) );
+    }
 }
 
 wxString wxComboBox::DoGetValue() const

--- a/src/qt/combobox.cpp
+++ b/src/qt/combobox.cpp
@@ -226,8 +226,7 @@ void wxComboBox::Replace(long from, long to, const wxString &value)
 
 void wxComboBox::WriteText(const wxString &value)
 {
-    long point = GetInsertionPoint();
-    Replace( point, point, value );
+    m_qtComboBox->lineEdit()->insert( wxQtConvertString( value ) );
 }
 
 wxString wxComboBox::DoGetValue() const

--- a/src/qt/textentry.cpp
+++ b/src/qt/textentry.cpp
@@ -20,9 +20,11 @@ void wxTextEntry::WriteText(const wxString& WXUNUSED(text))
 
 void wxTextEntry::Remove(long from, long to)
 {
+    const long insertionPoint = GetInsertionPoint();
     wxString string = GetValue();
     string.erase(from, to - from);
     SetValue(string);
+    SetInsertionPoint( std::min(insertionPoint, static_cast<long>(string.length())) );
 }
 
 void wxTextEntry::Copy()

--- a/tests/controls/textentrytest.cpp
+++ b/tests/controls/textentrytest.cpp
@@ -201,6 +201,28 @@ void TextEntryTestCase::Replace()
     CPPUNIT_ASSERT_EQUAL(2, entry->GetInsertionPoint());
 }
 
+void TextEntryTestCase::WriteText()
+{
+    wxTextEntry * const entry = GetTestEntry();
+
+    entry->SetValue("foo");
+    entry->SetInsertionPoint(3);
+    entry->WriteText("bar");
+    CPPUNIT_ASSERT_EQUAL( "foobar", entry->GetValue() );
+
+    entry->SetValue("foo");
+    entry->SetInsertionPoint(0);
+    entry->WriteText("bar");
+    CPPUNIT_ASSERT_EQUAL( "barfoo", entry->GetValue() );
+
+    entry->SetValue("abxxxhi");
+    entry->SetSelection(2, 5);
+    entry->WriteText("cdefg");
+    CPPUNIT_ASSERT_EQUAL( "abcdefghi", entry->GetValue() );
+    CPPUNIT_ASSERT_EQUAL( 7, entry->GetInsertionPoint() );
+    CPPUNIT_ASSERT_EQUAL( false, entry->HasSelection() );
+}
+
 #if wxUSE_UIACTIONSIMULATOR
 
 class TextEventHandler

--- a/tests/controls/textentrytest.h
+++ b/tests/controls/textentrytest.h
@@ -44,7 +44,8 @@ protected:
         WXUISIM_TEST( Editable ); \
         CPPUNIT_TEST( Hint ); \
         CPPUNIT_TEST( CopyPaste ); \
-        CPPUNIT_TEST( UndoRedo )
+        CPPUNIT_TEST( UndoRedo ); \
+        CPPUNIT_TEST( WriteText )
 
     void SetValue();
     void TextChangeEvents();
@@ -55,6 +56,7 @@ protected:
     void Hint();
     void CopyPaste();
     void UndoRedo();
+    void WriteText();
 
 private:
     // Selection() test helper: verify that selection is as described by the


### PR DESCRIPTION
In wxQt, wxComboBox and wxChoice were both failing tests for value, text events, selection, insertion point. The sorting was working, but not in lexical order. There was no test for WriteText(), which was also not working in wxComboBox. This attempts to address those issues.