### PR TITLE
Reimplement wxToolBar resizing

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -65,6 +65,11 @@ Changes in behaviour not resulting in compilation errors
 - wxGTK wxNotebook::AddPage() doesn't generate any events any more for the
   first page being added, for consistency with the other ports.
 
+- wxMSW wxToolBar height now adapts to the height of embedded controls, making
+  the toolbar taller if necessary, rather than making the controls smaller. To
+  return to the previous behaviour, you need to explicitly create controls of
+  smaller size.
+
 
 Changes in behaviour which may result in build errors
 -----------------------------------------------------

--- a/include/wx/msw/toolbar.h
+++ b/include/wx/msw/toolbar.h
@@ -183,6 +183,10 @@ private:
         return HasFlag(wxTB_TEXT) && !HasFlag(wxTB_NOICONS);
     }
 
+    // Return the size required to accommodate the given tool which must be of
+    // "control" type.
+    wxSize MSWGetFittingtSizeForControl(class wxToolBarTool* tool) const;
+
 
     wxDECLARE_EVENT_TABLE();
     wxDECLARE_DYNAMIC_CLASS(wxToolBar);

--- a/include/wx/msw/toolbar.h
+++ b/include/wx/msw/toolbar.h
@@ -174,6 +174,16 @@ private:
     WXHBRUSH MSWGetToolbarBgBrush();
 #endif // wxHAS_MSW_BACKGROUND_ERASE_HOOK
 
+    // Return true if we're showing the labels for the embedded controls: we
+    // only do it if text is enabled and, somewhat less expectedly, if icons
+    // are enabled too because showing both the control and its label when only
+    // text is shown for the other buttons is too inconsistent to be useful.
+    bool AreControlLabelsShown() const
+    {
+        return HasFlag(wxTB_TEXT) && !HasFlag(wxTB_NOICONS);
+    }
+
+
     wxDECLARE_EVENT_TABLE();
     wxDECLARE_DYNAMIC_CLASS(wxToolBar);
     wxDECLARE_NO_COPY_CLASS(wxToolBar);

--- a/samples/toolbar/toolbar.cpp
+++ b/samples/toolbar/toolbar.cpp
@@ -350,7 +350,7 @@ void MyFrame::RecreateToolbar()
             style |= wxTB_RIGHT;
             break;
         case TOOLBAR_BOTTOM:
-        style |= wxTB_BOTTOM;
+            style |= wxTB_BOTTOM;
         break;
     }
 

--- a/samples/toolbar/toolbar.cpp
+++ b/samples/toolbar/toolbar.cpp
@@ -574,16 +574,16 @@ MyFrame::MyFrame(wxFrame* parent,
 
     tbarMenu->AppendSeparator();
     tbarMenu->AppendRadioItem(IDM_TOOLBAR_TOP_ORIENTATION,
-                              "Set toolbar at the top of the window",
+                              "Set toolbar at the top of the window\tCtrl-Up",
                               "Set toolbar at the top of the window");
     tbarMenu->AppendRadioItem(IDM_TOOLBAR_LEFT_ORIENTATION,
-                              "Set toolbar at the left of the window",
+                              "Set toolbar at the left of the window\tCtrl-Left",
                               "Set toolbar at the left of the window");
     tbarMenu->AppendRadioItem(IDM_TOOLBAR_BOTTOM_ORIENTATION,
-                              "Set toolbar at the bottom of the window",
+                              "Set toolbar at the bottom of the window\tCtrl-Down",
                               "Set toolbar at the bottom of the window");
     tbarMenu->AppendRadioItem(IDM_TOOLBAR_RIGHT_ORIENTATION,
-                              "Set toolbar at the right edge of the window",
+                              "Set toolbar at the right edge of the window\tCtrl-Right",
                               "Set toolbar at the right edge of the window");
     tbarMenu->AppendSeparator();
 

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1325,29 +1325,6 @@ bool wxToolBar::Realize()
     InvalidateBestSize();
     UpdateSize();
 
-    if ( IsVertical() )
-    {
-        // For vertical toolbar heights of buttons are incorrect
-        // unless TB_AUTOSIZE in invoked.
-        // We need to recalculate fixed elements size again.
-        m_totalFixedSize = 0;
-        toolIndex = 0;
-        for ( node = m_tools.GetFirst(); node; node = node->GetNext(), toolIndex++ )
-        {
-            wxToolBarTool * const tool = (wxToolBarTool*)node->GetData();
-            if ( !tool->IsStretchableSpace() )
-            {
-                const RECT r = wxGetTBItemRect(GetHwnd(), toolIndex);
-                if ( !IsVertical() )
-                    m_totalFixedSize += r.right - r.left;
-                else if ( !tool->IsControl() )
-                    m_totalFixedSize += r.bottom - r.top;
-            }
-        }
-        // Enforce invoking UpdateStretchableSpacersSize() with correct value of fixed elements size.
-        UpdateSize();
-    }
-
     return true;
 }
 

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -597,14 +597,6 @@ wxSize wxToolBar::DoGetBestSize() const
                 sizeBest.IncTo(wxSize(-1, MSWGetFittingtSizeForControl(tool).y));
             }
         }
-
-        // Without the extra height, DoGetBestSize can report a size that's
-        // smaller than the actual window, causing windows to overlap slightly
-        // in some circumstances, leading to missing borders (especially noticeable
-        // in AUI layouts).
-        if (!(GetWindowStyle() & wxTB_NODIVIDER))
-            sizeBest.y += 2;
-        sizeBest.y ++;
     }
 
     return sizeBest;

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -540,7 +540,7 @@ wxSize wxToolBar::MSWGetFittingtSizeForControl(wxToolBarTool* tool) const
     }
 
     // Also account for the tool padding value.
-    size += wxSize(m_toolPacking, m_toolPacking);
+    size.x += m_toolPacking;
 
     return size;
 }

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1387,31 +1387,20 @@ void wxToolBar::UpdateStretchableSpacersSize()
         const int newSize = --numSpaces ? sizeSpacer : sizeLastSpacer;
         if ( newSize != oldSize)
         {
-            if ( !::SendMessage(GetHwnd(), TB_DELETEBUTTON, toolIndex, 0) )
+            WinStruct<TBBUTTONINFO> tbbi;
+            tbbi.dwMask = TBIF_BYINDEX | TBIF_SIZE;
+            tbbi.cx = newSize;
+            if ( !::SendMessage(GetHwnd(), TB_SETBUTTONINFO,
+                                toolIndex, (LPARAM)&tbbi) )
             {
-                wxLogLastError(wxT("TB_DELETEBUTTON (separator)"));
+                wxLogLastError(wxT("TB_SETBUTTONINFO (separator)"));
             }
             else
             {
-                TBBUTTON button;
-                wxZeroMemory(button);
-
-                button.idCommand = tool->GetId();
-                button.iBitmap = newSize; // set separator width/height
-                button.fsState = TBSTATE_ENABLED;
-                button.fsStyle = TBSTYLE_SEP;
-                if ( IsVertical() )
-                    button.fsState |= TBSTATE_WRAP;
-                if ( !::SendMessage(GetHwnd(), TB_INSERTBUTTON, toolIndex, (LPARAM)&button) )
-                {
-                    wxLogLastError(wxT("TB_INSERTBUTTON (separator)"));
-                }
-                else
-                {
-                    // We successfully replaced this seprator, move all the controls after it
-                    // by the corresponding amount (may be positive or negative)
-                    offset += newSize - oldSize;
-                }
+                // We successfully updated the separator width, move all the
+                // controls appearing after it by the corresponding amount
+                // (which may be positive or negative)
+                offset += newSize - oldSize;
             }
         }
 

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -94,6 +94,9 @@
     #define TB_GETMAXSIZE           (WM_USER + 83)
 #endif
 
+// Margin between the control and its label.
+static const int MARGIN_CONTROL_LABEL = 3;
+
 // ----------------------------------------------------------------------------
 // wxWin macros
 // ----------------------------------------------------------------------------
@@ -1227,7 +1230,7 @@ bool wxToolBar::Realize()
         if ( staticText && staticText->IsShown() )
         {
             staticTextSize = staticText->GetSize();
-            staticTextSize.y += 3; // margin between control and its label
+            staticTextSize.y += MARGIN_CONTROL_LABEL;
         }
 
         // position the control itself correctly vertically centering it on the

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -97,6 +97,13 @@
 // Margin between the control and its label.
 static const int MARGIN_CONTROL_LABEL = 3;
 
+// We make (flat-only) toolbars smaller by this amount than the value that
+// would be given to them by TB_AUTOSIZE. This is done for cosmetic reasons and
+// also to decrease the vertical space consumed by the toolbar and, finally and
+// perhaps most significantly, for compatibility, as people dislike their
+// toolbars changing height when updating to a new wxWidgets version.
+static const int AUTOSIZE_HEIGHT_ADJUSTMENT = 3;
+
 // ----------------------------------------------------------------------------
 // wxWin macros
 // ----------------------------------------------------------------------------
@@ -1719,7 +1726,7 @@ void wxToolBar::UpdateSize()
         // at all if this is the right thing to do, but continue doing it now
         // for compatibility.
         if ( HasFlag(wxTB_FLAT) )
-            size.y -= 3;
+            size.y -= AUTOSIZE_HEIGHT_ADJUSTMENT;
     }
 
     SetSize(wxRect(pos, size));

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1050,11 +1050,7 @@ bool wxToolBar::Realize()
             case wxTOOL_STYLE_CONTROL:
                 if ( wxStaticText *staticText = tool->GetStaticText() )
                 {
-                    // Display control and its label only if buttons have icons
-                    // and texts as otherwise there is not enough room on the
-                    // toolbar to fit the label.
-                    staticText->
-                        Show(HasFlag(wxTB_TEXT) && !HasFlag(wxTB_NOICONS));
+                    staticText->Show(AreControlLabelsShown());
                 }
 
                 // Set separator width/height to fit the control width/height

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1200,10 +1200,15 @@ bool wxToolBar::Realize()
 
         if ( !tool->IsControl() )
         {
-            if ( IsVertical() )
-                m_totalFixedSize += r.bottom - r.top;
-            else
-                m_totalFixedSize += r.right - r.left;
+            // Stretchable space don't have any fixed size and their current
+            // size shouldn't count at all.
+            if ( !tool->IsStretchableSpace() )
+            {
+                if ( IsVertical() )
+                    m_totalFixedSize += r.bottom - r.top;
+                else
+                    m_totalFixedSize += r.right - r.left;
+            }
 
             continue;
         }

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1678,6 +1678,8 @@ void wxToolBar::UpdateSize()
     wxPoint pos = GetPosition();
     ::SendMessage(GetHwnd(), TB_AUTOSIZE, 0, 0);
 
+    wxSize size = GetSize();
+
     // TB_AUTOSIZE doesn't seem to work for vertical toolbars which it resizes
     // to have the same width as a horizontal toolbar would have, even though
     // we do use TBSTATE_WRAP which should make it start a new row after each
@@ -1708,11 +1710,19 @@ void wxToolBar::UpdateSize()
                 maxWidth = width;
         }
 
-        SetSize(maxWidth, GetSize().y);
+        size.x = maxWidth;
+    }
+    else // horizontal
+    {
+        // For (flat) horizontal toolbars we used to make the toolbar 3px less
+        // tall in the previous wx versions, for some reason. It's not obvious
+        // at all if this is the right thing to do, but continue doing it now
+        // for compatibility.
+        if ( HasFlag(wxTB_FLAT) )
+            size.y -= 3;
     }
 
-    if (pos != GetPosition())
-        Move(pos);
+    SetSize(wxRect(pos, size));
 
     // In case Realize is called after the initial display (IOW the programmer
     // may have rebuilt the toolbar) give the frame the option of resizing the

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -553,8 +553,11 @@ wxSize wxToolBar::MSWGetFittingtSizeForControl(wxToolBarTool* tool) const
         }
     }
 
-    // Also account for the tool padding value.
-    size.x += m_toolPacking;
+    // Also account for the tool padding value: note that we only have to add
+    // half of it to each tool, as the total amount of packing is the sum of
+    // the right margin of the previous tool and the left margin of the next
+    // one.
+    size.x += m_toolPacking / 2;
 
     return size;
 }
@@ -603,7 +606,9 @@ wxSize wxToolBar::DoGetBestSize() const
                 sizeBest.x += sizeTool.x;
             }
 
-            sizeBest.x += m_toolPacking;
+            // As explained in MSWGetFittingtSizeForControl() above, the actual
+            // margin used for a single tool is one half of the total packing.
+            sizeBest.x += m_toolPacking / 2;
         }
     }
 
@@ -1271,8 +1276,10 @@ bool wxToolBar::Realize()
 
         const wxSize controlSize = control->GetSize();
 
-        // Take also into account tool padding value.
-        const int x = r.left + m_toolPacking/2;
+        // Take also into account tool padding value: the amount of padding
+        // used for each tool is half of m_toolPacking, so the margin on each
+        // side is a half of that.
+        const int x = r.left + m_toolPacking / 4;
 
         // Greater of control and its label widths.
         int totalWidth = controlSize.x;

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1854,8 +1854,7 @@ void wxToolBar::OnEraseBackground(wxEraseEvent& event)
 bool wxToolBar::HandleSize(WXWPARAM WXUNUSED(wParam), WXLPARAM lParam)
 {
     // wait until we have some tools
-    const int toolsCount = GetToolsCount();
-    if ( toolsCount == 0 )
+    if ( !GetToolsCount() )
         return false;
 
     // calculate our minor dimension ourselves - we're confusing the standard

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -165,17 +165,7 @@ public:
         if ( IsControl() && !m_label.empty() )
         {
             // Create a control to render the control's label.
-            // It has the same witdh as the control.
-            wxSize size(control->GetSize().GetWidth(), wxDefaultCoord);
-            m_staticText = new wxStaticText
-                               (
-                                 m_tbar,
-                                 wxID_ANY,
-                                 m_label,
-                                 wxDefaultPosition,
-                                 size,
-                                 wxALIGN_CENTRE | wxST_NO_AUTORESIZE
-                               );
+            m_staticText = new wxStaticText(m_tbar, wxID_ANY, m_label);
         }
         else // no label
         {
@@ -1057,6 +1047,7 @@ bool wxToolBar::Realize()
     // this array will hold the indices of all controls in the toolbar
     wxArrayInt controlIds;
 
+    int minReqHeight = 0;
     bool lastWasRadio = false;
     int i = 0;
     for ( node = m_tools.GetFirst(); node; node = node->GetNext() )
@@ -1071,16 +1062,11 @@ bool wxToolBar::Realize()
         switch ( tool->GetStyle() )
         {
             case wxTOOL_STYLE_CONTROL:
-                if ( wxStaticText *staticText = tool->GetStaticText() )
-                {
-                    staticText->Show(AreControlLabelsShown());
-                }
-
-                // Set separator width/height to fit the control width/height
-                // taking into account tool padding value.
-                // (height is not used but it is set for the sake of consistency).
+                if ( !IsVertical() )
                 {
                     const wxSize size = MSWGetFittingtSizeForControl(tool);
+                    if ( minReqHeight < size.y )
+                        minReqHeight = size.y;
                     button.iBitmap = size.x;
                 }
 
@@ -1197,6 +1183,15 @@ bool wxToolBar::Realize()
                 break;
         }
 
+        if ( IsVertical() )
+        {
+            // MSDN says that TBSTATE_WRAP should be used for all buttons in
+            // vertical toolbars, so do it even if it doesn't seem to actually
+            // change anything in practice (including the problem with
+            // TB_AUTOSIZE mentioned in UpdateSize()).
+            button.fsState |= TBSTATE_WRAP;
+        }
+
         lastWasRadio = isRadio;
 
         i++;
@@ -1205,6 +1200,24 @@ bool wxToolBar::Realize()
     if ( !::SendMessage(GetHwnd(), TB_ADDBUTTONS, i, (LPARAM)buttons.get()) )
     {
         wxLogLastError(wxT("TB_ADDBUTTONS"));
+    }
+
+
+    // Make sure the toolbar is tall enough to fit the embedded controls, which
+    // may be taller than the buttons.
+    wxSize toolSize = GetToolSize();
+    if ( toolSize.y < minReqHeight )
+    {
+        toolSize.y = minReqHeight;
+
+        // Surprisingly, we need to send TB_AUTOSIZE before TB_SETBUTTONSIZE
+        // and not after it, as might be expected: otherwise, the button size
+        // remains unchanged (doing TB_AUTOSIZE later doesn't seem to do any
+        // harm but doesn't change the button size neither).
+        ::SendMessage(GetHwnd(), TB_AUTOSIZE, 0, 0);
+
+        ::SendMessage(GetHwnd(), TB_SETBUTTONSIZE,
+                      0, MAKELPARAM(toolSize.x, toolSize.y));
     }
 
 
@@ -1243,57 +1256,51 @@ bool wxToolBar::Realize()
             // good and wxGTK doesn't do it neither (and the code below can't
             // deal with this case)
             control->Hide();
+            if ( wxStaticText * const staticText = tool->GetStaticText() )
+                staticText->Hide();
             continue;
         }
 
         control->Show();
-        wxStaticText * const staticText = tool->GetStaticText();
 
-        wxSize size = control->GetSize();
-        wxSize staticTextSize;
-        if ( staticText && staticText->IsShown() )
-        {
-            staticTextSize = staticText->GetSize();
-            staticTextSize.y += MARGIN_CONTROL_LABEL;
-        }
-
-        // position the control itself correctly vertically centering it on the
-        // icon area of the toolbar
-        int height = r.bottom - r.top - staticTextSize.y;
-
-        int diff = height - size.y;
-        if ( diff < 0 || !HasFlag(wxTB_TEXT) )
-        {
-            // not enough room for the static text
-            if ( staticText )
-                staticText->Hide();
-
-            // recalculate height & diff without the staticText control
-            height = r.bottom - r.top;
-            diff = height - size.y;
-            if ( diff < 0 )
-            {
-                // the control is too high, resize to fit
-                // Actually don't set the size, otherwise we can never fit
-                // the toolbar around the controls.
-                // control->SetSize(wxDefaultCoord, height - 2);
-
-                diff = 2;
-            }
-        }
-        else // enough space for both the control and the label
-        {
-            if ( staticText )
-                staticText->Show();
-        }
+        const wxSize controlSize = control->GetSize();
 
         // Take also into account tool padding value.
-        control->Move(r.left + m_toolPacking/2, r.top + (diff + 1) / 2);
-        if ( staticText )
+        const int x = r.left + m_toolPacking/2;
+        const int height = r.bottom - r.top;
+
+        // Greater of control and its label widths.
+        int totalWidth = controlSize.x;
+
+        // Height of control and its label, if any, including the margin
+        // between them.
+        int totalHeight = controlSize.y;
+
+        if ( wxStaticText * const staticText = tool->GetStaticText() )
         {
-            staticText->Move(r.left + m_toolPacking/2 + (size.x - staticTextSize.x)/2,
-                             r.bottom - staticTextSize.y);
+            const bool shown = AreControlLabelsShown();
+            staticText->Show(shown);
+
+            if ( shown )
+            {
+                const wxSize staticTextSize = staticText->GetSize();
+
+                if ( staticTextSize.x > totalWidth )
+                    totalWidth = staticTextSize.x;
+
+                // Center the static text horizontally for consistency with the
+                // button labels and position it below the control vertically.
+                staticText->Move(x + (totalWidth - staticTextSize.x)/2,
+                                 r.top + (height + controlSize.y
+                                                 - staticTextSize.y
+                                                 + MARGIN_CONTROL_LABEL)/2);
+
+                totalHeight += staticTextSize.y + MARGIN_CONTROL_LABEL;
+            }
         }
+
+        control->Move(x + (totalWidth - controlSize.x)/2,
+                      r.top + (height - totalHeight)/2);
 
         m_totalFixedSize += r.right - r.left;
     }
@@ -1638,14 +1645,25 @@ void wxToolBar::SetRows(int nRows)
     const bool enable = (!IsVertical() && m_maxRows == 1) ||
                            (IsVertical() && (size_t)m_maxRows == m_nButtons);
 
-    const LPARAM state = MAKELONG(enable ? TBSTATE_ENABLED : TBSTATE_HIDDEN, 0);
+    LPARAM state = enable ? TBSTATE_ENABLED : TBSTATE_HIDDEN;
+
+    if ( IsVertical() )
+    {
+        // As in Realize(), ensure that TBSTATE_WRAP is used for all the
+        // tools, including separators, in vertical toolbar, and here it does
+        // make a difference: without it, the following tools wouldn't be
+        // visible because they would be on the same row as the separator.
+        state |= TBSTATE_WRAP;
+    }
+
     wxToolBarToolsList::compatibility_iterator node;
     for ( node = m_tools.GetFirst(); node; node = node->GetNext() )
     {
         wxToolBarTool * const tool = (wxToolBarTool*)node->GetData();
         if ( tool->IsStretchableSpace() )
         {
-            if ( !::SendMessage(GetHwnd(), TB_SETSTATE, tool->GetId(), state) )
+            if ( !::SendMessage(GetHwnd(), TB_SETSTATE,
+                                tool->GetId(), MAKELONG(state, 0)) )
             {
                 wxLogLastError(wxT("TB_SETSTATE (stretchable spacer)"));
             }
@@ -1683,6 +1701,40 @@ void wxToolBar::UpdateSize()
 {
     wxPoint pos = GetPosition();
     ::SendMessage(GetHwnd(), TB_AUTOSIZE, 0, 0);
+
+    // TB_AUTOSIZE doesn't seem to work for vertical toolbars which it resizes
+    // to have the same width as a horizontal toolbar would have, even though
+    // we do use TBSTATE_WRAP which should make it start a new row after each
+    // tool. So override its width determination explicitly.
+    if ( IsVertical() )
+    {
+        // Find the widest tool in the toolbar.
+        int maxWidth = 0;
+
+        int i = 0;
+        for ( wxToolBarToolsList::compatibility_iterator node = m_tools.GetFirst();
+              node;
+              node = node->GetNext(), ++i )
+        {
+            wxToolBarTool * const tool = (wxToolBarTool*)node->GetData();
+            if ( tool->IsSeparator() )
+            {
+                // Somehow, separators get resized to have huge width, which
+                // probably explains why TB_AUTOSIZE doesn't work correctly for
+                // us in the first place. Because of this, don't take them into
+                // account: they can't be wider than any normal button, anyhow.
+                continue;
+            }
+
+            const RECT rc = wxGetTBItemRect(GetHwnd(), i);
+            const int width = rc.right - rc.left;
+            if ( width > maxWidth )
+                maxWidth = width;
+        }
+
+        SetSize(maxWidth, GetSize().y);
+    }
+
     if (pos != GetPosition())
         Move(pos);
 
@@ -1867,114 +1919,11 @@ void wxToolBar::OnEraseBackground(wxEraseEvent& event)
 #endif // wxHAS_MSW_BACKGROUND_ERASE_HOOK
 }
 
-bool wxToolBar::HandleSize(WXWPARAM WXUNUSED(wParam), WXLPARAM lParam)
+bool wxToolBar::HandleSize(WXWPARAM WXUNUSED(wParam), WXLPARAM WXUNUSED(lParam))
 {
     // wait until we have some tools
     if ( !GetToolsCount() )
         return false;
-
-    // calculate our minor dimension ourselves - we're confusing the standard
-    // logic (TB_AUTOSIZE) with our horizontal toolbars and other hacks
-    // Find bounding box for all rows.
-    RECT r;
-    ::SetRectEmpty(&r);
-    // Bounding box for single (current) row
-    RECT rcRow;
-    ::SetRectEmpty(&rcRow);
-    int rowPosX = INT_MIN;
-    wxToolBarToolsList::compatibility_iterator node;
-    int i = 0;
-    for ( node = m_tools.GetFirst(); node; node = node->GetNext() )
-    {
-        wxToolBarTool * const
-            tool = static_cast<wxToolBarTool *>(node->GetData());
-        if ( tool->IsToBeDeleted() )
-            continue;
-
-        // Skip hidden buttons
-        const RECT rcItem = wxGetTBItemRect(GetHwnd(), i);
-        if ( ::IsRectEmpty(&rcItem) )
-        {
-            i++;
-            continue;
-        }
-
-        if ( rcItem.top > rowPosX )
-        {
-            // We have the next row.
-            rowPosX = rcItem.top;
-
-            // Shift origin to (0, 0) to make it the same as for the total rect.
-            ::OffsetRect(&rcRow, -rcRow.left, -rcRow.top);
-
-            // And update the bounding box for all rows.
-            ::UnionRect(&r, &r, &rcRow);
-
-            // Reset the current row bounding box for the next row.
-            ::SetRectEmpty(&rcRow);
-        }
-
-        // Separators shouldn't be taken into account as they are sometimes
-        // reported to have the width of the entire client area by the toolbar.
-        // And we know that they are not the biggest items in the toolbar in
-        // any case, so just skip them.
-        if( !tool->IsSeparator() )
-        {
-            // Update bounding box of current row
-            ::UnionRect(&rcRow, &rcRow, &rcItem);
-        }
-
-        i++;
-    }
-
-    // Take into account the last row rectangle too.
-    ::OffsetRect(&rcRow, -rcRow.left, -rcRow.top);
-    ::UnionRect(&r, &r, &rcRow);
-
-    if ( !r.right )
-        return false;
-
-    int w, h;
-
-    if ( IsVertical() )
-    {
-        w = r.right - r.left;
-        h = HIWORD(lParam);
-    }
-    else
-    {
-        w = LOWORD(lParam);
-        if (HasFlag( wxTB_FLAT ))
-            h = r.bottom - r.top - 3;
-        else
-            h = r.bottom - r.top;
-
-        // Take control height into account
-        for ( node = m_tools.GetFirst(); node; node = node->GetNext() )
-        {
-            wxToolBarTool * const
-                tool = static_cast<wxToolBarTool *>(node->GetData());
-            if (tool->IsControl())
-            {
-                int y = (tool->GetControl()->GetSize().y - 2); // -2 since otherwise control height + 4 (below) is too much
-                if (y > h)
-                    h = y;
-            }
-        }
-
-        if ( m_maxRows )
-        {
-            // FIXME: hardcoded separator line height...
-            h += HasFlag(wxTB_NODIVIDER) ? 4 : 6;
-            h *= m_maxRows;
-        }
-    }
-
-    if ( MAKELPARAM(w, h) != lParam )
-    {
-        // size really changed
-        SetSize(w, h);
-    }
 
     UpdateStretchableSpacersSize();
 

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1312,8 +1312,16 @@ bool wxToolBar::Realize()
     if ( !IsVertical() )
     {
         if ( m_maxRows == 0 )
+        {
             // if not set yet, only one row
             SetRows(1);
+        }
+        else
+        {
+            // In all the other cases, UpdateSize() is called by SetRows(), but
+            // when we don't call it here, call it directly instead.
+            UpdateSize();
+        }
     }
     else if ( m_nButtons > 0 ) // vertical non empty toolbar
     {
@@ -1323,7 +1331,6 @@ bool wxToolBar::Realize()
     }
 
     InvalidateBestSize();
-    UpdateSize();
 
     return true;
 }

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -610,13 +610,16 @@ wxSize wxToolBar::DoGetBestSize() const
     // Note that this needs to be done after the loop to account for controls
     // too high to fit into the toolbar without the border size but that could
     // fit if we had added the border beforehand.
-    if ( IsVertical() )
+    if ( !HasFlag(wxTB_NODIVIDER) )
     {
-        sizeBest.x += 2 * ::GetSystemMetrics(SM_CXBORDER);
-    }
-    else
-    {
-        sizeBest.y += 2 * ::GetSystemMetrics(SM_CYBORDER);
+        if ( IsVertical() )
+        {
+            sizeBest.x += 2 * ::GetSystemMetrics(SM_CXBORDER);
+        }
+        else
+        {
+            sizeBest.y += 2 * ::GetSystemMetrics(SM_CYBORDER);
+        }
     }
 
     return sizeBest;
@@ -1218,8 +1221,14 @@ bool wxToolBar::Realize()
 
     // We don't trust the height returned by wxGetTBItemRect() as it may not
     // have been updated yet, use the height that the toolbar will actually
-    // have instead. Also, account for 2px toolbar border here.
-    const int height = GetBestSize().y - 2 * ::GetSystemMetrics(SM_CYBORDER);
+    // have instead.
+    int height = GetBestSize().y;
+    if ( !HasFlag(wxTB_NODIVIDER) )
+    {
+        // We want just the usable height, so remove the space taken by the
+        // border/divider.
+        height -= 2 * ::GetSystemMetrics(SM_CYBORDER);
+    }
 
     // adjust the controls size to fit nicely in the toolbar and compute its
     // total size while doing it


### PR DESCRIPTION
This fixes [ticket 18294](https://trac.wxwidgets.org/ticket/18294) without breaking support for putting taller controls into the toolbars as per 0185d61a2c6f91cf47932fce0d68d70b7e578b17 and generally speaking makes toolbar control more normal in wxMSW.

It also totally changes the code which remained more or less the same for 25 years, so it could perfectly well break things. Please test your programs with this PR to check if you see any regressions, TIA!