### PR TITLE
Improve building samples with CI

### DIFF
--- a/build/tools/appveyor.bat
+++ b/build/tools/appveyor.bat
@@ -52,32 +52,6 @@ bash -lc "g++ --version"
 bash -lc "LDFLAGS=-L/usr/lib/w32api ./configure --disable-optimise --disable-shared && make -j3 && make -j3 -C tests"
 goto :eof
 
-:cmake_msys
-if "%MSYSTEM%"=="" set MSYSTEM=MINGW32
-path C:\msys64\%MSYSTEM%\bin;C:\msys64\usr\bin;%path%
-set GENERATOR=MSYS Makefiles
-set SKIPTESTS=1
-set SKIPINSTALL=1
-set CMAKE_NATIVE_FLAGS=-j3
-goto cmake
-
-:cmake_cygwin
-C:\cygwin\setup-x86.exe -qnNdO -R C:/cygwin -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P libjpeg-devel -P libpng-devel -P libtiff-devel -P libexpat-devel
-path c:\cygwin\bin;%path%
-set GENERATOR=Unix Makefiles
-set SKIPTESTS=1
-set SKIPINSTALL=1
-set CMAKE_NATIVE_FLAGS=-j3
-goto cmake
-
-:cmake_mingw
-:: CMake requires a path without sh (added by git on AppVeyor)
-path C:\Program Files (x86)\CMake\bin;C:\MinGW\bin
-set GENERATOR=MinGW Makefiles
-set SKIPTESTS=1
-set CMAKE_NATIVE_FLAGS=-j3
-goto cmake
-
 :cmake_qt
 set SKIPINSTALL=1
 set QT5DIR="C:\Qt\5.11\msvc2015_64"
@@ -106,7 +80,7 @@ set WX_INSTALL_PATH=%HOMEDRIVE%%HOMEPATH%\wx_install_target
 mkdir %WX_INSTALL_PATH%
 mkdir build_cmake
 pushd build_cmake
-cmake -G "%GENERATOR%" -DwxBUILD_TESTS=%BUILD_TESTS% -DCMAKE_INSTALL_PREFIX=%WX_INSTALL_PATH% -DwxBUILD_SHARED=%SHARED% %CMAKE_CONFIGURE_FLAGS% ..
+cmake -G "%GENERATOR%" -DwxBUILD_TESTS=%BUILD_TESTS% -DwxBUILD_SAMPLES=SOME -DCMAKE_INSTALL_PREFIX=%WX_INSTALL_PATH% -DwxBUILD_SHARED=%SHARED% %CMAKE_CONFIGURE_FLAGS% ..
 if ERRORLEVEL 1 goto error
 echo.
 echo --- Starting the build
@@ -141,7 +115,6 @@ if NOT "%SKIPINSTALL%"=="1" (
     echo --- Building minimal sample with installed library
     cmake --build . --config %CONFIGURATION% -- %CMAKE_LOGGER%
     if ERRORLEVEL 1 goto error
-    popd
 )
 popd
 

--- a/build/tools/travis-ci.sh
+++ b/build/tools/travis-ci.sh
@@ -16,50 +16,67 @@ case $wxTOOLSET in
     cmake)
         if [ -z $wxCMAKE_TESTS ]; then wxCMAKE_TESTS=CONSOLE_ONLY; fi
         cmake --version
+
         echo 'travis_fold:start:configure'
         echo 'Configuring...'
         mkdir build_cmake
         pushd build_cmake
         cmake -G "$wxCMAKE_GENERATOR" $wxCMAKE_DEFINES -D wxBUILD_SAMPLES=SOME -D wxBUILD_TESTS=$wxCMAKE_TESTS ..
         echo 'travis_fold:end:configure'
+
         echo 'travis_fold:start:building'
         echo 'Building...'
         cmake --build . -- $wxJOBS
         echo 'travis_fold:end:building'
+
         if [ "$wxCMAKE_TESTS" != "OFF" ]; then
             echo 'travis_fold:start:testing'
             echo 'Testing...'
             ctest -V -C Debug -R "test_base" --output-on-failure --interactive-debug-mode 0 .
             echo 'travis_fold:end:testing'
         fi
+
         echo 'Installing...' && echo -en 'travis_fold:start:script.install\\r'
         sudo env "PATH=$PATH" cmake --build . --target install
-        echo -en 'travis_fold:end:script.install\\r'
         popd
+        echo -en 'travis_fold:end:script.install\\r'
+
+        echo 'Testing installation...' && echo -en 'travis_fold:start:script.testinstall\\r'
+        mkdir build_cmake_install_test
+        pushd build_cmake_install_test
+        cmake "$wxCMAKE_GENERATOR" $wxCMAKE_DEFINES ../samples/minimal
+        cmake --build .
+        popd
+        echo -en 'travis_fold:end:script.testinstall\\r'
         ;;
     *)
         echo 'Configuring...' && echo -en 'travis_fold:start:script.configure\\r'
         ./configure --disable-optimise $wxCONFIGURE_FLAGS
         echo -en 'travis_fold:end:script.configure\\r'
+
         echo 'Building...' && echo -en 'travis_fold:start:script.build\\r'
         make $wxJOBS
         echo -en 'travis_fold:end:script.build\\r'
+
         echo 'Building tests...' && echo -en 'travis_fold:start:script.tests\\r'
         make -C tests $wxJOBS
         echo -en 'travis_fold:end:script.tests\\r'
+
         echo 'Testing...' && echo -en 'travis_fold:start:script.testing\\r'
         pushd tests && ./test && popd
         echo -en 'travis_fold:end:script.testing\\r'
+
         echo 'Building samples...' && echo -en 'travis_fold:start:script.samples\\r'
         (test "$wxSKIP_SAMPLES" && echo 'SKIPPED') || make samples
         echo -en 'travis_fold:end:script.samples\\r'
+
         echo 'Installing...' && echo -en 'travis_fold:start:script.install\\r'
         sudo make install
         echo -en 'travis_fold:end:script.install\\r'
+
+        echo 'Testing installation...' && echo -en 'travis_fold:start:script.testinstall\\r'
+        make -C samples/minimal -f makefile.unx clean
+        make -C samples/minimal -f makefile.unx $wxMAKEFILE_FLAGS
+        echo -en 'travis_fold:end:script.testinstall\\r'
         ;;
 esac
-
-echo 'Testing installation...' && echo -en 'travis_fold:start:script.testinstall\\r'
-make -C samples/minimal -f makefile.unx clean
-make -C samples/minimal -f makefile.unx $wxMAKEFILE_FLAGS
-echo -en 'travis_fold:end:script.testinstall\\r'


### PR DESCRIPTION
Use CMake script for minimal sample to check Travis installation.

Build some samples on AppVeyor with CMake. These will also be included in the artifact, making it easy to check, for example, the widgets sample built with Qt.