### PR TITLE
Fix checking for the deepest shown window in focus handling code

### DIFF
--- a/include/wx/containr.h
+++ b/include/wx/containr.h
@@ -265,7 +265,7 @@ public:
     }
 
     WXDLLIMPEXP_INLINE_CORE
-    virtual void WXDoUpdatePendingFocus(wxWindow* win) wxOVERRIDE
+    virtual void WXSetPendingFocus(wxWindow* win) wxOVERRIDE
     {
         return m_container.SetLastFocus(win);
     }

--- a/include/wx/msw/toplevel.h
+++ b/include/wx/msw/toplevel.h
@@ -103,7 +103,7 @@ public:
 
     // called from wxWidgets code itself only when the pending focus, i.e. the
     // element which should get focus when this TLW is activated again, changes
-    virtual void WXDoUpdatePendingFocus(wxWindow* win) wxOVERRIDE
+    virtual void WXSetPendingFocus(wxWindow* win) wxOVERRIDE
     {
         m_winLastFocused = win;
     }

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -585,12 +585,11 @@ public:
     static bool MSWClickButtonIfPossible(wxButton* btn);
 
     // This method is used for handling wxRadioButton-related complications,
-    // see wxRadioButton::SetValue(). It calls WXDoUpdatePendingFocus() for
-    // this window and all its parents up to the enclosing TLW, recursively.
-    void WXSetPendingFocus(wxWindow* win);
-
-    // Should be overridden by all classes storing the "last focused" window.
-    virtual void WXDoUpdatePendingFocus(wxWindow* WXUNUSED(win)) {}
+    // see wxRadioButton::SetValue().
+    //
+    // It should be overridden by all classes storing the "last focused"
+    // window to avoid focusing an unset radio button when regaining focus.
+    virtual void WXSetPendingFocus(wxWindow* WXUNUSED(win)) {}
 
     // Called from WM_DPICHANGED handler for all windows to let them update
     // any sizes and fonts used internally when the DPI changes and generate

--- a/interface/wx/radiobut.h
+++ b/interface/wx/radiobut.h
@@ -109,6 +109,12 @@ public:
         value set to @true. To uncheck a radio button in a group you must check
         another button in the same group.
 
+        @note Under MSW, the focused radio button is always selected, i.e. its
+            value is @true. And, conversely, calling @c SetValue(true) will
+            also set focus to the radio button if the focus had previously been
+            on another radio button in the same group -- as otherwise setting
+            it on wouldn't work.
+
         @param value
             @true to check, @false to uncheck.
     */

--- a/src/common/containr.cpp
+++ b/src/common/containr.cpp
@@ -711,8 +711,15 @@ bool wxSetFocusToChild(wxWindow *win, wxWindow **childLastFocused)
                 else
                     deepestVisibleWindow = NULL;
 
-                if ( (*childLastFocused)->IsTopLevel() )
+                // We shouldn't be looking for the child to focus beyond the
+                // TLW boundary. And we use IsTopNavigationDomain() here
+                // instead of IsTopLevel() because wxMDIChildFrame is also TLW
+                // from this point of view.
+                if ( (*childLastFocused)->
+                        IsTopNavigationDomain(wxWindow::Navigation_Tab) )
+                {
                     break;
+                }
 
                 *childLastFocused = (*childLastFocused)->GetParent();
             }

--- a/src/common/containr.cpp
+++ b/src/common/containr.cpp
@@ -711,6 +711,9 @@ bool wxSetFocusToChild(wxWindow *win, wxWindow **childLastFocused)
                 else
                     deepestVisibleWindow = NULL;
 
+                if ( (*childLastFocused)->IsTopLevel() )
+                    break;
+
                 *childLastFocused = (*childLastFocused)->GetParent();
             }
 

--- a/src/msw/radiobut.cpp
+++ b/src/msw/radiobut.cpp
@@ -181,11 +181,29 @@ void wxRadioButton::SetValue(bool value)
     }
     else
     {
-        // Don't change focus right now, this could be unexpected, but do
-        // ensure that when our parent regains focus, it goes to this button
-        // and not another one, which would result in this one losing its
-        // checked status.
-        GetParent()->WXSetPendingFocus(this);
+        // We don't need to change the focus right now, so avoid doing it as it
+        // could be unexpected (and also would result in focus set/kill events
+        // that wouldn't be generated under the other platforms).
+        if ( !GetParent()->IsDescendant(FindFocus()) )
+        {
+            // However tell the parent to focus this radio button when it
+            // regains the focus the next time, to avoid focusing another one
+            // and this changing the value. Note that this is not ideal: it
+            // would be better to only change pending focus if it currently
+            // points to a radio button, but this is much simpler to do, as
+            // otherwise we'd need to not only check if the pending focus is a
+            // radio button, but also if we'd give the focus to a radio button
+            // when there is no current pending focus, so don't bother with it
+            // until somebody really complains about it being a problem in
+            // practice.
+            GetParent()->WXSetPendingFocus(this);
+        }
+        //else: don't overwrite the pending focus if the window has the focus
+        // currently, as this would make its state inconsistent and would be
+        // useless anyhow, as the problem we're trying to solve here won't
+        // happen in this case (we know that our focused sibling is not a radio
+        // button in the same group, otherwise we would have set shouldSetFocus
+        // to true above).
     }
 }
 

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -1024,25 +1024,6 @@ void wxWindowMSW::MSWUpdateUIState(int action, int state)
     ::SendMessage(GetHwnd(), WM_CHANGEUISTATE, MAKEWPARAM(action, state), 0);
 }
 
-void wxWindowMSW::WXSetPendingFocus(wxWindow* win)
-{
-    wxWindow * const focus = FindFocus();
-
-    for ( wxWindow* parent = this; parent; parent = parent->GetParent() )
-    {
-        // We shouldn't overwrite the pending focus if the window has the focus
-        // currently, as this would make its state inconsistent. And this would
-        // be useless anyhow, as we only remember pending focus in order to
-        // restore it properly when the window gets the focus back -- which is
-        // unnecessary if it has the focus already.
-        if ( !parent->IsDescendant(focus) )
-            parent->WXDoUpdatePendingFocus(win);
-
-        if ( parent->IsTopLevel() )
-            break;
-    }
-}
-
 // ---------------------------------------------------------------------------
 // scrolling stuff
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
wxSetFocusToChild() could recurse to the parent TLW, which was clearly
nonsensical as it means that restoring last focus in a dialog could end
up setting it to the parent frame.

Fix this by breaking out of the loop as soon as we reach a TLW.

See #18653.