### PR TITLE
Generate wxEVT_SPIN_UP and wxEVT_SPIN_DOWN events from wxSpinButton

### DIFF
--- a/include/wx/qt/spinbutt.h
+++ b/include/wx/qt/spinbutt.h
@@ -9,7 +9,7 @@
 #define _WX_QT_SPINBUTT_H_
 
 #include "wx/spinbutt.h"
-class QSpinBox;
+class wxQtSpinButton;
 
 class WXDLLIMPEXP_CORE wxSpinButton : public wxSpinButtonBase
 {
@@ -35,7 +35,7 @@ public:
     virtual QWidget *GetHandle() const;
 
 private:
-    QSpinBox *m_qtSpinBox;
+    wxQtSpinButton *m_qtSpinBox;
 
     wxDECLARE_DYNAMIC_CLASS( wxSpinButton );
 };

--- a/src/qt/spinbutt.cpp
+++ b/src/qt/spinbutt.cpp
@@ -18,6 +18,11 @@ class wxQtSpinButton : public wxQtEventSignalHandler< QSpinBox, wxSpinButton  >
 public:
     wxQtSpinButton( wxWindow *parent, wxSpinButton *handler );
 
+	void PreserveOldValue()
+	{
+		oldValue = value();
+	}
+
 private:
     void valueChanged(int value);
     int oldValue;
@@ -29,7 +34,7 @@ wxQtSpinButton::wxQtSpinButton( wxWindow *parent, wxSpinButton *handler )
     connect(this, static_cast<void (QSpinBox::*)(int index)>(&QSpinBox::valueChanged),
             this, &wxQtSpinButton::valueChanged);
 
-    oldValue = value();
+	PreserveOldValue();
 }
 
 void wxQtSpinButton::valueChanged(int newValue)
@@ -101,7 +106,10 @@ int wxSpinButton::GetValue() const
 
 void wxSpinButton::SetValue(int val)
 {
+	m_qtSpinBox->blockSignals(true);
+	m_qtSpinBox->PreserveOldValue();
     m_qtSpinBox->setValue( val );
+	m_qtSpinBox->blockSignals(false);
 }
 
 QWidget *wxSpinButton::GetHandle() const


### PR DESCRIPTION
This PR ensures that wxSpinButton now generates wxEVT_SPIN_UP and wxEVT_SPIN_DOWN events.  In addition the correct types are now used for events (wxSpinEvent rather than wxCommandEvent).