### PR TITLE
[Qt] Ensure that position for wxContextMenuEvent matches standard wx behavior

### DIFF
--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -1497,9 +1497,9 @@ bool wxWindowQt::QtHandleContextMenuEvent ( QWidget *WXUNUSED( handler ), QConte
 {
     wxContextMenuEvent e( wxEVT_CONTEXT_MENU, GetId() );
     e.SetPosition(
-        event->reason() != QContextMenuEvent::Keyboard ?
-        wxQtConvertPoint( event->globalPos() ) :
-        wxDefaultPosition
+        event->reason() == QContextMenuEvent::Keyboard ?
+        wxDefaultPosition :
+        wxQtConvertPoint( event->globalPos() )
     );
     e.SetEventObject(this);
 

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -1496,7 +1496,11 @@ bool wxWindowQt::QtHandleCloseEvent ( QWidget *handler, QCloseEvent *WXUNUSED( e
 bool wxWindowQt::QtHandleContextMenuEvent ( QWidget *WXUNUSED( handler ), QContextMenuEvent *event )
 {
     wxContextMenuEvent e( wxEVT_CONTEXT_MENU, GetId() );
-    e.SetPosition( wxQtConvertPoint( event->globalPos() ) );
+    e.SetPosition(
+        event->reason() != QContextMenuEvent::Keyboard ?
+        wxQtConvertPoint( event->globalPos() ) :
+        wxDefaultPosition
+    );
     e.SetEventObject(this);
 
     return ProcessWindowEvent( e );


### PR DESCRIPTION
While it is generally a good thing that Qt is able to generate the position for context menu events triggered by the keyboard, there are some occasions where it is incorrect. One example is in the wxListCtrl where it doesn't account for the header and gives the screen position above the actual selected item. Since there is already code that expects an invalid position it would be simpler to revert to the default position when dealing with keyboard events.