### PR TITLE
Send the autosize column event for grid native header columns

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2404,6 +2404,8 @@ private:
                                    wxGridColLabelWindow* colLabelWin);
     void ProcessCornerLabelMouseEvent(wxMouseEvent& event);
 
+    void HandleColumnAutosize(int col, const wxMouseEvent& event);
+
     void DoColHeaderClick(int col);
 
     void DoStartResizeCol(int col);

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2282,6 +2282,7 @@ protected:
     friend class wxGridWindow;
     friend class wxGridHeaderRenderer;
 
+    friend class wxGridHeaderColumn;
     friend class wxGridHeaderCtrl;
 
 private:

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -95,7 +95,7 @@ public:
     virtual wxString GetTitle() const wxOVERRIDE { return m_grid->GetColLabelValue(m_col); }
     virtual wxBitmap GetBitmap() const wxOVERRIDE { return wxNullBitmap; }
     virtual int GetWidth() const wxOVERRIDE { return m_grid->GetColSize(m_col); }
-    virtual int GetMinWidth() const wxOVERRIDE { return m_grid->GetColMinimalAcceptableWidth(); }
+    virtual int GetMinWidth() const wxOVERRIDE { return m_grid->GetColMinimalWidth(m_col); }
     virtual wxAlignment GetAlignment() const wxOVERRIDE
     {
         int horz,

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -191,15 +191,9 @@ private:
     }
 
     // override to implement column auto sizing
-    virtual bool UpdateColumnWidthToFit(unsigned int idx, int widthTitle) wxOVERRIDE
+    virtual bool UpdateColumnWidthToFit(unsigned int idx, int WXUNUSED(widthTitle)) wxOVERRIDE
     {
-        if ( !GetOwner()->SendGridSizeEvent(wxEVT_GRID_COL_AUTO_SIZE, -1, idx,
-                                            GetDummyMouseEvent()) )
-        {
-            // TODO: currently grid doesn't support computing the column best width
-            //       from its contents so we just use the best label width as is
-            GetOwner()->SetColSize(idx, widthTitle);
-        }
+        GetOwner()->HandleColumnAutosize(idx, GetDummyMouseEvent());
 
         return true;
     }

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -193,9 +193,13 @@ private:
     // override to implement column auto sizing
     virtual bool UpdateColumnWidthToFit(unsigned int idx, int widthTitle) wxOVERRIDE
     {
-        // TODO: currently grid doesn't support computing the column best width
-        //       from its contents so we just use the best label width as is
-        GetOwner()->SetColSize(idx, widthTitle);
+        if ( !GetOwner()->SendGridSizeEvent(wxEVT_GRID_COL_AUTO_SIZE, -1, idx,
+                                            GetDummyMouseEvent()) )
+        {
+            // TODO: currently grid doesn't support computing the column best width
+            //       from its contents so we just use the best label width as is
+            GetOwner()->SetColSize(idx, widthTitle);
+        }
 
         return true;
     }

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -9128,16 +9128,23 @@ void wxGrid::SetColSize( int col, int width )
     // show the column back using its old size.
     if ( width == -1 && GetColWidth(col) != 0 )
     {
-        long w, h;
-        wxArrayString lines;
-        wxClientDC dc(m_colLabelWin);
-        dc.SetFont(GetLabelFont());
-        StringToLines(GetColLabelValue(col), lines);
-        if ( GetColLabelTextOrientation() == wxHORIZONTAL )
-            GetTextBoxSize( dc, lines, &w, &h );
+        if ( m_useNativeHeader )
+        {
+            width = GetGridColHeader()->GetColumnTitleWidth(col);
+        }
         else
-            GetTextBoxSize( dc, lines, &h, &w );
-        width = w + 6;
+        {
+            long w, h;
+            wxArrayString lines;
+            wxClientDC dc(m_colLabelWin);
+            dc.SetFont(GetLabelFont());
+            StringToLines(GetColLabelValue(col), lines);
+            if ( GetColLabelTextOrientation() == wxHORIZONTAL )
+                GetTextBoxSize( dc, lines, &w, &h );
+            else
+                GetTextBoxSize( dc, lines, &h, &w );
+            width = w + 6;
+        }
 
         // Check that it is not less than the minimal width and do use the
         // possibly greater than minimal-acceptable-width minimal-width itself

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -3874,13 +3874,7 @@ void wxGrid::ProcessColLabelMouseEvent( wxMouseEvent& event, wxGridColLabelWindo
         }
         else
         {
-            // adjust column width depending on label text
-            //
-            // TODO: generate RESIZING event, see #10754
-            if ( !SendGridSizeEvent(wxEVT_GRID_COL_AUTO_SIZE, -1, colEdge, event) )
-                AutoSizeColLabelSize( colEdge );
-
-            SendGridSizeEvent(wxEVT_GRID_COL_SIZE, -1, colEdge, event);
+            HandleColumnAutosize(colEdge, event);
 
             ChangeCursorMode(WXGRID_CURSOR_SELECT_CELL, colLabelWin);
             m_dragLastPos = -1;
@@ -4021,6 +4015,17 @@ void wxGrid::ProcessCornerLabelMouseEvent( wxMouseEvent& event )
             // no default action at the moment
         }
     }
+}
+
+void wxGrid::HandleColumnAutosize(int col, const wxMouseEvent& event)
+{
+    // adjust column width depending on label text
+    //
+    // TODO: generate RESIZING event, see #10754
+    if ( !SendGridSizeEvent(wxEVT_GRID_COL_AUTO_SIZE, -1, col, event) )
+        AutoSizeColLabelSize(col);
+
+    SendGridSizeEvent(wxEVT_GRID_COL_SIZE, -1, col, event);
 }
 
 void wxGrid::CancelMouseCapture()


### PR DESCRIPTION
Send wxEVT_GRID_COL_AUTO_SIZE on double clicking on a separator line of
the grid native header to allow override default behaviour.