### PR TITLE
Resolve some recently introduced warnings

### DIFF
--- a/include/wx/msw/listctrl.h
+++ b/include/wx/msw/listctrl.h
@@ -363,8 +363,8 @@ public:
     // Override SetDoubleBuffered() to do nothing, its implementation in the
     // base class is incompatible with the double buffering done by this native
     // control.
-    virtual bool IsDoubleBuffered() const;
-    virtual void SetDoubleBuffered(bool on);
+    virtual bool IsDoubleBuffered() const wxOVERRIDE;
+    virtual void SetDoubleBuffered(bool on) wxOVERRIDE;
 
     virtual bool ShouldInheritColours() const wxOVERRIDE { return false; }
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -4201,7 +4201,7 @@ void wxGrid::GetDragGridWindows(int pos,
         if ( pos < lineEnd )
         {
             firstGridWindow = m_frozenCornerGridWin;
-            secondGridWindow = oper.GetFrozenGrid(this);;
+            secondGridWindow = oper.GetFrozenGrid(this);
         }
         else
         {

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2335,6 +2335,7 @@ wxTextCtrl::MSWHandleMessage(WXLRESULT *rc,
                         ::IsMenu(GetHmenuOf(wxCurrentPopupMenu)) )
                     ::SetCursor(GetHcursorOf(*wxSTANDARD_CURSOR));
             }
+            break;
 #endif // wxUSE_MENUS
 
         case WM_PASTE:

--- a/src/propgrid/property.cpp
+++ b/src/propgrid/property.cpp
@@ -2522,7 +2522,7 @@ wxPGProperty* wxPGProperty::GetPropertyByNameWH( const wxString& name, unsigned 
         i++;
         if ( i == GetChildCount() )
             i = 0;
-    };
+    }
 
     return NULL;
 }


### PR DESCRIPTION
Resolve some warings. Adding `break` is actually a bug fix, unless this was intended? In that case it should have `wxFALLTHROUGH`.