### PR TITLE
CMake: don't search SDL on macOS

### DIFF
--- a/build/cmake/init.cmake
+++ b/build/cmake/init.cmake
@@ -362,7 +362,7 @@ if(wxUSE_GUI)
         set(wxUSE_GSTREAMER_PLAYER OFF)
     endif()
 
-    if(wxUSE_SOUND AND UNIX AND wxUSE_LIBSDL)
+    if(wxUSE_SOUND AND wxUSE_LIBSDL AND UNIX AND NOT APPLE)
         find_package(SDL2)
         if(NOT SDL2_FOUND)
             find_package(SDL)


### PR DESCRIPTION
It doesn't compile when enabled.

https://groups.google.com/forum/#!topic/wx-users/9Fs3fZfLxZQ
