### PR TITLE
Fix sending of EVT_KEY_DOWN on wxGTK for non-ASCII characters

### DIFF
--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -1071,14 +1071,10 @@ wxTranslateGTKKeyEventToWx(wxKeyEvent& event,
 
     wxLogTrace(TRACE_KEYS, wxT("\t-> wxKeyCode %ld"), key_code);
 
-    // sending unknown key events doesn't really make sense
-    if ( !key_code )
-        return false;
-
     event.m_keyCode = key_code;
 
 #if wxUSE_UNICODE
-    event.m_uniChar = gdk_keyval_to_unicode(key_code);
+    event.m_uniChar = gdk_keyval_to_unicode(key_code ? key_code : gdk_event->keyval);
     if ( !event.m_uniChar && event.m_keyCode <= WXK_DELETE )
     {
         // Set Unicode key code to the ASCII equivalent for compatibility. E.g.
@@ -1087,6 +1083,10 @@ wxTranslateGTKKeyEventToWx(wxKeyEvent& event,
         event.m_uniChar = event.m_keyCode;
     }
 #endif // wxUSE_UNICODE
+
+    // sending unknown key events doesn't really make sense
+    if ( !key_code && !event.m_uniChar )
+        return false;
 
     // now fill all the other fields
     wxFillOtherKeyEventFields(event, win, gdk_event);


### PR DESCRIPTION
Instead of returning early if the keycode is invalid, try setting the unicode
character first, and if neither are valid, return.

Fixes #18054