### PR TITLE
Handle some mouse events explicitly when a wxQtScrollArea is set as mouse captured.

### DIFF
--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -59,14 +59,35 @@ wxQtWidget::wxQtWidget( wxWindowQt *parent, wxWindowQt *handler )
 
 class wxQtScrollArea : public wxQtEventSignalHandler< QScrollArea, wxWindowQt >
 {
-
-    public:
-        wxQtScrollArea( wxWindowQt *parent, wxWindowQt *handler );
-};
+public:
+    wxQtScrollArea(wxWindowQt *parent, wxWindowQt *handler);
+    bool event(QEvent *e) wxOVERRIDE;
+}; 
 
 wxQtScrollArea::wxQtScrollArea( wxWindowQt *parent, wxWindowQt *handler )
     : wxQtEventSignalHandler< QScrollArea, wxWindowQt >( parent, handler )
 {
+}
+
+bool wxQtScrollArea::event(QEvent *e)
+{
+    wxWindowQt* handler = GetHandler();
+    if (handler && handler->HasCapture())
+    {
+        switch (e->type())
+        {
+            case QEvent::MouseButtonRelease:
+            case QEvent::MouseButtonDblClick:
+            case QEvent::MouseMove:
+            case QEvent::Wheel:
+            case QEvent::TouchUpdate:
+            case QEvent::TouchEnd:
+                return viewportEvent(e);
+            default:
+                break;
+        }
+    }
+    return QScrollArea::event(e);
 }
 
 class wxQtInternalScrollBar : public wxQtEventSignalHandler< QScrollBar, wxWindowQt >

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -72,9 +72,9 @@ wxQtScrollArea::wxQtScrollArea( wxWindowQt *parent, wxWindowQt *handler )
 bool wxQtScrollArea::event(QEvent *e)
 {
     wxWindowQt* handler = GetHandler();
-    if (handler && handler->HasCapture())
+    if ( handler && handler->HasCapture() )
     {
-        switch (e->type())
+        switch ( e->type() )
         {
             case QEvent::MouseButtonRelease:
             case QEvent::MouseButtonDblClick:


### PR DESCRIPTION
The issue arises in that the QScrollArea has two methods: event() and viewportEvent(). Normally a "QAbstractScrollAreaFilter" is set up by Qt which routes any events to the viewportEvent() method. And the normal event() method throws mouse events away (for reasons I'm not aware of - but it is what it is). If a wx window with a scroll area (e.g. RichTextCtrl) sets capture, the wxQtScrollArea (QScroll-derived) gets set as the direct "mouse grabber", and all events then bypass the filter and are sent directly to the "event" method, which throws them away. The typical result is that the window setting capture no longer gets mouse events, it keeps capture since it's looking for a mouse up that never comes, and the app more or less locks up since all mouse events are being effectively discarded.

This change catches any event that comes in via the event() method and, when the mouse is captured by the widget, forwards it on to the viewportEvent method instead, performing what the filter would do via the normal event routing.

It doesn't forward on "mouse press" events because the initial event that causes the capture ends up being fed back again, resulting in a "captured twice" error. The underlying reason I can see for this "being fed back again" is that, for some inexplicable reason, the RichTextCtrl "skips" the event even though it has actually processed it and taken capture. That means this solution isn't 100%, but it does fix the 99%+ cases where the capture is only gotten to redirect mouse moves and button ups.

Somehow, this seems like a bug in Qt, but I couldn't find any mention of it in Google searchs. Maybe nobody has ever set a QScrollArea as the "mouse grabber".