### PR TITLE
Support Wrap for wxStaticText under wxQT

### DIFF
--- a/include/wx/qt/stattext.h
+++ b/include/wx/qt/stattext.h
@@ -30,11 +30,11 @@ public:
                 long style = 0,
                 const wxString &name = wxStaticTextNameStr );
 
-    virtual void SetLabel(const wxString& label) wxOVERRIDE;
     virtual wxString GetLabel() const wxOVERRIDE;
-
     virtual QWidget *GetHandle() const wxOVERRIDE;
 
+protected:
+    virtual void DoSetLabel(const wxString& label) wxOVERRIDE;
 private:
     QLabel *m_qtLabel;
 

--- a/src/qt/stattext.cpp
+++ b/src/qt/stattext.cpp
@@ -58,11 +58,6 @@ bool wxStaticText::Create(wxWindow *parent,
     return QtCreateControl( parent, id, pos, size, style, wxDefaultValidator, name );
 }
 
-void wxStaticText::SetLabel(const wxString& label)
-{
-    m_qtLabel->setText( wxQtConvertString( label ) );
-}
-
 wxString wxStaticText::GetLabel() const
 {
     return wxQtConvertString( m_qtLabel->text() );
@@ -71,4 +66,9 @@ wxString wxStaticText::GetLabel() const
 QWidget *wxStaticText::GetHandle() const
 {
     return m_qtLabel;
+}
+
+void wxStaticText::DoSetLabel(const wxString& label)
+{
+    m_qtLabel->setText(wxQtConvertString(label));
 }


### PR DESCRIPTION
Implementing SetLabel was preventing wx from being able to pre-process the label string.  Using DoSetLabel ensures that the string given to the QLabel has been processed.