### PR TITLE
Fix docs for wxDEPRECATED_MSG macro

### DIFF
--- a/interface/wx/defs.h
+++ b/interface/wx/defs.h
@@ -1623,6 +1623,7 @@ template <typename T> wxDELETEA(T*& array);
 
     @header{wx/defs.h}
  */
+#define wxDEPRECATED_MSG(msg)
 
 /**
     This macro can be used around a function declaration to generate warnings


### PR DESCRIPTION
In the current docs the definition for the `wxDEPRECATED_MSG` macro was missing, so its documentation was included inside the docs for `wxDEPRECATED` and it wasn't visible in the docs.