### PR TITLE
Cocoa: wxAppProgressIndicator memleak fixed (needless retain deleted)…

### DIFF
--- a/src/osx/cocoa/appprogress.mm
+++ b/src/osx/cocoa/appprogress.mm
@@ -42,15 +42,21 @@
         [m_progIndicator setBezeled:YES];
         [m_progIndicator setMinValue:0];
         [m_progIndicator setMaxValue:1];
-        [m_progIndicator release];
         [self setProgress:0.0];
     }
     return self;
 }
 
+- (void)dealloc
+{
+    [m_progIndicator release];
+    [super dealloc];
+}
+
 - (void)setProgress: (double)value
 {
     [m_progIndicator setHidden:NO];
+    [m_progIndicator setIndeterminate:NO];
     [m_progIndicator setDoubleValue:value];
     
     [m_dockTile display];
@@ -58,6 +64,7 @@
 
 - (void)setIndeterminate: (bool)indeterminate
 {
+    [m_progIndicator setHidden:NO];
     [m_progIndicator setIndeterminate:indeterminate];
 
     [m_dockTile display];
@@ -75,7 +82,7 @@
 wxAppProgressIndicator::wxAppProgressIndicator(wxWindow* WXUNUSED(parent), int maxValue ):
     m_maxValue(maxValue)
 {
-    wxAppProgressDockIcon* dockIcon = [[[wxAppProgressDockIcon alloc] init] retain];
+    wxAppProgressDockIcon* dockIcon = [[wxAppProgressDockIcon alloc] init]; // retainCount == 1
     
     m_dockIcon = dockIcon;
 }


### PR DESCRIPTION
…; 'multiple instances of wxAppProgressIndicator usage' fixed => two and more wxGauges with wxGA_PROCESS fixed