### PR TITLE
Make wxComboCtrl a wxCompositeWindow

### DIFF
--- a/include/wx/combo.h
+++ b/include/wx/combo.h
@@ -46,6 +46,7 @@
 #include "wx/bitmap.h" // wxBitmap used by-value
 #include "wx/textentry.h"
 #include "wx/time.h" // needed for wxMilliClock_t
+#include "wx/compositewin.h" // wxComboCtrlBase declaration
 
 class WXDLLIMPEXP_FWD_CORE wxTextCtrl;
 class WXDLLIMPEXP_FWD_CORE wxComboPopup;
@@ -140,14 +141,14 @@ struct wxComboCtrlFeatures
 };
 
 
-class WXDLLIMPEXP_CORE wxComboCtrlBase : public wxControl,
+class WXDLLIMPEXP_CORE wxComboCtrlBase : public wxCompositeWindow<wxControl>,
                                          public wxTextEntry
 {
     friend class wxComboPopup;
     friend class wxComboPopupEvtHandler;
 public:
     // ctors and such
-    wxComboCtrlBase() : wxControl(), wxTextEntry() { Init(); }
+    wxComboCtrlBase() : wxCompositeWindow<wxControl>(), wxTextEntry() { Init(); }
 
     bool Create(wxWindow *parent,
                 wxWindowID id,
@@ -472,7 +473,6 @@ public:
         { return m_mainCtrlWnd; }
 
     // also set the embedded wxTextCtrl colours
-    virtual bool SetForegroundColour(const wxColour& colour) wxOVERRIDE;
     virtual bool SetBackgroundColour(const wxColour& colour) wxOVERRIDE;
 
 protected:
@@ -598,10 +598,6 @@ protected:
     // Flags are same as for DoShowPopup.
     virtual bool AnimateShow( const wxRect& rect, int flags );
 
-#if wxUSE_TOOLTIPS
-    virtual void DoSetToolTip( wxToolTip *tip ) wxOVERRIDE;
-#endif
-
     // protected wxTextEntry methods
     virtual void DoSetValue(const wxString& value, int flags) wxOVERRIDE;
     virtual wxString DoGetValue() const wxOVERRIDE;
@@ -610,6 +606,8 @@ protected:
     // margins functions
     virtual bool DoSetMargins(const wxPoint& pt) wxOVERRIDE;
     virtual wxPoint DoGetMargins() const wxOVERRIDE;
+
+    virtual wxWindowList GetCompositeWindowParts() const wxOVERRIDE;
 
     // This is used when m_text is hidden (readonly).
     wxString                m_valueString;

--- a/src/common/combocmn.cpp
+++ b/src/common/combocmn.cpp
@@ -1535,37 +1535,6 @@ bool wxComboCtrlBase::SetFont ( const wxFont& font )
     return true;
 }
 
-#if wxUSE_TOOLTIPS
-void wxComboCtrlBase::DoSetToolTip(wxToolTip *tooltip)
-{
-    wxControl::DoSetToolTip(tooltip);
-
-    // Set tool tip for button and text box
-    if ( tooltip )
-    {
-        const wxString &tip = tooltip->GetTip();
-        if ( m_text ) m_text->SetToolTip(tip);
-        if ( m_btn ) m_btn->SetToolTip(tip);
-    }
-    else
-    {
-        if ( m_text ) m_text->SetToolTip( NULL );
-        if ( m_btn ) m_btn->SetToolTip( NULL );
-    }
-}
-#endif // wxUSE_TOOLTIPS
-
-bool wxComboCtrlBase::SetForegroundColour(const wxColour& colour)
-{
-    if ( wxControl::SetForegroundColour(colour) )
-    {
-        if ( m_text )
-            m_text->SetForegroundColour(colour);
-        return true;
-    }
-    return false;
-}
-
 bool wxComboCtrlBase::SetBackgroundColour(const wxColour& colour)
 {
     if ( m_text )
@@ -2746,6 +2715,16 @@ void wxComboCtrlBase::SetTextCtrlStyle( int style )
 
     if ( m_text )
         m_text->SetWindowStyle(style);
+}
+
+wxWindowList wxComboCtrlBase::GetCompositeWindowParts() const
+{
+    wxWindowList parts;
+    if ( m_text )
+        parts.push_back(m_text);
+    if ( m_btn )
+        parts.push_back(m_btn);
+    return parts;
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
wxComboCtrl consists of several controls (text entry, button, popup) and therefore should be implemented as a wxCompositeWindow to prevent problems with generating spurious events when e.g. focus is transferred between the sub-controls.

Closes https://trac.wxwidgets.org/ticket/18394