### PR TITLE
Fix GetSizeFromTextSize for generic wxSpinCtrl

### DIFF
--- a/src/generic/spinctlg.cpp
+++ b/src/generic/spinctlg.cpp
@@ -286,7 +286,9 @@ wxSize wxSpinCtrlGenericBase::DoGetSizeFromTextSize(int xlen, int ylen) const
     tsize.IncBy(4*totalS.y/10 + 4, 0);
 #elif defined(__WXGTK__)
     tsize.IncBy(totalS.y + 10, 0);
-#endif // MSW GTK
+#elif defined(__WXOSX_COCOA__)
+    tsize.IncBy(totalS.y - GetCharHeight(), 0);
+#endif
 
     // Check if the user requested a non-standard height.
     if ( ylen > 0 )


### PR DESCRIPTION
The width returned by GetSizeFromTextSize on wxOSX is too small. The code does not take the margins around the textCtrl into account when calculating total width. This PR fixes this by estimating margins using the vertical margin.

Sample:
```c
spinctrl->SetInitialSize(spinctrl->GetSizeFromTextSize(GetTextExtent(wxS("00"))));
```
Before PR:
![Capture1](https://user-images.githubusercontent.com/8182182/76363931-76a39700-62fa-11ea-95c3-8a3cb2c9d9df.PNG)
After PR:
![Capture2](https://user-images.githubusercontent.com/8182182/76363943-7acfb480-62fa-11ea-9715-079183d1f147.PNG)
