### PR TITLE
Remove unused wxUSE_COMCTL32_SAFELY from documentation

### DIFF
--- a/docs/doxygen/mainpages/const_wxusedef.h
+++ b/docs/doxygen/mainpages/const_wxusedef.h
@@ -318,7 +318,6 @@ library:
 @itemdef{wxUSE_ACCESSIBILITY, Enable accessibility support}
 @itemdef{wxUSE_ACTIVEX, Use wxActiveXContainer and related classes.}
 @itemdef{wxUSE_COMBOCTRL_POPUP_ANIMATION, See wx/msw/combo.h file.}
-@itemdef{wxUSE_COMCTL32_SAFELY, See src/msw/treectrl.cpp file.}
 @itemdef{wxUSE_COMMON_DIALOGS, Enable use of windows common dialogs from header commdlg.h; example PRINTDLG.}
 @itemdef{wxUSE_CRASHREPORT, Use wxCrashReport class.}
 @itemdef{wxUSE_DATEPICKCTRL_GENERIC, Use generic wxDatePickerCtrl implementation in addition to the native one.}


### PR DESCRIPTION
In addition to the commit, I also wonder if `wxUSE_DBGHELP` should not be moved from Generic to wxMSW section. It seems to be used only in wxMSW, being _dbghelp.dll_ wrapper....