### PR TITLE
Fix paper size correctly for printouts under MSW and Mac

### DIFF
--- a/src/common/prntbase.cpp
+++ b/src/common/prntbase.cpp
@@ -640,6 +640,8 @@ void wxPrintout::GetPageInfo(int *minPage, int *maxPage, int *fromPage, int *toP
 
 bool wxPrintout::SetUp(wxDC& dc)
 {
+    wxCHECK_MSG( dc.IsOk(), false, "should have a valid DC to set up" );
+
     SetPPIScreen(wxGetDisplayPPI());
 
     // We need to know printer PPI. In most ports, this can be retrieved from
@@ -659,7 +661,10 @@ bool wxPrintout::SetUp(wxDC& dc)
     SetDC(&dc);
 
     dc.GetSize(&m_pageWidthPixels, &m_pageHeightPixels);
-    m_paperRectPixels = wxRect(0, 0, m_pageWidthPixels, m_pageHeightPixels);
+    // This is ugly, but wxDCImpl itself has GetPaperRect() method while wxDC
+    // doesn't (only wxPrinterDC does), so use GetImpl() to avoid having to use
+    // a dynamic cast.
+    m_paperRectPixels = dc.GetImpl()->GetPaperRect();
     dc.GetSizeMM(&m_pageWidthMM, &m_pageHeightMM);
 
     return true;


### PR DESCRIPTION
This was broken by 048b7f44ec44a428f9b115121be299ea329276b2 which wasn't
supposed to change anything, but did because it effectively replaced the
call to wxDC::GetPaperRect() with wxDC::GetSize() when initializing
wxPrintout::m_paperRectPixels, and while GetPaperRect() is the same as
GetSize() in wxGTK, it returns the rectangle including non-printable
margins in wxMSW and wxOSX, and must be used here instead.

Closes [#18565](https://trac.wxwidgets.org/ticket/18565).