### PR TITLE
BUG FIX[macOS] - Flush did not update image associated with context

### DIFF
--- a/src/osx/carbon/graphics.cpp
+++ b/src/osx/carbon/graphics.cpp
@@ -2601,6 +2601,13 @@ public:
         m_image = m_bitmap.ConvertToImage();
     }
 
+
+    virtual void Flush() wxOVERRIDE
+    {
+      wxMacCoreGraphicsContext::Flush();
+      m_image = m_bitmap.ConvertToImage();
+    }
+
 private:
     wxImage& m_image;
     wxBitmap m_bitmap;


### PR DESCRIPTION
Only the internally used bitmap got updated by Flush() but not the associated image.