### PR TITLE
Fix native header label cropping on autosize for wxGrid

### DIFF
--- a/include/wx/headerctrl.h
+++ b/include/wx/headerctrl.h
@@ -159,6 +159,9 @@ public:
     // compute column title width
     int GetColumnTitleWidth(const wxHeaderColumn& col);
 
+    // compute column title width for the column with the given index
+    int GetColumnTitleWidth(unsigned int idx);
+
     // implementation only from now on
     // -------------------------------
 

--- a/interface/wx/headerctrl.h
+++ b/interface/wx/headerctrl.h
@@ -404,6 +404,13 @@ public:
      */
     int GetColumnTitleWidth(const wxHeaderColumn& col);
 
+    /**
+        Returns width needed for given column's title by the given column index.
+
+        @since 3.1.3
+     */
+    int GetColumnTitleWidth(unsigned int idx);
+
 protected:
     /**
         Method to be implemented by the derived classes to return the

--- a/src/common/headerctrlcmn.cpp
+++ b/src/common/headerctrlcmn.cpp
@@ -123,6 +123,11 @@ int wxHeaderCtrlBase::GetColumnTitleWidth(const wxHeaderColumn& col)
     return w;
 }
 
+int wxHeaderCtrlBase::GetColumnTitleWidth(unsigned int idx)
+{
+    return GetColumnTitleWidth(GetColumn(idx));
+}
+
 // ----------------------------------------------------------------------------
 // wxHeaderCtrlBase event handling
 // ----------------------------------------------------------------------------

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -9379,14 +9379,25 @@ wxGrid::AutoSizeColOrRow(int colOrRow, bool setAsMin, wxGridDirection direction)
     }
 
     // now also compare with the column label extent
-    wxCoord w, h;
+    wxCoord w = 0;
+    wxCoord h = 0;
     dc.SetFont( GetLabelFont() );
+
+    bool addMargin = true;
 
     if ( column )
     {
-        dc.GetMultiLineTextExtent( GetColLabelValue(colOrRow), &w, &h );
-        if ( GetColLabelTextOrientation() == wxVERTICAL )
-            w = h;
+        if (m_useNativeHeader)
+        {
+            w = GetGridColHeader()->GetColumnTitleWidth( colOrRow );
+            addMargin = false;
+        }
+        else
+        {
+            dc.GetMultiLineTextExtent( GetColLabelValue(colOrRow), &w, &h );
+            if ( GetColLabelTextOrientation() == wxVERTICAL )
+                w = h;
+        }
     }
     else
         dc.GetMultiLineTextExtent( GetRowLabelValue(colOrRow), &w, &h );
@@ -9403,11 +9414,14 @@ wxGrid::AutoSizeColOrRow(int colOrRow, bool setAsMin, wxGridDirection direction)
     }
     else
     {
-        if ( column )
-            // leave some space around text
-            extentMax += 10;
-        else
-            extentMax += 6;
+        if ( addMargin )
+        {
+            if ( column )
+                // leave some space around text
+                extentMax += 10;
+            else
+                extentMax += 6;
+        }
     }
 
     if ( column )

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -590,9 +590,9 @@ int wxRendererMSW::GetHeaderButtonHeight(wxWindow * win)
     return Header_Layout(hwndHeader, &hdl) ? wp.cy : DEFAULT_HEIGHT;
 }
 
-int wxRendererMSW::GetHeaderButtonMargin(wxWindow *WXUNUSED(win))
+int wxRendererMSW::GetHeaderButtonMargin(wxWindow *win)
 {
-    return 10;
+    return 6 * wxGetSystemMetrics(SM_CXEDGE, win);
 }
 
 // ============================================================================


### PR DESCRIPTION
Use the native headers own function to calculate the best minimal width for
the column label.

Also fix MSW version of GetHeaderButtonMargin to be more accurate (Wine
sources used as reference).