### PR TITLE
Document that wxDateTime::UNow() returns time in local time zone

### DIFF
--- a/interface/wx/datetime.h
+++ b/interface/wx/datetime.h
@@ -1527,7 +1527,7 @@ public:
     static bool IsWestEuropeanCountry(Country country = Country_Default);
 
     /**
-        Returns the object corresponding to the current time.
+        Returns the object corresponding to the current time in local time zone.
 
         Example:
 
@@ -1575,8 +1575,8 @@ public:
         Returns the object corresponding to the current UTC time including the
         milliseconds.
 
-        Notice that unlike Now(), this method creates a wxDateTime object
-        corresponding to UTC, not local, time.
+        Like Now(), this method creates the wxDateTime object corresponding to
+        the current moment in local time.
 
         @see Now(), wxGetUTCTimeMillis()
     */

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -1701,4 +1701,34 @@ TEST_CASE("wxDateTime-BST-bugs", "[datetime][dst][BST][.]")
     }
 }
 
+TEST_CASE("wxDateTime::UNow", "[datetime][now][unow]")
+{
+    const wxDateTime now = wxDateTime::Now();
+    const wxDateTime unow = wxDateTime::UNow();
+
+    CHECK( now.GetYear() == unow.GetYear() );
+    CHECK( now.GetMonth() == unow.GetMonth() );
+    CHECK( now.GetDay() == unow.GetDay() );
+    CHECK( now.GetHour() == unow.GetHour() );
+    CHECK( now.GetMinute() == unow.GetMinute() );
+    CHECK( now.GetSecond() == unow.GetSecond() );
+
+    CHECK( now.GetMillisecond() == 0 );
+
+    // Just checking unow.GetMillisecond() == 0 would fail once per 1000 test
+    // runs on average, which is certainly not a lot, but still try to avoid
+    // such spurious failures.
+    bool gotMS = false;
+    for ( int i = 0; i < 3; ++i )
+    {
+        if ( wxDateTime::UNow().GetMillisecond() != 0 )
+        {
+            gotMS = true;
+            break;
+        }
+    }
+
+    CHECK( gotMS );
+}
+
 #endif // wxUSE_DATETIME


### PR DESCRIPTION
This is its actual behaviour and it's the right thing to do, as it's
consistent with Now() -- even though the documentation wrongly stated
otherwise (since 324ab5e2dbfcae3582d9405819b46fef5e7c0e59).

Also add a unit test checking that UNow() == Now(), except for the
milliseconds.

See #14148.

Closes #18524.