### PR TITLE
Remove no-op uses of wxNO_FULL_REPAINT_ON_RESIZE

### DIFF
--- a/samples/animate/anitest.cpp
+++ b/samples/animate/anitest.cpp
@@ -115,8 +115,7 @@ MyFrame::MyFrame(wxWindow *parent,
                  const wxPoint& pos,
                  const wxSize& size,
                  const long style)
-       : wxFrame(parent, id, title, pos, size,
-                          style | wxNO_FULL_REPAINT_ON_RESIZE)
+       : wxFrame(parent, id, title, pos, size, style)
 {
     SetIcon(wxICON(sample));
 

--- a/samples/collpane/collpane.cpp
+++ b/samples/collpane/collpane.cpp
@@ -172,8 +172,7 @@ wxEND_EVENT_TABLE()
 // My frame constructor
 MyFrame::MyFrame()
        : wxFrame(NULL, wxID_ANY, "wxCollapsiblePane sample",
-                 wxDefaultPosition, wxSize(420, 300),
-                 wxDEFAULT_FRAME_STYLE | wxNO_FULL_REPAINT_ON_RESIZE)
+                 wxDefaultPosition, wxSize(420, 300))
 {
     SetIcon(wxICON(sample));
 

--- a/samples/drawing/drawing.cpp
+++ b/samples/drawing/drawing.cpp
@@ -524,7 +524,7 @@ wxEND_EVENT_TABLE()
 
 MyCanvas::MyCanvas(MyFrame *parent)
         : wxScrolledWindow(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize,
-                           wxHSCROLL | wxVSCROLL | wxNO_FULL_REPAINT_ON_RESIZE)
+                           wxHSCROLL | wxVSCROLL)
 {
     m_owner = parent;
     m_show = File_ShowDefault;
@@ -2162,8 +2162,7 @@ wxEND_EVENT_TABLE()
 
 // frame constructor
 MyFrame::MyFrame(const wxString& title, const wxPoint& pos, const wxSize& size)
-       : wxFrame((wxFrame *)NULL, wxID_ANY, title, pos, size,
-                 wxDEFAULT_FRAME_STYLE | wxNO_FULL_REPAINT_ON_RESIZE)
+       : wxFrame((wxFrame *)NULL, wxID_ANY, title, pos, size)
 {
     // set the frame icon
     SetIcon(wxICON(sample));

--- a/samples/mdi/mdi.cpp
+++ b/samples/mdi/mdi.cpp
@@ -363,9 +363,7 @@ void MyFrame::InitToolBar(wxToolBar* toolBar)
 // Define a constructor for my canvas
 MyCanvas::MyCanvas(wxFrame *parent, const wxPoint& pos, const wxSize& size)
         : wxScrolledWindow(parent, wxID_ANY, pos, size,
-                           wxSUNKEN_BORDER |
-                           wxNO_FULL_REPAINT_ON_RESIZE |
-                           wxVSCROLL | wxHSCROLL),
+                           wxSUNKEN_BORDER | wxVSCROLL | wxHSCROLL),
           MenuEventLogger("canvas", parent)
 
 {

--- a/samples/propgrid/propgrid.cpp
+++ b/samples/propgrid/propgrid.cpp
@@ -954,15 +954,10 @@ static const wxString _fs_windowstyle_labels[] = {
     "wxTRANSPARENT_WINDOW",
     "wxTAB_TRAVERSAL",
     "wxWANTS_CHARS",
-#if wxNO_FULL_REPAINT_ON_RESIZE
-    "wxNO_FULL_REPAINT_ON_RESIZE",
-#endif
     "wxVSCROLL",
     "wxALWAYS_SHOW_SB",
     "wxCLIP_CHILDREN",
-#if wxFULL_REPAINT_ON_RESIZE
     "wxFULL_REPAINT_ON_RESIZE",
-#endif
     };
 
 static const long _fs_windowstyle_values[] = {
@@ -974,15 +969,10 @@ static const long _fs_windowstyle_values[] = {
     wxTRANSPARENT_WINDOW,
     wxTAB_TRAVERSAL,
     wxWANTS_CHARS,
-#if wxNO_FULL_REPAINT_ON_RESIZE
-    wxNO_FULL_REPAINT_ON_RESIZE,
-#endif
     wxVSCROLL,
     wxALWAYS_SHOW_SB,
     wxCLIP_CHILDREN,
-#if wxFULL_REPAINT_ON_RESIZE
     wxFULL_REPAINT_ON_RESIZE
-#endif
 };
 
 static const wxString _fs_framestyle_labels[] = {
@@ -1982,7 +1972,7 @@ void FormMain::CreateGrid( int style, int extraStyle )
 FormMain::FormMain(const wxString& title, const wxPoint& pos, const wxSize& size) :
            wxFrame((wxFrame *)NULL, -1, title, pos, size,
                (wxMINIMIZE_BOX|wxMAXIMIZE_BOX|wxRESIZE_BORDER|wxSYSTEM_MENU|wxCAPTION|
-                wxTAB_TRAVERSAL|wxCLOSE_BOX|wxNO_FULL_REPAINT_ON_RESIZE) )
+                wxTAB_TRAVERSAL|wxCLOSE_BOX) )
 {
     SetIcon(wxICON(sample));
 

--- a/samples/sashtest/sashtest.cpp
+++ b/samples/sashtest/sashtest.cpp
@@ -46,7 +46,6 @@ bool MyApp::OnInit(void)
 
   frame = new MyFrame(NULL, wxID_ANY, "Sash Demo", wxPoint(0, 0), wxSize(500, 400),
                       wxDEFAULT_FRAME_STYLE |
-                      wxNO_FULL_REPAINT_ON_RESIZE |
                       wxHSCROLL | wxVSCROLL);
 
   // Give it an icon (this is ignored in MDI mode: uses resources)
@@ -223,9 +222,7 @@ void MyFrame::OnNewWindow(wxCommandEvent& WXUNUSED(event))
 {
       // Make another frame, containing a canvas
       MyChild *subframe = new MyChild(frame, "Canvas Frame",
-                                      wxPoint(10, 10), wxSize(300, 300),
-                                      wxDEFAULT_FRAME_STYLE |
-                                      wxNO_FULL_REPAINT_ON_RESIZE);
+                                      wxPoint(10, 10), wxSize(300, 300));
 
       subframe->SetTitle(wxString::Format("Canvas Frame %d", winNumber));
       winNumber ++;
@@ -282,8 +279,7 @@ wxEND_EVENT_TABLE()
 
 // Define a constructor for my canvas
 MyCanvas::MyCanvas(wxWindow *parent, const wxPoint& pos, const wxSize& size)
-        : wxScrolledWindow(parent, wxID_ANY, pos, size,
-                           wxSUNKEN_BORDER | wxNO_FULL_REPAINT_ON_RESIZE)
+        : wxScrolledWindow(parent, wxID_ANY, pos, size, wxSUNKEN_BORDER)
 {
     SetBackgroundColour(* wxWHITE);
 }

--- a/samples/sashtest/sashtest.cpp
+++ b/samples/sashtest/sashtest.cpp
@@ -346,9 +346,8 @@ wxBEGIN_EVENT_TABLE(MyChild, wxMDIChildFrame)
   EVT_MENU(SASHTEST_CHILD_QUIT, MyChild::OnQuit)
 wxEND_EVENT_TABLE()
 
-MyChild::MyChild(wxMDIParentFrame *parent, const wxString& title, const wxPoint& pos, const wxSize& size,
-const long style):
-  wxMDIChildFrame(parent, wxID_ANY, title, pos, size, style)
+MyChild::MyChild(wxMDIParentFrame *parent, const wxString& title, const wxPoint& pos, const wxSize& size):
+  wxMDIChildFrame(parent, wxID_ANY, title, pos, size)
 {
   canvas = NULL;
   my_children.Append(this);

--- a/samples/sashtest/sashtest.h
+++ b/samples/sashtest/sashtest.h
@@ -54,7 +54,7 @@ class MyChild: public wxMDIChildFrame
 {
   public:
     MyCanvas *canvas;
-    MyChild(wxMDIParentFrame *parent, const wxString& title, const wxPoint& pos, const wxSize& size, const long style);
+    MyChild(wxMDIParentFrame *parent, const wxString& title, const wxPoint& pos, const wxSize& size);
     ~MyChild(void);
     void OnActivate(wxActivateEvent& event);
     void OnQuit(wxCommandEvent& event);

--- a/samples/splitter/splitter.cpp
+++ b/samples/splitter/splitter.cpp
@@ -214,7 +214,7 @@ wxEND_EVENT_TABLE()
 // My frame constructor
 MyFrame::MyFrame()
        : wxFrame(NULL, wxID_ANY, "wxSplitterWindow sample",
-                 wxDefaultPosition, wxSize(420, 300));
+                 wxDefaultPosition, wxSize(420, 300))
 {
     SetIcon(wxICON(sample));
 

--- a/samples/splitter/splitter.cpp
+++ b/samples/splitter/splitter.cpp
@@ -214,8 +214,7 @@ wxEND_EVENT_TABLE()
 // My frame constructor
 MyFrame::MyFrame()
        : wxFrame(NULL, wxID_ANY, "wxSplitterWindow sample",
-                 wxDefaultPosition, wxSize(420, 300),
-                 wxDEFAULT_FRAME_STYLE | wxNO_FULL_REPAINT_ON_RESIZE)
+                 wxDefaultPosition, wxSize(420, 300));
 {
     SetIcon(wxICON(sample));
 
@@ -551,7 +550,7 @@ void MySplitterWindow::OnUnsplitEvent(wxSplitterEvent& event)
 
 MyCanvas::MyCanvas(wxWindow* parent, bool mirror)
         : wxScrolledWindow(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize,
-                           wxHSCROLL | wxVSCROLL | wxNO_FULL_REPAINT_ON_RESIZE)
+                           wxHSCROLL | wxVSCROLL)
 {
     m_mirror = mirror;
     SetScrollbars(20, 20, 5, 5);

--- a/samples/stc/stctest.cpp
+++ b/samples/stc/stctest.cpp
@@ -291,8 +291,7 @@ wxBEGIN_EVENT_TABLE (AppFrame, wxFrame)
 wxEND_EVENT_TABLE ()
 
 AppFrame::AppFrame (const wxString &title)
-        : wxFrame ((wxFrame *)NULL, wxID_ANY, title, wxDefaultPosition, wxSize(750,550),
-                    wxDEFAULT_FRAME_STYLE | wxNO_FULL_REPAINT_ON_RESIZE)
+        : wxFrame ((wxFrame *)NULL, wxID_ANY, title, wxDefaultPosition, wxSize(750,550))
 {
     SetIcon(wxICON(sample));
 

--- a/samples/toolbar/toolbar.cpp
+++ b/samples/toolbar/toolbar.cpp
@@ -98,7 +98,7 @@ public:
             const wxString& title = "wxToolBar Sample",
             const wxPoint& pos = wxDefaultPosition,
             const wxSize& size = wxDefaultSize,
-            long style = wxDEFAULT_FRAME_STYLE|wxCLIP_CHILDREN|wxNO_FULL_REPAINT_ON_RESIZE);
+            long style = wxDEFAULT_FRAME_STYLE|wxCLIP_CHILDREN);
     virtual ~MyFrame();
 
     void PopulateToolbar(wxToolBarBase* toolBar);

--- a/samples/widgets/widgets.cpp
+++ b/samples/widgets/widgets.cpp
@@ -1311,7 +1311,6 @@ WidgetsPage::WidgetsPage(WidgetsBookCtrl *book,
                          const char *const icon[])
            : wxPanel(book, wxID_ANY,
                      wxDefaultPosition, wxDefaultSize,
-                     wxNO_FULL_REPAINT_ON_RESIZE |
                      wxCLIP_CHILDREN |
                      wxTAB_TRAVERSAL)
 {

--- a/src/propgrid/manager.cpp
+++ b/src/propgrid/manager.cpp
@@ -505,7 +505,6 @@ void wxPropertyGridManager::Init1()
 
 // These flags are always used in wxPropertyGrid integrated in wxPropertyGridManager.
 #define wxPG_MAN_PROPGRID_FORCED_FLAGS (  wxBORDER_THEME | \
-                                          wxNO_FULL_REPAINT_ON_RESIZE| \
                                           wxCLIP_CHILDREN)
 
 // Which flags can be passed to underlying wxPropertyGrid.


### PR DESCRIPTION
This behaviour has been the default and this constant 0 since
e441e1f4e8671915ee9bb32049edb4f1d700126e which was over 16 years ago.