### PR TITLE
Qt dropdown

### DIFF
--- a/include/wx/qt/choice.h
+++ b/include/wx/qt/choice.h
@@ -71,6 +71,8 @@ protected:
     virtual void DoClear();
     virtual void DoDeleteOneItem(unsigned int pos);
 
+    virtual void InitialiseSort(QComboBox *combo);
+
     QComboBox *m_qtComboBox;
 
 private:

--- a/include/wx/qt/choice.h
+++ b/include/wx/qt/choice.h
@@ -14,44 +14,44 @@ class WXDLLIMPEXP_CORE wxChoice : public wxChoiceBase
 {
 public:
     wxChoice();
-    
-    wxChoice( wxWindow *parent, wxWindowID id,
+
+    wxChoice(wxWindow *parent, wxWindowID id,
             const wxPoint& pos = wxDefaultPosition,
             const wxSize& size = wxDefaultSize,
             int n = 0, const wxString choices[] = (const wxString *) NULL,
             long style = 0,
             const wxValidator& validator = wxDefaultValidator,
-            const wxString& name = wxChoiceNameStr );
-    
-    wxChoice( wxWindow *parent, wxWindowID id,
+            const wxString& name = wxChoiceNameStr);
+
+    wxChoice(wxWindow *parent, wxWindowID id,
             const wxPoint& pos,
             const wxSize& size,
             const wxArrayString& choices,
             long style = 0,
             const wxValidator& validator = wxDefaultValidator,
-            const wxString& name = wxChoiceNameStr );
+            const wxString& name = wxChoiceNameStr);
 
-    bool Create( wxWindow *parent, wxWindowID id,
+    bool Create(wxWindow *parent, wxWindowID id,
             const wxPoint& pos = wxDefaultPosition,
             const wxSize& size = wxDefaultSize,
             int n = 0, const wxString choices[] = NULL,
             long style = 0,
             const wxValidator& validator = wxDefaultValidator,
-            const wxString& name = wxChoiceNameStr );
-    
-    bool Create( wxWindow *parent, wxWindowID id,
+            const wxString& name = wxChoiceNameStr);
+
+    bool Create(wxWindow *parent, wxWindowID id,
             const wxPoint& pos,
             const wxSize& size,
             const wxArrayString& choices,
             long style = 0,
             const wxValidator& validator = wxDefaultValidator,
-            const wxString& name = wxChoiceNameStr );
+            const wxString& name = wxChoiceNameStr);
 
     virtual wxSize DoGetBestSize() const;
 
     virtual unsigned int GetCount() const;
     virtual wxString GetString(unsigned int n) const;
-    virtual void SetString(unsigned int n, const wxString& s);
+    virtual void SetString(unsigned int n, const wxString &s);
 
     virtual void SetSelection(int n);
     virtual int GetSelection() const;
@@ -59,12 +59,12 @@ public:
     virtual QWidget *GetHandle() const;
 
 protected:
-    virtual int DoInsertItems(const wxArrayStringsAdapter & items,
+    virtual int DoInsertItems(const wxArrayStringsAdapter &items,
                               unsigned int pos,
                               void **clientData,
                               wxClientDataType type);
     virtual int DoInsertOneItem(const wxString& item, unsigned int pos);
-    
+
     virtual void DoSetItemClientData(unsigned int n, void *clientData);
     virtual void *DoGetItemClientData(unsigned int n) const;
 

--- a/include/wx/qt/choice.h
+++ b/include/wx/qt/choice.h
@@ -71,7 +71,7 @@ protected:
     virtual void DoClear();
     virtual void DoDeleteOneItem(unsigned int pos);
 
-    virtual void InitialiseSort(QComboBox *combo);
+    void QtInitSort(QComboBox *combo);
 
     QComboBox *m_qtComboBox;
 

--- a/include/wx/qt/combobox.h
+++ b/include/wx/qt/combobox.h
@@ -43,6 +43,7 @@ public:
                 long style = 0,
                 const wxValidator& validator = wxDefaultValidator,
                 const wxString& name = wxComboBoxNameStr);
+
     bool Create(wxWindow *parent, wxWindowID id,
                 const wxString& value,
                 const wxPoint& pos,
@@ -55,7 +56,11 @@ public:
     virtual void SetSelection(int n) wxOVERRIDE;
     virtual void SetSelection(long from, long to) wxOVERRIDE;
 
-    virtual int GetSelection() const wxOVERRIDE { return wxChoice::GetSelection(); }
+    virtual int GetSelection() const wxOVERRIDE
+    {
+        return wxChoice::GetSelection();
+    }
+
     virtual void GetSelection(long *from, long *to) const wxOVERRIDE;
 
     virtual wxString GetStringSelection() const wxOVERRIDE
@@ -66,8 +71,14 @@ public:
     virtual void Clear() wxOVERRIDE;
 
     // See wxComboBoxBase discussion of IsEmpty().
-    bool IsListEmpty() const { return wxItemContainer::IsEmpty(); }
-    bool IsTextEmpty() const { return wxTextEntry::IsEmpty(); }
+    bool IsListEmpty() const
+    {
+        return wxItemContainer::IsEmpty();
+    }
+    bool IsTextEmpty() const
+    {
+        return wxTextEntry::IsEmpty();
+    }
 
     virtual void SetValue(const wxString& value) wxOVERRIDE;
     virtual void ChangeValue(const wxString& value) wxOVERRIDE;
@@ -86,10 +97,13 @@ protected:
     virtual wxString DoGetValue() const wxOVERRIDE;
 
 private:
-    void SetActualValue(const wxString& value);
+    void SetActualValue(const wxString &value);
 
     // From wxTextEntry:
-    virtual wxWindow *GetEditableWindow() wxOVERRIDE { return this; }
+    virtual wxWindow *GetEditableWindow() wxOVERRIDE
+    {
+        return this;
+    }
 
     wxDECLARE_DYNAMIC_CLASS(wxComboBox);
 };

--- a/include/wx/qt/combobox.h
+++ b/include/wx/qt/combobox.h
@@ -75,6 +75,7 @@ public:
     {
         return wxItemContainer::IsEmpty();
     }
+
     bool IsTextEmpty() const
     {
         return wxTextEntry::IsEmpty();

--- a/include/wx/qt/combobox.h
+++ b/include/wx/qt/combobox.h
@@ -52,7 +52,7 @@ public:
                 const wxValidator& validator = wxDefaultValidator,
                 const wxString& name = wxComboBoxNameStr);
 
-    virtual void SetSelection(int n) wxOVERRIDE { wxChoice::SetSelection(n); }
+    virtual void SetSelection(int n) wxOVERRIDE;
     virtual void SetSelection(long from, long to) wxOVERRIDE;
 
     virtual int GetSelection() const wxOVERRIDE { return wxChoice::GetSelection(); }
@@ -70,6 +70,12 @@ public:
     bool IsTextEmpty() const { return wxTextEntry::IsEmpty(); }
 
     virtual void SetValue(const wxString& value) wxOVERRIDE;
+    virtual void ChangeValue(const wxString& value) wxOVERRIDE;
+    virtual void AppendText(const wxString &value) wxOVERRIDE;
+    virtual void Replace(long from, long to, const wxString &value) wxOVERRIDE;
+    virtual void WriteText(const wxString &value) wxOVERRIDE;
+    virtual void SetInsertionPoint(long insertion) wxOVERRIDE;
+    virtual long GetInsertionPoint() const wxOVERRIDE;
 
     virtual void Popup();
     virtual void Dismiss();
@@ -80,6 +86,7 @@ protected:
     virtual wxString DoGetValue() const wxOVERRIDE;
 
 private:
+    void SetActualValue(const wxString& value);
 
     // From wxTextEntry:
     virtual wxWindow *GetEditableWindow() wxOVERRIDE { return this; }

--- a/include/wx/qt/textentry.h
+++ b/include/wx/qt/textentry.h
@@ -20,7 +20,7 @@ public:
     virtual void Copy();
     virtual void Cut();
     virtual void Paste();
-    
+
     virtual void Undo();
     virtual void Redo();
     virtual bool CanUndo() const;
@@ -32,10 +32,10 @@ public:
 
     virtual void SetSelection(long from, long to);
     virtual void GetSelection(long *from, long *to) const;
-    
+
     virtual bool IsEditable() const;
     virtual void SetEditable(bool editable);
-    
+
 protected:
     virtual wxString DoGetValue() const;
     virtual void DoSetValue(const wxString& value, int flags=0);

--- a/src/qt/choice.cpp
+++ b/src/qt/choice.cpp
@@ -215,7 +215,8 @@ int wxChoice::DoInsertOneItem(const wxString& item, unsigned int pos)
     if ( IsSorted() )
         m_qtComboBox->model()->sort(0);
 
-    if(unselected) m_qtComboBox->setCurrentIndex(-1);
+    if( unselected )
+        m_qtComboBox->setCurrentIndex(-1);
 
     return pos;
 }

--- a/src/qt/choice.cpp
+++ b/src/qt/choice.cpp
@@ -19,8 +19,8 @@ class LexicalSortProxyModel : public QSortFilterProxyModel
     public:
         bool lessThan( const QModelIndex &left, const QModelIndex &right ) const
         {
-            const QVariant leftData = sourceModel()->data(left);
-            const QVariant rightData = sourceModel()->data(right);
+            const QVariant leftData = sourceModel()->data( left );
+            const QVariant rightData = sourceModel()->data( right );
 
             if( leftData.type() != QVariant::String )
                 return false;
@@ -28,7 +28,7 @@ class LexicalSortProxyModel : public QSortFilterProxyModel
             int insensitiveResult = QString::compare(
                     leftData.value<QString>(),
                     rightData.value<QString>(),
-                    Qt::CaseInsensitive);
+                    Qt::CaseInsensitive );
 
             if ( insensitiveResult == 0 )
             {
@@ -70,12 +70,12 @@ wxChoice::wxChoice() :
 {
 }
 
-void wxChoice::InitialiseSort(QComboBox *combo)
+void wxChoice::InitialiseSort( QComboBox *combo )
 {
     QSortFilterProxyModel *proxyModel = new LexicalSortProxyModel();
-    proxyModel->setSourceModel(combo->model());
-    combo->model()->setParent(proxyModel);
-    combo->setModel(proxyModel);
+    proxyModel->setSourceModel( combo->model() );
+    combo->model()->setParent( proxyModel );
+    combo->setModel( proxyModel );
 }
 
 
@@ -126,7 +126,7 @@ bool wxChoice::Create( wxWindow *parent, wxWindowID id,
 {
     m_qtComboBox = new wxQtChoice( parent, this );
 
-    InitialiseSort(m_qtComboBox);
+    InitialiseSort( m_qtComboBox );
 
     while ( n-- > 0 )
         m_qtComboBox->addItem( wxQtConvertString( *choices++ ));
@@ -207,10 +207,15 @@ int wxChoice::DoInsertItems(const wxArrayStringsAdapter & items,
 
 int wxChoice::DoInsertOneItem(const wxString& item, unsigned int pos)
 {
+    // Maintain unselected state
+    const bool unselected = m_qtComboBox->currentIndex() == -1;
+
     m_qtComboBox->insertItem(pos, wxQtConvertString(item));
 
     if ( IsSorted() )
         m_qtComboBox->model()->sort(0);
+
+    if(unselected) m_qtComboBox->setCurrentIndex(-1);
 
     return pos;
 }
@@ -227,7 +232,6 @@ void *wxChoice::DoGetItemClientData(unsigned int n) const
     return variant.value<void *>();
 }
 
-
 void wxChoice::DoClear()
 {
     m_qtComboBox->clear();
@@ -235,9 +239,11 @@ void wxChoice::DoClear()
 
 void wxChoice::DoDeleteOneItem(unsigned int pos)
 {
-    if( GetSelection() == pos )
+    const int selection = GetSelection();
+
+    if( selection >= 0 && static_cast<unsigned int>(selection) == pos )
     {
-        SetSelection(wxNOT_FOUND);
+        SetSelection( wxNOT_FOUND );
     }
     m_qtComboBox->removeItem(pos);
 }

--- a/src/qt/choice.cpp
+++ b/src/qt/choice.cpp
@@ -10,7 +10,35 @@
 
 #include "wx/choice.h"
 #include "wx/qt/private/winevent.h"
+
 #include <QtWidgets/QComboBox>
+#include <QtCore/QSortFilterProxyModel>
+
+class LexicalSortProxyModel : public QSortFilterProxyModel
+{
+    public:
+        bool lessThan( const QModelIndex &left, const QModelIndex &right ) const
+        {
+            const QVariant leftData = sourceModel()->data(left);
+            const QVariant rightData = sourceModel()->data(right);
+
+            if( leftData.type() != QVariant::String )
+                return false;
+
+            int insensitiveResult = QString::compare(
+                    leftData.value<QString>(),
+                    rightData.value<QString>(),
+                    Qt::CaseInsensitive);
+
+            if ( insensitiveResult == 0 )
+            {
+                return QString::compare( leftData.value<QString>(),
+                        rightData.value<QString>() ) < 0;
+            }
+
+            return insensitiveResult < 0;
+        }
+};
 
 class wxQtChoice : public wxQtEventSignalHandler< QComboBox, wxChoice >
 {
@@ -40,6 +68,14 @@ void wxQtChoice::activated(int WXUNUSED(index))
 wxChoice::wxChoice() :
     m_qtComboBox(NULL)
 {
+}
+
+void wxChoice::InitialiseSort(QComboBox *combo)
+{
+    QSortFilterProxyModel *proxyModel = new LexicalSortProxyModel();
+    proxyModel->setSourceModel(combo->model());
+    combo->model()->setParent(proxyModel);
+    combo->setModel(proxyModel);
 }
 
 
@@ -89,6 +125,8 @@ bool wxChoice::Create( wxWindow *parent, wxWindowID id,
         const wxString& name )
 {
     m_qtComboBox = new wxQtChoice( parent, this );
+
+    InitialiseSort(m_qtComboBox);
 
     while ( n-- > 0 )
         m_qtComboBox->addItem( wxQtConvertString( *choices++ ));
@@ -197,6 +235,10 @@ void wxChoice::DoClear()
 
 void wxChoice::DoDeleteOneItem(unsigned int pos)
 {
+    if( GetSelection() == pos )
+    {
+        SetSelection(wxNOT_FOUND);
+    }
     m_qtComboBox->removeItem(pos);
 }
 

--- a/src/qt/choice.cpp
+++ b/src/qt/choice.cpp
@@ -18,44 +18,47 @@ namespace
 {
     class LexicalSortProxyModel : public QSortFilterProxyModel
     {
-        public:
-            bool lessThan( const QModelIndex &left, const QModelIndex &right ) const wxOVERRIDE
+    public:
+        bool lessThan(const QModelIndex &left,
+                      const QModelIndex &right) const wxOVERRIDE
+        {
+            const QVariant leftData = sourceModel()->data(left);
+            const QVariant rightData = sourceModel()->data(right);
+
+            if ( leftData.type() != QVariant::String )
+                return false;
+
+            int insensitiveResult = QString::compare(
+                                                     leftData.value<QString>(),
+                                                     rightData.value<QString>(),
+                                                     Qt::CaseInsensitive);
+
+            if ( insensitiveResult == 0 )
             {
-                const QVariant leftData = sourceModel()->data( left );
-                const QVariant rightData = sourceModel()->data( right );
-
-                if ( leftData.type() != QVariant::String )
-                    return false;
-
-                int insensitiveResult = QString::compare(
-                        leftData.value<QString>(),
-                        rightData.value<QString>(),
-                        Qt::CaseInsensitive );
-
-                if ( insensitiveResult == 0 )
-                {
-                    return QString::compare( leftData.value<QString>(),
-                            rightData.value<QString>() ) < 0;
-                }
-
-                return insensitiveResult < 0;
+                return QString::compare(leftData.value<QString>(),
+                                        rightData.value<QString>()) < 0;
             }
+
+            return insensitiveResult < 0;
+        }
     };
 
-    class wxQtChoice : public wxQtEventSignalHandler< QComboBox, wxChoice >
+    class wxQtChoice : public wxQtEventSignalHandler<QComboBox, wxChoice>
     {
-        public:
-            wxQtChoice( wxWindow *parent, wxChoice *handler );
+    public:
+        wxQtChoice(wxWindow *parent, wxChoice *handler);
 
-        private:
-            void activated(int index);
+    private:
+        void activated(int index);
     };
 
-    wxQtChoice::wxQtChoice( wxWindow *parent, wxChoice *handler )
-        : wxQtEventSignalHandler< QComboBox, wxChoice >( parent, handler )
+    wxQtChoice::wxQtChoice(wxWindow *parent, wxChoice *handler)
+        : wxQtEventSignalHandler<QComboBox, wxChoice>(parent, handler)
     {
-        // the activated signal is overloaded, the following explicit cast is needed:
-        connect(this, static_cast<void (QComboBox::*)(int index)>(&QComboBox::activated),
+        // the activated signal is overloaded, the following explicit cast is
+        // needed:
+        typedef void (QComboBox::*IntMemFunc)(int index);
+        connect(this, static_cast<IntMemFunc>(&QComboBox::activated),
                 this, &wxQtChoice::activated);
     }
 
@@ -72,68 +75,65 @@ wxChoice::wxChoice() :
 {
 }
 
-void wxChoice::QtInitSort( QComboBox *combo )
+void wxChoice::QtInitSort(QComboBox *combo)
 {
     QSortFilterProxyModel *proxyModel = new LexicalSortProxyModel();
-    proxyModel->setSourceModel( combo->model() );
-    combo->model()->setParent( proxyModel );
-    combo->setModel( proxyModel );
+    proxyModel->setSourceModel(combo->model());
+    combo->model()->setParent(proxyModel);
+    combo->setModel(proxyModel);
 }
 
-
-wxChoice::wxChoice( wxWindow *parent, wxWindowID id,
+wxChoice::wxChoice(wxWindow *parent, wxWindowID id,
         const wxPoint& pos,
         const wxSize& size,
         int n, const wxString choices[],
         long style,
         const wxValidator& validator,
-        const wxString& name )
+        const wxString& name)
 {
-    Create( parent, id, pos, size, n, choices, style, validator, name );
+    Create(parent, id, pos, size, n, choices, style, validator, name);
 }
 
-
-wxChoice::wxChoice( wxWindow *parent, wxWindowID id,
+wxChoice::wxChoice(wxWindow *parent, wxWindowID id,
         const wxPoint& pos,
         const wxSize& size,
         const wxArrayString& choices,
         long style,
         const wxValidator& validator,
-        const wxString& name )
+        const wxString& name)
 {
-    Create( parent, id, pos, size, choices, style, validator, name );
+    Create(parent, id, pos, size, choices, style, validator, name);
 }
 
-
-bool wxChoice::Create( wxWindow *parent, wxWindowID id,
+bool wxChoice::Create(wxWindow *parent, wxWindowID id,
         const wxPoint& pos,
         const wxSize& size,
         const wxArrayString& choices,
         long style,
         const wxValidator& validator,
-        const wxString& name )
+        const wxString& name)
 {
-    return Create( parent, id, pos, size, choices.size(), choices.size() ? &choices[ 0 ] : NULL, style,
-        validator, name );
+    return Create(parent, id, pos, size, choices.size(),
+                  choices.size() ? &choices[0] : NULL,
+                  style, validator, name);
 }
 
-
-bool wxChoice::Create( wxWindow *parent, wxWindowID id,
+bool wxChoice::Create(wxWindow *parent, wxWindowID id,
         const wxPoint& pos,
         const wxSize& size,
         int n, const wxString choices[],
         long style,
         const wxValidator& validator,
-        const wxString& name )
+        const wxString& name)
 {
-    m_qtComboBox = new wxQtChoice( parent, this );
+    m_qtComboBox = new wxQtChoice(parent, this);
 
-    QtInitSort( m_qtComboBox );
+    QtInitSort(m_qtComboBox);
 
     while ( n-- > 0 )
-        m_qtComboBox->addItem( wxQtConvertString( *choices++ ));
+        m_qtComboBox->addItem(wxQtConvertString(*choices++));
 
-    return QtCreateControl( parent, id, pos, size, style, validator, name );
+    return QtCreateControl(parent, id, pos, size, style, validator, name);
 }
 
 wxSize wxChoice::DoGetBestSize() const
@@ -141,13 +141,12 @@ wxSize wxChoice::DoGetBestSize() const
     wxSize basesize = wxChoiceBase::DoGetBestSize();
     wxSize size = wxControl::DoGetBestSize();
     // mix calculated size by wx base prioritizing qt hint (max):
-    if (size.GetWidth() < basesize.GetWidth())
+    if ( size.GetWidth() < basesize.GetWidth() )
         size.SetWidth(basesize.GetWidth());
-    if (size.GetHeight() < basesize.GetHeight())
+    if ( size.GetHeight() < basesize.GetHeight() )
         size.SetHeight(basesize.GetHeight());
     return size;
 }
-
 
 unsigned wxChoice::GetCount() const
 {
@@ -156,14 +155,13 @@ unsigned wxChoice::GetCount() const
 
 wxString wxChoice::GetString(unsigned int n) const
 {
-    return wxQtConvertString( m_qtComboBox->itemText(n) );
+    return wxQtConvertString(m_qtComboBox->itemText(n));
 }
 
 void wxChoice::SetString(unsigned int n, const wxString& s)
 {
     m_qtComboBox->setItemText(n, wxQtConvertString(s));
 }
-
 
 void wxChoice::SetSelection(int n)
 {
@@ -174,7 +172,6 @@ int wxChoice::GetSelection() const
 {
     return m_qtComboBox->currentIndex();
 }
-
 
 int wxChoice::DoInsertItems(const wxArrayStringsAdapter & items,
                   unsigned int pos,
@@ -246,7 +243,7 @@ void wxChoice::DoDeleteOneItem(unsigned int pos)
 
     if ( selection >= 0 && static_cast<unsigned int>(selection) == pos )
     {
-        SetSelection( wxNOT_FOUND );
+        SetSelection(wxNOT_FOUND);
     }
     m_qtComboBox->removeItem(pos);
 }

--- a/src/qt/combobox.cpp
+++ b/src/qt/combobox.cpp
@@ -13,16 +13,9 @@
 #include "wx/qt/private/converter.h"
 #include "wx/qt/private/winevent.h"
 
-#include <QtCore/QSortFilterProxyModel>
 #include <QtWidgets/QComboBox>
 #include <QtWidgets/QLineEdit>
 
-
-class LexicalSortProxyModel : public QSortFilterProxyModel
-{
-    public:
-        bool lessThan(const QModelIndex &left, const QModelIndex &right) const;
-};
 
 class wxQtComboBox : public wxQtEventSignalHandler< QComboBox, wxComboBox >
 {
@@ -34,16 +27,16 @@ public:
 
     struct Ignore
     {
-        Ignore(QComboBox *combo) :
-            handler(dynamic_cast<wxQtComboBox*>(combo))
+        Ignore( QComboBox *combo ) :
+            handler( dynamic_cast<wxQtComboBox*>(combo) )
         {
-            if(handler)
-                handler->ignoreTextChange(true);
+            if( handler )
+                handler->ignoreTextChange( true );
         }
         ~Ignore()
         {
-            if(handler)
-                handler->ignoreTextChange(false);
+            if( handler )
+                handler->ignoreTextChange( false );
         }
 
         private:
@@ -59,7 +52,7 @@ private:
 
 wxQtComboBox::wxQtComboBox( wxWindow *parent, wxComboBox *handler )
     : wxQtEventSignalHandler< QComboBox, wxComboBox >( parent, handler ),
-    textChangeIgnored(false)
+    textChangeIgnored( false )
 {
     setEditable( true );
     connect(this, static_cast<void (QComboBox::*)(int index)>(&QComboBox::activated),
@@ -89,7 +82,7 @@ void wxQtComboBox::activated(int WXUNUSED(index))
         handler->SendSelectionChangedEvent(wxEVT_COMBOBOX);
 }
 
-void wxQtComboBox::ignoreTextChange(bool ignore)
+void wxQtComboBox::ignoreTextChange( bool ignore )
 {
     textChangeIgnored = ignore;
 }
@@ -108,7 +101,7 @@ void wxQtComboBox::editTextChanged(const QString &text)
     }
 }
 
-void wxComboBox::SetSelection(int n)
+void wxComboBox::SetSelection( int n )
 {
     wxQtComboBox::Ignore ignore( m_qtComboBox );
     wxChoice::SetSelection( n );
@@ -171,7 +164,7 @@ bool wxComboBox::Create(wxWindow *parent, wxWindowID id,
             const wxString& name )
 {
     m_qtComboBox = new wxQtComboBox( parent, this );
-    InitialiseSort(m_qtComboBox);
+    InitialiseSort( m_qtComboBox );
 
     while ( n-- > 0 )
         m_qtComboBox->addItem( wxQtConvertString( *choices++ ));
@@ -183,10 +176,10 @@ bool wxComboBox::Create(wxWindow *parent, wxWindowID id,
 void wxComboBox::SetActualValue(const wxString &value)
 {
     if ( HasFlag(wxCB_READONLY) )
-        SetStringSelection(value);
+        SetStringSelection( value );
     else
     {
-        wxTextEntry::SetValue(value);
+        wxTextEntry::SetValue( value );
         m_qtComboBox->setEditText( wxQtConvertString(value) );
     }
 }
@@ -211,7 +204,8 @@ void wxComboBox::AppendText(const wxString &value)
 void wxComboBox::Replace(long from, long to, const wxString &value)
 {
     const wxString original( GetValue() );
-    if(from == 0)
+
+    if( from == 0 )
     {
         SetActualValue( value + original.SubString(to, original.length()) );
     }

--- a/src/qt/combobox.cpp
+++ b/src/qt/combobox.cpp
@@ -16,10 +16,10 @@
 #include <QtWidgets/QComboBox>
 #include <QtWidgets/QLineEdit>
 
-class wxQtComboBox : public wxQtEventSignalHandler< QComboBox, wxComboBox >
+class wxQtComboBox : public wxQtEventSignalHandler<QComboBox, wxComboBox>
 {
 public:
-    wxQtComboBox( wxWindow *parent, wxComboBox *handler );
+    wxQtComboBox(wxWindow *parent, wxComboBox *handler);
     virtual void showPopup() wxOVERRIDE;
     virtual void hidePopup() wxOVERRIDE;
     void ignoreTextChange(bool ignore);
@@ -27,20 +27,20 @@ public:
     class Ignore
     {
     public:
-        explicit Ignore( QComboBox *combo ) :
-            handler( dynamic_cast<wxQtComboBox*>(combo) )
+        explicit Ignore(QComboBox *combo) :
+            m_handler(static_cast<wxQtComboBox*>(combo))
         {
-            if ( handler )
-                handler->ignoreTextChange( true );
+            if ( m_handler )
+                m_handler->ignoreTextChange(true);
         }
         ~Ignore()
         {
-            if ( handler )
-                handler->ignoreTextChange( false );
+            if ( m_handler )
+                m_handler->ignoreTextChange(false);
         }
 
     private:
-        wxQtComboBox *handler;
+        wxQtComboBox *m_handler;
     };
 
 private:
@@ -50,12 +50,13 @@ private:
     bool textChangeIgnored;
 };
 
-wxQtComboBox::wxQtComboBox( wxWindow *parent, wxComboBox *handler )
-    : wxQtEventSignalHandler< QComboBox, wxComboBox >( parent, handler ),
-    textChangeIgnored( false )
+wxQtComboBox::wxQtComboBox(wxWindow *parent, wxComboBox *handler)
+    : wxQtEventSignalHandler<QComboBox, wxComboBox>(parent, handler),
+    textChangeIgnored(false)
 {
-    setEditable( true );
-    connect(this, static_cast<void (QComboBox::*)(int index)>(&QComboBox::activated),
+    setEditable(true);
+    connect(this,
+            static_cast<void (QComboBox::*)(int index)>(&QComboBox::activated),
             this, &wxQtComboBox::activated);
     connect(this, &QComboBox::editTextChanged,
             this, &wxQtComboBox::editTextChanged);
@@ -63,15 +64,15 @@ wxQtComboBox::wxQtComboBox( wxWindow *parent, wxComboBox *handler )
 
 void wxQtComboBox::showPopup()
 {
-    wxCommandEvent event( wxEVT_COMBOBOX_DROPDOWN, GetHandler()->GetId() );
-    EmitEvent( event );
+    wxCommandEvent event(wxEVT_COMBOBOX_DROPDOWN, GetHandler()->GetId());
+    EmitEvent(event);
     QComboBox::showPopup();
 }
 
 void wxQtComboBox::hidePopup()
 {
-    wxCommandEvent event( wxEVT_COMBOBOX_CLOSEUP, GetHandler()->GetId() );
-    EmitEvent( event );
+    wxCommandEvent event(wxEVT_COMBOBOX_CLOSEUP, GetHandler()->GetId());
+    EmitEvent(event);
     QComboBox::hidePopup();
 }
 
@@ -82,7 +83,7 @@ void wxQtComboBox::activated(int WXUNUSED(index))
         handler->SendSelectionChangedEvent(wxEVT_COMBOBOX);
 }
 
-void wxQtComboBox::ignoreTextChange( bool ignore )
+void wxQtComboBox::ignoreTextChange(bool ignore)
 {
     textChangeIgnored = ignore;
 }
@@ -95,22 +96,21 @@ void wxQtComboBox::editTextChanged(const QString &text)
     wxComboBox *handler = GetHandler();
     if ( handler )
     {
-        wxCommandEvent event( wxEVT_TEXT, handler->GetId() );
-        event.SetString( wxQtConvertString( text ) );
-        EmitEvent( event );
+        wxCommandEvent event(wxEVT_TEXT, handler->GetId());
+        event.SetString(wxQtConvertString(text));
+        EmitEvent(event);
     }
 }
 
-void wxComboBox::SetSelection( int n )
+void wxComboBox::SetSelection(int n)
 {
-    wxQtComboBox::Ignore ignore( m_qtComboBox );
-    wxChoice::SetSelection( n );
+    wxQtComboBox::Ignore ignore(m_qtComboBox);
+    wxChoice::SetSelection(n);
 }
 
 wxComboBox::wxComboBox()
 {
 }
-
 
 wxComboBox::wxComboBox(wxWindow *parent,
            wxWindowID id,
@@ -120,11 +120,10 @@ wxComboBox::wxComboBox(wxWindow *parent,
            int n, const wxString choices[],
            long style,
            const wxValidator& validator,
-           const wxString& name )
+           const wxString& name)
 {
-    Create( parent, id, value, pos, size, n, choices, style, validator, name );
+    Create(parent, id, value, pos, size, n, choices, style, validator, name);
 }
-
 
 wxComboBox::wxComboBox(wxWindow *parent, wxWindowID id,
            const wxString& value,
@@ -133,11 +132,10 @@ wxComboBox::wxComboBox(wxWindow *parent, wxWindowID id,
            const wxArrayString& choices,
            long style,
            const wxValidator& validator,
-           const wxString& name )
+           const wxString& name)
 {
-    Create( parent, id, value, pos, size, choices, style, validator, name );
+    Create(parent, id, value, pos, size, choices, style, validator, name);
 }
-
 
 bool wxComboBox::Create(wxWindow *parent, wxWindowID id,
             const wxString& value,
@@ -146,13 +144,12 @@ bool wxComboBox::Create(wxWindow *parent, wxWindowID id,
             const wxArrayString& choices,
             long style,
             const wxValidator& validator,
-            const wxString& name )
+            const wxString& name)
 {
     const wxString *pChoices = choices.size() ? &choices[ 0 ] : NULL;
     return Create(parent, id, value, pos, size, choices.size(), pChoices,
-                  style, validator, name );
+                  style, validator, name);
 }
-
 
 bool wxComboBox::Create(wxWindow *parent, wxWindowID id,
             const wxString& value,
@@ -161,84 +158,84 @@ bool wxComboBox::Create(wxWindow *parent, wxWindowID id,
             int n, const wxString choices[],
             long style,
             const wxValidator& validator,
-            const wxString& name )
+            const wxString& name)
 {
-    m_qtComboBox = new wxQtComboBox( parent, this );
-    QtInitSort( m_qtComboBox );
+    m_qtComboBox = new wxQtComboBox(parent, this);
+    QtInitSort(m_qtComboBox);
 
     while ( n-- > 0 )
-        m_qtComboBox->addItem( wxQtConvertString( *choices++ ));
-    m_qtComboBox->setEditText( wxQtConvertString( value ));
+        m_qtComboBox->addItem(wxQtConvertString(*choices++));
+    m_qtComboBox->setEditText(wxQtConvertString(value));
 
-    return QtCreateControl( parent, id, pos, size, style, validator, name );
+    return QtCreateControl(parent, id, pos, size, style, validator, name);
 }
 
 void wxComboBox::SetActualValue(const wxString &value)
 {
     if ( HasFlag(wxCB_READONLY) )
     {
-        SetStringSelection( value );
+        SetStringSelection(value);
     }
     else
     {
-        wxTextEntry::SetValue( value );
-        m_qtComboBox->setEditText( wxQtConvertString(value) );
+        wxTextEntry::SetValue(value);
+        m_qtComboBox->setEditText(wxQtConvertString(value));
     }
 }
 
 void wxComboBox::SetValue(const wxString& value)
 {
-    SetActualValue( value );
-    SetInsertionPoint( 0 );
+    SetActualValue(value);
+    SetInsertionPoint(0);
 }
 
 void wxComboBox::ChangeValue(const wxString &value)
 {
-    wxQtComboBox::Ignore ignore( m_qtComboBox );
-    SetValue( value );
+    wxQtComboBox::Ignore ignore(m_qtComboBox);
+    SetValue(value);
 }
 
 void wxComboBox::AppendText(const wxString &value)
 {
-    SetActualValue( GetValue() + value );
+    SetActualValue(GetValue() + value);
 }
 
 void wxComboBox::Replace(long from, long to, const wxString &value)
 {
-    const wxString original( GetValue() );
+    const wxString original(GetValue());
 
-    if( to < 0 )
+    if ( to < 0 )
     {
         to = original.length();
     }
 
     if ( from == 0 )
     {
-        SetActualValue( value + original.substr(to, original.length()) );
+        SetActualValue(value + original.substr(to, original.length()));
     }
 
-    wxString front = original.substr( 0, from ) + value;
+    wxString front = original.substr(0, from) + value;
 
     long iPoint = front.length();
     if ( front.length() <= original.length() )
     {
-        SetActualValue( front + original.substr(to, original.length()) );
+        SetActualValue(front + original.substr(to, original.length()));
     }
     else
     {
-        SetActualValue( front );
+        SetActualValue(front);
     }
-    SetInsertionPoint( iPoint );
+    SetInsertionPoint(iPoint);
 }
 
 void wxComboBox::WriteText(const wxString &value)
 {
-    m_qtComboBox->lineEdit()->insert( wxQtConvertString( value ) );
+    m_qtComboBox->lineEdit()->insert(wxQtConvertString(value));
 }
 
 wxString wxComboBox::DoGetValue() const
 {
-    return wxQtConvertString( m_qtComboBox->currentText() );
+    return wxQtConvertString(m_qtComboBox->currentText());
 }
 
 void wxComboBox::Popup()
@@ -257,7 +254,7 @@ void wxComboBox::Clear()
     wxItemContainer::Clear();
 }
 
-void wxComboBox::SetSelection( long from, long to )
+void wxComboBox::SetSelection(long from, long to)
 {
     if ( from == -1 )
     {
@@ -268,21 +265,21 @@ void wxComboBox::SetSelection( long from, long to )
         to = GetValue().length();
     }
 
-    SetInsertionPoint( from );
+    SetInsertionPoint(from);
     // use the inner text entry widget (note that can be null if not editable)
     if ( m_qtComboBox->lineEdit() != NULL )
     {
-        m_qtComboBox->lineEdit()->setSelection( from, to - from );
+        m_qtComboBox->lineEdit()->setSelection(from, to - from);
     }
 }
 
-void wxComboBox::SetInsertionPoint( long pos )
+void wxComboBox::SetInsertionPoint(long pos)
 {
     // check if pos indicates end of text:
     if ( pos == -1 )
-        m_qtComboBox->lineEdit()->end( false );
+        m_qtComboBox->lineEdit()->end(false);
     else
-        m_qtComboBox->lineEdit()->setCursorPosition( pos );
+        m_qtComboBox->lineEdit()->setCursorPosition(pos);
 }
 
 long wxComboBox::GetInsertionPoint() const

--- a/src/qt/combobox.cpp
+++ b/src/qt/combobox.cpp
@@ -16,7 +16,6 @@
 #include <QtWidgets/QComboBox>
 #include <QtWidgets/QLineEdit>
 
-
 class wxQtComboBox : public wxQtEventSignalHandler< QComboBox, wxComboBox >
 {
 public:
@@ -25,21 +24,22 @@ public:
     virtual void hidePopup() wxOVERRIDE;
     void ignoreTextChange(bool ignore);
 
-    struct Ignore
+    class Ignore
     {
-        Ignore( QComboBox *combo ) :
+    public:
+        explicit Ignore( QComboBox *combo ) :
             handler( dynamic_cast<wxQtComboBox*>(combo) )
         {
-            if( handler )
+            if ( handler )
                 handler->ignoreTextChange( true );
         }
         ~Ignore()
         {
-            if( handler )
+            if ( handler )
                 handler->ignoreTextChange( false );
         }
 
-        private:
+    private:
         wxQtComboBox *handler;
     };
 
@@ -89,7 +89,7 @@ void wxQtComboBox::ignoreTextChange( bool ignore )
 
 void wxQtComboBox::editTextChanged(const QString &text)
 {
-    if( textChangeIgnored )
+    if ( textChangeIgnored )
         return;
 
     wxComboBox *handler = GetHandler();
@@ -164,7 +164,7 @@ bool wxComboBox::Create(wxWindow *parent, wxWindowID id,
             const wxString& name )
 {
     m_qtComboBox = new wxQtComboBox( parent, this );
-    InitialiseSort( m_qtComboBox );
+    QtInitSort( m_qtComboBox );
 
     while ( n-- > 0 )
         m_qtComboBox->addItem( wxQtConvertString( *choices++ ));
@@ -176,7 +176,9 @@ bool wxComboBox::Create(wxWindow *parent, wxWindowID id,
 void wxComboBox::SetActualValue(const wxString &value)
 {
     if ( HasFlag(wxCB_READONLY) )
+    {
         SetStringSelection( value );
+    }
     else
     {
         wxTextEntry::SetValue( value );
@@ -205,17 +207,22 @@ void wxComboBox::Replace(long from, long to, const wxString &value)
 {
     const wxString original( GetValue() );
 
-    if( from == 0 )
+    if( to < 0 )
     {
-        SetActualValue( value + original.SubString(to, original.length()) );
+        to = original.length();
     }
 
-    wxString front = original.SubString( 0, from - 1 ) + value;
+    if ( from == 0 )
+    {
+        SetActualValue( value + original.substr(to, original.length()) );
+    }
+
+    wxString front = original.substr( 0, from ) + value;
 
     long iPoint = front.length();
-    if( front.length() <= original.length() )
+    if ( front.length() <= original.length() )
     {
-        SetActualValue( front + original.SubString(to, original.length()) );
+        SetActualValue( front + original.substr(to, original.length()) );
     }
     else
     {
@@ -252,11 +259,11 @@ void wxComboBox::Clear()
 
 void wxComboBox::SetSelection( long from, long to )
 {
-    if( from == -1 )
+    if ( from == -1 )
     {
         from = 0;
     }
-    if( to == -1 )
+    if ( to == -1 )
     {
         to = GetValue().length();
     }

--- a/src/qt/combobox.cpp
+++ b/src/qt/combobox.cpp
@@ -13,8 +13,16 @@
 #include "wx/qt/private/converter.h"
 #include "wx/qt/private/winevent.h"
 
+#include <QtCore/QSortFilterProxyModel>
 #include <QtWidgets/QComboBox>
 #include <QtWidgets/QLineEdit>
+
+
+class LexicalSortProxyModel : public QSortFilterProxyModel
+{
+    public:
+        bool lessThan(const QModelIndex &left, const QModelIndex &right) const;
+};
 
 class wxQtComboBox : public wxQtEventSignalHandler< QComboBox, wxComboBox >
 {
@@ -128,6 +136,8 @@ bool wxComboBox::Create(wxWindow *parent, wxWindowID id,
             const wxString& name )
 {
     m_qtComboBox = new wxQtComboBox( parent, this );
+    InitialiseSort(m_qtComboBox);
+
     while ( n-- > 0 )
         m_qtComboBox->addItem( wxQtConvertString( *choices++ ));
     m_qtComboBox->setEditText( wxQtConvertString( value ));
@@ -140,7 +150,10 @@ void wxComboBox::SetValue(const wxString& value)
     if ( HasFlag(wxCB_READONLY) )
         SetStringSelection(value);
     else
+    {
         wxTextEntry::SetValue(value);
+        m_qtComboBox->setEditText( wxQtConvertString(value) );
+    }
 }
 
 wxString wxComboBox::DoGetValue() const

--- a/src/qt/combobox.cpp
+++ b/src/qt/combobox.cpp
@@ -226,8 +226,7 @@ void wxComboBox::Replace(long from, long to, const wxString &value)
 
 void wxComboBox::WriteText(const wxString &value)
 {
-    long point = GetInsertionPoint();
-    Replace( point, point, value );
+    m_qtComboBox->lineEdit()->insert( wxQtConvertString( value ) );
 }
 
 wxString wxComboBox::DoGetValue() const

--- a/src/qt/textentry.cpp
+++ b/src/qt/textentry.cpp
@@ -20,9 +20,11 @@ void wxTextEntry::WriteText(const wxString& WXUNUSED(text))
 
 void wxTextEntry::Remove(long from, long to)
 {
+    const long insertionPoint = GetInsertionPoint();
     wxString string = GetValue();
     string.erase(from, to - from);
     SetValue(string);
+    SetInsertionPoint( std::min(insertionPoint, static_cast<long>(string.length())) );
 }
 
 void wxTextEntry::Copy()

--- a/src/qt/textentry.cpp
+++ b/src/qt/textentry.cpp
@@ -24,7 +24,8 @@ void wxTextEntry::Remove(long from, long to)
     wxString string = GetValue();
     string.erase(from, to - from);
     SetValue(string);
-    SetInsertionPoint( std::min(insertionPoint, static_cast<long>(string.length())) );
+    SetInsertionPoint(std::min(insertionPoint,
+                               static_cast<long>(string.length())));
 }
 
 void wxTextEntry::Copy()

--- a/tests/controls/textentrytest.cpp
+++ b/tests/controls/textentrytest.cpp
@@ -280,7 +280,6 @@ void TextEntryTestCase::Editable()
     CPPUNIT_ASSERT_EQUAL("abcdef", entry->GetValue());
     CPPUNIT_ASSERT_EQUAL(6, updated.GetCount());
 
-
     // And that the event carries the right value.
     TextEventHandler handler(window);
 
@@ -326,7 +325,7 @@ void TextEntryTestCase::CopyPaste()
     entry->AppendText("sometext");
     entry->SelectAll();
 
-    if(entry->CanCopy() && entry->CanPaste())
+    if ( entry->CanCopy() && entry->CanPaste() )
     {
         entry->Copy();
         entry->Clear();
@@ -346,12 +345,12 @@ void TextEntryTestCase::UndoRedo()
 
     entry->AppendText("sometext");
 
-    if(entry->CanUndo())
+    if ( entry->CanUndo() )
     {
         entry->Undo();
         CPPUNIT_ASSERT(entry->IsEmpty());
 
-        if(entry->CanRedo())
+        if ( entry->CanRedo() )
         {
             entry->Redo();
             CPPUNIT_ASSERT_EQUAL("sometext", entry->GetValue());

--- a/tests/controls/textentrytest.cpp
+++ b/tests/controls/textentrytest.cpp
@@ -201,6 +201,28 @@ void TextEntryTestCase::Replace()
     CPPUNIT_ASSERT_EQUAL(2, entry->GetInsertionPoint());
 }
 
+void TextEntryTestCase::WriteText()
+{
+    wxTextEntry * const entry = GetTestEntry();
+
+    entry->SetValue("foo");
+    entry->SetInsertionPoint(3);
+    entry->WriteText("bar");
+    CPPUNIT_ASSERT_EQUAL( "foobar", entry->GetValue() );
+
+    entry->SetValue("foo");
+    entry->SetInsertionPoint(0);
+    entry->WriteText("bar");
+    CPPUNIT_ASSERT_EQUAL( "barfoo", entry->GetValue() );
+
+    entry->SetValue("abxxxhi");
+    entry->SetSelection(2, 5);
+    entry->WriteText("cdefg");
+    CPPUNIT_ASSERT_EQUAL( "abcdefghi", entry->GetValue() );
+    CPPUNIT_ASSERT_EQUAL( 7, entry->GetInsertionPoint() );
+    CPPUNIT_ASSERT_EQUAL( false, entry->HasSelection() );
+}
+
 #if wxUSE_UIACTIONSIMULATOR
 
 class TextEventHandler

--- a/tests/controls/textentrytest.h
+++ b/tests/controls/textentrytest.h
@@ -44,7 +44,8 @@ protected:
         WXUISIM_TEST( Editable ); \
         CPPUNIT_TEST( Hint ); \
         CPPUNIT_TEST( CopyPaste ); \
-        CPPUNIT_TEST( UndoRedo )
+        CPPUNIT_TEST( UndoRedo ); \
+        CPPUNIT_TEST( WriteText )
 
     void SetValue();
     void TextChangeEvents();
@@ -55,6 +56,7 @@ protected:
     void Hint();
     void CopyPaste();
     void UndoRedo();
+    void WriteText();
 
 private:
     // Selection() test helper: verify that selection is as described by the


### PR DESCRIPTION
Fix sort ordering in wxQt dropdown classes, i.e. combobox/choice. Fix an existing bug in wxQt implementation of wxTextCtrl, which is related to combobox and choice through wxTextEntry. Remove RTTI from initial implementation, and apply coding style guidelines.