### PR TITLE
Hide page when remove from wxAuiNotebook

### DIFF
--- a/src/aui/auibook.cpp
+++ b/src/aui/auibook.cpp
@@ -2082,6 +2082,8 @@ bool wxAuiNotebook::RemovePage(size_t page_idx)
     if (!wnd)
         return false;
 
+    ShowWnd(wnd, false);
+
     // find out which onscreen tab ctrl owns this tab
     wxAuiTabCtrl* ctrl;
     int ctrl_idx;


### PR DESCRIPTION
Currently page still visible after removing and it overlapped new page. 