### PR TITLE
Always call setOpenGLContext so the NSOpenGLView uses our context

### DIFF
--- a/src/osx/cocoa/glcanvas.mm
+++ b/src/osx/cocoa/glcanvas.mm
@@ -201,23 +201,11 @@ bool wxGLContext::SetCurrent(const wxGLCanvas& win) const
 
     [m_glContext makeCurrentContext];
 
-    // the missing redraw upon resize problem only happens when linked against 10.14
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
+    // Set the openGLContext in all versions to avoid the NSOpenGLView from creating its own context
     // At least under macOS 10.14.5 we need to do this in order to update the
     // context with the new size information after the window is resized.
-    if ( WX_IS_MACOS_AVAILABLE_FULL(10, 14, 5) )
-    {
-        if ( WX_IS_MACOS_AVAILABLE(10, 15) )
-        {
-            // no workaround needed under 10.15 anymore
-        }
-        else
-        {
-            NSOpenGLView *v = (NSOpenGLView *)win.GetHandle();
-            [v setOpenGLContext: m_glContext];
-        }
-    }
-#endif
+    NSOpenGLView *v = (NSOpenGLView *)win.GetHandle();
+    [v setOpenGLContext: m_glContext];
         
     return true;
 }


### PR DESCRIPTION
This is option 1 from https://groups.google.com/forum/#!topic/wx-users/KivbyKAB0Po

I think this is essentially the safer option mainly because I don't know that I've experienced the resize issue that was being worked around and this leaves that in tact.