### PR TITLE
Provide work around for surprising behaviour of wxAuiToolBar::DeleteTool()

### DIFF
--- a/include/wx/aui/auibar.h
+++ b/include/wx/aui/auibar.h
@@ -525,6 +525,12 @@ public:
 
     void ClearTools() { Clear() ; }
     void Clear();
+
+    bool DestroyTool(int toolId);
+    bool DestroyToolByIndex(int idx);
+
+    // Note that these methods do _not_ delete the associated control, if any.
+    // Use DestroyTool() or DestroyToolByIndex() if this is wanted/
     bool DeleteTool(int toolId);
     bool DeleteByIndex(int toolId);
 

--- a/interface/wx/aui/auibar.h
+++ b/interface/wx/aui/auibar.h
@@ -722,8 +722,32 @@ public:
 
     void ClearTools();
     void Clear();
+
+    /**
+        Removes the tool with the given ID from the tool bar.
+
+        Note that if this tool was added by AddControl(), the associated
+        control is @e not deleted and must either be reused (e.g. by
+        reparenting it under a different window) or destroyed by caller.
+
+        @param tool_id ID of a previously added tool.
+        @return @true if the tool was removed or @false otherwise, e.g. if the
+            tool with the given ID was not found.
+     */
     bool DeleteTool(int tool_id);
-    bool DeleteByIndex(int tool_id);
+
+    /**
+        Removes the tool at the given position from the tool bar.
+
+        Note that if this tool was added by AddControl(), the associated
+        control is @e not deleted and must either be reused (e.g. by
+        reparenting it under a different window) or destroyed by caller.
+
+        @param idx The index, or position, of a previously added tool.
+        @return @true if the tool was removed or @false otherwise, e.g. if the
+            provided index is out of range.
+     */
+    bool DeleteByIndex(int idx);
 
     size_t GetToolCount() const;
     int GetToolPos(int tool_id) const;

--- a/interface/wx/aui/auibar.h
+++ b/interface/wx/aui/auibar.h
@@ -724,11 +724,33 @@ public:
     void Clear();
 
     /**
+        Destroys the tool with the given ID and its associated window, if any.
+
+        @param tool_id ID of a previously added tool.
+        @return @true if the tool was destroyed or @false otherwise, e.g. if
+            the tool with the given ID was not found.
+
+        @since 3.1.4
+     */
+    bool DestroyTool(int tool_id);
+
+    /**
+        Destroys the tool at the given position and its associated window, if
+        any.
+
+        @param idx The index, or position, of a previously added tool.
+        @return @true if the tool was destroyed or @false otherwise, e.g. if
+            the provided index is out of range.
+     */
+    bool DestroyToolByIndex(int idx);
+
+    /**
         Removes the tool with the given ID from the tool bar.
 
         Note that if this tool was added by AddControl(), the associated
         control is @e not deleted and must either be reused (e.g. by
         reparenting it under a different window) or destroyed by caller.
+        If this behaviour is unwanted, prefer using DestroyTool() instead.
 
         @param tool_id ID of a previously added tool.
         @return @true if the tool was removed or @false otherwise, e.g. if the
@@ -742,6 +764,8 @@ public:
         Note that if this tool was added by AddControl(), the associated
         control is @e not deleted and must either be reused (e.g. by
         reparenting it under a different window) or destroyed by caller.
+        If this behaviour is unwanted, prefer using DestroyToolByIndex()
+        instead.
 
         @param idx The index, or position, of a previously added tool.
         @return @true if the tool was removed or @false otherwise, e.g. if the

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -1938,14 +1938,14 @@ bool wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
     for (i = 0, count = m_items.GetCount(); i < count; ++i)
     {
         wxAuiToolBarItem& item = m_items.Item(i);
-        wxSizerItem* m_sizerItem = NULL;
+        wxSizerItem* sizerItem = NULL;
 
         switch (item.m_kind)
         {
             case wxITEM_LABEL:
             {
                 wxSize size = m_art->GetLabelSize(dc, this, item);
-                m_sizerItem = sizer->Add(size.x + (m_toolBorderPadding*2),
+                sizerItem = sizer->Add(size.x + (m_toolBorderPadding*2),
                                         size.y + (m_toolBorderPadding*2),
                                         item.m_proportion,
                                         item.m_alignment);
@@ -1962,7 +1962,7 @@ bool wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
             case wxITEM_RADIO:
             {
                 wxSize size = m_art->GetToolSize(dc, this, item);
-                m_sizerItem = sizer->Add(size.x + (m_toolBorderPadding*2),
+                sizerItem = sizer->Add(size.x + (m_toolBorderPadding*2),
                                         size.y + (m_toolBorderPadding*2),
                                         0,
                                         item.m_alignment);
@@ -1978,9 +1978,9 @@ bool wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
             case wxITEM_SEPARATOR:
             {
                 if (horizontal)
-                    m_sizerItem = sizer->Add(separatorSize, 1, 0, wxEXPAND);
+                    sizerItem = sizer->Add(separatorSize, 1, 0, wxEXPAND);
                 else
-                    m_sizerItem = sizer->Add(1, separatorSize, 0, wxEXPAND);
+                    sizerItem = sizer->Add(1, separatorSize, 0, wxEXPAND);
 
                 // add tool packing
                 if (i+1 < count)
@@ -1993,14 +1993,13 @@ bool wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
 
             case wxITEM_SPACER:
                 if (item.m_proportion > 0)
-                    m_sizerItem = sizer->AddStretchSpacer(item.m_proportion);
+                    sizerItem = sizer->AddStretchSpacer(item.m_proportion);
                 else
-                    m_sizerItem = sizer->Add(item.m_spacerPixels, 1);
+                    sizerItem = sizer->Add(item.m_spacerPixels, 1);
                 break;
 
             case wxITEM_CONTROL:
             {
-                //m_sizerItem = sizer->Add(item.m_window, item.m_proportion, wxEXPAND);
                 wxSizerItem* ctrl_m_sizerItem;
 
                 wxBoxSizer* vert_sizer = new wxBoxSizer(wxVERTICAL);
@@ -2016,7 +2015,7 @@ bool wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
                 }
 
 
-                m_sizerItem = sizer->Add(vert_sizer, item.m_proportion, wxEXPAND);
+                sizerItem = sizer->Add(vert_sizer, item.m_proportion, wxEXPAND);
 
                 wxSize min_size = item.m_minSize;
 
@@ -2030,7 +2029,7 @@ bool wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
 
                 if (min_size.IsFullySpecified())
                 {
-                    m_sizerItem->SetMinSize(min_size);
+                    sizerItem->SetMinSize(min_size);
                     ctrl_m_sizerItem->SetMinSize(min_size);
                 }
 
@@ -2042,7 +2041,7 @@ bool wxAuiToolBar::RealizeHelper(wxClientDC& dc, bool horizontal)
             }
         }
 
-        item.m_sizerItem = m_sizerItem;
+        item.m_sizerItem = sizerItem;
     }
 
     // add "right" padding

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -1180,6 +1180,22 @@ bool wxAuiToolBar::DeleteByIndex(int idx)
     return false;
 }
 
+bool wxAuiToolBar::DestroyTool(int tool_id)
+{
+    return DestroyToolByIndex(GetToolIndex(tool_id));
+}
+
+bool wxAuiToolBar::DestroyToolByIndex(int idx)
+{
+    if ( idx < 0 || static_cast<unsigned>(idx) >= m_items.GetCount() )
+        return false;
+
+    if ( wxWindow* window = m_items[idx].GetWindow() )
+        window->Destroy();
+
+    return DeleteByIndex(idx);
+}
+
 
 wxControl* wxAuiToolBar::FindControl(int id)
 {

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -1165,15 +1165,7 @@ void wxAuiToolBar::Clear()
 
 bool wxAuiToolBar::DeleteTool(int tool_id)
 {
-    int idx = GetToolIndex(tool_id);
-    if (idx >= 0 && idx < (int)m_items.GetCount())
-    {
-        m_items.RemoveAt(idx);
-        Realize();
-        return true;
-    }
-
-    return false;
+    return DeleteByIndex(GetToolIndex(tool_id));
 }
 
 bool wxAuiToolBar::DeleteByIndex(int idx)


### PR DESCRIPTION
Add `DestroyTool()` which deletes the associated window too, unlike `DeleteTool()`.