### PR TITLE
Fix DoMoveWindow to take into account the frame extent.

### DIFF
--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -953,11 +953,17 @@ void wxWindowQt::DoSetClientSize(int width, int height)
 void wxWindowQt::DoMoveWindow(int x, int y, int width, int height)
 {
     QWidget *qtWidget = GetHandle();
+    qtWidget->move(x, y);
 
-    qtWidget->move( x, y );
-    qtWidget->resize( width, height );
+    const QSize frameSize = qtWidget->frameSize();
+    const QSize innerSize = qtWidget->geometry().size();
+    const QSize frameSizeDiff = frameSize - innerSize;
+
+    const int client_width = std::max(width - frameSizeDiff.width(), 0);
+    const int client_height = std::max(height - frameSizeDiff.height(), 0);
+
+    qtWidget->resize(client_width, client_height);
 }
-
 
 #if wxUSE_TOOLTIPS
 void wxWindowQt::QtApplyToolTip(const wxString& text)


### PR DESCRIPTION
Using "move" is correct for positioning, as it takes into account the frame extent. Unfortunately, there is no corresponding API to set the frame size. So we need to compute the effective client size and use "resize".
We can't use "setGeometry" for this purpose, since a Widget's "geometry" excludes the frame size. We would need to adjust the position to go from frame to client coordinates. It's more straightforward to simply have Qt do it with "move".
This change corrects and supersedes the previous pending pull request 1227, which has been closed. (That "fix" caused windows which were closed and re-opened to march up the screen.)