### PR TITLE
Ignore GTK debug logs in the unit test unless they're enabled

### DIFF
--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -532,8 +532,6 @@ wxTestGLogHandler(const gchar* domain,
             wxGetCurrentTestName().c_str());
 
     g_log_default_handler(domain, level, message, data);
-
-    fprintf(stderr, "\n");
 }
 
 #endif // __WXGTK__

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -490,6 +490,15 @@ wxTestGLogHandler(const gchar* domain,
                   const gchar* message,
                   gpointer data)
 {
+    static int s_ignoreDebug = -1;
+    if ( s_ignoreDebug == -1 )
+    {
+        s_ignoreDebug = !wxGetEnv("G_MESSAGES_DEBUG", NULL);
+    }
+
+    if ( s_ignoreDebug && level == G_LOG_LEVEL_DEBUG )
+        return;
+
     fprintf(stderr, "\n*** GTK log message while running %s(): ",
             wxGetCurrentTestName().c_str());
 


### PR DESCRIPTION
Don't output "*** GTK log message while running" messages for every
g_debug() call when we can be sure that the debug messages themselves
will not be displayed because G_MESSAGES_DEBUG is not set.

This results in much more reasonable output from the test suite.

See #17400.