### PR TITLE
Also scale maximum value for wxProgressDialog.

### DIFF
--- a/src/generic/progdlgg.cpp
+++ b/src/generic/progdlgg.cpp
@@ -600,6 +600,7 @@ void wxGenericProgressDialog::SetMaximum(int maximum)
     // we can't have values > 65,536 in the progress control under Windows, so
     // scale everything down
     m_factor = m_maximum / 65536 + 1;
+    m_maximum /= m_factor;
 #endif // __WXMSW__
 }
 


### PR DESCRIPTION
MSW-specific code in wxProgressDialog scales the value with a factor. However the maximum value is not scaled. This means the progress bar and estimated remaining time are not correct.

I have seen some (very old) discussion to [remove this scaling altogether](https://trac.wxwidgets.org/ticket/15098) but this change fixes this issue for now.