### PR TITLE
Fix wxSpinCtrl overlap for control without a border

### DIFF
--- a/src/msw/spinctrl.cpp
+++ b/src/msw/spinctrl.cpp
@@ -738,7 +738,7 @@ int wxSpinCtrl::GetOverlap() const
         // We can be called from GetSizeFromTextSize() before the window is
         // created and still need to return something reasonable in this case,
         // so return the overlap equal to the default border size.
-        return FromDIP(2);
+        return HasFlag(wxBORDER_NONE) ? 0 : FromDIP(2);
     }
 
     // The sign here is correct because the button is positioned inside its


### PR DESCRIPTION
If wxBORDER_NONE style is set then the arrow buttons will be overlapped
by the text control. Use overlap of 0 to fix it.