### PR TITLE
Return unique modes from wxDisplay::GetModes

### DIFF
--- a/build/cmake/samples/CMakeLists.txt
+++ b/build/cmake/samples/CMakeLists.txt
@@ -35,7 +35,7 @@ if(WXGTK2)
 endif()
 wx_add_sample(dialogs ${SAMPLE_DIALOGS_SRC} DATA tips.txt)
 wx_add_sample(dialup nettest.cpp LIBRARIES net DEPENDS wxUSE_DIALUP_MANAGER)
-wx_add_sample(display DEPENDS wxUSE_DISPLAY)
+wx_add_sample(display)
 wx_add_sample(dnd dnd.cpp RES dnd.rc DATA wxwin.png DEPENDS wxUSE_DRAG_AND_DROP)
 wx_add_sample(docview docview.cpp doc.cpp view.cpp docview.h doc.h view.h
     RES docview.rc LIBRARIES aui DEPENDS wxUSE_DOC_VIEW_ARCHITECTURE)

--- a/samples/display/display.cpp
+++ b/samples/display/display.cpp
@@ -299,7 +299,7 @@ void MyFrame::PopuplateWithDisplayInfo()
 
         // add it to another sizer to have borders around it and button below
         wxSizer *sizerTop = new wxBoxSizer(wxVERTICAL);
-        sizerTop->Add(sizer, 1, wxALL | wxEXPAND, 10);
+        sizerTop->Add(sizer, wxSizerFlags(1).Expand().DoubleBorder());
 
 #if wxUSE_DISPLAY
         wxChoice *choiceModes = new wxChoice(page, Display_ChangeMode);
@@ -312,16 +312,18 @@ void MyFrame::PopuplateWithDisplayInfo()
             choiceModes->Append(VideoModeToText(mode),
                                 new MyVideoModeClientData(mode));
         }
+        const wxString currentMode = VideoModeToText(display.GetCurrentMode());
+        choiceModes->SetStringSelection(currentMode);
 
-        sizer->Add(new wxStaticText(page, wxID_ANY, "&Modes: "));
-        sizer->Add(choiceModes, 0, wxEXPAND);
+        sizer->Add(new wxStaticText(page, wxID_ANY, "&Modes: "),
+                   wxSizerFlags().CentreVertical());
+        sizer->Add(choiceModes, wxSizerFlags().Expand());
 
         sizer->Add(new wxStaticText(page, wxID_ANY, "Current: "));
-        sizer->Add(new wxStaticText(page, Display_CurrentMode,
-                                    VideoModeToText(display.GetCurrentMode())));
+        sizer->Add(new wxStaticText(page, Display_CurrentMode, currentMode));
 
         sizerTop->Add(new wxButton(page, Display_ResetMode, "&Reset mode"),
-                      0, wxALL | wxCENTRE, 5);
+                      wxSizerFlags().Centre().Border());
 #endif // wxUSE_DISPLAY
 
         page->SetSizer(sizerTop);
@@ -331,6 +333,7 @@ void MyFrame::PopuplateWithDisplayInfo()
     }
 
     SetClientSize(m_book->GetBestSize());
+    SetMinSize(GetSize());
 }
 
 #if wxUSE_DISPLAY

--- a/samples/display/display.cpp
+++ b/samples/display/display.cpp
@@ -96,6 +96,7 @@ private:
     wxDECLARE_EVENT_TABLE();
 };
 
+#if wxUSE_DISPLAY
 // Client data class for the choice control containing the video modes
 class MyVideoModeClientData : public wxClientData
 {
@@ -104,6 +105,7 @@ public:
 
     const wxVideoMode mode;
 };
+#endif // wxUSE_DISPLAY
 
 // ----------------------------------------------------------------------------
 // constants

--- a/src/msw/display.cpp
+++ b/src/msw/display.cpp
@@ -390,6 +390,14 @@ wxArrayVideoModes wxDisplayMSW::GetModes(const wxVideoMode& modeMatch) const
           ::EnumDisplaySettings(deviceName, iModeNum, &dm);
           iModeNum++ )
     {
+        // Only care about the default display output, this prevents duplicate
+        // entries in the modes list.
+        if ( dm.dmFields & DM_DISPLAYFIXEDOUTPUT &&
+             dm.dmDisplayFixedOutput != DMDFO_DEFAULT )
+        {
+            continue;
+        }
+
         const wxVideoMode mode = ConvertToVideoMode(dm);
         if ( mode.Matches(modeMatch) )
         {


### PR DESCRIPTION
And some small changes to the display sample.

Some `wxVideoMode` are returned two or three times with the same resolution and depth. It is added multiple times for different `DM_DISPLAYFIXEDOUTPUT` values. https://docs.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-devmodea

Hopefully MinGW knows `DM_DISPLAYFIXEDOUTPUT` and `DMDFO_DEFAULT` as well.