### PR TITLE
Fix documentation of Contains function

### DIFF
--- a/interface/wx/gdicmn.h
+++ b/interface/wx/gdicmn.h
@@ -301,11 +301,17 @@ public:
     /**
         Returns @true if the given point is inside the rectangle (or on its
         boundary) and @false otherwise.
+        A point is within a rectangle if it lies on the left or top side or is
+        within all four sides.
+        A point on the right or bottom side is considered outside the rectangle.
     */
     bool Contains(int x, int y) const;
     /**
         Returns @true if the given point is inside the rectangle (or on its
         boundary) and @false otherwise.
+        A point is within a rectangle if it lies on the left or top side or is
+        within all four sides.
+        A point on the right or bottom side is considered outside the rectangle.
     */
     bool Contains(const wxPoint& pt) const;
     /**


### PR DESCRIPTION
As discussed on the mailing list - mention that Contains() does not include the right and bottom boundaries of the current wxRect object.

Only documentation is updated - no code change.

Please review and apply.

TIA!
