### PR TITLE
Prevent a signal from being generated by wxChoice::SetSelection 

### DIFF
--- a/src/qt/choice.cpp
+++ b/src/qt/choice.cpp
@@ -127,9 +127,8 @@ void wxChoice::SetString(unsigned int n, const wxString& s)
 
 void wxChoice::SetSelection(int n)
 {
-    m_qtComboBox->blockSignals(true);
+    QSignalBlocker signalBlocker(m_qtComboBox);
     m_qtComboBox->setCurrentIndex(n);
-    m_qtComboBox->blockSignals(false);
 }
 
 int wxChoice::GetSelection() const

--- a/src/qt/choice.cpp
+++ b/src/qt/choice.cpp
@@ -127,7 +127,9 @@ void wxChoice::SetString(unsigned int n, const wxString& s)
 
 void wxChoice::SetSelection(int n)
 {
+    m_qtComboBox->blockSignals(true);
     m_qtComboBox->setCurrentIndex(n);
+    m_qtComboBox->blockSignals(false);
 }
 
 int wxChoice::GetSelection() const


### PR DESCRIPTION
This prevents a crash under QT 5.6.0 