### PR TITLE
wxT macro behaviour has been adapted to utf8 wxString

### DIFF
--- a/include/wx/chartype.h
+++ b/include/wx/chartype.h
@@ -214,7 +214,7 @@
    compatibility.
  */
 #ifndef wxT
-    #if !wxUSE_UNICODE
+    #if !wxUSE_UNICODE_WCHAR
         #define wxT(x) x
     #else /* Unicode */
         /*


### PR DESCRIPTION
It would be better to synchronize wxT behaviour with wxString internal structure