### PR TITLE
Give warnings for using "x = y" as condition inside wxASSERT

### DIFF
--- a/include/wx/debug.h
+++ b/include/wx/debug.h
@@ -282,7 +282,10 @@ extern WXDLLIMPEXP_BASE void wxOnAssert(const char *file,
     // the need for the ugly global flag.
     #define wxASSERT_MSG_AT(cond, msg, file, line, func)                      \
         wxSTATEMENT_MACRO_BEGIN                                               \
-            if ( wxTheAssertHandler && !(cond) &&                             \
+            if ( cond )                                                       \
+            {                                                                 \
+            }                                                                 \
+            else if ( wxTheAssertHandler &&                                   \
                     (wxOnAssert(file, line, func, #cond, msg),                \
                      wxTrapInAssert) )                                        \
             {                                                                 \


### PR DESCRIPTION
Using "!(cond)" inside wxASSERT macro expansion prevented both gcc and
clang (although not MSVC) from giving -Wparentheses warnings if the
assignment operator was accidentally used instead of the equality
comparison operator.

Change the macro definition to use the condition directly, without
negating it, to let gcc/clang give the warning if appropriate.