### PR TITLE
Use correct expander size in wxDataViewCtrl under MSW

### DIFF
--- a/include/wx/renderer.h
+++ b/include/wx/renderer.h
@@ -253,6 +253,9 @@ public:
     // Returns the default size of a check box.
     virtual wxSize GetCheckBoxSize(wxWindow *win) = 0;
 
+    // Returns the default size of a expander.
+    virtual wxSize GetExpanderSize(wxWindow *win) = 0;
+
     // draw blank button
     //
     // flags may use wxCONTROL_PRESSED, wxCONTROL_CURRENT and wxCONTROL_ISDEFAULT
@@ -478,6 +481,9 @@ public:
 
     virtual wxSize GetCheckBoxSize(wxWindow *win) wxOVERRIDE
         { return m_rendererNative.GetCheckBoxSize(win); }
+
+   virtual wxSize GetExpanderSize(wxWindow *win) wxOVERRIDE
+        { return m_rendererNative.GetExpanderSize(win); }
 
     virtual void DrawPushButton(wxWindow *win,
                                 wxDC& dc,

--- a/interface/wx/renderer.h
+++ b/interface/wx/renderer.h
@@ -236,6 +236,8 @@ public:
 
     virtual wxSize GetCheckBoxSize(wxWindow *win);
 
+    virtual wxSize GetExpanderSize(wxWindow* win);
+
     virtual void DrawPushButton(wxWindow *win, wxDC& dc,
                                 const wxRect& rect, int flags = 0 );
 
@@ -557,6 +559,16 @@ public:
             the theme defining the checkbox size under some platforms.
     */
     virtual wxSize GetCheckBoxSize(wxWindow* win) = 0;
+
+    /**
+        Returns the size of the expander used in tree-like controls.
+
+        @param win A valid, i.e. non-null, window pointer which is used to get
+            the theme defining the expander size under some platforms.
+
+        @since 3.1.3
+     */
+    virtual wxSize GetExpanderSize(wxWindow* win) = 0;
 
     /**
         Returns the height of a header button, either a fixed platform height if

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -2573,17 +2573,17 @@ void wxDataViewMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
                 // Calculate the indent first
                 indent = GetOwner()->GetIndent() * node->GetIndentLevel();
 
-                // We don't have any method to return the size of the expander
-                // button currently (TODO: add one to wxRendererNative), so
-                // just guesstimate it.
-                const int expWidth = 3*dc.GetCharWidth();
+                // Get expander size
+                wxSize expSize = wxRendererNative::Get().GetExpanderSize(this);
 
                 // draw expander if needed
                 if ( node->HasChildren() )
                 {
                     wxRect rect = cell_rect;
                     rect.x += indent;
-                    rect.width = expWidth;
+                    rect.y += (cell_rect.GetHeight() - expSize.GetHeight()) / 2; // center vertically
+                    rect.width = expSize.GetWidth();
+                    rect.height = expSize.GetHeight();
 
                     int flag = 0;
                     if ( m_underMouse == node )
@@ -2598,7 +2598,7 @@ void wxDataViewMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
                     wxRendererNative::Get().DrawTreeItemButton( this, dc, rect, flag);
                 }
 
-                indent += expWidth;
+                indent += expSize.GetWidth();
 
                 // force the expander column to left-center align
                 cell->SetAlignment( wxALIGN_CENTER_VERTICAL );

--- a/src/generic/renderg.cpp
+++ b/src/generic/renderg.cpp
@@ -108,6 +108,8 @@ public:
 
     virtual wxSize GetCheckBoxSize(wxWindow *win) wxOVERRIDE;
 
+    virtual wxSize GetExpanderSize(wxWindow *win) wxOVERRIDE;
+
     virtual void DrawPushButton(wxWindow *win,
                                 wxDC& dc,
                                 const wxRect& rect,
@@ -713,6 +715,13 @@ wxRendererGeneric::DrawCheckBox(wxWindow *WXUNUSED(win),
 }
 
 wxSize wxRendererGeneric::GetCheckBoxSize(wxWindow *win)
+{
+    wxCHECK_MSG( win, wxSize(0, 0), "Must have a valid window" );
+
+    return win->FromDIP(wxSize(16, 16));
+}
+
+wxSize wxRendererGeneric::GetExpanderSize(wxWindow *win)
 {
     wxCHECK_MSG( win, wxSize(0, 0), "Must have a valid window" );
 

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -273,6 +273,8 @@ public:
 
     virtual wxSize GetCheckBoxSize(wxWindow *win) wxOVERRIDE;
 
+    virtual wxSize GetExpanderSize(wxWindow *win) wxOVERRIDE;
+
     virtual void DrawGauge(wxWindow* win,
                            wxDC& dc,
                            const wxRect& rect,
@@ -848,6 +850,26 @@ wxSize wxRendererXP::GetCheckBoxSize(wxWindow* win)
         }
     }
     return m_rendererNative.GetCheckBoxSize(win);
+}
+
+wxSize wxRendererXP::GetExpanderSize(wxWindow* win)
+{
+    wxCHECK_MSG( win, wxSize(0, 0), "Must have a valid window" );
+
+    wxUxThemeHandle hTheme(win, L"TREEVIEW");
+    if ( hTheme )
+    {
+        if ( ::IsThemePartDefined(hTheme, TVP_GLYPH, 0) )
+        {
+            SIZE expSize;
+            if (::GetThemePartSize(hTheme, NULL, TVP_GLYPH, GLPS_CLOSED, NULL,
+                                   TS_DRAW, &expSize) == S_OK)
+                return wxSize(expSize.cx, expSize.cy);
+
+        }
+    }
+
+    return m_rendererNative.GetExpanderSize(win);
 }
 
 void


### PR DESCRIPTION
Add wxRendererNative::GetExpanderSize(), implement it using the
appropriate theme element and use it instead of hardcoding the expander
size to 3 character widths.

Closes #18449.