### PR TITLE
Improve focus handling

### DIFF
--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -242,4 +242,5 @@ wxQtMainWindow::wxQtMainWindow( wxWindow *parent, wxFrame *handler )
 wxQtCentralWidget::wxQtCentralWidget( wxWindow *parent, wxFrame *handler )
     : wxQtEventSignalHandler< QScrollArea, wxFrame >( parent, handler )
 {
+    setFocusPolicy(Qt::NoFocus);
 }

--- a/src/qt/spinbutt.cpp
+++ b/src/qt/spinbutt.cpp
@@ -26,6 +26,8 @@ private:
 wxQtSpinButton::wxQtSpinButton( wxWindow *parent, wxSpinButton *handler )
     : wxQtEventSignalHandler< QSpinBox, wxSpinButton >( parent, handler )
 {
+    setFocusPolicy(Qt::NoFocus);
+
     connect(this, static_cast<void (QSpinBox::*)(int index)>(&QSpinBox::valueChanged),
             this, &wxQtSpinButton::valueChanged);
 }


### PR DESCRIPTION
In `widgets` sample can be seen that when clicking the `wxSpinButton` it takes focus away from others, like a `wxSpinCtrl`. The former should not be allowed to be focused, and the first commit solved that.
But focus would still be lost by the `wxSpinCtrl` when clicking outside it (including on the now inert `wxSpinButton`) in favor of the "central widget". This was solved with the second commit.