### PR TITLE
Added wxOVERRIDE specifiers to wxMenu, wxMenuItem and wxMenuBar methods.

### DIFF
--- a/include/wx/qt/menu.h
+++ b/include/wx/qt/menu.h
@@ -20,9 +20,9 @@ public:
     virtual QMenu *GetHandle() const;
 
 protected:
-    virtual wxMenuItem *DoAppend(wxMenuItem *item);
-    virtual wxMenuItem *DoInsert(size_t pos, wxMenuItem *item);
-    virtual wxMenuItem *DoRemove(wxMenuItem *item);
+    virtual wxMenuItem *DoAppend(wxMenuItem *item) wxOVERRIDE;
+    virtual wxMenuItem *DoInsert(size_t pos, wxMenuItem *item) wxOVERRIDE;
+    virtual wxMenuItem *DoRemove(wxMenuItem *item) wxOVERRIDE;
 
 private:
     QMenu *m_qtMenu;
@@ -39,21 +39,21 @@ public:
     wxMenuBar(long style);
     wxMenuBar(size_t n, wxMenu *menus[], const wxString titles[], long style = 0);
 
-    virtual bool Append(wxMenu *menu, const wxString& title);
-    virtual bool Insert(size_t pos, wxMenu *menu, const wxString& title);
-    virtual wxMenu *Remove(size_t pos);
+    virtual bool Append(wxMenu *menu, const wxString& title) wxOVERRIDE;
+    virtual bool Insert(size_t pos, wxMenu *menu, const wxString& title) wxOVERRIDE;
+    virtual wxMenu *Remove(size_t pos) wxOVERRIDE;
 
-    virtual void EnableTop(size_t pos, bool enable);
+    virtual void EnableTop(size_t pos, bool enable) wxOVERRIDE;
     virtual bool IsEnabledTop(size_t pos) const wxOVERRIDE;
 
-    virtual void SetMenuLabel(size_t pos, const wxString& label);
-    virtual wxString GetMenuLabel(size_t pos) const;
+    virtual void SetMenuLabel(size_t pos, const wxString& label) wxOVERRIDE;
+    virtual wxString GetMenuLabel(size_t pos) const wxOVERRIDE;
 
     QMenuBar *GetQMenuBar() const { return m_qtMenuBar; }
-    virtual QWidget *GetHandle() const;
+    virtual QWidget *GetHandle() const wxOVERRIDE;
 
-    virtual void Attach(wxFrame *frame);
-    virtual void Detach();
+    virtual void Attach(wxFrame *frame) wxOVERRIDE;
+    virtual void Detach() wxOVERRIDE;
 
 private:
     QMenuBar *m_qtMenuBar;

--- a/include/wx/qt/menuitem.h
+++ b/include/wx/qt/menuitem.h
@@ -26,14 +26,14 @@ public:
                wxItemKind kind = wxITEM_NORMAL,
                wxMenu *subMenu = NULL);
 
-    virtual void SetItemLabel(const wxString& str);
-    virtual void SetCheckable(bool checkable);
+    virtual void SetItemLabel(const wxString& str) wxOVERRIDE;
+    virtual void SetCheckable(bool checkable) wxOVERRIDE;
 
-    virtual void Enable(bool enable = true);
-    virtual bool IsEnabled() const;
+    virtual void Enable(bool enable = true) wxOVERRIDE;
+    virtual bool IsEnabled() const wxOVERRIDE;
 
-    virtual void Check(bool check = true);
-    virtual bool IsChecked() const;
+    virtual void Check(bool check = true) wxOVERRIDE;
+    virtual bool IsChecked() const wxOVERRIDE;
 
     virtual void SetBitmap(const wxBitmap& bitmap);
     virtual const wxBitmap& GetBitmap() const { return m_bitmap; };

--- a/include/wx/qt/menuitem.h
+++ b/include/wx/qt/menuitem.h
@@ -13,7 +13,6 @@
 
 class QAction;
 
-class WXDLLIMPEXP_FWD_CORE wxBitmap;
 class WXDLLIMPEXP_FWD_CORE wxMenu;
 
 class WXDLLIMPEXP_CORE wxMenuItem : public wxMenuItemBase


### PR DESCRIPTION
Noticed the wxOVERRIDE specifier was missing from these derived classes' methods.