### PR TITLE
[Qt] Ensure that mouse position for wxMouseEvent is relative to the window raising it

### DIFF
--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -1388,7 +1388,14 @@ bool wxWindowQt::QtHandleMouseEvent ( QWidget *handler, QMouseEvent *event )
     }
 
     // Fill the event - convert screen position to the window's coordinates
-    const wxPoint mousePos = ScreenToClient(wxQtConvertPoint(event->globalPos()));
+    wxPoint mousePos = ScreenToClient(wxQtConvertPoint(event->globalPos()));
+
+    // Correct the mouse position if we have a caption
+    if (HasFlag(wxCAPTION))
+    {
+        mousePos.y -= wxSystemSettingsNative::GetMetric(wxSYS_CAPTION_Y);
+    }
+
     wxMouseEvent e( wxType );
     e.SetEventObject(this);
     e.m_clickCount = -1;

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -1387,12 +1387,12 @@ bool wxWindowQt::QtHandleMouseEvent ( QWidget *handler, QMouseEvent *event )
             wxFAIL_MSG( "Unknown mouse event type" );
     }
 
-    // Fill the event
-    QPoint mousePos = event->pos();
+    // Fill the event - convert screen position to the window's coordinates
+    const wxPoint mousePos = ScreenToClient(wxQtConvertPoint(event->globalPos()));
     wxMouseEvent e( wxType );
     e.SetEventObject(this);
     e.m_clickCount = -1;
-    e.SetPosition( wxQtConvertPoint( mousePos ) );
+    e.SetPosition(mousePos);
 
     // Mouse buttons
     wxQtFillMouseButtons( event->buttons(), &e );
@@ -1404,8 +1404,8 @@ bool wxWindowQt::QtHandleMouseEvent ( QWidget *handler, QMouseEvent *event )
 
     // Determine if mouse is inside the widget
     bool mouseInside = true;
-    if ( mousePos.x() < 0 || mousePos.x() > handler->width() ||
-        mousePos.y() < 0 || mousePos.y() > handler->height() )
+    if ( mousePos.x < 0 || mousePos.x > handler->width() ||
+        mousePos.y < 0 || mousePos.y > handler->height() )
         mouseInside = false;
 
     if ( e.GetEventType() == wxEVT_MOTION )

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -33,6 +33,7 @@
 #include "wx/window.h"
 #include "wx/dnd.h"
 #include "wx/tooltip.h"
+#include "wx/settings.h"
 #include "wx/qt/private/utils.h"
 #include "wx/qt/private/converter.h"
 #include "wx/qt/private/winevent.h"


### PR DESCRIPTION
Discovered that mouse position received in wxMouseEvents was incorrect if the event was raised by a sub-widget within qt wrappers (as is the case for wxListCtrl). The mouse position was relative to the sub-widget that wx has no knowledge of. We can instead convert the original screen position to the client space of the current window when creating the wx event.