### PR TITLE
Return -1 from GetLineLength() if line number is out of range

### DIFF
--- a/include/wx/stc/stc.h
+++ b/include/wx/stc/stc.h
@@ -5333,7 +5333,14 @@ public:
     // implement wxTextAreaBase pure virtual methods
     // ---------------------------------------------
 
-    virtual int GetLineLength(long lineNo) const wxOVERRIDE { return static_cast<int>(GetLineText(lineNo).length()); }
+    virtual int GetLineLength(long lineNo) const wxOVERRIDE
+    {
+        if ( lineNo < 0 || lineNo >= GetNumberOfLines() )
+            return -1;
+
+        return static_cast<int>(GetLineText(lineNo).length());
+    }
+
     virtual wxString GetLineText(long lineNo) const wxOVERRIDE
     {
         wxString text = GetLine(static_cast<int>(lineNo));

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -1803,6 +1803,9 @@ int wxTextCtrl::GetLineLength(long lineNo) const
 {
     long pos = XYToPosition(0, lineNo);
 
+    if ( pos == -1 )
+        return -1;
+
     return GetLengthOfLineContainingPos(pos);
 }
 

--- a/src/osx/textctrl_osx.cpp
+++ b/src/osx/textctrl_osx.cpp
@@ -776,7 +776,7 @@ int wxTextWidgetImpl::GetLineLength(long lineNo) const
             count++;
     }
 
-    return 0 ;
+    return -1 ;
 }
 
 void wxTextWidgetImpl::SetJustification()

--- a/src/stc/stc.h.in
+++ b/src/stc/stc.h.in
@@ -450,7 +450,14 @@ public:
     // implement wxTextAreaBase pure virtual methods
     // ---------------------------------------------
 
-    virtual int GetLineLength(long lineNo) const wxOVERRIDE { return static_cast<int>(GetLineText(lineNo).length()); }
+    virtual int GetLineLength(long lineNo) const wxOVERRIDE
+    {
+        if ( lineNo < 0 || lineNo >= GetNumberOfLines() )
+            return -1;
+
+        return static_cast<int>(GetLineText(lineNo).length());
+    }
+
     virtual wxString GetLineText(long lineNo) const wxOVERRIDE
     {
         wxString text = GetLine(static_cast<int>(lineNo));

--- a/src/univ/textctrl.cpp
+++ b/src/univ/textctrl.cpp
@@ -1684,8 +1684,8 @@ int wxTextCtrl::GetLineLength(wxTextCoord line) const
     }
     else // multiline
     {
-        wxCHECK_MSG( (size_t)line < GetLineCount(), -1,
-                     wxT("line index out of range") );
+        if ( line < 0 || line >= GetLineCount() )
+            return -1;
 
         return GetLines()[line].length();
     }

--- a/src/x11/textctrl.cpp
+++ b/src/x11/textctrl.cpp
@@ -347,8 +347,8 @@ void wxTextCtrl::DoSetValue(const wxString& value, int flags)
 
 int wxTextCtrl::GetLineLength(long lineNo) const
 {
-    if (lineNo >= (long)m_lines.GetCount())
-        return 0;
+    if (lineNo < 0 || lineNo >= (long)m_lines.GetCount())
+        return -1;
 
     return m_lines[lineNo].m_text.Len();
 }


### PR DESCRIPTION
Make wxTextCtrl behaviour in all ports consistent with the documentation
and also update wxStyledTextCtrl to behave accordingly.

Closes #18431.