### PR TITLE
Fix bug with wxRadioButton state changing unexpectedly in wxMSW

### DIFF
--- a/include/wx/containr.h
+++ b/include/wx/containr.h
@@ -266,6 +266,12 @@ public:
     {
         return m_container.HasTransparentBackground();
     }
+
+    WXDLLIMPEXP_INLINE_CORE
+    virtual void WXDoUpdatePendingFocus(wxWindow* win) wxOVERRIDE
+    {
+        return m_container.SetLastFocus(win);
+    }
 #endif // __WXMSW__
 
 protected:

--- a/include/wx/msw/toplevel.h
+++ b/include/wx/msw/toplevel.h
@@ -100,9 +100,12 @@ public:
     // event handlers
     void OnActivate(wxActivateEvent& event);
 
-    // called by wxWindow whenever it gets focus
-    void SetLastFocus(wxWindow *win) { m_winLastFocused = win; }
-    wxWindow *GetLastFocus() const { return m_winLastFocused; }
+    // called from wxWidgets code itself only when the pending focus, i.e. the
+    // element which should get focus when this TLW is activated again, changes
+    virtual void WXDoUpdatePendingFocus(wxWindow* win) wxOVERRIDE
+    {
+        m_winLastFocused = win;
+    }
 
     // translate wxWidgets flags to Windows ones
     virtual WXDWORD MSWGetStyle(long flags, WXDWORD *exstyle) const wxOVERRIDE;

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -576,6 +576,14 @@ public:
     // Return true if the button was clicked, false otherwise.
     static bool MSWClickButtonIfPossible(wxButton* btn);
 
+    // This method is used for handling wxRadioButton-related complications,
+    // see wxRadioButton::SetValue(). It calls WXDoUpdatePendingFocus() for
+    // this window and all its parents up to the enclosing TLW, recursively.
+    void WXSetPendingFocus(wxWindow* win);
+
+    // Should be overridden by all classes storing the "last focused" window.
+    virtual void WXDoUpdatePendingFocus(wxWindow* WXUNUSED(win)) {}
+
 protected:
     // this allows you to implement standard control borders without
     // repeating the code in different classes that are not derived from

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -1026,6 +1026,17 @@ void wxWindowMSW::MSWUpdateUIState(int action, int state)
     ::SendMessage(GetHwnd(), WM_CHANGEUISTATE, MAKEWPARAM(action, state), 0);
 }
 
+void wxWindowMSW::WXSetPendingFocus(wxWindow* win)
+{
+    for ( wxWindow* parent = this; parent; parent = parent->GetParent() )
+    {
+        parent->WXDoUpdatePendingFocus(win);
+
+        if ( parent->IsTopLevel() )
+            break;
+    }
+}
+
 // ---------------------------------------------------------------------------
 // scrolling stuff
 // ---------------------------------------------------------------------------

--- a/tests/controls/radiobuttontest.cpp
+++ b/tests/controls/radiobuttontest.cpp
@@ -16,7 +16,10 @@
 
 #ifndef WX_PRECOMP
     #include "wx/app.h"
+    #include "wx/button.h"
+    #include "wx/panel.h"
     #include "wx/radiobut.h"
+    #include "wx/sizer.h"
     #include "wx/stattext.h"
 #endif // WX_PRECOMP
 
@@ -193,6 +196,60 @@ void RadioButtonTestCase::Single()
 
     CHECK(gradio1->GetValue());
     CHECK(ngradio->GetValue());
+}
+
+TEST_CASE("wxRadioButton::Focus", "[radiobutton][focus]")
+{
+    // Create a container panel just to be able to destroy all the windows
+    // created here at once by simply destroying it.
+    wxWindow* const tlw = wxTheApp->GetTopWindow();
+    wxScopedPtr<wxPanel> parentPanel(new wxPanel(tlw));
+
+    // Create a panel containing 2 radio buttons and another control outside
+    // this panel, so that we could give focus to something different and then
+    // return it back to the panel.
+    wxPanel* const radioPanel = new wxPanel(parentPanel.get());
+    wxRadioButton* const radio1 = new wxRadioButton(radioPanel, wxID_ANY, "1");
+    wxRadioButton* const radio2 = new wxRadioButton(radioPanel, wxID_ANY, "2");
+    wxSizer* const radioSizer = new wxBoxSizer(wxHORIZONTAL);
+    radioSizer->Add(radio1);
+    radioSizer->Add(radio2);
+    radioPanel->SetSizer(radioSizer);
+
+    wxButton* const dummyButton = new wxButton(parentPanel.get(), wxID_OK);
+
+    wxSizer* const sizer = new wxBoxSizer(wxVERTICAL);
+    sizer->Add(radioPanel, wxSizerFlags(1).Expand());
+    sizer->Add(dummyButton, wxSizerFlags().Expand());
+    parentPanel->SetSizer(sizer);
+
+    parentPanel->SetSize(tlw->GetClientSize());
+    parentPanel->Layout();
+
+    // Initially the first radio button should be checked.
+    radio1->SetFocus();
+    CHECK(radio1->GetValue());
+    CHECK(wxWindow::FindFocus() == radio1);
+
+    // Switching focus from it shouldn't change this.
+    dummyButton->SetFocus();
+    CHECK(radio1->GetValue());
+
+    // Checking another radio button should make it checked and uncheck the
+    // first one.
+    radio2->SetValue(true);
+    CHECK(!radio1->GetValue());
+    CHECK(radio2->GetValue());
+
+    // While not changing focus.
+    CHECK(wxWindow::FindFocus() == dummyButton);
+
+    // And giving the focus to the panel shouldn't change radio button
+    // selection.
+    radioPanel->SetFocus();
+    CHECK(wxWindow::FindFocus() == radio2);
+    CHECK(!radio1->GetValue());
+    CHECK(radio2->GetValue());
 }
 
 #endif //wxUSE_RADIOBTN


### PR DESCRIPTION
In wxMSW, a focused wxRadioButton is always checked, which meant that
checking a wxRadioButton while focus was not in the window containing it
and later giving the focus to that window could uncheck it by giving
focus to another wxRadioButton that had had it previously.

Fix this by adding WXSetPendingFocus() to wxMSW wxWindow and calling it
from wxRadioButton::SetValue() to ensure that when the focus is
regained, it goes to the newly checked radio button and not some other
one.

This replaces the previously used, for the same purpose, wxMSW-specific
wxTopLevelWindow::SetLastFocus(), so while this solution is not exactly
pretty, it's not worse than we had before, while being more generic.

Also add a unit test checking that things work correctly in the scenario
described above.

Closes #18341.