### PR TITLE
Do not limit label width in wxToolBar by control width

### DIFF
--- a/interface/wx/toolbar.h
+++ b/interface/wx/toolbar.h
@@ -334,10 +334,6 @@ public:
             Text to be displayed near the control.
 
         @remarks
-            wxMSW: the label is only displayed if there is enough space
-            available below the embedded control.
-
-        @remarks
             wxMac: labels are only displayed if wxWidgets is built with @c
             wxMAC_USE_NATIVE_TOOLBAR set to 1
     */

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -194,39 +194,32 @@ public:
         {
             if ( m_staticText )
             {
-                 if ( !label.empty() )
-                 {
+                if ( !label.empty() )
+                {
                     m_staticText->SetLabel(label);
-                 }
-                 else
-                 {
+                }
+                else
+                {
                     delete m_staticText;
                     m_staticText = NULL;
-                 }
+                }
             }
             else
             {
-                 if ( !label.empty() )
-                 {
-                    // Create a control to render the control's label.
-                    // It has the same witdh as the control.
-                    wxSize size(m_control->GetSize().GetWidth(), wxDefaultCoord);
-                    m_staticText = new wxStaticText(m_tbar, wxID_ANY, label,
-                                        wxDefaultPosition, size,
-                                        wxALIGN_CENTRE | wxST_NO_AUTORESIZE);
-                 }
+                if ( !label.empty() )
+                {
+                    m_staticText = new wxStaticText(m_tbar, wxID_ANY, label);
+                }
             }
         }
-        else if ( IsButton() )
-        {
-            // Because new label can have different length than the old one
-            // so updating button's label with TB_SETBUTTONINFO would require
-            // also manual re-positionining items in the control tools located
-            // to the right in the toolbar and recalculation of stretchable
-            // spacers so it is easier just to recreate the toolbar with
-            // Realize(). Performance penalty should be negligible.
-            m_tbar->Realize();
-        }
+
+        // Because new label can have different length than the old one
+        // so updating button's label with TB_SETBUTTONINFO would require
+        // also manual re-positionining items in the control tools located
+        // to the right in the toolbar and recalculation of stretchable
+        // spacers so it is easier just to recreate the toolbar with
+        // Realize(). Performance penalty should be negligible.
+        m_tbar->Realize();
     }
 
     wxStaticText* GetStaticText()


### PR DESCRIPTION
This removes irregular behaviour in setting the label of a control. Creating
a control with label now behaves the same as setting or changing the label
later on. And behaves the same as for other tools in the wxToolBar.

The recent `wxToolbar` changes made it a lot easier to add per-monitor DPI support to it, but I came across this irregularity. I do not know if the old `wxToolBar` behaviour prevented changing the label width, but I do not see any reason why to keep this in place.