### PR TITLE
GetItemState() should assert in MSW for invalid item

### DIFF
--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -1077,6 +1077,9 @@ bool wxListCtrl::SetItem(long index, int col, const wxString& label, int imageId
 // Gets the item state
 int wxListCtrl::GetItemState(long item, long stateMask) const
 {
+    wxCHECK_MSG( item >= 0 && (size_t)item < GetItemCount(), 0,
+                 wxT("invalid list ctrl item index in GetItemState()") );
+
     wxListItem info;
 
     info.m_mask = wxLIST_MASK_STATE;


### PR DESCRIPTION
This will bring MSW code in par with GTK/OSX (generic).
Passing an invalid item to wxListCtrl::GetItemState() should assert if it takes an incorrect item.