### PR TITLE
Keep children of collapsed item selected in wxGenericTreeCtrl

### DIFF
--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -1752,7 +1752,10 @@ void wxGenericTreeCtrl::ChildrenClosing(wxGenericTreeItem* item)
 
     if ( item != m_current && IsDescendantOf(item, m_current) )
     {
-        m_current->SetHilight( false );
+        // Don't leave the only selected item invisible, but do leave selected
+        // items selected if we can have many of them.
+        if ( !HasFlag(wxTR_MULTIPLE) )
+            m_current->SetHilight( false );
         m_current = NULL;
         m_select_me = item;
     }

--- a/tests/controls/treectrltest.cpp
+++ b/tests/controls/treectrltest.cpp
@@ -244,6 +244,15 @@ void TreeCtrlTestCase::SelectItemMulti()
     m_tree->UnselectItem(m_child1);
     CPPUNIT_ASSERT( !m_tree->IsSelected(m_child1) );
     CPPUNIT_ASSERT( m_tree->IsSelected(m_child2) );
+
+    // collapsing a branch with selected items should still leave them selected
+    m_tree->Expand(m_child1);
+    m_tree->SelectItem(m_grandchild);
+    CHECK( m_tree->IsSelected(m_grandchild) );
+    m_tree->Collapse(m_child1);
+    CHECK( m_tree->IsSelected(m_grandchild) );
+    m_tree->Expand(m_child1);
+    CHECK( m_tree->IsSelected(m_grandchild) );
 }
 
 void TreeCtrlTestCase::ItemClick()


### PR DESCRIPTION
Collapsing a branch shouldn't deselect all the items under it in
multi-selection mode: this doesn't seem to be useful or otherwise make
sense and makes the generic version gratuitously incompatible with the
native MSW one.

Closes [#10239](http://trac.wxwidgets.org/ticket/10239).