### PR TITLE
Update wxAuiGenericTabArt and wxAuiSimpleTabArt to properly handle sc…

### DIFF
--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -634,7 +634,7 @@ wxSize wxAuiGenericToolBarArt::GetToolSize(
     // and add some extra space in front of the drop down button
     if (item.HasDropDown())
     {
-        int dropdownWidth = wnd->FromDIP(GetElementSize(wxAUI_TBART_DROPDOWN_SIZE));
+        int dropdownWidth = GetElementSize(wxAUI_TBART_DROPDOWN_SIZE);
         width += dropdownWidth + wnd->FromDIP(4);
     }
 

--- a/src/aui/dockart.cpp
+++ b/src/aui/dockart.cpp
@@ -92,7 +92,7 @@ wxBitmap wxAuiBitmapFromBits(const unsigned char bits[], int w, int h,
 // wxAuiScaleBitmap is a utility function that scales a TabArt bitmap
 wxBitmap wxAuiScaleBitmap(const wxBitmap& bmp, double scale)
 {
-#if wxUSE_IMAGE
+#if wxUSE_IMAGE && !defined(__WXGTK3__) && !defined(__WXMAC__)
     // scale to a close round number to improve quality
     scale = floor(scale + 0.25);
     if (scale > 1.0 && !(bmp.GetScaleFactor() > 1.0))

--- a/src/aui/dockart.cpp
+++ b/src/aui/dockart.cpp
@@ -765,6 +765,7 @@ void wxAuiDefaultDockArt::DrawPaneButton(wxDC& dc,
             break;
     }
 
+    bmp = wxAuiScaleBitmap(bmp, window->GetContentScaleFactor());
 
     wxRect rect = _rect;
 
@@ -791,9 +792,10 @@ void wxAuiDefaultDockArt::DrawPaneButton(wxDC& dc,
         }
 
         // draw the background behind the button
-        dc.DrawRectangle(rect.x, rect.y, 16-window->FromDIP(1), 16-window->FromDIP(1));
+        dc.DrawRectangle(rect.x, rect.y,
+            bmp.GetScaledWidth() - window->FromDIP(1),
+            bmp.GetScaledHeight() - window->FromDIP(1));
     }
-
 
     // draw the button itself
     dc.DrawBitmap(bmp, rect.x, rect.y, true);

--- a/src/aui/dockart.cpp
+++ b/src/aui/dockart.cpp
@@ -92,9 +92,9 @@ wxBitmap wxAuiBitmapFromBits(const unsigned char bits[], int w, int h,
 // wxAuiScaleBitmap is a utility function that scales a TabArt bitmap
 wxBitmap wxAuiScaleBitmap(const wxBitmap& bmp, double scale)
 {
-#if wxUSE_IMAGE && !defined(__WXGTK3__) && !defined(__WXMAC__)
     // scale to a close round number to improve quality
     scale = floor(scale + 0.25);
+#if wxUSE_IMAGE && !defined(__WXGTK3__) && !defined(__WXMAC__)
     if (scale > 1.0 && !(bmp.GetScaleFactor() > 1.0))
     {
         wxImage img = bmp.ConvertToImage();

--- a/src/aui/dockart.cpp
+++ b/src/aui/dockart.cpp
@@ -55,6 +55,7 @@
 #endif
 #endif
 
+#include <math.h>
 
 // -- wxAuiDefaultDockArt class implementation --
 
@@ -88,6 +89,22 @@ wxBitmap wxAuiBitmapFromBits(const unsigned char bits[], int w, int h,
     return wxBitmap(img);
 }
 
+// wxAuiScaleBitmap is a utility function that scales a TabArt bitmap
+wxBitmap wxAuiScaleBitmap(const wxBitmap& bmp, double scale)
+{
+#if wxUSE_IMAGE
+    // scale to a close round number to improve quality
+    scale = floor(scale + 0.25);
+    if (scale > 1.0 && !(bmp.GetScaleFactor() > 1.0))
+    {
+        wxImage img = bmp.ConvertToImage();
+        img.Rescale(bmp.GetWidth()*scale, bmp.GetHeight()*scale,
+            wxIMAGE_QUALITY_BOX_AVERAGE);
+        return wxBitmap(img);
+    }
+#endif // wxUSE_IMAGE
+    return bmp;
+}
 
 static void DrawGradientRectangle(wxDC& dc,
                                   const wxRect& rect,

--- a/src/aui/tabart.cpp
+++ b/src/aui/tabart.cpp
@@ -643,7 +643,7 @@ int wxAuiGenericTabArt::GetBorderWidth(wxWindow* wnd)
     wxAuiManager* mgr = wxAuiManager::GetManager(wnd);
     if (mgr)
     {
-       wxAuiDockArt*  art = mgr->GetArtProvider();
+        wxAuiDockArt* art = mgr->GetArtProvider();
         if (art)
             return art->GetMetric(wxAUI_DOCKART_PANE_BORDER_SIZE);
     }
@@ -676,8 +676,10 @@ wxSize wxAuiGenericTabArt::GetTabSize(wxDC& dc,
 
     // if the close button is showing, add space for it
     if (close_button_state != wxAUI_BUTTON_STATE_HIDDEN)
+    {
         // increase by button size plus the padding
         tab_width += wnd->FromDIP(16) + wnd->FromDIP(3);
+    }
 
     // if there's a bitmap, add space for it
     if (bitmap.IsOk())

--- a/src/aui/tabart.cpp
+++ b/src/aui/tabart.cpp
@@ -1191,8 +1191,10 @@ wxSize wxAuiSimpleTabArt::GetTabSize(wxDC& dc,
     wxCoord tab_width = measured_textx + tab_height + wnd->FromDIP(5);
 
     if (close_button_state != wxAUI_BUTTON_STATE_HIDDEN)
+    {
         // increase by button size plus the padding
         tab_width += wnd->FromDIP(16) + wnd->FromDIP(3);
+    }
 
     if (m_flags & wxAUI_NB_TAB_FIXED_WIDTH)
     {

--- a/src/aui/tabart.cpp
+++ b/src/aui/tabart.cpp
@@ -98,7 +98,7 @@ static void DrawButtons(wxDC& dc,
         dc.SetPen(wxPen(bkcolour.ChangeLightness(75)));
 
         // draw the background behind the button
-        dc.DrawRectangle(rect.x, rect.y, bmp.GetWidth()-offset.x, bmp.GetHeight()-offset.y);
+        dc.DrawRectangle(rect.x, rect.y, bmp.GetScaledWidth()-offset.x, bmp.GetScaledHeight()-offset.y);
     }
 
     // draw the button itself
@@ -226,9 +226,9 @@ void wxAuiGenericTabArt::SetSizingInfo(const wxSize& tab_ctrl_size,
     int tot_width = (int)tab_ctrl_size.x - GetIndentSize() - wxWindow::FromDIP(4, NULL);
 
     if (m_flags & wxAUI_NB_CLOSE_BUTTON)
-        tot_width -= m_activeCloseBmp.GetWidth();
+        tot_width -= m_activeCloseBmp.GetScaledWidth();
     if (m_flags & wxAUI_NB_WINDOWLIST_BUTTON)
-        tot_width -= m_activeWindowListBmp.GetWidth();
+        tot_width -= m_activeWindowListBmp.GetScaledWidth();
 
     if (tab_count > 0)
     {
@@ -567,9 +567,9 @@ void wxAuiGenericTabArt::DrawTab(wxDC& dc,
         if (m_flags & wxAUI_NB_BOTTOM)
             offsetY = 1;
 
-        wxRect rect(tab_x + tab_width - bmp.GetWidth() - wnd->FromDIP(1),
-                    offsetY + (tab_height/2) - (bmp.GetHeight()/2),
-                    bmp.GetWidth(),
+        wxRect rect(tab_x + tab_width - bmp.GetScaledWidth() - wnd->FromDIP(1),
+                    offsetY + (tab_height/2) - (bmp.GetScaledHeight()/2),
+                    bmp.GetScaledWidth(),
                     tab_height);
 
         IndentPressedBitmap(wnd->FromDIP(wxSize(1, 1)), &rect, close_button_state);
@@ -673,15 +673,15 @@ wxSize wxAuiGenericTabArt::GetTabSize(wxDC& dc,
     if (close_button_state != wxAUI_BUTTON_STATE_HIDDEN)
     {
         // increase by button size plus the padding
-        tab_width += wnd->FromDIP(16) + wnd->FromDIP(3);
+        tab_width += m_activeCloseBmp.GetScaledWidth() + wnd->FromDIP(3);
     }
 
     // if there's a bitmap, add space for it
     if (bitmap.IsOk())
     {
         // increase by bitmap plus right side bitmap padding
-        tab_width += bitmap.GetWidth() + wnd->FromDIP(3);
-        tab_height = wxMax(tab_height, bitmap.GetHeight());
+        tab_width += bitmap.GetScaledWidth() + wnd->FromDIP(3);
+        tab_height = wxMax(tab_height, bitmap.GetScaledHeight());
     }
 
     // add padding
@@ -750,15 +750,15 @@ void wxAuiGenericTabArt::DrawButton(wxDC& dc,
     if (orientation == wxLEFT)
     {
         rect.SetX(in_rect.x);
-        rect.SetY(((in_rect.y + in_rect.height)/2) - (bmp.GetHeight()/2));
-        rect.SetWidth(bmp.GetWidth());
-        rect.SetHeight(bmp.GetHeight());
+        rect.SetY(((in_rect.y + in_rect.height)/2) - (bmp.GetScaledHeight()/2));
+        rect.SetWidth(bmp.GetScaledWidth());
+        rect.SetHeight(bmp.GetScaledHeight());
     }
     else
     {
-        rect = wxRect(in_rect.x + in_rect.width - bmp.GetWidth(),
-                      ((in_rect.y + in_rect.height)/2) - (bmp.GetHeight()/2),
-                      bmp.GetWidth(), bmp.GetHeight());
+        rect = wxRect(in_rect.x + in_rect.width - bmp.GetScaledWidth(),
+                      ((in_rect.y + in_rect.height)/2) - (bmp.GetScaledHeight()/2),
+                      bmp.GetScaledWidth(), bmp.GetScaledHeight());
     }
 
     IndentPressedBitmap(wnd->FromDIP(wxSize(1, 1)), &rect, button_state);
@@ -943,9 +943,9 @@ void wxAuiSimpleTabArt::SetSizingInfo(const wxSize& tab_ctrl_size,
     int tot_width = (int)tab_ctrl_size.x - GetIndentSize() - wxWindow::FromDIP(4, NULL);
 
     if (m_flags & wxAUI_NB_CLOSE_BUTTON)
-        tot_width -= m_activeCloseBmp.GetWidth();
+        tot_width -= m_activeCloseBmp.GetScaledWidth();
     if (m_flags & wxAUI_NB_WINDOWLIST_BUTTON)
-        tot_width -= m_activeWindowListBmp.GetWidth();
+        tot_width -= m_activeWindowListBmp.GetScaledWidth();
 
     if (tab_count > 0)
     {
@@ -1109,14 +1109,14 @@ void wxAuiSimpleTabArt::DrawTab(wxDC& dc,
 
         bmp = wxAuiScaleBitmap(bmp, wnd->GetContentScaleFactor());
 
-        wxRect rect(tab_x + tab_width - bmp.GetWidth() - 1,
-                    tab_y + (tab_height/2) - (bmp.GetHeight()/2) + 1,
-                    bmp.GetWidth(),
+        wxRect rect(tab_x + tab_width - bmp.GetScaledWidth() - 1,
+                    tab_y + (tab_height/2) - (bmp.GetScaledHeight()/2) + 1,
+                    bmp.GetScaledWidth(),
                     tab_height - 1);
         DrawButtons(dc, wnd->FromDIP(wxSize(1, 1)), rect, bmp, *wxWHITE, close_button_state);
 
         *out_button_rect = rect;
-        close_button_width = bmp.GetWidth();
+        close_button_width = bmp.GetScaledWidth();
     }
 
     text_offset = tab_x + (tab_height/2) + ((tab_width-close_button_width)/2) - (textx/2);
@@ -1193,7 +1193,7 @@ wxSize wxAuiSimpleTabArt::GetTabSize(wxDC& dc,
     if (close_button_state != wxAUI_BUTTON_STATE_HIDDEN)
     {
         // increase by button size plus the padding
-        tab_width += wnd->FromDIP(16) + wnd->FromDIP(3);
+        tab_width += m_activeCloseBmp.GetScaledWidth() + wnd->FromDIP(3);
     }
 
     if (m_flags & wxAUI_NB_TAB_FIXED_WIDTH)

--- a/src/aui/tabart.cpp
+++ b/src/aui/tabart.cpp
@@ -72,6 +72,8 @@ private:
 wxBitmap wxAuiBitmapFromBits(const unsigned char bits[], int w, int h,
                              const wxColour& color);
 
+wxBitmap wxAuiScaleBitmap(const wxBitmap& bmp, double scale);
+
 wxString wxAuiChopText(wxDC& dc, const wxString& text, int max_size);
 
 static void DrawButtons(wxDC& dc,
@@ -224,9 +226,9 @@ void wxAuiGenericTabArt::SetSizingInfo(const wxSize& tab_ctrl_size,
     int tot_width = (int)tab_ctrl_size.x - GetIndentSize() - wxWindow::FromDIP(4, NULL);
 
     if (m_flags & wxAUI_NB_CLOSE_BUTTON)
-        tot_width -= m_activeCloseBmp.GetScaledWidth();
+        tot_width -= m_activeCloseBmp.GetWidth();
     if (m_flags & wxAUI_NB_WINDOWLIST_BUTTON)
-        tot_width -= m_activeWindowListBmp.GetScaledWidth();
+        tot_width -= m_activeWindowListBmp.GetWidth();
 
     if (tab_count > 0)
     {
@@ -559,14 +561,7 @@ void wxAuiGenericTabArt::DrawTab(wxDC& dc,
             bmp = m_activeCloseBmp;
         }
 
-#if wxUSE_IMAGE
-        if (wnd->FromDIP(1) > 1.0 && (bmp.GetWidth() == 16 || bmp.GetHeight() == 16))
-        {
-            wxImage img = bmp.ConvertToImage();
-            img.Rescale(wnd->FromDIP(16), wnd->FromDIP(16), wxIMAGE_QUALITY_BOX_AVERAGE);
-            bmp = img;
-        }
-#endif // wxUSE_IMAGE
+        bmp = wxAuiScaleBitmap(bmp, wnd->GetContentScaleFactor());
 
         int offsetY = tab_y-1;
         if (m_flags & wxAUI_NB_BOTTOM)
@@ -748,14 +743,7 @@ void wxAuiGenericTabArt::DrawButton(wxDC& dc,
     if (!bmp.IsOk())
         return;
 
-#if wxUSE_IMAGE
-    if (wnd->FromDIP(1) > 1.0 && (bmp.GetWidth() == 16 || bmp.GetHeight() == 16))
-    {
-        wxImage img = bmp.ConvertToImage();
-        img.Rescale(wnd->FromDIP(16), wnd->FromDIP(16), wxIMAGE_QUALITY_BOX_AVERAGE);
-        bmp = img;
-    }
-#endif // wxUSE_IMAGE
+    bmp = wxAuiScaleBitmap(bmp, wnd->GetContentScaleFactor());
 
     rect = in_rect;
 
@@ -955,9 +943,9 @@ void wxAuiSimpleTabArt::SetSizingInfo(const wxSize& tab_ctrl_size,
     int tot_width = (int)tab_ctrl_size.x - GetIndentSize() - wxWindow::FromDIP(4, NULL);
 
     if (m_flags & wxAUI_NB_CLOSE_BUTTON)
-        tot_width -= m_activeCloseBmp.GetScaledWidth();
+        tot_width -= m_activeCloseBmp.GetWidth();
     if (m_flags & wxAUI_NB_WINDOWLIST_BUTTON)
-        tot_width -= m_activeWindowListBmp.GetScaledWidth();
+        tot_width -= m_activeWindowListBmp.GetWidth();
 
     if (tab_count > 0)
     {
@@ -1119,14 +1107,7 @@ void wxAuiSimpleTabArt::DrawTab(wxDC& dc,
         else
             bmp = m_disabledCloseBmp;
 
-#if wxUSE_IMAGE
-        if (wnd->FromDIP(1) > 1.0 && (bmp.GetWidth() == 16 || bmp.GetHeight() == 16))
-        {
-            wxImage img = bmp.ConvertToImage();
-            img.Rescale(wnd->FromDIP(16), wnd->FromDIP(16), wxIMAGE_QUALITY_BOX_AVERAGE);
-            bmp = img;
-        }
-#endif // wxUSE_IMAGE
+        bmp = wxAuiScaleBitmap(bmp, wnd->GetContentScaleFactor());
 
         wxRect rect(tab_x + tab_width - bmp.GetWidth() - 1,
                     tab_y + (tab_height/2) - (bmp.GetHeight()/2) + 1,
@@ -1266,14 +1247,7 @@ void wxAuiSimpleTabArt::DrawButton(wxDC& dc,
     if (!bmp.IsOk())
         return;
 
-#if wxUSE_IMAGE
-    if (wnd->FromDIP(1) > 1.0 && (bmp.GetWidth() == 16 || bmp.GetHeight() == 16))
-    {
-        wxImage img = bmp.ConvertToImage();
-        img.Rescale(wnd->FromDIP(16), wnd->FromDIP(16), wxIMAGE_QUALITY_BOX_AVERAGE);
-        bmp = img;
-    }
-#endif // wxUSE_IMAGE
+    bmp = wxAuiScaleBitmap(bmp, wnd->GetContentScaleFactor());
 
     rect = in_rect;
 


### PR DESCRIPTION
…aled content.

This fixes both Generic and Simple tab arts. Here are the screenshots for both tab arts with the scale factor set at 3 on win10:

![wxwidgets-aui-scale-3-generic-fix](https://user-images.githubusercontent.com/77071/66626377-dc092580-ebac-11e9-9ef4-d67c187a30e6.png)

![wxwidgets-aui-scale-3-simple-fix](https://user-images.githubusercontent.com/77071/66626382-e3303380-ebac-11e9-96ea-1ec0433f9386.png)

Everything looks good so far and I've also tested with scalefactor=2 and confirmed that the changes look correct on hidpi screen on macos.

Couple of questions. Not sure what the best way to check if the scaling needs to be applied, but I added `wnd->FromDIP(1) > 1.0 && (bmp.GetWidth() == 16 || bmp.GetHeight() == 16)` to trigger the scaling. I don't like `==16` part, so if there is a better way to confirm that this is the original bmps, please advise/replace. This can probably be removed completely, but I wanted to protect against those cases where a different (appropriately scaled) image is passed to those routines (in the future).

I also replaced `GetScaledWidth/Height` with `GetWidth/Height` versions. I think it was a mistake, but it wasn't visible when scaling is 1. All the calculations are in screen pixels with fromDIP applied, so it probably doesn't make sense to combine `GetScaled` values with `fromDIP` results. I confirmed that everything looks correct and proportionate on the screen, but would welcome feedback to confirm.
