### PR TITLE
Avoid redundant declarations for wxQsort()

### DIFF
--- a/include/wx/utils.h
+++ b/include/wx/utils.h
@@ -603,6 +603,11 @@ WXDLLIMPEXP_BASE bool wxGetDiskSpace(const wxString& path,
 
 
 
+// See wx/vector.h for more about this hack.
+#ifndef wxQSORT_DECLARED
+
+#define wxQSORT_DECLARED
+
 typedef int (*wxSortCallback)(const void* pItem1,
                               const void* pItem2,
                               const void* user_data);
@@ -611,6 +616,8 @@ typedef int (*wxSortCallback)(const void* pItem1,
 WXDLLIMPEXP_BASE void wxQsort(void* pbase, size_t total_elems,
                               size_t size, wxSortCallback cmp,
                               const void* user_data);
+
+#endif // !wxQSORT_DECLARED
 
 
 #if wxUSE_GUI // GUI only things from now on

--- a/include/wx/vector.h
+++ b/include/wx/vector.h
@@ -41,12 +41,21 @@ inline void wxVectorSort(wxVector<T>& v)
 
 // wxQsort is declared in wx/utils.h, but can't include that file here,
 // it indirectly includes this file. Just lovely...
+//
+// Moreover, just declaring it here unconditionally results in gcc
+// -Wredundant-decls warning, so use a preprocessor guard to avoid this.
+#ifndef wxQSORT_DECLARED
+
+#define wxQSORT_DECLARED
+
 typedef int (*wxSortCallback)(const void* pItem1,
                               const void* pItem2,
                               const void* user_data);
 WXDLLIMPEXP_BASE void wxQsort(void* pbase, size_t total_elems,
                               size_t size, wxSortCallback cmp,
                               const void* user_data);
+
+#endif // !wxQSORT_DECLARED
 
 namespace wxPrivate
 {


### PR DESCRIPTION
This works around gcc -Wredundant-decls warning that was given (if
explicitly enabled) when both wx/vector.h and wx/utils.h were included.

The workaround is ugly, but it doesn't seem worth it to introduce a
separate wx/qsort.h header just for this single function, which seems to
be the only other way to fix this.