### PR TITLE
Implement wxSlider ticks under wxGTK

### DIFF
--- a/include/wx/gtk/slider.h
+++ b/include/wx/gtk/slider.h
@@ -9,6 +9,8 @@
 #ifndef _WX_GTK_SLIDER_H_
 #define _WX_GTK_SLIDER_H_
 
+#include "wx/gtk/private/wrapgtk.h"
+
 // ----------------------------------------------------------------------------
 // wxSlider
 // ----------------------------------------------------------------------------
@@ -56,6 +58,13 @@ public:
     virtual void SetThumbLength(int lenPixels) wxOVERRIDE;
     virtual int GetThumbLength() const wxOVERRIDE;
 
+#if GTK_CHECK_VERSION(2,16,0)
+    virtual void ClearTicks() wxOVERRIDE;
+    virtual void SetTick(int tickPos) wxOVERRIDE;
+    int GetTickFreq() const wxOVERRIDE 
+                        { return wx_is_at_least_gtk2(16) ? m_tickFreq : -1; }
+#endif
+
     static wxVisualAttributes
     GetClassDefaultAttributes(wxWindowVariant variant = wxWINDOW_VARIANT_NORMAL);
 
@@ -73,10 +82,17 @@ protected:
     GtkWidget *m_minLabel,*m_maxLabel;
     bool m_blockScrollEvent;
 
+    // Note the following two members are not used in GTK+2 < 2.16.
+    int m_tickFreq;
+    GtkPositionType m_posTicks;
+
     virtual GdkWindow *GTKGetWindow(wxArrayGdkWindows& windows) const wxOVERRIDE;
 
     // set the slider value unconditionally
     void GTKSetValue(int value);
+
+    // Platform-specific implementation of SetTickFreq
+    virtual void DoSetTickFreq(int freq) wxOVERRIDE;
 
     wxDECLARE_DYNAMIC_CLASS(wxSlider);
 };

--- a/include/wx/gtk/slider.h
+++ b/include/wx/gtk/slider.h
@@ -9,8 +9,6 @@
 #ifndef _WX_GTK_SLIDER_H_
 #define _WX_GTK_SLIDER_H_
 
-#include "wx/gtk/private/wrapgtk.h"
-
 // ----------------------------------------------------------------------------
 // wxSlider
 // ----------------------------------------------------------------------------
@@ -58,12 +56,9 @@ public:
     virtual void SetThumbLength(int lenPixels) wxOVERRIDE;
     virtual int GetThumbLength() const wxOVERRIDE;
 
-#if GTK_CHECK_VERSION(2,16,0)
     virtual void ClearTicks() wxOVERRIDE;
     virtual void SetTick(int tickPos) wxOVERRIDE;
-    int GetTickFreq() const wxOVERRIDE 
-                        { return wx_is_at_least_gtk2(16) ? m_tickFreq : -1; }
-#endif
+    int GetTickFreq() const wxOVERRIDE;
 
     static wxVisualAttributes
     GetClassDefaultAttributes(wxWindowVariant variant = wxWINDOW_VARIANT_NORMAL);
@@ -82,9 +77,8 @@ protected:
     GtkWidget *m_minLabel,*m_maxLabel;
     bool m_blockScrollEvent;
 
-    // Note the following two members are not used in GTK+2 < 2.16.
+    // Note the following member is not used in GTK+2 < 2.16.
     int m_tickFreq;
-    GtkPositionType m_posTicks;
 
     virtual GdkWindow *GTKGetWindow(wxArrayGdkWindows& windows) const wxOVERRIDE;
 
@@ -93,6 +87,9 @@ protected:
 
     // Platform-specific implementation of SetTickFreq
     virtual void DoSetTickFreq(int freq) wxOVERRIDE;
+
+private:
+    void Init();
 
     wxDECLARE_DYNAMIC_CLASS(wxSlider);
 };

--- a/interface/wx/slider.h
+++ b/interface/wx/slider.h
@@ -30,6 +30,8 @@
 
     On Windows, the track bar control is used.
 
+    On GTK+, tick marks are only available for version 2.16 and later.
+
     Slider generates the same events as wxScrollBar but in practice the most
     convenient way to process wxSlider updates is by handling the
     slider-specific @c wxEVT_SLIDER event which carries wxCommandEvent
@@ -41,7 +43,7 @@
     @style{wxSL_VERTICAL}
            Displays the slider vertically.
     @style{wxSL_AUTOTICKS}
-           Displays tick marks. Windows only.
+           Displays tick marks (Windows, GTK+ 2.16 and later).
     @style{wxSL_MIN_MAX_LABELS}
            Displays minimum, maximum labels (new since wxWidgets 2.9.1).
     @style{wxSL_VALUE_LABEL}
@@ -67,11 +69,11 @@
     @endStyleTable
 
     Notice that @c wxSL_LEFT, @c wxSL_TOP, @c wxSL_RIGHT and @c wxSL_BOTTOM
-    specify the position of the slider ticks in MSW implementation and that the
-    slider labels, if any, are positioned on the opposite side. So, to have a
-    label on the left side of a vertical slider, @b wxSL_RIGHT must be used (or
-    none of these styles at all should be specified as left and top are default
-    positions for the vertical and horizontal sliders respectively).
+    specify the position of the slider ticks and that the slider labels, if any,
+    are positioned on the opposite side. So, to have a label on the left side of
+    a vertical slider, @b wxSL_RIGHT must be used (or none of these styles at all
+    should be specified as left and top are default positions for the vertical
+    and horizontal sliders respectively).
 
     @beginEventEmissionTable{wxScrollEvent}
     You can use EVT_COMMAND_SCROLL... macros with window IDs for when intercepting
@@ -206,7 +208,7 @@ public:
     /**
         Clears the ticks.
 
-        @onlyfor{wxmsw}
+        @onlyfor{wxmsw,wxgtk}
     */
     virtual void ClearTicks();
 
@@ -278,7 +280,7 @@ public:
     /**
         Returns the tick frequency.
 
-        @onlyfor{wxmsw}
+        @onlyfor{wxmsw,wxgtk}
 
         @see SetTickFreq()
     */
@@ -372,7 +374,7 @@ public:
         @param tickPos
             The tick position.
 
-        @onlyfor{wxmsw}
+        @onlyfor{wxmsw,wxgtk}
 
         @see SetTickFreq()
     */
@@ -385,11 +387,11 @@ public:
             Frequency. For example, if the frequency is set to two, a tick mark is
             displayed for every other increment in the slider's range.
 
-        @onlyfor{wxmsw}
+        @onlyfor{wxmsw,wxgtk}
 
         @see GetTickFreq()
     */
-    virtual void SetTickFreq(int n);
+    virtual void SetTickFreq(int freq);
 
     /**
         Sets the slider position.

--- a/interface/wx/slider.h
+++ b/interface/wx/slider.h
@@ -52,11 +52,11 @@
            Displays minimum, maximum and value labels (same as wxSL_VALUE_LABEL
            and wxSL_MIN_MAX_LABELS together).
     @style{wxSL_LEFT}
-           Displays ticks on the left and forces the slider to be vertical.
+           Displays ticks on the left and forces the slider to be vertical (Windows and GTK+ 3 only).
     @style{wxSL_RIGHT}
            Displays ticks on the right and forces the slider to be vertical.
     @style{wxSL_TOP}
-           Displays ticks on the top.
+           Displays ticks on the top (Windows and GTK+ 3 only).
     @style{wxSL_BOTTOM}
            Displays ticks on the bottom (this is the default).
     @style{wxSL_BOTH}

--- a/src/gtk/slider.cpp
+++ b/src/gtk/slider.cpp
@@ -519,7 +519,7 @@ void wxSlider::ClearTicks()
 void wxSlider::SetTick(int tickPos)
 {
 #if GTK_CHECK_VERSION(2,16,0)
-    if (wx_is_at_least_gtk2(16))
+    if ( wx_is_at_least_gtk2(16) )
     {
         GtkPositionType posTicks;
         long style = GetWindowStyle();
@@ -541,13 +541,15 @@ void wxSlider::SetTick(int tickPos)
 
         gtk_scale_add_mark(GTK_SCALE (m_scale), (double)tickPos, posTicks, NULL);
     }
+#else
+    wxUnusedVar(tickPos);
 #endif
 }
 
 void wxSlider::DoSetTickFreq(int freq)
 {
 #if GTK_CHECK_VERSION(2,16,0)
-    if (wx_is_at_least_gtk2(16))
+    if ( wx_is_at_least_gtk2(16) )
     {
         m_tickFreq = freq;
         gtk_scale_clear_marks(GTK_SCALE (m_scale));
@@ -555,6 +557,8 @@ void wxSlider::DoSetTickFreq(int freq)
         for (int i = GetMin() + freq; i < GetMax(); i += freq)
             SetTick(i);
     }
+#else
+    wxUnusedVar(freq);
 #endif
 }
 


### PR DESCRIPTION
Implement wxSlider ticks under wxGTK

Tick marks were not available for wxSlider under GTK+ 2 or GTK+ 3
implementations of wxWidgets. However, tick marks have been available
for the GtkScale widget since GTK+ 2 version 2.16.

This change adds similar functionality in relation to tick marks
as was already available in wxMSW builds.

This has been tested using the 'samples/widgets' example under both GTK+ 2 and GTK+ 3 on Ubuntu 19.04.

There are a couple of limitations:
1. Ticks can only appear below (horizontal) and to the right (vertical) of the slider under GTK+ 2.
2. GTK+ 2 version 2.16 or later is required. It might be best to add a version check to avoid build errors with earlier versions of the toolkit?