### PR TITLE
Do not set focus to the rich tooltips window

### DIFF
--- a/src/generic/richtooltipg.cpp
+++ b/src/generic/richtooltipg.cpp
@@ -667,9 +667,6 @@ void wxRichToolTipGenericImpl::SetTitleFont(const wxFont& font)
 
 void wxRichToolTipGenericImpl::ShowFor(wxWindow* win, const wxRect* rect)
 {
-    // Set the focus to the window the tooltip refers to to make it look active.
-    win->SetFocus();
-
     wxRichToolTipPopup* const popup = new wxRichToolTipPopup
                                           (
                                             win,


### PR DESCRIPTION
Don't set the focus to the window the rich tooltip refers to.
Because it may lead to infinite recursion if tooltip shown on the set
focus event.