### PR TITLE
Change wxAuiDockArt DrawBorder to use m_borderPen color for all borders

### DIFF
--- a/src/aui/dockart.cpp
+++ b/src/aui/dockart.cpp
@@ -550,10 +550,9 @@ void wxAuiDefaultDockArt::DrawBorder(wxDC& dc, wxWindow* window, const wxRect& _
     {
         for (i = 0; i < border_width; ++i)
         {
-            dc.SetPen(*wxWHITE_PEN);
+            dc.SetPen(m_borderPen);
             dc.DrawLine(rect.x, rect.y, rect.x+rect.width, rect.y);
             dc.DrawLine(rect.x, rect.y, rect.x, rect.y+rect.height);
-            dc.SetPen(m_borderPen);
             dc.DrawLine(rect.x, rect.y+rect.height-1,
                         rect.x+rect.width, rect.y+rect.height-1);
             dc.DrawLine(rect.x+rect.width-1, rect.y,


### PR DESCRIPTION
Currently `m_borderPen` color only affects bottom and left border color behaving more like a shadow color than a border color. Top and left border colors are hardcoded to white making it very ridicule to change them and making AUI dock look really bad in a dark theme.

I propose to change the `DrawBorder` method to draw all borders in `m_borderPen` color and if needed add a separate shadow color.