### PR TITLE
Handle the situation when primary display is not the first one

### DIFF
--- a/include/wx/display.h
+++ b/include/wx/display.h
@@ -42,12 +42,14 @@ class WXDLLIMPEXP_FWD_CORE wxDisplayImpl;
 class WXDLLIMPEXP_CORE wxDisplay
 {
 public:
+    // default ctor creates the object corresponding to the primary display
+    wxDisplay();
+
     // initialize the object containing all information about the given
     // display
     //
-    // the displays are numbered from 0 to GetCount() - 1, 0 is always the
-    // primary display and the only one which is always supported
-    wxDisplay(unsigned n = 0);
+    // the displays are numbered from 0 to GetCount() - 1
+    explicit wxDisplay(unsigned n);
 
     // create display object corresponding to the display of the given window
     // or the default one if the window display couldn't be found

--- a/include/wx/private/display.h
+++ b/include/wx/private/display.h
@@ -37,6 +37,9 @@ public:
         return m_impls[n];
     }
 
+    // Return the primary display object, creating it if necessary.
+    wxDisplayImpl* GetPrimaryDisplay();
+
     // get the total number of displays
     virtual unsigned GetCount() = 0;
 

--- a/interface/wx/display.h
+++ b/interface/wx/display.h
@@ -17,6 +17,12 @@ class wxDisplay
 {
 public:
     /**
+        Default constructor creating wxDisplay object representing the primary
+        display.
+     */
+    wxDisplay();
+
+    /**
         Constructor, setting up a wxDisplay instance with the specified
         display.
 
@@ -24,7 +30,7 @@ public:
             The index of the display to use. This must be non-negative and
             lower than the value returned by GetCount().
     */
-    wxDisplay(unsigned int index = 0);
+    explicit wxDisplay(unsigned int index);
 
     /**
         Constructor creating the display object associated with the given

--- a/samples/display/display.cpp
+++ b/samples/display/display.cpp
@@ -327,9 +327,7 @@ void MyFrame::PopuplateWithDisplayInfo()
         page->SetSizer(sizerTop);
         page->Layout();
 
-        m_book->AddPage(page,
-                        wxString::Format("Display %lu",
-                                         (unsigned long)nDpy));
+        m_book->AddPage(page, wxString::Format("Display %zu", nDpy + 1));
     }
 
     SetClientSize(m_book->GetBestSize());

--- a/src/common/dpycmn.cpp
+++ b/src/common/dpycmn.cpp
@@ -159,7 +159,7 @@ wxString wxDisplay::GetName() const
 
 bool wxDisplay::IsPrimary() const
 {
-    return m_impl && m_impl->GetIndex() == 0;
+    return m_impl && m_impl->IsPrimary();
 }
 
 #if wxUSE_DISPLAY


### PR DESCRIPTION
This fixes several problems I found after experimenting with making the second monitor the primary one.

There are probably more efficient ways of implementing `wxDisplayFactory::GetPrimaryDisplay()` for GTK/Mac, but I'm not sure if it's worth it as, once all the displays are cached, this one should be fast enough too.