### PR TITLE
Initialize wxMemoryDC with a default font

### DIFF
--- a/src/msw/dcmemory.cpp
+++ b/src/msw/dcmemory.cpp
@@ -70,6 +70,7 @@ void wxMemoryDCImpl::Init()
     {
         SetBrush(*wxWHITE_BRUSH);
         SetPen(*wxBLACK_PEN);
+        SetFont(*wxNORMAL_FONT);
 
         // the background mode is only used for text background and is set in
         // DrawText() to OPAQUE as required, otherwise always TRANSPARENT

--- a/src/msw/textmeasure.cpp
+++ b/src/msw/textmeasure.cpp
@@ -167,5 +167,23 @@ bool wxTextMeasure::DoGetPartialTextExtents(const wxString& text,
         return false;
     }
 
+    // The width of \t determined by GetTextExtentExPoint is 0. Determine the
+    // actual width using DoGetTextExtent and update the widths accordingly.
+    int offset = 0;
+    int tabWidth = 0;
+    int tabHeight = 0;
+    for ( unsigned i = 0; i < text.length(); ++i )
+    {
+        if ( text[i] == '\t' )
+        {
+            if ( tabWidth == 0 )
+            {
+                DoGetTextExtent("\t", &tabWidth, &tabHeight);
+            }
+            offset += tabWidth;
+        }
+        widths[i] += offset;
+    }
+
     return true;
 }

--- a/tests/graphics/ellipsization.cpp
+++ b/tests/graphics/ellipsization.cpp
@@ -143,12 +143,15 @@ void EllipsizationTestCase::EnoughSpace()
 
     wxMemoryDC dc;
 
-    CPPUNIT_ASSERT_EQUAL("some label",
-                         wxControl::Ellipsize("some label", dc, wxELLIPSIZE_START, 200));
-    CPPUNIT_ASSERT_EQUAL("some label",
-                         wxControl::Ellipsize("some label", dc, wxELLIPSIZE_MIDDLE, 200));
-    CPPUNIT_ASSERT_EQUAL("some label",
-                         wxControl::Ellipsize("some label", dc, wxELLIPSIZE_END, 200));
+    wxString testString("some label");
+    const int width = dc.GetTextExtent(testString).GetWidth() + 50;
+
+    CPPUNIT_ASSERT_EQUAL(testString,
+                         wxControl::Ellipsize(testString, dc, wxELLIPSIZE_START, width));
+    CPPUNIT_ASSERT_EQUAL(testString,
+                         wxControl::Ellipsize(testString, dc, wxELLIPSIZE_MIDDLE, width));
+    CPPUNIT_ASSERT_EQUAL(testString,
+                         wxControl::Ellipsize(testString, dc, wxELLIPSIZE_END, width));
 }
 
 
@@ -158,14 +161,16 @@ void EllipsizationTestCase::VeryLittleSpace()
 
     wxMemoryDC dc;
 
+    const int width = dc.GetTextExtent("s...").GetWidth();
+
     CPPUNIT_ASSERT_EQUAL("...l",
-                         wxControl::Ellipsize("some label", dc, wxELLIPSIZE_START, 5));
+                         wxControl::Ellipsize("some label", dc, wxELLIPSIZE_START, width));
     CPPUNIT_ASSERT_EQUAL("s...",
-                         wxControl::Ellipsize("some label", dc, wxELLIPSIZE_MIDDLE, 5));
+                         wxControl::Ellipsize("some label", dc, wxELLIPSIZE_MIDDLE, width));
     CPPUNIT_ASSERT_EQUAL("s...",
-                         wxControl::Ellipsize("some label1", dc, wxELLIPSIZE_MIDDLE, 5));
+                         wxControl::Ellipsize("some label1", dc, wxELLIPSIZE_MIDDLE, width));
     CPPUNIT_ASSERT_EQUAL("s...",
-                         wxControl::Ellipsize("some label", dc, wxELLIPSIZE_END, 5));
+                         wxControl::Ellipsize("some label", dc, wxELLIPSIZE_END, width));
 }
 
 
@@ -173,12 +178,15 @@ void EllipsizationTestCase::HasThreeDots()
 {
     wxMemoryDC dc;
 
-    CPPUNIT_ASSERT( wxControl::Ellipsize("some longer text", dc, wxELLIPSIZE_START, 80).StartsWith("...") );
-    CPPUNIT_ASSERT( !wxControl::Ellipsize("some longer text", dc, wxELLIPSIZE_START, 80).EndsWith("...") );
+    wxString testString("some longer text");
+    const int width = dc.GetTextExtent(testString).GetWidth() - 5;
 
-    CPPUNIT_ASSERT( wxControl::Ellipsize("some longer text", dc, wxELLIPSIZE_END, 80).EndsWith("...") );
+    CPPUNIT_ASSERT( wxControl::Ellipsize(testString, dc, wxELLIPSIZE_START, width).StartsWith("...") );
+    CPPUNIT_ASSERT( !wxControl::Ellipsize(testString, dc, wxELLIPSIZE_START, width).EndsWith("...") );
 
-    CPPUNIT_ASSERT( wxControl::Ellipsize("some longer text", dc, wxELLIPSIZE_MIDDLE, 80).Contains("...") );
-    CPPUNIT_ASSERT( !wxControl::Ellipsize("some longer text", dc, wxELLIPSIZE_MIDDLE, 80).StartsWith("...") );
-    CPPUNIT_ASSERT( !wxControl::Ellipsize("some longer text", dc, wxELLIPSIZE_MIDDLE, 80).EndsWith("...") );
+    CPPUNIT_ASSERT( wxControl::Ellipsize(testString, dc, wxELLIPSIZE_END, width).EndsWith("...") );
+
+    CPPUNIT_ASSERT( wxControl::Ellipsize(testString, dc, wxELLIPSIZE_MIDDLE, width).Contains("...") );
+    CPPUNIT_ASSERT( !wxControl::Ellipsize(testString, dc, wxELLIPSIZE_MIDDLE, width).StartsWith("...") );
+    CPPUNIT_ASSERT( !wxControl::Ellipsize(testString, dc, wxELLIPSIZE_MIDDLE, width).EndsWith("...") );
 }

--- a/tests/graphics/ellipsization.cpp
+++ b/tests/graphics/ellipsization.cpp
@@ -23,34 +23,14 @@
 // test class
 // ----------------------------------------------------------------------------
 
-class EllipsizationTestCase : public CppUnit::TestCase
+class EllipsizationTestCase
 {
 public:
     EllipsizationTestCase() { }
-
-private:
-    CPPUNIT_TEST_SUITE( EllipsizationTestCase );
-        CPPUNIT_TEST( NormalCase );
-        CPPUNIT_TEST( EnoughSpace );
-        CPPUNIT_TEST( VeryLittleSpace );
-        CPPUNIT_TEST( HasThreeDots );
-    CPPUNIT_TEST_SUITE_END();
-
-    void NormalCase();
-    void EnoughSpace();
-    void VeryLittleSpace();
-    void HasThreeDots();
-
-    wxDECLARE_NO_COPY_CLASS(EllipsizationTestCase);
 };
 
-// register in the unnamed registry so that these tests are run by default
-CPPUNIT_TEST_SUITE_REGISTRATION( EllipsizationTestCase );
 
-// also include in its own registry so that these tests can be run alone
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( EllipsizationTestCase, "EllipsizationTestCase" );
-
-void EllipsizationTestCase::NormalCase()
+TEST_CASE_METHOD(EllipsizationTestCase, "Ellipsization::NormalCase", "[ellipsization]")
 {
     wxMemoryDC dc;
 
@@ -137,7 +117,7 @@ void EllipsizationTestCase::NormalCase()
 }
 
 
-void EllipsizationTestCase::EnoughSpace()
+TEST_CASE_METHOD(EllipsizationTestCase, "Ellipsization::EnoughSpace", "[ellipsization]")
 {
     // No ellipsization should occur if there's plenty of space.
 
@@ -146,16 +126,13 @@ void EllipsizationTestCase::EnoughSpace()
     wxString testString("some label");
     const int width = dc.GetTextExtent(testString).GetWidth() + 50;
 
-    CPPUNIT_ASSERT_EQUAL(testString,
-                         wxControl::Ellipsize(testString, dc, wxELLIPSIZE_START, width));
-    CPPUNIT_ASSERT_EQUAL(testString,
-                         wxControl::Ellipsize(testString, dc, wxELLIPSIZE_MIDDLE, width));
-    CPPUNIT_ASSERT_EQUAL(testString,
-                         wxControl::Ellipsize(testString, dc, wxELLIPSIZE_END, width));
+    CHECK( wxControl::Ellipsize(testString, dc, wxELLIPSIZE_START, width) == testString );
+    CHECK( wxControl::Ellipsize(testString, dc, wxELLIPSIZE_MIDDLE, width) == testString );
+    CHECK( wxControl::Ellipsize(testString, dc, wxELLIPSIZE_END, width) == testString );
 }
 
 
-void EllipsizationTestCase::VeryLittleSpace()
+TEST_CASE_METHOD(EllipsizationTestCase, "Ellipsization::VeryLittleSpace", "[ellipsization]")
 {
     // If there's not enough space, the shortened label should still contain "..." and one character
 
@@ -163,30 +140,26 @@ void EllipsizationTestCase::VeryLittleSpace()
 
     const int width = dc.GetTextExtent("s...").GetWidth();
 
-    CPPUNIT_ASSERT_EQUAL("...l",
-                         wxControl::Ellipsize("some label", dc, wxELLIPSIZE_START, width));
-    CPPUNIT_ASSERT_EQUAL("s...",
-                         wxControl::Ellipsize("some label", dc, wxELLIPSIZE_MIDDLE, width));
-    CPPUNIT_ASSERT_EQUAL("s...",
-                         wxControl::Ellipsize("some label1", dc, wxELLIPSIZE_MIDDLE, width));
-    CPPUNIT_ASSERT_EQUAL("s...",
-                         wxControl::Ellipsize("some label", dc, wxELLIPSIZE_END, width));
+    CHECK( wxControl::Ellipsize("some label", dc, wxELLIPSIZE_START, width) == "...l" );
+    CHECK( wxControl::Ellipsize("some label", dc, wxELLIPSIZE_MIDDLE, width) == "s..." );
+    CHECK( wxControl::Ellipsize("some label1", dc, wxELLIPSIZE_MIDDLE, width) == "s..." );
+    CHECK( wxControl::Ellipsize("some label", dc, wxELLIPSIZE_END, width) == "s..." );
 }
 
 
-void EllipsizationTestCase::HasThreeDots()
+TEST_CASE_METHOD(EllipsizationTestCase, "Ellipsization::HasThreeDots", "[ellipsization]")
 {
     wxMemoryDC dc;
 
     wxString testString("some longer text");
     const int width = dc.GetTextExtent(testString).GetWidth() - 5;
 
-    CPPUNIT_ASSERT( wxControl::Ellipsize(testString, dc, wxELLIPSIZE_START, width).StartsWith("...") );
-    CPPUNIT_ASSERT( !wxControl::Ellipsize(testString, dc, wxELLIPSIZE_START, width).EndsWith("...") );
+    CHECK( wxControl::Ellipsize(testString, dc, wxELLIPSIZE_START, width).StartsWith("...") );
+    CHECK( !wxControl::Ellipsize(testString, dc, wxELLIPSIZE_START, width).EndsWith("...") );
 
-    CPPUNIT_ASSERT( wxControl::Ellipsize(testString, dc, wxELLIPSIZE_END, width).EndsWith("...") );
+    CHECK( wxControl::Ellipsize(testString, dc, wxELLIPSIZE_END, width).EndsWith("...") );
 
-    CPPUNIT_ASSERT( wxControl::Ellipsize(testString, dc, wxELLIPSIZE_MIDDLE, width).Contains("...") );
-    CPPUNIT_ASSERT( !wxControl::Ellipsize(testString, dc, wxELLIPSIZE_MIDDLE, width).StartsWith("...") );
-    CPPUNIT_ASSERT( !wxControl::Ellipsize(testString, dc, wxELLIPSIZE_MIDDLE, width).EndsWith("...") );
+    CHECK( wxControl::Ellipsize(testString, dc, wxELLIPSIZE_MIDDLE, width).Contains("...") );
+    CHECK( !wxControl::Ellipsize(testString, dc, wxELLIPSIZE_MIDDLE, width).StartsWith("...") );
+    CHECK( !wxControl::Ellipsize(testString, dc, wxELLIPSIZE_MIDDLE, width).EndsWith("...") );
 }


### PR DESCRIPTION
In the drawing sample, there is an option to save the current screen to bmp or png.
When saving as png or bmp, the screen is drawn to a `wxBitmap` with `wxMemoryDC`, converted to `wxImage` and saved in the desired format. 
The font in the resulting image is incorrect (at least on Windows), unless the font is explicitly set (for example the text screen of the drawing sample). Fix this by always setting a default font.

Before - After
<a href="https://user-images.githubusercontent.com/8088070/62974925-86690480-be19-11e9-96f0-051bda03426d.png"><img src="https://user-images.githubusercontent.com/8088070/62974925-86690480-be19-11e9-96f0-051bda03426d.png" width="300"/></a> <a href="https://user-images.githubusercontent.com/8088070/62974927-8832c800-be19-11e9-8cb8-2cc3c6a8eae4.png"><img src="https://user-images.githubusercontent.com/8088070/62974927-8832c800-be19-11e9-8cb8-2cc3c6a8eae4.png" width="300"/></a>


