### PR TITLE
OSX: Eliminate header file's dependency on CoreServices.h

### DIFF
--- a/include/wx/osx/fswatcher_fsevents.h
+++ b/include/wx/osx/fswatcher_fsevents.h
@@ -15,10 +15,7 @@
 
 #if wxUSE_FSWATCHER
 
-#include <CoreServices/CoreServices.h>
 #include "wx/unix/fswatcher_kqueue.h"
-
-WX_DECLARE_STRING_HASH_MAP(FSEventStreamRef, FSEventStreamRefMap);
 
 /*
  The FSEvents watcher uses the newer FSEvents service
@@ -78,8 +75,10 @@ public:
 
 private:
 
-    // map of path => FSEventStreamRef
-    FSEventStreamRefMap m_streams;
+    // use the pImpl idiom to eliminate this header's dependency
+    // on CoreServices.h (and ultimately AssertMacros.h)
+    struct PrivateData;
+    PrivateData *m_pImpl;
 
 };
 


### PR DESCRIPTION
CoreServices.h ultimately #includes AssertMacros.h, which by default
on older SDKs (<10.12) introduces various macros whose names very easily
conflict with user code.

For example, if you #included <wx/fswatcher.h> in your own code, and
your code happened to contain a symbol called 'check', or 'verify',
compilation failed.

No other wx header has a dependency on CoreServices.h or AssertMacros.h.