### PR TITLE
Set initial size of wxControls to the size of the QT control.

### DIFF
--- a/src/qt/control.cpp
+++ b/src/qt/control.cpp
@@ -62,6 +62,7 @@ bool wxControl::QtCreateControl( wxWindow *parent, wxWindowID id,
     if (!CreateControl( parent, id, pos, size, style, validator, name ))
         return false;
 
+    SetInitialSize(wxQtConvertSize(GetHandle()->size()));
     PostCreation(false);
     return true;
 }


### PR DESCRIPTION
Allow QT to inform wx what the initial size of the controls are.