### PR TITLE
Add wxFileDialog::GetCurrentlySelectedFilterIndex() and wxEVT_UPDATE_UI event notification when the selected file type filter changes

### DIFF
--- a/include/wx/filedlg.h
+++ b/include/wx/filedlg.h
@@ -114,6 +114,9 @@ public:
     virtual wxString GetCurrentlySelectedFilename() const
         { return m_currentlySelectedFilename; }
 
+    virtual int GetCurrentlySelectedFilterIndex () const
+        { return m_currentlySelectedFilterIndex; }
+
     // this function is called with wxFileDialog as parameter and should
     // create the window containing the extra controls we want to show in it
     typedef wxWindow *(*ExtraControlCreatorFunction)(wxWindow*);
@@ -152,6 +155,12 @@ protected:
     // the platform-specific code to provide a useful implementation of
     // GetCurrentlySelectedFilename().
     wxString      m_currentlySelectedFilename;
+
+    // Currently selected, but not yet necessarily accepted by the user, file type / filter index.
+    // This should be updated whenever the selection in the control changes by
+    // the platform-specific code to provide a useful implementation of
+    // GetCurrentlySelectedFilterIndex().
+    int m_currentlySelectedFilterIndex;
 
     wxWindow*     m_extraControl;
 

--- a/include/wx/msw/filedlg.h
+++ b/include/wx/msw/filedlg.h
@@ -44,6 +44,9 @@ public:
     // called from the hook procedure on CDN_SELCHANGE.
     void MSWOnSelChange(WXHWND hDlg);
 
+    // called from the hook procedure on CDN_TYPECHANGE.
+    void MSWOnTypeChange(WXHWND hDlg, int nFilterIndex);
+
 protected:
 
     virtual void DoMoveWindow(int x, int y, int width, int height) wxOVERRIDE;

--- a/interface/wx/filedlg.h
+++ b/interface/wx/filedlg.h
@@ -211,6 +211,28 @@ public:
     virtual wxString GetCurrentlySelectedFilename() const;
 
     /**
+        Returns the file type filter index currently selected in dialog.
+
+        Notice that this file type filter is not necessarily going to be the one finally accepted by the
+        user, so calling this function mostly makes sense from an update UI
+        event handler of a custom file dialog extra control to update its state
+        depending on the currently selected file type filter.
+
+        Currently this function is fully implemented under MSW only and
+        returns an undefined value elsewhere.
+
+        @since 3.1.3
+
+        @return The 0-based index of the currently selected file type filter or wxNOT_FOUND if
+            nothing is selected.
+
+        @see SetExtraControlCreator()
+        @see GetFilterIndex()
+        @see SetFilterIndex()
+    */
+    virtual int GetCurrentlySelectedFilterIndex () const;
+
+    /**
         Returns the default directory.
     */
     virtual wxString GetDirectory() const;


### PR DESCRIPTION
Add wxFileDialog::GetCurrentlySelectedFilterIndex() and wxEVT_UPDATE_UI event notification when the selected file type filter changes

Added method wxFileDialog::GetCurrentlySelectedFilterIndex().
This method returns the 0-based file type filter currently selected in a file dialog, analogously to GetCurrentlySelectedFilename() does for the current file.
Only supported in MSW. The value returned is always undefined elsewhere.

Added a wxEVT_UPDATE_UI event notification when the selection of the file type filter changes.
This allows extra file dialog controls to adjust their state depending on the file type filter currently selected.
Only supported in MSW.
