### PR TITLE
Add a missing semicolon in few declaration macros in documentation

### DIFF
--- a/docs/doxygen/overviews/eventhandling.h
+++ b/docs/doxygen/overviews/eventhandling.h
@@ -101,7 +101,7 @@ return information is passed via the argument, which is why it is non-const).
 You also need to insert a macro
 
 @code
-wxDECLARE_EVENT_TABLE()
+wxDECLARE_EVENT_TABLE();
 @endcode
 
 somewhere in the class declaration. It doesn't matter where it appears but
@@ -132,7 +132,7 @@ private:
     // obligation to do that; this one is an event handler too:
     void DoTest(wxCommandEvent& event);
 
-    wxDECLARE_EVENT_TABLE()
+    wxDECLARE_EVENT_TABLE();
 };
 @endcode
 

--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -4799,7 +4799,7 @@ wxEventType wxNewEventType();
 
     This is mostly used by wxWidgets internally, e.g.
     @code
-    wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_BUTTON, wxCommandEvent)
+    wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_BUTTON, wxCommandEvent);
     @endcode
  */
 #define wxDECLARE_EXPORTED_EVENT( expdecl, name, cls ) \


### PR DESCRIPTION
Add a semicolon where missing to the code examples using wxDECLARE_EVENT_TABLE() and wxDECLARE_EXPORTED_EVENT macros.

See https://trac.wxwidgets.org/ticket/18408