### PR TITLE
Use native wxDragImage by default

### DIFF
--- a/samples/dragimag/dragimag.cpp
+++ b/samples/dragimag/dragimag.cpp
@@ -24,7 +24,7 @@
 // Under Windows, change this to 1
 // to use wxGenericDragImage
 
-#define wxUSE_GENERIC_DRAGIMAGE 1
+#define wxUSE_GENERIC_DRAGIMAGE 0
 
 #if wxUSE_GENERIC_DRAGIMAGE
 #include "wx/generic/dragimgg.h"
@@ -488,6 +488,7 @@ bool DragShape::Draw(wxDC& dc, bool highlight)
         return false;
 }
 
+#if wxUSE_GENERIC_DRAGIMAGE
 // MyDragImage
 
 // On some platforms, notably Mac OS X with Core Graphics, we can't blit from
@@ -503,4 +504,4 @@ bool MyDragImage::UpdateBackingFromWindow(wxDC& WXUNUSED(windowDC), wxMemoryDC& 
     m_canvas->DrawShapes(destDC);
     return true;
 }
-
+#endif

--- a/samples/dragimag/dragimag.h
+++ b/samples/dragimag/dragimag.h
@@ -177,10 +177,12 @@ public:
     {
     }
 
+#if wxUSE_GENERIC_DRAGIMAGE
     // On some platforms, notably Mac OS X with Core Graphics, we can't blit from
     // a window, so we need to draw the background explicitly.
     virtual bool UpdateBackingFromWindow(wxDC& windowDC, wxMemoryDC& destDC, const wxRect& sourceRect,
                     const wxRect& destRect) const wxOVERRIDE;
+#endif
 
 protected:
     MyCanvas*   m_canvas;


### PR DESCRIPTION
`UpdateBackingFromWindow` is part of `wxGenericDragImage`; the sample did not even compile with a modern compiler and without the guards, when trying the native drag image.