### PR TITLE
When windows are shown then created, their visible state is updated

### DIFF
--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -367,6 +367,9 @@ void wxWindowQt::PostCreation(bool generic)
 
     GetHandle()->setFont( wxWindowBase::GetFont().GetHandle() );
 
+    //Update the visible property on the QWidget as show may have been called before create
+    GetHandle()->setVisible(m_isShown);
+
     wxWindowCreateEvent event(this);
     HandleWindowEvent(event);
 }


### PR DESCRIPTION
If a window is created, then hidden, it will be correctly removed. However, if a window is hidden before being created, it was not removed from the screen so the shown state is reapplied after creation.