### PR TITLE
Fix wxPOPUP_WINDOW to work as documented (Cocoa):

### DIFF
--- a/src/osx/cocoa/nonownedwnd.mm
+++ b/src/osx/cocoa/nonownedwnd.mm
@@ -707,10 +707,6 @@ long style, long extraStyle, const wxString& WXUNUSED(name) )
     {
         windowstyle |= NSUtilityWindowMask;
     }
-    else if ( ( style & wxPOPUP_WINDOW ) )
-    {
-        level = NSPopUpMenuWindowLevel;
-    }
     else if ( ( style & wxFRAME_DRAWER ) )
     {
         /*
@@ -743,6 +739,9 @@ long style, long extraStyle, const wxString& WXUNUSED(name) )
 
     if ( ( style & wxSTAY_ON_TOP ) )
         level = NSModalPanelWindowLevel;
+
+    if ( ( style & wxPOPUP_WINDOW ) )
+        level = NSPopUpMenuWindowLevel;
 
     NSRect r = wxToNSRect( NULL, wxRect( pos, size) );
 


### PR DESCRIPTION
Ensure that wxPOPUP_WINDOW on Mac always sets the window level
to NSPopupWindowLevel, regardless of the wxSTAY_ON_TOP and
wxFRAME_TOOL_WINDOW flags.

As the comment for wxPOPUP_WINDOW in defs.h says,
"set this flag to create a special popup window:
it will be always shown on top of other windows"

So, that should *always* be true, even in relation to other
Windows with wxSTAY_ON_TOP, since NSPopUpMenuWindowLevel
is greater (higher) than NSModalPanelWindowLevel.

It should also *always* be true even if the window has both
wxPOPUP_WINDOW and wxFRAME_TOOL_WINDOW styles, since there's
no reason why we can't have a panel with NSUtilityWindowMask
and NSPopUpMenuWindowLevel.