### PR TITLE
Qt frame uses the central widget to determine client size

### DIFF
--- a/include/wx/qt/window.h
+++ b/include/wx/qt/window.h
@@ -135,6 +135,12 @@ public:
     virtual bool SetForegroundColour(const wxColour& colour) wxOVERRIDE;
 
     QWidget *GetHandle() const wxOVERRIDE;
+ 
+    virtual void SetMinSize(const wxSize& minSize) wxOVERRIDE;
+    virtual void SetMaxSize(const wxSize& maxSize) wxOVERRIDE;
+    virtual void DoSetSizeHints(int minW, int minH,
+        int maxW, int maxH,
+        int incW, int incH) wxOVERRIDE;
 
 #if wxUSE_DRAG_AND_DROP
     virtual void SetDropTarget( wxDropTarget *dropTarget ) wxOVERRIDE;

--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -208,22 +208,23 @@ QScrollArea *wxFrame::QtGetScrollBarsContainer() const
 
 void wxFrame::DoGetClientSize(int *width, int *height) const
 {
-    wxWindow::DoGetClientSize(width, height);
-
-    // Adjust the height, taking the status and menu bars into account, if any:
-    if ( height )
+    QMainWindow *main_window = GetQMainWindow();
+    QSize size;
+    if ( !main_window->isVisible() )
     {
-        if ( wxStatusBar *sb = GetStatusBar() )
-        {
-            *height -= sb->GetSize().y;
-        }
-
-
-        if ( QWidget *qmb = GetQMainWindow()->menuWidget() )
-        {
-            *height -= qmb->geometry().height();
-        }
+        size = main_window->geometry().size();
     }
+    else
+    {
+        QWidget *centralWidget = main_window->centralWidget();
+        size = centralWidget->geometry().size();
+    }
+    
+    if ( width != NULL )
+        *width = size.width();
+
+    if ( height != NULL )
+        *height = size.height();
 }
 
 QMainWindow *wxFrame::GetQMainWindow() const

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -350,6 +350,9 @@ void wxWindowQt::PostCreation(bool generic)
     wxWindowBase::SetBackgroundColour(wxColour(GetHandle()->palette().background().color()));
     wxWindowBase::SetForegroundColour(wxColour(GetHandle()->palette().foreground().color()));
 
+    m_qtWindow->setMinimumSize(QSize(std::max(m_minWidth, 0), std::max(m_minHeight, 0)));
+    m_qtWindow->setMaximumSize(QSize(m_maxWidth == -1 ? QWIDGETSIZE_MAX : m_maxWidth, m_maxHeight == -1 ? QWIDGETSIZE_MAX : m_maxHeight));
+ 
     GetHandle()->setFont( wxWindowBase::GetFont().GetHandle() );
 
     // The window might have been hidden before Create() and it needs to remain
@@ -1580,6 +1583,39 @@ void wxWindowQt::QtHandleShortcut ( int command )
 QWidget *wxWindowQt::GetHandle() const
 {
     return m_qtWindow;
+}
+
+void wxWindowQt::SetMinSize(const wxSize& minSize)
+{
+    wxWindowBase::SetMinSize(minSize);
+    const int width = minSize.GetWidth();
+    const int height = minSize.GetHeight();
+    QWidget* widget = GetHandle();
+    if ( widget != NULL )
+       widget->setMinimumSize(QSize(width == -1 ? 0 : width, height == -1 ? 0 : height));
+}
+
+void wxWindowQt::SetMaxSize(const wxSize& maxSize)
+{
+    wxWindowBase::SetMaxSize(maxSize);
+    const int width = maxSize.GetWidth();
+    const int height = maxSize.GetHeight();
+    QWidget* widget = GetHandle();
+    if ( widget != NULL )
+        widget->setMaximumSize(QSize(width == -1 ? QWIDGETSIZE_MAX : width, height == -1 ? QWIDGETSIZE_MAX : height));
+}
+
+void wxWindowQt::DoSetSizeHints(int minW, int minH,
+    int maxW, int maxH,
+    int incW, int incH)
+{
+    wxWindowBase::DoSetSizeHints(minW, minH, maxW, maxH, incW, incH);
+    QWidget *widget = GetHandle();
+    if ( widget != NULL )
+    {
+        widget->setMinimumSize(QSize(std::max(minW, 0), std::max(minH, 0)));
+        widget->setMaximumSize(QSize(maxW == -1 ? QWIDGETSIZE_MAX : maxW, maxH == -1 ? QWIDGETSIZE_MAX : maxH));
+    }
 }
 
 QScrollArea *wxWindowQt::QtGetScrollBarsContainer() const


### PR DESCRIPTION
When the QT frame is asked for it's client size, the central widget size should be used. Before this change, the status bar for a frame would render inside the client area on top of widgets inside the client area. Also, controls do not have a suitable min size. The calculated best size is used for the min size on construction of controls.