### PR TITLE
wxStaticBox with custom foreground color drawing text in wrong place

### DIFF
--- a/src/msw/statbox.cpp
+++ b/src/msw/statbox.cpp
@@ -550,15 +550,16 @@ void wxStaticBox::PaintForeground(wxDC& dc, const RECT&)
 
         // first we need to correctly paint the background of the label
         // as Windows ignores the brush offset when doing it
-        const int x = FromDIP(LABEL_HORZ_OFFSET);
+        // NOTE: Border intentionally does not use DIPs in order to match native look
+        const int x = LABEL_HORZ_OFFSET;
         RECT dimensions = { x, 0, 0, height };
         dimensions.left = x;
         dimensions.right = x + width;
 
         // need to adjust the rectangle to cover all the label background
-        dimensions.left -= FromDIP(LABEL_HORZ_BORDER);
-        dimensions.right += FromDIP(LABEL_HORZ_BORDER);
-        dimensions.bottom += FromDIP(LABEL_VERT_BORDER);
+        dimensions.left -= LABEL_HORZ_BORDER;
+        dimensions.right += LABEL_HORZ_BORDER;
+        dimensions.bottom += LABEL_VERT_BORDER;
 
         if ( UseBgCol() )
         {


### PR DESCRIPTION
Here are images for comparison. These were created at 4k resolution (that part doesn't matter) with 200% scaling.

Here is the image of master where you can still see the native text rendered to the left of it. If you measure the distance it's 9px which would be exactly double the 9px define we have because of 2x DIP scaling.
![image](https://user-images.githubusercontent.com/418576/74842717-d4931f00-52f8-11ea-87be-a13dd4211c40.png)

Here is the image of the same static box without the custom foreground for comparison. Note that if you measure the distance from the last letter to the box border it's much smaller than the distance in master because they don't DPI scale the label border size.
![image](https://user-images.githubusercontent.com/418576/74842777-e83e8580-52f8-11ea-9b5b-f39d77f6150e.png)

Finally here is the image with this change. If you overlay it on top of the native you'll see that the only thing changing is the font color.
![image](https://user-images.githubusercontent.com/418576/74843009-45d2d200-52f9-11ea-8de2-02711c634ef4.png)

I tested this at all scaling factors on Windows 10.