### PR TITLE
Added support for wxBORDER_NONE to wxQT

### DIFF
--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -331,21 +331,6 @@ void wxWindowQt::PostCreation(bool generic)
     else
         SetBackgroundStyle(wxBG_STYLE_SYSTEM);
 
-//    // Use custom Qt window flags (allow to turn on or off
-//    // the minimize/maximize/close buttons and title bar)
-//    Qt::WindowFlags qtFlags = GetHandle()->windowFlags();
-//
-//    qtFlags |= Qt::CustomizeWindowHint;
-//    qtFlags |= Qt::WindowTitleHint;
-//    qtFlags |= Qt::WindowSystemMenuHint;
-//    qtFlags |= Qt::WindowMinMaxButtonsHint;
-//    qtFlags |= Qt::WindowCloseButtonHint;
-//
-//    GetHandle()->setWindowFlags( qtFlags );
-//
-//    SetWindowStyleFlag( style );
-//
-
     // Set the default color so Paint Event default handler clears the DC:
     SetBackgroundColour(wxColour(GetHandle()->palette().background().color()));
     SetForegroundColour(wxColour(GetHandle()->palette().foreground().color()));

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -357,6 +357,15 @@ void wxWindowQt::PostCreation(bool generic)
     // any way to create the window initially hidden with Qt).
     GetHandle()->setVisible(m_isShown);
 
+    m_qtWindow->setStyleSheet(
+        "*[no-border=\"true\"]{border: none;}\n"
+        "*[transparent-background=\"true\"]{background: transparent;}"
+    );
+
+    if ( GetWindowStyleFlag() & wxBORDER_NONE )
+    {
+        m_qtWindow->setProperty("no-border", true);
+    }
     wxWindowCreateEvent event(this);
     HandleWindowEvent(event);
 }
@@ -1038,12 +1047,14 @@ bool wxWindowQt::QtSetBackgroundStyle()
         {
             // wx paint handler will draw the invalidated region completely:
             widget->setAttribute(Qt::WA_OpaquePaintEvent);
+            widget->setProperty("transparent-background", false);
         }
         else if (m_backgroundStyle == wxBG_STYLE_TRANSPARENT)
         {
             widget->setAttribute(Qt::WA_TranslucentBackground);
-            // avoid a default background color (usually black):
-            widget->setStyleSheet("background:transparent;");
+            // avoid a default background color (usually black). This property
+            // is used a part of a selector in the widget's stylesheet
+            widget->setProperty("transparent-background", true);
         }
         else if (m_backgroundStyle == wxBG_STYLE_SYSTEM)
         {
@@ -1052,6 +1063,7 @@ bool wxWindowQt::QtSetBackgroundStyle()
             //widget->setAutoFillBackground(true);
             // use system colors for background (default in Qt)
             widget->setAttribute(Qt::WA_NoSystemBackground, false);
+            widget->setProperty("transparent-background", false);
         }
         else if (m_backgroundStyle == wxBG_STYLE_ERASE)
         {
@@ -1059,6 +1071,7 @@ bool wxWindowQt::QtSetBackgroundStyle()
             widget->setAttribute(Qt::WA_OpaquePaintEvent);
             // Qt should not clear the background (default):
             widget->setAutoFillBackground(false);
+            widget->setProperty("transparent-background", false);
         }
     }
     return true;


### PR DESCRIPTION
Previously, the flag wxBORDER_NONE was ignored for wxQT.  This changes add support for this flag.

Unfortunately,  there's no direct mapping from the wx flag into a QT flag.  Instead, the border needs to be controlled using CSS in QT. 