### PR TITLE
Fix best size computation for multiline wxTextCtrl in wxGTK

### DIFF
--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -817,6 +817,7 @@ bool wxTextCtrl::Create( wxWindow *parent,
     if (!value.empty())
     {
         SetValue( value );
+        InvalidateBestSize();
     }
 
     if (style & wxTE_PASSWORD)


### PR DESCRIPTION
The initial value was not taken into account before because the best
size computed before it was set, i.e. for the empty control, was always
used, as it was never invalidated.

Do invalidate it now if the control is created with non-empty value, in
order to adjust its best, and initial, size appropriately to its
contents.

Closes [#18507](https://trac.wxwidgets.org/ticket/18507).