### PR TITLE
Fix XRC link in Hello World example

### DIFF
--- a/docs/doxygen/overviews/helloworld.h
+++ b/docs/doxygen/overviews/helloworld.h
@@ -17,7 +17,7 @@ important concepts and explains how to write a working wxWidgets application.
 
 Note that this simple example creates the UI entirely from C++ code which is
 fine for a simple example, but more realistic examples will typically define
-their UI at least partially in @c overview_xrc "XRC resource files".
+their UI at least partially in @ref overview_xrc "XRC resource files".
 
 First, you have to include wxWidgets' header files, of course. This can be done
 on a file by file basis (such as @c wx/window.h) or using one global include


### PR DESCRIPTION
TBH, I would not mind removing the sentence altogether. 

I am not sure if the XRC system is typically used more than hand-written or GUI designer-generated C++ code. I also believe that it may be better to not introduce any unnecessary information in this kind of text.