### PR TITLE
Use white background when rendering print preview

### DIFF
--- a/src/common/prntbase.cpp
+++ b/src/common/prntbase.cpp
@@ -2054,6 +2054,7 @@ bool wxPrintPreviewBase::RenderPageIntoBitmap(wxBitmap& bmp, int pageNum)
 {
     wxMemoryDC memoryDC;
     memoryDC.SelectObject(bmp);
+    memoryDC.SetBackground(*wxWHITE_BRUSH);
     memoryDC.Clear();
 
     return RenderPageIntoDC(memoryDC, pageNum);


### PR DESCRIPTION
Explicitly use the white brush when erasing background of the bitmap
used for print preview, to match the printed page appearance. Somehow it
worked even without this under other platforms before, but logically
resulted in black background under wxGTK 3.

Closes #18371.

---

I have no idea why did it work under the other platforms, but erasing the bitmap without specifying the colour seems obviously wrong and results in an unusable print preview with GTK 3 (as I've just experienced on my own).