### PR TITLE
Fix library link in doxygen docs for image handlers

### DIFF
--- a/interface/wx/imaggif.h
+++ b/interface/wx/imaggif.h
@@ -12,7 +12,7 @@
 
     This is the image handler for the GIF format.
 
-    @library{core}
+    @library{wxcore}
     @category{gdi}
 
     @see wxImage, wxImageHandler, wxInitAllImageHandlers()

--- a/interface/wx/imagiff.h
+++ b/interface/wx/imagiff.h
@@ -10,7 +10,7 @@
 
     This is the image handler for the IFF format.
 
-    @library{core}
+    @library{wxcore}
     @category{gdi}
 
     @see wxImage, wxImageHandler, wxInitAllImageHandlers()

--- a/interface/wx/imagjpeg.h
+++ b/interface/wx/imagjpeg.h
@@ -10,7 +10,7 @@
 
     This is the image handler for the JPEG format.
 
-    @library{core}
+    @library{wxcore}
     @category{gdi}
 
     @see wxImage, wxImageHandler, wxInitAllImageHandlers()

--- a/interface/wx/imagpcx.h
+++ b/interface/wx/imagpcx.h
@@ -10,7 +10,7 @@
 
     This is the image handler for the PCX format.
 
-    @library{core}
+    @library{wxcore}
     @category{gdi}
 
     @see wxImage, wxImageHandler, wxInitAllImageHandlers()

--- a/interface/wx/imagpng.h
+++ b/interface/wx/imagpng.h
@@ -30,7 +30,7 @@ enum
 
     This is the image handler for the PNG format.
 
-    @library{core}
+    @library{wxcore}
     @category{gdi}
 
     @see wxImage, wxImageHandler, wxInitAllImageHandlers()

--- a/interface/wx/imagpnm.h
+++ b/interface/wx/imagpnm.h
@@ -10,7 +10,7 @@
 
     This is the image handler for the PNM format.
 
-    @library{core}
+    @library{wxcore}
     @category{gdi}
 
     @see wxImage, wxImageHandler, wxInitAllImageHandlers()

--- a/interface/wx/imagtga.h
+++ b/interface/wx/imagtga.h
@@ -10,7 +10,7 @@
 
     This is the image handler for the TGA format.
 
-    @library{core}
+    @library{wxcore}
     @category{gdi}
 
     @see wxImage, wxImageHandler, wxInitAllImageHandlers()

--- a/interface/wx/imagxpm.h
+++ b/interface/wx/imagxpm.h
@@ -10,7 +10,7 @@
 
     This is the image handler for the XPM format.
 
-    @library{core}
+    @library{wxcore}
     @category{gdi}
 
     @see wxImage, wxImageHandler, wxInitAllImageHandlers()


### PR DESCRIPTION
Sorry, I messed up: For some reason, the replace was not saved for two files and I noticed it too late. The two commits should be squashed together but I do not know how and do not want to mess up the PR any further trying. 