### PR TITLE
Do not set null QPoint to wxDefaultPosition

### DIFF
--- a/src/qt/converter.cpp
+++ b/src/qt/converter.cpp
@@ -30,9 +30,6 @@
 
 wxPoint wxQtConvertPoint( const QPoint &point )
 {
-    if (point.isNull())
-        return wxDefaultPosition;
-
     return wxPoint( point.x(), point.y() );
 }
 


### PR DESCRIPTION
Do not set null QPoint to wxDefaultPosition as (0,0) is a valid point and should not be converted to (-1, -1)