### PR TITLE
DPI-Aware GetSystemMetrics and wxSystemParametersInfo

### DIFF
--- a/include/wx/msw/private.h
+++ b/include/wx/msw/private.h
@@ -300,6 +300,7 @@ extern HICON wxBitmapToHICON(const wxBitmap& bmp);
 extern
 HCURSOR wxBitmapToHCURSOR(const wxBitmap& bmp, int hotSpotX, int hotSpotY);
 
+extern int wxGetSystemMetrics(int nIndex, const wxWindow* win);
 
 #if wxUSE_OWNER_DRAWN
 

--- a/include/wx/msw/private.h
+++ b/include/wx/msw/private.h
@@ -302,6 +302,10 @@ HCURSOR wxBitmapToHCURSOR(const wxBitmap& bmp, int hotSpotX, int hotSpotY);
 
 extern int wxGetSystemMetrics(int nIndex, const wxWindow* win);
 
+extern bool wxSystemParametersInfo(UINT uiAction, UINT uiParam,
+                                   PVOID pvParam, UINT fWinIni,
+                                   const wxWindow* win);
+
 #if wxUSE_OWNER_DRAWN
 
 // Draw the bitmap in specified state (this is used by owner drawn controls)

--- a/include/wx/msw/private/metrics.h
+++ b/include/wx/msw/private/metrics.h
@@ -22,10 +22,14 @@ namespace wxMSWImpl
 // in the future
 //
 // MT-safety: this function is only meant to be called from the main thread
-inline const NONCLIENTMETRICS& GetNonClientMetrics(const wxWindow* win)
+inline const NONCLIENTMETRICS GetNonClientMetrics(const wxWindow* win)
 {
-    static WinStruct<NONCLIENTMETRICS> nm;
-    if ( !wxSystemParametersInfo(SPI_GETNONCLIENTMETRICS, 0, &nm, 0 , win) )
+    WinStruct<NONCLIENTMETRICS> nm;
+    if ( !wxSystemParametersInfo(SPI_GETNONCLIENTMETRICS,
+                                 sizeof(NONCLIENTMETRICS),
+                                 &nm,
+                                 0,
+                                 win) )
     {
 #if WINVER >= 0x0600
         // a new field has been added to NONCLIENTMETRICS under Vista, so
@@ -33,7 +37,11 @@ inline const NONCLIENTMETRICS& GetNonClientMetrics(const wxWindow* win)
         // size incorporating this new value on an older system -- retry
         // without it
         nm.cbSize -= sizeof(int);
-        if ( !wxSystemParametersInfo(SPI_GETNONCLIENTMETRICS, 0, &nm, 0, win) )
+        if ( !wxSystemParametersInfo(SPI_GETNONCLIENTMETRICS,
+                                     sizeof(NONCLIENTMETRICS),
+                                     &nm,
+                                     0,
+                                     win) )
 #endif // WINVER >= 0x0600
         {
             // maybe we should initialize the struct with some defaults?

--- a/include/wx/msw/private/metrics.h
+++ b/include/wx/msw/private/metrics.h
@@ -10,6 +10,8 @@
 #ifndef _WX_MSW_PRIVATE_METRICS_H_
 #define _WX_MSW_PRIVATE_METRICS_H_
 
+#include "wx/msw/private.h"
+
 namespace wxMSWImpl
 {
 
@@ -20,10 +22,10 @@ namespace wxMSWImpl
 // in the future
 //
 // MT-safety: this function is only meant to be called from the main thread
-inline const NONCLIENTMETRICS& GetNonClientMetrics()
+inline const NONCLIENTMETRICS& GetNonClientMetrics(const wxWindow* win)
 {
     static WinStruct<NONCLIENTMETRICS> nm;
-    if ( !::SystemParametersInfo(SPI_GETNONCLIENTMETRICS, 0, &nm, 0) )
+    if ( !wxSystemParametersInfo(SPI_GETNONCLIENTMETRICS, 0, &nm, 0 , win) )
     {
 #if WINVER >= 0x0600
         // a new field has been added to NONCLIENTMETRICS under Vista, so
@@ -31,7 +33,7 @@ inline const NONCLIENTMETRICS& GetNonClientMetrics()
         // size incorporating this new value on an older system -- retry
         // without it
         nm.cbSize -= sizeof(int);
-        if ( !::SystemParametersInfo(SPI_GETNONCLIENTMETRICS, 0, &nm, 0) )
+        if ( !wxSystemParametersInfo(SPI_GETNONCLIENTMETRICS, 0, &nm, 0, win) )
 #endif // WINVER >= 0x0600
         {
             // maybe we should initialize the struct with some defaults?

--- a/include/wx/settings.h
+++ b/include/wx/settings.h
@@ -216,7 +216,7 @@ public:
     static wxFont GetFont(wxSystemFont index);
 
     // get a system-dependent metric
-    static int GetMetric(wxSystemMetric index, wxWindow * win = NULL);
+    static int GetMetric(wxSystemMetric index, const wxWindow* win = NULL);
 
     // get the object describing the current system appearance
     static wxSystemAppearance GetAppearance();
@@ -240,7 +240,7 @@ public:
 
     // some metrics are toolkit-dependent and provided by wxUniv, some are
     // lowlevel
-    static int GetMetric(wxSystemMetric index, wxWindow *win = NULL);
+    static int GetMetric(wxSystemMetric index, const wxWindow* win = NULL);
 #endif // __WXUNIVERSAL__
 
     // Get system screen design (desktop, pda, ..) used for

--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -1290,8 +1290,8 @@ void wxAuiTabCtrl::OnMotion(wxMouseEvent& evt)
     }
 
 
-    int drag_x_threshold = wxSystemSettings::GetMetric(wxSYS_DRAG_X);
-    int drag_y_threshold = wxSystemSettings::GetMetric(wxSYS_DRAG_Y);
+    int drag_x_threshold = wxSystemSettings::GetMetric(wxSYS_DRAG_X, this);
+    int drag_y_threshold = wxSystemSettings::GetMetric(wxSYS_DRAG_Y, this);
 
     if (abs(pos.x - m_clickPt.x) > drag_x_threshold ||
         abs(pos.y - m_clickPt.y) > drag_y_threshold)

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -4589,8 +4589,8 @@ void wxAuiManager::OnMotion(wxMouseEvent& event)
     }
     else if (m_action == actionClickCaption)
     {
-        int drag_x_threshold = wxSystemSettings::GetMetric(wxSYS_DRAG_X);
-        int drag_y_threshold = wxSystemSettings::GetMetric(wxSYS_DRAG_Y);
+        int drag_x_threshold = wxSystemSettings::GetMetric(wxSYS_DRAG_X, m_frame);
+        int drag_y_threshold = wxSystemSettings::GetMetric(wxSYS_DRAG_Y, m_frame);
 
         // caption has been clicked.  we need to check if the mouse
         // is now being dragged. if it is, we need to change the

--- a/src/aui/tabmdi.cpp
+++ b/src/aui/tabmdi.cpp
@@ -611,8 +611,8 @@ void wxAuiMDIChildFrame::SetIcons(const wxIconBundle& icons)
     wxAuiMDIParentFrame* pParentFrame = GetMDIParentFrame();
     wxASSERT_MSG(pParentFrame, wxT("Missing MDI Parent Frame"));
 
-    const wxSize sizeIcon(wxSystemSettings::GetMetric(wxSYS_SMALLICON_X),
-                          wxSystemSettings::GetMetric(wxSYS_SMALLICON_Y));
+    const wxSize sizeIcon(wxSystemSettings::GetMetric(wxSYS_SMALLICON_X, this),
+                          wxSystemSettings::GetMetric(wxSYS_SMALLICON_Y, this));
     wxBitmap bmp;
     bmp.CopyFromIcon(icons.GetIcon(sizeIcon));
 

--- a/src/common/combocmn.cpp
+++ b/src/common/combocmn.cpp
@@ -2276,7 +2276,7 @@ void wxComboCtrlBase::ShowPopup()
     int maxHeightPopup;
     wxSize ctrlSz = GetSize();
 
-    screenHeight = wxSystemSettings::GetMetric( wxSYS_SCREEN_Y );
+    screenHeight = wxSystemSettings::GetMetric( wxSYS_SCREEN_Y, this );
     scrPos = GetScreenPosition();
 
     spaceAbove = scrPos.y;
@@ -2354,7 +2354,7 @@ void wxComboCtrlBase::ShowPopup()
     if ( wxTheApp->GetLayoutDirection() == wxLayout_RightToLeft )
         leftX -= ctrlSz.x;
 
-    int screenWidth = wxSystemSettings::GetMetric( wxSYS_SCREEN_X );
+    int screenWidth = wxSystemSettings::GetMetric( wxSYS_SCREEN_X, this );
 
     // If there is not enough horizontal space, anchor on the other side.
     // If there is no space even then, place the popup at x 0.

--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -1743,7 +1743,7 @@ wxSize wxDataViewSpinRenderer::GetSize() const
     // Allow some space for the spin buttons, which is approximately the size
     // of a scrollbar (and getting pixel-exact value would be complicated).
     // Also add some whitespace between the text and the button:
-    sz.x += wxSystemSettings::GetMetric(wxSYS_VSCROLL_X);
+    sz.x += wxSystemSettings::GetMetric(wxSYS_VSCROLL_X, m_editorCtrl);
     sz.x += GetTextExtent("M").x;
 
     return sz;
@@ -1821,7 +1821,7 @@ wxSize wxDataViewChoiceRenderer::GetSize() const
     // Allow some space for the right-side button, which is approximately the
     // size of a scrollbar (and getting pixel-exact value would be complicated).
     // Also add some whitespace between the text and the button:
-    sz.x += wxSystemSettings::GetMetric(wxSYS_VSCROLL_X);
+    sz.x += wxSystemSettings::GetMetric(wxSYS_VSCROLL_X, m_editorCtrl);
     sz.x += GetTextExtent("M").x;
 
     return sz;

--- a/src/common/dlgcmn.cpp
+++ b/src/common/dlgcmn.cpp
@@ -210,7 +210,7 @@ wxSizer *wxDialogBase::CreateTextSizer(const wxString& message,
     const bool is_pda = wxSystemSettings::GetScreenType() <= wxSYS_SCREEN_PDA;
     if (is_pda)
     {
-        widthMax = wxSystemSettings::GetMetric( wxSYS_SCREEN_X ) - 25;
+        widthMax = wxSystemSettings::GetMetric( wxSYS_SCREEN_X, this ) - 25;
     }
 
     return wrapper.CreateSizer(message, widthMax);

--- a/src/common/iconbndl.cpp
+++ b/src/common/iconbndl.cpp
@@ -20,6 +20,7 @@
     #ifdef __WINDOWS__
         #include "wx/msw/wrapwin.h"
     #endif
+    #include "wx/app.h"
     #include "wx/settings.h"
     #include "wx/log.h"
     #include "wx/intl.h"
@@ -266,8 +267,9 @@ wxIcon wxIconBundle::GetIcon(const wxSize& size, int flags) const
             sysY = 0;
     if ( flags & FALLBACK_SYSTEM )
     {
-        sysX = wxSystemSettings::GetMetric(wxSYS_ICON_X);
-        sysY = wxSystemSettings::GetMetric(wxSYS_ICON_Y);
+        wxWindow* win = wxTheApp ? wxTheApp->GetTopWindow() : NULL;
+        sysX = wxSystemSettings::GetMetric(wxSYS_ICON_X, win);
+        sysY = wxSystemSettings::GetMetric(wxSYS_ICON_Y, win);
     }
 
     // If size == wxDefaultSize, we use system default icon size by convention.

--- a/src/common/mousemanager.cpp
+++ b/src/common/mousemanager.cpp
@@ -155,9 +155,9 @@ void wxMouseEventsManager::OnMove(wxMouseEvent& event)
                 // assumption that they don't change -- which is wrong, of
                 // course, the user can change them but it doesn't happen often
                 static const int
-                    dragMinX = wxSystemSettings::GetMetric(wxSYS_DRAG_X);
+                    dragMinX = wxSystemSettings::GetMetric(wxSYS_DRAG_X, m_win);
                 static const int
-                    dragMinY = wxSystemSettings::GetMetric(wxSYS_DRAG_Y);
+                    dragMinY = wxSystemSettings::GetMetric(wxSYS_DRAG_Y, m_win);
 
                 const wxPoint& pos = event.GetPosition();
                 const wxPoint ofs = pos - m_posLast;

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -804,7 +804,7 @@ double wxWindowBase::GetContentScaleFactor() const
 static int wxGetMetricOrDefault(wxSystemMetric what, const wxWindowBase* win)
 {
     int rc = wxSystemSettings::GetMetric(
-        what, static_cast<wxWindow*>(const_cast<wxWindowBase*>(win)));
+        what, static_cast<const wxWindow*>(win));
     if ( rc == -1 )
     {
         switch ( what )

--- a/src/dfb/settings.cpp
+++ b/src/dfb/settings.cpp
@@ -63,7 +63,7 @@ wxFont wxSystemSettingsNative::GetFont(wxSystemFont index)
 }
 
 int wxSystemSettingsNative::GetMetric(wxSystemMetric index,
-                                      wxWindow* WXUNUSED(win))
+                                      const wxWindow* WXUNUSED(win))
 {
     int val;
 

--- a/src/generic/editlbox.cpp
+++ b/src/generic/editlbox.cpp
@@ -58,9 +58,9 @@ public:
     {
          int w = GetSize().x;
 #ifdef __WXMSW__
-         w -= wxSystemSettings::GetMetric(wxSYS_VSCROLL_X) + 6;
+         w -= wxSystemSettings::GetMetric(wxSYS_VSCROLL_X, this) + 6;
 #else
-         w -= 2*wxSystemSettings::GetMetric(wxSYS_VSCROLL_X);
+         w -= 2*wxSystemSettings::GetMetric(wxSYS_VSCROLL_X, this);
 #endif
          if (w < 0) w = 0;
          SetColumnWidth(0, w);

--- a/src/generic/odcombo.cpp
+++ b/src/generic/odcombo.cpp
@@ -830,7 +830,7 @@ wxSize wxVListBoxComboPopup::GetAdjustedSize( int minWidth, int prefHeight, int 
     CalcWidths();
 
     // Take scrollbar into account in width calculations
-    int widestWidth = m_widestWidth + wxSystemSettings::GetMetric(wxSYS_VSCROLL_X);
+    int widestWidth = m_widestWidth + wxSystemSettings::GetMetric(wxSYS_VSCROLL_X, this);
     return wxSize(minWidth > widestWidth ? minWidth : widestWidth,
                   height+2);
 }

--- a/src/generic/scrlwing.cpp
+++ b/src/generic/scrlwing.cpp
@@ -1553,11 +1553,12 @@ wxSize wxScrolledT_Helper::FilterBestSize(const wxWindow *win,
 
         wxSize minSize = win->GetMinSize();
 
+        wxWindow* window = const_cast<wxWindow*>(win);
         if ( ppuX > 0 )
-            best.x = minSize.x + wxSystemSettings::GetMetric(wxSYS_VSCROLL_X);
+            best.x = minSize.x + wxSystemSettings::GetMetric(wxSYS_VSCROLL_X, window);
 
         if ( ppuY > 0 )
-            best.y = minSize.y + wxSystemSettings::GetMetric(wxSYS_HSCROLL_Y);
+            best.y = minSize.y + wxSystemSettings::GetMetric(wxSYS_HSCROLL_Y, window);
     }
 
     return best;

--- a/src/generic/scrlwing.cpp
+++ b/src/generic/scrlwing.cpp
@@ -1553,12 +1553,11 @@ wxSize wxScrolledT_Helper::FilterBestSize(const wxWindow *win,
 
         wxSize minSize = win->GetMinSize();
 
-        wxWindow* window = const_cast<wxWindow*>(win);
         if ( ppuX > 0 )
-            best.x = minSize.x + wxSystemSettings::GetMetric(wxSYS_VSCROLL_X, window);
+            best.x = minSize.x + wxSystemSettings::GetMetric(wxSYS_VSCROLL_X, win);
 
         if ( ppuY > 0 )
-            best.y = minSize.y + wxSystemSettings::GetMetric(wxSYS_HSCROLL_Y, window);
+            best.y = minSize.y + wxSystemSettings::GetMetric(wxSYS_HSCROLL_Y, win);
     }
 
     return best;

--- a/src/generic/tipwin.cpp
+++ b/src/generic/tipwin.cpp
@@ -146,7 +146,7 @@ wxTipWindow::wxTipWindow(wxWindow *parent,
     // NB: the reason we use "/ 2" here is that we don't know where the current
     //     cursors hot spot is... it would be nice if we could find this out
     //     though
-    y += wxSystemSettings::GetMetric(wxSYS_CURSOR_Y) / 2;
+    y += wxSystemSettings::GetMetric(wxSYS_CURSOR_Y, this) / 2;
 
 #if wxUSE_POPUPWIN
     Position(wxPoint(x, y), wxSize(0,0));

--- a/src/generic/wizard.cpp
+++ b/src/generic/wizard.cpp
@@ -714,8 +714,8 @@ wxSize wxWizard::GetPageSize() const
     if ( wxSystemSettings::GetScreenType() <= wxSYS_SCREEN_PDA )
     {
         // Make the default page size small enough to fit on screen
-        DEFAULT_PAGE_WIDTH = wxSystemSettings::GetMetric(wxSYS_SCREEN_X) / 2;
-        DEFAULT_PAGE_HEIGHT = wxSystemSettings::GetMetric(wxSYS_SCREEN_Y) / 2;
+        DEFAULT_PAGE_WIDTH = wxSystemSettings::GetMetric(wxSYS_SCREEN_X, m_parent) / 2;
+        DEFAULT_PAGE_HEIGHT = wxSystemSettings::GetMetric(wxSYS_SCREEN_Y, m_parent) / 2;
     }
     else // !PDA
     {

--- a/src/gtk/settings.cpp
+++ b/src/gtk/settings.cpp
@@ -839,7 +839,7 @@ static GtkSettings *GetSettingsForWindowScreen(GdkWindow *window)
                   : gtk_settings_get_default();
 }
 
-static int GetBorderWidth(wxSystemMetric index, wxWindow* win)
+static int GetBorderWidth(wxSystemMetric index, const wxWindow* win)
 {
     if (win->m_wxwindow)
     {
@@ -912,7 +912,7 @@ static int GetScrollbarWidth()
     return width;
 }
 
-int wxSystemSettingsNative::GetMetric( wxSystemMetric index, wxWindow* win )
+int wxSystemSettingsNative::GetMetric( wxSystemMetric index, const wxWindow* win )
 {
     GdkWindow *window = NULL;
     if (win)

--- a/src/gtk1/settings.cpp
+++ b/src/gtk1/settings.cpp
@@ -358,7 +358,7 @@ wxFont wxSystemSettingsNative::GetFont( wxSystemFont index )
 }
 
 int
-wxSystemSettingsNative::GetMetric(wxSystemMetric index, wxWindow* WXUNUSED(win))
+wxSystemSettingsNative::GetMetric(wxSystemMetric index, const wxWindow* WXUNUSED(win))
 {
     switch (index)
     {

--- a/src/motif/settings.cpp
+++ b/src/motif/settings.cpp
@@ -196,7 +196,7 @@ wxFont wxSystemSettingsNative::GetFont(wxSystemFont index)
 }
 
 // Get a system metric, e.g. scrollbar size
-int wxSystemSettingsNative::GetMetric(wxSystemMetric index, wxWindow* WXUNUSED(win))
+int wxSystemSettingsNative::GetMetric(wxSystemMetric index, const wxWindow* WXUNUSED(win))
 {
     int return_value = 0;
 

--- a/src/msw/anybutton.cpp
+++ b/src/msw/anybutton.cpp
@@ -404,7 +404,7 @@ wxSize wxMSWButton::GetFittingSize(wxWindow *win,
 
     // account for the shield UAC icon if we have it
     if ( flags & Size_AuthNeeded )
-        sizeBtn.x += wxSystemSettings::GetMetric(wxSYS_SMALLICON_X);
+        sizeBtn.x += wxSystemSettings::GetMetric(wxSYS_SMALLICON_X, win);
 
     return sizeBtn;
 }

--- a/src/msw/artmsw.cpp
+++ b/src/msw/artmsw.cpp
@@ -20,6 +20,11 @@
 #endif
 
 #include "wx/artprov.h"
+
+#ifndef WX_PRECOMP
+    #include "wx/app.h"
+#endif
+
 #include "wx/image.h"
 #include "wx/dynlib.h"
 #include "wx/volume.h"
@@ -324,32 +329,33 @@ wxBitmap wxWindowsArtProvider::CreateBitmap(const wxArtID& id,
 /*static*/
 wxSize wxArtProvider::GetNativeSizeHint(const wxArtClient& client)
 {
+    const wxWindow* win = wxTheApp ? wxTheApp->GetTopWindow() : NULL;
     if ( client == wxART_TOOLBAR )
     {
-        return wxWindow::FromDIP(wxSize(24, 24), NULL);
+        return wxWindow::FromDIP(wxSize(24, 24), win);
     }
     else if ( client == wxART_MENU )
     {
-        return wxWindow::FromDIP(wxSize(16, 16), NULL);
+        return wxWindow::FromDIP(wxSize(16, 16), win);
     }
     else if ( client == wxART_FRAME_ICON )
     {
-        return wxSize(::GetSystemMetrics(SM_CXSMICON),
-                      ::GetSystemMetrics(SM_CYSMICON));
+        return wxSize(wxGetSystemMetrics(SM_CXSMICON, win),
+                      wxGetSystemMetrics(SM_CYSMICON, win));
     }
     else if ( client == wxART_CMN_DIALOG ||
               client == wxART_MESSAGE_BOX )
     {
-        return wxSize(::GetSystemMetrics(SM_CXICON),
-                      ::GetSystemMetrics(SM_CYICON));
+        return wxSize(wxGetSystemMetrics(SM_CXICON, win),
+                      wxGetSystemMetrics(SM_CYICON, win));
     }
     else if (client == wxART_BUTTON)
     {
-        return wxWindow::FromDIP(wxSize(16, 16), NULL);
+        return wxWindow::FromDIP(wxSize(16, 16), win);
     }
     else if (client == wxART_LIST)
     {
-        return wxWindow::FromDIP(wxSize(16, 16), NULL);
+        return wxWindow::FromDIP(wxSize(16, 16), win);
     }
 
     return wxDefaultSize;

--- a/src/msw/control.cpp
+++ b/src/msw/control.cpp
@@ -523,7 +523,7 @@ bool wxMSWOwnerDrawnButtonBase::MSWDrawButton(WXDRAWITEMSTRUCT *item)
     // choose the values consistent with those used for native, non
     // owner-drawn, buttons
     static const int MARGIN = 3;
-    int CXMENUCHECK = ::GetSystemMetrics(SM_CXMENUCHECK) + 1;
+    int CXMENUCHECK = wxGetSystemMetrics(SM_CXMENUCHECK, m_win) + 1;
 
     // the buttons were even bigger under Windows XP
     if ( wxGetWinVersion() < wxWinVersion_6 )

--- a/src/msw/cursor.cpp
+++ b/src/msw/cursor.cpp
@@ -115,7 +115,10 @@ wxSize wxCursorRefData::ms_sizeStd;
 wxCoord wxCursorRefData::GetStandardWidth()
 {
     if ( !ms_sizeStd.x )
-        ms_sizeStd.x = wxSystemSettings::GetMetric(wxSYS_CURSOR_X);
+    {
+        wxWindow* win = wxTheApp ? wxTheApp->GetTopWindow() : NULL;
+        ms_sizeStd.x = wxSystemSettings::GetMetric(wxSYS_CURSOR_X, win);
+    }
 
     return ms_sizeStd.x;
 }
@@ -123,7 +126,10 @@ wxCoord wxCursorRefData::GetStandardWidth()
 wxCoord wxCursorRefData::GetStandardHeight()
 {
     if ( !ms_sizeStd.y )
-        ms_sizeStd.y = wxSystemSettings::GetMetric(wxSYS_CURSOR_Y);
+    {
+        wxWindow* win = wxTheApp ? wxTheApp->GetTopWindow() : NULL;
+        ms_sizeStd.y = wxSystemSettings::GetMetric(wxSYS_CURSOR_Y, win);
+    }
 
     return ms_sizeStd.y;
 }

--- a/src/msw/datetimectrl.cpp
+++ b/src/msw/datetimectrl.cpp
@@ -148,7 +148,7 @@ wxSize wxDateTimePickerCtrl::DoGetBestSize() const
         size = dc.GetTextExtent(s);
 
         // account for the drop-down arrow or spin arrows
-        size.x += wxSystemSettings::GetMetric(wxSYS_HSCROLL_ARROW_X);
+        size.x += wxSystemSettings::GetMetric(wxSYS_HSCROLL_ARROW_X, m_parent);
     }
 
     // We need to account for the checkbox, if we have one, ourselves as

--- a/src/msw/dragimag.cpp
+++ b/src/msw/dragimag.cpp
@@ -334,8 +334,8 @@ bool wxDragImage::BeginDrag(const wxPoint& hotspot, wxWindow* window, bool fullS
 #else
         if (!m_hCursorImageList)
         {
-            int cxCursor = ::GetSystemMetrics(SM_CXCURSOR);
-            int cyCursor = ::GetSystemMetrics(SM_CYCURSOR);
+            int cxCursor = wxGetSystemMetrics(SM_CXCURSOR, window);
+            int cyCursor = wxGetSystemMetrics(SM_CYCURSOR, window);
             m_hCursorImageList = (WXHIMAGELIST) ImageList_Create(cxCursor, cyCursor, ILC_MASK, 1, 1);
         }
 

--- a/src/msw/gdiimage.cpp
+++ b/src/msw/gdiimage.cpp
@@ -473,9 +473,10 @@ bool wxICOFileHandler::LoadIcon(wxIcon *icon,
     }
     else
 #endif
-        // were we asked for a large icon?
-    if ( desiredWidth == ::GetSystemMetrics(SM_CXICON) &&
-         desiredHeight == ::GetSystemMetrics(SM_CYICON) )
+    // were we asked for a large icon?
+    const wxWindow* win = wxTheApp ? wxTheApp->GetTopWindow() : NULL;
+    if ( desiredWidth == wxGetSystemMetrics(SM_CXICON, win) &&
+         desiredHeight == wxGetSystemMetrics(SM_CYICON, win) )
     {
         // get the specified large icon from file
         if ( !::ExtractIconEx(nameReal.t_str(), iconIndex, &hicon, NULL, 1) )
@@ -487,8 +488,8 @@ bool wxICOFileHandler::LoadIcon(wxIcon *icon,
                        name.c_str());
         }
     }
-    else if ( desiredWidth == ::GetSystemMetrics(SM_CXSMICON) &&
-              desiredHeight == ::GetSystemMetrics(SM_CYSMICON) )
+    else if ( desiredWidth == wxGetSystemMetrics(SM_CXSMICON, win) &&
+              desiredHeight == wxGetSystemMetrics(SM_CYSMICON, win) )
     {
         // get the specified small icon from file
         if ( !::ExtractIconEx(nameReal.t_str(), iconIndex, NULL, &hicon, 1) )
@@ -668,8 +669,9 @@ wxSize wxGetHiconSize(HICON hicon)
     if ( !size.x )
     {
         // use default icon size on this hardware
-        size.x = ::GetSystemMetrics(SM_CXICON);
-        size.y = ::GetSystemMetrics(SM_CYICON);
+        const wxWindow* win = wxTheApp ? wxTheApp->GetTopWindow() : NULL;
+        size.x = wxGetSystemMetrics(SM_CXICON, win);
+        size.y = wxGetSystemMetrics(SM_CYICON, win);
     }
 
     return size;

--- a/src/msw/headerctrl.cpp
+++ b/src/msw/headerctrl.cpp
@@ -124,7 +124,7 @@ bool wxHeaderCtrl::Create(wxWindow *parent,
     // use 0 here but this starts to look ugly)
     if ( wxApp::GetComCtl32Version() >= 600 )
     {
-        (void)Header_SetBitmapMargin(GetHwnd(), ::GetSystemMetrics(SM_CXEDGE));
+        (void)Header_SetBitmapMargin(GetHwnd(), wxGetSystemMetrics(SM_CXEDGE, parent));
     }
 
     return true;

--- a/src/msw/listbox.cpp
+++ b/src/msw/listbox.cpp
@@ -625,7 +625,7 @@ wxSize wxListBox::DoGetBestClientSize() const
     wListbox += 3*GetCharWidth();
 
     // add room for the scrollbar
-    wListbox += wxSystemSettings::GetMetric(wxSYS_VSCROLL_X);
+    wListbox += wxSystemSettings::GetMetric(wxSYS_VSCROLL_X, m_parent);
 
     // don't make the listbox too tall (limit height to 10 items) but don't
     // make it too small neither

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -1486,9 +1486,9 @@ wxSize wxListCtrl::MSWGetBestViewRect(int x, int y) const
     const DWORD mswStyle = ::GetWindowLong(GetHwnd(), GWL_STYLE);
 
     if ( mswStyle & WS_HSCROLL )
-        size.y += wxSystemSettings::GetMetric(wxSYS_HSCROLL_Y);
+        size.y += wxSystemSettings::GetMetric(wxSYS_HSCROLL_Y, m_parent);
     if ( mswStyle & WS_VSCROLL )
-        size.x += wxSystemSettings::GetMetric(wxSYS_VSCROLL_X);
+        size.x += wxSystemSettings::GetMetric(wxSYS_VSCROLL_X, m_parent);
 
     // OTOH we have to subtract the size of our borders because the base class
     // public method already adds them, but ListView_ApproximateViewRect()

--- a/src/msw/menuitem.cpp
+++ b/src/msw/menuitem.cpp
@@ -126,10 +126,10 @@ private:
     int m_modeOld;
 };
 
-inline bool IsGreaterThanStdSize(const wxBitmap& bmp)
+inline bool IsGreaterThanStdSize(const wxBitmap& bmp, const wxWindow* win)
 {
-    return bmp.GetWidth() > ::GetSystemMetrics(SM_CXMENUCHECK) ||
-            bmp.GetHeight() > ::GetSystemMetrics(SM_CYMENUCHECK);
+    return bmp.GetWidth() > wxGetSystemMetrics(SM_CXMENUCHECK, win) ||
+            bmp.GetHeight() > wxGetSystemMetrics(SM_CYMENUCHECK, win);
 }
 
 } // anonymous namespace
@@ -306,9 +306,9 @@ MenuDrawData* MenuDrawData::ms_instance = NULL;
 void MenuDrawData::Init()
 {
 #if wxUSE_UXTHEME
+    const wxWindow* window = wxTheApp ? wxTheApp->GetTopWindow() : NULL;
     if ( IsUxThemeActive() )
     {
-        wxWindow* window = static_cast<wxApp*>(wxApp::GetInstance())->GetTopWindow();
         wxUxThemeHandle hTheme(window, L"MENU");
 
         ::GetThemeMargins(hTheme, NULL, MENU_POPUPITEM, 0,
@@ -366,12 +366,12 @@ void MenuDrawData::Init()
         const NONCLIENTMETRICS& metrics = wxMSWImpl::GetNonClientMetrics();
 
         CheckMargin.cxLeftWidth =
-        CheckMargin.cxRightWidth  = ::GetSystemMetrics(SM_CXEDGE);
+        CheckMargin.cxRightWidth  = wxGetSystemMetrics(SM_CXEDGE, window);
         CheckMargin.cyTopHeight =
-        CheckMargin.cyBottomHeight = ::GetSystemMetrics(SM_CYEDGE);
+        CheckMargin.cyBottomHeight = wxGetSystemMetrics(SM_CYEDGE, window);
 
-        CheckSize.cx = ::GetSystemMetrics(SM_CXMENUCHECK);
-        CheckSize.cy = ::GetSystemMetrics(SM_CYMENUCHECK);
+        CheckSize.cx = wxGetSystemMetrics(SM_CXMENUCHECK, window);
+        CheckSize.cy = wxGetSystemMetrics(SM_CYMENUCHECK, window);
 
         ArrowSize = CheckSize;
 
@@ -1293,8 +1293,9 @@ bool wxMenuItem::MSWMustUseOwnerDrawn()
         const wxBitmap& bmpUnchecked = GetBitmap(false),
                         bmpChecked   = GetBitmap(true);
 
-        if ( (bmpUnchecked.IsOk() && IsGreaterThanStdSize(bmpUnchecked)) ||
-                (bmpChecked.IsOk()   && IsGreaterThanStdSize(bmpChecked)) ||
+        const wxWindow* win = m_parentMenu ? m_parentMenu->GetWindow() : NULL;
+        if ( (bmpUnchecked.IsOk() && IsGreaterThanStdSize(bmpUnchecked, win)) ||
+                (bmpChecked.IsOk()   && IsGreaterThanStdSize(bmpChecked, win)) ||
                 (bmpChecked.IsOk() && IsCheckable()) )
         {
             mustUseOwnerDrawn = true;

--- a/src/msw/menuitem.cpp
+++ b/src/msw/menuitem.cpp
@@ -363,7 +363,7 @@ void MenuDrawData::Init()
     else
 #endif // wxUSE_UXTHEME
     {
-        const NONCLIENTMETRICS& metrics = wxMSWImpl::GetNonClientMetrics();
+        const NONCLIENTMETRICS& metrics = wxMSWImpl::GetNonClientMetrics(window);
 
         CheckMargin.cxLeftWidth =
         CheckMargin.cxRightWidth  = wxGetSystemMetrics(SM_CXEDGE, window);

--- a/src/msw/msgdlg.cpp
+++ b/src/msw/msgdlg.cpp
@@ -193,8 +193,8 @@ void wxMessageDialog::ReplaceStaticWithEdit()
     // some space above and below it
     const int hText = (7*rectDisplay.height)/8 -
                       (
-                         2*::GetSystemMetrics(SM_CYFIXEDFRAME) +
-                         ::GetSystemMetrics(SM_CYCAPTION) +
+                         2*wxGetSystemMetrics(SM_CYFIXEDFRAME, this) +
+                         wxGetSystemMetrics(SM_CYCAPTION, this) +
                          5*GetCharHeight() // buttons + margins
                       );
     const int dh = (rc.bottom - rc.top) - hText; // vertical space we save
@@ -207,8 +207,8 @@ void wxMessageDialog::ReplaceStaticWithEdit()
     // NB: you would have thought that 2*SM_CXEDGE would be enough but it
     //     isn't, somehow, and the text control breaks lines differently from
     //     the static one so fudge by adding some extra space
-    const int dw = ::GetSystemMetrics(SM_CXVSCROLL) +
-                        4*::GetSystemMetrics(SM_CXEDGE);
+    const int dw = wxGetSystemMetrics(SM_CXVSCROLL, this) +
+                        4*wxGetSystemMetrics(SM_CXEDGE, this);
     rc.right += dw;
 
 

--- a/src/msw/msgdlg.cpp
+++ b/src/msw/msgdlg.cpp
@@ -396,7 +396,8 @@ void wxMessageDialog::AdjustButtonLabels()
 /* static */
 wxFont wxMessageDialog::GetMessageFont()
 {
-    const NONCLIENTMETRICS& ncm = wxMSWImpl::GetNonClientMetrics();
+    const wxWindow* win = wxTheApp ? wxTheApp->GetTopWindow() : NULL;
+    const NONCLIENTMETRICS& ncm = wxMSWImpl::GetNonClientMetrics(win);
     return wxNativeFontInfo(ncm.lfMessageFont);
 }
 

--- a/src/msw/progdlg.cpp
+++ b/src/msw/progdlg.cpp
@@ -802,10 +802,10 @@ void wxProgressDialog::SetIcons(const wxIconBundle& icons)
         wxIcon iconBig;
         if (!icons.IsEmpty())
         {
-            const wxSize sizeSmall(::GetSystemMetrics(SM_CXSMICON), ::GetSystemMetrics(SM_CYSMICON));
+            const wxSize sizeSmall(wxGetSystemMetrics(SM_CXSMICON, this), wxGetSystemMetrics(SM_CYSMICON, this));
             iconSmall = icons.GetIcon(sizeSmall, wxIconBundle::FALLBACK_NEAREST_LARGER);
 
-            const wxSize sizeBig(::GetSystemMetrics(SM_CXICON), ::GetSystemMetrics(SM_CYICON));
+            const wxSize sizeBig(wxGetSystemMetrics(SM_CXICON, this), wxGetSystemMetrics(SM_CYICON, this));
             iconBig = icons.GetIcon(sizeBig, wxIconBundle::FALLBACK_NEAREST_LARGER);
         }
 

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -527,8 +527,8 @@ wxSize wxRendererMSW::GetCheckBoxSize(wxWindow* win)
     // that it's valid to avoid surprises when using themes.
     wxCHECK_MSG( win, wxSize(0, 0), "Must have a valid window" );
 
-    return wxSize(::GetSystemMetrics(SM_CXMENUCHECK),
-                  ::GetSystemMetrics(SM_CYMENUCHECK));
+    return wxSize(wxGetSystemMetrics(SM_CXMENUCHECK, win),
+                  wxGetSystemMetrics(SM_CYMENUCHECK, win));
 }
 
 int wxRendererMSW::GetHeaderButtonHeight(wxWindow * win)

--- a/src/msw/scrolbar.cpp
+++ b/src/msw/scrolbar.cpp
@@ -208,11 +208,11 @@ wxSize wxScrollBar::DoGetBestSize() const
 
     if ( IsVertical() )
     {
-        w = wxSystemSettings::GetMetric(wxSYS_VSCROLL_X);
+        w = wxSystemSettings::GetMetric(wxSYS_VSCROLL_X, m_parent);
     }
     else
     {
-        h = wxSystemSettings::GetMetric(wxSYS_HSCROLL_Y);
+        h = wxSystemSettings::GetMetric(wxSYS_HSCROLL_Y, m_parent);
     }
 
     return wxSize(w, h);

--- a/src/msw/settings.cpp
+++ b/src/msw/settings.cpp
@@ -260,7 +260,7 @@ static const int gs_metricsMap[] =
 };
 
 // Get a system metric, e.g. scrollbar size
-int wxSystemSettingsNative::GetMetric(wxSystemMetric index, wxWindow* WXUNUSED(win))
+int wxSystemSettingsNative::GetMetric(wxSystemMetric index, wxWindow* win)
 {
     wxCHECK_MSG( index > 0 && (size_t)index < WXSIZEOF(gs_metricsMap), 0,
                  wxT("invalid metric") );
@@ -297,7 +297,7 @@ int wxSystemSettingsNative::GetMetric(wxSystemMetric index, wxWindow* WXUNUSED(w
         return -1;
     }
 
-    int rc = ::GetSystemMetrics(indexMSW);
+    int rc = wxGetSystemMetrics(indexMSW, win);
     if ( index == wxSYS_NETWORK_PRESENT )
     {
         // only the last bit is significant according to the MSDN

--- a/src/msw/settings.cpp
+++ b/src/msw/settings.cpp
@@ -262,7 +262,7 @@ static const int gs_metricsMap[] =
 };
 
 // Get a system metric, e.g. scrollbar size
-int wxSystemSettingsNative::GetMetric(wxSystemMetric index, wxWindow* win)
+int wxSystemSettingsNative::GetMetric(wxSystemMetric index, const wxWindow* win)
 {
     wxCHECK_MSG( index > 0 && (size_t)index < WXSIZEOF(gs_metricsMap), 0,
                  wxT("invalid metric") );

--- a/src/msw/settings.cpp
+++ b/src/msw/settings.cpp
@@ -26,6 +26,7 @@
 #include "wx/settings.h"
 
 #ifndef WX_PRECOMP
+    #include "wx/app.h"
     #include "wx/utils.h"
     #include "wx/gdicmn.h"
     #include "wx/module.h"
@@ -181,8 +182,9 @@ wxFont wxSystemSettingsNative::GetFont(wxSystemFont index)
             // for most (simple) controls, e.g. buttons and such but other
             // controls may prefer to use lfStatusFont or lfCaptionFont if it
             // is more appropriate for them
+            const wxWindow* win = wxTheApp ? wxTheApp->GetTopWindow() : NULL;
             const wxNativeFontInfo
-                info(wxMSWImpl::GetNonClientMetrics().lfMessageFont);
+                info(wxMSWImpl::GetNonClientMetrics(win).lfMessageFont);
             gs_fontDefault = new wxFont(info);
         }
 
@@ -337,12 +339,14 @@ extern wxFont wxGetCCDefaultFont()
     // font which is also used for the icon titles and not the stock default
     // GUI font
     LOGFONT lf;
-    if ( ::SystemParametersInfo
+    const wxWindow* win = wxTheApp ? wxTheApp->GetTopWindow() : NULL;
+    if ( wxSystemParametersInfo
            (
                 SPI_GETICONTITLELOGFONT,
                 sizeof(lf),
                 &lf,
-                0
+                0,
+                win
            ) )
     {
         return wxFont(lf);

--- a/src/msw/spinbutt.cpp
+++ b/src/msw/spinbutt.cpp
@@ -150,8 +150,8 @@ wxSize wxSpinButton::DoGetBestSize() const
 {
     const bool vert = HasFlag(wxSP_VERTICAL);
 
-    wxSize bestSize(::GetSystemMetrics(vert ? SM_CXVSCROLL : SM_CXHSCROLL),
-                    ::GetSystemMetrics(vert ? SM_CYVSCROLL : SM_CYHSCROLL));
+    wxSize bestSize(wxGetSystemMetrics(vert ? SM_CXVSCROLL : SM_CXHSCROLL, m_parent),
+                    wxGetSystemMetrics(vert ? SM_CYVSCROLL : SM_CYHSCROLL, m_parent));
 
     if ( vert )
         bestSize.y *= 2;

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2442,14 +2442,14 @@ wxSize wxTextCtrl::DoGetSizeFromTextSize(int xlen, int ylen) const
     {
         // add space for vertical scrollbar
         if ( !(m_windowStyle & wxTE_NO_VSCROLL) )
-            wText += ::GetSystemMetrics(SM_CXVSCROLL);
+            wText += wxGetSystemMetrics(SM_CXVSCROLL, m_parent);
 
         if ( ylen <= 0 )
         {
             hText *= wxMax(wxMin(GetNumberOfLines(), 10), 2);
             // add space for horizontal scrollbar
             if ( m_windowStyle & wxHSCROLL )
-                hText += ::GetSystemMetrics(SM_CYHSCROLL);
+                hText += wxGetSystemMetrics(SM_CYHSCROLL, m_parent);
         }
     }
     // for single line control cy (height + external leading) is ok

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -581,11 +581,11 @@ wxSize wxToolBar::DoGetBestSize() const
     wxSize sizeBest;
     if ( IsVertical() )
     {
-        sizeBest.x = sizeTool.x + 2 * ::GetSystemMetrics(SM_CXBORDER);
+        sizeBest.x = sizeTool.x + 2 * wxGetSystemMetrics(SM_CXBORDER, this);
     }
     else
     {
-        sizeBest.y = sizeTool.y + 2 * ::GetSystemMetrics(SM_CYBORDER);
+        sizeBest.y = sizeTool.y + 2 * wxGetSystemMetrics(SM_CYBORDER, this);
     }
 
     wxToolBarToolsList::compatibility_iterator node;
@@ -634,11 +634,11 @@ wxSize wxToolBar::DoGetBestSize() const
     {
         if ( IsVertical() )
         {
-            sizeBest.x += 2 * ::GetSystemMetrics(SM_CXBORDER);
+            sizeBest.x += 2 * wxGetSystemMetrics(SM_CXBORDER, this);
         }
         else
         {
-            sizeBest.y += 2 * ::GetSystemMetrics(SM_CYBORDER);
+            sizeBest.y += 2 * wxGetSystemMetrics(SM_CYBORDER, this);
         }
     }
 
@@ -1247,7 +1247,7 @@ bool wxToolBar::Realize()
     {
         // We want just the usable height, so remove the space taken by the
         // border/divider.
-        height -= 2 * ::GetSystemMetrics(SM_CYBORDER);
+        height -= 2 * wxGetSystemMetrics(SM_CYBORDER, this);
     }
 
     // adjust the controls size to fit nicely in the toolbar and compute its

--- a/src/msw/toplevel.cpp
+++ b/src/msw/toplevel.cpp
@@ -984,7 +984,7 @@ bool wxTopLevelWindowMSW::DoSelectAndSetIcon(const wxIconBundle& icons,
                                              int smY,
                                              int i)
 {
-    const wxSize size(::GetSystemMetrics(smX), ::GetSystemMetrics(smY));
+    const wxSize size(wxGetSystemMetrics(smX, this), wxGetSystemMetrics(smY, this));
 
     wxIcon icon = icons.GetIcon(size, wxIconBundle::FALLBACK_NEAREST_LARGER);
 

--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -3018,8 +3018,8 @@ wxTreeCtrl::MSWWindowProc(WXUINT nMsg, WXWPARAM wParam, WXLPARAM lParam)
                     int cx = abs(m_ptClick.x - x);
                     int cy = abs(m_ptClick.y - y);
 
-                    if ( cx > ::GetSystemMetrics(SM_CXDRAG) ||
-                            cy > ::GetSystemMetrics(SM_CYDRAG) )
+                    if ( cx > wxGetSystemMetrics(SM_CXDRAG, this) ||
+                            cy > wxGetSystemMetrics(SM_CYDRAG, this) )
                     {
                         NM_TREEVIEW tv;
                         wxZeroMemory(tv);

--- a/src/osx/cocoa/settings.mm
+++ b/src/osx/cocoa/settings.mm
@@ -217,7 +217,7 @@ wxFont wxSystemSettingsNative::GetFont(wxSystemFont index)
 // ----------------------------------------------------------------------------
 
 // Get a system metric, e.g. scrollbar size
-int wxSystemSettingsNative::GetMetric(wxSystemMetric index, wxWindow *WXUNUSED(win))
+int wxSystemSettingsNative::GetMetric(wxSystemMetric index, const wxWindow* WXUNUSED(win))
 {
     int value;
 

--- a/src/osx/iphone/settings.mm
+++ b/src/osx/iphone/settings.mm
@@ -155,7 +155,7 @@ wxFont wxSystemSettingsNative::GetFont(wxSystemFont index)
 // ----------------------------------------------------------------------------
 
 // Get a system metric, e.g. scrollbar size
-int wxSystemSettingsNative::GetMetric(wxSystemMetric index, wxWindow *WXUNUSED(win))
+int wxSystemSettingsNative::GetMetric(wxSystemMetric index, const wxWindow* WXUNUSED(win))
 {
     int value;
 

--- a/src/propgrid/manager.cpp
+++ b/src/propgrid/manager.cpp
@@ -647,7 +647,7 @@ void wxPropertyGridManager::SetId( wxWindowID winid )
 wxSize wxPropertyGridManager::DoGetBestSize() const
 {
     // Width: margin=15 + columns=2*40 + scroll bar
-    return wxSize(15+2*40+wxSystemSettings::GetMetric(wxSYS_VSCROLL_X), 150);
+    return wxSize(15+2*40+wxSystemSettings::GetMetric(wxSYS_VSCROLL_X, m_pPropGrid), 150);
 }
 
 // -----------------------------------------------------------------------

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -1711,8 +1711,8 @@ wxPoint wxPropertyGrid::GetGoodEditorDialogPosition( wxPGProperty* p,
 
     ImprovedClientToScreen( &x, &y );
 
-    int sw = wxSystemSettings::GetMetric( ::wxSYS_SCREEN_X );
-    int sh = wxSystemSettings::GetMetric( ::wxSYS_SCREEN_Y );
+    int sw = wxSystemSettings::GetMetric( ::wxSYS_SCREEN_X, this );
+    int sh = wxSystemSettings::GetMetric( ::wxSYS_SCREEN_Y, this );
 
     int new_x;
     int new_y;

--- a/src/qt/settings.cpp
+++ b/src/qt/settings.cpp
@@ -163,7 +163,7 @@ wxFont wxSystemSettingsNative::GetFont(wxSystemFont index)
 
 }
 
-int wxSystemSettingsNative::GetMetric(wxSystemMetric index, wxWindow * WXUNUSED(win))
+int wxSystemSettingsNative::GetMetric(wxSystemMetric index, const wxWindow* WXUNUSED(win))
 {
     switch (index)
     {

--- a/src/stc/PlatWX.cpp
+++ b/src/stc/PlatWX.cpp
@@ -2718,7 +2718,8 @@ PRectangle wxSTCListBox::GetDesiredRect() const
 
     // Add space for a scrollbar if needed.
     if ( count > desiredVisibleRows )
-        maxw += wxSystemSettings::GetMetric(wxSYS_VSCROLL_X);
+        maxw += wxSystemSettings::GetMetric(wxSYS_VSCROLL_X,
+            const_cast<wxWindow*>(wxDynamicCast(this, wxWindow)));
 
     // Add borders.
     maxw += 2 * m_borderSize;

--- a/src/stc/PlatWX.cpp
+++ b/src/stc/PlatWX.cpp
@@ -2718,8 +2718,7 @@ PRectangle wxSTCListBox::GetDesiredRect() const
 
     // Add space for a scrollbar if needed.
     if ( count > desiredVisibleRows )
-        maxw += wxSystemSettings::GetMetric(wxSYS_VSCROLL_X,
-            const_cast<wxWindow*>(wxDynamicCast(this, wxWindow)));
+        maxw += wxSystemSettings::GetMetric(wxSYS_VSCROLL_X, this);
 
     // Add borders.
     maxw += 2 * m_borderSize;

--- a/src/univ/settingsuniv.cpp
+++ b/src/univ/settingsuniv.cpp
@@ -96,7 +96,7 @@ wxColour wxSystemSettings::GetColour(wxSystemColour index)
     return wxTheme::Get()->GetColourScheme()->Get(col);
 }
 
-int wxSystemSettings::GetMetric(wxSystemMetric index, wxWindow *win)
+int wxSystemSettings::GetMetric(wxSystemMetric index, const wxWindow* win)
 {
     switch ( index )
     {

--- a/src/x11/settings.cpp
+++ b/src/x11/settings.cpp
@@ -56,7 +56,7 @@ wxFont wxSystemSettingsNative::GetFont(wxSystemFont index)
 }
 
 // Get a system metric, e.g. scrollbar size
-int wxSystemSettingsNative::GetMetric(wxSystemMetric index, wxWindow* WXUNUSED(win))
+int wxSystemSettingsNative::GetMetric(wxSystemMetric index, const wxWindow* WXUNUSED(win))
 {
     switch ( index)
     {


### PR DESCRIPTION
Cherry-picked from #334.

Because TLW's don't have a DPI yet, use the DPI from `GetDeviceCaps(hdc, LOGPIXELSY);` as input for `GetSystemMetricsForDpi` and `SystemParametersInfoForDpi`.