### PR TITLE
Dynamic colour picker changes on MSW.

### DIFF
--- a/include/wx/clrpicker.h
+++ b/include/wx/clrpicker.h
@@ -162,7 +162,7 @@ private:
 
 wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_COLOURPICKER_CHANGED, wxColourPickerEvent );
 wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_COLOUR_SELECTED, wxColourPickerEvent );
-wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_COLOUR_CANCELED, wxColourPickerEvent );
+wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_COLOUR_CANCELLED, wxColourPickerEvent );
 
 class WXDLLIMPEXP_CORE wxColourPickerEvent : public wxCommandEvent
 {
@@ -203,8 +203,8 @@ typedef void (wxEvtHandler::*wxColourPickerEventFunction)(wxColourPickerEvent&);
 #define EVT_COLOUR_SELECTED(id, fn) \
     wx__DECLARE_EVT1(wxEVT_COLOUR_SELECTED, id, wxColourPickerEventHandler(fn))
 
-#define EVT_COLOUR_CANCELED(id, fn) \
-    wx__DECLARE_EVT1(wxEVT_COLOUR_CANCELED, id, wxColourPickerEventHandler(fn))
+#define EVT_COLOUR_CANCELLED(id, fn) \
+    wx__DECLARE_EVT1(wxEVT_COLOUR_CANCELLED, id, wxColourPickerEventHandler(fn))
 
 // old wxEVT_COMMAND_* constant
 #define wxEVT_COMMAND_COLOURPICKER_CHANGED   wxEVT_COLOURPICKER_CHANGED

--- a/include/wx/clrpicker.h
+++ b/include/wx/clrpicker.h
@@ -144,7 +144,7 @@ public:        // internal functions
 
     // event handlers for our picker
     void OnColourChange(wxColourPickerEvent &);
-    void OnColourSelected(wxColourPickerEvent &);
+    void OnColourSelect(wxColourPickerEvent &);
     void OnColourCancel(wxColourPickerEvent &);
 
 protected:
@@ -161,8 +161,8 @@ private:
 // ----------------------------------------------------------------------------
 
 wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_COLOURPICKER_CHANGED, wxColourPickerEvent );
-wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_COLOUR_SELECT, wxColourPickerEvent );
-wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_COLOUR_CANCEL, wxColourPickerEvent );
+wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_COLOUR_SELECTED, wxColourPickerEvent );
+wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_COLOUR_CANCELED, wxColourPickerEvent );
 
 class WXDLLIMPEXP_CORE wxColourPickerEvent : public wxCommandEvent
 {
@@ -200,11 +200,11 @@ typedef void (wxEvtHandler::*wxColourPickerEventFunction)(wxColourPickerEvent&);
 #define EVT_COLOURPICKER_CHANGED(id, fn) \
     wx__DECLARE_EVT1(wxEVT_COLOURPICKER_CHANGED, id, wxColourPickerEventHandler(fn))
 
-#define EVT_COLOUR_SELECT(id, fn) \
-    wx__DECLARE_EVT1(wxEVT_COLOUR_SELECT, id, wxColourPickerEventHandler(fn))
+#define EVT_COLOUR_SELECTED(id, fn) \
+    wx__DECLARE_EVT1(wxEVT_COLOUR_SELECTED, id, wxColourPickerEventHandler(fn))
 
-#define EVT_COLOUR_CANCEL(id, fn) \
-    wx__DECLARE_EVT1(wxEVT_COLOUR_CANCEL, id, wxColourPickerEventHandler(fn))
+#define EVT_COLOUR_CANCELED(id, fn) \
+    wx__DECLARE_EVT1(wxEVT_COLOUR_CANCELED, id, wxColourPickerEventHandler(fn))
 
 // old wxEVT_COMMAND_* constant
 #define wxEVT_COMMAND_COLOURPICKER_CHANGED   wxEVT_COLOURPICKER_CHANGED

--- a/include/wx/clrpicker.h
+++ b/include/wx/clrpicker.h
@@ -174,7 +174,7 @@ class WXDLLIMPEXP_CORE wxColourPickerEvent : public wxCommandEvent
 {
 public:
     wxColourPickerEvent() {}
-    wxColourPickerEvent(wxObject *generator, int id, const wxColour &col, wxEventType commandType)
+    wxColourPickerEvent(wxObject *generator, int id, const wxColour &col, wxEventType commandType = wxEVT_COLOURPICKER_CHANGED)
         : wxCommandEvent(commandType, id),
           m_colour(col)
     {

--- a/include/wx/clrpicker.h
+++ b/include/wx/clrpicker.h
@@ -126,6 +126,10 @@ public:         // public API
     wxColour GetColour() const
         { return ((wxColourPickerWidget *)m_picker)->GetColour(); }
 
+    // get the selected color
+    wxColour GetSelectedColour() const
+        { return m_selectedColour; }
+
     // set currently displayed color
     void SetColour(const wxColour& col);
 
@@ -152,6 +156,8 @@ protected:
         { return (style & (wxCLRP_SHOW_LABEL | wxCLRP_SHOW_ALPHA)); }
 
 private:
+    wxColour m_selectedColour;
+
     wxDECLARE_DYNAMIC_CLASS(wxColourPickerCtrl);
 };
 

--- a/include/wx/clrpicker.h
+++ b/include/wx/clrpicker.h
@@ -126,10 +126,6 @@ public:         // public API
     wxColour GetColour() const
         { return ((wxColourPickerWidget *)m_picker)->GetColour(); }
 
-    // get the selected color
-    wxColour GetSelectedColour() const
-        { return m_selectedColour; }
-
     // set currently displayed color
     void SetColour(const wxColour& col);
 
@@ -156,8 +152,6 @@ protected:
         { return (style & (wxCLRP_SHOW_LABEL | wxCLRP_SHOW_ALPHA)); }
 
 private:
-    wxColour m_selectedColour;
-
     wxDECLARE_DYNAMIC_CLASS(wxColourPickerCtrl);
 };
 

--- a/include/wx/clrpicker.h
+++ b/include/wx/clrpicker.h
@@ -142,8 +142,10 @@ public:        // internal functions
     // update the text control to match the button's colour
     void UpdateTextCtrlFromPicker() wxOVERRIDE;
 
-    // event handler for our picker
+    // event handlers for our picker
     void OnColourChange(wxColourPickerEvent &);
+    void OnColourSelected(wxColourPickerEvent &);
+    void OnColourCancel(wxColourPickerEvent &);
 
 protected:
     virtual long GetPickerStyle(long style) const wxOVERRIDE
@@ -159,13 +161,15 @@ private:
 // ----------------------------------------------------------------------------
 
 wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_COLOURPICKER_CHANGED, wxColourPickerEvent );
+wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_COLOUR_SELECT, wxColourPickerEvent );
+wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_COLOUR_CANCEL, wxColourPickerEvent );
 
 class WXDLLIMPEXP_CORE wxColourPickerEvent : public wxCommandEvent
 {
 public:
     wxColourPickerEvent() {}
-    wxColourPickerEvent(wxObject *generator, int id, const wxColour &col)
-        : wxCommandEvent(wxEVT_COLOURPICKER_CHANGED, id),
+    wxColourPickerEvent(wxObject *generator, int id, const wxColour &col, wxEventType commandType)
+        : wxCommandEvent(commandType, id),
           m_colour(col)
     {
         SetEventObject(generator);
@@ -196,6 +200,11 @@ typedef void (wxEvtHandler::*wxColourPickerEventFunction)(wxColourPickerEvent&);
 #define EVT_COLOURPICKER_CHANGED(id, fn) \
     wx__DECLARE_EVT1(wxEVT_COLOURPICKER_CHANGED, id, wxColourPickerEventHandler(fn))
 
+#define EVT_COLOUR_SELECT(id, fn) \
+    wx__DECLARE_EVT1(wxEVT_COLOUR_SELECT, id, wxColourPickerEventHandler(fn))
+
+#define EVT_COLOUR_CANCEL(id, fn) \
+    wx__DECLARE_EVT1(wxEVT_COLOUR_CANCEL, id, wxColourPickerEventHandler(fn))
 
 // old wxEVT_COMMAND_* constant
 #define wxEVT_COMMAND_COLOURPICKER_CHANGED   wxEVT_COLOURPICKER_CHANGED

--- a/include/wx/generic/clrpickerg.h
+++ b/include/wx/generic/clrpickerg.h
@@ -61,7 +61,6 @@ public:
 
     void OnButtonClick(wxCommandEvent &);
 
-
 protected:
     wxBitmap    m_bitmap;
 
@@ -75,6 +74,8 @@ protected:
     static wxColourData ms_data;
 
 private:
+    void OnColourSelected(wxColourPickerEvent &);
+
     wxDECLARE_DYNAMIC_CLASS(wxGenericColourButton);
 };
 

--- a/include/wx/msw/colordlg.h
+++ b/include/wx/msw/colordlg.h
@@ -32,6 +32,8 @@ public:
 
     wxColourData& GetColourData() { return m_colourData; }
 
+    void OnColorSelected(const wxColour& colour);
+
     // override some base class virtuals
     virtual void SetTitle(const wxString& title) wxOVERRIDE;
     virtual wxString GetTitle() const wxOVERRIDE;

--- a/include/wx/msw/colordlg.h
+++ b/include/wx/msw/colordlg.h
@@ -32,8 +32,6 @@ public:
 
     wxColourData& GetColourData() { return m_colourData; }
 
-    void OnColorSelected(const wxColour& colour);
-
     // override some base class virtuals
     virtual void SetTitle(const wxString& title) wxOVERRIDE;
     virtual wxString GetTitle() const wxOVERRIDE;
@@ -42,6 +40,9 @@ public:
 
     // wxMSW-specific implementation from now on
     // -----------------------------------------
+
+    // called from the subsclassing procedure.
+    void MSWOnColourSelected(const wxColour& colour);
 
     // called from the hook procedure on WM_INITDIALOG reception
     virtual void MSWOnInitDone(WXHWND hDlg);

--- a/interface/wx/clrpicker.h
+++ b/interface/wx/clrpicker.h
@@ -46,9 +46,9 @@ wxEventType wxEVT_COLOURPICKER_CHANGED;
            in this case the event is fired only if the user’s input is valid,
            i.e. recognizable).
     @event{EVT_COLOUR_SELECTED(id, func)}
-           The user changed the colour selected in the dialog associated with the control.
+           The user changed the colour selected in the dialog associated with the control. Currently only implemented on wxMSW.
     @event{EVT_COLOUR_CANCELLED(id, func)}
-           The user closed the colour dialog associated with the control or clicked on its cancel button.
+           The user closed the colour dialog associated with the control or clicked on its cancel button. Currently only implemented on wxMSW.
     @endEventTable
 
     @library{wxcore}

--- a/interface/wx/clrpicker.h
+++ b/interface/wx/clrpicker.h
@@ -45,6 +45,10 @@ wxEventType wxEVT_COLOURPICKER_CHANGED;
            button or using text control (see @c wxCLRP_USE_TEXTCTRL; note that
            in this case the event is fired only if the user’s input is valid,
            i.e. recognizable).
+    @event{EVT_COLOUR_SELECTED(id, func)}
+           The user changed the colour selected in the colour dialog associated with the control.
+    @event{EVT_COLOUR_CANCELLED(id, func)}
+           The user closed the colour dialog associated with the control or clicked on its cancel button.
     @endEventTable
 
     @library{wxcore}

--- a/interface/wx/clrpicker.h
+++ b/interface/wx/clrpicker.h
@@ -46,7 +46,7 @@ wxEventType wxEVT_COLOURPICKER_CHANGED;
            in this case the event is fired only if the user’s input is valid,
            i.e. recognizable).
     @event{EVT_COLOUR_SELECTED(id, func)}
-           The user changed the colour selected in the colour dialog associated with the control.
+           The user changed the colour selected in the dialog associated with the control.
     @event{EVT_COLOUR_CANCELLED(id, func)}
            The user closed the colour dialog associated with the control or clicked on its cancel button.
     @endEventTable

--- a/samples/widgets/clrpicker.cpp
+++ b/samples/widgets/clrpicker.cpp
@@ -83,6 +83,9 @@ protected:
 
 
     void OnColourChange(wxColourPickerEvent &ev);
+    void OnColourSelect(wxColourPickerEvent &ev);
+    void OnColourCancel(wxColourPickerEvent &ev);
+
     void OnCheckBox(wxCommandEvent &ev);
     void OnButtonReset(wxCommandEvent &ev);
 
@@ -111,6 +114,8 @@ wxBEGIN_EVENT_TABLE(ColourPickerWidgetsPage, WidgetsPage)
     EVT_BUTTON(PickerPage_Reset, ColourPickerWidgetsPage::OnButtonReset)
 
     EVT_COLOURPICKER_CHANGED(PickerPage_Colour, ColourPickerWidgetsPage::OnColourChange)
+    EVT_COLOUR_SELECTED(PickerPage_Colour, ColourPickerWidgetsPage::OnColourSelect)
+    EVT_COLOUR_CANCELLED(PickerPage_Colour, ColourPickerWidgetsPage::OnColourCancel)
 
     EVT_CHECKBOX(wxID_ANY, ColourPickerWidgetsPage::OnCheckBox)
 wxEND_EVENT_TABLE()
@@ -219,6 +224,18 @@ void ColourPickerWidgetsPage::OnColourChange(wxColourPickerEvent& event)
 {
     wxLogMessage("The colour changed to '%s' !",
                  event.GetColour().GetAsString(wxC2S_CSS_SYNTAX));
+}
+
+void ColourPickerWidgetsPage::OnColourSelect(wxColourPickerEvent& event)
+{
+    wxLogMessage("The selected colour changed to '%s' !",
+        event.GetColour().GetAsString(wxC2S_CSS_SYNTAX));
+}
+
+void ColourPickerWidgetsPage::OnColourCancel(wxColourPickerEvent& event)
+{
+    wxLogMessage("Colour cancel. Colour is now '%s' !",
+        event.GetColour().GetAsString(wxC2S_CSS_SYNTAX));
 }
 
 void ColourPickerWidgetsPage::OnCheckBox(wxCommandEvent &event)

--- a/src/common/clrpickercmn.cpp
+++ b/src/common/clrpickercmn.cpp
@@ -67,7 +67,6 @@ bool wxColourPickerCtrl::Create( wxWindow *parent, wxWindowID id,
                                         wxDefaultPosition, wxDefaultSize,
                                         GetPickerStyle(style));
 
-    m_selectedColour = col;
 
     // complete sizer creation
     wxPickerBase::PostCreation();
@@ -87,8 +86,6 @@ bool wxColourPickerCtrl::Create( wxWindow *parent, wxWindowID id,
 void wxColourPickerCtrl::SetColour(const wxColour &col)
 {
     M_PICKER->SetColour(col);
-    m_selectedColour = col;
-
     UpdateTextCtrlFromPicker();
 }
 
@@ -99,8 +96,6 @@ bool wxColourPickerCtrl::SetColour(const wxString &text)
         return false;
 
     M_PICKER->SetColour(col);
-    m_selectedColour = col;
-
     UpdateTextCtrlFromPicker();
 
     return true;
@@ -135,7 +130,6 @@ void wxColourPickerCtrl::UpdateTextCtrlFromPicker()
     m_text->ChangeValue(M_PICKER->GetColour().GetAsString());
 }
 
-
 // ----------------------------------------------------------------------------
 // wxColourPickerCtrl - event handlers
 // ----------------------------------------------------------------------------
@@ -152,16 +146,12 @@ void wxColourPickerCtrl::OnColourChange(wxColourPickerEvent &ev)
 
 void wxColourPickerCtrl::OnColourSelect(wxColourPickerEvent &ev)
 {
-    m_selectedColour = ev.GetColour();
-
     wxColourPickerEvent event(this, GetId(), ev.GetColour(), wxEVT_COLOUR_SELECTED);
     GetEventHandler()->ProcessEvent(event);
 }
 
 void wxColourPickerCtrl::OnColourCancel(wxColourPickerEvent &ev)
 {
-    m_selectedColour = ev.GetColour();
-
     wxColourPickerEvent event(this, GetId(), ev.GetColour(), wxEVT_COLOUR_CANCELED);
     GetEventHandler()->ProcessEvent(event);
 }

--- a/src/common/clrpickercmn.cpp
+++ b/src/common/clrpickercmn.cpp
@@ -40,7 +40,7 @@ const char wxColourPickerWidgetNameStr[] = "colourpickerwidget";
 
 wxDEFINE_EVENT(wxEVT_COLOURPICKER_CHANGED, wxColourPickerEvent);
 wxDEFINE_EVENT(wxEVT_COLOUR_SELECTED, wxColourPickerEvent);
-wxDEFINE_EVENT(wxEVT_COLOUR_CANCELED, wxColourPickerEvent);
+wxDEFINE_EVENT(wxEVT_COLOUR_CANCELLED, wxColourPickerEvent);
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxColourPickerCtrl, wxPickerBase);
 wxIMPLEMENT_DYNAMIC_CLASS(wxColourPickerEvent, wxEvent);
@@ -77,7 +77,7 @@ bool wxColourPickerCtrl::Create( wxWindow *parent, wxWindowID id,
     m_picker->Bind(wxEVT_COLOUR_SELECTED,
         &wxColourPickerCtrl::OnColourSelect, this);
 
-    m_picker->Bind(wxEVT_COLOUR_CANCELED,
+    m_picker->Bind(wxEVT_COLOUR_CANCELLED,
         &wxColourPickerCtrl::OnColourCancel, this);
 
     return true;
@@ -152,7 +152,7 @@ void wxColourPickerCtrl::OnColourSelect(wxColourPickerEvent &ev)
 
 void wxColourPickerCtrl::OnColourCancel(wxColourPickerEvent &ev)
 {
-    wxColourPickerEvent event(this, GetId(), ev.GetColour(), wxEVT_COLOUR_CANCELED);
+    wxColourPickerEvent event(this, GetId(), ev.GetColour(), wxEVT_COLOUR_CANCELLED);
     GetEventHandler()->ProcessEvent(event);
 }
 

--- a/src/common/clrpickercmn.cpp
+++ b/src/common/clrpickercmn.cpp
@@ -67,6 +67,8 @@ bool wxColourPickerCtrl::Create( wxWindow *parent, wxWindowID id,
                                         wxDefaultPosition, wxDefaultSize,
                                         GetPickerStyle(style));
 
+    m_selectedColour = col;
+
     // complete sizer creation
     wxPickerBase::PostCreation();
 
@@ -85,6 +87,8 @@ bool wxColourPickerCtrl::Create( wxWindow *parent, wxWindowID id,
 void wxColourPickerCtrl::SetColour(const wxColour &col)
 {
     M_PICKER->SetColour(col);
+    m_selectedColour = col;
+
     UpdateTextCtrlFromPicker();
 }
 
@@ -93,7 +97,10 @@ bool wxColourPickerCtrl::SetColour(const wxString &text)
     wxColour col(text);     // smart wxString->wxColour conversion
     if ( !col.IsOk() )
         return false;
+
     M_PICKER->SetColour(col);
+    m_selectedColour = col;
+
     UpdateTextCtrlFromPicker();
 
     return true;
@@ -145,12 +152,16 @@ void wxColourPickerCtrl::OnColourChange(wxColourPickerEvent &ev)
 
 void wxColourPickerCtrl::OnColourSelect(wxColourPickerEvent &ev)
 {
+    m_selectedColour = ev.GetColour();
+
     wxColourPickerEvent event(this, GetId(), ev.GetColour(), wxEVT_COLOUR_SELECTED);
     GetEventHandler()->ProcessEvent(event);
 }
 
 void wxColourPickerCtrl::OnColourCancel(wxColourPickerEvent &ev)
 {
+    m_selectedColour = ev.GetColour();
+
     wxColourPickerEvent event(this, GetId(), ev.GetColour(), wxEVT_COLOUR_CANCELED);
     GetEventHandler()->ProcessEvent(event);
 }

--- a/src/common/clrpickercmn.cpp
+++ b/src/common/clrpickercmn.cpp
@@ -39,6 +39,9 @@ const char wxColourPickerWidgetNameStr[] = "colourpickerwidget";
 // ============================================================================
 
 wxDEFINE_EVENT(wxEVT_COLOURPICKER_CHANGED, wxColourPickerEvent);
+wxDEFINE_EVENT(wxEVT_COLOUR_SELECT, wxColourPickerEvent);
+wxDEFINE_EVENT(wxEVT_COLOUR_CANCEL, wxColourPickerEvent);
+
 wxIMPLEMENT_DYNAMIC_CLASS(wxColourPickerCtrl, wxPickerBase);
 wxIMPLEMENT_DYNAMIC_CLASS(wxColourPickerEvent, wxEvent);
 
@@ -104,7 +107,7 @@ void wxColourPickerCtrl::UpdatePickerFromTextCtrl()
         M_PICKER->SetColour(col);
 
         // fire an event
-        wxColourPickerEvent event(this, GetId(), col);
+        wxColourPickerEvent event(this, GetId(), col, wxEVT_COLOURPICKER_CHANGED);
         GetEventHandler()->ProcessEvent(event);
     }
 }
@@ -131,7 +134,19 @@ void wxColourPickerCtrl::OnColourChange(wxColourPickerEvent &ev)
 
     // the wxColourPickerWidget sent us a colour-change notification.
     // forward this event to our parent
-    wxColourPickerEvent event(this, GetId(), ev.GetColour());
+    wxColourPickerEvent event(this, GetId(), ev.GetColour(), wxEVT_COLOURPICKER_CHANGED);
+    GetEventHandler()->ProcessEvent(event);
+}
+
+void wxColourPickerCtrl::OnColourSelected(wxColourPickerEvent &ev)
+{
+    wxColourPickerEvent event(this, GetId(), ev.GetColour(), wxEVT_COLOUR_SELECT);
+    GetEventHandler()->ProcessEvent(event);
+}
+
+void wxColourPickerCtrl::OnColourCancel(wxColourPickerEvent &ev)
+{
+    wxColourPickerEvent event(this, GetId(), ev.GetColour(), wxEVT_COLOUR_CANCEL);
     GetEventHandler()->ProcessEvent(event);
 }
 

--- a/src/common/clrpickercmn.cpp
+++ b/src/common/clrpickercmn.cpp
@@ -39,8 +39,8 @@ const char wxColourPickerWidgetNameStr[] = "colourpickerwidget";
 // ============================================================================
 
 wxDEFINE_EVENT(wxEVT_COLOURPICKER_CHANGED, wxColourPickerEvent);
-wxDEFINE_EVENT(wxEVT_COLOUR_SELECT, wxColourPickerEvent);
-wxDEFINE_EVENT(wxEVT_COLOUR_CANCEL, wxColourPickerEvent);
+wxDEFINE_EVENT(wxEVT_COLOUR_SELECTED, wxColourPickerEvent);
+wxDEFINE_EVENT(wxEVT_COLOUR_CANCELED, wxColourPickerEvent);
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxColourPickerCtrl, wxPickerBase);
 wxIMPLEMENT_DYNAMIC_CLASS(wxColourPickerEvent, wxEvent);
@@ -72,6 +72,12 @@ bool wxColourPickerCtrl::Create( wxWindow *parent, wxWindowID id,
 
     m_picker->Bind(wxEVT_COLOURPICKER_CHANGED,
             &wxColourPickerCtrl::OnColourChange, this);
+
+    m_picker->Bind(wxEVT_COLOUR_SELECTED,
+        &wxColourPickerCtrl::OnColourSelect, this);
+
+    m_picker->Bind(wxEVT_COLOUR_CANCELED,
+        &wxColourPickerCtrl::OnColourCancel, this);
 
     return true;
 }
@@ -123,7 +129,6 @@ void wxColourPickerCtrl::UpdateTextCtrlFromPicker()
 }
 
 
-
 // ----------------------------------------------------------------------------
 // wxColourPickerCtrl - event handlers
 // ----------------------------------------------------------------------------
@@ -138,15 +143,15 @@ void wxColourPickerCtrl::OnColourChange(wxColourPickerEvent &ev)
     GetEventHandler()->ProcessEvent(event);
 }
 
-void wxColourPickerCtrl::OnColourSelected(wxColourPickerEvent &ev)
+void wxColourPickerCtrl::OnColourSelect(wxColourPickerEvent &ev)
 {
-    wxColourPickerEvent event(this, GetId(), ev.GetColour(), wxEVT_COLOUR_SELECT);
+    wxColourPickerEvent event(this, GetId(), ev.GetColour(), wxEVT_COLOUR_SELECTED);
     GetEventHandler()->ProcessEvent(event);
 }
 
 void wxColourPickerCtrl::OnColourCancel(wxColourPickerEvent &ev)
 {
-    wxColourPickerEvent event(this, GetId(), ev.GetColour(), wxEVT_COLOUR_CANCEL);
+    wxColourPickerEvent event(this, GetId(), ev.GetColour(), wxEVT_COLOUR_CANCELED);
     GetEventHandler()->ProcessEvent(event);
 }
 

--- a/src/generic/clrpickerg.cpp
+++ b/src/generic/clrpickerg.cpp
@@ -86,15 +86,21 @@ void wxGenericColourButton::OnButtonClick(wxCommandEvent& WXUNUSED(ev))
 
     // create the colour dialog and display it
     wxColourDialog dlg(this, &ms_data);
-    if (dlg.ShowModal() == wxID_OK)
+    dlg.Bind(wxEVT_COLOUR_SELECTED, [this](wxColourPickerEvent& ev)
     {
-        ms_data = dlg.GetColourData();
-        SetColour(ms_data.GetColour());
-
-        // fire an event
-        wxColourPickerEvent event(this, GetId(), m_colour, wxEVT_COLOURPICKER_CHANGED);
+        wxColourPickerEvent event(this, GetId(), m_colour, wxEVT_COLOUR_SELECTED);
         GetEventHandler()->ProcessEvent(event);
-    }
+    });
+
+    const int res = dlg.ShowModal();
+    wxASSERT(res == wxID_OK || res == wxID_CANCEL);
+
+    ms_data = dlg.GetColourData();
+    SetColour(ms_data.GetColour());
+
+    // fire an event
+    wxColourPickerEvent event(this, GetId(), m_colour, res == wxID_OK ? wxEVT_COLOURPICKER_CHANGED : wxEVT_COLOUR_CANCELED);
+    GetEventHandler()->ProcessEvent(event);
 }
 
 void wxGenericColourButton::UpdateColour()

--- a/src/generic/clrpickerg.cpp
+++ b/src/generic/clrpickerg.cpp
@@ -92,7 +92,7 @@ void wxGenericColourButton::OnButtonClick(wxCommandEvent& WXUNUSED(ev))
         SetColour(ms_data.GetColour());
 
         // fire an event
-        wxColourPickerEvent event(this, GetId(), m_colour);
+        wxColourPickerEvent event(this, GetId(), m_colour, wxEVT_COLOURPICKER_CHANGED);
         GetEventHandler()->ProcessEvent(event);
     }
 }

--- a/src/generic/clrpickerg.cpp
+++ b/src/generic/clrpickerg.cpp
@@ -86,11 +86,7 @@ void wxGenericColourButton::OnButtonClick(wxCommandEvent& WXUNUSED(ev))
 
     // create the colour dialog and display it
     wxColourDialog dlg(this, &ms_data);
-    dlg.Bind(wxEVT_COLOUR_SELECTED, [this](wxColourPickerEvent& ev)
-    {
-        wxColourPickerEvent event(this, GetId(), ev.GetColour(), wxEVT_COLOUR_SELECTED);
-        GetEventHandler()->ProcessEvent(event);
-    });
+    dlg.Bind(wxEVT_COLOUR_SELECTED, &wxGenericColourButton::OnColourSelected, this);
 
     const int res = dlg.ShowModal();
     wxASSERT(res == wxID_OK || res == wxID_CANCEL);
@@ -99,8 +95,16 @@ void wxGenericColourButton::OnButtonClick(wxCommandEvent& WXUNUSED(ev))
     SetColour(ms_data.GetColour());
 
     // fire an event
-    wxColourPickerEvent event(this, GetId(), m_colour, res == wxID_OK ? wxEVT_COLOURPICKER_CHANGED : wxEVT_COLOUR_CANCELED);
-    GetEventHandler()->ProcessEvent(event);
+    const wxEventType eventType = res == wxID_OK ? wxEVT_COLOURPICKER_CHANGED : wxEVT_COLOUR_CANCELED;
+    wxColourPickerEvent event(this, GetId(), m_colour, eventType);
+
+    ProcessWindowEvent(event);
+}
+
+void wxGenericColourButton::OnColourSelected(wxColourPickerEvent& ev)
+{
+    wxColourPickerEvent event(this, GetId(), ev.GetColour(), wxEVT_COLOUR_SELECTED);
+    ProcessWindowEvent(event);
 }
 
 void wxGenericColourButton::UpdateColour()

--- a/src/generic/clrpickerg.cpp
+++ b/src/generic/clrpickerg.cpp
@@ -88,7 +88,7 @@ void wxGenericColourButton::OnButtonClick(wxCommandEvent& WXUNUSED(ev))
     wxColourDialog dlg(this, &ms_data);
     dlg.Bind(wxEVT_COLOUR_SELECTED, [this](wxColourPickerEvent& ev)
     {
-        wxColourPickerEvent event(this, GetId(), m_colour, wxEVT_COLOUR_SELECTED);
+        wxColourPickerEvent event(this, GetId(), ev.GetColour(), wxEVT_COLOUR_SELECTED);
         GetEventHandler()->ProcessEvent(event);
     });
 

--- a/src/generic/clrpickerg.cpp
+++ b/src/generic/clrpickerg.cpp
@@ -95,7 +95,7 @@ void wxGenericColourButton::OnButtonClick(wxCommandEvent& WXUNUSED(ev))
     SetColour(ms_data.GetColour());
 
     // fire an event
-    const wxEventType eventType = res == wxID_OK ? wxEVT_COLOURPICKER_CHANGED : wxEVT_COLOUR_CANCELED;
+    const wxEventType eventType = res == wxID_OK ? wxEVT_COLOURPICKER_CHANGED : wxEVT_COLOUR_CANCELLED;
     wxColourPickerEvent event(this, GetId(), m_colour, eventType);
 
     ProcessWindowEvent(event);

--- a/src/msw/colordlg.cpp
+++ b/src/msw/colordlg.cpp
@@ -278,7 +278,7 @@ int wxColourDialog::ShowModal()
 void wxColourDialog::OnColorSelected(const wxColour& colour)
 {
     wxColourPickerEvent event(this, GetId(), colour, wxEVT_COLOUR_SELECTED);
-    GetEventHandler()->ProcessEvent(event);
+    ProcessWindowEvent(event);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/msw/colordlg.cpp
+++ b/src/msw/colordlg.cpp
@@ -116,7 +116,7 @@ wxColourDialogSubClassProc(HWND hwnd,
 {
 
     DialogSubclassingData* const dialogData = static_cast<DialogSubclassingData*>(GetProp(hwnd, SUBCLASSING_PROP));
-    if (!dialogData)
+    if ( !dialogData )
     {
         // Must not happen since WM_NCDESTROY is the last message received when closing the dialog.
         wxASSERT_MSG(false, "No dialog data to process subclassing message");

--- a/src/msw/colordlg.cpp
+++ b/src/msw/colordlg.cpp
@@ -115,7 +115,7 @@ wxColourDialogSubClassProc(HWND hwnd,
                            LPARAM lParam)
 {
 
-    DialogSubclassingData* dialogData = (DialogSubclassingData*)GetProp(hwnd, SUBCLASSING_PROP);
+    DialogSubclassingData* const dialogData = static_cast<DialogSubclassingData*>(GetProp(hwnd, SUBCLASSING_PROP));
     if (!dialogData)
     {
         // Must not happen since WM_NCDESTROY is the last message received when closing the dialog.

--- a/src/msw/colordlg.cpp
+++ b/src/msw/colordlg.cpp
@@ -239,11 +239,12 @@ int wxColourDialog::ShowModal()
 
     chooseColorStruct.lStructSize = sizeof(CHOOSECOLOR);
     chooseColorStruct.hwndOwner = hWndParent;
-    chooseColorStruct.lCustData = (LPARAM)this;
+
     chooseColorStruct.rgbResult = wxColourToRGB(m_colourData.GetColour());
     chooseColorStruct.lpCustColors = custColours;
 
     chooseColorStruct.Flags = CC_RGBINIT | CC_ENABLEHOOK;
+    chooseColorStruct.lCustData = (LPARAM)this;
     chooseColorStruct.lpfnHook = wxColourDialogHookProc;
 
     if ( m_colourData.GetChooseFull() )

--- a/src/msw/colordlg.cpp
+++ b/src/msw/colordlg.cpp
@@ -127,7 +127,7 @@ wxColourDialogSubClassProc(HWND hwnd,
     const LRESULT retValue = CallWindowProc(dialogData->originalProc, hwnd, uiMsg, wParam, lParam);
 
     // Check the current selected color.
-   if (const COLORINFO* pCI = (COLORINFO*)GetProp(hwnd, COLORPROP))
+   if ( const COLORINFO* pCI = (COLORINFO*)GetProp(hwnd, COLORPROP) )
    {
        if (dialogData->selectedColor != pCI->currentRGB)
        {

--- a/src/msw/colordlg.cpp
+++ b/src/msw/colordlg.cpp
@@ -108,17 +108,21 @@ struct DialogSubclassingData
 // colour dialog subclass proc
 // ----------------------------------------------------------------------------
 
-LRESULT  CALLBACK
+LRESULT CALLBACK
 wxColourDialogSubClassProc(HWND hwnd,
-        UINT uiMsg,
-        WPARAM wParam,
-        LPARAM lParam)
+                           UINT uiMsg,
+                           WPARAM wParam,
+                           LPARAM lParam)
 {
 
     DialogSubclassingData* dialogData = (DialogSubclassingData*)GetProp(hwnd, SUBCLASSING_PROP);
-    wxASSERT(dialogData);
+    if (!dialogData)
+    {
+        // WM_NCDESTROY is the last message received when exiting but lets be safe.
+        return 0;
+    }
 
-    // Let the original procedure process the event first.
+    // Call the original procedure process the event first.
     const LRESULT retValue = CallWindowProc(dialogData->originalProc, hwnd, uiMsg, wParam, lParam);
 
     switch (uiMsg)
@@ -139,9 +143,10 @@ wxColourDialogSubClassProc(HWND hwnd,
          }
         break;
 
-        case WM_DESTROY:
+        case WM_NCDESTROY:
         {
             delete dialogData;
+            RemoveProp(hwnd, SUBCLASSING_PROP);
         }
         break;
     }

--- a/src/msw/colordlg.cpp
+++ b/src/msw/colordlg.cpp
@@ -119,7 +119,7 @@ wxColourDialogSubClassProc(HWND hwnd,
     if ( !dialogData )
     {
         // Must not happen since WM_NCDESTROY is the last message received when closing the dialog.
-        wxASSERT_MSG(false, "No dialog data to process subclassing message");
+        wxFAIL_MSG("No dialog data to process subclassing message");
         return 0;
     }
 

--- a/src/msw/colordlg.cpp
+++ b/src/msw/colordlg.cpp
@@ -95,7 +95,7 @@ struct COLORINFO
     RECT           rColorSamples;
     BOOL           bFoldOut;
     DWORD          rgbBoxColor[COLORBOXES];
-} ;
+};
 
 struct DialogSubclassingData
 {

--- a/src/msw/colordlg.cpp
+++ b/src/msw/colordlg.cpp
@@ -137,10 +137,13 @@ wxColourDialogSubClassProc(HWND hwnd,
                 dialogData->colourDialog->OnColorSelected(colour);
             }
          }
+        break;
+
         case WM_DESTROY:
         {
             delete dialogData;
         }
+        break;
     }
 
     return retValue;

--- a/src/msw/colordlg.cpp
+++ b/src/msw/colordlg.cpp
@@ -162,9 +162,8 @@ wxColourDialogHookProc(HWND hwnd,
     if ( uiMsg == WM_INITDIALOG )
     {
         CHOOSECOLOR *pCC = (CHOOSECOLOR *)lParam;
-        wxColourDialog * const
-            dialog = reinterpret_cast<wxColourDialog *>(pCC->lCustData);
-
+        wxColourDialog * const  dialog = (wxColourDialog *)(pCC->lCustData);
+           
         // Init the dialog procedure data
         DialogSubclassingData* procData = new DialogSubclassingData();
         procData->originalProc = (WNDPROC)SetWindowLongPtr(hwnd, GWLP_WNDPROC, (LONG_PTR)wxColourDialogSubClassProc);

--- a/src/msw/colordlg.cpp
+++ b/src/msw/colordlg.cpp
@@ -126,30 +126,24 @@ wxColourDialogSubClassProc(HWND hwnd,
     // Call the original procedure first.
     const LRESULT retValue = CallWindowProc(dialogData->originalProc, hwnd, uiMsg, wParam, lParam);
 
-    switch (uiMsg)
+    // Check the current selected color.
+   if (const COLORINFO* pCI = (COLORINFO*)GetProp(hwnd, COLORPROP))
+   {
+       if (dialogData->selectedColor != pCI->currentRGB)
+       {
+           dialogData->selectedColor = pCI->currentRGB;
+
+           wxColour colour;
+           wxRGBToColour(colour, pCI->currentRGB);
+           dialogData->colourDialog->OnColorSelected(colour);
+       }
+   }
+
+    // Handle the destroy message.
+    if (uiMsg == WM_NCDESTROY)
     {
-        case WM_LBUTTONDOWN:
-        case WM_MOUSEMOVE:
-        {
-
-            const COLORINFO* pCI = (COLORINFO*)GetProp(hwnd, COLORPROP);
-            if (dialogData->selectedColor != pCI->currentRGB)
-            {
-                dialogData->selectedColor = pCI->currentRGB;
-
-                wxColour colour;
-                wxRGBToColour(colour, pCI->currentRGB);
-                dialogData->colourDialog->OnColorSelected(colour);
-            }
-         }
-        break;
-
-        case WM_NCDESTROY:
-        {
-            delete dialogData;
-            RemoveProp(hwnd, SUBCLASSING_PROP);
-        }
-        break;
+        delete dialogData;
+        RemoveProp(hwnd, SUBCLASSING_PROP);
     }
 
     return retValue;

--- a/src/msw/colordlg.cpp
+++ b/src/msw/colordlg.cpp
@@ -97,7 +97,7 @@ struct COLORINFO
     DWORD          rgbBoxColor[COLORBOXES];
 };
 
-struct DialogSubclassingData
+struct ColourDialogSubclassingData
 {
     WNDPROC originalProc;
     COLORREF selectedColor;

--- a/src/msw/colordlg.cpp
+++ b/src/msw/colordlg.cpp
@@ -129,7 +129,7 @@ wxColourDialogSubClassProc(HWND hwnd,
     // Check the current selected color.
    if ( const COLORINFO* pCI = (COLORINFO*)GetProp(hwnd, COLORPROP) )
    {
-       if (dialogData->selectedColor != pCI->currentRGB)
+       if ( dialogData->selectedColor != pCI->currentRGB )
        {
            dialogData->selectedColor = pCI->currentRGB;
 

--- a/src/msw/colordlg.cpp
+++ b/src/msw/colordlg.cpp
@@ -119,7 +119,7 @@ wxColourDialogSubClassProc(HWND hwnd,
     if (!dialogData)
     {
         // Must not happen since WM_NCDESTROY is the last message received when closing the dialog.
-        wxASSERT(false, "No dialog data to process subclassing message");
+        wxASSERT_MSG(false, "No dialog data to process subclassing message");
         return 0;
     }
 

--- a/src/msw/colordlg.cpp
+++ b/src/msw/colordlg.cpp
@@ -160,7 +160,8 @@ wxColourDialogHookProc(HWND hwnd,
     if ( uiMsg == WM_INITDIALOG )
     {
         CHOOSECOLOR *pCC = (CHOOSECOLOR *)lParam;
-        wxColourDialog * const  dialog = (wxColourDialog *)pCC->lCustData;
+        wxColourDialog * const
+            dialog = reinterpret_cast<wxColourDialog *>(pCC->lCustData);
            
         // Init the subclassing data.
         g_subclassingData.originalProc = (WNDPROC)SetWindowLongPtr(hwnd, GWLP_WNDPROC, (LONG_PTR)wxColourDialogSubClassProc);


### PR DESCRIPTION
This pull request adds two new events to the wxColourPickerCtrl.
wxEVT_COLOUR_SELECTED: Called when the dialog selected color is changed.
wxEVT_COLOUR_CANCELED: Called when the dialog is closed or the user clicks on CANCEL.

The implementation, which is MSW only has been built from the following answers:
https://social.msdn.microsoft.com/Forums/en-US/c5fcfd9f-6b27-4848-bb9d-94bec105eabd/get-the-current-clicked-color-from-choosecolor-dialog?forum=windowsgeneraldevelopmentissues

The selected color corresponds to the current color for both user clicks and the Api client.
A Call to SetColour on the wxColourPickerCtrl will also set the selected color to that value.
A Call to GetSelectedColour will always return the current "desired" color allowing to not care about the dialog state.
The feature can be a little bit confusing or is probably too specific. Don't hesitate if you have improvements.

Here a gif showing a use case:
![picker](https://user-images.githubusercontent.com/9217999/52181140-c42b0780-27bc-11e9-8ea6-bb204ef411f3.gif)
