### PR TITLE
Fix error in OSX dataview attribute setting

### DIFF
--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2922,7 +2922,7 @@ void wxDataViewRenderer::SetAttr(const wxDataViewItemAttr& attr)
                     [cell respondsToSelector:@selector(backgroundColor)] )
             {
                 if ( !data->GetOriginalBackgroundColour() )
-                    data->SaveOriginalTextColour([(id)cell backgroundColor]);
+                    data->SaveOriginalBackgroundColour([(id)cell backgroundColor]);
 
                 colBack = attr.GetBackgroundColour().OSXGetNSColor();
             }


### PR DESCRIPTION
There is a small error in the new attribute handling code on the OSX dataview control. It is part of the cause for the issue that was observed in #1673 (but there is more to that than just this). The proper operation of the text columns can be seen with this patch to the dataview sample (then the background color and text color of the date and text columns are alternating):

```
diff --git a/samples/dataview/mymodels.cpp b/samples/dataview/mymodels.cpp
index 75f375d817..9875c0be98 100644
--- a/samples/dataview/mymodels.cpp
+++ b/samples/dataview/mymodels.cpp
@@ -507,11 +507,17 @@ bool MyListModel::GetAttrByRow( unsigned int row, unsigned int col,
     {
         case Col_EditableText:
         case Col_Date:
+            if ( !(row % 2) )
+            {
+                attr.SetBackgroundColour(*wxLIGHT_GREY);
+                attr.SetColour( wxColour( *wxYELLOW ) );
+            }
+
             if (row < m_toggleColValues.size())
             {
                 if (m_toggleColValues[row])
                 {
-                    attr.SetColour( wxColour( *wxLIGHT_GREY ) );
+                    attr.SetColour( wxColour( *wxYELLOW ) );
                     attr.SetStrikethrough( true );
                     return true;
                 }
```