### PR TITLE
Notify clients of initial selection change in wxNotebook for wxQT

### DIFF
--- a/include/wx/qt/notebook.h
+++ b/include/wx/qt/notebook.h
@@ -45,6 +45,8 @@ public:
     int SetSelection(size_t nPage) { return DoSetSelection(nPage, SetSelection_SendEvent); }
     int ChangeSelection(size_t nPage) { return DoSetSelection(nPage); }
 
+    virtual bool DeleteAllPages() wxOVERRIDE;
+
     virtual QWidget *GetHandle() const;
 
 protected:

--- a/src/qt/notebook.cpp
+++ b/src/qt/notebook.cpp
@@ -173,6 +173,17 @@ wxSize wxNotebook::CalcSizeFromPage(const wxSize& sizePage) const
     return sizePage;
 }
 
+bool wxNotebook::DeleteAllPages()
+{
+    if ( !wxNotebookBase::DeleteAllPages() )
+        return false;
+
+    m_qtTabWidget->blockSignals(true);
+    m_qtTabWidget->clear();
+    m_qtTabWidget->blockSignals(false);
+    return true;
+}
+
 int wxNotebook::DoSetSelection(size_t page, int flags)
 {
     wxCHECK_MSG(page < GetPageCount(), wxNOT_FOUND, "invalid notebook index");

--- a/src/qt/notebook.cpp
+++ b/src/qt/notebook.cpp
@@ -154,9 +154,13 @@ bool wxNotebook::InsertPage(size_t n, wxWindow *page, const wxString& text,
 
     // reenable firing qt signals as internal wx initialization was completed
     m_qtTabWidget->blockSignals(false);
-    m_selection = m_qtTabWidget->currentIndex();
 
-    if (bSelect && GetPageCount() > 1)
+    if ( m_selection == wxNOT_FOUND && GetPageCount() == 1 )
+    {
+        m_selection = m_qtTabWidget->currentIndex();
+        SendPageChangedEvent(m_selection, wxNOT_FOUND);
+    }
+    else if (bSelect && GetPageCount() > 1)
     {
         SetSelection( n );
     }

--- a/tests/controls/notebooktest.cpp
+++ b/tests/controls/notebooktest.cpp
@@ -45,10 +45,12 @@ private:
         CPPUNIT_TEST( Image );
         CPPUNIT_TEST( RowCount );
         CPPUNIT_TEST( NoEventsOnDestruction );
+        CPPUNIT_TEST( AddingInitialPageChangesSelection );
     CPPUNIT_TEST_SUITE_END();
 
     void RowCount();
     void NoEventsOnDestruction();
+    void AddingInitialPageChangesSelection();
 
     void OnPageChanged(wxNotebookEvent&) { m_numPageChanges++; }
 
@@ -116,6 +118,25 @@ void NotebookTestCase::NoEventsOnDestruction()
     m_notebook->Destroy();
     m_notebook = NULL;
     CHECK( m_numPageChanges == 1 );
+}
+
+void NotebookTestCase::AddingInitialPageChangesSelection()
+{
+    m_notebook->DeleteAllPages();
+    CHECK( m_notebook->GetSelection() == wxNOT_FOUND );
+
+    m_notebook->Bind(wxEVT_NOTEBOOK_PAGE_CHANGED,
+                     &NotebookTestCase::OnPageChanged, this);
+
+    wxPanel *first_panel = new wxPanel(m_notebook);
+    m_notebook->AddPage(first_panel, "Panel 1");
+    CHECK( m_numPageChanges == 1 );
+    CHECK( m_notebook->GetSelection() == 0);
+
+    wxPanel *second_panel = new wxPanel(m_notebook);
+    m_notebook->AddPage(second_panel, "Panel 2");
+    CHECK( m_numPageChanges == 1 );
+    CHECK( m_notebook->GetSelection() == 0);
 }
 
 #endif //wxUSE_NOTEBOOK


### PR DESCRIPTION
As a follow on from #1182.   wxNotebook now generates an event when the selection changes due to an initial page being added.  This makes the behaviour more consistent with the other ports.