### PR TITLE
Show tooltip in wxTreeCtrl for wxQT when item text doesn't fit on screen

### DIFF
--- a/include/wx/qt/private/treeitemdelegate.h
+++ b/include/wx/qt/private/treeitemdelegate.h
@@ -70,7 +70,7 @@ public:
 
     bool helpEvent(QHelpEvent *event, QAbstractItemView *view, const QStyleOptionViewItem &option, const QModelIndex &index)
     {
-        if ( event->type() == QEvent::ToolTip)
+        if ( event->type() == QEvent::ToolTip )
         {
             const QRect itemRect = view->visualRect(index);
             const QSize bestSize = sizeHint(option, index);

--- a/include/wx/qt/private/treeitemdelegate.h
+++ b/include/wx/qt/private/treeitemdelegate.h
@@ -72,7 +72,7 @@ public:
     {
         if ( event->type() == QEvent::ToolTip )
         {
-            const QRect itemRect = view->visualRect(index);
+            const QRect &itemRect = view->visualRect(index);
             const QSize bestSize = sizeHint(option, index);
             if ( itemRect.width() < bestSize.width() )
             {

--- a/include/wx/qt/private/treeitemdelegate.h
+++ b/include/wx/qt/private/treeitemdelegate.h
@@ -76,7 +76,7 @@ public:
             const QSize bestSize = sizeHint(option, index);
             if ( itemRect.width() < bestSize.width() )
             {
-                QString value = index.data(Qt::DisplayRole).toString();
+                const QString &value = index.data(Qt::DisplayRole).toString();
                 QToolTip::showText(event->globalPos(), value, view);
             }
             else

--- a/include/wx/qt/private/treeitemdelegate.h
+++ b/include/wx/qt/private/treeitemdelegate.h
@@ -11,6 +11,7 @@
 #define _WX_QT_PRIVATE_TREEITEM_DELEGATE_H
 
 #include <QtWidgets/QStyledItemDelegate>
+#include <QtWidgets/QToolTip>
 
 #include "wx/app.h"
 #include "wx/textctrl.h"
@@ -65,6 +66,28 @@ public:
     void AcceptModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const
     {
         QStyledItemDelegate::setModelData(editor, model, index);
+    }
+
+    bool helpEvent(QHelpEvent *event, QAbstractItemView *view, const QStyleOptionViewItem &option, const QModelIndex &index)
+    {
+        if ( event->type() == QEvent::ToolTip)
+        {
+            const QRect itemRect = view->visualRect(index);
+            const QSize bestSize = sizeHint(option, index);
+            if ( itemRect.width() < bestSize.width() )
+            {
+                QString value = index.data(Qt::DisplayRole).toString();
+                QToolTip::showText(event->globalPos(), value, view);
+            }
+            else
+            {
+                QToolTip::hideText();
+            }
+
+            return true;
+        }
+
+        return QStyledItemDelegate::helpEvent(event, view, option, index);
     }
 
 private:

--- a/include/wx/qt/private/treeitemdelegate.h
+++ b/include/wx/qt/private/treeitemdelegate.h
@@ -73,7 +73,7 @@ public:
         if ( event->type() == QEvent::ToolTip )
         {
             const QRect &itemRect = view->visualRect(index);
-            const QSize bestSize = sizeHint(option, index);
+            const QSize &bestSize = sizeHint(option, index);
             if ( itemRect.width() < bestSize.width() )
             {
                 const QString &value = index.data(Qt::DisplayRole).toString();


### PR DESCRIPTION
This PR adds a tooltip to wxTreeCtrl for wxQT when the tree item text is truncated.  The matches the behaviour wxMSW seems to get from Windows itself. 