### PR TITLE
Skip events when mouse is captured.

### DIFF
--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -4160,14 +4160,14 @@ void wxAuiManager::OnLeftDown(wxMouseEvent& event)
                                       event.m_y - part->rect.y);
             m_frame->CaptureMouse();
         }
-#ifdef __WXMAC__
+#if defined __WXMAC__ || defined __WXQT__
         else
         {
             event.Skip();
         }
 #endif
     }
-#ifdef __WXMAC__
+#if defined __WXMAC__ || defined __WXQT__
     else
     {
         event.Skip();


### PR DESCRIPTION
In QT builds, the same widget would try to capture the mouse on mouse down because the event was getting skipped and then passed back into the widget via a different route.

Skipping the event after capturing the mouse sounds like something that would not be desirable on any platform to me, but I only changed QT builds in case I am wrong.