### PR TITLE
Make OnExit protected

### DIFF
--- a/include/wx/thread.h
+++ b/include/wx/thread.h
@@ -621,16 +621,16 @@ protected:
     // This one is called by Kill() before killing the thread and is executed
     // in the context of the thread that called Kill().
     virtual void OnKill() {}
+    
+    // called when the thread exits - in the context of this thread
+    //
+    // NB: this function will not be called if the thread is Kill()ed
+    virtual void OnExit() {}
 
 private:
     // no copy ctor/assignment operator
     wxThread(const wxThread&);
     wxThread& operator=(const wxThread&);
-
-    // called when the thread exits - in the context of this thread
-    //
-    // NB: this function will not be called if the thread is Kill()ed
-    virtual void OnExit() { }
 
     friend class wxThreadInternal;
     friend class wxThreadModule;

--- a/interface/wx/thread.h
+++ b/interface/wx/thread.h
@@ -512,11 +512,11 @@ public:
         This function will not be called if the thread was @ref Kill() killed.
 
         This function can be overridden by the derived class to perform some
-        specific task when the thread is exited. Notice that it will be
-        executed in the context of the thread that called Exit() and <b>not</b>
-        in this thread's context. 
+        specific task when the thread is exited. The base class version does 
+        nothing and doesn't need to be called if this method is overridden.
 
-        @since 2.9.2 - private, 3.1.3 - protected
+        Note that this function is protected since wxWidgets 3.1.1, 
+        but previously existed as a private method since 2.9.2.
 
         @see OnDelete(), OnKill()
     */

--- a/interface/wx/thread.h
+++ b/interface/wx/thread.h
@@ -489,7 +489,7 @@ public:
 
         @since 2.9.2
 
-        @see OnKill()
+        @see OnKill(), OnExit()
     */
     virtual void OnDelete();
 
@@ -503,9 +503,24 @@ public:
 
         @since 2.9.2
 
-        @see OnDelete()
+        @see OnDelete(), OnExit()
     */
     virtual void OnKill();
+
+    /**
+        Callback called by Exit() before actually exiting the thread.
+        This function will not be called if the thread was @ref Kill() killed.
+
+        This function can be overridden by the derived class to perform some
+        specific task when the thread is exited. Notice that it will be
+        executed in the context of the thread that called Exit() and <b>not</b>
+        in this thread's context. 
+
+        @since 2.9.2 - private, 3.1.3 - protected
+
+        @see OnDelete(), OnKill()
+    */
+    virtual void OnExit();
 
     /**
         @deprecated
@@ -1371,19 +1386,6 @@ protected:
         OnExit() will be called just before exiting.
     */
     void Exit(ExitCode exitcode = 0);
-
-private:
-
-    /**
-        Called when the thread exits.
-
-        This function is called in the context of the thread associated with the
-        wxThread object, not in the context of the main thread.
-        This function will not be called if the thread was @ref Kill() killed.
-
-        This function should never be called directly.
-    */
-    virtual void OnExit();
 };
 
 


### PR DESCRIPTION
Fix for [Make wxThread::OnExit() protected](http://trac.wxwidgets.org/ticket/16749)

I'm not quite sure how correctly update the documentation,  but it should to be done because there are already two mentioning of function OnExit([here](https://github.com/wxWidgets/wxWidgets/blob/master/interface/wx/thread.h#L1187) and [here](https://github.com/wxWidgets/wxWidgets/blob/master/interface/wx/thread.h#L1371)) without documentation the function itself(it exists only in the private section and therefore doesn't show on documentations site). 