### PR TITLE
Fix when a monitor is removed from the system

### DIFF
--- a/include/wx/private/display.h
+++ b/include/wx/private/display.h
@@ -49,7 +49,7 @@ public:
     virtual int GetFromWindow(const wxWindow *window);
 
     // Trigger recreation of wxDisplayImpl when they're needed the next time.
-    void InvalidateCache() { ClearImpls(); }
+    virtual void InvalidateCache() { ClearImpls(); }
 
 protected:
     // create a new display object

--- a/src/msw/display.cpp
+++ b/src/msw/display.cpp
@@ -535,7 +535,8 @@ bool wxDisplayMSW::ChangeMode(const wxVideoMode& mode)
 LRESULT APIENTRY
 wxDisplayWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
-    if ( msg == WM_SETTINGCHANGE )
+    if ( msg == WM_SETTINGCHANGE ||
+         msg == WM_DISPLAYCHANGE)
     {
         wxDisplayFactoryMSW::RefreshMonitors();
 

--- a/src/msw/display.cpp
+++ b/src/msw/display.cpp
@@ -192,9 +192,15 @@ public:
     virtual int GetFromPoint(const wxPoint& pt) wxOVERRIDE;
     virtual int GetFromWindow(const wxWindow *window) wxOVERRIDE;
 
+    void InvalidateCache() override
+    {
+        wxDisplayFactory::InvalidateCache();
+        DoRefreshMonitors();
+    }
+
     // Called when we receive WM_SETTINGCHANGE to refresh the list of monitor
     // handles.
-    static void RefreshMonitors() { ms_factory->DoRefreshMonitors(); }
+    static void RefreshMonitors() { ms_factory->InvalidateCache(); }
 
     // Declare the second argument as int to avoid problems with older SDKs not
     // declaring MONITOR_DPI_TYPE enum.

--- a/src/msw/display.cpp
+++ b/src/msw/display.cpp
@@ -192,7 +192,7 @@ public:
     virtual int GetFromPoint(const wxPoint& pt) wxOVERRIDE;
     virtual int GetFromWindow(const wxWindow *window) wxOVERRIDE;
 
-    void InvalidateCache() override
+    void InvalidateCache() wxOVERRIDE
     {
         wxDisplayFactory::InvalidateCache();
         DoRefreshMonitors();

--- a/src/msw/display.cpp
+++ b/src/msw/display.cpp
@@ -612,15 +612,18 @@ wxDisplayFactoryMSW::GetDpiForMonitorPtr()
 
 void wxDisplayFactoryMSW::DoRefreshMonitors()
 {
-    m_displays.clear();
+    wxVector<wxDisplayInfo> displayInfos;
 
     // We need to pass a valid HDC here in order to get valid hdcMonitor in our
     // callback.
     ScreenHDC dc;
-    if ( !::EnumDisplayMonitors(dc, NULL, MultimonEnumProc, (LPARAM)this) )
+    if ( !::EnumDisplayMonitors(dc, NULL, MultimonEnumProc, (LPARAM)&displayInfos) )
     {
         wxLogLastError(wxT("EnumDisplayMonitors"));
     }
+    
+    if (!displayInfos.empty())
+        m_displays = displayInfos;
 }
 
 /* static */
@@ -631,9 +634,9 @@ wxDisplayFactoryMSW::MultimonEnumProc(
     LPRECT WXUNUSED(lprcMonitor),   // pointer to monitor intersection rectangle
     LPARAM dwData)                  // data passed from EnumDisplayMonitors (this)
 {
-    wxDisplayFactoryMSW *const self = (wxDisplayFactoryMSW *)dwData;
+    wxVector<wxDisplayInfo>& displayInfos = *(wxVector<wxDisplayInfo>*)dwData;
 
-    self->m_displays.push_back(wxDisplayInfo(hMonitor, wxGetHDCDepth(hdcMonitor)));
+    displayInfos.push_back(wxDisplayInfo(hMonitor, wxGetHDCDepth(hdcMonitor)));
 
     // continue the enumeration
     return TRUE;

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -4712,8 +4712,6 @@ bool wxWindowMSW::HandleSysColorChange()
 
 bool wxWindowMSW::HandleDisplayChange()
 {
-    wxDisplay::InvalidateCache();
-
     wxDisplayChangedEvent event;
     event.SetEventObject(this);
 


### PR DESCRIPTION
https://github.com/wxWidgets/wxWidgets/commit/ad6f09f543cc0dbf657cac4a6242d263b9d760dd#diff-acd379cfb2da9870f863ac4c590ba265 isn't always working reliably when a monitor is removed, for example when wxPaint events interfere. Have a look at the following sequence of events, that can happen when one of two monitors is turned off while a progress dialog is being updated:

1. WM_DISPLAYCHANGE
2. WM_PAINT
3. WM_SETTINGCHANGE


WM_DISPLAYCHANGE triggers

```
bool wxWindowMSW::HandleDisplayChange()
{
    wxDisplay::InvalidateCache();  => clears wxDisplayFactory::m_impls
[...]
}
```

Next WM_PAINT triggers wxDisplayFactory::GetDisplay:
```

wxmsw313ud_core_vc_x64!wxDisplayFactory::GetDisplay(unsigned int)
wxmsw313ud_core_vc_x64!wxDisplay::wxDisplay(unsigned int)
wxmsw313ud_core_vc_x64!wxDisplayDepth()
wxmsw313ud_core_vc_x64!wxMSWDCImpl::InitializePalette()
wxmsw313ud_core_vc_x64!wxWindowDCImpl::InitDC()
wxmsw313ud_core_vc_x64!wxClientDCImpl::InitDC()
wxmsw313ud_core_vc_x64!wxPaintDCImpl::wxPaintDCImpl(wxDC *, wxWindow *)
wxmsw313ud_core_vc_x64!wxNativeDCFactory::CreatePaintDC(wxPaintDC *, wxWindow *)
wxmsw313ud_core_vc_x64!wxPaintDC::wxPaintDC(wxWindow *)
wxmsw313ud_aui_vc_x64!wxAuiManager::OnPaint(wxPaintEvent &)
wxbase313ud_vc_x64!wxAppConsoleBase::HandleEvent(wxEvtHandler *, void(wxEvtHandler::*)(wxEvent &), wxEvent &)
```

```
wxDisplayImpl* GetDisplay(unsigned n)
{
    if ( m_impls.empty() )
        m_impls.resize(GetCount()); -> calls wxDisplayFactoryMSW():GetCount() which incorrectly returns 2!
[...]
}
```
wxDisplayFactoryMSW():GetCount() returns the wrong result (2) because:

`virtual unsigned GetCount() wxOVERRIDE { return unsigned(m_displays.size()); }`

m_displays has not yet been redetermined, because WM_SETTINGCHANGE has not happend yet!

Next WM_SETTINGCHANGE triggers wxDisplayFactoryMSW::DoRefreshMonitors(), but does nothing to resolve the inconsistent state in wxDisplayFactory::m_impls.

Functions like wxDisplayMSW::GetMonInfo() will now fail:
 'GetMonitorInfo' failed with error 0x000005b5 (Invalid monitor handle).
and new wxDialogs are positioned outside the visible screen area.

The attached patch fixes the above problem by always clearing wxDisplayFactory::m_impls and wxDisplayFactoryMSW::m_displays at the same time.