### PR TITLE
Fix wxGridCellAttr::GetNonDefaultAlignment() for invalid inputs

### DIFF
--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -835,13 +835,31 @@ void GridTestCase::GetNonDefaultAlignment()
     // preferred alignment, so check that if we don't reset the alignment
     // explicitly, it doesn't override the alignment used by default.
     wxGridCellAttr* attr = NULL;
-    int align = wxALIGN_RIGHT;
+    int hAlign = wxALIGN_RIGHT,
+        vAlign = wxALIGN_INVALID;
 
     attr = m_grid->CallGetCellAttr(0, 0);
     REQUIRE( attr );
 
-    attr->GetNonDefaultAlignment(&align, NULL);
-    CHECK( align == wxALIGN_RIGHT );
+    // Check that the specified alignment is preserved, while the unspecified
+    // component is filled with the default value (which is "top" by default).
+    attr->GetNonDefaultAlignment(&hAlign, &vAlign);
+    CHECK( hAlign == wxALIGN_RIGHT );
+    CHECK( vAlign == wxALIGN_TOP );
+
+    // Now change the defaults and check that the unspecified alignment
+    // component is filled with the new default.
+    m_grid->SetDefaultCellAlignment(wxALIGN_CENTRE_HORIZONTAL,
+                                    wxALIGN_CENTRE_VERTICAL);
+
+    vAlign = wxALIGN_INVALID;
+
+    attr = m_grid->CallGetCellAttr(0, 0);
+    REQUIRE( attr );
+
+    attr->GetNonDefaultAlignment(&hAlign, &vAlign);
+    CHECK( hAlign == wxALIGN_RIGHT );
+    CHECK( vAlign == wxALIGN_CENTRE_VERTICAL );
 }
 
 void GridTestCase::Editable()


### PR DESCRIPTION
The recent change of 19844d27acf8177b721e77d3ee696286ae6567ab fixed this
function for valid values of input/output parameters on input, but broke
it if the parameters had invalid value: in this case, we still need to
fill them even if this attribute doesn't have any specific alignment of
its own.

Account for this case too now, explain the logic of this function in the
comments inside it and extend the unit test to check for this case too.

Now the function should really conform to its documented (and expected,
including by the existing code in various grid renderers) behaviour.

---

@thesiv I think this is finally the right fix, the function was always documented to behave as it does after this change -- but unfortunately didn't, until now.