### PR TITLE
Fix two-finger scrolling on wxGTK under Wayland

### DIFF
--- a/src/gtk/win_gtk.cpp
+++ b/src/gtk/win_gtk.cpp
@@ -364,6 +364,9 @@ GtkWidget* wxPizza::New(long windowStyle)
     gtk_widget_add_events(widget,
         GDK_EXPOSURE_MASK |
         GDK_SCROLL_MASK |
+#if GTK_CHECK_VERSION(3,4,0)
+        GDK_SMOOTH_SCROLL_MASK |
+#endif
         GDK_POINTER_MOTION_MASK |
         GDK_POINTER_MOTION_HINT_MASK |
         GDK_BUTTON_MOTION_MASK |


### PR DESCRIPTION
When running under Wayland and using two-finger scrolling, GTK seems to only
emit "smooth" scrolling events.  The code was already setup to handle
GDK_SCROLL_SMOOTH events - we just needed to add GDK_SMOOTH_SCROLL_MASK to the
event mast of the window in order to receive the events.

Fixes #17734.