### PR TITLE
Returning the backtrace of the entire stack too

### DIFF
--- a/include/wx/private/jsscriptwrapper.h
+++ b/include/wx/private/jsscriptwrapper.h
@@ -50,13 +50,20 @@ public:
     // execution of this code.
     wxString GetWrappedCode() const
     {
-        return wxString::Format
-               (
-                "try { var %s = eval(\"%s\"); true; } "
-                "catch (e) { e.name + \": \" + e.message; }",
-                m_outputVarName,
-                m_escapedCode
-               );
+        return wxString::Format(
+            "try {"
+                "var %s = eval(\"%s\");"
+                "true;"
+            "}"
+            "catch (e) {"
+                "let r = e.toString();"
+                "if (typeof(e.stack) !== 'undefined') r += ('\\n'+ e.stack);"
+                "r;"
+            "}"
+            ,
+            m_outputVarName,
+            m_escapedCode
+        );
     }
 
     // Get code returning the result of the last successful execution of the


### PR DESCRIPTION
Obviously it helps if the users is able to know where their codes went wrong, especially when the codes is lengthy. I was trying to return a JSON.stringify(e), which provides more information, but have difficulty to remove method toJSON from the Error object e. If anyone knows how to do it (without jQuery), please let me know. I personally would like the whole contents of e to be returned, including both line number and column number. Anyway, it's better than nothing to have the callstack. By the way, the property stack of e seems non-standard, but it does exist in both IE 11 and WebKit-based browser.