### PR TITLE
wxIsPlatform64Bit: don't launch uname needlessly

### DIFF
--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -1078,12 +1078,17 @@ bool wxGetUserName(wxChar *buf, int sz)
 
 bool wxIsPlatform64Bit()
 {
+#if SIZEOF_VOID_P == 8
+    (void)wxGetCommandOutput;
+    return true;  // 64-bit programs run only on 64-bit platforms
+#else
     const wxString machine = wxGetCommandOutput(wxT("uname -m"));
 
     // the test for "64" is obviously not 100% reliable but seems to work fine
     // in practice
     return machine.Contains(wxT("64")) ||
                 machine.Contains(wxT("alpha"));
+#endif
 }
 
 #ifdef __LINUX__


### PR DESCRIPTION
Don't execute uname in Unix version of  wxIsPlatform64Bit() to determine if the current platform is 64-bit capable if the binary is already a 64bit one.

This is consistent with how MSW implementation behaves and avoids a pointless invocation when running 64-bit binaries.

As an added benefit, this prevents user harassment by macOS 10.15 if they launch a wx application from a "protected" location like ~/Desktop or ~/Downloads - apparently stat()ing CWD is considered evil and privacy-invading these days.

—

Asking for review in case I'm missing something about some non-Linux Unices or if there's a better way to check for 64-bitness at compilation time (`__LP64__` is OSX-specific I think?). 