### PR TITLE
Apply font family for wxFont under wxQT

### DIFF
--- a/src/qt/font.cpp
+++ b/src/qt/font.cpp
@@ -563,7 +563,7 @@ void wxNativeFontInfo::SetFamily(wxFontFamily family)
 {
     m_qtFont.setStyleHint(ConvertFontFamily(family));
     // reset the face name to force qt to choose a new font
-    m_qtFont.setFamily("");
+    m_qtFont.setFamily(m_qtFont.defaultFamily());
 }
 
 void wxNativeFontInfo::SetEncoding(wxFontEncoding WXUNUSED(encoding))


### PR DESCRIPTION
This changes ensures that a font can be correctly selected specifying just the family.  Prior to this QT was  ignoring the styleHint and empty family matching the first font on the system.