### PR TITLE
Ignore events when handler is scheduled for destruction

### DIFF
--- a/include/wx/qt/private/winevent.h
+++ b/include/wx/qt/private/winevent.h
@@ -63,6 +63,14 @@ public:
 
     }
 
+    bool event(QEvent *e) wxOVERRIDE
+    {
+        if ( !GetHandler() )
+            return false;
+
+        return Widget::event(e);
+    }
+
     void HandleDestroyedSignal()
     {
     }
@@ -71,11 +79,13 @@ public:
     {
         // Only process the signal / event if the wxWindow is not destroyed
         if ( !wxWindow::QtRetrieveWindowPointer( this ) )
-        {
             return NULL;
-        }
-        else
-            return wxQtSignalHandler< Handler >::GetHandler();
+
+        Handler *handler = wxQtSignalHandler< Handler >::GetHandler();
+        if ( wxTheApp && wxTheApp->IsScheduledForDestruction(handler) )
+            return NULL;
+
+        return handler;
     }
 
 protected:


### PR DESCRIPTION
Prevent events from being processed for handlers that are scheduled for destruction - this fixes a crash we were seeing in wxQt but not standard MSW implementation.