### PR TITLE
Qt dialog show modal

### DIFF
--- a/include/wx/qt/dialog.h
+++ b/include/wx/qt/dialog.h
@@ -31,9 +31,9 @@ public:
             long style = wxDEFAULT_DIALOG_STYLE,
             const wxString &name = wxDialogNameStr );
 
-    virtual int ShowModal();
-    virtual void EndModal(int retCode);
-    virtual bool IsModal() const;
+    virtual int ShowModal() wxOVERRIDE;
+    virtual void EndModal(int retCode) wxOVERRIDE;
+    virtual bool IsModal() const wxOVERRIDE;
 
     QDialog *GetDialogHandle() const;
 

--- a/include/wx/qt/dialog.h
+++ b/include/wx/qt/dialog.h
@@ -34,6 +34,7 @@ public:
     virtual int ShowModal() wxOVERRIDE;
     virtual void EndModal(int retCode) wxOVERRIDE;
     virtual bool IsModal() const wxOVERRIDE;
+    virtual bool Show(bool show) wxOVERRIDE;
 
     QDialog *GetDialogHandle() const;
 

--- a/src/qt/dialog.cpp
+++ b/src/qt/dialog.cpp
@@ -8,6 +8,7 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#include "wx/modalhook.h"
 #include "wx/dialog.h"
 #include "wx/qt/private/utils.h"
 #include "wx/qt/private/winevent.h"
@@ -70,6 +71,7 @@ bool wxDialog::Create( wxWindow *parent, wxWindowID id,
 
 int wxDialog::ShowModal()
 {
+    WX_HOOK_MODAL_DIALOG();
     wxCHECK_MSG( GetHandle() != NULL, -1, "Invalid dialog" );
 
     bool ret = GetDialogHandle()->exec();

--- a/src/qt/dialog.cpp
+++ b/src/qt/dialog.cpp
@@ -74,7 +74,12 @@ int wxDialog::ShowModal()
     WX_HOOK_MODAL_DIALOG();
     wxCHECK_MSG( GetHandle() != NULL, -1, "Invalid dialog" );
 
-    bool ret = GetDialogHandle()->exec();
+    QDialog *qDialog = GetDialogHandle();
+    qDialog->setModal(true);
+
+    Show(true);
+
+    bool ret = qDialog->exec();
     if ( GetReturnCode() == 0 )
         return ret ? wxID_OK : wxID_CANCEL;
     return GetReturnCode();
@@ -93,6 +98,25 @@ bool wxDialog::IsModal() const
     wxCHECK_MSG( GetDialogHandle() != NULL, false, "Invalid dialog" );
 
     return GetDialogHandle()->isModal();
+}
+
+bool wxDialog::Show(bool show)
+{
+    if ( show == IsShown() )
+        return false;
+
+    if ( !show && IsModal() )
+        EndModal(wxID_CANCEL);
+
+    if ( show && CanDoLayoutAdaptation() )
+        DoLayoutAdaptation();
+
+    const bool ret = wxDialogBase::Show(show);
+
+    if (show)
+        InitDialog();
+
+    return ret;
 }
 
 QDialog *wxDialog::GetDialogHandle() const

--- a/src/qt/msgdlg.cpp
+++ b/src/qt/msgdlg.cpp
@@ -8,6 +8,7 @@
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
+#include "wx/modalhook.h"
 #include "wx/msgdlg.h"
 #include "wx/qt/private/utils.h"
 #include "wx/qt/private/winevent.h"
@@ -115,6 +116,7 @@ wxIMPLEMENT_CLASS(wxMessageDialog,wxDialog);
 
 int wxMessageDialog::ShowModal()
 {
+    WX_HOOK_MODAL_DIALOG();
     wxCHECK_MSG( m_qtWindow, -1, "Invalid dialog" );
     
     // Exec may return a wx identifier if a close event is generated


### PR DESCRIPTION
Fixed issues with wxDialog::ShowModal under wxQT.  

* Dialog hooks are now registered
* wxInitDialogEvent
* wxDialog::Show is now overridden to match the behaviour of other ports.