### PR TITLE
Implement wxFD_NO_FOLLOW under Cocoa

### DIFF
--- a/interface/wx/filedlg.h
+++ b/interface/wx/filedlg.h
@@ -124,7 +124,7 @@ const char wxFileSelectorDefaultWildcardStr[];
     @style{wxFD_NO_FOLLOW}
            Directs the dialog to return the path and file name of the selected
            shortcut file, not its target as it does by default. Currently this
-           flag is only implemented in wxMSW and the non-dereferenced link path
+           flag is only implemented in wxMSW and OSX. The non-dereferenced link path
            is always returned, even without this flag, under Unix and so using
            it there doesn't do anything. This flag was added in wxWidgets
            3.1.0.

--- a/src/osx/cocoa/filedlg.mm
+++ b/src/osx/cocoa/filedlg.mm
@@ -350,7 +350,7 @@ void wxFileDialog::ShowWindowModal()
 
         [oPanel setTreatsFilePackagesAsDirectories:NO];
         [oPanel setCanChooseDirectories:NO];
-        [oPanel setResolvesAliases:YES];
+        [oPanel setResolvesAliases:HasFlag(wxFD_NO_FOLLOW) ? NO : YES];
         [oPanel setCanChooseFiles:YES];
         [oPanel setMessage:cf.AsNSString()];
         [oPanel setAllowsMultipleSelection: (HasFlag(wxFD_MULTIPLE) ? YES : NO )];
@@ -608,7 +608,7 @@ int wxFileDialog::ShowModal()
                 
         [oPanel setTreatsFilePackagesAsDirectories:NO];
         [oPanel setCanChooseDirectories:NO];
-        [oPanel setResolvesAliases:YES];
+        [oPanel setResolvesAliases:HasFlag(wxFD_NO_FOLLOW) ? NO : YES];
         [oPanel setCanChooseFiles:YES];
         [oPanel setMessage:cf.AsNSString()];
         [oPanel setAllowsMultipleSelection: (HasFlag(wxFD_MULTIPLE) ? YES : NO )];


### PR DESCRIPTION
This PR implements wxFD_NO_FOLLOW for Cocoa.

There are 2 scenarios:

1. Have a link to the directory, have some file in that directory and try to open that file.
2. Have a link to the file.

Scenario 1 is not covered. In this case the file dialog always return the real path.
Only scenario 2 is covered.

I updated the documentation for that style mentioning that there is OSX implementation. I didn't check the MSW implementation, so not sure if Windows port behaves the same in this regards. 

Please review and apply.

If there should be a not somewhere about 2 possible scenarios - let me know and I will try to add one.
