### PR TITLE
[OSX] Allow executing the bundle to return pid

### DIFF
--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -197,7 +197,6 @@ bool wxCocoaLaunch(const char* const* argv, pid_t &pid)
     // Obtains the number of arguments for determining the size of
     // the CFArray used to hold them
     NSUInteger cfiCount = 0;
-//    NSArray *arguments;
     for (const char* const* argvcopy = argv; *argvcopy != NULL; ++argvcopy)
     {
         ++cfiCount;

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -462,7 +462,7 @@ private:
 // ----------------------------------------------------------------------------
 
 #if defined(__DARWIN__) && !defined(__WXOSX_IPHONE__)
-bool wxMacLaunch(const char* const* argv);
+extern bool wxCocoaLaunch(const char* const* argv, pid_t &pid);
 #endif
 
 long wxExecute(const wxString& command, int flags, wxProcess *process,
@@ -585,15 +585,16 @@ long wxExecute(const char* const* argv, int flags, wxProcess* process,
     wxASSERT_MSG( wxThread::IsMain(),
                     wxT("wxExecute() can be called only from the main thread") );
 #endif // wxUSE_THREADS
-
+    pid_t pid;
 #if defined(__DARWIN__) && !defined(__WXOSX_IPHONE__)
+    pid = -1;
     // wxMacLaunch() only executes app bundles and only does it asynchronously.
     // It returns false if the target is not an app bundle, thus falling
     // through to the regular code for non app bundles.
-    if ( !(flags & wxEXEC_SYNC) && wxMacLaunch(argv) )
+    if ( !(flags & wxEXEC_SYNC) && wxCocoaLaunch(argv, pid) )
     {
         // we don't have any PID to return so just make up something non null
-        return -1;
+        return pid;
     }
 #endif // __DARWIN__
 
@@ -641,9 +642,9 @@ long wxExecute(const char* const* argv, int flags, wxProcess* process,
     //     But on OpenVMS we do not have fork so we have to use vfork and
     //     cross our fingers that it works.
 #ifdef __VMS
-   pid_t pid = vfork();
+   pid = vfork();
 #else
-   pid_t pid = fork();
+   pid = fork();
 #endif
    if ( pid == -1 )     // error?
     {

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -462,7 +462,7 @@ private:
 // ----------------------------------------------------------------------------
 
 #if defined(__DARWIN__) && !defined(__WXOSX_IPHONE__)
-extern bool wxCocoaLaunch(const char* const* argv, pid_t &pid);
+bool wxCocoaLaunch(const char* const* argv, pid_t &pid);
 #endif
 
 long wxExecute(const wxString& command, int flags, wxProcess *process,


### PR DESCRIPTION
This PR will take care of the ticket 9603 and 14883.

After applying you will receive proper pid after asynchronously executing OSX bundle.

The test suite does not test this functionality under OSX.

This code will need to be re-written for the next version of OSX (10.15), where the API used in this PR becomes deprecated.

However, I don't have the next version installed and can't test the new OSX. So this PR does not include support for the 10.15 Beta release.

The sample seems to work and it does return the pid of the running Bundle.

The code has been tested under 10.13 with the minimum deployment version of 10.9.

Please review and apply.
