### PR TITLE
No longer return fixed values from wxGauge::DoGetBestSize under wxGTK

### DIFF
--- a/include/wx/gtk/gauge.h
+++ b/include/wx/gtk/gauge.h
@@ -65,8 +65,6 @@ protected:
     // set the gauge value to the value of m_gaugePos
     void DoSetGauge();
 
-    virtual wxSize DoGetBestSize() const wxOVERRIDE;
-
 private:
     void Init() { m_rangeMax = m_gaugePos = 0; }
 

--- a/src/gtk/gauge.cpp
+++ b/src/gtk/gauge.cpp
@@ -70,16 +70,6 @@ void wxGauge::DoSetGauge()
                                    m_rangeMax ? ((double)m_gaugePos)/m_rangeMax : 0.0);
 }
 
-wxSize wxGauge::DoGetBestSize() const
-{
-    wxSize best;
-    if (HasFlag(wxGA_VERTICAL))
-        best = wxSize(28, 100);
-    else
-        best = wxSize(100, 28);
-    return best;
-}
-
 void wxGauge::SetRange( int range )
 {
     m_rangeMax = range;


### PR DESCRIPTION
Under wxGTK, wxGauge was returning fixed values for height and width.
This meant that the gauge would not center correctly in a sizer,
particularly under GTK+ 3 where the default gauge height is just a
few pixels.

Following this change, wxGauge renders correctly on GTK+ 3 and
matches the reference widget display in the gtk3-widget-factory app.

Note, this change will also result in a slimmer widget on GTK+ 2,
but the gauge height can be forced using wxGauge::SetMinSize() on
the older toolkit.

The gauge presentation is totally theme dependent under GTK+ 3.
For example, the user can have thicker gauges by setting the
following in their ~/.config/gtk-3.0/gtk.css file:

progress, trough {
  min-height: 20px;
}

This has been tested on Ubuntu 19.04 under both GTK+ 2 and GTK+ 3 and the default set of themes shipped with the standard distribution.