### PR TITLE
Added wxXRC_USE_ENVVARS to expand env vars in paths

### DIFF
--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -352,6 +352,8 @@ wxFileSystem URL) of the bitmap to use. For example:
 The value is interpreted as path relative to the location of XRC file where the
 reference occurs.
 
+Bitmap file paths can include environment variables that are expanded if wxXRC_USE_ENVVARS was passed to the wxXmlResource constructor.
+
 Alternatively, it is possible to specify the bitmap using wxArtProvider IDs.
 In this case, the property element has no textual value (filename) and instead
 has the @c stock_id XML attribute that contains stock art ID as accepted by

--- a/include/wx/xrc/xmlres.h
+++ b/include/wx/xrc/xmlres.h
@@ -76,7 +76,8 @@ enum wxXmlResourceFlags
 {
     wxXRC_USE_LOCALE     = 1,
     wxXRC_NO_SUBCLASSING = 2,
-    wxXRC_NO_RELOADING   = 4
+    wxXRC_NO_RELOADING   = 4,
+    wxXRC_USE_ENVVARS    = 8
 };
 
 // This class holds XML resources from one or more .xml files
@@ -95,6 +96,9 @@ public:
     //        wxXRC_NO_RELOADING
     //              don't check the modification time of the XRC files and
     //              reload them if they have changed on disk
+    //        wxXRC_USE_ENVVARS
+    //              expand environment variables for paths
+    //              (such as bitmaps or icons).
     wxXmlResource(int flags = wxXRC_USE_LOCALE,
                   const wxString& domain = wxEmptyString);
 
@@ -105,6 +109,12 @@ public:
     //        wxXRC_NO_SUBCLASSING
     //              subclass property of object nodes will be ignored
     //              (useful for previews in XRC editors)
+    //        wxXRC_NO_RELOADING
+    //              don't check the modification time of the XRC files and
+    //              reload them if they have changed on disk
+    //        wxXRC_USE_ENVVARS
+    //              expand environment variables for paths
+    //              (such as bitmaps or icons).
     wxXmlResource(const wxString& filemask, int flags = wxXRC_USE_LOCALE,
                   const wxString& domain = wxEmptyString);
 
@@ -279,7 +289,7 @@ public:
     // Sets the global resources object and returns a pointer to the previous one (may be NULL).
     static wxXmlResource *Set(wxXmlResource *res);
 
-    // Returns flags, which may be a bitlist of wxXRC_USE_LOCALE and wxXRC_NO_SUBCLASSING.
+    // Returns flags, which is a bitlist of wxXmlResourceFlags.
     int GetFlags() const { return m_flags; }
     // Set flags after construction.
     void SetFlags(int flags) { m_flags = flags; }

--- a/include/wx/xrc/xmlres.h
+++ b/include/wx/xrc/xmlres.h
@@ -601,6 +601,12 @@ public:
     // Gets the value of a boolean attribute (only "0" and "1" are valid values)
     bool GetBoolAttr(const wxString& attr, bool defaultv) wxOVERRIDE;
 
+    // Gets a file path.
+    wxString GetFilePath(const wxString& param) wxOVERRIDE;
+
+    // Gets a file path.
+    wxString GetFilePath(const wxXmlNode* node) wxOVERRIDE;
+
     // Returns the window associated with the handler (may be NULL).
     wxWindow* GetParentAsWindow() const { return m_handler->GetParentAsWindow(); }
 

--- a/include/wx/xrc/xmlreshandler.h
+++ b/include/wx/xrc/xmlreshandler.h
@@ -105,6 +105,8 @@ public:
 
     virtual wxFont GetFont(const wxString& param = wxT("font"), wxWindow* parent = NULL) = 0;
     virtual bool GetBoolAttr(const wxString& attr, bool defaultv) = 0;
+    virtual wxString GetFilePath(const wxString& param) = 0;
+    virtual wxString GetFilePath(const wxXmlNode* node) = 0;
     virtual void SetupWindow(wxWindow *wnd) = 0;
     virtual void CreateChildren(wxObject *parent, bool this_hnd_only = false) = 0;
     virtual void CreateChildrenPrivately(wxObject *parent,

--- a/interface/wx/xrc/xmlres.h
+++ b/interface/wx/xrc/xmlres.h
@@ -20,7 +20,11 @@ enum wxXmlResourceFlags
         since being last loaded (may slightly speed up loading them). */
     wxXRC_NO_RELOADING   = 4,
 
-    /** Expand environment variables for paths in XRC (such as bitmaps or icons). */
+    /**
+        Expand environment variables for paths in XRC (such as bitmaps or icons).
+
+        @since 3.1.3
+    */
     wxXRC_USE_ENVVARS    = 8
 };
 
@@ -739,6 +743,16 @@ protected:
         - calls wxGetTranslations (unless disabled in wxXmlResource)
     */
     wxString GetText(const wxString& param, bool translate = true);
+
+    /**
+        Gets a file path.
+    */
+    wxString GetFilePath(const wxString& param);
+
+    /**
+        Gets a file path.
+    */
+    wxString GetFilePath(const wxXmlNode* node);
 
     /**
         Check to see if a parameter exists.

--- a/interface/wx/xrc/xmlres.h
+++ b/interface/wx/xrc/xmlres.h
@@ -18,7 +18,10 @@ enum wxXmlResourceFlags
 
     /** Prevent the XRC files from being reloaded from disk in case they have been modified there
         since being last loaded (may slightly speed up loading them). */
-    wxXRC_NO_RELOADING   = 4
+    wxXRC_NO_RELOADING   = 4,
+
+    /** Expand environment variables for paths in XRC (such as bitmaps or icons). */
+    wxXRC_USE_ENVVARS    = 8
 };
 
 

--- a/src/xrc/xmladv.cpp
+++ b/src/xrc/xmladv.cpp
@@ -34,6 +34,7 @@
 
 #include "wx/animate.h"
 #include "wx/scopedptr.h"
+#include "wx/config.h"
 
 // ============================================================================
 // implementation
@@ -42,9 +43,12 @@
 #if wxUSE_ANIMATIONCTRL
 wxAnimation* wxXmlResourceHandlerImpl::GetAnimation(const wxString& param)
 {
-    const wxString name = GetParamValue(param);
+    wxString name = GetParamValue(param);
     if ( name.empty() )
         return NULL;
+
+    if (m_handler->m_resource->GetFlags() & wxXRC_USE_ENVVARS)
+        name = wxExpandEnvVars(name);
 
     // load the animation from file
     wxScopedPtr<wxAnimation> ani(new wxAnimation);

--- a/src/xrc/xmladv.cpp
+++ b/src/xrc/xmladv.cpp
@@ -43,12 +43,9 @@
 #if wxUSE_ANIMATIONCTRL
 wxAnimation* wxXmlResourceHandlerImpl::GetAnimation(const wxString& param)
 {
-    wxString name = GetParamValue(param);
+    wxString name = GetFilePath(param);
     if ( name.empty() )
         return NULL;
-
-    if (m_handler->m_resource->GetFlags() & wxXRC_USE_ENVVARS)
-        name = wxExpandEnvVars(name);
 
     // load the animation from file
     wxScopedPtr<wxAnimation> ani(new wxAnimation);

--- a/src/xrc/xmlres.cpp
+++ b/src/xrc/xmlres.cpp
@@ -44,6 +44,7 @@
 #include "wx/xml/xml.h"
 #include "wx/hashset.h"
 #include "wx/scopedptr.h"
+#include "wx/config.h"
 
 #include <limits.h>
 #include <locale.h>
@@ -1827,6 +1828,10 @@ wxBitmap wxXmlResourceHandlerImpl::GetBitmap(const wxXmlNode* node,
     /* ...or load the bitmap from file: */
     wxString name = GetParamValue(node);
     if (name.empty()) return wxNullBitmap;
+
+    if (m_handler->m_resource->GetFlags() & wxXRC_USE_ENVVARS)
+        name = wxExpandEnvVars(name);
+
 #if wxUSE_FILESYSTEM
     wxFSFile *fsfile = GetCurFileSystem().OpenFile(name, wxFS_READ | wxFS_SEEKABLE);
     if (fsfile == NULL)
@@ -1898,9 +1903,12 @@ wxIconBundle wxXmlResourceHandlerImpl::GetIconBundle(const wxString& param,
             return stockArt;
     }
 
-    const wxString name = GetParamValue(param);
+    wxString name = GetParamValue(param);
     if ( name.empty() )
         return wxNullIconBundle;
+
+    if (m_handler->m_resource->GetFlags() & wxXRC_USE_ENVVARS)
+        name = wxExpandEnvVars(name);
 
 #if wxUSE_FILESYSTEM
     wxFSFile *fsfile = GetCurFileSystem().OpenFile(name, wxFS_READ | wxFS_SEEKABLE);

--- a/src/xrc/xmlres.cpp
+++ b/src/xrc/xmlres.cpp
@@ -1826,11 +1826,9 @@ wxBitmap wxXmlResourceHandlerImpl::GetBitmap(const wxXmlNode* node,
     }
 
     /* ...or load the bitmap from file: */
-    wxString name = GetParamValue(node);
-    if (name.empty()) return wxNullBitmap;
-
-    if (m_handler->m_resource->GetFlags() & wxXRC_USE_ENVVARS)
-        name = wxExpandEnvVars(name);
+    wxString name = GetFilePath(node);
+    if (name.empty())
+        return wxNullBitmap;
 
 #if wxUSE_FILESYSTEM
     wxFSFile *fsfile = GetCurFileSystem().OpenFile(name, wxFS_READ | wxFS_SEEKABLE);
@@ -1903,12 +1901,9 @@ wxIconBundle wxXmlResourceHandlerImpl::GetIconBundle(const wxString& param,
             return stockArt;
     }
 
-    wxString name = GetParamValue(param);
+    wxString name = GetFilePath(param);
     if ( name.empty() )
         return wxNullIconBundle;
-
-    if (m_handler->m_resource->GetFlags() & wxXRC_USE_ENVVARS)
-        name = wxExpandEnvVars(name);
 
 #if wxUSE_FILESYSTEM
     wxFSFile *fsfile = GetCurFileSystem().OpenFile(name, wxFS_READ | wxFS_SEEKABLE);
@@ -1988,6 +1983,21 @@ wxImageList *wxXmlResourceHandlerImpl::GetImageList(const wxString& param)
 
     m_handler->m_node = oldnode;
     return imagelist;
+}
+
+wxString wxXmlResourceHandlerImpl::GetFilePath(const wxString& param)
+{
+    return GetFilePath(GetParamNode(param));
+}
+
+wxString wxXmlResourceHandlerImpl::GetFilePath(const wxXmlNode* node)
+{
+    wxString path = GetParamValue(node);
+
+    if (m_handler->m_resource->GetFlags() & wxXRC_USE_ENVVARS)
+        path = wxExpandEnvVars(path);
+
+    return path;
 }
 
 wxXmlNode *wxXmlResourceHandlerImpl::GetParamNode(const wxString& param)


### PR DESCRIPTION
Added a new flag wxXRC_USE_ENVVARS for wxXmlResourceFlags that triggers a call to wxExpandEnvVars for bitmap, icon and animation paths. Not set by default for compatibility reasons (e.g. % in Windows paths).