### PR TITLE
Return (0, 0) from wxMDIChildFrame::GetPosition() in wxGTK

### DIFF
--- a/include/wx/gtk/mdi.h
+++ b/include/wx/gtk/mdi.h
@@ -122,6 +122,9 @@ public:
     wxMenuBar         *m_menuBar;
     bool               m_justInserted;
 
+protected:
+    virtual void DoGetPosition(int *x, int *y) const wxOVERRIDE;
+
 private:
     void Init();
 

--- a/src/gtk/mdi.cpp
+++ b/src/gtk/mdi.cpp
@@ -371,6 +371,17 @@ void wxMDIChildFrame::SetTitle( const wxString &title )
     gtk_notebook_set_tab_label_text(notebook, m_widget, wxGTK_CONV( title ) );
 }
 
+void wxMDIChildFrame::DoGetPosition(int *x, int *y) const
+{
+    // Pages of notebook always have position (0, 0) in its client area, so
+    // override this method to return this instead of the actual offset from
+    // the parent top left corner that the base class version returns.
+    if ( x )
+        *x = 0;
+    if ( y )
+        *y = 0;
+}
+
 //-----------------------------------------------------------------------------
 // wxMDIClientWindow
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This makes more sense for a page of a GtkNotebook, which is always
positioned at (0, 0) relative to its client area, and is also more
compatible with wxMSW.

Closes #18548.