### PR TITLE
Fix Qt implementation of wxTreeCtrl::Toggle

### DIFF
--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -1158,7 +1158,7 @@ void wxTreeCtrl::Toggle(const wxTreeItemId& item)
     wxCHECK_RET(item.IsOk(), "invalid tree item");
 
     QTreeWidgetItem *qTreeItem = wxQtConvertTreeItem(item);
-    qTreeItem->setSelected(!qTreeItem->isSelected());
+    qTreeItem->setExpanded(!qTreeItem->isExpanded());
 }
 
 void wxTreeCtrl::Unselect()


### PR DESCRIPTION
Mistakenly implemented as toggling selected item, not whether item is collapsed or expanded