### PR TITLE
Fixed for undocked AUI window constantly growing under wxQT

### DIFF
--- a/src/aui/floatpane.cpp
+++ b/src/aui/floatpane.cpp
@@ -289,10 +289,8 @@ void wxAuiFloatingFrame::OnMoveEvent(wxMoveEvent& event)
     m_last2Rect = m_lastRect;
     m_lastRect = winRect;
 
-#ifndef __WXQT__
     if (!isMouseDown())
         return;
-#endif
 
     if (!m_moving)
     {

--- a/src/aui/floatpane.cpp
+++ b/src/aui/floatpane.cpp
@@ -233,7 +233,7 @@ void wxAuiFloatingFrame::OnMoveEvent(wxMoveEvent& event)
 
     // as on OSX moving windows are not getting all move events, only sporadically, this difference
     // is almost always big on OSX, so avoid this early exit opportunity
-#ifndef __WXOSX__
+#if !defined(__WXOSX__) && !defined(__WXQT__)
     // skip if moving too fast to avoid massive redraws and
     // jumping hint windows
     // TODO: Should 3x3px threshold increase on Retina displays?
@@ -289,8 +289,10 @@ void wxAuiFloatingFrame::OnMoveEvent(wxMoveEvent& event)
     m_last2Rect = m_lastRect;
     m_lastRect = winRect;
 
+#ifndef __WXQT__
     if (!isMouseDown())
         return;
+#endif
 
     if (!m_moving)
     {

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -35,7 +35,7 @@
 #include "wx/qt/private/utils.h"
 #include "wx/qt/private/converter.h"
 #include "wx/qt/private/winevent.h"
-
+#include <algorithm>
 
 #define VERT_SCROLLBAR_POSITION 0, 1
 #define HORZ_SCROLLBAR_POSITION 1, 0
@@ -913,7 +913,15 @@ void wxWindowQt::DoSetSize(int x, int y, int width, int height, int sizeFlags )
     if (height == -1)
         height = h;
 
-    DoMoveWindow( x, y, width, height );
+    QWidget *qtWidget = GetHandle();
+    const QSize frameSize = qtWidget->frameSize();
+    const QSize innerSize = qtWidget->geometry().size();
+    const QSize frameSizeDiff = frameSize - innerSize;
+
+    int client_width = std::max( width - frameSizeDiff.width(), 0 );
+    int client_height = std::max( height - frameSizeDiff.height(), 0 );
+
+    DoMoveWindow( x, y, client_width, client_height );
 
     // An annoying feature of Qt
     // if a control is created with size of zero, it is set as hidden by qt
@@ -944,27 +952,7 @@ void wxWindowQt::DoSetClientSize(int width, int height)
 void wxWindowQt::DoMoveWindow(int x, int y, int width, int height)
 {
     QWidget *qtWidget = GetHandle();
-
-    int w, h;
-    GetSize(&w, &h);
-
-    if ( width == -1 )
-    {
-        width = w;
-    }
-
-    if ( height == -1 )
-    {
-        height = h;
-    }
-
-    const QSize frameSize = qtWidget->frameSize();
-    const QSize innerSize = qtWidget->geometry().size();
-    const QSize frameSizeDiff = frameSize - innerSize;
-
-    int client_width = width - frameSizeDiff.width();
-    int client_height = height - frameSizeDiff.height();
-    qtWidget->setGeometry(QRect(x,y, client_width, client_height));
+    qtWidget->setGeometry(QRect(x,y, width, height));
 }
 
 

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -948,13 +948,23 @@ void wxWindowQt::DoMoveWindow(int x, int y, int width, int height)
     int w, h;
     GetSize(&w, &h);
 
-    qtWidget->move( x, y );
+    if ( width == -1 )
+    {
+        width = w;
+    }
+
+    if ( height == -1 )
+    {
+        height = h;
+    }
 
     const QSize frameSize = qtWidget->frameSize();
     const QSize innerSize = qtWidget->geometry().size();
     const QSize frameSizeDiff = frameSize - innerSize;
-    // QWidget::resize takes the size excluding any decoration
-    qtWidget->resize(width - frameSizeDiff.width(), height - frameSizeDiff.height());
+
+    int client_width = width - frameSizeDiff.width();
+    int client_height = height - frameSizeDiff.height();
+    qtWidget->setGeometry(QRect(x,y, client_width, client_height));
 }
 
 

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -945,8 +945,16 @@ void wxWindowQt::DoMoveWindow(int x, int y, int width, int height)
 {
     QWidget *qtWidget = GetHandle();
 
+    int w, h;
+    GetSize(&w, &h);
+
     qtWidget->move( x, y );
-    qtWidget->resize( width, height );
+
+    const QSize frameSize = qtWidget->frameSize();
+    const QSize innerSize = qtWidget->geometry().size();
+    const QSize frameSizeDiff = frameSize - innerSize;
+    // QWidget::resize takes the size excluding any decoration
+    qtWidget->resize(width - frameSizeDiff.width(), height - frameSizeDiff.height());
 }
 
 


### PR DESCRIPTION
This PR allows a pane to be undocked, moved around and redocked when using wxQT without the window constantly growing with each drag. 