### PR TITLE
Fixes for wxSpinCtrl::GetSizeFromTextSize()

### DIFF
--- a/include/wx/gtk/spinctrl.h
+++ b/include/wx/gtk/spinctrl.h
@@ -71,7 +71,9 @@ protected:
     void GtkDisableEvents() const;
     void GtkEnableEvents() const;
 
-    virtual wxSize DoGetBestSize() const wxOVERRIDE;
+    // Update the number of digits used to match our range (and base).
+    void GtkSetEntryWidth();
+
     virtual wxSize DoGetSizeFromTextSize(int xlen, int ylen = -1) const wxOVERRIDE;
     virtual GdkWindow *GTKGetWindow(wxArrayGdkWindows& windows) const wxOVERRIDE;
 

--- a/include/wx/private/spinctrl.h
+++ b/include/wx/private/spinctrl.h
@@ -17,6 +17,10 @@ namespace wxSpinCtrlImpl
 // string containing hexadecimal representation of the given number.
 extern wxString FormatAsHex(long val, long maxVal);
 
+// Another helper returning the maximum length of a string representing a value
+// valid in the given control.
+extern int GetMaxValueLength(int minVal, int maxVal, int base);
+
 // The helper function to determine the best size for the given control.
 // We can't implement this function in the wxSpinCtrlBase because MSW implementation
 // of wxSpinCtrl is derived from wxSpinButton but uses the same algorithm.

--- a/include/wx/private/spinctrl.h
+++ b/include/wx/private/spinctrl.h
@@ -1,0 +1,27 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/private/spinctrl.h
+// Purpose:     Private functions used in wxSpinCtrl implementation.
+// Author:      Vadim Zeitlin
+// Created:     2019-11-13
+// Copyright:   (c) 2019 Vadim Zeitlin <vadim@wxwidgets.org>
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_PRIVATE_SPINCTRL_H_
+#define _WX_PRIVATE_SPINCTRL_H_
+
+namespace wxPrivate
+{
+
+// This is an internal helper function currently used by all ports: return the
+// string containing hexadecimal representation of the given number.
+extern wxString wxSpinCtrlFormatAsHex(long val, long maxVal);
+
+// The helper function to determine the best size for the given control.
+// We can't implement this function in the wxSpinCtrlBase because MSW implementation
+// of wxSpinCtrl is derived from wxSpinButton but uses the same algorithm.
+extern wxSize wxSpinCtrlGetBestSize(const wxControl* spin, int minVal, int maxVal, int base);
+
+} // namespace wxPrivate
+
+#endif // _WX_PRIVATE_SPINCTRL_H_

--- a/include/wx/private/spinctrl.h
+++ b/include/wx/private/spinctrl.h
@@ -10,18 +10,18 @@
 #ifndef _WX_PRIVATE_SPINCTRL_H_
 #define _WX_PRIVATE_SPINCTRL_H_
 
-namespace wxPrivate
+namespace wxSpinCtrlImpl
 {
 
 // This is an internal helper function currently used by all ports: return the
 // string containing hexadecimal representation of the given number.
-extern wxString wxSpinCtrlFormatAsHex(long val, long maxVal);
+extern wxString FormatAsHex(long val, long maxVal);
 
 // The helper function to determine the best size for the given control.
 // We can't implement this function in the wxSpinCtrlBase because MSW implementation
 // of wxSpinCtrl is derived from wxSpinButton but uses the same algorithm.
-extern wxSize wxSpinCtrlGetBestSize(const wxControl* spin, int minVal, int maxVal, int base);
+extern wxSize GetBestSize(const wxControl* spin, int minVal, int maxVal, int base);
 
-} // namespace wxPrivate
+} // namespace wxSpinCtrlImpl
 
 #endif // _WX_PRIVATE_SPINCTRL_H_

--- a/include/wx/spinctrl.h
+++ b/include/wx/spinctrl.h
@@ -136,19 +136,6 @@ typedef void (wxEvtHandler::*wxSpinDoubleEventFunction)(wxSpinDoubleEvent&);
 #if !defined(wxHAS_NATIVE_SPINCTRL) || !defined(wxHAS_NATIVE_SPINCTRLDOUBLE)
     #include "wx/generic/spinctlg.h"
 #endif
-namespace wxPrivate
-{
-
-// This is an internal helper function currently used by all ports: return the
-// string containing hexadecimal representation of the given number.
-extern wxString wxSpinCtrlFormatAsHex(long val, long maxVal);
-
-// The helper function to determine the best size for the given control.
-// We can't implement this function in the wxSpinCtrlBase because MSW implementation
-// of wxSpinCtrl is derived from wxSpinButton but uses the same algorithm.
-extern wxSize wxSpinCtrlGetBestSize(const wxControl* spin, int minVal, int maxVal, int base);
-
-} // namespace wxPrivate
 
 // old wxEVT_COMMAND_* constants
 #define wxEVT_COMMAND_SPINCTRL_UPDATED         wxEVT_SPINCTRL

--- a/src/common/spinctrlcmn.cpp
+++ b/src/common/spinctrlcmn.cpp
@@ -104,7 +104,9 @@ wxCONSTRUCTOR_6( wxSpinCtrl, wxWindow*, Parent, wxWindowID, Id, \
                 wxSize, Size, long, WindowStyle )
 
 
-wxString wxPrivate::wxSpinCtrlFormatAsHex(long val, long maxVal)
+using namespace wxSpinCtrlImpl;
+
+wxString wxSpinCtrlImpl::FormatAsHex(long val, long maxVal)
 {
     // We format the value like this is for compatibility with (native
     // behaviour of) wxMSW
@@ -117,14 +119,14 @@ wxString wxPrivate::wxSpinCtrlFormatAsHex(long val, long maxVal)
     return text;
 }
 
-wxSize wxPrivate::wxSpinCtrlGetBestSize(const wxControl* spin,
-                                        int minVal, int maxVal, int base)
+wxSize wxSpinCtrlImpl::GetBestSize(const wxControl* spin,
+                                   int minVal, int maxVal, int base)
 {
     const int lenMin = (base == 16 ?
-                       wxSpinCtrlFormatAsHex(minVal, maxVal) :
+                       FormatAsHex(minVal, maxVal) :
                        wxString::Format("%d", minVal)).length();
     const int lenMax = (base == 16 ?
-                       wxSpinCtrlFormatAsHex(maxVal, maxVal) :
+                       FormatAsHex(maxVal, maxVal) :
                        wxString::Format("%d", maxVal)).length();
     const wxString largestString('8', wxMax(lenMin, lenMax));
     return spin->GetSizeFromText(largestString);

--- a/src/common/spinctrlcmn.cpp
+++ b/src/common/spinctrlcmn.cpp
@@ -119,8 +119,7 @@ wxString wxSpinCtrlImpl::FormatAsHex(long val, long maxVal)
     return text;
 }
 
-wxSize wxSpinCtrlImpl::GetBestSize(const wxControl* spin,
-                                   int minVal, int maxVal, int base)
+int wxSpinCtrlImpl::GetMaxValueLength(int minVal, int maxVal, int base)
 {
     const int lenMin = (base == 16 ?
                        FormatAsHex(minVal, maxVal) :
@@ -128,7 +127,13 @@ wxSize wxSpinCtrlImpl::GetBestSize(const wxControl* spin,
     const int lenMax = (base == 16 ?
                        FormatAsHex(maxVal, maxVal) :
                        wxString::Format("%d", maxVal)).length();
-    const wxString largestString('8', wxMax(lenMin, lenMax));
+    return wxMax(lenMin, lenMax);
+}
+
+wxSize wxSpinCtrlImpl::GetBestSize(const wxControl* spin,
+                                   int minVal, int maxVal, int base)
+{
+    const wxString largestString('8', GetMaxValueLength(minVal, maxVal, base));
     return spin->GetSizeFromText(largestString);
 }
 

--- a/src/common/spinctrlcmn.cpp
+++ b/src/common/spinctrlcmn.cpp
@@ -25,6 +25,8 @@
 #include "wx/spinbutt.h"
 #include "wx/spinctrl.h"
 
+#include "wx/private/spinctrl.h"
+
 #if wxUSE_SPINCTRL
 
 wxDEFINE_EVENT(wxEVT_SPINCTRL, wxSpinEvent);

--- a/src/generic/spinctlg.cpp
+++ b/src/generic/spinctlg.cpp
@@ -656,8 +656,7 @@ wxString wxSpinCtrl::DoValueToText(double val)
     switch ( GetBase() )
     {
         case 16:
-            return wxPrivate::wxSpinCtrlFormatAsHex(static_cast<long>(val),
-                                                    GetMax());
+            return wxSpinCtrlImpl::FormatAsHex(static_cast<long>(val), GetMax());
 
         default:
             wxFAIL_MSG( wxS("Unsupported spin control base") );

--- a/src/generic/spinctlg.cpp
+++ b/src/generic/spinctlg.cpp
@@ -32,6 +32,8 @@
 
 #if wxUSE_SPINCTRL
 
+#include "wx/private/spinctrl.h"
+
 wxIMPLEMENT_DYNAMIC_CLASS(wxSpinDoubleEvent, wxNotifyEvent);
 
 // There are port-specific versions for the wxSpinCtrl, so exclude the

--- a/src/gtk/spinctrl.cpp
+++ b/src/gtk/spinctrl.cpp
@@ -137,6 +137,8 @@ bool wxSpinCtrlGTKBase::Create(wxWindow *parent, wxWindowID id,
 
     gtk_entry_set_alignment(GTK_ENTRY(m_widget), align);
 
+    GtkSetEntryWidth();
+
     gtk_spin_button_set_wrap( GTK_SPIN_BUTTON(m_widget),
                               (int)(m_windowStyle & wxSP_WRAP) );
 
@@ -271,6 +273,8 @@ void wxSpinCtrlGTKBase::DoSetRange(double minVal, double maxVal)
     gtk_spin_button_set_range( GTK_SPIN_BUTTON(m_widget), minVal, maxVal);
 
     InvalidateBestSize();
+
+    GtkSetEntryWidth();
 }
 
 void wxSpinCtrlGTKBase::DoSetIncrement(double inc)
@@ -355,11 +359,16 @@ GdkWindow *wxSpinCtrlGTKBase::GTKGetWindow(wxArrayGdkWindows& windows) const
     return NULL;
 }
 
-wxSize wxSpinCtrlGTKBase::DoGetBestSize() const
+void wxSpinCtrlGTKBase::GtkSetEntryWidth()
 {
     const int minVal = static_cast<int>(DoGetMin());
     const int maxVal = static_cast<int>(DoGetMax());
-    return wxSpinCtrlImpl::GetBestSize(this, minVal, maxVal, GetBase());
+
+    gtk_entry_set_width_chars
+    (
+        GTK_ENTRY(m_widget),
+        wxSpinCtrlImpl::GetMaxValueLength(minVal, maxVal, GetBase())
+    );
 }
 
 wxSize wxSpinCtrlGTKBase::DoGetSizeFromTextSize(int xlen, int ylen) const
@@ -475,6 +484,8 @@ bool wxSpinCtrl::SetBase(int base)
     }
 
     InvalidateBestSize();
+
+    GtkSetEntryWidth();
 
     // Update the displayed text after changing the base it uses.
     SetValue(GetValue());

--- a/src/gtk/spinctrl.cpp
+++ b/src/gtk/spinctrl.cpp
@@ -384,21 +384,9 @@ wxSize wxSpinCtrlGTKBase::DoGetSizeFromTextSize(int xlen, int ylen) const
 
     const gint widthChars = gtk_entry_get_width_chars(GTK_ENTRY(m_widget));
     gtk_entry_set_width_chars(GTK_ENTRY(m_widget), numDigits);
-#if GTK_CHECK_VERSION(3,12,0)
-    gint maxWidthChars = 0;
-    if ( gtk_check_version(3,12,0) == NULL )
-    {
-        maxWidthChars = gtk_entry_get_max_width_chars(GTK_ENTRY(m_widget));
-        gtk_entry_set_max_width_chars(GTK_ENTRY(m_widget), numDigits);
-    }
-#endif // GTK+ 3.12+
 
     wxSize tsize = GTKGetPreferredSize(m_widget);
 
-#if GTK_CHECK_VERSION(3,12,0)
-    if ( gtk_check_version(3,12,0) == NULL )
-        gtk_entry_set_max_width_chars(GTK_ENTRY(m_widget), maxWidthChars);
-#endif // GTK+ 3.12+
     gtk_entry_set_width_chars(GTK_ENTRY(m_widget), widthChars);
 
     // Check if the user requested a non-standard height.

--- a/src/gtk/spinctrl.cpp
+++ b/src/gtk/spinctrl.cpp
@@ -359,7 +359,7 @@ wxSize wxSpinCtrlGTKBase::DoGetBestSize() const
 {
     const int minVal = static_cast<int>(DoGetMin());
     const int maxVal = static_cast<int>(DoGetMax());
-    return wxPrivate::wxSpinCtrlGetBestSize(this, minVal, maxVal, GetBase());
+    return wxSpinCtrlImpl::GetBestSize(this, minVal, maxVal, GetBase());
 }
 
 wxSize wxSpinCtrlGTKBase::DoGetSizeFromTextSize(int xlen, int ylen) const
@@ -433,7 +433,7 @@ wx_gtk_spin_output(GtkSpinButton* spin, wxSpinCtrl* win)
     gtk_entry_set_text
     (
         GTK_ENTRY(spin),
-        wxPrivate::wxSpinCtrlFormatAsHex(val, win->GetMax()).utf8_str()
+        wxSpinCtrlImpl::FormatAsHex(val, win->GetMax()).utf8_str()
     );
 
     return TRUE;

--- a/src/gtk/spinctrl.cpp
+++ b/src/gtk/spinctrl.cpp
@@ -20,6 +20,8 @@
     #include "wx/wxcrtvararg.h"
 #endif
 
+#include "wx/private/spinctrl.h"
+
 #include "wx/gtk/private.h"
 
 //-----------------------------------------------------------------------------

--- a/src/gtk1/spinctrl.cpp
+++ b/src/gtk1/spinctrl.cpp
@@ -71,7 +71,7 @@ wx_gtk_spin_output(GtkSpinButton* spin, wxSpinCtrl* win)
     gtk_entry_set_text
     (
         GTK_ENTRY(spin),
-        wxPrivate::wxSpinCtrlFormatAsHex(val, win->GetMax()).utf8_str()
+        wxSpinCtrlImpl::FormatAsHex(val, win->GetMax()).utf8_str()
     );
 
     return TRUE;

--- a/src/gtk1/spinctrl.cpp
+++ b/src/gtk1/spinctrl.cpp
@@ -21,6 +21,8 @@
     #include "wx/crt.h"
 #endif
 
+#include "wx/private/spinctrl.h"
+
 #include "wx/gtk1/private.h"
 
 //-----------------------------------------------------------------------------

--- a/src/msw/spinctrl.cpp
+++ b/src/msw/spinctrl.cpp
@@ -476,7 +476,7 @@ void  wxSpinCtrl::SetValue(int val)
                 (text[1] != 'x' && text[1] != 'X')) )
     {
         ::SetWindowText(GetBuddyHwnd(),
-                        wxPrivate::wxSpinCtrlFormatAsHex(val, m_max).t_str());
+                        wxSpinCtrlImpl::FormatAsHex(val, m_max).t_str());
     }
 
     m_oldValue = GetValue();
@@ -743,7 +743,7 @@ int wxSpinCtrl::GetOverlap() const
 
 wxSize wxSpinCtrl::DoGetBestSize() const
 {
-    return wxPrivate::wxSpinCtrlGetBestSize(this, GetMin(), GetMax(), GetBase());
+    return wxSpinCtrlImpl::GetBestSize(this, GetMin(), GetMax(), GetBase());
 }
 
 wxSize wxSpinCtrl::DoGetSizeFromTextSize(int xlen, int ylen) const

--- a/src/msw/spinctrl.cpp
+++ b/src/msw/spinctrl.cpp
@@ -35,6 +35,8 @@
     #include "wx/wxcrtvararg.h"
 #endif
 
+#include "wx/private/spinctrl.h"
+
 #include "wx/msw/private.h"
 #include "wx/msw/private/winstyle.h"
 


### PR DESCRIPTION
This works better (i.e. without leaving excess space for GTK 3) for me with both GTK 2 and 3 and seems reasonable, but I'd still be grateful if you could please look at these changes, Paul. TIA!