### PR TITLE
Fix clearing a selection in a grid with reordered columns

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -1522,6 +1522,8 @@ public:
     // reverse mapping currently
     int GetColPos(int idx) const
     {
+        wxASSERT_MSG( idx != wxNOT_FOUND, "invalid column index" );
+
         if ( m_colAt.IsEmpty() )
             return idx;
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -5277,6 +5277,30 @@ void wxGrid::RefreshBlock(const wxGridCellCoords& topLeft,
 void wxGrid::RefreshBlock(int topRow, int leftCol,
                           int bottomRow, int rightCol)
 {
+    const bool noTopLeft = topRow == -1 && leftCol == -1;
+    const bool noBottomRight = bottomRow == -1 && rightCol == -1;
+
+    if ( noTopLeft && noBottomRight )
+        return;
+    if ( noTopLeft )
+    {
+        topRow = 0;
+        leftCol = 0;
+    }
+    else
+    {
+        wxASSERT( topRow != -1 || leftCol != -1 );
+    }
+    if ( noBottomRight )
+    {
+        bottomRow = topRow;
+        rightCol = leftCol;
+    }
+    else
+    {
+        wxASSERT( bottomRow != -1 || rightCol != -1 );
+    }
+
     int row = topRow;
     int col = leftCol;
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -5287,18 +5287,10 @@ void wxGrid::RefreshBlock(int topRow, int leftCol,
         topRow = 0;
         leftCol = 0;
     }
-    else
-    {
-        wxASSERT( topRow != -1 || leftCol != -1 );
-    }
     if ( noBottomRight )
     {
         bottomRow = topRow;
         rightCol = leftCol;
-    }
-    else
-    {
-        wxASSERT( bottomRow != -1 || rightCol != -1 );
     }
 
     int row = topRow;

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -49,6 +49,7 @@ private:
     CPPUNIT_TEST_SUITE( GridTestCase );
         WXUISIM_TEST( CellEdit );
         NONGTK_TEST( CellClick );
+        NONGTK_TEST( ReorderedColumnsCellClick );
         NONGTK_TEST( CellSelect );
         NONGTK_TEST( LabelClick );
         NONGTK_TEST( SortClick );
@@ -83,6 +84,7 @@ private:
 
     void CellEdit();
     void CellClick();
+    void ReorderedColumnsCellClick();
     void CellSelect();
     void LabelClick();
     void SortClick();
@@ -229,6 +231,35 @@ void GridTestCase::CellClick()
 
     CPPUNIT_ASSERT_EQUAL(1, rclick.GetCount());
     CPPUNIT_ASSERT_EQUAL(1, rdclick.GetCount());
+#endif
+}
+
+void GridTestCase::ReorderedColumnsCellClick()
+{
+#if wxUSE_UIACTIONSIMULATOR
+    EventCounter click(m_grid, wxEVT_GRID_CELL_LEFT_CLICK);
+
+    wxUIActionSimulator sim;
+
+    wxArrayInt neworder;
+    neworder.push_back(1);
+    neworder.push_back(0);
+
+    m_grid->SetColumnsOrder(neworder);
+
+    wxRect rect = m_grid->CellToRect(0, 1);
+    wxPoint point = m_grid->CalcScrolledPosition(rect.GetPosition());
+    point = m_grid->ClientToScreen(point + wxPoint(m_grid->GetRowLabelSize(),
+        m_grid->GetColLabelSize())
+        + wxPoint(2, 2));
+
+    sim.MouseMove(point);
+    wxYield();
+
+    sim.MouseClick();
+    wxYield();
+
+    CPPUNIT_ASSERT_EQUAL(1, click.GetCount());
 #endif
 }
 


### PR DESCRIPTION
`wxGrid::GetColPos` must not be called with invalid index (-1) so fix
`wxGrid::RefreshBlock` to pass to `GetColPos` only valid indices.