### PR TITLE
Add support for passing nullptr to wx pseudo-vararg functions

### DIFF
--- a/include/wx/strvararg.h
+++ b/include/wx/strvararg.h
@@ -425,6 +425,12 @@ wxFORMAT_STRING_SPECIFIER(int*, wxFormatString::Arg_IntPtr | wxFormatString::Arg
 wxFORMAT_STRING_SPECIFIER(short int*, wxFormatString::Arg_ShortIntPtr | wxFormatString::Arg_Pointer)
 wxFORMAT_STRING_SPECIFIER(long int*, wxFormatString::Arg_LongIntPtr | wxFormatString::Arg_Pointer)
 
+// Support for nullptr is available since MSVS 2010, even though it doesn't
+// define __cplusplus as a C++11 compiler.
+#if __cplusplus >= 201103 || wxCHECK_VISUALC_VERSION(10)
+wxFORMAT_STRING_SPECIFIER(std::nullptr_t, wxFormatString::Arg_Pointer)
+#endif
+
 #undef wxFORMAT_STRING_SPECIFIER
 
 

--- a/tests/strings/vararg.cpp
+++ b/tests/strings/vararg.cpp
@@ -249,6 +249,13 @@ void VarArgTestCase::ArgsValidation()
     wxString::Format("a string(%s,%s), ptr %p, int %i",
                      wxString(), "foo", "char* as pointer", 1);
 
+#if __cplusplus >= 201103 || wxCHECK_VISUALC_VERSION(10)
+    // Unfortunately we can't check the result as different standard libraries
+    // implementations format it in different ways, so just check that it
+    // compiles.
+    wxString::Format("null pointer is %p", nullptr);
+#endif
+
     // Microsoft has helpfully disabled support for "%n" in their CRT by
     // default starting from VC8 and somehow even calling
     // _set_printf_count_output() doesn't help here, so don't use "%n" at all


### PR DESCRIPTION
Allow passing literal nullptr as an argument corresponding to "%p" in
the format string.

Closes #18355.