### PR TITLE
Cancel any edit that may be in progress when tree control is scrolled

### DIFF
--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -23,8 +23,8 @@
 
 #include <QtWidgets/QTreeWidget>
 #include <QtWidgets/QHeaderView>
+#include <QtWidgets/QScrollBar>
 #include <QtGui/QPainter>
-#include <QScrollBar>
 
 namespace
 {
@@ -437,7 +437,7 @@ private:
 
     void OnTreeScrolled(int)
     {
-        if (GetEditControl() == NULL)
+        if ( GetEditControl() == NULL )
             return;
 
         closeEditor(GetEditControl()->GetHandle(), QAbstractItemDelegate::RevertModelCache);

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -437,10 +437,8 @@ private:
 
     void OnTreeScrolled(int)
     {
-        if ( GetEditControl() == NULL )
-            return;
-
-        closeEditor(GetEditControl()->GetHandle(), QAbstractItemDelegate::RevertModelCache);
+        if ( GetEditControl() != NULL )
+            closeEditor(GetEditControl()->GetHandle(), QAbstractItemDelegate::RevertModelCache);
     }
 
     void tryStartDrag(const QMouseEvent *event)

--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -24,6 +24,7 @@
 #include <QtWidgets/QTreeWidget>
 #include <QtWidgets/QHeaderView>
 #include <QtGui/QPainter>
+#include <QScrollBar>
 
 namespace
 {
@@ -142,6 +143,8 @@ public:
                 this, &wxQTreeWidget::OnItemCollapsed);
         connect(this, &QTreeWidget::itemExpanded,
                 this, &wxQTreeWidget::OnItemExpanded);
+        connect(verticalScrollBar(), &QScrollBar::valueChanged,
+                this, &wxQTreeWidget::OnTreeScrolled);
 
         setItemDelegate(&m_item_delegate);
         setDragEnabled(true);
@@ -430,6 +433,14 @@ private:
             wxQtConvertTreeItem(item)
         );
         EmitEvent(expandedEvent);
+    }
+
+    void OnTreeScrolled(int)
+    {
+        if (GetEditControl() == NULL)
+            return;
+
+        closeEditor(GetEditControl()->GetHandle(), QAbstractItemDelegate::RevertModelCache);
     }
 
     void tryStartDrag(const QMouseEvent *event)


### PR DESCRIPTION
Discovered that if an item in a tree control was mid-edit and the whole tree was scrolled with the mouse wheel, then the edit text control did not lose focus and would remain displayed in the original location of the tree item. This can be seen in the treectrl sample if lots of items are expanded.

To match the original MSW behaviour I have added a function to close any in progress edit when the vertical scrollbar's value changes. It is passed the RevertModelCache flag so that this does not accidentally commit unfinished changes.