### PR TITLE
Make wxRegEx copyable

### DIFF
--- a/include/wx/regex.h
+++ b/include/wx/regex.h
@@ -103,7 +103,7 @@ public:
     // get the start index and the length of the match of the expression
     // (index 0) or a bracketed subexpression (index != 0)
     //
-    // may only be called after successful call to Matches()
+    // may only be called right after successful call to Matches()
     //
     // return false if no match or on error
     bool GetMatch(size_t *start, size_t *len, size_t index = 0) const;
@@ -111,7 +111,7 @@ public:
     // return the part of string corresponding to the match, empty string is
     // returned if match failed
     //
-    // may only be called after successful call to Matches()
+    // may only be called right after successful call to Matches()
     wxString GetMatch(const wxString& text, size_t index = 0) const;
 
     // return the size of the array of matches, i.e. the number of bracketed
@@ -145,12 +145,23 @@ public:
     // dtor not virtual, don't derive from this class
     ~wxRegEx();
 
+    // copy constructor & assignment operator.
     wxRegEx(const wxRegEx&);
     wxRegEx &operator=(const wxRegEx&);
 
 private:
     // common part of all ctors
     void Init();
+
+    // Notice that wxRegExImpl is a ref-counted class. And as such, wxRegExImpl::
+    // {m_Matches & m_nMatches} will be shared by all the wxRegEx objects sharing
+    // the same m_impl handle. And to prevent any API misuse, m_impl will always
+    // remember the wxRegEx object which successfully called Matches(), because
+    // {m_Matches & m_nMatches} will ever be meaningful to that object only.
+
+    // Return @true if the last successful call to Matches()
+    // was performed by this object.
+    bool CanGetMatches() const;
 
     // the real guts of this class
     wxRegExImpl *m_impl;

--- a/include/wx/regex.h
+++ b/include/wx/regex.h
@@ -145,17 +145,15 @@ public:
     // dtor not virtual, don't derive from this class
     ~wxRegEx();
 
+    wxRegEx(const wxRegEx&);
+    wxRegEx &operator=(const wxRegEx&);
+
 private:
     // common part of all ctors
     void Init();
 
     // the real guts of this class
     wxRegExImpl *m_impl;
-
-    // as long as the class wxRegExImpl is not ref-counted,
-    // instances of the handle wxRegEx must not be copied.
-    wxRegEx(const wxRegEx&);
-    wxRegEx &operator=(const wxRegEx&);
 };
 
 #endif // wxUSE_REGEX

--- a/src/common/regex.cpp
+++ b/src/common/regex.cpp
@@ -167,10 +167,10 @@ public:
     int Replace(wxString *pattern, const wxString& replacement,
                 size_t maxMatches = 0) const;
 
-    void SetInstance(wxRegEx* instance) { m_reInstance = instance; }
-    bool IsCurrentInstance(wxRegEx* instance) const
+    void SetInstance(wxUIntPtr instance) { m_reInstance = instance; }
+    bool IsCurrentInstance(wxUIntPtr instance) const
     {
-        return (m_reInstance != NULL) && (m_reInstance == instance);
+        return (m_reInstance != 0u) && (m_reInstance == instance);
     }
 
 private:
@@ -183,7 +183,7 @@ private:
         m_isCompiled = false;
         m_Matches = NULL;
         m_nMatches = 0;
-        m_reInstance = NULL;
+        m_reInstance = 0u;
     }
 
     // free the RE if compiled
@@ -216,7 +216,7 @@ private:
 
     // Will be updated to the last wxRegEx object which successfully called
     // Matches(), NULL otherwise. (see notice at wxRegEx::CanGetMatches()).
-    wxRegEx*        m_reInstance;
+    wxUIntPtr       m_reInstance;
 };
 
 
@@ -666,16 +666,16 @@ wxRegEx::~wxRegEx()
     if ( IsValid() )
     {
         if ( CanGetMatches() )
-            m_impl->SetInstance(NULL);
+            m_impl->SetInstance(0u);
 
         m_impl->DecRef();
         m_impl = NULL;
     }
 }
 
-bool wxRegEx::CanGetMatches() const;
+bool wxRegEx::CanGetMatches() const
 {
-    m_impl->IsCurrentInstance(this);
+    return m_impl->IsCurrentInstance(wxPtrToUInt(this));
 }
 
 bool wxRegEx::Compile(const wxString& expr, int flags)
@@ -705,7 +705,7 @@ bool wxRegEx::Matches(const wxString& str, int flags) const
         m_impl->Matches(WXREGEX_CHAR(str), flags
                             WXREGEX_IF_NEED_LEN(str.length()));
 
-    m_impl->SetInstance(success ? this : (wxRegEx *)NULL);
+    m_impl->SetInstance(success ? wxPtrToUInt(this) : 0u);
 
     return success;
 }


### PR DESCRIPTION
**If accepted, i'll update the unit test with more test cases.**

Testing this PR with the following patch works correctly:

```
diff --git a/samples/minimal/minimal.cpp b/samples/minimal/minimal.cpp
index f765a70dac..f403911f52 100644
--- a/samples/minimal/minimal.cpp
+++ b/samples/minimal/minimal.cpp
@@ -29,6 +29,8 @@
     #include "wx/wx.h"
 #endif
 
+#include "wx/regex.h"
+
 // ----------------------------------------------------------------------------
 // resources
 // ----------------------------------------------------------------------------
@@ -66,6 +68,9 @@ public:
     // event handlers (these functions should _not_ be virtual)
     void OnQuit(wxCommandEvent& event);
     void OnAbout(wxCommandEvent& event);
+    void OnTest(wxCommandEvent& event);
+
+    bool MatchesBar(const wxRegEx& regex);
 
 private:
     // any class wishing to process wxWidgets events must use this macro
@@ -85,7 +90,9 @@ enum
     // it is important for the id corresponding to the "About" command to have
     // this standard value as otherwise it won't be handled properly under Mac
     // (where it is special and put into the "Apple" menu)
-    Minimal_About = wxID_ABOUT
+    Minimal_About = wxID_ABOUT,
+
+    Minimal_Test = wxID_HIGHEST
 };
 
 // ----------------------------------------------------------------------------
@@ -98,6 +105,7 @@ enum
 wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(Minimal_Quit,  MyFrame::OnQuit)
     EVT_MENU(Minimal_About, MyFrame::OnAbout)
+    EVT_MENU(Minimal_Test, MyFrame::OnTest)
 wxEND_EVENT_TABLE()
 
 // Create a new application object: this macro will allow wxWidgets to create
@@ -155,6 +163,7 @@ MyFrame::MyFrame(const wxString& title)
     wxMenu *helpMenu = new wxMenu;
     helpMenu->Append(Minimal_About, "&About\tF1", "Show about dialog");
 
+    fileMenu->Append(Minimal_Test, "&Test\tAlt-T", "Test wxRegEx");
     fileMenu->Append(Minimal_Quit, "E&xit\tAlt-X", "Quit this program");
 
     // now append the freshly created menu to the menu bar...
@@ -203,3 +212,36 @@ void MyFrame::OnAbout(wxCommandEvent& WXUNUSED(event))
                  wxOK | wxICON_INFORMATION,
                  this);
 }
+
+void MyFrame::OnTest(wxCommandEvent& WXUNUSED(event))
+{
+    wxRegEx r1("foo");
+    wxRegEx r2 = r1;
+    wxRegEx r3;
+
+    r2.Compile("bar");
+
+    wxASSERT( r1.Matches("foo") );
+    wxASSERT( r1.GetMatchCount() != 0 );
+
+    wxASSERT( !MatchesBar(r1) );
+    wxASSERT( MatchesBar(r2) );
+    wxASSERT( !MatchesBar(r3) );
+
+    r3 = r2;
+
+    wxASSERT( MatchesBar(r3) );
+
+    r3.Compile("baz");
+
+    wxASSERT( MatchesBar(r2) );
+    wxASSERT( !MatchesBar(r3) );
+}
+
+bool MyFrame::MatchesBar(const wxRegEx& re)
+{
+    if ( !re.IsValid() )
+        return false;
+
+    return re.Matches("bar");
+}
```

**This PR correctly implement the COW idiom.**