### PR TITLE
OSX: Miscellaneous small fixes

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -6106,15 +6106,9 @@ void wxGrid::DrawCell( wxDC& dc, const wxGridCellCoords& coords )
     // Note: However, only if it is really _shown_, i.e. not hidden!
     if ( isCurrent && IsCellEditControlShown() )
     {
-        // NB: this "#if..." is temporary and fixes a problem where the
-        // edit control is erased by this code after being rendered.
-        // On wxMac (QD build only), the cell editor is a wxTextCntl and is rendered
-        // implicitly, causing this out-of order render.
-#if !defined(__WXMAC__)
         wxGridCellEditor *editor = attr->GetEditor(this, row, col);
         editor->PaintBackground(dc, rect, *attr);
         editor->DecRef();
-#endif
     }
     else
     {

--- a/src/osx/cocoa/nonownedwnd.mm
+++ b/src/osx/cocoa/nonownedwnd.mm
@@ -939,9 +939,13 @@ void wxNonOwnedWindowCocoaImpl::SetWindowStyleFlag( long style )
             level = NSModalPanelWindowLevel;
         else if (( style & wxFRAME_FLOAT_ON_PARENT ) || ( style & wxFRAME_TOOL_WINDOW ))
             level = NSFloatingWindowLevel;
-        
-        [m_macWindow setLevel: level];
-        m_macWindowLevel = level;
+
+        // Only update the level when it has changed, setting a level can cause the OS to reorder the windows in the level
+        if ( level != m_macWindowLevel )
+        {
+            [m_macWindow setLevel: level];
+            m_macWindowLevel = level;
+        }
     }
 }
 

--- a/src/osx/dataview_osx.cpp
+++ b/src/osx/dataview_osx.cpp
@@ -365,6 +365,10 @@ bool wxDataViewCtrl::Create(wxWindow *parent,
                             const wxValidator& validator,
                             const wxString& name)
 {
+  // Remove wxVSCROLL and wxHSCROLL from the style, since the dataview panel has scrollbars
+  // by default, and wxControl::Create trys to make some but crashes in the process
+  style &= ~(wxVSCROLL | wxHSCROLL);
+
   DontCreatePeer();
   if (!(wxControl::Create(parent,id,pos,size,style,validator,name)))
     return false;


### PR DESCRIPTION
This PR contains 3 small fixes for OSX:

* Don't update the level in `wxNonOwnedWindow::SetWindowStyle` unless the level has actually been updated in that call. There is a bug in some OSX versions that can cause the windows in a level to be reordered when `setLevel` is called. I don't have a MWE for that shows the affect of this change though.
* Make `wxDataViewCtrl` ignore the `wxHSCROLL` and `wxVSCROLL` styles, since using those causes the constructor to crash and the control already has scrollbars enabled. (see http://trac.wxwidgets.org/ticket/17028). This is easily seen using this diff to the dataview sample:
```
diff --git a/samples/dataview/dataview.cpp b/samples/dataview/dataview.cpp
index e7a00ab617..2141198be0 100644
--- a/samples/dataview/dataview.cpp
+++ b/samples/dataview/dataview.cpp
@@ -593,7 +593,7 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, int x, int y, int w, int
 
     wxPanel *firstPanel = new wxPanel( m_notebook, wxID_ANY );
 
-    BuildDataViewCtrl(firstPanel, Page_Music);
+    BuildDataViewCtrl(firstPanel, Page_Music, wxHSCROLL);
 
     const wxSizerFlags border = wxSizerFlags().DoubleBorder();
 
```

* Draw the background color in a `wxGrid` cell when the editor is shown using the editor. This change was commented out due to some problems with it and the Quick Draw framework, but Quick Draw is deprecated and no longer used and this is preventing the background color from appearing correctly.

Without change (note subdued background color when editor is active):
![WithoutPatch](https://user-images.githubusercontent.com/2262453/73034873-2baeec80-3e3e-11ea-9345-44a1e801974d.gif)

With change (note full background color when editor is active):
![WithPatch](https://user-images.githubusercontent.com/2262453/73034879-2d78b000-3e3e-11ea-83a7-a5e9533decd3.gif)
