### PR TITLE
Default to wxTB_TOP if no toolbar position is given

### DIFF
--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -110,10 +110,10 @@ void wxFrame::SetToolBar(wxToolBar *toolbar)
     int area = 0;
     if ( toolbar != NULL )
     {
-        if      (toolbar->HasFlag(wxTB_LEFT))  { area |= Qt::LeftToolBarArea;  }
-        else if (toolbar->HasFlag(wxTB_RIGHT)) { area |= Qt::RightToolBarArea; }
-        else if (toolbar->HasFlag(wxTB_TOP))   { area |= Qt::TopToolBarArea;   }
-        else if (toolbar->HasFlag(wxTB_BOTTOM)){ area |= Qt::BottomToolBarArea;}
+        if      (toolbar->HasFlag(wxTB_LEFT))  { area = Qt::LeftToolBarArea;  }
+        else if (toolbar->HasFlag(wxTB_RIGHT)) { area = Qt::RightToolBarArea; }
+        else if (toolbar->HasFlag(wxTB_BOTTOM)){ area = Qt::BottomToolBarArea;}
+        else { area = Qt::TopToolBarArea;   }
 
         // We keep the current toolbar handle in our own member variable
         // because we can't get it from half-destroyed wxToolBar when it calls


### PR DESCRIPTION
QT requires a toolbar area to be specified or the toolbar is not added to the window.  This PR ensures that is no toolbar flag is given to the wxFrame then wxTB_TOP is assumed.