### PR TITLE
Qt docking fix for linux

### DIFF
--- a/build/cmake/toolkit.cmake
+++ b/build/cmake/toolkit.cmake
@@ -117,6 +117,12 @@ endif()
 
 if(WXQT)
     set(QT_COMPONENTS Core Widgets Gui OpenGL Test)
+
+    # add in the Qt5X11Extras lib when using wxqt on X11
+    if(UNIX AND NOT APPLE AND NOT WIN32)
+        set(QT_COMPONENTS ${QT_COMPONENTS} X11Extras)
+    endif()
+
     foreach(QT_COMPONENT ${QT_COMPONENTS})
         find_package(Qt5 COMPONENTS ${QT_COMPONENT} REQUIRED)
         list(APPEND wxTOOLKIT_INCLUDE_DIRS ${Qt5${QT_COMPONENT}_INCLUDE_DIRS})

--- a/configure
+++ b/configure
@@ -27354,14 +27354,105 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
         if test -n "$QT5_CUSTOM_DIR" ; then
                         TOOLKIT_INCLUDE="${TOOLKIT_INCLUDE} -I${QT5_CUSTOM_DIR}/include"
-            GUI_TK_LIBRARY="${GUI_TK_LIBRARY} -L${QT5_CUSTOM_DIR}/lib \
+
+            if test "$wxUSE_UNIX" = "yes" -a "$wxUSE_MAC" != 1; then
+                GUI_TK_LIBRARY="${GUI_TK_LIBRARY} -L${QT5_CUSTOM_DIR}/lib \
+                            -lQt5Core -lQt5Widgets -lQt5Gui -lQt5OpenGL -lQt5Test -lQt5X11Extras \
+                            -Wl,-rpath,${QT5_CUSTOM_DIR}/lib"
+            else
+                GUI_TK_LIBRARY="${GUI_TK_LIBRARY} -L${QT5_CUSTOM_DIR}/lib \
                             -lQt5Core -lQt5Widgets -lQt5Gui -lQt5OpenGL -lQt5Test \
                             -Wl,-rpath,${QT5_CUSTOM_DIR}/lib"
+            fi
 
         elif test -z "$PKG_CONFIG" ; then
             as_fn_error $? "specify QT5_CUSTOM_DIR or make sure pkg-config is available to search for Qt5 libraries" "$LINENO" 5
 
         else
+            if test "$wxUSE_UNIX" = "yes" -a "$wxUSE_MAC" != 1; then
+
+pkg_failed=no
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for QT5" >&5
+$as_echo_n "checking for QT5... " >&6; }
+
+if test -n "$PKG_CONFIG"; then
+    if test -n "$QT5_CFLAGS"; then
+        pkg_cv_QT5_CFLAGS="$QT5_CFLAGS"
+    else
+        if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"Qt5Core Qt5Widgets Qt5Gui Qt5OpenGL Qt5Test Qt5X11Extras\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "Qt5Core Qt5Widgets Qt5Gui Qt5OpenGL Qt5Test Qt5X11Extras") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_QT5_CFLAGS=`$PKG_CONFIG --cflags "Qt5Core Qt5Widgets Qt5Gui Qt5OpenGL Qt5Test Qt5X11Extras" 2>/dev/null`
+else
+  pkg_failed=yes
+fi
+    fi
+else
+	pkg_failed=untried
+fi
+if test -n "$PKG_CONFIG"; then
+    if test -n "$QT5_LIBS"; then
+        pkg_cv_QT5_LIBS="$QT5_LIBS"
+    else
+        if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"Qt5Core Qt5Widgets Qt5Gui Qt5OpenGL Qt5Test Qt5X11Extras\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "Qt5Core Qt5Widgets Qt5Gui Qt5OpenGL Qt5Test Qt5X11Extras") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_QT5_LIBS=`$PKG_CONFIG --libs "Qt5Core Qt5Widgets Qt5Gui Qt5OpenGL Qt5Test Qt5X11Extras" 2>/dev/null`
+else
+  pkg_failed=yes
+fi
+    fi
+else
+	pkg_failed=untried
+fi
+
+
+
+if test $pkg_failed = yes; then
+
+if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+        _pkg_short_errors_supported=yes
+else
+        _pkg_short_errors_supported=no
+fi
+        if test $_pkg_short_errors_supported = yes; then
+	        QT5_PKG_ERRORS=`$PKG_CONFIG --short-errors --errors-to-stdout --print-errors "Qt5Core Qt5Widgets Qt5Gui Qt5OpenGL Qt5Test Qt5X11Extras"`
+        else
+	        QT5_PKG_ERRORS=`$PKG_CONFIG --errors-to-stdout --print-errors "Qt5Core Qt5Widgets Qt5Gui Qt5OpenGL Qt5Test Qt5X11Extras"`
+        fi
+	# Put the nasty error message in config.log where it belongs
+	echo "$QT5_PKG_ERRORS" >&5
+
+
+                        as_fn_error $? "Qt5 libraries are not available" "$LINENO" 5
+
+
+elif test $pkg_failed = untried; then
+
+                        as_fn_error $? "Qt5 libraries are not available" "$LINENO" 5
+
+
+else
+	QT5_CFLAGS=$pkg_cv_QT5_CFLAGS
+	QT5_LIBS=$pkg_cv_QT5_LIBS
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+                    TOOLKIT_INCLUDE="${TOOLKIT_INCLUDE} ${QT5_CFLAGS}"
+                    GUI_TK_LIBRARY="${GUI_TK_LIBRARY} ${QT5_LIBS}"
+                    if `pkg-config --variable qt_config Qt5Core | grep "reduce_relocations" >/dev/null`; then
+                                                SAMPLES_CXXFLAGS="-fPIC $SAMPLES_CXXFLAGS"
+                        WXCONFIG_CXXFLAGS="-fPIC $WXCONFIG_CXXFLAGS"
+                    fi
+
+fi
+            else
 
 pkg_failed=no
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for QT5" >&5
@@ -27422,12 +27513,12 @@ fi
 	echo "$QT5_PKG_ERRORS" >&5
 
 
-                    as_fn_error $? "Qt5 libraries are not available" "$LINENO" 5
+                        as_fn_error $? "Qt5 libraries are not available" "$LINENO" 5
 
 
 elif test $pkg_failed = untried; then
 
-                    as_fn_error $? "Qt5 libraries are not available" "$LINENO" 5
+                        as_fn_error $? "Qt5 libraries are not available" "$LINENO" 5
 
 
 else
@@ -27436,14 +27527,15 @@ else
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 
-                TOOLKIT_INCLUDE="${TOOLKIT_INCLUDE} ${QT5_CFLAGS}"
-                GUI_TK_LIBRARY="${GUI_TK_LIBRARY} ${QT5_LIBS}"
-                if `pkg-config --variable qt_config Qt5Core | grep "reduce_relocations" >/dev/null`; then
-                                        SAMPLES_CXXFLAGS="-fPIC $SAMPLES_CXXFLAGS"
-                    WXCONFIG_CXXFLAGS="-fPIC $WXCONFIG_CXXFLAGS"
-                fi
+                    TOOLKIT_INCLUDE="${TOOLKIT_INCLUDE} ${QT5_CFLAGS}"
+                    GUI_TK_LIBRARY="${GUI_TK_LIBRARY} ${QT5_LIBS}"
+                    if `pkg-config --variable qt_config Qt5Core | grep "reduce_relocations" >/dev/null`; then
+                                                SAMPLES_CXXFLAGS="-fPIC $SAMPLES_CXXFLAGS"
+                        WXCONFIG_CXXFLAGS="-fPIC $WXCONFIG_CXXFLAGS"
+                    fi
 
 fi
+            fi
         fi
     fi
         TOOLKIT_DIR=`echo ${TOOLKIT} | tr '[A-Z]' '[a-z]'`

--- a/configure.in
+++ b/configure.in
@@ -3407,29 +3407,54 @@ libraries returned by 'pkg-config gtk+-2.0 --libs' or 'gtk-config
         if test -n "$QT5_CUSTOM_DIR" ; then
             dnl the name of the directory where the files for this toolkit live
             TOOLKIT_INCLUDE="${TOOLKIT_INCLUDE} -I${QT5_CUSTOM_DIR}/include"
-            GUI_TK_LIBRARY="${GUI_TK_LIBRARY} -L${QT5_CUSTOM_DIR}/lib \
+
+            if test "$wxUSE_UNIX" = "yes" -a "$wxUSE_MAC" != 1; then
+                GUI_TK_LIBRARY="${GUI_TK_LIBRARY} -L${QT5_CUSTOM_DIR}/lib \
+                            -lQt5Core -lQt5Widgets -lQt5Gui -lQt5OpenGL -lQt5Test -lQt5X11Extras \
+                            -Wl,-rpath,${QT5_CUSTOM_DIR}/lib"
+            else
+                GUI_TK_LIBRARY="${GUI_TK_LIBRARY} -L${QT5_CUSTOM_DIR}/lib \
                             -lQt5Core -lQt5Widgets -lQt5Gui -lQt5OpenGL -lQt5Test \
                             -Wl,-rpath,${QT5_CUSTOM_DIR}/lib"
+            fi
 
         elif test -z "$PKG_CONFIG" ; then
             AC_MSG_ERROR([specify QT5_CUSTOM_DIR or make sure pkg-config is available to search for Qt5 libraries])
 
         else
-            PKG_CHECK_MODULES(QT5,
+            if test "$wxUSE_UNIX" = "yes" -a "$wxUSE_MAC" != 1; then
+                PKG_CHECK_MODULES(QT5,
+                          [Qt5Core Qt5Widgets Qt5Gui Qt5OpenGL Qt5Test Qt5X11Extras],
+                    [
+                    TOOLKIT_INCLUDE="${TOOLKIT_INCLUDE} ${QT5_CFLAGS}"
+                    GUI_TK_LIBRARY="${GUI_TK_LIBRARY} ${QT5_LIBS}"
+                    if `pkg-config --variable qt_config Qt5Core | grep "reduce_relocations" >/dev/null`; then
+                        dnl build with position independent code if Qt needs it
+                        SAMPLES_CXXFLAGS="-fPIC $SAMPLES_CXXFLAGS"
+                        WXCONFIG_CXXFLAGS="-fPIC $WXCONFIG_CXXFLAGS"
+                    fi
+                    ],
+                    [
+                        AC_MSG_ERROR([Qt5 libraries are not available])
+                    ]
+                )
+            else
+                PKG_CHECK_MODULES(QT5,
                           [Qt5Core Qt5Widgets Qt5Gui Qt5OpenGL Qt5Test],
-                [
-                TOOLKIT_INCLUDE="${TOOLKIT_INCLUDE} ${QT5_CFLAGS}"
-                GUI_TK_LIBRARY="${GUI_TK_LIBRARY} ${QT5_LIBS}"
-                if `pkg-config --variable qt_config Qt5Core | grep "reduce_relocations" >/dev/null`; then
-                    dnl build with position independent code if Qt needs it
-                    SAMPLES_CXXFLAGS="-fPIC $SAMPLES_CXXFLAGS"
-                    WXCONFIG_CXXFLAGS="-fPIC $WXCONFIG_CXXFLAGS"
-                fi
-                ],
-                [
-                    AC_MSG_ERROR([Qt5 libraries are not available])
-                ]
-            )
+                    [
+                    TOOLKIT_INCLUDE="${TOOLKIT_INCLUDE} ${QT5_CFLAGS}"
+                    GUI_TK_LIBRARY="${GUI_TK_LIBRARY} ${QT5_LIBS}"
+                    if `pkg-config --variable qt_config Qt5Core | grep "reduce_relocations" >/dev/null`; then
+                        dnl build with position independent code if Qt needs it
+                        SAMPLES_CXXFLAGS="-fPIC $SAMPLES_CXXFLAGS"
+                        WXCONFIG_CXXFLAGS="-fPIC $WXCONFIG_CXXFLAGS"
+                    fi
+                    ],
+                    [
+                        AC_MSG_ERROR([Qt5 libraries are not available])
+                    ]
+                )
+            fi
         fi
     fi
     dnl the name of the directory where the files for this toolkit live

--- a/src/aui/floatpane.cpp
+++ b/src/aui/floatpane.cpp
@@ -381,9 +381,9 @@ bool wxAuiFloatingFrame::isMouseDown()
         &root_x, &root_y, &win_x, &win_y, &key_state);
 
     return key_state == Button1Mask;
-#endif
-
+#else
     return wxGetMouseState().LeftIsDown();
+#endif
 }
 
 

--- a/src/aui/floatpane.cpp
+++ b/src/aui/floatpane.cpp
@@ -380,7 +380,7 @@ bool wxAuiFloatingFrame::isMouseDown()
     XQueryPointer(QX11Info::display(), QX11Info::appRootWindow(), &root, &child,
         &root_x, &root_y, &win_x, &win_y, &key_state);
 
-    return key_state == Button1Mask;
+    return key_state & Button1Mask;
 #else
     return wxGetMouseState().LeftIsDown();
 #endif

--- a/src/aui/floatpane.cpp
+++ b/src/aui/floatpane.cpp
@@ -35,6 +35,11 @@
 #include "wx/msw/private.h"
 #endif
 
+#ifdef __LINUX__
+#include <QtX11Extras/qx11info_x11.h>
+#include <X11/Xlib.h>
+#endif
+
 wxIMPLEMENT_CLASS(wxAuiFloatingFrame, wxAuiFloatingFrameBaseClass);
 
 wxAuiFloatingFrame::wxAuiFloatingFrame(wxWindow* parent,
@@ -365,6 +370,19 @@ void wxAuiFloatingFrame::OnActivate(wxActivateEvent& event)
 // functionality to wxWidgets itself)
 bool wxAuiFloatingFrame::isMouseDown()
 {
+#ifdef __LINUX__
+    Window root;
+    Window child;
+    int root_x, root_y;
+    int win_x, win_y;
+    unsigned int key_state;
+
+    XQueryPointer(QX11Info::display(), QX11Info::appRootWindow(), &root, &child,
+        &root_x, &root_y, &win_x, &win_y, &key_state);
+
+    return key_state == Button1Mask;
+#endif
+
     return wxGetMouseState().LeftIsDown();
 }
 


### PR DESCRIPTION
Fixes docking windows in Linux. The cause of which was the mouseDown() method in floatpane. The use of QApplication::mouseButtons() isn't guaranteed to get the current mouse event so for Linux drop to ask X11 what the actual state is. 