### PR TITLE
Fixed wrong wxDELETE.

### DIFF
--- a/src/common/imagiff.cpp
+++ b/src/common/imagiff.cpp
@@ -414,7 +414,7 @@ int wxIFFDecoder::ReadIFF()
         const byte *cmapptr = dataptr + 8;
         colors = chunkLen / 3;                  // calc no of colors
 
-        wxDELETE(m_image->pal);
+        wxDELETEA(m_image->pal);
         m_image->colors = colors;
         if (colors > 0) {
         m_image->pal = new byte[3*colors];


### PR DESCRIPTION
`image->pal` was allocated using `new[]`, therefore `wxDELETA` shall be used.