### PR TITLE
Update year in string returned by wxGetLibraryVersionInfo()

### DIFF
--- a/src/common/utilscmn.cpp
+++ b/src/common/utilscmn.cpp
@@ -1442,7 +1442,7 @@ wxVersionInfo wxGetLibraryVersionInfo()
                          wxMINOR_VERSION,
                          wxRELEASE_NUMBER,
                          msg,
-                         wxS("Copyright (c) 1995-2018 wxWidgets team"));
+                         wxS("Copyright (c) 1995-2019 wxWidgets team"));
 }
 
 void wxInfoMessageBox(wxWindow* parent)


### PR DESCRIPTION
Change years in the copyright information returned by wxGetLibraryVersionInfo() from "1995-2018" to "1995-2019".