### PR TITLE
Make vcpkg MSW instructions more MSW-like

### DIFF
--- a/docs/msw/install.md
+++ b/docs/msw/install.md
@@ -336,11 +336,11 @@ Installing and building wxWidgets using vcpkg         {#msw_install_and_build}
 You can download and install wxWidgets using the [vcpkg](https://github.com/Microsoft/vcpkg) 
 dependency manager:
 
-    $ git clone https://github.com/Microsoft/vcpkg.git
-    $ cd vcpkg
-    $ ./bootstrap-vcpkg.sh
-    $ ./vcpkg integrate install
-    $ vcpkg install wxwidgets
+    > git clone https://github.com/Microsoft/vcpkg.git
+    > cd vcpkg
+    > bootstrap-vcpkg.bat
+    > vcpkg integrate install
+    > vcpkg install wxwidgets
 
 The wxWidgets port in vcpkg is kept up to date by Microsoft team members and community 
 contributors. If the version is out of date, please [create an issue or pull request]


### PR DESCRIPTION
Make command line instructions for vcpgk more similar to those used
for example for nmake. The MS Windows command line does not use $ as
the command prompt and batch files are more commonly used then Unix
shell scripts.