### PR TITLE
Remove context help button unless wxDIALOG_EX_CONTEXTHELP is specified

### DIFF
--- a/src/qt/dialog.cpp
+++ b/src/qt/dialog.cpp
@@ -59,7 +59,14 @@ bool wxDialog::Create( wxWindow *parent, wxWindowID id,
     // all dialogs should have tab traversal enabled
     style |= wxTAB_TRAVERSAL;
 
-    m_qtWindow = new wxQtDialog( parent, this );
+    m_qtWindow = new wxQtDialog(parent, this);
+
+    if (!(GetExtraStyle() & wxDIALOG_EX_CONTEXTHELP))
+    {
+        Qt::WindowFlags qtFlags = m_qtWindow->windowFlags();
+        qtFlags &= ~Qt::WindowContextHelpButtonHint;
+        m_qtWindow->setWindowFlags(qtFlags);
+    }
 
     if ( !wxTopLevelWindow::Create( parent, id, title, pos, size, style, name ) )
         return false;


### PR DESCRIPTION
By default QT adds the context help button to a dialog.  This PR ensures that the wx flag is honoured.