### PR TITLE
Fix inconsistent function declarations in documentation

### DIFF
--- a/interface/wx/html/winpars.h
+++ b/interface/wx/html/winpars.h
@@ -59,7 +59,7 @@ public:
         Assigns @a parser to this handler. Each @b instance of handler
         is guaranteed to be called only from the one parser.
     */
-    virtual void SetParser(wxHtmlWinParser* parser);
+    virtual void SetParser(wxHtmlParser* parser);
 
 protected:
     /**

--- a/interface/wx/image.h
+++ b/interface/wx/image.h
@@ -227,7 +227,7 @@ public:
                 for which this function returns the number of frames in the
                 animation).
     */
-    virtual int GetImageCount(wxInputStream& stream);
+    int GetImageCount(wxInputStream& stream);
 
     /**
         Gets the MIME type associated with this handler.

--- a/interface/wx/intl.h
+++ b/interface/wx/intl.h
@@ -367,15 +367,15 @@ public:
     /**
         Calls wxGetTranslation(const wxString&, const wxString&).
     */
-    virtual const wxString& GetString(const wxString& origString,
-                                      const wxString& domain = wxEmptyString) const;
+    const wxString& GetString(const wxString& origString,
+                              const wxString& domain = wxEmptyString) const;
 
     /**
         Calls wxGetTranslation(const wxString&, const wxString&, unsigned, const wxString&).
     */
-    virtual const wxString& GetString(const wxString& origString,
-                                      const wxString& origString2, unsigned n,
-                                      const wxString& domain = wxEmptyString) const;
+    const wxString& GetString(const wxString& origString,
+                              const wxString& origString2, unsigned n,
+                              const wxString& domain = wxEmptyString) const;
 
     /**
         Returns current platform-specific locale name as passed to setlocale().

--- a/interface/wx/print.h
+++ b/interface/wx/print.h
@@ -262,7 +262,7 @@ public:
 
         @since 2.9.2
     */
-    virtual void InitializeWithModality(wxPreviewFrameModalityKind kind);
+    void InitializeWithModality(wxPreviewFrameModalityKind kind);
 
     /**
         Enables any disabled frames in the application, and deletes the print preview

--- a/interface/wx/propgrid/propgridiface.h
+++ b/interface/wx/propgrid/propgridiface.h
@@ -691,7 +691,7 @@ public:
     /**
         Returns @true if property is selected.
     */
-    virtual bool IsPropertySelected( wxPGPropArg id ) const;
+    bool IsPropertySelected( wxPGPropArg id ) const;
 
     /**
         Returns @true if property is shown (i.e. HideProperty() with @true not


### PR DESCRIPTION
Mostly remove the virtual keyword where the actual implementation isn't
virtual.