### PR TITLE
Fix ability to replay wxSound sample on OSX

### DIFF
--- a/src/osx/core/sound.cpp
+++ b/src/osx/core/sound.cpp
@@ -58,6 +58,7 @@ wxOSXAudioToolboxSoundData::wxOSXAudioToolboxSoundData(SystemSoundID soundID) :
 wxOSXAudioToolboxSoundData::~wxOSXAudioToolboxSoundData()
 {
     DoStop();
+    AudioServicesDisposeSystemSoundID (m_soundID);
 }
 
 void
@@ -95,8 +96,6 @@ void wxOSXAudioToolboxSoundData::DoStop()
     {
         m_playing = false;
         AudioServicesRemoveSystemSoundCompletion(m_soundID);
-        AudioServicesDisposeSystemSoundID (m_soundID);
-
         wxSound::SoundStopped(this);
     }
 }


### PR DESCRIPTION
The sound handle was returned to the OS after the first play completed (or the loop first stopped), making it impossible to replay that sound again.

Now the handle is returned upon destruction of the wxSound object.