### PR TITLE
Add event to wxSpinCtrlDouble under wxQt

### DIFF
--- a/src/qt/spinctrl.cpp
+++ b/src/qt/spinctrl.cpp
@@ -162,8 +162,24 @@ class wxQtDoubleSpinBox : public wxQtSpinBoxBase< QDoubleSpinBox >
 public:
     wxQtDoubleSpinBox( wxWindow *parent, wxControl *handler )
         : wxQtSpinBoxBase< QDoubleSpinBox >( parent, handler )
-    { }
+    {
+        connect(this, static_cast<void (QDoubleSpinBox::*)(double value)>(&QDoubleSpinBox::valueChanged),
+                this, &wxQtDoubleSpinBox::valueChanged);
+    }
+private:
+    void valueChanged(double value);
 };
+
+void wxQtDoubleSpinBox::valueChanged(double value)
+{
+    wxControl *handler = GetHandler();
+    if ( handler )
+    {
+        wxSpinDoubleEvent event( wxEVT_SPINCTRLDOUBLE, handler->GetId() );
+        event.SetValue(value);
+        EmitEvent( event );
+    }
+}
 
 
 //##############################################################################


### PR DESCRIPTION
Finished implementation of wxQtDoubleSpinBox so that it sends events for value changes.