### PR TITLE
Allow disabling saving wxFileConfig automatically on program exit

### DIFF
--- a/include/wx/fileconf.h
+++ b/include/wx/fileconf.h
@@ -182,6 +182,16 @@ public:
   virtual bool Save(wxOutputStream& os, const wxMBConv& conv = wxConvAuto());
 #endif // wxUSE_STREAMS
 
+void EnableAutoSave()
+{
+    m_autosave = true;
+}
+
+void DisableAutoSave()
+{
+    m_autosave = false;
+}
+
 public:
   // functions to work with this list
   wxFileConfigLineList *LineListAppend(const wxString& str);
@@ -250,6 +260,7 @@ private:
 #endif // __UNIX__
 
   bool m_isDirty;                       // if true, we have unsaved changes
+  bool m_autosave;
 
   wxDECLARE_NO_COPY_CLASS(wxFileConfig);
   wxDECLARE_ABSTRACT_CLASS(wxFileConfig);

--- a/interface/wx/fileconf.h
+++ b/interface/wx/fileconf.h
@@ -96,6 +96,20 @@ public:
     virtual bool Save(wxOutputStream& os, const wxMBConv& conv = wxConvAuto());
 
     /**
+        Enables autosaving the info on program exit
+
+        @since 3.1.3
+    */
+    void EnableAutoSave();
+
+    /**
+        Disables autosaving the info on program exit
+
+        @since 3.1.3
+    */
+    void DisableAutoSave();
+
+    /**
         Allows setting the mode to be used for the config file creation. For example, to
         create a config file which is not readable by other users (useful if it stores
         some sensitive information, such as passwords), you could use @c SetUmask(0077).

--- a/src/common/fileconf.cpp
+++ b/src/common/fileconf.cpp
@@ -346,6 +346,7 @@ void wxFileConfig::Init()
     }
 
     m_isDirty = false;
+    m_autosave = true;
 }
 
 // constructor supports creation of wxFileConfig objects of any type
@@ -487,7 +488,8 @@ void wxFileConfig::CleanUp()
 
 wxFileConfig::~wxFileConfig()
 {
-    Flush();
+    if( m_autosave )
+        Flush();
 
     CleanUp();
 


### PR DESCRIPTION
Allow disabling saving wxFileConfig on destruction.
Patch is made by ollydbg in ticket 13788.
Updated with documentation and submitted.

Please review and apply.