### PR TITLE
Added overload of Refresh for properly changing background/foreground colours for wxSpinCtrl (MSW)

### DIFF
--- a/include/wx/msw/spinctrl.h
+++ b/include/wx/msw/spinctrl.h
@@ -65,6 +65,8 @@ public:
     virtual int GetBase() const;
     virtual bool SetBase(int base);
 
+    virtual void Refresh( bool eraseBackground = true,
+                          const wxRect *rect = (const wxRect *) NULL ) wxOVERRIDE;
 
     // implementation only from now on
     // -------------------------------

--- a/src/msw/spinctrl.cpp
+++ b/src/msw/spinctrl.cpp
@@ -407,7 +407,10 @@ wxSpinCtrl::~wxSpinCtrl()
 void wxSpinCtrl::Refresh(bool eraseBackground, const wxRect *rect)
 {
     wxControl::Refresh(eraseBackground, rect); 
-    ::RedrawWindow(GetBuddyHwnd(), 0, 0, RDW_INVALIDATE | RDW_UPDATENOW);
+    if ( eraseBackground )
+        ::RedrawWindow(GetBuddyHwnd(), NULL, NULL, RDW_INVALIDATE | RDW_ERASE);
+    else
+        ::RedrawWindow(GetBuddyHwnd(), NULL, NULL, RDW_INVALIDATE);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/msw/spinctrl.cpp
+++ b/src/msw/spinctrl.cpp
@@ -404,6 +404,12 @@ wxSpinCtrl::~wxSpinCtrl()
     gs_spinForTextCtrl.erase(GetBuddyHwnd());
 }
 
+void wxSpinCtrl::Refresh(bool eraseBackground, const wxRect *rect)
+{
+    wxControl::Refresh(eraseBackground, rect); 
+    ::RedrawWindow(GetBuddyHwnd(), 0, 0, RDW_INVALIDATE | RDW_UPDATENOW);
+}
+
 // ----------------------------------------------------------------------------
 // wxSpinCtrl-specific methods
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Patch for [ticket 12382 - Can't change wxSpinCtrl background or foreground color](https://trac.wxwidgets.org/ticket/12382)