### PR TITLE
Improvements to boolean grid renderer/editor

### DIFF
--- a/include/wx/checkbox.h
+++ b/include/wx/checkbox.h
@@ -99,6 +99,11 @@ public:
 
     virtual bool HasTransparentBackground() wxOVERRIDE { return true; }
 
+    // This semi-private function is currently used to allow wxMSW checkbox to
+    // blend in with its parent background colour without changing the
+    // background colour of the checkbox itself under the other platforms.
+    virtual void SetTransparentPartColour(const wxColour& WXUNUSED(col)) { }
+
     // wxCheckBox-specific processing after processing the update event
     virtual void DoUpdateWindowUI(wxUpdateUIEvent& event) wxOVERRIDE
     {

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -15,6 +15,8 @@
 
 #if wxUSE_GRID
 
+#include "wx/headerctrl.h"
+
 // Internally used (and hence intentionally not exported) event telling wxGrid
 // to hide the currently shown editor.
 wxDECLARE_EVENT( wxEVT_GRID_HIDE_EDITOR, wxCommandEvent );

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -1007,12 +1007,16 @@ private:
     wxGridDataTypeInfoArray m_typeinfo;
 };
 
-// Returns the rect of the check box in a cell with the given alignmens
-// and the size.
-// The function is used by wxGridCellBoolEditor and wxGridCellBoolRenderer.
-wxRect wxGetGridCheckBoxRect(const wxSize& checkBoxSize,
-                             const wxRect& cellRect,
-                             int hAlign, int vAlign);
+// Returns the rectangle for showing a check box in a cell with the given
+// alignment.
+//
+// The function is used by wxGridCellBoolEditor and wxGridCellBoolRenderer to
+// draw a check mark and position wxCheckBox respectively.
+wxRect
+wxGetGridCheckBoxRect(wxWindow* win,
+                      const wxRect& cellRect,
+                      int hAlign,
+                      int vAlign);
 
 #endif // wxUSE_GRID
 #endif // _WX_GENERIC_GRID_PRIVATE_H_

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -1007,16 +1007,16 @@ private:
     wxGridDataTypeInfoArray m_typeinfo;
 };
 
-// Returns the rectangle for showing a check box in a cell with the given
-// alignment.
+// Returns the rectangle for showing something of the given size in a cell with
+// the given alignment.
 //
 // The function is used by wxGridCellBoolEditor and wxGridCellBoolRenderer to
 // draw a check mark and position wxCheckBox respectively.
 wxRect
-wxGetGridCheckBoxRect(wxWindow* win,
-                      const wxRect& cellRect,
-                      int hAlign,
-                      int vAlign);
+wxGetContentRect(wxSize contentSize,
+                 const wxRect& cellRect,
+                 int hAlign,
+                 int vAlign);
 
 #endif // wxUSE_GRID
 #endif // _WX_GENERIC_GRID_PRIVATE_H_

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -1007,5 +1007,12 @@ private:
     wxGridDataTypeInfoArray m_typeinfo;
 };
 
+// Returns the rect of the check box in a cell with the given alignmens
+// and the size.
+// The function is used by wxGridCellBoolEditor and wxGridCellBoolRenderer.
+wxRect wxGetGridCheckBoxRect(const wxSize& checkBoxSize,
+                             const wxRect& cellRect,
+                             int hAlign, int vAlign);
+
 #endif // wxUSE_GRID
 #endif // _WX_GENERIC_GRID_PRIVATE_H_

--- a/include/wx/msw/checkbox.h
+++ b/include/wx/msw/checkbox.h
@@ -45,6 +45,11 @@ public:
     // override some base class virtuals
     virtual void SetLabel(const wxString& label) wxOVERRIDE;
 
+    virtual void SetTransparentPartColour(const wxColour& col) wxOVERRIDE
+    {
+        SetBackgroundColour(col);
+    }
+
     virtual bool MSWCommand(WXUINT param, WXWORD id) wxOVERRIDE;
     virtual void Command(wxCommandEvent& event) wxOVERRIDE;
 

--- a/include/wx/renderer.h
+++ b/include/wx/renderer.h
@@ -259,7 +259,7 @@ public:
                                int flags = 0) = 0;
 
     // Returns the default size of a check box.
-    virtual wxSize GetCheckBoxSize(wxWindow *win) = 0;
+    virtual wxSize GetCheckBoxSize(wxWindow *win, int flags = 0) = 0;
 
     // Returns the default size of a check mark.
     virtual wxSize GetCheckMarkSize(wxWindow *win) = 0;
@@ -496,8 +496,8 @@ public:
                               int flags = 0) wxOVERRIDE
         { m_rendererNative.DrawCheckMark( win, dc, rect, flags ); }
 
-    virtual wxSize GetCheckBoxSize(wxWindow *win) wxOVERRIDE
-        { return m_rendererNative.GetCheckBoxSize(win); }
+    virtual wxSize GetCheckBoxSize(wxWindow *win, int flags = 0) wxOVERRIDE
+        { return m_rendererNative.GetCheckBoxSize(win, flags); }
 
     virtual wxSize GetCheckMarkSize(wxWindow *win) wxOVERRIDE
         { return m_rendererNative.GetCheckMarkSize(win); }

--- a/interface/wx/renderer.h
+++ b/interface/wx/renderer.h
@@ -237,7 +237,7 @@ public:
     virtual void DrawCheckMark(wxWindow *win, wxDC& dc,
                                const wxRect& rect, int flags = 0 );
 
-    virtual wxSize GetCheckBoxSize(wxWindow *win);
+    virtual wxSize GetCheckBoxSize(wxWindow *win, int flags = 0);
 
     virtual wxSize GetCheckMarkSize(wxWindow *win);
 
@@ -573,8 +573,13 @@ public:
 
         @param win A valid, i.e. non-null, window pointer which is used to get
             the theme defining the checkbox size under some platforms.
+
+        @param flags The only acceptable flag is @c wxCONTROL_CELL which means
+            that just the size of the checkbox itself is returned, without any
+            margins that are included by default. This parameter is only
+            available in wxWidgets 3.1.4 or later.
     */
-    virtual wxSize GetCheckBoxSize(wxWindow* win) = 0;
+    virtual wxSize GetCheckBoxSize(wxWindow* win, int flags = 0) = 0;
 
     /**
         Returns the size of a check mark.

--- a/samples/grid/griddemo.cpp
+++ b/samples/grid/griddemo.cpp
@@ -521,6 +521,10 @@ GridFrame::GridFrame()
     grid->SetCellEditor(3, 0, new wxGridCellBoolEditor);
     grid->SetCellBackgroundColour(3, 0, wxColour(255, 127, 127));
 
+    grid->SetCellRenderer(3, 1, new wxGridCellBoolRenderer);
+    grid->SetCellEditor(3, 1, new wxGridCellBoolEditor);
+    grid->SetCellValue(3, 1, "1");
+
     wxGridCellAttr *attr;
     attr = new wxGridCellAttr;
     attr->SetTextColour(*wxBLUE);

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -10332,13 +10332,17 @@ wxGridCellEditor* wxGridTypeRegistry::GetEditor(int index)
     return editor;
 }
 
-wxRect wxGetGridCheckBoxRect(const wxSize& checkBoxSize,
+wxRect wxGetGridCheckBoxRect(wxWindow* win,
                              const wxRect& cellRect,
-                             int hAlign, int WXUNUSED(vAlign))
+                             int hAlign,
+                             int WXUNUSED(vAlign))
 {
-    // TODO: support vAlign
+    const wxSize checkBoxSize =
+        wxRendererNative::Get().GetCheckBoxSize(win, wxCONTROL_CELL);
 
     wxRect checkBoxRect;
+
+    // TODO: support vAlign
     checkBoxRect.SetY(cellRect.y + cellRect.height / 2 - checkBoxSize.y / 2);
 
     wxCoord minSize = wxMin(cellRect.width, cellRect.height);

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -10335,7 +10335,7 @@ wxGridCellEditor* wxGridTypeRegistry::GetEditor(int index)
 wxRect wxGetGridCheckBoxRect(wxWindow* win,
                              const wxRect& cellRect,
                              int hAlign,
-                             int WXUNUSED(vAlign))
+                             int vAlign)
 {
     wxSize checkBoxSize =
         wxRendererNative::Get().GetCheckBoxSize(win, wxCONTROL_CELL);
@@ -10368,8 +10368,19 @@ wxRect wxGetGridCheckBoxRect(wxWindow* win,
         checkBoxRect.SetX(cellRect.x + GRID_CELL_CHECKBOX_MARGIN);
     }
 
-    // TODO: support vAlign
-    checkBoxRect = checkBoxRect.CentreIn(cellRect, wxVERTICAL);
+    if ( vAlign & wxALIGN_CENTER_VERTICAL )
+    {
+        checkBoxRect = checkBoxRect.CentreIn(cellRect, wxVERTICAL);
+    }
+    else if ( vAlign & wxALIGN_BOTTOM )
+    {
+        checkBoxRect.SetY(cellRect.y + cellRect.height
+                          - checkBoxRect.y - GRID_CELL_CHECKBOX_MARGIN);
+    }
+    else // wxALIGN_TOP
+    {
+        checkBoxRect.SetY(cellRect.y + GRID_CELL_CHECKBOX_MARGIN);
+    }
 
     return checkBoxRect;
 }

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -10332,57 +10332,55 @@ wxGridCellEditor* wxGridTypeRegistry::GetEditor(int index)
     return editor;
 }
 
-wxRect wxGetGridCheckBoxRect(wxWindow* win,
-                             const wxRect& cellRect,
-                             int hAlign,
-                             int vAlign)
+wxRect
+wxGetContentRect(wxSize contentSize,
+                 const wxRect& cellRect,
+                 int hAlign,
+                 int vAlign)
 {
-    wxSize checkBoxSize =
-        wxRendererNative::Get().GetCheckBoxSize(win, wxCONTROL_CELL);
-
     // Keep square aspect ratio for the checkbox, but ensure that it fits into
     // the available space, even if it's smaller than the standard size.
     const wxCoord minSize = wxMin(cellRect.width, cellRect.height);
-    if ( checkBoxSize.x >= minSize || checkBoxSize.y >= minSize )
+    if ( contentSize.x >= minSize || contentSize.y >= minSize )
     {
         // It must still have positive size, however.
         const int fittingSize = wxMax(1, minSize - 2*GRID_CELL_CHECKBOX_MARGIN);
 
-        checkBoxSize.x =
-        checkBoxSize.y = fittingSize;
+        contentSize.x =
+        contentSize.y = fittingSize;
     }
 
-    wxRect checkBoxRect(checkBoxSize);
+    wxRect contentRect(contentSize);
 
     if ( hAlign & wxALIGN_CENTER_HORIZONTAL )
     {
-        checkBoxRect = checkBoxRect.CentreIn(cellRect, wxHORIZONTAL);
+        contentRect = contentRect.CentreIn(cellRect, wxHORIZONTAL);
     }
     else if ( hAlign & wxALIGN_RIGHT )
     {
-        checkBoxRect.SetX(cellRect.x + cellRect.width
-                          - checkBoxSize.x - GRID_CELL_CHECKBOX_MARGIN);
+        contentRect.SetX(cellRect.x + cellRect.width
+                          - contentSize.x - GRID_CELL_CHECKBOX_MARGIN);
     }
     else // ( hAlign == wxALIGN_LEFT ) and invalid alignment value
     {
-        checkBoxRect.SetX(cellRect.x + GRID_CELL_CHECKBOX_MARGIN);
+        contentRect.SetX(cellRect.x + GRID_CELL_CHECKBOX_MARGIN);
     }
 
     if ( vAlign & wxALIGN_CENTER_VERTICAL )
     {
-        checkBoxRect = checkBoxRect.CentreIn(cellRect, wxVERTICAL);
+        contentRect = contentRect.CentreIn(cellRect, wxVERTICAL);
     }
     else if ( vAlign & wxALIGN_BOTTOM )
     {
-        checkBoxRect.SetY(cellRect.y + cellRect.height
-                          - checkBoxRect.y - GRID_CELL_CHECKBOX_MARGIN);
+        contentRect.SetY(cellRect.y + cellRect.height
+                          - contentRect.y - GRID_CELL_CHECKBOX_MARGIN);
     }
     else // wxALIGN_TOP
     {
-        checkBoxRect.SetY(cellRect.y + GRID_CELL_CHECKBOX_MARGIN);
+        contentRect.SetY(cellRect.y + GRID_CELL_CHECKBOX_MARGIN);
     }
 
-    return checkBoxRect;
+    return contentRect;
 }
 
 #endif // wxUSE_GRID

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -112,7 +112,7 @@ const int GRID_HASH_SIZE = 100;
 const int DRAG_SENSITIVITY = 3;
 
 // the space between the cell edge and the checkbox mark
-const int GRID_CELL_CHECKBOX_MARGIN_X = 2;
+const int GRID_CELL_CHECKBOX_MARGIN = 2;
 
 } // anonymous namespace
 
@@ -10366,11 +10366,11 @@ wxRect wxGetGridCheckBoxRect(wxWindow* win,
     else if ( hAlign & wxALIGN_RIGHT )
     {
         checkBoxRect.SetX(cellRect.x + cellRect.width
-                          - checkBoxSize.x - GRID_CELL_CHECKBOX_MARGIN_X);
+                          - checkBoxSize.x - GRID_CELL_CHECKBOX_MARGIN);
     }
     else // ( hAlign == wxALIGN_LEFT ) and invalid alignment value
     {
-        checkBoxRect.SetX(cellRect.x + GRID_CELL_CHECKBOX_MARGIN_X);
+        checkBoxRect.SetX(cellRect.x + GRID_CELL_CHECKBOX_MARGIN);
     }
 
     return checkBoxRect;

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -10356,7 +10356,7 @@ wxRect wxGetGridCheckBoxRect(wxWindow* win,
 
     if ( hAlign & wxALIGN_CENTER_HORIZONTAL )
     {
-        checkBoxRect.SetX(cellRect.x + cellRect.width / 2 - checkBoxSize.x / 2);
+        checkBoxRect = checkBoxRect.CentreIn(cellRect, wxHORIZONTAL);
     }
     else if ( hAlign & wxALIGN_RIGHT )
     {
@@ -10369,7 +10369,7 @@ wxRect wxGetGridCheckBoxRect(wxWindow* win,
     }
 
     // TODO: support vAlign
-    checkBoxRect.SetY(cellRect.y + cellRect.height / 2 - checkBoxSize.y / 2);
+    checkBoxRect = checkBoxRect.CentreIn(cellRect, wxVERTICAL);
 
     return checkBoxRect;
 }

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -10337,27 +10337,22 @@ wxRect wxGetGridCheckBoxRect(wxWindow* win,
                              int hAlign,
                              int WXUNUSED(vAlign))
 {
-    const wxSize checkBoxSize =
+    wxSize checkBoxSize =
         wxRendererNative::Get().GetCheckBoxSize(win, wxCONTROL_CELL);
 
-    wxRect checkBoxRect;
-
-    // TODO: support vAlign
-    checkBoxRect.SetY(cellRect.y + cellRect.height / 2 - checkBoxSize.y / 2);
-
-    wxCoord minSize = wxMin(cellRect.width, cellRect.height);
-    if ( checkBoxRect.GetWidth() >= minSize || checkBoxRect.GetHeight() >= minSize )
+    // Keep square aspect ratio for the checkbox, but ensure that it fits into
+    // the available space, even if it's smaller than the standard size.
+    const wxCoord minSize = wxMin(cellRect.width, cellRect.height);
+    if ( checkBoxSize.x >= minSize || checkBoxSize.y >= minSize )
     {
-        // let the checkbox mark be even smaller than the min size
-        // to leave some space between cell edges and the checkbox
-        const int newSize = wxMax(1, minSize - 2);
-        checkBoxRect.SetWidth(newSize);
-        checkBoxRect.SetHeight(newSize);
+        // It must still have positive size, however.
+        const int fittingSize = wxMax(1, minSize - 2*GRID_CELL_CHECKBOX_MARGIN);
+
+        checkBoxSize.x =
+        checkBoxSize.y = fittingSize;
     }
-    else
-    {
-        checkBoxRect.SetSize(checkBoxSize);
-    }
+
+    wxRect checkBoxRect(checkBoxSize);
 
     if ( hAlign & wxALIGN_CENTER_HORIZONTAL )
     {
@@ -10372,6 +10367,9 @@ wxRect wxGetGridCheckBoxRect(wxWindow* win,
     {
         checkBoxRect.SetX(cellRect.x + GRID_CELL_CHECKBOX_MARGIN);
     }
+
+    // TODO: support vAlign
+    checkBoxRect.SetY(cellRect.y + cellRect.height / 2 - checkBoxSize.y / 2);
 
     return checkBoxRect;
 }

--- a/src/generic/gridctrl.cpp
+++ b/src/generic/gridctrl.cpp
@@ -953,8 +953,9 @@ void wxGridCellBoolRenderer::Draw(wxGrid& grid,
 {
     wxGridCellRenderer::Draw(grid, attr, dc, rect, row, col, isSelected);
 
-    int vAlign, hAlign;
-    attr.GetAlignment(&hAlign, &vAlign);
+    int hAlign = wxALIGN_LEFT;
+    int vAlign = wxALIGN_CENTRE_VERTICAL;
+    attr.GetNonDefaultAlignment(&hAlign, &vAlign);
 
     const wxRect
         checkBoxRect = wxGetGridCheckBoxRect

--- a/src/generic/gridctrl.cpp
+++ b/src/generic/gridctrl.cpp
@@ -937,11 +937,8 @@ wxSize wxGridCellBoolRenderer::GetBestSize(wxGrid& grid,
     // compute it only once (no locks for MT safeness in GUI thread...)
     if ( !ms_sizeCheckMark.x )
     {
-        // Use rectangle big enough for the check box to fit into it.
-        const wxRect r(0, 0, 1000, 1000);
-
         ms_sizeCheckMark =
-            wxGetGridCheckBoxRect(&grid, r, wxALIGN_LEFT, wxALIGN_TOP).GetSize();
+            wxRendererNative::Get().GetCheckBoxSize(&grid, wxCONTROL_CELL);
     }
 
     return ms_sizeCheckMark;
@@ -960,8 +957,9 @@ void wxGridCellBoolRenderer::Draw(wxGrid& grid,
     int vAlign = wxALIGN_CENTRE_VERTICAL;
     attr.GetNonDefaultAlignment(&hAlign, &vAlign);
 
-    const wxRect
-        checkBoxRect = wxGetGridCheckBoxRect(&grid, rect, hAlign, vAlign);
+    const wxRect checkBoxRect =
+        wxGetContentRect(GetBestSize(grid, attr, dc, row, col),
+                         rect, hAlign, vAlign);
 
     bool value;
     if ( grid.GetTable()->CanGetValueAs(row, col, wxGRID_VALUE_BOOL) )

--- a/src/generic/gridctrl.cpp
+++ b/src/generic/gridctrl.cpp
@@ -937,8 +937,11 @@ wxSize wxGridCellBoolRenderer::GetBestSize(wxGrid& grid,
     // compute it only once (no locks for MT safeness in GUI thread...)
     if ( !ms_sizeCheckMark.x )
     {
+        // Use rectangle big enough for the check box to fit into it.
+        const wxRect r(0, 0, 1000, 1000);
+
         ms_sizeCheckMark =
-            wxRendererNative::Get().GetCheckBoxSize(&grid, wxCONTROL_CELL);
+            wxGetGridCheckBoxRect(&grid, r, wxALIGN_LEFT, wxALIGN_TOP).GetSize();
     }
 
     return ms_sizeCheckMark;
@@ -958,12 +961,7 @@ void wxGridCellBoolRenderer::Draw(wxGrid& grid,
     attr.GetNonDefaultAlignment(&hAlign, &vAlign);
 
     const wxRect
-        checkBoxRect = wxGetGridCheckBoxRect
-                       (
-                            GetBestSize(grid, attr, dc, row, col),
-                            rect,
-                            hAlign, vAlign
-                        );
+        checkBoxRect = wxGetGridCheckBoxRect(&grid, rect, hAlign, vAlign);
 
     bool value;
     if ( grid.GetTable()->CanGetValueAs(row, col, wxGRID_VALUE_BOOL) )

--- a/src/generic/gridctrl.cpp
+++ b/src/generic/gridctrl.cpp
@@ -31,6 +31,7 @@
 #include "wx/tokenzr.h"
 #include "wx/renderer.h"
 
+#include "wx/generic/private/grid.h"
 
 // ----------------------------------------------------------------------------
 // wxGridCellRenderer
@@ -936,7 +937,8 @@ wxSize wxGridCellBoolRenderer::GetBestSize(wxGrid& grid,
     // compute it only once (no locks for MT safeness in GUI thread...)
     if ( !ms_sizeCheckMark.x )
     {
-        ms_sizeCheckMark = wxRendererNative::Get().GetCheckBoxSize(&grid);
+        ms_sizeCheckMark =
+            wxRendererNative::Get().GetCheckBoxSize(&grid, wxCONTROL_CELL);
     }
 
     return ms_sizeCheckMark;
@@ -951,43 +953,16 @@ void wxGridCellBoolRenderer::Draw(wxGrid& grid,
 {
     wxGridCellRenderer::Draw(grid, attr, dc, rect, row, col, isSelected);
 
-    // draw a check mark in the centre (ignoring alignment - TODO)
-    wxSize size = GetBestSize(grid, attr, dc, row, col);
-
-    // don't draw outside the cell
-    wxCoord minSize = wxMin(rect.width, rect.height);
-    if ( size.x >= minSize || size.y >= minSize )
-    {
-        // and even leave (at least) 1 pixel margin
-        size.x = size.y = minSize;
-    }
-
-    // draw a border around checkmark
     int vAlign, hAlign;
     attr.GetAlignment(&hAlign, &vAlign);
 
-    wxRect rectBorder;
-    if (hAlign == wxALIGN_CENTRE)
-    {
-        rectBorder.x = rect.x + rect.width / 2 - size.x / 2;
-        rectBorder.y = rect.y + rect.height / 2 - size.y / 2;
-        rectBorder.width = size.x;
-        rectBorder.height = size.y;
-    }
-    else if (hAlign == wxALIGN_LEFT)
-    {
-        rectBorder.x = rect.x + 2;
-        rectBorder.y = rect.y + rect.height / 2 - size.y / 2;
-        rectBorder.width = size.x;
-        rectBorder.height = size.y;
-    }
-    else if (hAlign == wxALIGN_RIGHT)
-    {
-        rectBorder.x = rect.x + rect.width - size.x - 2;
-        rectBorder.y = rect.y + rect.height / 2 - size.y / 2;
-        rectBorder.width = size.x;
-        rectBorder.height = size.y;
-    }
+    const wxRect
+        checkBoxRect = wxGetGridCheckBoxRect
+                       (
+                            GetBestSize(grid, attr, dc, row, col),
+                            rect,
+                            hAlign, vAlign
+                        );
 
     bool value;
     if ( grid.GetTable()->CanGetValueAs(row, col, wxGRID_VALUE_BOOL) )
@@ -1000,11 +975,11 @@ void wxGridCellBoolRenderer::Draw(wxGrid& grid,
         value = wxGridCellBoolEditor::IsTrueValue(cellval);
     }
 
-    int flags = 0;
+    int flags = wxCONTROL_CELL;
     if (value)
         flags |= wxCONTROL_CHECKED;
 
-    wxRendererNative::Get().DrawCheckBox( &grid, dc, rectBorder, flags );
+    wxRendererNative::Get().DrawCheckBox( &grid, dc, checkBoxRect, flags );
 }
 
 #endif // wxUSE_GRID

--- a/src/generic/grideditors.cpp
+++ b/src/generic/grideditors.cpp
@@ -1218,10 +1218,10 @@ void wxGridCellBoolEditor::Create(wxWindow* parent,
 
 void wxGridCellBoolEditor::SetSize(const wxRect& r)
 {
-    int hAlign = wxALIGN_CENTRE;
-    int vAlign = wxALIGN_CENTRE;
+    int hAlign = wxALIGN_LEFT;
+    int vAlign = wxALIGN_CENTRE_VERTICAL;
     if (GetCellAttr())
-        GetCellAttr()->GetAlignment(& hAlign, & vAlign);
+        GetCellAttr()->GetNonDefaultAlignment(&hAlign, &vAlign);
 
     const wxRect
         checkBoxRect = wxGetGridCheckBoxRect

--- a/src/generic/grideditors.cpp
+++ b/src/generic/grideditors.cpp
@@ -37,7 +37,6 @@
 #include "wx/spinctrl.h"
 #include "wx/tokenzr.h"
 #include "wx/renderer.h"
-#include "wx/headerctrl.h"
 #include "wx/datectrl.h"
 
 #include "wx/generic/gridsel.h"

--- a/src/generic/grideditors.cpp
+++ b/src/generic/grideditors.cpp
@@ -1240,10 +1240,33 @@ void wxGridCellBoolEditor::Show(bool show, wxGridCellAttr *attr)
 {
     m_control->Show(show);
 
+    // Under MSW we need to set the checkbox background colour to the same
+    // colour as is used by the cell in order for it to blend in, but using
+    // just SetBackgroundColour() would be wrong as this would actually change
+    // the background of the checkbox with e.g. GTK 3, making it unusable in
+    // any theme where the check mark colour is the same, or close to, our
+    // background colour -- which happens to be the case for the default GTK 3
+    // theme, making this a rather serious problem.
+    //
+    // One possible workaround would be to set the foreground colour too, but
+    // wxRendererNative methods used in wxGridCellBoolRenderer don't currently
+    // take the colours into account, so this would mean that starting to edit
+    // a boolean field would change its colours, which would be jarring (and
+    // especially so as we currently set custom colours for all cells, not just
+    // those that really need them).
+    //
+    // A more portable solution could be to create a parent window using the
+    // background colour if it's different from the default and reparent the
+    // checkbox under it, so that the parent window colour showed through the
+    // transparent parts of the checkbox, but this would be more complicated
+    // for no real gain in practice.
+    //
+    // So, finally, just use the bespoke function that will change the
+    // background under MSW, but doesn't do anything elsewhere.
     if ( show )
     {
         wxColour colBg = attr ? attr->GetBackgroundColour() : *wxLIGHT_GREY;
-        CBox()->SetBackgroundColour(colBg);
+        CBox()->SetTransparentPartColour(colBg);
     }
 }
 

--- a/src/generic/grideditors.cpp
+++ b/src/generic/grideditors.cpp
@@ -1224,13 +1224,7 @@ void wxGridCellBoolEditor::SetSize(const wxRect& r)
         GetCellAttr()->GetNonDefaultAlignment(&hAlign, &vAlign);
 
     const wxRect
-        checkBoxRect = wxGetGridCheckBoxRect
-                       (
-                            wxRendererNative::Get().
-                                GetCheckBoxSize(GetWindow(), wxCONTROL_CELL),
-                            r,
-                            hAlign, vAlign
-                       );
+        checkBoxRect = wxGetGridCheckBoxRect(GetWindow(), r, hAlign, vAlign);
 
     // resize the control if required
     if ( m_control->GetSize() != checkBoxRect.GetSize() )

--- a/src/generic/grideditors.cpp
+++ b/src/generic/grideditors.cpp
@@ -1223,16 +1223,11 @@ void wxGridCellBoolEditor::SetSize(const wxRect& r)
     if (GetCellAttr())
         GetCellAttr()->GetNonDefaultAlignment(&hAlign, &vAlign);
 
-    const wxRect
-        checkBoxRect = wxGetGridCheckBoxRect(GetWindow(), r, hAlign, vAlign);
+    const wxRect checkBoxRect =
+        wxGetContentRect(m_control->GetSize(), r, hAlign, vAlign);
 
-    // resize the control if required
-    if ( m_control->GetSize() != checkBoxRect.GetSize() )
-    {
-        m_control->SetSize(checkBoxRect.GetSize());
-    }
-
-    // and move it
+    // Don't resize the checkbox, it should have its default (and fitting)
+    // size, but do move it to the right position.
     m_control->Move(checkBoxRect.GetPosition());
 }
 

--- a/src/generic/renderg.cpp
+++ b/src/generic/renderg.cpp
@@ -111,7 +111,7 @@ public:
                                const wxRect& rect,
                                int flags = 0) wxOVERRIDE;
 
-    virtual wxSize GetCheckBoxSize(wxWindow *win) wxOVERRIDE;
+    virtual wxSize GetCheckBoxSize(wxWindow *win, int flags = 0) wxOVERRIDE;
 
     virtual wxSize GetCheckMarkSize(wxWindow *win) wxOVERRIDE;
 
@@ -731,7 +731,7 @@ wxRendererGeneric::DrawCheckMark(wxWindow *WXUNUSED(win),
     dc.DrawCheckMark(rect);
 }
 
-wxSize wxRendererGeneric::GetCheckBoxSize(wxWindow *win)
+wxSize wxRendererGeneric::GetCheckBoxSize(wxWindow *win, int WXUNUSED(flags))
 {
     wxCHECK_MSG( win, wxSize(0, 0), "Must have a valid window" );
 
@@ -740,7 +740,7 @@ wxSize wxRendererGeneric::GetCheckBoxSize(wxWindow *win)
 
 wxSize wxRendererGeneric::GetCheckMarkSize(wxWindow *win)
 {
-    return GetCheckBoxSize(win);
+    return GetCheckBoxSize(win, wxCONTROL_CELL);
 }
 
 wxSize wxRendererGeneric::GetExpanderSize(wxWindow *win)

--- a/src/gtk/checkbox.cpp
+++ b/src/gtk/checkbox.cpp
@@ -156,7 +156,21 @@ bool wxCheckBox::Create(wxWindow *parent,
 
     m_parent->DoAddChild( this );
 
+#ifdef __WXGTK3__
+    // CSS added if the window has wxNO_BORDER inside base class PostCreation()
+    // makes checkbox look broken in the default GTK 3 theme, so avoid doing
+    // this by temporarily turning this flag off.
+    if ( style & wxNO_BORDER )
+        ToggleWindowStyle(wxNO_BORDER);
+#endif
+
     PostCreation(size);
+
+#ifdef __WXGTK3__
+    // Turn it back on if necessary.
+    if ( style & wxNO_BORDER )
+        ToggleWindowStyle(wxNO_BORDER);
+#endif
 
     return true;
 }

--- a/src/gtk/checkbox.cpp
+++ b/src/gtk/checkbox.cpp
@@ -146,6 +146,11 @@ bool wxCheckBox::Create(wxWindow *parent,
     g_object_ref(m_widget);
     SetLabel( label );
 
+    if ( style & wxNO_BORDER )
+    {
+        gtk_container_set_border_width(GTK_CONTAINER(m_widgetCheckbox), 0);
+    }
+
     g_signal_connect (m_widgetCheckbox, "toggled",
                       G_CALLBACK (gtk_checkbox_toggled_callback), this);
 

--- a/src/gtk/renderer.cpp
+++ b/src/gtk/renderer.cpp
@@ -620,7 +620,7 @@ wxRendererGTK::GetCheckBoxSize(wxWindow* win, int flags)
     }
 
     size.y = size.x;
-#endif // !__WXGTK3__
+#endif // __WXGTK3__/!__WXGTK3__
 
     return size;
 }
@@ -631,38 +631,6 @@ wxRendererGTK::DrawCheckBox(wxWindow*,
                             const wxRect& rect,
                             int flags )
 {
-#ifndef __WXGTK3__
-    GtkWidget *button = wxGTKPrivate::GetCheckButtonWidget();
-
-    gint indicator_size, indicator_spacing, focus_width, focus_pad;
-    gtk_widget_style_get(button,
-                         "indicator_size", &indicator_size,
-                         "indicator_spacing", &indicator_spacing,
-                         "focus-line-width", &focus_width,
-                         "focus-padding", &focus_pad,
-                         NULL);
-
-    GtkStateType state;
-
-    if ( flags & wxCONTROL_PRESSED )
-        state = GTK_STATE_ACTIVE;
-    else if ( flags & wxCONTROL_DISABLED )
-        state = GTK_STATE_INSENSITIVE;
-    else if ( flags & wxCONTROL_CURRENT )
-        state = GTK_STATE_PRELIGHT;
-    else
-        state = GTK_STATE_NORMAL;
-
-    GtkShadowType shadow_type;
-
-    if ( flags & wxCONTROL_UNDETERMINED )
-        shadow_type = GTK_SHADOW_ETCHED_IN;
-    else if ( flags & wxCONTROL_CHECKED )
-        shadow_type = GTK_SHADOW_IN;
-    else
-        shadow_type = GTK_SHADOW_OUT;
-#endif
-
 #ifdef __WXGTK3__
     cairo_t* cr = wxGetGTKDrawable(dc);
     if (cr == NULL)
@@ -723,7 +691,37 @@ wxRendererGTK::DrawCheckBox(wxWindow*,
         gtk_render_check(sc, cr, x, y, w, h);
         gtk_style_context_restore(sc);
     }
-#else
+#else // !__WXGTK3__
+    GtkWidget *button = wxGTKPrivate::GetCheckButtonWidget();
+
+    gint indicator_size, indicator_spacing, focus_width, focus_pad;
+    gtk_widget_style_get(button,
+                         "indicator_size", &indicator_size,
+                         "indicator_spacing", &indicator_spacing,
+                         "focus-line-width", &focus_width,
+                         "focus-padding", &focus_pad,
+                         NULL);
+
+    GtkStateType state;
+
+    if ( flags & wxCONTROL_PRESSED )
+        state = GTK_STATE_ACTIVE;
+    else if ( flags & wxCONTROL_DISABLED )
+        state = GTK_STATE_INSENSITIVE;
+    else if ( flags & wxCONTROL_CURRENT )
+        state = GTK_STATE_PRELIGHT;
+    else
+        state = GTK_STATE_NORMAL;
+
+    GtkShadowType shadow_type;
+
+    if ( flags & wxCONTROL_UNDETERMINED )
+        shadow_type = GTK_SHADOW_ETCHED_IN;
+    else if ( flags & wxCONTROL_CHECKED )
+        shadow_type = GTK_SHADOW_IN;
+    else
+        shadow_type = GTK_SHADOW_OUT;
+
     GdkWindow* gdk_window = wxGetGTKDrawable(dc);
     if (gdk_window == NULL)
         return;
@@ -751,7 +749,7 @@ wxRendererGTK::DrawCheckBox(wxWindow*,
         dc.LogicalToDeviceY(rect.y) + (rect.height - indicator_size) / 2,
         indicator_size, indicator_size
     );
-#endif
+#endif // __WXGTK3__/!__WXGTK3__
 }
 
 void

--- a/src/gtk/renderer.cpp
+++ b/src/gtk/renderer.cpp
@@ -633,6 +633,35 @@ struct CheckBoxInfo
     }
 #endif // __WXGTK3__/!__WXGTK3__
 
+    // Make sure we fit into the provided rectangle, eliminating margins and
+    // even reducing the size if necessary.
+    void FitInto(const wxRect& rect)
+    {
+        if ( indicator_width > rect.width )
+        {
+            indicator_width = rect.width;
+            margin_left =
+            margin_right = 0;
+        }
+        else if ( indicator_width + margin_left + margin_right > rect.width )
+        {
+            margin_left =
+            margin_right = (rect.width - indicator_width) / 2;
+        }
+
+        if ( indicator_height > rect.height )
+        {
+            indicator_height = rect.height;
+            margin_top =
+            margin_bottom = 0;
+        }
+        else if ( indicator_height + margin_top + margin_bottom > rect.height )
+        {
+            margin_top =
+            margin_bottom = (rect.height - indicator_height) / 2;
+        }
+    }
+
     gint indicator_width,
          indicator_height;
     gint margin_left,
@@ -695,7 +724,8 @@ wxRendererGTK::DrawCheckBox(wxWindow*,
 
     wxGtkStyleContext sc(dc.GetContentScaleFactor());
 
-    const CheckBoxInfo info(sc, flags);
+    CheckBoxInfo info(sc, flags);
+    info.FitInto(rect);
 
     const int w = info.indicator_width + info.margin_left + info.margin_right;
     const int h = info.indicator_height + info.margin_top + info.margin_bottom;
@@ -728,7 +758,8 @@ wxRendererGTK::DrawCheckBox(wxWindow*,
 #else // !__WXGTK3__
     GtkWidget* button = wxGTKPrivate::GetCheckButtonWidget();
 
-    const CheckBoxInfo info(button, flags);
+    CheckBoxInfo info(button, flags);
+    info.FitInto(rect);
 
     GtkStateType state;
 

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -162,7 +162,7 @@ public:
                                     wxTitleBarButton button,
                                     int flags = 0) wxOVERRIDE;
 
-    virtual wxSize GetCheckBoxSize(wxWindow *win) wxOVERRIDE;
+    virtual wxSize GetCheckBoxSize(wxWindow *win, int flags = 0) wxOVERRIDE;
 
     virtual int GetHeaderButtonHeight(wxWindow *win) wxOVERRIDE;
 
@@ -288,7 +288,7 @@ public:
                                     wxTitleBarButton button,
                                     int flags = 0) wxOVERRIDE;
 
-    virtual wxSize GetCheckBoxSize(wxWindow *win) wxOVERRIDE;
+    virtual wxSize GetCheckBoxSize(wxWindow *win, int flags = 0) wxOVERRIDE;
 
     virtual wxSize GetCheckMarkSize(wxWindow* win) wxOVERRIDE;
 
@@ -548,7 +548,7 @@ wxRendererMSW::DrawTitleBarBitmap(wxWindow *win,
     DoDrawFrameControl(DFC_CAPTION, kind, win, dc, rect, flags);
 }
 
-wxSize wxRendererMSW::GetCheckBoxSize(wxWindow* win)
+wxSize wxRendererMSW::GetCheckBoxSize(wxWindow* win, int WXUNUSED(flags))
 {
     // We must have a valid window in order to return the size which is correct
     // for the display this window is on.
@@ -893,7 +893,7 @@ wxRendererXP::DrawTitleBarBitmap(wxWindow *win,
     DoDrawButtonLike(hTheme, part, dc, rect, flags);
 }
 
-wxSize wxRendererXP::GetCheckBoxSize(wxWindow* win)
+wxSize wxRendererXP::GetCheckBoxSize(wxWindow* win, int flags)
 {
     wxCHECK_MSG( win, wxSize(0, 0), "Must have a valid window" );
 
@@ -907,7 +907,7 @@ wxSize wxRendererXP::GetCheckBoxSize(wxWindow* win)
                 return wxSize(checkSize.cx, checkSize.cy);
         }
     }
-    return m_rendererNative.GetCheckBoxSize(win);
+    return m_rendererNative.GetCheckBoxSize(win, flags);
 }
 
 wxSize wxRendererXP::GetCheckMarkSize(wxWindow* win)

--- a/src/osx/carbon/renderer.cpp
+++ b/src/osx/carbon/renderer.cpp
@@ -90,7 +90,7 @@ public:
                               const wxRect& rect,
                               int flags = 0) wxOVERRIDE;
 
-    virtual wxSize GetCheckBoxSize(wxWindow* win) wxOVERRIDE;
+    virtual wxSize GetCheckBoxSize(wxWindow* win, int flags = 0) wxOVERRIDE;
 
     virtual void DrawComboBoxDropButton(wxWindow *win,
                                         wxDC& dc,
@@ -491,7 +491,7 @@ wxRendererMac::DrawCheckBox(wxWindow *win,
                        kind, kThemeAdornmentNone);
 }
 
-wxSize wxRendererMac::GetCheckBoxSize(wxWindow* win)
+wxSize wxRendererMac::GetCheckBoxSize(wxWindow* win, int WXUNUSED(flags))
 {
     // Even though we don't use the window in this implementation, still check
     // that it's valid to avoid surprises when running the same code under the


### PR DESCRIPTION
In particular, make sure that the checkbox drawn by the renderer is positioned at exactly the same place as the actual checkbox shown when editing starts to avoid jarring jumps when starting/finishing editing boolean cells in the grid.