### PR TITLE
Document wxHtmlCellEvent::GetMouseEvent()

### DIFF
--- a/interface/wx/html/htmlwin.h
+++ b/interface/wx/html/htmlwin.h
@@ -622,6 +622,11 @@ public:
     wxPoint GetPoint() const;
 
     /**
+        Returns the wxMouseEvent associated with the event.
+    */
+    wxMouseEvent GetMouseEvent() const;
+
+    /**
         Call this function with @a linkclicked set to @true if the cell which has
         been clicked contained a link or @false otherwise (which is the default).
 


### PR DESCRIPTION
I couldn't see any reason for this not to be documented and we've got a user over in Phoenix (https://github.com/wxWidgets/Phoenix/issues/1147).

Backport requested.  :)