### PR TITLE
OSX Cocoa supports only subsets of masking operations - show it in th…

### DIFF
--- a/samples/drawing/drawing.cpp
+++ b/samples/drawing/drawing.cpp
@@ -972,21 +972,23 @@ static const struct
     wxRasterOperationMode rop;
 } rasterOperations[] =
 {
+#ifndef __WXOSX__
     { "wxAND",          wxAND           },
     { "wxAND_INVERT",   wxAND_INVERT    },
     { "wxAND_REVERSE",  wxAND_REVERSE   },
-    { "wxCLEAR",        wxCLEAR         },
-    { "wxCOPY",         wxCOPY          },
     { "wxEQUIV",        wxEQUIV         },
     { "wxINVERT",       wxINVERT        },
     { "wxNAND",         wxNAND          },
-    { "wxNO_OP",        wxNO_OP         },
-    { "wxOR",           wxOR            },
     { "wxOR_INVERT",    wxOR_INVERT     },
     { "wxOR_REVERSE",   wxOR_REVERSE    },
     { "wxSET",          wxSET           },
     { "wxSRC_INVERT",   wxSRC_INVERT    },
-    { "wxXOR",          wxXOR           },
+#endif
+    { "wxCOPY",         wxCOPY          },
+    { "wxOR",           wxOR            },
+    { "wxCLEAR",        wxCLEAR         },
+    { "wxNO_OP",        wxNO_OP         },
+    { "wxXOR",          wxXOR           }
 };
 
 void MyCanvas::DrawImages(wxDC& dc, DrawMode mode)


### PR DESCRIPTION
…e sample

OSX Cocoa does not support all raster operation.

However the current drawing sample crashes on OSX when executed with unsupported masks.

Prevent the crash in a sample.

Also clearly show which mask operation can be used in a cross-platform manner.
