### PR TITLE
Remove macro expansions from event documentation

### DIFF
--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -4827,8 +4827,7 @@ wxEventType wxNewEventType();
 
     @see wxDECLARE_EVENT(), @ref overview_events_custom
  */
-#define wxDEFINE_EVENT(name, cls) \
-    const wxEventTypeTag< cls > name(wxNewEventType())
+#define wxDEFINE_EVENT(name, cls)
 
 /**
     Declares a custom event type.
@@ -4848,8 +4847,7 @@ wxEventType wxNewEventType();
     wxDECLARE_EVENT(MY_CUSTOM_EVENT, MyCustomEvent);
     @endcode
  */
-#define wxDECLARE_EVENT(name, cls) \
-        wxDECLARE_EXPORTED_EVENT(wxEMPTY_PARAMETER_VALUE, name, cls)
+#define wxDECLARE_EVENT(name, cls)
 
 /**
     Variant of wxDECLARE_EVENT() used for event types defined inside a shared
@@ -4860,8 +4858,7 @@ wxEventType wxNewEventType();
     wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_BUTTON, wxCommandEvent);
     @endcode
  */
-#define wxDECLARE_EXPORTED_EVENT( expdecl, name, cls ) \
-    extern const expdecl wxEventTypeTag< cls > name;
+#define wxDECLARE_EXPORTED_EVENT( expdecl, name, cls )
 
 /**
     Helper macro for definition of custom event table macros.
@@ -4875,7 +4872,7 @@ wxEventType wxNewEventType();
 
     @see @ref overview_events_custom_ownclass
  */
-#define wxEVENT_HANDLER_CAST(functype, func) (&func)
+#define wxEVENT_HANDLER_CAST(functype, func)
 
 /**
     This macro is used to define event table macros for handling custom
@@ -4909,8 +4906,7 @@ wxEventType wxNewEventType();
     @param fn
         The event handler method.
  */
-#define wx__DECLARE_EVT1(evt, id, fn) \
-    wx__DECLARE_EVT2(evt, id, wxID_ANY, fn)
+#define wx__DECLARE_EVT1(evt, id, fn)
 
 /**
     Generalized version of the wx__DECLARE_EVT1() macro taking a range of
@@ -4918,16 +4914,14 @@ wxEventType wxNewEventType();
     Argument @a id1 is the first identifier of the range, @a id2 is the
     second identifier of the range.
 */
-#define wx__DECLARE_EVT2(evt, id1, id2, fn) \
-    DECLARE_EVENT_TABLE_ENTRY(evt, id1, id2, fn, NULL),
+#define wx__DECLARE_EVT2(evt, id1, id2, fn)
 
 /**
     Simplified version of the wx__DECLARE_EVT1() macro, to be used when the
     event type must be handled regardless of the ID associated with the
     specific event instances.
 */
-#define wx__DECLARE_EVT0(evt, fn) \
-    wx__DECLARE_EVT1(evt, wxID_ANY, fn)
+#define wx__DECLARE_EVT0(evt, fn)
 
 /**
     Use this macro inside a class declaration to declare a @e static event table


### PR DESCRIPTION
The expansions do not really add anything to the documentation page, and can be confusing at first.