### PR TITLE
[OSX] wxGLCanvas resize fix on macOS 10.14.5

### DIFF
--- a/src/osx/cocoa/glcanvas.mm
+++ b/src/osx/cocoa/glcanvas.mm
@@ -151,6 +151,7 @@ WXGLPixelFormat WXGLChoosePixelFormat(const int *GLAttrs,
 
 - (void) update
 {
+    // Empty impl fixes wrong resize on macOS 10.14.5
 }
 
 @end

--- a/src/osx/cocoa/glcanvas.mm
+++ b/src/osx/cocoa/glcanvas.mm
@@ -149,6 +149,10 @@ WXGLPixelFormat WXGLChoosePixelFormat(const int *GLAttrs,
         impl->doCommandBySelector(aSelector, self, _cmd);
 }
 
+- (void) update
+{
+}
+
 @end
 
 bool wxGLCanvas::DoCreate(wxWindow *parent,


### PR DESCRIPTION
Related ticket: https://trac.wxwidgets.org/ticket/18402

I honestly can't explain why this works, but it does. Maybe some bugs with multithreading in Apple macOS SDK .
Checked in macOS 10.14.5 and macOS 10.14.5 with Xcode 10.2.1.