### PR TITLE
Don't move wxTextCtrl insertion point if it doesn't really change

### DIFF
--- a/interface/wx/textentry.h
+++ b/interface/wx/textentry.h
@@ -533,7 +533,8 @@ public:
         would return @false immediately after the call to SetValue().
 
         The insertion point is set to the start of the control (i.e. position
-        0) by this function.
+        0) by this function unless the control value doesn't change at all, in
+        which case the insertion point is left at its original position.
 
         Note that, unlike most other functions changing the controls values,
         this function generates a @c wxEVT_TEXT event. To avoid

--- a/src/gtk/textentry.cpp
+++ b/src/gtk/textentry.cpp
@@ -570,12 +570,16 @@ void wxTextEntry::DoSetValue(const wxString& value, int flags)
             EventsSuppressor noevents(this);
             WriteText(value);
         }
+
+        // Changing the value is supposed to reset the insertion point. Note,
+        // however, that this does not happen if the text doesn't really change.
+        SetInsertionPoint(0);
     }
 
+    // OTOH we must send the event even if the text didn't really change for
+    // consistency.
     if ( flags & SetValue_SendEvent )
         SendTextUpdatedEvent(GetEditableWindow());
-
-    SetInsertionPoint(0);
 }
 
 wxString wxTextEntry::DoGetValue() const

--- a/tests/controls/textentrytest.cpp
+++ b/tests/controls/textentrytest.cpp
@@ -165,6 +165,12 @@ void TextEntryTestCase::InsertionPoint()
     CPPUNIT_ASSERT_EQUAL( 3, entry->GetLastPosition() );
     CPPUNIT_ASSERT_EQUAL( 1, entry->GetInsertionPoint() );
 
+    entry->SetValue("012"); // shouldn't change the position if no real change
+    CPPUNIT_ASSERT_EQUAL( 1, entry->GetInsertionPoint() );
+
+    entry->ChangeValue("012"); // same as for SetValue()
+    CPPUNIT_ASSERT_EQUAL( 1, entry->GetInsertionPoint() );
+
     entry->SetInsertionPointEnd();
     CPPUNIT_ASSERT_EQUAL( 3, entry->GetInsertionPoint() );
 


### PR DESCRIPTION
Resetting the insertion point position to 0 after calling
wxTextCtrl::SetValue() or ChangeValue() which didn't really change the
control contents was unexpected, as such calls are supposed to be
"optimized away", and this was indeed the case under wxMSW and wxOSX,
but not in wxGTK.

So change wxGTK to follow the other ports, add a unit test checking for
this behaviour and officially document it.

As a side effect, this ensures that the numeric validator classes don't
reset the insertion point position to 0 on every focus loss under wxGTK,
as happened before.