### PR TITLE
Reduce Xcode output in Travis CI CMake build

### DIFF
--- a/build/tools/travis-ci.sh
+++ b/build/tools/travis-ci.sh
@@ -26,7 +26,10 @@ case $wxTOOLSET in
 
         echo 'travis_fold:start:building'
         echo 'Building...'
-        cmake --build . -- $wxJOBS
+        if [ "$wxCMAKE_GENERATOR" == "Xcode" ]; then
+            wxTOOL_ARG="-quiet"
+        fi
+        cmake --build . -- $wxJOBS $wxTOOL_ARG
         echo 'travis_fold:end:building'
 
         if [ "$wxCMAKE_TESTS" != "OFF" ]; then


### PR DESCRIPTION
This should fix builds that terminate due to: job exceeded the maximum log length.