### PR TITLE
 more event loop improvements for wxQT

### DIFF
--- a/include/wx/qt/evtloop.h
+++ b/include/wx/qt/evtloop.h
@@ -8,7 +8,7 @@
 #ifndef _WX_QT_EVTLOOP_H_
 #define _WX_QT_EVTLOOP_H_
 
-class QTimer;
+class wxQtIdleTimer;
 class QEventLoop;
 
 class WXDLLIMPEXP_CORE wxQtEventLoopBase : public wxEventLoopBase
@@ -30,12 +30,11 @@ public:
 #if wxUSE_EVENTLOOP_SOURCE
     virtual wxEventLoopSource *AddSourceForFD(int fd, wxEventLoopSourceHandler *handler, int flags);
 #endif // wxUSE_EVENTLOOP_SOURCE
-protected:
 
 private:
     QEventLoop *m_qtEventLoop;
-    QTimer *m_qtIdleTimer;
-    
+    wxObjectDataPtr<wxQtIdleTimer> m_qtIdleTimer;
+
     wxDECLARE_NO_COPY_CLASS(wxQtEventLoopBase);
 };
 

--- a/src/qt/evtloop.cpp
+++ b/src/qt/evtloop.cpp
@@ -81,7 +81,7 @@ void wxQtIdleTimer::idle()
 
 namespace
 {
-    wxQtIdleTimer *gs_idleTimer = NULL;
+    wxObjectDataPtr<wxQtIdleTimer> gs_idleTimer;
 }
 
 void wxQtIdleTimer::ScheduleIdleCheck()
@@ -95,13 +95,7 @@ wxQtEventLoopBase::wxQtEventLoopBase()
 {
     // Create an idle timer to run each time there are no events (timeout = 0)
     if ( !gs_idleTimer )
-    {
-        gs_idleTimer = new wxQtIdleTimer();
-    }
-    else
-    {
-        gs_idleTimer->IncRef();
-    }
+        gs_idleTimer.reset(new wxQtIdleTimer());
 
     m_qtIdleTimer = gs_idleTimer;
     m_qtEventLoop = new QEventLoop;
@@ -109,8 +103,9 @@ wxQtEventLoopBase::wxQtEventLoopBase()
 
 wxQtEventLoopBase::~wxQtEventLoopBase()
 {
-    if ( gs_idleTimer->GetRefCount() <= 1 )
-        gs_idleTimer = NULL;
+    //Clear the shared timer if this is the only external reference to it
+    if ( gs_idleTimer->GetRefCount() <= 2 )
+        gs_idleTimer.reset(NULL);
 
     delete m_qtEventLoop;
 }

--- a/src/qt/evtloop.cpp
+++ b/src/qt/evtloop.cpp
@@ -141,13 +141,13 @@ void wxQtEventLoopBase::DoYieldFor(long eventsToProcess)
         flags |= QEventLoop::ExcludeSocketNotifiers;
 
     m_qtEventLoop->processEvents(flags);
-    
+
     wxEventLoopBase::DoYieldFor(eventsToProcess);
 }
 
 void wxQtEventLoopBase::ScheduleIdleCheck()
 {
-    if ( IsInsideRun() )
+    if ( IsInsideRun() && !m_shouldExit )
         m_qtIdleTimer->start(0);
 }
 

--- a/src/qt/evtloop.cpp
+++ b/src/qt/evtloop.cpp
@@ -131,10 +131,17 @@ void wxQtEventLoopBase::WakeUp()
 
 void wxQtEventLoopBase::DoYieldFor(long eventsToProcess)
 {
-    while (wxTheApp && wxTheApp->Pending())
-        // TODO: implement event filtering using the eventsToProcess mask
-        wxTheApp->Dispatch();
 
+    QEventLoop::ProcessEventsFlags flags = QEventLoop::AllEvents;
+
+    if ( !(eventsToProcess & wxEVT_CATEGORY_USER_INPUT) )
+        flags |= QEventLoop::ExcludeUserInputEvents;
+
+    if ( !(eventsToProcess & wxEVT_CATEGORY_SOCKET) )
+        flags |= QEventLoop::ExcludeSocketNotifiers;
+
+    m_qtEventLoop->processEvents(flags);
+    
     wxEventLoopBase::DoYieldFor(eventsToProcess);
 }
 


### PR DESCRIPTION
This PR improves the event loop by ensuring that only a single idle timer is ever used and ensures that YieldFor doesn't block the application (due to there always being a an active timer event pending). 