### PR TITLE
[Qt] Ensure that wxListCtrl::HitTest finds correct index under qt

### DIFF
--- a/samples/listctrl/listtest.cpp
+++ b/samples/listctrl/listtest.cpp
@@ -1515,7 +1515,8 @@ void MyListCtrl::OnContextMenu(wxContextMenuEvent& event)
         {
             point = ScreenToClient(point);
         }
-        ShowContextMenu(point);
+        int flags;
+        ShowContextMenu(point, HitTest(point, flags));
     }
     else
     {
@@ -1527,10 +1528,12 @@ void MyListCtrl::OnContextMenu(wxContextMenuEvent& event)
 }
 #endif
 
-void MyListCtrl::ShowContextMenu(const wxPoint& pos)
+void MyListCtrl::ShowContextMenu(const wxPoint& pos, long item)
 {
     wxMenu menu;
-
+    wxString itemNumber;
+    itemNumber.Printf("Item %ld", item);
+    menu.Append(wxID_ANY, itemNumber);
     menu.Append(wxID_ABOUT, "&About");
     menu.AppendSeparator();
     menu.Append(wxID_EXIT, "E&xit");

--- a/samples/listctrl/listtest.h
+++ b/samples/listctrl/listtest.h
@@ -78,7 +78,7 @@ public:
     virtual bool IsItemChecked(long item) const wxOVERRIDE;
 
 private:
-    void ShowContextMenu(const wxPoint& pos);
+    void ShowContextMenu(const wxPoint& pos, long item);
     wxLog *m_logOld;
     void SetColumnImage(int col, int image);
 

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -141,6 +141,11 @@ public:
         return m_editorFactory.GetEditControl();
     }
 
+    int GetHeaderHeight() const
+    {
+        return header() != NULL ? header()->height() : 0;
+    }
+
 private:
     void itemClicked(QTreeWidgetItem * item, int column);
     void itemActivated(QTreeWidgetItem * item, int column);
@@ -595,7 +600,7 @@ bool wxListCtrl::GetItemRect(long item, wxRect& rect, int WXUNUSED(code)) const
     if ( qitem != NULL )
     {
         rect = wxQtConvertRect( m_qtTreeWidget->visualItemRect(qitem) );
-        rect.Offset(0, m_qtTreeWidget->header()->height());
+        rect.Offset(0, m_qtTreeWidget->GetHeaderHeight());
         return true;
     }
     else
@@ -613,7 +618,7 @@ bool wxListCtrl::GetSubItemRect(long item, long subItem, wxRect& rect, int WXUNU
                      wxT("invalid column index in GetSubItemRect") );
         QModelIndex qindex = m_qtTreeWidget->model()->index(item, subItem);
         rect = wxQtConvertRect( m_qtTreeWidget->visualRect(qindex) );
-        rect.Offset(0, m_qtTreeWidget->header()->height());
+        rect.Offset(0, m_qtTreeWidget->GetHeaderHeight());
         return true;
     }
     else
@@ -914,7 +919,7 @@ long wxListCtrl::HitTest(const wxPoint& point, int &flags, long* ptrSubItem) con
 {
     // Remove the header height as qt expects point relative to the table sub widget
     QPoint qPoint = wxQtConvertPoint(point);
-    qPoint.setY(qPoint.y() - m_qtTreeWidget->header()->height());
+    qPoint.setY(qPoint.y() - m_qtTreeWidget->GetHeaderHeight());
 
     QModelIndex index = m_qtTreeWidget->indexAt(qPoint);
     if ( index.isValid() )

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -595,6 +595,7 @@ bool wxListCtrl::GetItemRect(long item, wxRect& rect, int WXUNUSED(code)) const
     if ( qitem != NULL )
     {
         rect = wxQtConvertRect( m_qtTreeWidget->visualItemRect(qitem) );
+        rect.Offset(0, m_qtTreeWidget->header()->height());
         return true;
     }
     else
@@ -612,6 +613,7 @@ bool wxListCtrl::GetSubItemRect(long item, long subItem, wxRect& rect, int WXUNU
                      wxT("invalid column index in GetSubItemRect") );
         QModelIndex qindex = m_qtTreeWidget->model()->index(item, subItem);
         rect = wxQtConvertRect( m_qtTreeWidget->visualRect(qindex) );
+        rect.Offset(0, m_qtTreeWidget->header()->height());
         return true;
     }
     else

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -910,7 +910,11 @@ long wxListCtrl::FindItem(long WXUNUSED(start), const wxPoint& WXUNUSED(pt), int
 
 long wxListCtrl::HitTest(const wxPoint& point, int &flags, long* ptrSubItem) const
 {
-    QModelIndex index = m_qtTreeWidget->indexAt(wxQtConvertPoint(point));
+    // Remove the header height as qt expects point relative to the table sub widget
+    QPoint qPoint = wxQtConvertPoint(point);
+    qPoint.setY(qPoint.y() - m_qtTreeWidget->header()->height());
+
+    QModelIndex index = m_qtTreeWidget->indexAt(qPoint);
     if ( index.isValid() )
     {
         flags = wxLIST_HITTEST_ONITEM;


### PR DESCRIPTION
Discovered that HitTest was not returning the correct index for positions relative to the wxListCtrl, as the underlying qt indexAt function expected the position to be relative to the sub widget that contains the actual items, which excludes the column headers.

I've added a report of the item index that was hit when an item is right clicked to the listctrl sample to demonstrate the issue.