### PR TITLE
Update QPainter/QPicture mechanism used in drawing.

### DIFF
--- a/include/wx/qt/dcclient.h
+++ b/include/wx/qt/dcclient.h
@@ -37,10 +37,10 @@ public:
 
     ~wxClientDCImpl();
 private:
+    wxScopedPtr<QPicture> m_pict;
+
     wxDECLARE_CLASS(wxClientDCImpl);
     wxDECLARE_NO_COPY_CLASS(wxClientDCImpl);
-
-    QPicture* m_pic;
 };
 
 

--- a/include/wx/qt/dcclient.h
+++ b/include/wx/qt/dcclient.h
@@ -10,6 +10,8 @@
 
 #include "wx/qt/dc.h"
 
+class QPicture;
+
 class WXDLLIMPEXP_CORE wxWindowDCImpl : public wxQtDCImpl
 {
 public:
@@ -37,6 +39,8 @@ public:
 private:
     wxDECLARE_CLASS(wxClientDCImpl);
     wxDECLARE_NO_COPY_CLASS(wxClientDCImpl);
+
+    QPicture* m_pic;
 };
 
 

--- a/include/wx/qt/window.h
+++ b/include/wx/qt/window.h
@@ -147,7 +147,7 @@ public:
 
     // wxQt implementation internals:
 
-    virtual QPicture *QtGetPicture() const;
+    void QtSetPicture( QPicture* pict );
 
     QPainter *QtGetPainter();
 

--- a/include/wx/qt/window.h
+++ b/include/wx/qt/window.h
@@ -147,6 +147,7 @@ public:
 
     // wxQt implementation internals:
 
+    // Caller maintains ownership of pict - window will NOT delete it
     void QtSetPicture( QPicture* pict );
 
     QPainter *QtGetPainter();

--- a/src/qt/dcclient.cpp
+++ b/src/qt/dcclient.cpp
@@ -127,6 +127,7 @@ wxClientDCImpl::~wxClientDCImpl()
         }
     }
 
+    delete m_pic;
     // Painter will be deleted by base class
 }
 

--- a/src/qt/dcclient.cpp
+++ b/src/qt/dcclient.cpp
@@ -118,7 +118,6 @@ wxClientDCImpl::~wxClientDCImpl()
 
         if ( m_window != NULL )
         {
-            //m_window->QtSetPicture( m_pic );
             QtPictureSetter(m_window, m_pic);
 
             // get the inner widget in scroll areas:
@@ -142,8 +141,6 @@ wxClientDCImpl::~wxClientDCImpl()
                 // Not drawing anything, reset picture to avoid issues in handler
                 m_pic->setData( NULL, 0 );
             }
-
-            //m_window->QtSetPicture( NULL );
 
             // let destroy the m_qtPainter (see inherited classes destructors)
             m_window = NULL;

--- a/src/qt/dcclient.cpp
+++ b/src/qt/dcclient.cpp
@@ -27,6 +27,28 @@
 
 //##############################################################################
 
+namespace
+{
+    class QtPictureSetter
+    {
+    public:
+        QtPictureSetter(wxWindow *window, QPicture *pic)
+        {
+            m_window = window;
+            m_window->QtSetPicture( pic );
+        }
+
+        ~QtPictureSetter()
+        {
+            m_window->QtSetPicture( NULL );
+        }
+
+    private:
+        wxWindow *m_window;
+    };
+}
+
+
 wxIMPLEMENT_CLASS(wxWindowDCImpl,wxQtDCImpl);
 
 wxWindowDCImpl::wxWindowDCImpl( wxDC *owner )
@@ -96,7 +118,8 @@ wxClientDCImpl::~wxClientDCImpl()
 
         if ( m_window != NULL )
         {
-            m_window->QtSetPicture( m_pic );
+            //m_window->QtSetPicture( m_pic );
+            QtPictureSetter(m_window, m_pic);
 
             // get the inner widget in scroll areas:
             QWidget *widget;
@@ -112,7 +135,7 @@ wxClientDCImpl::~wxClientDCImpl()
             if ( !m_pic->isNull() && !widget->paintingActive() && !rect.isEmpty() )
             {
                 // only force the update of the rect affected by the DC
-                widget->update( rect );
+                widget->repaint( rect );
             }
             else
             {
@@ -120,7 +143,7 @@ wxClientDCImpl::~wxClientDCImpl()
                 m_pic->setData( NULL, 0 );
             }
 
-            m_window->QtSetPicture( NULL );
+            //m_window->QtSetPicture( NULL );
 
             // let destroy the m_qtPainter (see inherited classes destructors)
             m_window = NULL;

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -1093,7 +1093,7 @@ bool wxWindowQt::QtHandlePaintEvent ( QWidget *handler, QPaintEvent *event )
         {
             bool handled;
 
-            if ( m_qtPicture == NULL)
+            if ( m_qtPicture == NULL )
             {
                 // Real paint event (not for wxClientDC), prepare the background
                 switch ( GetBackgroundStyle() )

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -213,7 +213,7 @@ void wxWindowQt::Init()
     m_horzScrollBar = NULL;
     m_vertScrollBar = NULL;
 
-    m_qtPicture = new QPicture();
+    m_qtPicture = NULL;
     m_qtPainter = new QPainter();
 
     m_mouseInside = false;
@@ -252,7 +252,6 @@ wxWindowQt::~wxWindowQt()
 
     DestroyChildren(); // This also destroys scrollbars
 
-    delete m_qtPicture;
     delete m_qtPainter;
 
 #if wxUSE_ACCEL
@@ -1094,7 +1093,7 @@ bool wxWindowQt::QtHandlePaintEvent ( QWidget *handler, QPaintEvent *event )
         {
             bool handled;
 
-            if ( m_qtPicture->isNull() )
+            if ( m_qtPicture == NULL)
             {
                 // Real paint event (not for wxClientDC), prepare the background
                 switch ( GetBackgroundStyle() )
@@ -1522,9 +1521,9 @@ QScrollArea *wxWindowQt::QtGetScrollBarsContainer() const
     return m_qtContainer;
 }
 
-QPicture *wxWindowQt::QtGetPicture() const
+void wxWindowQt::QtSetPicture( QPicture* pict )
 {
-    return m_qtPicture;
+    m_qtPicture = pict;
 }
 
 QPainter *wxWindowQt::QtGetPainter()


### PR DESCRIPTION
The original drawing mechanism was generating lots of `QWarning` messages when running samples (e.g. htlbox, caret, etc.) and in some cases was not actually completely drawing every element of the sample. The issue was that the `QPicture` was being shared incorrectly between **window** and **dcclient** and attempts to start painting, update, etc. were generating console warnings.