### PR TITLE
Paint over larger part of MSW buttons with custom background

### DIFF
--- a/src/msw/anybutton.cpp
+++ b/src/msw/anybutton.cpp
@@ -1156,31 +1156,16 @@ void DrawXPBackground(wxAnyButton *button, HDC hdc, RECT& rectBtn, UINT state)
     ::GetThemeMargins(theme, hdc, BP_PUSHBUTTON, iState,
                             TMT_CONTENTMARGINS, &rectBtn, &margins);
     ::InflateRect(&rectBtn, -margins.cxLeftWidth, -margins.cyTopHeight);
-    ::InflateRect(&rectBtn, -XP_BUTTON_EXTRA_MARGIN, -XP_BUTTON_EXTRA_MARGIN);
 
     if ( button->UseBgCol() && iState != PBS_HOT )
     {
         COLORREF colBg = wxColourToRGB(button->GetBackgroundColour());
         AutoHBRUSH hbrushBackground(colBg);
 
-        // don't overwrite the focus rect
-        RECT rectClient;
-        ::CopyRect(&rectClient, &rectBtn);
-        ::InflateRect(&rectClient, -1, -1);
-
-        if ( wxGetWinVersion() >= wxWinVersion_10 )
-        {
-            // buttons have flat appearance so we can fully color them
-            // even outside the "safe" rectangle
-            SelectInHDC brush(hdc, hbrushBackground);
-            COLORREF colTheme = GetPixel(hdc, rectClient.left, rectClient.top);
-            ExtFloodFill(hdc, rectClient.left, rectClient.top, colTheme, FLOODFILLSURFACE);
-        }
-        else
-        {
-            FillRect(hdc, &rectClient, hbrushBackground);
-        }
+        FillRect(hdc, &rectBtn, hbrushBackground);
     }
+
+    ::InflateRect(&rectBtn, -XP_BUTTON_EXTRA_MARGIN, -XP_BUTTON_EXTRA_MARGIN);
 }
 #endif // wxUSE_UXTHEME
 


### PR DESCRIPTION
Don't use ExtFloodFill() to extend the custom background colour to the
edges as this results in weird problems due to an apparent bug in nVidia
drivers, see #18387.

Instead, just extend the rectangle passed to FillRect(), which doesn't
look quite as good under Windows 10, but is pretty close, and shouldn't
suffer from the nVidia bug while also slightly improving appearance
under Windows 7.