### PR TITLE
Prevent selection by dragging in wxTreeCtrl under wxQT

### DIFF
--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -474,6 +474,11 @@ private:
         EmitEvent(tree_event);
     }
 
+    virtual QItemSelectionModel::SelectionFlags selectionCommand(const QModelIndex &index, const QEvent *event) const wxOVERRIDE
+    {
+        return state() == DragSelectingState ? QItemSelectionModel::NoUpdate : QTreeWidget::selectionCommand(index, event);
+    }
+
     virtual void dropEvent(QDropEvent* event) wxOVERRIDE
     {
         endDrag(event->pos());


### PR DESCRIPTION
Unlike the other wx ports, wxQT allowed the user to select tree items by dragging the mouse over them. This PR ensures that wxQT behaves consistently with the other parts. 