### PR TITLE
Add basic information to wxDisplayChangedEvent documentation

### DIFF
--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -3291,7 +3291,25 @@ public:
     wxMouseCaptureLostEvent(wxWindowID windowId = 0);
 };
 
+/**
+    @class wxDisplayChangedEvent
 
+    A display changed event is sent to top-level windows when the display resolution has changed.
+    
+    This event is currently emitted under Windows only.
+
+    @beginEventTable{wxDisplayChangedEvent}
+    @event{EVT_DISPLAY_CHANGED(func)}
+        Process a @c wxEVT_DISPLAY_CHANGED event.
+    @endEventTable
+
+    @onlyfor{wxmsw}
+
+    @library{wxcore}
+    @category{events}
+
+    @see wxDisplay
+*/ 
 
 class wxDisplayChangedEvent : public wxEvent
 {


### PR DESCRIPTION
Not sure how useful the event actually is these days, but any public class should have at least some description. The two palette events still have none but hopefully the era of OS palettes mattering is for ever behind us.