### PR TITLE
Remove wxUSE_WCHAR_T, it must always be 1 anyhow

### DIFF
--- a/build/cmake/init.cmake
+++ b/build/cmake/init.cmake
@@ -194,9 +194,6 @@ endif()
 
 # Constants for setup.h creation
 set(wxUSE_STD_DEFAULT ON)
-if(wxUSE_UNICODE)
-    set(wxUSE_WCHAR_T ON)
-endif()
 if(NOT wxUSE_EXPAT)
     set(wxUSE_XRC OFF)
 endif()

--- a/build/cmake/setup.h.in
+++ b/build/cmake/setup.h.in
@@ -182,8 +182,6 @@
     #cmakedefine01 wxUSE_UNICODE
 #endif
 
-#cmakedefine01 wxUSE_WCHAR_T
-
 
 #cmakedefine01 wxUSE_EXCEPTIONS
 

--- a/configure
+++ b/configure
@@ -19573,8 +19573,6 @@ _ACEOF
 if test "$ac_cv_sizeof_wchar_t" = 0; then
     as_fn_error $? "wxWidgets requires wchar_t support." "$LINENO" 5
 fi
-$as_echo "#define wxUSE_WCHAR_T 1" >>confdefs.h
-
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for va_copy" >&5
 $as_echo_n "checking for va_copy... " >&6; }

--- a/configure.in
+++ b/configure.in
@@ -1561,7 +1561,6 @@ AC_CHECK_SIZEOF(wchar_t, 0,
 if test "$ac_cv_sizeof_wchar_t" = 0; then
     AC_MSG_ERROR([wxWidgets requires wchar_t support.])
 fi
-AC_DEFINE(wxUSE_WCHAR_T)
 
 dnl checks needed to define wxVaCopy
 AC_CACHE_CHECK([for va_copy],

--- a/include/wx/android/setup.h
+++ b/include/wx/android/setup.h
@@ -183,16 +183,13 @@
 // Unicode support
 // ----------------------------------------------------------------------------
 
-// These settings are obsolete: the library is always built in Unicode mode
+// This option is deprecated: the library should be always built in Unicode mode
 // now, only set wxUSE_UNICODE to 0 to compile legacy code in ANSI mode if
 // absolutely necessary -- updating it is strongly recommended as the ANSI mode
 // will disappear completely in future wxWidgets releases.
 #ifndef wxUSE_UNICODE
     #define wxUSE_UNICODE 1
 #endif
-
-// wxUSE_WCHAR_T is required by wxWidgets now, don't change.
-#define wxUSE_WCHAR_T 1
 
 // ----------------------------------------------------------------------------
 // global features

--- a/include/wx/chartype.h
+++ b/include/wx/chartype.h
@@ -21,26 +21,9 @@
  */
 #include "wx/types.h"
 
-/* check whether we have wchar_t and which size it is if we do */
-#if !defined(wxUSE_WCHAR_T)
-    #if defined(__UNIX__)
-        #if defined(HAVE_WCSTR_H) || defined(HAVE_WCHAR_H) || defined(__FreeBSD__) || defined(__DARWIN__)
-            #define wxUSE_WCHAR_T 1
-        #else
-            #define wxUSE_WCHAR_T 0
-        #endif
-    #elif defined(__GNUWIN32__) && !defined(__MINGW32__)
-        #define wxUSE_WCHAR_T 0
-    #else
-        /* add additional compiler checks if this fails */
-        #define wxUSE_WCHAR_T 1
-    #endif
-#endif /* !defined(wxUSE_WCHAR_T) */
-
-/* Unicode support requires wchar_t */
-#if !wxUSE_WCHAR_T
-    #error "wchar_t must be available"
-#endif /* Unicode */
+/* This is kept only for backwards compatibility, in case some application code
+   checks for it. It's always 1 and can't be changed. */
+#define wxUSE_WCHAR_T 1
 
 /*
    non Unix compilers which do have wchar.h (but not tchar.h which is included
@@ -123,11 +106,6 @@
 #ifdef wxHAVE_TCHAR_SUPPORT
     /* get TCHAR definition if we've got it */
     #include <tchar.h>
-
-    /* we surely do have wchar_t if we have TCHAR */
-    #ifndef wxUSE_WCHAR_T
-        #define wxUSE_WCHAR_T 1
-    #endif /* !defined(wxUSE_WCHAR_T) */
 #endif /* wxHAVE_TCHAR_SUPPORT */
 
 /* ------------------------------------------------------------------------- */

--- a/include/wx/gtk/setup0.h
+++ b/include/wx/gtk/setup0.h
@@ -184,16 +184,13 @@
 // Unicode support
 // ----------------------------------------------------------------------------
 
-// These settings are obsolete: the library is always built in Unicode mode
+// This option is deprecated: the library should be always built in Unicode mode
 // now, only set wxUSE_UNICODE to 0 to compile legacy code in ANSI mode if
 // absolutely necessary -- updating it is strongly recommended as the ANSI mode
 // will disappear completely in future wxWidgets releases.
 #ifndef wxUSE_UNICODE
     #define wxUSE_UNICODE 1
 #endif
-
-// wxUSE_WCHAR_T is required by wxWidgets now, don't change.
-#define wxUSE_WCHAR_T 1
 
 // ----------------------------------------------------------------------------
 // global features

--- a/include/wx/motif/setup0.h
+++ b/include/wx/motif/setup0.h
@@ -184,16 +184,13 @@
 // Unicode support
 // ----------------------------------------------------------------------------
 
-// These settings are obsolete: the library is always built in Unicode mode
+// This option is deprecated: the library should be always built in Unicode mode
 // now, only set wxUSE_UNICODE to 0 to compile legacy code in ANSI mode if
 // absolutely necessary -- updating it is strongly recommended as the ANSI mode
 // will disappear completely in future wxWidgets releases.
 #ifndef wxUSE_UNICODE
     #define wxUSE_UNICODE 1
 #endif
-
-// wxUSE_WCHAR_T is required by wxWidgets now, don't change.
-#define wxUSE_WCHAR_T 1
 
 // ----------------------------------------------------------------------------
 // global features

--- a/include/wx/msw/chkconf.h
+++ b/include/wx/msw/chkconf.h
@@ -175,14 +175,6 @@
 #   undef  wxUSE_DEBUG_NEW_ALWAYS
 #   define wxUSE_DEBUG_NEW_ALWAYS          0
 
-/* some Cygwin versions don't have wcslen */
-#   if defined(__CYGWIN__) || defined(__CYGWIN32__)
-#   if ! ((__GNUC__>2) ||((__GNUC__==2) && (__GNUC_MINOR__>=95)))
-#       undef wxUSE_WCHAR_T
-#       define wxUSE_WCHAR_T 0
-#   endif
-#endif
-
 #endif /* __GNUWIN32__ */
 
 /* MinGW32 doesn't provide wincred.h defining the API needed by this */

--- a/include/wx/msw/setup0.h
+++ b/include/wx/msw/setup0.h
@@ -184,16 +184,13 @@
 // Unicode support
 // ----------------------------------------------------------------------------
 
-// These settings are obsolete: the library is always built in Unicode mode
+// This option is deprecated: the library should be always built in Unicode mode
 // now, only set wxUSE_UNICODE to 0 to compile legacy code in ANSI mode if
 // absolutely necessary -- updating it is strongly recommended as the ANSI mode
 // will disappear completely in future wxWidgets releases.
 #ifndef wxUSE_UNICODE
     #define wxUSE_UNICODE 1
 #endif
-
-// wxUSE_WCHAR_T is required by wxWidgets now, don't change.
-#define wxUSE_WCHAR_T 1
 
 // ----------------------------------------------------------------------------
 // global features

--- a/include/wx/osx/setup0.h
+++ b/include/wx/osx/setup0.h
@@ -190,16 +190,13 @@
 // Unicode support
 // ----------------------------------------------------------------------------
 
-// These settings are obsolete: the library is always built in Unicode mode
+// This option is deprecated: the library should be always built in Unicode mode
 // now, only set wxUSE_UNICODE to 0 to compile legacy code in ANSI mode if
 // absolutely necessary -- updating it is strongly recommended as the ANSI mode
 // will disappear completely in future wxWidgets releases.
 #ifndef wxUSE_UNICODE
     #define wxUSE_UNICODE 1
 #endif
-
-// wxUSE_WCHAR_T is required by wxWidgets now, don't change.
-#define wxUSE_WCHAR_T 1
 
 // ----------------------------------------------------------------------------
 // global features

--- a/include/wx/setup_inc.h
+++ b/include/wx/setup_inc.h
@@ -180,16 +180,13 @@
 // Unicode support
 // ----------------------------------------------------------------------------
 
-// These settings are obsolete: the library is always built in Unicode mode
+// This option is deprecated: the library should be always built in Unicode mode
 // now, only set wxUSE_UNICODE to 0 to compile legacy code in ANSI mode if
 // absolutely necessary -- updating it is strongly recommended as the ANSI mode
 // will disappear completely in future wxWidgets releases.
 #ifndef wxUSE_UNICODE
     #define wxUSE_UNICODE 1
 #endif
-
-// wxUSE_WCHAR_T is required by wxWidgets now, don't change.
-#define wxUSE_WCHAR_T 1
 
 // ----------------------------------------------------------------------------
 // global features

--- a/include/wx/univ/setup0.h
+++ b/include/wx/univ/setup0.h
@@ -183,16 +183,13 @@
 // Unicode support
 // ----------------------------------------------------------------------------
 
-// These settings are obsolete: the library is always built in Unicode mode
+// This option is deprecated: the library should be always built in Unicode mode
 // now, only set wxUSE_UNICODE to 0 to compile legacy code in ANSI mode if
 // absolutely necessary -- updating it is strongly recommended as the ANSI mode
 // will disappear completely in future wxWidgets releases.
 #ifndef wxUSE_UNICODE
     #define wxUSE_UNICODE 1
 #endif
-
-// wxUSE_WCHAR_T is required by wxWidgets now, don't change.
-#define wxUSE_WCHAR_T 1
 
 // ----------------------------------------------------------------------------
 // global features

--- a/setup.h.in
+++ b/setup.h.in
@@ -182,8 +182,6 @@
     #define wxUSE_UNICODE 0
 #endif
 
-#define wxUSE_WCHAR_T 0
-
 
 #define wxUSE_EXCEPTIONS    0
 

--- a/setup.h_vms
+++ b/setup.h_vms
@@ -218,8 +218,6 @@ typedef pid_t GPid;
 #endif
 #endif
 
-#define wxUSE_WCHAR_T 1
-
 
 #define wxUSE_EXCEPTIONS 1
 

--- a/src/html/helpdata.cpp
+++ b/src/html/helpdata.cpp
@@ -502,16 +502,12 @@ bool wxHtmlHelpData::AddBookParam(const wxFSFile& bookfile,
                                   const wxString& indexfile, const wxString& deftopic,
                                   const wxString& path)
 {
-#if wxUSE_WCHAR_T
-        #if wxUSE_UNICODE
-            #define CORRECT_STR(str, conv) \
-                str = wxString((str).mb_str(wxConvISO8859_1), conv)
-        #else
-            #define CORRECT_STR(str, conv) \
-                str = wxString((str).wc_str(conv), wxConvLocal)
-        #endif
+#if wxUSE_UNICODE
+    #define CORRECT_STR(str, conv) \
+        str = wxString((str).mb_str(wxConvISO8859_1), conv)
 #else
-    #define CORRECT_STR(str, conv)
+    #define CORRECT_STR(str, conv) \
+        str = wxString((str).wc_str(conv), wxConvLocal)
 #endif
 
     wxFileSystem fsys;


### PR DESCRIPTION
This is not really an option as building requires it to be 1, so don't
make it one in setup.h/configure/cmake and just hardcode it as 1 for
compatibility.

Closes #18558.