### PR TITLE
Fix OpenGL samples when using HiDPI displays

### DIFF
--- a/samples/opengl/cube/cube.cpp
+++ b/samples/opengl/cube/cube.cpp
@@ -349,7 +349,7 @@ void TestGLCanvas::OnPaint(wxPaintEvent& WXUNUSED(event))
     // multiple canvases: If we updated the viewport in the wxSizeEvent
     // handler, changing the size of one canvas causes a viewport setting that
     // is wrong when next another canvas is repainted.
-    const wxSize ClientSize = GetClientSize();
+    const wxSize ClientSize = GetClientSize() * GetContentScaleFactor();
 
     TestGLContext& canvas = wxGetApp().GetContext(this, m_useStereo);
     glViewport(0, 0, ClientSize.x, ClientSize.y);

--- a/samples/opengl/isosurf/isosurf.cpp
+++ b/samples/opengl/isosurf/isosurf.cpp
@@ -284,7 +284,8 @@ void TestGLCanvas::OnSize(wxSizeEvent& event)
     // This is OK here only because there is only one canvas that uses the
     // context. See the cube sample for that case that multiple canvases are
     // made current with one context.
-    glViewport(0, 0, event.GetSize().x, event.GetSize().y);
+    const wxSize size = event.GetSize() * GetContentScaleFactor();
+    glViewport(0, 0, size.x, size.y);
 }
 
 void TestGLCanvas::OnChar(wxKeyEvent& event)

--- a/samples/opengl/penguin/penguin.cpp
+++ b/samples/opengl/penguin/penguin.cpp
@@ -306,17 +306,16 @@ void TestGLCanvas::ResetProjectionMode()
     // or more than one wxGLContext in the application.
     SetCurrent(*m_glRC);
 
-    int w, h;
-    GetClientSize(&w, &h);
+    const wxSize ClientSize = GetClientSize() * GetContentScaleFactor();
 
     // It's up to the application code to update the OpenGL viewport settings.
     // In order to avoid extensive context switching, consider doing this in
     // OnPaint() rather than here, though.
-    glViewport(0, 0, (GLint) w, (GLint) h);
+    glViewport(0, 0, ClientSize.x, ClientSize.y);
 
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
-    gluPerspective(45.0f, (GLfloat)w/h, 1.0, 100.0);
+    gluPerspective(45.0f, (GLfloat)ClientSize.x/ClientSize.y, 1.0, 100.0);
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
 }

--- a/samples/opengl/pyramid/pyramid.cpp
+++ b/samples/opengl/pyramid/pyramid.cpp
@@ -565,8 +565,9 @@ void MyGLCanvas::OnSize(wxSizeEvent& event)
     SetCurrent(*m_oglContext);
 
     // It's up to the application code to update the OpenGL viewport settings.
-    m_winHeight = event.GetSize().y;
-    m_oglManager->SetViewport(0, 0, event.GetSize().x, m_winHeight);
+    const wxSize size = event.GetSize() * GetContentScaleFactor();
+    m_winHeight = size.y;
+    m_oglManager->SetViewport(0, 0, size.x, m_winHeight);
 
     // Generate paint event without erasing the background.
     Refresh(false);


### PR DESCRIPTION
OpenGL seems to operate using physical pixels, so we need to factor in the
scale factor when setting the GL viewport.

Fixes #17391.