### PR TITLE
Make wxRegEx copyable

### DIFF
--- a/include/wx/regex.h
+++ b/include/wx/regex.h
@@ -153,7 +153,7 @@ private:
     void Init();
 
     // Return true if Matches() was called for this object.
-    bool IsValidObject() const;
+    bool IsActiveObject() const;
 
     // the real guts of this class
     wxRegExImpl *m_impl;

--- a/include/wx/regex.h
+++ b/include/wx/regex.h
@@ -152,6 +152,9 @@ private:
     // common part of all ctors
     void Init();
 
+    // Return true if Matches() was called for this object.
+    bool IsValidObject() const;
+
     // the real guts of this class
     wxRegExImpl *m_impl;
 };

--- a/include/wx/regex.h
+++ b/include/wx/regex.h
@@ -82,6 +82,9 @@ public:
         (void)Compile(expr, flags);
     }
 
+    wxRegEx(const wxRegEx& rhs);
+    wxRegEx &operator=(const wxRegEx& rhs);
+
     // return true if this is a valid compiled regular expression
     bool IsValid() const { return m_impl != NULL; }
 
@@ -151,11 +154,6 @@ private:
 
     // the real guts of this class
     wxRegExImpl *m_impl;
-
-    // as long as the class wxRegExImpl is not ref-counted,
-    // instances of the handle wxRegEx must not be copied.
-    wxRegEx(const wxRegEx&);
-    wxRegEx &operator=(const wxRegEx&);
 };
 
 #endif // wxUSE_REGEX

--- a/src/common/regex.cpp
+++ b/src/common/regex.cpp
@@ -661,6 +661,9 @@ wxRegEx::~wxRegEx()
 {
     if ( m_impl )
     {
+        if ( IsValidObject() )
+            m_impl->SetObject(0u);
+
         m_impl->DecRef();
         m_impl = NULL;
     }

--- a/src/common/regex.cpp
+++ b/src/common/regex.cpp
@@ -670,6 +670,7 @@ bool wxRegEx::Compile(const wxString& expr, int flags)
     {
         // error message already given in wxRegExImpl::Compile
         m_impl->DecRef();
+        m_impl = NULL;
 
         return false;
     }

--- a/src/common/regex.cpp
+++ b/src/common/regex.cpp
@@ -167,8 +167,8 @@ public:
     int Replace(wxString *pattern, const wxString& replacement,
                 size_t maxMatches = 0) const;
 
-    void SetObject(wxUIntPtr obj) { m_obj = obj; }
-    bool IsValidObject(wxUIntPtr obj) const { return m_obj == obj; }
+    void SetActiveObject(wxUIntPtr obj) { m_obj = obj; }
+    bool IsActiveObject(wxUIntPtr obj) const { return m_obj == obj; }
 
 private:
     // return the string containing the error message for the given err code
@@ -661,18 +661,18 @@ wxRegEx::~wxRegEx()
 {
     if ( m_impl )
     {
-        if ( IsValidObject() )
-            m_impl->SetObject(0u);
+        if ( IsActiveObject() )
+            m_impl->SetActiveObject(0u);
 
         m_impl->DecRef();
         m_impl = NULL;
     }
 }
 
-bool wxRegEx::IsValidObject() const
+bool wxRegEx::IsActiveObject() const
 {
     // This will be called after IsValid() return true.
-    return m_impl->IsValidObject(wxPtrToUInt(this));
+    return m_impl->IsActiveObject(wxPtrToUInt(this));
 }
 
 bool wxRegEx::Compile(const wxString& expr, int flags)
@@ -699,7 +699,7 @@ bool wxRegEx::Matches(const wxString& str, int flags) const
     wxCHECK_MSG( IsValid(), false, wxT("must successfully Compile() first") );
 
     // Register the object which most recently called Matches().
-    m_impl->SetObject(wxPtrToUInt(this));
+    m_impl->SetActiveObject(wxPtrToUInt(this));
 
     return m_impl->Matches(WXREGEX_CHAR(str), flags
                             WXREGEX_IF_NEED_LEN(str.length()));
@@ -708,7 +708,7 @@ bool wxRegEx::Matches(const wxString& str, int flags) const
 bool wxRegEx::GetMatch(size_t *start, size_t *len, size_t index) const
 {
     wxCHECK_MSG( IsValid(), false, wxT("must successfully Compile() first") );
-    wxCHECK_MSG( IsValidObject(), false, "must call Matches() first" );
+    wxCHECK_MSG( IsActiveObject(), false, "must call Matches() first" );
 
     return m_impl->GetMatch(start, len, index);
 }
@@ -725,7 +725,7 @@ wxString wxRegEx::GetMatch(const wxString& text, size_t index) const
 size_t wxRegEx::GetMatchCount() const
 {
     wxCHECK_MSG( IsValid(), 0, wxT("must successfully Compile() first") );
-    wxCHECK_MSG( IsValidObject(), 0, "must call Matches() first" );
+    wxCHECK_MSG( IsActiveObject(), 0, "must call Matches() first" );
 
     return m_impl->GetMatchCount();
 }
@@ -735,7 +735,7 @@ int wxRegEx::Replace(wxString *pattern,
                      size_t maxMatches) const
 {
     wxCHECK_MSG( IsValid(), wxNOT_FOUND, wxT("must successfully Compile() first") );
-    wxCHECK_MSG( IsValidObject(), wxNOT_FOUND, "must call Matches() first" );
+    wxCHECK_MSG( IsActiveObject(), wxNOT_FOUND, "must call Matches() first" );
 
     return m_impl->Replace(pattern, replacement, maxMatches);
 }

--- a/src/common/regex.cpp
+++ b/src/common/regex.cpp
@@ -148,7 +148,7 @@ typedef char wxRegChar;
 #endif
 
 // the real implementation of wxRegEx
-class wxRegExImpl
+class wxRegExImpl : public wxRefCounter
 {
 public:
     // ctor and dtor
@@ -627,22 +627,49 @@ void wxRegEx::Init()
     m_impl = NULL;
 }
 
+wxRegEx::wxRegEx(const wxRegEx& rhs)
+    : m_impl(rhs.m_impl)
+{
+    if ( m_impl )
+        m_impl->IncRef();
+}
+
+wxRegEx& wxRegEx::operator=(const wxRegEx& rhs)
+{
+    if ( this != &rhs )
+    {
+        if ( m_impl )
+            m_impl->DecRef();
+
+        m_impl = rhs.m_impl;
+
+        if ( m_impl )
+            m_impl->IncRef();
+    }
+
+    return *this;
+}
+
 wxRegEx::~wxRegEx()
 {
-    delete m_impl;
+    if ( m_impl )
+    {
+        m_impl->DecRef();
+        m_impl = NULL;
+    }
 }
 
 bool wxRegEx::Compile(const wxString& expr, int flags)
 {
-    if ( !m_impl )
-    {
-        m_impl = new wxRegExImpl;
-    }
+    if ( m_impl )
+        m_impl->DecRef();
+
+    m_impl = new wxRegExImpl;
 
     if ( !m_impl->Compile(expr, flags) )
     {
         // error message already given in wxRegExImpl::Compile
-        wxDELETE(m_impl);
+        m_impl->DecRef();
 
         return false;
     }


### PR DESCRIPTION
This test passed successfully:

```
    wxRegEx r1("foo");
    wxRegEx r2 = r1;
    r2.Compile("bar");

    wxDisableAsserts();
    
    assert( r1.GetMatchCount() == 0 );
    assert( r1.Matches("foo") );
    assert( r1.GetMatchCount() != 0 );
```