### PR TITLE
Check the expected WebView2 interface is defined

### DIFF
--- a/include/wx/msw/private/webview_edge.h
+++ b/include/wx/msw/private/webview_edge.h
@@ -15,6 +15,10 @@
 
 #include <Webview2.h>
 
+#ifndef __ICoreWebView2Environment_INTERFACE_DEFINED__
+    #error "WebView2 SDK version 0.9.430 or newer is required"
+#endif
+
 class wxWebViewEdgeImpl
 {
 public:


### PR DESCRIPTION
This results in a single intelligible error instead of a hundred of less
clear ones in case our code is compiled against an out of date SDK
version.

There doesn't seem to be any way to check the version directly, so just
check that the interface which hadn't been defined in the previous
version is defined now to check for it indirectly.

---

@MaartenBent do you mind applying this?