### PR TITLE
Fix the issue with the composite grid editor focus

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -7088,7 +7088,7 @@ void wxGrid::HideCellEditControl()
 
         wxGridCellAttr *attr = GetCellAttr(row, col);
         wxGridCellEditor *editor = attr->GetEditor(this, row, col);
-        const bool editorHadFocus = editor->GetWindow()->HasFocus();
+        const bool editorHadFocus = editor->GetWindow()->IsDescendant(FindFocus());
 
         if ( editor->GetWindow()->GetParent() != m_gridWin )
             editor->GetWindow()->Reparent(m_gridWin);


### PR DESCRIPTION
The grid editor window can be composite so it must be taken into account
when determining whether we should set the focus to the grid when the grid
editor is hiding.