### PR TITLE
CMake: Fix the include directories for the builtin libraries

### DIFF
--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -466,6 +466,12 @@ function(wx_set_builtin_target_properties target_name)
         )
     endif()
 
+    target_include_directories(${target_name}
+        BEFORE
+        PUBLIC
+            ${wxSETUP_HEADER_PATH}
+        )
+
     set_target_properties(${target_name} PROPERTIES FOLDER "Third Party Libraries")
 
     wx_set_common_target_properties(${target_name} DEFAULT_WARNINGS)


### PR DESCRIPTION
Without this fix, when building with built-in libraries, I get an error "'wx/setup.h' file not found".

Below is a description of my build system and steps to reproduce.

Build system: macOS Mojave 10.14, Xcode 10.2, CMake 3.8.0.

Commands:
```
mkdir @_build
cd @_build

cmake .. \
    -DCMAKE_VERBOSE_MAKEFILE=ON \
    -DCMAKE_BUILD_TYPE=Release \
    -DBUILD_SHARED_LIBS=ON \
    -DCMAKE_GENERATOR="Xcode" \
    -DCMAKE_CONFIGURATION_TYPES=Release \
    -DwxUSE_EXPAT=builtin \

cmake --build . --config Release -- -jobs 4
```

Output:
```
=== BUILD TARGET wxexpat OF PROJECT wxWidgets WITH CONFIGURATION Release ===

Check dependencies

Write auxiliary files
/bin/mkdir -p /Volumes/macOS_Work/work/projects/Feographia/LibCMaker/LibCMaker_wxWidgets/samples/TestCompileWithwxWidgets/build/download/unpacked/wxWidgets-3.1.2.20190503/LibCMaker_wxWidgets_Sources-3.1.2.20190503/@_build/libs/wxWidgets.build/Release/wxexpat.build/Objects-normal/x86_64
write-file /Volumes/macOS_Work/work/projects/Feographia/LibCMaker/LibCMaker_wxWidgets/samples/TestCompileWithwxWidgets/build/download/unpacked/wxWidgets-3.1.2.20190503/LibCMaker_wxWidgets_Sources-3.1.2.20190503/@_build/libs/wxWidgets.build/Release/wxexpat.build/Objects-normal/x86_64/wxexpat-3.1.LinkFileList

CompileC @_build/libs/wxWidgets.build/Release/wxexpat.build/Objects-normal/x86_64/xmlrole.o src/expat/expat/lib/xmlrole.c normal x86_64 c com.apple.compilers.llvm.clang.1_0.compiler
    cd /Volumes/macOS_Work/work/projects/Feographia/LibCMaker/LibCMaker_wxWidgets/samples/TestCompileWithwxWidgets/build/download/unpacked/wxWidgets-3.1.2.20190503/LibCMaker_wxWidgets_Sources-3.1.2.20190503
    export LANG=en_US.US-ASCII
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c -arch x86_64 -fmessage-length=224 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit=0 -fcolor-diagnostics -Wno-trigraphs -fpascal-strings -O3 -Wno-missing-field-initializers -Wno-missing-prototypes -Wno-return-type -Wno-missing-braces -Wparentheses -Wswitch -Wno-unused-function -Wno-unused-label -Wno-unused-parameter -Wno-unused-variable -Wunused-value -Wno-empty-body -Wno-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wno-constant-conversion -Wno-int-conversion -Wno-bool-conversion -Wno-enum-conversion -Wno-float-conversion -Wno-non-literal-null-conversion -Wno-objc-literal-conversion -Wno-shorten-64-to-32 -Wpointer-sign -Wno-newline-eof -DCMAKE_INTDIR=\"Release\" -D_UNICODE -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk -fasm-blocks -fstrict-aliasing -Wdeprecated-declarations -mmacosx-version-min=10.9 -Wno-sign-conversion -Wno-infinite-recursion -Wno-comma -Wno-block-capture-autoreleasing -Wno-strict-prototypes -Wno-semicolon-before-method-body -I/Volumes/macOS_Work/work/projects/Feographia/LibCMaker/LibCMaker_wxWidgets/samples/TestCompileWithwxWidgets/build/download/unpacked/wxWidgets-3.1.2.20190503/LibCMaker_wxWidgets_Sources-3.1.2.20190503/@_build/lib/Release/include -I/Volumes/macOS_Work/work/projects/Feographia/LibCMaker/LibCMaker_wxWidgets/samples/TestCompileWithwxWidgets/build/download/unpacked/wxWidgets-3.1.2.20190503/LibCMaker_wxWidgets_Sources-3.1.2.20190503/@_build/libs/wxWidgets.build/Release/wxexpat.build/DerivedSources-normal/x86_64 -I/Volumes/macOS_Work/work/projects/Feographia/LibCMaker/LibCMaker_wxWidgets/samples/TestCompileWithwxWidgets/build/download/unpacked/wxWidgets-3.1.2.20190503/LibCMaker_wxWidgets_Sources-3.1.2.20190503/@_build/libs/wxWidgets.build/Release/wxexpat.build/DerivedSources/x86_64 -I/Volumes/macOS_Work/work/projects/Feographia/LibCMaker/LibCMaker_wxWidgets/samples/TestCompileWithwxWidgets/build/download/unpacked/wxWidgets-3.1.2.20190503/LibCMaker_wxWidgets_Sources-3.1.2.20190503/@_build/libs/wxWidgets.build/Release/wxexpat.build/DerivedSources -Wmost -Wno-four-char-constants -Wno-unknown-pragmas -F/Volumes/macOS_Work/work/projects/Feographia/LibCMaker/LibCMaker_wxWidgets/samples/TestCompileWithwxWidgets/build/download/unpacked/wxWidgets-3.1.2.20190503/LibCMaker_wxWidgets_Sources-3.1.2.20190503/@_build/lib/Release -DNDEBUG -fPIC -pthread -MMD -MT dependencies -MF /Volumes/macOS_Work/work/projects/Feographia/LibCMaker/LibCMaker_wxWidgets/samples/TestCompileWithwxWidgets/build/download/unpacked/wxWidgets-3.1.2.20190503/LibCMaker_wxWidgets_Sources-3.1.2.20190503/@_build/libs/wxWidgets.build/Release/wxexpat.build/Objects-normal/x86_64/xmlrole.d --serialize-diagnostics /Volumes/macOS_Work/work/projects/Feographia/LibCMaker/LibCMaker_wxWidgets/samples/TestCompileWithwxWidgets/build/download/unpacked/wxWidgets-3.1.2.20190503/LibCMaker_wxWidgets_Sources-3.1.2.20190503/@_build/libs/wxWidgets.build/Release/wxexpat.build/Objects-normal/x86_64/xmlrole.dia -c /Volumes/macOS_Work/work/projects/Feographia/LibCMaker/LibCMaker_wxWidgets/samples/TestCompileWithwxWidgets/build/download/unpacked/wxWidgets-3.1.2.20190503/LibCMaker_wxWidgets_Sources-3.1.2.20190503/src/expat/expat/lib/xmlrole.c -o /Volumes/macOS_Work/work/projects/Feographia/LibCMaker/LibCMaker_wxWidgets/samples/TestCompileWithwxWidgets/build/download/unpacked/wxWidgets-3.1.2.20190503/LibCMaker_wxWidgets_Sources-3.1.2.20190503/@_build/libs/wxWidgets.build/Release/wxexpat.build/Objects-normal/x86_64/xmlrole.o
In file included from /Volumes/macOS_Work/work/projects/Feographia/LibCMaker/LibCMaker_wxWidgets/samples/TestCompileWithwxWidgets/build/download/unpacked/wxWidgets-3.1.2.20190503/LibCMaker_wxWidgets_Sources-3.1.2.20190503/src/expat/expat/lib/xmlrole.c:38:
/Volumes/macOS_Work/work/projects/Feographia/LibCMaker/LibCMaker_wxWidgets/samples/TestCompileWithwxWidgets/build/download/unpacked/wxWidgets-3.1.2.20190503/LibCMaker_wxWidgets_Sources-3.1.2.20190503/src/expat/expat/lib/macconfig.h:15:10: fatal error: 
      'wx/setup.h' file not found
#include "wx/setup.h"
         ^~~~~~~~~~~~
1 error generated.
```
