### PR TITLE
OSX: Implement background color attribute for wxDataViewCtrl

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -147,6 +147,9 @@ Changes in behaviour which may result in build errors
 3.1.4: (released ????-??-??)
 ----------------------------
 
+wxOSX:
+
+- Support background colour in wxDataViewCtrl attributes (Ian McInerney).
 
 3.1.3: (released 2019-10-28)
 ----------------------------

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -147,9 +147,6 @@ Changes in behaviour which may result in build errors
 3.1.4: (released ????-??-??)
 ----------------------------
 
-wxOSX:
-
-- Support background colour in wxDataViewCtrl attributes (Ian McInerney).
 
 3.1.3: (released 2019-10-28)
 ----------------------------

--- a/include/wx/osx/cocoa/dataview.h
+++ b/include/wx/osx/cocoa/dataview.h
@@ -142,6 +142,7 @@ public:
 
         [m_origFont release];
         [m_origTextColour release];
+        [m_origBackgroundColour release];
     }
 
     NSCell* GetColumnCell() const { return m_ColumnCell; }
@@ -186,6 +187,7 @@ public:
     // ones that do.
     NSFont *GetOriginalFont() const { return m_origFont; }
     NSColor *GetOriginalTextColour() const { return m_origTextColour; }
+    NSColor *GetOriginalBackgroundColour() const { return m_origBackgroundColour; }
 
     void SaveOriginalFont(NSFont *font)
     {
@@ -195,6 +197,11 @@ public:
     void SaveOriginalTextColour(NSColor *textColour)
     {
         m_origTextColour = [textColour retain];
+    }
+
+    void SaveOriginalBackgroundColour(NSColor *backgroundColour)
+    {
+        m_origBackgroundColour = [backgroundColour retain];
     }
 
     // The ellipsization mode which we need to set for each cell being rendered.
@@ -226,6 +233,7 @@ private:
     // we own those if they're non-NULL
     NSFont *m_origFont;
     NSColor *m_origTextColour;
+    NSColor *m_origBackgroundColour;
 
     wxEllipsizeMode m_ellipsizeMode;
 

--- a/interface/wx/dataview.h
+++ b/interface/wx/dataview.h
@@ -713,10 +713,9 @@ public:
     /**
         Call this to set the background colour to use.
 
-        Currently this attribute is only supported in the generic version of
-        wxDataViewCtrl and ignored by the native GTK+ and OS X implementations.
-
-        @since 2.9.4
+        @since 2.9.4 - Generic
+        @since 3.1.1 - wxGTK
+        @since 3.1.4 - wxOSX
     */
     void SetBackgroundColour(const wxColour& colour);
 

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2901,7 +2901,7 @@ void wxDataViewRenderer::SetAttr(const wxDataViewItemAttr& attr)
         {
             // we can set font for any cell but only NSTextFieldCell provides
             // a method for setting text colour so check that this method is
-            // available before using it.
+            // available before using it
             if ( [cell respondsToSelector:@selector(setTextColor:)] &&
                     [cell respondsToSelector:@selector(textColor)] )
             {
@@ -2919,8 +2919,7 @@ void wxDataViewRenderer::SetAttr(const wxDataViewItemAttr& attr)
         {
             // Use the same logic as the text colour check above
             if ( [cell respondsToSelector:@selector(setBackgroundColor:)] &&
-                    [cell respondsToSelector:@selector(backgroundColor)] &&
-                    [cell respondsToSelector:@selector(setDrawsBackground:)] )
+                    [cell respondsToSelector:@selector(backgroundColor)] )
             {
                 if ( !data->GetOriginalBackgroundColour() )
                     data->SaveOriginalTextColour([(id)cell backgroundColor]);
@@ -2944,15 +2943,18 @@ void wxDataViewRenderer::SetAttr(const wxDataViewItemAttr& attr)
     if ( colText )
         [(id)cell setTextColor:colText];
 
-    if ( colBack )
+    if ( [cell respondsToSelector:@selector(setDrawsBackground:)] )
     {
-        [(id)cell setDrawsBackground:true];
-        [(id)cell setBackgroundColor:colBack];
+        if ( colBack )
+        {
+            [(id)cell setDrawsBackground:true];
+            [(id)cell setBackgroundColor:colBack];
+        }
+        else
+        {
+            [(id)cell setDrawsBackground:false];
+        }
     }
-    // Use the same logic as the text colour check above
-    else if ( [cell respondsToSelector:@selector(setDrawsBackground:)] )
-        [(id)cell setDrawsBackground:false];
-
 }
 
 void wxDataViewRenderer::SetEnabled(bool enabled)

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2720,6 +2720,7 @@ void wxDataViewRendererNativeData::Init()
 {
     m_origFont = NULL;
     m_origTextColour = NULL;
+    m_origBackgroundColour = NULL;
     m_ellipsizeMode = wxELLIPSIZE_MIDDLE;
     m_hasCustomFont = false;
 
@@ -2862,12 +2863,13 @@ void wxDataViewRenderer::SetAttr(const wxDataViewItemAttr& attr)
     wxDataViewRendererNativeData * const data = GetNativeData();
     NSCell * const cell = data->GetItemCell();
 
-    // set the font and text colour to use: we need to do it if we had ever
-    // changed them before, even if this item itself doesn't have any special
-    // attributes as otherwise it would reuse the attributes from the previous
-    // cell rendered using the same renderer
+    // set the font, background and text colour to use: we need to do it if we
+    // had ever changed them before, even if this item itself doesn't have any
+    // special attributes as otherwise it would reuse the attributes from the
+    // previous cell rendered using the same renderer
     NSFont *font = NULL;
     NSColor *colText = NULL;
+    NSColor *colBack = NULL;
 
     if ( attr.HasFont() )
     {
@@ -2892,34 +2894,65 @@ void wxDataViewRenderer::SetAttr(const wxDataViewItemAttr& attr)
         //else: can't change font if the cell doesn't have any
     }
 
-    if ( attr.HasColour() && [cell backgroundStyle] == NSBackgroundStyleLight )
+    // We don't apply the text or background colours if the cell is selected.
+    if ( [cell backgroundStyle] == NSBackgroundStyleLight )
     {
-        // we can set font for any cell but only NSTextFieldCell provides
-        // a method for setting text colour so check that this method is
-        // available before using it
-        if ( [cell respondsToSelector:@selector(setTextColor:)] &&
-                [cell respondsToSelector:@selector(textColor)] )
+        if ( attr.HasColour() )
         {
-            if ( !data->GetOriginalTextColour() )
+            // we can set font for any cell but only NSTextFieldCell provides
+            // a method for setting text colour so check that this method is
+            // available before using it.
+            if ( [cell respondsToSelector:@selector(setTextColor:)] &&
+                    [cell respondsToSelector:@selector(textColor)] )
             {
-                // the cast to (untyped) id is safe because of the check above
-                data->SaveOriginalTextColour([(id)cell textColor]);
-            }
+                if ( !data->GetOriginalTextColour() )
+                {
+                    // the cast to (untyped) id is safe because of the check above
+                    data->SaveOriginalTextColour([(id)cell textColor]);
+                }
 
-            colText = attr.GetColour().OSXGetNSColor();
+                colText = attr.GetColour().OSXGetNSColor();
+            }
+        }
+
+        if ( attr.HasBackgroundColour() )
+        {
+            // Use the same logic as the text colour check above
+            if ( [cell respondsToSelector:@selector(setBackgroundColor:)] &&
+                    [cell respondsToSelector:@selector(backgroundColor)] &&
+                    [cell respondsToSelector:@selector(setDrawsBackground:)] )
+            {
+                if ( !data->GetOriginalBackgroundColour() )
+                    data->SaveOriginalTextColour([(id)cell backgroundColor]);
+
+                colBack = attr.GetBackgroundColour().OSXGetNSColor();
+            }
         }
     }
+
 
     if ( !font )
         font = data->GetOriginalFont();
     if ( !colText )
         colText = data->GetOriginalTextColour();
+    if ( !colBack )
+        colBack = data->GetOriginalBackgroundColour();
 
     if ( font )
         [cell setFont:font];
 
     if ( colText )
         [(id)cell setTextColor:colText];
+
+    if ( colBack )
+    {
+        [(id)cell setDrawsBackground:true];
+        [(id)cell setBackgroundColor:colBack];
+    }
+    // Use the same logic as the text colour check above
+    else if ( [cell respondsToSelector:@selector(setDrawsBackground:)] )
+        [(id)cell setDrawsBackground:false];
+
 }
 
 void wxDataViewRenderer::SetEnabled(bool enabled)


### PR DESCRIPTION
This PR implements the background color attribute inside the wxDataViewCtrl on OSX. It had already been implemented on the generic and GTK versions, so OSX was the only one that didn't support it. It can be seen in the 2nd tab of the dataview sample (the icon background). I have made it behave like the text color, so it isn't applied if the cell is selected.

Also, this updates the documentation to say that it has been implemented (including on wxGTK, which was done for 3.1.1, but the documentation was not modified to say that).