### PR TITLE
Improve returning wxSYS_CARET_* metrics in wxMSW

### DIFF
--- a/interface/wx/settings.h
+++ b/interface/wx/settings.h
@@ -197,7 +197,7 @@ enum wxSystemMetric
         Time, in milliseconds, for how long a blinking caret should
         stay visible during a single blink cycle before it disappears.
         If this value is negative, the platform does not support the
-        user setting.  Implemented only on GTK+ and MacOS X.
+        user setting.
 
         @since 3.1.1
     */
@@ -208,8 +208,7 @@ enum wxSystemMetric
         stay invisible during a single blink cycle before it reappears.
         If this value is zero, carets should be visible all the time
         instead of blinking.  If the value is negative, the platform
-        does not support the user setting.  Implemented only on GTK+
-        and MacOS X.
+        does not support the user setting.
 
         @since 3.1.1
     */

--- a/src/msw/settings.cpp
+++ b/src/msw/settings.cpp
@@ -253,7 +253,10 @@ static const int gs_metricsMap[] =
     SM_PENWINDOWS,
     SM_SHOWSOUNDS,
     SM_SWAPBUTTON,
-    -1   // wxSYS_DCLICK_MSEC - not available as system metric
+    -1,   // wxSYS_DCLICK_MSEC - not available as system metric
+    -1,   // wxSYS_CARET_ON_MSEC - not available as system metric
+    -1,   // wxSYS_CARET_OFF_MSEC - not available as system metric
+    -1    // wxSYS_CARET_TIMEOUT_MSEC - not available as system metric
 };
 
 // Get a system metric, e.g. scrollbar size
@@ -266,6 +269,25 @@ int wxSystemSettingsNative::GetMetric(wxSystemMetric index, wxWindow* WXUNUSED(w
     {
         // This one is not a Win32 system metric
         return ::GetDoubleClickTime();
+    }
+
+    // return the caret blink time for both
+    // wxSYS_CARET_ON_MSEC and wxSYS_CARET_OFF_MSEC
+    if ( index == wxSYS_CARET_ON_MSEC || index == wxSYS_CARET_OFF_MSEC )
+    {
+        const UINT blinkTime = ::GetCaretBlinkTime();
+
+        if ( blinkTime == 0 ) // error
+        {
+            return -1;
+        }
+        
+        if ( blinkTime == INFINITE ) // caret does not blink
+        {
+            return 0;
+        }
+
+        return blinkTime;
     }
 
     int indexMSW = gs_metricsMap[index];


### PR DESCRIPTION
I was dumping the values for all system metrics and was surprised when the code had multiple assertions, so I looked into it.

I am not claiming my solution is ideal but hopefully it somewhat improves the current situation.

I wonder if `0` (not blinking) should be returned instead of `-1` (always blinks) for `wxSYS_CARET_TIMEOUT_MSEC` when the caret is set to not blink.

BTW, I also noticed there is no `wxEvent` for `WM_SETTINGCHANGE` message, even when there are similar MSW-only `wxDisplayChangedEvent` (for `WM_DISPLAYCHANGE`) and `wxSysColourChangedEvent` (for `WM_SYSCOLORCHANGE`). I guess there was no demand for this and it is probably trivial to do it in user code when needed.

Edit: I noticed too late that "| TIMEOUT" should be removed from the second sentence of the commit message.