### PR TITLE
Add tab stops support for wxListBox (windows-only).

### DIFF
--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -1557,6 +1557,8 @@ enum wxBorder
 #define wxLB_HSCROLL        wxHSCROLL
 /*  always show an entire number of rows */
 #define wxLB_INT_HEIGHT     0x0800
+/* Windows-only: recognize and expand tab characters when drawing strings */
+#define wxLB_USETABSTOPS    0x1000
 
 /*
  * wxComboBox style flags

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -1557,8 +1557,6 @@ enum wxBorder
 #define wxLB_HSCROLL        wxHSCROLL
 /*  always show an entire number of rows */
 #define wxLB_INT_HEIGHT     0x0800
-/* Windows-only: recognize and expand tab characters when drawing strings */
-#define wxLB_USETABSTOPS    0x1000
 
 /*
  * wxComboBox style flags

--- a/include/wx/msw/listbox.h
+++ b/include/wx/msw/listbox.h
@@ -128,9 +128,8 @@ public:
     // extent of all strings is used. In any case calls InvalidateBestSize()
     virtual void SetHorizontalExtent(const wxString& s = wxEmptyString);
 
-    // Windows-specific code to set tab stops when wxLB_USETABSTOPS is enabled
     // measured in "quarters of the average character width for the font that is selected into the list box"
-    virtual void SetTabStops(const wxArrayInt& tabStops);
+    virtual void MSWSetTabStops(const wxArrayInt& tabStops);
 
     // Windows callbacks
     bool MSWCommand(WXUINT param, WXWORD id) wxOVERRIDE;

--- a/include/wx/msw/listbox.h
+++ b/include/wx/msw/listbox.h
@@ -129,7 +129,7 @@ public:
     virtual void SetHorizontalExtent(const wxString& s = wxEmptyString);
 
     // measured in "quarters of the average character width for the font that is selected into the list box"
-    virtual void MSWSetTabStops(const wxArrayInt& tabStops);
+    virtual void MSWSetTabStops(const wxVector<int>& tabStops);
 
     // Windows callbacks
     bool MSWCommand(WXUINT param, WXWORD id) wxOVERRIDE;

--- a/include/wx/msw/listbox.h
+++ b/include/wx/msw/listbox.h
@@ -129,7 +129,7 @@ public:
     virtual void SetHorizontalExtent(const wxString& s = wxEmptyString);
 
     // measured in "quarters of the average character width for the font that is selected into the list box"
-    virtual void MSWSetTabStops(const wxVector<int>& tabStops);
+    virtual bool MSWSetTabStops(const wxVector<int>& tabStops);
 
     // Windows callbacks
     bool MSWCommand(WXUINT param, WXWORD id) wxOVERRIDE;

--- a/include/wx/msw/listbox.h
+++ b/include/wx/msw/listbox.h
@@ -128,6 +128,10 @@ public:
     // extent of all strings is used. In any case calls InvalidateBestSize()
     virtual void SetHorizontalExtent(const wxString& s = wxEmptyString);
 
+    // Windows-specific code to set tab stops when wxLB_USETABSTOPS is enabled
+    // measured in "quarters of the average character width for the font that is selected into the list box"
+    virtual void SetTabStops(const wxArrayInt& tabStops);
+
     // Windows callbacks
     bool MSWCommand(WXUINT param, WXWORD id) wxOVERRIDE;
     WXDWORD MSWGetStyle(long style, WXDWORD *exstyle) const wxOVERRIDE;

--- a/interface/wx/listbox.h
+++ b/interface/wx/listbox.h
@@ -324,9 +324,7 @@ public:
         @param tabStops
             Cumulative tab distances array measured in "quarters of the average character width for the font that is selected into the list box."
 
-        This function is not available in the other ports by design, any
-        occurrences of it in the portable code must be guarded by
-        @code #ifdef __WXMSW__ @endcode preprocessor guards.
+        @return @true if all specified tabs are set, @false otherwise
 
         @onlyfor{wxmsw}
 

--- a/interface/wx/listbox.h
+++ b/interface/wx/listbox.h
@@ -330,7 +330,7 @@ public:
 
         @onlyfor{wxmsw}
 
-        @since 3.1.0
+        @since 3.1.4
      */
     virtual void MSWSetTabStops(const wxArrayInt& tabStops);
 
@@ -341,4 +341,3 @@ public:
     virtual void SetString(unsigned int n, const wxString& s);
     virtual int FindString(const wxString& s, bool bCase = false) const;
 };
-

--- a/interface/wx/listbox.h
+++ b/interface/wx/listbox.h
@@ -24,10 +24,7 @@
     performance nor from user interface point of view, for large number of
     items.
 
-    Notice that currently @c TAB characters in list box items text are not
-    handled consistently under all platforms, so they should be replaced by
-    spaces to display strings properly everywhere. The list box doesn't
-    support any other control characters at all.
+    Notice that the list box doesn't support control characters other than @c TAB.
 
     @beginStyleTable
     @style{wxLB_SINGLE}
@@ -320,6 +317,20 @@ public:
         @since 3.1.0
     */
     int GetTopItem() const;
+
+    /**
+        MSW-specific function for setting custom tab stop distances.
+
+        @param tabStops
+            Cumulative tab distances array measured in "quarters of the average character width for the font that is selected into the list box."
+
+        This function is not available in the other ports by design, any
+        occurrences of it in the portable code must be guarded by
+        @code #ifdef __WXMSW__ @endcode preprocessor guards.
+
+        @onlyfor{wxmsw}
+     */
+    virtual void MSWSetTabStops(const wxArrayInt& tabStops);
 
     // NOTE: Phoenix needs to see the implementation of pure virtuals so it
     // knows that this class is not abstract.

--- a/interface/wx/listbox.h
+++ b/interface/wx/listbox.h
@@ -329,6 +329,8 @@ public:
         @code #ifdef __WXMSW__ @endcode preprocessor guards.
 
         @onlyfor{wxmsw}
+
+        @since 3.1.0
      */
     virtual void MSWSetTabStops(const wxArrayInt& tabStops);
 

--- a/samples/widgets/listbox.cpp
+++ b/samples/widgets/listbox.cpp
@@ -337,7 +337,7 @@ void ListboxWidgetsPage::CreateContent()
 
     wxSizer *sizerRow = new wxBoxSizer(wxHORIZONTAL);
     btn = new wxButton(this, ListboxPage_Add, "&Add this string");
-    m_textAdd = new wxTextCtrl(this, ListboxPage_AddText, "test item 0");
+    m_textAdd = new wxTextCtrl(this, ListboxPage_AddText, "test item \t0");
     sizerRow->Add(btn, 0, wxRIGHT, 5);
     sizerRow->Add(m_textAdd, 1, wxLEFT, 5);
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
@@ -395,7 +395,7 @@ void ListboxWidgetsPage::CreateContent()
     m_lbox = new wxListBox(this, ListboxPage_Listbox,
                            wxDefaultPosition, wxDefaultSize,
                            0, NULL,
-                           wxLB_HSCROLL);
+                           wxLB_HSCROLL | wxLB_USETABSTOPS);
     sizerRight->Add(m_lbox, 1, wxGROW | wxALL, 5);
     sizerRight->SetMinSize(150, 0);
     m_sizerLbox = sizerRight; // save it to modify it later
@@ -619,7 +619,7 @@ void ListboxWidgetsPage::OnButtonAdd(wxCommandEvent& WXUNUSED(event))
     if ( !m_textAdd->IsModified() )
     {
         // update the default string
-        m_textAdd->SetValue(wxString::Format("test item %u", ++s_item));
+        m_textAdd->SetValue(wxString::Format("test item \t%u", ++s_item));
     }
 
     m_lbox->Append(s);

--- a/samples/widgets/listbox.cpp
+++ b/samples/widgets/listbox.cpp
@@ -395,7 +395,7 @@ void ListboxWidgetsPage::CreateContent()
     m_lbox = new wxListBox(this, ListboxPage_Listbox,
                            wxDefaultPosition, wxDefaultSize,
                            0, NULL,
-                           wxLB_HSCROLL | wxLB_USETABSTOPS);
+                           wxLB_HSCROLL);
     sizerRight->Add(m_lbox, 1, wxGROW | wxALL, 5);
     sizerRight->SetMinSize(150, 0);
     m_sizerLbox = sizerRight; // save it to modify it later

--- a/src/msw/listbox.cpp
+++ b/src/msw/listbox.cpp
@@ -614,10 +614,10 @@ void wxListBox::SetHorizontalExtent(const wxString& s)
     //else: it shouldn't change
 }
 
-void wxListBox::MSWSetTabStops(const wxVector<int>& tabStops)
+bool wxListBox::MSWSetTabStops(const wxVector<int>& tabStops)
 {
-    SendMessage(GetHwnd(), LB_SETTABSTOPS, (WPARAM)tabStops.size(),
-                tabStops.size() ? (LPARAM)tabStops.begin() : NULL);
+    return SendMessage(GetHwnd(), LB_SETTABSTOPS, (WPARAM)tabStops.size(),
+                       tabStops.size() ? (LPARAM)tabStops.begin() : NULL);
 }
 
 wxSize wxListBox::DoGetBestClientSize() const

--- a/src/msw/listbox.cpp
+++ b/src/msw/listbox.cpp
@@ -187,8 +187,8 @@ WXDWORD wxListBox::MSWGetStyle(long style, WXDWORD *exstyle) const
     }
 #endif // wxUSE_OWNER_DRAWN
 
-    if (m_windowStyle & wxLB_USETABSTOPS)
-        msStyle |= LBS_USETABSTOPS;
+    // tabs stops are expanded by default on linux/GTK and macOS/Cocoa
+    msStyle |= LBS_USETABSTOPS;
 
     return msStyle;
 }
@@ -614,7 +614,7 @@ void wxListBox::SetHorizontalExtent(const wxString& s)
     //else: it shouldn't change
 }
 
-void wxListBox::SetTabStops(const wxArrayInt& tabStops)
+void wxListBox::MSWSetTabStops(const wxArrayInt& tabStops)
 {
     SendMessage(GetHwnd(), LB_SETTABSTOPS, (WPARAM)tabStops.Count(), (LPARAM)tabStops.begin());
 }

--- a/src/msw/listbox.cpp
+++ b/src/msw/listbox.cpp
@@ -614,9 +614,10 @@ void wxListBox::SetHorizontalExtent(const wxString& s)
     //else: it shouldn't change
 }
 
-void wxListBox::MSWSetTabStops(const wxArrayInt& tabStops)
+void wxListBox::MSWSetTabStops(const wxVector<int>& tabStops)
 {
-    SendMessage(GetHwnd(), LB_SETTABSTOPS, (WPARAM)tabStops.Count(), (LPARAM)tabStops.begin());
+    SendMessage(GetHwnd(), LB_SETTABSTOPS, (WPARAM)tabStops.size(),
+                tabStops.size() ? (LPARAM)tabStops.begin() : NULL);
 }
 
 wxSize wxListBox::DoGetBestClientSize() const

--- a/src/msw/listbox.cpp
+++ b/src/msw/listbox.cpp
@@ -187,6 +187,9 @@ WXDWORD wxListBox::MSWGetStyle(long style, WXDWORD *exstyle) const
     }
 #endif // wxUSE_OWNER_DRAWN
 
+    if (m_windowStyle & wxLB_USETABSTOPS)
+        msStyle |= LBS_USETABSTOPS;
+
     return msStyle;
 }
 
@@ -609,6 +612,11 @@ void wxListBox::SetHorizontalExtent(const wxString& s)
         SendMessage(GetHwnd(), LB_SETHORIZONTALEXTENT, LOWORD(largestExtent), 0L);
     }
     //else: it shouldn't change
+}
+
+void wxListBox::SetTabStops(const wxArrayInt& tabStops)
+{
+    SendMessage(GetHwnd(), LB_SETTABSTOPS, (WPARAM)tabStops.Count(), (LPARAM)tabStops.begin());
 }
 
 wxSize wxListBox::DoGetBestClientSize() const


### PR DESCRIPTION
Add wxLB_USETABSTOPS so that '\t' (tab) characters in wxListBox strings get recognized and expanded. The flag forwards to the native LB_USETABSTOPS one.
Add wxListBox::SetTabStops() to optionally specify tab stop distances. It is equivalent to using native LB_SETTABSTOPS message.
Illustrate the usage of tab stops in widgets/listbox sample.