### PR TITLE
Update the size of QLabel after setting text. 

### DIFF
--- a/src/qt/stattext.cpp
+++ b/src/qt/stattext.cpp
@@ -61,6 +61,7 @@ bool wxStaticText::Create(wxWindow *parent,
 void wxStaticText::SetLabel(const wxString& label)
 {
     m_qtLabel->setText( wxQtConvertString( label ) );
+    m_qtLabel->adjustSize();
 }
 
 wxString wxStaticText::GetLabel() const

--- a/src/qt/stattext.cpp
+++ b/src/qt/stattext.cpp
@@ -61,7 +61,7 @@ bool wxStaticText::Create(wxWindow *parent,
 void wxStaticText::SetLabel(const wxString& label)
 {
     m_qtLabel->setText( wxQtConvertString( label ) );
-    m_qtLabel->adjustSize();
+    AutoResizeIfNecessary();
 }
 
 wxString wxStaticText::GetLabel() const


### PR DESCRIPTION
QLabel doesn't automatically update its size when new text is set, but wxStaticText assumes the size has been updated. So we explicitly do it.