### PR TITLE
Add option for using generic wxDataViewCtrl and fixes to make it work under GTK and Mac

### DIFF
--- a/build/cmake/setup.h.in
+++ b/build/cmake/setup.h.in
@@ -411,6 +411,8 @@
 #cmakedefine01 wxUSE_TREECTRL
 #cmakedefine01 wxUSE_TREELISTCTRL
 
+#cmakedefine01 wxUSE_NATIVE_DATAVIEWCTRL
+
 #cmakedefine01 wxUSE_STATUSBAR
 
 #cmakedefine01 wxUSE_NATIVE_STATUSBAR

--- a/configure
+++ b/configure
@@ -1249,6 +1249,7 @@ enable_combobox
 enable_comboctrl
 enable_commandlinkbutton
 enable_dataviewctrl
+enable_nativedvc
 enable_datepick
 enable_detect_sm
 enable_dirpicker
@@ -2203,6 +2204,7 @@ Optional Features:
   --enable-comboctrl      use wxComboCtrl class
   --enable-commandlinkbutton      use wxCommmandLinkButton class
   --enable-dataviewctrl   use wxDataViewCtrl class
+  --disable-nativedvc     disable use of native wxDataViewCtrl even if available
   --enable-datepick       use wxDatePickerCtrl class
   --enable-detect_sm      use code to detect X11 session manager
   --enable-dirpicker      use wxDirPickerCtrl class
@@ -9717,6 +9719,35 @@ fi
 
 
           eval "$wx_cv_use_dataviewctrl"
+
+
+          enablestring=disable
+          defaultval=
+          if test -z "$defaultval"; then
+              if test x"$enablestring" = xdisable; then
+                  defaultval=yes
+              else
+                  defaultval=no
+              fi
+          fi
+
+          # Check whether --enable-nativedvc was given.
+if test "${enable_nativedvc+set}" = set; then :
+  enableval=$enable_nativedvc;
+                          if test "$enableval" = yes; then
+                            wx_cv_use_nativedvc='wxUSE_NATIVE_DATAVIEWCTRL=yes'
+                          else
+                            wx_cv_use_nativedvc='wxUSE_NATIVE_DATAVIEWCTRL=no'
+                          fi
+
+else
+
+                          wx_cv_use_nativedvc='wxUSE_NATIVE_DATAVIEWCTRL=${'DEFAULT_wxUSE_NATIVE_DATAVIEWCTRL":-$defaultval}"
+
+fi
+
+
+          eval "$wx_cv_use_nativedvc"
 
 
           enablestring=
@@ -35900,6 +35931,11 @@ if test "$wxUSE_DATAVIEWCTRL" = "yes"; then
 
   USES_CONTROLS=1
   SAMPLES_SUBDIRS="$SAMPLES_SUBDIRS dataview"
+
+  if test "$wxUSE_NATIVE_DATAVIEWCTRL" = "yes"; then
+    $as_echo "#define wxUSE_NATIVE_DATAVIEWCTRL 1" >>confdefs.h
+
+  fi
 fi
 
 if test "$wxUSE_IMAGLIST" = "yes"; then

--- a/configure.in
+++ b/configure.in
@@ -922,6 +922,7 @@ WX_ARG_FEATURE(combobox,    [  --enable-combobox       use wxComboBox class], wx
 WX_ARG_FEATURE(comboctrl,   [  --enable-comboctrl      use wxComboCtrl class], wxUSE_COMBOCTRL)
 WX_ARG_FEATURE(commandlinkbutton, [  --enable-commandlinkbutton      use wxCommmandLinkButton class], wxUSE_COMMANDLINKBUTTON)
 WX_ARG_FEATURE(dataviewctrl,[  --enable-dataviewctrl   use wxDataViewCtrl class], wxUSE_DATAVIEWCTRL)
+WX_ARG_DISABLE(nativedvc,   [  --disable-nativedvc     disable use of native wxDataViewCtrl even if available], wxUSE_NATIVE_DATAVIEWCTRL)
 WX_ARG_FEATURE(datepick,    [  --enable-datepick       use wxDatePickerCtrl class], wxUSE_DATEPICKCTRL)
 WX_ARG_FEATURE(detect_sm,   [  --enable-detect_sm      use code to detect X11 session manager], wxUSE_DETECT_SM)
 WX_ARG_FEATURE(dirpicker,   [  --enable-dirpicker      use wxDirPickerCtrl class], wxUSE_DIRPICKERCTRL)
@@ -6834,6 +6835,10 @@ if test "$wxUSE_DATAVIEWCTRL" = "yes"; then
   AC_DEFINE(wxUSE_DATAVIEWCTRL)
   USES_CONTROLS=1
   SAMPLES_SUBDIRS="$SAMPLES_SUBDIRS dataview"
+
+  if test "$wxUSE_NATIVE_DATAVIEWCTRL" = "yes"; then
+    AC_DEFINE(wxUSE_NATIVE_DATAVIEWCTRL)
+  fi
 fi
 
 if test "$wxUSE_IMAGLIST" = "yes"; then

--- a/docs/doxygen/mainpages/const_cpp.h
+++ b/docs/doxygen/mainpages/const_cpp.h
@@ -185,6 +185,7 @@ Currently the following symbols exist:
     decide whether some function should be overloaded for both
     <code>long</code> and <code>long long</code> types.}
 @itemdef{wxHAS_MULTIPLE_FILEDLG_FILTERS, Defined if wxFileDialog supports multiple ('|'-separated) filters.}
+@itemdef{wxHAS_NATIVE_DATAVIEWCTRL, Defined if native wxDataViewCtrl class is being used (this symbol only exists in wxWidgets 3.1.4 and later).}
 @itemdef{wxHAS_NATIVE_WINDOW, Defined if wxNativeWindow class is available.}
 @itemdef{wxHAS_IMAGES_IN_RESOURCES, Defined if <a href="http://en.wikipedia.org/wiki/Resource_(Windows)">
     Windows resource files</a> or OS/2 resource files are available on the current platform.}

--- a/docs/doxygen/mainpages/const_wxusedef.h
+++ b/docs/doxygen/mainpages/const_wxusedef.h
@@ -175,6 +175,7 @@ library:
 @itemdef{wxUSE_MINIFRAME, Use wxMiniFrame class.}
 @itemdef{wxUSE_MOUSEWHEEL, Support mouse wheel events.}
 @itemdef{wxUSE_MSGDLG, Use wxMessageDialog class and wxMessageBox function.}
+@itemdef{wxUSE_NATIVE_DATAVIEWCTRL, Use native wxDataViewCtrl class (this option is new since wxWidgets 3.1.4).}
 @itemdef{wxUSE_NATIVE_STATUSBAR, Use native wxStatusBar class.}
 @itemdef{wxUSE_NOTEBOOK, Use wxNotebook and related classes.}
 @itemdef{wxUSE_NUMBERDLG, Use wxNumberEntryDialog class.}

--- a/include/wx/android/setup.h
+++ b/include/wx/android/setup.h
@@ -907,6 +907,14 @@
 #define wxUSE_TREECTRL      1   // wxTreeCtrl
 #define wxUSE_TREELISTCTRL  1   // wxTreeListCtrl
 
+// Use generic version of wxDataViewCtrl even if a native one is available?
+//
+// Default is 0.
+//
+// Recommended setting: 0, but can be set to 1 if your program is affected by
+// the native control limitations.
+#define wxUSE_NATIVE_DATAVIEWCTRL 1
+
 // Use a status bar class? Depending on the value of wxUSE_NATIVE_STATUSBAR
 // below either wxStatusBar95 or a generic wxStatusBar will be used.
 //

--- a/include/wx/chkconf.h
+++ b/include/wx/chkconf.h
@@ -649,6 +649,14 @@
 #   endif
 #endif /* !defined(wxUSE_DATAVIEWCTRL) */
 
+#ifndef wxUSE_NATIVE_DATAVIEWCTRL
+#   ifdef wxABORT_ON_CONFIG_ERROR
+#       error "wxUSE_NATIVE_DATAVIEWCTRL must be defined, please read comment near the top of this file."
+#   else
+#       define wxUSE_NATIVE_DATAVIEWCTRL 1
+#   endif
+#endif /* !defined(wxUSE_NATIVE_DATAVIEWCTRL) */
+
 #ifndef wxUSE_DATEPICKCTRL
 #   ifdef wxABORT_ON_CONFIG_ERROR
 #       error "wxUSE_DATEPICKCTRL must be defined, please read comment near the top of this file."

--- a/include/wx/dataview.h
+++ b/include/wx/dataview.h
@@ -33,8 +33,13 @@ class WXDLLIMPEXP_FWD_CORE wxImageList;
 class wxItemAttr;
 class WXDLLIMPEXP_FWD_CORE wxHeaderCtrl;
 
-#if !(defined(__WXGTK20__) || defined(__WXOSX__) ) || defined(__WXUNIVERSAL__)
-// #if !(defined(__WXOSX__)) || defined(__WXUNIVERSAL__)
+#if wxUSE_NATIVE_DATAVIEWCTRL && !defined(__WXUNIVERSAL__)
+    #if defined(__WXGTK20__) || defined(__WXOSX__)
+        #define wxHAS_NATIVE_DATAVIEWCTRL
+    #endif
+#endif
+
+#ifndef wxHAS_NATIVE_DATAVIEWCTRL
     #define wxHAS_GENERIC_DATAVIEWCTRL
 #endif
 

--- a/include/wx/dvrenderers.h
+++ b/include/wx/dvrenderers.h
@@ -539,7 +539,7 @@ typedef wxDataViewTextRenderer wxDataViewDateRenderer;
 // wxDataViewCheckIconTextRenderer: 3-state checkbox + text + optional icon
 // ----------------------------------------------------------------------------
 
-#ifndef __WXOSX__
+#if defined(wxHAS_GENERIC_DATAVIEWCTRL) || !defined(__WXOSX__)
 
 class WXDLLIMPEXP_CORE wxDataViewCheckIconTextRenderer
     : public wxDataViewCustomRenderer
@@ -591,7 +591,7 @@ private:
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxDataViewCheckIconTextRenderer);
 };
 
-#endif // !__WXOSX__
+#endif // ! native __WXOSX__
 
 // this class is obsolete, its functionality was merged in
 // wxDataViewTextRenderer itself now, don't use it any more

--- a/include/wx/gtk/setup0.h
+++ b/include/wx/gtk/setup0.h
@@ -908,6 +908,14 @@
 #define wxUSE_TREECTRL      1   // wxTreeCtrl
 #define wxUSE_TREELISTCTRL  1   // wxTreeListCtrl
 
+// Use generic version of wxDataViewCtrl even if a native one is available?
+//
+// Default is 0.
+//
+// Recommended setting: 0, but can be set to 1 if your program is affected by
+// the native control limitations.
+#define wxUSE_NATIVE_DATAVIEWCTRL 1
+
 // Use a status bar class? Depending on the value of wxUSE_NATIVE_STATUSBAR
 // below either wxStatusBar95 or a generic wxStatusBar will be used.
 //

--- a/include/wx/motif/setup0.h
+++ b/include/wx/motif/setup0.h
@@ -908,6 +908,14 @@
 #define wxUSE_TREECTRL      1   // wxTreeCtrl
 #define wxUSE_TREELISTCTRL  1   // wxTreeListCtrl
 
+// Use generic version of wxDataViewCtrl even if a native one is available?
+//
+// Default is 0.
+//
+// Recommended setting: 0, but can be set to 1 if your program is affected by
+// the native control limitations.
+#define wxUSE_NATIVE_DATAVIEWCTRL 1
+
 // Use a status bar class? Depending on the value of wxUSE_NATIVE_STATUSBAR
 // below either wxStatusBar95 or a generic wxStatusBar will be used.
 //

--- a/include/wx/msw/setup0.h
+++ b/include/wx/msw/setup0.h
@@ -908,6 +908,14 @@
 #define wxUSE_TREECTRL      1   // wxTreeCtrl
 #define wxUSE_TREELISTCTRL  1   // wxTreeListCtrl
 
+// Use generic version of wxDataViewCtrl even if a native one is available?
+//
+// Default is 0.
+//
+// Recommended setting: 0, but can be set to 1 if your program is affected by
+// the native control limitations.
+#define wxUSE_NATIVE_DATAVIEWCTRL 1
+
 // Use a status bar class? Depending on the value of wxUSE_NATIVE_STATUSBAR
 // below either wxStatusBar95 or a generic wxStatusBar will be used.
 //

--- a/include/wx/osx/setup0.h
+++ b/include/wx/osx/setup0.h
@@ -914,6 +914,14 @@
 #define wxUSE_TREECTRL      1   // wxTreeCtrl
 #define wxUSE_TREELISTCTRL  1   // wxTreeListCtrl
 
+// Use generic version of wxDataViewCtrl even if a native one is available?
+//
+// Default is 0.
+//
+// Recommended setting: 0, but can be set to 1 if your program is affected by
+// the native control limitations.
+#define wxUSE_NATIVE_DATAVIEWCTRL 1
+
 // Use a status bar class? Depending on the value of wxUSE_NATIVE_STATUSBAR
 // below either wxStatusBar95 or a generic wxStatusBar will be used.
 //

--- a/include/wx/setup_inc.h
+++ b/include/wx/setup_inc.h
@@ -904,6 +904,14 @@
 #define wxUSE_TREECTRL      1   // wxTreeCtrl
 #define wxUSE_TREELISTCTRL  1   // wxTreeListCtrl
 
+// Use generic version of wxDataViewCtrl even if a native one is available?
+//
+// Default is 0.
+//
+// Recommended setting: 0, but can be set to 1 if your program is affected by
+// the native control limitations.
+#define wxUSE_NATIVE_DATAVIEWCTRL 1
+
 // Use a status bar class? Depending on the value of wxUSE_NATIVE_STATUSBAR
 // below either wxStatusBar95 or a generic wxStatusBar will be used.
 //

--- a/include/wx/univ/setup0.h
+++ b/include/wx/univ/setup0.h
@@ -907,6 +907,14 @@
 #define wxUSE_TREECTRL      1   // wxTreeCtrl
 #define wxUSE_TREELISTCTRL  1   // wxTreeListCtrl
 
+// Use generic version of wxDataViewCtrl even if a native one is available?
+//
+// Default is 0.
+//
+// Recommended setting: 0, but can be set to 1 if your program is affected by
+// the native control limitations.
+#define wxUSE_NATIVE_DATAVIEWCTRL 1
+
 // Use a status bar class? Depending on the value of wxUSE_NATIVE_STATUSBAR
 // below either wxStatusBar95 or a generic wxStatusBar will be used.
 //

--- a/setup.h.in
+++ b/setup.h.in
@@ -411,6 +411,8 @@
 #define wxUSE_TREECTRL      0
 #define wxUSE_TREELISTCTRL  0
 
+#define wxUSE_NATIVE_DATAVIEWCTRL 0
+
 #define wxUSE_STATUSBAR    0
 
 #define wxUSE_NATIVE_STATUSBAR        0

--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -2004,7 +2004,7 @@ wxSize wxDataViewDateRenderer::GetSize() const
 // wxDataViewCheckIconTextRenderer implementation
 // ----------------------------------------------------------------------------
 
-#ifndef __WXOSX__
+#if defined(wxHAS_GENERIC_DATAVIEWCTRL) || !defined(__WXOSX__)
 
 IMPLEMENT_VARIANT_OBJECT_EXPORTED(wxDataViewCheckIconText, WXDLLIMPEXP_ADV)
 
@@ -2196,7 +2196,7 @@ wxSize wxDataViewCheckIconTextRenderer::GetCheckSize() const
     return wxRendererNative::Get().GetCheckBoxSize(GetView());
 }
 
-#endif // !__WXOSX__
+#endif // ! native __WXOSX__
 
 //-----------------------------------------------------------------------------
 // wxDataViewListStore

--- a/src/generic/treelist.cpp
+++ b/src/generic/treelist.cpp
@@ -735,7 +735,7 @@ bool wxTreeListModel::IsContainer(const wxDataViewItem& item) const
     //        adding the item itself) and we can't know whether we're container
     //        or not by then. Luckily, always returning true doesn't have any
     //        serious drawbacks for us.
-#ifdef __WXGTK__
+#if defined(__WXGTK__) && defined(wxHAS_NATIVE_DATAVIEWCTRL)
     wxUnusedVar(item);
 
     return true;


### PR DESCRIPTION
Unfortunately native DVC implementations have so many problems that sometimes using the generic version is the only alternative, so make it at least less painful to use it.

See [this ticket](https://trac.wxwidgets.org/ticket/18632) for the fixes.