### PR TITLE
Only apply one Qt::ToolBarArea to a QToolBar

### DIFF
--- a/include/wx/qt/toolbar.h
+++ b/include/wx/qt/toolbar.h
@@ -5,13 +5,12 @@
 // Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
-class QToolBar;
 
 #ifndef _WX_QT_TOOLBAR_H_
 #define _WX_QT_TOOLBAR_H_
 
 class QActionGroup;
-class wxQtToolBar;
+class QToolBar;
 
 class WXDLLIMPEXP_CORE wxToolBar : public wxToolBarBase
 {

--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -120,10 +120,10 @@ void wxFrame::SetToolBar(wxToolBar *toolbar)
     int area = 0;
     if ( toolbar != NULL )
     {
-        if (toolbar->HasFlag(wxTB_LEFT))   area |= Qt::LeftToolBarArea;
-        if (toolbar->HasFlag(wxTB_RIGHT))  area |= Qt::RightToolBarArea;
-        if (toolbar->HasFlag(wxTB_TOP))    area |= Qt::TopToolBarArea;
-        if (toolbar->HasFlag(wxTB_BOTTOM)) area |= Qt::BottomToolBarArea;
+        if      (toolbar->HasFlag(wxTB_LEFT))  { area |= Qt::LeftToolBarArea;  }
+        else if (toolbar->HasFlag(wxTB_RIGHT)) { area |= Qt::RightToolBarArea; }
+        else if (toolbar->HasFlag(wxTB_TOP))   { area |= Qt::TopToolBarArea;   }
+        else if (toolbar->HasFlag(wxTB_BOTTOM)){ area |= Qt::BottomToolBarArea;}
 
         GetQMainWindow()->addToolBar((Qt::ToolBarArea)area, toolbar->GetQToolBar());
     }

--- a/src/qt/toolbar.cpp
+++ b/src/qt/toolbar.cpp
@@ -16,6 +16,7 @@
 
 #include <QtWidgets/QActionGroup>
 #include <QtWidgets/QToolButton>
+#include <QtWidgets/QToolBar>
 
 #ifndef WX_PRECOMP
     #include "wx/menu.h"
@@ -25,7 +26,6 @@
 #include "wx/qt/private/winevent.h"
 #include "wx/qt/private/converter.h"
 
-#include <QtWidgets/QToolBar>
 
 class wxQtToolButton;
 class wxToolBarTool : public wxToolBarToolBase


### PR DESCRIPTION
In `wxFrame::SetToolBar` we will now only apply one position style to a QToolBar. Also did some minor tidy up to the toolbar header and implementation files.