### PR TITLE
Fix occassionally failing FormatMessage call

### DIFF
--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -1066,7 +1066,8 @@ static const wxChar* GetSysErrorMsg(wxChar* szBuf, size_t sizeBuf, unsigned long
     LPVOID lpMsgBuf;
     if ( ::FormatMessage
          (
-            FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
+            FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+            FORMAT_MESSAGE_IGNORE_INSERTS,
             NULL,
             nErrCode,
             MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -1075,9 +1075,11 @@ static const wxChar* GetSysErrorMsg(wxChar* szBuf, size_t sizeBuf, unsigned long
             NULL
          ) == 0 )
     {
+        wxLogDebug(wxS("FormatMessage failed with error 0x%lx in %s"),
+            GetLastError(), __WXFUNCTION__ ? __WXFUNCTION__ : "");
         // if this happens, something is seriously wrong, so don't use _() here
         // for safety
-        wxSprintf(szBuf, wxS("unknown error %lx"), nErrCode);
+        wxSprintf(szBuf, wxS("unknown error 0x%lx"), nErrCode);
         return szBuf;
     }
 


### PR DESCRIPTION
The FormatMessage call in `GetSysErrorMsg()` will fail if the error message contains inserts, and therefore FormatMessage should be called with the `FORMAT_MESSAGE_IGNORE_INSERTS` flag.

To reproduce, simply call e.g. `wxSysErrorMsgStr(193)` on MSW.
