### PR TITLE
Control right after creation shouldn't become modified - this flag is…

### DIFF
--- a/src/richtext/richtextctrl.cpp
+++ b/src/richtext/richtextctrl.cpp
@@ -343,7 +343,7 @@ bool wxRichTextCtrl::Create( wxWindow* parent, wxWindowID id, const wxString& va
 #if wxUSE_DRAG_AND_DROP
     SetDropTarget(new wxRichTextDropTarget(this));
 #endif
-
+    SetModified( false );
     return true;
 }
 

--- a/tests/controls/richtextctrltest.cpp
+++ b/tests/controls/richtextctrltest.cpp
@@ -119,16 +119,9 @@ void RichTextCtrlTestCase::tearDown()
 
 void RichTextCtrlTestCase::Modify()
 {
-#if wxUSE_UIACTIONSIMULATOR
-    
-    // There seems to be an event sequence problem on GTK+ that causes the events
-    // to be disconnected before they're processed, generating spurious errors.
-#if !defined(__WXGTK__)
     CPPUNIT_ASSERT_EQUAL( false, m_rich->IsModified() );
     m_rich->WriteText("abcdef");
     CPPUNIT_ASSERT_EQUAL( true, m_rich->IsModified() );
-#endif
-#endif
 }
 
 void RichTextCtrlTestCase::CharacterEvent()

--- a/tests/controls/richtextctrltest.cpp
+++ b/tests/controls/richtextctrltest.cpp
@@ -34,6 +34,7 @@ public:
 
 private:
     CPPUNIT_TEST_SUITE( RichTextCtrlTestCase );
+        CPPUNIT_TEST( Modify );
         WXUISIM_TEST( CharacterEvent );
         WXUISIM_TEST( DeleteEvent );
         WXUISIM_TEST( ReturnEvent );
@@ -64,6 +65,7 @@ private:
         CPPUNIT_TEST( Table );
     CPPUNIT_TEST_SUITE_END();
 
+    void Modify();
     void CharacterEvent();
     void DeleteEvent();
     void ReturnEvent();
@@ -113,6 +115,22 @@ void RichTextCtrlTestCase::setUp()
 void RichTextCtrlTestCase::tearDown()
 {
     wxDELETE(m_rich);
+}
+
+void RichTextCtrlTestCase::Modify()
+{
+#if wxUSE_UIACTIONSIMULATOR
+    
+    // There seems to be an event sequence problem on GTK+ that causes the events
+    // to be disconnected before they're processed, generating spurious errors.
+#if !defined(__WXGTK__)
+    CPPUNIT_ASSERT_EQUAL( false, m_rich->IsModified() );
+    wxUIActionSimulator sim;
+    sim.Text("abcdef");
+    wxYield();
+    CPPUNIT_ASSERT_EQUAL( true, m_rich->IsModified() );
+#endif
+#endif
 }
 
 void RichTextCtrlTestCase::CharacterEvent()

--- a/tests/controls/richtextctrltest.cpp
+++ b/tests/controls/richtextctrltest.cpp
@@ -125,9 +125,7 @@ void RichTextCtrlTestCase::Modify()
     // to be disconnected before they're processed, generating spurious errors.
 #if !defined(__WXGTK__)
     CPPUNIT_ASSERT_EQUAL( false, m_rich->IsModified() );
-    wxUIActionSimulator sim;
-    sim.Text("abcdef");
-    wxYield();
+    m_rich->WriteText("abcdef");
     CPPUNIT_ASSERT_EQUAL( true, m_rich->IsModified() );
 #endif
 #endif


### PR DESCRIPTION
… for user action

This PR will take care of the ticket 11721.

It is very simple change.

Tested with ther following patch:

```diff
diff --git a/samples/richtext/richtext.cpp b/samples/richtext/richtext.cpp
index cc6582e576..d54ae9a1b8 100644
--- a/samples/richtext/richtext.cpp
+++ b/samples/richtext/richtext.cpp
@@ -930,6 +930,8 @@ MyFrame::MyFrame(const wxString& title, wxWindowID id, const wxPoint& pos,
     sizer->Add(splitter, 1, wxEXPAND);
 
     m_richTextCtrl = new MyRichTextCtrl(splitter, ID_RICHTEXT_CTRL, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxVSCROLL|wxHSCROLL/*|wxWANTS_CHARS*/);
+    if( m_richTextCtrl->IsModified() )
+        wxMessageBox( "Modified" );
     wxASSERT(!m_richTextCtrl->GetBuffer().GetAttributes().HasFontPixelSize());
 
     wxFont font(wxFontInfo(12).Family(wxFONTFAMILY_ROMAN));
```

Please review and apply.
