### PR TITLE
wxQT/Win32: Fix wxDROP_ICON define

### DIFF
--- a/include/wx/qt/dnd.h
+++ b/include/wx/qt/dnd.h
@@ -8,7 +8,11 @@
 #ifndef _WX_QT_DND_H_
 #define _WX_QT_DND_H_
 
+#if defined(__WINDOWS__) && wxUSE_WXDIB
+#define wxDROP_ICON(name)   wxCursor(wxT(#name))
+#else
 #define wxDROP_ICON(name)   wxCursor(name##_xpm)
+#endif
 
 class WXDLLIMPEXP_CORE wxDropTarget : public wxDropTargetBase
 {


### PR DESCRIPTION
This is needed for the dnd sample to build under wxQT/Win32.

Tim S.

The sample build error is
```
../../../wxWidgets-git/samples/dnd/dnd.cpp: In member function 'void DnDFrame::OnLeftDown(wxMouseEvent&)':
../../../wxWidgets-git/samples/dnd/dnd.cpp:1229:41: error: 'dnd_copy_xpm' was not declared in this scope
 1229 |                             wxDROP_ICON(dnd_copy),
      |                                         ^~~~~~~~
../../../wxWidgets-git/include/wx/qt/dnd.h:11:38: note: in definition of macro 'wxDROP_ICON'
   11 | #define wxDROP_ICON(name)   wxCursor(name##_xpm)
      |                                      ^~~~
../../../wxWidgets-git/samples/dnd/dnd.cpp:1230:41: error: 'dnd_move_xpm' was not declared in this scope
 1230 |                             wxDROP_ICON(dnd_move),
      |                                         ^~~~~~~~
../../../wxWidgets-git/include/wx/qt/dnd.h:11:38: note: in definition of macro 'wxDROP_ICON'
   11 | #define wxDROP_ICON(name)   wxCursor(name##_xpm)
      |                                      ^~~~
```
