### PR TITLE
Enable the columns visibility popup menu from wxGrid

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -1359,6 +1359,11 @@ public:
     void     DisableDragColMove() { EnableDragColMove( false ); }
     bool     CanDragColMove() const { return m_canDragColMove; }
 
+    // interactive column hiding (enabled by default, works only for native header)
+    bool     EnableHidingColumns( bool enable = true );
+    void     DisableHidingColumns() { EnableHidingColumns(false); }
+    bool     CanHideColumns() { return m_canHideColumns; }
+
     // interactive resizing of grid cells (enabled by default)
     void     EnableDragGridSize(bool enable = true);
     void     DisableDragGridSize() { EnableDragGridSize(false); }
@@ -2172,6 +2177,7 @@ protected:
     bool    m_canDragRowSize;
     bool    m_canDragColSize;
     bool    m_canDragColMove;
+    bool    m_canHideColumns;
     bool    m_canDragGridSize;
     bool    m_canDragCell;
 

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -147,7 +147,7 @@ public:
                        wxID_ANY,
                        wxDefaultPosition,
                        wxDefaultSize,
-                       wxHD_ALLOW_HIDE |
+                       (owner->CanHideColumns() ? wxHD_ALLOW_HIDE : 0) |
                        (owner->CanDragColMove() ? wxHD_ALLOW_REORDER : 0))
     {
     }

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -3709,6 +3709,8 @@ public:
 
     /**
         Returns @true if columns can be hidden from the popup menu of the native header.
+
+        @since 3.1.3
     */
     bool CanHideColumns() const;
 
@@ -3774,6 +3776,8 @@ public:
         Disables column hiding from the popup menu.
 
         Equivalent to passing @false to EnableHidingColumns().
+
+        @since 3.1.3
     */
     void DisableHidingColumns();
 
@@ -3820,6 +3824,8 @@ public:
         and if this method is called for the grid with default header it returns
         @false without doing anything. Otherwise it returns @true to
         indicate that it was successful.
+
+        @since 3.1.3
 
         @see UseNativeColHeader()
     */

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -3708,6 +3708,11 @@ public:
     bool CanDragRowSize(int row) const;
 
     /**
+        Returns @true if columns can be hidden from the popup menu of the native header.
+    */
+    bool CanHideColumns() const;
+
+    /**
         Disable interactive resizing of the specified column.
 
         This method allows one to disable resizing of an individual column in a
@@ -3766,6 +3771,13 @@ public:
     void DisableDragRowSize();
 
     /**
+        Disables column hiding from the popup menu.
+
+        Equivalent to passing @false to EnableHidingColumns().
+    */
+    void DisableHidingColumns();
+
+    /**
         Enables or disables cell dragging with the mouse.
     */
     void EnableDragCell(bool enable = true);
@@ -3800,6 +3812,18 @@ public:
         @see DisableRowResize()
     */
     void EnableDragRowSize(bool enable = true);
+
+    /**
+        Enables or disables column hiding from the popup menu.
+
+        Note that currently the popup menu appers only for the native header
+        and if this method is called for the grid with default header it returns
+        @false without doing anything. Otherwise it returns @true to
+        indicate that it was successful.
+
+        @see UseNativeColHeader()
+    */
+    bool EnableHidingColumns(bool enable = true);
 
     /**
         Returns the column ID of the specified column position.

--- a/samples/grid/griddemo.cpp
+++ b/samples/grid/griddemo.cpp
@@ -154,6 +154,7 @@ wxBEGIN_EVENT_TABLE( GridFrame, wxFrame )
     EVT_MENU( ID_TOGGLEROWSIZING, GridFrame::ToggleRowSizing )
     EVT_MENU( ID_TOGGLECOLSIZING, GridFrame::ToggleColSizing )
     EVT_MENU( ID_TOGGLECOLMOVING, GridFrame::ToggleColMoving )
+    EVT_MENU( ID_TOGGLECOLHIDING, GridFrame::ToggleColHiding )
     EVT_MENU( ID_TOGGLEGRIDSIZING, GridFrame::ToggleGridSizing )
     EVT_MENU( ID_TOGGLEGRIDDRAGCELL, GridFrame::ToggleGridDragCell )
     EVT_MENU( ID_COLNATIVEHEADER, GridFrame::SetNativeColHeader )
@@ -298,6 +299,7 @@ GridFrame::GridFrame()
     viewMenu->AppendCheckItem(ID_TOGGLEROWSIZING, "Ro&w drag-resize");
     viewMenu->AppendCheckItem(ID_TOGGLECOLSIZING, "C&ol drag-resize");
     viewMenu->AppendCheckItem(ID_TOGGLECOLMOVING, "Col drag-&move");
+    viewMenu->AppendCheckItem(ID_TOGGLECOLHIDING, "Col hiding popup menu");
     viewMenu->AppendCheckItem(ID_TOGGLEGRIDSIZING, "&Grid drag-resize");
     viewMenu->AppendCheckItem(ID_TOGGLEGRIDDRAGCELL, "&Grid drag-cell");
     viewMenu->AppendCheckItem(ID_TOGGLEGRIDLINES, "&Grid Lines");
@@ -634,6 +636,7 @@ void GridFrame::SetDefaults()
     GetMenuBar()->Check( ID_TOGGLEROWSIZING, true );
     GetMenuBar()->Check( ID_TOGGLECOLSIZING, true );
     GetMenuBar()->Check( ID_TOGGLECOLMOVING, false );
+    GetMenuBar()->Check( ID_TOGGLECOLHIDING, true );
     GetMenuBar()->Check( ID_TOGGLEGRIDSIZING, true );
     GetMenuBar()->Check( ID_TOGGLEGRIDDRAGCELL, false );
     GetMenuBar()->Check( ID_TOGGLEGRIDLINES, true );
@@ -691,6 +694,15 @@ void GridFrame::ToggleColMoving( wxCommandEvent& WXUNUSED(ev) )
 {
     grid->EnableDragColMove(
         GetMenuBar()->IsChecked( ID_TOGGLECOLMOVING ) );
+}
+
+void GridFrame::ToggleColHiding( wxCommandEvent& WXUNUSED(ev) )
+{
+    if ( !grid->EnableHidingColumns(
+        GetMenuBar()->IsChecked( ID_TOGGLECOLHIDING ) ) )
+    {
+        GetMenuBar()->Check( ID_TOGGLECOLHIDING, grid->CanHideColumns() );
+    }
 }
 
 void GridFrame::ToggleGridSizing( wxCommandEvent& WXUNUSED(ev) )

--- a/samples/grid/griddemo.h
+++ b/samples/grid/griddemo.h
@@ -36,6 +36,7 @@ class GridFrame : public wxFrame
     void ToggleRowSizing( wxCommandEvent& );
     void ToggleColSizing( wxCommandEvent& );
     void ToggleColMoving( wxCommandEvent& );
+    void ToggleColHiding( wxCommandEvent& );
     void ToggleGridSizing( wxCommandEvent& );
     void ToggleGridDragCell ( wxCommandEvent& );
     void SetNativeColHeader ( wxCommandEvent& );
@@ -140,6 +141,7 @@ public:
         ID_TOGGLEROWSIZING,
         ID_TOGGLECOLSIZING,
         ID_TOGGLECOLMOVING,
+        ID_TOGGLECOLHIDING,
         ID_TOGGLEGRIDSIZING,
         ID_TOGGLEGRIDDRAGCELL,
         ID_TOGGLEGRIDLINES,

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -4835,13 +4835,7 @@ bool wxGrid::EnableHidingColumns(bool enable)
     if (m_canHideColumns == enable || !m_useNativeHeader)
         return false;
 
-    wxHeaderCtrl *header = GetGridColHeader();
-    long setFlags = header->GetWindowStyleFlag();
-
-    if (enable)
-        header->SetWindowStyleFlag(setFlags | wxHD_ALLOW_HIDE);
-    else
-        header->SetWindowStyleFlag(setFlags & ~wxHD_ALLOW_HIDE);
+    GetGridColHeader()->ToggleWindowStyle(wxHD_ALLOW_HIDE);
 
     m_canHideColumns = enable;
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -2607,6 +2607,7 @@ void wxGrid::Init()
     m_gridFrozenBorderPenWidth = 2;
 
     m_canDragColMove = false;
+    m_canHideColumns = true;
 
     m_cursorMode  = WXGRID_CURSOR_SELECT_CELL;
     m_winCapture = NULL;
@@ -4826,6 +4827,24 @@ bool wxGrid::EnableDragColMove( bool enable )
     // right as it would mean there would be no way to "freeze" the current
     // columns order by disabling moving them after putting them in the desired
     // order, whereas now you can always call ResetColPos() manually if needed
+    return true;
+}
+
+bool wxGrid::EnableHidingColumns(bool enable)
+{
+    if (m_canHideColumns == enable || !m_useNativeHeader)
+        return false;
+
+    wxHeaderCtrl *header = GetGridColHeader();
+    long setFlags = header->GetWindowStyleFlag();
+
+    if (enable)
+        header->SetWindowStyleFlag(setFlags | wxHD_ALLOW_HIDE);
+    else
+        header->SetWindowStyleFlag(setFlags & ~wxHD_ALLOW_HIDE);
+
+    m_canHideColumns = enable;
+
     return true;
 }
 


### PR DESCRIPTION
Provide access to enable/disable the native headers popup menu to show/hide
grids columns.