### PR TITLE
Use wxWindow as a control for wxGridCellEditor

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -220,8 +220,8 @@ public:
     wxGridCellEditor();
 
     bool IsCreated() const { return m_control != NULL; }
-    wxControl* GetControl() const { return m_control; }
-    void SetControl(wxControl* control) { m_control = control; }
+    wxWindow* GetControl() const { return m_control; }
+    void SetControl(wxWindow* control) { m_control = control; }
 
     wxGridCellAttr* GetCellAttr() const { return m_attr; }
     void SetCellAttr(wxGridCellAttr* attr) { m_attr = attr; }
@@ -306,7 +306,7 @@ protected:
     virtual ~wxGridCellEditor();
 
     // the control we show on screen
-    wxControl*  m_control;
+    wxWindow*  m_control;
 
     // a temporary pointer to the attribute being edited
     wxGridCellAttr* m_attr;
@@ -2619,21 +2619,21 @@ public:
         }
 
     wxGridEditorCreatedEvent(int id, wxEventType type, wxObject* obj,
-                             int row, int col, wxControl* ctrl);
+                             int row, int col, wxWindow* ctrl);
 
     int GetRow()                        { return m_row; }
     int GetCol()                        { return m_col; }
-    wxControl* GetControl()             { return m_ctrl; }
+    wxWindow* GetControl()              { return m_ctrl; }
     void SetRow(int row)                { m_row = row; }
     void SetCol(int col)                { m_col = col; }
-    void SetControl(wxControl* ctrl)    { m_ctrl = ctrl; }
+    void SetControl(wxWindow* ctrl)     { m_ctrl = ctrl; }
 
     virtual wxEvent *Clone() const wxOVERRIDE { return new wxGridEditorCreatedEvent(*this); }
 
 private:
     int m_row;
     int m_col;
-    wxControl* m_ctrl;
+    wxWindow* m_ctrl;
 
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(wxGridEditorCreatedEvent);
 };

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -220,8 +220,15 @@ public:
     wxGridCellEditor();
 
     bool IsCreated() const { return m_control != NULL; }
-    wxWindow* GetControl() const { return m_control; }
-    void SetControl(wxWindow* control) { m_control = control; }
+
+    wxWindow* GetWindow() const { return m_control; }
+    void SetWindow(wxWindow* window) { m_control = window; }
+
+    // This function is for backward compatibility, use GetWindow instead
+    wxControl* GetControl() { return wxDynamicCast(m_control, wxControl); }
+
+    // This function is for backward compatibility, use SetWindow instead
+    void SetControl(wxControl* control) { m_control = control; }
 
     wxGridCellAttr* GetCellAttr() const { return m_attr; }
     void SetCellAttr(wxGridCellAttr* attr) { m_attr = attr; }
@@ -306,6 +313,8 @@ protected:
     virtual ~wxGridCellEditor();
 
     // the control we show on screen
+    // the variable should actually be named m_window, but m_control
+    // was keeped for backward compatibility
     wxWindow*  m_control;
 
     // a temporary pointer to the attribute being edited
@@ -2615,25 +2624,30 @@ public:
         {
             m_row  = 0;
             m_col  = 0;
-            m_ctrl = NULL;
+            m_window = NULL;
         }
 
     wxGridEditorCreatedEvent(int id, wxEventType type, wxObject* obj,
-                             int row, int col, wxWindow* ctrl);
+                             int row, int col, wxWindow* window);
 
     int GetRow()                        { return m_row; }
     int GetCol()                        { return m_col; }
-    wxWindow* GetControl()              { return m_ctrl; }
+    wxWindow* GetWindow()               { return m_window; }
     void SetRow(int row)                { m_row = row; }
     void SetCol(int col)                { m_col = col; }
-    void SetControl(wxWindow* ctrl)     { m_ctrl = ctrl; }
+    void SetWindow(wxWindow* window)    { m_window = window; }
+
+    // this functions is for backward compatibility,
+    // use GetWindow/SetWindow instead
+    wxControl* GetControl()             { return wxDynamicCast(m_window, wxControl); }
+    void SetControl(wxControl* ctrl)    { m_window = ctrl; }
 
     virtual wxEvent *Clone() const wxOVERRIDE { return new wxGridEditorCreatedEvent(*this); }
 
 private:
     int m_row;
     int m_col;
-    wxWindow* m_ctrl;
+    wxWindow* m_window;
 
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(wxGridEditorCreatedEvent);
 };

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -547,13 +547,25 @@ public:
     virtual wxString GetValue() const = 0;
 
     /**
-       Get the wxControl used by this editor.
+       Get the edit window used by this editor.
+    */
+    wxWindow* GetWindow() const;
+
+    /**
+       Set the wxWindow that will be used by this cell editor for editing the
+       value.
+    */
+    void SetWindow(wxWindow* window);
+
+    /**
+       Get the wxControl used by this editor. This function is obsolete,
+       please use GetWindow instead.
     */
     wxControl* GetControl() const;
 
     /**
        Set the wxControl that will be used by this cell editor for editing the
-       value.
+       value. This function is obsolete, please use SetWindow instead.
     */
     void SetControl(wxControl* control);
 
@@ -5285,7 +5297,7 @@ public:
     int GetCol();
 
     /**
-        Returns the edit control.
+        Returns the edit control. This function is obsolete, please use GetWindow instead.
     */
     wxControl* GetControl();
 
@@ -5295,12 +5307,17 @@ public:
     int GetRow();
 
     /**
+        Returns the edit window.
+    */
+    wxWindow* GetWindow();
+
+    /**
         Sets the column at which the event occurred.
     */
     void SetCol(int col);
 
     /**
-        Sets the edit control.
+        Sets the edit control. This function is obsolete, please use SetWindow instead.
     */
     void SetControl(wxControl* ctrl);
 
@@ -5308,6 +5325,11 @@ public:
         Sets the row at which the event occurred.
     */
     void SetRow(int row);
+
+    /**
+        Sets the edit window.
+    */
+    void SetWindow(wxWindow* window);
 };
 
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -9333,7 +9333,7 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxGridEditorCreatedEvent, wxCommandEvent);
 
 wxGridEditorCreatedEvent::wxGridEditorCreatedEvent(int id, wxEventType type,
                                                    wxObject* obj, int row,
-                                                   int col, wxControl* ctrl)
+                                                   int col, wxWindow* ctrl)
     : wxCommandEvent(type, id)
 {
     SetEventObject(obj);

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -9333,13 +9333,13 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxGridEditorCreatedEvent, wxCommandEvent);
 
 wxGridEditorCreatedEvent::wxGridEditorCreatedEvent(int id, wxEventType type,
                                                    wxObject* obj, int row,
-                                                   int col, wxWindow* ctrl)
+                                                   int col, wxWindow* window)
     : wxCommandEvent(type, id)
 {
     SetEventObject(obj);
     m_row = row;
     m_col = col;
-    m_ctrl = ctrl;
+    m_window = window;
 }
 
 


### PR DESCRIPTION
Use wxWindow instead of wxControl in wxGridCellEditor to allow using
any window as an editor control.