### PR TITLE
Do not switch to drag selecting state if drag and drop is not allowed.

### DIFF
--- a/src/qt/treectrl.cpp
+++ b/src/qt/treectrl.cpp
@@ -448,14 +448,14 @@ private:
 
         tree_event.SetPoint(wxQtConvertPoint(event->pos()));
 
-        // Vetoed unless explicitly accepted.
+        // Client must explicitly accept drag and drop. Vetoed by default.
         tree_event.Veto();
 
         EmitEvent(tree_event);
 
         if ( !tree_event.IsAllowed() )
         {
-            setState(DragSelectingState);
+            setState(NoState);
         }
     }
 


### PR DESCRIPTION
This causes bad behaviour downstream with subsequent selections when the client does anything in the event handler beyond simply not allowing the event.
Basically, we can't be guaranteed of the mouse state on return from the event handler, so dropping into drag selection mode is potentially inappropriate (or just plain bad).