### PR TITLE
Various macOS warning fixes

### DIFF
--- a/include/wx/osx/bitmap.h
+++ b/include/wx/osx/bitmap.h
@@ -149,8 +149,8 @@ public:
     bool CreateScaled(int logwidth, int logheight, int depth, double logicalScale) wxOVERRIDE;
 
     // virtual bool Create( WXHICON icon) ;
-    virtual bool LoadFile(const wxString& name, wxBitmapType type = wxBITMAP_DEFAULT_TYPE);
-    virtual bool SaveFile(const wxString& name, wxBitmapType type, const wxPalette *cmap = NULL) const;
+    virtual bool LoadFile(const wxString& name, wxBitmapType type = wxBITMAP_DEFAULT_TYPE) wxOVERRIDE;
+    virtual bool SaveFile(const wxString& name, wxBitmapType type, const wxPalette *cmap = NULL) const wxOVERRIDE;
 
     const wxBitmapRefData *GetBitmapData() const
         { return (const wxBitmapRefData *)m_refData; }

--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -148,13 +148,21 @@ public :
     virtual bool        SetupCursor(NSEvent* event);
 
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_10
-    virtual void        PanGestureEvent(NSPanGestureRecognizer *panGestureRecognizer);
-    virtual void        ZoomGestureEvent(NSMagnificationGestureRecognizer *magnificationGestureRecognizer);
-    virtual void        RotateGestureEvent(NSRotationGestureRecognizer *rotationGestureRecognizer);
-    virtual void        LongPressEvent(NSPressGestureRecognizer *pressGestureRecognizer);
-    virtual void        TouchesBegan(NSEvent *event);
-    virtual void        TouchesMoved(NSEvent *event);
-    virtual void        TouchesEnded(NSEvent *event);
+    #ifdef API_AVAILABLE
+        #define WX_AVAILABLE_10_10 API_AVAILABLE(macos(10.10))
+    #else
+        #define WX_AVAILABLE_10_10
+    #endif
+
+    WX_AVAILABLE_10_10 virtual void        PanGestureEvent(NSPanGestureRecognizer *panGestureRecognizer);
+    WX_AVAILABLE_10_10 virtual void        ZoomGestureEvent(NSMagnificationGestureRecognizer *magnificationGestureRecognizer);
+    WX_AVAILABLE_10_10 virtual void        RotateGestureEvent(NSRotationGestureRecognizer *rotationGestureRecognizer);
+    WX_AVAILABLE_10_10 virtual void        LongPressEvent(NSPressGestureRecognizer *pressGestureRecognizer);
+    WX_AVAILABLE_10_10 virtual void        TouchesBegan(NSEvent *event);
+    WX_AVAILABLE_10_10 virtual void        TouchesMoved(NSEvent *event);
+    WX_AVAILABLE_10_10 virtual void        TouchesEnded(NSEvent *event);
+
+    #undef WX_AVAILABLE_10_10
 #endif // MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_10
 
 #if !wxOSX_USE_NATIVE_FLIPPED

--- a/include/wx/osx/core/private/strconv_cf.h
+++ b/include/wx/osx/core/private/strconv_cf.h
@@ -320,8 +320,8 @@ public:
         m_encoding = encoding ;
     }
 
-    virtual size_t ToWChar(wchar_t * dst, size_t dstSize, const char * src, size_t srcSize = wxNO_LEN) const;
-    virtual size_t FromWChar(char *dst, size_t dstSize, const wchar_t *src, size_t srcSize = wxNO_LEN) const;
+    virtual size_t ToWChar(wchar_t * dst, size_t dstSize, const char * src, size_t srcSize = wxNO_LEN) const wxOVERRIDE;
+    virtual size_t FromWChar(char *dst, size_t dstSize, const wchar_t *src, size_t srcSize = wxNO_LEN) const wxOVERRIDE;
 
     virtual wxMBConv *Clone() const wxOVERRIDE { return new wxMBConv_cf(*this); }
 

--- a/include/wx/osx/filedlg.h
+++ b/include/wx/osx/filedlg.h
@@ -83,7 +83,7 @@ protected:
     // not supported for file dialog, RR
     virtual void DoSetSize(int WXUNUSED(x), int WXUNUSED(y),
                            int WXUNUSED(width), int WXUNUSED(height),
-                           int WXUNUSED(sizeFlags) = wxSIZE_AUTO) {}
+                           int WXUNUSED(sizeFlags) = wxSIZE_AUTO) wxOVERRIDE {}
 
     void SetupExtraControls(WXWindow nativeWindow);
 

--- a/include/wx/osx/menuitem.h
+++ b/include/wx/osx/menuitem.h
@@ -39,8 +39,8 @@ public:
     // override base class virtuals
     virtual void SetItemLabel(const wxString& strName) wxOVERRIDE;
 
-    virtual void Enable(bool bDoEnable = true);
-    virtual void Check(bool bDoCheck = true);
+    virtual void Enable(bool bDoEnable = true) wxOVERRIDE;
+    virtual void Check(bool bDoCheck = true) wxOVERRIDE;
 
     virtual void SetBitmap(const wxBitmap& bitmap) ;
     virtual const wxBitmap& GetBitmap() const { return m_bitmap; }

--- a/include/wx/osx/msgdlg.h
+++ b/include/wx/osx/msgdlg.h
@@ -36,7 +36,7 @@ protected:
     // not supported for message dialog
     virtual void DoSetSize(int WXUNUSED(x), int WXUNUSED(y),
                            int WXUNUSED(width), int WXUNUSED(height),
-                           int WXUNUSED(sizeFlags) = wxSIZE_AUTO) {}
+                           int WXUNUSED(sizeFlags) = wxSIZE_AUTO) wxOVERRIDE {}
 
 #if wxOSX_USE_COCOA
     void* ConstructNSAlert();

--- a/include/wx/osx/private/available.h
+++ b/include/wx/osx/private/available.h
@@ -1,0 +1,34 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/osx/private/available.h
+// Purpose:     Helper for checking API availability under macOS.
+// Author:      Vadim Zeitlin
+// Created:     2019-04-17
+// Copyright:   (c) 2019 Vadim Zeitlin <vadim@wxwidgets.org>
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_OSX_PRIVATE_AVAILABLE_H_
+#define _WX_OSX_PRIVATE_AVAILABLE_H_
+
+// Xcode 9 adds new @available keyword and the corresponding __builtin_available
+// builtin which should be used instead of manually checks for API availability
+// as using this builtin suppresses the compiler -Wunguarded-availability
+// warnings, so use it if possible for the implementation of our own macro.
+#if defined(__clang__) && __has_builtin(__builtin_available)
+    #define WX_IS_MACOS_AVAILABLE(major, minor) \
+        __builtin_available(macOS major ## . ## minor, *)
+
+    // Note that we can't easily forward to API_AVAILABLE macro here, so go
+    // directly to its expansion instead.
+    #define WX_API_AVAILABLE_MACOS(major, minor) \
+         __attribute__((availability(macos,introduced=major ## . ## minor)))
+#else // Not clang or old clang version without __builtin_available
+    #include "wx/platinfo.h"
+
+    #define WX_IS_MACOS_AVAILABLE(major, minor) \
+        wxPlatformInfo::Get().CheckOSVersion(major, minor)
+
+    #define WX_API_AVAILABLE_MACOS(major, minor)
+#endif
+
+#endif // _WX_OSX_PRIVATE_AVAILABLE_H_

--- a/include/wx/osx/textentry.h
+++ b/include/wx/osx/textentry.h
@@ -76,7 +76,7 @@ public:
     virtual void SetInsertionPoint(long pos) wxOVERRIDE;
     virtual void SetInsertionPointEnd() wxOVERRIDE;
     virtual long GetInsertionPoint() const wxOVERRIDE;
-    virtual wxTextPos GetLastPosition() const;
+    virtual wxTextPos GetLastPosition() const wxOVERRIDE;
 
     virtual void SetSelection(long from, long to) wxOVERRIDE;
     virtual void SetEditable(bool editable) wxOVERRIDE;

--- a/src/osx/carbon/statbrma.cpp
+++ b/src/osx/carbon/statbrma.cpp
@@ -24,6 +24,7 @@
 #endif
 
 #include "wx/osx/private.h"
+#include "wx/osx/private/available.h"
 
 // Margin between the field text and the field rect
 #define wxFIELD_TEXT_MARGIN 2
@@ -75,33 +76,9 @@ bool wxStatusBarMac::Create(wxWindow *parent, wxWindowID id,
 
 void wxStatusBarMac::InitColours()
 {
-#if MAC_OS_X_VERSION_MIN_REQUIRED < 101000
-    if ( !wxPlatformInfo::Get().CheckOSVersion(10, 10) )
+    if ( WX_IS_MACOS_AVAILABLE(10, 10) )
     {
-        // 10.9 Mavericks and older:
-        m_textActive = wxColour(0x2F, 0x2F, 0x2F);
-        m_textInactive = wxColour(0x4D, 0x4D, 0x4D);
-        m_bgActiveFrom = wxColour(0xDA, 0xDA, 0xDA);
-        m_bgActiveTo = wxColour(0xA0, 0xA0, 0xA0);
-        m_borderActive = wxColour(0x6E, 0x6E, 0x6E);
-        m_borderInactive = wxColour(0xA3, 0xA3, 0xA3);
-        SetBackgroundColour(wxColour(0xE1, 0xE1, 0xE1)); // inactive bg
-    }
-    else
-#endif // MAC_OS_X_VERSION_MIN_REQUIRED < 101000
-    {
-        if (!wxPlatformInfo::Get().CheckOSVersion(10, 14))
-        {
-            // 10.10 Yosemite to 10.13 :
-            m_textActive = wxColour(0x40, 0x40, 0x40);
-            m_textInactive = wxColour(0x4B, 0x4B, 0x4B);
-            m_bgActiveFrom = wxColour(0xE9, 0xE7, 0xEA);
-            m_bgActiveTo = wxColour(0xCD, 0xCB, 0xCE);
-            m_borderActive = wxColour(0xBA, 0xB8, 0xBB);
-            m_borderInactive = wxColour(0xC3, 0xC3, 0xC3);
-            SetBackgroundColour(wxColour(0xF4, 0xF4, 0xF4)); // inactive bg
-        }
-        else
+        if ( WX_IS_MACOS_AVAILABLE(10, 14) )
         {
             // FIXME: None of this is correct and is only very loose
             //        approximation. 10.14's dark mode uses dynamic colors that
@@ -129,7 +106,31 @@ void wxStatusBarMac::InitColours()
             }
             SetBackgroundColour(bg); // inactive bg
         }
+        else
+        {
+            // 10.10 Yosemite to 10.13 :
+            m_textActive = wxColour(0x40, 0x40, 0x40);
+            m_textInactive = wxColour(0x4B, 0x4B, 0x4B);
+            m_bgActiveFrom = wxColour(0xE9, 0xE7, 0xEA);
+            m_bgActiveTo = wxColour(0xCD, 0xCB, 0xCE);
+            m_borderActive = wxColour(0xBA, 0xB8, 0xBB);
+            m_borderInactive = wxColour(0xC3, 0xC3, 0xC3);
+            SetBackgroundColour(wxColour(0xF4, 0xF4, 0xF4)); // inactive bg
+        }
     }
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 101000
+    else
+    {
+        // 10.9 Mavericks and older:
+        m_textActive = wxColour(0x2F, 0x2F, 0x2F);
+        m_textInactive = wxColour(0x4D, 0x4D, 0x4D);
+        m_bgActiveFrom = wxColour(0xDA, 0xDA, 0xDA);
+        m_bgActiveTo = wxColour(0xA0, 0xA0, 0xA0);
+        m_borderActive = wxColour(0x6E, 0x6E, 0x6E);
+        m_borderInactive = wxColour(0xA3, 0xA3, 0xA3);
+        SetBackgroundColour(wxColour(0xE1, 0xE1, 0xE1)); // inactive bg
+    }
+#endif // MAC_OS_X_VERSION_MIN_REQUIRED < 101000
 }
 
 void wxStatusBarMac::DrawFieldText(wxDC& dc, const wxRect& rect, int i, int textHeight)

--- a/src/osx/carbon/utilscocoa.mm
+++ b/src/osx/carbon/utilscocoa.mm
@@ -23,6 +23,7 @@
 
 #ifdef __WXMAC__
 #include "wx/osx/private.h"
+#include "wx/osx/private/available.h"
 #endif
 
 #include "wx/fontutil.h"
@@ -624,7 +625,7 @@ NSString* wxNSStringWithWxString(const wxString &wxstring)
 wxOSXEffectiveAppearanceSetter::wxOSXEffectiveAppearanceSetter()
 {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
-    if ( wxPlatformInfo::Get().CheckOSVersion(10, 14 ) )
+    if ( WX_IS_MACOS_AVAILABLE(10, 14 ) )
     {
         formerAppearance = NSAppearance.currentAppearance;
         NSAppearance.currentAppearance = NSApp.effectiveAppearance;
@@ -637,7 +638,7 @@ wxOSXEffectiveAppearanceSetter::wxOSXEffectiveAppearanceSetter()
 wxOSXEffectiveAppearanceSetter::~wxOSXEffectiveAppearanceSetter()
 {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
-    if ( wxPlatformInfo::Get().CheckOSVersion(10, 14 ) )
+    if ( WX_IS_MACOS_AVAILABLE(10, 14 ) )
         NSAppearance.currentAppearance = (NSAppearance*) formerAppearance;
 #endif
 }

--- a/src/osx/cocoa/colour.mm
+++ b/src/osx/cocoa/colour.mm
@@ -12,6 +12,7 @@
 #include "wx/colour.h"
 
 #include "wx/osx/private.h"
+#include "wx/osx/private/available.h"
 
 class wxNSColorRefData : public wxColourRefData
 {
@@ -104,7 +105,7 @@ bool wxNSColorRefData::IsSolid() const
 CGColorRef wxNSColorRefData::GetCGColor() const
 {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_8
-    if (wxPlatformInfo::Get().CheckOSVersion(10, 8)) {
+    if ( WX_IS_MACOS_AVAILABLE(10, 8) ) {
         wxOSXEffectiveAppearanceSetter helper;
         return [m_nsColour CGColor];
     }

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -25,6 +25,7 @@
 #endif
 
 #include "wx/osx/private.h"
+#include "wx/osx/private/available.h"
 #include "wx/osx/cocoa/dataview.h"
 #include "wx/renderer.h"
 #include "wx/stopwatch.h"
@@ -2956,14 +2957,14 @@ bool wxDataViewTextRenderer::MacRender()
             // Tightening looks very ugly when combined with non-tightened rows,
             // so disabled it on OS X version where it's used:
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_11
-            if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_11)
+            if ( WX_IS_MACOS_AVAILABLE(10, 11) )
             {
                 [par setAllowsDefaultTighteningForTruncation:NO];
             }
             else
 #endif
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_10
-            if (floor(NSAppKitVersionNumber) >= NSAppKitVersionNumber10_10)
+            if ( WX_IS_MACOS_AVAILABLE(10, 10) )
             {
                 [par setTighteningFactorForTruncation:0.0];
             }

--- a/src/osx/cocoa/mediactrl.mm
+++ b/src/osx/cocoa/mediactrl.mm
@@ -31,6 +31,7 @@
 #include "wx/mediactrl.h"
 
 #include "wx/osx/private.h"
+#include "wx/osx/private/available.h"
 
 #if wxOSX_USE_COCOA && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_9 && defined(__LP64__)
     #define wxOSX_USE_AVKIT 1
@@ -276,6 +277,7 @@ private:
 
 #if wxOSX_USE_AVKIT
 
+WX_API_AVAILABLE_MACOS(10, 10)
 @interface wxAVPlayerView : AVPlayerView
 {
 }
@@ -395,7 +397,7 @@ bool wxAVMediaBackend::CreateControl(wxControl* inctrl, wxWindow* parent,
 
     WXWidget view = NULL;
 #if wxOSX_USE_AVKIT
-    if ( NSClassFromString(@"AVPlayerView") )
+    if ( WX_IS_MACOS_AVAILABLE(10, 10) )
     {
         view = [[wxAVPlayerView alloc] initWithFrame: r player:m_player];
         [(wxAVPlayerView*) view setControlsStyle:AVPlayerViewControlsStyleNone];
@@ -563,14 +565,17 @@ bool wxAVMediaBackend::ShowPlayerControls(wxMediaCtrlPlayerControls flags)
 void wxAVMediaBackend::DoShowPlayerControls(wxMediaCtrlPlayerControls flags)
 {
 #if wxOSX_USE_AVKIT
-    NSView* view = m_ctrl->GetHandle();
-    if ( [view isKindOfClass:[wxAVPlayerView class]] )
+    if ( WX_IS_MACOS_AVAILABLE(10, 10) )
     {
-        wxAVPlayerView* playerView = (wxAVPlayerView*) view;
-        if (flags == wxMEDIACTRLPLAYERCONTROLS_NONE )
-            playerView.controlsStyle = AVPlayerViewControlsStyleNone;
-        else
-            playerView.controlsStyle = AVPlayerViewControlsStyleDefault;
+        NSView* view = m_ctrl->GetHandle();
+        if ( [view isKindOfClass:[wxAVPlayerView class]] )
+        {
+            wxAVPlayerView* playerView = (wxAVPlayerView*) view;
+            if (flags == wxMEDIACTRLPLAYERCONTROLS_NONE )
+                playerView.controlsStyle = AVPlayerViewControlsStyleNone;
+            else
+                playerView.controlsStyle = AVPlayerViewControlsStyleDefault;
+        }
     }
 #endif
 }

--- a/src/osx/cocoa/mediactrl.mm
+++ b/src/osx/cocoa/mediactrl.mm
@@ -162,7 +162,7 @@ private:
         id val = [change objectForKey:NSKeyValueChangeNewKey];
         if ( val != [NSNull null ] )
         {
-            AVPlayerStatus status = (AVPlayerStatus) [ val integerValue];
+            AVPlayerItemStatus status = (AVPlayerItemStatus) [ val integerValue];
 
             switch (status)
             {

--- a/src/osx/cocoa/notifmsg.mm
+++ b/src/osx/cocoa/notifmsg.mm
@@ -31,6 +31,7 @@
 #endif // WX_PRECOMP
 
 #include "wx/osx/private.h"
+#include "wx/osx/private/available.h"
 #include "wx/generic/notifmsg.h"
 #include "wx/private/notifmsg.h"
 #include "wx/generic/private/notifmsg.h"
@@ -43,6 +44,7 @@
 #include "wx/utils.h"
 #include <map>
 
+WX_API_AVAILABLE_MACOS(10, 8)
 @interface wxUserNotificationHandler : NSObject <NSUserNotificationCenterDelegate>
 
 @end
@@ -51,7 +53,7 @@
 // wxUserNotificationMsgImpl
 // ----------------------------------------------------------------------------
 
-class wxUserNotificationMsgImpl : public wxNotificationMessageImpl
+class WX_API_AVAILABLE_MACOS(10, 8) wxUserNotificationMsgImpl : public wxNotificationMessageImpl
 {
 public:
     wxUserNotificationMsgImpl(wxNotificationMessageBase* notification) :
@@ -121,7 +123,7 @@ public:
     {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_9
         // Additional icon in the notification is only supported on OS X 10.9+
-        if ([NSUserNotification instancesRespondToSelector:@selector(setContentImage:)])
+        if ( WX_IS_MACOS_AVAILABLE(10, 9) )
             m_notif.contentImage = icon.GetNSImage();
 #endif
     }
@@ -247,7 +249,7 @@ void wxNotificationMessage::Init()
 {
     // Native notifications are not available prior to 10.8, fallback
     // to generic ones on 10.7
-    if (wxPlatformInfo::Get().CheckOSVersion(10, 8))
+    if ( WX_IS_MACOS_AVAILABLE(10, 8) )
         m_impl = new wxUserNotificationMsgImpl(this);
     else
         m_impl = new wxGenericNotificationMessageImpl(this);

--- a/src/osx/cocoa/power.mm
+++ b/src/osx/cocoa/power.mm
@@ -15,8 +15,8 @@
 
 #include "wx/power.h"
 #include "wx/atomic.h"
-#include "wx/platinfo.h"
 #include "wx/osx/private.h"
+#include "wx/osx/private/available.h"
 
 #include <IOKit/pwr_mgt/IOPMLib.h>
 
@@ -38,7 +38,7 @@ bool UpdatePowerResourceUsage(wxPowerResourceKind kind, const wxString& reason)
             cfreason = wxString("User Activity");
 
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_9
-        if ( wxPlatformInfo::Get().CheckOSVersion(10, 9) )
+        if ( WX_IS_MACOS_AVAILABLE(10, 9) )
         {
             // Use NSProcessInfo for 10.9 and newer
             if ( !g_processInfoActivity )
@@ -83,7 +83,7 @@ bool UpdatePowerResourceUsage(wxPowerResourceKind kind, const wxString& reason)
     {
         // Release power assertion
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_9
-        if ( wxPlatformInfo::Get().CheckOSVersion(10, 9) )
+        if ( WX_IS_MACOS_AVAILABLE(10, 9) )
         {
             // Use NSProcessInfo for 10.9 and newer
             if ( g_processInfoActivity )

--- a/src/osx/cocoa/settings.mm
+++ b/src/osx/cocoa/settings.mm
@@ -19,6 +19,7 @@
 
 #include "wx/osx/core/private.h"
 #include "wx/osx/cocoa/private.h"
+#include "wx/osx/private/available.h"
 
 #import <AppKit/NSColor.h>
 #import <Foundation/Foundation.h>
@@ -79,7 +80,7 @@ wxColour wxSystemSettingsNative::GetColour(wxSystemColour index)
         sysColor = [NSColor controlBackgroundColor];
         break;
     case wxSYS_COLOUR_BTNFACE:
-        if ( wxPlatformInfo::Get().CheckOSVersion(10, 14 ) )
+        if ( WX_IS_MACOS_AVAILABLE(10, 14 ) )
             sysColor = [NSColor windowBackgroundColor];
         else
             sysColor = [NSColor controlColor];

--- a/src/osx/cocoa/toolbar.mm
+++ b/src/osx/cocoa/toolbar.mm
@@ -19,6 +19,7 @@
 #include "wx/toolbar.h"
 #include "wx/app.h"
 #include "wx/osx/private.h"
+#include "wx/osx/private/available.h"
 #include "wx/geometry.h"
 #include "wx/sysopt.h"
 
@@ -1674,8 +1675,14 @@ void wxToolBar::OnPaint(wxPaintEvent& event)
         wxRect rect(0,0,w,h);
         
         //  TODO determine whether to use flat appearance in earlier system
-        if ( !wxPlatformInfo::Get().CheckOSVersion(10, 14 ) )
+        if ( WX_IS_MACOS_AVAILABLE(10, 14 ) )
+        {
+            // No gradient.
+        }
+        else
+        {
             dc.GradientFillLinear( rect , wxColour( 0xCC,0xCC,0xCC ), wxColour( 0xA8,0xA8,0xA8 ) , wxSOUTH );
+        }
         
         dc.SetPen( wxPen( wxColour( 0x51,0x51,0x51 ) ) );
         if ( HasFlag(wxTB_LEFT) )

--- a/src/osx/cocoa/utils.mm
+++ b/src/osx/cocoa/utils.mm
@@ -26,6 +26,7 @@
 #include "wx/apptrait.h"
 
 #include "wx/osx/private.h"
+#include "wx/osx/private/available.h"
 
 #if wxUSE_GUI
 #if wxOSX_USE_COCOA_OR_CARBON
@@ -349,7 +350,7 @@ void wxBell()
     ProcessSerialNumber psn = { 0, kCurrentProcess };
     TransformProcessType(&psn, kProcessTransformToForegroundApplication);
     
-    if ( wxPlatformInfo::Get().CheckOSVersion(10, 9) )
+    if ( WX_IS_MACOS_AVAILABLE(10, 9) )
     {
         [[NSRunningApplication currentApplication] activateWithOptions:
          (NSApplicationActivateAllWindows | NSApplicationActivateIgnoringOtherApps)];

--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -32,6 +32,13 @@
 wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
 {
 #ifdef wxHAS_NSPROCESSINFO
+    // Note: we don't use WX_IS_MACOS_AVAILABLE() here because these properties
+    // are only officially supported since 10.10, but are actually available
+    // under 10.9 too, so we prefer to check for them explicitly and suppress
+    // the warnings that using without a __builtin_available() check around
+    // them generates.
+    wxCLANG_WARNING_SUPPRESS(unguarded-availability)
+
     if ([NSProcessInfo instancesRespondToSelector:@selector(operatingSystemVersion)])
     {
         NSOperatingSystemVersion osVer = [NSProcessInfo processInfo].operatingSystemVersion;
@@ -45,6 +52,9 @@ wxOperatingSystemId wxGetOsVersion(int *verMaj, int *verMin, int *verMicro)
         if ( verMicro != NULL )
             *verMicro = osVer.patchVersion;
     }
+
+    wxCLANG_WARNING_RESTORE(unguarded-availability)
+
     else
 #endif
     {
@@ -79,6 +89,10 @@ wxGCC_WARNING_RESTORE()
 bool wxCheckOsVersion(int majorVsn, int minorVsn, int microVsn)
 {
 #ifdef wxHAS_NSPROCESSINFO
+    // As above, this API is effectively available earlier than its
+    // availability attribute indicates, so check for it manually.
+    wxCLANG_WARNING_SUPPRESS(unguarded-availability)
+
     if ([NSProcessInfo instancesRespondToSelector:@selector(isOperatingSystemAtLeastVersion:)])
     {
         NSOperatingSystemVersion osVer;
@@ -88,6 +102,9 @@ bool wxCheckOsVersion(int majorVsn, int minorVsn, int microVsn)
 
         return [[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:osVer] != NO;
     }
+
+    wxCLANG_WARNING_RESTORE(unguarded-availability)
+
     else
 #endif
     {

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -21,6 +21,7 @@
 
 #ifdef __WXMAC__
     #include "wx/osx/private.h"
+    #include "wx/osx/private/available.h"
 #endif
 
 #include "wx/evtloop.h"
@@ -1092,6 +1093,7 @@ void wxOSX_insertText(NSView* self, SEL _cmd, NSString* text)
 }
 
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_10
+WX_API_AVAILABLE_MACOS(10, 10)
 void wxOSX_panGestureEvent(NSView* self, SEL _cmd, NSPanGestureRecognizer* panGestureRecognizer)
 {
     wxWidgetCocoaImpl* impl = (wxWidgetCocoaImpl* ) wxWidgetImpl::FindFromWXWidget( self );
@@ -1101,6 +1103,7 @@ void wxOSX_panGestureEvent(NSView* self, SEL _cmd, NSPanGestureRecognizer* panGe
     impl->PanGestureEvent(panGestureRecognizer);
 }
 
+WX_API_AVAILABLE_MACOS(10, 10)
 void wxOSX_zoomGestureEvent(NSView* self, SEL _cmd, NSMagnificationGestureRecognizer* magnificationGestureRecognizer)
 {
     wxWidgetCocoaImpl* impl = (wxWidgetCocoaImpl* ) wxWidgetImpl::FindFromWXWidget( self );
@@ -1110,6 +1113,7 @@ void wxOSX_zoomGestureEvent(NSView* self, SEL _cmd, NSMagnificationGestureRecogn
     impl->ZoomGestureEvent(magnificationGestureRecognizer);
 }
 
+WX_API_AVAILABLE_MACOS(10, 10)
 void wxOSX_rotateGestureEvent(NSView* self, SEL _cmd, NSRotationGestureRecognizer* rotationGestureRecognizer)
 {
     wxWidgetCocoaImpl* impl = (wxWidgetCocoaImpl* ) wxWidgetImpl::FindFromWXWidget( self );
@@ -1119,6 +1123,7 @@ void wxOSX_rotateGestureEvent(NSView* self, SEL _cmd, NSRotationGestureRecognize
     impl->RotateGestureEvent(rotationGestureRecognizer);
 }
 
+WX_API_AVAILABLE_MACOS(10, 10)
 void wxOSX_longPressEvent(NSView* self, SEL _cmd, NSPressGestureRecognizer* pressGestureRecognizer)
 {
     wxWidgetCocoaImpl* impl = (wxWidgetCocoaImpl* ) wxWidgetImpl::FindFromWXWidget( self );
@@ -1128,6 +1133,7 @@ void wxOSX_longPressEvent(NSView* self, SEL _cmd, NSPressGestureRecognizer* pres
     impl->LongPressEvent(pressGestureRecognizer);
 }
 
+WX_API_AVAILABLE_MACOS(10, 10)
 void wxOSX_touchesBegan(NSView* self, SEL _cmd, NSEvent *event)
 {
     wxWidgetCocoaImpl* impl = (wxWidgetCocoaImpl* ) wxWidgetImpl::FindFromWXWidget( self );
@@ -1137,6 +1143,7 @@ void wxOSX_touchesBegan(NSView* self, SEL _cmd, NSEvent *event)
     impl->TouchesBegan(event);
 }
 
+WX_API_AVAILABLE_MACOS(10, 10)
 void wxOSX_touchesMoved(NSView* self, SEL _cmd, NSEvent *event)
 {
     wxWidgetCocoaImpl* impl = (wxWidgetCocoaImpl* ) wxWidgetImpl::FindFromWXWidget( self );
@@ -1146,6 +1153,7 @@ void wxOSX_touchesMoved(NSView* self, SEL _cmd, NSEvent *event)
     impl->TouchesMoved(event);
 }
 
+WX_API_AVAILABLE_MACOS(10, 10)
 void wxOSX_touchesEnded(NSView* self, SEL _cmd, NSEvent *event)
 {
     wxWidgetCocoaImpl* impl = (wxWidgetCocoaImpl* ) wxWidgetImpl::FindFromWXWidget( self );
@@ -1545,7 +1553,7 @@ void wxWidgetCocoaImpl::keyEvent(WX_NSEvent event, WXWidget slf, void *_cmd)
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_10
 
 // Class containing data used for gestures support.
-class wxCocoaGesturesImpl
+class WX_API_AVAILABLE_MACOS(10, 10) wxCocoaGesturesImpl
 {
 public:
     wxCocoaGesturesImpl(wxWidgetCocoaImpl* impl, NSView* view, int eventsMask)
@@ -1669,6 +1677,12 @@ private:
 // itself because most windows don't need it and it seems wasteful to
 // always increase their size unnecessarily.
 
+// wxCocoaGesturesImpl is only used under 10.10+ and so clang warns about
+// wxCocoaGesturesImplMap not having 10.10 availability attribute, but there is
+// no simple way to make it pass through the macro, so just suppress the
+// warning instead.
+wxCLANG_WARNING_SUPPRESS(unguarded-availability)
+
 #include "wx/hashmap.h"
 WX_DECLARE_HASH_MAP(wxWidgetCocoaImpl*, wxCocoaGesturesImpl*,
                     wxPointerHash, wxPointerEqual,
@@ -1678,6 +1692,8 @@ WX_DECLARE_HASH_MAP(wxWidgetCocoaImpl*, wxCocoaGesturesImpl*,
 typedef wxExternalField<wxWidgetCocoaImpl,
                         wxCocoaGesturesImpl,
                         wxCocoaGesturesImplMap> wxCocoaGestures;
+
+wxCLANG_WARNING_RESTORE(unguarded-availability)
 
 void wxWidgetCocoaImpl::PanGestureEvent(NSPanGestureRecognizer* panGestureRecognizer)
 {
@@ -2578,7 +2594,7 @@ void wxWidgetCocoaImpl::SetVisibility( bool visible )
     
     // trigger redraw upon shown for layer-backed views
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
-    if ( wxPlatformInfo::Get().CheckOSVersion(10, 14 ) )
+    if ( WX_IS_MACOS_AVAILABLE(10, 14 ) )
         if( !m_osxView.isHiddenOrHasHiddenAncestor )
             SetNeedsDisplay(NULL);
 #endif
@@ -3056,7 +3072,7 @@ void wxWidgetCocoaImpl::SetNeedsDisplay( const wxRect* where )
     // their children implicitly redrawn with the parent. For compatibility,
     // do it manually here:
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
-    if ( wxPlatformInfo::Get().CheckOSVersion(10, 14 ) )
+    if ( WX_IS_MACOS_AVAILABLE(10, 14 ) )
         SetSubviewsNeedDisplay(m_osxView);
 #endif
 }
@@ -3525,7 +3541,7 @@ void wxWidgetCocoaImpl::InstallEventHandler( WXWidget control )
 bool wxWidgetCocoaImpl::EnableTouchEvents(int eventsMask)
 {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_10
-    if ( wxPlatformInfo::Get().CheckOSVersion(10, 10) )
+    if ( WX_IS_MACOS_AVAILABLE(10, 10) )
     {
         if ( HasUserMouseHandling() )
         {

--- a/src/osx/core/colour.cpp
+++ b/src/osx/core/colour.cpp
@@ -17,6 +17,7 @@
 #endif
 
 #include "wx/osx/private.h"
+#include "wx/osx/private/available.h"
 
 CGColorSpaceRef wxMacGetGenericRGBColorSpace();
 
@@ -118,7 +119,7 @@ wxCGColorRefData::wxCGColorRefData(CGColorRef col)
     else if (model != kCGColorSpaceModelRGB)
     {
 #if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_11
-        if (wxPlatformInfo::Get().CheckOSVersion(10, 11))
+        if ( WX_IS_MACOS_AVAILABLE(10, 11) )
         {
             rgbacol = CGColorCreateCopyByMatchingToColorSpace(wxMacGetGenericRGBColorSpace(), kCGRenderingIntentDefault, col, NULL);
             noComp = CGColorGetNumberOfComponents(rgbacol);

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -2052,17 +2052,8 @@ bool wxWindowMac::MacHasScrollBarCorner() const
 {
 #if wxUSE_SCROLLBAR && !wxOSX_USE_IPHONE
     /* Returns whether the scroll bars in a wxScrolledWindow should be
-     * shortened. Scroll bars should be shortened if either:
-     *
-     * - both scroll bars are visible, or
-     *
-     * - there is a resize box in the parent frame's corner and this
-     *   window shares the bottom and right edge with the parent
-     *   frame.
+     * shortened, which happens only when both scroll bars are visible.
      */
-
-    if ( m_hScrollBar == NULL && m_vScrollBar == NULL )
-        return false;
 
     if ( ( m_hScrollBar && m_hScrollBar->IsShown() )
          && ( m_vScrollBar && m_vScrollBar->IsShown() ) )
@@ -2070,51 +2061,9 @@ bool wxWindowMac::MacHasScrollBarCorner() const
         // Both scroll bars visible
         return true;
     }
-    else
-    {
-        wxPoint thisWindowBottomRight = GetScreenRect().GetBottomRight();
-
-        for ( const wxWindow *win = (wxWindow*)this; win; win = win->GetParent() )
-        {
-            const wxFrame *frame = wxDynamicCast( win, wxFrame ) ;
-            if ( frame )
-            {
-                // starting from 10.7 there are no resize indicators anymore
-                if ( (frame->GetWindowStyleFlag() & wxRESIZE_BORDER) && !wxPlatformInfo::Get().CheckOSVersion(10, 7) )
-                {
-                    // Parent frame has resize handle
-                    wxPoint frameBottomRight = frame->GetScreenRect().GetBottomRight();
-
-                    // Note: allow for some wiggle room here as wxMac's
-                    // window rect calculations seem to be imprecise
-                    if ( abs( thisWindowBottomRight.x - frameBottomRight.x ) <= 2
-                        && abs( thisWindowBottomRight.y - frameBottomRight.y ) <= 2 )
-                    {
-                        // Parent frame has resize handle and shares
-                        // right bottom corner
-                        return true ;
-                    }
-                    else
-                    {
-                        // Parent frame has resize handle but doesn't
-                        // share right bottom corner
-                        return false ;
-                    }
-                }
-                else
-                {
-                    // Parent frame doesn't have resize handle
-                    return false ;
-                }
-            }
-        }
-
-        // No parent frame found
-        return false ;
-    }
-#else
-    return false;
 #endif
+
+    return false;
 }
 
 void wxWindowMac::MacCreateScrollBars( long style )


### PR DESCRIPTION
The most important commit is the last one, which adds `WX_IS_MACOS_AVAILABLE()` and replaces all the existing `wxPlatformInfo::Get().CheckOSVersion()` with it.

At least with Xcode 10 this results in a clean build even with `-Wunguarded-availability` turned on.