### PR TITLE
Set the wrap mode for linear gradient brushes

### DIFF
--- a/src/msw/graphics.cpp
+++ b/src/msw/graphics.cpp
@@ -974,6 +974,7 @@ wxGDIPlusBrushData::CreateLinearGradientBrush(wxDouble x1, wxDouble y1,
         brush = new LinearGradientBrush(PointF(x1, y1) , PointF(x2, y2),
                                         wxColourToColor(stops.GetStartColour()),
                                         wxColourToColor(stops.GetEndColour()));
+    brush->SetWrapMode(WrapModeTileFlipXY);
     m_brush =  brush;
 
     SetGradientStops(brush, stops);


### PR DESCRIPTION
Set the wrap mode for linear gradient brushes, so the areas beyond the end points are properly filled with the end point colors like the other platforms.