### PR TITLE
Fix two simple cases of --disable-something causing build error

### DIFF
--- a/src/common/filesys.cpp
+++ b/src/common/filesys.cpp
@@ -130,20 +130,21 @@ wxString wxFileSystemHandler::GetMimeTypeFromExt(const wxString& location)
 
         return mime;
     }
-#endif
-    {
-        if ( ext.IsSameAs(wxT("htm"), false) || ext.IsSameAs(wxT("html"), false) )
-            return wxT("text/html");
-        if ( ext.IsSameAs(wxT("jpg"), false) || ext.IsSameAs(wxT("jpeg"), false) )
-            return wxT("image/jpeg");
-        if ( ext.IsSameAs(wxT("gif"), false) )
-            return wxT("image/gif");
-        if ( ext.IsSameAs(wxT("png"), false) )
-            return wxT("image/png");
-        if ( ext.IsSameAs(wxT("bmp"), false) )
-            return wxT("image/bmp");
-        return wxEmptyString;
-    }
+#endif // wxUSE_MIMETYPE
+
+    // Without wxUSE_MIMETYPE, recognize just a few hardcoded special cases.
+    if ( ext.IsSameAs(wxT("htm"), false) || ext.IsSameAs(wxT("html"), false) )
+        return wxT("text/html");
+    if ( ext.IsSameAs(wxT("jpg"), false) || ext.IsSameAs(wxT("jpeg"), false) )
+        return wxT("image/jpeg");
+    if ( ext.IsSameAs(wxT("gif"), false) )
+        return wxT("image/gif");
+    if ( ext.IsSameAs(wxT("png"), false) )
+        return wxT("image/png");
+    if ( ext.IsSameAs(wxT("bmp"), false) )
+        return wxT("image/bmp");
+
+    return wxString();
 }
 
 

--- a/src/common/filesys.cpp
+++ b/src/common/filesys.cpp
@@ -130,7 +130,6 @@ wxString wxFileSystemHandler::GetMimeTypeFromExt(const wxString& location)
 
         return mime;
     }
-    else
 #endif
     {
         if ( ext.IsSameAs(wxT("htm"), false) || ext.IsSameAs(wxT("html"), false) )

--- a/src/gtk/nonownedwnd.cpp
+++ b/src/gtk/nonownedwnd.cpp
@@ -27,6 +27,7 @@
     #include "wx/dcclient.h"
     #include "wx/dcmemory.h"
     #include "wx/region.h"
+    #include "wx/scopedptr.h"
 #endif // WX_PRECOMP
 
 #include "wx/graphics.h"


### PR DESCRIPTION
Fix build with --disable-intl (GTK) and --disable-sysoptions (all platforms).