### PR TITLE
Layout controls to make the wxInfoBar behave the same across platforms

### DIFF
--- a/src/generic/infobar.cpp
+++ b/src/generic/infobar.cpp
@@ -275,6 +275,7 @@ void wxInfoBarGeneric::AddButton(wxWindowID btnid, const wxString& label)
 #endif // __WXMAC__
 
     sizer->Add(button, wxSizerFlags().Centre().DoubleBorder());
+    sizer->Layout();
 }
 
 size_t wxInfoBarGeneric::GetButtonCount() const

--- a/src/generic/infobar.cpp
+++ b/src/generic/infobar.cpp
@@ -275,7 +275,8 @@ void wxInfoBarGeneric::AddButton(wxWindowID btnid, const wxString& label)
 #endif // __WXMAC__
 
     sizer->Add(button, wxSizerFlags().Centre().DoubleBorder());
-    sizer->Layout();
+    if ( IsShown() )
+        sizer->Layout();
 }
 
 size_t wxInfoBarGeneric::GetButtonCount() const


### PR DESCRIPTION
This one line patch makes GTK (native) and generic wxInfoBar behaves the same. Following patch was used for testing:

```
diff --git a/samples/dialogs/dialogs.cpp b/samples/dialogs/dialogs.cpp
index 6b9ef63ec8..5b177f9928 100644
--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -672,10 +672,6 @@ MyFrame::MyFrame(const wxString& title)
     // or it can also be customized by
     m_infoBarAdvanced = new wxInfoBar(this);
 
-    // ... adding extra buttons (but more than two will usually be too many)
-    m_infoBarAdvanced->AddButton(wxID_UNDO);
-    m_infoBarAdvanced->AddButton(wxID_REDO);
-
     m_infoBarAdvanced->Bind(wxEVT_BUTTON, &MyFrame::OnInfoBarRedo, this,
                             wxID_REDO);
 
@@ -888,6 +884,7 @@ void MyFrame::InfoBarSimple(wxCommandEvent& WXUNUSED(event))
                      (
                       wxString::Format("Message #%d in the info bar.", ++s_count)
                      );
+    m_infoBarSimple->AddButton( wxID_OK, "OK" );
 }
 
 void MyFrame::InfoBarAdvanced(wxCommandEvent& WXUNUSED(event))

```

As explained in ticket #14120 GTK (native version) supports it.
