### PR TITLE
Update to reflect use of vc14x binary in place of vc140/vc141/vc142

### DIFF
--- a/docs/contributing/how-to-release.md
+++ b/docs/contributing/how-to-release.md
@@ -157,7 +157,7 @@ in the generated files too.
 
 To build official x86 and x64 shared binaries the following are prerequisites:
 
-     - Visual Studio 2008, 2010, 2012, 2013, 2015, 2017, 2019
+     - Visual Studio 2008, 2010, 2012, 2013 and 2015
      - Windows SDK 6.1, 7.1 (required for x64 builds for Visual Studio 2008, 2010)
      - 7z (required for packaging the files)
      - fciv (required for generating the checksums)
@@ -172,15 +172,6 @@ WINDOWS71SDK
 
 If either of these are blank they are set to the default install location.
 
-For Visual Studio 2017 and 2019 the VSxxxxCOMNTOOLS environment variable is not
-set by the installer as these two versions support multiple toolsets.
-The build script will check the following in sequence:
- - If VSxxxCOMNTOOLS is set (xxx=141: VS2017, xxx=142: VS2019) it is used as
-   the path to call VsDevCmd.bat to set up the environmet.
- - If VSxxxCOMNTOOLS is not set, then the Visual Studio tool vswhere is used
-   to find the latest installed toolset for the compiler and the associated
-   VsDevCmd.bat file is used to set up the environment.
-
 To build binaries for a single compiler, open a command prompt (for Visual
 Studio 2008 only an SDK 6.1 developer's command prompt must be used),
 cd to the build\tools\msvs folder and run the batch file 'officialbuild'
@@ -190,9 +181,10 @@ with the vcXXX version number:
     Visual Studio 2010  vc100
     Visual Studio 2012  vc110
     Visual Studio 2014  vc120
-    Visual Studio 2015  vc140
-    Visual Studio 2017  vc141
-    Visual Studio 2019  vc142
+    Visual Studio 2015  vc14x
+
+The Visual Studio 2015, 2017 and 2019 are binary compatible, allowing the
+vc14x binary to be used with any of them.
 
 This will build all of the x86 and x64 binaries for the selected compiler version,
 package them in 7z files and calculate the checksums. The 7z files and the

--- a/docs/msw/binaries.md
+++ b/docs/msw/binaries.md
@@ -35,7 +35,7 @@ or the ones without this suffix for the still more common 32-bit builds. After
 determining the combination of suffixes you need, you should download the
 "Dev" and the "ReleaseDLL" files in addition to the "Headers" one above,
 e.g. for 32-bit MSVS 2017 development you need
-`wxMSW-3.1.1_vc14x_Dev.7z` and `wxMSW-3.1.1_vc1x1_ReleaseDLL.7z`.
+`wxMSW-3.1.1_vc14x_Dev.7z` and `wxMSW-3.1.1_vc14x_ReleaseDLL.7z`.
 
 All binaries are available at:
 

--- a/docs/msw/binaries.md
+++ b/docs/msw/binaries.md
@@ -7,8 +7,8 @@ Supported Compilers
 -------------------
 We provide pre-built binary files for the following compilers:
 
-* Microsoft Visual C++ compiler versions 9.0, 10.0, 11.0, 12.0, 14.0 and 14.1
-  (corresponding to marketing product names of Microsoft Visual Studio 2008, 2010, 2012, 2013, 2015 and 2017 respectively).
+* Microsoft Visual C++ compiler versions 9.0, 10.0, 11.0, 12.0, 14.0, 14.1 and 14.2
+  (corresponding to marketing product names of Microsoft Visual Studio 2008, 2010, 2012, 2013, 2015, 2017 and 2019 respectively).
 * TDM-GCC version 5.1 and MinGW-w64 version 7.2 (with the default SJLJ
   exceptions propagation method, using C++11). Please note that you need to use
   the very latest MinGW-w64 7.2 compiler release with this version of the
@@ -27,15 +27,15 @@ First, you need to get the correct files. You will always need the
 `wxWidgets-3.1.1-headers.7z` one but the rest depends on your compiler version
 and architecture: as different versions of MSVC compiler are not binary
 compatible, you should select the files with the correct
-`vc80`, `vc90`, `vc100`, `vc110`, `vc120`, `vc140` or `vc141`
+`vc80`, `vc90`, `vc100`, `vc110`, `vc120`, or `vc14x`
 suffix depending on whether you use
-Visual Studio 2005, 2008, 2010, 2012, 2013, 2015 or 2017 respectively.
+Visual Studio 2005, 2008, 2010, 2012, 2013, or 2015/2017/2019 respectively (the Visual Studio 2015/2017/2019 compilers are binary compatible).
 You also need to decide whether you use the `x64` files for 64-bit development
 or the ones without this suffix for the still more common 32-bit builds. After
 determining the combination of suffixes you need, you should download the
 "Dev" and the "ReleaseDLL" files in addition to the "Headers" one above,
 e.g. for 32-bit MSVS 2017 development you need
-`wxMSW-3.1.1_vc141_Dev.7z` and `wxMSW-3.1.1_vc141_ReleaseDLL.7z`.
+`wxMSW-3.1.1_vc14x_Dev.7z` and `wxMSW-3.1.1_vc1x1_ReleaseDLL.7z`.
 
 All binaries are available at:
 
@@ -59,7 +59,7 @@ following:
         Directories". Notice that the order is important here, putting the
         MSVC-specific directory first ensures that you use `wx/setup.h`
         automatically linking in wxWidgets libraries.
-    *   Add `WXUSINGDLL` and `wxMSVC_VERSION_AUTO` to the list of defined
+    *   Add `WXUSINGDLL` and `wxMSVC_VERSION_ABI_COMPAT` to the list of defined
         symbols in "Preprocessor Definitions". The first should be
         self-explanatory (we only provide DLLs, not static libraries) while the
         second one is necessary to use the libraries from e.g. `lib\vc100_dll`


### PR DESCRIPTION
This is not quite complete, but serves at least as a starting point.

In binaries.md the following is stated:

In the linker options you only need to add `$``(wxwin)\lib\vc$``(PlatformToolsetVersion)_dll`
  (the standard `PlatformToolsetVersion` macro expands into something like
  `141`, depending on the toolset version being used, and you could also use
  the version number directly if you prefer) to "Additional Library
  Directories" under "Linker\\General" in the options. Thanks to the use of
  MSVC-specific `setup.h` you don't need to list wxWidgets libraries manually,
  i.e. you do **not** need to put anything in the list of "Additional
  Dependencies".

When using vc14x binaries I don't think this is true and I'm not sure if it can be made true?