### PR TITLE
Redraw overflowed wxGrid cells to update the background

### DIFF
--- a/src/generic/gridctrl.cpp
+++ b/src/generic/gridctrl.cpp
@@ -650,6 +650,10 @@ void wxGridCellStringRenderer::Draw(wxGrid& grid,
                 col_end = grid.GetNumberCols() - 1;
             for (int i = col + cell_cols; i <= col_end; i++)
             {
+                // redraw the cell to update the background
+                wxGridCellCoords coords(row, i);
+                grid.DrawCell(dc, coords);
+
                 clip.width = grid.GetColSize(i) - 1;
                 wxDCClipper clipper(dc, clip);
 


### PR DESCRIPTION
Before we draw the overflowed text we should redraw corresponding cells
to avoid visual artefacts.