### PR TITLE
Fix retrieving the size of icon and label in native MSW wxListCtrl

### DIFF
--- a/samples/listctrl/listtest.cpp
+++ b/samples/listctrl/listtest.cpp
@@ -1310,14 +1310,15 @@ void MyListCtrl::OnListKeyDown(wxListEvent& event)
                     wxLogError("Failed to retrieve rect of item %ld column %d", item, subItem + 1);
                     break;
                 }
-                wxString message;
+                wxString message = "Bounding rect of %s item %ld column %d is (%d, %d)-(%d, %d)";
+                wxString part;
                 if( code == wxLIST_RECT_BOUNDS )
-                    message = wxString::Format( "Bounding rect of item %ld column %d is (%d, %d)-(%d, %d)", item, subItem + 1, r.x, r.y, r.x + r.width, r.y + r.height );
+                    part = "subitem";
                 if( code == wxLIST_RECT_ICON )
-                    message = wxString::Format( "Bounding rect of item icon %ld column %d is (%d, %d)-(%d, %d)", item, subItem + 1, r.x, r.y, r.x + r.width, r.y + r.height );
+                    part = "icon";
                 if( code == wxLIST_RECT_LABEL )
-                    message = wxString::Format( "Bounding rect of item label %ld column %d is (%d, %d)-(%d, %d)", item, subItem + 1, r.x, r.y, r.x + r.width, r.y + r.height );
-                wxLogMessage( message );
+                    part = "label";
+                wxLogMessage( message, part, item, subItem + 1, r.x, r.y, r.x + r.width, r.y + r.height );
             }
             break;
 

--- a/samples/listctrl/listtest.cpp
+++ b/samples/listctrl/listtest.cpp
@@ -1229,6 +1229,12 @@ void MyListCtrl::OnListKeyDown(wxListEvent& event)
 {
     long item;
 
+    if ( !wxGetKeyState(WXK_SHIFT) )
+    {
+        LogEvent(event, "OnListKeyDown");
+        event.Skip();
+    }
+
     switch ( event.GetKeyCode() )
     {
         case 'C': // colorize

--- a/samples/listctrl/listtest.cpp
+++ b/samples/listctrl/listtest.cpp
@@ -1229,13 +1229,6 @@ void MyListCtrl::OnListKeyDown(wxListEvent& event)
 {
     long item;
 
-    if ( !wxGetKeyState(WXK_SHIFT) )
-    {
-        LogEvent(event, "OnListKeyDown");
-        event.Skip();
-        return;
-    }
-
     switch ( event.GetKeyCode() )
     {
         case 'C': // colorize
@@ -1311,10 +1304,14 @@ void MyListCtrl::OnListKeyDown(wxListEvent& event)
                     wxLogError("Failed to retrieve rect of item %ld column %d", item, subItem + 1);
                     break;
                 }
-
-                wxLogMessage("Bounding rect of item %ld column %d is (%d, %d)-(%d, %d)",
-                             item, subItem + 1,
-                             r.x, r.y, r.x + r.width, r.y + r.height);
+                wxString message;
+                if( code == wxLIST_RECT_BOUNDS )
+                    message = wxString::Format( "Bounding rect of item %ld column %d is (%d, %d)-(%d, %d)", item, subItem + 1, r.x, r.y, r.x + r.width, r.y + r.height );
+                if( code == wxLIST_RECT_ICON )
+                    message = wxString::Format( "Bounding rect of item icon %ld column %d is (%d, %d)-(%d, %d)", item, subItem + 1, r.x, r.y, r.x + r.width, r.y + r.height );
+                if( code == wxLIST_RECT_LABEL )
+                    message = wxString::Format( "Bounding rect of item label %ld column %d is (%d, %d)-(%d, %d)", item, subItem + 1, r.x, r.y, r.x + r.width, r.y + r.height );
+                wxLogMessage( message );
             }
             break;
 

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -103,9 +103,25 @@ namespace
 inline bool
 wxGetListCtrlSubItemRect(HWND hwnd, int item, int subitem, int flags, RECT& rect)
 {
+    int ret;
     rect.top = subitem;
     rect.left = flags;
-    return ::SendMessage(hwnd, LVM_GETSUBITEMRECT, item, (LPARAM)&rect) != 0;
+    if( flags == LVIR_BOUNDS || flags == LVIR_ICON )
+        ret = ::SendMessage(hwnd, LVM_GETSUBITEMRECT, item, (LPARAM)&rect);
+    else
+    {
+        RECT rectIcon;
+        rectIcon.top = subitem;
+        rectIcon.left = LVIR_ICON;
+        ret = ::SendMessage(hwnd, LVM_GETSUBITEMRECT, item, (LPARAM)&rect);
+        if( ret != 0 )
+        {
+            ret = ::SendMessageA(hwnd, LVM_GETSUBITEMRECT, item, (LPARAM)&rectIcon);
+            if( ret != 0 )
+                rect.left = rectIcon.left + rectIcon.right;
+        }
+    }
+    return ret != 0;
 }
 
 inline bool

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -106,20 +106,15 @@ wxGetListCtrlSubItemRect(HWND hwnd, int item, int subitem, int flags, RECT& rect
     int ret;
     rect.top = subitem;
     rect.left = flags;
-    if( flags == LVIR_BOUNDS || flags == LVIR_ICON )
-        ret = ::SendMessage(hwnd, LVM_GETSUBITEMRECT, item, (LPARAM)&rect);
-    else
+    ret = ::SendMessage(hwnd, LVM_GETSUBITEMRECT, item, (LPARAM)&rect);
+    if( flags == LVIR_LABEL && ret != 0 )
     {
         RECT rectIcon;
         rectIcon.top = subitem;
         rectIcon.left = LVIR_ICON;
-        ret = ::SendMessage(hwnd, LVM_GETSUBITEMRECT, item, (LPARAM)&rect);
+        ret = ::SendMessageA(hwnd, LVM_GETSUBITEMRECT, item, (LPARAM)&rectIcon);
         if( ret != 0 )
-        {
-            ret = ::SendMessageA(hwnd, LVM_GETSUBITEMRECT, item, (LPARAM)&rectIcon);
-            if( ret != 0 )
-                rect.left = rectIcon.left + rectIcon.right;
-        }
+            rect.left = rectIcon.right;
     }
     return ret != 0;
 }

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -103,20 +103,9 @@ namespace
 inline bool
 wxGetListCtrlSubItemRect(HWND hwnd, int item, int subitem, int flags, RECT& rect)
 {
-    int ret;
     rect.top = subitem;
     rect.left = flags;
-    ret = ::SendMessage(hwnd, LVM_GETSUBITEMRECT, item, (LPARAM)&rect);
-    if( flags == LVIR_LABEL && ret != 0 )
-    {
-        RECT rectIcon;
-        rectIcon.top = subitem;
-        rectIcon.left = LVIR_ICON;
-        ret = ::SendMessageA(hwnd, LVM_GETSUBITEMRECT, item, (LPARAM)&rectIcon);
-        if( ret != 0 )
-            rect.left = rectIcon.right;
-    }
-    return ret != 0;
+    return ::SendMessage(hwnd, LVM_GETSUBITEMRECT, item, (LPARAM)&rect) != 0;
 }
 
 inline bool
@@ -1228,6 +1217,16 @@ bool wxListCtrl::GetSubItemRect(long item, long subItem, wxRect& rect, int code)
           ) )
     {
         return false;
+    }
+    if( code == wxLIST_RECT_LABEL )
+    {
+        RECT rectIcon;
+        rectIcon.top = subItem;
+        rectIcon.left = LVIR_ICON;
+        if( !( ::SendMessageA(GetHwnd(), LVM_GETSUBITEMRECT, item, (LPARAM)&rectIcon) ) )
+            return false;
+		else
+            rectWin.left = rectIcon.right;
     }
 
     wxCopyRECTToRect(rectWin, rect);


### PR DESCRIPTION
This PR will take care of ticket #11355 (Calculating the rect for the wxListCtrl sub-item for label and icon).
Only MSW port is fixed.

Sample is updated to show the results.

Please review and apply.