### PR TITLE
Private.h

### DIFF
--- a/include/wx/msw/private.h
+++ b/include/wx/msw/private.h
@@ -680,6 +680,8 @@ public:
     // allocates a block of given size
     void Init(size_t size, unsigned flags = GMEM_MOVEABLE)
     {
+        if (m_hGlobal)
+            ::GlobalFree(m_hGlobal);
         m_hGlobal = ::GlobalAlloc(flags, size);
         if ( !m_hGlobal )
         {

--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -146,6 +146,7 @@ public:
     inline wxCStrData(char *buf);
     inline wxCStrData(wchar_t *buf);
     inline wxCStrData(const wxCStrData& data);
+    inline wxCStrData& operator = (const wxCStrData& data);
 
     inline ~wxCStrData();
 
@@ -4019,6 +4020,13 @@ inline wxCStrData::wxCStrData(const wxCStrData& data)
       m_offset(data.m_offset),
       m_owned(data.m_owned)
 {
+}
+
+inline wxCStrData& wxCStrData::operator = (const wxCStrData& data)
+{
+    m_str = data.m_owned ? new wxString(*data.m_str) : data.m_str;
+    m_offset = data.m_offset;
+    m_owned = data.m_owned;
 }
 
 inline wxCStrData::~wxCStrData()


### PR DESCRIPTION
GlobalPtr::Init can be called more than once so we should check ptr state and deallocate it if necessary.