### PR TITLE
Make wxWindow::GetContentScaleFactor() work for GTK3

### DIFF
--- a/include/wx/gtk/window.h
+++ b/include/wx/gtk/window.h
@@ -90,6 +90,9 @@ public:
 
     virtual int GetCharHeight() const;
     virtual int GetCharWidth() const;
+#if defined __WXGTK3__
+    virtual double GetContentScaleFactor() const;
+#endif
 
     virtual void SetScrollbar( int orient, int pos, int thumbVisible,
                                int range, bool refresh = true );

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -3429,6 +3429,20 @@ void wxWindowGTK::DoGetTextExtent( const wxString& string,
     txm.GetTextExtent(string, x, y, descent, externalLeading);
 }
 
+#ifdef __WXGTK3__
+double wxWindowGTK::GetContentScaleFactor() const
+{
+    double scaleFactor = 1;
+#if GTK_CHECK_VERSION(3,10,0)
+    if (m_widget && gtk_check_version(3,10,0) == NULL)
+    {
+        scaleFactor = gtk_widget_get_scale_factor(m_widget);
+    }
+#endif
+    return scaleFactor;
+}
+#endif
+
 void wxWindowGTK::GTKDisableFocusOutEvent()
 {
     g_signal_handlers_block_by_func( m_focusWidget,

--- a/version-script.in
+++ b/version-script.in
@@ -27,6 +27,7 @@
     *wxSVGFileDCImpl*SetAxisOrientation*;
     *wxSVGFileDCImpl*SetDeviceOrigin*;
     *wxSVGFileDCImpl*SetLogicalOrigin*;
+    *wxWindow*GetContentScaleFactor*;
 };
 
 # public symbols added in 3.0.4 (please keep in alphabetical order):
@@ -64,5 +65,8 @@
         # Explicitly mention this one as otherwise it would be caught by
         # wxDataViewRenderer*FinishEditing wildcard in 3.0.3 above.
         *wxDataViewRendererBase*FinishEditing*;
+        # This would otherwise match *wxWindow*GetContentScaleFactor*
+        # in 3.0.5 above.
+        *wxWindowBase*GetContentScaleFactor*;
         *;
 };


### PR DESCRIPTION
This is a partial backport of f95fd11e08482697c3b0c0a9d2ccd661134480ee.