### PR TITLE
Add menu object to the menu highlight event

### DIFF
--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -3295,7 +3295,7 @@ public:
     @class wxDisplayChangedEvent
 
     A display changed event is sent to top-level windows when the display resolution has changed.
-    
+
     This event is currently emitted under Windows only.
 
     @beginEventTable{wxDisplayChangedEvent}
@@ -3309,7 +3309,7 @@ public:
     @category{events}
 
     @see wxDisplay
-*/ 
+*/
 
 class wxDisplayChangedEvent : public wxEvent
 {
@@ -4445,13 +4445,16 @@ public:
     wxMenuEvent(wxEventType type = wxEVT_NULL, int id = 0, wxMenu* menu = NULL);
 
     /**
-        Returns the menu which is being opened or closed.
-
-        This method can only be used with the @c OPEN and @c CLOSE events.
+        Returns the menu which is being opened or closed, or the menu containing
+        the highlighted item.
 
         Note that the returned value can be @NULL if the menu being opened
         doesn't have a corresponding wxMenu, e.g. this happens when opening the
         system menu in wxMSW port.
+
+        @remarks Since 3.1.3 this function can be used with @c OPEN, @c CLOSE
+        and @c HIGHLIGHT events. Before 3.1.3, this method can only be used
+        with the @c OPEN and @c CLOSE events.
     */
     wxMenu* GetMenu() const;
 

--- a/samples/menu/menu.cpp
+++ b/samples/menu/menu.cpp
@@ -1235,19 +1235,21 @@ void MyFrame::LogMenuOpenCloseOrHighlight(const wxMenuEvent& event, const wxStri
 
     if ( event.GetEventType() == wxEVT_MENU_HIGHLIGHT )
     {
-        msg << " (id=" << event.GetId() << ")";
+        msg << " (id=" << event.GetId() << " in ";
     }
-    else // wxEVT_MENU_{OPEN,CLOSE}
+    else
     {
-        wxMenu* const menu = event.GetMenu();
-        if ( menu )
-        {
-            msg << " (menu with title \"" << menu->GetTitle() << "\")";
-        }
-        else
-        {
-            msg << " (no menu)";
-        }
+        msg << " (";
+    }
+
+    wxMenu* const menu = event.GetMenu();
+    if ( menu )
+    {
+        msg << "menu with title \"" << menu->GetTitle() << "\")";
+    }
+    else
+    {
+        msg << "no menu provided)";
     }
 
     msg << ".";

--- a/src/gtk/menu.cpp
+++ b/src/gtk/menu.cpp
@@ -560,7 +560,7 @@ static void menuitem_select(GtkWidget*, wxMenuItem* item)
     if (!item->IsEnabled())
         return;
 
-    wxMenuEvent event(wxEVT_MENU_HIGHLIGHT, item->GetId());
+    wxMenuEvent event(wxEVT_MENU_HIGHLIGHT, item->GetId(), item->GetMenu());
     DoCommonMenuCallbackCode(item->GetMenu(), event);
 }
 }
@@ -575,7 +575,7 @@ static void menuitem_deselect(GtkWidget*, wxMenuItem* item)
     if (!item->IsEnabled())
         return;
 
-    wxMenuEvent event( wxEVT_MENU_HIGHLIGHT, -1 );
+    wxMenuEvent event(wxEVT_MENU_HIGHLIGHT, -1, item->GetMenu());
     DoCommonMenuCallbackCode(item->GetMenu(), event);
 }
 }

--- a/src/gtk1/menu.cpp
+++ b/src/gtk1/menu.cpp
@@ -645,7 +645,7 @@ static void gtk_menu_hilight_callback( GtkWidget *widget, wxMenu *menu )
     if (!menu->IsEnabled(id))
         return;
 
-    wxMenuEvent event( wxEVT_MENU_HIGHLIGHT, id );
+    wxMenuEvent event( wxEVT_MENU_HIGHLIGHT, id, menu );
     event.SetEventObject( menu );
 
     wxEvtHandler* handler = menu->GetEventHandler();
@@ -673,7 +673,7 @@ static void gtk_menu_nolight_callback( GtkWidget *widget, wxMenu *menu )
     if (!menu->IsEnabled(id))
         return;
 
-    wxMenuEvent event( wxEVT_MENU_HIGHLIGHT, -1 );
+    wxMenuEvent event( wxEVT_MENU_HIGHLIGHT, -1, menu );
     event.SetEventObject( menu );
 
     wxEvtHandler* handler = menu->GetEventHandler();

--- a/src/motif/menuitem.cpp
+++ b/src/motif/menuitem.cpp
@@ -385,7 +385,7 @@ void wxMenuItemArmCallback (Widget WXUNUSED(w), XtPointer clientData,
     {
         if (item->GetMenuBar() && item->GetMenuBar()->GetMenuBarFrame())
         {
-            wxMenuEvent menuEvent(wxEVT_MENU_HIGHLIGHT, item->GetId());
+            wxMenuEvent menuEvent(wxEVT_MENU_HIGHLIGHT, item->GetId(), item->GetMenu());
             menuEvent.SetEventObject(item->GetMenuBar()->GetMenuBarFrame());
 
             item->GetMenuBar()->GetMenuBarFrame()
@@ -405,7 +405,7 @@ wxMenuItemDisarmCallback (Widget WXUNUSED(w), XtPointer clientData,
         {
             // TODO: not sure this is correct, since -1 means something
             // special to event system
-            wxMenuEvent menuEvent(wxEVT_MENU_HIGHLIGHT, -1);
+            wxMenuEvent menuEvent(wxEVT_MENU_HIGHLIGHT, -1, item->GetMenu());
             menuEvent.SetEventObject(item->GetMenuBar()->GetMenuBarFrame());
 
             item->GetMenuBar()->GetMenuBarFrame()

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -2420,8 +2420,9 @@ wxWindowMSW::HandleMenuSelect(WXWORD nItem, WXWORD flags, WXHMENU hMenu)
     if ( flags & (MF_POPUP | MF_SEPARATOR) )
         item = wxID_NONE;
 
-    wxMenuEvent event(wxEVT_MENU_HIGHLIGHT, item);
-    if ( wxMenu::ProcessMenuEvent(MSWFindMenuFromHMENU(hMenu), event, this) )
+    wxMenu* menu = MSWFindMenuFromHMENU(hMenu);
+    wxMenuEvent event(wxEVT_MENU_HIGHLIGHT, item, menu);
+    if ( wxMenu::ProcessMenuEvent(menu, event, this) )
         return true;
 
     // by default, i.e. if the event wasn't handled above, clear the status bar


### PR DESCRIPTION
This adds the menu object to the menu HIGHLIGHT event, so it can be found using ```GetMenu()``` in the event. It also updates the menu sample to give the menu name of the highlighted item, and update the documentation.

This was already in the wxOSX port since at least 2011, so this normalizes the behavior across the platforms.

Can someone please verify using the sample on MSW? I only have access to GTK right now.