### PR TITLE
Work around QT incorrectly drawing scroll buttons in a QTabWidget

### DIFF
--- a/src/qt/notebook.cpp
+++ b/src/qt/notebook.cpp
@@ -14,6 +14,7 @@
 #include "wx/qt/private/winevent.h"
 
 #include <QtWidgets/QTabWidget>
+#include <QtWidgets/QTabBar>
 
 class wxQtTabWidget : public wxQtEventSignalHandler< QTabWidget, wxNotebook >
 {
@@ -73,6 +74,11 @@ bool wxNotebook::Create(wxWindow *parent,
           const wxString& name)
 {
     m_qtTabWidget = new wxQtTabWidget( parent, this );
+
+    //Work around tab bar arrows drawing over tab headings https://bugreports.qt.io/browse/QTBUG-50866
+    const wxColor bg_color = wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE);
+    const wxString css = "background: " + bg_color.GetAsString();
+    m_qtTabWidget->tabBar()->setStyleSheet(wxQtConvertString(css));
 
     return QtCreateControl( parent, id, pos, size, style, wxDefaultValidator, name );
 }

--- a/src/qt/notebook.cpp
+++ b/src/qt/notebook.cpp
@@ -9,6 +9,7 @@
 #include "wx/wxprec.h"
 
 #include "wx/notebook.h"
+#include "wx/settings.h"
 #include "wx/qt/private/utils.h"
 #include "wx/qt/private/converter.h"
 #include "wx/qt/private/winevent.h"


### PR DESCRIPTION
As a result of the following QT bug, https://bugreports.qt.io/browse/QTBUG-50866,  the tab bar of wxNotebook has rendering issues under wxQT.  This fix works around that issue.  

Unfortunately,   it does mean that wxNotebook will have an incorrect background if the user changes their theme/system colours while the application is running. 