### PR TITLE
Implement wxPolygonFillMode in GDI+ and D2D graphics contexts

### DIFF
--- a/src/msw/graphics.cpp
+++ b/src/msw/graphics.cpp
@@ -1857,7 +1857,7 @@ void wxGDIPlusContext::StrokeLines( size_t n, const wxPoint2DDouble *points)
    }
 }
 
-void wxGDIPlusContext::DrawLines( size_t n, const wxPoint2DDouble *points, wxPolygonFillMode WXUNUSED(fillStyle) )
+void wxGDIPlusContext::DrawLines( size_t n, const wxPoint2DDouble *points, wxPolygonFillMode fillStyle )
 {
    if (m_composition == wxCOMPOSITION_DEST)
         return;
@@ -1871,7 +1871,8 @@ void wxGDIPlusContext::DrawLines( size_t n, const wxPoint2DDouble *points, wxPol
 
     } // for (int i = 0; i < n; i++)
     if ( !m_brush.IsNull() )
-        m_context->FillPolygon( ((wxGDIPlusBrushData*)m_brush.GetRefData())->GetGDIPlusBrush() , cpoints , n ) ;
+        m_context->FillPolygon( ((wxGDIPlusBrushData*)m_brush.GetRefData())->GetGDIPlusBrush() , cpoints , n ,
+                                fillStyle == wxODDEVEN_RULE ? FillModeAlternate : FillModeWinding ) ;
     if ( !m_pen.IsNull() )
         m_context->DrawLines( ((wxGDIPlusPenData*)m_pen.GetGraphicsData())->GetGDIPlusPen() , cpoints , n ) ;
     delete[] cpoints;


### PR DESCRIPTION
I noticed in the drawing sample that this did not work, and indeed found some `WXUNUSED(fillStyle)` in the GDI+ and D2D code.
Before - After
<a href="https://user-images.githubusercontent.com/8088070/62839272-4292c580-bc88-11e9-95c1-5b6d73344045.png"><img src="https://user-images.githubusercontent.com/8088070/62839272-4292c580-bc88-11e9-95c1-5b6d73344045.png" width="300"/></a> <a href="https://user-images.githubusercontent.com/8088070/62839274-458db600-bc88-11e9-8f3f-e7bdc90da207.png"><img src="https://user-images.githubusercontent.com/8088070/62839274-458db600-bc88-11e9-8f3f-e7bdc90da207.png" width="300"/></a>
