### PR TITLE
Guard for a null entry in wxTextEntry::EnableTextChangedEvents

### DIFF
--- a/src/gtk/textentry.cpp
+++ b/src/gtk/textentry.cpp
@@ -1003,14 +1003,18 @@ int wxTextEntry::GTKEntryIMFilterKeypress(GdkEventKey* event) const
 
 void wxTextEntry::EnableTextChangedEvents(bool enable)
 {
+    void* entry = GetTextObject();
+    if ( !entry )
+        return;
+
     if ( enable )
     {
-        g_signal_handlers_unblock_by_func(GetTextObject(),
+        g_signal_handlers_unblock_by_func(entry,
             (gpointer)wx_gtk_text_changed_callback, this);
     }
     else // disable events
     {
-        g_signal_handlers_block_by_func(GetTextObject(),
+        g_signal_handlers_block_by_func(entry,
             (gpointer)wx_gtk_text_changed_callback, this);
     }
 }


### PR DESCRIPTION
GetTextObject might return null when overridden via GetEntry in
wxComboBox or wxBitmapComboBox.

Because EnableTextChangedEvents is indirectly called via the generic
GTKDisableEvents in several places (including during construction!), we
need to guard against this scenario.

This avoids endless gobject assertion failures in several wx
projects.