### PR TITLE
Fix regression in wxDC::Clear() and make wxGCDC::Clear() consistent with it

### DIFF
--- a/interface/wx/dc.h
+++ b/interface/wx/dc.h
@@ -261,6 +261,9 @@ public:
         Note that SetBackground() method must be used to set the brush used by
         Clear(), the brush used for filling the shapes set by SetBrush() is
         ignored by it.
+
+        If no background brush was set, solid white brush is used to clear the
+        device context.
     */
     void Clear();
 

--- a/src/common/dcgraph.cpp
+++ b/src/common/dcgraph.cpp
@@ -543,8 +543,6 @@ void wxGCDCImpl::SetBrush( const wxBrush &brush )
 void wxGCDCImpl::SetBackground( const wxBrush &brush )
 {
     m_backgroundBrush = brush;
-    if (!m_backgroundBrush.IsOk())
-        return;
 }
 
 void wxGCDCImpl::SetLogicalFunction( wxRasterOperationMode function )

--- a/src/common/dcgraph.cpp
+++ b/src/common/dcgraph.cpp
@@ -1284,6 +1284,9 @@ void wxGCDCImpl::Clear(void)
 {
     wxCHECK_RET( IsOk(), wxT("wxGCDC(cg)::Clear - invalid DC") );
 
+    if ( m_backgroundBrush.IsTransparent() )
+        return;
+
     if ( m_backgroundBrush.IsOk() )
     {
         m_graphicContext->SetBrush( m_backgroundBrush );

--- a/src/common/dcgraph.cpp
+++ b/src/common/dcgraph.cpp
@@ -1287,28 +1287,20 @@ void wxGCDCImpl::Clear(void)
     if ( m_backgroundBrush.IsTransparent() )
         return;
 
-    if ( m_backgroundBrush.IsOk() )
-    {
-        m_graphicContext->SetBrush( m_backgroundBrush );
-        wxPen p = *wxTRANSPARENT_PEN;
-        m_graphicContext->SetPen( p );
-        wxCompositionMode formerMode = m_graphicContext->GetCompositionMode();
-        m_graphicContext->SetCompositionMode(wxCOMPOSITION_SOURCE);
+    m_graphicContext->SetBrush( m_backgroundBrush.IsOk() ? m_backgroundBrush
+                                                         : *wxWHITE_BRUSH );
+    wxPen p = *wxTRANSPARENT_PEN;
+    m_graphicContext->SetPen( p );
+    wxCompositionMode formerMode = m_graphicContext->GetCompositionMode();
+    m_graphicContext->SetCompositionMode(wxCOMPOSITION_SOURCE);
 
-        double x, y, w, h;
-        m_graphicContext->GetClipBox(&x, &y, &w, &h);
-        m_graphicContext->DrawRectangle(x, y, w, h);
+    double x, y, w, h;
+    m_graphicContext->GetClipBox(&x, &y, &w, &h);
+    m_graphicContext->DrawRectangle(x, y, w, h);
 
-        m_graphicContext->SetCompositionMode(formerMode);
-        m_graphicContext->SetPen( m_pen );
-        m_graphicContext->SetBrush( m_brush );
-    }
-    else
-    {
-        double x, y, w, h;
-        m_graphicContext->GetClipBox(&x, &y, &w, &h);
-        m_graphicContext->ClearRectangle(x, y, w, h);
-    }
+    m_graphicContext->SetCompositionMode(formerMode);
+    m_graphicContext->SetPen( m_pen );
+    m_graphicContext->SetBrush( m_brush );
 }
 
 void wxGCDCImpl::DoGetSize(int *width, int *height) const

--- a/src/common/prntbase.cpp
+++ b/src/common/prntbase.cpp
@@ -2054,7 +2054,6 @@ bool wxPrintPreviewBase::RenderPageIntoBitmap(wxBitmap& bmp, int pageNum)
 {
     wxMemoryDC memoryDC;
     memoryDC.SelectObject(bmp);
-    memoryDC.SetBackground(*wxWHITE_BRUSH);
     memoryDC.Clear();
 
     return RenderPageIntoDC(memoryDC, pageNum);

--- a/src/gtk/dcclient.cpp
+++ b/src/gtk/dcclient.cpp
@@ -1508,7 +1508,7 @@ void wxWindowDCImpl::Clear()
 
     if (!m_gdkwindow) return;
 
-    if (!m_backgroundBrush.IsOk() || m_backgroundBrush.GetStyle() == wxBRUSHSTYLE_TRANSPARENT)
+    if (m_backgroundBrush.IsTransparent())
         return;
 
     int width,height;

--- a/src/gtk/dcclient.cpp
+++ b/src/gtk/dcclient.cpp
@@ -1738,7 +1738,8 @@ void wxWindowDCImpl::SetBackground( const wxBrush &brush )
 
     m_backgroundBrush = brush;
 
-    if (!m_backgroundBrush.IsOk()) return;
+    if (!m_backgroundBrush.IsOk())
+        m_backgroundBrush = *wxWHITE_BRUSH;
 
     if (!m_gdkwindow) return;
 

--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -729,8 +729,23 @@ void wxMSWDCImpl::Clear()
             return;
     }
 
+    HBRUSH hbr;
     if ( !m_backgroundBrush.IsOk() )
+    {
+        // By default, use the stock white brush for compatibility with the
+        // previous wx versions.
+        hbr = WHITE_BRUSH;
+    }
+    else if ( !m_backgroundBrush.IsTransparent() )
+    {
+        hbr = GetHbrushOf(m_backgroundBrush);
+    }
+    else // Using transparent background brush.
+    {
+        // Clearing with transparent brush doesn't do anything, just as drawing
+        // with transparent pen doesn't.
         return;
+    }
 
     RECT rect;
     ::GetClipBox(GetHdc(), &rect);
@@ -738,7 +753,7 @@ void wxMSWDCImpl::Clear()
     // to compensate rounding errors if DC is the subject
     // of complex transformation (is e.g. rotated).
     ::InflateRect(&rect, 1, 1);
-    ::FillRect(GetHdc(), &rect, GetHbrushOf(m_backgroundBrush));
+    ::FillRect(GetHdc(), &rect, hbr);
 
     RealizeScaleAndOrigin();
 }


### PR DESCRIPTION
This fixes [#18371](http://trac.wxwidgets.org/ticket/18371) after the changes done to fix [#10273](http://trac.wxwidgets.org/ticket/10273) broke it by making `Clear()` a NOP unless the background brush had been explicitly set, instead of using the white brush by default as was done previously.