### PR TITLE
Fix to make sure that the qt close button flags reflect the wx style

### DIFF
--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -173,6 +173,10 @@ void wxFrame::SetWindowStyleFlag( long style )
     {
         qtFlags |= Qt::WindowCloseButtonHint;
     }
+    else
+    {
+        qtFlags &= ~Qt::WindowCloseButtonHint;
+    }
 
     if ( HasFlag(wxNO_BORDER) )
     {


### PR DESCRIPTION
Fix to make sure that the qt close button flags reflect the wx style flag passed in