### PR TITLE
Improve notebook page size calculations under wxQT

### DIFF
--- a/src/qt/notebook.cpp
+++ b/src/qt/notebook.cpp
@@ -14,6 +14,7 @@
 #include "wx/qt/private/winevent.h"
 
 #include <QtWidgets/QTabWidget>
+#include <QtWidgets/QTabBar>
 
 class wxQtTabWidget : public wxQtEventSignalHandler< QTabWidget, wxNotebook >
 {
@@ -162,7 +163,10 @@ bool wxNotebook::InsertPage(size_t n, wxWindow *page, const wxString& text,
 
 wxSize wxNotebook::CalcSizeFromPage(const wxSize& sizePage) const
 {
-    return sizePage;
+    QTabBar *tabBar = m_qtTabWidget->tabBar();
+    const QSize tabBarSize = tabBar->size();
+    return wxSize(sizePage.GetWidth(),
+        sizePage.GetHeight() + tabBarSize.height());
 }
 
 bool wxNotebook::DeleteAllPages()

--- a/src/qt/notebook.cpp
+++ b/src/qt/notebook.cpp
@@ -164,7 +164,7 @@ bool wxNotebook::InsertPage(size_t n, wxWindow *page, const wxString& text,
 wxSize wxNotebook::CalcSizeFromPage(const wxSize& sizePage) const
 {
     QTabBar *tabBar = m_qtTabWidget->tabBar();
-    const QSize tabBarSize = tabBar->size();
+    const QSize &tabBarSize = tabBar->size();
     return wxSize(sizePage.GetWidth(),
         sizePage.GetHeight() + tabBarSize.height());
 }


### PR DESCRIPTION
The implementation of wxNotebook::CalcSizeFromPage for wxQT doesn't include the size of the tab bar.  This PR fixes that.