### PR TITLE
[Qt] event object not set when generating wxEVT_CHAR

### DIFF
--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -1225,6 +1225,7 @@ bool wxWindowQt::QtHandleKeyEvent ( QWidget *WXUNUSED( handler ), QKeyEvent *eve
 
     // Build the event
     wxKeyEvent e( event->type() == QEvent::KeyPress ? wxEVT_KEY_DOWN : wxEVT_KEY_UP );
+    e.SetEventObject(this);
     // TODO: m_x, m_y
     e.m_keyCode = wxQtConvertKeyCode( event->key(), event->modifiers() );
 

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -1267,6 +1267,7 @@ bool wxWindowQt::QtHandleKeyEvent ( QWidget *WXUNUSED( handler ), QKeyEvent *eve
 #endif // wxUSE_ACCEL
 
         e.SetEventType( wxEVT_CHAR );
+        e.SetEventObject(this);
 
         // Translated key code (including control + letter -> 1-26)
         int translated = 0;


### PR DESCRIPTION
`wxTextValidator` & `wxNumValidator` not doing any filtering at all.

**Cause:**

According to  [How Events are Processed](https://docs.wxwidgets.org/3.0/overview_events.html):

2. If the object is a `wxWindow` and has an associated validator, `wxValidator` gets a chance to process the event.

...and without the event object being set to the window generating the event, the associated validator won't get any chance to process the event first.

Let me know if we should call `SetEventObject()` in other places, (wxWindowQt::QtHandleFocusEvent(), maybe?), Thank you!