### PR TITLE
Avoid build errors if wxUSE_DEBUG_CONTEXT = 1 when building on Win64

### DIFF
--- a/src/common/memory.cpp
+++ b/src/common/memory.cpp
@@ -321,7 +321,7 @@ void wxMemStruct::PrintNode ()
       msg += wxT("object");
 
     wxString msg2;
-    msg2.Printf(wxT(" at 0x%lX, size %d"), (long)GetActualData(), (int)RequestSize());
+    msg2.Printf(wxT(" at %#zx, size %d"), wxPtrToUInt(GetActualData()), (int)RequestSize());
     msg += msg2;
 
     wxLogMessage(msg);
@@ -334,7 +334,7 @@ void wxMemStruct::PrintNode ()
       msg.Printf(wxT("%s(%d): "), m_fileName, (int)m_lineNum);
     msg += wxT("non-object data");
     wxString msg2;
-    msg2.Printf(wxT(" at 0x%lX, size %d\n"), (long)GetActualData(), (int)RequestSize());
+    msg2.Printf(wxT(" at %#zx, size %d\n"), wxPtrToUInt(GetActualData()), (int)RequestSize());
     msg += msg2;
 
     wxLogMessage(msg);
@@ -367,7 +367,7 @@ void wxMemStruct::Dump ()
       msg += wxT("unknown object class");
 
     wxString msg2;
-    msg2.Printf(wxT(" at 0x%lX, size %d"), (long)GetActualData(), (int)RequestSize());
+    msg2.Printf(wxT(" at %#zx, size %d"), wxPtrToUInt(GetActualData()), (int)RequestSize());
     msg += msg2;
 
     wxDebugContext::OutputDumpLine(msg.c_str());
@@ -379,7 +379,7 @@ void wxMemStruct::Dump ()
       msg.Printf(wxT("%s(%d): "), m_fileName, (int)m_lineNum);
 
     wxString msg2;
-    msg2.Printf(wxT("non-object data at 0x%lX, size %d"), (long)GetActualData(), (int)RequestSize() );
+    msg2.Printf(wxT("non-object data at %#zx, size %d"), wxPtrToUInt(GetActualData()), (int)RequestSize() );
     msg += msg2;
     wxDebugContext::OutputDumpLine(msg.c_str());
   }


### PR DESCRIPTION
wxMemStruct debug functions cast memory addresses to "long" which can be smaller than pointer
size on some platforms and notably is under Win64.

Use wxPtrToUInt instead to cast to wxUIntPtr, which is guaranteed to be large enough.

Note: This change is relatively useless because wxMemStruct is more or less obsolete. The purpose of the PR is purely to avoid build errors - there is no guarantee that the corrections will ensure this code will work as desired.