### PR TITLE
Add missing #if wxUSE_CAIRO macros in the src/x11/dcclient.cpp and

### DIFF
--- a/include/wx/x11/dcclient.h
+++ b/include/wx/x11/dcclient.h
@@ -107,9 +107,9 @@ public:
     WXWindow GetX11Window() const { return m_x11window; }
 
     virtual void ComputeScaleAndOrigin();
-
+#if wxUSE_CAIRO
     virtual void* GetCairoContext() const wxOVERRIDE;
-
+#endif
 protected:
     // implementation
     // --------------

--- a/src/x11/dcclient.cpp
+++ b/src/x11/dcclient.cpp
@@ -28,7 +28,9 @@
 #include "wx/x11/dcclient.h"
 #include "wx/x11/dcmemory.h"
 
+#if wxUSE_CAIRO
 #include "cairo-xlib.h"
+#endif
 
 #if wxUSE_UNICODE
 #include "glib.h"
@@ -345,6 +347,7 @@ void wxWindowDCImpl::SetUpDC()
     }
 }
 
+#if wxUSE_CAIRO
 void* wxWindowDCImpl::GetCairoContext() const
 {
     int width, height;
@@ -355,6 +358,7 @@ void* wxWindowDCImpl::GetCairoContext() const
     cairo_t *cr = cairo_create(surface);
     return cr;
 }
+#endif
 
 void wxWindowDCImpl::DoGetSize( int* width, int* height ) const
 {
@@ -1664,6 +1668,7 @@ void wxWindowDCImpl::DoDrawRotatedText(const wxString& text,
                                    wxCoord x, wxCoord y,
                                    double angle)
 {
+#if wxUSE_CAIRO
     // use cairo to draw rotated text
     cairo_surface_t *surface = cairo_xlib_surface_create((Display*) m_display,
                                                          (Drawable) m_x11window,
@@ -1682,6 +1687,9 @@ void wxWindowDCImpl::DoDrawRotatedText(const wxString& text,
     cairo_show_text(cr, text.utf8_str());
     cairo_restore(cr);
     cairo_destroy(cr);
+#else
+    wxFAIL_MSG( "failed: DoDrawRotatedText requires cairo" );
+#endif    
 }
 
 void wxWindowDCImpl::DoGetTextExtent( const wxString &string, wxCoord *width, wxCoord *height,


### PR DESCRIPTION
include/wx/x11/dcclient.h files. wxWidgets will not compile when configure is executed with the --disable-graphics_ctx parameter. The macros are added to avoid compiling code that uses the cairo library which is not added when the --disable-graphics_ctx parameter is used.