### PR TITLE
Implement label wrapping on wxInfoBar GTK and show it in the sample

### DIFF
--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -159,6 +159,7 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
 #endif // wxUSE_LOG_DIALOG
 #if wxUSE_INFOBAR
     EVT_MENU(DIALOGS_INFOBAR_SIMPLE,                MyFrame::InfoBarSimple)
+    EVT_MENU(DIALOGS_INFOBAR_SIMPLE_WRAPPED,        MyFrame::InfoBarSimpleWrapped)
     EVT_MENU(DIALOGS_INFOBAR_ADVANCED,              MyFrame::InfoBarAdvanced)
 #endif // wxUSE_INFOBAR
 
@@ -530,6 +531,7 @@ bool MyApp::OnInit()
 
     #if wxUSE_INFOBAR
        info_menu->Append(DIALOGS_INFOBAR_SIMPLE, "Simple &info bar\tCtrl-I");
+       info_menu->Append(DIALOGS_INFOBAR_SIMPLE_WRAPPED, "Simple info bar with wrapped text");
        info_menu->Append(DIALOGS_INFOBAR_ADVANCED, "&Advanced info bar\tShift-Ctrl-I");
     #endif // wxUSE_INFOBAR
 
@@ -888,6 +890,11 @@ void MyFrame::InfoBarSimple(wxCommandEvent& WXUNUSED(event))
                      (
                       wxString::Format("Message #%d in the info bar.", ++s_count)
                      );
+}
+
+void MyFrame::InfoBarSimpleWrapped(wxCommandEvent &WXUNUSED(event))
+{
+    m_infoBarSimple->ShowMessage( "This is very very long message to try the label wrapping on the info bar" );
 }
 
 void MyFrame::InfoBarAdvanced(wxCommandEvent& WXUNUSED(event))

--- a/samples/dialogs/dialogs.h
+++ b/samples/dialogs/dialogs.h
@@ -391,6 +391,7 @@ public:
 
 #if wxUSE_INFOBAR
     void InfoBarSimple(wxCommandEvent& event);
+    void InfoBarSimpleWrapped(wxCommandEvent &event);
     void InfoBarAdvanced(wxCommandEvent& event);
 #endif // wxUSE_INFOBAR
 
@@ -598,6 +599,7 @@ enum
     DIALOGS_NUM_ENTRY,
     DIALOGS_LOG_DIALOG,
     DIALOGS_INFOBAR_SIMPLE,
+    DIALOGS_INFOBAR_SIMPLE_WRAPPED,
     DIALOGS_INFOBAR_ADVANCED,
     DIALOGS_MODAL,
     DIALOGS_MODELESS,

--- a/src/generic/infobar.cpp
+++ b/src/generic/infobar.cpp
@@ -236,7 +236,7 @@ void wxInfoBarGeneric::ShowMessage(const wxString& msg, int flags)
     // notice the use of EscapeMnemonics() to ensure that "&" come through
     // correctly
     m_text->SetLabel(wxControl::EscapeMnemonics(msg));
-	m_text->Wrap( GetClientSize().GetWidth() );
+    m_text->Wrap( GetClientSize().GetWidth() );
 
     // then show this entire window if not done yet
     if ( !IsShown() )

--- a/src/generic/infobar.cpp
+++ b/src/generic/infobar.cpp
@@ -236,7 +236,7 @@ void wxInfoBarGeneric::ShowMessage(const wxString& msg, int flags)
     // notice the use of EscapeMnemonics() to ensure that "&" come through
     // correctly
     m_text->SetLabel(wxControl::EscapeMnemonics(msg));
-
+	m_text->Wrap( GetClientSize().GetWidth() );
 
     // then show this entire window if not done yet
     if ( !IsShown() )

--- a/src/gtk/infobar.cpp
+++ b/src/gtk/infobar.cpp
@@ -196,7 +196,9 @@ void wxInfoBar::ShowMessage(const wxString& msg, int flags)
     if ( wxGTKImpl::ConvertMessageTypeFromWX(flags, &type) )
         gtk_info_bar_set_message_type(GTK_INFO_BAR(m_widget), type);
     gtk_label_set_text(GTK_LABEL(m_impl->m_label), wxGTK_CONV(msg));
-
+    gtk_label_set_line_wrap(GTK_LABEL(m_impl->m_label), TRUE );
+    if( gtk_check_version( 2, 10, 0 ) )
+        gtk_label_set_line_wrap_mode(GTK_LABEL(m_impl->m_label), PANGO_WRAP_WORD );
     if ( !IsShown() )
         Show();
 

--- a/src/gtk/infobar.cpp
+++ b/src/gtk/infobar.cpp
@@ -197,8 +197,10 @@ void wxInfoBar::ShowMessage(const wxString& msg, int flags)
         gtk_info_bar_set_message_type(GTK_INFO_BAR(m_widget), type);
     gtk_label_set_text(GTK_LABEL(m_impl->m_label), wxGTK_CONV(msg));
     gtk_label_set_line_wrap(GTK_LABEL(m_impl->m_label), TRUE );
-    if( gtk_check_version( 2, 10, 0 ) )
-        gtk_label_set_line_wrap_mode(GTK_LABEL(m_impl->m_label), PANGO_WRAP_WORD );
+#if GTK_CHECK_VERSION(2,10,0)
+    if( wx_is_at_least_gtk2( 10 ) )
+        gtk_label_set_line_wrap_mode(GTK_LABEL(m_impl->m_label), PANGO_WRAP_WORD);
+#endif
     if ( !IsShown() )
         Show();
 


### PR DESCRIPTION
(Sorry about wasting the PR. I picked the wrong branch and didn't realize).

This implements text wrapping on the wxInfoBar for GTK+ native version. Sample is also updated to easily test the functionality.

I tried to check the generic version, but I guess there is a code that works around this ticket by wrapping the code by explicit \n' character.

I hope someone will be able to fix the generic version and make the label of wxInfoBar wrap.