### PR TITLE
Fix grid editors placing

### DIFF
--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -1008,9 +1008,9 @@ private:
 // Returns the rect of the check box in a cell with the given alignmens
 // and the size.
 // The function is used by wxGridCellBoolEditor and wxGridCellBoolRenderer.
-wxRect GetGridCheckBoxRect(const wxSize& checkBoxSize,
-                           const wxRect& cellRect,
-                           int hAlign, int vAlign);
+wxRect wxGetGridCheckBoxRect(const wxSize& checkBoxSize,
+                             const wxRect& cellRect,
+                             int hAlign, int vAlign);
 
 #endif // wxUSE_GRID
 #endif // _WX_GENERIC_GRID_PRIVATE_H_

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -1005,5 +1005,12 @@ private:
     wxGridDataTypeInfoArray m_typeinfo;
 };
 
+// Returns the rect of the check box in a cell with the given alignmens
+// and the size.
+// The function is used by wxGridCellBoolEditor and wxGridCellBoolRenderer.
+wxRect GetGridCheckBoxRect(const wxSize& checkBoxSize,
+                           const wxRect& cellRect,
+                           int hAlign, int vAlign);
+
 #endif // wxUSE_GRID
 #endif // _WX_GENERIC_GRID_PRIVATE_H_

--- a/include/wx/renderer.h
+++ b/include/wx/renderer.h
@@ -259,7 +259,7 @@ public:
                                int flags = 0) = 0;
 
     // Returns the default size of a check box.
-    virtual wxSize GetCheckBoxSize(wxWindow *win) = 0;
+    virtual wxSize GetCheckBoxSize(wxWindow *win, int flags = 0) = 0;
 
     // Returns the default size of a check mark.
     virtual wxSize GetCheckMarkSize(wxWindow *win) = 0;
@@ -496,8 +496,8 @@ public:
                               int flags = 0) wxOVERRIDE
         { m_rendererNative.DrawCheckMark( win, dc, rect, flags ); }
 
-    virtual wxSize GetCheckBoxSize(wxWindow *win) wxOVERRIDE
-        { return m_rendererNative.GetCheckBoxSize(win); }
+    virtual wxSize GetCheckBoxSize(wxWindow *win, int flags = 0) wxOVERRIDE
+        { return m_rendererNative.GetCheckBoxSize(win, flags); }
 
     virtual wxSize GetCheckMarkSize(wxWindow *win) wxOVERRIDE
         { return m_rendererNative.GetCheckMarkSize(win); }

--- a/interface/wx/renderer.h
+++ b/interface/wx/renderer.h
@@ -574,9 +574,10 @@ public:
         @param win A valid, i.e. non-null, window pointer which is used to get
             the theme defining the checkbox size under some platforms.
 
-        @param flags The only acceptable flag is @c wxCONTROL_CELL which mean
-            that the size of the only checkbox mark will be returned without
-            any margins.
+        @param flags The only acceptable flag is @c wxCONTROL_CELL which means
+            that just the size of the checkbox mark itself will be returned,
+            without any margins. This parameter is only available in wxWidgets
+            3.1.4 or later.
     */
     virtual wxSize GetCheckBoxSize(wxWindow* win, int flags = 0) = 0;
 

--- a/interface/wx/renderer.h
+++ b/interface/wx/renderer.h
@@ -237,7 +237,7 @@ public:
     virtual void DrawCheckMark(wxWindow *win, wxDC& dc,
                                const wxRect& rect, int flags = 0 );
 
-    virtual wxSize GetCheckBoxSize(wxWindow *win);
+    virtual wxSize GetCheckBoxSize(wxWindow *win, int flags = 0);
 
     virtual wxSize GetCheckMarkSize(wxWindow *win);
 
@@ -573,8 +573,12 @@ public:
 
         @param win A valid, i.e. non-null, window pointer which is used to get
             the theme defining the checkbox size under some platforms.
+
+        @param flags The only acceptable flag is @c wxCONTROL_CELL which mean
+            that the size of the only checkbox mark will be returned without
+            any margins.
     */
-    virtual wxSize GetCheckBoxSize(wxWindow* win) = 0;
+    virtual wxSize GetCheckBoxSize(wxWindow* win, int flags = 0) = 0;
 
     /**
         Returns the size of a check mark.

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -10327,21 +10327,21 @@ wxGridCellEditor* wxGridTypeRegistry::GetEditor(int index)
     return editor;
 }
 
-wxRect GetGridCheckBoxRect(const wxSize& checkBoxSize,
-                           const wxRect& cellRect,
-                           int hAlign, int WXUNUSED(vAlign))
+wxRect wxGetGridCheckBoxRect(const wxSize& checkBoxSize,
+                             const wxRect& cellRect,
+                             int hAlign, int WXUNUSED(vAlign))
 {
     // TODO: support vAlign
 
     wxRect checkBoxRect;
     checkBoxRect.SetY(cellRect.y + cellRect.height / 2 - checkBoxSize.y / 2);
 
-     wxCoord minSize = wxMin(cellRect.width, cellRect.height);
+    wxCoord minSize = wxMin(cellRect.width, cellRect.height);
     if ( checkBoxRect.GetWidth() >= minSize || checkBoxRect.GetHeight() >= minSize )
     {
-        // let the checkbox mark be even smaller then the min size
+        // let the checkbox mark be even smaller than the min size
         // to leave some space between cell edges and the checkbox
-        const int newSize = minSize - 2;
+        const int newSize = wxMax(1, minSize - 2);
         checkBoxRect.SetWidth(newSize);
         checkBoxRect.SetHeight(newSize);
     }

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -6978,6 +6978,7 @@ void wxGrid::ShowCellEditControl()
 #ifdef __WXQT__
             // Substract 1 pixel in every dimension to fit in the cell area.
             // If not, Qt will draw the control outside the cell.
+            // TODO: Check offsets under Qt.
             rect.Deflate(1, 1);
 #endif
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -111,6 +111,9 @@ const int GRID_HASH_SIZE = 100;
 // operation
 const int DRAG_SENSITIVITY = 3;
 
+// the space between the cell edge and the checkbox mark
+const int GRID_CELL_CHECKBOX_MARGIN_X = 2;
+
 } // anonymous namespace
 
 #include "wx/arrimpl.cpp"
@@ -10322,6 +10325,46 @@ wxGridCellEditor* wxGridTypeRegistry::GetEditor(int index)
         editor->IncRef();
 
     return editor;
+}
+
+wxRect GetGridCheckBoxRect(const wxSize& checkBoxSize,
+                           const wxRect& cellRect,
+                           int hAlign, int WXUNUSED(vAlign))
+{
+    // TODO: support vAlign
+
+    wxRect checkBoxRect;
+    checkBoxRect.SetY(cellRect.y + cellRect.height / 2 - checkBoxSize.y / 2);
+
+     wxCoord minSize = wxMin(cellRect.width, cellRect.height);
+    if ( checkBoxRect.GetWidth() >= minSize || checkBoxRect.GetHeight() >= minSize )
+    {
+        // let the checkbox mark be even smaller then the min size
+        // to leave some space between cell edges and the checkbox
+        const int newSize = minSize - 2;
+        checkBoxRect.SetWidth(newSize);
+        checkBoxRect.SetHeight(newSize);
+    }
+    else
+    {
+        checkBoxRect.SetSize(checkBoxSize);
+    }
+
+    if ( hAlign & wxALIGN_CENTER_HORIZONTAL )
+    {
+        checkBoxRect.SetX(cellRect.x + cellRect.width / 2 - checkBoxSize.x / 2);
+    }
+    else if ( hAlign & wxALIGN_RIGHT )
+    {
+        checkBoxRect.SetX(cellRect.x + cellRect.width
+                          - checkBoxSize.x - GRID_CELL_CHECKBOX_MARGIN_X);
+    }
+    else // ( hAlign == wxALIGN_LEFT ) and invalid alignment value
+    {
+        checkBoxRect.SetX(cellRect.x + GRID_CELL_CHECKBOX_MARGIN_X);
+    }
+
+    return checkBoxRect;
 }
 
 #endif // wxUSE_GRID

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -6975,16 +6975,7 @@ void wxGrid::ShowCellEditControl()
             if (rect.x < 0)
                 nXMove = rect.x;
 
-#ifndef __WXQT__
-            // cell is shifted by one pixel
-            // However, don't allow x or y to become negative
-            // since the SetSize() method interprets that as
-            // "don't change."
-            if (rect.x > 0)
-                rect.x--;
-            if (rect.y > 0)
-                rect.y--;
-#else
+#ifdef __WXQT__
             // Substract 1 pixel in every dimension to fit in the cell area.
             // If not, Qt will draw the control outside the cell.
             rect.Deflate(1, 1);

--- a/src/generic/gridctrl.cpp
+++ b/src/generic/gridctrl.cpp
@@ -956,9 +956,9 @@ void wxGridCellBoolRenderer::Draw(wxGrid& grid,
     int vAlign, hAlign;
     attr.GetAlignment(&hAlign, &vAlign);
 
-    wxRect checkBoxRect =
-        GetGridCheckBoxRect(GetBestSize(grid, attr, dc, row, col),
-                            rect, hAlign, vAlign);
+    const wxRect checkBoxRect =
+        wxGetGridCheckBoxRect(GetBestSize(grid, attr, dc, row, col),
+                              rect, hAlign, vAlign);
 
     bool value;
     if ( grid.GetTable()->CanGetValueAs(row, col, wxGRID_VALUE_BOOL) )

--- a/src/generic/gridctrl.cpp
+++ b/src/generic/gridctrl.cpp
@@ -959,7 +959,7 @@ void wxGridCellBoolRenderer::Draw(wxGrid& grid,
     if ( size.x >= minSize || size.y >= minSize )
     {
         // and even leave (at least) 1 pixel margin
-        size.x = size.y = minSize;
+        size.x = size.y = minSize - 2;
     }
 
     // draw a border around checkmark

--- a/src/generic/grideditors.cpp
+++ b/src/generic/grideditors.cpp
@@ -1221,9 +1221,9 @@ void wxGridCellBoolEditor::SetSize(const wxRect& r)
     if (GetCellAttr())
         GetCellAttr()->GetAlignment(& hAlign, & vAlign);
 
-    wxRect checkBoxRect =
-        GetGridCheckBoxRect(wxRendererNative::Get().
-                                GetCheckBoxSize(GetWindow(), wxCONTROL_CELL),
+    const wxRect checkBoxRect =
+        wxGetGridCheckBoxRect(wxRendererNative::Get().
+                                  GetCheckBoxSize(GetWindow(), wxCONTROL_CELL),
                             r, hAlign, vAlign);
 
     // resize the control if required

--- a/src/generic/grideditors.cpp
+++ b/src/generic/grideditors.cpp
@@ -1216,64 +1216,24 @@ void wxGridCellBoolEditor::Create(wxWindow* parent,
 
 void wxGridCellBoolEditor::SetSize(const wxRect& r)
 {
-    bool resize = false;
-    wxSize size = m_control->GetSize();
-    wxCoord minSize = wxMin(r.width, r.height);
-
-    // check if the checkbox is not too big/small for this cell
-    wxSize sizeBest = m_control->GetBestSize();
-    if ( !(size == sizeBest) )
-    {
-        // reset to default size if it had been made smaller
-        size = sizeBest;
-
-        resize = true;
-    }
-
-    if ( size.x >= minSize || size.y >= minSize )
-    {
-        // leave 1 pixel margin
-        size.x = size.y = minSize - 2;
-
-        resize = true;
-    }
-
-    if ( resize )
-    {
-        m_control->SetSize(size);
-    }
-
-    // position it in the centre of the rectangle (TODO: support alignment?)
-
     int hAlign = wxALIGN_CENTRE;
     int vAlign = wxALIGN_CENTRE;
     if (GetCellAttr())
         GetCellAttr()->GetAlignment(& hAlign, & vAlign);
 
-    // wxGridCellBoolRenderer and wxGridCellBoolEditor should draw checkboxes
-    // to the same place in a cell but the check mark is aligned right in wxCheckbox
-    // so we should use the width of the checkbox to align our control horizontally
-    // instead of the controls width
-    const wxSize checkBoxSize = wxRendererNative::Get().GetCheckBoxSize(GetWindow());
+    wxRect checkBoxRect =
+        GetGridCheckBoxRect(wxRendererNative::Get().
+                                GetCheckBoxSize(GetWindow(), wxCONTROL_CELL),
+                            r, hAlign, vAlign);
 
-    int x = 0, y = 0;
-    if (hAlign == wxALIGN_LEFT)
+    // resize the control if required
+    if ( checkBoxRect.GetSize() != m_control->GetSize())
     {
-        x = r.x + 2;
-        y = r.y + r.height / 2 - size.y / 2;
-    }
-    else if (hAlign == wxALIGN_RIGHT)
-    {
-        x = r.x + r.width - checkBoxSize.x - 2;
-        y = r.y + r.height / 2 - size.y / 2;
-    }
-    else if (hAlign == wxALIGN_CENTRE)
-    {
-        x = r.x + r.width / 2 - checkBoxSize.x / 2;
-        y = r.y + r.height / 2 - size.y / 2;
+        m_control->SetSize(checkBoxRect.GetSize());
     }
 
-    m_control->Move(x, y);
+    // and move it
+    m_control->Move(checkBoxRect.GetPosition());
 }
 
 void wxGridCellBoolEditor::Show(bool show, wxGridCellAttr *attr)

--- a/src/generic/grideditors.cpp
+++ b/src/generic/grideditors.cpp
@@ -441,38 +441,17 @@ void wxGridCellTextEditor::SetSize(const wxRect& rectOrig)
 
     // Make the edit control large enough to allow for internal margins
     //
-    // TODO: remove this if the text ctrl sizing is improved esp. for unix
+    // TODO: remove this if the text ctrl sizing is improved
     //
-#if defined(__WXGTK__)
-    if (rect.x != 0)
-    {
-        rect.x += 1;
-        rect.y += 1;
-        rect.width -= 1;
-        rect.height -= 1;
-    }
-#elif defined(__WXMSW__)
-    if ( rect.x == 0 )
-        rect.x += 2;
-    else
-        rect.x += 3;
-
-    if ( rect.y == 0 )
-        rect.y += 2;
-    else
-        rect.y += 3;
+#if defined(__WXMSW__)
+    rect.x += 2;
+    rect.y += 2;
 
     rect.width -= 2;
     rect.height -= 2;
-#elif defined(__WXOSX__)
-    rect.x += 1;
-    rect.y += 1;
-    
-    rect.width -= 1;
-    rect.height -= 1;
-#else
-    int extra_x = ( rect.x > 2 ) ? 2 : 1;
-    int extra_y = ( rect.y > 2 ) ? 2 : 1;
+#elif !defined(__WXGTK__)
+    int extra_x = 2;
+    int extra_y = 2;
 
     #if defined(__WXMOTIF__)
         extra_x *= 2;
@@ -1266,14 +1245,26 @@ void wxGridCellBoolEditor::SetSize(const wxRect& r)
 
     // position it in the centre of the rectangle (TODO: support alignment?)
 
+    wxRect cellRect = r;
+
 #if defined(__WXGTK__) || defined (__WXMOTIF__)
+#if defined(__WXGTK3__)
+    cellRect.x += 6;
+    cellRect.width -= 12;
+#else
     // the checkbox without label still has some space to the right in wxGTK,
     // so shift it to the right
+    // TODO: check offsets
+    cellRect.x += 2;
+    cellRect.width -= 2;
     size.x -= 8;
+#endif
 #elif defined(__WXMSW__)
-    // here too, but in other way
-    size.x += 1;
-    size.y -= 2;
+    cellRect.x += 2;
+    cellRect.width -= 2;
+#elif defined(__WXOSX__)
+    cellRect.x += 3;
+    cellRect.width -= 6;
 #endif
 
     int hAlign = wxALIGN_CENTRE;
@@ -1284,23 +1275,18 @@ void wxGridCellBoolEditor::SetSize(const wxRect& r)
     int x = 0, y = 0;
     if (hAlign == wxALIGN_LEFT)
     {
-        x = r.x + 2;
-
-#ifdef __WXMSW__
-        x += 2;
-#endif
-
-        y = r.y + r.height / 2 - size.y / 2;
+        x = cellRect.x;
+        y = cellRect.y + cellRect.height / 2 - size.y / 2;
     }
     else if (hAlign == wxALIGN_RIGHT)
     {
-        x = r.x + r.width - size.x - 2;
-        y = r.y + r.height / 2 - size.y / 2;
+        x = cellRect.x + cellRect.width - size.x;
+        y = cellRect.y + cellRect.height / 2 - size.y / 2;
     }
     else if (hAlign == wxALIGN_CENTRE)
     {
-        x = r.x + r.width / 2 - size.x / 2;
-        y = r.y + r.height / 2 - size.y / 2;
+        x = cellRect.x + cellRect.width / 2 - size.x / 2;
+        y = cellRect.y + cellRect.height / 2 - size.y / 2;
     }
 
     m_control->Move(x, y);

--- a/src/generic/grideditors.cpp
+++ b/src/generic/grideditors.cpp
@@ -1245,48 +1245,32 @@ void wxGridCellBoolEditor::SetSize(const wxRect& r)
 
     // position it in the centre of the rectangle (TODO: support alignment?)
 
-    wxRect cellRect = r;
-
-#if defined(__WXGTK__) || defined (__WXMOTIF__)
-#if defined(__WXGTK3__)
-    cellRect.x += 6;
-    cellRect.width -= 12;
-#else
-    // the checkbox without label still has some space to the right in wxGTK,
-    // so shift it to the right
-    // TODO: check offsets
-    cellRect.x += 2;
-    cellRect.width -= 2;
-    size.x -= 8;
-#endif
-#elif defined(__WXMSW__)
-    cellRect.x += 2;
-    cellRect.width -= 2;
-#elif defined(__WXOSX__)
-    cellRect.x += 3;
-    cellRect.width -= 6;
-#endif
-
     int hAlign = wxALIGN_CENTRE;
     int vAlign = wxALIGN_CENTRE;
     if (GetCellAttr())
         GetCellAttr()->GetAlignment(& hAlign, & vAlign);
 
+    // wxGridCellBoolRenderer and wxGridCellBoolEditor should draw checkboxes
+    // to the same place in a cell but the check mark is aligned right in wxCheckbox
+    // so we should use the width of the checkbox to align our control horizontally
+    // instead of the controls width
+    const wxSize checkBoxSize = wxRendererNative::Get().GetCheckBoxSize(GetWindow());
+
     int x = 0, y = 0;
     if (hAlign == wxALIGN_LEFT)
     {
-        x = cellRect.x;
-        y = cellRect.y + cellRect.height / 2 - size.y / 2;
+        x = r.x + 2;
+        y = r.y + r.height / 2 - size.y / 2;
     }
     else if (hAlign == wxALIGN_RIGHT)
     {
-        x = cellRect.x + cellRect.width - size.x;
-        y = cellRect.y + cellRect.height / 2 - size.y / 2;
+        x = r.x + r.width - checkBoxSize.x - 2;
+        y = r.y + r.height / 2 - size.y / 2;
     }
     else if (hAlign == wxALIGN_CENTRE)
     {
-        x = cellRect.x + cellRect.width / 2 - size.x / 2;
-        y = cellRect.y + cellRect.height / 2 - size.y / 2;
+        x = r.x + r.width / 2 - checkBoxSize.x / 2;
+        y = r.y + r.height / 2 - size.y / 2;
     }
 
     m_control->Move(x, y);

--- a/src/generic/renderg.cpp
+++ b/src/generic/renderg.cpp
@@ -111,7 +111,7 @@ public:
                                const wxRect& rect,
                                int flags = 0) wxOVERRIDE;
 
-    virtual wxSize GetCheckBoxSize(wxWindow *win) wxOVERRIDE;
+    virtual wxSize GetCheckBoxSize(wxWindow *win, int flags = 0) wxOVERRIDE;
 
     virtual wxSize GetCheckMarkSize(wxWindow *win) wxOVERRIDE;
 
@@ -731,7 +731,7 @@ wxRendererGeneric::DrawCheckMark(wxWindow *WXUNUSED(win),
     dc.DrawCheckMark(rect);
 }
 
-wxSize wxRendererGeneric::GetCheckBoxSize(wxWindow *win)
+wxSize wxRendererGeneric::GetCheckBoxSize(wxWindow *win, int WXUNUSED(flags))
 {
     wxCHECK_MSG( win, wxSize(0, 0), "Must have a valid window" );
 
@@ -740,7 +740,7 @@ wxSize wxRendererGeneric::GetCheckBoxSize(wxWindow *win)
 
 wxSize wxRendererGeneric::GetCheckMarkSize(wxWindow *win)
 {
-    return GetCheckBoxSize(win);
+    return GetCheckBoxSize(win, wxCONTROL_CELL);
 }
 
 wxSize wxRendererGeneric::GetExpanderSize(wxWindow *win)

--- a/src/gtk/renderer.cpp
+++ b/src/gtk/renderer.cpp
@@ -133,7 +133,7 @@ public:
 
     virtual void DrawFocusRect(wxWindow* win, wxDC& dc, const wxRect& rect, int flags = 0) wxOVERRIDE;
 
-    virtual wxSize GetCheckBoxSize(wxWindow *win) wxOVERRIDE;
+    virtual wxSize GetCheckBoxSize(wxWindow *win, int flags = 0) wxOVERRIDE;
 
     virtual wxSplitterRenderParams GetSplitterParams(const wxWindow *win) wxOVERRIDE;
 };
@@ -552,12 +552,14 @@ wxRendererGTK::DrawComboBoxDropButton(wxWindow *win,
 }
 
 wxSize
-wxRendererGTK::GetCheckBoxSize(wxWindow* win)
+wxRendererGTK::GetCheckBoxSize(wxWindow* win, int flags)
 {
     // Even though we don't use the window in this implementation, still check
     // that it's valid to avoid surprises when running the same code under the
     // other platforms.
     wxCHECK_MSG( win, wxSize(0, 0), "Must have a valid window" );
+
+    const bool addMargins = (flags & wxCONTROL_CELL) == 0;
 
 #ifdef __WXGTK3__
     int min_width, min_height;
@@ -568,10 +570,13 @@ wxRendererGTK::GetCheckBoxSize(wxWindow* win)
         sc.Add("check");
         gtk_style_context_get(sc, GTK_STATE_FLAG_NORMAL,
             "min-width", &min_width, "min-height", &min_height, NULL);
-        GtkBorder margin;
-        gtk_style_context_get_margin(sc, GTK_STATE_FLAG_NORMAL, &margin);
-        min_width += margin.left + margin.right;
-        min_height += margin.top + margin.bottom;
+        if ( addMargins )
+        {
+            GtkBorder margin;
+            gtk_style_context_get_margin(sc, GTK_STATE_FLAG_NORMAL, &margin);
+            min_width += margin.left + margin.right;
+            min_height += margin.top + margin.bottom;
+        }
     }
     else
     {
@@ -579,15 +584,26 @@ wxRendererGTK::GetCheckBoxSize(wxWindow* win)
         g_value_init(&value, G_TYPE_INT);
         gtk_style_context_get_style_property(sc, "indicator-size", &value);
         min_width = g_value_get_int(&value);
-        gtk_style_context_get_style_property(sc, "indicator-spacing", &value);
-        min_width += 2 * g_value_get_int(&value);
+        if ( addMargins )
+        {
+            gtk_style_context_get_style_property(sc, "indicator-spacing", &value);
+            min_width += 2 * g_value_get_int(&value);
+        }
         min_height = min_width;
         g_value_unset(&value);
     }
 
     return wxSize(min_width, min_height);
 #else // !__WXGTK3__
-    gint indicator_size, indicator_spacing;
+    gint indicator_size;
+    if ( !addMargins )
+    {
+        gtk_widget_style_get(wxGTKPrivate::GetCheckButtonWidget(),
+                            "indicator_size", &indicator_size);
+        return wxSize(indicator_size, indicator_size);
+    }
+
+    gint indicator_spacing;
     gtk_widget_style_get(wxGTKPrivate::GetCheckButtonWidget(),
                          "indicator_size", &indicator_size,
                          "indicator_spacing", &indicator_spacing,

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -162,7 +162,7 @@ public:
                                     wxTitleBarButton button,
                                     int flags = 0) wxOVERRIDE;
 
-    virtual wxSize GetCheckBoxSize(wxWindow *win) wxOVERRIDE;
+    virtual wxSize GetCheckBoxSize(wxWindow *win, int flags = 0) wxOVERRIDE;
 
     virtual int GetHeaderButtonHeight(wxWindow *win) wxOVERRIDE;
 
@@ -288,7 +288,7 @@ public:
                                     wxTitleBarButton button,
                                     int flags = 0) wxOVERRIDE;
 
-    virtual wxSize GetCheckBoxSize(wxWindow *win) wxOVERRIDE;
+    virtual wxSize GetCheckBoxSize(wxWindow *win, int flags = 0) wxOVERRIDE;
 
     virtual wxSize GetCheckMarkSize(wxWindow* win) wxOVERRIDE;
 
@@ -548,7 +548,7 @@ wxRendererMSW::DrawTitleBarBitmap(wxWindow *win,
     DoDrawFrameControl(DFC_CAPTION, kind, win, dc, rect, flags);
 }
 
-wxSize wxRendererMSW::GetCheckBoxSize(wxWindow* win)
+wxSize wxRendererMSW::GetCheckBoxSize(wxWindow* win, int WXUNUSED(flags))
 {
     // We must have a valid window in order to return the size which is correct
     // for the display this window is on.
@@ -893,7 +893,7 @@ wxRendererXP::DrawTitleBarBitmap(wxWindow *win,
     DoDrawButtonLike(hTheme, part, dc, rect, flags);
 }
 
-wxSize wxRendererXP::GetCheckBoxSize(wxWindow* win)
+wxSize wxRendererXP::GetCheckBoxSize(wxWindow* win, int flags)
 {
     wxCHECK_MSG( win, wxSize(0, 0), "Must have a valid window" );
 
@@ -907,7 +907,7 @@ wxSize wxRendererXP::GetCheckBoxSize(wxWindow* win)
                 return wxSize(checkSize.cx, checkSize.cy);
         }
     }
-    return m_rendererNative.GetCheckBoxSize(win);
+    return m_rendererNative.GetCheckBoxSize(win, flags);
 }
 
 wxSize wxRendererXP::GetCheckMarkSize(wxWindow* win)

--- a/src/osx/carbon/renderer.cpp
+++ b/src/osx/carbon/renderer.cpp
@@ -491,7 +491,7 @@ wxRendererMac::DrawCheckBox(wxWindow *win,
                        kind, kThemeAdornmentNone);
 }
 
-wxSize wxRendererMac::GetCheckBoxSize(wxWindow* win, int UXUNUSED(flags))
+wxSize wxRendererMac::GetCheckBoxSize(wxWindow* win, int WXUNUSED(flags))
 {
     // Even though we don't use the window in this implementation, still check
     // that it's valid to avoid surprises when running the same code under the

--- a/src/osx/carbon/renderer.cpp
+++ b/src/osx/carbon/renderer.cpp
@@ -90,7 +90,7 @@ public:
                               const wxRect& rect,
                               int flags = 0) wxOVERRIDE;
 
-    virtual wxSize GetCheckBoxSize(wxWindow* win) wxOVERRIDE;
+    virtual wxSize GetCheckBoxSize(wxWindow* win, int flags = 0) wxOVERRIDE;
 
     virtual void DrawComboBoxDropButton(wxWindow *win,
                                         wxDC& dc,
@@ -491,7 +491,7 @@ wxRendererMac::DrawCheckBox(wxWindow *win,
                        kind, kThemeAdornmentNone);
 }
 
-wxSize wxRendererMac::GetCheckBoxSize(wxWindow* win)
+wxSize wxRendererMac::GetCheckBoxSize(wxWindow* win, int UXUNUSED(flags))
 {
     // Even though we don't use the window in this implementation, still check
     // that it's valid to avoid surprises when running the same code under the


### PR DESCRIPTION
Fix the redundant old code in wxGrid::ShowCellEditControl which moves grid
editors but we don't want it. So remove it and also remove workarounds in
editors SetSize functions.