### PR TITLE
Make wxRegEx copyable

### DIFF
--- a/include/wx/regex.h
+++ b/include/wx/regex.h
@@ -82,6 +82,9 @@ public:
         (void)Compile(expr, flags);
     }
 
+    wxRegEx(const wxRegEx& rhs);
+    wxRegEx &operator=(const wxRegEx& rhs);
+
     // return true if this is a valid compiled regular expression
     bool IsValid() const { return m_impl != NULL; }
 
@@ -151,11 +154,6 @@ private:
 
     // the real guts of this class
     wxRegExImpl *m_impl;
-
-    // as long as the class wxRegExImpl is not ref-counted,
-    // instances of the handle wxRegEx must not be copied.
-    wxRegEx(const wxRegEx&);
-    wxRegEx &operator=(const wxRegEx&);
 };
 
 #endif // wxUSE_REGEX

--- a/src/common/regex.cpp
+++ b/src/common/regex.cpp
@@ -148,7 +148,7 @@ typedef char wxRegChar;
 #endif
 
 // the real implementation of wxRegEx
-class wxRegExImpl
+class wxRegExImpl : public wxRefCounter
 {
 public:
     // ctor and dtor
@@ -627,22 +627,49 @@ void wxRegEx::Init()
     m_impl = NULL;
 }
 
+wxRegEx::wxRegEx(const wxRegEx& rhs)
+    : m_impl(rhs.m_impl)
+{
+    if ( m_impl )
+        m_impl->IncRef();
+}
+
+wxRegEx& wxRegEx::operator=(const wxRegEx& rhs)
+{
+    if ( this != &rhs )
+    {
+        if ( m_impl )
+            m_impl->DecRef();
+
+        m_impl = rhs.m_impl;
+
+        if ( m_impl )
+            m_impl->IncRef();
+    }
+
+    return *this;
+}
+
 wxRegEx::~wxRegEx()
 {
-    delete m_impl;
+    if ( m_impl )
+    {
+        m_impl->DecRef();
+        m_impl = NULL;
+    }
 }
 
 bool wxRegEx::Compile(const wxString& expr, int flags)
 {
-    if ( !m_impl )
-    {
-        m_impl = new wxRegExImpl;
-    }
+    if ( m_impl )
+        m_impl->DecRef();
+
+    m_impl = new wxRegExImpl;
 
     if ( !m_impl->Compile(expr, flags) )
     {
         // error message already given in wxRegExImpl::Compile
-        wxDELETE(m_impl);
+        m_impl->DecRef();
 
         return false;
     }


### PR DESCRIPTION
By making the handle `wxRegExImpl` a ref-counted class, `wxRegEx` now have value semantic.