### PR TITLE
Fix event generation for emty tree control branch

### DIFF
--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -1885,9 +1885,13 @@ void wxGenericTreeCtrl::Expand(const wxTreeItemId& itemId)
     {
         m_dirty = true;
     }
-
-    event.SetEventType(wxEVT_TREE_ITEM_EXPANDED);
-    GetEventHandler()->ProcessEvent( event );
+    wxTreeItemIdValue cookie;
+    wxTreeItemId child = GetFirstChild( item, cookie );
+    if( child && child.IsOk() )
+    {
+        event.SetEventType(wxEVT_TREE_ITEM_EXPANDED);
+        GetEventHandler()->ProcessEvent( event );
+    }
 }
 
 void wxGenericTreeCtrl::Collapse(const wxTreeItemId& itemId)


### PR DESCRIPTION
If an item in the tree does not have children and user tries to expand it - only the expanding event should be generated.
Native Windows control already works this way.
This simple patch fixes it for generic implementation.

Please review and apply.

The PR takes care of the ticket 13866.