### PR TITLE
Implement wxListCtrl::GetEditControl for wxQT

### DIFF
--- a/include/wx/qt/listctrl.h
+++ b/include/wx/qt/listctrl.h
@@ -305,7 +305,6 @@ protected:
                       m_ownsImageListState;
 private:
     wxQtTreeWidget *m_qtTreeWidget;
-    wxQtItemEditorFactory *m_qtEditorFactory;
 
     wxDECLARE_DYNAMIC_CLASS( wxListCtrl );
 };

--- a/include/wx/qt/listctrl.h
+++ b/include/wx/qt/listctrl.h
@@ -10,8 +10,9 @@
 
 #include "wx/textctrl.h"
 
-class QTreeWidget;
+class wxQtTreeWidget;
 class QTreeWidgetItem;
+class wxQtItemEditorFactory;
 
 class WXDLLIMPEXP_FWD_CORE wxImageList;
 
@@ -303,7 +304,8 @@ protected:
                       m_ownsImageListSmall,
                       m_ownsImageListState;
 private:
-    QTreeWidget *m_qtTreeWidget;
+    wxQtTreeWidget *m_qtTreeWidget;
+    wxQtItemEditorFactory *m_qtEditorFactory;
 
     wxDECLARE_DYNAMIC_CLASS( wxListCtrl );
 };

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -77,7 +77,7 @@ public:
 
     QWidget *createEditor(int WXUNUSED(userType), QWidget *parent) const wxOVERRIDE
     {
-        m_textCtrl =  new wxQtListTextCtrl(m_parent, parent);
+        m_textCtrl = new wxQtListTextCtrl(m_parent, parent);
         m_textCtrl->SetFocus();
         return m_textCtrl->GetHandle();
     }

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -51,10 +51,15 @@ namespace
         {
            const QPoint event_position = wxQtConvertPoint(event.GetPosition());
            const QPoint global_position  = m_actualParent->mapToGlobal(event_position);
+
            //For some reason this always gives us the offset from the header info the internal control
            //So we need to treat this as an offset rather than a position.
-           const QPoint offset = GetHandle()->mapFromGlobal(global_position);
-           GetHandle()->move(event_position + offset);
+            QWidget *widget = GetHandle();
+            const QPoint offset = widget->mapFromGlobal(global_position);
+
+            widget->blockSignals(true);
+            widget->move(event_position + offset);
+            widget->blockSignals(false);
         }
 
     private:

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -50,7 +50,6 @@ namespace
 
         void onMove(wxMoveEvent &event)
         {
-
             //QWidget::move generates a QMoveEvent so we need to guard against reenterant calls
             if ( m_moving )
             {
@@ -58,11 +57,9 @@ namespace
                 return;
             }
 
-
             m_moving = true;
 
-
-            const QPoint event_position = wxQtConvertPoint(event.GetPosition());
+           const QPoint event_position = wxQtConvertPoint(event.GetPosition());
            const QPoint global_position  = m_actualParent->mapToGlobal(event_position);
 
            //For some reason this always gives us the offset from the header info the internal control

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -13,6 +13,9 @@
 #endif
 
 #include <QtWidgets/QHeaderView>
+#include <QtWidgets/QTreeWidget>
+#include <QtWidgets/QItemDelegate>
+#include <QtWidgets/QItemEditorFactory>
 
 #ifndef WX_PRECOMP
     #include "wx/bitmap.h"
@@ -22,27 +25,124 @@
 #include "wx/imaglist.h"
 #include "wx/qt/private/winevent.h"
 
-#include <QtWidgets/QTreeWidget>
+namespace
+{
+    //wxQT Doesn't have a mechanism for "adopting" external widgets so
+    //we have to create an instance of wxTextCtrl rather than adopting
+    //the control QT would create.
+    //
+    // Unfortunately the factory is given an internal widget as the parent for editor.
+    //
+    // To work around these issues we create a wxTextCtl parented by the wxListCtrl then recalculate
+    // its position relative to the internal widget.
+    //
+    class wxQtListTextCtrl : public wxTextCtrl
+    {
+    public:
+        wxQtListTextCtrl(wxWindow *parent, QWidget *actualParent) :
+            wxTextCtrl(parent, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxNO_BORDER),
+            m_actualParent(actualParent)
+        {
+
+            Bind(wxEVT_MOVE, &wxQtListTextCtrl::onMove, this);
+        }
+
+        void onMove(wxMoveEvent &event)
+        {
+           const QPoint event_position = wxQtConvertPoint(event.GetPosition());
+           const QPoint global_position  = m_actualParent->mapToGlobal(event_position);
+           //For some reason this always gives us the offset from the header info the internal control
+           //So we need to treat this as an offset rather than a position.
+           const QPoint offset = GetHandle()->mapFromGlobal(global_position);
+           GetHandle()->move(event_position + offset);
+        }
+
+    private:
+        QWidget *m_actualParent;
+    };
+}
+
+
+//QT doesn't give us direct access to the editor within the QTreeWidget.
+//Instead, we'll supply a factory to create the widget for QT and
+//keep track of it ourselves.
+class wxQtItemEditorFactory : public QItemEditorFactory
+{
+public:
+    wxQtItemEditorFactory(wxWindow *parent) :
+        m_parent(parent),
+        m_textCtrl(NULL)
+    {
+    }
+
+    QWidget *createEditor(int WXUNUSED(userType), QWidget *parent) const wxOVERRIDE
+    {
+        m_textCtrl =  new wxQtListTextCtrl(m_parent, parent);
+        m_textCtrl->SetFocus();
+        return m_textCtrl->GetHandle();
+    }
+
+    wxTextCtrl* GetEditControl()
+    {
+        return m_textCtrl;
+    }
+
+    void ClearEditor()
+    {
+        delete m_textCtrl;
+        m_textCtrl = NULL;
+    }
+
+private:
+    wxWindow *m_parent;
+    mutable wxTextCtrl *m_textCtrl;
+
+};
 
 class wxQtTreeWidget : public wxQtEventSignalHandler< QTreeWidget, wxListCtrl >
 {
 public:
-    wxQtTreeWidget( wxWindow *parent, wxListCtrl *handler );
+    wxQtTreeWidget( wxWindow *parent, wxListCtrl *handler, wxQtItemEditorFactory* editorFactory );
 
     void EmitListEvent(wxEventType typ, QTreeWidgetItem *qitem, int column) const;
+
+    void closeEditor(QWidget *editor, QAbstractItemDelegate::EndEditHint hint) wxOVERRIDE
+    {
+        QTreeWidget::closeEditor(editor, hint);
+        m_editorFactory->ClearEditor();
+    }
+
+    void RestoreDefaultEditorFactory()
+    {
+        QItemDelegate *qItemDelegate = static_cast<QItemDelegate*>(itemDelegate());
+        qItemDelegate->setItemEditorFactory(m_oldFactory);
+    }
 
 private:
     void itemClicked(QTreeWidgetItem * item, int column);
     void itemActivated(QTreeWidgetItem * item, int column);
     void itemPressed(QTreeWidgetItem * item, int column);
+
+    void ChangeEditorFactory(QItemEditorFactory *editorFactory)
+    {
+        QItemDelegate *qItemDelegate = static_cast<QItemDelegate*>(itemDelegate());
+        m_oldFactory = qItemDelegate->itemEditorFactory();
+        qItemDelegate->setItemEditorFactory(editorFactory);
+    }
+
+    wxQtItemEditorFactory *m_editorFactory;
+    QItemEditorFactory *m_oldFactory;
 };
 
-wxQtTreeWidget::wxQtTreeWidget( wxWindow *parent, wxListCtrl *handler )
-    : wxQtEventSignalHandler< QTreeWidget, wxListCtrl >( parent, handler )
+wxQtTreeWidget::wxQtTreeWidget( wxWindow *parent, wxListCtrl *handler, wxQtItemEditorFactory* editorFactory )
+    : wxQtEventSignalHandler< QTreeWidget, wxListCtrl >( parent, handler ),
+	m_editorFactory(editorFactory)
 {
     connect(this, &QTreeWidget::itemClicked, this, &wxQtTreeWidget::itemClicked);
     connect(this, &QTreeWidget::itemPressed, this, &wxQtTreeWidget::itemPressed);
     connect(this, &QTreeWidget::itemActivated, this, &wxQtTreeWidget::itemActivated);
+
+    ChangeEditorFactory(editorFactory);
 }
 
 void wxQtTreeWidget::EmitListEvent(wxEventType typ, QTreeWidgetItem *qitem, int column) const
@@ -136,7 +236,7 @@ bool wxListCtrl::Create(wxWindow *parent,
             const wxValidator& validator,
             const wxString& name)
 {
-    m_qtTreeWidget = new wxQtTreeWidget( parent, this );
+    m_qtTreeWidget = new wxQtTreeWidget(parent, this, m_qtEditorFactory);
 
     if (style & wxLC_NO_HEADER)
         m_qtTreeWidget->setHeaderHidden(true);
@@ -148,6 +248,8 @@ bool wxListCtrl::Create(wxWindow *parent,
 
 void wxListCtrl::Init()
 {
+    m_qtEditorFactory = new wxQtItemEditorFactory(this);
+
     m_imageListNormal = NULL;
     m_ownsImageListNormal = false;
     m_imageListSmall = NULL;
@@ -159,6 +261,11 @@ void wxListCtrl::Init()
 
 wxListCtrl::~wxListCtrl()
 {
+    if ( m_qtTreeWidget )
+    {
+        m_qtTreeWidget->RestoreDefaultEditorFactory();
+        delete m_qtEditorFactory;
+    }
 
     if (m_ownsImageListNormal)
         delete m_imageListNormal;
@@ -251,7 +358,7 @@ wxRect wxListCtrl::GetViewRect() const
 
 wxTextCtrl* wxListCtrl::GetEditControl() const
 {
-    return NULL;
+    return m_qtEditorFactory->GetEditControl();
 }
 
 QTreeWidgetItem *wxListCtrl::QtGetItem(int id) const

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -27,7 +27,7 @@
 
 namespace
 {
-    //wxQT Doesn't have a mechanism for "adopting" external widgets so
+    // wxQT Doesn't have a mechanism for "adopting" external widgets so
     //we have to create an instance of wxTextCtrl rather than adopting
     //the control QT would create.
     //


### PR DESCRIPTION
This PR implements wxListCtrl::GetEditControl for wxQT.   Unfortunately, it's a bit more complicated than I'd like it to be due to a few specifics of QT.

QT doesn't seem to provide direct access to the edit control from it's QTreeWidget (which is what wxListCtrl delegates to).  Even if it did there's no way for us to adopt an existing QWidget as wxWindow uses inheritance to map QWidget events into wx events.

QT does however, also a factory to be supplied to QTreeWidget.   I've used this to supply a factory that creates a wxTextCtrl and keeps track of it for when we need to return the editor.

To further confuse matters,  when QT calls the factory it doesn't supply the QTreeWidget as the parent,  instead is supplies an internal components (seemingly the tree part of the tree which is distinct from the header).   In order to correctly position our wxTextCtrl we have to map the the coordinates back to the QTreeWidget space.

wxQT currently doesn't honour the wxBORDER_NONE flag so the text control has a border but I'll address this as a separate PR. 