### PR TITLE
Fix GetColumnCount not working for wxRadioBox under QT

### DIFF
--- a/src/qt/radiobox.cpp
+++ b/src/qt/radiobox.cpp
@@ -188,6 +188,7 @@ bool wxRadioBox::Create(wxWindow *parent,
 
     m_qtGroupBox->setLayout(horzLayout);
 
+    SetMajorDim(majorDim == 0 ? n : majorDim, style);
     return QtCreateControl( parent, id, pos, size, style, val, name );
 }
 


### PR DESCRIPTION
Previous implementation wasn't calling wxRadioBoxBase::SetMajorDim