### PR TITLE
Fix wxWindow::setBackgroundColour(wxNullColour) on OS X.

### DIFF
--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -3177,7 +3177,8 @@ void wxWidgetCocoaImpl::SetBackgroundColour( const wxColour &col )
             wxTopLevelWindow* toplevel = wxDynamicCast(peer,wxTopLevelWindow);
 
             if ( toplevel == NULL || toplevel->GetShape().IsEmpty() )
-                [targetView setBackgroundColor: col.OSXGetNSColor()];
+                [targetView setBackgroundColor:
+                        col.IsOk() ? col.OSXGetNSColor() : nil];
         }
     }
 }


### PR DESCRIPTION
Commit 91aa6ba36e64ed11021f4bdc13c7210f96c1d6e1 introduced a
regression causing this to crash. We need to validate that the color
is valid before attempting to call OSXGetNSColor; if it is not, we
should clear any previously-set background color.

Fixes #18470