### PR TITLE
Remove outdated and even initially odd comment about making functions const

### DIFF
--- a/include/wx/textbuf.h
+++ b/include/wx/textbuf.h
@@ -115,16 +115,14 @@ public:
     // lines, i.e. you may write something like:
     //  for ( str = GetFirstLine(); !Eof(); str = GetNextLine() ) { ... }
 
-    // NB: const is commented out because not all compilers understand
-    //     'mutable' keyword yet (m_nCurLine should be mutable)
-    wxString& GetFirstLine() /* const */
+    wxString& GetFirstLine()
         { return m_aLines.empty() ? ms_eof : m_aLines[m_nCurLine = 0]; }
-    wxString& GetNextLine()  /* const */
+    wxString& GetNextLine()
         { return ++m_nCurLine == m_aLines.size() ? ms_eof
                                                  : m_aLines[m_nCurLine]; }
-    wxString& GetPrevLine()  /* const */
+    wxString& GetPrevLine()
         { wxASSERT(m_nCurLine > 0); return m_aLines[--m_nCurLine]; }
-    wxString& GetLastLine() /* const */
+    wxString& GetLastLine()
         { return m_aLines.empty() ? ms_eof : m_aLines[m_nCurLine = m_aLines.size() - 1]; }
 
     // get the type of the line (see also GetEOL)


### PR DESCRIPTION
The comment suggested Get{First,Next,Prev,Last}Line() should be changed to
const functions once compilers understand the 'mutable' keyword.

Hopefully now, after 19 years, compilers do understand the 'mutable' keyword,
but regardless of that the functions should not be const, as they very clearly
modify the state of the object that is observable through the public interface.