### PR TITLE
Handle wxSL_MIN_MAX_LABELS and wxSL_VALUE_LABEL correctly in wxMac

### DIFF
--- a/src/osx/slider_osx.cpp
+++ b/src/osx/slider_osx.cpp
@@ -117,10 +117,14 @@ bool wxSlider::Create(wxWindow *parent,
     // other values
 #endif
     
-    if (style & wxSL_LABELS)
+    if (style & wxSL_MIN_MAX_LABELS)
     {
         m_macMinimumStatic = new wxStaticText( parent, wxID_ANY, wxEmptyString );
         m_macMaximumStatic = new wxStaticText( parent, wxID_ANY, wxEmptyString );
+    }
+
+    if (style & wxSL_VALUE_LABEL)
+    {
         m_macValueStatic = new wxStaticText( parent, wxID_ANY, wxEmptyString );
     }
 


### PR DESCRIPTION
Create the labels corresponding to each style instead of always creating
all 3 of them whenever any of the styles is specified.

See #11427.