### PR TITLE
[Qt] Fixed issue with windows docking incorrectly. Also implemented a hint for where the window will dock.

### DIFF
--- a/include/wx/qt/frame.h
+++ b/include/wx/qt/frame.h
@@ -55,7 +55,9 @@ public:
     virtual QScrollArea *QtGetScrollBarsContainer() const wxOVERRIDE;
 
 protected:
+    virtual void Adopt(wxWindow *child) wxOVERRIDE;
     virtual void DoGetClientSize(int *width, int *height) const wxOVERRIDE;
+    virtual void DoSetClientSize(int width, int height) wxOVERRIDE;
 
 private:
     // Common part of all ctors.

--- a/include/wx/qt/frame.h
+++ b/include/wx/qt/frame.h
@@ -55,9 +55,9 @@ public:
     virtual QScrollArea *QtGetScrollBarsContainer() const wxOVERRIDE;
 
 protected:
-    virtual void Adopt(wxWindow *child) wxOVERRIDE;
-    virtual void DoGetClientSize(int *width, int *height) const wxOVERRIDE;
-    virtual void DoSetClientSize(int width, int height) wxOVERRIDE;
+    virtual void Adopt( wxWindow *child ) wxOVERRIDE;
+    virtual void DoGetClientSize( int *width, int *height ) const wxOVERRIDE;
+    virtual void DoSetClientSize( int width, int height ) wxOVERRIDE;
 
 private:
     // Common part of all ctors.

--- a/include/wx/qt/window.h
+++ b/include/wx/qt/window.h
@@ -178,6 +178,7 @@ public:
 #endif // wxUSE_TOOLTIPS
 
 protected:
+    virtual void Adopt(wxWindow *child);
     virtual void DoGetTextExtent(const wxString& string,
                                  int *x, int *y,
                                  int *descent = NULL,

--- a/include/wx/qt/window.h
+++ b/include/wx/qt/window.h
@@ -178,7 +178,7 @@ public:
 #endif // wxUSE_TOOLTIPS
 
 protected:
-    virtual void Adopt(wxWindow *child);
+    virtual void Adopt( wxWindow *child );
     virtual void DoGetTextExtent(const wxString& string,
                                  int *x, int *y,
                                  int *descent = NULL,

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -848,7 +848,7 @@ void wxAuiManager::UpdateHintWindowConfig()
     if ((m_flags & wxAUI_MGR_TRANSPARENT_HINT) && can_do_transparent)
     {
         // Make a window to use for a transparent hint
-        #if defined(__WXMSW__) || defined(__WXGTK__)
+        #if defined(__WXMSW__) || defined(__WXGTK__) || defined(__WXQT__)
             m_hintWnd = new wxFrame(m_frame, wxID_ANY, wxEmptyString,
                                      wxDefaultPosition, wxSize(1,1),
                                          wxFRAME_TOOL_WINDOW |

--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -196,9 +196,9 @@ void wxFrame::AddChild( wxWindowBase *child )
     wxFrameBase::AddChild( child );
 }
 
-void wxFrame::Adopt(wxWindow *child)
+void wxFrame::Adopt( wxWindow *child )
 {
-    QtReparent(child->GetHandle(), GetQMainWindow()->centralWidget());
+    QtReparent( child->GetHandle(), GetQMainWindow()->centralWidget() );
 }
 
 void wxFrame::RemoveChild( wxWindowBase *child )
@@ -231,16 +231,16 @@ void wxFrame::DoGetClientSize(int *width, int *height) const
     }
 }
 
-void wxFrame::DoSetClientSize(int width, int height)
+void wxFrame::DoSetClientSize( int width, int height )
 {
-    wxWindow::DoSetClientSize(width, height);
+    wxWindow::DoSetClientSize( width, height );
 
     int adjustedWidth, adjustedHeight;
-    DoGetClientSize(&adjustedWidth, &adjustedHeight);
+    DoGetClientSize( &adjustedWidth, &adjustedHeight );
 
     QWidget *centralWidget = GetQMainWindow()->centralWidget();
     QRect geometry = centralWidget->geometry();
-    geometry.setSize(QSize(adjustedWidth, adjustedHeight));
+    geometry.setSize( QSize(adjustedWidth, adjustedHeight) );
     centralWidget->setGeometry(geometry);
 }
 

--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -196,6 +196,11 @@ void wxFrame::AddChild( wxWindowBase *child )
     wxFrameBase::AddChild( child );
 }
 
+void wxFrame::Adopt(wxWindow *child)
+{
+    QtReparent(child->GetHandle(), GetQMainWindow()->centralWidget());
+}
+
 void wxFrame::RemoveChild( wxWindowBase *child )
 {
     wxFrameBase::RemoveChild( child );
@@ -224,6 +229,19 @@ void wxFrame::DoGetClientSize(int *width, int *height) const
             *height -= qmb->geometry().height();
         }
     }
+}
+
+void wxFrame::DoSetClientSize(int width, int height)
+{
+    wxWindow::DoSetClientSize(width, height);
+
+    int adjustedWidth, adjustedHeight;
+    DoGetClientSize(&adjustedWidth, &adjustedHeight);
+
+    QWidget *centralWidget = GetQMainWindow()->centralWidget();
+    QRect geometry = centralWidget->geometry();
+    geometry.setSize(QSize(adjustedWidth, adjustedHeight));
+    centralWidget->setGeometry(geometry);
 }
 
 QMainWindow *wxFrame::GetQMainWindow() const

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -436,10 +436,13 @@ bool wxWindowQt::Reparent( wxWindowBase *parent )
 {
     if ( !wxWindowBase::Reparent( parent ))
         return false;
-
-    QtReparent( GetHandle(), parent->GetHandle() );
-
+    wxDynamicCast(parent, wxWindow)->Adopt(this);
     return true;
+}
+
+void wxWindowQt::Adopt(wxWindow *child)
+{
+    QtReparent(child->GetHandle(), GetHandle());
 }
 
 

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -436,13 +436,13 @@ bool wxWindowQt::Reparent( wxWindowBase *parent )
 {
     if ( !wxWindowBase::Reparent( parent ))
         return false;
-    wxDynamicCast(parent, wxWindow)->Adopt(this);
+    wxDynamicCast( parent, wxWindow )->Adopt( this );
     return true;
 }
 
-void wxWindowQt::Adopt(wxWindow *child)
+void wxWindowQt::Adopt( wxWindow *child )
 {
-    QtReparent(child->GetHandle(), GetHandle());
+    QtReparent( child->GetHandle(), GetHandle() );
 }
 
 


### PR DESCRIPTION
1 - The change in `framemanager.cpp`  now provides a hint of where the drop target is for a floating window. The sizing of this is slightly off, and we are currently investigating that.
 
2 - The floating window when docked will now be the correct size. Previously it was docking itself to the `QMainWindow` resulting in the wrong size. We actually want it to dock to the `Central Widget` (see this  [link](https://doc.qt.io/qt-5/qmainwindow.html#qt-main-window-framework) ).