### PR TITLE
MSW: Add manifest for ARM and ARM64

### DIFF
--- a/include/wx/msw/arm.manifest
+++ b/include/wx/msw/arm.manifest
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assemblyIdentity
+    version="0.64.1.0"
+    processorArchitecture="arm"
+    name="Controls"
+    type="win32"
+/>
+<description>wxWindows application</description>
+<dependency>
+    <dependentAssembly>
+        <assemblyIdentity
+            type="win32"
+            name="Microsoft.Windows.Common-Controls"
+            version="6.0.0.0"
+            processorArchitecture="arm"
+            publicKeyToken="6595b64144ccf1df"
+            language="*"
+        />
+    </dependentAssembly>
+</dependency>
+</assembly>

--- a/include/wx/msw/arm64.manifest
+++ b/include/wx/msw/arm64.manifest
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<assemblyIdentity
+    version="0.64.1.0"
+    processorArchitecture="arm64"
+    name="Controls"
+    type="win32"
+/>
+<description>wxWindows application</description>
+<dependency>
+    <dependentAssembly>
+        <assemblyIdentity
+            type="win32"
+            name="Microsoft.Windows.Common-Controls"
+            version="6.0.0.0"
+            processorArchitecture="arm64"
+            publicKeyToken="6595b64144ccf1df"
+            language="*"
+        />
+    </dependentAssembly>
+</dependency>
+</assembly>

--- a/include/wx/msw/genrcdefs.h
+++ b/include/wx/msw/genrcdefs.h
@@ -23,11 +23,11 @@ EMIT(#define wxUSE_RC_MANIFEST 1)
 EMIT(#define WX_CPU_AMD64)
 #endif
 
-#ifdef _M_ARM
+#if defined _M_ARM || defined __arm__
 EMIT(#define WX_CPU_ARM)
 #endif
 
-#ifdef _M_ARM64
+#if defined _M_ARM64 || defined __aarch64__
 EMIT(#define WX_CPU_ARM64)
 #endif
 

--- a/include/wx/msw/rcdefs.h
+++ b/include/wx/msw/rcdefs.h
@@ -31,6 +31,14 @@
         #ifndef WX_CPU_IA64
             #define WX_CPU_IA64
         #endif
+    #elif defined __arm__
+        #ifndef WX_CPU_ARM
+            #define WX_CPU_ARM
+        #endif
+    #elif defined __aarch64__
+        #ifndef WX_CPU_ARM64
+            #define WX_CPU_ARM64
+        #endif
     #endif
 #endif
 

--- a/include/wx/msw/wx.rc
+++ b/include/wx/msw/wx.rc
@@ -111,6 +111,10 @@ wxBITMAP_STD_COLOURS    BITMAP "wx/msw/colours.bmp"
     #define wxMANIFEST_CPU "ia64"
 #elif defined(WX_CPU_X86)
     #define wxMANIFEST_CPU "wx"
+#elif defined(WX_CPU_ARM)
+    #define wxMANIFEST_CPU "arm"
+#elif defined(WX_CPU_ARM64)
+    #define wxMANIFEST_CPU "arm64"
 #else
 // Notice that if the manifest is included, WX_CPU_XXX constant corresponding
 // to the architecture we're compiling for must be defined. This can be done


### PR DESCRIPTION
Also add __arm__ and __aarch64__ defines to support the LLVM/MinGW toolchain.