### PR TITLE
When setting wxNullCursor in wxQT substitute it for the default cursor

### DIFF
--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -521,7 +521,7 @@ bool wxWindowQt::SetCursor( const wxCursor &cursor )
     if ( cursor.IsOk() )
         GetHandle()->setCursor(cursor.GetHandle());
     else
-        GetHandle()->setCursor(wxCursor(wxCURSOR_DEFAULT).GetHandle());
+        GetHandle()->unsetCursor();
     
     return true;
 }

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -518,7 +518,10 @@ bool wxWindowQt::SetCursor( const wxCursor &cursor )
     if (!wxWindowBase::SetCursor(cursor))
         return false;
 
-    GetHandle()->setCursor(cursor.GetHandle());
+    if ( cursor.IsOk() )
+        GetHandle()->setCursor(cursor.GetHandle());
+    else
+        GetHandle()->setCursor(wxCursor(wxCURSOR_DEFAULT).GetHandle());
     
     return true;
 }


### PR DESCRIPTION
When setting the cursor to wxNullCursor or any cursor not found within QT, substitute it for the default cursor so has the effect of clearing any custom cursor as is the intention on other ports.