### PR TITLE
Updated manner in which QWidgets are painted in the DC client.

### DIFF
--- a/src/qt/dcclient.cpp
+++ b/src/qt/dcclient.cpp
@@ -106,7 +106,7 @@ wxClientDCImpl::~wxClientDCImpl()
             if ( !pict->isNull() && !widget->paintingActive() && !rect.isEmpty() )
             {
                 // only force the update of the rect affected by the DC
-                widget->repaint( rect );
+                widget->update( rect );
             }
             else
             {


### PR DESCRIPTION
The current mechanism for handling repaints was functional, however we were seeing a LOT of QWarnings being printed to the screen when resizing windows in the samples (e.g. caret):

**QPainter::begin: Painter already active
QWidget::repaint: Recursive repaint detected**

The QT5 documentation for `void QWidget::repaint()` suggests that:  "_...we should only use `repaint` for an immediate repaint, for example during animation. In almost all circumstances `update()` is better, as it permits Qt to optimize for speed and minimize flicker._"

Replacing the call to repaint with update ensures the QWarnings are no longer printed out.