### PR TITLE
Improve checks in ScintillaWX::ModifyScrollBars

### DIFF
--- a/src/stc/ScintillaWX.cpp
+++ b/src/stc/ScintillaWX.cpp
@@ -392,7 +392,7 @@ bool ScintillaWX::ModifyScrollBars(int nMax, int nPage) {
 
     int vertEnd = nMax+1;
     if (!verticalScrollBarVisible)
-        vertEnd = 0;
+        nPage = vertEnd + 1;
 
     // Check the vertical scrollbar
     if (stc->m_vScrollBar == NULL) {  // Use built-in scrollbar
@@ -420,15 +420,15 @@ bool ScintillaWX::ModifyScrollBars(int nMax, int nPage) {
     int horizEnd = scrollWidth;
     if (horizEnd < 0)
         horizEnd = 0;
+    int pageWidth = static_cast<int>(rcText.Width());
     if (!horizontalScrollBarVisible || Wrapping())
-        horizEnd = 0;
-    int pageWidth = wxRound(rcText.Width());
+        pageWidth = horizEnd + 1;
 
     if (stc->m_hScrollBar == NULL) {  // Use built-in scrollbar
         int sbMax    = stc->GetScrollRange(wxHORIZONTAL);
         int sbThumb  = stc->GetScrollThumb(wxHORIZONTAL);
         int sbPos    = stc->GetScrollPos(wxHORIZONTAL);
-        if ((sbMax != horizEnd) || (sbThumb != pageWidth) || (sbPos != 0)) {
+        if ((sbMax != horizEnd) || (sbThumb != pageWidth)) {
             stc->SetScrollbar(wxHORIZONTAL, sbPos, pageWidth, horizEnd);
             modified = true;
             if (scrollWidth < pageWidth) {
@@ -440,7 +440,7 @@ bool ScintillaWX::ModifyScrollBars(int nMax, int nPage) {
         int sbMax    = stc->m_hScrollBar->GetRange();
         int sbThumb  = stc->m_hScrollBar->GetPageSize();
         int sbPos    = stc->m_hScrollBar->GetThumbPosition();
-        if ((sbMax != horizEnd) || (sbThumb != pageWidth) || (sbPos != 0)) {
+        if ((sbMax != horizEnd) || (sbThumb != pageWidth)) {
             stc->m_hScrollBar->SetScrollbar(sbPos, pageWidth, horizEnd, pageWidth);
             modified = true;
             if (scrollWidth < pageWidth) {


### PR DESCRIPTION
It was requested that I make a new pull request based on the discussion in #1326.  Although there are only a few changes made in this pull request, it’s really hard to explain what these changes do and why they’re being made.  I’ll try to be as brief and clear as possible. 

In short, the ScintillaWX::ModifyScrollBars method is supposed to ensure that the horizontal and vertical scrollbars have the correct max and page size, update them if they do not, and return true when updating to signal that additional processing is needed.

However it currently updates the scrollbars and returns true in some cases when it should not. This led to the problem reported in #1326 because one of the addition processing steps returning true causes is to generate a dwell end event.

There seem be 2 cases where it tries to update the scrollbars when not needed. 

The first is if a scrollbar is hidden. In this case, ModifyScrollBars tries to set the scrollbar’s max to 0. However on windows, this call fails and the max is set to 1 instead. Consequently on subsequent calls to ModifyScrollBars, it thinks the max should be 0, sees that the max is currently 1, and tries to set the max to 0 again. That process repeats over and over again. To solve this, I looked at how this case is handled in the ModifyScrollBars from Scintilla’s platform layer for windows. Most of the code for ScintillaWX::ModifyScrollBars seems to be based on that code. There, instead of trying to set the max to 0, it tries to set the page size to 1 more than the max. 

The second case is only for the horizontal scrollbar. Currently ModifyScrollBars checks if the position is not 0 and updates if not. I couldn’t figure out the reason for this check, and ultimately I don’t think it should be done. If you apply the patch for the minimal sample I posted in #1326, the same issue appears when the horizontal scrollbar is positioned anywhere but 0. And the issue disappears when I take out this check.