### PR TITLE
Add support for gradients in wxGraphicsPen

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -150,12 +150,8 @@ All (GUI):
   in wxPGArrayEditorDialog.
 - Fix wxPropertyGrid issues with horizontal scrolling.
 - Add wxPG_DIALOG_TITLE wxPGProperty attribute.
-- Add support for creating a wxGraphicsPen with a gradient. The gradient will 
-  be used when stroking a path in a wxGraphicsContext, if supported by the 
-  graphics context backend.
-- Add support for applying a transformation matrix to a gradient for both 
-  wxGraphicsPen and wxGraphicsBrush, if supported by the graphics context 
-  backend.
+- Add support for creating a wxGraphicsPen with a gradient.
+- Add support for applying a transformation matrix to a gradient.
 
 
 wxGTK:

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -150,6 +150,13 @@ All (GUI):
   in wxPGArrayEditorDialog.
 - Fix wxPropertyGrid issues with horizontal scrolling.
 - Add wxPG_DIALOG_TITLE wxPGProperty attribute.
+- Add support for creating a wxGraphicsPen with a gradient. The gradient will 
+  be used when stroking a path in a wxGraphicsContext, if supported by the 
+  graphics context backend.
+- Add support for applying a transformation matrix to a gradient for both 
+  wxGraphicsPen and wxGraphicsBrush, if supported by the graphics context 
+  backend.
+
 
 wxGTK:
 

--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -71,7 +71,8 @@ enum wxCompositionMode
     wxCOMPOSITION_ADD /* R = S + D */
 };
 
-enum wxGradientType {
+enum wxGradientType
+{
     wxGRADIENT_NONE,
     wxGRADIENT_LINEAR,
     wxGRADIENT_RADIAL

--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -71,6 +71,13 @@ enum wxCompositionMode
     wxCOMPOSITION_ADD /* R = S + D */
 };
 
+enum wxGradientType {
+    wxGRADIENT_NONE,
+    wxGRADIENT_LINEAR,
+    wxGRADIENT_RADIAL
+};
+
+
 class WXDLLIMPEXP_FWD_CORE wxDC;
 class WXDLLIMPEXP_FWD_CORE wxWindowDC;
 class WXDLLIMPEXP_FWD_CORE wxMemoryDC;
@@ -91,6 +98,7 @@ class WXDLLIMPEXP_FWD_CORE wxGraphicsPen;
 class WXDLLIMPEXP_FWD_CORE wxGraphicsBrush;
 class WXDLLIMPEXP_FWD_CORE wxGraphicsFont;
 class WXDLLIMPEXP_FWD_CORE wxGraphicsBitmap;
+class wxGraphicsPenInfo; 
 
 /*
  * notes about the graphics context apis
@@ -133,33 +141,7 @@ protected:
     wxDECLARE_DYNAMIC_CLASS(wxGraphicsObject);
 };
 
-// ----------------------------------------------------------------------------
-// wxGraphicsPenInfo describes a wxGraphicsPen
-// ----------------------------------------------------------------------------
 
-class wxGraphicsPenInfo : public wxPenInfoBase<wxGraphicsPenInfo>
-{
-public:
-    explicit wxGraphicsPenInfo(const wxColour& colour = wxColour(),
-                               wxDouble width = 1.0,
-                               wxPenStyle style = wxPENSTYLE_SOLID)
-        : wxPenInfoBase<wxGraphicsPenInfo>(colour, style)
-    {
-        m_width = width;
-    }
-
-    // Setters
-
-    wxGraphicsPenInfo& Width(wxDouble width)
-        { m_width = width; return *this; }
-
-    // Accessors
-
-    wxDouble GetWidth() const { return m_width; }
-
-private:
-    wxDouble m_width;
-};
 
 class WXDLLIMPEXP_CORE wxGraphicsPen : public wxGraphicsObject
 {
@@ -448,6 +430,93 @@ private:
     // All the stops stored in ascending order of positions.
     wxVector<wxGraphicsGradientStop> m_stops;
 };
+
+// ----------------------------------------------------------------------------
+// wxGraphicsPenInfo describes a wxGraphicsPen
+// ----------------------------------------------------------------------------
+
+class wxGraphicsPenInfo : public wxPenInfoBase<wxGraphicsPenInfo>
+{
+public:
+    explicit wxGraphicsPenInfo(const wxColour& colour = wxColour(),
+                               wxDouble width = 1.0,
+                               wxPenStyle style = wxPENSTYLE_SOLID)
+        : wxPenInfoBase<wxGraphicsPenInfo>(colour, style)
+    {
+        m_width = width;
+        m_gradientType = wxGRADIENT_NONE;
+    }
+
+    // Setters
+
+    wxGraphicsPenInfo& Width(wxDouble width)
+        { m_width = width; return *this; }
+
+    wxGraphicsPenInfo& 
+    LinearGradient(wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2,
+                   const wxColour& c1, const wxColour& c2)
+        { 
+            m_gradientType = wxGRADIENT_LINEAR;
+            m_x1 = x1; m_y1 = y1; m_x2 = x2; m_y2 = y2;
+            m_stops.SetStartColour(c1);
+            m_stops.SetEndColour(c2);
+            return *this; 
+        }                                      
+
+    wxGraphicsPenInfo& 
+    LinearGradient(wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2,
+                   const wxGraphicsGradientStops& stops)
+        { 
+            m_gradientType = wxGRADIENT_LINEAR;
+            m_x1 = x1; m_y1 = y1; m_x2 = x2; m_y2 = y2;
+            m_stops = stops;
+            return *this; 
+        }
+
+    wxGraphicsPenInfo& 
+    RadialGradient(wxDouble xo, wxDouble yo, wxDouble xc, wxDouble yc, wxDouble radius, 
+                   const wxColour& oColor, const wxColour& cColor)
+        { 
+            m_gradientType = wxGRADIENT_RADIAL;
+            m_x1 = xo; m_y1 = yo; m_x2 = xc; m_y2 = yc;
+            m_stops.SetStartColour(oColor);
+            m_stops.SetEndColour(cColor);
+            return *this; 
+        }                                      
+
+    wxGraphicsPenInfo& 
+    RadialGradient(wxDouble xo, wxDouble yo, wxDouble xc, wxDouble yc, 
+                   wxDouble radius, const wxGraphicsGradientStops& stops)
+        { 
+            m_gradientType = wxGRADIENT_RADIAL;
+            m_x1 = xo; m_y1 = yo; m_x2 = xc; m_y2 = yc;
+            m_stops = stops;
+            return *this; 
+        }
+
+    // Accessors
+
+    wxDouble GetWidth() const { return m_width; }
+    wxGradientType GetGradientType() const { return m_gradientType; }
+    wxDouble GetX1() const { return m_x1; }
+    wxDouble GetY1() const { return m_y1; }
+    wxDouble GetX2() const { return m_x2; }
+    wxDouble GetY2() const { return m_y2; }
+    wxDouble GetXO() const { return m_x1; }
+    wxDouble GetYO() const { return m_y1; }
+    wxDouble GetXC() const { return m_x2; }
+    wxDouble GetYC() const { return m_y2; }
+    wxDouble GetRadius() const { return m_radius; }
+    const wxGraphicsGradientStops& GetStops() const { return m_stops; }
+
+private:
+    wxDouble m_width;
+    wxGradientType m_gradientType;
+    wxDouble m_x1, m_y1, m_x2, m_y2; // also used for m_xo, m_yo, m_xc, m_yx
+    wxDouble m_radius;
+    wxGraphicsGradientStops m_stops;
+};
+
 
 class WXDLLIMPEXP_CORE wxGraphicsContext : public wxGraphicsObject
 {

--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -458,7 +458,10 @@ public:
                    const wxColour& c1, const wxColour& c2)
         { 
             m_gradientType = wxGRADIENT_LINEAR;
-            m_x1 = x1; m_y1 = y1; m_x2 = x2; m_y2 = y2;
+            m_x1 = x1;
+            m_y1 = y1;
+            m_x2 = x2;
+            m_y2 = y2;
             m_stops.SetStartColour(c1);
             m_stops.SetEndColour(c2);
             return *this; 

--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -143,6 +143,137 @@ protected:
 };
 
 
+
+class WXDLLIMPEXP_CORE wxGraphicsPen : public wxGraphicsObject
+{
+public:
+    wxGraphicsPen() {}
+    virtual ~wxGraphicsPen() {}
+private:
+    wxDECLARE_DYNAMIC_CLASS(wxGraphicsPen);
+};
+
+extern WXDLLIMPEXP_DATA_CORE(wxGraphicsPen) wxNullGraphicsPen;
+
+class WXDLLIMPEXP_CORE wxGraphicsBrush : public wxGraphicsObject
+{
+public:
+    wxGraphicsBrush() {}
+    virtual ~wxGraphicsBrush() {}
+private:
+    wxDECLARE_DYNAMIC_CLASS(wxGraphicsBrush);
+};
+
+extern WXDLLIMPEXP_DATA_CORE(wxGraphicsBrush) wxNullGraphicsBrush;
+
+class WXDLLIMPEXP_CORE wxGraphicsFont : public wxGraphicsObject
+{
+public:
+    wxGraphicsFont() {}
+    virtual ~wxGraphicsFont() {}
+private:
+    wxDECLARE_DYNAMIC_CLASS(wxGraphicsFont);
+};
+
+extern WXDLLIMPEXP_DATA_CORE(wxGraphicsFont) wxNullGraphicsFont;
+
+class WXDLLIMPEXP_CORE wxGraphicsBitmap : public wxGraphicsObject
+{
+public:
+    wxGraphicsBitmap() {}
+    virtual ~wxGraphicsBitmap() {}
+
+    // Convert bitmap to wxImage: this is more efficient than converting to
+    // wxBitmap first and then to wxImage and also works without X server
+    // connection under Unix that wxBitmap requires.
+#if wxUSE_IMAGE
+    wxImage ConvertToImage() const;
+#endif // wxUSE_IMAGE
+
+    void* GetNativeBitmap() const;
+
+    const wxGraphicsBitmapData* GetBitmapData() const
+    { return (const wxGraphicsBitmapData*) GetRefData(); }
+    wxGraphicsBitmapData* GetBitmapData()
+    { return (wxGraphicsBitmapData*) GetRefData(); }
+
+private:
+    wxDECLARE_DYNAMIC_CLASS(wxGraphicsBitmap);
+};
+
+extern WXDLLIMPEXP_DATA_CORE(wxGraphicsBitmap) wxNullGraphicsBitmap;
+
+class WXDLLIMPEXP_CORE wxGraphicsMatrix : public wxGraphicsObject
+{
+public:
+    wxGraphicsMatrix() {}
+
+    virtual ~wxGraphicsMatrix() {}
+
+    // concatenates the matrix
+    virtual void Concat( const wxGraphicsMatrix *t );
+    void Concat( const wxGraphicsMatrix &t ) { Concat( &t ); }
+
+    // sets the matrix to the respective values
+    virtual void Set(wxDouble a=1.0, wxDouble b=0.0, wxDouble c=0.0, wxDouble d=1.0,
+        wxDouble tx=0.0, wxDouble ty=0.0);
+
+    // gets the component valuess of the matrix
+    virtual void Get(wxDouble* a=NULL, wxDouble* b=NULL,  wxDouble* c=NULL,
+                     wxDouble* d=NULL, wxDouble* tx=NULL, wxDouble* ty=NULL) const;
+
+    // makes this the inverse matrix
+    virtual void Invert();
+
+    // returns true if the elements of the transformation matrix are equal ?
+    virtual bool IsEqual( const wxGraphicsMatrix* t) const;
+    bool IsEqual( const wxGraphicsMatrix& t) const { return IsEqual( &t ); }
+
+    // return true if this is the identity matrix
+    virtual bool IsIdentity() const;
+
+    //
+    // transformation
+    //
+
+    // add the translation to this matrix
+    virtual void Translate( wxDouble dx , wxDouble dy );
+
+    // add the scale to this matrix
+    virtual void Scale( wxDouble xScale , wxDouble yScale );
+
+    // add the rotation to this matrix (radians)
+    virtual void Rotate( wxDouble angle );
+
+    //
+    // apply the transforms
+    //
+
+    // applies that matrix to the point
+    virtual void TransformPoint( wxDouble *x, wxDouble *y ) const;
+
+    // applies the matrix except for translations
+    virtual void TransformDistance( wxDouble *dx, wxDouble *dy ) const;
+
+    // returns the native representation
+    virtual void * GetNativeMatrix() const;
+
+    const wxGraphicsMatrixData* GetMatrixData() const
+    { return (const wxGraphicsMatrixData*) GetRefData(); }
+    wxGraphicsMatrixData* GetMatrixData()
+    { return (wxGraphicsMatrixData*) GetRefData(); }
+
+private:
+    wxDECLARE_DYNAMIC_CLASS(wxGraphicsMatrix);
+};
+
+extern WXDLLIMPEXP_DATA_CORE(wxGraphicsMatrix) wxNullGraphicsMatrix;
+
+// ----------------------------------------------------------------------------
+// wxGradientStop and wxGradientStops: Controls how colors are spread in 
+// a gradient
+// ----------------------------------------------------------------------------
+
 // Describes a single gradient stop.
 class wxGraphicsGradientStop
 {
@@ -330,130 +461,6 @@ private:
 };
 
 
-class WXDLLIMPEXP_CORE wxGraphicsPen : public wxGraphicsObject
-{
-public:
-    wxGraphicsPen() {}
-    virtual ~wxGraphicsPen() {}
-private:
-    wxDECLARE_DYNAMIC_CLASS(wxGraphicsPen);
-};
-
-extern WXDLLIMPEXP_DATA_CORE(wxGraphicsPen) wxNullGraphicsPen;
-
-class WXDLLIMPEXP_CORE wxGraphicsBrush : public wxGraphicsObject
-{
-public:
-    wxGraphicsBrush() {}
-    virtual ~wxGraphicsBrush() {}
-private:
-    wxDECLARE_DYNAMIC_CLASS(wxGraphicsBrush);
-};
-
-extern WXDLLIMPEXP_DATA_CORE(wxGraphicsBrush) wxNullGraphicsBrush;
-
-class WXDLLIMPEXP_CORE wxGraphicsFont : public wxGraphicsObject
-{
-public:
-    wxGraphicsFont() {}
-    virtual ~wxGraphicsFont() {}
-private:
-    wxDECLARE_DYNAMIC_CLASS(wxGraphicsFont);
-};
-
-extern WXDLLIMPEXP_DATA_CORE(wxGraphicsFont) wxNullGraphicsFont;
-
-class WXDLLIMPEXP_CORE wxGraphicsBitmap : public wxGraphicsObject
-{
-public:
-    wxGraphicsBitmap() {}
-    virtual ~wxGraphicsBitmap() {}
-
-    // Convert bitmap to wxImage: this is more efficient than converting to
-    // wxBitmap first and then to wxImage and also works without X server
-    // connection under Unix that wxBitmap requires.
-#if wxUSE_IMAGE
-    wxImage ConvertToImage() const;
-#endif // wxUSE_IMAGE
-
-    void* GetNativeBitmap() const;
-
-    const wxGraphicsBitmapData* GetBitmapData() const
-    { return (const wxGraphicsBitmapData*) GetRefData(); }
-    wxGraphicsBitmapData* GetBitmapData()
-    { return (wxGraphicsBitmapData*) GetRefData(); }
-
-private:
-    wxDECLARE_DYNAMIC_CLASS(wxGraphicsBitmap);
-};
-
-extern WXDLLIMPEXP_DATA_CORE(wxGraphicsBitmap) wxNullGraphicsBitmap;
-
-class WXDLLIMPEXP_CORE wxGraphicsMatrix : public wxGraphicsObject
-{
-public:
-    wxGraphicsMatrix() {}
-
-    virtual ~wxGraphicsMatrix() {}
-
-    // concatenates the matrix
-    virtual void Concat( const wxGraphicsMatrix *t );
-    void Concat( const wxGraphicsMatrix &t ) { Concat( &t ); }
-
-    // sets the matrix to the respective values
-    virtual void Set(wxDouble a=1.0, wxDouble b=0.0, wxDouble c=0.0, wxDouble d=1.0,
-        wxDouble tx=0.0, wxDouble ty=0.0);
-
-    // gets the component valuess of the matrix
-    virtual void Get(wxDouble* a=NULL, wxDouble* b=NULL,  wxDouble* c=NULL,
-                     wxDouble* d=NULL, wxDouble* tx=NULL, wxDouble* ty=NULL) const;
-
-    // makes this the inverse matrix
-    virtual void Invert();
-
-    // returns true if the elements of the transformation matrix are equal ?
-    virtual bool IsEqual( const wxGraphicsMatrix* t) const;
-    bool IsEqual( const wxGraphicsMatrix& t) const { return IsEqual( &t ); }
-
-    // return true if this is the identity matrix
-    virtual bool IsIdentity() const;
-
-    //
-    // transformation
-    //
-
-    // add the translation to this matrix
-    virtual void Translate( wxDouble dx , wxDouble dy );
-
-    // add the scale to this matrix
-    virtual void Scale( wxDouble xScale , wxDouble yScale );
-
-    // add the rotation to this matrix (radians)
-    virtual void Rotate( wxDouble angle );
-
-    //
-    // apply the transforms
-    //
-
-    // applies that matrix to the point
-    virtual void TransformPoint( wxDouble *x, wxDouble *y ) const;
-
-    // applies the matrix except for translations
-    virtual void TransformDistance( wxDouble *dx, wxDouble *dy ) const;
-
-    // returns the native representation
-    virtual void * GetNativeMatrix() const;
-
-    const wxGraphicsMatrixData* GetMatrixData() const
-    { return (const wxGraphicsMatrixData*) GetRefData(); }
-    wxGraphicsMatrixData* GetMatrixData()
-    { return (wxGraphicsMatrixData*) GetRefData(); }
-
-private:
-    wxDECLARE_DYNAMIC_CLASS(wxGraphicsMatrix);
-};
-
-extern WXDLLIMPEXP_DATA_CORE(wxGraphicsMatrix) wxNullGraphicsMatrix;
 
 class WXDLLIMPEXP_CORE wxGraphicsPath : public wxGraphicsObject
 {

--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -242,7 +242,8 @@ public:
 
     wxGraphicsPenInfo& 
     LinearGradient(wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2,
-                   const wxColour& c1, const wxColour& c2)
+                   const wxColour& c1, const wxColour& c2,
+                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix)
     { 
         m_gradientType = wxGRADIENT_LINEAR;
         m_x1 = x1;
@@ -251,12 +252,14 @@ public:
         m_y2 = y2;
         m_stops.SetStartColour(c1);
         m_stops.SetEndColour(c2);
+        m_matrix = matrix;
         return *this; 
     }                                      
 
     wxGraphicsPenInfo& 
     LinearGradient(wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2,
-                   const wxGraphicsGradientStops& stops)
+                   const wxGraphicsGradientStops& stops,
+                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix)
     { 
         m_gradientType = wxGRADIENT_LINEAR;
         m_x1 = x1;
@@ -264,27 +267,31 @@ public:
         m_x2 = x2;
         m_y2 = y2;
         m_stops = stops;
+        m_matrix = matrix;
         return *this; 
     }
 
     wxGraphicsPenInfo& 
     RadialGradient(wxDouble xo, wxDouble yo, wxDouble xc, wxDouble yc, wxDouble radius, 
-                   const wxColour& oColor, const wxColour& cColor)
+                   const wxColour& oColor, const wxColour& cColor,
+                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix)
     { 
         m_gradientType = wxGRADIENT_RADIAL;
-        m_x1 = xo; 
+        m_x1 = xo;
         m_y1 = yo; 
         m_x2 = xc; 
         m_y2 = yc;
         m_radius = radius;
         m_stops.SetStartColour(oColor);
         m_stops.SetEndColour(cColor);
+        m_matrix = matrix;
         return *this; 
     }                                      
 
     wxGraphicsPenInfo& 
     RadialGradient(wxDouble xo, wxDouble yo, wxDouble xc, wxDouble yc, 
-                   wxDouble radius, const wxGraphicsGradientStops& stops)
+                   wxDouble radius, const wxGraphicsGradientStops& stops,
+                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix)
     { 
         m_gradientType = wxGRADIENT_RADIAL;
         m_x1 = xo; 
@@ -293,6 +300,7 @@ public:
         m_y2 = yc;
         m_radius = radius;
         m_stops = stops;
+        m_matrix = matrix;
         return *this; 
     }
 
@@ -310,6 +318,7 @@ public:
     wxDouble GetYC() const { return m_y2; }
     wxDouble GetRadius() const { return m_radius; }
     const wxGraphicsGradientStops& GetStops() const { return m_stops; }
+    const wxGraphicsMatrix& GetMatrix() const { return m_matrix; }
 
 private:
     wxDouble m_width;
@@ -317,6 +326,7 @@ private:
     wxDouble m_x1, m_y1, m_x2, m_y2; // also used for m_xo, m_yo, m_xc, m_yx
     wxDouble m_radius;
     wxGraphicsGradientStops m_stops;
+    wxGraphicsMatrix m_matrix;
 };
 
 
@@ -606,11 +616,13 @@ public:
     wxGraphicsBrush
     CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
                               wxDouble x2, wxDouble y2,
-                              const wxColour& c1, const wxColour& c2) const;
+                              const wxColour& c1, const wxColour& c2,
+                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) const;
     wxGraphicsBrush
     CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
                               wxDouble x2, wxDouble y2,
-                              const wxGraphicsGradientStops& stops) const;
+                              const wxGraphicsGradientStops& stops,
+                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) const;
 
     // sets the brush to a radial gradient originating at (xo,yc) and ending
     // on a circle around (xc,yc) with the given radius; the colours may be
@@ -618,12 +630,14 @@ public:
     wxGraphicsBrush
     CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
                               wxDouble xc, wxDouble yc, wxDouble radius,
-                              const wxColour& oColor, const wxColour& cColor) const;
+                              const wxColour& oColor, const wxColour& cColor,
+                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) const;
 
     wxGraphicsBrush
     CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
                               wxDouble xc, wxDouble yc, wxDouble radius,
-                              const wxGraphicsGradientStops& stops) const;
+                              const wxGraphicsGradientStops& stops,
+                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) const;
 
     // creates a font
     virtual wxGraphicsFont CreateFont( const wxFont &font , const wxColour &col = *wxBLACK ) const;
@@ -999,13 +1013,15 @@ public:
     virtual wxGraphicsBrush
     CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
                               wxDouble x2, wxDouble y2,
-                              const wxGraphicsGradientStops& stops) = 0;
+                              const wxGraphicsGradientStops& stops,
+                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) = 0;
 
     virtual wxGraphicsBrush
     CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
                               wxDouble xc, wxDouble yc,
                               wxDouble radius,
-                              const wxGraphicsGradientStops& stops) = 0;
+                              const wxGraphicsGradientStops& stops,
+                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) = 0;
 
     // sets the font
     virtual wxGraphicsFont CreateFont( const wxFont &font , const wxColour &col = *wxBLACK ) = 0;

--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -270,8 +270,8 @@ private:
 extern WXDLLIMPEXP_DATA_CORE(wxGraphicsMatrix) wxNullGraphicsMatrix;
 
 // ----------------------------------------------------------------------------
-// wxGradientStop and wxGradientStops: Controls how colors are spread in 
-// a gradient
+// wxGradientStop and wxGradientStops: Specify what intermediate colors are used
+// and how they are are spread out in a gradient
 // ----------------------------------------------------------------------------
 
 // Describes a single gradient stop.
@@ -454,7 +454,7 @@ public:
 private:
     wxDouble m_width;
     wxGradientType m_gradientType;
-    wxDouble m_x1, m_y1, m_x2, m_y2; // also used for m_xo, m_yo, m_xc, m_yx
+    wxDouble m_x1, m_y1, m_x2, m_y2; // also used for m_xo, m_yo, m_xc, m_yc
     wxDouble m_radius;
     wxGraphicsGradientStops m_stops;
     wxGraphicsMatrix m_matrix;

--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -479,6 +479,7 @@ public:
         { 
             m_gradientType = wxGRADIENT_RADIAL;
             m_x1 = xo; m_y1 = yo; m_x2 = xc; m_y2 = yc;
+            m_radius = radius;
             m_stops.SetStartColour(oColor);
             m_stops.SetEndColour(cColor);
             return *this; 
@@ -490,6 +491,7 @@ public:
         { 
             m_gradientType = wxGRADIENT_RADIAL;
             m_x1 = xo; m_y1 = yo; m_x2 = xc; m_y2 = yc;
+            m_radius = radius;
             m_stops = stops;
             return *this; 
         }

--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -243,58 +243,58 @@ public:
     wxGraphicsPenInfo& 
     LinearGradient(wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2,
                    const wxColour& c1, const wxColour& c2)
-        { 
-            m_gradientType = wxGRADIENT_LINEAR;
-            m_x1 = x1;
-            m_y1 = y1;
-            m_x2 = x2;
-            m_y2 = y2;
-            m_stops.SetStartColour(c1);
-            m_stops.SetEndColour(c2);
-            return *this; 
-        }                                      
+    { 
+        m_gradientType = wxGRADIENT_LINEAR;
+        m_x1 = x1;
+        m_y1 = y1;
+        m_x2 = x2;
+        m_y2 = y2;
+        m_stops.SetStartColour(c1);
+        m_stops.SetEndColour(c2);
+        return *this; 
+    }                                      
 
     wxGraphicsPenInfo& 
     LinearGradient(wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2,
                    const wxGraphicsGradientStops& stops)
-        { 
-            m_gradientType = wxGRADIENT_LINEAR;
-            m_x1 = x1;
-            m_y1 = y1;
-            m_x2 = x2;
-            m_y2 = y2;
-            m_stops = stops;
-            return *this; 
-        }
+    { 
+        m_gradientType = wxGRADIENT_LINEAR;
+        m_x1 = x1;
+        m_y1 = y1;
+        m_x2 = x2;
+        m_y2 = y2;
+        m_stops = stops;
+        return *this; 
+    }
 
     wxGraphicsPenInfo& 
     RadialGradient(wxDouble xo, wxDouble yo, wxDouble xc, wxDouble yc, wxDouble radius, 
                    const wxColour& oColor, const wxColour& cColor)
-        { 
-            m_gradientType = wxGRADIENT_RADIAL;
-            m_x1 = xo; 
-            m_y1 = yo; 
-            m_x2 = xc; 
-            m_y2 = yc;
-            m_radius = radius;
-            m_stops.SetStartColour(oColor);
-            m_stops.SetEndColour(cColor);
-            return *this; 
-        }                                      
+    { 
+        m_gradientType = wxGRADIENT_RADIAL;
+        m_x1 = xo; 
+        m_y1 = yo; 
+        m_x2 = xc; 
+        m_y2 = yc;
+        m_radius = radius;
+        m_stops.SetStartColour(oColor);
+        m_stops.SetEndColour(cColor);
+        return *this; 
+    }                                      
 
     wxGraphicsPenInfo& 
     RadialGradient(wxDouble xo, wxDouble yo, wxDouble xc, wxDouble yc, 
                    wxDouble radius, const wxGraphicsGradientStops& stops)
-        { 
-            m_gradientType = wxGRADIENT_RADIAL;
-            m_x1 = xo; 
-            m_y1 = yo; 
-            m_x2 = xc; 
-            m_y2 = yc;
-            m_radius = radius;
-            m_stops = stops;
-            return *this; 
-        }
+    { 
+        m_gradientType = wxGRADIENT_RADIAL;
+        m_x1 = xo; 
+        m_y1 = yo; 
+        m_x2 = xc; 
+        m_y2 = yc;
+        m_radius = radius;
+        m_stops = stops;
+        return *this; 
+    }
 
     // Accessors
 

--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -637,14 +637,14 @@ public:
     // on a circle around (xc,yc) with the given radius; the colours may be
     // specified by just the two extremes or the full array of gradient stops
     wxGraphicsBrush
-    CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
-                              wxDouble xc, wxDouble yc, wxDouble radius,
+    CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
+                              wxDouble endX, wxDouble endY, wxDouble radius,
                               const wxColour& oColor, const wxColour& cColor,
                               const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) const;
 
     wxGraphicsBrush
-    CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
-                              wxDouble xc, wxDouble yc, wxDouble radius,
+    CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
+                              wxDouble endX, wxDouble endY, wxDouble radius,
                               const wxGraphicsGradientStops& stops,
                               const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) const;
 
@@ -1026,8 +1026,8 @@ public:
                               const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) = 0;
 
     virtual wxGraphicsBrush
-    CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
-                              wxDouble xc, wxDouble yc,
+    CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
+                              wxDouble endX, wxDouble endY,
                               wxDouble radius,
                               const wxGraphicsGradientStops& stops,
                               const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) = 0;

--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -403,15 +403,16 @@ public:
     }
 
     wxGraphicsPenInfo& 
-    RadialGradient(wxDouble xo, wxDouble yo, wxDouble xc, wxDouble yc, wxDouble radius, 
+    RadialGradient(wxDouble startX, wxDouble startY,
+                   wxDouble endX, wxDouble endY, wxDouble radius, 
                    const wxColour& oColor, const wxColour& cColor,
                    const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix)
     { 
         m_gradientType = wxGRADIENT_RADIAL;
-        m_x1 = xo;
-        m_y1 = yo; 
-        m_x2 = xc; 
-        m_y2 = yc;
+        m_x1 = startX;
+        m_y1 = startY; 
+        m_x2 = endX; 
+        m_y2 = endY;
         m_radius = radius;
         m_stops.SetStartColour(oColor);
         m_stops.SetEndColour(cColor);
@@ -420,15 +421,16 @@ public:
     }                                      
 
     wxGraphicsPenInfo& 
-    RadialGradient(wxDouble xo, wxDouble yo, wxDouble xc, wxDouble yc, 
+    RadialGradient(wxDouble startX, wxDouble startY,
+                   wxDouble endX, wxDouble endY, 
                    wxDouble radius, const wxGraphicsGradientStops& stops,
                    const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix)
     { 
         m_gradientType = wxGRADIENT_RADIAL;
-        m_x1 = xo; 
-        m_y1 = yo; 
-        m_x2 = xc; 
-        m_y2 = yc;
+        m_x1 = startX; 
+        m_y1 = startY; 
+        m_x2 = endX; 
+        m_y2 = endY;
         m_radius = radius;
         m_stops = stops;
         m_matrix = matrix;
@@ -443,10 +445,10 @@ public:
     wxDouble GetY1() const { return m_y1; }
     wxDouble GetX2() const { return m_x2; }
     wxDouble GetY2() const { return m_y2; }
-    wxDouble GetXO() const { return m_x1; }
-    wxDouble GetYO() const { return m_y1; }
-    wxDouble GetXC() const { return m_x2; }
-    wxDouble GetYC() const { return m_y2; }
+    wxDouble GetStartX() const { return m_x1; }
+    wxDouble GetStartY() const { return m_y1; }
+    wxDouble GetEndX() const { return m_x2; }
+    wxDouble GetEndY() const { return m_y2; }
     wxDouble GetRadius() const { return m_radius; }
     const wxGraphicsGradientStops& GetStops() const { return m_stops; }
     const wxGraphicsMatrix& GetMatrix() const { return m_matrix; }

--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -271,7 +271,7 @@ extern WXDLLIMPEXP_DATA_CORE(wxGraphicsMatrix) wxNullGraphicsMatrix;
 
 // ----------------------------------------------------------------------------
 // wxGradientStop and wxGradientStops: Specify what intermediate colors are used
-// and how they are are spread out in a gradient
+// and how they are spread out in a gradient
 // ----------------------------------------------------------------------------
 
 // Describes a single gradient stop.
@@ -374,7 +374,7 @@ public:
     wxGraphicsPenInfo& 
     LinearGradient(wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2,
                    const wxColour& c1, const wxColour& c2,
-                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix)
+                   const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix)
     { 
         m_gradientType = wxGRADIENT_LINEAR;
         m_x1 = x1;
@@ -390,7 +390,7 @@ public:
     wxGraphicsPenInfo& 
     LinearGradient(wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2,
                    const wxGraphicsGradientStops& stops,
-                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix)
+                   const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix)
     { 
         m_gradientType = wxGRADIENT_LINEAR;
         m_x1 = x1;
@@ -406,7 +406,7 @@ public:
     RadialGradient(wxDouble startX, wxDouble startY,
                    wxDouble endX, wxDouble endY, wxDouble radius, 
                    const wxColour& oColor, const wxColour& cColor,
-                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix)
+                   const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix)
     { 
         m_gradientType = wxGRADIENT_RADIAL;
         m_x1 = startX;
@@ -424,7 +424,7 @@ public:
     RadialGradient(wxDouble startX, wxDouble startY,
                    wxDouble endX, wxDouble endY, 
                    wxDouble radius, const wxGraphicsGradientStops& stops,
-                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix)
+                   const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix)
     { 
         m_gradientType = wxGRADIENT_RADIAL;
         m_x1 = startX; 
@@ -626,12 +626,12 @@ public:
     CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
                               wxDouble x2, wxDouble y2,
                               const wxColour& c1, const wxColour& c2,
-                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) const;
+                              const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix) const;
     wxGraphicsBrush
     CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
                               wxDouble x2, wxDouble y2,
                               const wxGraphicsGradientStops& stops,
-                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) const;
+                              const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix) const;
 
     // sets the brush to a radial gradient originating at (xo,yc) and ending
     // on a circle around (xc,yc) with the given radius; the colours may be
@@ -640,13 +640,13 @@ public:
     CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
                               wxDouble endX, wxDouble endY, wxDouble radius,
                               const wxColour& oColor, const wxColour& cColor,
-                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) const;
+                              const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix) const;
 
     wxGraphicsBrush
     CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
                               wxDouble endX, wxDouble endY, wxDouble radius,
                               const wxGraphicsGradientStops& stops,
-                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) const;
+                              const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix) const;
 
     // creates a font
     virtual wxGraphicsFont CreateFont( const wxFont &font , const wxColour &col = *wxBLACK ) const;
@@ -1023,14 +1023,14 @@ public:
     CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
                               wxDouble x2, wxDouble y2,
                               const wxGraphicsGradientStops& stops,
-                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) = 0;
+                              const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix) = 0;
 
     virtual wxGraphicsBrush
     CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
                               wxDouble endX, wxDouble endY,
                               wxDouble radius,
                               const wxGraphicsGradientStops& stops,
-                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) = 0;
+                              const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix) = 0;
 
     // sets the font
     virtual wxGraphicsFont CreateFont( const wxFont &font , const wxColour &col = *wxBLACK ) = 0;

--- a/include/wx/motif/cursor.h
+++ b/include/wx/motif/cursor.h
@@ -43,7 +43,7 @@ public:
 
     // Motif-specific.
     // Create/get a cursor for the current display
-    WXCursor GetEndXursor(WXDisplay* display) const;
+    WXCursor GetXCursor(WXDisplay* display) const;
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const;

--- a/include/wx/motif/cursor.h
+++ b/include/wx/motif/cursor.h
@@ -43,7 +43,7 @@ public:
 
     // Motif-specific.
     // Create/get a cursor for the current display
-    WXCursor GetXCursor(WXDisplay* display) const;
+    WXCursor GetEndXursor(WXDisplay* display) const;
 
 protected:
     virtual wxGDIRefData *CreateGDIRefData() const;

--- a/interface/wx/graphics.h
+++ b/interface/wx/graphics.h
@@ -1644,6 +1644,15 @@ public:
     RadialGradient(wxDouble xo, wxDouble yo, wxDouble xc, wxDouble yc, 
                    wxDouble radius, const wxGraphicsGradientStops& stops);
 
+    wxColour GetColour() const;
+    wxBitmap GetStipple() const;
+    wxPenStyle GetStyle() const;
+    wxPenJoin GetJoin() const;
+    wxPenCap GetCap() const;
+    int GetDashes(wxDash **ptr);
+    int GetDashCount() const;
+    wxDash* GetDash() const;
+    bool IsTransparent() const;    
     wxDouble GetWidth() const;
     wxGradientType GetGradientType() const;
     wxDouble GetX1() const;

--- a/interface/wx/graphics.h
+++ b/interface/wx/graphics.h
@@ -644,7 +644,8 @@ public:
     wxGraphicsBrush
     CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
                               wxDouble x2, wxDouble y2,
-                              const wxColour& c1, const wxColour& c2) const;
+                              const wxColour& c1, const wxColour& c2,
+                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) const;
 
     /**
         @overload
@@ -652,7 +653,8 @@ public:
     wxGraphicsBrush
     CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
                               wxDouble x2, wxDouble y2,
-                              const wxGraphicsGradientStops& stops) const;
+                              const wxGraphicsGradientStops& stops,
+                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) const;
 
     /**
         Creates a native brush with a radial gradient.
@@ -670,7 +672,8 @@ public:
                               wxDouble xc, wxDouble yc,
                               wxDouble radius,
                               const wxColour& oColor,
-                              const wxColour& cColor) const;
+                              const wxColour& cColor,
+                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) const;
 
     /**
         @overload
@@ -679,7 +682,8 @@ public:
     CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
                               wxDouble xc, wxDouble yc,
                               wxDouble radius,
-                              const wxGraphicsGradientStops& stops) = 0;
+                              const wxGraphicsGradientStops& stops,
+                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) = 0;
 
     /**
         Sets the brush for filling paths.
@@ -1456,7 +1460,8 @@ public:
                                                       wxDouble y1,
                                                       wxDouble x2,
                                                       wxDouble y2,
-                                                      const wxGraphicsGradientStops& stops) = 0;
+                                                      const wxGraphicsGradientStops& stops,
+                                                      const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) = 0;
 
     /**
         Creates a native affine transformation matrix from the passed in
@@ -1488,7 +1493,8 @@ public:
     virtual wxGraphicsBrush CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
                                                       wxDouble xc, wxDouble yc,
                                                       wxDouble radius,
-                                                      const wxGraphicsGradientStops& stops) = 0;
+                                                      const wxGraphicsGradientStops& stops,
+                                                      const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) = 0;
 
     /**
         Extracts a sub-bitmap from an existing bitmap.
@@ -1630,19 +1636,23 @@ public:
 
     wxGraphicsPenInfo& 
     LinearGradient(wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2,
-                   const wxColour& c1, const wxColour& c2);
+                   const wxColour& c1, const wxColour& c2,
+                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
 
     wxGraphicsPenInfo& 
     LinearGradient(wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2,
-                   const wxGraphicsGradientStops& stops);
+                   const wxGraphicsGradientStops& stops,
+                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
 
     wxGraphicsPenInfo& 
     RadialGradient(wxDouble xo, wxDouble yo, wxDouble xc, wxDouble yc, wxDouble radius, 
-                   const wxColour& oColor, const wxColour& cColor);
+                   const wxColour& oColor, const wxColour& cColor,
+                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
 
     wxGraphicsPenInfo& 
     RadialGradient(wxDouble xo, wxDouble yo, wxDouble xc, wxDouble yc, 
-                   wxDouble radius, const wxGraphicsGradientStops& stops);
+                   wxDouble radius, const wxGraphicsGradientStops& stops,
+                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
 
     wxColour GetColour() const;
     wxBitmap GetStipple() const;

--- a/interface/wx/graphics.h
+++ b/interface/wx/graphics.h
@@ -305,6 +305,13 @@ enum wxCompositionMode
     wxCOMPOSITION_ADD  /**< @e R = @e S + @e D */
 };
 
+enum wxGradientType {
+    wxGRADIENT_NONE,
+    wxGRADIENT_LINEAR,
+    wxGRADIENT_RADIAL
+};
+
+
 /**
     Represents a bitmap.
 
@@ -1620,6 +1627,35 @@ public:
     wxGraphicsPenInfo& Join(wxPenJoin join);
 
     wxGraphicsPenInfo& Cap(wxPenCap cap);
+
+    wxGraphicsPenInfo& 
+    LinearGradient(wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2,
+                   const wxColour& c1, const wxColour& c2);
+
+    wxGraphicsPenInfo& 
+    LinearGradient(wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2,
+                   const wxGraphicsGradientStops& stops);
+
+    wxGraphicsPenInfo& 
+    RadialGradient(wxDouble xo, wxDouble yo, wxDouble xc, wxDouble yc, wxDouble radius, 
+                   const wxColour& oColor, const wxColour& cColor);
+
+    wxGraphicsPenInfo& 
+    RadialGradient(wxDouble xo, wxDouble yo, wxDouble xc, wxDouble yc, 
+                   wxDouble radius, const wxGraphicsGradientStops& stops);
+
+    wxDouble GetWidth() const;
+    wxGradientType GetGradientType() const;
+    wxDouble GetX1() const;
+    wxDouble GetY1() const;
+    wxDouble GetX2() const;
+    wxDouble GetY2() const;
+    wxDouble GetXO() const;
+    wxDouble GetYO() const;
+    wxDouble GetXC() const;
+    wxDouble GetYC() const;
+    wxDouble GetRadius() const;
+    const wxGraphicsGradientStops& GetStops() const;
 };
 
 

--- a/interface/wx/graphics.h
+++ b/interface/wx/graphics.h
@@ -640,6 +640,8 @@ public:
         of gradient @a stops can be specified.
 
         The version taking wxGraphicsGradientStops is new in wxWidgets 2.9.1.
+
+        The ability to apply a transformation matrix to the gradient was added in 3.1.3
     */
     wxGraphicsBrush
     CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
@@ -666,6 +668,8 @@ public:
         oColor and @a cColor or by a full set of gradient @a stops.
 
         The version taking wxGraphicsGradientStops is new in wxWidgets 2.9.1.
+
+        The ability to apply a transformation matrix to the gradient was added in 3.1.3
     */
     virtual wxGraphicsBrush
     CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
@@ -1455,6 +1459,9 @@ public:
 
         Stops support is new since wxWidgets 2.9.1, previously only the start
         and end colours could be specified.
+
+        The ability to apply a transformation matrix to the gradient was added in 3.1.3
+        
     */
     virtual wxGraphicsBrush CreateLinearGradientBrush(wxDouble x1,
                                                       wxDouble y1,
@@ -1489,6 +1496,8 @@ public:
 
         Stops support is new since wxWidgets 2.9.1, previously only the start
         and end colours could be specified.
+
+        The ability to apply a transformation matrix to the gradient was added in 3.1.3
     */
     virtual wxGraphicsBrush CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
                                                       wxDouble endX, wxDouble endY,

--- a/interface/wx/graphics.h
+++ b/interface/wx/graphics.h
@@ -647,7 +647,7 @@ public:
 
         The version taking wxGraphicsGradientStops is new in wxWidgets 2.9.1.
 
-        The @ matrix parameter was added in wxWidgets 3.1.3
+        The @a matrix parameter was added in wxWidgets 3.1.3
     */
     wxGraphicsBrush
     CreateLinearGradientBrush(wxDouble x1, wxDouble y1,

--- a/interface/wx/graphics.h
+++ b/interface/wx/graphics.h
@@ -305,6 +305,12 @@ enum wxCompositionMode
     wxCOMPOSITION_ADD  /**< @e R = @e S + @e D */
 };
 
+/**
+   Used to indicate what kind of gradient is set in a wxGraphicsPenInfo
+   object.
+
+   @since 3.1.3
+ */
 enum wxGradientType {
     wxGRADIENT_NONE,
     wxGRADIENT_LINEAR,
@@ -641,13 +647,13 @@ public:
 
         The version taking wxGraphicsGradientStops is new in wxWidgets 2.9.1.
 
-        The ability to apply a transformation matrix to the gradient was added in 3.1.3
+        The @ matrix parameter was added in wxWidgets 3.1.3
     */
     wxGraphicsBrush
     CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
                               wxDouble x2, wxDouble y2,
                               const wxColour& c1, const wxColour& c2,
-                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) const;
+                              const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix) const;
 
     /**
         @overload
@@ -656,7 +662,7 @@ public:
     CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
                               wxDouble x2, wxDouble y2,
                               const wxGraphicsGradientStops& stops,
-                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) const;
+                              const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix) const;
 
     /**
         Creates a native brush with a radial gradient.
@@ -677,7 +683,7 @@ public:
                               wxDouble radius,
                               const wxColour& oColor,
                               const wxColour& cColor,
-                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) const;
+                              const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix) const;
 
     /**
         @overload
@@ -687,7 +693,7 @@ public:
                               wxDouble endX, wxDouble endY,
                               wxDouble radius,
                               const wxGraphicsGradientStops& stops,
-                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) = 0;
+                              const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix) = 0;
 
     /**
         Sets the brush for filling paths.
@@ -1468,7 +1474,7 @@ public:
                                                       wxDouble x2,
                                                       wxDouble y2,
                                                       const wxGraphicsGradientStops& stops,
-                                                      const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) = 0;
+                                                      const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix) = 0;
 
     /**
         Creates a native affine transformation matrix from the passed in
@@ -1503,7 +1509,7 @@ public:
                                                       wxDouble endX, wxDouble endY,
                                                       wxDouble radius,
                                                       const wxGraphicsGradientStops& stops,
-                                                      const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) = 0;
+                                                      const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix) = 0;
 
     /**
         Extracts a sub-bitmap from an existing bitmap.
@@ -1646,24 +1652,24 @@ public:
     wxGraphicsPenInfo& 
     LinearGradient(wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2,
                    const wxColour& c1, const wxColour& c2,
-                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
+                   const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix);
 
     wxGraphicsPenInfo& 
     LinearGradient(wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2,
                    const wxGraphicsGradientStops& stops,
-                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
+                   const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix);
 
     wxGraphicsPenInfo& 
     RadialGradient(wxDouble startX, wxDouble startY,
                    wxDouble endX, wxDouble endY, wxDouble radius, 
                    const wxColour& oColor, const wxColour& cColor,
-                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
+                   const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix);
 
     wxGraphicsPenInfo& 
     RadialGradient(wxDouble startX, wxDouble startY,
                    wxDouble endX, wxDouble endY, 
                    wxDouble radius, const wxGraphicsGradientStops& stops,
-                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
+                   const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix);
 
     wxColour GetColour() const;
     wxBitmap GetStipple() const;

--- a/interface/wx/graphics.h
+++ b/interface/wx/graphics.h
@@ -1645,12 +1645,14 @@ public:
                    const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
 
     wxGraphicsPenInfo& 
-    RadialGradient(wxDouble xo, wxDouble yo, wxDouble xc, wxDouble yc, wxDouble radius, 
+    RadialGradient(wxDouble startX, wxDouble startY,
+                   wxDouble endX, wxDouble endY, wxDouble radius, 
                    const wxColour& oColor, const wxColour& cColor,
                    const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
 
     wxGraphicsPenInfo& 
-    RadialGradient(wxDouble xo, wxDouble yo, wxDouble xc, wxDouble yc, 
+    RadialGradient(wxDouble startX, wxDouble startY,
+                   wxDouble endX, wxDouble endY, 
                    wxDouble radius, const wxGraphicsGradientStops& stops,
                    const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
 
@@ -1669,10 +1671,10 @@ public:
     wxDouble GetY1() const;
     wxDouble GetX2() const;
     wxDouble GetY2() const;
-    wxDouble GetXO() const;
-    wxDouble GetYO() const;
-    wxDouble GetXC() const;
-    wxDouble GetYC() const;
+    wxDouble GetStartX() const;
+    wxDouble GetStartY() const;
+    wxDouble GetEndX() const;
+    wxDouble GetEndY() const;
     wxDouble GetRadius() const;
     const wxGraphicsGradientStops& GetStops() const;
 };

--- a/interface/wx/graphics.h
+++ b/interface/wx/graphics.h
@@ -659,8 +659,8 @@ public:
     /**
         Creates a native brush with a radial gradient.
 
-        The brush originates at (@a xo, @a yc) and ends on a circle around
-        (@a xc, @a yc) with the given @a radius.
+        The brush originates at (@a startX, @a startY) and ends on a circle around
+        (@a endX, @a endY) with the given @a radius.
 
         The gradient may be specified either by its start and end colours @a
         oColor and @a cColor or by a full set of gradient @a stops.
@@ -668,8 +668,8 @@ public:
         The version taking wxGraphicsGradientStops is new in wxWidgets 2.9.1.
     */
     virtual wxGraphicsBrush
-    CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
-                              wxDouble xc, wxDouble yc,
+    CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
+                              wxDouble endX, wxDouble endY,
                               wxDouble radius,
                               const wxColour& oColor,
                               const wxColour& cColor,
@@ -679,8 +679,8 @@ public:
         @overload
     */
     virtual wxGraphicsBrush
-    CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
-                              wxDouble xc, wxDouble yc,
+    CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
+                              wxDouble endX, wxDouble endY,
                               wxDouble radius,
                               const wxGraphicsGradientStops& stops,
                               const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) = 0;
@@ -1490,8 +1490,8 @@ public:
         Stops support is new since wxWidgets 2.9.1, previously only the start
         and end colours could be specified.
     */
-    virtual wxGraphicsBrush CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
-                                                      wxDouble xc, wxDouble yc,
+    virtual wxGraphicsBrush CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
+                                                      wxDouble endX, wxDouble endY,
                                                       wxDouble radius,
                                                       const wxGraphicsGradientStops& stops,
                                                       const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) = 0;

--- a/interface/wx/pen.h
+++ b/interface/wx/pen.h
@@ -137,6 +137,17 @@ public:
     wxPenInfo& Join(wxPenJoin join);
 
     wxPenInfo& Cap(wxPenCap cap);
+
+    wxColour GetColour() const;
+    wxBitmap GetStipple() const;
+    wxPenStyle GetStyle() const;
+    wxPenJoin GetJoin() const;
+    wxPenCap GetCap() const;
+    int GetDashes(wxDash **ptr);
+    int GetDashCount() const;
+    wxDash* GetDash() const;
+    bool IsTransparent() const;    
+    int GetWidth() const;
 };
 
 

--- a/samples/drawing/drawing.cpp
+++ b/samples/drawing/drawing.cpp
@@ -1638,6 +1638,29 @@ void MyCanvas::DrawGradients(wxDC& dc)
         pth.GetBox(&boxX, &boxY, &boxWidth, &boxHeight);
         dc.CalcBoundingBox(wxRound(boxX), wxRound(boxY));
         dc.CalcBoundingBox(wxRound(boxX+boxWidth), wxRound(boxY+boxHeight));
+
+        gfr.Offset(0, gfr.height + 10);
+        dc.DrawText("Stroked path with a gradient pen", gfr.x, gfr.y);
+        gfr.Offset(0, TEXT_HEIGHT);
+
+        pth = gc->CreatePath();
+        pth.MoveToPoint(gfr.x + gfr.width/2, gfr.y);
+        pth.AddLineToPoint(gfr.x + gfr.width, gfr.y + gfr.height/2);
+        pth.AddLineToPoint(gfr.x + gfr.width/2, gfr.y + gfr.height);
+        pth.AddLineToPoint(gfr.x, gfr.y + gfr.height/2);
+        pth.CloseSubpath();
+
+        stops = wxGraphicsGradientStops(*wxRED, *wxBLUE);
+        stops.Add(wxColour(255,255,0), 0.33f);
+        stops.Add(*wxGREEN, 0.67f);
+
+        wxGraphicsPen pen = gc->CreatePen(
+            wxGraphicsPenInfo(wxColour(0,0,0)).Width(6).Join(wxJOIN_BEVEL).LinearGradient(
+                gfr.x + gfr.width/2, gfr.y, 
+                gfr.x + gfr.width/2, gfr.y + gfr.height,
+                stops));
+        gc->SetPen(pen);
+        gc->StrokePath(pth);
     }
 #endif // wxUSE_GRAPHICS_CONTEXT
 }

--- a/src/common/cairo.cpp
+++ b/src/common/cairo.cpp
@@ -110,6 +110,8 @@
         (cairo_pattern_t *pattern, cairo_extend_t extend), (pattern, extend) ) \
     m( cairo_pattern_set_filter, \
         (cairo_pattern_t *pattern, cairo_filter_t filter), (pattern, filter) ) \
+    m( cairo_pattern_set_matrix, \
+        (cairo_pattern_t *pattern, const cairo_matrix_t *matrix), (pattern, matrix) ) \
     m( cairo_pop_group_to_source, \
         (cairo_t *cr), (cr) ) \
     m( cairo_push_group, \

--- a/src/common/graphcmn.cpp
+++ b/src/common/graphcmn.cpp
@@ -883,13 +883,15 @@ wxGraphicsBrush
 wxGraphicsContext::CreateLinearGradientBrush(
     wxDouble x1, wxDouble y1,
     wxDouble x2, wxDouble y2,
-    const wxColour& c1, const wxColour& c2) const
+    const wxColour& c1, const wxColour& c2,
+    const wxGraphicsMatrix& matrix) const
 {
     return GetRenderer()->CreateLinearGradientBrush
                           (
                             x1, y1,
                             x2, y2,
-                            wxGraphicsGradientStops(c1,c2)
+                            wxGraphicsGradientStops(c1,c2),
+                            matrix
                           );
 }
 
@@ -897,22 +899,15 @@ wxGraphicsBrush
 wxGraphicsContext::CreateLinearGradientBrush(
     wxDouble x1, wxDouble y1,
     wxDouble x2, wxDouble y2,
-    const wxGraphicsGradientStops& gradientStops) const
+    const wxGraphicsGradientStops& gradientStops,
+    const wxGraphicsMatrix& matrix) const
 {
-    return GetRenderer()->CreateLinearGradientBrush(x1,y1,x2,y2, gradientStops);
-}
-
-wxGraphicsBrush
-wxGraphicsContext::CreateRadialGradientBrush(
-        wxDouble xo, wxDouble yo,
-        wxDouble xc, wxDouble yc, wxDouble radius,
-        const wxColour &oColor, const wxColour &cColor) const
-{
-    return GetRenderer()->CreateRadialGradientBrush
+    return GetRenderer()->CreateLinearGradientBrush
                           (
-                            xo, yo,
-                            xc, yc, radius,
-                            wxGraphicsGradientStops(oColor, cColor)
+                            x1, y1,
+                            x2, y2, 
+                            gradientStops, 
+                            matrix
                           );
 }
 
@@ -920,13 +915,31 @@ wxGraphicsBrush
 wxGraphicsContext::CreateRadialGradientBrush(
         wxDouble xo, wxDouble yo,
         wxDouble xc, wxDouble yc, wxDouble radius,
-        const wxGraphicsGradientStops& gradientStops) const
+        const wxColour &oColor, const wxColour &cColor,
+        const wxGraphicsMatrix& matrix) const
 {
     return GetRenderer()->CreateRadialGradientBrush
                           (
                             xo, yo,
                             xc, yc, radius,
-                            gradientStops
+                            wxGraphicsGradientStops(oColor, cColor),
+                            matrix
+                          );
+}
+
+wxGraphicsBrush
+wxGraphicsContext::CreateRadialGradientBrush(
+        wxDouble xo, wxDouble yo,
+        wxDouble xc, wxDouble yc, wxDouble radius,
+        const wxGraphicsGradientStops& gradientStops,
+        const wxGraphicsMatrix& matrix) const
+{
+    return GetRenderer()->CreateRadialGradientBrush
+                          (
+                            xo, yo,
+                            xc, yc, radius,
+                            gradientStops,
+                            matrix
                           );
 }
 

--- a/src/common/graphcmn.cpp
+++ b/src/common/graphcmn.cpp
@@ -913,15 +913,15 @@ wxGraphicsContext::CreateLinearGradientBrush(
 
 wxGraphicsBrush
 wxGraphicsContext::CreateRadialGradientBrush(
-        wxDouble xo, wxDouble yo,
-        wxDouble xc, wxDouble yc, wxDouble radius,
+        wxDouble startX, wxDouble startY,
+        wxDouble endX, wxDouble endY, wxDouble radius,
         const wxColour &oColor, const wxColour &cColor,
         const wxGraphicsMatrix& matrix) const
 {
     return GetRenderer()->CreateRadialGradientBrush
                           (
-                            xo, yo,
-                            xc, yc, radius,
+                            startX, startY,
+                            endX, endY, radius,
                             wxGraphicsGradientStops(oColor, cColor),
                             matrix
                           );
@@ -929,15 +929,15 @@ wxGraphicsContext::CreateRadialGradientBrush(
 
 wxGraphicsBrush
 wxGraphicsContext::CreateRadialGradientBrush(
-        wxDouble xo, wxDouble yo,
-        wxDouble xc, wxDouble yc, wxDouble radius,
+        wxDouble startX, wxDouble startY,
+        wxDouble endX, wxDouble endY, wxDouble radius,
         const wxGraphicsGradientStops& gradientStops,
         const wxGraphicsMatrix& matrix) const
 {
     return GetRenderer()->CreateRadialGradientBrush
                           (
-                            xo, yo,
-                            xc, yc, radius,
+                            startX, startY,
+                            endX, endY, radius,
                             gradientStops,
                             matrix
                           );

--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -260,6 +260,13 @@ public:
 
     virtual void Apply( wxGraphicsContext* context );
 
+    void CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
+                                   wxDouble x2, wxDouble y2,
+                                   const wxGraphicsGradientStops& stops);
+    void CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
+                                   wxDouble xc, wxDouble yc, wxDouble radius,
+                                   const wxGraphicsGradientStops& stops);
+
 protected:
     // Call this to use the given bitmap as stipple. Bitmap must be non-null
     // and valid.
@@ -268,6 +275,8 @@ protected:
     // Call this to use the given hatch style. Hatch style must be valid.
     void InitHatch(wxHatchStyle hatchStyle);
 
+    // common part of Create{Linear,Radial}GradientBrush()
+    void AddGradientStops(const wxGraphicsGradientStops& stops);
 
     double m_red;
     double m_green;
@@ -316,18 +325,8 @@ public:
     wxCairoBrushData( wxGraphicsRenderer* renderer );
     wxCairoBrushData( wxGraphicsRenderer* renderer, const wxBrush &brush );
 
-    void CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
-                                   wxDouble x2, wxDouble y2,
-                                   const wxGraphicsGradientStops& stops);
-    void CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
-                                   wxDouble xc, wxDouble yc, wxDouble radius,
-                                   const wxGraphicsGradientStops& stops);
-
 protected:
     void Init();
-
-    // common part of Create{Linear,Radial}GradientBrush()
-    void AddGradientStops(const wxGraphicsGradientStops& stops);
 };
 
 class wxCairoFontData : public wxGraphicsObjectRefData
@@ -732,6 +731,7 @@ wxCairoPenData::~wxCairoPenData()
 
 void wxCairoPenData::Init()
 {
+    m_pattern = NULL;
     m_lengths = NULL;
     m_userLengths = NULL;
     m_width = 0;
@@ -867,6 +867,20 @@ wxCairoPenData::wxCairoPenData( wxGraphicsRenderer* renderer, const wxGraphicsPe
         }
         break;
     }
+
+    if (info.GetGradientType() == wxGRADIENT_LINEAR)
+    {
+        CreateLinearGradientBrush(info.GetX1(), info.GetY1(),
+                                  info.GetX2(), info.GetY2(),
+                                  info.GetStops());
+    }
+    if (info.GetGradientType() == wxGRADIENT_RADIAL)
+    {
+        CreateRadialGradientBrush(info.GetXO(), info.GetYO(),
+                                  info.GetXC(), info.GetYC(),
+                                  info.GetRadius(),
+                                  info.GetStops());
+    }
 }
 
 void wxCairoPenData::Apply( wxGraphicsContext* context )
@@ -911,7 +925,7 @@ wxCairoBrushData::wxCairoBrushData( wxGraphicsRenderer* renderer,
     }
 }
 
-void wxCairoBrushData::AddGradientStops(const wxGraphicsGradientStops& stops)
+void wxCairoPenBrushBaseData::AddGradientStops(const wxGraphicsGradientStops& stops)
 {
     // loop over all the stops, they include the beginning and ending ones
     const unsigned numStops = stops.GetCount();
@@ -937,7 +951,7 @@ void wxCairoBrushData::AddGradientStops(const wxGraphicsGradientStops& stops)
 }
 
 void
-wxCairoBrushData::CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
+wxCairoPenBrushBaseData::CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
                                             wxDouble x2, wxDouble y2,
                                             const wxGraphicsGradientStops& stops)
 {
@@ -947,7 +961,7 @@ wxCairoBrushData::CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
 }
 
 void
-wxCairoBrushData::CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
+wxCairoPenBrushBaseData::CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
                                             wxDouble xc, wxDouble yc,
                                             wxDouble radius,
                                             const wxGraphicsGradientStops& stops)

--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -260,12 +260,12 @@ public:
 
     virtual void Apply( wxGraphicsContext* context );
 
-    void CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
-                                   wxDouble x2, wxDouble y2,
-                                   const wxGraphicsGradientStops& stops);
-    void CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
-                                   wxDouble xc, wxDouble yc, wxDouble radius,
-                                   const wxGraphicsGradientStops& stops);
+    void CreateLinearGradientPattern(wxDouble x1, wxDouble y1,
+                                     wxDouble x2, wxDouble y2,
+                                     const wxGraphicsGradientStops& stops);
+    void CreateRadialGradientPattern(wxDouble xo, wxDouble yo,
+                                     wxDouble xc, wxDouble yc, wxDouble radius,
+                                     const wxGraphicsGradientStops& stops);
 
 protected:
     // Call this to use the given bitmap as stipple. Bitmap must be non-null
@@ -275,7 +275,7 @@ protected:
     // Call this to use the given hatch style. Hatch style must be valid.
     void InitHatch(wxHatchStyle hatchStyle);
 
-    // common part of Create{Linear,Radial}GradientBrush()
+    // common part of Create{Linear,Radial}GradientPattern()
     void AddGradientStops(const wxGraphicsGradientStops& stops);
 
     double m_red;
@@ -746,9 +746,9 @@ void wxCairoPenBrushBaseData::AddGradientStops(const wxGraphicsGradientStops& st
 }
 
 void
-wxCairoPenBrushBaseData::CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
-                                            wxDouble x2, wxDouble y2,
-                                            const wxGraphicsGradientStops& stops)
+wxCairoPenBrushBaseData::CreateLinearGradientPattern(wxDouble x1, wxDouble y1,
+                                                     wxDouble x2, wxDouble y2,
+                                                     const wxGraphicsGradientStops& stops)
 {
     m_pattern = cairo_pattern_create_linear(x1,y1,x2,y2);
 
@@ -756,10 +756,10 @@ wxCairoPenBrushBaseData::CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
 }
 
 void
-wxCairoPenBrushBaseData::CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
-                                            wxDouble xc, wxDouble yc,
-                                            wxDouble radius,
-                                            const wxGraphicsGradientStops& stops)
+wxCairoPenBrushBaseData::CreateRadialGradientPattern(wxDouble xo, wxDouble yo,
+                                                     wxDouble xc, wxDouble yc,
+                                                     wxDouble radius,
+                                                     const wxGraphicsGradientStops& stops)
 {
     m_pattern = cairo_pattern_create_radial(xo,yo,0.0,xc,yc,radius);
 
@@ -3169,7 +3169,7 @@ wxCairoRenderer::CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
     wxGraphicsBrush p;
     ENSURE_LOADED_OR_RETURN(p);
     wxCairoBrushData* d = new wxCairoBrushData( this );
-    d->CreateLinearGradientBrush(x1, y1, x2, y2, stops);
+    d->CreateLinearGradientPattern(x1, y1, x2, y2, stops);
     p.SetRefData(d);
     return p;
 }
@@ -3182,7 +3182,7 @@ wxCairoRenderer::CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
     wxGraphicsBrush p;
     ENSURE_LOADED_OR_RETURN(p);
     wxCairoBrushData* d = new wxCairoBrushData( this );
-    d->CreateRadialGradientBrush(xo, yo, xc, yc, r, stops);
+    d->CreateRadialGradientPattern(xo, yo, xc, yc, r, stops);
     p.SetRefData(d);
     return p;
 }

--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -262,10 +262,12 @@ public:
 
     void CreateLinearGradientPattern(wxDouble x1, wxDouble y1,
                                      wxDouble x2, wxDouble y2,
-                                     const wxGraphicsGradientStops& stops);
+                                     const wxGraphicsGradientStops& stops,
+                                     const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
     void CreateRadialGradientPattern(wxDouble xo, wxDouble yo,
                                      wxDouble xc, wxDouble yc, wxDouble radius,
-                                     const wxGraphicsGradientStops& stops);
+                                     const wxGraphicsGradientStops& stops,
+                                     const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
 
 protected:
     // Call this to use the given bitmap as stipple. Bitmap must be non-null
@@ -748,9 +750,16 @@ void wxCairoPenBrushBaseData::AddGradientStops(const wxGraphicsGradientStops& st
 void
 wxCairoPenBrushBaseData::CreateLinearGradientPattern(wxDouble x1, wxDouble y1,
                                                      wxDouble x2, wxDouble y2,
-                                                     const wxGraphicsGradientStops& stops)
+                                                     const wxGraphicsGradientStops& stops,
+                                                     const wxGraphicsMatrix& matrix)
 {
     m_pattern = cairo_pattern_create_linear(x1,y1,x2,y2);
+
+    if (! matrix.IsNull())
+    {
+        cairo_matrix_t m = *((cairo_matrix_t*) matrix.GetNativeMatrix());
+        cairo_pattern_set_matrix(m_pattern, &m);
+    }
 
     AddGradientStops(stops);
 }
@@ -759,9 +768,16 @@ void
 wxCairoPenBrushBaseData::CreateRadialGradientPattern(wxDouble xo, wxDouble yo,
                                                      wxDouble xc, wxDouble yc,
                                                      wxDouble radius,
-                                                     const wxGraphicsGradientStops& stops)
+                                                     const wxGraphicsGradientStops& stops,
+                                                     const wxGraphicsMatrix& matrix)
 {
     m_pattern = cairo_pattern_create_radial(xo,yo,0.0,xc,yc,radius);
+
+    if (! matrix.IsNull())
+    {
+        cairo_matrix_t m = *((cairo_matrix_t*) matrix.GetNativeMatrix());
+        cairo_pattern_set_matrix(m_pattern, &m);
+    }
 
     AddGradientStops(stops);
 }
@@ -922,14 +938,16 @@ wxCairoPenData::wxCairoPenData( wxGraphicsRenderer* renderer, const wxGraphicsPe
     case wxGRADIENT_LINEAR:
         CreateLinearGradientPattern(info.GetX1(), info.GetY1(),
                                     info.GetX2(), info.GetY2(),
-                                    info.GetStops());
+                                    info.GetStops(),
+                                    info.GetMatrix());
         break;
 
     case wxGRADIENT_RADIAL:
         CreateRadialGradientPattern(info.GetXO(), info.GetYO(),
                                     info.GetXC(), info.GetYC(),
                                     info.GetRadius(),
-                                    info.GetStops());
+                                    info.GetStops(),
+                                    info.GetMatrix());
         break;
     }
 }
@@ -2975,13 +2993,15 @@ public :
     virtual wxGraphicsBrush
     CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
                               wxDouble x2, wxDouble y2,
-                              const wxGraphicsGradientStops& stops) wxOVERRIDE;
+                              const wxGraphicsGradientStops& stops,
+                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
 
     virtual wxGraphicsBrush
     CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
                               wxDouble xc, wxDouble yc,
                               wxDouble radius,
-                              const wxGraphicsGradientStops& stops) wxOVERRIDE;
+                              const wxGraphicsGradientStops& stops,
+                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
 
     // sets the font
     virtual wxGraphicsFont CreateFont( const wxFont &font , const wxColour &col = *wxBLACK ) wxOVERRIDE ;
@@ -3169,12 +3189,13 @@ wxGraphicsBrush wxCairoRenderer::CreateBrush(const wxBrush& brush )
 wxGraphicsBrush
 wxCairoRenderer::CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
                                            wxDouble x2, wxDouble y2,
-                                           const wxGraphicsGradientStops& stops)
+                                           const wxGraphicsGradientStops& stops,
+                                           const wxGraphicsMatrix& matrix)
 {
     wxGraphicsBrush p;
     ENSURE_LOADED_OR_RETURN(p);
     wxCairoBrushData* d = new wxCairoBrushData( this );
-    d->CreateLinearGradientPattern(x1, y1, x2, y2, stops);
+    d->CreateLinearGradientPattern(x1, y1, x2, y2, stops, matrix);
     p.SetRefData(d);
     return p;
 }
@@ -3182,15 +3203,17 @@ wxCairoRenderer::CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
 wxGraphicsBrush
 wxCairoRenderer::CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
                                            wxDouble xc, wxDouble yc, wxDouble r,
-                                           const wxGraphicsGradientStops& stops)
+                                           const wxGraphicsGradientStops& stops,
+                                           const wxGraphicsMatrix& matrix)
 {
     wxGraphicsBrush p;
     ENSURE_LOADED_OR_RETURN(p);
     wxCairoBrushData* d = new wxCairoBrushData( this );
-    d->CreateRadialGradientPattern(xo, yo, xc, yc, r, stops);
+    d->CreateRadialGradientPattern(xo, yo, xc, yc, r, stops, matrix);
     p.SetRefData(d);
     return p;
 }
+
 
 wxGraphicsFont wxCairoRenderer::CreateFont( const wxFont &font , const wxColour &col )
 {

--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -914,18 +914,23 @@ wxCairoPenData::wxCairoPenData( wxGraphicsRenderer* renderer, const wxGraphicsPe
         break;
     }
 
-    if (info.GetGradientType() == wxGRADIENT_LINEAR)
+    switch ( info.GetGradientType() )
     {
-        CreateLinearGradientBrush(info.GetX1(), info.GetY1(),
-                                  info.GetX2(), info.GetY2(),
-                                  info.GetStops());
-    }
-    if (info.GetGradientType() == wxGRADIENT_RADIAL)
-    {
-        CreateRadialGradientBrush(info.GetXO(), info.GetYO(),
-                                  info.GetXC(), info.GetYC(),
-                                  info.GetRadius(),
-                                  info.GetStops());
+    case wxGRADIENT_NONE:
+        break;
+
+    case wxGRADIENT_LINEAR:
+        CreateLinearGradientPattern(info.GetX1(), info.GetY1(),
+                                    info.GetX2(), info.GetY2(),
+                                    info.GetStops());
+        break;
+
+    case wxGRADIENT_RADIAL:
+        CreateRadialGradientPattern(info.GetXO(), info.GetYO(),
+                                    info.GetXC(), info.GetYC(),
+                                    info.GetRadius(),
+                                    info.GetStops());
+        break;
     }
 }
 

--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -720,6 +720,52 @@ void wxCairoPenBrushBaseData::Apply( wxGraphicsContext* context )
         cairo_set_source_rgba(ctext, m_red, m_green, m_blue, m_alpha);
 }
 
+void wxCairoPenBrushBaseData::AddGradientStops(const wxGraphicsGradientStops& stops)
+{
+    // loop over all the stops, they include the beginning and ending ones
+    const unsigned numStops = stops.GetCount();
+    for ( unsigned n = 0; n < numStops; n++ )
+    {
+        const wxGraphicsGradientStop stop = stops.Item(n);
+
+        const wxColour col = stop.GetColour();
+
+        cairo_pattern_add_color_stop_rgba
+        (
+            m_pattern,
+            stop.GetPosition(),
+            col.Red()/255.0,
+            col.Green()/255.0,
+            col.Blue()/255.0,
+            col.Alpha()/255.0
+        );
+    }
+
+    wxASSERT_MSG(cairo_pattern_status(m_pattern) == CAIRO_STATUS_SUCCESS,
+                 wxT("Couldn't create cairo pattern"));
+}
+
+void
+wxCairoPenBrushBaseData::CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
+                                            wxDouble x2, wxDouble y2,
+                                            const wxGraphicsGradientStops& stops)
+{
+    m_pattern = cairo_pattern_create_linear(x1,y1,x2,y2);
+
+    AddGradientStops(stops);
+}
+
+void
+wxCairoPenBrushBaseData::CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
+                                            wxDouble xc, wxDouble yc,
+                                            wxDouble radius,
+                                            const wxGraphicsGradientStops& stops)
+{
+    m_pattern = cairo_pattern_create_radial(xo,yo,0.0,xc,yc,radius);
+
+    AddGradientStops(stops);
+}
+
 //-----------------------------------------------------------------------------
 // wxCairoPenData implementation
 //-----------------------------------------------------------------------------
@@ -923,52 +969,6 @@ wxCairoBrushData::wxCairoBrushData( wxGraphicsRenderer* renderer,
                 InitHatch(static_cast<wxHatchStyle>(brush.GetStyle()));
             break;
     }
-}
-
-void wxCairoPenBrushBaseData::AddGradientStops(const wxGraphicsGradientStops& stops)
-{
-    // loop over all the stops, they include the beginning and ending ones
-    const unsigned numStops = stops.GetCount();
-    for ( unsigned n = 0; n < numStops; n++ )
-    {
-        const wxGraphicsGradientStop stop = stops.Item(n);
-
-        const wxColour col = stop.GetColour();
-
-        cairo_pattern_add_color_stop_rgba
-        (
-            m_pattern,
-            stop.GetPosition(),
-            col.Red()/255.0,
-            col.Green()/255.0,
-            col.Blue()/255.0,
-            col.Alpha()/255.0
-        );
-    }
-
-    wxASSERT_MSG(cairo_pattern_status(m_pattern) == CAIRO_STATUS_SUCCESS,
-                 wxT("Couldn't create cairo pattern"));
-}
-
-void
-wxCairoPenBrushBaseData::CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
-                                            wxDouble x2, wxDouble y2,
-                                            const wxGraphicsGradientStops& stops)
-{
-    m_pattern = cairo_pattern_create_linear(x1,y1,x2,y2);
-
-    AddGradientStops(stops);
-}
-
-void
-wxCairoPenBrushBaseData::CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
-                                            wxDouble xc, wxDouble yc,
-                                            wxDouble radius,
-                                            const wxGraphicsGradientStops& stops)
-{
-    m_pattern = cairo_pattern_create_radial(xo,yo,0.0,xc,yc,radius);
-
-    AddGradientStops(stops);
 }
 
 void wxCairoBrushData::Init()

--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -3201,7 +3201,7 @@ wxCairoRenderer::CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
 }
 
 wxGraphicsBrush
-wxCairoRenderer::CreateRadialGradientBrush(wxDouble startX, wxDouble startX,
+wxCairoRenderer::CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
                                            wxDouble endX, wxDouble endY, wxDouble r,
                                            const wxGraphicsGradientStops& stops,
                                            const wxGraphicsMatrix& matrix)

--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -263,11 +263,11 @@ public:
     void CreateLinearGradientPattern(wxDouble x1, wxDouble y1,
                                      wxDouble x2, wxDouble y2,
                                      const wxGraphicsGradientStops& stops,
-                                     const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
+                                     const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix);
     void CreateRadialGradientPattern(wxDouble startX, wxDouble startY,
                                      wxDouble endX, wxDouble endY, wxDouble radius,
                                      const wxGraphicsGradientStops& stops,
-                                     const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
+                                     const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix);
 
 protected:
     // Call this to use the given bitmap as stipple. Bitmap must be non-null
@@ -755,7 +755,7 @@ wxCairoPenBrushBaseData::CreateLinearGradientPattern(wxDouble x1, wxDouble y1,
 {
     m_pattern = cairo_pattern_create_linear(x1,y1,x2,y2);
 
-    if (! matrix.IsNull())
+    if ( !matrix.IsNull() )
     {
         cairo_matrix_t m = *((cairo_matrix_t*) matrix.GetNativeMatrix());
         cairo_pattern_set_matrix(m_pattern, &m);
@@ -773,7 +773,7 @@ wxCairoPenBrushBaseData::CreateRadialGradientPattern(wxDouble startX, wxDouble s
 {
     m_pattern = cairo_pattern_create_radial(startX,startY,0.0,endX,endY,radius);
 
-    if (! matrix.IsNull())
+    if ( !matrix.IsNull() )
     {
         cairo_matrix_t m = *((cairo_matrix_t*) matrix.GetNativeMatrix());
         cairo_pattern_set_matrix(m_pattern, &m);
@@ -2994,14 +2994,14 @@ public :
     CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
                               wxDouble x2, wxDouble y2,
                               const wxGraphicsGradientStops& stops,
-                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
+                              const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix) wxOVERRIDE;
 
     virtual wxGraphicsBrush
     CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
                               wxDouble endX, wxDouble endY,
                               wxDouble radius,
                               const wxGraphicsGradientStops& stops,
-                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
+                              const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix) wxOVERRIDE;
 
     // sets the font
     virtual wxGraphicsFont CreateFont( const wxFont &font , const wxColour &col = *wxBLACK ) wxOVERRIDE ;

--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -264,8 +264,8 @@ public:
                                      wxDouble x2, wxDouble y2,
                                      const wxGraphicsGradientStops& stops,
                                      const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
-    void CreateRadialGradientPattern(wxDouble xo, wxDouble yo,
-                                     wxDouble xc, wxDouble yc, wxDouble radius,
+    void CreateRadialGradientPattern(wxDouble startX, wxDouble startY,
+                                     wxDouble endX, wxDouble endY, wxDouble radius,
                                      const wxGraphicsGradientStops& stops,
                                      const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
 
@@ -765,13 +765,13 @@ wxCairoPenBrushBaseData::CreateLinearGradientPattern(wxDouble x1, wxDouble y1,
 }
 
 void
-wxCairoPenBrushBaseData::CreateRadialGradientPattern(wxDouble xo, wxDouble yo,
-                                                     wxDouble xc, wxDouble yc,
+wxCairoPenBrushBaseData::CreateRadialGradientPattern(wxDouble startX, wxDouble startY,
+                                                     wxDouble endX, wxDouble endY,
                                                      wxDouble radius,
                                                      const wxGraphicsGradientStops& stops,
                                                      const wxGraphicsMatrix& matrix)
 {
-    m_pattern = cairo_pattern_create_radial(xo,yo,0.0,xc,yc,radius);
+    m_pattern = cairo_pattern_create_radial(startX,startY,0.0,endX,endY,radius);
 
     if (! matrix.IsNull())
     {
@@ -2997,8 +2997,8 @@ public :
                               const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
 
     virtual wxGraphicsBrush
-    CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
-                              wxDouble xc, wxDouble yc,
+    CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
+                              wxDouble endX, wxDouble endY,
                               wxDouble radius,
                               const wxGraphicsGradientStops& stops,
                               const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
@@ -3201,15 +3201,15 @@ wxCairoRenderer::CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
 }
 
 wxGraphicsBrush
-wxCairoRenderer::CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
-                                           wxDouble xc, wxDouble yc, wxDouble r,
+wxCairoRenderer::CreateRadialGradientBrush(wxDouble startX, wxDouble startX,
+                                           wxDouble endX, wxDouble endY, wxDouble r,
                                            const wxGraphicsGradientStops& stops,
                                            const wxGraphicsMatrix& matrix)
 {
     wxGraphicsBrush p;
     ENSURE_LOADED_OR_RETURN(p);
     wxCairoBrushData* d = new wxCairoBrushData( this );
-    d->CreateRadialGradientPattern(xo, yo, xc, yc, r, stops, matrix);
+    d->CreateRadialGradientPattern(startX, startY, endX, endY, r, stops, matrix);
     p.SetRefData(d);
     return p;
 }

--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -943,8 +943,8 @@ wxCairoPenData::wxCairoPenData( wxGraphicsRenderer* renderer, const wxGraphicsPe
         break;
 
     case wxGRADIENT_RADIAL:
-        CreateRadialGradientPattern(info.GetXO(), info.GetYO(),
-                                    info.GetXC(), info.GetYC(),
+        CreateRadialGradientPattern(info.GetStartX(), info.GetStartY(),
+                                    info.GetEndX(), info.GetEndY(),
                                     info.GetRadius(),
                                     info.GetStops(),
                                     info.GetMatrix());

--- a/src/msw/graphics.cpp
+++ b/src/msw/graphics.cpp
@@ -752,7 +752,7 @@ wxGDIPlusPenBrushBaseData::CreateLinearGradientBrush(
     wxDouble x1, wxDouble y1,
     wxDouble x2, wxDouble y2,
     const wxGraphicsGradientStops& stops,
-    const wxGraphicsMatrix& WXUNUSED(matrix))
+    const wxGraphicsMatrix& matrix)
 {
     LinearGradientBrush * const
         brush = new LinearGradientBrush(PointF(x1, y1) , PointF(x2, y2),
@@ -762,14 +762,13 @@ wxGDIPlusPenBrushBaseData::CreateLinearGradientBrush(
     // Tell the brush how to draw what's beyond the ends of the gradient
     brush->SetWrapMode(WrapModeTileFlipXY);
 
-    // Apply the matrix
-    // This doesn't work as I expected it to. Comment-out for now...
-    // FIXME
-    // if (! matrix.IsNull())
-    // {
-    //     const Matrix* m = static_cast<const Matrix*>(matrix.GetNativeMatrix());
-    //     brush->SetTransform(m);
-    // }
+    // Apply the matrix if there is one
+    if (! matrix.IsNull())
+    {
+        Matrix* m = static_cast<Matrix*>(matrix.GetNativeMatrix());
+        m->Invert();
+        brush->MultiplyTransform(m);
+    }
 
     SetGradientStops(brush, stops);
     m_brush = brush;    
@@ -781,7 +780,7 @@ wxGDIPlusPenBrushBaseData::CreateRadialGradientBrush(
     wxDouble xc, wxDouble yc,
     wxDouble radius,
     const wxGraphicsGradientStops& stops,
-    const wxGraphicsMatrix& WXUNUSED(matrix))
+    const wxGraphicsMatrix& matrix)
 {
     m_brushPath = new GraphicsPath();
     m_brushPath->AddEllipse( (REAL)(xc-radius), (REAL)(yc-radius),
@@ -795,14 +794,16 @@ wxGDIPlusPenBrushBaseData::CreateRadialGradientBrush(
     int count = 1;
     brush->SetSurroundColors(&col, &count);
 
-    // Apply the matrix
-    // This doesn't work as I expected it to. Comment-out for now...
-    // FIXME
-    // if (! matrix.IsNull())
-    // {
-    //     const Matrix* m = static_cast<const Matrix*>(matrix.GetNativeMatrix());
-    //     brush->SetTransform(m);
-    // }
+    // TODO: There doesn't seem to be an equivallent for SetWrapMode, so
+    // the area outside of the gradient's radius is not getting painted. 
+
+    // Apply the matrix if there is one
+    if (! matrix.IsNull())
+    {
+        Matrix* m = static_cast<Matrix*>(matrix.GetNativeMatrix());
+        m->Invert();
+        brush->SetTransform(m);
+    }
 
     // Because the GDI+ API draws radial gradients from outside towards the
     // center we have to reverse the order of the gradient stops.

--- a/src/msw/graphics.cpp
+++ b/src/msw/graphics.cpp
@@ -974,6 +974,7 @@ wxGDIPlusBrushData::CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
         brush = new LinearGradientBrush(PointF(x1, y1) , PointF(x2, y2),
                                         wxColourToColor(stops.GetStartColour()),
                                         wxColourToColor(stops.GetEndColour()));
+    brush->SetWrapMode(WrapModeTileFlipXY);
     m_brush =  brush;
 
     SetGradientStops(brush, stops);

--- a/src/msw/graphics.cpp
+++ b/src/msw/graphics.cpp
@@ -996,8 +996,8 @@ wxGDIPlusPenData::wxGDIPlusPenData( wxGraphicsRenderer* renderer,
     case wxGRADIENT_RADIAL:
         if (m_brush)
             delete m_brush;
-        CreateRadialGradientBrush(info.GetXO(), info.GetYO(),
-                                  info.GetXC(), info.GetYC(),
+        CreateRadialGradientBrush(info.GetStartX(), info.GetStartY(),
+                                  info.GetEndX(), info.GetEndY(),
                                   info.GetRadius(),
                                   info.GetStops());
         m_pen->SetBrush(m_brush);

--- a/src/msw/graphics.cpp
+++ b/src/msw/graphics.cpp
@@ -261,20 +261,21 @@ class wxGDIPlusPenBrushBaseData : public wxGraphicsObjectRefData
 {
 public:
     wxGDIPlusPenBrushBaseData(wxGraphicsRenderer* renderer);
-    ~wxGDIPlusPenBrushBaseData();
 
-    virtual void Init();
+    virtual void Init() wxOVERRIDE;
 
     void CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
                                    wxDouble x2, wxDouble y2,
                                    const wxGraphicsGradientStops& stops,
-                                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
+                                   const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix);
     void CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
                                    wxDouble endX, wxDouble endY,
                                    wxDouble radius,
                                    const wxGraphicsGradientStops& stops,
-                                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
+                                   const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix);
 protected:
+    virtual ~wxGDIPlusPenBrushBaseData();
+
     Brush* m_brush;
     GraphicsPath* m_brushPath;
     Image* m_image;
@@ -636,14 +637,14 @@ public :
     CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
                               wxDouble x2, wxDouble y2,
                               const wxGraphicsGradientStops& stops,
-                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
+                              const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix) wxOVERRIDE;
 
     virtual wxGraphicsBrush
     CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
                               wxDouble endX, wxDouble endY,
                               wxDouble radius,
                               const wxGraphicsGradientStops& stops,
-                              const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
+                              const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix) wxOVERRIDE;
 
     // create a native bitmap representation
     virtual wxGraphicsBitmap CreateBitmap( const wxBitmap &bitmap ) wxOVERRIDE;
@@ -763,7 +764,7 @@ wxGDIPlusPenBrushBaseData::CreateLinearGradientBrush(
     brush->SetWrapMode(WrapModeTileFlipXY);
 
     // Apply the matrix if there is one
-    if (! matrix.IsNull())
+    if ( !matrix.IsNull() )
     {
         Matrix* m = static_cast<Matrix*>(matrix.GetNativeMatrix());
         m->Invert();
@@ -798,7 +799,7 @@ wxGDIPlusPenBrushBaseData::CreateRadialGradientBrush(
     // the area outside of the gradient's radius is not getting painted. 
 
     // Apply the matrix if there is one
-    if (! matrix.IsNull())
+    if ( !matrix.IsNull() )
     {
         Matrix* m = static_cast<Matrix*>(matrix.GetNativeMatrix());
         m->Invert();

--- a/src/msw/graphics.cpp
+++ b/src/msw/graphics.cpp
@@ -296,7 +296,7 @@ public:
     wxGDIPlusPenData( wxGraphicsRenderer* renderer, const wxGraphicsPenInfo &info );
     ~wxGDIPlusPenData();
 
-    virtual void Init();
+    virtual void Init() wxOVERRIDE;
 
     virtual wxDouble GetWidth() { return m_width; }
     virtual Pen* GetGDIPlusPen() { return m_pen; }

--- a/src/msw/graphics.cpp
+++ b/src/msw/graphics.cpp
@@ -269,8 +269,8 @@ public:
                                    wxDouble x2, wxDouble y2,
                                    const wxGraphicsGradientStops& stops,
                                    const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
-    void CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
-                                   wxDouble xc, wxDouble yc,
+    void CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
+                                   wxDouble endX, wxDouble endY,
                                    wxDouble radius,
                                    const wxGraphicsGradientStops& stops,
                                    const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
@@ -639,8 +639,8 @@ public :
                               const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
 
     virtual wxGraphicsBrush
-    CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
-                              wxDouble xc, wxDouble yc,
+    CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
+                              wxDouble endX, wxDouble endY,
                               wxDouble radius,
                               const wxGraphicsGradientStops& stops,
                               const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
@@ -776,18 +776,18 @@ wxGDIPlusPenBrushBaseData::CreateLinearGradientBrush(
 
 void
 wxGDIPlusPenBrushBaseData::CreateRadialGradientBrush(
-    wxDouble xo, wxDouble yo,
-    wxDouble xc, wxDouble yc,
+    wxDouble startX, wxDouble startY,
+    wxDouble endX, wxDouble endY,
     wxDouble radius,
     const wxGraphicsGradientStops& stops,
     const wxGraphicsMatrix& matrix)
 {
     m_brushPath = new GraphicsPath();
-    m_brushPath->AddEllipse( (REAL)(xc-radius), (REAL)(yc-radius),
+    m_brushPath->AddEllipse( (REAL)(endX-radius), (REAL)(endY-radius),
                              (REAL)(2*radius), (REAL)(2*radius));
 
     PathGradientBrush * const brush = new PathGradientBrush(m_brushPath);
-    brush->SetCenterPoint(PointF(xo, yo));
+    brush->SetCenterPoint(PointF(startX, startY));
     brush->SetCenterColor(wxColourToColor(stops.GetStartColour()));
 
     const Color col(wxColourToColor(stops.GetEndColour()));
@@ -2701,8 +2701,8 @@ wxGDIPlusRenderer::CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
  }
 
 wxGraphicsBrush
-wxGDIPlusRenderer::CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
-                                             wxDouble xc, wxDouble yc,
+wxGDIPlusRenderer::CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
+                                             wxDouble endX, wxDouble endY,
                                              wxDouble radius,
                                              const wxGraphicsGradientStops& stops,
                                              const wxGraphicsMatrix& matrix)
@@ -2710,7 +2710,7 @@ wxGDIPlusRenderer::CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
     ENSURE_LOADED_OR_RETURN(wxNullGraphicsBrush);
     wxGraphicsBrush p;
     wxGDIPlusBrushData* d = new wxGDIPlusBrushData( this );
-    d->CreateRadialGradientBrush(xo,yo,xc,yc,radius,stops,matrix);
+    d->CreateRadialGradientBrush(startX,startY,endX,endY,radius,stops,matrix);
     p.SetRefData(d);
     return p;
 }

--- a/src/msw/graphics.cpp
+++ b/src/msw/graphics.cpp
@@ -262,7 +262,7 @@ class wxGDIPlusPenBrushBaseData : public wxGraphicsObjectRefData
 public:
     wxGDIPlusPenBrushBaseData(wxGraphicsRenderer* renderer);
 
-    virtual void Init() wxOVERRIDE;
+    virtual void Init();
 
     void CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
                                    wxDouble x2, wxDouble y2,

--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -2551,8 +2551,8 @@ public:
                                    const wxGraphicsGradientStops& stops,
                                    const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
 
-    void CreateRadialGradientBrush(wxDouble xo, wxDouble yo, 
-                                   wxDouble xc, wxDouble yc, 
+    void CreateRadialGradientBrush(wxDouble startX, wxDouble startY, 
+                                   wxDouble endX, wxDouble endY, 
                                    wxDouble radius, 
                                    const wxGraphicsGradientStops& stops,
                                    const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
@@ -2608,14 +2608,14 @@ void wxD2DBrushData::CreateLinearGradientBrush(
 }
 
 void wxD2DBrushData::CreateRadialGradientBrush(
-    wxDouble xo, wxDouble yo,
-    wxDouble xc, wxDouble yc,
+    wxDouble startX, wxDouble startY,
+    wxDouble endX, wxDouble endY,
     wxDouble radius,
     const wxGraphicsGradientStops& stops,
     const wxGraphicsMatrix& matrix)
 {
     m_brushResourceHolder = new wxD2DRadialGradientBrushResourceHolder(
-        xo, yo, xc, yc, radius, stops, matrix);
+        startX, startY, endX, endY, radius, stops, matrix);
 }
 
 wxD2DBrushData* wxGetD2DBrushData(const wxGraphicsBrush& brush)
@@ -4645,8 +4645,8 @@ public :
         const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
 
     wxGraphicsBrush CreateRadialGradientBrush(
-        wxDouble xo, wxDouble yo,
-        wxDouble xc, wxDouble yc,
+        wxDouble startX, wxDouble startY,
+        wxDouble endX, wxDouble endY,
         wxDouble radius,
         const wxGraphicsGradientStops& stops,
         const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
@@ -4847,14 +4847,14 @@ wxGraphicsBrush wxD2DRenderer::CreateLinearGradientBrush(
 }
 
 wxGraphicsBrush wxD2DRenderer::CreateRadialGradientBrush(
-    wxDouble xo, wxDouble yo,
-    wxDouble xc, wxDouble yc,
+    wxDouble startX, wxDouble startY,
+    wxDouble endX, wxDouble endY,
     wxDouble radius,
     const wxGraphicsGradientStops& stops,
     const wxGraphicsMatrix& matrix)
 {
     wxD2DBrushData* brushData = new wxD2DBrushData(this);
-    brushData->CreateRadialGradientBrush(xo, yo, xc, yc, radius, stops, matrix);
+    brushData->CreateRadialGradientBrush(startX, startY, endX, endY, radius, stops, matrix);
 
     wxGraphicsBrush brush;
     brush.SetRefData(brushData);

--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -2549,13 +2549,13 @@ public:
     void CreateLinearGradientBrush(wxDouble x1, wxDouble y1, 
                                    wxDouble x2, wxDouble y2, 
                                    const wxGraphicsGradientStops& stops,
-                                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
+                                   const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix);
 
     void CreateRadialGradientBrush(wxDouble startX, wxDouble startY, 
                                    wxDouble endX, wxDouble endY, 
                                    wxDouble radius, 
                                    const wxGraphicsGradientStops& stops,
-                                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
+                                   const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix);
 
     ID2D1Brush* GetBrush() const
     {
@@ -4642,14 +4642,14 @@ public :
         wxDouble x1, wxDouble y1,
         wxDouble x2, wxDouble y2,
         const wxGraphicsGradientStops& stops,
-        const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
+        const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix) wxOVERRIDE;
 
     wxGraphicsBrush CreateRadialGradientBrush(
         wxDouble startX, wxDouble startY,
         wxDouble endX, wxDouble endY,
         wxDouble radius,
         const wxGraphicsGradientStops& stops,
-        const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
+        const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix) wxOVERRIDE;
 
     // create a native bitmap representation
     wxGraphicsBitmap CreateBitmap(const wxBitmap& bitmap) wxOVERRIDE;

--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -2510,7 +2510,6 @@ protected:
         wxD2DGradientStopsHelper helper(m_radialGradientInfo.stops, GetContext());
         ID2D1RadialGradientBrush *radialGradientBrush;
 
-        // TODO: double check this. The other backends just use the passed in values for xo, yo
         wxDouble xo = m_radialGradientInfo.x1 - m_radialGradientInfo.x2;
         wxDouble yo = m_radialGradientInfo.y1 - m_radialGradientInfo.y2;
 

--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -2445,14 +2445,23 @@ protected:
     void DoAcquireResource() wxOVERRIDE
     {
         wxD2DGradientStopsHelper helper(m_linearGradientInfo.stops, GetContext());
+        ID2D1LinearGradientBrush  *linearGradientBrush;
 
         HRESULT hr = GetContext()->CreateLinearGradientBrush(
             D2D1::LinearGradientBrushProperties(
-            D2D1::Point2F(m_linearGradientInfo.direction.GetX(), m_linearGradientInfo.direction.GetY()),
-            D2D1::Point2F(m_linearGradientInfo.direction.GetWidth(), m_linearGradientInfo.direction.GetHeight())),
+                D2D1::Point2F(m_linearGradientInfo.direction.GetX(), m_linearGradientInfo.direction.GetY()),
+                D2D1::Point2F(m_linearGradientInfo.direction.GetWidth(), m_linearGradientInfo.direction.GetHeight())),
             helper.GetGradientStopCollection(),
-            &m_nativeResource);
+            &linearGradientBrush);
         wxCHECK_HRESULT_RET(hr);
+
+        if (! m_linearGradientInfo.matrix.IsNull())
+        {
+            D2D1::Matrix3x2F matrix = wxGetD2DMatrixData(m_linearGradientInfo.matrix)->GetMatrix3x2F();
+            matrix.Invert();
+            linearGradientBrush->SetTransform(matrix);
+        }
+        m_nativeResource = linearGradientBrush;
     }
 private:
     const LinearGradientInfo m_linearGradientInfo;
@@ -2486,18 +2495,27 @@ protected:
     void DoAcquireResource() wxOVERRIDE
     {
         wxD2DGradientStopsHelper helper(m_radialGradientInfo.stops, GetContext());
+        ID2D1RadialGradientBrush *radialGradientBrush;
 
         int xo = m_radialGradientInfo.direction.GetLeft() - m_radialGradientInfo.direction.GetWidth();
         int yo = m_radialGradientInfo.direction.GetTop() - m_radialGradientInfo.direction.GetHeight();
 
         HRESULT hr = GetContext()->CreateRadialGradientBrush(
             D2D1::RadialGradientBrushProperties(
-            D2D1::Point2F(m_radialGradientInfo.direction.GetLeft(), m_radialGradientInfo.direction.GetTop()),
-            D2D1::Point2F(xo, yo),
-            m_radialGradientInfo.radius, m_radialGradientInfo.radius),
+                D2D1::Point2F(m_radialGradientInfo.direction.GetLeft(), m_radialGradientInfo.direction.GetTop()),
+                D2D1::Point2F(xo, yo),
+                m_radialGradientInfo.radius, m_radialGradientInfo.radius),
             helper.GetGradientStopCollection(),
-            &m_nativeResource);
+            &radialGradientBrush);
         wxCHECK_HRESULT_RET(hr);
+
+        if (! m_radialGradientInfo.matrix.IsNull())
+        {
+            D2D1::Matrix3x2F matrix = wxGetD2DMatrixData(m_radialGradientInfo.matrix)->GetMatrix3x2F();
+            matrix.Invert();
+            radialGradientBrush->SetTransform(matrix);
+        }
+        m_nativeResource = radialGradientBrush;
     }
 
 private:

--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -2741,8 +2741,8 @@ wxD2DPenData::wxD2DPenData(
     case wxGRADIENT_RADIAL:
         m_stippleBrush = new wxD2DBrushData(renderer);
         m_stippleBrush->CreateRadialGradientBrush(
-                                m_penInfo.GetXO(), m_penInfo.GetYO(),
-                                m_penInfo.GetXC(), m_penInfo.GetYC(),
+                                m_penInfo.GetStartX(), m_penInfo.GetStartY(),
+                                m_penInfo.GetEndX(), m_penInfo.GetEndY(),
                                 m_penInfo.GetRadius(),
                                 m_penInfo.GetStops(),
                                 m_penInfo.GetMatrix());

--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -2425,14 +2425,17 @@ class wxD2DLinearGradientBrushResourceHolder : public wxD2DResourceHolder<ID2D1L
 {
 public:
     struct LinearGradientInfo {
-        const wxRect direction;
+        const wxDouble x1;
+        const wxDouble y1;
+        const wxDouble x2;
+        const wxDouble y2;
         const wxGraphicsGradientStops stops;
         const wxGraphicsMatrix matrix;
-        LinearGradientInfo(wxDouble& x1, wxDouble& y1, 
-                           wxDouble& x2, wxDouble& y2, 
+        LinearGradientInfo(wxDouble& x1_, wxDouble& y1_, 
+                           wxDouble& x2_, wxDouble& y2_, 
                            const wxGraphicsGradientStops& stops_,
                            const wxGraphicsMatrix& matrix_)
-            : direction(x1, y1, x2, y2), stops(stops_), matrix(matrix_) {}
+            : x1(x1_), y1(y1_), x2(x2_), y2(y2_), stops(stops_), matrix(matrix_) {}
     };
 
     wxD2DLinearGradientBrushResourceHolder(wxDouble& x1, wxDouble& y1, 
@@ -2449,8 +2452,8 @@ protected:
 
         HRESULT hr = GetContext()->CreateLinearGradientBrush(
             D2D1::LinearGradientBrushProperties(
-                D2D1::Point2F(m_linearGradientInfo.direction.GetX(), m_linearGradientInfo.direction.GetY()),
-                D2D1::Point2F(m_linearGradientInfo.direction.GetWidth(), m_linearGradientInfo.direction.GetHeight())),
+                D2D1::Point2F(m_linearGradientInfo.x1, m_linearGradientInfo.y1),
+                D2D1::Point2F(m_linearGradientInfo.x2, m_linearGradientInfo.y2)),
             helper.GetGradientStopCollection(),
             &linearGradientBrush);
         wxCHECK_HRESULT_RET(hr);
@@ -2471,17 +2474,20 @@ class wxD2DRadialGradientBrushResourceHolder : public wxD2DResourceHolder<ID2D1R
 {
 public:
     struct RadialGradientInfo {
-        const wxRect direction;
+        const wxDouble x1;
+        const wxDouble y1;
+        const wxDouble x2;
+        const wxDouble y2;
         const wxDouble radius;
         const wxGraphicsGradientStops stops;
         const wxGraphicsMatrix matrix;
 
-        RadialGradientInfo(wxDouble x1, wxDouble y1, 
-                           wxDouble x2, wxDouble y2, 
+        RadialGradientInfo(wxDouble x1_, wxDouble y1_, 
+                           wxDouble x2_, wxDouble y2_, 
                            wxDouble r, 
                            const wxGraphicsGradientStops& stops_,
                            const wxGraphicsMatrix& matrix_)
-            : direction(x1, y1, x2, y2), radius(r), stops(stops_), matrix(matrix_) {}
+            : x1(x1_), y1(y1_), x2(x2_), y2(y2_), radius(r), stops(stops_), matrix(matrix_) {}
     };
 
     wxD2DRadialGradientBrushResourceHolder(wxDouble& x1, wxDouble& y1, 
@@ -2497,12 +2503,13 @@ protected:
         wxD2DGradientStopsHelper helper(m_radialGradientInfo.stops, GetContext());
         ID2D1RadialGradientBrush *radialGradientBrush;
 
-        int xo = m_radialGradientInfo.direction.GetLeft() - m_radialGradientInfo.direction.GetWidth();
-        int yo = m_radialGradientInfo.direction.GetTop() - m_radialGradientInfo.direction.GetHeight();
+        // TODO: double check this. The other backends just use the passed in values for xo, yo
+        wxDouble xo = m_radialGradientInfo.x1 - m_radialGradientInfo.x2;
+        wxDouble yo = m_radialGradientInfo.y1 - m_radialGradientInfo.y2;
 
         HRESULT hr = GetContext()->CreateRadialGradientBrush(
             D2D1::RadialGradientBrushProperties(
-                D2D1::Point2F(m_radialGradientInfo.direction.GetLeft(), m_radialGradientInfo.direction.GetTop()),
+                D2D1::Point2F(m_radialGradientInfo.x1, m_radialGradientInfo.y1),
                 D2D1::Point2F(xo, yo),
                 m_radialGradientInfo.radius, m_radialGradientInfo.radius),
             helper.GetGradientStopCollection(),

--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -2427,12 +2427,19 @@ public:
     struct LinearGradientInfo {
         const wxRect direction;
         const wxGraphicsGradientStops stops;
-        LinearGradientInfo(wxDouble& x1, wxDouble& y1, wxDouble& x2, wxDouble& y2, const wxGraphicsGradientStops& stops_)
-            : direction(x1, y1, x2, y2), stops(stops_) {}
+        const wxGraphicsMatrix matrix;
+        LinearGradientInfo(wxDouble& x1, wxDouble& y1, 
+                           wxDouble& x2, wxDouble& y2, 
+                           const wxGraphicsGradientStops& stops_,
+                           const wxGraphicsMatrix& matrix_)
+            : direction(x1, y1, x2, y2), stops(stops_), matrix(matrix_) {}
     };
 
-    wxD2DLinearGradientBrushResourceHolder(wxDouble& x1, wxDouble& y1, wxDouble& x2, wxDouble& y2, const wxGraphicsGradientStops& stops)
-        : m_linearGradientInfo(x1, y1, x2, y2, stops) {}
+    wxD2DLinearGradientBrushResourceHolder(wxDouble& x1, wxDouble& y1, 
+                                           wxDouble& x2, wxDouble& y2, 
+                                           const wxGraphicsGradientStops& stops,
+                                           const wxGraphicsMatrix& matrix)
+        : m_linearGradientInfo(x1, y1, x2, y2, stops, matrix) {}
 
 protected:
     void DoAcquireResource() wxOVERRIDE
@@ -2458,13 +2465,22 @@ public:
         const wxRect direction;
         const wxDouble radius;
         const wxGraphicsGradientStops stops;
+        const wxGraphicsMatrix matrix;
 
-        RadialGradientInfo(wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2, wxDouble r, const wxGraphicsGradientStops& stops_)
-            : direction(x1, y1, x2, y2), radius(r), stops(stops_) {}
+        RadialGradientInfo(wxDouble x1, wxDouble y1, 
+                           wxDouble x2, wxDouble y2, 
+                           wxDouble r, 
+                           const wxGraphicsGradientStops& stops_,
+                           const wxGraphicsMatrix& matrix_)
+            : direction(x1, y1, x2, y2), radius(r), stops(stops_), matrix(matrix_) {}
     };
 
-    wxD2DRadialGradientBrushResourceHolder(wxDouble& x1, wxDouble& y1, wxDouble& x2, wxDouble& y2, wxDouble& r, const wxGraphicsGradientStops& stops)
-        : m_radialGradientInfo(x1, y1, x2, y2, r, stops) {}
+    wxD2DRadialGradientBrushResourceHolder(wxDouble& x1, wxDouble& y1, 
+                                           wxDouble& x2, wxDouble& y2, 
+                                           wxDouble& r, 
+                                           const wxGraphicsGradientStops& stops,
+                                           const wxGraphicsMatrix& matrix)
+        : m_radialGradientInfo(x1, y1, x2, y2, r, stops, matrix) {}
 
 protected:
     void DoAcquireResource() wxOVERRIDE
@@ -2499,9 +2515,16 @@ public:
 
     wxD2DBrushData(wxGraphicsRenderer* renderer);
 
-    void CreateLinearGradientBrush(wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2, const wxGraphicsGradientStops& stops);
+    void CreateLinearGradientBrush(wxDouble x1, wxDouble y1, 
+                                   wxDouble x2, wxDouble y2, 
+                                   const wxGraphicsGradientStops& stops,
+                                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
 
-    void CreateRadialGradientBrush(wxDouble xo, wxDouble yo, wxDouble xc, wxDouble yc, wxDouble radius, const wxGraphicsGradientStops& stops);
+    void CreateRadialGradientBrush(wxDouble xo, wxDouble yo, 
+                                   wxDouble xc, wxDouble yc, 
+                                   wxDouble radius, 
+                                   const wxGraphicsGradientStops& stops,
+                                   const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix);
 
     ID2D1Brush* GetBrush() const
     {
@@ -2546,18 +2569,20 @@ wxD2DBrushData::wxD2DBrushData(wxGraphicsRenderer* renderer)
 void wxD2DBrushData::CreateLinearGradientBrush(
     wxDouble x1, wxDouble y1,
     wxDouble x2, wxDouble y2,
-    const wxGraphicsGradientStops& stops)
+    const wxGraphicsGradientStops& stops,
+    const wxGraphicsMatrix& matrix)
 {
-    m_brushResourceHolder = new wxD2DLinearGradientBrushResourceHolder(x1, y1, x2, y2, stops);
+    m_brushResourceHolder = new wxD2DLinearGradientBrushResourceHolder(x1, y1, x2, y2, stops, matrix);
 }
 
 void wxD2DBrushData::CreateRadialGradientBrush(
     wxDouble xo, wxDouble yo,
     wxDouble xc, wxDouble yc,
     wxDouble radius,
-    const wxGraphicsGradientStops& stops)
+    const wxGraphicsGradientStops& stops,
+    const wxGraphicsMatrix& matrix)
 {
-    m_brushResourceHolder = new wxD2DRadialGradientBrushResourceHolder(xo, yo, xc, yc, radius, stops);
+    m_brushResourceHolder = new wxD2DRadialGradientBrushResourceHolder(xo, yo, xc, yc, radius, stops, matrix);
 }
 
 wxD2DBrushData* wxGetD2DBrushData(const wxGraphicsBrush& brush)
@@ -4558,13 +4583,15 @@ public :
     wxGraphicsBrush CreateLinearGradientBrush(
         wxDouble x1, wxDouble y1,
         wxDouble x2, wxDouble y2,
-        const wxGraphicsGradientStops& stops) wxOVERRIDE;
+        const wxGraphicsGradientStops& stops,
+        const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
 
     wxGraphicsBrush CreateRadialGradientBrush(
         wxDouble xo, wxDouble yo,
         wxDouble xc, wxDouble yc,
         wxDouble radius,
-        const wxGraphicsGradientStops& stops) wxOVERRIDE;
+        const wxGraphicsGradientStops& stops,
+        const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
 
     // create a native bitmap representation
     wxGraphicsBitmap CreateBitmap(const wxBitmap& bitmap) wxOVERRIDE;
@@ -4749,10 +4776,11 @@ wxGraphicsBrush wxD2DRenderer::CreateBrush(const wxBrush& brush)
 wxGraphicsBrush wxD2DRenderer::CreateLinearGradientBrush(
     wxDouble x1, wxDouble y1,
     wxDouble x2, wxDouble y2,
-    const wxGraphicsGradientStops& stops)
+    const wxGraphicsGradientStops& stops,
+    const wxGraphicsMatrix& matrix)
 {
     wxD2DBrushData* brushData = new wxD2DBrushData(this);
-    brushData->CreateLinearGradientBrush(x1, y1, x2, y2, stops);
+    brushData->CreateLinearGradientBrush(x1, y1, x2, y2, stops, matrix);
 
     wxGraphicsBrush brush;
     brush.SetRefData(brushData);
@@ -4764,10 +4792,11 @@ wxGraphicsBrush wxD2DRenderer::CreateRadialGradientBrush(
     wxDouble xo, wxDouble yo,
     wxDouble xc, wxDouble yc,
     wxDouble radius,
-    const wxGraphicsGradientStops& stops)
+    const wxGraphicsGradientStops& stops,
+    const wxGraphicsMatrix& matrix)
 {
     wxD2DBrushData* brushData = new wxD2DBrushData(this);
-    brushData->CreateRadialGradientBrush(xo, yo, xc, yc, radius, stops);
+    brushData->CreateRadialGradientBrush(xo, yo, xc, yc, radius, stops, matrix);
 
     wxGraphicsBrush brush;
     brush.SetRefData(brushData);

--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -2572,7 +2572,8 @@ void wxD2DBrushData::CreateLinearGradientBrush(
     const wxGraphicsGradientStops& stops,
     const wxGraphicsMatrix& matrix)
 {
-    m_brushResourceHolder = new wxD2DLinearGradientBrushResourceHolder(x1, y1, x2, y2, stops, matrix);
+    m_brushResourceHolder = new wxD2DLinearGradientBrushResourceHolder(
+        x1, y1, x2, y2, stops, matrix);
 }
 
 void wxD2DBrushData::CreateRadialGradientBrush(
@@ -2582,7 +2583,8 @@ void wxD2DBrushData::CreateRadialGradientBrush(
     const wxGraphicsGradientStops& stops,
     const wxGraphicsMatrix& matrix)
 {
-    m_brushResourceHolder = new wxD2DRadialGradientBrushResourceHolder(xo, yo, xc, yc, radius, stops, matrix);
+    m_brushResourceHolder = new wxD2DRadialGradientBrushResourceHolder(
+        xo, yo, xc, yc, radius, stops, matrix);
 }
 
 wxD2DBrushData* wxGetD2DBrushData(const wxGraphicsBrush& brush)
@@ -2690,8 +2692,33 @@ wxD2DPenData::wxD2DPenData(
         strokeBrush.SetStyle(wxBRUSHSTYLE_SOLID);
     }
 
-    m_stippleBrush = new wxD2DBrushData(renderer, strokeBrush);
+    switch ( m_penInfo.GetGradientType() )
+    {
+    case wxGRADIENT_NONE:
+        m_stippleBrush = new wxD2DBrushData(renderer, strokeBrush);
+        break;
+
+    case wxGRADIENT_LINEAR:
+        m_stippleBrush = new wxD2DBrushData(renderer);
+        m_stippleBrush->CreateLinearGradientBrush(
+                                m_penInfo.GetX1(), m_penInfo.GetY1(),
+                                m_penInfo.GetX2(), m_penInfo.GetY2(),
+                                m_penInfo.GetStops(),
+                                m_penInfo.GetMatrix());
+        break;
+
+    case wxGRADIENT_RADIAL:
+        m_stippleBrush = new wxD2DBrushData(renderer);
+        m_stippleBrush->CreateRadialGradientBrush(
+                                m_penInfo.GetXO(), m_penInfo.GetYO(),
+                                m_penInfo.GetXC(), m_penInfo.GetYC(),
+                                m_penInfo.GetRadius(),
+                                m_penInfo.GetStops(),
+                                m_penInfo.GetMatrix());
+        break;
+    }
 }
+
 
 void wxD2DPenData::CreateStrokeStyle(ID2D1Factory* const direct2dfactory)
 {

--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -1772,9 +1772,12 @@ void wxD2DPathData::AddPath(const wxGraphicsPathData* path)
     GeometryStateData curStateSrc;
     pathSrc->SaveGeometryState(curStateSrc);
 
+    // I think this assert is incorrect. We need to support paths where the end
+    // is not connected to the beginning. --Robin
     // Raise warning if appended path has an open non-empty sub-path.
-    wxASSERT_MSG( pathSrc->IsStateSafeForFlush(),
-        wxS("Sub-path in appended path should be closed prior to this operation") );
+    // wxASSERT_MSG( pathSrc->IsStateSafeForFlush(),
+    //     wxS("Sub-path in appended path should be closed prior to this operation") );
+
     // Close appended geometry.
     pathSrc->Flush();
 
@@ -1893,8 +1896,12 @@ void wxD2DPathData::Transform(const wxGraphicsMatrixData* matrix)
     // constraints this can be fully done only if open figure was empty.
     // So, Transform() can be safely called if path doesn't contain the open
     // sub-path or if open sub-path is empty.
-    wxASSERT_MSG( IsStateSafeForFlush(),
-            wxS("Consider closing sub-path before calling Transform()") );
+    
+    // I think this assert is incorrect. We need to support paths where the end
+    // is not connected to the beginning. --Robin
+    // wxASSERT_MSG( IsStateSafeForFlush(),
+    //         wxS("Consider closing sub-path before calling Transform()") );
+    
     // Close current geometry.
     Flush();
 

--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -1772,12 +1772,6 @@ void wxD2DPathData::AddPath(const wxGraphicsPathData* path)
     GeometryStateData curStateSrc;
     pathSrc->SaveGeometryState(curStateSrc);
 
-    // I think this assert is incorrect. We need to support paths where the end
-    // is not connected to the beginning. --Robin
-    // Raise warning if appended path has an open non-empty sub-path.
-    // wxASSERT_MSG( pathSrc->IsStateSafeForFlush(),
-    //     wxS("Sub-path in appended path should be closed prior to this operation") );
-
     // Close appended geometry.
     pathSrc->Flush();
 
@@ -1896,11 +1890,6 @@ void wxD2DPathData::Transform(const wxGraphicsMatrixData* matrix)
     // constraints this can be fully done only if open figure was empty.
     // So, Transform() can be safely called if path doesn't contain the open
     // sub-path or if open sub-path is empty.
-    
-    // I think this assert is incorrect. We need to support paths where the end
-    // is not connected to the beginning. --Robin
-    // wxASSERT_MSG( IsStateSafeForFlush(),
-    //         wxS("Consider closing sub-path before calling Transform()") );
     
     // Close current geometry.
     Flush();

--- a/src/osx/carbon/graphics.cpp
+++ b/src/osx/carbon/graphics.cpp
@@ -475,6 +475,7 @@ void * wxMacCoreGraphicsMatrixData::GetNativeMatrix() const
 }
 
 
+
 // ----------------------------------------------------------------------------
 // Pen and Brush common data. Base class for information shared between pens and
 // brushes, basically just the things needed for gradient support.
@@ -587,8 +588,11 @@ wxMacCoreGraphicsPenBrushDataBase::CreateLinearGradientShading(
                                       CGPointMake((CGFloat) x2, (CGFloat) y2), 
                                       m_gradientFunction, true, true );
     m_isShading = true;
-    m_shadingMatrix = (wxMacCoreGraphicsMatrixData*)((wxMacCoreGraphicsMatrixData*)matrix.GetRefData())->Clone();
-    m_shadingMatrix->Invert();
+    if (! matrix.IsNull() )
+    {
+        m_shadingMatrix = (wxMacCoreGraphicsMatrixData*)((wxMacCoreGraphicsMatrixData*)matrix.GetRefData())->Clone();
+        m_shadingMatrix->Invert();
+    }
 }
 
 void
@@ -605,8 +609,11 @@ wxMacCoreGraphicsPenBrushDataBase::CreateRadialGradientShading(
                                        CGPointMake((CGFloat) xc, (CGFloat) yc), (CGFloat) radius, 
                                        m_gradientFunction, true, true );
     m_isShading = true;
-    m_shadingMatrix = (wxMacCoreGraphicsMatrixData*)((wxMacCoreGraphicsMatrixData*)matrix.GetRefData())->Clone();
-    m_shadingMatrix->Invert();
+    if (! matrix.IsNull() )
+    {
+        m_shadingMatrix = (wxMacCoreGraphicsMatrixData*)((wxMacCoreGraphicsMatrixData*)matrix.GetRefData())->Clone();
+        m_shadingMatrix->Invert();
+    }
 }
 
 void wxMacCoreGraphicsPenBrushDataBase::CalculateShadingValues(void *info, const CGFloat *in, CGFloat *out)

--- a/src/osx/carbon/graphics.cpp
+++ b/src/osx/carbon/graphics.cpp
@@ -605,10 +605,12 @@ public:
     virtual void Apply( wxGraphicsContext* context );
     void CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
                                    wxDouble x2, wxDouble y2,
-                                   const wxGraphicsGradientStops& stops);
+                                   const wxGraphicsGradientStops& stops,
+                                   const wxGraphicsMatrix& matrix);
     void CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
                                    wxDouble xc, wxDouble yc, wxDouble radius,
-                                   const wxGraphicsGradientStops& stops);
+                                   const wxGraphicsGradientStops& stops,
+                                   const wxGraphicsMatrix& matrix);
 
     virtual bool IsShading() { return m_isShading; }
     CGShadingRef GetShading() { return m_shading; }
@@ -669,7 +671,8 @@ wxMacCoreGraphicsBrushData::wxMacCoreGraphicsBrushData( wxGraphicsRenderer* rend
 void
 wxMacCoreGraphicsBrushData::CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
                                                       wxDouble x2, wxDouble y2,
-                                                      const wxGraphicsGradientStops& stops)
+                                                      const wxGraphicsGradientStops& stops,
+                                                      const wxGraphicsMatrix& matrix)
 {
     m_gradientFunction = CreateGradientFunction(stops);
     m_shading = CGShadingCreateAxial( wxMacGetGenericRGBColorSpace(), CGPointMake((CGFloat) x1, (CGFloat) y1),
@@ -681,7 +684,8 @@ void
 wxMacCoreGraphicsBrushData::CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
                                                       wxDouble xc, wxDouble yc,
                                                       wxDouble radius,
-                                                      const wxGraphicsGradientStops& stops)
+                                                      const wxGraphicsGradientStops& stops,
+                                                      const wxGraphicsMatrix& matrix)
 {
     m_gradientFunction = CreateGradientFunction(stops);
     m_shading = CGShadingCreateRadial( wxMacGetGenericRGBColorSpace(), CGPointMake((CGFloat) xo,(CGFloat) yo), 0,
@@ -2667,13 +2671,15 @@ public :
     virtual wxGraphicsBrush
     CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
                               wxDouble x2, wxDouble y2,
-                              const wxGraphicsGradientStops& stops) wxOVERRIDE;
+                              const wxGraphicsGradientStops& stops,
+                              const wxGraphicsMatrix& matrix) wxOVERRIDE;
 
     virtual wxGraphicsBrush
     CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
                               wxDouble xc, wxDouble yc,
                               wxDouble radius,
-                              const wxGraphicsGradientStops& stops) wxOVERRIDE;
+                              const wxGraphicsGradientStops& stops,
+                              const wxGraphicsMatrix& matrix) wxOVERRIDE;
 
    // sets the font
     virtual wxGraphicsFont CreateFont( const wxFont &font , const wxColour &col = *wxBLACK ) wxOVERRIDE ;
@@ -2924,11 +2930,12 @@ void wxMacCoreGraphicsRenderer::GetVersion(int *major, int *minor, int *micro) c
 wxGraphicsBrush
 wxMacCoreGraphicsRenderer::CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
                                                      wxDouble x2, wxDouble y2,
-                                                     const wxGraphicsGradientStops& stops)
+                                                     const wxGraphicsGradientStops& stops,
+                                                     const wxGraphicsMatrix& matrix)
 {
     wxGraphicsBrush p;
     wxMacCoreGraphicsBrushData* d = new wxMacCoreGraphicsBrushData( this );
-    d->CreateLinearGradientBrush(x1, y1, x2, y2, stops);
+    d->CreateLinearGradientBrush(x1, y1, x2, y2, stops, matrix);
     p.SetRefData(d);
     return p;
 }
@@ -2937,11 +2944,12 @@ wxGraphicsBrush
 wxMacCoreGraphicsRenderer::CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
                                                      wxDouble xc, wxDouble yc,
                                                      wxDouble radius,
-                                                     const wxGraphicsGradientStops& stops)
+                                                     const wxGraphicsGradientStops& stops,
+                                                     const wxGraphicsMatrix& matrix)
 {
     wxGraphicsBrush p;
     wxMacCoreGraphicsBrushData* d = new wxMacCoreGraphicsBrushData( this );
-    d->CreateRadialGradientBrush(xo, yo, xc, yc, radius, stops);
+    d->CreateRadialGradientBrush(xo, yo, xc, yc, radius, stops, matrix);
     p.SetRefData(d);
     return p;
 }

--- a/src/osx/carbon/graphics.cpp
+++ b/src/osx/carbon/graphics.cpp
@@ -87,7 +87,7 @@ extern "C"
 const double M_PI = 3.14159265358979;
 #endif
 
-//
+//-----------------------------------------------------------------------------
 // Pen, Brushes and Fonts
 //
 
@@ -117,6 +117,7 @@ CGColorRef wxMacCreateCGColor( const wxColour& col )
     return retval;
 }
 
+//-----------------------------------------------------------------------------
 // CGPattern wrapper class: always allocate on heap, never call destructor
 
 class wxMacCoreGraphicsPattern
@@ -732,9 +733,8 @@ void wxMacCoreGraphicsPenData::Apply( wxGraphicsContext* context )
     }
 }
 
-//
-// Brush
-//
+//-----------------------------------------------------------------------------
+// Brush data and supporting colour class
 
 // make sure we all use one class for all conversions from wx to native colour
 
@@ -864,9 +864,8 @@ void wxMacCoreGraphicsBrushData::Apply( wxGraphicsContext* context )
 }
 
 
-//
-// Font
-//
+//-----------------------------------------------------------------------------
+// Font data
 
 class wxMacCoreGraphicsFontData : public wxGraphicsObjectRefData
 {
@@ -913,6 +912,9 @@ wxMacCoreGraphicsFontData::~wxMacCoreGraphicsFontData()
 {
 }
 
+//-----------------------------------------------------------------------------
+// Bitmap data
+
 class wxMacCoreGraphicsBitmapData : public wxGraphicsBitmapData
 {
 public:
@@ -946,13 +948,8 @@ wxMacCoreGraphicsBitmapData::~wxMacCoreGraphicsBitmapData()
 }
 
 
-//
-// Graphics Matrix
-//
-
 //-----------------------------------------------------------------------------
-// wxMacCoreGraphicsMatrix declaration
-//-----------------------------------------------------------------------------
+// Graphics Matrix data
 
 class WXDLLIMPEXP_CORE wxMacCoreGraphicsMatrixData : public wxGraphicsMatrixData
 {
@@ -1013,9 +1010,6 @@ private :
     CGAffineTransform m_matrix;
 } ;
 
-//-----------------------------------------------------------------------------
-// wxMacCoreGraphicsMatrix implementation
-//-----------------------------------------------------------------------------
 
 wxMacCoreGraphicsMatrixData::wxMacCoreGraphicsMatrixData(wxGraphicsRenderer* renderer) : wxGraphicsMatrixData(renderer)
 {
@@ -1125,13 +1119,8 @@ void * wxMacCoreGraphicsMatrixData::GetNativeMatrix() const
     return (void*) &m_matrix;
 }
 
-//
-// Graphics Path
-//
-
 //-----------------------------------------------------------------------------
-// wxMacCoreGraphicsPath declaration
-//-----------------------------------------------------------------------------
+// Graphics Path data
 
 class WXDLLEXPORT wxMacCoreGraphicsPathData : public wxGraphicsPathData
 {
@@ -1200,9 +1189,6 @@ private :
     CGMutablePathRef m_path;
 };
 
-//-----------------------------------------------------------------------------
-// wxMacCoreGraphicsPath implementation
-//-----------------------------------------------------------------------------
 
 wxMacCoreGraphicsPathData::wxMacCoreGraphicsPathData( wxGraphicsRenderer* renderer, CGMutablePathRef path) : wxGraphicsPathData(renderer)
 {
@@ -1359,13 +1345,9 @@ bool wxMacCoreGraphicsPathData::Contains( wxDouble x, wxDouble y, wxPolygonFillM
     return CGPathContainsPoint( m_path, NULL, CGPointMake((CGFloat) x,(CGFloat) y), fillStyle == wxODDEVEN_RULE );
 }
 
-//
-// Graphics Context
-//
 
 //-----------------------------------------------------------------------------
-// wxMacCoreGraphicsContext declaration
-//-----------------------------------------------------------------------------
+// Graphics Context
 
 class WXDLLEXPORT wxMacCoreGraphicsContext : public wxGraphicsContext
 {

--- a/src/osx/carbon/graphics.cpp
+++ b/src/osx/carbon/graphics.cpp
@@ -870,8 +870,8 @@ wxMacCoreGraphicsPenData::wxMacCoreGraphicsPenData( wxGraphicsRenderer* renderer
         break;
 
     case wxGRADIENT_RADIAL:
-        CreateRadialGradientShading(info.GetXO(), info.GetYO(),
-                                    info.GetXC(), info.GetYC(),
+        CreateRadialGradientShading(info.GetStartX(), info.GetStartY(),
+                                    info.GetEndX(), info.GetEndY(),
                                     info.GetRadius(),
                                     info.GetStops(),
                                     info.GetMatrix());

--- a/src/osx/carbon/graphics.cpp
+++ b/src/osx/carbon/graphics.cpp
@@ -490,8 +490,8 @@ public:
                                      wxDouble x2, wxDouble y2,
                                      const wxGraphicsGradientStops& stops,
                                      const wxGraphicsMatrix& matrix);
-    void CreateRadialGradientShading(wxDouble xo, wxDouble yo,
-                                     wxDouble xc, wxDouble yc, wxDouble radius,
+    void CreateRadialGradientShading(wxDouble startX, wxDouble startY,
+                                     wxDouble endX, wxDouble endY, wxDouble radius,
                                      const wxGraphicsGradientStops& stops,
                                      const wxGraphicsMatrix& matrix);
 
@@ -597,16 +597,16 @@ wxMacCoreGraphicsPenBrushDataBase::CreateLinearGradientShading(
 
 void
 wxMacCoreGraphicsPenBrushDataBase::CreateRadialGradientShading(
-        wxDouble xo, wxDouble yo,
-        wxDouble xc, wxDouble yc,
+        wxDouble startX, wxDouble startY,
+        wxDouble endX, wxDouble endY,
         wxDouble radius,
         const wxGraphicsGradientStops& stops,
         const wxGraphicsMatrix& matrix)
 {
     m_gradientFunction = CreateGradientFunction(stops);
     m_shading = CGShadingCreateRadial( wxMacGetGenericRGBColorSpace(), 
-                                       CGPointMake((CGFloat) xo, (CGFloat) yo), 0,
-                                       CGPointMake((CGFloat) xc, (CGFloat) yc), (CGFloat) radius, 
+                                       CGPointMake((CGFloat) startX, (CGFloat) startY), 0,
+                                       CGPointMake((CGFloat) endX, (CGFloat) endY), (CGFloat) radius, 
                                        m_gradientFunction, true, true );
     m_isShading = true;
     if (! matrix.IsNull() )
@@ -2766,8 +2766,8 @@ public :
                               const wxGraphicsMatrix& matrix) wxOVERRIDE;
 
     virtual wxGraphicsBrush
-    CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
-                              wxDouble xc, wxDouble yc,
+    CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
+                              wxDouble endX, wxDouble endY,
                               wxDouble radius,
                               const wxGraphicsGradientStops& stops,
                               const wxGraphicsMatrix& matrix) wxOVERRIDE;
@@ -3032,15 +3032,15 @@ wxMacCoreGraphicsRenderer::CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
 }
 
 wxGraphicsBrush
-wxMacCoreGraphicsRenderer::CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
-                                                     wxDouble xc, wxDouble yc,
+wxMacCoreGraphicsRenderer::CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
+                                                     wxDouble endX, wxDouble endY,
                                                      wxDouble radius,
                                                      const wxGraphicsGradientStops& stops,
                                                      const wxGraphicsMatrix& matrix)
 {
     wxGraphicsBrush p;
     wxMacCoreGraphicsBrushData* d = new wxMacCoreGraphicsBrushData( this );
-    d->CreateRadialGradientShading(xo, yo, xc, yc, radius, stops, matrix);
+    d->CreateRadialGradientShading(startX, startY, endX, endY, radius, stops, matrix);
     p.SetRefData(d);
     return p;
 }

--- a/src/osx/carbon/graphics.cpp
+++ b/src/osx/carbon/graphics.cpp
@@ -588,7 +588,7 @@ wxMacCoreGraphicsPenBrushDataBase::CreateLinearGradientShading(
                                       CGPointMake((CGFloat) x2, (CGFloat) y2), 
                                       m_gradientFunction, true, true );
     m_isShading = true;
-    if (! matrix.IsNull() )
+    if ( !matrix.IsNull() )
     {
         m_shadingMatrix = (wxMacCoreGraphicsMatrixData*)((wxMacCoreGraphicsMatrixData*)matrix.GetRefData())->Clone();
         m_shadingMatrix->Invert();
@@ -609,7 +609,7 @@ wxMacCoreGraphicsPenBrushDataBase::CreateRadialGradientShading(
                                        CGPointMake((CGFloat) endX, (CGFloat) endY), (CGFloat) radius, 
                                        m_gradientFunction, true, true );
     m_isShading = true;
-    if (! matrix.IsNull() )
+    if ( !matrix.IsNull() )
     {
         m_shadingMatrix = (wxMacCoreGraphicsMatrixData*)((wxMacCoreGraphicsMatrixData*)matrix.GetRefData())->Clone();
         m_shadingMatrix->Invert();

--- a/src/qt/graphics.cpp
+++ b/src/qt/graphics.cpp
@@ -91,12 +91,12 @@ public:
         m_brush = QBrush(gradient);
     }
 
-    void CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
-                                   wxDouble xc, wxDouble yc,
+    void CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
+                                   wxDouble endX, wxDouble endY,
                                    wxDouble radius,
                                    const wxGraphicsGradientStops& stops)
     {
-        QRadialGradient gradient(QPointF(xc, yc), radius, QPointF(xo, yo));
+        QRadialGradient gradient(QPointF(endX, endY), radius, QPointF(startX, startY));
         SetStops(gradient, stops);
         m_brush = QBrush(gradient);
     }
@@ -1141,8 +1141,8 @@ public:
         const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
 
     virtual wxGraphicsBrush
-        CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
-        wxDouble xc, wxDouble yc,
+        CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
+        wxDouble endX, wxDouble endY,
         wxDouble radius,
         const wxGraphicsGradientStops& stops,
         const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
@@ -1287,14 +1287,14 @@ wxGraphicsBrush wxQtGraphicsRenderer::CreateLinearGradientBrush(
 }
 
 wxGraphicsBrush wxQtGraphicsRenderer::CreateRadialGradientBrush(
-    wxDouble xo, wxDouble yo,
-    wxDouble xc, wxDouble yc, wxDouble r,
+    wxDouble startX, wxDouble startY,
+    wxDouble endX, wxDouble endY, wxDouble r,
     const wxGraphicsGradientStops& stops, 
     const wxGraphicsMatrix& WXUNUSED(matrix))
 {
     wxGraphicsBrush p;
     wxQtBrushData* d = new wxQtBrushData(this);
-    d->CreateRadialGradientBrush(xo, yo, xc, yc, r, stops);
+    d->CreateRadialGradientBrush(startX, startY, endX, endY, r, stops);
     p.SetRefData(d);
     return p;
 }

--- a/src/qt/graphics.cpp
+++ b/src/qt/graphics.cpp
@@ -1137,13 +1137,15 @@ public:
     virtual wxGraphicsBrush
         CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
         wxDouble x2, wxDouble y2,
-        const wxGraphicsGradientStops& stops) wxOVERRIDE;
+        const wxGraphicsGradientStops& stops,
+        const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
 
     virtual wxGraphicsBrush
         CreateRadialGradientBrush(wxDouble xo, wxDouble yo,
         wxDouble xc, wxDouble yc,
         wxDouble radius,
-        const wxGraphicsGradientStops& stops) wxOVERRIDE;
+        const wxGraphicsGradientStops& stops,
+        const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
 
     // sets the font
     virtual wxGraphicsFont CreateFont(const wxFont& font,
@@ -1274,7 +1276,8 @@ wxGraphicsBrush wxQtGraphicsRenderer::CreateBrush(const wxBrush& brush)
 wxGraphicsBrush wxQtGraphicsRenderer::CreateLinearGradientBrush(
     wxDouble x1, wxDouble y1,
     wxDouble x2, wxDouble y2,
-    const wxGraphicsGradientStops& stops)
+    const wxGraphicsGradientStops& stops, 
+    const wxGraphicsMatrix& WXUNUSED(matrix))
 {
     wxGraphicsBrush p;
     wxQtBrushData* d = new wxQtBrushData(this);
@@ -1286,7 +1289,8 @@ wxGraphicsBrush wxQtGraphicsRenderer::CreateLinearGradientBrush(
 wxGraphicsBrush wxQtGraphicsRenderer::CreateRadialGradientBrush(
     wxDouble xo, wxDouble yo,
     wxDouble xc, wxDouble yc, wxDouble r,
-    const wxGraphicsGradientStops& stops)
+    const wxGraphicsGradientStops& stops, 
+    const wxGraphicsMatrix& WXUNUSED(matrix))
 {
     wxGraphicsBrush p;
     wxQtBrushData* d = new wxQtBrushData(this);

--- a/src/qt/graphics.cpp
+++ b/src/qt/graphics.cpp
@@ -1138,14 +1138,14 @@ public:
         CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
         wxDouble x2, wxDouble y2,
         const wxGraphicsGradientStops& stops,
-        const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
+        const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix) wxOVERRIDE;
 
     virtual wxGraphicsBrush
         CreateRadialGradientBrush(wxDouble startX, wxDouble startY,
         wxDouble endX, wxDouble endY,
         wxDouble radius,
         const wxGraphicsGradientStops& stops,
-        const wxGraphicsMatrix& matrix=wxNullGraphicsMatrix) wxOVERRIDE;
+        const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix) wxOVERRIDE;
 
     // sets the font
     virtual wxGraphicsFont CreateFont(const wxFont& font,


### PR DESCRIPTION
This PR adds support for using gradients in wxGraphicsPen.

TODO:

- [x] Add gradient related info and methods to wxGraphicsPenInfo
- [x] Cairo
- [x] OSX
- [x] GDI+
- [x] Direct2D
- [x] Documentation
- [x] Sample

See also: https://github.com/wxWidgets/Phoenix/pull/1323, https://discuss.wxpython.org/t/scalable-icons/33015