### PR TITLE
Fix inconsistent function declarations in documentation

### DIFF
--- a/interface/wx/dataview.h
+++ b/interface/wx/dataview.h
@@ -132,7 +132,7 @@ public:
         Called to inform the model that all data has been cleared.
         The control will reread the data from the model again.
     */
-    virtual bool Cleared();
+    bool Cleared();
 
     /**
         The compare function to be used by control. The default compare function
@@ -336,8 +336,8 @@ public:
         This will eventually emit a @c wxEVT_DATAVIEW_ITEM_VALUE_CHANGED
         event to the user.
     */
-    virtual bool ValueChanged(const wxDataViewItem& item,
-                              unsigned int col);
+    bool ValueChanged(const wxDataViewItem& item,
+                      unsigned int col);
 
     
     virtual bool IsListModel() const;

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -446,7 +446,7 @@ public:
         Draws the part of the cell not occupied by the control: the base class
         version just fills it with background colour from the attribute.
     */
-    virtual void PaintBackground(wxDC& dc, const wxRect& rectCell, wxGridCellAttr& attr);
+    virtual void PaintBackground(wxDC& dc, const wxRect& rectCell, const wxGridCellAttr& attr);
 
     /**
         Reset the value in the control back to its starting value.

--- a/interface/wx/html/winpars.h
+++ b/interface/wx/html/winpars.h
@@ -59,7 +59,7 @@ public:
         Assigns @a parser to this handler. Each @b instance of handler
         is guaranteed to be called only from the one parser.
     */
-    virtual void SetParser(wxHtmlWinParser* parser);
+    virtual void SetParser(wxHtmlParser* parser);
 
 protected:
     /**

--- a/interface/wx/image.h
+++ b/interface/wx/image.h
@@ -224,7 +224,7 @@ public:
                 for which this function returns the number of frames in the
                 animation).
     */
-    virtual int GetImageCount(wxInputStream& stream);
+    int GetImageCount(wxInputStream& stream);
 
     /**
         Gets the MIME type associated with this handler.

--- a/interface/wx/intl.h
+++ b/interface/wx/intl.h
@@ -362,15 +362,15 @@ public:
     /**
         Calls wxGetTranslation(const wxString&, const wxString&).
     */
-    virtual const wxString& GetString(const wxString& origString,
-                                      const wxString& domain = wxEmptyString) const;
+    const wxString& GetString(const wxString& origString,
+                              const wxString& domain = wxEmptyString) const;
 
     /**
         Calls wxGetTranslation(const wxString&, const wxString&, unsigned, const wxString&).
     */
-    virtual const wxString& GetString(const wxString& origString,
-                                      const wxString& origString2, unsigned n,
-                                      const wxString& domain = wxEmptyString) const;
+    const wxString& GetString(const wxString& origString,
+                              const wxString& origString2, unsigned n,
+                              const wxString& domain = wxEmptyString) const;
 
     /**
         Returns current platform-specific locale name as passed to setlocale().

--- a/interface/wx/print.h
+++ b/interface/wx/print.h
@@ -262,7 +262,7 @@ public:
 
         @since 2.9.2
     */
-    virtual void InitializeWithModality(wxPreviewFrameModalityKind kind);
+    void InitializeWithModality(wxPreviewFrameModalityKind kind);
 
     /**
         Enables any disabled frames in the application, and deletes the print preview

--- a/interface/wx/propgrid/propgridiface.h
+++ b/interface/wx/propgrid/propgridiface.h
@@ -596,7 +596,7 @@ public:
     /**
         Returns true if property is selected.
     */
-    virtual bool IsPropertySelected( wxPGPropArg id ) const;
+    bool IsPropertySelected( wxPGPropArg id ) const;
 
     /**
         Returns @true if property is shown (ie. HideProperty() with @true not


### PR DESCRIPTION
Mostly remove the virtual keyword where the actual implementation isn't
virtual.

(Backport of ac18cfe7cc1c7c6f8e545ccdcb1a947392c3f320 plus some additional
fixes that were already in master.)