### PR TITLE
Fix dangling else warnigs for all wx(V)LogXXX

### DIFF
--- a/samples/minimal/minimal.cpp
+++ b/samples/minimal/minimal.cpp
@@ -115,9 +115,66 @@ wxIMPLEMENT_APP(MyApp);
 // the application class
 // ----------------------------------------------------------------------------
 
+#include <cstdarg>
+
+static void blabla(int x, ...) {
+	va_list list;
+	va_start(list, x);
+
+	if (true)
+		wxVLogGeneric(Info, "vhello generic %d", list);
+	if (true)
+		wxVLogTrace(wxTRACE_Messages, "vhello trace %d", list);
+	if (true)
+		wxVLogError("vhello error %d", list);
+	if (true)
+		wxVLogMessage("vhello message %d", list);
+	if (true)
+		wxVLogVerbose("vhello verbose %d", list);
+	if (true)
+		wxVLogWarning("vhello warning %d", list);
+#if 0
+	if (true)
+		wxVLogFatalError("vhello fatal %d", list);
+#endif
+	if (true)
+		wxVLogSysError("vhello syserror %d", list);
+	if (true)
+		wxVLogStatus("vhello status %d", list);
+	if (true)
+		wxVLogDebug("vhello debug %d", list);
+
+	va_end(list);
+}
+
 // 'Main program' equivalent: the program execution "starts" here
 bool MyApp::OnInit()
 {
+	wxLog::SetLogLevel(wxLOG_Max);
+	blabla(123, 456);
+	if (true)
+		wxLogGeneric(wxLOG_Info, "hello generic %d", 42);
+	if (true)
+		wxLogTrace(wxTRACE_Messages, "hello trace %d", 42);
+	if (true)
+		wxLogError("hello error %d", 42);
+	if (true)
+		wxLogMessage("hello message %d", 42);
+	if (true)
+		wxLogVerbose("hello verbose %d", 42);
+	if (true)
+		wxLogWarning("hello warning %d", 42);
+#if 0
+	if (true)
+		wxLogFatalError("hello fatal %d", 42);
+#endif
+	if (true)
+		wxLogSysError("hello syserror %d", 42);
+	if (true)
+		wxLogStatus("hello status %d", 42);
+	if (true)
+		wxLogDebug("hello debug %d", 42);
+
     // call the base class initialization method, currently it only parses a
     // few common command-line options but it could be do more in the future
     if ( !wxApp::OnInit() )

--- a/tests/log/logtest.cpp
+++ b/tests/log/logtest.cpp
@@ -394,4 +394,66 @@ void LogTestCase::NoWarnings()
     CPPUNIT_ASSERT_EQUAL( "If", m_log->GetLog(wxLOG_Error) );
 }
 
+// The following two functions (v, macroCompilabilityTest) are not run by
+// any test, and their purpose is merely to guarantee that the wx(V)LogXXX
+// macros compile without 'dangling else' warnings.
+#pragma GCC diagnostic error "-Wdangling-else"
+
+static void v(int x, ...) {
+	va_list list;
+	va_start(list, x);
+
+	if (true)
+		wxVLogGeneric(Info, "vhello generic %d", list);
+	if (true)
+		wxVLogTrace(wxTRACE_Messages, "vhello trace %d", list);
+	if (true)
+		wxVLogError("vhello error %d", list);
+	if (true)
+		wxVLogMessage("vhello message %d", list);
+	if (true)
+		wxVLogVerbose("vhello verbose %d", list);
+	if (true)
+		wxVLogWarning("vhello warning %d", list);
+	if (true)
+		wxVLogFatalError("vhello fatal %d", list);
+	if (true)
+		wxVLogSysError("vhello syserror %d", list);
+#if wxUSE_GUI
+	if (true)
+		wxVLogStatus("vhello status %d", list);
+#endif
+	if (true)
+		wxVLogDebug("vhello debug %d", list);
+
+	va_end(list);
+}
+
+void macroCompilabilityTest()
+{
+	v(123, 456);
+	if (true)
+		wxLogGeneric(wxLOG_Info, "hello generic %d", 42);
+	if (true)
+		wxLogTrace(wxTRACE_Messages, "hello trace %d", 42);
+	if (true)
+		wxLogError("hello error %d", 42);
+	if (true)
+		wxLogMessage("hello message %d", 42);
+	if (true)
+		wxLogVerbose("hello verbose %d", 42);
+	if (true)
+		wxLogWarning("hello warning %d", 42);
+	if (true)
+		wxLogFatalError("hello fatal %d", 42);
+	if (true)
+		wxLogSysError("hello syserror %d", 42);
+#if wxUSE_GUI
+	if (true)
+		wxLogStatus("hello status %d", 42);
+#endif
+	if (true)
+		wxLogDebug("hello debug %d", 42);
+}
+
 #endif // wxUSE_LOG


### PR DESCRIPTION
Various `wxLogXXX`/`wxVLogXXX` calls still cause dangling else warnings by Clang:
`warning: add explicit braces to avoid dangling else [-Wdangling-else]`

Here is an attempt to fix the rest of them. There are two commits: The first one demonstrates the problem in the minimal sample, and shouldn't be merged. The latter commit is the actual fix.

I've tested this branch on three platforms, but obviously not on all the compilers there are out there.