### PR TITLE
Move the code that enables mouse tracking to the common PostCreation,…

### DIFF
--- a/include/wx/qt/private/winevent.h
+++ b/include/wx/qt/private/winevent.h
@@ -61,7 +61,7 @@ public:
         QObject::connect( this, &QObject::destroyed, this,
                           &wxQtEventSignalHandler::HandleDestroyedSignal );
 
-        setMouseTracking(true);
+        Widget::setMouseTracking(true);
     }
 
     void HandleDestroyedSignal()

--- a/include/wx/qt/private/winevent.h
+++ b/include/wx/qt/private/winevent.h
@@ -61,6 +61,7 @@ public:
         QObject::connect( this, &QObject::destroyed, this,
                           &wxQtEventSignalHandler::HandleDestroyedSignal );
 
+        setMouseTracking(true);
     }
 
     void HandleDestroyedSignal()

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -322,8 +322,6 @@ void wxWindowQt::PostCreation(bool generic)
     }
     wxLogTrace(TRACE_QT_WINDOW, wxT("wxWindow::Create %s m_qtWindow=%p"), GetName(), m_qtWindow);
 
-    widget->setMouseTracking(true);
-
     // set the background style after creation (not before like in wxGTK)
     // (only for generic controls, to use qt defaults elsewere)
     if (generic)

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -297,8 +297,6 @@ bool wxWindowQt::Create( wxWindowQt * parent, wxWindowID id, const wxPoint & pos
             m_qtWindow = new wxQtWidget( parent, this );
     }
 
-
-    GetHandle()->setMouseTracking(true);
     if ( !wxWindowBase::CreateBase( parent, id, pos, size, style, wxDefaultValidator, name ))
         return false;
 
@@ -323,6 +321,8 @@ void wxWindowQt::PostCreation(bool generic)
         m_qtWindow = GetHandle();
     }
     wxLogTrace(TRACE_QT_WINDOW, wxT("wxWindow::Create %s m_qtWindow=%p"), GetName(), m_qtWindow);
+
+    widget->setMouseTracking(true);
 
     // set the background style after creation (not before like in wxGTK)
     // (only for generic controls, to use qt defaults elsewere)


### PR DESCRIPTION
… as controls don't go through the Create method.

Not enabling mouse tracking manifested as combo controls eating mouse wheel events, as they never unblocked via the mouse move events that never came.