### PR TITLE
Improve the wxDateTime::SetToWeekDay documentation

### DIFF
--- a/interface/wx/datetime.h
+++ b/interface/wx/datetime.h
@@ -1166,6 +1166,10 @@ public:
         SetToWeekDay(wxDateTime::Sun, -1) will set the date to the last Sunday
         in the current month.
 
+        Note that leaving the month or year parameters as their default values
+        will result in the current month or year being substituted, overwriting
+        any previous values in the wxDateTime object.
+
         @return @true if the date was modified successfully, @false otherwise
                  meaning that the specified date doesn't exist.
     */

--- a/interface/wx/datetime.h
+++ b/interface/wx/datetime.h
@@ -1161,9 +1161,9 @@ public:
         @a n may be either positive (counting from the beginning of the month)
         or negative (counting from the end of it).
 
-        For example, SetToWeekDay(2, wxDateTime::Wed) will set the date to the
+        For example, SetToWeekDay(wxDateTime::Wed, 2) will set the date to the
         second Wednesday in the current month and
-        SetToWeekDay(-1, wxDateTime::Sun) will set the date to the last Sunday
+        SetToWeekDay(wxDateTime::Sun, -1) will set the date to the last Sunday
         in the current month.
 
         @return @true if the date was modified successfully, @false otherwise


### PR DESCRIPTION
Fix the order of parameters in the wxDateTime::SetToWeekDay examples, where Weekday and int are reversed.

Clarify the result of omitting the month or year parameters. At present it states: "the current month and year are used by default". That might be understood (it was by me!) to mean that any valid 'current' values in the wxDateTime object would be retained. In fact, they are overwritten by 'current' wxDateTime::Now values.