### PR TITLE
Ensure wxFRAME_NO_TASKBAR is correctly applied under wxQT

### DIFF
--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -53,7 +53,8 @@ wxFrame::~wxFrame()
 bool wxFrame::Create( wxWindow *parent, wxWindowID id, const wxString& title,
     const wxPoint& pos, const wxSize& size, long style, const wxString& name )
 {
-    m_qtWindow = new wxQtMainWindow( parent, this );
+    wxWindow *effectiveParent = style & wxFRAME_NO_TASKBAR ? parent : NULL;
+    m_qtWindow = new wxQtMainWindow(effectiveParent, this );
 
     // TODO: Could we use a wxPanel as the central widget? If so then we could
     // remove wxWindow::QtReparent.
@@ -135,8 +136,7 @@ void wxFrame::SetWindowStyleFlag( long style )
     wxWindow::SetWindowStyleFlag( style );
 
     QMainWindow *qtFrame = GetQMainWindow();
-    Qt::WindowFlags qtFlags = qtFrame->windowFlags();
-    qtFlags |= Qt::CustomizeWindowHint;
+    Qt::WindowFlags qtFlags = Qt::CustomizeWindowHint | (qtFrame->windowFlags() & Qt::WindowType_Mask);
 
     if ( HasFlag( wxFRAME_TOOL_WINDOW ) )
     {


### PR DESCRIPTION
This PR ensure that the wxFRAME_NO_TASKBAR for wxFrame works under wxQT.   

Qt5 has the concept of primary and secondary windows (see https://doc.qt.io/qt-5/application-windows.html).  

Any widget with a NULL parent is a primary window and will appear in the taskbar.  Windows with non-NULL parents are treated as secondary windows and will not appear in the taskbar.

There doesn't seem to be anyway to promote and demote windows between primary and secondary.  So we've had to supply a NULL parent to QMainWindow if we want it to be on the taskbar and supply the real parent otherwise.