### PR TITLE
Setting the default page size on wxSliders in the same way as other i…

### DIFF
--- a/src/qt/slider.cpp
+++ b/src/qt/slider.cpp
@@ -80,6 +80,7 @@ bool wxSlider::Create(wxWindow *parent,
     m_qtSlider->blockSignals(true);
     SetRange( minValue, maxValue );
     m_qtSlider->blockSignals(false);
+    SetPageSize(wxMax(1, (maxValue - minValue) / 10));
 
 #if 0 // there are not normally ticks for a wxSlider
     // draw ticks marks (default bellow if horizontal, right if vertical):


### PR DESCRIPTION
The default page size for wxSliders was fixed at 10 regardless of the initial range of the slider.  On other implementations it is 1/10 of the full range.  I have made wxSliders work the same way.