### PR TITLE
Redo fix toplevel window test for wxQt

### DIFF
--- a/tests/toplevel/toplevel.cpp
+++ b/tests/toplevel/toplevel.cpp
@@ -31,6 +31,10 @@ static void TopLevelWindowShowTest(wxTopLevelWindow* tlw)
     CHECK(!tlw->IsShown());
 
     wxTextCtrl* textCtrl = new wxTextCtrl(tlw, -1, "test");
+#ifndef __WXGTK__
+    EventCounter countShow(textCtrl, wxEVT_ACTIVATE);
+#endif
+
     textCtrl->SetFocus();
 
 // only run this test on platforms where ShowWithoutActivating is implemented.
@@ -50,6 +54,7 @@ static void TopLevelWindowShowTest(wxTopLevelWindow* tlw)
     // wxGTK needs many event loop iterations before the TLW becomes active and
     // this doesn't happen in this test, so avoid checking for it.
 #ifndef __WXGTK__
+    countShow.WaitEvent();
     CHECK(tlw->IsActive());
 #endif
     CHECK(tlw->IsShown());

--- a/tests/toplevel/toplevel.cpp
+++ b/tests/toplevel/toplevel.cpp
@@ -31,9 +31,7 @@ static void TopLevelWindowShowTest(wxTopLevelWindow* tlw)
     CHECK(!tlw->IsShown());
 
     wxTextCtrl* textCtrl = new wxTextCtrl(tlw, -1, "test");
-#ifndef __WXGTK__
     EventCounter countShow(textCtrl, wxEVT_ACTIVATE);
-#endif
 
     textCtrl->SetFocus();
 
@@ -50,11 +48,11 @@ static void TopLevelWindowShowTest(wxTopLevelWindow* tlw)
 #endif
 
     tlw->Show(true);
+    countShow.WaitEvent();
 
     // wxGTK needs many event loop iterations before the TLW becomes active and
     // this doesn't happen in this test, so avoid checking for it.
 #ifndef __WXGTK__
-    countShow.WaitEvent();
     CHECK(tlw->IsActive());
 #endif
     CHECK(tlw->IsShown());

--- a/tests/toplevel/toplevel.cpp
+++ b/tests/toplevel/toplevel.cpp
@@ -31,7 +31,7 @@ static void TopLevelWindowShowTest(wxTopLevelWindow* tlw)
     CHECK(!tlw->IsShown());
 
     wxTextCtrl* textCtrl = new wxTextCtrl(tlw, -1, "test");
-    EventCounter countShow(textCtrl, wxEVT_ACTIVATE);
+    EventCounter countActivate(tlw, wxEVT_ACTIVATE);
 
     textCtrl->SetFocus();
 
@@ -48,7 +48,7 @@ static void TopLevelWindowShowTest(wxTopLevelWindow* tlw)
 #endif
 
     tlw->Show(true);
-    countShow.WaitEvent();
+    countActivate.WaitEvent();
 
     // wxGTK needs many event loop iterations before the TLW becomes active and
     // this doesn't happen in this test, so avoid checking for it.


### PR DESCRIPTION
This repeats the changes made in #1170, following the advice to use the new function WaitEvent(). I have no strong feelings about the ifndef block line 34. It will work on GTK doing EventCounter/WaitEvent. If you'd rather it be decluttered of this, just say.