### PR TITLE
Ensure mask is preserved when copying wxBitmapRefData to avoid crashes

### DIFF
--- a/src/msw/bitmap.cpp
+++ b/src/msw/bitmap.cpp
@@ -223,10 +223,6 @@ wxBitmapRefData::wxBitmapRefData(const wxBitmapRefData& data)
 {
     Init();
 
-    // (deep) copy the mask if present
-    if (data.m_bitmapMask)
-        m_bitmapMask = new wxMask(*data.m_bitmapMask);
-
 #if wxUSE_WXDIB
     wxASSERT_MSG( !data.m_dib,
                     wxT("can't copy bitmap locked for raw access!") );
@@ -261,6 +257,11 @@ wxBitmapRefData::wxBitmapRefData(const wxBitmapRefData& data)
         }
     }
 #endif // wxUSE_WXDIB
+
+    // Ensure this is done after the block above otherwise if the color depth didn't match we'll lose the mask
+    // (deep) copy the mask if present
+    if (data.m_bitmapMask)
+        m_bitmapMask = new wxMask(*data.m_bitmapMask);
 }
 
 void wxBitmapRefData::Free()


### PR DESCRIPTION
This crash was introduced in 2d15218c9db91d348e8c3a1c8e4a2a968bf3c70a. It happens inside wxBitmap::MSWBlendMaskWithAlpha(). The logic checks for a mask and alpha, but the mask may be lost after AllocExclusive(). I've only seen the crash happen on a Windows 7 Hyper-V VM because the Hyper-V graphics drivers are intentionally limited to 16-bit color. The crash happened in our XRC during the loading of the icon image.

Another potential option would be to change MSWBlendMaskWithAlpha() to check for the mask again after AllocExclusive(), but that would look a little odd. Additionally I think it just makes more sense for the mask to still exist on the copied bitmap data.