### PR TITLE
Update menu UI before showing a popup menu under wxQT

### DIFF
--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -983,9 +983,10 @@ void wxWindowQt::DoSetToolTip( wxToolTip *tip )
 #if wxUSE_MENUS
 bool wxWindowQt::DoPopupMenu(wxMenu *menu, int x, int y)
 {
+    menu->UpdateUI();
     menu->GetHandle()->exec( GetHandle()->mapToGlobal( QPoint( x, y ) ) );
 
-    return ( true );
+    return true;
 }
 #endif // wxUSE_MENUS
 


### PR DESCRIPTION
This PR ensures that the application's update UI event handlers are given a chance to customise a popup menu before its displayed.