### PR TITLE
Handle GdkAtom (typedef'd to const char *) in GTK4

### DIFF
--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -2906,7 +2906,9 @@ typedef struct _GdkColor        GdkColor;
 typedef struct _GdkCursor       GdkCursor;
 typedef struct _GdkDragContext  GdkDragContext;
 
-#if defined(__WXGTK20__)
+#if defined(__WXGTK4__)
+    typedef const char *GdkAtom;
+#elif defined(__WXGTK20__)
     typedef struct _GdkAtom* GdkAtom;
 #else
     typedef unsigned long GdkAtom;

--- a/include/wx/gtk/dataform.h
+++ b/include/wx/gtk/dataform.h
@@ -24,7 +24,9 @@ public:
     // we have to provide all the overloads to allow using strings instead of
     // data formats (as a lot of existing code does)
     wxDataFormat( const wxString& id ) { InitFromString(id); }
+#ifndef __WXGTK4__
     wxDataFormat( const char *id ) { InitFromString(id); }
+#endif
     wxDataFormat( const wchar_t *id ) { InitFromString(id); }
     wxDataFormat( const wxCStrData& id ) { InitFromString(id); }
 

--- a/include/wx/gtk/private.h
+++ b/include/wx/gtk/private.h
@@ -103,7 +103,6 @@ extern const gchar *wx_pango_version_check(int major, int minor, int micro);
 
 // GdkAtom is char* in GTK4, so provide missing functions
 #ifdef __WXGTK4__
-    #define gdk_atom_name(x) (x)
     #define gdk_atom_intern(x, _) g_intern_string((x))
 #endif
 

--- a/include/wx/gtk/private.h
+++ b/include/wx/gtk/private.h
@@ -101,6 +101,12 @@ extern const gchar *wx_pango_version_check(int major, int minor, int micro);
     #define wxGTK_CONV_FN(s) (s).fn_str()
 #endif
 
+// GdkAtom is char* in GTK4, so provide missing functions
+#ifdef __WXGTK4__
+    #define gdk_atom_name(x) (x)
+    #define gdk_atom_intern(x, _) g_intern_string((x))
+#endif
+
 // ----------------------------------------------------------------------------
 // various private helper functions
 // ----------------------------------------------------------------------------

--- a/include/wx/gtk/private/string.h
+++ b/include/wx/gtk/private/string.h
@@ -13,6 +13,7 @@
 // ----------------------------------------------------------------------------
 // Convenience class for g_freeing a gchar* on scope exit automatically
 // ----------------------------------------------------------------------------
+#include <glib.h>
 
 class wxGtkString
 {

--- a/src/gtk/clipbrd.cpp
+++ b/src/gtk/clipbrd.cpp
@@ -143,7 +143,11 @@ targets_selection_received( GtkWidget *WXUNUSED(widget),
     GdkAtom type = gtk_selection_data_get_data_type(selection_data);
     if ( type != GDK_SELECTION_TYPE_ATOM )
     {
+#ifdef __WXGTK4__
+        if ( type != g_intern_static_string("TARGETS") )
+#else
         if ( strcmp(wxGtkString(gdk_atom_name(type)), "TARGETS") != 0 )
+#endif
         {
             wxLogTrace( TRACE_CLIPBOARD,
                         wxT("got unsupported clipboard target") );
@@ -290,6 +294,15 @@ selection_handler( GtkWidget *WXUNUSED(widget),
 
     wxDataFormat format(gtk_selection_data_get_target(selection_data));
 
+#ifdef __WXGTK4__
+    wxLogTrace(TRACE_CLIPBOARD,
+               wxT("clipboard data in format %s, GtkSelectionData is target=%s type=%s timestamp=%u"),
+               format.GetId().c_str(),
+               gtk_selection_data_get_target(selection_data),
+               gtk_selection_data_get_data_type(selection_data),
+               GPOINTER_TO_UINT( signal_data )
+               );
+#else
     wxLogTrace(TRACE_CLIPBOARD,
                wxT("clipboard data in format %s, GtkSelectionData is target=%s type=%s selection=%s timestamp=%u"),
                format.GetId().c_str(),
@@ -298,6 +311,7 @@ selection_handler( GtkWidget *WXUNUSED(widget),
                wxString::FromAscii(wxGtkString(gdk_atom_name(gtk_selection_data_get_selection(selection_data)))).c_str(),
                GPOINTER_TO_UINT( signal_data )
                );
+#endif
 
     if ( !data->IsSupportedFormat( format ) )
         return;
@@ -387,7 +401,11 @@ async_targets_selection_received( GtkWidget *WXUNUSED(widget),
     GdkAtom type = gtk_selection_data_get_data_type(selection_data);
     if ( type != GDK_SELECTION_TYPE_ATOM )
     {
+#ifdef __WXGTK4__
+        if ( type != g_intern_static_string("TARGETS") )
+#else
         if ( strcmp(wxGtkString(gdk_atom_name(type)), "TARGETS") != 0 )
+#endif
         {
             wxLogTrace( TRACE_CLIPBOARD,
                         wxT("got unsupported clipboard target") );

--- a/src/gtk/dataobj.cpp
+++ b/src/gtk/dataobj.cpp
@@ -118,11 +118,15 @@ wxString wxDataFormat::GetId() const
 #endif
 }
 
-#ifdef __WXGTK4__
 void wxDataFormat::SetId( NativeFormat format )
 {
     PrepareFormats();
+#ifdef __WXGTK4__
+    // NativeFormat is const char *, so canonicalize first
     m_format = g_intern_string(format);
+#else
+    m_format = format;
+#endif
 
     if (m_format == g_textAtom)
 #if wxUSE_UNICODE
@@ -146,46 +150,18 @@ void wxDataFormat::SetId( NativeFormat format )
         m_type = wxDF_PRIVATE;
 }
 
+#ifdef __WXGTK4__
 void wxDataFormat::SetId( const wxString& id )
 {
     SetId((NativeFormat)id.ToAscii());
 }
-
 #else
-void wxDataFormat::SetId( NativeFormat format )
-{
-    PrepareFormats();
-    m_format = format;
-
-    if (m_format == g_textAtom)
-#if wxUSE_UNICODE
-        m_type = wxDF_UNICODETEXT;
-#else
-        m_type = wxDF_TEXT;
-#endif
-    else
-    if (m_format == g_altTextAtom)
-        m_type = wxDF_TEXT;
-    else
-    if (m_format == g_pngAtom)
-        m_type = wxDF_BITMAP;
-    else
-    if (m_format == g_fileAtom)
-        m_type = wxDF_FILENAME;
-    else
-    if (m_format == g_htmlAtom)
-        m_type = wxDF_HTML;
-    else
-        m_type = wxDF_PRIVATE;
-}
-
 void wxDataFormat::SetId( const wxString& id )
 {
     PrepareFormats();
     m_type = wxDF_PRIVATE;
     m_format = gdk_atom_intern( id.ToAscii(), FALSE );
 }
-
 #endif
 
 void wxDataFormat::PrepareFormats()

--- a/src/gtk/dataobj.cpp
+++ b/src/gtk/dataobj.cpp
@@ -110,10 +110,48 @@ wxDataFormatId wxDataFormat::GetType() const
 
 wxString wxDataFormat::GetId() const
 {
+#ifdef __WXGTK4__
+    return wxString::FromAscii(m_format);
+#else
     wxGtkString atom_name(gdk_atom_name(m_format));
     return wxString::FromAscii(atom_name);
+#endif
 }
 
+#ifdef __WXGTK4__
+void wxDataFormat::SetId( NativeFormat format )
+{
+    PrepareFormats();
+    m_format = g_intern_string(format);
+
+    if (m_format == g_textAtom)
+#if wxUSE_UNICODE
+        m_type = wxDF_UNICODETEXT;
+#else
+        m_type = wxDF_TEXT;
+#endif
+    else
+    if (m_format == g_altTextAtom)
+        m_type = wxDF_TEXT;
+    else
+    if (m_format == g_pngAtom)
+        m_type = wxDF_BITMAP;
+    else
+    if (m_format == g_fileAtom)
+        m_type = wxDF_FILENAME;
+    else
+    if (m_format == g_htmlAtom)
+        m_type = wxDF_HTML;
+    else
+        m_type = wxDF_PRIVATE;
+}
+
+void wxDataFormat::SetId( const wxString& id )
+{
+    SetId((NativeFormat)id.ToAscii());
+}
+
+#else
 void wxDataFormat::SetId( NativeFormat format )
 {
     PrepareFormats();
@@ -147,6 +185,8 @@ void wxDataFormat::SetId( const wxString& id )
     m_type = wxDF_PRIVATE;
     m_format = gdk_atom_intern( id.ToAscii(), FALSE );
 }
+
+#endif
 
 void wxDataFormat::PrepareFormats()
 {

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -3716,8 +3716,12 @@ void wxDataViewCtrlInternal::BuildBranch( wxGtkTreeModelNode *node )
 
 bool wxDataViewCtrlInternal::EnableDragSource( const wxDataFormat &format )
 {
+#ifdef __WXGTK4__
+    m_dragSourceTargetEntryTarget = wxCharBuffer( format.GetFormatId() );
+#else
     wxGtkString atom_str( gdk_atom_name( format  ) );
     m_dragSourceTargetEntryTarget = wxCharBuffer( atom_str );
+#endif
 
     m_dragSourceTargetEntry.target =  m_dragSourceTargetEntryTarget.data();
     m_dragSourceTargetEntry.flags = 0;
@@ -3731,8 +3735,12 @@ bool wxDataViewCtrlInternal::EnableDragSource( const wxDataFormat &format )
 
 bool wxDataViewCtrlInternal::EnableDropTarget( const wxDataFormat &format )
 {
+#ifdef __WXGTK4__
+    m_dropTargetTargetEntryTarget = wxCharBuffer( format.GetFormatId() );
+#else
     wxGtkString atom_str( gdk_atom_name( format  ) );
     m_dropTargetTargetEntryTarget = wxCharBuffer( atom_str );
+#endif
 
     m_dropTargetTargetEntry.target =  m_dropTargetTargetEntryTarget.data();
     m_dropTargetTargetEntry.flags = 0;

--- a/src/gtk/dnd.cpp
+++ b/src/gtk/dnd.cpp
@@ -24,6 +24,7 @@
 
 #include "wx/scopeguard.h"
 
+#include "wx/gtk/private/string.h"
 #include "wx/gtk/private/wrapgtk.h"
 
 //----------------------------------------------------------------------------
@@ -198,7 +199,7 @@ static gboolean target_drag_motion( GtkWidget *WXUNUSED(widget),
     GList *tmp_list;
     for (tmp_list = context->targets; tmp_list; tmp_list = tmp_list->next)
     {
-        wxString atom = wxString::FromAscii( gdk_atom_name (GDK_POINTER_TO_ATOM (tmp_list->data)) );
+        wxString atom = wxString::FromAscii(wxGtkString(gdk_atom_name(GDK_POINTER_TO_ATOM(tmp_list->data))));
         wxPrintf( "Atom: %s\n", atom );
     }
 #endif
@@ -842,9 +843,13 @@ wxDragResult wxDropSource::DoDragDrop(int flags)
     size_t count = m_data->GetFormatCount();
     for (size_t i = 0; i < count; i++)
     {
-        GdkAtom atom = array[i];
+        GdkAtom atom = array[i].GetFormatId();
+#ifdef __WXGTK4__
+        wxLogTrace(TRACE_DND, wxT("Drop source: Supported atom %s"), atom);
+#else
         wxLogTrace(TRACE_DND, wxT("Drop source: Supported atom %s"),
-                   gdk_atom_name( atom ));
+                   wxGtkString(gdk_atom_name( atom )).c_str());
+#endif
         gtk_target_list_add( target_list, atom, 0, 0 );
     }
     delete[] array;

--- a/src/gtk1/clipbrd.cpp
+++ b/src/gtk1/clipbrd.cpp
@@ -262,14 +262,20 @@ selection_handler( GtkWidget *WXUNUSED(widget),
 
     wxDataFormat format( selection_data->target );
 
+    gchar *atom_target = gdk_atom_name(selection_data->target),
+          *atom_type = gdk_atom_name(selection_data->type),
+          *atom_selection = gdk_atom_name(selection_data->selection);
     wxLogTrace(TRACE_CLIPBOARD,
                wxT("clipboard data in format %s, GtkSelectionData is target=%s type=%s selection=%s timestamp=%u"),
                format.GetId().c_str(),
-               wxString::FromAscii(gdk_atom_name(selection_data->target)).c_str(),
-               wxString::FromAscii(gdk_atom_name(selection_data->type)).c_str(),
-               wxString::FromAscii(gdk_atom_name(selection_data->selection)).c_str(),
+               wxString::FromAscii(atom_target).c_str(),
+               wxString::FromAscii(atom_type).c_str(),
+               wxString::FromAscii(atom_selection).c_str(),
                GPOINTER_TO_UINT( signal_data )
                );
+    g_free(atom_target);
+    g_free(atom_type);
+    g_free(atom_selection);
 
     if (!data->IsSupportedFormat( format )) return;
 

--- a/src/gtk1/dnd.cpp
+++ b/src/gtk1/dnd.cpp
@@ -867,7 +867,9 @@ wxDragResult wxDropSource::DoDragDrop(int flags)
     for (size_t i = 0; i < count; i++)
     {
         GdkAtom atom = array[i];
-        wxLogTrace(TRACE_DND, wxT("Drop source: Supported atom %s"), gdk_atom_name( atom ));
+        gchar *atom_name = gdk_atom_name( atom );
+        wxLogTrace(TRACE_DND, wxT("Drop source: Supported atom %s"), atom_name);
+        g_free(atom_name);
         gtk_target_list_add( target_list, atom, 0, 0 );
     }
     delete[] array;


### PR DESCRIPTION
Instead of internal values, `GdkAtom` is now `const char *` pointing to internal strings. For generic `char*`, always call `g_intern_string` to get the internal pointer from gdk, so we can compare pointers instead of doing strcmp.