### PR TITLE
Fix grid content autosizing

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -9378,11 +9378,16 @@ wxGrid::AutoSizeColOrRow(int colOrRow, bool setAsMin, wxGridDirection direction)
     wxCoord w, h;
     dc.SetFont( GetLabelFont() );
 
+    bool addSpace = true;
+
     if ( column )
     {
         if ( m_useNativeHeader )
         {
             w = GetGridColHeader()->GetColumnTitleWidth(colOrRow);
+
+            // GetColumnTitleWidth already add the required space
+            addSpace = false;
             h = 0;
         }
         else
@@ -9390,18 +9395,11 @@ wxGrid::AutoSizeColOrRow(int colOrRow, bool setAsMin, wxGridDirection direction)
             dc.GetMultiLineTextExtent( GetColLabelValue(colOrRow), &w, &h );
             if ( GetColLabelTextOrientation() == wxVERTICAL )
                 w = h;
-
-            // leave some space around text
-            if ( w )
-                w += 10;
         }
     }
     else
     {
         dc.GetMultiLineTextExtent( GetRowLabelValue(colOrRow), &w, &h );
-
-        if ( h )
-            h += 6;
     }
 
     extent = column ? w : h;
@@ -9413,6 +9411,14 @@ wxGrid::AutoSizeColOrRow(int colOrRow, bool setAsMin, wxGridDirection direction)
         // empty column - give default extent (notice that if extentMax is less
         // than default extent but != 0, it's OK)
         extentMax = column ? m_defaultColWidth : m_defaultRowHeight;
+    }
+    else if ( addSpace )
+    {
+        if ( column )
+            // leave some space around text
+            extentMax += 10;
+        else
+            extentMax += 6;
     }
 
     if ( column )


### PR DESCRIPTION
Fix autosizing broked in 3c72396a3670326e6824d1605954920b351a76d2.
Additional spacing was removed for the grid data so return it back.

See https://github.com/wxWidgets/wxWidgets/pull/1559