### PR TITLE
Fix expanding window bug when de-docking in wxQt.

### DIFF
--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -907,7 +907,7 @@ void wxWindowQt::DoSetSize(int x, int y, int width, int height, int sizeFlags )
     }
 
     int w, h;
-    GetSize(&w, &h);
+    DoGetClientSize(&w, &h);
     if (width == -1)
         width = w;
     if (height == -1)


### PR DESCRIPTION
In situations where we have docked windows, such as in the aui sample program, de-docking would produce a runaway expansion of the newly removed window. This change prevents that problem.