### PR TITLE
Disable native header popup menu for wxGrid

### DIFF
--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -147,7 +147,6 @@ public:
                        wxID_ANY,
                        wxDefaultPosition,
                        wxDefaultSize,
-                       wxHD_ALLOW_HIDE |
                        (owner->CanDragColMove() ? wxHD_ALLOW_REORDER : 0))
     {
     }


### PR DESCRIPTION
Default grid columns doesn't support popup menu allowing the user to show
or hide the columns. So disable the menu for the native header too as it
not always wanted and better for consistency.