### PR TITLE
Fix assert in virtual wxListCtrl when OnGetItemIsChecked is not implemented

### DIFF
--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -1681,7 +1681,11 @@ void wxListMainWindow::CacheLineData(size_t line)
         ld->SetImage(col, listctrl->OnGetItemColumnImage(line, col));
     }
 
-    ld->Check(listctrl->OnGetItemIsChecked(line));
+    if ( HasCheckBoxes() )
+    {
+        ld->Check(listctrl->OnGetItemIsChecked(line));
+    }
+
     ld->SetAttr(listctrl->OnGetItemAttr(line));
 }
 


### PR DESCRIPTION
This is only require when checkboxes are enabled.
See [#18393](https://trac.wxwidgets.org/ticket/18393).