### PR TITLE
Fix recent regression in grid content autosizing

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -9400,47 +9400,65 @@ wxGrid::AutoSizeColOrRow(int colOrRow, bool setAsMin, wxGridDirection direction)
     wxCoord w, h;
     dc.SetFont( GetLabelFont() );
 
+    bool noContent = (extentMax == 0);
     bool addMargin = true;
 
     if ( column )
     {
         if ( m_useNativeHeader )
         {
-            w = GetGridColHeader()->GetColumnTitleWidth(colOrRow);
+            wxHeaderCtrl* header = GetGridColHeader();
+            w = header->GetColumnTitleWidth(colOrRow);
 
             // GetColumnTitleWidth already adds margins internally.
             addMargin = false;
             h = 0;
+
+            // GetColumnTitleWidth uses GetTextExtent and not
+            // GetMultiLineTextExtent so use the same funtion.
+            if ( header->GetTextExtent(GetColLabelValue(colOrRow)).x > 0 )
+                noContent = false;
         }
         else
         {
             dc.GetMultiLineTextExtent( GetColLabelValue(colOrRow), &w, &h );
             if ( GetColLabelTextOrientation() == wxVERTICAL )
                 w = h;
+
+            noContent = noContent && (w == 0);
         }
     }
     else
     {
         dc.GetMultiLineTextExtent( GetRowLabelValue(colOrRow), &w, &h );
+        noContent = noContent && (h == 0);
     }
 
-    extent = column ? w : h;
-    if ( extent > extentMax )
-        extentMax = extent;
-
-    if ( !extentMax )
+    if ( noContent )
     {
         // empty column - give default extent (notice that if extentMax is less
         // than default extent but != 0, it's OK)
         extentMax = column ? m_defaultColWidth : m_defaultRowHeight;
     }
-    else if ( addMargin )
+    else
     {
-        // leave some space around text
-        if ( column )
-            extentMax += 10;
-        else
-            extentMax += 6;
+        const int margin = column ? 10 : 6;
+
+        // The current extentMax is the max extent of columns/rows values
+        // so always add margin.
+        extentMax += margin;
+
+        // The current extent is the extent of the column/row title.
+        extent = column ? w : h;
+
+        // Add the margin to the current extent only if needed.
+        if ( addMargin )
+            extent += margin;
+
+        // Find out the final max extent when the margin affected to the max extent
+        // and the current extent.
+        if ( extent > extentMax )
+            extentMax = extent;
     }
 
     if ( column )

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -16,9 +16,11 @@
 
 #ifndef WX_PRECOMP
     #include "wx/app.h"
+    #include "wx/dcclient.h"
 #endif // WX_PRECOMP
 
 #include "wx/grid.h"
+#include "wx/headerctrl.h"
 #include "testableframe.h"
 #include "asserthelper.h"
 #include "wx/uiaction.h"
@@ -70,18 +72,21 @@ private:
         WXUISIM_TEST( ReadOnly );
         WXUISIM_TEST( ResizeScrolledHeader );
         WXUISIM_TEST( ColumnMinWidth );
+        WXUISIM_TEST( AutoSizeColumn );
         CPPUNIT_TEST( PseudoTest_NativeHeader );
         NONGTK_TEST( LabelClick );
         NONGTK_TEST( SortClick );
         CPPUNIT_TEST( ColumnOrder );
         WXUISIM_TEST( ResizeScrolledHeader );
         WXUISIM_TEST( ColumnMinWidth );
+        WXUISIM_TEST( AutoSizeColumn );
         CPPUNIT_TEST( DeleteAndAddRowCol );
         CPPUNIT_TEST( PseudoTest_NativeLabels );
         NONGTK_TEST( LabelClick );
         NONGTK_TEST( SortClick );
         CPPUNIT_TEST( ColumnOrder );
         WXUISIM_TEST( WindowAsEditorControl );
+        WXUISIM_TEST( AutoSizeColumn );
     CPPUNIT_TEST_SUITE_END();
 
     void CellEdit();
@@ -108,9 +113,22 @@ private:
     void WindowAsEditorControl();
     void ResizeScrolledHeader();
     void ColumnMinWidth();
+    void AutoSizeColumn();
     void PseudoTest_NativeHeader() { ms_nativeheader = true; }
     void PseudoTest_NativeLabels() { ms_nativeheader = false;
                                      ms_nativelabels = true; }
+
+    // The helper function to determine the width of the column label depending
+    // on whether the native column is used.
+    int GetColumnLabelWidth(wxClientDC& dc, int col, int margin) const
+    {
+        if (ms_nativeheader)
+            return m_grid->GetGridColHeader()->GetColumnTitleWidth(col);
+
+        int w, h;
+        dc.GetMultiLineTextExtent(m_grid->GetColLabelValue(col), &w, &h);
+        return w + margin;
+    }
 
     static bool ms_nativeheader;
     static bool ms_nativelabels;
@@ -948,6 +966,93 @@ void GridTestCase::ColumnMinWidth()
     else
         CPPUNIT_ASSERT_EQUAL(newminwidth, m_grid->GetColSize(0));
 #endif
+}
+
+void GridTestCase::AutoSizeColumn()
+{
+    // Hardcoded margin for columns.
+    const int margin = 10;
+    int maxWidth;
+
+    wxGridCellAttr *attr = m_grid->GetOrCreateCellAttr(0, 0);
+    wxGridCellRenderer *renderer = attr->GetRenderer(m_grid, 0, 0);
+    REQUIRE(renderer != nullptr);
+
+    wxClientDC dcCell(m_grid->GetGridWindow());
+
+    wxClientDC dcLabel(m_grid->GetGridWindow());
+    dcLabel.SetFont(m_grid->GetLabelFont());
+
+    const wxString shortStr     = "W";
+    const wxString mediumStr    = "WWWW";
+    const wxString longStr      = "WWWWWWWW";
+    const wxString multilineStr = mediumStr + "\n" + longStr;
+
+    SECTION("Empty column")
+    {
+        m_grid->SetColLabelValue(0, wxEmptyString);
+        maxWidth = m_grid->GetDefaultColSize();
+    }
+
+    SECTION("Autosize by the title")
+    {
+        m_grid->SetColLabelValue(0, mediumStr);
+        maxWidth = GetColumnLabelWidth(dcLabel, 0, margin);
+    }
+
+    SECTION("Autosize by cells")
+    {
+        m_grid->SetColLabelValue(0, wxEmptyString);
+        m_grid->SetCellValue(0, 0, mediumStr);
+        m_grid->SetCellValue(1, 0, shortStr);
+        m_grid->SetCellValue(3, 0, longStr);
+        maxWidth = renderer->GetBestWidth(*m_grid, *attr, dcCell, 3, 0,
+                                          m_grid->GetRowHeight(3))
+                   + margin;
+    }
+
+    SECTION("Autosize with the longest title")
+    {
+        m_grid->SetColLabelValue(0, multilineStr);
+        m_grid->SetCellValue(0, 0, mediumStr);
+        m_grid->SetCellValue(1, 0, shortStr);
+        maxWidth = GetColumnLabelWidth(dcLabel, 0, margin);
+    }
+
+    SECTION("Autosize with the longest cell")
+    {
+        m_grid->SetColLabelValue(0, mediumStr);
+        m_grid->SetCellValue(0, 0, mediumStr);
+        m_grid->SetCellValue(1, 0, shortStr);
+        m_grid->SetCellValue(3, 0, multilineStr);
+        maxWidth = renderer->GetBestWidth(*m_grid, *attr, dcCell, 3, 0,
+                                          m_grid->GetRowHeight(3))
+                   + margin;
+    }
+
+    SECTION("Autosize with the same values")
+    {
+        m_grid->SetColLabelValue(0, mediumStr);
+        m_grid->SetCellValue(0, 0, mediumStr);
+        m_grid->SetCellValue(1, 0, mediumStr);
+        m_grid->SetCellValue(3, 0, mediumStr);
+
+        const int labelWidth = GetColumnLabelWidth(dcLabel, 0, margin);
+
+        const int cellWidth =
+            renderer->GetBestWidth(*m_grid, *attr, dcCell, 3, 0,
+                                   m_grid->GetRowHeight(3))
+            + margin;
+
+        // We can't be sure which size will be greater because of different fonts
+        // so just calculate the maximum width.
+        maxWidth = wxMax(labelWidth, cellWidth);
+    }
+
+    m_grid->AutoSizeColumn(0);
+
+    wxYield();
+    CHECK(m_grid->GetColSize(0) == maxWidth);
 }
 
 #endif //wxUSE_GRID

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -976,7 +976,7 @@ void GridTestCase::AutoSizeColumn()
 
     wxGridCellAttr *attr = m_grid->GetOrCreateCellAttr(0, 0);
     wxGridCellRenderer *renderer = attr->GetRenderer(m_grid, 0, 0);
-    REQUIRE(renderer != nullptr);
+    REQUIRE(renderer != NULL);
 
     wxClientDC dcCell(m_grid->GetGridWindow());
 


### PR DESCRIPTION
Autosizing was not fixed in https://github.com/wxWidgets/wxWidgets/pull/1578. Sorry.

The margin must always be added to the columns/rows content extents and default titles content extent. And must not be added only to the native header title extent.

See also: https://github.com/wxWidgets/wxWidgets/pull/1559.