### PR TITLE
private.h: possible memory leak has been fixed

### DIFF
--- a/include/wx/msw/private.h
+++ b/include/wx/msw/private.h
@@ -680,6 +680,8 @@ public:
     // allocates a block of given size
     void Init(size_t size, unsigned flags = GMEM_MOVEABLE)
     {
+        if (m_hGlobal)
+            ::GlobalFree(m_hGlobal);
         m_hGlobal = ::GlobalAlloc(flags, size);
         if ( !m_hGlobal )
         {


### PR DESCRIPTION
GlobalPtr::Init can be called more than one time so memory leak was possible