### PR TITLE
Don't use invalid grid cell coordinates when deleting grid rows

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -3640,13 +3640,21 @@ void wxGrid::UpdateCurrentCellOnRedim()
         }
         else
         {
-            int col = m_currentCellCoords.GetCol();
-            int row = m_currentCellCoords.GetRow();
-            if (col >= m_numCols)
-                col = m_numCols - 1;
-            if (row >= m_numRows)
-                row = m_numRows - 1;
-            SetCurrentCell(row, col);
+            // Check if the current cell coordinates are still valid.
+            wxGridCellCoords updatedCoords = m_currentCellCoords;
+            if ( updatedCoords.GetCol() >= m_numCols )
+                updatedCoords.SetCol(m_numCols - 1);
+            if ( updatedCoords.GetRow() >= m_numRows )
+                updatedCoords.SetRow(m_numRows - 1);
+
+            // And change them if they're not.
+            if ( updatedCoords != m_currentCellCoords )
+            {
+                // Prevent SetCurrentCell() from redrawing the previous current
+                // cell whose coordinates are invalid now.
+                m_currentCellCoords = wxGridNoCellCoords;
+                SetCurrentCell(updatedCoords);
+            }
         }
     }
 }


### PR DESCRIPTION
Since the changes of dda6aa6bdc8e30ba3a1feefa9aba3ce6fec076e8 wxGrid
code could ask the grid table for the data of an invalid cell due to
redrawing the old, and now possibly invalid, current cell from inside
SetCurrentCell() called from wxGrid::Redimension().

Fix this by explicitly resetting the old current cell to an invalid
value when changing it in UpdateCurrentCellOnRedim().

Also avoid calling SetCurrentCell() entirely if the current cell doesn't
change, as this is just completely unnecessary and results in a possible
unexpected wxEVT_GRID_SELECT_CELL event.

See https://github.com/wxWidgets/wxWidgets/pull/1546

---

@thesiv FYI, this fixes a nasty crash in lmi when deleting more than half of the rows with the current cursor positioned on the last of them.