### PR TITLE
Add Raw variants for replacement functions to wxSTC

### DIFF
--- a/include/wx/stc/stc.h
+++ b/include/wx/stc/stc.h
@@ -235,7 +235,6 @@ class WXDLLIMPEXP_FWD_CORE wxScrollBar;
 #define wxSTC_FIND_WORDSTART 0x00100000
 #define wxSTC_FIND_REGEXP 0x00200000
 #define wxSTC_FIND_POSIX 0x00400000
-#define wxSTC_FIND_CXX11REGEX 0x00800000
 #define wxSTC_FOLDLEVELBASE 0x400
 #define wxSTC_FOLDLEVELWHITEFLAG 0x1000
 #define wxSTC_FOLDLEVELHEADERFLAG 0x2000
@@ -2527,6 +2526,14 @@ class WXDLLIMPEXP_FWD_CORE wxScrollBar;
     "wxSTC_SCVS_NOWRAPLINESTART is deprecated. Use wxSTC_VS_NOWRAPLINESTART instead.")
 
 #endif // WXWIN_COMPATIBILITY_3_0
+
+// wxSTC is currently built without c++11 regex support, but the search flag
+// wxSTC_FIND_CXX11REGEX was included with wxSTC any way. gen_iface.py has since
+// been changed so that this flag will no longer be generated or documented,
+// but the flag is preserved here so that any code using the flag before
+// gen_iface.py was changed will not be broken.
+
+#define wxSTC_FIND_CXX11REGEX 0x00800000
 
 //----------------------------------------------------------------------
 // Commands that can be bound to keystrokes section {{{
@@ -5229,6 +5236,15 @@ public:
 
     // Append a string to the end of the document without changing the selection.
     void AppendTextRaw(const char* text, int length=-1);
+
+    // Replace the selected text with the argument text.
+    void ReplaceSelectionRaw(const char* text);
+
+    // Replace the target text with the argument text.
+    int ReplaceTargetRaw(const char* text, int length=-1);
+
+    // Replace the target text with the argument text after \d processing.
+    int ReplaceTargetRERaw(const char* text, int length=-1);
 
 #ifdef SWIG
     %pythoncode "_stc_utf8_methods.py"

--- a/interface/wx/stc/stc.h
+++ b/interface/wx/stc/stc.h
@@ -191,7 +191,6 @@
 #define wxSTC_FIND_WORDSTART 0x00100000
 #define wxSTC_FIND_REGEXP 0x00200000
 #define wxSTC_FIND_POSIX 0x00400000
-#define wxSTC_FIND_CXX11REGEX 0x00800000
 #define wxSTC_FOLDLEVELBASE 0x400
 #define wxSTC_FOLDLEVELWHITEFLAG 0x1000
 #define wxSTC_FOLDLEVELHEADERFLAG 0x2000
@@ -7411,6 +7410,52 @@ public:
        Append a string to the end of the document without changing the selection.
     */
     void AppendTextRaw(const char* text, int length=-1);
+
+    /**
+       Replace the current selection with text. If there is no current
+       selection, text is inserted at the current caret position.
+
+        @param text
+            The null terminated string used for the replacement.
+
+       @since 3.1.3
+    */
+    void ReplaceSelectionRaw(const char* text);
+
+    /**
+       Replace the current target with text.
+
+       @return
+            The return value is the length of the replacement string.
+
+       @remarks
+            If length=-1, text must be null terminated.
+
+       @since 3.1.3
+    */
+    int ReplaceTargetRaw(const char* text, int length=-1);
+
+    /**
+       Replace the current target with text using regular expressions.
+
+       The replacement string will be formed from text with any occurrences '\1'
+       through '\9' replaced by tagged matches from the most recent regular
+       expression search. In addition, any occurrences of '\0' will be replaced
+       with all the matched text from the most recent search. After replacement,
+       the target range refers to the replacement text.
+
+       @return
+            The return value is the length of the replacement string.
+
+       @remarks
+            If length=-1, text must be null terminated.
+
+       @see
+            SearchInTarget()
+
+       @since 3.1.3
+    */
+    int ReplaceTargetRERaw(const char* text, int length=-1);
 
     //@}
 

--- a/src/stc/gen_iface.py
+++ b/src/stc/gen_iface.py
@@ -78,7 +78,8 @@ notMappedSciValues = set([
     'INDIC0_MASK',
     'INDIC1_MASK',
     'INDIC2_MASK',
-    'INDICS_MASK'
+    'INDICS_MASK',
+    'SCFIND_CXX11REGEX'
 ])
 
 # Map some generic typenames to wx types, using return value syntax

--- a/src/stc/stc.cpp
+++ b/src/stc/stc.cpp
@@ -5155,6 +5155,27 @@ void wxStyledTextCtrl::AppendTextRaw(const char* text, int length)
     SendMsg(SCI_APPENDTEXT, length, (sptr_t)text);
 }
 
+void wxStyledTextCtrl::ReplaceSelectionRaw(const char* text)
+{
+    SendMsg(SCI_REPLACESEL, 0, reinterpret_cast<sptr_t>(text));
+}
+
+int wxStyledTextCtrl::ReplaceTargetRaw(const char* text, int length)
+{
+    if ( length == -1 )
+        length = strlen(text);
+
+    return SendMsg(SCI_REPLACETARGET, length, reinterpret_cast<sptr_t>(text));
+}
+
+int wxStyledTextCtrl::ReplaceTargetRERaw(const char* text, int length)
+{
+    if ( length == -1 )
+        length = strlen(text);
+
+    return SendMsg(SCI_REPLACETARGETRE, length, reinterpret_cast<sptr_t>(text));
+}
+
 #if WXWIN_COMPATIBILITY_3_0
 // Deprecated since Scintilla 3.7.2
 void wxStyledTextCtrl::UsePopUp(bool allowPopUp)

--- a/src/stc/stc.cpp.in
+++ b/src/stc/stc.cpp.in
@@ -682,6 +682,27 @@ void wxStyledTextCtrl::AppendTextRaw(const char* text, int length)
     SendMsg(SCI_APPENDTEXT, length, (sptr_t)text);
 }
 
+void wxStyledTextCtrl::ReplaceSelectionRaw(const char* text)
+{
+    SendMsg(SCI_REPLACESEL, 0, reinterpret_cast<sptr_t>(text));
+}
+
+int wxStyledTextCtrl::ReplaceTargetRaw(const char* text, int length)
+{
+    if ( length == -1 )
+        length = strlen(text);
+
+    return SendMsg(SCI_REPLACETARGET, length, reinterpret_cast<sptr_t>(text));
+}
+
+int wxStyledTextCtrl::ReplaceTargetRERaw(const char* text, int length)
+{
+    if ( length == -1 )
+        length = strlen(text);
+
+    return SendMsg(SCI_REPLACETARGETRE, length, reinterpret_cast<sptr_t>(text));
+}
+
 #if WXWIN_COMPATIBILITY_3_0
 // Deprecated since Scintilla 3.7.2
 void wxStyledTextCtrl::UsePopUp(bool allowPopUp)

--- a/src/stc/stc.h.in
+++ b/src/stc/stc.h.in
@@ -347,6 +347,15 @@ public:
     // Append a string to the end of the document without changing the selection.
     void AppendTextRaw(const char* text, int length=-1);
 
+    // Replace the selected text with the argument text.
+    void ReplaceSelectionRaw(const char* text);
+
+    // Replace the target text with the argument text.
+    int ReplaceTargetRaw(const char* text, int length=-1);
+
+    // Replace the target text with the argument text after \d processing.
+    int ReplaceTargetRERaw(const char* text, int length=-1);
+
 #ifdef SWIG
     %%pythoncode "_stc_utf8_methods.py"
 #endif

--- a/src/stc/stc.h.in
+++ b/src/stc/stc.h.in
@@ -124,6 +124,14 @@ class WXDLLIMPEXP_FWD_CORE wxScrollBar;
 
 #endif // WXWIN_COMPATIBILITY_3_0
 
+// wxSTC is currently built without c++11 regex support, but the search flag
+// wxSTC_FIND_CXX11REGEX was included with wxSTC any way. gen_iface.py has since
+// been changed so that this flag will no longer be generated or documented,
+// but the flag is preserved here so that any code using the flag before
+// gen_iface.py was changed will not be broken.
+
+#define wxSTC_FIND_CXX11REGEX 0x00800000
+
 //----------------------------------------------------------------------
 // Commands that can be bound to keystrokes section {{{
 

--- a/src/stc/stc.interface.h.in
+++ b/src/stc/stc.interface.h.in
@@ -352,6 +352,52 @@ public:
     */
     void AppendTextRaw(const char* text, int length=-1);
 
+    /**
+       Replace the current selection with text. If there is no current
+       selection, text is inserted at the current caret position.
+
+        @param text
+            The null terminated string used for the replacement.
+
+       @since 3.1.3
+    */
+    void ReplaceSelectionRaw(const char* text);
+
+    /**
+       Replace the current target with text.
+
+       @return
+            The return value is the length of the replacement string.
+
+       @remarks
+            If length=-1, text must be null terminated.
+
+       @since 3.1.3
+    */
+    int ReplaceTargetRaw(const char* text, int length=-1);
+
+    /**
+       Replace the current target with text using regular expressions.
+
+       The replacement string will be formed from text with any occurrences '\1'
+       through '\9' replaced by tagged matches from the most recent regular
+       expression search. In addition, any occurrences of '\0' will be replaced
+       with all the matched text from the most recent search. After replacement,
+       the target range refers to the replacement text.
+
+       @return
+            The return value is the length of the replacement string.
+
+       @remarks
+            If length=-1, text must be null terminated.
+
+       @see
+            SearchInTarget()
+
+       @since 3.1.3
+    */
+    int ReplaceTargetRERaw(const char* text, int length=-1);
+
     //@}
 
 


### PR DESCRIPTION
This should address  [trac ticket 18108](https://trac.wxwidgets.org/ticket/18108) by adding raw variants for `ReplaceSelection`, `ReplaceTarget`, and `ReplaceTargetRE`.  Even though the Scintilla interface spec lists ReplaceTarget and ReplaceTargetRE as follows:

```
fun int ReplaceTarget=2194(int length, string text)
fun int ReplaceTargetRE=2195(int length, string text)
```

For consistency with how `AddTextRaw` and `AppendTextRaw` are defined, I defined them as follows:

```
int ReplaceTargetRaw(const char* text, int length=-1);
int ReplaceTargetRERaw(const char* text, int length=-1);
```
Other notes:

- `ReplaceTargetRERaw` is a pretty terrible name, but I guess that's what it needs to be to keep the naming convention used for the other Raw functions.

- The second commit in this PR removes the wxSTC_FIND_CXX11REGEX flag from the documentation.  This is a flag that can be passed to `SearchInTarget`, and I noticed it while testing `ReplaceTargetRERaw`.  Since wxSTC is currently built without c++11 regex support, I assume this flag does nothing. I changed gen_iface.py and stc.h.in so that the flag will not be generated but will be preserved with its current defined value.  That will prevent any code which might be using this flag from becoming broken.