### PR TITLE
Qt clipboard bitmap

### DIFF
--- a/include/wx/dataobj.h
+++ b/include/wx/dataobj.h
@@ -428,7 +428,8 @@ public:
 
 private:
 #if defined(__WXQT__)
-	void DoSetDataFrom(const class QMimeData &mimeData, const wxDataFormat &format) wxOVERRIDE;
+    // Overridden to set text directly instead of extracting byte array
+    void QtSetDataSingleFormat(const class QMimeData &mimeData, const wxDataFormat &format) wxOVERRIDE;
 #endif
 
     wxString m_text;

--- a/include/wx/dataobj.h
+++ b/include/wx/dataobj.h
@@ -427,6 +427,10 @@ public:
 #endif // different wxTextDataObject implementations
 
 private:
+#if defined(__WXQT__)
+	void DoSetDataFrom(const class QMimeData &mimeData, const wxDataFormat &format) wxOVERRIDE;
+#endif
+
     wxString m_text;
 
     wxDECLARE_NO_COPY_CLASS(wxTextDataObject);

--- a/include/wx/qt/dataobj.h
+++ b/include/wx/qt/dataobj.h
@@ -21,11 +21,15 @@ public:
     virtual ~wxDataObject();
 
     virtual bool IsSupportedFormat( const wxDataFormat& format, Direction dir = Get ) const;
-	virtual void AddDataTo(QMimeData &mimeData) const;
-	virtual bool SetDataFrom(const QMimeData &mimeData);
+
+    // Adds object's data to Qt mime data appropriately for type
+    virtual void QtAddDataTo(QMimeData &mimeData) const;
+    // Sets object's data from Qt mime data appropriately for type
+    virtual bool QtSetDataFrom(const QMimeData &mimeData);
 
 private:
-	virtual void DoSetDataFrom(const QMimeData &mimeData, const wxDataFormat &format);
+    // Sets object's data from Qt mime data in specific format
+    virtual void QtSetDataSingleFormat(const QMimeData &mimeData, const wxDataFormat &format);
 };
 
 #endif // _WX_QT_DATAOBJ_H_

--- a/include/wx/qt/dataobj.h
+++ b/include/wx/qt/dataobj.h
@@ -12,6 +12,8 @@
 // wxDataObject is the same as wxDataObjectBase under wxQT
 // ----------------------------------------------------------------------------
 
+class QMimeData;
+
 class WXDLLIMPEXP_CORE wxDataObject : public wxDataObjectBase
 {
 public:
@@ -19,6 +21,11 @@ public:
     virtual ~wxDataObject();
 
     virtual bool IsSupportedFormat( const wxDataFormat& format, Direction dir = Get ) const;
+	virtual void AddDataTo(QMimeData &mimeData) const;
+	virtual bool SetDataFrom(const QMimeData &mimeData);
+
+private:
+	virtual void DoSetDataFrom(const QMimeData &mimeData, const wxDataFormat &format);
 };
 
 #endif // _WX_QT_DATAOBJ_H_

--- a/include/wx/qt/dataobj2.h
+++ b/include/wx/qt/dataobj2.h
@@ -8,28 +8,15 @@
 #ifndef _WX_QT_DATAOBJ2_H_
 #define _WX_QT_DATAOBJ2_H_
 
-#include <wx/scopedptr.h>
-
-class QByteArray;
-
 class WXDLLIMPEXP_CORE wxBitmapDataObject : public wxBitmapDataObjectBase
 {
 public:
     wxBitmapDataObject();
     wxBitmapDataObject(const wxBitmap& bitmap);
 
-    ~wxBitmapDataObject();
-
-    void SetBitmap(const wxBitmap& bitmap) wxOVERRIDE;
-    size_t GetDataSize() const wxOVERRIDE;
-    bool GetDataHere(void *buf) const wxOVERRIDE;
-    bool SetData(const wxDataFormat& format, size_t len, const void *buf) wxOVERRIDE;
-
 protected:
-    void DoConvertToPng();
 
 private:
-    wxScopedPtr<QByteArray> m_imageBytes;
 };
 
 

--- a/include/wx/qt/dataobj2.h
+++ b/include/wx/qt/dataobj2.h
@@ -14,8 +14,10 @@ public:
     wxBitmapDataObject();
     wxBitmapDataObject(const wxBitmap& bitmap);
 
-	void AddDataTo(QMimeData &mimeData) const wxOVERRIDE;
-	bool SetDataFrom(const QMimeData &mimeData) wxOVERRIDE;
+    // Overridden to set image data directly, which Qt will write to clipboard in many formats
+    void QtAddDataTo(QMimeData &mimeData) const wxOVERRIDE;
+    // Overridden to retrieve image data from any format that Qt can read from clipboard
+    bool QtSetDataFrom(const QMimeData &mimeData) wxOVERRIDE;
 
 protected:
 

--- a/include/wx/qt/dataobj2.h
+++ b/include/wx/qt/dataobj2.h
@@ -8,15 +8,28 @@
 #ifndef _WX_QT_DATAOBJ2_H_
 #define _WX_QT_DATAOBJ2_H_
 
+#include <wx/scopedptr.h>
+
+class QByteArray;
+
 class WXDLLIMPEXP_CORE wxBitmapDataObject : public wxBitmapDataObjectBase
 {
 public:
     wxBitmapDataObject();
     wxBitmapDataObject(const wxBitmap& bitmap);
 
+    ~wxBitmapDataObject();
+
+    void SetBitmap(const wxBitmap& bitmap) wxOVERRIDE;
+    size_t GetDataSize() const wxOVERRIDE;
+    bool GetDataHere(void *buf) const wxOVERRIDE;
+    bool SetData(const wxDataFormat& format, size_t len, const void *buf) wxOVERRIDE;
+
 protected:
+    void DoConvertToPng();
 
 private:
+    wxScopedPtr<QByteArray> m_imageBytes;
 };
 
 

--- a/include/wx/qt/dataobj2.h
+++ b/include/wx/qt/dataobj2.h
@@ -14,6 +14,9 @@ public:
     wxBitmapDataObject();
     wxBitmapDataObject(const wxBitmap& bitmap);
 
+	void AddDataTo(QMimeData &mimeData) const wxOVERRIDE;
+	bool SetDataFrom(const QMimeData &mimeData) wxOVERRIDE;
+
 protected:
 
 private:

--- a/src/qt/clipbrd.cpp
+++ b/src/qt/clipbrd.cpp
@@ -152,7 +152,7 @@ bool wxClipboard::GetData( wxDataObject& data )
             textdata->SetText(wxQtConvertString(MimeData->text()));
         else
         {
-            QByteArray bytearray = MimeData->data( wxQtConvertString(format.GetMimeType()) ).data();
+            QByteArray bytearray = MimeData->data( wxQtConvertString(format.GetMimeType()) );
             data.SetData(format, bytearray.size(), bytearray.constData());
         }
 

--- a/src/qt/clipbrd.cpp
+++ b/src/qt/clipbrd.cpp
@@ -88,8 +88,8 @@ bool wxClipboard::IsOpened() const
 
 bool wxClipboard::AddData( wxDataObject *data )
 {
-	QMimeData *MimeData = new QMimeData;
-	data->AddDataTo(*MimeData);
+    QMimeData *MimeData = new QMimeData;
+    data->QtAddDataTo(*MimeData);
     delete data;
 
     QtClipboard->setMimeData(MimeData, (QClipboard::Mode)Mode());
@@ -113,7 +113,7 @@ bool wxClipboard::GetData( wxDataObject& data )
     wxCHECK_MSG( m_open, false, wxT("clipboard not open") );
 
     const QMimeData *MimeData = QtClipboard->mimeData( (QClipboard::Mode)Mode() );
-	return data.SetDataFrom(*MimeData);
+    return data.QtSetDataFrom(*MimeData);
 }
 
 void wxClipboard::Clear()

--- a/src/qt/dataobj.cpp
+++ b/src/qt/dataobj.cpp
@@ -26,7 +26,7 @@ wxString DataFormatIdToMimeType(wxDataFormatId formatId)
     switch ( formatId )
     {
         case wxDF_TEXT: return "text/plain";
-        case wxDF_BITMAP: return "image/bmp";
+        case wxDF_BITMAP: return "PNG";
         case wxDF_TIFF: return "image/tiff";
         case wxDF_WAVE: return "audio/x-wav";
         case wxDF_UNICODETEXT: return "text/plain";

--- a/src/qt/dataobj.cpp
+++ b/src/qt/dataobj.cpp
@@ -12,8 +12,14 @@
     #pragma hdrstop
 #endif
 
+#include <QtCore/QMimeData>
+#include <QtGui/QPixmap>
+
 #include "wx/dataobj.h"
 #include "wx/scopedarray.h"
+#include "wx/qt/private/converter.h"
+
+typedef wxScopedArray<wxDataFormat> wxDataFormatArray;
 
 namespace
 {
@@ -150,6 +156,58 @@ bool wxDataObject::IsSupportedFormat(const wxDataFormat& format,
     return false;
 }
 
+void wxDataObject::AddDataTo(QMimeData &mimeData) const
+{
+	const size_t count = GetFormatCount();
+	wxDataFormatArray formats(count);
+	GetAllFormats(formats.get());
+
+	// how to add timestamp?
+
+	// Unfortunately I cannot find a way to use the qt clipboard with
+	// a callback to select the data type, so I must copy it all here
+
+	for (size_t i = 0; i < count; i++)
+	{
+		const wxDataFormat format(formats[i]);
+
+		int size = GetDataSize(format);
+		if (!size)
+			continue;
+
+		QByteArray bytearray(size, 0);
+		GetDataHere(format, bytearray.data());
+		mimeData.setData(wxQtConvertString(format.GetMimeType()), bytearray);
+	}
+}
+
+bool wxDataObject::SetDataFrom(const QMimeData &mimeData)
+{
+	const size_t count = GetFormatCount(Set);
+	wxDataFormatArray formats(count);
+	GetAllFormats(formats.get(), Set);
+
+	for (size_t i = 0; i < count; i++)
+	{
+		const wxDataFormat format(formats[i]);
+
+		// is this format supported by clipboard ?
+		if (!mimeData.hasFormat(wxQtConvertString(format.GetMimeType())))
+			continue;
+
+		DoSetDataFrom(mimeData, format);
+		return true;
+	}
+
+	return false;
+}
+
+void wxDataObject::DoSetDataFrom(const QMimeData &mimeData, const wxDataFormat &format)
+{
+	QByteArray bytearray = mimeData.data(wxQtConvertString(format.GetMimeType()));
+	SetData(format, bytearray.size(), bytearray.constData());
+}
+
 //############################################################################
 
 wxBitmapDataObject::wxBitmapDataObject()
@@ -159,6 +217,20 @@ wxBitmapDataObject::wxBitmapDataObject()
 wxBitmapDataObject::wxBitmapDataObject( const wxBitmap &bitmap )
     : wxBitmapDataObjectBase( bitmap )
 {
+}
+
+void wxBitmapDataObject::AddDataTo(QMimeData &mimeData) const
+{
+	mimeData.setImageData(GetBitmap().GetHandle()->toImage());
+}
+
+bool wxBitmapDataObject::SetDataFrom(const QMimeData &mimeData)
+{
+	if (!mimeData.hasImage())
+		return false;
+
+	SetBitmap(wxBitmap(QPixmap::fromImage(qvariant_cast<QImage>(mimeData.imageData()))));
+	return true;
 }
 
 //#############################################################################
@@ -174,6 +246,11 @@ void wxTextDataObject::GetAllFormats(wxDataFormat *formats,
     formats[1] = wxDataFormat(wxDF_TEXT);
 }
 #endif
+
+void wxTextDataObject::DoSetDataFrom(const QMimeData &mimeData, const wxDataFormat &WXUNUSED(format))
+{
+	SetText(wxQtConvertString(mimeData.text()));
+}
 
 //#############################################################################
 

--- a/src/qt/dataobj.cpp
+++ b/src/qt/dataobj.cpp
@@ -156,56 +156,56 @@ bool wxDataObject::IsSupportedFormat(const wxDataFormat& format,
     return false;
 }
 
-void wxDataObject::AddDataTo(QMimeData &mimeData) const
+void wxDataObject::QtAddDataTo(QMimeData &mimeData) const
 {
-	const size_t count = GetFormatCount();
-	wxDataFormatArray formats(count);
-	GetAllFormats(formats.get());
+    const size_t count = GetFormatCount();
+    wxDataFormatArray formats(count);
+    GetAllFormats(formats.get());
 
-	// how to add timestamp?
+    // how to add timestamp?
 
-	// Unfortunately I cannot find a way to use the qt clipboard with
-	// a callback to select the data type, so I must copy it all here
+    // Unfortunately I cannot find a way to use the qt clipboard with
+    // a callback to select the data type, so I must copy it all here
 
-	for (size_t i = 0; i < count; i++)
-	{
-		const wxDataFormat format(formats[i]);
+    for (size_t i = 0; i < count; i++)
+    {
+        const wxDataFormat format(formats[i]);
 
-		int size = GetDataSize(format);
-		if (!size)
-			continue;
+        int size = GetDataSize(format);
+        if (!size)
+            continue;
 
-		QByteArray bytearray(size, 0);
-		GetDataHere(format, bytearray.data());
-		mimeData.setData(wxQtConvertString(format.GetMimeType()), bytearray);
-	}
+        QByteArray bytearray(size, 0);
+        GetDataHere(format, bytearray.data());
+        mimeData.setData(wxQtConvertString(format.GetMimeType()), bytearray);
+    }
 }
 
-bool wxDataObject::SetDataFrom(const QMimeData &mimeData)
+bool wxDataObject::QtSetDataFrom(const QMimeData &mimeData)
 {
-	const size_t count = GetFormatCount(Set);
-	wxDataFormatArray formats(count);
-	GetAllFormats(formats.get(), Set);
+    const size_t count = GetFormatCount(Set);
+    wxDataFormatArray formats(count);
+    GetAllFormats(formats.get(), Set);
 
-	for (size_t i = 0; i < count; i++)
-	{
-		const wxDataFormat format(formats[i]);
+    for (size_t i = 0; i < count; i++)
+    {
+        const wxDataFormat format(formats[i]);
 
-		// is this format supported by clipboard ?
-		if (!mimeData.hasFormat(wxQtConvertString(format.GetMimeType())))
-			continue;
+        // is this format supported by clipboard ?
+        if (!mimeData.hasFormat(wxQtConvertString(format.GetMimeType())))
+            continue;
 
-		DoSetDataFrom(mimeData, format);
-		return true;
-	}
+        QtSetDataSingleFormat(mimeData, format);
+        return true;
+    }
 
-	return false;
+    return false;
 }
 
-void wxDataObject::DoSetDataFrom(const QMimeData &mimeData, const wxDataFormat &format)
+void wxDataObject::QtSetDataSingleFormat(const QMimeData &mimeData, const wxDataFormat &format)
 {
-	QByteArray bytearray = mimeData.data(wxQtConvertString(format.GetMimeType()));
-	SetData(format, bytearray.size(), bytearray.constData());
+    QByteArray bytearray = mimeData.data(wxQtConvertString(format.GetMimeType()));
+    SetData(format, bytearray.size(), bytearray.constData());
 }
 
 //############################################################################
@@ -219,18 +219,18 @@ wxBitmapDataObject::wxBitmapDataObject( const wxBitmap &bitmap )
 {
 }
 
-void wxBitmapDataObject::AddDataTo(QMimeData &mimeData) const
+void wxBitmapDataObject::QtAddDataTo(QMimeData &mimeData) const
 {
-	mimeData.setImageData(GetBitmap().GetHandle()->toImage());
+    mimeData.setImageData(GetBitmap().GetHandle()->toImage());
 }
 
-bool wxBitmapDataObject::SetDataFrom(const QMimeData &mimeData)
+bool wxBitmapDataObject::QtSetDataFrom(const QMimeData &mimeData)
 {
-	if (!mimeData.hasImage())
-		return false;
+    if (!mimeData.hasImage())
+        return false;
 
-	SetBitmap(wxBitmap(QPixmap::fromImage(qvariant_cast<QImage>(mimeData.imageData()))));
-	return true;
+    SetBitmap(wxBitmap(QPixmap::fromImage(qvariant_cast<QImage>(mimeData.imageData()))));
+    return true;
 }
 
 //#############################################################################
@@ -247,9 +247,9 @@ void wxTextDataObject::GetAllFormats(wxDataFormat *formats,
 }
 #endif
 
-void wxTextDataObject::DoSetDataFrom(const QMimeData &mimeData, const wxDataFormat &WXUNUSED(format))
+void wxTextDataObject::QtSetDataSingleFormat(const QMimeData &mimeData, const wxDataFormat &WXUNUSED(format))
 {
-	SetText(wxQtConvertString(mimeData.text()));
+    SetText(wxQtConvertString(mimeData.text()));
 }
 
 //#############################################################################

--- a/src/qt/dataobj.cpp
+++ b/src/qt/dataobj.cpp
@@ -12,9 +12,6 @@
     #pragma hdrstop
 #endif
 
-#include <QPixmap>
-#include <QBuffer>
-
 #include "wx/dataobj.h"
 #include "wx/scopedarray.h"
 
@@ -26,7 +23,7 @@ wxString DataFormatIdToMimeType(wxDataFormatId formatId)
     switch ( formatId )
     {
         case wxDF_TEXT: return "text/plain";
-        case wxDF_BITMAP: return "PNG";
+        case wxDF_BITMAP: return "image/bmp";
         case wxDF_TIFF: return "image/tiff";
         case wxDF_WAVE: return "audio/x-wav";
         case wxDF_UNICODETEXT: return "text/plain";
@@ -156,54 +153,12 @@ bool wxDataObject::IsSupportedFormat(const wxDataFormat& format,
 //############################################################################
 
 wxBitmapDataObject::wxBitmapDataObject()
-    : m_imageBytes(new QByteArray())
 {
 }
 
 wxBitmapDataObject::wxBitmapDataObject( const wxBitmap &bitmap )
-    : wxBitmapDataObjectBase( bitmap ),
-    m_imageBytes(new QByteArray())
+    : wxBitmapDataObjectBase( bitmap )
 {
-    DoConvertToPng();
-}
-
-wxBitmapDataObject::~wxBitmapDataObject()
-{
-}
-
-void wxBitmapDataObject::SetBitmap(const wxBitmap &bitmap)
-{
-    wxBitmapDataObjectBase::SetBitmap(bitmap);
-
-    DoConvertToPng();
-}
-
-size_t wxBitmapDataObject::GetDataSize() const
-{
-    return m_imageBytes->size();
-}
-
-bool wxBitmapDataObject::GetDataHere(void *buf) const
-{
-    memcpy(buf, m_imageBytes->constData(), GetDataSize());
-    return true;
-}
-
-bool wxBitmapDataObject::SetData(const wxDataFormat &WXUNUSED(format), size_t len, const void *buf)
-{
-    m_imageBytes->resize(len);
-    memcpy(m_imageBytes->data(), buf, len);
-    QPixmap pix;
-    pix.loadFromData(*m_imageBytes);
-    m_bitmap = wxBitmap(pix);
-    return true;
-}
-
-void wxBitmapDataObject::DoConvertToPng()
-{
-    QBuffer buffer(m_imageBytes.get());
-    buffer.open(QIODevice::WriteOnly);
-    m_bitmap.GetHandle()->save(&buffer, "PNG");
 }
 
 //#############################################################################


### PR DESCRIPTION
Implement bitmap copy to clipboard for wxQt.

Due to difficulties in setting mime type that would work with all applications, we decided to instead rely on Qt's functions to add images to the clipboard directly that would take care of it.