### PR TITLE
Fixes displaying disabled wxDataViewItem with native appearance

### DIFF
--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -1067,7 +1067,7 @@ wxDataViewCustomRendererBase::RenderText(const wxString& text,
     int flags = 0;
     if ( state & wxDATAVIEW_CELL_SELECTED )
         flags |= wxCONTROL_SELECTED;
-    if ( !GetEnabled() )
+    if ( !(GetOwner()->GetOwner()->IsEnabled() && GetEnabled()) )
         flags |= wxCONTROL_DISABLED;
 
     // Notice that we intentionally don't use any alignment here: it is not

--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -1067,7 +1067,7 @@ wxDataViewCustomRendererBase::RenderText(const wxString& text,
     int flags = 0;
     if ( state & wxDATAVIEW_CELL_SELECTED )
         flags |= wxCONTROL_SELECTED;
-    if ( !GetOwner()->GetOwner()->IsEnabled() )
+    if ( !GetEnabled() )
         flags |= wxCONTROL_DISABLED;
 
     // Notice that we intentionally don't use any alignment here: it is not

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -1298,7 +1298,7 @@ bool wxDataViewToggleRenderer::Render( wxRect cell, wxDC *dc, int WXUNUSED(state
     if (m_toggle)
         flags |= wxCONTROL_CHECKED;
     if (GetMode() != wxDATAVIEW_CELL_ACTIVATABLE ||
-        GetEnabled() == false)
+        !(GetOwner()->GetOwner()->IsEnabled() && GetEnabled()))
         flags |= wxCONTROL_DISABLED;
 
     // Ensure that the check boxes always have at least the minimal required


### PR DESCRIPTION
wxDataViewItems are displayed in the same way whether they are enable or disabled with native appearance (Windows) since it doesn't apply the wxCONTROL_DISABLED flag based on the results of the wxDataViewModel's IsEnabled() method. This change fixes that.

Here are before and after screenshots of the unchanged dataview sample with this fix. Notice how 'good' is now displayed in a way that indicates that it is disabled.

Before:
![before](https://user-images.githubusercontent.com/6620767/54899611-947bb000-4e8d-11e9-8924-60302578b25e.png)

After:
![after](https://user-images.githubusercontent.com/6620767/54899614-980f3700-4e8d-11e9-915b-2867cfa55076.png)
