### PR TITLE
InsertRows() call in the grid shouldn't generate an event

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -5021,9 +5021,6 @@ wxGrid::DoModifyLines(bool (wxGridTableBase::*funcModify)(size_t, size_t),
     if ( !m_table )
         return false;
 
-    if ( IsCellEditControlEnabled() )
-        DisableCellEditControl();
-
     return (m_table->*funcModify)(pos, num);
 
     // the table will have sent the results of the insert row


### PR DESCRIPTION
This PR will close ticket #2287 (Call to InsertRows() shouldn't generate an event).

The change seems to work OK. Unit tests for the grid control are passing.

Please review and apply.
