### PR TITLE
Patch wxWidgetCocoaImpl::GetContentArea to handle a 'nil' contentView.

### DIFF
--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -3026,7 +3026,7 @@ void wxWidgetCocoaImpl::GetSize( int &width, int &height ) const
 
 void wxWidgetCocoaImpl::GetContentArea( int&left, int &top, int &width, int &height ) const
 {
-    if ( [m_osxView respondsToSelector:@selector(contentView) ] )
+    if ( [m_osxView respondsToSelector:@selector(contentView) ] && [m_osxView contentView] )
     {
         NSView* cv = [m_osxView contentView];
 


### PR DESCRIPTION
In macOS 10.15 (Catalina) some controls newly respond to the 'contentView' selector and return nil.  This has the effect of suppressing wxEVT_PAINT events, because the rectangle in which to draw/paint is calculated incorrectly.