### PR TITLE
Fix deletion of array in fswatcher_inotify

### DIFF
--- a/src/unix/fswatcher_inotify.cpp
+++ b/src/unix/fswatcher_inotify.cpp
@@ -533,7 +533,7 @@ protected:
             }
 
             m_cookies.erase(it);
-            delete &inevt;
+            delete[] (char*)&inevt;
             it = m_cookies.begin();
         }
     }


### PR DESCRIPTION
Fix the deletion of the object to be an array-type deletion instead of normal deletion (since it was created by an array-type constructor).