### PR TITLE
[wxMSW] Fix drawing bitmaps with transparency and mask

### DIFF
--- a/include/wx/msw/bitmap.h
+++ b/include/wx/msw/bitmap.h
@@ -205,6 +205,9 @@ public:
     // values in its alpha channel.
     void MSWUpdateAlpha();
 
+    // Blend mask with alpha channel and remove the mask
+    void MSWBlendMaskWithAlpha();
+
 public:
 #if WXWIN_COMPATIBILITY_3_0
     wxDEPRECATED_INLINE(void SetHBITMAP(WXHBITMAP bmp), SetHandle((WXHANDLE)bmp); )

--- a/interface/wx/bitmap.h
+++ b/interface/wx/bitmap.h
@@ -734,6 +734,10 @@ public:
 
         @remarks The bitmap object owns the mask once this has been called.
 
+        @note A mask can be set also for bitmap with an alpha channel but
+        doing so under wxMSW is not recommended because performance of drawing
+        such bitmap is not very good.
+
         @see GetMask(), wxMask
     */
     virtual void SetMask(wxMask* mask);
@@ -776,6 +780,10 @@ wxBitmap wxNullBitmap;
 
     When associated with a bitmap and drawn in a device context, the unmasked
     area of the bitmap will be drawn, and the masked area will not be drawn.
+
+    @note A mask can be associated also with a bitmap with an alpha channel
+    but drawing such bitmaps under wxMSW may be slow so using them should be
+    avoided if drawing performance is an important factor.
 
     @library{wxcore}
     @category{gdi}

--- a/src/msw/bitmap.cpp
+++ b/src/msw/bitmap.cpp
@@ -1780,6 +1780,20 @@ HICON wxBitmapToIconOrCursor(const wxBitmap& bmp,
 
     if ( bmp.HasAlpha() )
     {
+        // Make a copy in case we would neeed to remove its mask.
+        // If this will not be necessary, the copy is cheap as bitmaps are reference-counted.
+        wxBitmap curBmp(bmp);
+
+        // For bitmap with both alpha channel and mask we have to apply mask on our own
+        // because 32 bpp icons don't work properly with mask bitmaps.
+        // To do so we will create a temporary bitmap with copy of RGB data and with alpha channel
+        // being a superposition of the original alpha values and the mask - for non-masked pixels
+        // alpha channel values will remain intact and for masked pixels they will be set to the transparent value.
+        if ( curBmp.GetMask() )
+        {
+            curBmp.MSWBlendMaskWithAlpha();
+        }
+
         HBITMAP hbmp;
 
 #if wxUSE_WXDIB && wxUSE_IMAGE
@@ -1788,17 +1802,17 @@ HICON wxBitmapToIconOrCursor(const wxBitmap& bmp,
         // a special DIB in such format to pass to it. This is inefficient but
         // better than creating an icon with wrong colours.
         AutoHBITMAP hbmpRelease;
-        hbmp = wxDIB(bmp.ConvertToImage(),
+        hbmp = wxDIB(curBmp.ConvertToImage(),
                      wxDIB::PixelFormat_NotPreMultiplied).Detach();
         hbmpRelease.Init(hbmp);
 #else // !(wxUSE_WXDIB && wxUSE_IMAGE)
-        hbmp = GetHbitmapOf(bmp);
+        hbmp = GetHbitmapOf(curBmp);
 #endif // wxUSE_WXDIB && wxUSE_IMAGE
 
         // Create an empty mask bitmap.
         // it doesn't seem to work if we mess with the mask at all.
         AutoHBITMAP
-            hMonoBitmap(CreateBitmap(bmp.GetWidth(),bmp.GetHeight(),1,1,NULL));
+            hMonoBitmap(CreateBitmap(curBmp.GetWidth(),curBmp.GetHeight(),1,1,NULL));
 
         ICONINFO iconInfo;
         wxZeroMemory(iconInfo);


### PR DESCRIPTION
This is the fix for bug [18498](http://trac.wxwidgets.org/ticket/18498).
With this fix applied the ouput produced by the sample looks like this:
![obraz](https://user-images.githubusercontent.com/7330332/64824511-872cbc00-d5ba-11e9-968f-4cbaccc80b14.png)
