### PR TITLE
Prevent crash in wxButton under wxQT

### DIFF
--- a/src/qt/anybutton.cpp
+++ b/src/qt/anybutton.cpp
@@ -57,14 +57,18 @@ void wxQtPushButton::action()
 
 bool wxQtPushButton::event(QEvent* e)
 {
-    switch ( e->type() )
+    wxAnyButton *handler = GetHandler();
+    if ( handler != NULL )
     {
-    case QEvent::EnabledChange:
-    case QEvent::Enter:
-    case QEvent::Leave:
-    case QEvent::FocusIn:
-    case QEvent::FocusOut:
-        GetHandler()->QtUpdateState();
+        switch ( e->type() )
+        {
+        case QEvent::EnabledChange:
+        case QEvent::Enter:
+        case QEvent::Leave:
+        case QEvent::FocusIn:
+        case QEvent::FocusOut:
+            handler->QtUpdateState();
+        }
     }
 
     return QPushButton::event(e);


### PR DESCRIPTION
Prevent crash in wxButton when there are pending QT events after wxButton as been destroyed