### PR TITLE
[Qt] wxListBox selection improvements

### DIFF
--- a/include/wx/qt/listbox.h
+++ b/include/wx/qt/listbox.h
@@ -49,8 +49,8 @@ public:
                 const wxValidator& validator = wxDefaultValidator,
                 const wxString& name = wxListBoxNameStr);
 
-    virtual bool IsSelected(int n) const;
-    virtual int GetSelections(wxArrayInt& aSelections) const;
+    virtual bool IsSelected(int n) const wxOVERRIDE;
+    virtual int GetSelections(wxArrayInt& aSelections) const wxOVERRIDE;
     
     virtual unsigned int GetCount() const;
     virtual wxString GetString(unsigned int n) const;
@@ -63,9 +63,9 @@ public:
     void QtSendEvent(wxEventType evtType, const QModelIndex &index, bool selected);
 
 protected:
-    virtual void DoSetFirstItem(int n);
+    virtual void DoSetFirstItem(int n) wxOVERRIDE;
 
-    virtual void DoSetSelection(int n, bool select);
+    virtual void DoSetSelection(int n, bool select) wxOVERRIDE;
     
     virtual int DoInsertItems(const wxArrayStringsAdapter & items,
                               unsigned int pos,

--- a/include/wx/qt/listbox.h
+++ b/include/wx/qt/listbox.h
@@ -90,6 +90,7 @@ protected:
 private:
     virtual void Init(); //common construction
 
+    void setStyle(long style);
     void UnSelectAll();
 
     wxDECLARE_DYNAMIC_CLASS(wxListBox);

--- a/src/qt/listbox.cpp
+++ b/src/qt/listbox.cpp
@@ -90,10 +90,7 @@ bool wxListBox::Create(wxWindow *parent, wxWindowID id,
     QListWidgetItem* item;
     m_qtWindow = m_qtListWidget = new wxQtListWidget( parent, this );
 
-    if ( style == wxLB_SORT )
-    {
-        m_qtListWidget->setSortingEnabled(true);
-    }
+    setStyle(style);
 
     while ( n-- > 0 )
     {
@@ -120,6 +117,8 @@ bool wxListBox::Create(wxWindow *parent, wxWindowID id,
     Init();
     m_qtWindow = m_qtListWidget = new wxQtListWidget( parent, this );
 
+    setStyle(style);
+
     QStringList items;
 
     for (size_t i = 0; i < choices.size(); ++i)
@@ -128,6 +127,27 @@ bool wxListBox::Create(wxWindow *parent, wxWindowID id,
     m_qtListWidget->addItems(items);
 
     return wxListBoxBase::Create( parent, id, pos, size, style, validator, name );
+}
+
+void wxListBox::setStyle(long style)
+{
+    if ( style & wxLB_SORT )
+    {
+        m_qtListWidget->setSortingEnabled(true);
+    }
+
+    if ( style & wxLB_SINGLE )
+    {
+        m_qtListWidget->setSelectionMode(QAbstractItemView::SingleSelection);
+    }
+    else if ( style & wxLB_MULTIPLE )
+    {
+        m_qtListWidget->setSelectionMode(QAbstractItemView::MultiSelection);
+    }
+    else if ( style & wxLB_EXTENDED )
+    {
+        wxMISSING_IMPLEMENTATION( wxSTRINGIZE( wxLB_EXTENDED ));
+    }
 }
 
 void wxListBox::Init()

--- a/src/qt/listbox.cpp
+++ b/src/qt/listbox.cpp
@@ -136,6 +136,7 @@ void wxListBox::setStyle(long style)
         m_qtListWidget->setSortingEnabled(true);
     }
 
+    // The following styles are mutually exclusive
     if ( style & wxLB_SINGLE )
     {
         m_qtListWidget->setSelectionMode(QAbstractItemView::SingleSelection);

--- a/src/qt/listbox.cpp
+++ b/src/qt/listbox.cpp
@@ -207,15 +207,10 @@ int wxListBox::GetSelection() const
         return wxNOT_FOUND;
     }
 
-    for ( unsigned int i = 0; i < GetCount(); ++i)
-    {
-        if( m_qtListWidget->item(i) == m_qtListWidget->selectedItems().first() )
-        {
-            return i;
-        }
-    }
 
-    return wxNOT_FOUND;
+    QListWidgetItem* item = m_qtListWidget->selectedItems().first();
+
+    return m_qtListWidget->row(item);
 }
 
 void wxListBox::DoSetFirstItem(int WXUNUSED(n))

--- a/src/qt/listbox.cpp
+++ b/src/qt/listbox.cpp
@@ -167,10 +167,9 @@ int wxListBox::GetSelections(wxArrayInt& aSelections) const
 {
     aSelections.clear();
 
-    for ( unsigned int i = 0; i < GetCount(); ++i)
+    Q_FOREACH(QListWidgetItem* l, m_qtListWidget->selectedItems())
     {
-        if ( IsSelected(i) )
-            aSelections.push_back(i);
+        aSelections.push_back( m_qtListWidget->row(l) );
     }
 
     return aSelections.size();
@@ -299,9 +298,8 @@ QScrollArea *wxListBox::QtGetScrollBarsContainer() const
 
 void wxListBox::UnSelectAll()
 {
-    for ( unsigned int i = 0; i < GetCount(); ++i )
+    Q_FOREACH(QListWidgetItem* l, m_qtListWidget->selectedItems())
     {
-        if ( IsSelected(i) )
-            DoSetSelection(i, false);
+        m_qtListWidget->setItemSelected( l, false );
     }
 }

--- a/src/qt/listbox.cpp
+++ b/src/qt/listbox.cpp
@@ -202,7 +202,20 @@ void wxListBox::SetString(unsigned int n, const wxString& s)
 
 int wxListBox::GetSelection() const
 {
-    return m_qtListWidget->currentIndex().row();
+    if ( m_qtListWidget->selectedItems().empty() )
+    {
+        return wxNOT_FOUND;
+    }
+
+    for ( unsigned int i = 0; i < GetCount(); ++i)
+    {
+        if( m_qtListWidget->item(i) == m_qtListWidget->selectedItems().first() )
+        {
+            return i;
+        }
+    }
+
+    return wxNOT_FOUND;
 }
 
 void wxListBox::DoSetFirstItem(int WXUNUSED(n))
@@ -217,7 +230,7 @@ void wxListBox::DoSetSelection(int n, bool select)
         return;
     }
 
-    return m_qtListWidget->setCurrentRow(n, select ? QItemSelectionModel::Select : QItemSelectionModel::Deselect );
+    m_qtListWidget->setItemSelected( m_qtListWidget->item(n), select);
 }
 
 int wxListBox::DoInsertItems(const wxArrayStringsAdapter & items,


### PR DESCRIPTION
This PR includes the following changes:

- Now using QListWidget's `setItemSelected` and `selectedItems' methods to set and get selected QListWidgetItems rather than the old way which was a mix of `currentIndex` and `currentRow`.

- Improvements to setting the correct style.
 
- General tidy up.

In addition this change now passes the  `RearrangeListTestCase::SelectionAfterDelete` test.