### PR TITLE
Reset grid editor when applying attributes

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -8677,6 +8677,7 @@ void wxGrid::SetRowAttr(int row, wxGridCellAttr *attr)
 
 void wxGrid::SetColAttr(int col, wxGridCellAttr *attr)
 {
+    DisableCellEditControl();
     if ( CanHaveAttributes() )
     {
         m_table->SetColAttr(attr, col);


### PR DESCRIPTION
This PR is proposed fix for ticket #2621.

As explained in the ticket it might not be a good idea to allow switching editor/renderer in the grid after creation.

So, until the decision is made this will at least prevent the crash of the application that uses such code.

