### PR TITLE
sample/splitter: window to be replaced may be null

### DIFF
--- a/samples/splitter/splitter.cpp
+++ b/samples/splitter/splitter.cpp
@@ -448,8 +448,10 @@ void MyFrame::OnReplace(wxCommandEvent& WXUNUSED(event) )
 {
     if (m_replacewindow == NULL) {
         m_replacewindow = m_splitter->GetWindow2();
-        m_splitter->ReplaceWindow(m_replacewindow, new wxPanel(m_splitter, wxID_ANY));
-        m_replacewindow->Hide();
+        if (m_replacewindow != NULL) {
+            m_splitter->ReplaceWindow(m_replacewindow, new wxPanel(m_splitter, wxID_ANY));
+            m_replacewindow->Hide();
+        }
     } else {
         wxWindow *empty = m_splitter->GetWindow2();
         wxASSERT(empty != m_replacewindow);


### PR DESCRIPTION
how to reproduce:
1. Resize splitter to hide the right/left window;
1. Active replace menu action;