### PR TITLE
Use critical alert style for wxICON_ERROR too in wxOSX

### DIFF
--- a/src/osx/cocoa/msgdlg.mm
+++ b/src/osx/cocoa/msgdlg.mm
@@ -31,7 +31,7 @@ namespace
 {
     NSAlertStyle GetAlertStyleFromWXStyle( long style )
     {
-        if (style & wxICON_WARNING)
+        if (style & (wxICON_WARNING | wxICON_ERROR))
         {
             // NSCriticalAlertStyle should only be used for questions where
             // caution is needed per the OS X HIG. wxICON_WARNING alone doesn't
@@ -42,8 +42,6 @@ namespace
             else
                 return NSWarningAlertStyle;
         }
-        else if (style & wxICON_ERROR)
-            return NSWarningAlertStyle;
         else
             return NSInformationalAlertStyle;
     }


### PR DESCRIPTION
After the changes of 6b8b3ee37906b5f49382741b4e1b44f48a9794c9 we could
use NSCriticalAlertStyle for message boxes with wxICON_WARNING, if they
also has Yes/No or Cancel button, but never for wxICON_ERROR, for which
just NSWarningAlertStyle was used, which seems counterintuitive, so
change the code to use NSCriticalAlertStyle for either wxICON_WARNING or
wxICON_ERROR message boxes asking the user about something.

---

@vslavik Please see [this message](https://groups.google.com/d/msg/wx-users/vwp7VjT9cv4/OdHRczkSAgAJ) for more context.