### PR TITLE
Improve enter handling in both wxTextCtrl and wxComboBox on macOS

### DIFF
--- a/include/wx/osx/combobox.h
+++ b/include/wx/osx/combobox.h
@@ -131,6 +131,7 @@ protected:
     virtual void EnableTextChangedEvents(bool enable) wxOVERRIDE;
 
     // callbacks
+    void OnChar(wxKeyEvent& event); // Process 'enter' if required
     void OnKeyDown(wxKeyEvent& event); // Process clipboard shortcuts
 
     // the subcontrols

--- a/include/wx/osx/combobox.h
+++ b/include/wx/osx/combobox.h
@@ -130,11 +130,17 @@ protected:
 
     virtual void EnableTextChangedEvents(bool enable) wxOVERRIDE;
 
+    // callbacks
+    void OnKeyDown(wxKeyEvent& event); // Process clipboard shortcuts
+
     // the subcontrols
     wxComboBoxText*     m_text;
     wxComboBoxChoice*   m_choice;
 
     wxComboBoxDataArray m_datas;
+
+private:
+    wxDECLARE_EVENT_TABLE();
 };
 
 #endif // _WX_COMBOBOX_H_

--- a/samples/minimal/minimal.cpp
+++ b/samples/minimal/minimal.cpp
@@ -85,8 +85,15 @@ enum
     // it is important for the id corresponding to the "About" command to have
     // this standard value as otherwise it won't be handled properly under Mac
     // (where it is special and put into the "Apple" menu)
-    Minimal_About = wxID_ABOUT
+    Minimal_About = wxID_ABOUT,
 };
+
+namespace {
+    int idTextCtrl1 = wxNewId();
+    int idTextCtrl2 = wxNewId();
+    int idComboCtrl1 = wxNewId();
+    int idComboCtrl2 = wxNewId();
+}
 
 // ----------------------------------------------------------------------------
 // event tables and other macros for wxWidgets
@@ -140,6 +147,56 @@ bool MyApp::OnInit()
 // main frame
 // ----------------------------------------------------------------------------
 
+class TestDialog : public wxDialog
+{
+public:
+    TestDialog(wxWindow* parent) : wxDialog(parent, wxID_ANY, "Test")
+    {
+        wxTextCtrl* tc1 = new wxTextCtrl(this, idTextCtrl1, "12345678", wxDefaultPosition, wxDefaultSize, 0);
+        wxTextCtrl* tc2 = new wxTextCtrl(this, idTextCtrl2, "ABCDEFGH", wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+        wxComboBox* cb1 = new wxComboBox(this, idComboCtrl1, "12345678", wxDefaultPosition, wxDefaultSize, 0);
+        wxComboBox* cb2 = new wxComboBox(this, idComboCtrl2, "12345678", wxDefaultPosition, wxDefaultSize, 0, NULL, wxTE_PROCESS_ENTER);
+        wxButton* btn1 = new wxButton(this, wxID_OK, "OK");
+        btn1->SetDefault();
+        wxButton* btn2 = new wxButton(this, wxID_CANCEL, "Cancel");
+
+        wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
+        sizer->Add(tc1, 1, wxEXPAND | wxALL, 10);
+        sizer->Add(tc2, 1, wxEXPAND | wxALL, 10);
+        sizer->Add(cb1, 1, wxEXPAND | wxALL, 10);
+        sizer->Add(cb2, 1, wxEXPAND | wxALL, 10);
+        sizer->Add(btn1, 1, wxEXPAND | wxALL, 10);
+        sizer->Add(btn2, 1, wxEXPAND | wxALL, 10);
+        SetSizerAndFit(sizer);
+
+        Connect(idTextCtrl2, wxEVT_TEXT_ENTER, wxTextEventHandler(TestDialog::OnTextEnter));
+        Connect(idComboCtrl2, wxEVT_TEXT_ENTER, wxTextEventHandler(TestDialog::OnTextEnter));
+
+        Connect(idTextCtrl1, wxEVT_CHAR, wxKeyEventHandler(TestDialog::OnChar));
+        Connect(idTextCtrl2, wxEVT_CHAR, wxKeyEventHandler(TestDialog::OnChar));
+        Connect(idComboCtrl1, wxEVT_CHAR, wxKeyEventHandler(TestDialog::OnChar));
+        Connect(idComboCtrl2, wxEVT_CHAR, wxKeyEventHandler(TestDialog::OnChar));
+    }
+
+    virtual ~TestDialog() {}
+    
+    void OnTextEnter(wxCommandEvent &event)
+    {
+        wxMessageBox("This is text Enter");
+    }
+    
+    void OnChar(wxKeyEvent &event)
+    {
+        printf("TestDialog::OnChar: %d\n", event.GetKeyCode());
+    }
+    
+    void EndModal(int retCode) wxOVERRIDE
+    {
+        wxDialog::EndModal(retCode);
+    }
+
+};
+
 // frame constructor
 MyFrame::MyFrame(const wxString& title)
        : wxFrame(NULL, wxID_ANY, title)
@@ -178,6 +235,9 @@ MyFrame::MyFrame(const wxString& title)
     CreateStatusBar(2);
     SetStatusText("Welcome to wxWidgets!");
 #endif // wxUSE_STATUSBAR
+
+    TestDialog dlg(this);
+    dlg.ShowModal();
 }
 
 
@@ -191,6 +251,10 @@ void MyFrame::OnQuit(wxCommandEvent& WXUNUSED(event))
 
 void MyFrame::OnAbout(wxCommandEvent& WXUNUSED(event))
 {
+    TestDialog dlg(this);
+    dlg.ShowModal();
+    return;
+
     wxMessageBox(wxString::Format
                  (
                     "Welcome to %s!\n"

--- a/src/osx/cocoa/combobox.mm
+++ b/src/osx/cocoa/combobox.mm
@@ -158,6 +158,44 @@
         }
     }
 }
+
+
+- (BOOL)control:(NSControl*)control textView:(NSTextView*)textView doCommandBySelector:(SEL)commandSelector
+{
+    wxUnusedVar(textView);
+    wxUnusedVar(control);
+    
+    BOOL handled = NO;
+
+    // send back key events wx' common code knows how to handle
+    
+    wxWidgetCocoaImpl* impl = (wxWidgetCocoaImpl* ) wxWidgetImpl::FindFromWXWidget( self );
+    if ( impl  )
+    {
+        wxWindow* wxpeer = (wxWindow*) impl->GetWXPeer();
+        if ( wxpeer )
+        {
+            if (commandSelector == @selector(insertNewline:))
+            {
+                [textView insertNewlineIgnoringFieldEditor:self];
+                handled = YES;
+            }
+            else if ( commandSelector == @selector(insertTab:))
+            {
+                [textView insertTabIgnoringFieldEditor:self];
+                handled = YES;
+            }
+            else if ( commandSelector == @selector(insertBacktab:))
+            {
+                [textView insertTabIgnoringFieldEditor:self];
+                handled = YES;
+            }
+        }
+    }
+
+    return handled;
+}
+
 @end
 
 wxNSComboBoxControl::wxNSComboBoxControl( wxComboBox *wxPeer, WXWidget w )

--- a/src/osx/combobox_osx.cpp
+++ b/src/osx/combobox_osx.cpp
@@ -18,6 +18,12 @@
 #ifndef WX_PRECOMP
 #endif
 
+typedef wxWindowWithItems<wxControl, wxComboBoxBase> RealwxComboBoxBase;
+
+wxBEGIN_EVENT_TABLE(wxComboBox, RealwxComboBoxBase)
+    EVT_KEY_DOWN(wxComboBox::OnKeyDown)
+wxEND_EVENT_TABLE()
+
 // work in progress
 
 wxComboBox::~wxComboBox()
@@ -232,6 +238,35 @@ void wxComboBox::Popup()
 void wxComboBox::Dismiss()
 {
     GetComboPeer()->Dismiss();
+}
+
+void wxComboBox::OnKeyDown(wxKeyEvent& event)
+{
+    if (event.GetModifiers() == wxMOD_CONTROL)
+    {
+        switch(event.GetKeyCode())
+        {
+            case 'A':
+                SelectAll();
+                return;
+            case 'C':
+                if (CanCopy())
+                    Copy();
+                return;
+            case 'V':
+                if (CanPaste())
+                    Paste();
+                return;
+            case 'X':
+                if (CanCut())
+                    Cut();
+                return;
+            default:
+                break;
+        }
+    }
+    // no, we didn't process it
+    event.Skip();
 }
 
 #endif // wxUSE_COMBOBOX && wxOSX_USE_COCOA

--- a/src/osx/combobox_osx.cpp
+++ b/src/osx/combobox_osx.cpp
@@ -16,11 +16,14 @@
 #include "wx/osx/private.h"
 
 #ifndef WX_PRECOMP
+    #include "wx/button.h"
+    #include "wx/toplevel.h"
 #endif
 
 typedef wxWindowWithItems<wxControl, wxComboBoxBase> RealwxComboBoxBase;
 
 wxBEGIN_EVENT_TABLE(wxComboBox, RealwxComboBoxBase)
+    EVT_CHAR(wxComboBox::OnChar)
     EVT_KEY_DOWN(wxComboBox::OnKeyDown)
 wxEND_EVENT_TABLE()
 
@@ -238,6 +241,52 @@ void wxComboBox::Popup()
 void wxComboBox::Dismiss()
 {
     GetComboPeer()->Dismiss();
+}
+
+void wxComboBox::OnChar(wxKeyEvent& event)
+{
+    const int key = event.GetKeyCode();
+    bool eat_key = false;
+
+    switch (key)
+    {
+        case WXK_RETURN:
+        case WXK_NUMPAD_ENTER:
+            if (m_windowStyle & wxTE_PROCESS_ENTER)
+            {
+                wxCommandEvent event(wxEVT_TEXT_ENTER, m_windowId);
+                event.SetEventObject(this);
+                event.SetString(GetValue());
+                if (HandleWindowEvent(event))
+                    return;
+            }
+            else
+            {
+                wxTopLevelWindow *tlw = wxDynamicCast(wxGetTopLevelParent(this), wxTopLevelWindow);
+                if (tlw && tlw->GetDefaultItem())
+                {
+                    wxButton *def = wxDynamicCast(tlw->GetDefaultItem(), wxButton);
+                    if (def && def->IsEnabled())
+                    {
+                        wxCommandEvent event(wxEVT_BUTTON, def->GetId());
+                        event.SetEventObject(def);
+                        def->Command(event);
+                        return;
+                    }
+                }
+
+                // this will make wxWidgets eat the ENTER key so that
+                // we actually prevent line wrapping in a single line text control
+                eat_key = true;
+            }
+            break;
+    }
+
+    if (!eat_key)
+    {
+        // perform keystroke handling
+        event.Skip(true);
+    }
 }
 
 void wxComboBox::OnKeyDown(wxKeyEvent& event)

--- a/src/osx/textctrl_osx.cpp
+++ b/src/osx/textctrl_osx.cpp
@@ -412,9 +412,10 @@ void wxTextCtrl::OnChar(wxKeyEvent& event)
                 event.SetString( GetValue() );
                 if ( HandleWindowEvent(event) )
                     return;
+                // If we don't eat the key a space character is appended to the text control.
+                eat_key = true;
             }
-
-            if ( !(m_windowStyle & wxTE_MULTILINE) )
+            else if ( !(m_windowStyle & wxTE_MULTILINE) )
             {
                 wxTopLevelWindow *tlw = wxDynamicCast(wxGetTopLevelParent(this), wxTopLevelWindow);
                 if ( tlw && tlw->GetDefaultItem() )


### PR DESCRIPTION
This pull request is an attempt to fix the problems depicted in https://trac.wxwidgets.org/ticket/18273
The issue that is still opened, but has worse description is here: https://trac.wxwidgets.org/ticket/15680

I've also implemented some useful key shortcuts for wxComboBox which were missing (ctrl-a, ctrl-c/x/v).

The last commit is just temporary way to experiment with the modified text and combo controls. It must not be pushed.

There is a lot of code duplication, I'd be happy if someone can suggest where to place it, so it could be common for both wxTextCtrl and wxComboBox.