### PR TITLE
Remove wxTimerEvent default constructor

### DIFF
--- a/include/wx/timer.h
+++ b/include/wx/timer.h
@@ -159,26 +159,23 @@ private:
 class WXDLLIMPEXP_BASE wxTimerEvent : public wxEvent
 {
 public:
-    wxTimerEvent()
-        : wxEvent(wxID_ANY, wxEVT_TIMER) { m_timer=NULL; }
-
     wxTimerEvent(wxTimer& timer)
         : wxEvent(timer.GetId(), wxEVT_TIMER),
-          m_timer(&timer)
+          m_timer(timer)
     {
         SetEventObject(timer.GetOwner());
     }
 
     // accessors
-    int GetInterval() const { return m_timer->GetInterval(); }
-    wxTimer& GetTimer() const { return *m_timer; }
+    int GetInterval() const { return m_timer.GetInterval(); }
+    wxTimer& GetTimer() const { return m_timer; }
 
     // implement the base class pure virtual
     virtual wxEvent *Clone() const wxOVERRIDE { return new wxTimerEvent(*this); }
     virtual wxEventCategory GetEventCategory() const wxOVERRIDE { return wxEVT_CATEGORY_TIMER; }
 
 private:
-    wxTimer* m_timer;
+    wxTimer& m_timer;
 
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(wxTimerEvent);
 };

--- a/src/common/timercmn.cpp
+++ b/src/common/timercmn.cpp
@@ -38,7 +38,9 @@
 // wxWin macros
 // ----------------------------------------------------------------------------
 
-wxIMPLEMENT_DYNAMIC_CLASS(wxTimerEvent, wxEvent);
+// This class is not really abstract, but this macro has to be used because it
+// doesn't have a default ctor.
+wxIMPLEMENT_ABSTRACT_CLASS(wxTimerEvent, wxEvent);
 
 wxDEFINE_EVENT(wxEVT_TIMER, wxTimerEvent);
 

--- a/tests/events/clone.cpp
+++ b/tests/events/clone.cpp
@@ -21,32 +21,7 @@
     #include "wx/timer.h"
 #endif // WX_PRECOMP
 
-// --------------------------------------------------------------------------
-// test class
-// --------------------------------------------------------------------------
-
-class EventCloneTestCase : public CppUnit::TestCase
-{
-public:
-    EventCloneTestCase() {}
-
-private:
-    CPPUNIT_TEST_SUITE( EventCloneTestCase );
-        CPPUNIT_TEST( CheckAll );
-    CPPUNIT_TEST_SUITE_END();
-
-    void CheckAll();
-
-    wxDECLARE_NO_COPY_CLASS(EventCloneTestCase);
-};
-
-// register in the unnamed registry so that these tests are run by default
-CPPUNIT_TEST_SUITE_REGISTRATION( EventCloneTestCase );
-
-// also include in its own registry so that these tests can be run alone
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( EventCloneTestCase, "EventCloneTestCase" );
-
-void EventCloneTestCase::CheckAll()
+TEST_CASE("EventClone", "[wxEvent][clone]")
 {
     // Dummy timer needed just to create a wxTimerEvent.
     wxTimer dummyTimer;


### PR DESCRIPTION
This ctor just created unusable wxTimerEvent objects (all of the methods
specific to this class would just crash if called on them) and doesn't
seem to be useful at all.

It was added in e47859daebd15efcecb969e612295c868e944d79 apparently only
in order to allow using wxIMPLEMENT_DYNAMIC_CLASS() instead of the
previously used wxIMPLEMENT_ABSTRACT_CLASS() for wxTimerEvent, but there
doesn't seem to be any reason to prefer macro over another, and there
are good reasons to not allow creating objects in an invalid state.