### PR TITLE
Add Mac OS 10.15 to OS version case

### DIFF
--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -160,6 +160,9 @@ wxString wxGetOsDescription()
             case 14:
                 osName = "Mojave";
                 break;
+            case 15:
+                osName = "Catalina";
+                break;
         };
     }
 #else


### PR DESCRIPTION
Since Catalina has been released, this lets us properly identify it.