### PR TITLE
Check if window is initialised before getting its screen position

### DIFF
--- a/src/common/dpycmn.cpp
+++ b/src/common/dpycmn.cpp
@@ -249,6 +249,10 @@ int wxDisplayFactory::GetFromWindow(const wxWindow *window)
 {
     wxCHECK_MSG( window, wxNOT_FOUND, "window can't be NULL" );
 
+    // check if the window is initialised
+    if ( !window->GetHandle() )
+        return wxNOT_FOUND;
+
     // consider that the window belongs to the display containing its centre
     const wxRect r(window->GetScreenRect());
     return GetFromPoint(wxPoint(r.x + r.width/2, r.y + r.height/2));


### PR DESCRIPTION
Check if window is initialised before getting its screen position.

If it is not initialised, getting the screen rectangle will fail. Return
`wxNOT_FOUND` instead, so the main display will be used.

Closes [#18481](https://trac.wxwidgets.org/ticket/18481)