### PR TITLE
OSX: Allow automatic tabbing to be enabled/disabled

### DIFF
--- a/include/wx/osx/app.h
+++ b/include/wx/osx/app.h
@@ -139,6 +139,9 @@ public:
     // override this to return false from a non-bundled console app in order to stay in background ...
     virtual bool         OSXIsGUIApplication() { return true; }
 
+    // Allow the user to disable the tab bar support in the application
+    void                 OSXEnableAutomaticTabbing(bool enable);
+
 #if wxOSX_USE_COCOA_OR_IPHONE
     // immediately before the native event loop launches
     virtual void         OSXOnWillFinishLaunching();

--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -1068,6 +1068,21 @@ public:
     */
     virtual bool OSXIsGUIApplication();
 
+    /**
+        Enable the automatic tabbing features of macOS.
+
+        This feature is native to the operating system. When it is enabled, macOS
+        will automatically place windows inside tabs and show a tab bar in the
+        application. Entries are also added to the View menu to show/hide the tab bar.
+
+        @onlyfor{wxosx}
+
+        @remarks Requires macOS 10.12+, does nothing under earlier OS versions.
+
+        @since 3.1.4
+    */
+    bool OSXEnableAutomaticTabbing(bool enable);
+
     //@}
 
 };

--- a/src/osx/cocoa/utils.mm
+++ b/src/osx/cocoa/utils.mm
@@ -475,6 +475,15 @@ void wxApp::DoCleanUp()
     }
 }
 
+void wxApp::OSXEnableAutomaticTabbing(bool enable)
+{
+    // Automatic tabbing was first introduced in 10.12
+    if ( WX_IS_MACOS_AVAILABLE(10, 12) )
+    {
+        [NSWindow setAllowsAutomaticWindowTabbing:enable];
+    }
+}
+
 extern // used from src/osx/core/display.cpp
 wxRect wxOSXGetMainDisplayClientArea()
 {


### PR DESCRIPTION
10.12+ implements automatic tabbing in the OS. This adds entries to the menus and also adds a tab bar. Some applications might want to disable this, so we should provide an interface.

Its effect can be seen by adding this to the auidemo:
```
diff --git a/samples/aui/auidemo.cpp b/samples/aui/auidemo.cpp
index 816a2c5d4e..7ce4fd491b 100644
--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -566,6 +566,10 @@ bool MyApp::OnInit()
     if ( !wxApp::OnInit() )
         return false;

+#ifdef __WXMAC__
+    wxApp::OSXEnableAutomaticTabbing(false);
+#endif
+
     wxFrame* frame = new MyFrame(NULL,
                                  wxID_ANY,
                                  "wxAUI Sample Application",
```

Without this, there are menu options in the View menu to show the tab bar (which when clicked will add a bar to the top of the application). With this patch and this PR, those menu options are removed and there is no way to get the tab bar.
