### PR TITLE
Improvements to wxDynamicLibrary error reporting

### DIFF
--- a/include/wx/dynlib.h
+++ b/include/wx/dynlib.h
@@ -231,9 +231,9 @@ public:
     // return the platform standard DLL extension (with leading dot)
     static wxString GetDllExt(wxDynamicLibraryCategory cat = wxDL_LIBRARY);
 
-    wxDynamicLibrary() : m_handle(0) { }
+    wxDynamicLibrary() : m_handle(0), m_flags(wxDL_DEFAULT) { }
     wxDynamicLibrary(const wxString& libname, int flags = wxDL_DEFAULT)
-        : m_handle(0)
+        : m_handle(0), m_flags(flags)
     {
         Load(libname, flags);
     }
@@ -259,10 +259,17 @@ public:
     wxDllType Detach() { wxDllType h = m_handle; m_handle = 0; return h; }
 
     // unload the given library handle (presumably returned by Detach() before)
-    static void Unload(wxDllType handle);
+    static void Unload(wxDllType handle, int flags = 0);
 
     // unload the library, also done automatically in dtor
-    void Unload() { if ( IsLoaded() ) { Unload(m_handle); m_handle = 0; } }
+    void Unload()
+    {
+        if ( IsLoaded() )
+        {
+            Unload(m_handle, m_flags & wxDL_QUIET);
+            m_handle = 0;
+        }
+    }
 
     // Return the raw handle from dlopen and friends.
     wxDllType GetLibHandle() const { return m_handle; }
@@ -373,6 +380,9 @@ protected:
 
     // the handle to DLL or NULL
     wxDllType m_handle;
+
+    // flags given to the constructor
+    int m_flags;
 
     // no copy ctor/assignment operators (or we'd try to unload the library
     // twice)

--- a/include/wx/dynlib.h
+++ b/include/wx/dynlib.h
@@ -271,6 +271,9 @@ public:
         }
     }
 
+    // return error message from failure
+    static wxString GetErrorStr() { return sm_lastError; }
+
     // Return the raw handle from dlopen and friends.
     wxDllType GetLibHandle() const { return m_handle; }
 
@@ -373,8 +376,9 @@ protected:
     void *DoGetSymbol(const wxString& name, bool *success = 0) const;
 
 #ifdef wxHAVE_DYNLIB_ERROR
-    // log the error after a dlxxx() function failure
-    static void Error();
+    // if errStr is NULL, log the error after a dlxxx() function failure
+    // if errStr is non-NULL, assign the error message to *errStr
+    static void Error(wxString *errStr = NULL);
 #endif // wxHAVE_DYNLIB_ERROR
 
 
@@ -383,6 +387,9 @@ protected:
 
     // flags given to the constructor
     int m_flags;
+
+    // system error after failing to load a library
+    static wxString sm_lastError;
 
     // no copy ctor/assignment operators (or we'd try to unload the library
     // twice)

--- a/interface/wx/dynlib.h
+++ b/interface/wx/dynlib.h
@@ -99,7 +99,7 @@ enum wxPluginCategory
     @style{wxDL_DEFAULT}
            Default flags, same as wxDL_NOW currently.
     @style{wxDL_QUIET}
-           Don't log an error message if the library couldn't be loaded.
+           Don't log an error message if the library or symbol couldn't be (un)loaded.
     @endStyleTable
 
     @library{wxbase}
@@ -243,8 +243,10 @@ public:
         in memory during a longer period of time than the scope of the
         wxDynamicLibrary object. In this case you may call Detach() and store
         the handle somewhere and call this static method later to unload it.
+
+        @param flags The optional flag @c wxDL_QUIET suppresses logging errors.
     */
-    static void Unload(wxDllType handle);
+    static void Unload(wxDllType handle, int flags = 0);
 };
 
 

--- a/interface/wx/dynlib.h
+++ b/interface/wx/dynlib.h
@@ -247,6 +247,15 @@ public:
         @param flags The optional flag @c wxDL_QUIET suppresses logging errors.
     */
     static void Unload(wxDllType handle, int flags = 0);
+    /**
+        Returns an error string describing the latest error that occurred.
+
+        Note that this is the latest error from any wxDynamicLibrary object,
+        and gets overwritten by subsequent errors.
+
+        @since 3.1.3
+    */
+    static wxString GetErrorStr();
 };
 
 

--- a/src/common/dynlib.cpp
+++ b/src/common/dynlib.cpp
@@ -69,6 +69,8 @@ bool wxDynamicLibrary::Load(const wxString& libnameOrig, int flags)
 {
     wxASSERT_MSG(m_handle == 0, wxT("Library already loaded."));
 
+    m_flags = flags;
+
     // add the proper extension for the DLL ourselves unless told not to
     wxString libname = libnameOrig;
     if ( !(flags & wxDL_VERBATIM) )
@@ -115,10 +117,12 @@ void *wxDynamicLibrary::GetSymbol(const wxString& name, bool *success) const
     if ( !symbol )
     {
 #ifdef wxHAVE_DYNLIB_ERROR
-        Error();
+        if ( !(m_flags & wxDL_QUIET) )
+            Error();
 #else
-        wxLogSysError(_("Couldn't find symbol '%s' in a dynamic library"),
-                      name.c_str());
+        if ( !(m_flags & wxDL_QUIET) )
+            wxLogSysError(_("Couldn't find symbol '%s' in a dynamic library"),
+                          name.c_str());
 #endif
     }
 

--- a/src/msw/dlmsw.cpp
+++ b/src/msw/dlmsw.cpp
@@ -164,11 +164,15 @@ wxDynamicLibrary::RawLoad(const wxString& libname, int flags)
 }
 
 /* static */
-void wxDynamicLibrary::Unload(wxDllType handle)
+void wxDynamicLibrary::Unload(wxDllType handle, int flags)
 {
+    wxCHECK_RET( (flags | wxDL_QUIET) == wxDL_QUIET,
+                wxT("Unload() only supports the wxDL_QUIET flag") );
+
     if ( !::FreeLibrary(handle) )
     {
-        wxLogSysError(_("Failed to unload shared library"));
+        if ( !(flags & wxDL_QUIET) )
+            wxLogSysError(_("Failed to unload shared library"));
     }
 }
 

--- a/src/msw/dlmsw.cpp
+++ b/src/msw/dlmsw.cpp
@@ -166,7 +166,10 @@ wxDynamicLibrary::RawLoad(const wxString& libname, int flags)
 /* static */
 void wxDynamicLibrary::Unload(wxDllType handle)
 {
-    ::FreeLibrary(handle);
+    if ( !::FreeLibrary(handle) )
+    {
+        wxLogSysError(_("Failed to unload shared library"));
+    }
 }
 
 /* static */

--- a/src/unix/dlunix.cpp
+++ b/src/unix/dlunix.cpp
@@ -110,8 +110,11 @@ wxDllType wxDynamicLibrary::RawLoad(const wxString& libname, int flags)
 }
 
 /* static */
-void wxDynamicLibrary::Unload(wxDllType handle)
+void wxDynamicLibrary::Unload(wxDllType handle, int flags)
 {
+    wxCHECK_RET( (flags | wxDL_QUIET) == wxDL_QUIET,
+                wxT("Unload() only supports the wxDL_QUIET flag") );
+
 #ifdef wxHAVE_DYNLIB_ERROR
     int rc =
 #endif
@@ -124,7 +127,10 @@ void wxDynamicLibrary::Unload(wxDllType handle)
 
 #if defined(USE_POSIX_DL_FUNCS) && defined(wxHAVE_DYNLIB_ERROR)
     if ( rc != 0 )
-        Error();
+    {
+        if ( !(flags & wxDL_QUIET) )
+            Error();
+    }
 #endif
 }
 

--- a/src/unix/dlunix.cpp
+++ b/src/unix/dlunix.cpp
@@ -128,8 +128,9 @@ void wxDynamicLibrary::Unload(wxDllType handle, int flags)
 #if defined(USE_POSIX_DL_FUNCS) && defined(wxHAVE_DYNLIB_ERROR)
     if ( rc != 0 )
     {
+        Error(&sm_lastError);
         if ( !(flags & wxDL_QUIET) )
-            Error();
+            wxLogError(wxT("%s"), sm_lastError);
     }
 #endif
 }
@@ -158,14 +159,17 @@ void *wxDynamicLibrary::RawGetSymbol(wxDllType handle, const wxString& name)
 #ifdef wxHAVE_DYNLIB_ERROR
 
 /* static */
-void wxDynamicLibrary::Error()
+void wxDynamicLibrary::Error(wxString *ret)
 {
     wxString err(dlerror());
 
     if ( err.empty() )
         err = _("Unknown dynamic library error");
 
-    wxLogError(wxT("%s"), err);
+    if ( ret == NULL )
+        wxLogError(wxT("%s"), err);
+    else
+        *ret = err;
 }
 
 #endif // wxHAVE_DYNLIB_ERROR


### PR DESCRIPTION
Main improvements:
* Allow suppressing logging about `wxDynamicLibrary` errors in most places.
* And most importantly, add a function for obtaining dynamic library error messages.