### PR TITLE
Fix check for GTK3 native double buffering

### DIFF
--- a/include/wx/dcbuffer.h
+++ b/include/wx/dcbuffer.h
@@ -17,7 +17,7 @@
 
 // Split platforms into two groups - those which have well-working
 // double-buffering by default, and those which do not.
-#if defined(__WXMAC__) || defined(__WXGTK20__) || defined(__WXDFB__) || defined(__WXQT__)
+#if defined(__WXMAC__) || defined(__WXGTK20__) || defined(__WXGTK3__) || defined(__WXDFB__) || defined(__WXQT__)
     #define wxALWAYS_NATIVE_DOUBLE_BUFFER       1
 #else
     #define wxALWAYS_NATIVE_DOUBLE_BUFFER       0


### PR DESCRIPTION
__GTK20__ is only defined for GTK2, not GTK3.

Probably fixes #18017.