### PR TITLE
Ensure that QCloseEvents can be vetoed by wx

### DIFF
--- a/include/wx/qt/private/winevent.h
+++ b/include/wx/qt/private/winevent.h
@@ -104,7 +104,7 @@ protected:
         if ( !this->GetHandler()->QtHandleCloseEvent(this, event) )
             Widget::closeEvent(event);
         else
-            event->accept();
+            event->ignore();
     }
 
     //wxContextMenuEvent

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -1490,7 +1490,10 @@ bool wxWindowQt::QtHandleCloseEvent ( QWidget *handler, QCloseEvent *WXUNUSED( e
     if ( GetHandle() != handler )
         return false;
 
-    return Close();
+    if (!IsEnabled())
+        return true;
+
+    return !Close();
 }
 
 bool wxWindowQt::QtHandleContextMenuEvent ( QWidget *WXUNUSED( handler ), QContextMenuEvent *event )

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -1485,6 +1485,7 @@ bool wxWindowQt::QtHandleChangeEvent ( QWidget *handler, QEvent *event )
         return false;
 }
 
+// Returns true if the closing should be vetoed and false if the window should be closed.
 bool wxWindowQt::QtHandleCloseEvent ( QWidget *handler, QCloseEvent *WXUNUSED( event ) )
 {
     if ( GetHandle() != handler )

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -1491,7 +1491,8 @@ bool wxWindowQt::QtHandleCloseEvent ( QWidget *handler, QCloseEvent *WXUNUSED( e
     if ( GetHandle() != handler )
         return false;
 
-    if (!IsEnabled())
+    // This is required as Qt will still send out close events when the window is disabled.
+    if ( !IsEnabled() )
         return true;
 
     return !Close();


### PR DESCRIPTION
For some unknown reason, QCloseEvents are the only type of Qt event that should be **_ignored_** to indicate that they have been dealt with and the default close action should not occur (see https://doc.qt.io/archives/qq/qq11-events.html#acceptorignore). The QtHandleCloseEvent function also had its condition reversed as the Close function returns true to indicate that the window should be closed, ie. the event wasn't handled/vetoed.

I've also added a check on whether the window is enabled before allowing close, as a disabled Qt window does not disable the close button. This meant that disabled windows could be closed, which can currently be seen in the 'dialogs' sample if you try to close the main window while displaying a 'Busy info dialog'.