### PR TITLE
Remove last remnants of Windows CE related code

### DIFF
--- a/include/wx/msw/msvcrt.h
+++ b/include/wx/msw/msvcrt.h
@@ -22,8 +22,7 @@
 // use debug CRT functions for memory leak detections in VC++ 5.0+ in debug
 // builds
 #undef wxUSE_VC_CRTDBG
-#if defined(_DEBUG) && defined(__VISUALC__) \
-    && !defined(UNDER_CE)
+#if defined(_DEBUG) && defined(__VISUALC__)
     // it doesn't combine well with wxWin own memory debugging methods
     #if !wxUSE_GLOBAL_MEMORY_OPERATORS && !wxUSE_MEMORY_TRACING && !defined(__NO_VC_CRTDBG__)
         #define wxUSE_VC_CRTDBG

--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -3380,7 +3380,6 @@ SettingsDialog::SettingsDialog(wxWindow* win, SettingsData& settingsData, int di
     int tabImage2 = -1;
 
     bool useToolBook = (dialogType == DIALOGS_PROPERTY_SHEET_TOOLBOOK || dialogType == DIALOGS_PROPERTY_SHEET_BUTTONTOOLBOOK);
-    int resizeBorder = wxRESIZE_BORDER;
 
     if (useToolBook)
     {
@@ -3415,13 +3414,11 @@ SettingsDialog::SettingsDialog(wxWindow* win, SettingsData& settingsData, int di
         m_imageList = NULL;
 
     Create(win, wxID_ANY, "Preferences", wxDefaultPosition, wxDefaultSize,
-        wxDEFAULT_DIALOG_STYLE| (int)wxPlatform::IfNot(wxOS_WINDOWS_CE, resizeBorder)
-    );
+        wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
 
     // If using a toolbook, also follow Mac style and don't create buttons
     if (!useToolBook)
-        CreateButtons(wxOK | wxCANCEL |
-                        (int)wxPlatform::IfNot(wxOS_WINDOWS_CE, wxHELP)
+        CreateButtons(wxOK | wxCANCEL | wxHELP);
     );
 
     wxBookCtrlBase* notebook = GetBookCtrl();

--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -3380,11 +3380,9 @@ SettingsDialog::SettingsDialog(wxWindow* win, SettingsData& settingsData, int di
     int tabImage2 = -1;
 
     bool useToolBook = (dialogType == DIALOGS_PROPERTY_SHEET_TOOLBOOK || dialogType == DIALOGS_PROPERTY_SHEET_BUTTONTOOLBOOK);
-    int resizeBorder = wxRESIZE_BORDER;
 
     if (useToolBook)
     {
-        resizeBorder = 0;
         tabImage1 = 0;
         tabImage2 = 1;
 
@@ -3415,14 +3413,11 @@ SettingsDialog::SettingsDialog(wxWindow* win, SettingsData& settingsData, int di
         m_imageList = NULL;
 
     Create(win, wxID_ANY, "Preferences", wxDefaultPosition, wxDefaultSize,
-        wxDEFAULT_DIALOG_STYLE| (int)wxPlatform::IfNot(wxOS_WINDOWS_CE, resizeBorder)
-    );
+        wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
 
     // If using a toolbook, also follow Mac style and don't create buttons
     if (!useToolBook)
-        CreateButtons(wxOK | wxCANCEL |
-                        (int)wxPlatform::IfNot(wxOS_WINDOWS_CE, wxHELP)
-    );
+        CreateButtons(wxOK | wxCANCEL | wxHELP);
 
     wxBookCtrlBase* notebook = GetBookCtrl();
     notebook->SetImageList(m_imageList);

--- a/src/richtext/richtextformatdlg.cpp
+++ b/src/richtext/richtextformatdlg.cpp
@@ -120,13 +120,9 @@ bool wxRichTextFormattingDialog::Create(long flags, wxWindow* parent, const wxSt
     SetWindowVariant(wxWINDOW_VARIANT_SMALL);
 #endif
 
-    int resizeBorder = wxRESIZE_BORDER;
-
     GetFormattingDialogFactory()->SetSheetStyle(this);
 
-    wxPropertySheetDialog::Create(parent, id, title, pos, sz,
-        style | (int)wxPlatform::IfNot(wxOS_WINDOWS_CE, resizeBorder)
-    );
+    wxPropertySheetDialog::Create(parent, id, title, pos, sz, style | wxRESIZE_BORDER);
 
     GetFormattingDialogFactory()->CreateButtons(this);
     GetFormattingDialogFactory()->CreatePages(flags, this);


### PR DESCRIPTION
Speaking of legacy platforms: there are also checks for  `wxSYS_SCREEN_PDA` scattered through the codebase. They do no harm but I wonder if there is still a supported platform with horizontal resolution < 640 pixels?

**EDIT:** Sorry for messing up the commits. The first commit had some compile errors and when trying to fix it I lost the battle with GIT as I usually do. Hopefully if the PR is accepted the commits can be somehow merged to not mess up wxWidgets commit history as well.