### PR TITLE
Fix the native implementation on GTK

### DIFF
--- a/interface/wx/infobar.h
+++ b/interface/wx/infobar.h
@@ -168,6 +168,8 @@ public:
         If the bar is currently hidden, it will be shown. Otherwise its message
         will be updated in place.
 
+        Note that long messages will be shown as cut-off
+
         @param msg
             The text of the message.
         @param flags


### PR DESCRIPTION
This implements text wrapping on the wxInfoBar for GTK+ native version.

I tried to check the generic version, but I guess there is a code that works around this ticket by wrapping the code by explicit \n' character.

I hope someone will be able to fix the generic version and make the label of wxInfoBar wrap.