### PR TITLE
Consistent DrawPoint and DrawCheckMark on all platforms

### DIFF
--- a/include/wx/msw/dc.h
+++ b/include/wx/msw/dc.h
@@ -202,8 +202,6 @@ public:
     virtual void DoDrawArc(wxCoord x1, wxCoord y1,
                            wxCoord x2, wxCoord y2,
                            wxCoord xc, wxCoord yc) wxOVERRIDE;
-    virtual void DoDrawCheckMark(wxCoord x, wxCoord y,
-                                 wxCoord width, wxCoord height) wxOVERRIDE;
     virtual void DoDrawEllipticArc(wxCoord x, wxCoord y, wxCoord w, wxCoord h,
                                    double sa, double ea) wxOVERRIDE;
 

--- a/include/wx/renderer.h
+++ b/include/wx/renderer.h
@@ -250,8 +250,19 @@ public:
                               const wxRect& rect,
                               int flags = 0) = 0;
 
+    // draw check mark
+    //
+    // flags may use wxCONTROL_DISABLED
+    virtual void DrawCheckMark(wxWindow *win,
+                               wxDC& dc,
+                               const wxRect& rect,
+                               int flags = 0) = 0;
+
     // Returns the default size of a check box.
     virtual wxSize GetCheckBoxSize(wxWindow *win) = 0;
+
+    // Returns the default size of a check mark.
+    virtual wxSize GetCheckMarkSize(wxWindow *win) = 0;
 
     // Returns the default size of a expander.
     virtual wxSize GetExpanderSize(wxWindow *win) = 0;
@@ -479,10 +490,19 @@ public:
                               int flags = 0) wxOVERRIDE
         { m_rendererNative.DrawCheckBox( win, dc, rect, flags ); }
 
+    virtual void DrawCheckMark(wxWindow *win,
+                              wxDC& dc,
+                              const wxRect& rect,
+                              int flags = 0) wxOVERRIDE
+        { m_rendererNative.DrawCheckMark( win, dc, rect, flags ); }
+
     virtual wxSize GetCheckBoxSize(wxWindow *win) wxOVERRIDE
         { return m_rendererNative.GetCheckBoxSize(win); }
 
-   virtual wxSize GetExpanderSize(wxWindow *win) wxOVERRIDE
+    virtual wxSize GetCheckMarkSize(wxWindow *win) wxOVERRIDE
+        { return m_rendererNative.GetCheckMarkSize(win); }
+
+    virtual wxSize GetExpanderSize(wxWindow *win) wxOVERRIDE
         { return m_rendererNative.GetExpanderSize(win); }
 
     virtual void DrawPushButton(wxWindow *win,

--- a/interface/wx/renderer.h
+++ b/interface/wx/renderer.h
@@ -234,7 +234,12 @@ public:
     virtual void DrawCheckBox(wxWindow *win, wxDC& dc,
                               const wxRect& rect, int flags = 0 );
 
+    virtual void DrawCheckMark(wxWindow *win, wxDC& dc,
+                               const wxRect& rect, int flags = 0 );
+
     virtual wxSize GetCheckBoxSize(wxWindow *win);
+
+    virtual wxSize GetCheckMarkSize(wxWindow *win);
 
     virtual wxSize GetExpanderSize(wxWindow* win);
 
@@ -533,6 +538,17 @@ public:
                                     int flags = 0) = 0;
 
     /**
+        Draw a check mark.
+
+        @a flags may have the @c wxCONTROL_DISABLED bit set, see
+        @ref wxCONTROL_FLAGS.
+
+        @since 3.1.3
+    */
+    virtual void DrawCheckMark(wxWindow* win, wxDC& dc, const wxRect& rect,
+                               int flags = 0) = 0;
+
+    /**
         Return the currently used renderer.
     */
     static wxRendererNative& Get();
@@ -559,6 +575,16 @@ public:
             the theme defining the checkbox size under some platforms.
     */
     virtual wxSize GetCheckBoxSize(wxWindow* win) = 0;
+
+    /**
+        Returns the size of a check mark.
+
+        @param win A valid, i.e. non-null, window pointer which is used to get
+            the theme defining the checkmark size under some platforms.
+
+        @since 3.1.3
+    */
+    virtual wxSize GetCheckMarkSize(wxWindow* win) = 0;
 
     /**
         Returns the size of the expander used in tree-like controls.

--- a/samples/drawing/drawing.cpp
+++ b/samples/drawing/drawing.cpp
@@ -123,10 +123,6 @@ public:
     {   if ( !m_renderer ) return false;
         return m_renderer == wxGraphicsRenderer::GetDefaultRenderer();
     }
-    bool IsRendererName(const wxString& name) const
-    {   if ( !m_renderer ) return name.empty();
-        return m_renderer->GetName() == name;
-    }
     wxGraphicsRenderer* GetRenderer() const { return m_renderer; }
 #endif // wxUSE_GRAPHICS_CONTEXT
     void UseBuffer(bool use) { m_useBuffer = use; Refresh(); }
@@ -206,7 +202,7 @@ public:
 
     void OnGraphicContextNoneUpdateUI(wxUpdateUIEvent& event)
     {
-        event.Check(m_canvas->IsRendererName(wxEmptyString));
+        event.Check(m_canvas->GetRenderer() == NULL);
     }
 
     void OnGraphicContextDefault(wxCommandEvent& WXUNUSED(event))
@@ -227,7 +223,7 @@ public:
 
     void OnGraphicContextCairoUpdateUI(wxUpdateUIEvent& event)
     {
-        event.Check(m_canvas->IsRendererName("cairo"));
+        event.Check(m_canvas->GetRenderer() == wxGraphicsRenderer::GetCairoRenderer());
     }
 #endif // wxUSE_CAIRO
 #ifdef __WXMSW__
@@ -239,7 +235,7 @@ public:
 
     void OnGraphicContextGDIPlusUpdateUI(wxUpdateUIEvent& event)
     {
-        event.Check(m_canvas->IsRendererName("gdiplus"));
+        event.Check(m_canvas->GetRenderer() == wxGraphicsRenderer::GetGDIPlusRenderer());
     }
 #endif
 #if wxUSE_GRAPHICS_DIRECT2D
@@ -250,7 +246,7 @@ public:
 
     void OnGraphicContextDirect2DUpdateUI(wxUpdateUIEvent& event)
     {
-        event.Check(m_canvas->IsRendererName("direct2d"));
+        event.Check(m_canvas->GetRenderer() == wxGraphicsRenderer::GetDirect2DRenderer());
     }
 #endif
 #endif // __WXMSW__
@@ -2142,17 +2138,17 @@ MyFrame::MyFrame(const wxString& title, const wxPoint& pos, const wxSize& size)
 
     wxMenu *menuFile = new wxMenu;
 #if wxUSE_GRAPHICS_CONTEXT
-    menuFile->AppendCheckItem(File_GC_Default, "Use default wx&GraphicContext\tCtrl-Y");
-    m_menuItemUseDC = menuFile->AppendRadioItem(File_DC, "Use wx&DC\tShift-Ctrl-Y");
+    menuFile->AppendCheckItem(File_GC_Default, "Use default wx&GraphicContext\t1");
+    m_menuItemUseDC = menuFile->AppendRadioItem(File_DC, "Use wx&DC\t0");
 #if wxUSE_CAIRO
-    menuFile->AppendRadioItem(File_GC_Cairo, "Use &Cairo\tCtrl-O");
+    menuFile->AppendRadioItem(File_GC_Cairo, "Use &Cairo\t2");
 #endif // wxUSE_CAIRO
 #ifdef __WXMSW__
 #if wxUSE_GRAPHICS_GDIPLUS
-    menuFile->AppendRadioItem(File_GC_GDIPlus, "Use &GDI+\tCtrl-+");
+    menuFile->AppendRadioItem(File_GC_GDIPlus, "Use &GDI+\t3");
 #endif
 #if wxUSE_GRAPHICS_DIRECT2D
-    menuFile->AppendRadioItem(File_GC_Direct2D, "Use &Direct2D\tCtrl-2");
+    menuFile->AppendRadioItem(File_GC_Direct2D, "Use &Direct2D\t4");
 #endif
 #endif // __WXMSW__
 #endif // wxUSE_GRAPHICS_CONTEXT

--- a/samples/render/render.cpp
+++ b/samples/render/render.cpp
@@ -247,6 +247,12 @@ private:
                               wxRect(wxPoint(x2, y), sizeCheck), m_flags);
         y += lineHeight + sizeCheck.y;
 
+        dc.DrawText("DrawCheckMark()", x1, y);
+        const wxSize sizeMark = renderer.GetCheckMarkSize(this);
+        renderer.DrawCheckMark(this, dc,
+                               wxRect(wxPoint(x2, y), sizeMark), m_flags);
+        y += lineHeight + sizeMark.y;
+
         dc.DrawText("DrawRadioBitmap()", x1, y);
         renderer.DrawRadioBitmap(this, dc,
                                  wxRect(wxPoint(x2, y), sizeCheck), m_flags);
@@ -259,9 +265,10 @@ private:
         y += lineHeight + sizeCollapse.y;
 
         dc.DrawText("DrawTreeItemButton()", x1, y);
+        const wxSize sizeExpand = renderer.GetExpanderSize(this);
         renderer.DrawTreeItemButton(this, dc,
-                                    wxRect(x2, y, 20, 20), m_flags);
-        y += lineHeight + 20;
+                                    wxRect(wxPoint(x2, y), sizeExpand), m_flags);
+        y += lineHeight + sizeExpand.y;
 
 #ifdef wxHAS_DRAW_TITLE_BAR_BITMAP
         dc.DrawText("DrawTitleBarBitmap()", x1, y);

--- a/src/common/dcgraph.cpp
+++ b/src/common/dcgraph.cpp
@@ -752,6 +752,9 @@ void wxGCDCImpl::DoDrawPoint( wxCoord x, wxCoord y )
     if (!m_logicalFunctionSupported)
         return;
 
+    wxPen pointPen(m_pen.GetColour());
+    wxDCPenChanger penChanger(*GetOwner(), pointPen);
+
 #if defined(__WXMSW__) && wxUSE_GRAPHICS_GDIPLUS
     // single point path does not work with GDI+
     if (m_graphicContext->GetRenderer() == wxGraphicsRenderer::GetGDIPlusRenderer())

--- a/src/generic/renderg.cpp
+++ b/src/generic/renderg.cpp
@@ -106,7 +106,14 @@ public:
                               const wxRect& rect,
                               int flags = 0) wxOVERRIDE;
 
+    virtual void DrawCheckMark(wxWindow *win,
+                               wxDC& dc,
+                               const wxRect& rect,
+                               int flags = 0) wxOVERRIDE;
+
     virtual wxSize GetCheckBoxSize(wxWindow *win) wxOVERRIDE;
+
+    virtual wxSize GetCheckMarkSize(wxWindow *win) wxOVERRIDE;
 
     virtual wxSize GetExpanderSize(wxWindow *win) wxOVERRIDE;
 
@@ -714,11 +721,26 @@ wxRendererGeneric::DrawCheckBox(wxWindow *WXUNUSED(win),
     }
 }
 
+void
+wxRendererGeneric::DrawCheckMark(wxWindow *WXUNUSED(win),
+                                 wxDC& dc,
+                                 const wxRect& rect,
+                                 int flags)
+{
+    dc.SetPen(*(flags & wxCONTROL_DISABLED ? wxGREY_PEN : wxBLACK_PEN));
+    dc.DrawCheckMark(rect);
+}
+
 wxSize wxRendererGeneric::GetCheckBoxSize(wxWindow *win)
 {
     wxCHECK_MSG( win, wxSize(0, 0), "Must have a valid window" );
 
     return win->FromDIP(wxSize(16, 16));
+}
+
+wxSize wxRendererGeneric::GetCheckMarkSize(wxWindow *win)
+{
+    return GetCheckBoxSize(win);
 }
 
 wxSize wxRendererGeneric::GetExpanderSize(wxWindow *win)

--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -861,24 +861,6 @@ void wxMSWDCImpl::DoDrawArc(wxCoord x1, wxCoord y1,
     CalcBoundingBox(xc + r, yc + r);
 }
 
-void wxMSWDCImpl::DoDrawCheckMark(wxCoord x1, wxCoord y1,
-                           wxCoord width, wxCoord height)
-{
-    wxCoord x2 = x1 + width,
-            y2 = y1 + height;
-
-    RECT rect;
-    rect.left   = x1;
-    rect.top    = y1;
-    rect.right  = x2;
-    rect.bottom = y2;
-
-    DrawFrameControl(GetHdc(), &rect, DFC_MENU, DFCS_MENUCHECK);
-
-    CalcBoundingBox(x1, y1);
-    CalcBoundingBox(x2, y2);
-}
-
 void wxMSWDCImpl::DoDrawPoint(wxCoord x, wxCoord y)
 {
     COLORREF color = 0x00ffffff;


### PR DESCRIPTION
Use the generic `DrawCheckMark` implementation in MSW `wxDC`, so it looks the same across all platforms and renderers and not like a Windows control.

Before - After
![before](https://user-images.githubusercontent.com/8088070/62651680-da777300-b959-11e9-9a42-28e8de26c66d.png)![after](https://user-images.githubusercontent.com/8088070/62651681-db100980-b959-11e9-90e9-92ac94685447.png)

Fix `DrawPoint` in Direct2D renderer.
Draw a point with the `wxPen` width in MSW `wxDC`, similar to other platforms and renderers.

Update the drawing sample to simplify switching between renderers, and add an option the toggle anti-aliasing.