### PR TITLE
Fix show a tips bug on Windows.

### DIFF
--- a/src/stc/ScintillaWX.cpp
+++ b/src/stc/ScintillaWX.cpp
@@ -428,7 +428,7 @@ bool ScintillaWX::ModifyScrollBars(int nMax, int nPage) {
         int sbMax    = stc->GetScrollRange(wxHORIZONTAL);
         int sbThumb  = stc->GetScrollThumb(wxHORIZONTAL);
         int sbPos    = stc->GetScrollPos(wxHORIZONTAL);
-        if ((sbMax != horizEnd) || (sbThumb != pageWidth) || (sbPos != 0)) {
+        if ((!Wrapping() && sbMax != horizEnd) || (sbThumb != pageWidth) || (sbPos != 0)) {
             stc->SetScrollbar(wxHORIZONTAL, sbPos, pageWidth, horizEnd);
             modified = true;
             if (scrollWidth < pageWidth) {


### PR DESCRIPTION
In Windows I wanna show a tips,and find a bug in wrapping mode. My tips starts in wxEVT_STC_DWELLSTART and ends in wxEVT_STC_DWELLEND . When receive the event wxEVT_STC_DWELLSTART. The horizontal scroll bar is always modified in wrapping mode. And receives wxEVT_STC_DWELLEND immediately. Because horizEnd is always 0,and sbMax is always 1. There is no problem in non-wrapping mode.