### PR TITLE
Fix the issue with the grid cell editor special chars handling

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -6996,6 +6996,10 @@ void wxGrid::ShowCellEditControl()
                 editor->Create(gridWindow, wxID_ANY,
                                new wxGridCellEditorEvtHandler(this, editor));
 
+                // Add wxWANTS_CHARS flag to allow editor controls process Tab, Enter and Esc keys
+                wxWindow* editorWindow = editor->GetWindow();
+                editorWindow->SetWindowStyle(editorWindow->GetWindowStyle() | wxWANTS_CHARS);
+
                 wxGridEditorCreatedEvent evt(GetId(),
                                              wxEVT_GRID_EDITOR_CREATED,
                                              this,


### PR DESCRIPTION
Some of the grid cell editors (wxGridCellBoolEditor, wxGridCellChoiceEditor,                                                  wxGridCellEnumEditor) doesn't process Esc, Enter and Tab under MSW so                                                         corresponding grid functions doesn't work. Fixed by adding wxWANTS_CHARS                                                      style flag.