### PR TITLE
Fix width for toolbar items with dropdown when scalefactor >1.

### DIFF
--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -634,7 +634,7 @@ wxSize wxAuiGenericToolBarArt::GetToolSize(
     // and add some extra space in front of the drop down button
     if (item.HasDropDown())
     {
-        int dropdownWidth = wnd->FromDIP(GetElementSize(wxAUI_TBART_DROPDOWN_SIZE));
+        int dropdownWidth = GetElementSize(wxAUI_TBART_DROPDOWN_SIZE);
         width += dropdownWidth + wnd->FromDIP(4);
     }
 


### PR DESCRIPTION
This is a leftover that was missed in acd7ea61.

See https://groups.google.com/forum/#!topic/wx-dev/g1sp5HMvQvY for related discussion.