### PR TITLE
Fix the use case when toolbar already has tools

### DIFF
--- a/src/osx/carbon/frame.cpp
+++ b/src/osx/carbon/frame.cpp
@@ -301,6 +301,7 @@ void wxFrame::SetToolBar(wxToolBar *toolbar)
 #if wxOSX_USE_NATIVE_TOOLBAR
     if ( toolbar )
         toolbar->MacInstallNativeToolbar( true ) ;
+    toolbar->Realize();
 #endif
 #endif
 }

--- a/src/osx/cocoa/toolbar.mm
+++ b/src/osx/cocoa/toolbar.mm
@@ -1250,11 +1250,11 @@ bool wxToolBar::Realize()
                             cfidentifier = wxCFStringRef(wxString::Format("%ld", (long)tool));
                             nsItemId = cfidentifier.AsNSString();
                         }
-                    
+
                         [refTB insertItemWithItemIdentifier:nsItemId atIndex:currentPosition];
                         tool->SetIndex( currentPosition );
                     }
-                
+
                     currentPosition++;
                 }
             }
@@ -1262,11 +1262,11 @@ bool wxToolBar::Realize()
         }
     
 #endif
-    
+
         DoLayout();
-    
+
         // adjust radio items
-        
+
         bool lastIsRadio = false;
         bool curIsRadio = false;
     
@@ -1279,7 +1279,7 @@ bool wxToolBar::Realize()
                 node = node->GetNext();
                 continue;
             }
-            
+
             // update radio button (and group) state
             lastIsRadio = curIsRadio;
             curIsRadio = ( tool->IsButton() && (tool->GetKind() == wxITEM_RADIO) );


### PR DESCRIPTION
This PR fixes the ticket #13888.

The patch attached there fixes the case for the XRC, however it is still present in the core library.

Please review and apply.

Code was tested with the patch attached to the ticket itself and ran on OSX 10.13 compiled against minimal required of 10.9.

The sample is not modified and documentation changes is not needed.

Please review and apply.
