### PR TITLE
Fix assert with setting current cell while redimension

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2309,6 +2309,9 @@ private:
     // common part of Clip{Horz,Vert}GridLines
     void DoClipGridLines(bool& var, bool clip);
 
+    // update m_currentCellCoords from Redimension function
+    void UpdateCurrentCellWhileRedim();
+
     // update the sorting indicator shown in the specified column (whose index
     // must be valid)
     //

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2310,7 +2310,7 @@ private:
     void DoClipGridLines(bool& var, bool clip);
 
     // update m_currentCellCoords from Redimension function
-    void UpdateCurrentCellWhileRedim();
+    void UpdateCurrentCellOnRedim();
 
     // update the sorting indicator shown in the specified column (whose index
     // must be valid)

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -2915,13 +2915,7 @@ bool wxGrid::Redimension( wxGridTableMessage& msg )
                 }
             }
 
-            if ( m_currentCellCoords == wxGridNoCellCoords )
-            {
-                // if we have just inserted cols into an empty grid the current
-                // cell will be undefined...
-                //
-                SetCurrentCell( 0, 0 );
-            }
+            UpdateCurrentCellWhileRedim();
 
             if ( m_selection )
                 m_selection->UpdateRows( pos, numRows );
@@ -2960,13 +2954,7 @@ bool wxGrid::Redimension( wxGridTableMessage& msg )
                 }
             }
 
-            if ( m_currentCellCoords == wxGridNoCellCoords )
-            {
-                // if we have just inserted cols into an empty grid the current
-                // cell will be undefined...
-                //
-                SetCurrentCell( 0, 0 );
-            }
+            UpdateCurrentCellWhileRedim();
 
             if ( !GetBatchCount() )
             {
@@ -2996,15 +2984,7 @@ bool wxGrid::Redimension( wxGridTableMessage& msg )
                 }
             }
 
-            if ( !m_numRows )
-            {
-                m_currentCellCoords = wxGridNoCellCoords;
-            }
-            else
-            {
-                if ( m_currentCellCoords.GetRow() >= m_numRows )
-                    m_currentCellCoords.Set( 0, 0 );
-            }
+            UpdateCurrentCellWhileRedim();
 
             if ( m_selection )
                 m_selection->UpdateRows( pos, -((int)numRows) );
@@ -3080,13 +3060,7 @@ bool wxGrid::Redimension( wxGridTableMessage& msg )
                 }
             }
 
-            if ( m_currentCellCoords == wxGridNoCellCoords )
-            {
-                // if we have just inserted cols into an empty grid the current
-                // cell will be undefined...
-                //
-                SetCurrentCell( 0, 0 );
-            }
+            UpdateCurrentCellWhileRedim();
 
             if ( m_selection )
                 m_selection->UpdateCols( pos, numCols );
@@ -3144,13 +3118,8 @@ bool wxGrid::Redimension( wxGridTableMessage& msg )
             if ( m_useNativeHeader )
                 GetGridColHeader()->SetColumnCount(m_numCols);
 
-            if ( m_currentCellCoords == wxGridNoCellCoords )
-            {
-                // if we have just inserted cols into an empty grid the current
-                // cell will be undefined...
-                //
-                SetCurrentCell( 0, 0 );
-            }
+            UpdateCurrentCellWhileRedim();
+
             if ( !GetBatchCount() )
             {
                 CalcDimensions();
@@ -3199,15 +3168,7 @@ bool wxGrid::Redimension( wxGridTableMessage& msg )
                 }
             }
 
-            if ( !m_numCols )
-            {
-                m_currentCellCoords = wxGridNoCellCoords;
-            }
-            else
-            {
-                if ( m_currentCellCoords.GetCol() >= m_numCols )
-                  m_currentCellCoords.Set( 0, 0 );
-            }
+            UpdateCurrentCellWhileRedim();
 
             if ( m_selection )
                 m_selection->UpdateCols( pos, -((int)numCols) );
@@ -3618,6 +3579,41 @@ void wxGrid::ProcessRowLabelMouseEvent( wxMouseEvent& event, wxGridRowLabelWindo
         else if ( m_cursorMode != WXGRID_CURSOR_SELECT_CELL )
         {
             ChangeCursorMode(WXGRID_CURSOR_SELECT_CELL, rowLabelWin, false);
+        }
+    }
+}
+
+void wxGrid::UpdateCurrentCellWhileRedim()
+{
+    if (m_currentCellCoords == wxGridNoCellCoords)
+    {
+        // if we have just inserted cols into an empty grid the current
+        // cell will be undefined...
+        // but if a grid has no columns or rows it actually has no cells too
+        // (and calling SetCurrentCell(0, 0) with zero columns will fail the
+        // precondition assert in GetColPos())
+        if (m_numCols > 0 && m_numRows > 0)
+        {
+            SetCurrentCell(0, 0);
+        }
+    }
+    else
+    {
+        if (m_numCols == 0 || m_numRows == 0)
+        {
+            // wxGridNoCellCoords is not valid agrument for
+            // SetCurrentCell and there are no cells we need to update
+            m_currentCellCoords = wxGridNoCellCoords;
+        }
+        else
+        {
+            int col = m_currentCellCoords.GetCol();
+            int row = m_currentCellCoords.GetRow();
+            if (col >= m_numCols)
+                col = m_numCols - 1;
+            if (row >= m_numRows)
+                row = m_numRows - 1;
+            SetCurrentCell(col, row);
         }
     }
 }

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -2915,7 +2915,7 @@ bool wxGrid::Redimension( wxGridTableMessage& msg )
                 }
             }
 
-            UpdateCurrentCellWhileRedim();
+            UpdateCurrentCellOnRedim();
 
             if ( m_selection )
                 m_selection->UpdateRows( pos, numRows );
@@ -2954,7 +2954,7 @@ bool wxGrid::Redimension( wxGridTableMessage& msg )
                 }
             }
 
-            UpdateCurrentCellWhileRedim();
+            UpdateCurrentCellOnRedim();
 
             if ( !GetBatchCount() )
             {
@@ -2984,7 +2984,7 @@ bool wxGrid::Redimension( wxGridTableMessage& msg )
                 }
             }
 
-            UpdateCurrentCellWhileRedim();
+            UpdateCurrentCellOnRedim();
 
             if ( m_selection )
                 m_selection->UpdateRows( pos, -((int)numRows) );
@@ -3060,7 +3060,7 @@ bool wxGrid::Redimension( wxGridTableMessage& msg )
                 }
             }
 
-            UpdateCurrentCellWhileRedim();
+            UpdateCurrentCellOnRedim();
 
             if ( m_selection )
                 m_selection->UpdateCols( pos, numCols );
@@ -3118,7 +3118,7 @@ bool wxGrid::Redimension( wxGridTableMessage& msg )
             if ( m_useNativeHeader )
                 GetGridColHeader()->SetColumnCount(m_numCols);
 
-            UpdateCurrentCellWhileRedim();
+            UpdateCurrentCellOnRedim();
 
             if ( !GetBatchCount() )
             {
@@ -3168,7 +3168,7 @@ bool wxGrid::Redimension( wxGridTableMessage& msg )
                 }
             }
 
-            UpdateCurrentCellWhileRedim();
+            UpdateCurrentCellOnRedim();
 
             if ( m_selection )
                 m_selection->UpdateCols( pos, -((int)numCols) );
@@ -3583,15 +3583,14 @@ void wxGrid::ProcessRowLabelMouseEvent( wxMouseEvent& event, wxGridRowLabelWindo
     }
 }
 
-void wxGrid::UpdateCurrentCellWhileRedim()
+void wxGrid::UpdateCurrentCellOnRedim()
 {
     if (m_currentCellCoords == wxGridNoCellCoords)
     {
-        // if we have just inserted cols into an empty grid the current
-        // cell will be undefined...
-        // but if a grid has no columns or rows it actually has no cells too
-        // (and calling SetCurrentCell(0, 0) with zero columns will fail the
-        // precondition assert in GetColPos())
+        // We didn't have any valid selection before, which can only happen
+        // if the grid was empty.
+        // Check if this is still the case and ensure we do have valid
+        // selection if the grid is not empty any more.
         if (m_numCols > 0 && m_numRows > 0)
         {
             SetCurrentCell(0, 0);
@@ -3601,8 +3600,9 @@ void wxGrid::UpdateCurrentCellWhileRedim()
     {
         if (m_numCols == 0 || m_numRows == 0)
         {
-            // wxGridNoCellCoords is not valid agrument for
-            // SetCurrentCell and there are no cells we need to update
+            // We have to reset the selection, as it must either use validate
+            // coordinates otherwise, but there are no valid coordinates for
+            // the grid cells any more now that it is empty.
             m_currentCellCoords = wxGridNoCellCoords;
         }
         else

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -58,6 +58,7 @@ private:
         CPPUNIT_TEST( Cursor );
         CPPUNIT_TEST( Selection );
         CPPUNIT_TEST( AddRowCol );
+        CPPUNIT_TEST( DeleteAndAddRowCol );
         CPPUNIT_TEST( ColumnOrder );
         CPPUNIT_TEST( ColumnVisibility );
         CPPUNIT_TEST( LineFormatting );
@@ -75,6 +76,7 @@ private:
         CPPUNIT_TEST( ColumnOrder );
         WXUISIM_TEST( ResizeScrolledHeader );
         WXUISIM_TEST( ColumnMinWidth );
+        CPPUNIT_TEST( DeleteAndAddRowCol );
         CPPUNIT_TEST( PseudoTest_NativeLabels );
         NONGTK_TEST( LabelClick );
         NONGTK_TEST( SortClick );
@@ -93,6 +95,7 @@ private:
     void Cursor();
     void Selection();
     void AddRowCol();
+    void DeleteAndAddRowCol();
     void ColumnOrder();
     void ColumnVisibility();
     void LineFormatting();
@@ -538,6 +541,35 @@ void GridTestCase::AddRowCol()
 
     CPPUNIT_ASSERT_EQUAL(16, m_grid->GetNumberRows());
     CPPUNIT_ASSERT_EQUAL(7, m_grid->GetNumberCols());
+}
+
+void GridTestCase::DeleteAndAddRowCol()
+{
+    CPPUNIT_ASSERT_EQUAL(10, m_grid->GetNumberRows());
+    CPPUNIT_ASSERT_EQUAL(2, m_grid->GetNumberCols());
+
+    m_grid->DeleteRows(0, 10);
+    m_grid->DeleteCols(0, 2);
+
+    CPPUNIT_ASSERT_EQUAL(0, m_grid->GetNumberRows());
+    CPPUNIT_ASSERT_EQUAL(0, m_grid->GetNumberCols());
+
+    m_grid->AppendRows(5);
+    m_grid->AppendCols(3);
+
+    CPPUNIT_ASSERT_EQUAL(5, m_grid->GetNumberRows());
+    CPPUNIT_ASSERT_EQUAL(3, m_grid->GetNumberCols());
+
+    // The order of functions calls can be important
+    m_grid->DeleteCols(0, 3);
+    m_grid->DeleteRows(0, 5);
+
+    CPPUNIT_ASSERT_EQUAL(0, m_grid->GetNumberRows());
+    CPPUNIT_ASSERT_EQUAL(0, m_grid->GetNumberCols());
+
+    // Different functions calls order
+    m_grid->AppendCols(3);
+    m_grid->AppendRows(5);
 }
 
 void GridTestCase::ColumnOrder()


### PR DESCRIPTION
Avoid calling wxGrid::SetCurrentCell with indices (0, 0) from
wxGrid::Redimension when a grid has no columns as it fail the precondition
assert in GetColPos(). It also wrong logically because the grid with no
columns has no cells.

Add a unit test verifying that this works as intended.