### PR TITLE
[Qt] wxListCtrl FindItem and GetItemText fixes

### DIFF
--- a/include/wx/qt/listctrl.h
+++ b/include/wx/qt/listctrl.h
@@ -292,7 +292,7 @@ protected:
     void Init();
 
     // Implement base class pure virtual methods.
-    long DoInsertColumn(long col, const wxListItem& info);
+    virtual long DoInsertColumn(long col, const wxListItem& info) wxOVERRIDE;
 
     QTreeWidgetItem *QtGetItem(int id) const;
 

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -413,11 +413,11 @@ bool wxListCtrl::SetItemColumnImage(long item, long column, int image)
     return SetItem(info);
 }
 
-wxString wxListCtrl::GetItemText(long item, int WXUNUSED(col)) const
+wxString wxListCtrl::GetItemText(long item, int col) const
 {
     QTreeWidgetItem *qitem = QtGetItem(item);
     if ( qitem )
-        return wxQtConvertString( qitem->text(0) );
+        return wxQtConvertString( qitem->text(col) );
     else
         return wxString();
 }

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -762,7 +762,7 @@ long wxListCtrl::FindItem(long start, const wxString& str, bool partial)
                 !partial ? Qt::MatchExactly : Qt::MatchContains );
     for (int i=0; i<qitems.length(); i++)
     {
-        ret = m_qtTreeWidget->indexOfTopLevelItem(qitems.at(0));
+        ret = m_qtTreeWidget->indexOfTopLevelItem(qitems.at(i));
         if ( ret >= start )
             return ret;
     }


### PR DESCRIPTION
- The FindItem method previously iterated through all the items but only used the first item to search against.
- The GetItemText now used the column to properly get the correct text from the QTreeWidgetItem

These fix the ItemText and Find tests of the ListViewTestCase.