### PR TITLE
Refactor code waiting for events in the test suite

### DIFF
--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -26,6 +26,10 @@
 #include "wx/scopeguard.h"
 #include "wx/uiaction.h"
 
+#ifdef __WXGTK__
+    #include "wx/stopwatch.h"
+#endif
+
 #include "textentrytest.h"
 #include "testableframe.h"
 #include "asserthelper.h"

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -24,11 +24,11 @@
 #endif // WX_PRECOMP
 
 #include "wx/scopeguard.h"
+#include "wx/uiaction.h"
 
 #include "textentrytest.h"
 #include "testableframe.h"
 #include "asserthelper.h"
-#include "wx/uiaction.h"
 
 static const int TEXT_HEIGHT = 200;
 

--- a/tests/controls/webtest.cpp
+++ b/tests/controls/webtest.cpp
@@ -72,7 +72,7 @@ private:
 };
 
 //Convenience macro
-#define ENSURE_LOADED WX_ASSERT_EVENT_OCCURS_IN((*m_loaded), 1, 1000)
+#define ENSURE_LOADED CHECK( m_loaded->WaitEvent() )
 
 // register in the unnamed registry so that these tests are run by default
 CPPUNIT_TEST_SUITE_REGISTRATION( WebTestCase );

--- a/tests/controls/windowtest.cpp
+++ b/tests/controls/windowtest.cpp
@@ -152,7 +152,7 @@ void WindowTestCase::FocusEvent()
 
     m_window->SetFocus();
 
-    WX_ASSERT_EVENT_OCCURS_IN(setfocus, 1, 500);
+    CPPUNIT_ASSERT(setfocus.WaitEvent(500));
     CPPUNIT_ASSERT(m_window->HasFocus());
 
     wxButton* button = new wxButton(wxTheApp->GetTopWindow(), wxID_ANY);

--- a/tests/testableframe.cpp
+++ b/tests/testableframe.cpp
@@ -63,3 +63,26 @@ EventCounter::~EventCounter()
     m_frame = NULL;
     m_win = NULL;
 }
+
+bool EventCounter::WaitEvent(int timeInMs)
+{
+    static const int SINGLE_WAIT_DURATION = 50;
+
+    for ( int i = 0; i < timeInMs / SINGLE_WAIT_DURATION; ++i )
+    {
+        wxYield();
+
+        const int count = GetCount();
+        if ( count )
+        {
+            CHECK( count == 1 );
+
+            Clear();
+            return true;
+        }
+
+        wxMilliSleep(SINGLE_WAIT_DURATION);
+    }
+
+    return false;
+}

--- a/tests/testableframe.h
+++ b/tests/testableframe.h
@@ -35,6 +35,13 @@ public:
     int GetCount() { return m_frame->GetEventCount(m_type); }
     void Clear() { m_frame->ClearEventCount(m_type); }
 
+    // Sometimes we need to yield a few times before getting the event we
+    // expect, so provide a function waiting for the expected event for up to
+    // the given number of milliseconds (supposed to be divisible by 50).
+    //
+    // Return true if we did receive the event or false otherwise.
+    bool WaitEvent(int timeInMs = 1000);
+
 private:
     wxEventType m_type;
     wxTestableFrame* m_frame;

--- a/tests/testprec.h
+++ b/tests/testprec.h
@@ -2,7 +2,6 @@
 #define WX_TESTPREC_INCLUDED 1
 
 #include "wx/wxprec.h"
-#include "wx/stopwatch.h"
 #include "wx/evtloop.h"
 
 // This needs to be included before catch.hpp to be taken into account.
@@ -107,27 +106,6 @@ public:
     // wxDEBUG_LEVEL == 0 case, so just don't do anything at all now).
     #define WX_ASSERT_FAILS_WITH_ASSERT(cond)
 #endif
-
-#define WX_ASSERT_EVENT_OCCURS_IN(eventcounter, count, ms) \
-{\
-    wxStopWatch sw; \
-    wxEventLoopBase* loop = wxEventLoopBase::GetActive(); \
-    while(eventcounter.GetCount() < count) \
-    { \
-        if(sw.Time() < ms) \
-            loop->Dispatch(); \
-        else \
-        { \
-            CPPUNIT_FAIL(wxString::Format("timeout reached with %d " \
-                                          "events received, %d expected", \
-                                          eventcounter.GetCount(), count).ToStdString()); \
-            break; \
-        } \
-    } \
-    eventcounter.Clear(); \
-}
-
-#define WX_ASSERT_EVENT_OCCURS(eventcounter,count) WX_ASSERT_EVENT_OCCURS_IN(eventcounter, count, 100)
 
 // these functions can be used to hook into wxApp event processing and are
 // currently used by the events propagation test

--- a/tests/toplevel/toplevel.cpp
+++ b/tests/toplevel/toplevel.cpp
@@ -88,19 +88,5 @@ TEST_CASE("wxTopLevel::ShowEvent", "[tlw][show][event]")
     frame->Maximize();
     frame->Show();
 
-    // Wait for the event to be received for the maximum of 2 seconds.
-    int showCount = 0;
-    for ( int i = 0; i < 40; i++ )
-    {
-        wxYield();
-
-        showCount = countShow.GetCount();
-
-        if ( showCount )
-            break;
-
-        wxMilliSleep(50);
-    }
-
-    CHECK( showCount == 1 );
+    CHECK( countShow.WaitEvent() );
 }


### PR DESCRIPTION
We already had WX_ASSERT_EVENT_OCCURS_IN macro and a recent commit also
added code doing almost the same thing manually in wxTopLevelWindow unit
test, which was one version too many.

Replace both of them with the new EventCounter::WaitEvent().

No real changes, this is just a refactoring.