### PR TITLE
Improve wxSVGFileDC::Draw[Rotated]Text

### DIFF
--- a/include/wx/msw/dc.h
+++ b/include/wx/msw/dc.h
@@ -77,6 +77,7 @@ public:
     virtual bool CanGetTextExtent() const wxOVERRIDE;
     virtual int GetDepth() const wxOVERRIDE;
     virtual wxSize GetPPI() const wxOVERRIDE;
+    virtual double GetContentScaleFactor() const wxOVERRIDE;
 
 
     virtual void SetMapMode(wxMappingMode mode) wxOVERRIDE;

--- a/src/common/dcsvg.cpp
+++ b/src/common/dcsvg.cpp
@@ -275,8 +275,6 @@ wxString wxCreateBrushFill(wxBrush& brush)
 
 void wxSetScaledScreenDCFont(wxScreenDC& sDC, const wxFont& font)
 {
-    sDC.SetFont(font);
-
     const double scale = sDC.GetContentScaleFactor();
     if ( scale > 1 )
     {
@@ -287,9 +285,13 @@ void wxSetScaledScreenDCFont(wxScreenDC& sDC, const wxFont& font)
         // We can't just divide the returned sizes by the scale factor, because
         // text does not scale linear (at least on Windows). Therefore, we scale
         // the font size instead.
-        wxFont scaledFont = sDC.GetFont();
+        wxFont scaledFont = font;
         scaledFont.SetFractionalPointSize(scaledFont.GetFractionalPointSize() / scale);
         sDC.SetFont(scaledFont);
+    }
+    else
+    {
+        sDC.SetFont(font);
     }
 }
 

--- a/src/common/dcsvg.cpp
+++ b/src/common/dcsvg.cpp
@@ -588,7 +588,11 @@ void wxSVGFileDCImpl::DoDrawRotatedText(const wxString& sText, wxCoord x, wxCoor
     style += wxString::Format(wxS("%s %s stroke-width:0; "),
                               wxBrushString(m_textForegroundColour),
                               wxPenString(m_textForegroundColour));
+    style += wxS("white-space: pre;");
     style += wxS("\"");
+
+    // this is deprecated in favour of "white-space: pre", keep it for now to
+    // support SVG viewers that do not support the new tag
     style += wxS(" xml:space=\"preserve\"");
 
     // Draw all text line by line

--- a/src/common/dcsvg.cpp
+++ b/src/common/dcsvg.cpp
@@ -571,7 +571,7 @@ void wxSVGFileDCImpl::DoDrawRotatedText(const wxString& sText, wxCoord x, wxCoor
     style += wxString::Format(wxS("font-family:%s; "), m_font.GetFaceName());
     style += wxString::Format(wxS("font-weight:%d; "), m_font.GetWeight());
     style += wxString::Format(wxS("font-style:%s; "), fontstyle);
-    style += wxString::Format(wxS("font-size:%dpt; "), m_font.GetPointSize());
+    style += wxString::Format(wxS("font-size:%spt; "), NumStr(m_font.GetFractionalPointSize()));
     style += wxString::Format(wxS("text-decoration:%s; "), textDecoration);
     style += wxString::Format(wxS("%s %s stroke-width:0; "),
                               wxBrushString(m_textForegroundColour),

--- a/src/common/dcsvg.cpp
+++ b/src/common/dcsvg.cpp
@@ -278,7 +278,8 @@ void wxSetScaledScreenDCFont(wxScreenDC& sDC, const wxFont& font)
     sDC.SetFont(font);
 
     const double scale = sDC.GetContentScaleFactor();
-    if (scale > 1) {
+    if ( scale > 1 )
+    {
         // wxScreenDC uses the DPI of the main screen to determine the text
         // extent and character width/height. Because the SVG should be
         // DPI-independent we want the text extent of the default (96) DPI.

--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -2440,6 +2440,11 @@ wxSize wxMSWDCImpl::GetPPI() const
     return wxSize(x, y);
 }
 
+double wxMSWDCImpl::GetContentScaleFactor() const
+{
+    return GetPPI().y / 96.0;
+}
+
 // ----------------------------------------------------------------------------
 // DC caching
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Improve SVG output so text looks the same as in wxDC.

- scale text to screen DPI
- new tag for preserving white-space
- draw background rectangles per line, so background colour of shorter lines is only behind the text
- add support for fractional point size from wxFont