### PR TITLE
Fix mojibake in text sample

### DIFF
--- a/samples/text/text.cpp
+++ b/samples/text/text.cpp
@@ -1200,11 +1200,11 @@ MyPanel::MyPanel( wxFrame *frame, int x, int y, int w, int h )
 
     m_tab = new MyTextCtrl( this, 100, "Multiline, allow <TAB> processing.",
       wxPoint(180,90), wxSize(200,70), wxTE_MULTILINE |  wxTE_PROCESS_TAB );
-    m_tab->SetClientData((void *)"tab");
+    m_tab->SetClientData((void *)wxS("tab"));
 
     m_enter = new MyTextCtrl( this, 100, "Multiline, allow <ENTER> processing.",
       wxPoint(180,170), wxSize(200,70), wxTE_MULTILINE | wxTE_PROCESS_ENTER );
-    m_enter->SetClientData((void *)"enter");
+    m_enter->SetClientData((void *)wxS("enter"));
 
     m_textrich = new MyTextCtrl(this, wxID_ANY, "Allows more than 30Kb of text\n"
                                 "(on all Windows versions)\n"


### PR DESCRIPTION
During the samples-wide removal of obsolete string macros, it seems the macros were accidentally removed also from the place where they were required in the text sample, which leads to some strings being garbled:
![text-mojibake](https://user-images.githubusercontent.com/12495521/52526138-a1b15680-2cb4-11e9-9180-68ea8c65af74.jpg)

There are two string literals casted to `void*` and then retrieved as `wxChar*`, which is wrong in Unicode builds, e.g.:
```cpp
m_tab->SetClientData((void *)"tab");
....
const wxChar *data = (const wxChar *)(win->GetClientData()); 
```

I fixed it using `wxS`, not sure if `wxT` used originally would be better.