### PR TITLE
[Qt] Add default parameter to wxDialog Show method

### DIFF
--- a/include/wx/qt/dialog.h
+++ b/include/wx/qt/dialog.h
@@ -34,7 +34,7 @@ public:
     virtual int ShowModal() wxOVERRIDE;
     virtual void EndModal(int retCode) wxOVERRIDE;
     virtual bool IsModal() const wxOVERRIDE;
-    virtual bool Show(bool show) wxOVERRIDE;
+    virtual bool Show(bool show = true) wxOVERRIDE;
 
     QDialog *GetDialogHandle() const;
 


### PR DESCRIPTION
The `Show` method in the Qt implementation of wxDialog overrides the wxWindowBase method  but lacks a default value to match that of the base method. A derived class does not get the default arguments from the function it overrides. 