### PR TITLE
Fix wrapsizer min size calculation

### DIFF
--- a/src/common/wrapsizer.cpp
+++ b/src/common/wrapsizer.cpp
@@ -465,7 +465,11 @@ void wxWrapSizer::CalcMinFromMinor(int totMinor)
 
         // No spill over?
         if ( !tailSize )
+        {
+            // Add minor size of the last line
+            sumMinor += maxMinor;
             break;
+        }
     }
 
     // Now have min size in the opposite direction

--- a/tests/sizers/wrapsizer.cpp
+++ b/tests/sizers/wrapsizer.cpp
@@ -24,104 +24,53 @@
 
 #include "asserthelper.h"
 
-// ----------------------------------------------------------------------------
-// test class
-// ----------------------------------------------------------------------------
-
-class WrapSizerTestCase : public CppUnit::TestCase
+TEST_CASE("wxWrapSizer::CalcMin", "[wxWrapSizer]")
 {
-public:
-    WrapSizerTestCase() { }
+    wxScopedPtr<wxWindow> win(new wxWindow(wxTheApp->GetTopWindow(), wxID_ANY));
+    win->SetClientSize(180, 240);
 
-    virtual void setUp() wxOVERRIDE;
-    virtual void tearDown() wxOVERRIDE;
+    wxSizer *sizer = new wxWrapSizer(wxHORIZONTAL);
+    win->SetSizer(sizer);
 
-private:
-    CPPUNIT_TEST_SUITE( WrapSizerTestCase );
-        CPPUNIT_TEST( CalcMin );
-    CPPUNIT_TEST_SUITE_END();
-
-    void CalcMin();
-
-    wxWindow *m_win;
-    wxSizer *m_sizer;
-
-    wxDECLARE_NO_COPY_CLASS(WrapSizerTestCase);
-};
-
-// register in the unnamed registry so that these tests are run by default
-CPPUNIT_TEST_SUITE_REGISTRATION( WrapSizerTestCase );
-
-// also include in its own registry so that these tests can be run alone
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( WrapSizerTestCase, "WrapSizerTestCase" );
-
-// ----------------------------------------------------------------------------
-// test initialization
-// ----------------------------------------------------------------------------
-
-void WrapSizerTestCase::setUp()
-{
-    m_win = new wxWindow(wxTheApp->GetTopWindow(), wxID_ANY);
-    m_win->SetClientSize(180, 240);
-
-    m_sizer = new wxWrapSizer(wxHORIZONTAL);
-    m_win->SetSizer(m_sizer);
-}
-
-void WrapSizerTestCase::tearDown()
-{
-    delete m_win;
-    m_win = NULL;
-
-    m_sizer = NULL;
-}
-
-// ----------------------------------------------------------------------------
-// tests themselves
-// ----------------------------------------------------------------------------
-
-void WrapSizerTestCase::CalcMin()
-{
-    const wxSize sizeTotal = m_win->GetClientSize();
     wxSize sizeMinExpected;
 
     // With a single child the min size must be the same as child size.
-    const wxSize sizeChild1 = wxSize(sizeTotal.x/2 - 10, sizeTotal.y/4);
+    const wxSize sizeChild1 = wxSize(80, 60);
     sizeMinExpected = sizeChild1;
 
     wxWindow * const
-        child1 = new wxWindow(m_win, wxID_ANY, wxDefaultPosition, sizeChild1);
+        child1 = new wxWindow(win.get(), wxID_ANY, wxDefaultPosition, sizeChild1);
     child1->SetBackgroundColour(*wxRED);
-    m_sizer->Add(child1);
-    m_win->Layout();
+    sizer->Add(child1);
+    win->Layout();
 
-    CPPUNIT_ASSERT_EQUAL( sizeMinExpected, m_sizer->CalcMin() );
+    CHECK( sizeMinExpected == sizer->CalcMin() );
 
     // If both children can fit in the same row, the minimal size of the sizer
     // is determined by the sum of their minimal horizontal dimensions and
     // the maximum of their minimal vertical dimensions.
-    const wxSize sizeChild2 = wxSize(sizeTotal.x/2 + 10, sizeTotal.y/3);
+    const wxSize sizeChild2 = wxSize(100, 80);
     sizeMinExpected.x += sizeChild2.x;
     sizeMinExpected.y = wxMax(sizeChild1.y, sizeChild2.y);
 
     wxWindow * const
-        child2 = new wxWindow(m_win, wxID_ANY, wxDefaultPosition, sizeChild2);
+        child2 = new wxWindow(win.get(), wxID_ANY, wxDefaultPosition, sizeChild2);
     child2->SetBackgroundColour(*wxYELLOW);
-    m_sizer->Add(child2);
-    m_win->Layout();
+    sizer->Add(child2);
+    win->Layout();
 
-    CPPUNIT_ASSERT_EQUAL( sizeMinExpected, m_sizer->CalcMin() );
+    CHECK( sizeMinExpected == sizer->CalcMin() );
 
     // Three children will take at least two rows so the minimal size in
     // vertical direction must increase.
-    const wxSize sizeChild3 = wxSize(sizeTotal.x/2, sizeTotal.y/5);
+    const wxSize sizeChild3 = wxSize(90, 40);
     sizeMinExpected.y += sizeChild3.y;
 
     wxWindow * const
-        child3 = new wxWindow(m_win, wxID_ANY, wxDefaultPosition, sizeChild3);
+        child3 = new wxWindow(win.get(), wxID_ANY, wxDefaultPosition, sizeChild3);
     child3->SetBackgroundColour(*wxGREEN);
-    m_sizer->Add(child3);
-    m_win->Layout();
+    sizer->Add(child3);
+    win->Layout();
 
-    CPPUNIT_ASSERT_EQUAL( sizeMinExpected, m_sizer->CalcMin() );
+    CHECK( sizeMinExpected == sizer->CalcMin() );
 }

--- a/tests/sizers/wrapsizer.cpp
+++ b/tests/sizers/wrapsizer.cpp
@@ -74,3 +74,42 @@ TEST_CASE("wxWrapSizer::CalcMin", "[wxWrapSizer]")
 
     CHECK( sizeMinExpected == sizer->CalcMin() );
 }
+
+TEST_CASE("wxWrapSizer::CalcMinFromMinor", "[wxWrapSizer]")
+{
+    wxScopedPtr<wxWindow> win(new wxWindow(wxTheApp->GetTopWindow(), wxID_ANY));
+    win->SetClientSize(180, 240);
+
+    wxSizer* boxSizer = new wxBoxSizer(wxHORIZONTAL);
+    win->SetSizer(boxSizer);
+
+    // To test CalcMinFromMinor function the wrap sizer with the
+    // horizonral align added to the box sizer with horizontal align.
+    wxSizer* wrapSizer = new wxWrapSizer(wxHORIZONTAL);
+    boxSizer->Add(wrapSizer);
+
+    // Add three child windows. Sum of the first and the second windows widths should
+    // be less than the width of the third window.
+    const wxSize sizeChild1 = wxSize(40, 60);
+    wxWindow * const
+        child1 = new wxWindow(win.get(), wxID_ANY, wxDefaultPosition, sizeChild1);
+    child1->SetBackgroundColour(*wxRED);
+    wrapSizer->Add(child1);
+
+    const wxSize sizeChild2 = wxSize(50, 80);
+    wxWindow * const
+        child2 = new wxWindow(win.get(), wxID_ANY, wxDefaultPosition, sizeChild2);
+    child2->SetBackgroundColour(*wxGREEN);
+    wrapSizer->Add(child2);
+
+    const wxSize sizeChild3 = wxSize(100, 120);
+    wxWindow * const
+        child3 = new wxWindow(win.get(), wxID_ANY, wxDefaultPosition, sizeChild3);
+    child3->SetBackgroundColour(*wxBLUE);
+    wrapSizer->Add(child3);
+
+    // First two windows should be in a first row and the third in a second row.
+    const wxSize sizeMinExpected = wxSize(sizeChild3.x, sizeChild2.y + sizeChild3.y);
+    win->Layout();
+    CHECK(sizeMinExpected == wrapSizer->CalcMin());
+}


### PR DESCRIPTION
Fix the `wxWrapSizer::CalcMinFromMinor` function: at the end of the
calculation a `sumMinor` variable contain minor size sum without minor
size of a last line, so add `maxMinor` size to the result min size.