### PR TITLE
CMake: wxNO_RTTI definition has been moved to setup.h

### DIFF
--- a/build/cmake/init.cmake
+++ b/build/cmake/init.cmake
@@ -103,7 +103,6 @@ if(wxUSE_NO_RTTI)
     elseif(("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") OR ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang"))
         wx_string_append(CMAKE_CXX_FLAGS " -fno-rtti")
     endif()
-    add_definitions("-DwxNO_RTTI")
 endif()
 
 # Build wxBUILD_FILE_ID used for config and setup path

--- a/build/cmake/setup.h.in
+++ b/build/cmake/setup.h.in
@@ -187,6 +187,11 @@
 
 #cmakedefine01 wxUSE_EXCEPTIONS
 
+#cmakedefine01 wxUSE_NO_RTTI
+#if wxUSE_NO_RTTI
+    #define wxNO_RTTI 1
+#endif
+
 #cmakedefine01 wxUSE_EXTENDED_RTTI
 
 #cmakedefine01 wxUSE_LOG

--- a/include/wx/setup_inc.h
+++ b/include/wx/setup_inc.h
@@ -211,6 +211,16 @@
 //                      in your own code (1 if you do, 0 if you don't)
 #define wxUSE_EXCEPTIONS    1
 
+// Set wxUSE_NO_RTTI to 1 to disable RTTI. Affects at least wxAny class.
+//
+// Default is 0
+//
+// Recommended setting: 0
+#define wxUSE_NO_RTTI 0
+#if wxUSE_NO_RTTI
+    #define wxNO_RTTI wxUSE_NO_RTTI
+#endif
+
 // Set wxUSE_EXTENDED_RTTI to 1 to use extended RTTI
 //
 // Default is 0


### PR DESCRIPTION
I think we should add wxNO_RTTI definition using setup.h, not from cmake directly because of projects that use wxWidgets should use the same settings. Correct me if I'm wrong.