### PR TITLE
Various documentation fixes and suggestions for improvements

### DIFF
--- a/docs/contributing/binary-compatibility.md
+++ b/docs/contributing/binary-compatibility.md
@@ -10,8 +10,8 @@ wxWidgets.
 Releases
 --------
 
-General overview of releases can be found in tn0012.txt, but for
-completeness the wxWidgets release version number is as follows:
+General overview of releases can be found in [wxWidgets naming conventions](about-platform-toolkit-and-library-names.md),
+but for completeness the wxWidgets release version number is as follows:
 
 	2.6.2
 
@@ -20,9 +20,9 @@ Where
 	  2      6      2
 	Major  Minor Release
 
-(I.E. Major.Minor.Release).
+(i.e. Major.Minor.Release).
 
-All versions with EVEN minor version component (e.g. 2.4.x, 2.6.x etc.)
+All versions with EVEN minor version component (e.g. 2.8.x, 3.0.x etc.)
 are expected to be binary compatible (ODD minors are development versions
 and the compatibility constraints don't apply to them). Note that by
 preserving binary compatibility we mean BACKWARDS compatibility only,
@@ -37,8 +37,7 @@ also the section about `wxABI_VERSION`.
 What kind of changes are NOT binary compatible
 ----------------------------------------------
 
-If it's still up, the
-[KDE guide](http://techbase.kde.org/Policies/Binary_Compatibility_Issues_With_C++)
+[The KDE guide](https://community.kde.org/Policies/Binary_Compatibility_Issues_With_C%2B%2B)
 is a good reference.
 
 
@@ -68,8 +67,8 @@ Changes which are compatible
 - Adding a new non-virtual method to an existing class
 - Adding a new constructor to an existing class
 - Overriding the implementation of an existing virtual function
-(this is considered to be backwards binary compatible until we find a
- counter example; currently it's known to work with Apple gcc at least)
+  (this is considered to be backwards binary compatible until we find a
+  counter example; currently it's known to work with Apple gcc at least)
 - Anything which doesn't result in ABI change at all, e.g. adding new
   macros, constants and, of course, private changes in the implementation
 
@@ -99,7 +98,7 @@ where
 	 2     06     02
 	Major Minor Release
 
-I.E. it corresponds to the wxWidgets release in (1).
+I.e. it corresponds to the wxWidgets release in section Releases.
 
 An example of using `wxABI_VERSION` is as follows for symbols
 only in a 2.6.2 release:
@@ -178,11 +177,11 @@ anything which fits the conditions of being `#if`'ed via `wxABI_VERSION`
 needs to go here also.
 
 See 'info ld scripts version' on a GNU system, it's online here:
-http://www.gnu.org/software/binutils/manual/ld-2.9.1/html_node/ld_25.html
+https://ftp.gnu.org/old-gnu/Manuals/ld-2.9.1/html_node/ld_25.html
 
 Or see chapter 5 of the 'Linker and Libraries Guide' for Solaris, available
 online here:
-http://docsun.cites.uiuc.edu/sun_docs/C/solaris_9/SUNWdev/LLM/p1.html
+https://docs.oracle.com/cd/E19120-01/open.solaris/819-0690/chapter5-84101/index.html
 
 The file has the layout as follows:
 

--- a/docs/contributing/how-to-release.md
+++ b/docs/contributing/how-to-release.md
@@ -171,7 +171,7 @@ If either of these are blank they are set to the default install location.
 
 To build binaries for a single compiler, open a command prompt (for Visual
 Studio 2008 only an SDK 6.1 developer's command prompt must be used),
-cd to the build\msw\tools\msvs folder and run the batch file 'buildofficial'
+cd to the build\tools\msvs folder and run the batch file 'officialbuild'
 with the vcXXX version number:
 
 Visual Studio 2008  vc90

--- a/docs/msw/install.md
+++ b/docs/msw/install.md
@@ -572,7 +572,7 @@ application.
 
 Advanced Library Configurations        {#msw_advanced}
 ===============================
-Build instructions to less common library configuartions using different UI
+Build instructions to less common library configurations using different UI
 backends are avaiable here.
 
 @subpage plat_msw_msys2 "Building with Win32 MSys2 backend"


### PR DESCRIPTION
The commits in this PR include various minor documentation corrections.

In addition to those, I have found several issues which I believe should be addressed but was not sure how.

### docs/base/readme.txt
This document seems badly outdated. Is it (in its current form) even necessary and/or useful? 

### docs/contributing/about-platform-toolkit-and-library-names.md
Qt is missing from the allowed toolkit names?

### docs/contributing/how-to-release.md
In section MSW Visual Studio Official Builds, MSVC versions end with 2015. I believe wxWidgets 3.1.2 already supports 2017 and 3.1.3 will support 2019 as well (see release.md / Binaries )?
The last line of the file mentions non-existing MSVS version 2000?

### docs/msw/binaries.md
wxWidgets version used anywhere is 3.1.1.
The list of compilers with binaries provided is missing MinGW-w64 8.10. 
For wxWidgets 3.1.3, MSVS 2019 will be supported as well (see release.md / Binaries)?

### Comment in _include/wx/platinfo.h_
> wxPORT_QT       = 1 << 10       // wxQT, using QT**_4_**

I do not know anything about Qt, but `docs/qt/readme.txt `says  Qt **_5_** is required?