### PR TITLE
Note about logical function on wxGCDC

### DIFF
--- a/interface/wx/graphics.h
+++ b/interface/wx/graphics.h
@@ -391,6 +391,8 @@ public:
     results visible you need to update the content of the context
     by calling wxGraphicsContext::Flush() or by destroying the context.
 
+    @remarks Logical functions does not work with wxGraphicsContext.
+
     @library{wxcore}
     @category{gdi,dc}
 


### PR DESCRIPTION
Ticket says that we should deprecate them.
But at least we will document that they do not work with wxGraphiocsContext.