### PR TITLE
(OSX) Allow SetToolBar call when the toolbar already has tools

### DIFF
--- a/src/osx/carbon/frame.cpp
+++ b/src/osx/carbon/frame.cpp
@@ -300,7 +300,10 @@ void wxFrame::SetToolBar(wxToolBar *toolbar)
 #ifndef __WXOSX_IPHONE__
 #if wxOSX_USE_NATIVE_TOOLBAR
     if ( toolbar )
+    {
         toolbar->MacInstallNativeToolbar( true ) ;
+        toolbar->Realize();
+    }
 #endif
 #endif
 }

--- a/src/osx/cocoa/toolbar.mm
+++ b/src/osx/cocoa/toolbar.mm
@@ -1170,6 +1170,9 @@ void wxToolBar::DoLayout()
 
 bool wxToolBar::Realize()
 {
+    wxFrame *frame = dynamic_cast<wxFrame *>( GetParent() );
+    if( frame && !frame->GetToolBar() )
+        return false;
     if ( !wxToolBarBase::Realize() )
         return false;
 


### PR DESCRIPTION
This PR will take care of the ticket 13888.

It makes the PR #1448 obsolete.

Both unmodified sample and and the sample modified with the patch attached to the ticket works.

Please check the ticket, review PR and apply.

Thank you.
