### PR TITLE
Suppress warnings due to use of deprecated WebKit functions

### DIFF
--- a/src/gtk/webview_webkit2_extension.cpp
+++ b/src/gtk/webview_webkit2_extension.cpp
@@ -13,6 +13,12 @@
 #include <webkitdom/WebKitDOMDOMSelection.h>
 #include <webkitdom/WebKitDOMDOMWindowUnstable.h>
 
+// We can't easily avoid deprecation warnings about many WebKit functions, e.g.
+// webkit_dom_document_get_default_view() and just about everything related to
+// the selection, so for now just disable the warnings as we can't do anything
+// about them anyhow.
+wxGCC_WARNING_SUPPRESS(deprecated-declarations)
+
 static const char introspection_xml[] =
   "<node>"
   " <interface name='org.wxwidgets.wxGTK.WebExtension'>"


### PR DESCRIPTION
This is not the best solution, but getting dozens of lines of warnings
when compiling this file is not great neither and there doesn't seem to
be anything else to do about this.

---

@swt2c I think you already confirmed that there was no simple way to avoid these warnings, but I'd like to run this by you one last time before committing it. TIA!