### PR TITLE
Fix mismatched malloc/delete as reported by valgrind

### DIFF
--- a/src/qt/app.cpp
+++ b/src/qt/app.cpp
@@ -28,7 +28,7 @@ wxApp::~wxApp()
     // Delete command line arguments
     for ( int i = 0; i < m_qtArgc; ++i )
     {
-        delete m_qtArgv[i];
+        free(m_qtArgv[i]);
     }
 }
 


### PR DESCRIPTION
The string was created using strdrup should so should be free'd rather than delete'd