### PR TITLE
Add wxTimerSimple class and wxCallIn()

### DIFF
--- a/tests/events/timertest.cpp
+++ b/tests/events/timertest.cpp
@@ -145,3 +145,16 @@ void TimerEventTestCase::Multiple()
     CPPUNIT_ASSERT( numTicks > 1 );
 #endif // !(wxGTK Unicode)
 }
+
+#ifdef wxHAS_TIMER_SIMPLE
+
+TEST_CASE("Timer::Simple", "[timer]")
+{
+    wxEventLoop loop;
+
+    wxCallIn(50, [&loop]() { loop.Exit(); });
+
+    loop.Run();
+}
+
+#endif // wxHAS_TIMER_SIMPLE


### PR DESCRIPTION
Allow executing some code, specified using lambdas, easily after some
timeout expires, similarly to how it can already be postponed just
slightly later using CallAfter().

---

I think this would be useful to have, but I'm not sure about naming (neither for the class nor for the function) and whether it's really useful enough to have it in the library (seeing that it can be implemented as trivially as this). Any comments/opinions would be welcome -- if they're globally positive, I'll add the docs and merge this in.