### PR TITLE
Cache the preferred control size under GTK

### DIFF
--- a/src/gtk/control.cpp
+++ b/src/gtk/control.cpp
@@ -341,9 +341,20 @@ wxSize wxControl::GTKGetPreferredSize(GtkWidget* widget) const
 #ifdef __WXGTK3__
     int w, h;
     gtk_widget_get_size_request(widget, &w, &h);
+    // gtk_widget_get_preferred_size is not works correctly for the hidden contol.
+    // So workaround this case.
+    const bool hiddenAtStart = !gtk_widget_get_visible(widget);
+    if ( hiddenAtStart )
+    {
+        gtk_widget_show(widget);
+    }
     gtk_widget_set_size_request(widget, -1, -1);
     gtk_widget_get_preferred_size(widget, NULL, &req);
     gtk_widget_set_size_request(widget, w, h);
+    if ( hiddenAtStart )
+    {
+        gtk_widget_hide(widget);
+    }
 #else
     GTK_WIDGET_GET_CLASS(widget)->size_request(widget, &req);
 #endif

--- a/tests/controls/choicetest.cpp
+++ b/tests/controls/choicetest.cpp
@@ -36,9 +36,11 @@ private:
     CPPUNIT_TEST_SUITE( ChoiceTestCase );
         wxITEM_CONTAINER_TESTS();
         CPPUNIT_TEST( Sort );
+        CPPUNIT_TEST( GetBestSize );
     CPPUNIT_TEST_SUITE_END();
 
     void Sort();
+    void GetBestSize();
 
     wxChoice* m_choice;
 
@@ -87,6 +89,35 @@ void ChoiceTestCase::Sort()
 
     CPPUNIT_ASSERT_EQUAL("a", m_choice->GetString(0));
 #endif
+}
+
+void ChoiceTestCase::GetBestSize()
+{
+    wxArrayString testitems;
+    testitems.Add("1");
+    testitems.Add("11");
+    m_choice->Append(testitems);
+
+    SECTION("Normal best size")
+    {
+        // nothing to do here
+    }
+
+    // Ensure that the hidden contol return a valid best size too.
+    SECTION("Hidden best size")
+    {
+        m_choice->Hide();
+    }
+
+    wxYield();
+
+    m_choice->InvalidateBestSize();
+    const wxSize bestSize = m_choice->GetBestSize();
+
+    CHECK(bestSize.GetWidth() > 30);
+    CHECK(bestSize.GetWidth() < 120);
+    CHECK(bestSize.GetHeight() > 15);
+    CHECK(bestSize.GetHeight() < 35);
 }
 
 #endif //wxUSE_CHOICE


### PR DESCRIPTION
gtk_widget_get_preferred_size return the size of zero if the GTK widget is
hidden. Cache the preferred size and use it for a hidden control.

Also add the test for wxChoice. We can't test wxControl directly because
the tested control must implement an GTK contol and call
wxControl::PostCreation.