### PR TITLE
Fix wxThread::SetPriority() documentation and avoid a spurious error message

### DIFF
--- a/include/wx/thread.h
+++ b/include/wx/thread.h
@@ -559,9 +559,6 @@ public:
     // priority
         // Sets the priority to "prio" which must be in 0..100 range (see
         // also wxPRIORITY_XXX constants).
-        //
-        // NB: under MSW the priority can only be set after the thread is
-        //     created (but possibly before it is launched)
     void SetPriority(unsigned int prio);
 
         // Get the current priority.

--- a/interface/wx/thread.h
+++ b/interface/wx/thread.h
@@ -1267,11 +1267,6 @@ public:
           - @c wxPRIORITY_DEFAULT: 50
           - @c wxPRIORITY_MAX: 100
 
-        Notice that in the MSW implementation the thread priority can currently
-        be only set after creating the thread with CreateThread(). But under
-        all platforms this method can be called either before launching the
-        thread using Run() or after doing it.
-
         Please note that currently this function is not implemented when using
         the default (@c SCHED_OTHER) scheduling policy under POSIX systems.
     */

--- a/src/msw/thread.cpp
+++ b/src/msw/thread.cpp
@@ -624,10 +624,12 @@ void wxThreadInternal::SetPriority(unsigned int priority)
         win_priority = THREAD_PRIORITY_NORMAL;
     }
 
-    if ( !::SetThreadPriority(m_hThread, win_priority) )
+    if ( m_hThread && !::SetThreadPriority(m_hThread, win_priority) )
     {
         wxLogSysError(_("Can't set thread priority"));
     }
+    // else: If m_hThread is NULL, the thread hasn't been created yet,
+    // but once it is created, the priority will be set by Create().
 }
 
 bool wxThreadInternal::Create(wxThread *thread, unsigned int stackSize)


### PR DESCRIPTION
Don't call ::SetThreadPriority() with a NULL handle, as it will obviously fail.

The documentation's notes about MSW limitations about setting priority before
creating the thread do not appear to be true (anymore). Thread priority is
already set by Create() if SetPriority() was called earlier. Setting it
immediately just failed, because the thread did not exist yet.

Also cherry-pickable to 3.0 branch.