### PR TITLE
In wxListCtrl SetTooltip should have precedence

### DIFF
--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -1805,6 +1805,16 @@ void wxWindowMSW::DragAcceptFiles(bool accept)
 
 void wxWindowMSW::DoSetToolTip(wxToolTip *tooltip)
 {
+#if wxUSE_LISTCTRL
+    if( wxDynamicCast( this, wxListCtrl ) )
+    {
+        WXWORD extStyle = ::SendMessage( GetHwnd(), LVM_GETEXTENDEDLISTVIEWSTYLE, 0, 0 );
+        if( tooltip )
+            ::SendMessage( GetHwnd(), LVM_SETEXTENDEDLISTVIEWSTYLE, 0, extStyle & ~LVS_EX_LABELTIP );
+        else
+            ::SendMessage( GetHwnd(), LVM_SETEXTENDEDLISTVIEWSTYLE, 0, extStyle | LVS_EX_LABELTIP );
+    }
+#endif
     wxWindowBase::DoSetToolTip(tooltip);
 
     if ( m_tooltip )


### PR DESCRIPTION
This PR will take care of ticket #10492.

From the ticket:

[quote]
It is possible for wxListCtrl to end up with 2 tooltips displayed if the SetTooltip() was called and the column size is less than the minimum required to display the cell completely.
[/quote]

This PR removes the internal list control tooltip if the SetTooltip() was called.

Please review and apply.
