### PR TITLE
Ensure static text fields use the alignment specified by WX on creation.

### DIFF
--- a/src/qt/stattext.cpp
+++ b/src/qt/stattext.cpp
@@ -55,6 +55,34 @@ bool wxStaticText::Create(wxWindow *parent,
     m_qtLabel->setBuddy( m_qtLabel );
     m_qtLabel->setTextInteractionFlags( Qt::NoTextInteraction );
 
+    Qt::AlignmentFlag qt_alignment = Qt::AlignAbsolute;
+
+    switch (style & wxALIGN_MASK)
+    {
+        case wxALIGN_RIGHT:
+            qt_alignment = Qt::AlignRight;
+            break;
+        case wxALIGN_LEFT:
+            qt_alignment = Qt::AlignLeft;
+            break;
+        case wxALIGN_CENTER:
+            qt_alignment = Qt::AlignCenter;
+            break;
+        case wxALIGN_CENTER_HORIZONTAL:
+            qt_alignment = Qt::AlignHCenter;
+            break;
+        case wxALIGN_CENTER_VERTICAL:
+            qt_alignment = Qt::AlignVCenter;
+            break;
+        case wxALIGN_BOTTOM:
+            qt_alignment = Qt::AlignBottom;
+            break;
+        default:
+            qt_alignment = Qt::AlignAbsolute;
+    }
+
+    m_qtLabel->setAlignment(qt_alignment);
+
     return QtCreateControl( parent, id, pos, size, style, wxDefaultValidator, name );
 }
 

--- a/src/qt/stattext.cpp
+++ b/src/qt/stattext.cpp
@@ -55,33 +55,15 @@ bool wxStaticText::Create(wxWindow *parent,
     m_qtLabel->setBuddy( m_qtLabel );
     m_qtLabel->setTextInteractionFlags( Qt::NoTextInteraction );
 
-    Qt::AlignmentFlag qt_alignment = Qt::AlignAbsolute;
-
-    switch (style & wxALIGN_MASK)
-    {
-        case wxALIGN_RIGHT:
-            qt_alignment = Qt::AlignRight;
-            break;
-        case wxALIGN_LEFT:
-            qt_alignment = Qt::AlignLeft;
-            break;
-        case wxALIGN_CENTER:
-            qt_alignment = Qt::AlignCenter;
-            break;
-        case wxALIGN_CENTER_HORIZONTAL:
-            qt_alignment = Qt::AlignHCenter;
-            break;
-        case wxALIGN_CENTER_VERTICAL:
-            qt_alignment = Qt::AlignVCenter;
-            break;
-        case wxALIGN_BOTTOM:
-            qt_alignment = Qt::AlignBottom;
-            break;
-        default:
-            qt_alignment = Qt::AlignAbsolute;
-    }
-
-    m_qtLabel->setAlignment(qt_alignment);
+    // Translate the WX alignment flags to QT alignment flags
+    if ((style & wxALIGN_MASK) == wxALIGN_LEFT)
+        m_qtLabel->setAlignment(Qt::AlignLeft);
+    else if ((style & wxALIGN_MASK) == wxALIGN_CENTER_HORIZONTAL)
+        m_qtLabel->setAlignment(Qt::AlignHCenter);
+    else if ((style & wxALIGN_MASK) == wxALIGN_RIGHT)
+        m_qtLabel->setAlignment(Qt::AlignRight);
+    else if ((style & wxALIGN_MASK) == wxALIGN_CENTER)
+        m_qtLabel->setAlignment(Qt::AlignCenter);
 
     return QtCreateControl( parent, id, pos, size, style, wxDefaultValidator, name );
 }


### PR DESCRIPTION
The WX type `wxStaticText` was not respecting alignment specified upon creation. This change ensures that we map WX alignment flags to the equivalent QT alignment flags when creating `wxStaticText` types.