### PR TITLE
Ensure correct previous page is sent for notebook events

### DIFF
--- a/src/qt/notebook.cpp
+++ b/src/qt/notebook.cpp
@@ -192,8 +192,8 @@ int wxNotebook::SetSelection(size_t page)
     int selOld = GetSelection();
 
     // change the QTabWidget selected page:
-    m_selection = page;
     m_qtTabWidget->setCurrentIndex( page );
+    m_selection = page;
 
     return selOld;
 }


### PR DESCRIPTION
QT Notebook page changed events had the wrong "previous page" id in circumstances where the page has been changed by methods other than clicking on the tabs, for example using the "Pages->Next page" menu option in the Notebook Sample.

This change corrects this problem.