### PR TITLE
[OSX] Implement case sensitivity check under OSX

### DIFF
--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -25,6 +25,8 @@
 
 // bring in theming types without pulling in the headers
 
+extern bool CocoaFileNameGetSensitivity();
+
 #if wxUSE_GUI
 typedef SInt16 ThemeBrush;
 CGColorRef WXDLLIMPEXP_CORE wxMacCreateCGColorFromHITheme( ThemeBrush brush ) ;

--- a/samples/minimal/minimal.cpp
+++ b/samples/minimal/minimal.cpp
@@ -32,7 +32,7 @@
 // ----------------------------------------------------------------------------
 // resources
 // ----------------------------------------------------------------------------
-
+#include "wx/filename.h"
 // the application icon (under Windows it is in resources and even
 // though we could still include the XPM here it would be unused)
 #ifndef wxHAS_IMAGES_IN_RESOURCES
@@ -191,6 +191,8 @@ void MyFrame::OnQuit(wxCommandEvent& WXUNUSED(event))
 
 void MyFrame::OnAbout(wxCommandEvent& WXUNUSED(event))
 {
+    if( wxFileName::IsCaseSensitive() )
+        wxMessageBox( "File system is case sensitive" );
     wxMessageBox(wxString::Format
                  (
                     "Welcome to %s!\n"

--- a/src/common/filename.cpp
+++ b/src/common/filename.cpp
@@ -1806,6 +1806,9 @@ bool wxFileName::SameAs(const wxFileName& filepath, wxPathFormat format) const
 /* static */
 bool wxFileName::IsCaseSensitive( wxPathFormat format )
 {
+#ifdef __WXMAC__
+    return CocoaFileNameGetSensitivity();
+#endif
     // only Unix filenames are truly case-sensitive
     return GetFormat(format) == wxPATH_UNIX;
 }

--- a/src/osx/cocoa/stdpaths.mm
+++ b/src/osx/cocoa/stdpaths.mm
@@ -29,6 +29,14 @@
 // ============================================================================
 // implementation
 // ============================================================================
+bool CocoaFileNameGetSensitivity()
+{
+    NSNumber *value = [NSNumber numberWithBool:TRUE];
+    NSURL *url = [NSURL URLWithString:@"file:///"];
+    BOOL result = [url getResourceValue: &value forKey: NSURLVolumeSupportsCaseSensitiveNamesKey error: nil];
+    if( result == YES )
+        return [value boolValue] == YES;
+}
 
 static wxString GetFMDirectory(
                                    NSSearchPathDirectory directory,


### PR DESCRIPTION
This PR will take care of the ticket 10975.
On my Mac (which is set by default and has OSX 10.13) I have exactly the same results as the one that Stefan had back when he submitted his comment.

So if anyone has Mac which configured differently, it would be nice to check the results of running this PR.

I also welcome a review from Stefan.

More comment - the stdpath.mm file is the closest one I could have used. If there is a better choice - I'm all ears. Also if there is a better function name for checking this on OSX/Cocoa.

I will push modified minimal sample to easily check functionality of this function to whoever will try this PR.

No documentation changes is required 

Please review and apply.
