### PR TITLE
Harmonize wxEVT_TEXT events in wxGTK with other ports

### DIFF
--- a/include/wx/gtk/combobox.h
+++ b/include/wx/gtk/combobox.h
@@ -145,6 +145,10 @@ protected:
     virtual GtkEntry *GetEntry() const wxOVERRIDE
         { return m_entry; }
 
+    virtual int GTKIMFilterKeypress(GdkEventKey* event) const wxOVERRIDE
+        { return GTKEntryIMFilterKeypress(event); }
+
+
     GtkEntry*   m_entry;
 
 private:

--- a/include/wx/gtk/combobox.h
+++ b/include/wx/gtk/combobox.h
@@ -151,7 +151,6 @@ private:
     // From wxTextEntry:
     virtual wxWindow *GetEditableWindow() wxOVERRIDE { return this; }
     virtual GtkEditable *GetEditable() const wxOVERRIDE;
-    virtual void EnableTextChangedEvents(bool enable) wxOVERRIDE;
 
     void Init();
 

--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -142,6 +142,8 @@ public:
     static wxVisualAttributes
     GetClassDefaultAttributes(wxWindowVariant variant = wxWINDOW_VARIANT_NORMAL);
 
+    void GTKOnTextChanged() wxOVERRIDE;
+
 protected:
     // overridden wxWindow virtual methods
     virtual wxSize DoGetBestSize() const wxOVERRIDE;

--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -184,7 +184,6 @@ private:
     // overridden wxTextEntry virtual methods
     virtual GtkEditable *GetEditable() const wxOVERRIDE;
     virtual GtkEntry *GetEntry() const wxOVERRIDE;
-    virtual void EnableTextChangedEvents(bool enable) wxOVERRIDE;
 
     // change the font for everything in this control
     void ChangeFontGlobally();
@@ -198,7 +197,7 @@ private:
     // returns either m_text or m_buffer depending on whether the control is
     // single- or multi-line; convenient for the GTK+ functions which work with
     // both
-    void *GetTextObject() const
+    void *GetTextObject() const wxOVERRIDE
     {
         return IsMultiLine() ? static_cast<void *>(m_buffer)
                              : static_cast<void *>(m_text);

--- a/include/wx/gtk/textentry.h
+++ b/include/wx/gtk/textentry.h
@@ -76,6 +76,10 @@ protected:
     // And this one to connect "insert-text" signal.
     void GTKConnectInsertTextSignal(GtkEntry* entry);
 
+    // Finally this one connects to the "changed" signal on the object returned
+    // by GetTextObject().
+    void GTKConnectChangedSignal();
+
 
     virtual void DoSetValue(const wxString& value, int flags) wxOVERRIDE;
     virtual wxString DoGetValue() const wxOVERRIDE;
@@ -92,6 +96,12 @@ protected:
 
     static int GTKGetEntryTextLength(GtkEntry* entry);
 
+    // Block/unblock the corresponding GTK signal.
+    //
+    // Note that we make it protected in wxGTK as it is called from wxComboBox
+    // currently.
+    virtual void EnableTextChangedEvents(bool enable) wxOVERRIDE;
+
 private:
     // implement this to return the associated GtkEntry or another widget
     // implementing GtkEditable
@@ -99,6 +109,12 @@ private:
 
     // implement this to return the associated GtkEntry
     virtual GtkEntry *GetEntry() const = 0;
+
+    // This one exists in order to be overridden by wxTextCtrl which uses
+    // either GtkEditable or GtkTextBuffer depending on whether it is single-
+    // or multi-line.
+    virtual void *GetTextObject() const { return GetEntry(); }
+
 
     // Various auto-completion-related stuff, only used if any of AutoComplete()
     // methods are called.

--- a/include/wx/gtk/textentry.h
+++ b/include/wx/gtk/textentry.h
@@ -62,6 +62,12 @@ public:
     bool GTKEntryOnInsertText(const char* text);
     bool GTKIsUpperCase() const { return m_isUpperCase; }
 
+    // Called from "changed" signal handler for GtkEntry.
+    //
+    // By default just generates a wxEVT_TEXT, but overridden to do more things
+    // in wxTextCtrl.
+    virtual void GTKOnTextChanged() { SendTextUpdatedEvent(); }
+
 protected:
     // This method must be called from the derived class Create() to connect
     // the handlers for the clipboard (cut/copy/paste) events.

--- a/include/wx/gtk/textentry.h
+++ b/include/wx/gtk/textentry.h
@@ -91,8 +91,9 @@ protected:
     virtual bool DoAutoCompleteStrings(const wxArrayString& choices) wxOVERRIDE;
     virtual bool DoAutoCompleteCustom(wxTextCompleter *completer) wxOVERRIDE;
 
-    // Override the base class method to use GtkEntry IM context.
-    virtual int GTKIMFilterKeypress(GdkEventKey* event) const;
+    // Call this from the overridden wxWindow::GTKIMFilterKeypress() to use
+    // GtkEntry IM context.
+    int GTKEntryIMFilterKeypress(GdkEventKey* event) const;
 
     static int GTKGetEntryTextLength(GtkEntry* entry);
 

--- a/samples/widgets/textctrl.cpp
+++ b/samples/widgets/textctrl.cpp
@@ -989,15 +989,8 @@ void TextWidgetsPage::OnUpdateUIResetButton(wxUpdateUIEvent& event)
 
 void TextWidgetsPage::OnText(wxCommandEvent& event)
 {
-    // small hack to suppress the very first message: by then the logging is
-    // not yet redirected and so initial setting of the text value results in
-    // an annoying message box
-    static bool s_firstTime = true;
-    if ( s_firstTime )
-    {
-        s_firstTime = false;
+    if ( !IsUsingLogWindow() )
         return;
-    }
 
     // Replace middle of long text with ellipsis just to avoid filling up the
     // log control with too much unnecessary stuff.

--- a/samples/widgets/textctrl.cpp
+++ b/samples/widgets/textctrl.cpp
@@ -31,6 +31,7 @@
     #include "wx/bitmap.h"
     #include "wx/button.h"
     #include "wx/checkbox.h"
+    #include "wx/dcclient.h"
     #include "wx/radiobox.h"
     #include "wx/statbox.h"
     #include "wx/stattext.h"
@@ -986,7 +987,7 @@ void TextWidgetsPage::OnUpdateUIResetButton(wxUpdateUIEvent& event)
                   (m_radioWrap->GetSelection() != DEFAULTS.wrapStyle) );
 }
 
-void TextWidgetsPage::OnText(wxCommandEvent& WXUNUSED(event))
+void TextWidgetsPage::OnText(wxCommandEvent& event)
 {
     // small hack to suppress the very first message: by then the logging is
     // not yet redirected and so initial setting of the text value results in
@@ -998,7 +999,16 @@ void TextWidgetsPage::OnText(wxCommandEvent& WXUNUSED(event))
         return;
     }
 
-    wxLogMessage("Text ctrl value changed");
+    // Replace middle of long text with ellipsis just to avoid filling up the
+    // log control with too much unnecessary stuff.
+    wxLogMessage("Text control value changed (now '%s')",
+                 wxControl::Ellipsize
+                 (
+                    event.GetString(),
+                    wxClientDC(this),
+                    wxELLIPSIZE_MIDDLE,
+                    GetTextExtent('W').x*100
+                 ));
 }
 
 void TextWidgetsPage::OnTextEnter(wxCommandEvent& event)

--- a/samples/widgets/widgets.h
+++ b/samples/widgets/widgets.h
@@ -155,6 +155,10 @@ public:
     // the default attributes for the widget
     static WidgetAttributes& GetAttrs();
 
+    // return true if we're showing logs in the log window (always the case
+    // except during startup and shutdown)
+    static bool IsUsingLogWindow();
+
 protected:
     // several helper functions for page creation
 

--- a/src/gtk/combobox.cpp
+++ b/src/gtk/combobox.cpp
@@ -219,7 +219,7 @@ void wxComboBox::GTKCreateComboBoxWidget()
 
 GtkEditable *wxComboBox::GetEditable() const
 {
-    return GTK_EDITABLE(gtk_bin_get_child(GTK_BIN(m_widget)));
+    return GTK_EDITABLE(m_entry);
 }
 
 void wxComboBox::OnChar( wxKeyEvent &event )

--- a/src/gtk/combobox.cpp
+++ b/src/gtk/combobox.cpp
@@ -27,14 +27,6 @@
 // ----------------------------------------------------------------------------
 
 extern "C" {
-static void
-gtkcombobox_text_changed_callback( GtkWidget *WXUNUSED(widget), wxComboBox *combo )
-{
-    wxCommandEvent event( wxEVT_TEXT, combo->GetId() );
-    event.SetString( combo->GetValue() );
-    event.SetEventObject( combo );
-    combo->HandleWindowEvent( event );
-}
 
 static void
 gtkcombobox_changed_callback( GtkWidget *WXUNUSED(widget), wxComboBox *combo )
@@ -185,9 +177,7 @@ bool wxComboBox::Create( wxWindow *parent, wxWindowID id, const wxString& value,
             gtk_entry_set_text( entry, wxGTK_CONV(value) );
         }
 
-        g_signal_connect_after (entry, "changed",
-                                G_CALLBACK (gtkcombobox_text_changed_callback), this);
-
+        GTKConnectChangedSignal();
         GTKConnectInsertTextSignal(entry);
         GTKConnectClipboardSignals(GTK_WIDGET(entry));
     }
@@ -246,23 +236,6 @@ void wxComboBox::OnChar( wxKeyEvent &event )
     }
 
     event.Skip();
-}
-
-void wxComboBox::EnableTextChangedEvents(bool enable)
-{
-    if ( !GetEntry() )
-        return;
-
-    if ( enable )
-    {
-        g_signal_handlers_unblock_by_func(gtk_bin_get_child(GTK_BIN(m_widget)),
-            (gpointer)gtkcombobox_text_changed_callback, this);
-    }
-    else // disable
-    {
-        g_signal_handlers_block_by_func(gtk_bin_get_child(GTK_BIN(m_widget)),
-            (gpointer)gtkcombobox_text_changed_callback, this);
-    }
 }
 
 void wxComboBox::GTKDisableEvents()

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -858,7 +858,11 @@ GtkEntry *wxTextCtrl::GetEntry() const
 int wxTextCtrl::GTKIMFilterKeypress(GdkEventKey* event) const
 {
     if (IsSingleLine())
-        return wxTextEntry::GTKIMFilterKeypress(event);
+        return GTKEntryIMFilterKeypress(event);
+
+    // When not calling GTKEntryIMFilterKeypress(), we need to notify the code
+    // in wxTextEntry about the key presses explicitly.
+    GTKEntryOnKeypress(m_text);
 
     int result = false;
 #if GTK_CHECK_VERSION(2, 22, 0)

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -575,13 +575,7 @@ extern "C" {
 static void
 gtk_text_changed_callback( GtkWidget *WXUNUSED(widget), wxTextCtrl *win )
 {
-    if ( win->IgnoreTextUpdate() )
-        return;
-
-    if ( win->MarkDirtyOnChange() )
-        win->MarkDirty();
-
-    win->SendTextUpdatedEvent();
+    win->GTKOnTextChanged();
 }
 }
 
@@ -1369,6 +1363,17 @@ void wxTextCtrl::MarkDirty()
 void wxTextCtrl::DiscardEdits()
 {
     m_modified = false;
+}
+
+void wxTextCtrl::GTKOnTextChanged()
+{
+    if ( IgnoreTextUpdate() )
+        return;
+
+    if ( MarkDirtyOnChange() )
+        MarkDirty();
+
+    SendTextUpdatedEvent();
 }
 
 // ----------------------------------------------------------------------------

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -568,18 +568,6 @@ gtk_textctrl_populate_popup( GtkEntry *WXUNUSED(entry), GtkMenu *menu, wxTextCtr
 }
 
 //-----------------------------------------------------------------------------
-//  "changed"
-//-----------------------------------------------------------------------------
-
-extern "C" {
-static void
-gtk_text_changed_callback( GtkWidget *WXUNUSED(widget), wxTextCtrl *win )
-{
-    win->GTKOnTextChanged();
-}
-}
-
-//-----------------------------------------------------------------------------
 //  "mark_set"
 //-----------------------------------------------------------------------------
 
@@ -768,16 +756,7 @@ bool wxTextCtrl::Create( wxWindow *parent,
     }
 
     // We want to be notified about text changes.
-    if (multi_line)
-    {
-        g_signal_connect (m_buffer, "changed",
-                          G_CALLBACK (gtk_text_changed_callback), this);
-    }
-    else
-    {
-        g_signal_connect (m_text, "changed",
-                          G_CALLBACK (gtk_text_changed_callback), this);
-    }
+    GTKConnectChangedSignal();
 
     // Catch to disable focus out handling
     g_signal_connect (m_text, "populate_popup",
@@ -1379,20 +1358,6 @@ void wxTextCtrl::GTKOnTextChanged()
 // ----------------------------------------------------------------------------
 // event handling
 // ----------------------------------------------------------------------------
-
-void wxTextCtrl::EnableTextChangedEvents(bool enable)
-{
-    if ( enable )
-    {
-        g_signal_handlers_unblock_by_func(GetTextObject(),
-            (gpointer)gtk_text_changed_callback, this);
-    }
-    else // disable events
-    {
-        g_signal_handlers_block_by_func(GetTextObject(),
-            (gpointer)gtk_text_changed_callback, this);
-    }
-}
 
 bool wxTextCtrl::IgnoreTextUpdate()
 {

--- a/src/gtk/textentry.cpp
+++ b/src/gtk/textentry.cpp
@@ -862,7 +862,7 @@ void wxTextEntry::ForceUpper()
 // IM handling
 // ----------------------------------------------------------------------------
 
-int wxTextEntry::GTKIMFilterKeypress(GdkEventKey* event) const
+int wxTextEntry::GTKEntryIMFilterKeypress(GdkEventKey* event) const
 {
     int result = false;
 #if GTK_CHECK_VERSION(2, 22, 0)

--- a/src/gtk/textentry.cpp
+++ b/src/gtk/textentry.cpp
@@ -57,8 +57,16 @@ static int GetEntryTextLength(GtkEntry* entry)
 // signal handlers implementation
 // ============================================================================
 
-// "insert_text" handler for GtkEntry
 extern "C" {
+
+// "changed" handler for GtkEntry
+static void
+wx_gtk_text_changed_callback(GtkWidget* WXUNUSED(widget), wxTextEntry* entry)
+{
+    entry->GTKOnTextChanged();
+}
+
+// "insert_text" handler for GtkEntry
 static void
 wx_gtk_insert_text_callback(GtkEditable *editable,
                             const gchar * new_text,
@@ -867,6 +875,31 @@ int wxTextEntry::GTKIMFilterKeypress(GdkEventKey* event) const
 #endif // GTK+ 2.22+
 
     return result;
+}
+
+// ----------------------------------------------------------------------------
+// signals and events
+// ----------------------------------------------------------------------------
+
+void wxTextEntry::EnableTextChangedEvents(bool enable)
+{
+    if ( enable )
+    {
+        g_signal_handlers_unblock_by_func(GetTextObject(),
+            (gpointer)wx_gtk_text_changed_callback, this);
+    }
+    else // disable events
+    {
+        g_signal_handlers_block_by_func(GetTextObject(),
+            (gpointer)wx_gtk_text_changed_callback, this);
+    }
+}
+
+void wxTextEntry::GTKConnectChangedSignal()
+{
+    g_signal_connect(GetTextObject(), "changed",
+                     G_CALLBACK(wx_gtk_text_changed_callback), this);
+
 }
 
 void wxTextEntry::GTKConnectInsertTextSignal(GtkEntry* entry)


### PR DESCRIPTION
The main goal here is to fix [this ticket](https://trac.wxwidgets.org/ticket/10050) and send only a single `wxEVT_TEXT` under wxGTK when a text control (including comboboxes) has selection.

In order to do it (this is the last commit, 2c6dcc2) without duplicating not completely trivial code between `wxTextCtrl` and `wxComboBox` I had to do some relatively non-trivial refactoring (see 
c024944  and 5c766c0). While doing this, I only discovered a couple of problems in wxComboBox code: one was minor (c75067f), while another was pretty bad as this control didn't use IME at all (fixed in 
958df5f). Finally I also made some changes in the widgets sample to facilitate testing this.

I'm explaining all this to say that I'd really appreciate reviews for the new code (2c6dcc2) and would also very much like more eyes on the refactoring changes, even if they're not supposed to change anything. The rest is either trivial or can be skipped (changes to the sample).

TIA!