### PR TITLE
[Qt] Send set cursor events whenever there is mouse movement

### DIFF
--- a/include/wx/qt/window.h
+++ b/include/wx/qt/window.h
@@ -168,6 +168,7 @@ public:
 
     static void QtStoreWindowPointer( QWidget *widget, const wxWindowQt *window );
     static wxWindowQt *QtRetrieveWindowPointer( const QWidget *widget );
+    static void SendSetCursorEvent(wxWindowQt* win, wxPoint posClient);
 
 #if wxUSE_ACCEL
     virtual void QtHandleShortcut ( int command );


### PR DESCRIPTION
Looking at the auidemo sample for Qt, it currently does not change cursor when hovering over splitters between different panes. Looking at the MSW and GTK implementations, this is accomplished via set cursor events, so the same behaviour for Qt was implemented mostly following the GTK implementation where each parent is checked recursively to see if it wants to apply a cursor.

This also relies on #1528 to ensure that the widget the mouse hovers over receives mouse move events all the time. Without this change the cursors do not change unless you hold down the mouse button before moving over the splitter.