### PR TITLE
Track QT Tab widget selection when adding pages to wxNotebook

### DIFF
--- a/src/qt/notebook.cpp
+++ b/src/qt/notebook.cpp
@@ -154,6 +154,7 @@ bool wxNotebook::InsertPage(size_t n, wxWindow *page, const wxString& text,
 
     // reenable firing qt signals as internal wx initialization was completed
     m_qtTabWidget->blockSignals(false);
+    m_selection = m_qtTabWidget->currentIndex();
 
     if (bSelect && GetPageCount() > 1)
     {


### PR DESCRIPTION
When adding pages to a wxNotebook under wxQT,  the base class field m_selection was not updated to match the state of the m_qTabWidget.   

So for example, adding 2 pages to a notebook without explicitly selecting a page will result in the user seeing the first page but wxNotebook::GetSelection returning wxNOT_FOUND