### PR TITLE
Don't include scrollbars in client area size for wxQT

### DIFF
--- a/include/wx/qt/window.h
+++ b/include/wx/qt/window.h
@@ -224,6 +224,7 @@ private:
     QScrollBar *m_horzScrollBar; // owned by m_qtWindow when allocated
     QScrollBar *m_vertScrollBar; // owned by m_qtWindow when allocated
 
+    QWidget *QtGetClientWidget() const;
     QScrollBar *QtGetScrollBar( int orientation ) const;
     QScrollBar *QtSetScrollBar( int orientation, QScrollBar *scrollBar=NULL );
 

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -560,6 +560,23 @@ void wxWindowQt::DoGetTextExtent(const wxString& string, int *x, int *y, int *de
         *externalLeading = fontMetrics.lineSpacing();
 }
 
+QWidget *wxWindowQt::QtGetClientWidget() const
+{
+    QWidget *qtWidget = NULL;
+    if ( m_qtContainer != NULL )
+    {
+        qtWidget = m_qtContainer->viewport();
+    }
+
+    if ( qtWidget == NULL )
+    {
+        //We don't have scrollbars or the QScrollArea has no children
+        qtWidget = GetHandle();
+    }
+
+    return qtWidget;
+}
+
 /* Returns a scrollbar for the given orientation, or NULL if the scrollbar
  * has not been previously created and create is false */
 QScrollBar *wxWindowQt::QtGetScrollBar( int orientation ) const
@@ -935,7 +952,8 @@ void wxWindowQt::DoSetSize(int x, int y, int width, int height, int sizeFlags )
 
 void wxWindowQt::DoGetClientSize(int *width, int *height) const
 {
-    QRect geometry = GetHandle()->geometry();
+    QWidget *qtWidget = QtGetClientWidget();
+    const QRect geometry = qtWidget->geometry();
     if (width)  *width = geometry.width();
     if (height) *height = geometry.height();
 }
@@ -943,7 +961,7 @@ void wxWindowQt::DoGetClientSize(int *width, int *height) const
 
 void wxWindowQt::DoSetClientSize(int width, int height)
 {
-    QWidget *qtWidget = GetHandle();
+    QWidget *qtWidget = QtGetClientWidget();
     QRect geometry = qtWidget->geometry();
     geometry.setWidth( width );
     geometry.setHeight( height );


### PR DESCRIPTION
wxWindow::DoGetClientSize and wxWindow::DoSetClientSize previously included the size of the scrollbars under wxQT.  This resulted in controls being clipped by the scollbars rather than being sized to accommodate them.