### PR TITLE
Add semi-private wxHtmlCell::Dump()

### DIFF
--- a/include/wx/html/htmlcell.h
+++ b/include/wx/html/htmlcell.h
@@ -347,7 +347,15 @@ public:
     virtual wxString ConvertToText(wxHtmlSelection *WXUNUSED(sel)) const
         { return wxEmptyString; }
 
+    // This method is useful for debugging, to customize it for particular cell
+    // type, override GetDescription() and not this function itself.
+    virtual wxString Dump(int indent = 0) const;
+
 protected:
+    // Return the description used by Dump().
+    virtual wxString GetDescription() const;
+
+
     // pointer to the next cell
     wxHtmlCell *m_Next;
     // pointer to parent cell
@@ -399,6 +407,8 @@ public:
     void SetPreviousWord(wxHtmlWordCell *cell);
 
 protected:
+    virtual wxString GetDescription() const wxOVERRIDE;
+
     virtual wxString GetAllAsText() const
         { return m_Word; }
     virtual wxString GetPartAsText(int begin, int end) const
@@ -524,6 +534,8 @@ public:
     // Call Layout at least once before using GetMaxTotalWidth()
     virtual int GetMaxTotalWidth() const wxOVERRIDE { return m_MaxTotalWidth; }
 
+    virtual wxString Dump(int indent = 0) const wxOVERRIDE;
+
 protected:
     void UpdateRenderingStatePre(wxHtmlRenderingInfo& info,
                                  wxHtmlCell *cell) const;
@@ -577,6 +589,8 @@ public:
     virtual void DrawInvisible(wxDC& dc, int x, int y,
                                wxHtmlRenderingInfo& info) wxOVERRIDE;
 
+    virtual wxString GetDescription() const wxOVERRIDE;
+
 protected:
     wxColour m_Colour;
     unsigned m_Flags;
@@ -601,6 +615,8 @@ public:
                       wxHtmlRenderingInfo& info) wxOVERRIDE;
     virtual void DrawInvisible(wxDC& dc, int x, int y,
                                wxHtmlRenderingInfo& info) wxOVERRIDE;
+
+    virtual wxString GetDescription() const wxOVERRIDE;
 
 protected:
     wxFont m_Font;

--- a/src/html/htmlcell.cpp
+++ b/src/html/htmlcell.cpp
@@ -284,6 +284,21 @@ bool wxHtmlCell::IsBefore(wxHtmlCell *cell) const
     return false;
 }
 
+wxString wxHtmlCell::GetDescription() const
+{
+    return GetClassInfo()->GetClassName();
+}
+
+wxString wxHtmlCell::Dump(int indent) const
+{
+    wxString s(' ', indent);
+    s += wxString::Format("%s at (%d, %d) %dx%d",
+                          GetDescription(), m_PosX, m_PosY, m_Width, m_Height);
+    if ( !m_id.empty() )
+        s += wxString::Format(" [id=%s]", m_id);
+
+    return s;
+}
 
 //-----------------------------------------------------------------------------
 // wxHtmlWordCell
@@ -620,6 +635,15 @@ wxString wxHtmlWordWithTabsCell::GetPartAsText(int begin, int end) const
     return sel;
 }
 
+wxString wxHtmlWordCell::GetDescription() const
+{
+    wxString s;
+    s = wxString::Format("wxHtmlWordCell(%s)", m_Word);
+    if ( !m_allowLinebreak )
+        s += " no line break";
+
+    return s;
+}
 
 
 //-----------------------------------------------------------------------------
@@ -1437,6 +1461,15 @@ void wxHtmlContainerCell::RemoveExtraSpacing(bool top, bool bottom)
     }
 }
 
+wxString wxHtmlContainerCell::Dump(int indent) const
+{
+    wxString s = wxHtmlCell::Dump(indent);
+
+    for ( wxHtmlCell* c = m_Cells; c; c = c->GetNext() )
+        s << "\n" << c->Dump(indent + 4);
+
+    return s;
+}
 
 
 
@@ -1491,6 +1524,10 @@ void wxHtmlColourCell::DrawInvisible(wxDC& dc,
     }
 }
 
+wxString wxHtmlColourCell::GetDescription() const
+{
+    return wxString::Format("wxHtmlColourCell(%s)", m_Colour.GetAsString());
+}
 
 
 
@@ -1515,6 +1552,10 @@ void wxHtmlFontCell::DrawInvisible(wxDC& dc, int WXUNUSED(x), int WXUNUSED(y),
 }
 
 
+wxString wxHtmlFontCell::GetDescription() const
+{
+    return wxString::Format("wxHtmlFontCell(%s)", m_Font.GetNativeFontInfoUserDesc());
+}
 
 
 

--- a/src/html/m_image.cpp
+++ b/src/html/m_image.cpp
@@ -310,6 +310,12 @@ public:
 
     virtual void Layout(int w) wxOVERRIDE;
 
+    virtual wxString GetDescription() const wxOVERRIDE
+    {
+        return wxString::Format("wxHtmlImageCell with bitmap of size %d*%d",
+                                m_bmpW, m_bmpH);
+    }
+
 private:
     wxBitmap           *m_bitmap;
     int                 m_align;


### PR DESCRIPTION
This is useful to see the results of wxHTML layout algorithm.

@vslavik I wanted to have something like this several times when trying to understand what was going on in wxHTML, so I've finally added it. Please let me know if you have any comments.