### PR TITLE
"Native" implementation of wxTreeCtrl for wxQT

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -3575,7 +3575,8 @@ COND_TOOLKIT_QT_GUI_HDR =  \
 	wx/generic/activityindicator.h \
 	wx/qt/dataview.h \
 	wx/qt/dvrenderers.h \
-	$(QT_PLATFORM_HDR)
+	$(QT_PLATFORM_HDR) \
+	wx/qt/treectrl.h
 @COND_TOOLKIT_QT@GUI_HDR = $(COND_TOOLKIT_QT_GUI_HDR)
 @COND_TOOLKIT_COCOA@MEDIA_PLATFORM_HDR = 
 @COND_TOOLKIT_GTK@MEDIA_PLATFORM_HDR = 
@@ -5542,7 +5543,7 @@ COND_TOOLKIT_MSW___GUI_SRC_OBJECTS =  \
 	monodll_msw_textctrl.o \
 	monodll_msw_textentry.o \
 	monodll_msw_tglbtn.o \
-	monodll_treectrl.o \
+	monodll_msw_treectrl.o \
 	monodll_systhemectrl.o \
 	monodll_customdraw.o \
 	monodll_animateg.o \
@@ -5736,7 +5737,8 @@ COND_TOOLKIT_QT___GUI_SRC_OBJECTS =  \
 	monodll_qt_uiaction.o \
 	monodll_qt_utils.o \
 	monodll_qt_window.o \
-	$(__QT_PLATFORM_SRC_OBJECTS)
+	$(__QT_PLATFORM_SRC_OBJECTS) \
+	monodll_qt_treectrl.o
 @COND_TOOLKIT_QT@__GUI_SRC_OBJECTS = $(COND_TOOLKIT_QT___GUI_SRC_OBJECTS)
 COND_PLATFORM_WIN32_1___QT_PLATFORM_SRC_OBJECTS =  \
 	monodll_comimpl.o \
@@ -7521,7 +7523,7 @@ COND_TOOLKIT_MSW___GUI_SRC_OBJECTS_1 =  \
 	monolib_msw_textctrl.o \
 	monolib_msw_textentry.o \
 	monolib_msw_tglbtn.o \
-	monolib_treectrl.o \
+	monolib_msw_treectrl.o \
 	monolib_systhemectrl.o \
 	monolib_customdraw.o \
 	monolib_animateg.o \
@@ -7715,7 +7717,8 @@ COND_TOOLKIT_QT___GUI_SRC_OBJECTS_1 =  \
 	monolib_qt_uiaction.o \
 	monolib_qt_utils.o \
 	monolib_qt_window.o \
-	$(__QT_PLATFORM_SRC_OBJECTS_1)
+	$(__QT_PLATFORM_SRC_OBJECTS_1) \
+	monolib_qt_treectrl.o
 @COND_TOOLKIT_QT@__GUI_SRC_OBJECTS_1 = $(COND_TOOLKIT_QT___GUI_SRC_OBJECTS_1)
 COND_PLATFORM_WIN32_1___QT_PLATFORM_SRC_OBJECTS_1 =  \
 	monolib_comimpl.o \
@@ -9647,7 +9650,7 @@ COND_TOOLKIT_MSW___GUI_SRC_OBJECTS_2 =  \
 	coredll_msw_textctrl.o \
 	coredll_msw_textentry.o \
 	coredll_msw_tglbtn.o \
-	coredll_treectrl.o \
+	coredll_msw_treectrl.o \
 	coredll_systhemectrl.o \
 	coredll_customdraw.o \
 	coredll_animateg.o \
@@ -9841,7 +9844,8 @@ COND_TOOLKIT_QT___GUI_SRC_OBJECTS_2 =  \
 	coredll_qt_uiaction.o \
 	coredll_qt_utils.o \
 	coredll_qt_window.o \
-	$(__QT_PLATFORM_SRC_OBJECTS_2)
+	$(__QT_PLATFORM_SRC_OBJECTS_2) \
+	coredll_qt_treectrl.o
 @COND_TOOLKIT_QT@__GUI_SRC_OBJECTS_2 = $(COND_TOOLKIT_QT___GUI_SRC_OBJECTS_2)
 COND_PLATFORM_WIN32_1___QT_PLATFORM_SRC_OBJECTS_2 =  \
 	coredll_comimpl.o \
@@ -11368,7 +11372,7 @@ COND_TOOLKIT_MSW___GUI_SRC_OBJECTS_3 =  \
 	corelib_msw_textctrl.o \
 	corelib_msw_textentry.o \
 	corelib_msw_tglbtn.o \
-	corelib_treectrl.o \
+	corelib_msw_treectrl.o \
 	corelib_systhemectrl.o \
 	corelib_customdraw.o \
 	corelib_animateg.o \
@@ -11562,7 +11566,8 @@ COND_TOOLKIT_QT___GUI_SRC_OBJECTS_3 =  \
 	corelib_qt_uiaction.o \
 	corelib_qt_utils.o \
 	corelib_qt_window.o \
-	$(__QT_PLATFORM_SRC_OBJECTS_3)
+	$(__QT_PLATFORM_SRC_OBJECTS_3) \
+	corelib_qt_treectrl.o
 @COND_TOOLKIT_QT@__GUI_SRC_OBJECTS_3 = $(COND_TOOLKIT_QT___GUI_SRC_OBJECTS_3)
 COND_PLATFORM_WIN32_1___QT_PLATFORM_SRC_OBJECTS_3 =  \
 	corelib_comimpl.o \
@@ -16338,7 +16343,7 @@ monodll_msw_textentry.o: $(srcdir)/src/msw/textentry.cpp $(MONODLL_ODEP)
 monodll_msw_tglbtn.o: $(srcdir)/src/msw/tglbtn.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/msw/tglbtn.cpp
 
-monodll_treectrl.o: $(srcdir)/src/msw/treectrl.cpp $(MONODLL_ODEP)
+monodll_msw_treectrl.o: $(srcdir)/src/msw/treectrl.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/msw/treectrl.cpp
 
 monodll_systhemectrl.o: $(srcdir)/src/msw/systhemectrl.cpp $(MONODLL_ODEP)
@@ -16832,6 +16837,9 @@ monodll_qt_window.o: $(srcdir)/src/qt/window.cpp $(MONODLL_ODEP)
 
 monodll_qt_graphics.o: $(srcdir)/src/qt/graphics.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/qt/graphics.cpp
+
+monodll_qt_treectrl.o: $(srcdir)/src/qt/treectrl.cpp $(MONODLL_ODEP)
+	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/qt/treectrl.cpp
 
 monodll_univ_anybutton.o: $(srcdir)/src/univ/anybutton.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/univ/anybutton.cpp
@@ -21597,7 +21605,7 @@ monolib_msw_textentry.o: $(srcdir)/src/msw/textentry.cpp $(MONOLIB_ODEP)
 monolib_msw_tglbtn.o: $(srcdir)/src/msw/tglbtn.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/msw/tglbtn.cpp
 
-monolib_treectrl.o: $(srcdir)/src/msw/treectrl.cpp $(MONOLIB_ODEP)
+monolib_msw_treectrl.o: $(srcdir)/src/msw/treectrl.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/msw/treectrl.cpp
 
 monolib_systhemectrl.o: $(srcdir)/src/msw/systhemectrl.cpp $(MONOLIB_ODEP)
@@ -22091,6 +22099,9 @@ monolib_qt_window.o: $(srcdir)/src/qt/window.cpp $(MONOLIB_ODEP)
 
 monolib_qt_graphics.o: $(srcdir)/src/qt/graphics.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/qt/graphics.cpp
+
+monolib_qt_treectrl.o: $(srcdir)/src/qt/treectrl.cpp $(MONOLIB_ODEP)
+	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/qt/treectrl.cpp
 
 monolib_univ_anybutton.o: $(srcdir)/src/univ/anybutton.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/univ/anybutton.cpp
@@ -27516,7 +27527,7 @@ coredll_msw_textentry.o: $(srcdir)/src/msw/textentry.cpp $(COREDLL_ODEP)
 coredll_msw_tglbtn.o: $(srcdir)/src/msw/tglbtn.cpp $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/msw/tglbtn.cpp
 
-coredll_treectrl.o: $(srcdir)/src/msw/treectrl.cpp $(COREDLL_ODEP)
+coredll_msw_treectrl.o: $(srcdir)/src/msw/treectrl.cpp $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/msw/treectrl.cpp
 
 coredll_systhemectrl.o: $(srcdir)/src/msw/systhemectrl.cpp $(COREDLL_ODEP)
@@ -28010,6 +28021,9 @@ coredll_qt_window.o: $(srcdir)/src/qt/window.cpp $(COREDLL_ODEP)
 
 coredll_qt_graphics.o: $(srcdir)/src/qt/graphics.cpp $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/qt/graphics.cpp
+
+coredll_qt_treectrl.o: $(srcdir)/src/qt/treectrl.cpp $(COREDLL_ODEP)
+	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/qt/treectrl.cpp
 
 coredll_univ_anybutton.o: $(srcdir)/src/univ/anybutton.cpp $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/univ/anybutton.cpp
@@ -31770,7 +31784,7 @@ corelib_msw_textentry.o: $(srcdir)/src/msw/textentry.cpp $(CORELIB_ODEP)
 corelib_msw_tglbtn.o: $(srcdir)/src/msw/tglbtn.cpp $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/msw/tglbtn.cpp
 
-corelib_treectrl.o: $(srcdir)/src/msw/treectrl.cpp $(CORELIB_ODEP)
+corelib_msw_treectrl.o: $(srcdir)/src/msw/treectrl.cpp $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/msw/treectrl.cpp
 
 corelib_systhemectrl.o: $(srcdir)/src/msw/systhemectrl.cpp $(CORELIB_ODEP)
@@ -32264,6 +32278,9 @@ corelib_qt_window.o: $(srcdir)/src/qt/window.cpp $(CORELIB_ODEP)
 
 corelib_qt_graphics.o: $(srcdir)/src/qt/graphics.cpp $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/qt/graphics.cpp
+
+corelib_qt_treectrl.o: $(srcdir)/src/qt/treectrl.cpp $(CORELIB_ODEP)
+	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/qt/treectrl.cpp
 
 corelib_univ_anybutton.o: $(srcdir)/src/univ/anybutton.cpp $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/univ/anybutton.cpp

--- a/Makefile.in
+++ b/Makefile.in
@@ -3576,7 +3576,13 @@ COND_TOOLKIT_QT_GUI_HDR =  \
 	wx/qt/dataview.h \
 	wx/qt/dvrenderers.h \
 	$(QT_PLATFORM_HDR) \
-	wx/qt/treectrl.h
+	wx/qt/treectrl.h \
+	wx/qt/private/winevent.h \
+	wx/qt/private/converter.h \
+	wx/qt/private/treeitemfactory.h \
+	wx/qt/private/pointer.h \
+	wx/qt/private/timer.h \
+	wx/qt/private/utils.h
 @COND_TOOLKIT_QT@GUI_HDR = $(COND_TOOLKIT_QT_GUI_HDR)
 @COND_TOOLKIT_COCOA@MEDIA_PLATFORM_HDR = 
 @COND_TOOLKIT_GTK@MEDIA_PLATFORM_HDR = 

--- a/Makefile.in
+++ b/Makefile.in
@@ -3579,6 +3579,7 @@ COND_TOOLKIT_QT_GUI_HDR =  \
 	wx/qt/treectrl.h \
 	wx/qt/private/winevent.h \
 	wx/qt/private/converter.h \
+	wx/qt/private/treeitemdelegate.h \
 	wx/qt/private/treeitemfactory.h \
 	wx/qt/private/pointer.h \
 	wx/qt/private/timer.h \

--- a/build/bakefiles/files.bkl
+++ b/build/bakefiles/files.bkl
@@ -364,6 +364,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     wx/qt/treectrl.h
     wx/qt/private/winevent.h
     wx/qt/private/converter.h
+    wx/qt/private/treeitemdelegate.h
     wx/qt/private/treeitemfactory.h
     wx/qt/private/pointer.h
     wx/qt/private/timer.h

--- a/build/bakefiles/files.bkl
+++ b/build/bakefiles/files.bkl
@@ -362,6 +362,12 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     wx/qt/dvrenderers.h
     $(QT_PLATFORM_HDR)
     wx/qt/treectrl.h
+    wx/qt/private/winevent.h
+    wx/qt/private/converter.h
+    wx/qt/private/treeitemfactory.h
+    wx/qt/private/pointer.h
+    wx/qt/private/timer.h
+    wx/qt/private/utils.h
 </set>
 
 <set var="QT_SRC" hints="files">

--- a/build/bakefiles/files.bkl
+++ b/build/bakefiles/files.bkl
@@ -347,7 +347,6 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     wx/qt/toolbar.h
     wx/qt/tooltip.h
     wx/qt/toplevel.h
-    <!-- wx/qt/treectrl.h -->
     wx/qt/window.h
     wx/generic/fdrepdlg.h
     wx/generic/filepickerg.h
@@ -362,6 +361,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     wx/qt/dataview.h
     wx/qt/dvrenderers.h
     $(QT_PLATFORM_HDR)
+    wx/qt/treectrl.h
 </set>
 
 <set var="QT_SRC" hints="files">
@@ -460,6 +460,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     src/qt/utils.cpp
     src/qt/window.cpp
     $(QT_PLATFORM_SRC)
+    src/qt/treectrl.cpp
 </set>
 
 <set var="MEDIA_QT_SRC" hints="files">

--- a/build/cmake/files.cmake
+++ b/build/cmake/files.cmake
@@ -276,6 +276,7 @@ set(QT_HDR
     wx/qt/dataview.h
     wx/generic/activityindicator.h
     ${QT_PLATFORM_HDR}
+    wx/qt/treectrl.h
 )
 
 set(QT_SRC
@@ -374,6 +375,7 @@ set(QT_SRC
     src/qt/dataview.cpp
     src/qt/taskbar.cpp
     ${QT_PLATFORM_SRC}
+    src/qt/treectrl.cpp
 )
 
 set(MEDIA_QT_SRC

--- a/build/cmake/files.cmake
+++ b/build/cmake/files.cmake
@@ -277,6 +277,12 @@ set(QT_HDR
     wx/generic/activityindicator.h
     ${QT_PLATFORM_HDR}
     wx/qt/treectrl.h
+    wx/qt/private/converter.h
+    wx/qt/private/winevent.h
+    wx/qt/private/timer.h
+    wx/qt/private/pointer.h
+    wx/qt/private/treeitemfactory.h
+    wx/qt/private/utils.h
 )
 
 set(QT_SRC

--- a/build/cmake/files.cmake
+++ b/build/cmake/files.cmake
@@ -281,6 +281,7 @@ set(QT_HDR
     wx/qt/private/winevent.h
     wx/qt/private/timer.h
     wx/qt/private/pointer.h
+    wx/qt/private/treeitemdelegate.h
     wx/qt/private/treeitemfactory.h
     wx/qt/private/utils.h
 )

--- a/build/files
+++ b/build/files
@@ -305,6 +305,7 @@ QT_HDR =
     wx/qt/private/converter.h
     wx/qt/private/pointer.h
     wx/qt/private/timer.h
+    wx/qt/private/treeitemdelegate.h
     wx/qt/private/treeitemfactory.h
     wx/qt/private/utils.h
 

--- a/build/files
+++ b/build/files
@@ -297,16 +297,16 @@ QT_HDR =
     wx/qt/toolbar.h
     wx/qt/tooltip.h
     wx/qt/toplevel.h
-		wx/qt/treectrl.h
-		wx/qt/window.h
-		wx/qt/private/converter.h
-		wx/qt/private/winevent.h
-		wx/qt/private/winevent.h
-		wx/qt/private/converter.h
-		wx/qt/private/pointer.h
-		wx/qt/private/timer.h
-		wx/qt/private/treeitemfactory.h
-		wx/qt/private/utils.h
+    wx/qt/treectrl.h
+    wx/qt/window.h
+    wx/qt/private/converter.h
+    wx/qt/private/winevent.h
+    wx/qt/private/winevent.h
+    wx/qt/private/converter.h
+    wx/qt/private/pointer.h
+    wx/qt/private/timer.h
+    wx/qt/private/treeitemfactory.h
+    wx/qt/private/utils.h
 
 QT_SRC=
     $(QT_PLATFORM_SRC)
@@ -401,7 +401,7 @@ QT_SRC=
     src/qt/toolbar.cpp
     src/qt/tooltip.cpp
     src/qt/toplevel.cpp
-		src/qt/treectrl.cpp
+    src/qt/treectrl.cpp
     src/qt/uiaction.cpp
     src/qt/utils.cpp
     src/qt/window.cpp

--- a/build/files
+++ b/build/files
@@ -297,6 +297,7 @@ QT_HDR =
     wx/qt/toolbar.h
     wx/qt/tooltip.h
     wx/qt/toplevel.h
+		wx/qt/treectrl.h
     wx/qt/window.h
 
 QT_SRC=
@@ -392,6 +393,7 @@ QT_SRC=
     src/qt/toolbar.cpp
     src/qt/tooltip.cpp
     src/qt/toplevel.cpp
+		src/qt/treectrl.cpp
     src/qt/uiaction.cpp
     src/qt/utils.cpp
     src/qt/window.cpp

--- a/build/files
+++ b/build/files
@@ -298,7 +298,15 @@ QT_HDR =
     wx/qt/tooltip.h
     wx/qt/toplevel.h
 		wx/qt/treectrl.h
-    wx/qt/window.h
+		wx/qt/window.h
+		wx/qt/private/converter.h
+		wx/qt/private/winevent.h
+		wx/qt/private/winevent.h
+		wx/qt/private/converter.h
+		wx/qt/private/pointer.h
+		wx/qt/private/timer.h
+		wx/qt/private/treeitemfactory.h
+		wx/qt/private/utils.h
 
 QT_SRC=
     $(QT_PLATFORM_SRC)

--- a/include/wx/generic/treectlg.h
+++ b/include/wx/generic/treectlg.h
@@ -360,7 +360,7 @@ private:
     wxDECLARE_NO_COPY_CLASS(wxGenericTreeCtrl);
 };
 
-#if !defined(__WXMSW__) || defined(__WXUNIVERSAL__)
+#if !defined(__WXMSW__) && ! defined(__WXQT__) || defined(__WXUNIVERSAL__)
 /*
  * wxTreeCtrl has to be a real class or we have problems with
  * the run-time information.

--- a/include/wx/qt/listctrl.h
+++ b/include/wx/qt/listctrl.h
@@ -10,7 +10,7 @@
 
 #include "wx/textctrl.h"
 
-class wxQtTreeWidget;
+class wxQtListTreeWidget;
 class QTreeWidgetItem;
 
 class WXDLLIMPEXP_FWD_CORE wxImageList;
@@ -303,7 +303,7 @@ protected:
                       m_ownsImageListSmall,
                       m_ownsImageListState;
 private:
-    wxQtTreeWidget *m_qtTreeWidget;
+    wxQtListTreeWidget *m_qtTreeWidget;
 
     wxDECLARE_DYNAMIC_CLASS( wxListCtrl );
 };

--- a/include/wx/qt/private/converter.h
+++ b/include/wx/qt/private/converter.h
@@ -19,6 +19,7 @@
 #include <QtCore/QRect>
 #include <QtCore/QSize>
 #include <QtCore/QString>
+#include <QtGui/QColor>
 
 // Rely on overloading and let the compiler pick the correct version, which makes
 // them easier to use then to write wxQtConvertQtRectToWxRect() or wxQtConvertWxRectToQtRect()
@@ -52,6 +53,16 @@ inline wxString wxQtConvertString( const QString &str )
 inline QString wxQtConvertString( const wxString &str )
 {
     return QString( str.utf8_str() );
+}
+
+inline wxColour wxQtConvertColour(const QColor &colour)
+{
+    return wxColour(colour.red(), colour.green(), colour.blue(), colour.alpha());
+}
+
+inline QColor wxQtConvertColour(const wxColour &colour)
+{
+    return QColor(colour.Red(), colour.Green(), colour.Blue(), colour.Alpha());
 }
 
 #if wxUSE_DATETIME

--- a/include/wx/qt/private/converter.h
+++ b/include/wx/qt/private/converter.h
@@ -15,6 +15,7 @@
 
 #include "wx/kbdstate.h"
 #include "wx/gdicmn.h"
+#include "wx/colour.h"
 
 #include <QtCore/QRect>
 #include <QtCore/QSize>

--- a/include/wx/qt/private/treeitemdelegate.h
+++ b/include/wx/qt/private/treeitemdelegate.h
@@ -7,8 +7,8 @@
 // Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
-#ifndef _WX_TREEITEM_DELEGATE_H
-#define _WX_TREEITEM_DELEGATE_H
+#ifndef _WX_QT_PRIVATE_TREEITEM_DELEGATE_H
+#define _WX_QT_PRIVATE_TREEITEM_DELEGATE_H
 
 #include <QtWidgets/QStyledItemDelegate>
 
@@ -28,7 +28,10 @@ public:
 
     QWidget* createEditor(QWidget *parent, const QStyleOptionViewItem &WXUNUSED(option), const QModelIndex &index) const wxOVERRIDE
     {
-        m_current_model_index = index;
+        if ( m_textCtrl != NULL )
+            destroyEditor(m_textCtrl->GetHandle(), m_currentModelIndex);
+
+        m_currentModelIndex = index;
         m_textCtrl = new wxQtListTextCtrl(m_parent, parent);
         m_textCtrl->SetFocus();
         return m_textCtrl->GetHandle();
@@ -36,9 +39,9 @@ public:
 
     void destroyEditor(QWidget *WXUNUSED(editor), const QModelIndex &WXUNUSED(index)) const wxOVERRIDE
     {
-        if (!wxTheApp->IsScheduledForDestruction(m_textCtrl))
+        if ( m_textCtrl != NULL )
         {
-            m_current_model_index = QModelIndex();
+            m_currentModelIndex = QModelIndex(); // invalidate the index
             wxTheApp->ScheduleForDestruction(m_textCtrl);
             m_textCtrl = NULL;
         }
@@ -56,7 +59,7 @@ public:
 
     QModelIndex GetCurrentModelIndex() const
     {
-        return m_current_model_index;
+        return m_currentModelIndex;
     }
 
     void AcceptModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const
@@ -67,7 +70,7 @@ public:
 private:
     wxWindow* m_parent;
     mutable wxTextCtrl* m_textCtrl;
-    mutable QModelIndex m_current_model_index;
+    mutable QModelIndex m_currentModelIndex;
 };
 
-#endif // _WX_TREEITEM_DELEGATE_H
+#endif // _WX_QT_PRIVATE_TREEITEM_DELEGATE_H

--- a/include/wx/qt/private/treeitemdelegate.h
+++ b/include/wx/qt/private/treeitemdelegate.h
@@ -40,7 +40,7 @@ public:
         m_textCtrl = NULL;
     }
 
-    void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const wxOVERRIDE
+        void setModelData(QWidget *WXUNUSED(editor), QAbstractItemModel *WXUNUSED(model), const QModelIndex &WXUNUSED(index)) const wxOVERRIDE
     {
         // Don't set model data until wx has had a chance to send out events
     }

--- a/include/wx/qt/private/treeitemdelegate.h
+++ b/include/wx/qt/private/treeitemdelegate.h
@@ -40,7 +40,7 @@ public:
         m_textCtrl = NULL;
     }
 
-        void setModelData(QWidget *WXUNUSED(editor), QAbstractItemModel *WXUNUSED(model), const QModelIndex &WXUNUSED(index)) const wxOVERRIDE
+    void setModelData(QWidget *WXUNUSED(editor), QAbstractItemModel *WXUNUSED(model), const QModelIndex &WXUNUSED(index)) const wxOVERRIDE
     {
         // Don't set model data until wx has had a chance to send out events
     }

--- a/include/wx/qt/private/treeitemdelegate.h
+++ b/include/wx/qt/private/treeitemdelegate.h
@@ -1,0 +1,69 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        wx/qt/private/treeitemdelegate.h
+// Purpose:     Delegate to create text edit controls for the tree items
+// Author:      Matthew Griffin
+// Created:     2019-05-29
+// Copyright:   Matthew Griffin
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_TREEITEM_DELEGATE_H
+#define _WX_TREEITEM_DELEGATE_H
+
+#include <QtWidgets/QStyledItemDelegate>
+
+#include "wx/textctrl.h"
+
+#include "treeitemfactory.h"
+
+class wxQTTreeItemDelegate : public QStyledItemDelegate
+{
+public:
+    explicit wxQTTreeItemDelegate(wxWindow* parent)
+        : m_parent(parent),
+        m_textCtrl(NULL)
+    {
+    }
+
+    QWidget* createEditor(QWidget *parent, const QStyleOptionViewItem &WXUNUSED(option), const QModelIndex &index) const wxOVERRIDE
+    {
+        m_current_model_index = index;
+        m_textCtrl = new wxQtListTextCtrl(m_parent, parent);
+        m_textCtrl->SetFocus();
+        return m_textCtrl->GetHandle();
+    }
+
+    void destroyEditor(QWidget *WXUNUSED(editor), const QModelIndex &WXUNUSED(index)) const wxOVERRIDE
+    {
+        m_current_model_index = QModelIndex();
+        delete m_textCtrl;
+        m_textCtrl = NULL;
+    }
+
+    void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const wxOVERRIDE
+    {
+        // Don't set model data until wx has had a chance to send out events
+    }
+
+    wxTextCtrl* GetEditControl() const
+    {
+        return m_textCtrl;
+    }
+
+    QModelIndex GetCurrentModelIndex() const
+    {
+        return m_current_model_index;
+    }
+
+    void AcceptModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const
+    {
+        QStyledItemDelegate::setModelData(editor, model, index);
+    }
+
+private:
+    wxWindow* m_parent;
+    mutable wxTextCtrl* m_textCtrl;
+    mutable QModelIndex m_current_model_index;
+};
+
+#endif // _WX_TREEITEM_DELEGATE_H

--- a/include/wx/qt/private/treeitemdelegate.h
+++ b/include/wx/qt/private/treeitemdelegate.h
@@ -12,6 +12,7 @@
 
 #include <QtWidgets/QStyledItemDelegate>
 
+#include "wx/app.h"
 #include "wx/textctrl.h"
 
 #include "treeitemfactory.h"
@@ -35,9 +36,12 @@ public:
 
     void destroyEditor(QWidget *WXUNUSED(editor), const QModelIndex &WXUNUSED(index)) const wxOVERRIDE
     {
-        m_current_model_index = QModelIndex();
-        delete m_textCtrl;
-        m_textCtrl = NULL;
+        if (!wxTheApp->IsScheduledForDestruction(m_textCtrl))
+        {
+            m_current_model_index = QModelIndex();
+            wxTheApp->ScheduleForDestruction(m_textCtrl);
+            m_textCtrl = NULL;
+        }
     }
 
     void setModelData(QWidget *WXUNUSED(editor), QAbstractItemModel *WXUNUSED(model), const QModelIndex &WXUNUSED(index)) const wxOVERRIDE

--- a/include/wx/qt/private/treeitemfactory.h
+++ b/include/wx/qt/private/treeitemfactory.h
@@ -2,6 +2,8 @@
 #define _WX_TREEITEM_FACTORY_H_
 
 #include <QtWidgets/QItemEditorFactory>
+#include <QtWidgets/QTreeWidget>
+#include <QtWidgets/QItemDelegate>
 
 #include "wx/recguard.h"
 #include "wx/textctrl.h"
@@ -69,6 +71,12 @@ public:
         : m_parent(parent),
         m_textCtrl(NULL)
     {
+    }
+
+    void AttachTo(QTreeWidget *tree)
+    {
+        QItemDelegate *qItemDelegate = static_cast<QItemDelegate*>(tree->itemDelegate());
+        qItemDelegate->setItemEditorFactory(this);
     }
 
     QWidget* createEditor(int WXUNUSED(userType), QWidget* parent) const wxOVERRIDE

--- a/include/wx/qt/private/treeitemfactory.h
+++ b/include/wx/qt/private/treeitemfactory.h
@@ -1,9 +1,8 @@
 /////////////////////////////////////////////////////////////////////////////
-// Name:        wx/treeitemfactory.h
+// Name:        wx/qt/private/treeitemfactory.h
 // Purpose:     Factory to create text edit controls for the tree items
 // Author:      Graham Dawes
-// Modified by:
-// Created:     02/2019
+// Created:     2019-02-07
 // Copyright:   Graham Dawes
 // Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////

--- a/include/wx/qt/private/treeitemfactory.h
+++ b/include/wx/qt/private/treeitemfactory.h
@@ -1,0 +1,100 @@
+#ifndef _WX_TREEITEM_FACTORY_H_
+#define _WX_TREEITEM_FACTORY_H_
+
+#include <QtWidgets/QItemEditorFactory>
+
+#include "wx/recguard.h"
+#include "wx/textctrl.h"
+
+// wxQT Doesn't have a mechanism for "adopting" external widgets so we have to
+// create an instance of wxTextCtrl rather than adopting the control QT would
+// create.
+//
+// Unfortunately the factory is given an internal widget as the parent for
+// editor.
+//
+// To work around these issues we create a wxTextCtl parented by the wxListCtrl
+// then recalculate its position relative to the internal widget.
+class wxQtListTextCtrl : public wxTextCtrl
+{
+public:
+    wxQtListTextCtrl(wxWindow* parent, QWidget* actualParent)
+        : wxTextCtrl(parent, wxID_ANY, wxEmptyString,
+            wxDefaultPosition, wxDefaultSize,
+            wxNO_BORDER),
+        m_actualParent(actualParent),
+        m_moving(0)
+    {
+
+        Bind(wxEVT_MOVE, &wxQtListTextCtrl::onMove, this);
+    }
+
+    void onMove(wxMoveEvent &event)
+    {
+        // QWidget::move generates a QMoveEvent so we need to guard against
+        // reentrant calls.
+        wxRecursionGuard guard(m_moving);
+        if (guard.IsInside())
+        {
+            event.Skip();
+            return;
+        }
+
+        const QPoint eventPosition = wxQtConvertPoint(event.GetPosition());
+        const QPoint globalPosition = m_actualParent->mapToGlobal(eventPosition);
+
+        // For some reason this always gives us the offset from the header info
+        // the internal control. So we need to treat this as an offset rather
+        // than a position.
+        QWidget* widget = GetHandle();
+        const QPoint offset = widget->mapFromGlobal(globalPosition);
+
+        widget->move(eventPosition + offset);
+    }
+
+private:
+    QWidget* m_actualParent;
+    wxRecursionGuardFlag m_moving;
+
+    wxDECLARE_NO_COPY_CLASS(wxQtListTextCtrl);
+};
+
+// QT doesn't give us direct access to the editor within the QTreeWidget.
+// Instead, we'll supply a factory to create the widget for QT and keep track
+// of it ourselves.
+class wxQtTreeItemEditorFactory : public QItemEditorFactory
+{
+public:
+    explicit wxQtTreeItemEditorFactory(wxWindow* parent)
+        : m_parent(parent),
+        m_textCtrl(NULL)
+    {
+    }
+
+    QWidget* createEditor(int WXUNUSED(userType), QWidget* parent) const wxOVERRIDE
+    {
+        m_textCtrl = new wxQtListTextCtrl(m_parent, parent);
+        m_textCtrl->SetFocus();
+        return m_textCtrl->GetHandle();
+    }
+
+    wxTextCtrl* GetEditControl()
+    {
+        return m_textCtrl;
+    }
+
+    void ClearEditor()
+    {
+        delete m_textCtrl;
+        m_textCtrl = NULL;
+    }
+
+private:
+    wxWindow* m_parent;
+    mutable wxTextCtrl* m_textCtrl;
+
+    wxDECLARE_NO_COPY_CLASS(wxQtTreeItemEditorFactory);
+};
+
+#endif //_WX_TREEITEM_FACTORY_H_
+

--- a/include/wx/qt/private/treeitemfactory.h
+++ b/include/wx/qt/private/treeitemfactory.h
@@ -7,8 +7,8 @@
 // Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
 
-#ifndef _WX_TREEITEM_FACTORY_H_
-#define _WX_TREEITEM_FACTORY_H_
+#ifndef _WX_QT_PRIVATE_TREEITEM_FACTORY_H_
+#define _WX_QT_PRIVATE_TREEITEM_FACTORY_H_
 
 #include <QtWidgets/QItemEditorFactory>
 #include <QtWidgets/QTreeWidget>
@@ -91,11 +91,11 @@ public:
         qItemDelegate->setItemEditorFactory(this);
     }
 
-    virtual QWidget* createEditor(
-        int WXUNUSED(userType),
-        QWidget* parent
-    ) const wxOVERRIDE
+    QWidget* createEditor(int WXUNUSED(userType), QWidget* parent) const wxOVERRIDE
     {
+        if (m_textCtrl != NULL)
+            ClearEditor();
+
         m_textCtrl = new wxQtListTextCtrl(m_parent, parent);
         m_textCtrl->SetFocus();
         return m_textCtrl->GetHandle();
@@ -106,7 +106,7 @@ public:
         return m_textCtrl;
     }
 
-    void ClearEditor()
+    void ClearEditor() const
     {
         delete m_textCtrl;
         m_textCtrl = NULL;
@@ -119,4 +119,4 @@ private:
     wxDECLARE_NO_COPY_CLASS(wxQtTreeItemEditorFactory);
 };
 
-#endif //_WX_TREEITEM_FACTORY_H_
+#endif //_WX_QT_PRIVATE_TREEITEM_FACTORY_H_

--- a/include/wx/qt/treectrl.h
+++ b/include/wx/qt/treectrl.h
@@ -112,6 +112,8 @@ public:
 
     virtual bool GetBoundingRect(const wxTreeItemId& item, wxRect& rect, bool textOnly = false) const wxOVERRIDE;
 
+    virtual void SetWindowStyleFlag(long styles) wxOVERRIDE;
+
     virtual QWidget *GetHandle() const wxOVERRIDE;
 
 protected:

--- a/include/wx/qt/treectrl.h
+++ b/include/wx/qt/treectrl.h
@@ -21,6 +21,8 @@ public:
                const wxValidator& validator = wxDefaultValidator,
                const wxString& name = wxTreeCtrlNameStr);
 
+    virtual ~wxTreeCtrl();
+
     bool Create(wxWindow *parent, wxWindowID id = wxID_ANY,
                 const wxPoint& pos = wxDefaultPosition,
                 const wxSize& size = wxDefaultSize,

--- a/include/wx/qt/treectrl.h
+++ b/include/wx/qt/treectrl.h
@@ -28,113 +28,115 @@ public:
                 const wxValidator& validator = wxDefaultValidator,
                 const wxString& name = wxTreeCtrlNameStr);
 
-    virtual unsigned int GetCount() const;
+    virtual unsigned int GetCount() const wxOVERRIDE;
 
-    virtual unsigned int GetIndent() const;
-    virtual void SetIndent(unsigned int indent);
+    virtual unsigned int GetIndent() const wxOVERRIDE;
+    virtual void SetIndent(unsigned int indent) wxOVERRIDE;
 
-    virtual void SetImageList(wxImageList *imageList);
-    virtual void SetStateImageList(wxImageList *imageList);
+    virtual void SetImageList(wxImageList *imageList) wxOVERRIDE;
+    virtual void SetStateImageList(wxImageList *imageList) wxOVERRIDE;
 
-    virtual wxString GetItemText(const wxTreeItemId& item) const;
+    virtual wxString GetItemText(const wxTreeItemId& item) const wxOVERRIDE;
     virtual int GetItemImage(const wxTreeItemId& item,
-                     wxTreeItemIcon which = wxTreeItemIcon_Normal) const;
-    virtual wxTreeItemData *GetItemData(const wxTreeItemId& item) const;
-    virtual wxColour GetItemTextColour(const wxTreeItemId& item) const;
-    virtual wxColour GetItemBackgroundColour(const wxTreeItemId& item) const;
-    virtual wxFont GetItemFont(const wxTreeItemId& item) const;
+                     wxTreeItemIcon which = wxTreeItemIcon_Normal) const wxOVERRIDE;
+    virtual wxTreeItemData *GetItemData(const wxTreeItemId& item) const wxOVERRIDE;
+    virtual wxColour GetItemTextColour(const wxTreeItemId& item) const wxOVERRIDE;
+    virtual wxColour GetItemBackgroundColour(const wxTreeItemId& item) const wxOVERRIDE;
+    virtual wxFont GetItemFont(const wxTreeItemId& item) const wxOVERRIDE;
 
-    virtual void SetItemText(const wxTreeItemId& item, const wxString& text);
+    virtual void SetItemText(const wxTreeItemId& item, const wxString& text) wxOVERRIDE;
     virtual void SetItemImage(const wxTreeItemId& item,
                               int image,
-                              wxTreeItemIcon which = wxTreeItemIcon_Normal);
-    virtual void SetItemData(const wxTreeItemId& item, wxTreeItemData *data);
-    virtual void SetItemHasChildren(const wxTreeItemId& item, bool has = true);
-    virtual void SetItemBold(const wxTreeItemId& item, bool bold = true);
-    virtual void SetItemDropHighlight(const wxTreeItemId& item, bool highlight = true);
-    virtual void SetItemTextColour(const wxTreeItemId& item, const wxColour& col);
-    virtual void SetItemBackgroundColour(const wxTreeItemId& item, const wxColour& col);
-    virtual void SetItemFont(const wxTreeItemId& item, const wxFont& font);
+                              wxTreeItemIcon which = wxTreeItemIcon_Normal) wxOVERRIDE;
+    virtual void SetItemData(const wxTreeItemId& item, wxTreeItemData *data) wxOVERRIDE;
+    virtual void SetItemHasChildren(const wxTreeItemId& item, bool has = true) wxOVERRIDE;
+    virtual void SetItemBold(const wxTreeItemId& item, bool bold = true) wxOVERRIDE;
+    virtual void SetItemDropHighlight(const wxTreeItemId& item, bool highlight = true) wxOVERRIDE;
+    virtual void SetItemTextColour(const wxTreeItemId& item, const wxColour& col) wxOVERRIDE;
+    virtual void SetItemBackgroundColour(const wxTreeItemId& item, const wxColour& col) wxOVERRIDE;
+    virtual void SetItemFont(const wxTreeItemId& item, const wxFont& font) wxOVERRIDE;
 
-    virtual bool IsVisible(const wxTreeItemId& item) const;
-    virtual bool ItemHasChildren(const wxTreeItemId& item) const;
-    virtual bool IsExpanded(const wxTreeItemId& item) const;
-    virtual bool IsSelected(const wxTreeItemId& item) const;
-    virtual bool IsBold(const wxTreeItemId& item) const;
+    virtual bool IsVisible(const wxTreeItemId& item) const wxOVERRIDE;
+    virtual bool ItemHasChildren(const wxTreeItemId& item) const wxOVERRIDE;
+    virtual bool IsExpanded(const wxTreeItemId& item) const wxOVERRIDE;
+    virtual bool IsSelected(const wxTreeItemId& item) const wxOVERRIDE;
+    virtual bool IsBold(const wxTreeItemId& item) const wxOVERRIDE;
 
-    virtual size_t GetChildrenCount(const wxTreeItemId& item, bool recursively = true) const;
+    virtual size_t GetChildrenCount(const wxTreeItemId& item, bool recursively = true) const wxOVERRIDE;
 
-    virtual wxTreeItemId GetRootItem() const;
-    virtual wxTreeItemId GetSelection() const;
-    virtual size_t GetSelections(wxArrayTreeItemIds& selections) const;
+    virtual wxTreeItemId GetRootItem() const wxOVERRIDE;
+    virtual wxTreeItemId GetSelection() const wxOVERRIDE;
+    virtual size_t GetSelections(wxArrayTreeItemIds& selections) const wxOVERRIDE;
 
-    virtual void SetFocusedItem(const wxTreeItemId& item);
-    virtual void ClearFocusedItem();
-    virtual wxTreeItemId GetFocusedItem() const;
+    virtual void SetFocusedItem(const wxTreeItemId& item) wxOVERRIDE;
+    virtual void ClearFocusedItem() wxOVERRIDE;
+    virtual wxTreeItemId GetFocusedItem() const wxOVERRIDE;
 
-    virtual wxTreeItemId GetItemParent(const wxTreeItemId& item) const;
-
-    virtual wxTreeItemId GetFirstChild(const wxTreeItemId& item, wxTreeItemIdValue& cookie) const;
-    virtual wxTreeItemId GetNextChild(const wxTreeItemId& item, wxTreeItemIdValue& cookie) const;
-    virtual wxTreeItemId GetLastChild(const wxTreeItemId& item) const;
-    virtual wxTreeItemId GetNextSibling(const wxTreeItemId& item) const;
-    virtual wxTreeItemId GetPrevSibling(const wxTreeItemId& item) const;
-    virtual wxTreeItemId GetFirstVisibleItem() const;
-    virtual wxTreeItemId GetNextVisible(const wxTreeItemId& item) const;
-    virtual wxTreeItemId GetPrevVisible(const wxTreeItemId& item) const;
+    virtual wxTreeItemId GetItemParent(const wxTreeItemId& item) const wxOVERRIDE;
+     
+    virtual wxTreeItemId GetFirstChild(const wxTreeItemId& item, wxTreeItemIdValue& cookie) const wxOVERRIDE;
+    virtual wxTreeItemId GetNextChild(const wxTreeItemId& item, wxTreeItemIdValue& cookie) const wxOVERRIDE;
+    virtual wxTreeItemId GetLastChild(const wxTreeItemId& item) const wxOVERRIDE;
+    virtual wxTreeItemId GetNextSibling(const wxTreeItemId& item) const wxOVERRIDE;
+    virtual wxTreeItemId GetPrevSibling(const wxTreeItemId& item) const wxOVERRIDE;
+    virtual wxTreeItemId GetFirstVisibleItem() const wxOVERRIDE;
+    virtual wxTreeItemId GetNextVisible(const wxTreeItemId& item) const wxOVERRIDE;
+    virtual wxTreeItemId GetPrevVisible(const wxTreeItemId& item) const wxOVERRIDE;
 
     virtual wxTreeItemId AddRoot(const wxString& text,
                                  int image = -1, int selImage = -1,
-                                 wxTreeItemData *data = NULL);
+                                 wxTreeItemData *data = NULL) wxOVERRIDE;
 
-    virtual void Delete(const wxTreeItemId& item);
-    virtual void DeleteChildren(const wxTreeItemId& item);
-    virtual void DeleteAllItems();
+    virtual void Delete(const wxTreeItemId& item) wxOVERRIDE;
+    virtual void DeleteChildren(const wxTreeItemId& item) wxOVERRIDE;
+    virtual void DeleteAllItems() wxOVERRIDE;
 
-    virtual void Expand(const wxTreeItemId& item);
-    virtual void Collapse(const wxTreeItemId& item);
-    virtual void CollapseAndReset(const wxTreeItemId& item);
-    virtual void Toggle(const wxTreeItemId& item);
+    virtual void Expand(const wxTreeItemId& item) wxOVERRIDE;
+    virtual void Collapse(const wxTreeItemId& item) wxOVERRIDE;
+    virtual void CollapseAndReset(const wxTreeItemId& item) wxOVERRIDE;
+    virtual void Toggle(const wxTreeItemId& item) wxOVERRIDE;
 
-    virtual void Unselect();
-    virtual void UnselectAll();
-    virtual void SelectItem(const wxTreeItemId& item, bool select = true);
-    virtual void SelectChildren(const wxTreeItemId& parent);
+    virtual void Unselect() wxOVERRIDE;
+    virtual void UnselectAll() wxOVERRIDE;
+    virtual void SelectItem(const wxTreeItemId& item, bool select = true) wxOVERRIDE;
+    virtual void SelectChildren(const wxTreeItemId& parent) wxOVERRIDE;
 
-    virtual void EnsureVisible(const wxTreeItemId& item);
-    virtual void ScrollTo(const wxTreeItemId& item);
+    virtual void EnsureVisible(const wxTreeItemId& item) wxOVERRIDE;
+    virtual void ScrollTo(const wxTreeItemId& item) wxOVERRIDE;
 
-    virtual wxTextCtrl *EditLabel(const wxTreeItemId& item, wxClassInfo* textCtrlClass = CLASSINFO(wxTextCtrl));
-    virtual wxTextCtrl *GetEditControl() const;
-    virtual void EndEditLabel(const wxTreeItemId& item, bool discardChanges = false);
+    virtual wxTextCtrl *EditLabel(const wxTreeItemId& item, wxClassInfo* textCtrlClass = CLASSINFO(wxTextCtrl)) wxOVERRIDE;
+    virtual wxTextCtrl *GetEditControl() const wxOVERRIDE;
+    virtual void EndEditLabel(const wxTreeItemId& item, bool discardChanges = false) wxOVERRIDE;
 
-    virtual void SortChildren(const wxTreeItemId& item);
+    virtual void SortChildren(const wxTreeItemId& item) wxOVERRIDE;
 
-    virtual bool GetBoundingRect(const wxTreeItemId& item, wxRect& rect, bool textOnly = false) const;
+    virtual bool GetBoundingRect(const wxTreeItemId& item, wxRect& rect, bool textOnly = false) const wxOVERRIDE;
 
-    virtual QWidget *GetHandle() const;
+    virtual QWidget *GetHandle() const wxOVERRIDE;
 
 protected:
-    virtual int DoGetItemState(const wxTreeItemId& item) const;
-    virtual void DoSetItemState(const wxTreeItemId& item, int state);
+    virtual int DoGetItemState(const wxTreeItemId& item) const wxOVERRIDE;
+    virtual void DoSetItemState(const wxTreeItemId& item, int state) wxOVERRIDE;
 
     virtual wxTreeItemId DoInsertItem(const wxTreeItemId& parent,
                                       size_t pos,
                                       const wxString& text,
                                       int image, int selImage,
-                                      wxTreeItemData *data);
+                                      wxTreeItemData *data) wxOVERRIDE;
 
     virtual wxTreeItemId DoInsertAfter(const wxTreeItemId& parent,
                                        const wxTreeItemId& idPrevious,
                                        const wxString& text,
                                        int image = -1, int selImage = -1,
-                                       wxTreeItemData *data = NULL);
+                                       wxTreeItemData *data = NULL) wxOVERRIDE;
 
-    virtual wxTreeItemId DoTreeHitTest(const wxPoint& point, int& flags) const;
+    virtual wxTreeItemId DoTreeHitTest(const wxPoint& point, int& flags) const wxOVERRIDE;
 
 private:
-    QTreeWidget *m_qtTreeWidget;
+    void SendDeleteEvent(const wxTreeItemId &item);
+    wxTreeItemId GetNext(const wxTreeItemId &item) const;
 
+    QTreeWidget *m_qtTreeWidget;
     wxDECLARE_DYNAMIC_CLASS(wxTreeCtrl);
 };
 

--- a/include/wx/qt/treectrl.h
+++ b/include/wx/qt/treectrl.h
@@ -75,7 +75,6 @@ public:
     virtual wxTreeItemId GetFocusedItem() const wxOVERRIDE;
 
     virtual wxTreeItemId GetItemParent(const wxTreeItemId& item) const wxOVERRIDE;
-     
     virtual wxTreeItemId GetFirstChild(const wxTreeItemId& item, wxTreeItemIdValue& cookie) const wxOVERRIDE;
     virtual wxTreeItemId GetNextChild(const wxTreeItemId& item, wxTreeItemIdValue& cookie) const wxOVERRIDE;
     virtual wxTreeItemId GetLastChild(const wxTreeItemId& item) const wxOVERRIDE;

--- a/include/wx/qt/treectrl.h
+++ b/include/wx/qt/treectrl.h
@@ -8,7 +8,7 @@
 #ifndef _WX_QT_TREECTRL_H_
 #define _WX_QT_TREECTRL_H_
 
-class QTreeWidget;
+class wxQTreeWidget;
 
 class WXDLLIMPEXP_CORE wxTreeCtrl : public wxTreeCtrlBase
 {
@@ -140,7 +140,7 @@ private:
     void SendDeleteEvent(const wxTreeItemId &item);
     wxTreeItemId GetNext(const wxTreeItemId &item) const;
 
-    QTreeWidget *m_qtTreeWidget;
+    wxQTreeWidget *m_qtTreeWidget;
     wxDECLARE_DYNAMIC_CLASS(wxTreeCtrl);
 };
 

--- a/include/wx/treectrl.h
+++ b/include/wx/treectrl.h
@@ -26,7 +26,7 @@
 
 class WXDLLIMPEXP_FWD_CORE wxImageList;
 
-#if !defined(__WXMSW__) || defined(__WXUNIVERSAL__)
+#if !defined(__WXMSW__) && !defined(__WXQT__) || defined(__WXUNIVERSAL__)
     #define wxHAS_GENERIC_TREECTRL
 #endif
 
@@ -465,6 +465,8 @@ private:
     #include "wx/generic/treectlg.h"
 #elif defined(__WXMSW__)
     #include "wx/msw/treectrl.h"
+#elif defined(__WXQT__)
+    #include "wx/qt/treectrl.h"
 #else
     #error "unknown native wxTreeCtrl implementation"
 #endif

--- a/samples/treectrl/treetest.cpp
+++ b/samples/treectrl/treetest.cpp
@@ -1055,7 +1055,7 @@ void MyTreeCtrl::CreateStateImageList(bool del)
     AssignStateImageList(states);
 }
 
-#if USE_GENERIC_TREECTRL || !defined(__WXMSW__)
+#if USE_GENERIC_TREECTRL || (!defined(__WXMSW__) && !defined(__WXQT__))
 void MyTreeCtrl::CreateButtonsImageList(int size)
 {
     if ( size == -1 )

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -123,10 +123,10 @@ private:
     wxDECLARE_NO_COPY_CLASS(wxQtItemEditorFactory);
 };
 
-class wxQtTreeWidget : public wxQtEventSignalHandler< QTreeWidget, wxListCtrl >
+class wxQtListTreeWidget : public wxQtEventSignalHandler< QTreeWidget, wxListCtrl >
 {
 public:
-    wxQtTreeWidget( wxWindow *parent, wxListCtrl *handler );
+    wxQtListTreeWidget( wxWindow *parent, wxListCtrl *handler );
 
     void EmitListEvent(wxEventType typ, QTreeWidgetItem *qitem, int column) const;
 
@@ -156,18 +156,18 @@ private:
     wxQtItemEditorFactory m_editorFactory;
 };
 
-wxQtTreeWidget::wxQtTreeWidget( wxWindow *parent, wxListCtrl *handler )
+wxQtListTreeWidget::wxQtListTreeWidget( wxWindow *parent, wxListCtrl *handler )
     : wxQtEventSignalHandler< QTreeWidget, wxListCtrl >( parent, handler ),
       m_editorFactory(handler)
 {
-    connect(this, &QTreeWidget::itemClicked, this, &wxQtTreeWidget::itemClicked);
-    connect(this, &QTreeWidget::itemPressed, this, &wxQtTreeWidget::itemPressed);
-    connect(this, &QTreeWidget::itemActivated, this, &wxQtTreeWidget::itemActivated);
+    connect(this, &QTreeWidget::itemClicked, this, &wxQtListTreeWidget::itemClicked);
+    connect(this, &QTreeWidget::itemPressed, this, &wxQtListTreeWidget::itemPressed);
+    connect(this, &QTreeWidget::itemActivated, this, &wxQtListTreeWidget::itemActivated);
 
     ChangeEditorFactory();
 }
 
-void wxQtTreeWidget::EmitListEvent(wxEventType typ, QTreeWidgetItem *qitem, int column) const
+void wxQtListTreeWidget::EmitListEvent(wxEventType typ, QTreeWidgetItem *qitem, int column) const
 {
     wxListCtrl *handler = GetHandler();
     if ( handler )
@@ -187,17 +187,17 @@ void wxQtTreeWidget::EmitListEvent(wxEventType typ, QTreeWidgetItem *qitem, int 
     }
 }
 
-void wxQtTreeWidget::itemClicked(QTreeWidgetItem *qitem, int column)
+void wxQtListTreeWidget::itemClicked(QTreeWidgetItem *qitem, int column)
 {
     EmitListEvent(wxEVT_LIST_ITEM_SELECTED, qitem, column);
 }
 
-void wxQtTreeWidget::itemPressed(QTreeWidgetItem *qitem, int column)
+void wxQtListTreeWidget::itemPressed(QTreeWidgetItem *qitem, int column)
 {
     EmitListEvent(wxEVT_LIST_ITEM_SELECTED, qitem, column);
 }
 
-void wxQtTreeWidget::itemActivated(QTreeWidgetItem *qitem, int column)
+void wxQtListTreeWidget::itemActivated(QTreeWidgetItem *qitem, int column)
 {
     EmitListEvent(wxEVT_LIST_ITEM_ACTIVATED, qitem, column);
 }
@@ -258,7 +258,7 @@ bool wxListCtrl::Create(wxWindow *parent,
             const wxValidator& validator,
             const wxString& name)
 {
-    m_qtTreeWidget = new wxQtTreeWidget( parent, this );
+    m_qtTreeWidget = new wxQtListTreeWidget( parent, this );
 
     if (style & wxLC_NO_HEADER)
         m_qtTreeWidget->setHeaderHidden(true);

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -15,7 +15,6 @@
 #include <QtWidgets/QHeaderView>
 #include <QtWidgets/QTreeWidget>
 #include <QtWidgets/QItemDelegate>
-#include <QtWidgets/QItemEditorFactory>
 
 #ifndef WX_PRECOMP
     #include "wx/bitmap.h"
@@ -23,105 +22,9 @@
 
 #include "wx/listctrl.h"
 #include "wx/imaglist.h"
-#include "wx/recguard.h"
 
 #include "wx/qt/private/winevent.h"
-
-namespace
-{
-
-// wxQT Doesn't have a mechanism for "adopting" external widgets so we have to
-// create an instance of wxTextCtrl rather than adopting the control QT would
-// create.
-//
-// Unfortunately the factory is given an internal widget as the parent for
-// editor.
-//
-// To work around these issues we create a wxTextCtl parented by the wxListCtrl
-// then recalculate its position relative to the internal widget.
-class wxQtListTextCtrl : public wxTextCtrl
-{
-public:
-    wxQtListTextCtrl(wxWindow* parent, QWidget* actualParent)
-        : wxTextCtrl(parent, wxID_ANY, wxEmptyString,
-                     wxDefaultPosition, wxDefaultSize,
-                     wxNO_BORDER),
-        m_actualParent(actualParent),
-        m_moving(0)
-    {
-
-        Bind(wxEVT_MOVE, &wxQtListTextCtrl::onMove, this);
-    }
-
-    void onMove(wxMoveEvent &event)
-    {
-        // QWidget::move generates a QMoveEvent so we need to guard against
-        // reentrant calls.
-        wxRecursionGuard guard(m_moving);
-        if ( guard.IsInside() )
-        {
-            event.Skip();
-            return;
-        }
-
-        const QPoint eventPosition = wxQtConvertPoint(event.GetPosition());
-        const QPoint globalPosition  = m_actualParent->mapToGlobal(eventPosition);
-
-        // For some reason this always gives us the offset from the header info
-        // the internal control. So we need to treat this as an offset rather
-        // than a position.
-        QWidget* widget = GetHandle();
-        const QPoint offset = widget->mapFromGlobal(globalPosition);
-
-        widget->move(eventPosition + offset);
-    }
-
-private:
-    QWidget* m_actualParent;
-    wxRecursionGuardFlag m_moving;
-
-    wxDECLARE_NO_COPY_CLASS(wxQtListTextCtrl);
-};
-
-} // anonymous namespace
-
-
-// QT doesn't give us direct access to the editor within the QTreeWidget.
-// Instead, we'll supply a factory to create the widget for QT and keep track
-// of it ourselves.
-class wxQtTreeItemEditorFactory : public QItemEditorFactory
-{
-public:
-    explicit wxQtTreeItemEditorFactory(wxWindow* parent)
-        : m_parent(parent),
-          m_textCtrl(NULL)
-    {
-    }
-
-    QWidget* createEditor(int WXUNUSED(userType), QWidget* parent) const wxOVERRIDE
-    {
-        m_textCtrl = new wxQtListTextCtrl(m_parent, parent);
-        m_textCtrl->SetFocus();
-        return m_textCtrl->GetHandle();
-    }
-
-    wxTextCtrl* GetEditControl()
-    {
-        return m_textCtrl;
-    }
-
-    void ClearEditor()
-    {
-        delete m_textCtrl;
-        m_textCtrl = NULL;
-    }
-
-private:
-    wxWindow* m_parent;
-    mutable wxTextCtrl* m_textCtrl;
-
-    wxDECLARE_NO_COPY_CLASS(wxQtTreeItemEditorFactory);
-};
+#include "wx/qt/private/treeitemfactory.h"
 
 class wxQtListTreeWidget : public wxQtEventSignalHandler< QTreeWidget, wxListCtrl >
 {

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -89,10 +89,10 @@ private:
 // QT doesn't give us direct access to the editor within the QTreeWidget.
 // Instead, we'll supply a factory to create the widget for QT and keep track
 // of it ourselves.
-class wxQtItemEditorFactory : public QItemEditorFactory
+class wxQtTreeItemEditorFactory : public QItemEditorFactory
 {
 public:
-    explicit wxQtItemEditorFactory(wxWindow* parent)
+    explicit wxQtTreeItemEditorFactory(wxWindow* parent)
         : m_parent(parent),
           m_textCtrl(NULL)
     {
@@ -120,7 +120,7 @@ private:
     wxWindow* m_parent;
     mutable wxTextCtrl* m_textCtrl;
 
-    wxDECLARE_NO_COPY_CLASS(wxQtItemEditorFactory);
+    wxDECLARE_NO_COPY_CLASS(wxQtTreeItemEditorFactory);
 };
 
 class wxQtListTreeWidget : public wxQtEventSignalHandler< QTreeWidget, wxListCtrl >
@@ -153,7 +153,7 @@ private:
         qItemDelegate->setItemEditorFactory(&m_editorFactory);
     }
 
-    wxQtItemEditorFactory m_editorFactory;
+    wxQtTreeItemEditorFactory m_editorFactory;
 };
 
 wxQtListTreeWidget::wxQtListTreeWidget( wxWindow *parent, wxListCtrl *handler )

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -189,6 +189,7 @@ private:
         wxTreeCtrl* treeCtrl = GetHandler();
 
         wxTreeEvent changingEvent(wxEVT_TREE_SEL_CHANGING, treeCtrl, wxQtConvertTreeItem(current));
+        changingEvent.SetOldItem(wxQtConvertTreeItem(previous));
         EmitEvent(changingEvent);
 
         if ( !changingEvent.IsAllowed() )
@@ -204,6 +205,7 @@ private:
         // wxTreeCtrl::GetSelection returns the new selection in the
         // wx event handler.
         wxTreeEvent changedEvent(wxEVT_TREE_SEL_CHANGED, treeCtrl, wxQtConvertTreeItem(current));
+        changedEvent.SetOldItem(wxQtConvertTreeItem(previous));
         wxPostEvent(treeCtrl, changedEvent);
     }
 

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -371,7 +371,7 @@ private:
             GetHandler(),
             wxQtConvertTreeItem(itemFromIndex(current_index))
         );
-        if (hint == QAbstractItemDelegate::EndEditHint::RevertModelCache)
+        if (hint == QAbstractItemDelegate::RevertModelCache)
         {
             event.SetEditCanceled(true);
             EmitEvent(event);

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -14,6 +14,7 @@
 #include "wx/qt/private/treeitemfactory.h"
 
 #include <QtWidgets/QTreeWidget>
+#include <QtWidgets/QHeaderView>
 #include <QtGui/QPainter>
 
 namespace
@@ -254,6 +255,8 @@ bool wxTreeCtrl::Create(wxWindow *parent, wxWindowID id,
             const wxString& name)
 {
     m_qtTreeWidget = new wxQTreeWidget(parent, this);
+    m_qtTreeWidget->header()->hide();
+
     SetWindowStyleFlag(style);
 
     return QtCreateControl(parent, id, pos, size, style, validator, name);

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -140,8 +140,6 @@ public:
                 this, &wxQTreeWidget::OnItemExpanded);
         connect(this, &QTreeWidget::itemChanged,
                 this, &wxQTreeWidget::OnItemChanged);
-        connect(this, &QTreeWidget::iconSizeChanged,
-                this, &wxQTreeWidget::OnIconSizeChanged);
 
         m_editorFactory.AttachTo(this);
         setDragEnabled(true);
@@ -189,6 +187,13 @@ public:
         return i->second.GetState();
     }
 
+    void ResizeIcons(const QSize &size)
+    {
+        m_placeHolderImage = QPixmap(size);
+        m_placeHolderImage.fill(Qt::transparent);
+        ReplaceIcons(invisibleRootItem());
+    }
+
     QPixmap GetPlaceHolderImage() const
     {
         return m_placeHolderImage;
@@ -217,6 +222,16 @@ protected:
     }
 
 private:
+    void ReplaceIcons(QTreeWidgetItem *item)
+    {
+        item->setIcon(0, m_placeHolderImage);
+        const int childCount = item->childCount();
+        for ( int i = 0; i < childCount; ++i )
+        {
+            ReplaceIcons(item->child(i));
+        }
+    }
+
     void OnCurrentItemChanged(
         QTreeWidgetItem *current,
         QTreeWidgetItem *previous
@@ -339,12 +354,6 @@ private:
             wxQtConvertTreeItem(item)
         );
         EmitEvent(event);
-    }
-
-    void OnIconSizeChanged(const QSize &size)
-    {
-        m_placeHolderImage = QPixmap(size);
-        m_placeHolderImage.fill(Qt::transparent);
     }
 
     void tryStartDrag(const QMouseEvent *event)
@@ -513,7 +522,7 @@ void wxTreeCtrl::SetImageList(wxImageList *imageList)
 
     int width, height;
     m_imageListNormal->GetSize(0, width, height);
-    m_qtTreeWidget->setIconSize(QSize(width, height));
+    m_qtTreeWidget->ResizeIcons(QSize(width, height));
     m_qtTreeWidget->update();
 }
 

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -15,6 +15,7 @@
 #include "wx/treectrl.h"
 #include "wx/imaglist.h"
 #include "wx/settings.h"
+#include "wx/sharedptr.h"
 
 #include "wx/qt/private/winevent.h"
 #include "wx/qt/private/treeitemdelegate.h"

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -933,6 +933,10 @@ wxTextCtrl *wxTreeCtrl::EditLabel(const wxTreeItemId& item, wxClassInfo* WXUNUSE
 {
     wxCHECK_MSG(item.IsOk(), NULL, "invalid tree item");
 
+    wxTreeEvent event(wxEVT_TREE_BEGIN_LABEL_EDIT, this, item);
+    if ( HandleWindowEvent(event) && !event.IsAllowed() )
+        return NULL;
+
     QTreeWidgetItem *qTreeItem = wxQtConvertTreeItem(item);
     m_qtTreeWidget->openPersistentEditor(qTreeItem);
     return m_qtTreeWidget->GetEditControl();

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -76,6 +76,12 @@ bool wxTreeCtrl::Create(wxWindow *parent, wxWindowID id,
     return QtCreateControl(parent, id, pos, size, style, validator, name);
 }
 
+wxTreeCtrl::~wxTreeCtrl()
+{
+    if (m_qtTreeWidget != NULL)
+        m_qtTreeWidget->deleteLater();
+}
+
 unsigned wxTreeCtrl::GetCount() const
 {
     return m_qtTreeWidget->topLevelItemCount();

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -366,7 +366,6 @@ private:
 
     void endDrag(QPoint position)
     {
-        const wxPoint pos = wxQtConvertPoint(position);
         QTreeWidgetItem *hitItem = itemAt(position);
 
         wxTreeEvent tree_event(

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -38,11 +38,11 @@ namespace
     bool TreeItemDataQt::registered = false;
     Q_DECLARE_METATYPE(TreeItemDataQt)
 
-    QDataStream &operator<<(QDataStream &out, const TreeItemDataQt &myObj)
+    QDataStream &operator<<(QDataStream &out, const TreeItemDataQt &)
     {
         return out;
     }
-    QDataStream &operator>>(QDataStream &in, TreeItemDataQt &myObj)
+    QDataStream &operator>>(QDataStream &in, TreeItemDataQt &)
     {
         return in;
     }
@@ -228,49 +228,49 @@ private:
         EmitEvent(expandedEvent);
     }
 
-        virtual void dragEnterEvent(QDragEnterEvent* event) wxOVERRIDE
+    virtual void dragEnterEvent(QDragEnterEvent* event) wxOVERRIDE
+    {
+        wxEventType command = (event->mouseButtons() & Qt::RightButton)
+            ? wxEVT_TREE_BEGIN_RDRAG
+            : wxEVT_TREE_BEGIN_DRAG;
+
+
+        QTreeWidgetItem *hitItem = itemAt(event->pos());
+
+        wxTreeEvent tree_event(
+            command,
+            GetHandler(),
+            wxQtConvertTreeItem(hitItem)
+        );
+
+        tree_event.SetPoint(wxQtConvertPoint(event->pos()));
+
+        // Vetoed unless explicitly accepted.
+        tree_event.Veto();
+
+        EmitEvent(tree_event);
+
+        if ( tree_event.IsAllowed() )
         {
-            wxEventType command = (event->mouseButtons() & Qt::RightButton)
-                ? wxEVT_TREE_BEGIN_RDRAG
-                : wxEVT_TREE_BEGIN_DRAG;
-
-
-            QTreeWidgetItem *hitItem = itemAt(event->pos());
-
-            wxTreeEvent tree_event(
-                command,
-                GetHandler(),
-                wxQtConvertTreeItem(hitItem)
-            );
-
-            tree_event.SetPoint(wxQtConvertPoint(event->pos()));
-
-            // Vetoed unless explicitly accepted.
-            tree_event.Veto();
-
-            EmitEvent(tree_event);
-
-            if ( tree_event.IsAllowed() )
-            {
-                event->accept();
-            }
+            event->accept();
         }
+    }
 
-        virtual void dropEvent(QDropEvent* event) wxOVERRIDE
-        {
-            const wxPoint pos = wxQtConvertPoint(event->pos());
-            QTreeWidgetItem *hitItem = itemAt(event->pos());
+    virtual void dropEvent(QDropEvent* event) wxOVERRIDE
+    {
+        const wxPoint pos = wxQtConvertPoint(event->pos());
+        QTreeWidgetItem *hitItem = itemAt(event->pos());
 
-            wxTreeEvent tree_event(
-                wxEVT_TREE_END_DRAG,
-                GetHandler(),
-                wxQtConvertTreeItem(hitItem)
-            );
+        wxTreeEvent tree_event(
+            wxEVT_TREE_END_DRAG,
+            GetHandler(),
+            wxQtConvertTreeItem(hitItem)
+        );
 
-            tree_event.SetPoint(wxQtConvertPoint(event->pos()));
+        tree_event.SetPoint(wxQtConvertPoint(event->pos()));
 
-            EmitEvent(tree_event);
-        }
+        EmitEvent(tree_event);
+    }
 
     int ChooseBestImage(QTreeWidgetItem *item) const
     {

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -579,7 +579,7 @@ void wxTreeCtrl::SetItemBackgroundColour(const wxTreeItemId& item, const wxColou
     wxCHECK_RET(item.IsOk(), "invalid tree item");
 
     QTreeWidgetItem *qTreeItem = wxQtConvertTreeItem(item);
-    qTreeItem->setTextColor(0, wxQtConvertColour(col));
+    qTreeItem->setBackgroundColor(0, wxQtConvertColour(col));
 }
 
 void wxTreeCtrl::SetItemFont(const wxTreeItemId& item, const wxFont& font)

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -1067,11 +1067,31 @@ void wxTreeCtrl::Delete(const wxTreeItemId& item)
     delete qTreeItem;
 }
 
+class wxQtEnsureSignalsBlocked
+{
+public:
+    wxQtEnsureSignalsBlocked(QWidget *widget) :
+        m_widget(widget)
+    {
+        m_restore = m_widget->blockSignals(true);
+    }
+
+    ~wxQtEnsureSignalsBlocked()
+    {
+        m_widget->blockSignals(m_restore);
+    }
+
+private:
+    QWidget *m_widget;
+    bool m_restore;
+};
+
 void wxTreeCtrl::DeleteChildren(const wxTreeItemId& item)
 {
     wxCHECK_RET(item.IsOk(), "invalid tree item");
 
     QTreeWidgetItem *qTreeItem = wxQtConvertTreeItem(item);
+    wxQtEnsureSignalsBlocked ensureSignalsBlock(m_qtTreeWidget);
     while ( qTreeItem->childCount() > 0 )
     {
         QTreeWidgetItem *child = qTreeItem->child(0);

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -511,11 +511,10 @@ size_t wxTreeCtrl::GetSelections(wxArrayTreeItemIds& selections) const
     QList<QTreeWidgetItem*> qtSelections = m_qtTreeWidget->selectedItems();
 
     const size_t numberOfSelections = qtSelections.size();
-    selections.SetCount(numberOfSelections);
-
     for (size_t i = 0; i < numberOfSelections; ++i)
     {
-        selections[i] = qtSelections[i];
+        QTreeWidgetItem *item = qtSelections[i];
+        selections.Add(wxQtConvertTreeItem(item));
     }
 
     return numberOfSelections;

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -1075,15 +1075,6 @@ wxTreeItemId wxTreeCtrl::DoInsertItem(const wxTreeItemId& parent,
 
     newItem->setData(0, Qt::UserRole, QVariant::fromValue(treeItemData));
 
-    if (pos == static_cast<size_t>(-1))
-    {
-        qTreeItem->addChild(newItem);
-    }
-    else
-    {
-        qTreeItem->insertChild(pos, newItem);
-    }
-
     m_qtTreeWidget->SetItemImage(newItem, image, wxTreeItemIcon_Normal);
     m_qtTreeWidget->SetItemImage(newItem, selImage, wxTreeItemIcon_Selected);
 
@@ -1093,6 +1084,15 @@ wxTreeItemId wxTreeCtrl::DoInsertItem(const wxTreeItemId& parent,
 
     if (data != NULL)
         data->SetId(wxItem);
+
+    if (pos == static_cast<size_t>(-1))
+    {
+        qTreeItem->addChild(newItem);
+    }
+    else
+    {
+        qTreeItem->insertChild(pos, newItem);
+    }
 
     return wxItem;
 }

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -149,6 +149,14 @@ public:
         setDropIndicatorShown(true);
     }
 
+    virtual void paintEvent (QPaintEvent * event)
+    {
+        //QT generates warnings if we try to paint to a QTreeWidget
+        //(perhaps because it's a compound widget) so we've disabled
+        //wx paint and erase background events
+        QTreeWidget::paintEvent(event);
+    }
+
     wxTextCtrl *GetEditControl()
     {
         return m_editorFactory.GetEditControl();
@@ -187,22 +195,24 @@ public:
     }
 
 protected:
-    virtual void drawBranches(
+    virtual void drawRow(
         QPainter *painter,
-        const QRect &rect,
+        const QStyleOptionViewItem &options,
         const QModelIndex &index
+
     ) const wxOVERRIDE
     {
+        QTreeWidget::drawRow(painter, options, index);
+
         QTreeWidgetItem *item = itemFromIndex(index);
-
-        QTreeWidget::drawBranches(painter, rect, index);
-
         const int imageIndex = ChooseBestImage(item);
+
         if ( imageIndex != -1 )
         {
             const wxImageList *imageList = GetHandler()->GetImageList();
             const wxBitmap bitmap = imageList->GetBitmap(imageIndex);
-            painter->drawPixmap(rect.topRight(), *bitmap.GetHandle());
+            const QRect rect = visualRect(index);
+            painter->drawPixmap(rect.topLeft(), *bitmap.GetHandle());
         }
     }
 

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -1286,10 +1286,7 @@ wxTreeItemId wxTreeCtrl::DoTreeHitTest(const wxPoint& point, int& flags) const
         return wxTreeItemId();
 
     QTreeWidgetItem *hitItem = m_qtTreeWidget->itemAt(wxQtConvertPoint(point));
-
-    if ( hitItem == NULL )
-        flags |= wxTREE_HITTEST_NOWHERE;
-
+    flags = hitItem == NULL ? wxTREE_HITTEST_NOWHERE : wxTREE_HITTEST_ONITEM;
     return wxQtConvertTreeItem(hitItem);
 }
 

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -167,8 +167,10 @@ private:
             return;
         }
 
-        //QT doesnt update the selection until this singal has been processed.  //Defering this event ensures 
-        //that wxTreeCtrl::GetSelection returns the new selection in the wx event handler.
+        // QT doesn't update the selection until this signal has been
+        // processed. Deferring this event ensures that
+        // wxTreeCtrl::GetSelection returns the new selection in the
+        // wx event handler.
         wxTreeEvent changedEvent(wxEVT_TREE_SEL_CHANGED, treeCtrl, wxQtConvertTreeItem(current));
         wxPostEvent(treeCtrl, changedEvent);
     }

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -71,6 +71,7 @@ bool wxTreeCtrl::Create(wxWindow *parent, wxWindowID id,
             const wxString& name)
 {
     m_qtTreeWidget = new wxQTreeWidget(parent, this);
+    SetWindowStyleFlag(style);
 
     return QtCreateControl(parent, id, pos, size, style, validator, name);
 }
@@ -337,9 +338,7 @@ void wxTreeCtrl::SetFocusedItem(const wxTreeItemId& item)
 
 void wxTreeCtrl::ClearFocusedItem()
 {
-    QTreeWidgetItem *current = m_qtTreeWidget->currentItem();
-    if (current != NULL)
-        current->setSelected(false);
+    m_qtTreeWidget->setCurrentItem(NULL);
 }
 
 wxTreeItemId wxTreeCtrl::GetFocusedItem() const
@@ -622,11 +621,7 @@ void wxTreeCtrl::SelectItem(const wxTreeItemId& item, bool select)
     {
         QList<QTreeWidgetItem *> selections = m_qtTreeWidget->selectedItems();
         const size_t nSelections = selections.size();
-
-        for (size_t i = 0; i < nSelections; ++i)
-        {
-            selections[i]->setSelected(false);
-        }
+        m_qtTreeWidget->clearSelection();
     }
 
     QTreeWidgetItem *qTreeItem = wxQtConvertTreeItem(item);
@@ -698,6 +693,13 @@ bool wxTreeCtrl::GetBoundingRect(const wxTreeItemId& item, wxRect& rect, bool te
 {
     wxCHECK_MSG(item.IsOk(), false, "invalid tree item");
     return false;
+}
+
+void wxTreeCtrl::SetWindowStyleFlag(long styles)
+{
+    wxControl::SetWindowStyleFlag(styles);
+    m_qtTreeWidget->invisibleRootItem()->setHidden((styles & wxTR_HIDE_ROOT) != 0);
+    m_qtTreeWidget->setSelectionMode(styles & wxTR_MULTIPLE ? QTreeWidget::MultiSelection : QTreeWidget::SingleSelection);
 }
 
 int wxTreeCtrl::DoGetItemState(const wxTreeItemId& item) const

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -110,6 +110,7 @@ public:
         connect(this, &QTreeWidget::itemClicked, this, &wxQTreeWidget::OnItemClicked);
         connect(this, &QTreeWidget::itemCollapsed, this, &wxQTreeWidget::OnItemCollapsed);
         connect(this, &QTreeWidget::itemExpanded, this, &wxQTreeWidget::OnItemExpanded);
+        connect(this, &QTreeWidget::itemChanged, this, &wxQTreeWidget::OnItemChanged);
 
         m_editorFactory.AttachTo(this);
         setDragEnabled(true);
@@ -226,6 +227,12 @@ private:
 
         wxTreeEvent expandedEvent(wxEVT_TREE_ITEM_EXPANDED, GetHandler(), wxQtConvertTreeItem(item));
         EmitEvent(expandedEvent);
+    }
+
+    void OnItemChanged(QTreeWidgetItem *item, int WXUNUSED(column))
+    {
+        wxTreeEvent event(wxEVT_TREE_END_LABEL_EDIT, GetHandler(), wxQtConvertTreeItem(item));
+        EmitEvent(event);
     }
 
     virtual void dragEnterEvent(QDragEnterEvent* event) wxOVERRIDE

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -977,6 +977,8 @@ void wxTreeCtrl::Delete(const wxTreeItemId& item)
     QTreeWidgetItem *qTreeItem = wxQtConvertTreeItem(item);
     QTreeWidgetItem *parent = qTreeItem->parent();
 
+    DeleteChildren(qTreeItem);
+
     if ( parent != NULL )
     {
         parent->removeChild(qTreeItem);

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -76,7 +76,8 @@ namespace
 class ImageState
 {
 public:
-    ImageState()
+    ImageState() :
+        m_state(wxTREE_ITEMSTATE_NONE)
     {
         for (int i = wxTreeItemIcon_Normal; i < wxTreeItemIcon_Max; ++i)
         {
@@ -94,7 +95,19 @@ public:
         return m_imageStates[index];
     }
 
+    void SetState(int state)
+    {
+        m_state = state;
+    }
+
+    int GetState() const
+    {
+        return m_state;
+    }
+
+private:
     int m_imageStates[wxTreeItemIcon_Max];
+    int m_state;
     
 };
 
@@ -134,6 +147,20 @@ public:
             return 0;
 
         return m_imageStates[item][which];
+    }
+
+    void SetItemState(QTreeWidgetItem *item, int state)
+    {
+        m_imageStates[item].SetState(state);
+    }
+        
+    int GetItemState(QTreeWidgetItem *item) const
+    {
+        ImageStateMap::const_iterator i = m_imageStates.find(item);
+        if (i == m_imageStates.end())
+            return wxTREE_ITEMSTATE_NONE;
+
+        return i->second.GetState();
     }
 
 protected:
@@ -985,12 +1012,13 @@ void wxTreeCtrl::SetWindowStyleFlag(long styles)
 int wxTreeCtrl::DoGetItemState(const wxTreeItemId& item) const
 {
     wxCHECK_MSG(item.IsOk(), wxTREE_ITEMSTATE_NONE, "invalid tree item");
-    return 0;
+    return m_qtTreeWidget->GetItemState(wxQtConvertTreeItem(item));
 }
 
-void wxTreeCtrl::DoSetItemState(const wxTreeItemId& item, int WXUNUSED(state))
+void wxTreeCtrl::DoSetItemState(const wxTreeItemId& item, int state)
 {
     wxCHECK_RET(item.IsOk(), "invalid tree item");
+    m_qtTreeWidget->SetItemState(wxQtConvertTreeItem(item), state);
 }
 
 wxTreeItemId wxTreeCtrl::DoInsertItem(const wxTreeItemId& parent,

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -851,8 +851,13 @@ wxTreeItemId wxTreeCtrl::AddRoot(const wxString& text,
                              wxTreeItemData *data)
 {
     QTreeWidgetItem *root = m_qtTreeWidget->invisibleRootItem();
-    wxTreeItemId newItem =  DoInsertItem(wxQtConvertTreeItem(root), 0, text, image, selImage, data);
+    wxTreeItemId newItem = DoInsertItem(wxQtConvertTreeItem(root), 0, text, image, selImage, data);
     m_qtTreeWidget->setCurrentItem(NULL);
+
+    if ( (GetWindowStyleFlag() & wxTR_HIDE_ROOT) != 0 )
+        m_qtTreeWidget->setRootIndex(m_qtTreeWidget->model()->index(0, 0));
+    else
+        m_qtTreeWidget->setRootIndex(QModelIndex());
 
     return newItem;
 }
@@ -1043,7 +1048,7 @@ bool wxTreeCtrl::GetBoundingRect(const wxTreeItemId& item, wxRect& WXUNUSED(rect
 void wxTreeCtrl::SetWindowStyleFlag(long styles)
 {
     wxControl::SetWindowStyleFlag(styles);
-    m_qtTreeWidget->invisibleRootItem()->setHidden((styles & wxTR_HIDE_ROOT) != 0);
+
     m_qtTreeWidget->setSelectionMode(styles & wxTR_MULTIPLE ? QTreeWidget::ExtendedSelection : QTreeWidget::SingleSelection);
 }
 

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -1152,12 +1152,19 @@ void wxTreeCtrl::SortChildren(const wxTreeItemId& item)
 
 bool wxTreeCtrl::GetBoundingRect(
     const wxTreeItemId& item,
-    wxRect& WXUNUSED(rect),
+    wxRect& rect,
     bool WXUNUSED(textOnly)
 ) const
 {
     wxCHECK_MSG(item.IsOk(), false, "invalid tree item");
-    return false;
+
+    const QTreeWidgetItem *qTreeItem = wxQtConvertTreeItem(item);
+    const QRect visualRect = m_qtTreeWidget->visualItemRect(qTreeItem);
+    if ( !visualRect.isValid() )
+        return false;
+
+    rect = wxQtConvertRect(visualRect);
+    return true;
 }
 
 void wxTreeCtrl::SetWindowStyleFlag(long styles)

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -883,7 +883,7 @@ wxTreeItemId wxTreeCtrl::GetFirstVisibleItem() const
 
     do
     {
-        if (IsVisible(itemid))
+        if ( IsVisible(itemid) )
             return itemid;
         itemid = GetNext(itemid);
     } while ( itemid.IsOk() );
@@ -893,8 +893,8 @@ wxTreeItemId wxTreeCtrl::GetFirstVisibleItem() const
 
 wxTreeItemId wxTreeCtrl::GetNextVisible(const wxTreeItemId& item) const
 {
-    wxCHECK_MSG(item.IsOk(), wxTreeItemId(), wxT("invalid tree item"));
-    wxASSERT_MSG(IsVisible(item), wxT("this item itself should be visible"));
+    wxCHECK_MSG(item.IsOk(), wxTreeItemId(), "invalid tree item");
+    wxASSERT_MSG(IsVisible(item), "this item itself should be visible");
 
     wxTreeItemId id = item;
     if ( id.IsOk() )
@@ -910,8 +910,8 @@ wxTreeItemId wxTreeCtrl::GetNextVisible(const wxTreeItemId& item) const
 
 wxTreeItemId wxTreeCtrl::GetPrevVisible(const wxTreeItemId& item) const
 {
-    wxCHECK_MSG(item.IsOk(), wxTreeItemId(), wxT("invalid tree item"));
-    wxASSERT_MSG(IsVisible(item), wxT("this item itself should be visible"));
+    wxCHECK_MSG(item.IsOk(), wxTreeItemId(), "invalid tree item");
+    wxASSERT_MSG(IsVisible(item), "this item itself should be visible");
 
     // find out the starting point
     wxTreeItemId prevItem = GetPrevSibling(item);
@@ -1247,16 +1247,22 @@ wxTreeItemId wxTreeCtrl::DoTreeHitTest(const wxPoint& point, int& flags) const
     int w, h;
     GetSize(&w, &h);
     flags = 0;
-    if ( point.x < 0 ) flags |= wxTREE_HITTEST_TOLEFT;
-    else if ( point.x > w ) flags |= wxTREE_HITTEST_TORIGHT;
-    if ( point.y < 0 ) flags |= wxTREE_HITTEST_ABOVE;
-    else if ( point.y > h ) flags |= wxTREE_HITTEST_BELOW;
+    if ( point.x < 0 )
+        flags |= wxTREE_HITTEST_TOLEFT;
+    else if ( point.x > w )
+        flags |= wxTREE_HITTEST_TORIGHT;
+
+    if ( point.y < 0 )
+        flags |= wxTREE_HITTEST_ABOVE;
+    else if ( point.y > h )
+        flags |= wxTREE_HITTEST_BELOW;
+
     if ( flags != 0 )
         return wxTreeItemId();
 
     QTreeWidgetItem *hitItem = m_qtTreeWidget->itemAt(wxQtConvertPoint(point));
 
-    if (hitItem == NULL)
+    if ( hitItem == NULL )
         flags |= wxTREE_HITTEST_NOWHERE;
 
     return wxQtConvertTreeItem(hitItem);
@@ -1276,7 +1282,7 @@ void wxTreeCtrl::SendDeleteEvent(const wxTreeItemId &item)
 
 wxTreeItemId wxTreeCtrl::GetNext(const wxTreeItemId &item) const
 {
-    wxCHECK_MSG(item.IsOk(), wxTreeItemId(), wxT("invalid tree item"));
+    wxCHECK_MSG(item.IsOk(), wxTreeItemId(), "invalid tree item");
 
     QTreeWidgetItem *qTreeItem = wxQtConvertTreeItem(item);
 

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -185,7 +185,7 @@ public:
     }
 
 protected:
-    void drawBranches(
+    virtual void drawBranches(
         QPainter *painter,
         const QRect &rect,
         const QModelIndex &index

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -426,7 +426,7 @@ private:
                 imageIndex = states[wxTreeItemIcon_Selected];
         }
 
-        return QIcon::Normal;
+        return imageIndex;
     }
 
     wxQtTreeItemEditorFactory m_editorFactory;

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -813,7 +813,6 @@ void wxTreeCtrl::SelectItem(const wxTreeItemId& item, bool select)
     if ( !HasFlag(wxTR_MULTIPLE) )
     {
         QList<QTreeWidgetItem *> selections = m_qtTreeWidget->selectedItems();
-        const size_t nSelections = selections.size();
         m_qtTreeWidget->clearSelection();
     }
 
@@ -858,7 +857,7 @@ void wxTreeCtrl::ScrollTo(const wxTreeItemId& item)
     m_qtTreeWidget->scrollToItem(qTreeItem);
 }
 
-wxTextCtrl *wxTreeCtrl::EditLabel(const wxTreeItemId& item, wxClassInfo* textCtrlClass)
+wxTextCtrl *wxTreeCtrl::EditLabel(const wxTreeItemId& item, wxClassInfo* WXUNUSED(textCtrlClass))
 {
     wxCHECK_MSG(item.IsOk(), NULL, "invalid tree item");
 
@@ -872,7 +871,7 @@ wxTextCtrl *wxTreeCtrl::GetEditControl() const
     return m_qtTreeWidget->GetEditControl();
 }
 
-void wxTreeCtrl::EndEditLabel(const wxTreeItemId& item, bool discardChanges)
+void wxTreeCtrl::EndEditLabel(const wxTreeItemId& item, bool WXUNUSED(discardChanges))
 {
     wxCHECK_RET(item.IsOk(), "invalid tree item");
     QTreeWidgetItem *qTreeItem = wxQtConvertTreeItem(item);
@@ -887,7 +886,7 @@ void wxTreeCtrl::SortChildren(const wxTreeItemId& item)
     qTreeItem->sortChildren(0, Qt::AscendingOrder);
 }
 
-bool wxTreeCtrl::GetBoundingRect(const wxTreeItemId& item, wxRect& rect, bool textOnly) const
+bool wxTreeCtrl::GetBoundingRect(const wxTreeItemId& item, wxRect& WXUNUSED(rect), bool WXUNUSED(textOnly)) const
 {
     wxCHECK_MSG(item.IsOk(), false, "invalid tree item");
     return false;
@@ -906,7 +905,7 @@ int wxTreeCtrl::DoGetItemState(const wxTreeItemId& item) const
     return 0;
 }
 
-void wxTreeCtrl::DoSetItemState(const wxTreeItemId& item, int state)
+void wxTreeCtrl::DoSetItemState(const wxTreeItemId& item, int WXUNUSED(state))
 {
     wxCHECK_RET(item.IsOk(), "invalid tree item");
 }

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -297,14 +297,6 @@ size_t wxTreeCtrl::GetChildrenCount(const wxTreeItemId& item, bool recursively) 
 wxTreeItemId wxTreeCtrl::GetRootItem() const
 {
     QTreeWidgetItem *root = m_qtTreeWidget->invisibleRootItem();
-    if (HasFlag(wxTR_HIDE_ROOT))
-    {
-        return wxQtConvertTreeItem(root);
-    }
-
-    if (root->childCount() == 0)
-        return wxTreeItemId();
-
     return wxQtConvertTreeItem(root->child(0));
 }
 
@@ -509,15 +501,8 @@ wxTreeItemId wxTreeCtrl::AddRoot(const wxString& text,
                              int image, int selImage,
                              wxTreeItemData *data)
 {
-    QTreeWidgetItem *item = m_qtTreeWidget->invisibleRootItem();
-
-    if ( HasFlag(wxTR_HIDE_ROOT) )
-    {
-        item->setText(0, wxQtConvertString(text));
-        return wxQtConvertTreeItem(item);
-    }
-
-    return DoInsertItem(wxQtConvertTreeItem(item), 0, text, image, selImage, data);
+    QTreeWidgetItem *root = m_qtTreeWidget->invisibleRootItem();
+    return DoInsertItem(wxQtConvertTreeItem(root), 0, text, image, selImage, data);
 }
 
 void wxTreeCtrl::Delete(const wxTreeItemId& item)

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -426,6 +426,9 @@ private:
                 imageIndex = states[wxTreeItemIcon_Selected];
         }
 
+        if ( imageIndex == -1 )
+            imageIndex = states[wxTreeItemIcon_Normal];
+
         return imageIndex;
     }
 

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -14,6 +14,7 @@
 
 #include "wx/treectrl.h"
 #include "wx/imaglist.h"
+#include "wx/settings.h"
 
 #include "wx/qt/private/winevent.h"
 #include "wx/qt/private/treeitemfactory.h"
@@ -46,7 +47,6 @@ struct TreeItemDataQt
 };
 
 bool TreeItemDataQt::registered = false;
-Q_DECLARE_METATYPE(TreeItemDataQt)
 
 QDataStream &operator<<(QDataStream &out, const TreeItemDataQt &WXUNUSED(obj))
 {
@@ -119,11 +119,13 @@ private:
 
 }
 
+Q_DECLARE_METATYPE(TreeItemDataQt)
+
 class wxQTreeWidget : public wxQtEventSignalHandler<QTreeWidget, wxTreeCtrl>
 {
 public:
     wxQTreeWidget(wxWindow *parent, wxTreeCtrl *handler) :
-        wxQtEventSignalHandler(parent, handler),
+        wxQtEventSignalHandler<QTreeWidget, wxTreeCtrl>(parent, handler),
         m_editorFactory(handler)
     {
         connect(this, &QTreeWidget::currentItemChanged,
@@ -796,7 +798,7 @@ wxTreeItemId wxTreeCtrl::GetNextChild(
 {
     wxCHECK_MSG(item.IsOk(), wxTreeItemId(), "invalid tree item");
 
-    int currentIndex = reinterpret_cast<int>(cookie);
+    wxIntPtr currentIndex = reinterpret_cast<wxIntPtr>(cookie);
     ++currentIndex;
 
     const QTreeWidgetItem *qTreeItem = wxQtConvertTreeItem(item);

--- a/tests/controls/treectrltest.cpp
+++ b/tests/controls/treectrltest.cpp
@@ -70,6 +70,7 @@ private:
         CPPUNIT_TEST( SelectItemMulti );
         CPPUNIT_TEST( PseudoTest_SetHiddenRoot );
         CPPUNIT_TEST( HasChildren );
+        CPPUNIT_TEST( GetCount );
     CPPUNIT_TEST_SUITE_END();
 
     void ItemClick();
@@ -94,6 +95,7 @@ private:
     void Sort();
     void KeyNavigation();
     void HasChildren();
+    void GetCount();
     void SelectItemSingle();
     void SelectItemMulti();
     void PseudoTest_MultiSelect() { ms_multiSelect = true; }
@@ -173,6 +175,11 @@ void TreeCtrlTestCase::HasChildren()
     CPPUNIT_ASSERT( m_tree->HasChildren(m_child1) );
     CPPUNIT_ASSERT( !m_tree->HasChildren(m_child2) );
     CPPUNIT_ASSERT( !m_tree->HasChildren(m_grandchild) );
+}
+
+void TreeCtrlTestCase::GetCount()
+{
+    CPPUNIT_ASSERT_EQUAL(3, m_tree->GetCount());
 }
 
 void TreeCtrlTestCase::SelectItemSingle()

--- a/tests/controls/treectrltest.cpp
+++ b/tests/controls/treectrltest.cpp
@@ -279,9 +279,10 @@ void TreeCtrlTestCase::DeleteItem()
     EventCounter deleteitem(m_tree, wxEVT_TREE_DELETE_ITEM);
 
     wxTreeItemId todelete = m_tree->AppendItem(m_root, "deleteme");
+    m_tree->AppendItem(todelete, "deleteme2");
     m_tree->Delete(todelete);
 
-    CPPUNIT_ASSERT_EQUAL(1, deleteitem.GetCount());
+    CPPUNIT_ASSERT_EQUAL(2, deleteitem.GetCount());
 }
 
 void TreeCtrlTestCase::DeleteChildren()


### PR DESCRIPTION
This pull requests contains an in implementation of wxTreeCtrl.  Previously wxQT was using wxGenericTreeCtrl.

There are a couple of advantages to a native implementation.  Firstly,  wxTreeCtrl is now fully accessibly to screen readers (and test automation software for that matter).  Secondly, the overall appearance of the tree is more consistent with the rest of wxQT. 