### PR TITLE
Fixes for mnemonics in wxGTK

### DIFF
--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -4786,7 +4786,8 @@ void wxWindowGTK::RealizeTabOrder()
                         }
                     }
                 }
-                else if ( win->GTKWidgetNeedsMnemonic() )
+
+                if ( win->GTKWidgetNeedsMnemonic() )
                 {
                     mnemonicWindow = win;
                 }

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -4768,22 +4768,21 @@ void wxWindowGTK::RealizeTabOrder()
                 {
                     if ( focusableFromKeyboard )
                     {
-                        // wxComboBox et al. needs to focus on on a different
-                        // widget than m_widget, so if the main widget isn't
-                        // focusable try the connect widget
+                        // We may need to focus on the connect widget if the
+                        // main one isn't focusable, but note that we still use
+                        // the main widget if neither it nor connect widget is
+                        // focusable, without this using a wxStaticText before
+                        // wxChoice wouldn't work at all, for example.
                         GtkWidget* w = win->m_widget;
                         if ( !gtk_widget_get_can_focus(w) )
                         {
-                            w = win->GetConnectWidget();
-                            if ( !gtk_widget_get_can_focus(w) )
-                                w = NULL;
+                            GtkWidget* const cw = win->GetConnectWidget();
+                            if ( cw != w && gtk_widget_get_can_focus(cw) )
+                                w = cw;
                         }
 
-                        if ( w )
-                        {
-                            mnemonicWindow->GTKWidgetDoSetMnemonic(w);
-                            mnemonicWindow = NULL;
-                        }
+                        mnemonicWindow->GTKWidgetDoSetMnemonic(w);
+                        mnemonicWindow = NULL;
                     }
                 }
 


### PR DESCRIPTION
See [this ticket](https://trac.wxwidgets.org/ticket/15776) which contains this test case:
```cpp
#include <wx/wx.h>
#include <wx/spinctrl.h>

class CDialog : public wxDialog
{
public:
        CDialog(const wxString & sTitle) : wxDialog(NULL, wxID_ANY, sTitle) {
                int x0 = 10, y0 = 10, dx = 50, dy = 40;
                // a static text
                new wxStaticText(this, wxID_STATIC, "Apple", wxPoint(x0, y0));
                // a text control and its label
                new wxStaticText(this, wxID_STATIC, "&Banana", wxPoint(x0, y0 + dy));
                new wxTextCtrl(this, wxID_ANY, wxEmptyString, wxPoint(x0 + dx, y0 + dy));
                // a spin control and its label
                new wxStaticText(this, wxID_STATIC, "&Cherry", wxPoint(x0, y0 + 2 * dy));
                new wxSpinCtrl(this, wxID_ANY, wxEmptyString, wxPoint(x0 + dx, y0 + 2 * dy));
                // a choice control and its label
                new wxStaticText(this, wxID_STATIC, "&Durian", wxPoint(x0, y0 + 3 * dy));
                wxString wxsChoices[] = { "Hello World!", "Goodbye World!" };
                (new wxChoice(this, wxID_ANY, wxPoint(x0 + dx, y0 + 3 * dy), wxDefaultSize, sizeof(wxsChoices)/sizeof(wxString), wxsChoices, 0))->SetSelection(0);
                // a checkbox control
                new wxCheckBox(this, wxID_ANY, "&Eggplant", wxPoint(x0, y0 + 4 * dy));
        }
};

class CApp : public wxApp
{
public:
        bool OnInit() {
                CDialog * dlg = new CDialog("buggy");
                dlg->ShowModal();
                return false;
        }
};
DECLARE_APP(CApp)
IMPLEMENT_APP(CApp)
```

It didn't work before as the first text control couldn't be activated by pressing `Alt-B` and pressing `Alt-D` activated the checkbox instead of the choice, and both problems are fixed by this PR.