### PR TITLE
Make Cleared() behave consistently with the other ports in wxGTK

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -605,6 +605,11 @@ wxGTK:
 
 - Fix position of popup menus shown in wxListCtrl.
 - Fix not showing wxInfoBar with GTK+ 3 < 3.22.29.
+- Potentially incompatible change: wxDataViewModel::Cleared() now works as
+  documented cross-platform.  Previously on wxGTK it just emptied the model
+  rather than triggering a reload of the model.  If you are working around the
+  broken behaviour with wxGTK-specific code in your application you should
+  check that your application works correctly with this change.
 
 
 3.0.4: (released 2018-03-08)

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -1788,40 +1788,7 @@ bool wxGtkDataViewModelNotifier::AfterReset()
 
 bool wxGtkDataViewModelNotifier::Cleared()
 {
-    GtkWxTreeModel *wxgtk_model = m_internal->GetGtkModel();
-
-    // There is no call to tell the model that everything
-    // has been deleted so call row_deleted() for every
-    // child of root...
-
-    int count = m_internal->iter_n_children( NULL ); // number of children of root
-
-    GtkTreePath *path = gtk_tree_path_new_first();  // points to root
-
-    // It is important to avoid selection changed events being generated from
-    // here as they would reference the already deleted model items, which
-    // would result in crashes in any code attempting to handle these events.
-    m_internal->GtkDisableSelectionEvents();
-
-    // We also need to prevent wxGtkTreeCellDataFunc from using the model items
-    // not existing any longer, so change the model stamp to indicate that it
-    // temporarily can't be used.
-    const gint stampOrig = wxgtk_model->stamp;
-    wxgtk_model->stamp = 0;
-
-    int i;
-    for (i = 0; i < count; i++)
-        gtk_tree_model_row_deleted( GTK_TREE_MODEL(wxgtk_model), path );
-
-    gtk_tree_path_free( path );
-
-    wxgtk_model->stamp = stampOrig;
-
-    m_internal->Cleared();
-
-    m_internal->GtkEnableSelectionEvents();
-
-    return true;
+    return BeforeReset() && AfterReset();
 }
 
 // ---------------------------------------------------------


### PR DESCRIPTION
Instead of actually deleting all the items from the control, just
refresh it by resetting the model, as this is what Cleared() does in
both the generic and native macOS versions of wxDataViewCtrl, so calling
it there resulted in very different results from doing it under wxGTK,
where instead of refreshing the control contents it raelly cleared it.

The name of this method is unfortunately confusing, but it seems better
to change its behaviour in wxGTK, even if this doesn't match the name,
rather than change it in the other ports to make them do the same thing,
as this could break some currently working code.

Also, this change results in a welcome code simplification.

Fixes #18603.

(cherry picked from commit 5403ec4e086c4fbc3d9ee9bf4b38964a48357826)