### PR TITLE
Add Per-Monitor DPI awareness to more controls

### DIFF
--- a/include/wx/dc.h
+++ b/include/wx/dc.h
@@ -269,6 +269,8 @@ public:
 
     wxWindow* GetWindow() const { return m_window; }
 
+    void SetWindow(wxWindow* w) { m_window = w; }
+
     virtual bool IsOk() const { return m_ok; }
 
     // query capabilities
@@ -1363,6 +1365,9 @@ protected:
     wxDC(wxDCImpl *pimpl) : m_pimpl(pimpl) { }
 
     wxDCImpl * const m_pimpl;
+
+    void SetWindow(wxWindow* w)
+        { return m_pimpl->SetWindow(w); }
 
 private:
     wxDECLARE_ABSTRACT_CLASS(wxDC);

--- a/include/wx/dcbuffer.h
+++ b/include/wx/dcbuffer.h
@@ -153,6 +153,8 @@ public:
     wxBufferedPaintDC(wxWindow *window, wxBitmap& buffer, int style = wxBUFFER_CLIENT_AREA)
         : m_paintdc(window)
     {
+        SetWindow(window);
+
         // If we're buffering the virtual window, scale the paint DC as well
         if (style & wxBUFFER_VIRTUAL_AREA)
             window->PrepareDC( m_paintdc );
@@ -167,6 +169,8 @@ public:
     wxBufferedPaintDC(wxWindow *window, int style = wxBUFFER_CLIENT_AREA)
         : m_paintdc(window)
     {
+        SetWindow(window);
+
         // If we're using the virtual window, scale the paint DC as well
         if (style & wxBUFFER_VIRTUAL_AREA)
             window->PrepareDC( m_paintdc );

--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -727,7 +727,7 @@ public:
     }
 
     // returns the resolution of the graphics context in device points per inch
-    virtual void GetDPI( wxDouble* dpiX, wxDouble* dpiY);
+    virtual void GetDPI( wxDouble* dpiX, wxDouble* dpiY) const;
 
 #if 0
     // sets the current alpha on this context
@@ -1038,6 +1038,9 @@ public:
                                       const wxString& facename,
                                       int flags = wxFONTFLAG_DEFAULT,
                                       const wxColour& col = *wxBLACK) = 0;
+    virtual wxGraphicsFont CreateFontAtDPI(const wxFont& font,
+                                           const wxRealPoint& dpi,
+                                           const wxColour& col = *wxBLACK) = 0;
 
     // create a native bitmap representation
     virtual wxGraphicsBitmap CreateBitmap( const wxBitmap &bitmap ) = 0;

--- a/include/wx/propgrid/propgrid.h
+++ b/include/wx/propgrid/propgrid.h
@@ -1766,6 +1766,8 @@ protected:
 
     void OnSysColourChanged( wxSysColourChangedEvent &event );
 
+    void OnDPIChanged(wxDPIChangedEvent& event);
+
     void OnTLPClose( wxCloseEvent& event );
 
 protected:

--- a/include/wx/stc/stc.h
+++ b/include/wx/stc/stc.h
@@ -5479,6 +5479,7 @@ protected:
     void OnKeyDown(wxKeyEvent& evt);
     void OnLoseFocus(wxFocusEvent& evt);
     void OnGainFocus(wxFocusEvent& evt);
+    void OnDPIChanged(wxDPIChangedEvent& evt);
     void OnSysColourChanged(wxSysColourChangedEvent& evt);
     void OnEraseBackground(wxEraseEvent& evt);
     void OnMenu(wxCommandEvent& evt);

--- a/interface/wx/graphics.h
+++ b/interface/wx/graphics.h
@@ -1116,7 +1116,7 @@ public:
     /**
        Returns the resolution of the graphics context in device points per inch.
     */
-    virtual void GetDPI( wxDouble* dpiX, wxDouble* dpiY);
+    virtual void GetDPI( wxDouble* dpiX, wxDouble* dpiY) const;
 
     /**
         Returns the associated window if any.
@@ -1459,6 +1459,17 @@ public:
                                       int flags = wxFONTFLAG_DEFAULT,
                                       const wxColour& col = *wxBLACK) = 0;
 
+    /**
+        Creates a native graphics font from a wxFont and a text colour.
+
+        The specified DPI is used to convert the (fractional) wxFont point-size
+        to a fractional pixel-size.
+
+        @since 3.1.3
+    */
+    virtual wxGraphicsFont CreateFontAtDPI(const wxFont& font,
+                                           const wxRealPoint& dpi,
+                                           const wxColour& col = *wxBLACK) = 0;
 
     /**
         Creates a native brush with a linear gradient.

--- a/src/common/graphcmn.cpp
+++ b/src/common/graphcmn.cpp
@@ -948,12 +948,12 @@ wxGraphicsFont wxGraphicsContext::CreateFont( const wxFont &font , const wxColou
 }
 
 wxGraphicsFont
-wxGraphicsContext::CreateFont(double size,
+wxGraphicsContext::CreateFont(double sizeInPixels,
                               const wxString& facename,
                               int flags,
                               const wxColour& col) const
 {
-    return GetRenderer()->CreateFont(size, facename, flags, col);
+    return GetRenderer()->CreateFont(sizeInPixels, facename, flags, col);
 }
 
 wxGraphicsBitmap wxGraphicsContext::CreateBitmap( const wxBitmap& bmp ) const

--- a/src/common/graphcmn.cpp
+++ b/src/common/graphcmn.cpp
@@ -619,7 +619,7 @@ wxDouble wxGraphicsContext::GetAlpha() const
 }
 #endif
 
-void wxGraphicsContext::GetDPI( wxDouble* dpiX, wxDouble* dpiY)
+void wxGraphicsContext::GetDPI( wxDouble* dpiX, wxDouble* dpiY) const
 {
     if ( m_window )
     {
@@ -944,7 +944,9 @@ wxGraphicsContext::CreateRadialGradientBrush(
 
 wxGraphicsFont wxGraphicsContext::CreateFont( const wxFont &font , const wxColour &col ) const
 {
-    return GetRenderer()->CreateFont(font,col);
+    wxRealPoint dpi;
+    GetDPI(&dpi.x, &dpi.y);
+    return GetRenderer()->CreateFontAtDPI(font, dpi, col);
 }
 
 wxGraphicsFont

--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -3009,6 +3009,9 @@ public :
                                       const wxString& facename,
                                       int flags = wxFONTFLAG_DEFAULT,
                                       const wxColour& col = *wxBLACK) wxOVERRIDE;
+    virtual wxGraphicsFont CreateFontAtDPI(const wxFont& font,
+                                           const wxRealPoint& dpi,
+                                           const wxColour& col) wxOVERRIDE;
 
     // create a native bitmap representation
     virtual wxGraphicsBitmap CreateBitmap( const wxBitmap &bitmap ) wxOVERRIDE;
@@ -3236,6 +3239,14 @@ wxCairoRenderer::CreateFont(double sizeInPixels,
     ENSURE_LOADED_OR_RETURN(font);
     font.SetRefData(new wxCairoFontData(this, sizeInPixels, facename, flags, col));
     return font;
+}
+
+wxGraphicsFont
+wxCairoRenderer::CreateFontAtDPI(const wxFont& font,
+                                 const wxRealPoint& WXUNUSED(dpi),
+                                 const wxColour& col)
+{
+    return CreateFont(font, col);
 }
 
 wxGraphicsBitmap wxCairoRenderer::CreateBitmap( const wxBitmap& bmp )

--- a/src/msw/anybutton.cpp
+++ b/src/msw/anybutton.cpp
@@ -431,8 +431,15 @@ wxSize wxMSWButton::IncreaseToStdSizeAndCache(wxControl *btn, const wxSize& size
         //
         // Note that we intentionally don't use GetDefaultSize() here, because
         // it's inexact -- dialog units depend on this dialog's font.
-        const wxSize sizeDef = btn->ConvertDialogToPixels(btn->FromDIP(wxSize(50, 14)));
-
+        wxSize sizeDef = btn->ConvertDialogToPixels(wxSize(50, 14));
+        if ( btn->GetContentScaleFactor() > 1.0 )
+        {
+            // At higher DPI, the returned height is too big compared to
+            // standard Windows buttons (like Save, Open, OK). FromDIP(25)
+            // matches the size of the buttons in standard Windows dialogs, see
+            // https://trac.wxwidgets.org/ticket/18528 for the discussion.
+            sizeDef.y = btn->FromDIP(25);
+        }
         sizeBtn.IncTo(sizeDef);
     }
     else // wxBU_EXACTFIT case

--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -2452,10 +2452,24 @@ void wxMSWDCImpl::DoGetSizeMM(int *w, int *h) const
 
 wxSize wxMSWDCImpl::GetPPI() const
 {
-    int x = ::GetDeviceCaps(GetHdc(), LOGPIXELSX);
-    int y = ::GetDeviceCaps(GetHdc(), LOGPIXELSY);
+    // As documented by MSDN, GetDeviceCaps() returns the same value for all
+    // HDCs on the system, and so can't be used to retrieve the correct value
+    // for the HDCs associated with the windows on monitors other than the
+    // primary one if they use different DPI. Hence prefer to get this
+    // information from the associated window, if possible.
+    wxSize ppi;
+    if ( m_window )
+    {
+        ppi = m_window->GetDPI();
+    }
 
-    return wxSize(x, y);
+    if ( !ppi.x || !ppi.y )
+    {
+        ppi.x = ::GetDeviceCaps(GetHdc(), LOGPIXELSX);
+        ppi.y = ::GetDeviceCaps(GetHdc(), LOGPIXELSY);
+    }
+
+    return ppi;
 }
 
 double wxMSWDCImpl::GetContentScaleFactor() const

--- a/src/msw/gauge.cpp
+++ b/src/msw/gauge.cpp
@@ -122,9 +122,9 @@ wxSize wxGauge::DoGetBestSize() const
     // the smaller one.
 
     if (HasFlag(wxGA_VERTICAL))
-        return ConvertDialogToPixels(FromDIP(wxSize(8, 107)));
+        return ConvertDialogToPixels(wxSize(8, 107));
     else
-        return ConvertDialogToPixels(FromDIP(wxSize(107, 8)));
+        return ConvertDialogToPixels(wxSize(107, 8));
 }
 
 // ----------------------------------------------------------------------------

--- a/src/msw/graphics.cpp
+++ b/src/msw/graphics.cpp
@@ -458,6 +458,7 @@ public:
     virtual void GetPartialTextExtents(const wxString& text, wxArrayDouble& widths) const wxOVERRIDE;
     virtual bool ShouldOffset() const wxOVERRIDE;
     virtual void GetSize( wxDouble* width, wxDouble *height );
+    virtual void GetDPI(wxDouble* dpiX, wxDouble* dpiY) const wxOVERRIDE;
 
     Graphics* GetGraphics() const { return m_context; }
 
@@ -2395,6 +2396,26 @@ void wxGDIPlusContext::GetSize( wxDouble* width, wxDouble *height )
 {
     *width = m_width;
     *height = m_height;
+}
+
+void wxGDIPlusContext::GetDPI(wxDouble* dpiX, wxDouble* dpiY) const
+{
+    if ( GetWindow() )
+    {
+        const wxSize dpi = GetWindow()->GetDPI();
+
+        if ( dpiX )
+            *dpiX = dpi.x;
+        if ( dpiY )
+            *dpiY = dpi.y;
+    }
+    else
+    {
+        if ( dpiX )
+            *dpiX = GetGraphics()->GetDpiX();
+        if ( dpiY )
+            *dpiY = GetGraphics()->GetDpiY();
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/src/msw/graphics.cpp
+++ b/src/msw/graphics.cpp
@@ -345,14 +345,14 @@ public:
                        const wxColour& col );
     wxGDIPlusFontData(wxGraphicsRenderer* renderer,
                       const wxString& name,
-                      REAL size,
+                      REAL sizeInPixels,
                       int style,
                       const wxColour& col);
 
     // This ctor takes ownership of the brush.
     wxGDIPlusFontData(wxGraphicsRenderer* renderer,
                       const wxString& name,
-                      REAL size,
+                      REAL sizeInPixels,
                       int style,
                       Brush* textBrush);
 
@@ -365,17 +365,17 @@ private :
     // Common part of all ctors, flags here is a combination of values of
     // FontStyle GDI+ enum.
     void Init(const wxString& name,
-              REAL size,
+              REAL sizeInPixels,
               int style,
               Brush* textBrush);
 
     // Common part of ctors taking wxColour.
     void Init(const wxString& name,
-              REAL size,
+              REAL sizeInPixels,
               int style,
               const wxColour& col)
     {
-        Init(name, size, style, new SolidBrush(wxColourToColor(col)));
+        Init(name, sizeInPixels, style, new SolidBrush(wxColourToColor(col)));
     }
 
     Brush* m_textBrush;
@@ -656,7 +656,7 @@ public :
     virtual wxGraphicsFont CreateFont( const wxFont& font,
                                        const wxColour& col) wxOVERRIDE;
 
-    virtual wxGraphicsFont CreateFont(double size,
+    virtual wxGraphicsFont CreateFont(double sizeInPixels,
                                       const wxString& facename,
                                       int flags = wxFONTFLAG_DEFAULT,
                                       const wxColour& col = *wxBLACK) wxOVERRIDE;
@@ -1105,7 +1105,7 @@ extern const wxArrayString& wxGetPrivateFontFileNames();
 
 void
 wxGDIPlusFontData::Init(const wxString& name,
-                        REAL size,
+                        REAL sizeInPixels,
                         int style,
                         Brush* textBrush)
 {
@@ -1127,7 +1127,7 @@ wxGDIPlusFontData::Init(const wxString& name,
             int rc = gs_pFontFamily[j].GetFamilyName(familyName);
             if ( rc == 0 && name == familyName )
             {
-                m_font = new Font(&gs_pFontFamily[j], size, style, UnitPoint);
+                m_font = new Font(&gs_pFontFamily[j], sizeInPixels, style, UnitPixel);
                 break;
             }
         }
@@ -1136,7 +1136,7 @@ wxGDIPlusFontData::Init(const wxString& name,
     if ( !m_font )
 #endif // wxUSE_PRIVATE_FONTS
     {
-        m_font = new Font(name.wc_str(), size, style, UnitPoint);
+        m_font = new Font(name.wc_str(), sizeInPixels, style, UnitPixel);
     }
 
     m_textBrush = textBrush;
@@ -1157,27 +1157,27 @@ wxGDIPlusFontData::wxGDIPlusFontData( wxGraphicsRenderer* renderer,
     if ( font.GetWeight() == wxFONTWEIGHT_BOLD )
         style |= FontStyleBold;
 
-    Init(font.GetFaceName(), font.GetFractionalPointSize(), style, col);
+    Init(font.GetFaceName(), (REAL)(font.GetPixelSize().GetHeight()), style, col);
 }
 
 wxGDIPlusFontData::wxGDIPlusFontData(wxGraphicsRenderer* renderer,
                                      const wxString& name,
-                                     REAL size,
+                                     REAL sizeInPixels,
                                      int style,
                                      const wxColour& col) :
     wxGraphicsObjectRefData(renderer)
 {
-    Init(name, size, style, col);
+    Init(name, sizeInPixels, style, col);
 }
 
 wxGDIPlusFontData::wxGDIPlusFontData(wxGraphicsRenderer* renderer,
                                      const wxString& name,
-                                     REAL size,
+                                     REAL sizeInPixels,
                                      int style,
                                      Brush* brush)
     : wxGraphicsObjectRefData(renderer)
 {
-    Init(name, size, style, brush);
+    Init(name, sizeInPixels, style, brush);
 }
 
 wxGDIPlusFontData::~wxGDIPlusFontData()
@@ -2732,7 +2732,7 @@ wxGDIPlusRenderer::CreateFont( const wxFont &font,
 }
 
 wxGraphicsFont
-wxGDIPlusRenderer::CreateFont(double size,
+wxGDIPlusRenderer::CreateFont(double sizeInPixels,
                               const wxString& facename,
                               int flags,
                               const wxColour& col)
@@ -2752,7 +2752,7 @@ wxGDIPlusRenderer::CreateFont(double size,
 
 
     wxGraphicsFont f;
-    f.SetRefData(new wxGDIPlusFontData(this, facename, size, style, col));
+    f.SetRefData(new wxGDIPlusFontData(this, facename, sizeInPixels, style, col));
     return f;
 }
 

--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -2876,9 +2876,7 @@ wxD2DFontData::wxD2DFontData(wxGraphicsRenderer* renderer, const wxFont& font, c
         m_font->GetWeight(),
         m_font->GetStyle(),
         m_font->GetStretch(),
-        // We need to use DIP units for the font size, with 1dip = 1/96in,
-        // while wxFont uses points with 1pt = 1/72in.
-        font.GetFractionalPointSize()*96/72,
+        (FLOAT)(font.GetPixelSize().GetHeight()),
         L"en-us",
         &m_textFormat);
 
@@ -4651,7 +4649,7 @@ public :
     wxGraphicsFont CreateFont(const wxFont& font, const wxColour& col) wxOVERRIDE;
 
     wxGraphicsFont CreateFont(
-        double size, const wxString& facename,
+        double sizeInPixels, const wxString& facename,
         int flags = wxFONTFLAG_DEFAULT,
         const wxColour& col = *wxBLACK) wxOVERRIDE;
 
@@ -4904,12 +4902,12 @@ wxGraphicsFont wxD2DRenderer::CreateFont(const wxFont& font, const wxColour& col
 }
 
 wxGraphicsFont wxD2DRenderer::CreateFont(
-    double size, const wxString& facename,
+    double sizeInPixels, const wxString& facename,
     int flags,
     const wxColour& col)
 {
     return CreateFont(
-        wxFontInfo(size).AllFlags(flags).FaceName(facename),
+        wxFontInfo(wxSize(sizeInPixels, sizeInPixels)).AllFlags(flags).FaceName(facename),
         col);
 }
 

--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -2792,7 +2792,7 @@ wxD2DPenData* wxGetD2DPenData(const wxGraphicsPen& pen)
 class wxD2DFontData : public wxGraphicsObjectRefData
 {
 public:
-    wxD2DFontData(wxGraphicsRenderer* renderer, const wxFont& font, const wxColor& color);
+    wxD2DFontData(wxGraphicsRenderer* renderer, const wxFont& font, const wxRealPoint& dpi, const wxColor& color);
 
     wxCOMPtr<IDWriteTextLayout> CreateTextLayout(const wxString& text) const;
 
@@ -2817,7 +2817,7 @@ private:
     bool m_strikethrough;
 };
 
-wxD2DFontData::wxD2DFontData(wxGraphicsRenderer* renderer, const wxFont& font, const wxColor& color) :
+wxD2DFontData::wxD2DFontData(wxGraphicsRenderer* renderer, const wxFont& font, const wxRealPoint& dpi, const wxColor& color) :
     wxGraphicsObjectRefData(renderer), m_brushData(renderer, wxBrush(color)),
     m_underlined(font.GetUnderlined()), m_strikethrough(font.GetStrikethrough())
 {
@@ -2870,13 +2870,17 @@ wxD2DFontData::wxD2DFontData(wxGraphicsRenderer* renderer, const wxFont& font, c
     hr = familyNames->GetString(0, name, length+1);
     wxCHECK_HRESULT_RET(hr);
 
+    FLOAT fontSize = (FLOAT)(!dpi.y
+        ? font.GetPixelSize().GetHeight()
+        : (font.GetFractionalPointSize() * dpi.y / 72.0f));
+
     hr = wxDWriteFactory()->CreateTextFormat(
         name,
         NULL,
         m_font->GetWeight(),
         m_font->GetStyle(),
         m_font->GetStretch(),
-        (FLOAT)(font.GetPixelSize().GetHeight()),
+        fontSize,
         L"en-us",
         &m_textFormat);
 
@@ -3644,7 +3648,7 @@ public:
 
     void Flush() wxOVERRIDE;
 
-    void GetDPI(wxDouble* dpiX, wxDouble* dpiY) wxOVERRIDE;
+    void GetDPI(wxDouble* dpiX, wxDouble* dpiY) const wxOVERRIDE;
 
     wxD2DContextSupplier::ContextType GetContext() wxOVERRIDE
     {
@@ -4570,7 +4574,7 @@ void wxD2DContext::Flush()
     GetRenderTarget()->SetTransform(&currTransform);
 }
 
-void wxD2DContext::GetDPI(wxDouble* dpiX, wxDouble* dpiY)
+void wxD2DContext::GetDPI(wxDouble* dpiX, wxDouble* dpiY) const
 {
     FLOAT x, y;
     GetRenderTarget()->GetDpi(&x, &y);
@@ -4652,6 +4656,10 @@ public :
         double sizeInPixels, const wxString& facename,
         int flags = wxFONTFLAG_DEFAULT,
         const wxColour& col = *wxBLACK) wxOVERRIDE;
+
+    virtual wxGraphicsFont CreateFontAtDPI(const wxFont& font,
+                                           const wxRealPoint& dpi,
+                                           const wxColour& col) wxOVERRIDE;
 
     // create a graphics bitmap from a native bitmap
     wxGraphicsBitmap CreateBitmapFromNativeBitmap(void* bitmap) wxOVERRIDE;
@@ -4886,7 +4894,30 @@ wxImage wxD2DRenderer::CreateImageFromBitmap(const wxGraphicsBitmap& bmp)
 
 wxGraphicsFont wxD2DRenderer::CreateFont(const wxFont& font, const wxColour& col)
 {
-    wxD2DFontData* fontData = new wxD2DFontData(this, font, col);
+    return CreateFontAtDPI(font, wxRealPoint(), col);
+}
+
+wxGraphicsFont wxD2DRenderer::CreateFont(
+    double sizeInPixels, const wxString& facename,
+    int flags,
+    const wxColour& col)
+{
+    // Use the same DPI as wxFont will use in SetPixelSize, so these cancel
+    // each other out and we are left with the actual pixel size.
+    ScreenHDC hdc;
+    wxRealPoint dpi(::GetDeviceCaps(hdc, LOGPIXELSX),
+                    ::GetDeviceCaps(hdc, LOGPIXELSY));
+
+    return CreateFontAtDPI(
+        wxFontInfo(wxSize(sizeInPixels, sizeInPixels)).AllFlags(flags).FaceName(facename),
+        dpi, col);
+}
+
+wxGraphicsFont wxD2DRenderer::CreateFontAtDPI(const wxFont& font,
+                                              const wxRealPoint& dpi,
+                                              const wxColour& col)
+{
+    wxD2DFontData* fontData = new wxD2DFontData(this, font, dpi, col);
     if ( !fontData->GetFont() )
     {
         // Apparently a non-TrueType font is given and hence
@@ -4899,16 +4930,6 @@ wxGraphicsFont wxD2DRenderer::CreateFont(const wxFont& font, const wxColour& col
     graphicsFont.SetRefData(fontData);
 
     return graphicsFont;
-}
-
-wxGraphicsFont wxD2DRenderer::CreateFont(
-    double sizeInPixels, const wxString& facename,
-    int flags,
-    const wxColour& col)
-{
-    return CreateFont(
-        wxFontInfo(wxSize(sizeInPixels, sizeInPixels)).AllFlags(flags).FaceName(facename),
-        col);
 }
 
 // create a sub-image from a native image representation

--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -4576,10 +4576,25 @@ void wxD2DContext::Flush()
 
 void wxD2DContext::GetDPI(wxDouble* dpiX, wxDouble* dpiY) const
 {
-    FLOAT x, y;
-    GetRenderTarget()->GetDpi(&x, &y);
-    if (dpiX != NULL) *dpiX = x;
-    if (dpiY != NULL) *dpiY = y;
+    if ( GetWindow() )
+    {
+        const wxSize dpi = GetWindow()->GetDPI();
+
+        if ( dpiX )
+            *dpiX = dpi.x;
+        if ( dpiY )
+            *dpiY = dpi.y;
+    }
+    else
+    {
+        FLOAT x, y;
+        GetRenderTarget()->GetDpi(&x, &y);
+
+        if ( dpiX )
+            *dpiX = x;
+        if ( dpiY )
+            *dpiY = y;
+    }
 }
 
 //-----------------------------------------------------------------------------

--- a/src/osx/carbon/graphics.cpp
+++ b/src/osx/carbon/graphics.cpp
@@ -2778,6 +2778,9 @@ public :
                                       const wxString& facename,
                                       int flags = wxFONTFLAG_DEFAULT,
                                       const wxColour& col = *wxBLACK) wxOVERRIDE;
+    virtual wxGraphicsFont CreateFontAtDPI(const wxFont& font,
+                                           const wxRealPoint& dpi,
+                                           const wxColour& col) wxOVERRIDE;
 
     // create a native bitmap representation
     virtual wxGraphicsBitmap CreateBitmap( const wxBitmap &bitmap ) wxOVERRIDE ;
@@ -3071,6 +3074,14 @@ wxMacCoreGraphicsRenderer::CreateFont(double sizeInPixels,
     wxGraphicsFont f;
     f.SetRefData(new wxMacCoreGraphicsFontData(this, font, col));
     return f;
+}
+
+wxGraphicsFont
+wxMacCoreGraphicsRenderer::CreateFontAtDPI(const wxFont& font,
+                                           const wxRealPoint& WXUNUSED(dpi),
+                                           const wxColour& col)
+{
+    return CreateFont(font, col);
 }
 
 //

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -260,6 +260,7 @@ wxBEGIN_EVENT_TABLE(wxPropertyGrid, wxControl)
   EVT_SET_FOCUS(wxPropertyGrid::OnFocusEvent)
   EVT_KILL_FOCUS(wxPropertyGrid::OnFocusEvent)
   EVT_SYS_COLOUR_CHANGED(wxPropertyGrid::OnSysColourChanged)
+  EVT_DPI_CHANGED(wxPropertyGrid::OnDPIChanged)
   EVT_MOTION(wxPropertyGrid::OnMouseMove)
   EVT_LEFT_DOWN(wxPropertyGrid::OnMouseClick)
   EVT_LEFT_UP(wxPropertyGrid::OnMouseUp)
@@ -453,9 +454,9 @@ void wxPropertyGrid::Init2()
     m_cursorSizeWE = new wxCursor( wxCURSOR_SIZEWE );
 
     // adjust bitmap icon y position so they are centered
-    m_vspacing = wxPG_DEFAULT_VSPACING;
+    m_vspacing = FromDIP(wxPG_DEFAULT_VSPACING);
 
-    CalculateFontAndBitmapStuff( wxPG_DEFAULT_VSPACING );
+    CalculateFontAndBitmapStuff( m_vspacing );
 
     // Allocate cell data
     m_propertyDefaultCell.SetEmptyData();
@@ -1167,7 +1168,7 @@ void wxPropertyGrid::SetExtraStyle( long exStyle )
 // returns the best acceptable minimal size
 wxSize wxPropertyGrid::DoGetBestSize() const
 {
-    int lineHeight = wxMax(15, m_lineHeight);
+    int lineHeight = wxMax(FromDIP(15), m_lineHeight);
 
     // don't make the grid too tall (limit height to 10 items) but don't
     // make it too small neither
@@ -1301,7 +1302,7 @@ void wxPropertyGrid::CalculateFontAndBitmapStuff( int vspacing )
     m_fontHeight = y;
 
 #if wxPG_USE_RENDERER_NATIVE
-    m_iconWidth = wxPG_ICON_WIDTH;
+    m_iconWidth = FromDIP(wxPG_ICON_WIDTH);
 #elif wxPG_ICON_WIDTH
     // scale icon
     m_iconWidth = (m_fontHeight * wxPG_ICON_WIDTH) / 13;
@@ -1354,6 +1355,13 @@ void wxPropertyGrid::OnSysColourChanged( wxSysColourChangedEvent &WXUNUSED(event
         RegainColours();
         Refresh();
     }
+}
+
+void wxPropertyGrid::OnDPIChanged(wxDPIChangedEvent &WXUNUSED(event))
+{
+    m_vspacing = FromDIP(wxPG_DEFAULT_VSPACING);
+    CalculateFontAndBitmapStuff(m_vspacing);
+    Refresh();
 }
 
 // -----------------------------------------------------------------------

--- a/src/qt/graphics.cpp
+++ b/src/qt/graphics.cpp
@@ -1154,6 +1154,9 @@ public:
         const wxString& facename,
         int flags = wxFONTFLAG_DEFAULT,
         const wxColour& col = *wxBLACK) wxOVERRIDE;
+    virtual wxGraphicsFont CreateFontAtDPI(const wxFont& font,
+                                           const wxRealPoint& dpi,
+                                           const wxColour& col) wxOVERRIDE;
 
     // create a native bitmap representation
     virtual wxGraphicsBitmap CreateBitmap(const wxBitmap& bitmap) wxOVERRIDE;
@@ -1319,6 +1322,14 @@ wxGraphicsFont wxQtGraphicsRenderer::CreateFont(
     wxGraphicsFont font;
     font.SetRefData(new wxQtFontData(this, sizeInPixels, facename, flags, col));
     return font;
+}
+
+wxGraphicsFont
+wxQtGraphicsRenderer::CreateFontAtDPI(const wxFont& font,
+                                      const wxRealPoint& WXUNUSED(dpi),
+                                      const wxColour& col)
+{
+    return CreateFont(font, col);
 }
 
 wxGraphicsBitmap wxQtGraphicsRenderer::CreateBitmap(const wxBitmap& bmp)

--- a/src/stc/stc.cpp
+++ b/src/stc/stc.cpp
@@ -241,12 +241,14 @@ bool wxStyledTextCtrl::Create(wxWindow *parent,
 #endif
 
 #ifdef __WXMSW__
-    // Set zoom for DPI
-    double baseDPI = ::GetDeviceCaps(WindowHDC(parent->GetHWND()), LOGPIXELSY);
-    double activeDPI = parent->GetDPI().y;
+    // Set initial zoom for active DPI
+    const HDC hdc = ::GetDC(parent->GetHWND());
+    const int baseDPI = ::GetDeviceCaps(hdc, LOGPIXELSY);
+    const int activeDPI = parent->GetDPI().y;
+    ::ReleaseDC(parent->GetHWND(), hdc);
 
-    int ptSizeOld = StyleGetSize(wxSTC_STYLE_DEFAULT);
-    int ptSizeNew = (int)wxMulDivInt32(ptSizeOld, activeDPI, baseDPI);
+    const int ptSizeOld = StyleGetSize(wxSTC_STYLE_DEFAULT);
+    const int ptSizeNew = (int)wxMulDivInt32(ptSizeOld, activeDPI, baseDPI);
     SetZoom(GetZoom() + (ptSizeNew - ptSizeOld));
 #endif
 

--- a/src/stc/stc.cpp.in
+++ b/src/stc/stc.cpp.in
@@ -159,6 +159,7 @@ wxBEGIN_EVENT_TABLE(wxStyledTextCtrl, wxControl)
     EVT_KEY_DOWN                (wxStyledTextCtrl::OnKeyDown)
     EVT_KILL_FOCUS              (wxStyledTextCtrl::OnLoseFocus)
     EVT_SET_FOCUS               (wxStyledTextCtrl::OnGainFocus)
+    EVT_DPI_CHANGED             (wxStyledTextCtrl::OnDPIChanged)
     EVT_SYS_COLOUR_CHANGED      (wxStyledTextCtrl::OnSysColourChanged)
     EVT_ERASE_BACKGROUND        (wxStyledTextCtrl::OnEraseBackground)
     EVT_MENU_RANGE              (10, 16, wxStyledTextCtrl::OnMenu)
@@ -237,6 +238,16 @@ bool wxStyledTextCtrl::Create(wxWindow *parent,
 
 #if wxUSE_GRAPHICS_DIRECT2D
     SetFontQuality(wxSTC_EFF_QUALITY_DEFAULT);
+#endif
+
+#ifdef __WXMSW__
+    // Set zoom for DPI
+    double baseDPI = ::GetDeviceCaps(WindowHDC(parent->GetHWND()), LOGPIXELSY);
+    double activeDPI = parent->GetDPI().y;
+
+    int ptSizeOld = StyleGetSize(wxSTC_STYLE_DEFAULT);
+    int ptSizeNew = (int)wxMulDivInt32(ptSizeOld, activeDPI, baseDPI);
+    SetZoom(GetZoom() + (ptSizeNew - ptSizeOld));
 #endif
 
     return true;
@@ -959,6 +970,19 @@ void wxStyledTextCtrl::OnGainFocus(wxFocusEvent& evt) {
 }
 
 
+void wxStyledTextCtrl::OnDPIChanged(wxDPIChangedEvent& evt)
+{
+    int ptSizeOld = StyleGetSize(wxSTC_STYLE_DEFAULT);
+    int ptSizeNew = (int)wxMulDivInt32(ptSizeOld, evt.GetNewDPI().y, evt.GetOldDPI().y);
+    SetZoom(GetZoom() + (ptSizeNew - ptSizeOld));
+
+    for ( int i = 0; i < SC_MAX_MARGIN; ++i )
+    {
+        SetMarginWidth(i, (int)wxMulDivInt32(GetMarginWidth(i), evt.GetNewDPI().y, evt.GetOldDPI().y));
+    }
+}
+
+
 void wxStyledTextCtrl::OnSysColourChanged(wxSysColourChangedEvent& WXUNUSED(evt)) {
     m_swx->DoSysColourChange();
 }
@@ -994,7 +1018,7 @@ wxSize wxStyledTextCtrl::DoGetBestSize() const
 {
     // What would be the best size for a wxSTC?
     // Just give a reasonable minimum until something else can be figured out.
-    return wxSize(200,100);
+    return FromDIP(wxSize(200,100));
 }
 
 

--- a/src/stc/stc.cpp.in
+++ b/src/stc/stc.cpp.in
@@ -241,12 +241,14 @@ bool wxStyledTextCtrl::Create(wxWindow *parent,
 #endif
 
 #ifdef __WXMSW__
-    // Set zoom for DPI
-    double baseDPI = ::GetDeviceCaps(WindowHDC(parent->GetHWND()), LOGPIXELSY);
-    double activeDPI = parent->GetDPI().y;
+    // Set initial zoom for active DPI
+    const HDC hdc = ::GetDC(parent->GetHWND());
+    const int baseDPI = ::GetDeviceCaps(hdc, LOGPIXELSY);
+    const int activeDPI = parent->GetDPI().y;
+    ::ReleaseDC(parent->GetHWND(), hdc);
 
-    int ptSizeOld = StyleGetSize(wxSTC_STYLE_DEFAULT);
-    int ptSizeNew = (int)wxMulDivInt32(ptSizeOld, activeDPI, baseDPI);
+    const int ptSizeOld = StyleGetSize(wxSTC_STYLE_DEFAULT);
+    const int ptSizeNew = (int)wxMulDivInt32(ptSizeOld, activeDPI, baseDPI);
     SetZoom(GetZoom() + (ptSizeNew - ptSizeOld));
 #endif
 

--- a/src/stc/stc.h.in
+++ b/src/stc/stc.h.in
@@ -597,6 +597,7 @@ protected:
     void OnKeyDown(wxKeyEvent& evt);
     void OnLoseFocus(wxFocusEvent& evt);
     void OnGainFocus(wxFocusEvent& evt);
+    void OnDPIChanged(wxDPIChangedEvent& evt);
     void OnSysColourChanged(wxSysColourChangedEvent& evt);
     void OnEraseBackground(wxEraseEvent& evt);
     void OnMenu(wxCommandEvent& evt);


### PR DESCRIPTION
Add Per-Monitor DPI awareness to `wxDC` and `wxGraphicsContext` (font only), `wxSTC`, `wxPropertyGrid`, and `wxMenuItem`.

This is the last batch of changes from #334. As a nice side effect, font scaling in `wxGDIPlusPrintingContext` is not needed anymore.

Please don't merge yet, I want to do more testing. I created the PR to get some feedback.