### PR TITLE
wxComboBox issue with setting an initial value and its editable status

### DIFF
--- a/src/qt/combobox.cpp
+++ b/src/qt/combobox.cpp
@@ -167,7 +167,7 @@ bool wxComboBox::Create(wxWindow *parent, wxWindowID id,
 
     while ( n-- > 0 )
         m_qtComboBox->addItem( wxQtConvertString( *choices++ ));
-    m_qtComboBox->setEditText( wxQtConvertString( value ));
+    m_qtComboBox->setCurrentText( wxQtConvertString( value ));
 
     return QtCreateControl( parent, id, pos, size, style, validator, name );
 }


### PR DESCRIPTION
Hi,

I noticed an issue when creating a wxComboBox where the initial value specified may not be what's actually displayed.

A non-editable QComboBox calling `setEditText()` is not valid. If done I have seen that the QComboBox displays the first item that it has but the 'actual' value under the hood differs from that.

To remedy this, the [Qt docs](https://doc.qt.io/qt-5/qcombobox.html#currentText-prop) indicate that we should call `setCurrentText()`.

> The setter setCurrentText() simply calls setEditText() if the combo box is editable. Otherwise, if there is a matching text in the list, currentIndex is set to the corresponding index.

Hope this is ok.