### PR TITLE
Track QT Tab widget selection when adding pages to wxNotebook

### DIFF
--- a/src/qt/notebook.cpp
+++ b/src/qt/notebook.cpp
@@ -154,6 +154,7 @@ bool wxNotebook::InsertPage(size_t n, wxWindow *page, const wxString& text,
 
     // reenable firing qt signals as internal wx initialization was completed
     m_qtTabWidget->blockSignals(false);
+    m_selection = m_qtTabWidget->currentIndex();
 
     if (bSelect && GetPageCount() > 1)
     {


### PR DESCRIPTION
Ensure the selected state tracks the QT selection without this, if pages are added and no explicit selection is made, wxNotebook::GetSelection returns wxNOT_FOUND even though the first page is selected.