### PR TITLE
Adjust column width when the row is added

### DIFF
--- a/src/osx/dataview_osx.cpp
+++ b/src/osx/dataview_osx.cpp
@@ -104,6 +104,7 @@ bool wxOSXDataViewModelNotifier::ItemAdded(wxDataViewItem const& parent, wxDataV
   wxCHECK_MSG(item.IsOk(),false,"Added item is invalid.");
   noFailureFlag = m_DataViewCtrlPtr->GetDataViewPeer()->Add(parent,item);
   AdjustRowHeight(item);
+  AdjustAutosizedColumns();
   return noFailureFlag;
 }
 
@@ -116,6 +117,7 @@ bool wxOSXDataViewModelNotifier::ItemsAdded(wxDataViewItem const& parent, wxData
   noFailureFlag = m_DataViewCtrlPtr->GetDataViewPeer()->Add(parent,items);
  // adjust row heights:
   AdjustRowHeights(items);
+  AdjustAutosizedColumns();
  // done:
   return noFailureFlag;
 }


### PR DESCRIPTION
When the item is added to the wxDVC the width of the column was not modified.
The width is modified in case the item is inserted or deleted or when the item is edited.

This PR corrects that.

Please review and apply.

Thank you.
