### PR TITLE
Warnings

### DIFF
--- a/include/wx/any.h
+++ b/include/wx/any.h
@@ -41,6 +41,11 @@ union wxAnyValueBuffer
 
     void*   m_ptr;
     wxByte  m_buffer[WX_ANY_VALUE_BUFFER_SIZE];
+
+    wxAnyValueBuffer()
+    {
+        m_ptr = NULL;
+    }
 };
 
 //
@@ -730,7 +735,6 @@ public:
     wxAny()
     {
         m_type = wxAnyNullValueType;
-        m_buffer = { 0 };
     }
 
     /**

--- a/include/wx/any.h
+++ b/include/wx/any.h
@@ -730,6 +730,7 @@ public:
     wxAny()
     {
         m_type = wxAnyNullValueType;
+        m_buffer = { 0 };
     }
 
     /**

--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -244,7 +244,7 @@ private:
     wxEventFunction m_method;
 
     // Provide a dummy default ctor for type info purposes
-    wxObjectEventFunctor() { }
+    wxObjectEventFunctor() : m_handler(NULL), m_method(NULL) { }
 
     WX_DECLARE_TYPEINFO_INLINE(wxObjectEventFunctor)
 };

--- a/include/wx/gauge.h
+++ b/include/wx/gauge.h
@@ -52,6 +52,9 @@ class WXDLLIMPEXP_CORE wxGaugeBase : public wxControl
 {
 public:
     wxGaugeBase() : m_rangeMax(0), m_gaugePos(0),
+#if wxGAUGE_EMULATE_INDETERMINATE_MODE
+        m_nDirection(wxRIGHT),
+#endif
         m_appProgressIndicator(NULL) { }
 
     virtual ~wxGaugeBase();

--- a/include/wx/generic/choicdgg.h
+++ b/include/wx/generic/choicdgg.h
@@ -33,7 +33,7 @@ class WXDLLIMPEXP_FWD_CORE wxListBoxBase;
 class WXDLLIMPEXP_CORE wxAnyChoiceDialog : public wxDialog
 {
 public:
-    wxAnyChoiceDialog() { }
+    wxAnyChoiceDialog() : m_listbox(NULL) { }
 
     wxAnyChoiceDialog(wxWindow *parent,
                       const wxString& message,

--- a/include/wx/generic/textdlgg.h
+++ b/include/wx/generic/textdlgg.h
@@ -39,6 +39,7 @@ public:
     wxTextEntryDialog()
     {
         m_textctrl = NULL;
+        m_dialogStyle = 0;
     }
 
     wxTextEntryDialog(wxWindow *parent,

--- a/include/wx/geometry.h
+++ b/include/wx/geometry.h
@@ -133,7 +133,7 @@ inline void wxPoint2DInt::GetRounded( wxInt32 *x , wxInt32 *y ) const
 inline wxDouble wxPoint2DInt::GetVectorLength() const
 {
     // cast needed MIPSpro compiler under SGI
-    return sqrt( (double)(m_x)*(m_x) + (m_y)*(m_y) );
+    return sqrt( (wxDouble)(m_x)*(m_x) + (wxDouble)(m_y)*(m_y) );
 }
 
 inline void wxPoint2DInt::SetVectorLength( wxDouble length )
@@ -155,7 +155,7 @@ inline wxDouble wxPoint2DInt::GetDistance( const wxPoint2DInt &pt ) const
 
 inline wxDouble wxPoint2DInt::GetDistanceSquare( const wxPoint2DInt &pt ) const
 {
-    return ( (pt.m_x-m_x)*(pt.m_x-m_x) + (pt.m_y-m_y)*(pt.m_y-m_y) );
+    return ( (wxDouble)(pt.m_x-m_x)*(pt.m_x-m_x) + (wxDouble)(pt.m_y-m_y)*(pt.m_y-m_y) );
 }
 
 inline wxInt32 wxPoint2DInt::GetDotProduct( const wxPoint2DInt &vec ) const

--- a/include/wx/geometry.h
+++ b/include/wx/geometry.h
@@ -155,7 +155,8 @@ inline wxDouble wxPoint2DInt::GetDistance( const wxPoint2DInt &pt ) const
 
 inline wxDouble wxPoint2DInt::GetDistanceSquare( const wxPoint2DInt &pt ) const
 {
-    return ( (wxDouble)(pt.m_x-m_x)*(pt.m_x-m_x) + (wxDouble)(pt.m_y-m_y)*(pt.m_y-m_y) );
+    return ( ((wxDouble)pt.m_x-m_x)*((wxDouble)pt.m_x-m_x) +
+             ((wxDouble)pt.m_y-m_y)*((wxDouble)pt.m_y-m_y) );
 }
 
 inline wxInt32 wxPoint2DInt::GetDotProduct( const wxPoint2DInt &vec ) const

--- a/include/wx/list.h
+++ b/include/wx/list.h
@@ -333,7 +333,7 @@ class WXDLLIMPEXP_BASE wxListKey
 public:
     // implicit ctors
     wxListKey() : m_keyType(wxKEY_NONE)
-        { }
+        { m_key.integer = 0; }
     wxListKey(long i) : m_keyType(wxKEY_INTEGER)
         { m_key.integer = i; }
     wxListKey(const wxString& s) : m_keyType(wxKEY_STRING)

--- a/include/wx/math.h
+++ b/include/wx/math.h
@@ -136,7 +136,7 @@ inline bool wxIsNullDouble(double x) { return wxIsSameDouble(x, 0.); }
 
 inline int wxRound(double x)
 {
-    wxASSERT_MSG( x > INT_MIN - 0.5 && x < INT_MAX + 0.5,
+    wxASSERT_MSG( x > (double)INT_MIN - 0.5 && x < (double)INT_MAX + 0.5,
                   wxT("argument out of supported range") );
 
     #if defined(HAVE_ROUND)

--- a/include/wx/msw/checkbox.h
+++ b/include/wx/msw/checkbox.h
@@ -17,7 +17,7 @@
 class WXDLLIMPEXP_CORE wxCheckBox : public wxMSWOwnerDrawnButton<wxCheckBoxBase>
 {
 public:
-    wxCheckBox() { }
+    wxCheckBox() : m_state(wxCHK_UNCHECKED) { }
     wxCheckBox(wxWindow *parent,
                wxWindowID id,
                const wxString& label,

--- a/include/wx/strconv.h
+++ b/include/wx/strconv.h
@@ -288,7 +288,7 @@ private:
 
     public:
         // the initial state is direct
-        DecoderState() { mode = Direct; }
+        DecoderState() { mode = Direct; accum = bit = msb = 0; }
 
         // switch to/from shifted mode
         void ToDirect() { mode = Direct; }
@@ -317,7 +317,7 @@ private:
         Mode mode;
 
     public:
-        EncoderState() { mode = Direct; }
+        EncoderState() { mode = Direct; accum = bit = 0; }
 
         void ToDirect() { mode = Direct; }
         void ToShifted() { mode = Shifted; accum = bit = 0; }

--- a/include/wx/strconv.h
+++ b/include/wx/strconv.h
@@ -288,7 +288,7 @@ private:
 
     public:
         // the initial state is direct
-        DecoderState() { mode = Direct; accum = bit = msb = 0; }
+        DecoderState() { mode = Direct; accum = bit = msb = 0; isLSB = false; }
 
         // switch to/from shifted mode
         void ToDirect() { mode = Direct; }

--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -3379,7 +3379,7 @@ private:
   {
       // notice that there is no need to initialize m_len here as it's unused
       // as long as m_str is NULL
-      ConvertedBuffer() : m_str(NULL) {}
+      ConvertedBuffer() : m_str(NULL), m_len(0) {}
       ~ConvertedBuffer()
           { free(m_str); }
 


### PR DESCRIPTION
The warnings that this is about:
`C26451` Arithmetic overflow: Using operator '\*' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '\*' to avoid overflow (io.2).
`C26451` Arithmetic overflow: Using operator '-' on a 4 byte value and then casting the result to a 8 byte value. Cast the value to the wider type before calling operator '-' to avoid overflow (io.2).
`C26495` Variable 'XXX' is uninitialized. Always initialize a member variable (type.6).

I don't know if the last commit which added `isLSB = false` is correct though. Should it be `true`?