### PR TITLE
Empty list control column resizing

### DIFF
--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -1337,9 +1337,13 @@ void wxListHeaderWindow::OnMouse( wxMouseEvent &event )
                                 event.GetPosition());
             }
         }
-        else if( event.LeftDClick() && hit_border && dynamic_cast<wxGenericListCtrl *>( GetParent() )->GetItemCount() == 0 )
+        else if( event.LeftDClick() && hit_border )
         {
-            dynamic_cast<wxGenericListCtrl *>( GetParent() )->SetColumnWidth( m_column, wxLIST_AUTOSIZE_USEHEADER );
+            wxGenericListCtrl *ctrl = dynamic_cast<wxGenericListCtrl *>( GetParent() );
+            if( ctrl->GetItemCount() == 0 )
+                ctrl->SetColumnWidth( m_column, wxLIST_AUTOSIZE_USEHEADER );
+            else
+                ctrl->SetColumnWidth( m_column, wxLIST_AUTOSIZE );
         }
         else if (event.Moving())
         {

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -1337,6 +1337,10 @@ void wxListHeaderWindow::OnMouse( wxMouseEvent &event )
                                 event.GetPosition());
             }
         }
+        else if( event.LeftDClick() && hit_border && dynamic_cast<wxGenericListCtrl *>( GetParent() )->GetItemCount() == 0 )
+        {
+            dynamic_cast<wxGenericListCtrl *>( GetParent() )->SetColumnWidth( m_column, wxLIST_AUTOSIZE_USEHEADER );
+        }
         else if (event.Moving())
         {
             bool setCursor;

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -2187,6 +2187,18 @@ bool wxListCtrl::MSWOnNotify(int idCtrl, WXLPARAM lParam, WXLPARAM *result)
                 event.m_col = nmHDR->iItem;
                 break;
 
+            case HDN_DIVIDERDBLCLICK:
+            {
+                NMHEADER *pHeader = (NMHEADER *) lParam;
+                const int item = pHeader->iItem;
+                if( GetItemCount() == 0 )
+                {
+                    SetColumnWidth( item, wxLIST_AUTOSIZE_USEHEADER );
+                    return true;
+                }
+            }
+            break;
+
             case NM_RCLICK:
                 {
                     POINT ptClick;


### PR DESCRIPTION
This PR will take care of the ticket 9926.
The behaviour will be the same for both MSW and generic version (GTK/OSX).

If the control does not have any items (rows) and the user double click the column divider, the column will be resized according to AUTOSIZE_USEHEADER.

Please review and apply.
