### PR TITLE
Added default text colour, background mode members to the HTML parser…

### DIFF
--- a/include/wx/html/htmprint.h
+++ b/include/wx/html/htmprint.h
@@ -53,6 +53,16 @@ public:
     // isdir is false if basepath is filename, true if it is directory name
     // (see wxFileSystem for detailed explanation)
     void SetHtmlText(const wxString& html, const wxString& basepath = wxEmptyString, bool isdir = true);
+    
+    // Sets the text to be displayed, use initialState to override default cell colours.
+    // Basepath is base directory (html string would be stored there if it was in
+    // file). It is used to determine path for loading images, for example.
+    // isdir is false if basepath is filename, true if it is directory name
+    // (see wxFileSystem for detailed explanation)
+    void SetHtmlText(const wxString& html,
+                     const wxHtmlRenderingState& initialState,
+                     const wxString& basepath = wxEmptyString,
+                     bool isdir = true);    
 
     // Sets the HTML cell that will be rendered: this is more efficient than
     // using text as it allows to parse it only once. Note that the cell will

--- a/include/wx/html/winpars.h
+++ b/include/wx/html/winpars.h
@@ -123,6 +123,17 @@ public:
     long GetScriptBaseline() const { return m_ScriptBaseline; }
     void SetScriptBaseline(long base) { m_ScriptBaseline = base; }
 
+    // Access default colours, allowing pre-parsing cell color customization
+    const wxColour& GetLinkColorDefault() const { return m_LinkColorDefault; }
+    void SetLinkColorDefault(const wxColour& clr) { m_LinkColorDefault = clr; }
+    const wxColour& GetColorDefault() const { return m_ColorDefault; }
+    void SetColorDefault(const wxColour& clr) { m_ColorDefault = clr ;}
+    const wxColour& GetBackgroundColorDefault() const { return m_BackgroundColorDefault; }
+    void SetBackgroundColorDefault(const wxColour& clr) { m_BackgroundColorDefault = clr;}
+    int GetBackgroundModeDefault() const { return m_BackgroundModeDefault; }
+    void SetBackgroundModeDefault(int mode) { m_BackgroundModeDefault = mode;}    
+    
+    // Access currently used colours
     const wxColour& GetLinkColor() const { return m_LinkColor; }
     void SetLinkColor(const wxColour& clr) { m_LinkColor = clr; }
     const wxColour& GetActualColor() const { return m_ActualColor; }
@@ -190,6 +201,12 @@ private:
 
     int m_FontBold, m_FontItalic, m_FontUnderlined, m_FontFixed; // this is not true,false but 1,0, we need it for indexing
     int m_FontSize; // From 1 (smallest) to 7, default is 3.
+
+    wxColour m_LinkColorDefault;
+    wxColour m_ColorDefault;
+    wxColour m_BackgroundColorDefault;
+    int m_BackgroundModeDefault;
+    
     wxColour m_LinkColor;
     wxColour m_ActualColor;
     wxColour m_ActualBackgroundColor;

--- a/interface/wx/html/htmprint.h
+++ b/interface/wx/html/htmprint.h
@@ -167,6 +167,28 @@ public:
     void SetHtmlText(const wxString& html,
                      const wxString& basepath = wxEmptyString,
                      bool isdir = true);
+                     
+    /**
+        Assign text to the renderer, using specified wxHtmlRenderingState
+        to override default parced cell colours. Render() then draws the text onto DC.
+
+        @param html
+            HTML text. This is not a filename.
+        @param initialState
+            wxHtmlRenderingState instance to be used to override cells base colours
+        @param basepath
+            base directory (html string would be stored there if it was in file).
+            It is used to determine path for loading images, for example.
+        @param isdir
+            @false if basepath is filename, @true if it is directory name
+            (see wxFileSystem for detailed explanation).
+
+            @since 3.1.3
+    */
+    void SetHtmlText(const wxString& html,
+                     const wxHtmlRenderingState& initialState,
+                     const wxString& basepath = wxEmptyString,
+                     bool isdir = true);
 
     /**
         Associate the given HTML contents to the renderer.

--- a/interface/wx/html/winpars.h
+++ b/interface/wx/html/winpars.h
@@ -316,5 +316,61 @@ public:
         Sets colour of hypertext link.
     */
     void SetLinkColor(const wxColour& clr);
+    
+    /**
+        Return default colour of hypertext link.
+        
+        @since 3.1.3
+    */
+    const wxColour& GetLinkColorDefault() const;
+    
+    /**
+        Sets default colour of hypertext link.
+        
+        @since 3.1.3
+    */
+    void SetLinkColorDefault(const wxColour& clr);
+    
+    /**
+        Return default base colour of hypertext.
+        
+        @since 3.1.3
+    */
+    const wxColour& GetColorDefault() const;
+    
+    /**
+        Sets default base colour of hypertext.
+        
+        @since 3.1.3
+    */
+    void SetColorDefault(const wxColour& clr);
+    
+    /**
+        Return default background colour of hypertext.
+        
+        @since 3.1.3
+    */
+    const wxColour& GetBackgroundColorDefault() const;
+    
+    /**
+        Sets default background colour of hypertext.
+        
+        @since 3.1.3
+    */
+    void SetBackgroundColorDefault(const wxColour& clr);
+    
+    /**
+        Return default hypertext background mode.
+        
+        @since 3.1.3
+    */
+    int GetBackgroundModeDefault() const;
+    
+    /**
+        Sets default hypertext background mode.
+        
+        @since 3.1.3
+    */
+    void SetBackgroundModeDefault(int mode);
 };
 

--- a/src/html/htmprint.cpp
+++ b/src/html/htmprint.cpp
@@ -118,6 +118,25 @@ void wxHtmlDCRenderer::SetHtmlText(const wxString& html, const wxString& basepat
     m_ownsCells = true;
 }
 
+void wxHtmlDCRenderer::SetHtmlText( const wxString& html, const wxHtmlRenderingState& initialState, const wxString& basepath, bool isdir)
+{
+    wxCHECK_RET( m_DC, "SetDC() must be called before SetHtmlText()" );
+    wxCHECK_RET( m_Width, "SetSize() must be called before SetHtmlText()" );
+
+    m_FS.ChangePathTo(basepath, isdir);
+
+    m_Parser.SetColorDefault(initialState.GetFgColour());
+    m_Parser.SetBackgroundColorDefault(initialState.GetBgColour());
+    m_Parser.SetBackgroundModeDefault(initialState.GetBgMode());
+    
+    wxHtmlContainerCell* const cell = (wxHtmlContainerCell*) m_Parser.Parse(html);
+    wxCHECK_RET( cell, "Failed to parse HTML" );
+
+    DoSetHtmlCell(cell);
+
+    m_ownsCells = true;
+}
+
 void wxHtmlDCRenderer::DoSetHtmlCell(wxHtmlContainerCell* cell)
 {
     if ( m_ownsCells )

--- a/src/html/winpars.cpp
+++ b/src/html/winpars.cpp
@@ -56,6 +56,11 @@ wxHtmlWinParser::wxHtmlWinParser(wxHtmlWindowInterface *wndIface)
     m_lastWordCell = NULL;
     m_posColumn = 0;
 
+    m_LinkColorDefault.Set(0, 0, 0xFF);
+    m_ColorDefault.Set(0, 0, 0);
+    m_BackgroundColorDefault = wxNullColour;
+    m_BackgroundModeDefault = wxBRUSHSTYLE_INVALID;    
+    
     {
         int i, j, k, l, m;
         for (i = 0; i < 2; i++)
@@ -211,13 +216,26 @@ void wxHtmlWinParser::InitParser(const wxString& source)
 
     m_UseLink = false;
     m_Link = wxHtmlLinkInfo( wxEmptyString );
-    m_LinkColor.Set(0, 0, 0xFF);
-    m_ActualColor.Set(0, 0, 0);
-    const wxColour windowColour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW) ;
-    m_ActualBackgroundColor = m_windowInterface
-                            ? m_windowInterface->GetHTMLBackgroundColour()
-                            : windowColour;
-    m_ActualBackgroundMode = wxBRUSHSTYLE_TRANSPARENT;
+    
+    m_LinkColor = m_LinkColorDefault;
+    m_ActualColor = m_ColorDefault;
+
+    if( m_BackgroundColorDefault.IsOk() )
+        m_ActualBackgroundColor = m_BackgroundColorDefault;
+    else
+    {
+        const wxColour windowColour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW) ;
+        m_ActualBackgroundColor = m_windowInterface
+                                ? m_windowInterface->GetHTMLBackgroundColour()
+                                : windowColour;
+    }
+
+    if(m_BackgroundModeDefault != wxPENSTYLE_INVALID)
+        m_ActualBackgroundMode = m_BackgroundModeDefault;
+    else
+        m_ActualBackgroundMode = wxBRUSHSTYLE_TRANSPARENT;
+   
+    
     m_Align = wxHTML_ALIGN_LEFT;
     m_ScriptMode = wxHTML_SCRIPT_NORMAL;
     m_ScriptBaseline = 0;


### PR DESCRIPTION
… class, to allow non hard-coded colours to be used when generating parsed HTML cell objects.

Added SetHtmlText method to wxHtmlDCRenderer class, taking const wxHtmlRenderingState& initialState parameter utilized to change base HTML Parser cell colours.