### PR TITLE
Crash when child has focus while TLW is destroyed

### DIFF
--- a/src/msw/button.cpp
+++ b/src/msw/button.cpp
@@ -253,9 +253,8 @@ wxWindow *wxButton::SetDefault()
 static wxTopLevelWindow *GetTLWParentIfNotBeingDeleted(wxWindow *win)
 {
     wxWindow* const parent = wxGetTopLevelParent(win);
-    wxASSERT_MSG( parent, wxT("button without top level parent?") );
 
-    if ( parent->IsBeingDeleted() )
+    if (!parent || parent->IsBeingDeleted() )
         return NULL;
 
     // Note that this may still return null for a button inside wxPopupWindow.


### PR DESCRIPTION
This is a regression as of https://github.com/wxWidgets/wxWidgets/commit/17055fb8c6fdbba5fb92b6519b801da7a7e77491#diff-8fcbd7aecf4957f449fa1761e956da79

The
`wxASSERT_MSG( parent, wxT("button without top level parent?") );`
fires, here's how:

1. A wxDialog is being destroyed that has two wxButtons as children.
2. ~wxDialog runs and calls ~wxWindowMSW()  Note: at this point dialog->IsTopLevel() returns false! Why? because the dynamic type of wxDialog is wxWindowMSW during ~wxWindowMSW() => this will cause the crash later.
3. ~wxWindowMSW() calls DestroyChildren(); and destroys one of the buttons that has focus
4. Win32 DestroyWindow() is called on this button, which internally sends a WM_SETFOCUS to the parent dialog, which wxWidgets just forwards to Win32 CallWindowProc()
5. inside CallWindowProc() a new WM_SETFOCUS is sent to the second button that does not yet have focus and is not destructed yet; it handles the message, and calls SetTmpDefault():

> WXLRESULT wxButton::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam)
{
    // when we receive focus, we want to temporarily become the default button in
    // our parent panel so that pressing "Enter" would activate us -- and when
    // losing it we should restore the previous default button as well
    if ( nMsg == WM_SETFOCUS )
    {
        SetTmpDefault();

6. SetTmpDefault() calls:
>void wxButton::SetTmpDefault()
{
    wxTopLevelWindow* const tlw = GetTLWParentIfNotBeingDeleted(this);

7. GetTLWParentIfNotBeingDeleted() calls wxGetTopLevelParent() which returns null:
>static wxTopLevelWindow* GetTLWParentIfNotBeingDeleted(wxWindow* win)
{
    wxWindow* const parent = wxGetTopLevelParent(win);
    wxASSERT_MSG( parent, wxT("button without top level parent?") );

8. Why does wxGetTopLevelParent() return null? Because it calls "win->IsTopLevel()" which is false for wxDialog (because we're still inside ~wxWindowMSW() as called by ~wxDialog()):

>wxWindow* wxGetTopLevelParent(wxWindow* win)
{
    while ( win && !win->IsTopLevel() )
        win = win->GetParent();
    return win;
}

Fix is attached. Regards. For the record, here is a full call stack of the crash discussed above:

wxmsw312ud_core_vc_x64!wxWindowBase::IsTopLevel()
wxmsw312ud_core_vc_x64!wxGetTopLevelParent(wxWindow *)
wxmsw312ud_core_vc_x64!GetTLWParentIfNotBeingDeleted(wxWindow *)
wxmsw312ud_core_vc_x64!wxButton::SetTmpDefault()
wxmsw312ud_core_vc_x64!wxButton::MSWWindowProc()
wxmsw312ud_core_vc_x64!wxWndProc()
user32.dll!UserCallWinProcCheckWow()
user32.dll!DispatchClientMessage()
user32.dll!__fnDWORD()
ntdll.dll!KiUserCallbackDispatcherContinue()
win32u.dll!NtUserSetFocus()
user32.dll!DefDlgProcWorker()
user32.dll!DefDlgProcW()
user32.dll!UserCallWinProcCheckWow()
user32.dll!CallWindowProcW()
wxmsw312ud_core_vc_x64!wxWindow::MSWDefWindowProc()
wxmsw312ud_core_vc_x64!wxWindow::MSWWindowProc()
wxmsw312ud_core_vc_x64!wxWndProc()
user32.dll!UserCallWinProcCheckWow()
user32.dll!DispatchClientMessage()
user32.dll!__fnDWORD()
ntdll.dll!KiUserCallbackDispatcherContinue()
win32u.dll!NtUserDestroyWindow()
wxmsw312ud_core_vc_x64!wxWindow::~wxWindow()
wxmsw312ud_core_vc_x64!wxControlBase::~wxControlBase()
wxmsw312ud_core_vc_x64!wxControl::~wxControl()
wxmsw312ud_core_vc_x64!wxAnyButtonBase::~wxAnyButtonBase()
wxmsw312ud_core_vc_x64!wxAnyButton::~wxAnyButton()
wxmsw312ud_core_vc_x64!wxButtonBase::~wxButtonBase()
wxmsw312ud_core_vc_x64!wxButton::~wxButton()
wxButton::`scalar deleting destructor'(unsigned int)
wxmsw312ud_core_vc_x64!wxWindowBase::Destroy()
wxmsw312ud_core_vc_x64!wxWindowBase::DestroyChildren()
wxmsw312ud_core_vc_x64!wxWindow::~wxWindow()
wxmsw312ud_core_vc_x64!wxNonOwnedWindowBase::~wxNonOwnedWindowBase()
wxmsw312ud_core_vc_x64!wxNonOwnedWindow::~wxNonOwnedWindow()
wxmsw312ud_core_vc_x64!wxTopLevelWindowBase::~wxTopLevelWindowBase()
wxmsw312ud_core_vc_x64!wxTopLevelWindowMSW::~wxTopLevelWindowMSW()
wxmsw312ud_core_vc_x64!wxTopLevelWindow::~wxTopLevelWindow()
wxmsw312ud_core_vc_x64!wxNavigationEnabled<wxTopLevelWindow>::~wxNavigationEnabled<wxTopLevelWindow>()
wxmsw312ud_core_vc_x64!wxDialogBase::~wxDialogBase()
wxmsw312ud_core_vc_x64!wxDialog::~wxDialog()


