### PR TITLE
Disable Qt's automatic "auto default" state for buttons in dialogs.

### DIFF
--- a/src/qt/anybutton.cpp
+++ b/src/qt/anybutton.cpp
@@ -85,8 +85,9 @@ wxAnyButton::wxAnyButton() :
 
 void wxAnyButton::QtCreate(wxWindow *parent)
 {
-    // create the default push button (used in button and bmp button)
-    m_qtPushButton = new wxQtPushButton( parent, this );
+    // create the basic push button (used in button and bmp button)
+    m_qtPushButton = new wxQtPushButton(parent, this);
+    m_qtPushButton->setAutoDefault(false);
 }
 
 void wxAnyButton::QtSetBitmap( const wxBitmap &bitmap )


### PR DESCRIPTION
Let the Wx layer handle default-ness, as the auto behaviour has unhappy consequences that can't be controlled via the wx API. (For example, a Delete button being considered default simply because it's the first button in the dialog.)