### PR TITLE
Fix for some crashes in readonly comboboxes for wxQT

### DIFF
--- a/include/wx/qt/combobox.h
+++ b/include/wx/qt/combobox.h
@@ -87,6 +87,7 @@ protected:
 
 private:
     void SetActualValue(const wxString& value);
+    bool IsReadOnly() const;
 
     // From wxTextEntry:
     virtual wxWindow *GetEditableWindow() wxOVERRIDE { return this; }

--- a/src/qt/combobox.cpp
+++ b/src/qt/combobox.cpp
@@ -185,7 +185,9 @@ void wxComboBox::SetActualValue(const wxString &value)
 void wxComboBox::SetValue(const wxString& value)
 {
     SetActualValue( value );
-    SetInsertionPoint( 0 );
+
+    if ( !HasFlag(wxCB_READONLY) )
+        SetInsertionPoint( 0 );
 }
 
 void wxComboBox::ChangeValue(const wxString &value)
@@ -249,7 +251,9 @@ void wxComboBox::Dismiss()
 
 void wxComboBox::Clear()
 {
-    wxTextEntry::Clear();
+    if ( !HasFlag(wxCB_READONLY) )
+        wxTextEntry::Clear();
+
     wxItemContainer::Clear();
 }
 

--- a/src/qt/combobox.cpp
+++ b/src/qt/combobox.cpp
@@ -171,7 +171,7 @@ bool wxComboBox::Create(wxWindow *parent, wxWindowID id,
 
 void wxComboBox::SetActualValue(const wxString &value)
 {
-    if ( HasFlag(wxCB_READONLY) )
+    if ( IsReadOnly() )
     {
         SetStringSelection( value );
     }
@@ -182,11 +182,16 @@ void wxComboBox::SetActualValue(const wxString &value)
     }
 }
 
+bool wxComboBox::IsReadOnly() const
+{
+    return HasFlag( wxCB_READONLY );
+}
+
 void wxComboBox::SetValue(const wxString& value)
 {
     SetActualValue( value );
 
-    if ( !HasFlag(wxCB_READONLY) )
+    if ( !IsReadOnly() )
         SetInsertionPoint( 0 );
 }
 
@@ -251,7 +256,7 @@ void wxComboBox::Dismiss()
 
 void wxComboBox::Clear()
 {
-    if ( !HasFlag(wxCB_READONLY) )
+    if ( !IsReadOnly() )
         wxTextEntry::Clear();
 
     wxItemContainer::Clear();


### PR DESCRIPTION
This PR fixes a few crashes when the wxCB_READONLY is set for wxComboBox under wxQT.     

