### PR TITLE
Fixed missmatching free/delete issue

### DIFF
--- a/src/common/list.cpp
+++ b/src/common/list.cpp
@@ -351,7 +351,7 @@ void wxListBase::DoDeleteNode(wxNodeBase *node)
     // free node's data
     if ( m_keyType == wxKEY_STRING )
     {
-        free(node->m_key.string);
+        wxDELETE(node->m_key.string);
     }
 
     if ( m_destroy )


### PR DESCRIPTION
`m_key.string `was allocated using `new`, therefore use `wxDELETE` to release memory.