### PR TITLE
Replace dynamic casts with virtual wxWindow::WXGetTextEntry()

### DIFF
--- a/include/wx/gtk/combobox.h
+++ b/include/wx/gtk/combobox.h
@@ -128,6 +128,8 @@ public:
     static wxVisualAttributes
     GetClassDefaultAttributes(wxWindowVariant variant = wxWINDOW_VARIANT_NORMAL);
 
+    virtual const wxTextEntry* WXGetTextEntry() const wxOVERRIDE { return this; }
+
 protected:
     // From wxWindowGTK:
     virtual GdkWindow *GTKGetWindow(wxArrayGdkWindows& windows) const wxOVERRIDE;

--- a/include/wx/gtk1/combobox.h
+++ b/include/wx/gtk1/combobox.h
@@ -157,6 +157,8 @@ public:
     static wxVisualAttributes
     GetClassDefaultAttributes(wxWindowVariant variant = wxWINDOW_VARIANT_NORMAL);
 
+    virtual const wxTextEntry* WXGetTextEntry() const { return this; }
+
 protected:
     virtual int DoInsertItems(const wxArrayStringsAdapter& items,
                               unsigned int pos,

--- a/include/wx/motif/combobox.h
+++ b/include/wx/motif/combobox.h
@@ -108,6 +108,8 @@ public:
     virtual void Popup() { wxFAIL_MSG( wxT("Not implemented") ); }
     virtual void Dismiss() { wxFAIL_MSG( wxT("Not implemented") ); }
 
+    virtual const wxTextEntry* WXGetTextEntry() const { return this; }
+
 protected:
     virtual wxSize DoGetBestSize() const;
     virtual void DoSetSize(int x, int y,

--- a/include/wx/msw/combobox.h
+++ b/include/wx/msw/combobox.h
@@ -128,6 +128,8 @@ public:
 
     virtual void SetLayoutDirection(wxLayoutDirection dir) wxOVERRIDE;
 
+    virtual const wxTextEntry* WXGetTextEntry() const wxOVERRIDE { return this; }
+
 protected:
 #if wxUSE_TOOLTIPS
     virtual void DoSetToolTip(wxToolTip *tip) wxOVERRIDE;

--- a/include/wx/osx/combobox.h
+++ b/include/wx/osx/combobox.h
@@ -102,6 +102,8 @@ class WXDLLIMPEXP_CORE wxComboBox :
 #endif // wxOSX_USE_COCOA
 
 
+    virtual const wxTextEntry* WXGetTextEntry() const wxOVERRIDE { return this; }
+
     // osx specific event handling common for all osx-ports
 
     virtual bool OSXHandleClicked(double timestampsec) wxOVERRIDE;

--- a/include/wx/qt/combobox.h
+++ b/include/wx/qt/combobox.h
@@ -80,6 +80,8 @@ public:
     virtual void Popup();
     virtual void Dismiss();
 
+    virtual const wxTextEntry* WXGetTextEntry() const wxOVERRIDE { return this; }
+
     virtual bool QtHandleFocusEvent(QWidget *handler, QFocusEvent *event) wxOVERRIDE;
 protected:
 

--- a/include/wx/srchctrl.h
+++ b/include/wx/srchctrl.h
@@ -82,6 +82,10 @@ public:
     virtual void SetDescriptiveText(const wxString& text) = 0;
     virtual wxString GetDescriptiveText() const = 0;
 
+#if wxUSE_NATIVE_SEARCH_CONTROL
+    virtual const wxTextEntry* WXGetTextEntry() const wxOVERRIDE { return this; }
+#endif // wxUSE_NATIVE_SEARCH_CONTROL
+
 private:
     // implement wxTextEntry pure virtual method
     virtual wxWindow *GetEditableWindow() wxOVERRIDE { return this; }

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -759,6 +759,8 @@ public:
         return GetCompositeControlsDefaultAttributes(variant);
     }
 
+    virtual const wxTextEntry* WXGetTextEntry() const wxOVERRIDE { return this; }
+
 protected:
     // Override wxEvtHandler method to check for a common problem of binding
     // wxEVT_TEXT_ENTER to a control without wxTE_PROCESS_ENTER style, which is

--- a/include/wx/univ/combobox.h
+++ b/include/wx/univ/combobox.h
@@ -161,6 +161,8 @@ public:
     virtual wxClientDataType GetClientDataType() const wxOVERRIDE;
     virtual void SetClientDataType(wxClientDataType clientDataItemsType) wxOVERRIDE;
 
+    virtual const wxTextEntry* WXGetTextEntry() const wxOVERRIDE { return this; }
+
 protected:
     virtual int DoInsertItems(const wxArrayStringsAdapter& items,
                               unsigned int pos,

--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -58,6 +58,7 @@ class WXDLLIMPEXP_FWD_CORE wxDC;
 class WXDLLIMPEXP_FWD_CORE wxDropTarget;
 class WXDLLIMPEXP_FWD_CORE wxLayoutConstraints;
 class WXDLLIMPEXP_FWD_CORE wxSizer;
+class WXDLLIMPEXP_FWD_CORE wxTextEntry;
 class WXDLLIMPEXP_FWD_CORE wxToolTip;
 class WXDLLIMPEXP_FWD_CORE wxWindowBase;
 class WXDLLIMPEXP_FWD_CORE wxWindow;
@@ -1582,6 +1583,8 @@ public:
         return false;
     }
 
+    // This is an internal helper function implemented by text-like controls.
+    virtual const wxTextEntry* WXGetTextEntry() const { return NULL; }
 
 protected:
     // helper for the derived class Create() methods: the first overload, with

--- a/src/common/event.cpp
+++ b/src/common/event.cpp
@@ -37,19 +37,13 @@
 
     #if wxUSE_GUI
         #include "wx/window.h"
-        #include "wx/combobox.h"
         #include "wx/control.h"
         #include "wx/dc.h"
-        #include "wx/srchctrl.h"
         #include "wx/spinbutt.h"
-        #include "wx/textctrl.h"
+        #include "wx/textentry.h"
         #include "wx/validate.h"
     #endif // wxUSE_GUI
 #endif
-
-#if wxUSE_GUI
-    #include "wx/srchctrl.h"
-#endif // wxUSE_GUI
 
 #include "wx/thread.h"
 
@@ -448,28 +442,17 @@ wxString wxCommandEvent::GetString() const
 {
     // This is part of the hack retrieving the event string from the control
     // itself only when/if it's really needed to avoid copying potentially huge
-    // strings coming from multiline text controls. For consistency we also do
-    // it for combo boxes, even though there are no real performance advantages
-    // in doing this for them.
+    // strings coming from multiline text controls.
     if (m_eventType == wxEVT_TEXT && m_eventObject)
     {
-#if wxUSE_TEXTCTRL
-        wxTextCtrl *txt = wxDynamicCast(m_eventObject, wxTextCtrl);
-        if ( txt )
-            return txt->GetValue();
-#endif // wxUSE_TEXTCTRL
-
-#if wxUSE_COMBOBOX
-        wxComboBox* combo = wxDynamicCast(m_eventObject, wxComboBox);
-        if ( combo )
-            return combo->GetValue();
-#endif // wxUSE_COMBOBOX
-
-#if wxUSE_SEARCHCTRL
-        wxSearchCtrl* search = wxDynamicCast(m_eventObject, wxSearchCtrl);
-        if ( search )
-            return search->GetValue();
-#endif // wxUSE_SEARCHCTRL
+        // Only windows generate wxEVT_TEXT events, so this cast should really
+        // succeed, but err on the side of caution just in case somebody
+        // created a bogus event of this type.
+        if ( wxWindow* const w = wxDynamicCast(m_eventObject, wxWindow) )
+        {
+            if ( const wxTextEntry* const entry = w->WXGetTextEntry() )
+                return entry->GetValue();
+        }
     }
 
     return m_cmdString;


### PR DESCRIPTION
Instead of checking for all text-like controls one by one in
wxCommandEvent::GetString(), call a virtual function checking for this.

This is simpler, less error-prone and faster -- at the cost of
increasing the vtbl size of all wxWindow-derived classes.