### PR TITLE
Unify unhighlight events across ports

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -83,6 +83,9 @@ Changes in behaviour not resulting in compilation errors
   coordinates, e.g. returned by wxWindow::GetSize() by GetContentScaleFactor()
   before using them with OpenGL functions.
 
+- wxGTK now uses the wxID_NONE item ID inside EVT_MENU_HIGHLIGHT events sent when
+  the menu item is unhighlighted (it used to use wxID_ANY).
+
 
 Changes in behaviour which may result in build errors
 -----------------------------------------------------
@@ -143,6 +146,9 @@ Changes in behaviour which may result in build errors
 3.1.4: (released ????-??-??)
 ----------------------------
 
+wxOSX:
+
+- Send EVT_MENU_HIGHLIGHT events when menu items are unhighlighted
 
 3.1.3: (released 2019-10-28)
 ----------------------------

--- a/interface/wx/menuitem.h
+++ b/interface/wx/menuitem.h
@@ -31,8 +31,9 @@
         A menu has been just closed.
         This type of event is sent as wxMenuEvent.
     @event{EVT_MENU_HIGHLIGHT(id, func)}
-        The menu item with the specified id has been highlighted: used to show
-        help prompts in the status bar by wxFrame
+        The menu item with the specified id has been highlighted. If the id is wxID_NONE, a
+        menu item has ben unhighlighted. This is used by wxFrame to show help prompts in
+        the status bar
         This type of event is sent as wxMenuEvent.
     @event{EVT_MENU_HIGHLIGHT_ALL(func)}
         A menu item has been highlighted, i.e. the currently selected menu item has changed.

--- a/src/gtk/menu.cpp
+++ b/src/gtk/menu.cpp
@@ -575,7 +575,7 @@ static void menuitem_deselect(GtkWidget*, wxMenuItem* item)
     if (!item->IsEnabled())
         return;
 
-    wxMenuEvent event(wxEVT_MENU_HIGHLIGHT, -1, item->GetMenu());
+    wxMenuEvent event(wxEVT_MENU_HIGHLIGHT, wxID_NONE, item->GetMenu());
     DoCommonMenuCallbackCode(item->GetMenu(), event);
 }
 }

--- a/src/gtk1/menu.cpp
+++ b/src/gtk1/menu.cpp
@@ -673,7 +673,7 @@ static void gtk_menu_nolight_callback( GtkWidget *widget, wxMenu *menu )
     if (!menu->IsEnabled(id))
         return;
 
-    wxMenuEvent event( wxEVT_MENU_HIGHLIGHT, -1, menu );
+    wxMenuEvent event( wxEVT_MENU_HIGHLIGHT, wxID_NONE, menu );
     event.SetEventObject( menu );
 
     wxEvtHandler* handler = menu->GetEventHandler();

--- a/src/osx/cocoa/menu.mm
+++ b/src/osx/cocoa/menu.mm
@@ -127,14 +127,21 @@
     wxMenuImpl* menuimpl = [menu implementation];
     if ( menuimpl )
     {
+        wxMenuItem* menuitem = nullptr;
         wxMenu* wxpeer = (wxMenu*) menuimpl->GetWXPeer();
+        
         if ( [ item isKindOfClass:[wxNSMenuItem class] ] )
         {
             wxMenuItemImpl* menuitemimpl = (wxMenuItemImpl*) [ (wxNSMenuItem*) item implementation ];
-            if ( wxpeer && menuitemimpl )
+            if ( menuitemimpl )
             {
-                wxpeer->HandleMenuItemHighlighted( menuitemimpl->GetWXPeer() );
+                menuitem = menuitemimpl->GetWXPeer();
             }
+        }
+
+        if ( wxpeer )
+        {
+            wxpeer->HandleMenuItemHighlighted( menuitem );
         }
     }
 }

--- a/src/osx/menu_osx.cpp
+++ b/src/osx/menu_osx.cpp
@@ -379,7 +379,7 @@ bool wxMenu::HandleCommandProcess( wxMenuItem* item, wxWindow* senderWindow )
 
 void wxMenu::HandleMenuItemHighlighted( wxMenuItem* item )
 {
-    int menuid = item ? item->GetId() : 0;
+    int menuid = item ? item->GetId() : wxID_NONE;
     wxMenuEvent wxevent(wxEVT_MENU_HIGHLIGHT, menuid, this);
     ProcessMenuEvent(this, wxevent, GetWindow());
 }


### PR DESCRIPTION
This PR unifies the handling of unhighlight commands across the GTK, OSX and MSW ports. Specifically it does:
* Implement unhighlight events on OSX (they already were on in MSW and GTK)
* Use `wxID_NONE` in OSX for these events (non-breaking change)
* Change GTK to use `wxID_NONE` instead of `wxID_ANY` for these events (breaking change)

The only remaining difference between the ports is that OSX doesn't actually generate an unhighlight event if a new item is highlighted immediately after (it only generates one if no items will be highlighted). This is internal to OSX and is something we can't change unfortunately.