### PR TITLE
Added SetUIStyle to Qt variant of app. 

### DIFF
--- a/include/wx/qt/app.h
+++ b/include/wx/qt/app.h
@@ -18,6 +18,8 @@ public:
     
     virtual bool Initialize(int& argc, wxChar **argv);
 
+    static void SetUIStyle(const wxString& style_name);
+
 private:
     QApplication *m_qtApplication;
     int m_qtArgc;

--- a/src/qt/app.cpp
+++ b/src/qt/app.cpp
@@ -10,9 +10,6 @@
 
 #include "wx/app.h"
 #include "wx/apptrait.h"
-#include "wx/qt/private/utils.h"
-#include "wx/qt/private/converter.h"
-#include <QtCore/QStringList>
 #include <QtWidgets/QApplication>
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxApp, wxEvtHandler);
@@ -87,4 +84,9 @@ bool wxApp::Initialize( int &argc, wxChar **argv )
     }
 
     return true;
+}
+
+void wxApp::SetUIStyle(const wxString& style_name)
+{
+    QApplication::setStyle(QString(style_name));
 }


### PR DESCRIPTION
This allows the developer to set the Qt UI style via the wxApp object. (see, for example, https://doc.qt.io/archives/qt-5.8/gallery.html)

This is particularly important because Qt 5.6 defaults to a Gtk style that is bad enough that it was removed in Qt 5.7. There are some cross-platform styles (e.g. Fusion) which are quite nice.

This is just a pass through to the QApplication (set statically). but it allows the developer to not have to dive down to the Qt level to set the style.

I wasn't positive about the naming, so I took a best guess. 