### PR TITLE
 Add support for different underline types in wxTextCtrl

### DIFF
--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -329,9 +329,9 @@ public:
     void SetFontWeight(wxFontWeight fontWeight) { m_fontWeight = fontWeight; m_flags |= wxTEXT_ATTR_FONT_WEIGHT; }
     void SetFontFaceName(const wxString& faceName) { m_fontFaceName = faceName; m_flags |= wxTEXT_ATTR_FONT_FACE; }
     void SetFontUnderlined(bool underlined) { m_fontUnderlined = underlined; m_flags |= wxTEXT_ATTR_FONT_UNDERLINE; }
-    void SetFontUnderline(bool underlined, wxTextAttrUnderlineType type = wxTEXT_ATTR_UNDERLINE_SOLID, wxColour colour = *wxBLACK)
+    void SetFontUnderline(bool underlined, wxTextAttrUnderlineType type = wxTEXT_ATTR_UNDERLINE_SOLID, const wxColour &colour = wxNullColour)
     {
-        m_flags |= type;
+        m_flags |= wxTEXT_ATTR_FONT_UNDERLINE;
         m_fontUnderlined = underlined;
         m_fontUnderlineType = type;
         m_colUnderline = colour;

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -272,10 +272,10 @@ enum wxTextAttrLineSpacing
 
 enum wxTextAttrUnderlineType
  {
-     wxTEXT_ATTR_UNDERLINE_NONE              = 0,
-     wxTEXT_ATTR_UNDERLINE_SOLID             = 1,
-     wxTEXT_ATTR_UNDERLINE_DOUBLE            = 20,
-     wxTEXT_ATTR_UNDERLINE_WAVE              = 25
+     wxTEXT_ATTR_UNDERLINE_NONE,
+     wxTEXT_ATTR_UNDERLINE_SOLID,
+     wxTEXT_ATTR_UNDERLINE_DOUBLE,
+     wxTEXT_ATTR_UNDERLINE_WAVE
 };
 	
 // ----------------------------------------------------------------------------

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -329,11 +329,11 @@ public:
     void SetFontWeight(wxFontWeight fontWeight) { m_fontWeight = fontWeight; m_flags |= wxTEXT_ATTR_FONT_WEIGHT; }
     void SetFontFaceName(const wxString& faceName) { m_fontFaceName = faceName; m_flags |= wxTEXT_ATTR_FONT_FACE; }
     void SetFontUnderlined(bool underlined) { m_fontUnderlined = underlined; m_flags |= wxTEXT_ATTR_FONT_UNDERLINE; }
-    void SetFontUnderlinedWithEffects(bool underlined, wxTextAttrUnderlineType type = wxTEXT_ATTR_UNDERLINE_SOLID, wxColour colour = *wxBLACK)
+    void SetFontUnderline(bool underlined, wxTextAttrUnderlineType type = wxTEXT_ATTR_UNDERLINE_SOLID, wxColour colour = *wxBLACK)
     {
         m_fontUnderlined = underlined;
         m_fontUnderlinedType = type;
-        m_fontUnderlineColor = colour;
+        m_colUnderline = colour;
     }
     void SetFontStrikethrough(bool strikethrough) { m_fontStrikethrough = strikethrough; m_flags |= wxTEXT_ATTR_FONT_STRIKETHROUGH; }
     void SetFontEncoding(wxFontEncoding encoding) { m_fontEncoding = encoding; m_flags |= wxTEXT_ATTR_FONT_ENCODING; }
@@ -374,8 +374,8 @@ public:
     wxFontStyle GetFontStyle() const { return m_fontStyle; }
     wxFontWeight GetFontWeight() const { return m_fontWeight; }
     bool GetFontUnderlined() const { return m_fontUnderlined; }
-    wxTextAttrUnderlineType GetUnderlinedType() const { return m_fontUnderlinedType; }
-    const wxColour &GetUnderlineColour() const { return m_fontUnderlineColor; }
+    wxTextAttrUnderlineType GetUnderlineType() const { return m_fontUnderlinedType; }
+    const wxColour &GetUnderlineColour() const { return m_colUnderline; }
     bool GetFontStrikethrough() const { return m_fontStrikethrough; }
     const wxString& GetFontFaceName() const { return m_fontFaceName; }
     wxFontEncoding GetFontEncoding() const { return m_fontEncoding; }
@@ -527,7 +527,7 @@ private:
     wxFontFamily        m_fontFamily;
     bool                m_fontUnderlined;
     wxTextAttrUnderlineType m_fontUnderlinedType;
-    wxColour            m_fontUnderlineColor;
+    wxColour            m_colUnderline;
     bool                m_fontStrikethrough;
     wxString            m_fontFaceName;
 

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -270,6 +270,14 @@ enum wxTextAttrLineSpacing
     wxTEXT_ATTR_LINE_SPACING_TWICE          = 20
 };
 
+enum wxTextAttrUnderlineType
+ {
+     wxTEXT_ATTR_UNDERLINE_NONE              = 0,
+     wxTEXT_ATTR_UNDERLINE_SOLID             = 1,
+     wxTEXT_ATTR_UNDERLINE_DOUBLE            = 20,
+     wxTEXT_ATTR_UNDERLINE_WAVE              = 25
+};
+	
 // ----------------------------------------------------------------------------
 // wxTextAttr: a structure containing the visual attributes of a text
 // ----------------------------------------------------------------------------
@@ -321,6 +329,12 @@ public:
     void SetFontWeight(wxFontWeight fontWeight) { m_fontWeight = fontWeight; m_flags |= wxTEXT_ATTR_FONT_WEIGHT; }
     void SetFontFaceName(const wxString& faceName) { m_fontFaceName = faceName; m_flags |= wxTEXT_ATTR_FONT_FACE; }
     void SetFontUnderlined(bool underlined) { m_fontUnderlined = underlined; m_flags |= wxTEXT_ATTR_FONT_UNDERLINE; }
+    void SetFontUnderlinedWithEffects(bool underlined, wxTextAttrUnderlineType type = wxTEXT_ATTR_UNDERLINE_SOLID, wxColour colour = *wxBLACK)
+    {
+        m_fontUnderlined = underlined;
+        m_fontUnderlinedType = type;
+        m_fontUnderlineColor = colour;
+    }
     void SetFontStrikethrough(bool strikethrough) { m_fontStrikethrough = strikethrough; m_flags |= wxTEXT_ATTR_FONT_STRIKETHROUGH; }
     void SetFontEncoding(wxFontEncoding encoding) { m_fontEncoding = encoding; m_flags |= wxTEXT_ATTR_FONT_ENCODING; }
     void SetFontFamily(wxFontFamily family) { m_fontFamily = family; m_flags |= wxTEXT_ATTR_FONT_FAMILY; }
@@ -360,6 +374,8 @@ public:
     wxFontStyle GetFontStyle() const { return m_fontStyle; }
     wxFontWeight GetFontWeight() const { return m_fontWeight; }
     bool GetFontUnderlined() const { return m_fontUnderlined; }
+    wxTextAttrUnderlineType GetUnderlinedType() const { return m_fontUnderlinedType; }
+    const wxColour &GetUnderlineColour() const { return m_fontUnderlineColor; }
     bool GetFontStrikethrough() const { return m_fontStrikethrough; }
     const wxString& GetFontFaceName() const { return m_fontFaceName; }
     wxFontEncoding GetFontEncoding() const { return m_fontEncoding; }
@@ -397,6 +413,7 @@ public:
     bool HasFontPixelSize() const { return HasFlag(wxTEXT_ATTR_FONT_PIXEL_SIZE); }
     bool HasFontItalic() const { return HasFlag(wxTEXT_ATTR_FONT_ITALIC); }
     bool HasFontUnderlined() const { return HasFlag(wxTEXT_ATTR_FONT_UNDERLINE); }
+    bool HasFontUnderlinedWithEffect() const { return !( m_fontUnderlinedType == wxTEXT_ATTR_UNDERLINE_NONE || m_fontUnderlinedType == wxTEXT_ATTR_UNDERLINE_SOLID ); }
     bool HasFontStrikethrough() const { return HasFlag(wxTEXT_ATTR_FONT_STRIKETHROUGH); }
     bool HasFontFaceName() const { return HasFlag(wxTEXT_ATTR_FONT_FACE); }
     bool HasFontEncoding() const { return HasFlag(wxTEXT_ATTR_FONT_ENCODING); }
@@ -509,6 +526,8 @@ private:
     wxFontWeight        m_fontWeight;
     wxFontFamily        m_fontFamily;
     bool                m_fontUnderlined;
+    wxTextAttrUnderlineType m_fontUnderlinedType;
+    wxColour            m_fontUnderlineColor;
     bool                m_fontStrikethrough;
     wxString            m_fontFaceName;
 

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -333,7 +333,7 @@ public:
     {
         m_flags |= type;
         m_fontUnderlined = underlined;
-        m_fontUnderlinedType = type;
+        m_fontUnderlineType = type;
         m_colUnderline = colour;
     }
     void SetFontStrikethrough(bool strikethrough) { m_fontStrikethrough = strikethrough; m_flags |= wxTEXT_ATTR_FONT_STRIKETHROUGH; }
@@ -375,7 +375,7 @@ public:
     wxFontStyle GetFontStyle() const { return m_fontStyle; }
     wxFontWeight GetFontWeight() const { return m_fontWeight; }
     bool GetFontUnderlined() const { return m_fontUnderlined; }
-    wxTextAttrUnderlineType GetUnderlineType() const { return m_fontUnderlinedType; }
+    wxTextAttrUnderlineType GetUnderlineType() const { return m_fontUnderlineType; }
     const wxColour &GetUnderlineColour() const { return m_colUnderline; }
     bool GetFontStrikethrough() const { return m_fontStrikethrough; }
     const wxString& GetFontFaceName() const { return m_fontFaceName; }
@@ -526,7 +526,7 @@ private:
     wxFontWeight        m_fontWeight;
     wxFontFamily        m_fontFamily;
     bool                m_fontUnderlined;
-    wxTextAttrUnderlineType m_fontUnderlinedType;
+    wxTextAttrUnderlineType m_fontUnderlineType;
     wxColour            m_colUnderline;
     bool                m_fontStrikethrough;
     wxString            m_fontFaceName;

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -414,6 +414,7 @@ public:
     bool HasFontPixelSize() const { return HasFlag(wxTEXT_ATTR_FONT_PIXEL_SIZE); }
     bool HasFontItalic() const { return HasFlag(wxTEXT_ATTR_FONT_ITALIC); }
     bool HasFontUnderlined() const { return m_fontUnderlined; }
+	bool HasFontUnderline() const { return HasFlag( wxTEXT_ATTR_UNDERLINE_SOLID ) || HasFlag( wxTEXT_ATTR_UNDERLINE_DOUBLE ) || HasFlag( wxTEXT_ATTR_UNDERLINE_WAVE ); }
     bool HasFontStrikethrough() const { return HasFlag(wxTEXT_ATTR_FONT_STRIKETHROUGH); }
     bool HasFontFaceName() const { return HasFlag(wxTEXT_ATTR_FONT_FACE); }
     bool HasFontEncoding() const { return HasFlag(wxTEXT_ATTR_FONT_ENCODING); }

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -413,7 +413,6 @@ public:
     bool HasFontPixelSize() const { return HasFlag(wxTEXT_ATTR_FONT_PIXEL_SIZE); }
     bool HasFontItalic() const { return HasFlag(wxTEXT_ATTR_FONT_ITALIC); }
     bool HasFontUnderlined() const { return HasFlag(wxTEXT_ATTR_FONT_UNDERLINE); }
-    bool HasFontUnderlinedWithEffect() const { return !( m_fontUnderlinedType == wxTEXT_ATTR_UNDERLINE_NONE || m_fontUnderlinedType == wxTEXT_ATTR_UNDERLINE_SOLID ); }
     bool HasFontStrikethrough() const { return HasFlag(wxTEXT_ATTR_FONT_STRIKETHROUGH); }
     bool HasFontFaceName() const { return HasFlag(wxTEXT_ATTR_FONT_FACE); }
     bool HasFontEncoding() const { return HasFlag(wxTEXT_ATTR_FONT_ENCODING); }

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -331,6 +331,7 @@ public:
     void SetFontUnderlined(bool underlined) { m_fontUnderlined = underlined; m_flags |= wxTEXT_ATTR_FONT_UNDERLINE; }
     void SetFontUnderline(bool underlined, wxTextAttrUnderlineType type = wxTEXT_ATTR_UNDERLINE_SOLID, wxColour colour = *wxBLACK)
     {
+        m_flags |= type;
         m_fontUnderlined = underlined;
         m_fontUnderlinedType = type;
         m_colUnderline = colour;
@@ -412,7 +413,7 @@ public:
     bool HasFontPointSize() const { return HasFlag(wxTEXT_ATTR_FONT_POINT_SIZE); }
     bool HasFontPixelSize() const { return HasFlag(wxTEXT_ATTR_FONT_PIXEL_SIZE); }
     bool HasFontItalic() const { return HasFlag(wxTEXT_ATTR_FONT_ITALIC); }
-    bool HasFontUnderlined() const { return HasFlag(wxTEXT_ATTR_FONT_UNDERLINE); }
+    bool HasFontUnderlined() const { return m_fontUnderlined; }
     bool HasFontStrikethrough() const { return HasFlag(wxTEXT_ATTR_FONT_STRIKETHROUGH); }
     bool HasFontFaceName() const { return HasFlag(wxTEXT_ATTR_FONT_FACE); }
     bool HasFontEncoding() const { return HasFlag(wxTEXT_ATTR_FONT_ENCODING); }

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -220,7 +220,9 @@ enum wxTextAttrLineSpacing
 
 
 /**
-    Those values can be used with SetFontUnderlinedWithEffects
+    The values that can be used with SetFontUnderline
+
+	@since 3.1.3
 */
 enum wxTextAttrUnderlineType
 {
@@ -435,11 +437,15 @@ public:
 
     /**
         Returns the underline type, which is one of the @wxTextAttrUnderlineType values
+
+		@since 3.1.3
     */
     wxTextAttrUnderlineType GetUnderlinedType() const;
 
     /**
         Returns the underline color used
+
+		@since 3.1.3
     */
     const wxColour &GetUnderlineColour() const;
 
@@ -628,8 +634,10 @@ public:
     /**
         Returns @true if the attribute object specifies different underline types
         and color
+
+		@since 3.1.3
     */
-    bool HasFontUnderlinedWithEffect() const;
+    bool HasFontUnderline() const;
 
     /**
         Returns @true if the attribute object specifies font weight (bold, light or
@@ -836,8 +844,10 @@ public:
 
     /**
         Set the different underline type and the underline color
+
+		@since 3.1.3
     */
-    void SetFontUnderlinedWithEffects(bool underlined, wxTextAttrUnderlineType type = wxTEXT_ATTR_UNDERLINE_SOLID, wxColour colour = *wxBLACK);
+    void SetFontUnderline(bool underlined, wxTextAttrUnderlineType type = wxTEXT_ATTR_UNDERLINE_SOLID, wxColour colour = *wxBLACK);
 
     /**
         Sets the font weight.

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -220,6 +220,17 @@ enum wxTextAttrLineSpacing
 
 
 /**
+    Those values can be used with SetFontUnderlinedWithEffects
+*/
+enum wxTextAttrUnderlineType
+{
+     wxTEXT_ATTR_UNDERLINE_NONE              = 0,
+     wxTEXT_ATTR_UNDERLINE_SOLID             = 1,
+     wxTEXT_ATTR_UNDERLINE_DOUBLE            = 20,
+     wxTEXT_ATTR_UNDERLINE_WAVE              = 25
+};
+
+/**
     Describes the possible return values of wxTextCtrl::HitTest().
 
     The element names correspond to the relationship between the point asked
@@ -423,6 +434,16 @@ public:
     bool GetFontUnderlined() const;
 
     /**
+        Returns the underline type, which is one of the @wxTextAttrUnderlineType values
+    */
+    wxTextAttrUnderlineType GetUnderlinedType() const;
+
+    /**
+        Returns the underline color used
+    */
+    const wxColour &GetUnderlineColour() const;
+
+    /**
         Returns the font weight.
     */
     wxFontWeight GetFontWeight() const;
@@ -603,6 +624,12 @@ public:
         underlining.
     */
     bool HasFontUnderlined() const;
+
+    /**
+        Returns @true if the attribute object specifies different underline types
+        and color
+    */
+    bool HasFontUnderlinedWithEffect() const;
 
     /**
         Returns @true if the attribute object specifies font weight (bold, light or
@@ -806,6 +833,11 @@ public:
         Sets the font underlining.
     */
     void SetFontUnderlined(bool underlined);
+
+    /**
+        Set the different underline type and the underline color
+    */
+    void SetFontUnderlinedWithEffects(bool underlined, wxTextAttrUnderlineType type = wxTEXT_ATTR_UNDERLINE_SOLID, wxColour colour = *wxBLACK);
 
     /**
         Sets the font weight.

--- a/samples/text/UpgradeLog.XML
+++ b/samples/text/UpgradeLog.XML
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type='text/xsl' href='_UpgradeReport_Files/UpgradeReport.xslt'?><UpgradeLog>
+<Properties><Property Name="Solution" Value="text_vc9">
+</Property><Property Name="Solution File" Value="C:\wxFork\samples\text\text_vc9.sln">
+</Property><Property Name="Date" Value="Friday, June 21, 2019">
+</Property><Property Name="Time" Value="0:55:29 AM">
+</Property></Properties><Event ErrorLevel="0" Project="text_vc9" Source="text_vc9.vcproj" Description="Converting project file 'C:\wxFork\samples\text\text_vc9.vcproj'.">
+</Event><Event ErrorLevel="1" Project="text_vc9" Source="text_vc9.vcproj" Description="VCWebServiceProxyGeneratorTool is no longer supported. The tool has been removed from your project settings.">
+</Event><Event ErrorLevel="0" Project="text_vc9" Source="text_vc9.vcproj" Description="Done converting to new project file 'C:\wxFork\samples\text\text_vc9.vcxproj'.">
+</Event><Event ErrorLevel="3" Project="text_vc9" Source="text_vc9.vcproj" Description="Converted">
+</Event></UpgradeLog>

--- a/samples/text/text.cpp
+++ b/samples/text/text.cpp
@@ -1232,7 +1232,7 @@ MyPanel::MyPanel( wxFrame *frame, int x, int y, int w, int h )
     m_textrich->SetDefaultStyle( wxTextAttr() );
     m_textrich->AppendText(wxT("And there is a "));
     wxTextAttr attr = m_textrich->GetDefaultStyle();
-    attr.SetFontUnderline( TRUE, wxTEXT_ATTR_UNDERLINE_WAVE, *wxRED );
+    attr.SetFontUnderline( true, wxTEXT_ATTR_UNDERLINE_WAVE, *wxRED );
     m_textrich->SetDefaultStyle( attr );
     m_textrich->AppendText(wxT("mispeled "));
     attr.SetFontUnderline( false, wxTEXT_ATTR_UNDERLINE_NONE );

--- a/samples/text/text.cpp
+++ b/samples/text/text.cpp
@@ -1228,7 +1228,8 @@ MyPanel::MyPanel( wxFrame *frame, int x, int y, int w, int h )
     m_textrich->AppendText("This text should be cyan on blue\n");
     m_textrich->SetDefaultStyle(wxTextAttr(*wxBLUE, *wxWHITE));
     m_textrich->AppendText("And this should be in blue and the text you "
-                           "type should be in blue as well");
+                           "type should be in blue as well.\n");
+    m_textrich->SetDefaultStyle( wxTextAttr() );
     m_textrich->AppendText(wxT("And there is a "));
     wxTextAttr attr = m_textrich->GetDefaultStyle();
     attr.SetFontUnderline( TRUE, wxTEXT_ATTR_UNDERLINE_WAVE, *wxRED );

--- a/samples/text/text.cpp
+++ b/samples/text/text.cpp
@@ -1229,7 +1229,16 @@ MyPanel::MyPanel( wxFrame *frame, int x, int y, int w, int h )
     m_textrich->SetDefaultStyle(wxTextAttr(*wxBLUE, *wxWHITE));
     m_textrich->AppendText("And this should be in blue and the text you "
                            "type should be in blue as well");
-
+    m_textrich->AppendText(wxT("And there is a "));
+    wxTextAttr attr = m_textrich->GetDefaultStyle();
+    attr.SetFontUnderlinedWithEffects( TRUE, wxTEXT_ATTR_UNDERLINE_WAVE, *wxRED );
+    m_textrich->SetDefaultStyle( attr );
+    m_textrich->AppendText(wxT("mispeled "));
+    attr.SetFontUnderlinedWithEffects( false, wxTEXT_ATTR_UNDERLINE_NONE );
+    m_textrich->SetDefaultStyle( attr );
+    m_textrich->AppendText(wxT("word"));
+    m_textrich->SetDefaultStyle(wxTextAttr(*wxBLUE, *wxWHITE));
+	
 
     // lay out the controls
     wxBoxSizer *column1 = new wxBoxSizer(wxVERTICAL);

--- a/samples/text/text.cpp
+++ b/samples/text/text.cpp
@@ -1231,10 +1231,10 @@ MyPanel::MyPanel( wxFrame *frame, int x, int y, int w, int h )
                            "type should be in blue as well");
     m_textrich->AppendText(wxT("And there is a "));
     wxTextAttr attr = m_textrich->GetDefaultStyle();
-    attr.SetFontUnderlinedWithEffects( TRUE, wxTEXT_ATTR_UNDERLINE_WAVE, *wxRED );
+    attr.SetFontUnderline( TRUE, wxTEXT_ATTR_UNDERLINE_WAVE, *wxRED );
     m_textrich->SetDefaultStyle( attr );
     m_textrich->AppendText(wxT("mispeled "));
-    attr.SetFontUnderlinedWithEffects( false, wxTEXT_ATTR_UNDERLINE_NONE );
+    attr.SetFontUnderline( false, wxTEXT_ATTR_UNDERLINE_NONE );
     m_textrich->SetDefaultStyle( attr );
     m_textrich->AppendText(wxT("word"));
     m_textrich->SetDefaultStyle(wxTextAttr(*wxBLUE, *wxWHITE));

--- a/src/common/gdicmn.cpp
+++ b/src/common/gdicmn.cpp
@@ -370,7 +370,13 @@ void wxColourDatabase::Initialize()
         {wxT("WHEAT"), 216, 216, 191},
         {wxT("WHITE"), 255, 255, 255},
         {wxT("YELLOW"), 255, 255, 0},
-        {wxT("YELLOW GREEN"), 153, 204, 50}
+        {wxT("YELLOW GREEN"), 153, 204, 50},
+        {wxT("wxNAVY"), 0, 0, 128},
+        {wxT("wxTEAL"), 0, 128, 128},
+        {wxT("wxLIGHT GREEN"), 0, 128, 0},
+        {wxT("wxPURPLE"), 128, 0, 128},
+        {wxT("wxMAROON"), 128, 0, 0},
+        {wxT("wxDARK GREY"), 128, 128, 128}
     };
 
     size_t n;

--- a/src/common/textcmn.cpp
+++ b/src/common/textcmn.cpp
@@ -163,6 +163,8 @@ void wxTextAttr::Init()
     m_fontStyle = wxFONTSTYLE_NORMAL;
     m_fontWeight = wxFONTWEIGHT_NORMAL;
     m_fontUnderlined = false;
+    m_fontUnderlinedType = wxTEXT_ATTR_UNDERLINE_NONE;
+    m_fontUnderlineColor = *wxWHITE;
     m_fontStrikethrough = false;
     m_fontEncoding = wxFONTENCODING_DEFAULT;
     m_fontFamily = wxFONTFAMILY_DEFAULT;
@@ -193,6 +195,8 @@ void wxTextAttr::Copy(const wxTextAttr& attr)
     m_fontStyle = attr.m_fontStyle;
     m_fontWeight = attr.m_fontWeight;
     m_fontUnderlined = attr.m_fontUnderlined;
+    m_fontUnderlinedType = attr.m_fontUnderlinedType;
+    m_fontUnderlineColor = attr.m_fontUnderlineColor;
     m_fontStrikethrough = attr.m_fontStrikethrough;
     m_fontFaceName = attr.m_fontFaceName;
     m_fontEncoding = attr.m_fontEncoding;
@@ -258,6 +262,7 @@ bool wxTextAttr::operator== (const wxTextAttr& attr) const
             (!HasFontItalic() || (GetFontStyle() == attr.GetFontStyle())) &&
             (!HasFontWeight() || (GetFontWeight() == attr.GetFontWeight())) &&
             (!HasFontUnderlined() || (GetFontUnderlined() == attr.GetFontUnderlined())) &&
+            (!HasFontUnderlinedWithEffect() || (GetUnderlinedType() == attr.GetUnderlinedType() && GetUnderlineColour() == attr.GetUnderlineColour())) &&
             (!HasFontStrikethrough() || (GetFontStrikethrough() == attr.GetFontStrikethrough())) &&
             (!HasFontFaceName() || (GetFontFaceName() == attr.GetFontFaceName())) &&
             (!HasFontEncoding() || (GetFontEncoding() == attr.GetFontEncoding())) &&
@@ -791,6 +796,7 @@ wxTextAttr wxTextAttr::Combine(const wxTextAttr& attr,
     }
 
     wxTextAttr newAttr(colFg, colBg, font);
+    newAttr.SetFontUnderlinedWithEffects( attr.GetFontUnderlined(), attr.GetUnderlinedType(), attr.GetUnderlineColour() );
 
     if (attr.HasAlignment())
         newAttr.SetAlignment(attr.GetAlignment());

--- a/src/common/textcmn.cpp
+++ b/src/common/textcmn.cpp
@@ -164,7 +164,6 @@ void wxTextAttr::Init()
     m_fontWeight = wxFONTWEIGHT_NORMAL;
     m_fontUnderlined = false;
     m_fontUnderlinedType = wxTEXT_ATTR_UNDERLINE_NONE;
-    m_fontUnderlineColor = *wxWHITE;
     m_fontStrikethrough = false;
     m_fontEncoding = wxFONTENCODING_DEFAULT;
     m_fontFamily = wxFONTFAMILY_DEFAULT;
@@ -196,7 +195,7 @@ void wxTextAttr::Copy(const wxTextAttr& attr)
     m_fontWeight = attr.m_fontWeight;
     m_fontUnderlined = attr.m_fontUnderlined;
     m_fontUnderlinedType = attr.m_fontUnderlinedType;
-    m_fontUnderlineColor = attr.m_fontUnderlineColor;
+    m_colUnderline = attr.m_colUnderline;
     m_fontStrikethrough = attr.m_fontStrikethrough;
     m_fontFaceName = attr.m_fontFaceName;
     m_fontEncoding = attr.m_fontEncoding;
@@ -262,7 +261,7 @@ bool wxTextAttr::operator== (const wxTextAttr& attr) const
             (!HasFontItalic() || (GetFontStyle() == attr.GetFontStyle())) &&
             (!HasFontWeight() || (GetFontWeight() == attr.GetFontWeight())) &&
             (!HasFontUnderlined() || (GetFontUnderlined() == attr.GetFontUnderlined())) &&
-            (!HasFontUnderlinedWithEffect() || (GetUnderlinedType() == attr.GetUnderlinedType() && GetUnderlineColour() == attr.GetUnderlineColour())) &&
+            (!HasFontUnderlinedWithEffect() || (GetUnderlineType() == attr.GetUnderlineType() && GetUnderlineColour() == attr.GetUnderlineColour())) &&
             (!HasFontStrikethrough() || (GetFontStrikethrough() == attr.GetFontStrikethrough())) &&
             (!HasFontFaceName() || (GetFontFaceName() == attr.GetFontFaceName())) &&
             (!HasFontEncoding() || (GetFontEncoding() == attr.GetFontEncoding())) &&
@@ -796,7 +795,7 @@ wxTextAttr wxTextAttr::Combine(const wxTextAttr& attr,
     }
 
     wxTextAttr newAttr(colFg, colBg, font);
-    newAttr.SetFontUnderlinedWithEffects( attr.GetFontUnderlined(), attr.GetUnderlinedType(), attr.GetUnderlineColour() );
+    newAttr.SetFontUnderline( attr.GetFontUnderlined(), attr.GetUnderlineType(), attr.GetUnderlineColour() );
 
     if (attr.HasAlignment())
         newAttr.SetAlignment(attr.GetAlignment());

--- a/src/common/textcmn.cpp
+++ b/src/common/textcmn.cpp
@@ -176,7 +176,7 @@ void wxTextAttr::Init()
     m_textEffectFlags = wxTEXT_ATTR_EFFECT_NONE;
     m_outlineLevel = 0;
     m_bulletNumber = 0;
-    m_fontUnderlined = false;
+    m_colUnderline = wxNullColour;
 }
 
 // Copy

--- a/src/common/textcmn.cpp
+++ b/src/common/textcmn.cpp
@@ -261,7 +261,7 @@ bool wxTextAttr::operator== (const wxTextAttr& attr) const
             (!HasFontItalic() || (GetFontStyle() == attr.GetFontStyle())) &&
             (!HasFontWeight() || (GetFontWeight() == attr.GetFontWeight())) &&
             (!HasFontUnderlined() || (GetFontUnderlined() == attr.GetFontUnderlined())) &&
-            (!HasFontUnderlinedWithEffect() || (GetUnderlineType() == attr.GetUnderlineType() && GetUnderlineColour() == attr.GetUnderlineColour())) &&
+            ( ( GetUnderlineType() == attr.GetUnderlineType() ) && ( GetUnderlineColour() == attr.GetUnderlineColour() ) ) &&
             (!HasFontStrikethrough() || (GetFontStrikethrough() == attr.GetFontStrikethrough())) &&
             (!HasFontFaceName() || (GetFontFaceName() == attr.GetFontFaceName())) &&
             (!HasFontEncoding() || (GetFontEncoding() == attr.GetFontEncoding())) &&

--- a/src/common/textcmn.cpp
+++ b/src/common/textcmn.cpp
@@ -163,7 +163,7 @@ void wxTextAttr::Init()
     m_fontStyle = wxFONTSTYLE_NORMAL;
     m_fontWeight = wxFONTWEIGHT_NORMAL;
     m_fontUnderlined = false;
-    m_fontUnderlinedType = wxTEXT_ATTR_UNDERLINE_NONE;
+    m_fontUnderlineType = wxTEXT_ATTR_UNDERLINE_NONE;
     m_fontStrikethrough = false;
     m_fontEncoding = wxFONTENCODING_DEFAULT;
     m_fontFamily = wxFONTFAMILY_DEFAULT;
@@ -195,7 +195,7 @@ void wxTextAttr::Copy(const wxTextAttr& attr)
     m_fontStyle = attr.m_fontStyle;
     m_fontWeight = attr.m_fontWeight;
     m_fontUnderlined = attr.m_fontUnderlined;
-    m_fontUnderlinedType = attr.m_fontUnderlinedType;
+    m_fontUnderlineType = attr.m_fontUnderlineType;
     m_colUnderline = attr.m_colUnderline;
     m_fontStrikethrough = attr.m_fontStrikethrough;
     m_fontFaceName = attr.m_fontFaceName;

--- a/src/common/textcmn.cpp
+++ b/src/common/textcmn.cpp
@@ -176,6 +176,7 @@ void wxTextAttr::Init()
     m_textEffectFlags = wxTEXT_ATTR_EFFECT_NONE;
     m_outlineLevel = 0;
     m_bulletNumber = 0;
+    m_fontUnderlined = false;
 }
 
 // Copy

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -126,6 +126,7 @@ static void wxGtkTextApplyTagsFromAttr(GtkWidget *text,
 
     if( attr.HasFontUnderlinedWithEffect() )
     {
+        GtkTextTag *tag1;
         PangoUnderline pg_style;
         if( !(attr.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_NONE || attr.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_SOLID ) )
         {
@@ -143,11 +144,19 @@ static void wxGtkTextApplyTagsFromAttr(GtkWidget *text,
         tag = gtk_text_tag_table_lookup( gtk_text_buffer_get_tag_table( text_buffer ),
                                          buf );
         if (!tag)
+        {
             tag = gtk_text_buffer_create_tag( text_buffer, buf,
                                               "underline-set", TRUE,
                                               "underline", pg_style,
                                               NULL );
+            if( gtk_check_version( 3, 16, 0 ) )
+                tag1 = gtk_text_buffer_create_tag( text_buffer, buf,
+                                                   "underline-rgba-set", TRUE,
+                                                   "underline-rgba", attr.GetUnderlineColour(),
+                                                   NULL );
+        }
         gtk_text_buffer_apply_tag (text_buffer, tag, start, end);
+        gtk_text_buffer_apply_tag (text_buffer, tag1, start, end);
     }
 
     if (attr.HasTextColour())

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -158,6 +158,13 @@ static void wxGtkTextApplyTagsFromAttr(GtkWidget *text,
 #ifdef __WXGTK3__
         if( gtk_check_version( 3, 16, 0 ) )
         {
+            wxColour color = attr.GetUnderlineColour();
+            if( !color.IsOk() )
+            {
+                color = attr.GetTextColour();
+                if( !color.IsOk() )
+                    color = *wxBLACK;
+            }
             const GdkColor *gdkColor = attr.GetUnderlineColour().GetColor();
             GdkRGBA color_rgba = {
                 .red = CLAMP( (double) gdkColor->red / 65535.0,   0.0, 1.0 ),

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -124,6 +124,32 @@ static void wxGtkTextApplyTagsFromAttr(GtkWidget *text,
         }
     }
 
+    if( attr.HasFontUnderlinedWithEffect() )
+    {
+        PangoUnderline pg_style;
+        if( !(attr.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_NONE || attr.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_SOLID ) )
+        {
+            if( attr.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_NONE )
+                pg_style = PANGO_UNDERLINE_NONE;
+            if( attr.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_SOLID )
+                pg_style = PANGO_UNDERLINE_SINGLE;
+            if( attr.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_DOUBLE )
+                pg_style = PANGO_UNDERLINE_DOUBLE;
+            if( attr.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_WAVE )
+                pg_style = PANGO_UNDERLINE_ERROR;
+        }
+
+        g_snprintf(buf, sizeof(buf), "WXFONTUNDERLINEWITHEFFECT");
+        tag = gtk_text_tag_table_lookup( gtk_text_buffer_get_tag_table( text_buffer ),
+                                         buf );
+        if (!tag)
+            tag = gtk_text_buffer_create_tag( text_buffer, buf,
+                                              "underline-set", TRUE,
+                                              "underline", pg_style,
+                                              NULL );
+        gtk_text_buffer_apply_tag (text_buffer, tag, start, end);
+    }
+
     if (attr.HasTextColour())
     {
         wxGtkTextRemoveTagsWithPrefix(text_buffer, "WXFORECOLOR", start, end);

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -124,19 +124,19 @@ static void wxGtkTextApplyTagsFromAttr(GtkWidget *text,
         }
     }
 
-    if( attr.HasFontUnderlinedWithEffect() )
+    if( attr.HasFontUnderlined() )
     {
         GtkTextTag *tag1;
         PangoUnderline pg_style;
-        if( !(attr.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_NONE || attr.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_SOLID ) )
+        if( !(attr.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_NONE || attr.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_SOLID ) )
         {
-            if( attr.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_NONE )
+            if( attr.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_NONE )
                 pg_style = PANGO_UNDERLINE_NONE;
-            if( attr.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_SOLID )
+            if( attr.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_SOLID )
                 pg_style = PANGO_UNDERLINE_SINGLE;
-            if( attr.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_DOUBLE )
+            if( attr.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_DOUBLE )
                 pg_style = PANGO_UNDERLINE_DOUBLE;
-            if( attr.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_WAVE )
+            if( attr.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_WAVE )
                 pg_style = PANGO_UNDERLINE_ERROR;
         }
 
@@ -149,14 +149,25 @@ static void wxGtkTextApplyTagsFromAttr(GtkWidget *text,
                                               "underline-set", TRUE,
                                               "underline", pg_style,
                                               NULL );
-            if( gtk_check_version( 3, 16, 0 ) )
-                tag1 = gtk_text_buffer_create_tag( text_buffer, buf,
-                                                   "underline-rgba-set", TRUE,
-                                                   "underline-rgba", attr.GetUnderlineColour(),
-                                                   NULL );
         }
         gtk_text_buffer_apply_tag (text_buffer, tag, start, end);
-        gtk_text_buffer_apply_tag (text_buffer, tag1, start, end);
+#ifdef __WXGTK3__
+        if( gtk_check_version( 3, 16, 0 ) )
+        {
+            const GdkColor *gdkColor = attr.GetUnderlineColour().GetColor();
+            GdkRGBA color_rgba = {
+                .red = CLAMP( (double) gdkColor->red / 65535.0,   0.0, 1.0 ),
+                .green = CLAMP( (double) gdkColor->green / 65535.0, 0.0, 1.0 ),
+                .blue  = CLAMP ((double) gdkColor->blue / 65535.0,  0.0, 1.0 ),
+                .alpha = 1.0,
+            };
+            tag1 = gtk_text_buffer_create_tag( text_buffer, buf,
+                                               "underline-rgba-set", TRUE,
+                                               "underline-rgba", color_rgba,
+                                               NULL );
+            gtk_text_buffer_apply_tag (text_buffer, tag1, start, end);
+        }
+#endif
     }
 
     if (attr.HasTextColour())

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -126,18 +126,22 @@ static void wxGtkTextApplyTagsFromAttr(GtkWidget *text,
 
     if( attr.HasFontUnderlined() )
     {
-        GtkTextTag *tag1;
-        PangoUnderline pg_style;
-        if( !(attr.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_NONE || attr.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_SOLID ) )
+        GtkTextTag *underlineColorTag;
+        PangoUnderline pangoUnderlineStyle;
+        switch( attr.GetUnderlineType() )
         {
-            if( attr.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_NONE )
-                pg_style = PANGO_UNDERLINE_NONE;
-            if( attr.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_SOLID )
-                pg_style = PANGO_UNDERLINE_SINGLE;
-            if( attr.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_DOUBLE )
-                pg_style = PANGO_UNDERLINE_DOUBLE;
-            if( attr.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_WAVE )
-                pg_style = PANGO_UNDERLINE_ERROR;
+            case wxTEXT_ATTR_UNDERLINE_NONE:
+                pangoUnderlineStyle = PANGO_UNDERLINE_NONE;
+                break;
+            case wxTEXT_ATTR_UNDERLINE_SOLID:
+                pangoUnderlineStyle = PANGO_UNDERLINE_SINGLE;
+                break;
+            case wxTEXT_ATTR_UNDERLINE_DOUBLE:
+                pangoUnderlineStyle = PANGO_UNDERLINE_DOUBLE;
+                break;
+            case wxTEXT_ATTR_UNDERLINE_WAVE:
+                pangoUnderlineStyle = PANGO_UNDERLINE_ERROR;
+                break;
         }
 
         g_snprintf(buf, sizeof(buf), "WXFONTUNDERLINEWITHEFFECT");
@@ -147,7 +151,7 @@ static void wxGtkTextApplyTagsFromAttr(GtkWidget *text,
         {
             tag = gtk_text_buffer_create_tag( text_buffer, buf,
                                               "underline-set", TRUE,
-                                              "underline", pg_style,
+                                              "underline", pangoUnderlineStyle,
                                               NULL );
         }
         gtk_text_buffer_apply_tag (text_buffer, tag, start, end);
@@ -161,11 +165,11 @@ static void wxGtkTextApplyTagsFromAttr(GtkWidget *text,
                 .blue  = CLAMP ((double) gdkColor->blue / 65535.0,  0.0, 1.0 ),
                 .alpha = 1.0,
             };
-            tag1 = gtk_text_buffer_create_tag( text_buffer, buf,
+            underlineColorTag = gtk_text_buffer_create_tag( text_buffer, buf,
                                                "underline-rgba-set", TRUE,
                                                "underline-rgba", color_rgba,
                                                NULL );
-            gtk_text_buffer_apply_tag (text_buffer, tag1, start, end);
+            gtk_text_buffer_apply_tag (text_buffer, underlineColorTag, start, end);
         }
 #endif
     }

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2823,7 +2823,7 @@ bool wxTextCtrl::MSWSetCharFormat(const wxTextAttr& style, long start, long end)
         //     but using it doesn't seem to hurt neither so leaving it for now
 
         cf.dwMask |= CFM_FACE | CFM_SIZE | CFM_CHARSET |
-                     CFM_ITALIC | CFM_BOLD | CFM_UNDERLINE | CFM_STRIKEOUT;
+                     CFM_ITALIC | CFM_BOLD | CFM_UNDERLINE | CFM_STRIKEOUT | CFM_UNDERLINETYPE;
 
         // fill in data from LOGFONT but recalculate lfHeight because we need
         // the real height in twips and not the negative number which
@@ -2860,6 +2860,18 @@ bool wxTextCtrl::MSWSetCharFormat(const wxTextAttr& style, long start, long end)
         {
             cf.dwEffects |= CFE_STRIKEOUT;
         }
+    }
+
+    if( !(style.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_NONE || style.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_SOLID ) )
+    {
+        if( style.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_NONE )
+            cf.bUnderlineType = CFU_UNDERLINENONE;
+        if( style.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_SOLID )
+            cf.bUnderlineType = CFU_UNDERLINE;
+        if( style.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_DOUBLE )
+            cf.bUnderlineType = CFU_UNDERLINEDOUBLE;
+        if( style.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_WAVE )
+            cf.bUnderlineType = CFU_UNDERLINEWAVE;
     }
 
     if ( style.HasTextColour() )

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2816,14 +2816,14 @@ bool wxTextCtrl::MSWSetCharFormat(const wxTextAttr& style, long start, long end)
         // CHARFORMAT or CHARFORMAT2
         cf.cbSize = sizeof(cf);
     }
-
+    cf.dwMask |= CFM_UNDERLINETYPE;
     if ( style.HasFont() )
     {
         // VZ: CFM_CHARSET doesn't seem to do anything at all in RichEdit 2.0
         //     but using it doesn't seem to hurt neither so leaving it for now
 
         cf.dwMask |= CFM_FACE | CFM_SIZE | CFM_CHARSET |
-                     CFM_ITALIC | CFM_BOLD | CFM_UNDERLINE | CFM_STRIKEOUT | CFM_UNDERLINETYPE;
+                     CFM_ITALIC | CFM_BOLD | CFM_UNDERLINE | CFM_STRIKEOUT;
 
         // fill in data from LOGFONT but recalculate lfHeight because we need
         // the real height in twips and not the negative number which
@@ -2861,21 +2861,25 @@ bool wxTextCtrl::MSWSetCharFormat(const wxTextAttr& style, long start, long end)
             cf.dwEffects |= CFE_STRIKEOUT;
         }
     }
-
-    if( !(style.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_NONE || style.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_SOLID ) )
+    wxTextAttrUnderlineType underlineType = style.GetUnderlineType();
+    switch( underlineType )
     {
-        if( style.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_NONE )
+        case wxTEXT_ATTR_UNDERLINE_NONE:
             cf.bUnderlineType = CFU_UNDERLINENONE;
-        if( style.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_SOLID )
+            break;
+		case wxTEXT_ATTR_UNDERLINE_SOLID:
             cf.bUnderlineType = CFU_UNDERLINE;
-        if( style.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_DOUBLE )
+            break;
+		case wxTEXT_ATTR_UNDERLINE_DOUBLE:
             cf.bUnderlineType = CFU_UNDERLINEDOUBLE;
-        if( style.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_WAVE )
+            break;
+		case wxTEXT_ATTR_UNDERLINE_WAVE:
             cf.bUnderlineType = CFU_UNDERLINEWAVE;
+            break;
+    }
 #if _RICHEDIT_VER >= 0x0800
 		cf.bUnderlineColor = style.GetUnderlineColour();
 #endif
-    }
 
     if ( style.HasTextColour() )
     {

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -81,10 +81,21 @@
 #endif
 
 // missing defines for MinGW build
-#define	CFM_UNDERLINETYPE			0x00800000		// Many displayed by 3.0 
-#define CFU_UNDERLINE					1
-#define CFU_UNDERLINEDOUBLE				3
-#define CFU_UNDERLINEWAVE				8
+#ifndef CFM_UNDERLINETYPE
+#define CFM_UNDERLINETYPE               0x00800000
+#endif
+
+#ifndef CFU_UNDERLINE
+#define CFU_UNDERLINE                   1
+#endif
+
+#ifndef CFU_UNDERLINEDOUBLE
+#define CFU_UNDERLINEDOUBLE             3
+#endif
+
+#ifndef CFU_UNDERLINEWAVE
+#define CFU_UNDERLINEWAVE               8
+#endif
 
 #if wxUSE_DRAG_AND_DROP && wxUSE_RICHEDIT
 
@@ -2904,22 +2915,22 @@ bool wxTextCtrl::MSWSetCharFormat(const wxTextAttr& style, long start, long end)
             colour = 0x07;
         else if( col == wxTheColourDatabase->Find( "WHITE" ) )
             colour = 0x08;
-        else if( col == wxTheColourDatabase->Find( "wxNAVY" ) )
+        else if( col == wxTheColourDatabase->Find( "WXNAVY" ) )
             colour = 0x09;
-        else if( col == wxTheColourDatabase->Find( "wxTEAL" ) )
+        else if( col == wxTheColourDatabase->Find( "WXTEAL" ) )
             colour = 0x0A;
-        else if( col == wxTheColourDatabase->Find( "wxLIGHT GREEN" ) )
+        else if( col == wxTheColourDatabase->Find( "WXLIGHT GREEN" ) )
             colour = 0x0B;
-        else if( col == wxTheColourDatabase->Find( "wxPURPLE" ) )
+        else if( col == wxTheColourDatabase->Find( "WXPURPLE" ) )
             colour = 0x0C;
-        else if( col == wxTheColourDatabase->Find( "wxMAROON" ) )
+        else if( col == wxTheColourDatabase->Find( "WXMAROON" ) )
             colour = 0x0D;
-        else if( col == wxTheColourDatabase->Find( "GREY" ) )
+        else if( col == wxTheColourDatabase->Find( "OLIVE" ) )
             colour = 0x0E;
         else if( col == wxTheColourDatabase->Find( "wxDARK GREY" ) )
             colour = 0x0F;
         else if( col == wxTheColourDatabase->Find( "LIGHT GREY" ) )
-            colour = 0x0F;
+            colour = 0x10;
         cf.bUnderlineColor = colour;
 #endif
     }

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -80,6 +80,11 @@
     #define CFE_AUTOBACKCOLOR 0x04000000
 #endif
 
+// missing defines for MinGW build
+#define CFU_UNDERLINE					1
+#define CFU_UNDERLINEDOUBLE				3
+#define CFU_UNDERLINEWAVE				8
+
 #if wxUSE_DRAG_AND_DROP && wxUSE_RICHEDIT
 
 // dummy value used for m_dropTarget, different from any valid pointer value

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -81,6 +81,7 @@
 #endif
 
 // missing defines for MinGW build
+#define	CFM_UNDERLINETYPE			0x00800000		// Many displayed by 3.0 
 #define CFU_UNDERLINE					1
 #define CFU_UNDERLINEDOUBLE				3
 #define CFU_UNDERLINEWAVE				8

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2816,7 +2816,6 @@ bool wxTextCtrl::MSWSetCharFormat(const wxTextAttr& style, long start, long end)
         // CHARFORMAT or CHARFORMAT2
         cf.cbSize = sizeof(cf);
     }
-    cf.dwMask |= CFM_UNDERLINETYPE;
     if ( style.HasFont() )
     {
         // VZ: CFM_CHARSET doesn't seem to do anything at all in RichEdit 2.0
@@ -2861,63 +2860,63 @@ bool wxTextCtrl::MSWSetCharFormat(const wxTextAttr& style, long start, long end)
             cf.dwEffects |= CFE_STRIKEOUT;
         }
     }
-    wxTextAttrUnderlineType underlineType = style.GetUnderlineType();
-    switch( underlineType )
+    if( style.HasFontUnderline() )
     {
-        case wxTEXT_ATTR_UNDERLINE_NONE:
-            cf.bUnderlineType = CFU_UNDERLINENONE;
-            break;
-        case wxTEXT_ATTR_UNDERLINE_SOLID:
-            cf.bUnderlineType = CFU_UNDERLINE;
-            break;
-        case wxTEXT_ATTR_UNDERLINE_DOUBLE:
-            cf.bUnderlineType = CFU_UNDERLINEDOUBLE;
-            break;
-        case wxTEXT_ATTR_UNDERLINE_WAVE:
-            cf.bUnderlineType = CFU_UNDERLINEWAVE;
-            break;
-    }
+        cf.dwMask |= CFM_UNDERLINETYPE;
+        wxTextAttrUnderlineType underlineType = style.GetUnderlineType();
+        switch( underlineType )
+        {
+            case wxTEXT_ATTR_UNDERLINE_SOLID:
+                cf.bUnderlineType = CFU_UNDERLINE;
+                break;
+            case wxTEXT_ATTR_UNDERLINE_DOUBLE:
+                cf.bUnderlineType = CFU_UNDERLINEDOUBLE;
+                break;
+            case wxTEXT_ATTR_UNDERLINE_WAVE:
+                cf.bUnderlineType = CFU_UNDERLINEWAVE;
+                break;
+        }
 #if _RICHEDIT_VER >= 0x0800
 // The colours are coming from https://docs.microsoft.com/en-us/windows/desktop/api/tom/nf-tom-itextdocument2-geteffectcolor.
 // Not all values from wxTheColourDatabase are supported as can be seen from the code
 // Those are commented out currently
-    BYTE colour = 0;
-    wxColour col = style.GetUnderlineColour();
-    if( col == wxTheColourDatabase->Find( "BLACK" ) )
-        colour = 0x01;
-    else if( col == wxTheColourDatabase->Find( "BLUE" ) )
-        colour = 0x02;
-    else if( col == wxTheColourDatabase->Find( "CYAN" ) )
-        colour = 0x03;
-    else if( col == wxTheColourDatabase->Find( "GREEN" ) )
-        colour = 0x04;
-    else if( col == wxTheColourDatabase->Find( "MAGENTA" ) )
-        colour = 0x05;
-    else if( col == wxTheColourDatabase->Find( "RED" ) )
-        colour = 0x06;
-    else if( col == wxTheColourDatabase->Find( "YELLOW" ) )
-        colour = 0x07;
-    else if( col == wxTheColourDatabase->Find( "WHITE" ) )
-        colour = 0x08;
-//    else if( col == wxTheColourDatabase->Find( "NAVY" ) )
-//        colour = 0x09;
-//    else if( col == wxTheColourDatabase->Find( "TEAL" ) )
-//        colour = 0x0A;
-//    else if( col == wxTheColourDatabase->Find( "GREEN" ) )
-//        colour = 0x0B;
-//    else if( col == wxTheColourDatabase->Find( "PURPLE" ) )
-//        colour = 0x0C;
-//    else if( col == wxTheColourDatabase->Find( "MAROON" ) )
-//        colour = 0x0D;
-    else if( col == wxTheColourDatabase->Find( "GREY" ) )
-        colour = 0x0E;
-//    else if( col == wxTheColourDatabase->Find( "DARK GREY" ) )
-//        colour = 0x0F;
-    else if( col == wxTheColourDatabase->Find( "LIGHT GREY" ) )
-        colour = 0x0F;
-    cf.bUnderlineColor = colour;
+        BYTE colour = 0;
+        wxColour col = style.GetUnderlineColour();
+        if( col == wxTheColourDatabase->Find( "BLACK" ) )
+            colour = 0x01;
+        else if( col == wxTheColourDatabase->Find( "BLUE" ) )
+            colour = 0x02;
+        else if( col == wxTheColourDatabase->Find( "CYAN" ) )
+            colour = 0x03;
+        else if( col == wxTheColourDatabase->Find( "GREEN" ) )
+            colour = 0x04;
+        else if( col == wxTheColourDatabase->Find( "MAGENTA" ) )
+            colour = 0x05;
+        else if( col == wxTheColourDatabase->Find( "RED" ) )
+            colour = 0x06;
+        else if( col == wxTheColourDatabase->Find( "YELLOW" ) )
+            colour = 0x07;
+        else if( col == wxTheColourDatabase->Find( "WHITE" ) )
+            colour = 0x08;
+        else if( col == wxTheColourDatabase->Find( "wxNAVY" ) )
+            colour = 0x09;
+        else if( col == wxTheColourDatabase->Find( "wxTEAL" ) )
+            colour = 0x0A;
+        else if( col == wxTheColourDatabase->Find( "wxLIGHT GREEN" ) )
+            colour = 0x0B;
+        else if( col == wxTheColourDatabase->Find( "wxPURPLE" ) )
+            colour = 0x0C;
+        else if( col == wxTheColourDatabase->Find( "wxMAROON" ) )
+            colour = 0x0D;
+        else if( col == wxTheColourDatabase->Find( "GREY" ) )
+            colour = 0x0E;
+        else if( col == wxTheColourDatabase->Find( "wxDARK GREY" ) )
+            colour = 0x0F;
+        else if( col == wxTheColourDatabase->Find( "LIGHT GREY" ) )
+            colour = 0x0F;
+        cf.bUnderlineColor = colour;
 #endif
-
+    }
     if ( style.HasTextColour() )
     {
         cf.dwMask |= CFM_COLOR;

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -3044,7 +3044,7 @@ bool wxTextCtrl::SetStyle(long start, long end, const wxTextAttr& style)
     // even try to do anything if it's the only thing we want to change
     if ( m_verRichEdit == 1 && !style.HasFont() && !style.HasTextColour() &&
         !style.HasLeftIndent() && !style.HasRightIndent() && !style.HasAlignment() &&
-        !style.HasTabs() )
+        !style.HasTabs() && !style.GetFontUnderlined())
     {
         // nothing to do: return true if there was really nothing to do and
         // false if we failed to set bg colour

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2862,15 +2862,15 @@ bool wxTextCtrl::MSWSetCharFormat(const wxTextAttr& style, long start, long end)
         }
     }
 
-    if( !(style.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_NONE || style.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_SOLID ) )
+    if( !(style.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_NONE || style.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_SOLID ) )
     {
-        if( style.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_NONE )
+        if( style.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_NONE )
             cf.bUnderlineType = CFU_UNDERLINENONE;
-        if( style.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_SOLID )
+        if( style.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_SOLID )
             cf.bUnderlineType = CFU_UNDERLINE;
-        if( style.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_DOUBLE )
+        if( style.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_DOUBLE )
             cf.bUnderlineType = CFU_UNDERLINEDOUBLE;
-        if( style.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_WAVE )
+        if( style.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_WAVE )
             cf.bUnderlineType = CFU_UNDERLINEWAVE;
 #if( _RICHEDIT_VER >= 0x0800 )
 		cf.bUnderlineColor = style.GetUnderlineColour();

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2872,7 +2872,7 @@ bool wxTextCtrl::MSWSetCharFormat(const wxTextAttr& style, long start, long end)
             cf.bUnderlineType = CFU_UNDERLINEDOUBLE;
         if( style.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_WAVE )
             cf.bUnderlineType = CFU_UNDERLINEWAVE;
-#if( _RICHEDIT_VER >= 0x0800 )
+#if _RICHEDIT_VER >= 0x0800
 		cf.bUnderlineColor = style.GetUnderlineColour();
 #endif
     }

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2878,7 +2878,44 @@ bool wxTextCtrl::MSWSetCharFormat(const wxTextAttr& style, long start, long end)
             break;
     }
 #if _RICHEDIT_VER >= 0x0800
-		cf.bUnderlineColor = style.GetUnderlineColour();
+// The colours are coming from https://docs.microsoft.com/en-us/windows/desktop/api/tom/nf-tom-itextdocument2-geteffectcolor.
+// Not all values from wxTheColourDatabase are supported as can be seen from the code
+// Those are commented out currently
+    BYTE colour;
+    wxColour col = style.GetUnderlineColour();
+    if( col == wxTheColourDatabase->Find( "BLACK" ) )
+        colour = 0x01;
+    else if( col == wxTheColourDatabase->Find( "BLUE" ) )
+        colour = 0x02;
+    else if( col == wxTheColourDatabase->Find( "CYAN" ) )
+        colour = 0x03;
+    else if( col == wxTheColourDatabase->Find( "GREEN" ) )
+        colour = 0x04;
+    else if( col == wxTheColourDatabase->Find( "MAGENTA" ) )
+        colour = 0x05;
+    else if( col == wxTheColourDatabase->Find( "RED" ) )
+        colour = 0x06;
+    else if( col == wxTheColourDatabase->Find( "YELLOW" ) )
+        colour = 0x07;
+    else if( col == wxTheColourDatabase->Find( "WHITE" ) )
+        colour = 0x08;
+//    else if( col == wxTheColourDatabase->Find( "NAVY" ) )
+//        colour = 0x09;
+//    else if( col == wxTheColourDatabase->Find( "TEAL" ) )
+//        colour = 0x0A;
+//    else if( col == wxTheColourDatabase->Find( "GREEN" ) )
+//        colour = 0x0B;
+//    else if( col == wxTheColourDatabase->Find( "PURPLE" ) )
+//        colour = 0x0C;
+//    else if( col == wxTheColourDatabase->Find( "MAROON" ) )
+//        colour = 0x0D;
+    else if( col == wxTheColourDatabase->Find( "GREY" ) )
+        colour = 0x0E;
+    else if( col == wxTheColourDatabase->Find( "LIGHT GREY" ) )
+        colour = 0x0F;
+    else if( col == wxTheColourDatabase->Find( "LIGHT GREY" ) )
+        colour = 0x0F;
+    cf.bUnderlineColor = colour;
 #endif
 
     if ( style.HasTextColour() )

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2872,6 +2872,9 @@ bool wxTextCtrl::MSWSetCharFormat(const wxTextAttr& style, long start, long end)
             cf.bUnderlineType = CFU_UNDERLINEDOUBLE;
         if( style.GetUnderlinedType() == wxTEXT_ATTR_UNDERLINE_WAVE )
             cf.bUnderlineType = CFU_UNDERLINEWAVE;
+#if( _RICHEDIT_VER >= 0x0800 )
+		cf.bUnderlineColor = style.GetUnderlineColour();
+#endif
     }
 
     if ( style.HasTextColour() )

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2867,13 +2867,13 @@ bool wxTextCtrl::MSWSetCharFormat(const wxTextAttr& style, long start, long end)
         case wxTEXT_ATTR_UNDERLINE_NONE:
             cf.bUnderlineType = CFU_UNDERLINENONE;
             break;
-		case wxTEXT_ATTR_UNDERLINE_SOLID:
+        case wxTEXT_ATTR_UNDERLINE_SOLID:
             cf.bUnderlineType = CFU_UNDERLINE;
             break;
-		case wxTEXT_ATTR_UNDERLINE_DOUBLE:
+        case wxTEXT_ATTR_UNDERLINE_DOUBLE:
             cf.bUnderlineType = CFU_UNDERLINEDOUBLE;
             break;
-		case wxTEXT_ATTR_UNDERLINE_WAVE:
+        case wxTEXT_ATTR_UNDERLINE_WAVE:
             cf.bUnderlineType = CFU_UNDERLINEWAVE;
             break;
     }
@@ -2881,7 +2881,7 @@ bool wxTextCtrl::MSWSetCharFormat(const wxTextAttr& style, long start, long end)
 // The colours are coming from https://docs.microsoft.com/en-us/windows/desktop/api/tom/nf-tom-itextdocument2-geteffectcolor.
 // Not all values from wxTheColourDatabase are supported as can be seen from the code
 // Those are commented out currently
-    BYTE colour;
+    BYTE colour = 0;
     wxColour col = style.GetUnderlineColour();
     if( col == wxTheColourDatabase->Find( "BLACK" ) )
         colour = 0x01;
@@ -2911,8 +2911,8 @@ bool wxTextCtrl::MSWSetCharFormat(const wxTextAttr& style, long start, long end)
 //        colour = 0x0D;
     else if( col == wxTheColourDatabase->Find( "GREY" ) )
         colour = 0x0E;
-    else if( col == wxTheColourDatabase->Find( "LIGHT GREY" ) )
-        colour = 0x0F;
+//    else if( col == wxTheColourDatabase->Find( "DARK GREY" ) )
+//        colour = 0x0F;
     else if( col == wxTheColourDatabase->Find( "LIGHT GREY" ) )
         colour = 0x0F;
     cf.bUnderlineColor = colour;

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -1111,8 +1111,13 @@ void wxNSTextViewControl::SetStyle(long start,
                     break;
             }
             wxColour color = style.GetUnderlineColour();
-            if( color.IsOk() )
-                [attrs setValue:color.OSXGetNSColor() forKey:NSUnderlineColorAttributeName];
+            if( !color.IsOk() )
+            {
+                color = style.GetTextColour();
+                if( !color.IsOk() )
+                    color = *wxBLACK;
+            }
+            [attrs setValue:color.OSXGetNSColor() forKey:NSUnderlineColorAttributeName];
         }
         [m_textView setTypingAttributes:attrs];
     }
@@ -1145,8 +1150,13 @@ void wxNSTextViewControl::SetStyle(long start,
             if( style.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_WAVE )
                 [dict setObject:[NSNumber numberWithInt:( NSUnderlinePatternDot )] forKey:NSUnderlineStyleAttributeName];
             wxColour color = style.GetUnderlineColour();
-            if( color.IsOk() )
-                [dict setValue:color.OSXGetNSColor() forKey:NSUnderlineColorAttributeName];
+            if( !color.IsOk() )
+            {
+                color = style.GetTextColour();
+                if( !color.IsOk() )
+                    color = *wxBLACK;
+            }
+            [dict setValue:color.OSXGetNSColor() forKey:NSUnderlineColorAttributeName];
 
             [storage addAttributes:dict range:range];
             [dict release];

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -1082,14 +1082,36 @@ void wxNSTextViewControl::SetStyle(long start,
     if ( start == -1 && end == -1 )
     {
         NSMutableDictionary* const
-            attrs = [NSMutableDictionary dictionaryWithCapacity:3];
+            attrs = [NSMutableDictionary dictionaryWithCapacity:5];
         if ( style.HasFont() )
             [attrs setValue:style.GetFont().OSXGetNSFont() forKey:NSFontAttributeName];
         if ( style.HasBackgroundColour() )
             [attrs setValue:style.GetBackgroundColour().OSXGetNSColor() forKey:NSBackgroundColorAttributeName];
         if ( style.HasTextColour() )
             [attrs setValue:style.GetTextColour().OSXGetNSColor() forKey:NSForegroundColorAttributeName];
+        if( style.GetUnderlineType() )
+        {
+            wxTextAttrUnderlineType underlineType = style.GetUnderlineType();
+            switch( underlineType )
+            {
+                case wxTEXT_ATTR_UNDERLINE_NONE:
+                    [attrs setObject:[NSNumber numberWithInt:( NSUnderlineStyleNone )] forKey:NSUnderlineStyleAttributeName];
+                    break;
 
+                case wxTEXT_ATTR_UNDERLINE_SOLID:
+                    [attrs setObject:[NSNumber numberWithInt:( NSUnderlineStyleSingle | NSUnderlineStyleSingle )] forKey:NSUnderlineStyleAttributeName];
+                    break;
+
+                case wxTEXT_ATTR_UNDERLINE_DOUBLE:
+                    [attrs setObject:[NSNumber numberWithInt:( NSUnderlineStyleSingle | NSUnderlineStyleDouble )] forKey:NSUnderlineStyleAttributeName];
+                    break;
+
+                case wxTEXT_ATTR_UNDERLINE_WAVE:
+                    [attrs setObject:[NSNumber numberWithInt:( NSUnderlineStyleSingle | NSUnderlinePatternDot )] forKey:NSUnderlineStyleAttributeName];
+                    break;
+            }
+            [attrs setValue:style.GetUnderlineColour().OSXGetNSColor() forKey:NSUnderlineColorAttributeName];
+        }
         [m_textView setTypingAttributes:attrs];
     }
     else // Set the attributes just for this range.
@@ -1105,6 +1127,26 @@ void wxNSTextViewControl::SetStyle(long start,
 
         if ( style.HasTextColour() )
             [storage addAttribute:NSForegroundColorAttributeName value:style.GetTextColour().OSXGetNSColor() range:range];
+
+        if( style.HasFontUnderlined() )
+        {
+            NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
+            if( style.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_NONE )
+                [dict setObject:[NSNumber numberWithInt:(NSUnderlineStyleNone)] forKey:NSUnderlineStyleAttributeName];
+
+            if( style.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_SOLID )
+                [dict setObject:[NSNumber numberWithInt:( NSUnderlineStyleSingle )] forKey:NSUnderlineStyleAttributeName];
+
+            if( style.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_DOUBLE )
+                [dict setObject:[NSNumber numberWithInt:( NSUnderlineStyleDouble )] forKey:NSUnderlineStyleAttributeName];
+
+            if( style.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_WAVE )
+                [dict setObject:[NSNumber numberWithInt:( NSUnderlinePatternDot )] forKey:NSUnderlineStyleAttributeName];
+            [dict setValue:style.GetUnderlineColour().OSXGetNSColor() forKey:NSUnderlineColorAttributeName];
+
+            [storage addAttributes:dict range:range];
+            [dict release];
+        }
     }
         
     if ( style.HasAlignment() )

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -1144,7 +1144,9 @@ void wxNSTextViewControl::SetStyle(long start,
 
             if( style.GetUnderlineType() == wxTEXT_ATTR_UNDERLINE_WAVE )
                 [dict setObject:[NSNumber numberWithInt:( NSUnderlinePatternDot )] forKey:NSUnderlineStyleAttributeName];
-            [dict setValue:style.GetUnderlineColour().OSXGetNSColor() forKey:NSUnderlineColorAttributeName];
+            wxColour color = style.GetUnderlineColour();
+            if( color.IsOk() )
+                [dict setValue:color.OSXGetNSColor() forKey:NSUnderlineColorAttributeName];
 
             [storage addAttributes:dict range:range];
             [dict release];

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -1110,7 +1110,9 @@ void wxNSTextViewControl::SetStyle(long start,
                     [attrs setObject:[NSNumber numberWithInt:( NSUnderlineStyleSingle | NSUnderlinePatternDot )] forKey:NSUnderlineStyleAttributeName];
                     break;
             }
-            [attrs setValue:style.GetUnderlineColour().OSXGetNSColor() forKey:NSUnderlineColorAttributeName];
+            wxColour color = style.GetUnderlineColour();
+            if( color.IsOk() )
+                [attrs setValue:color.OSXGetNSColor() forKey:NSUnderlineColorAttributeName];
         }
         [m_textView setTypingAttributes:attrs];
     }


### PR DESCRIPTION
This PR implements the feature from the ticket for MSW and GTK.
It shows its usage in the sample and adds documentation.

If someone who is better doc write than me can check the documentation - it would be great.
If there is a questions about new function(s) name - let me know. We will try to figure it out.

I have a OSX implementation ready, but unfortunately I screw up somewhere and it someone can look at it, I will be pushing the change to my fork under the same branch.

Please review and apply.