### PR TITLE
Fixed wrong delete for m_extendedHdr-variable.

### DIFF
--- a/src/common/tarstrm.cpp
+++ b/src/common/tarstrm.cpp
@@ -1474,7 +1474,7 @@ void wxTarOutputStream::SetExtendedHeader(const wxString& key,
             m_extendedHdr = new char[m_extendedSize];
             if (oldHdr) {
                 strcpy(m_extendedHdr, oldHdr);
-                delete oldHdr;
+                delete [] oldHdr;
             } else {
                 *m_extendedHdr = 0;
             }


### PR DESCRIPTION
`m_extendedHdr` was allocated using `new[]`, therefore `delete []` shall be used.