### PR TITLE
Fix dangling else warnings in wxLog macros

### DIFF
--- a/include/wx/cpp.h
+++ b/include/wx/cpp.h
@@ -97,6 +97,27 @@
 #define wxSTATEMENT_MACRO_END } while ( (void)0, 0 )
 
 /*
+    Helper for executing the following statement conditionally without using
+    conditional statements.
+
+    This strange macro is needed in the first place to avoid the problems due
+    to nested if/else inside macros. E.g. if some MACRO started with "if", then
+
+        if ( cond )
+            MACRO();
+        else
+            ...
+
+    would be broken because "..." would bind to the wrong "if" inside the macro
+    rather than the visible one. So we use wxDO_IF() inside the macro instead
+    to avoid this problem.
+ */
+#define wxDO_IF_HELPER(loopvar, condition)                                    \
+    for ( bool loopvar = false; !loopvar && condition; loopvar = true )
+
+#define wxDO_IF(condition) wxDO_IF_HELPER(wxMAKE_UNIQUE_NAME(wxdoif), condition)
+
+/*
     Define __WXFUNCTION__ which is like standard __FUNCTION__ but defined as
     NULL for the compilers which don't support the latter.
  */

--- a/tests/log/logtest.cpp
+++ b/tests/log/logtest.cpp
@@ -398,7 +398,13 @@ void LogTestCase::NoWarnings()
 // any test, and their purpose is merely to guarantee that the wx(V)LogXXX
 // macros compile without 'dangling else' warnings.
 #if defined(__clang__) || wxCHECK_GCC_VERSION(4, 6)
-    #pragma GCC diagnostic error "-Wdangling-else"
+    // gcc 7 split -Wdangling-else from the much older -Wparentheses, so use
+    // the new warning if it's available or the old one otherwise.
+    #if wxCHECK_GCC_VERSION(7, 0)
+        #pragma GCC diagnostic error "-Wdangling-else"
+    #else
+        #pragma GCC diagnostic error "-Wparentheses"
+    #endif
 #endif
 
 static void v(int x, ...)

--- a/tests/log/logtest.cpp
+++ b/tests/log/logtest.cpp
@@ -422,10 +422,6 @@ static void v(int x, ...)
         wxVLogFatalError("vhello fatal %d", list);
     if (true)
         wxVLogSysError("vhello syserror %d", list);
-#if wxUSE_GUI
-    if (true)
-        wxVLogStatus("vhello status %d", list);
-#endif
     if (true)
         wxVLogDebug("vhello debug %d", list);
 
@@ -451,10 +447,6 @@ void macroCompilabilityTest()
         wxLogFatalError("hello fatal %d", 42);
     if (true)
         wxLogSysError("hello syserror %d", 42);
-#if wxUSE_GUI
-    if (true)
-        wxLogStatus("hello status %d", 42);
-#endif
     if (true)
         wxLogDebug("hello debug %d", 42);
 }

--- a/tests/log/logtest.cpp
+++ b/tests/log/logtest.cpp
@@ -394,4 +394,66 @@ void LogTestCase::NoWarnings()
     CPPUNIT_ASSERT_EQUAL( "If", m_log->GetLog(wxLOG_Error) );
 }
 
+// The following two functions (v, macroCompilabilityTest) are not run by
+// any test, and their purpose is merely to guarantee that the wx(V)LogXXX
+// macros compile without 'dangling else' warnings.
+#pragma GCC diagnostic error "-Wdangling-else"
+
+static void v(int x, ...) {
+	va_list list;
+	va_start(list, x);
+
+	if (true)
+		wxVLogGeneric(Info, "vhello generic %d", list);
+	if (true)
+		wxVLogTrace(wxTRACE_Messages, "vhello trace %d", list);
+	if (true)
+		wxVLogError("vhello error %d", list);
+	if (true)
+		wxVLogMessage("vhello message %d", list);
+	if (true)
+		wxVLogVerbose("vhello verbose %d", list);
+	if (true)
+		wxVLogWarning("vhello warning %d", list);
+	if (true)
+		wxVLogFatalError("vhello fatal %d", list);
+	if (true)
+		wxVLogSysError("vhello syserror %d", list);
+#if wxUSE_GUI
+	if (true)
+		wxVLogStatus("vhello status %d", list);
+#endif
+	if (true)
+		wxVLogDebug("vhello debug %d", list);
+
+	va_end(list);
+}
+
+void macroCompilabilityTest()
+{
+	v(123, 456);
+	if (true)
+		wxLogGeneric(wxLOG_Info, "hello generic %d", 42);
+	if (true)
+		wxLogTrace(wxTRACE_Messages, "hello trace %d", 42);
+	if (true)
+		wxLogError("hello error %d", 42);
+	if (true)
+		wxLogMessage("hello message %d", 42);
+	if (true)
+		wxLogVerbose("hello verbose %d", 42);
+	if (true)
+		wxLogWarning("hello warning %d", 42);
+	if (true)
+		wxLogFatalError("hello fatal %d", 42);
+	if (true)
+		wxLogSysError("hello syserror %d", 42);
+#if wxUSE_GUI
+	if (true)
+		wxLogStatus("hello status %d", 42);
+#endif
+	if (true)
+		wxLogDebug("hello debug %d", 42);
+}
+
 #endif // wxUSE_LOG

--- a/tests/log/logtest.cpp
+++ b/tests/log/logtest.cpp
@@ -397,63 +397,66 @@ void LogTestCase::NoWarnings()
 // The following two functions (v, macroCompilabilityTest) are not run by
 // any test, and their purpose is merely to guarantee that the wx(V)LogXXX
 // macros compile without 'dangling else' warnings.
-#pragma GCC diagnostic error "-Wdangling-else"
-
-static void v(int x, ...) {
-	va_list list;
-	va_start(list, x);
-
-	if (true)
-		wxVLogGeneric(Info, "vhello generic %d", list);
-	if (true)
-		wxVLogTrace(wxTRACE_Messages, "vhello trace %d", list);
-	if (true)
-		wxVLogError("vhello error %d", list);
-	if (true)
-		wxVLogMessage("vhello message %d", list);
-	if (true)
-		wxVLogVerbose("vhello verbose %d", list);
-	if (true)
-		wxVLogWarning("vhello warning %d", list);
-	if (true)
-		wxVLogFatalError("vhello fatal %d", list);
-	if (true)
-		wxVLogSysError("vhello syserror %d", list);
-#if wxUSE_GUI
-	if (true)
-		wxVLogStatus("vhello status %d", list);
+#if defined(__clang__) || wxCHECK_GCC_VERSION(4, 6)
+    #pragma GCC diagnostic error "-Wdangling-else"
 #endif
-	if (true)
-		wxVLogDebug("vhello debug %d", list);
 
-	va_end(list);
+static void v(int x, ...)
+{
+    va_list list;
+    va_start(list, x);
+
+    if (true)
+        wxVLogGeneric(Info, "vhello generic %d", list);
+    if (true)
+        wxVLogTrace(wxTRACE_Messages, "vhello trace %d", list);
+    if (true)
+        wxVLogError("vhello error %d", list);
+    if (true)
+        wxVLogMessage("vhello message %d", list);
+    if (true)
+        wxVLogVerbose("vhello verbose %d", list);
+    if (true)
+        wxVLogWarning("vhello warning %d", list);
+    if (true)
+        wxVLogFatalError("vhello fatal %d", list);
+    if (true)
+        wxVLogSysError("vhello syserror %d", list);
+#if wxUSE_GUI
+    if (true)
+        wxVLogStatus("vhello status %d", list);
+#endif
+    if (true)
+        wxVLogDebug("vhello debug %d", list);
+
+    va_end(list);
 }
 
 void macroCompilabilityTest()
 {
-	v(123, 456);
-	if (true)
-		wxLogGeneric(wxLOG_Info, "hello generic %d", 42);
-	if (true)
-		wxLogTrace(wxTRACE_Messages, "hello trace %d", 42);
-	if (true)
-		wxLogError("hello error %d", 42);
-	if (true)
-		wxLogMessage("hello message %d", 42);
-	if (true)
-		wxLogVerbose("hello verbose %d", 42);
-	if (true)
-		wxLogWarning("hello warning %d", 42);
-	if (true)
-		wxLogFatalError("hello fatal %d", 42);
-	if (true)
-		wxLogSysError("hello syserror %d", 42);
+    v(123, 456);
+    if (true)
+        wxLogGeneric(wxLOG_Info, "hello generic %d", 42);
+    if (true)
+        wxLogTrace(wxTRACE_Messages, "hello trace %d", 42);
+    if (true)
+        wxLogError("hello error %d", 42);
+    if (true)
+        wxLogMessage("hello message %d", 42);
+    if (true)
+        wxLogVerbose("hello verbose %d", 42);
+    if (true)
+        wxLogWarning("hello warning %d", 42);
+    if (true)
+        wxLogFatalError("hello fatal %d", 42);
+    if (true)
+        wxLogSysError("hello syserror %d", 42);
 #if wxUSE_GUI
-	if (true)
-		wxLogStatus("hello status %d", 42);
+    if (true)
+        wxLogStatus("hello status %d", 42);
 #endif
-	if (true)
-		wxLogDebug("hello debug %d", 42);
+    if (true)
+        wxLogDebug("hello debug %d", 42);
 }
 
 #endif // wxUSE_LOG


### PR DESCRIPTION
@lanurmi This is based on your #1718 but does it in IMO more readable and maintainable way. Please let me know if you see any problems with doing it like this. Thanks!