### PR TITLE
Fix wxTreeCtrl not generating right click and middle click events under wxQT

### DIFF
--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -138,8 +138,6 @@ public:
                 this, &wxQTreeWidget::OnCurrentItemChanged);
         connect(this, &QTreeWidget::itemActivated,
                 this, &wxQTreeWidget::OnItemActivated);
-        connect(this, &QTreeWidget::itemClicked,
-                this, &wxQTreeWidget::OnItemClicked);
         connect(this, &QTreeWidget::itemCollapsed,
                 this, &wxQTreeWidget::OnItemCollapsed);
         connect(this, &QTreeWidget::itemExpanded,
@@ -158,6 +156,48 @@ public:
         //(perhaps because it's a compound widget) so we've disabled
         //wx paint and erase background events
         QTreeWidget::paintEvent(event);
+    }
+
+    virtual void mouseReleaseEvent(QMouseEvent * event) wxOVERRIDE
+    {
+        const QPoint qPos = event->pos();
+        QTreeWidgetItem *item = itemAt(qPos);
+        if (item != NULL)
+        {
+            const wxPoint pos(qPos.x(), qPos.y());
+            switch (event->button())
+            {
+                case Qt::RightButton:
+                {
+                    wxTreeEvent treeEvent(wxEVT_TREE_ITEM_RIGHT_CLICK,
+                        GetHandler(),
+                        wxQtConvertTreeItem(item));
+                    treeEvent.SetPoint(pos);
+                    EmitEvent(treeEvent);
+
+                    wxTreeEvent menuEvent(wxEVT_TREE_ITEM_MENU,
+                        GetHandler(),
+                        wxQtConvertTreeItem(item));
+                    menuEvent.SetPoint(pos);
+                    EmitEvent(menuEvent);
+
+                    break;
+                }
+                case Qt::MiddleButton:
+                {
+                    wxTreeEvent treeEvent(wxEVT_TREE_ITEM_MIDDLE_CLICK,
+                        GetHandler(),
+                        wxQtConvertTreeItem(item));
+                    treeEvent.SetPoint(pos);
+                    EmitEvent(treeEvent);
+                    break;
+                }
+                default:
+                    break;
+                }
+        }
+
+        return wxQtEventSignalHandler<QTreeWidget, wxTreeCtrl>::mouseReleaseEvent(event);
     }
 
     wxTextCtrl *GetEditControl()
@@ -338,22 +378,6 @@ private:
             wxQtConvertTreeItem(item)
         );
 
-        EmitEvent(event);
-    }
-
-    void OnItemClicked(QTreeWidgetItem *item)
-    {
-        wxMouseState mouseState = wxGetMouseState();
-
-        wxEventType eventType;
-        if ( mouseState.RightIsDown() )
-            eventType = wxEVT_TREE_ITEM_RIGHT_CLICK;
-        else if ( mouseState.MiddleIsDown() )
-            eventType = wxEVT_TREE_ITEM_MIDDLE_CLICK;
-        else
-            return;
-
-        wxTreeEvent event(eventType, GetHandler(), wxQtConvertTreeItem(item));
         EmitEvent(event);
     }
 

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -162,10 +162,10 @@ public:
     {
         const QPoint qPos = event->pos();
         QTreeWidgetItem *item = itemAt(qPos);
-        if (item != NULL)
+        if ( item != NULL )
         {
             const wxPoint pos(qPos.x(), qPos.y());
-            switch (event->button())
+            switch ( event->button() )
             {
                 case Qt::RightButton:
                 {


### PR DESCRIPTION
This fixes the issue in the sample with the context menu not appearing when the user right clicks on an item. 