### PR TITLE
Fix the issue with a last DVC column width on Mac

### DIFF
--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2564,8 +2564,7 @@ void wxCocoaDataViewControl::SetRowHeight(const wxDataViewItem& WXUNUSED(item), 
 
 void wxCocoaDataViewControl::OnSize()
 {
-    if ([m_OutlineView numberOfColumns] == 1)
-        [m_OutlineView sizeLastColumnToFit];
+    [m_OutlineView sizeLastColumnToFit];
 }
 
 //


### PR DESCRIPTION
In Cocoa implementation of `wxDataViewControl`: call
`sizeLastColumnToFit` function of `NSTableView` in `OnSize` handler
(for any amount of columns, previously this function was called only
for a singe colunm DVCs).

`sizeLastColumnToFit` resizes the last column so the table view fits
exactly within its enclosing clip view.

This behavior is equivalent to `gtk` and `MSW` realizations.