### PR TITLE
Fix wxSpinCtrl arrow position in RTL layout and High DPI

### DIFF
--- a/src/msw/spinctrl.cpp
+++ b/src/msw/spinctrl.cpp
@@ -728,17 +728,9 @@ bool wxSpinCtrl::MSWOnNotify(int WXUNUSED(idCtrl), WXLPARAM lParam, WXLPARAM *re
 
 int wxSpinCtrl::GetOverlap() const
 {
-    if ( !GetHwnd() )
-    {
-        // We can be called from GetSizeFromTextSize() before the window is
-        // created and still need to return something reasonable in this case,
-        // so return the overlap equal to the default border size.
-        return FromDIP(2);
-    }
-
-    // The sign here is correct because the button is positioned inside its
-    // buddy window.
-    return wxGetWindowRect(m_hwndBuddy).right - wxGetWindowRect(GetHwnd()).left;
+    // Don't use FromDIP here. The gap between the control border and the
+    // button seems to be always 1px.
+    return 2;
 }
 
 wxSize wxSpinCtrl::DoGetBestSize() const


### PR DESCRIPTION
Subtracting positions does not work in RTL, and for LTR it will return the initially set `2`, so just use that.

<a href="https://user-images.githubusercontent.com/8088070/69385287-1ba05280-0cbf-11ea-81cc-326a56a5e1c0.png"><img src="https://user-images.githubusercontent.com/8088070/69385287-1ba05280-0cbf-11ea-81cc-326a56a5e1c0.png" width="300" alt="Before"/></a>  <a href="https://user-images.githubusercontent.com/8088070/69385289-1e9b4300-0cbf-11ea-9dcf-6d5d7c2bde57.png"><img src="https://user-images.githubusercontent.com/8088070/69385289-1e9b4300-0cbf-11ea-9dcf-6d5d7c2bde57.png" width="300" alt="After"/></a>

Also, using `FromDIP` should not be used, see the small glitch in the right control when moving the mouse over it:
![spin dpi](https://user-images.githubusercontent.com/8088070/69385316-37a3f400-0cbf-11ea-9878-c1d4baf77ef5.png)
