### PR TITLE
Take scrolling into account when resetting clipping in GTK 3

### DIFF
--- a/src/gtk/dc.cpp
+++ b/src/gtk/dc.cpp
@@ -355,7 +355,8 @@ void wxPaintDCImpl::DestroyClippingRegion()
     int x, y, w, h;
     m_clip.GetBox(x, y, w, h);
     cairo_t* cr = static_cast<cairo_t*>(GetCairoContext());
-    cairo_rectangle(cr, x, y, w, h);
+    cairo_rectangle(cr, DeviceToLogicalX(x), DeviceToLogicalY(y),
+                        DeviceToLogicalXRel(w), DeviceToLogicalYRel(h));
     cairo_clip(cr);
 }
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
The changes of 4697ce23d915852b75706a5e68e6de3fa351e417 didn't work if
the window was scrolled and prevented it from being properly redrawn.

Fix this by converting our device coordinates to logical ones before
passing them to Cairo.

See [#18560](http://trac.wxwidgets.org/ticket/18560).

Closes [#18584](https://trac.wxwidgets.org/ticket/18584).

---

Paul the fix works for me but I just don't understand why is it needed. It seems wrong that we don't do any coordinate conversion in `wxWindowGTK::GTKSendPaintEvents()` but do here. Yet, if we don't, nothing works and with it everything seems to work correctly. What am I missing?