### PR TITLE
[Qt] Accelerator key support for wxMenuItem

### DIFF
--- a/src/qt/menuitem.cpp
+++ b/src/qt/menuitem.cpp
@@ -43,18 +43,6 @@ wxMenuItem::wxMenuItem(wxMenu *parentMenu, int id, const wxString& text,
     : wxMenuItemBase( parentMenu, id, text, help, kind, subMenu )
 {
     m_qtAction = new wxQtAction( parentMenu, id, text, help, kind, subMenu, this );
-
-    #if wxUSE_ACCEL
-
-    QString qtext = wxQtConvertString( text );
-    int index = qtext.indexOf( QChar( '&' ) );
-
-    if( ( index != -1 ) && ( qtext[index+1] != QChar( '&' ) ) )
-    {
-        m_qtAction->setShortcut( QKeySequence( QChar( qtext[index+1] ) ) );
-    }
-
-    #endif
 }
 
 

--- a/src/qt/menuitem.cpp
+++ b/src/qt/menuitem.cpp
@@ -43,65 +43,39 @@ wxMenuItem::wxMenuItem(wxMenu *parentMenu, int id, const wxString& text,
     : wxMenuItemBase( parentMenu, id, text, help, kind, subMenu )
 {
     m_qtAction = new wxQtAction( parentMenu, id, text, help, kind, subMenu, this );
+
+    #if wxUSE_ACCEL
+
+    QString qtext = wxQtConvertString( text );
+    int index = qtext.indexOf( QChar( '&' ) );
+
+    if( ( index != -1 ) && ( qtext[index+1] != QChar( '&' ) ) )
+    {
+        m_qtAction->setShortcut( QKeySequence( QChar( qtext[index+1] ) ) );
+    }
+
+    #endif
 }
 
 
 
 void wxMenuItem::SetItemLabel( const wxString &label )
 {
-    //std::cout << "wxMenuItem::SetItemLabel( " << label.ToStdString() << " )\n";
     wxMenuItemBase::SetItemLabel( label );
 
     #if wxUSE_ACCEL
 
-    QList<QKeySequence> shortcuts;
+    QString qlabel = wxQtConvertString( label );
+    int index = qlabel.lastIndexOf( QChar( '\t' ) );
 
-    // Get appended shortcut
-
-    std::string label_str = label.ToStdString();
-    std::size_t found = label_str.find_last_of("\t");
-
-    if(found != std::string::npos)
+    if ( index != -1 )
     {
-        QString shortcut_key = QString::fromStdString( label_str.substr( found+1 ) );
-        shortcuts.append(QKeySequence( shortcut_key ));
-        //std::cout << "Added t shortcut: " << shortcut_key.toStdString() << ".\n";
+        QList<QKeySequence> shortcuts = m_qtAction->shortcuts();
+        QString shortcut_key = qlabel.remove( 0, index+1 );
+
+        shortcuts.append( QKeySequence( shortcut_key ) );
+        m_qtAction->setShortcuts( shortcuts );
     }
-    else
-    {
-        //std::cout << "Did not find...\n";
-    }
-
-    // END
-
-    // Get Ampersand shortcut
-
-    std::size_t found_ampersand = label_str.find_first_of("&");
-
-    if(found_ampersand != std::string::npos)
-    {
-        std::string shortcut_std = label_str.substr(found_ampersand+1,1);
-        //std::cout << "found ampersand... position is: " << found_ampersand << "  next character is " << shortcut_std << "\n";
-        if(shortcut_std != "&")
-        {
-            //std::cout << "adding shortcut..." << shortcut_std << "\n";
-            QString shortcut_key = QString::fromStdString( shortcut_std );
-            shortcuts.append(QKeySequence( shortcut_key ));
-
-        }
-    }
-
-    // END
-
-    // Add them
-
-    if(!shortcuts.empty())
-    {
-        //std::cout << "Shortcuts are not empty!";
-         m_qtAction->setShortcuts( shortcuts );
-    }
-
-    //std::cout << "\n\n";
 
     #endif
 

--- a/src/qt/menuitem.cpp
+++ b/src/qt/menuitem.cpp
@@ -49,17 +49,60 @@ wxMenuItem::wxMenuItem(wxMenu *parentMenu, int id, const wxString& text,
 
 void wxMenuItem::SetItemLabel( const wxString &label )
 {
+    //std::cout << "wxMenuItem::SetItemLabel( " << label.ToStdString() << " )\n";
     wxMenuItemBase::SetItemLabel( label );
 
     #if wxUSE_ACCEL
+
+    QList<QKeySequence> shortcuts;
+
+    // Get appended shortcut
+
     std::string label_str = label.ToStdString();
-    std::size_t found = label_str.find_last_of("\\t");
+    std::size_t found = label_str.find_last_of("\t");
 
     if(found != std::string::npos)
     {
-        QString shortcut_key = QString::fromStdString( label_str.substr( found-1 ) );
-        m_qtAction->setShortcut( QKeySequence( shortcut_key ) );
+        QString shortcut_key = QString::fromStdString( label_str.substr( found+1 ) );
+        shortcuts.append(QKeySequence( shortcut_key ));
+        //std::cout << "Added t shortcut: " << shortcut_key.toStdString() << ".\n";
     }
+    else
+    {
+        //std::cout << "Did not find...\n";
+    }
+
+    // END
+
+    // Get Ampersand shortcut
+
+    std::size_t found_ampersand = label_str.find_first_of("&");
+
+    if(found_ampersand != std::string::npos)
+    {
+        std::string shortcut_std = label_str.substr(found_ampersand+1,1);
+        //std::cout << "found ampersand... position is: " << found_ampersand << "  next character is " << shortcut_std << "\n";
+        if(shortcut_std != "&")
+        {
+            //std::cout << "adding shortcut..." << shortcut_std << "\n";
+            QString shortcut_key = QString::fromStdString( shortcut_std );
+            shortcuts.append(QKeySequence( shortcut_key ));
+
+        }
+    }
+
+    // END
+
+    // Add them
+
+    if(!shortcuts.empty())
+    {
+        //std::cout << "Shortcuts are not empty!";
+         m_qtAction->setShortcuts( shortcuts );
+    }
+
+    //std::cout << "\n\n";
+
     #endif
 
     m_qtAction->setText( wxQtConvertString( label ));

--- a/src/qt/menuitem.cpp
+++ b/src/qt/menuitem.cpp
@@ -51,6 +51,17 @@ void wxMenuItem::SetItemLabel( const wxString &label )
 {
     wxMenuItemBase::SetItemLabel( label );
 
+    #if wxUSE_ACCEL
+    std::string label_str = label.ToStdString();
+    std::size_t found = label_str.find_last_of("\\t");
+
+    if(found != std::string::npos)
+    {
+        QString shortcut_key = QString::fromStdString( label_str.substr( found-1 ) );
+        m_qtAction->setShortcut( QKeySequence( shortcut_key ) );
+    }
+    #endif
+
     m_qtAction->setText( wxQtConvertString( label ));
 }
 


### PR DESCRIPTION
Hi,

This PR implements accelerator key support in wxMenuItem. We discovered that the `<accel>` tags in .xrc files were not respected. As per the [docs](https://docs.wxwidgets.org/3.0/classwx_menu_item.html#a8b0517fb35e3eada66b51568aa87f261), an accelerator key can be specified by a string of characters following a tab characters.

Let me know if anything needs to be changed, thanks!

