### PR TITLE
Fix the issue with non wxControl grid cell editor control

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -2774,7 +2774,7 @@ void wxGrid::CalcDimensions()
         // how big is the editor
         wxGridCellAttr* attr = GetCellAttr(r, c);
         wxGridCellEditor* editor = attr->GetEditor(this, r, c);
-        editor->GetControl()->GetSize(&w2, &h2);
+        editor->GetWindow()->GetSize(&w2, &h2);
         w2 += x;
         h2 += y;
         if ( w2 > w )
@@ -6877,7 +6877,7 @@ bool wxGrid::IsCellEditControlShown() const
         {
             if ( editor->IsCreated() )
             {
-                isShown = editor->GetControl()->IsShown();
+                isShown = editor->GetWindow()->IsShown();
             }
 
             editor->DecRef();
@@ -6959,13 +6959,13 @@ void wxGrid::ShowCellEditControl()
                                              this,
                                              row,
                                              col,
-                                             editor->GetControl());
+                                             editor->GetWindow());
                 GetEventHandler()->ProcessEvent(evt);
             }
-            else if ( editor->GetControl() &&
-                      editor->GetControl()->GetParent() != gridWindow )
+            else if ( editor->GetWindow() &&
+                      editor->GetWindow()->GetParent() != gridWindow )
             {
-                editor->GetControl()->Reparent(gridWindow);
+                editor->GetWindow()->Reparent(gridWindow);
             }
 
             // resize editor to overflow into righthand cells if allowed
@@ -7009,9 +7009,9 @@ void wxGrid::ShowCellEditControl()
             editor->SetCellAttr( attr );
             editor->SetSize( rect );
             if (nXMove != 0)
-                editor->GetControl()->Move(
-                    editor->GetControl()->GetPosition().x + nXMove,
-                    editor->GetControl()->GetPosition().y );
+                editor->GetWindow()->Move(
+                    editor->GetWindow()->GetPosition().x + nXMove,
+                    editor->GetWindow()->GetPosition().y );
             editor->Show( true, attr );
 
             // recalc dimensions in case we need to
@@ -7036,10 +7036,10 @@ void wxGrid::HideCellEditControl()
 
         wxGridCellAttr *attr = GetCellAttr(row, col);
         wxGridCellEditor *editor = attr->GetEditor(this, row, col);
-        const bool editorHadFocus = editor->GetControl()->HasFocus();
+        const bool editorHadFocus = editor->GetWindow()->HasFocus();
 
-        if ( editor->GetControl()->GetParent() != m_gridWin )
-            editor->GetControl()->Reparent(m_gridWin);
+        if ( editor->GetWindow()->GetParent() != m_gridWin )
+            editor->GetWindow()->Reparent(m_gridWin);
 
         editor->Show( false );
         editor->DecRef();

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -747,31 +747,31 @@ void GridTestCase::ReadOnly()
 void GridTestCase::WindowAsEditorControl()
 {
 #if wxUSE_UIACTIONSIMULATOR
-    //The simple editor using wxWindow as a control
+    //A very simple editor using a window not derived from wxControl as the editor.
     class TestEditor : public wxGridCellEditor
     {
     public:
-        TestEditor() = default;
-        TestEditor(const TestEditor&) = delete;
-        TestEditor& operator=(TestEditor const&) = delete;
-        void Create(wxWindow* parent, wxWindowID id, wxEvtHandler* evtHandler) override
+        TestEditor() {}
+        void Create(wxWindow* parent, wxWindowID id, wxEvtHandler* evtHandler) wxOVERRIDE
         {
             SetWindow(new wxWindow(parent, id));
             wxGridCellEditor::Create(parent, id, evtHandler);
         }
-        void BeginEdit(int, int, wxGrid*) override {}
-        bool EndEdit(int, int, wxGrid const*, wxString const&, wxString* newval) override
+        void BeginEdit(int, int, wxGrid*) wxOVERRIDE {}
+        bool EndEdit(int, int, wxGrid const*, wxString const&, wxString* newval) wxOVERRIDE
         {
             *newval = GetValue();
             return true;
         }
-        void ApplyEdit(int row, int col, wxGrid* grid) override
+        void ApplyEdit(int row, int col, wxGrid* grid) wxOVERRIDE
         {
             grid->GetTable()->SetValue(row, col, GetValue());
         }
-        void Reset() override {}
-        wxGridCellEditor* Clone() const override { return new TestEditor(); }
-        wxString GetValue() const override { return "value"; }
+        void Reset() wxOVERRIDE {}
+        wxGridCellEditor* Clone() const wxOVERRIDE { return new TestEditor(); }
+        wxString GetValue() const wxOVERRIDE { return "value"; }
+
+        wxDECLARE_NO_COPY_CLASS(TestEditor);
     };
 
     wxGridCellAttr* attr = new wxGridCellAttr();
@@ -792,9 +792,6 @@ void GridTestCase::WindowAsEditorControl()
     wxYield();
 
     CPPUNIT_ASSERT_EQUAL(1, created.GetCount());
-
-    //Clean up
-    m_grid->SetAttr(1, 1, nullptr);
 #endif
 }
 


### PR DESCRIPTION
The wxWindow based class can be used as a control in wxGridCellEditor. So use
`wxGridCellEditor::GetWindow` inside the grid internal code.