### PR TITLE
Fix misaligned icons in wxTreeCtrl for wxQT

### DIFF
--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -222,7 +222,8 @@ protected:
             const wxImageList *imageList = GetHandler()->GetImageList();
             const wxBitmap bitmap = imageList->GetBitmap(imageIndex);
             const QRect rect = visualRect(index);
-            painter->drawPixmap(rect.topLeft(), *bitmap.GetHandle());
+            const int offset = (rect.height() / 2) - (bitmap.GetHeight() / 2);
+            painter->drawPixmap(rect.topLeft() + QPoint(0,offset), *bitmap.GetHandle());
         }
     }
 


### PR DESCRIPTION
The following fix centres the tree icon within the item's rect. 

 The default QT theme under RedHat 6 and Windows don't show the issue.   However, I was able to recreate the issue under Linux customising my GTK theme to use a bigger font size.
