### PR TITLE
Fix focus after disabling the currently focused control in wxMSW

### DIFF
--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -1023,9 +1023,17 @@ void wxWindowMSW::MSWUpdateUIState(int action, int state)
 
 void wxWindowMSW::WXSetPendingFocus(wxWindow* win)
 {
+    wxWindow * const focus = FindFocus();
+
     for ( wxWindow* parent = this; parent; parent = parent->GetParent() )
     {
-        parent->WXDoUpdatePendingFocus(win);
+        // We shouldn't overwrite the pending focus if the window has the focus
+        // currently, as this would make its state inconsistent. And this would
+        // be useless anyhow, as we only remember pending focus in order to
+        // restore it properly when the window gets the focus back -- which is
+        // unnecessary if it has the focus already.
+        if ( !parent->IsDescendant(focus) )
+            parent->WXDoUpdatePendingFocus(win);
 
         if ( parent->IsTopLevel() )
             break;


### PR DESCRIPTION
Fix a regression since 23ddf26571eafc96c3c46d706005fbb6ae3600c7: initial
focus was wrong in a dialog with radio button if the focused control was
disabled. This happened because m_winLastFocused didn't correspond to
the actual focus when we tried to find the next control to focus in this
case, as m_winLastFocused was changed by wxRadioButton::SetValue().

Don't change m_winLastFocused for the window which already has focus to
avoid this problem, and also because it was useless to do this anyhow.

Closes #18521.