### PR TITLE
Use macros to define default copy constructor and assignment operator

### DIFF
--- a/docs/doxygen/mainpages/const_cpp.h
+++ b/docs/doxygen/mainpages/const_cpp.h
@@ -172,8 +172,7 @@ Currently the following symbols exist:
 @itemdef{wxHAS_CONFIG_TEMPLATE_RW, Defined if the currently used compiler
     supports template Read() and Write() methods in wxConfig.}
 @itemdef{wxHAS_MEMBER_DEFAULT, Defined if the currently used compiler supports
-    C++11 @c =default. @c wxMEMBER_DEFAULT is defined as this keyword in this
-    case, and as nothing otherwise.}
+    C++11 @c =default.}
 @itemdef{wxHAS_LARGE_FILES, Defined if wxFile supports files more than 4GB in
     size (notice that you must include @c wx/filefn.h before testing for this
     symbol).}

--- a/include/wx/animate.h
+++ b/include/wx/animate.h
@@ -38,7 +38,10 @@ public:
     wxAnimation();
     explicit wxAnimation(const wxString &name, wxAnimationType type = wxANIMATION_TYPE_ANY);
 
-    wxDECLARE_DEFAULT_COPY_CLASS(wxAnimation);
+#ifdef wxHAS_MEMBER_DEFAULT
+    wxAnimation(const wxAnimation&) = default;
+    wxAnimation& operator=(const wxAnimation&) = default;
+#endif
 
     bool IsOk() const;
     bool IsCompatibleWith(wxClassInfo* ci) const;

--- a/include/wx/animate.h
+++ b/include/wx/animate.h
@@ -38,10 +38,7 @@ public:
     wxAnimation();
     explicit wxAnimation(const wxString &name, wxAnimationType type = wxANIMATION_TYPE_ANY);
 
-#ifdef wxHAS_MEMBER_DEFAULT
-    wxAnimation(const wxAnimation&) wxMEMBER_DEFAULT;
-    wxAnimation& operator=(const wxAnimation&) wxMEMBER_DEFAULT;
-#endif
+    wxDECLARE_DEFAULT_COPY_CLASS(wxAnimation);
 
     bool IsOk() const;
     bool IsCompatibleWith(wxClassInfo* ci) const;

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -3040,22 +3040,6 @@ typedef const void* WXWidget;
     wxDECLARE_NO_ASSIGN_CLASS(classname);
 
 /*  --------------------------------------------------------------------------- */
-/*  macros to define a class with default copy constructor and/or assignment operator */
-/*  --------------------------------------------------------------------------- */
-
-#ifdef wxHAS_MEMBER_DEFAULT
-#define wxDECLARE_DEFAULT_COPY_CTOR(classname) \
-    classname(const classname&) = default
-
-#define wxDECLARE_DEFAULT_COPY_CLASS(classname) \
-    wxDECLARE_DEFAULT_COPY_CTOR(classname); \
-    classname& operator=(const classname&) = default
-#else
-#define wxDECLARE_DEFAULT_COPY_CTOR(classname)
-#define wxDECLARE_DEFAULT_COPY_CLASS(classname)
-#endif
-
-/*  --------------------------------------------------------------------------- */
 /*  If a manifest is being automatically generated, add common controls 6 to it */
 /*  --------------------------------------------------------------------------- */
 

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -290,13 +290,10 @@ typedef short int WXTYPE;
    still requires handling MSVS specially, unfortunately) */
 #if __cplusplus >= 201103L || wxCHECK_VISUALC_VERSION(14)
     #define wxHAS_MEMBER_DEFAULT
-    #define wxMEMBER_DEFAULT = default
 
     #define wxHAS_NOEXCEPT
     #define wxNOEXCEPT noexcept
 #else
-    #define wxMEMBER_DEFAULT
-
     #define wxNOEXCEPT
 #endif
 
@@ -3041,6 +3038,22 @@ typedef const void* WXWidget;
     wxDECLARE_NO_COPY_TEMPLATE_CLASS(classname, arg);
 #define DECLARE_NO_ASSIGN_CLASS(classname) \
     wxDECLARE_NO_ASSIGN_CLASS(classname);
+
+/*  --------------------------------------------------------------------------- */
+/*  macros to define a class with default copy constructor and/or assignment operator */
+/*  --------------------------------------------------------------------------- */
+
+#ifdef wxHAS_MEMBER_DEFAULT
+#define wxDECLARE_DEFAULT_COPY_CTOR(classname) \
+    classname(const classname&) = default
+
+#define wxDECLARE_DEFAULT_COPY_CLASS(classname) \
+    wxDECLARE_DEFAULT_COPY_CTOR(classname); \
+    classname& operator=(const classname&) = default
+#else
+#define wxDECLARE_DEFAULT_COPY_CTOR(classname)
+#define wxDECLARE_DEFAULT_COPY_CLASS(classname)
+#endif
 
 /*  --------------------------------------------------------------------------- */
 /*  If a manifest is being automatically generated, add common controls 6 to it */

--- a/include/wx/unichar.h
+++ b/include/wx/unichar.h
@@ -267,7 +267,9 @@ public:
     wxUniCharRef& operator=(const wxUniCharRef& c)
         { if (&c != this) *this = c.UniChar(); return *this; }
 
-    wxDECLARE_DEFAULT_COPY_CTOR(wxUniCharRef);
+#ifdef wxHAS_MEMBER_DEFAULT
+    wxUniCharRef(const wxUniCharRef&) = default;
+#endif
 
 #define wxUNICHAR_REF_DEFINE_OPERATOR_EQUAL(type) \
     wxUniCharRef& operator=(type c) { return *this = wxUniChar(c); }

--- a/include/wx/unichar.h
+++ b/include/wx/unichar.h
@@ -267,9 +267,7 @@ public:
     wxUniCharRef& operator=(const wxUniCharRef& c)
         { if (&c != this) *this = c.UniChar(); return *this; }
 
-#ifdef wxHAS_MEMBER_DEFAULT
-    wxUniCharRef(const wxUniCharRef&) wxMEMBER_DEFAULT;
-#endif
+    wxDECLARE_DEFAULT_COPY_CTOR(wxUniCharRef);
 
 #define wxUNICHAR_REF_DEFINE_OPERATOR_EQUAL(type) \
     wxUniCharRef& operator=(type c) { return *this = wxUniChar(c); }

--- a/interface/wx/defs.h
+++ b/interface/wx/defs.h
@@ -1562,22 +1562,6 @@ typedef double wxDouble;
 #define wxDECLARE_NO_COPY_TEMPLATE_CLASS_2(classname, arg1, arg2)
 
 /**
-    This macro can be used in a class declaration to enable declaring the
-    default copy constructor and assignment operator.
-
-    @since 3.1.4
- */
-#define wxDECLARE_DEFAULT_COPY_CLASS(classname)
-
-/**
-    This macro can be used in a class declaration to enable declaring the
-    default copy constructor.
-
-    @since 3.1.4
- */
-#define wxDECLARE_DEFAULT_COPY_CTOR(classname)
-
-/**
     A function which deletes and nulls the pointer.
 
     This function uses operator delete to free the pointer and also sets it to

--- a/interface/wx/defs.h
+++ b/interface/wx/defs.h
@@ -1562,6 +1562,22 @@ typedef double wxDouble;
 #define wxDECLARE_NO_COPY_TEMPLATE_CLASS_2(classname, arg1, arg2)
 
 /**
+    This macro can be used in a class declaration to enable declaring the
+    default copy constructor and assignment operator.
+
+    @since 3.1.4
+ */
+#define wxDECLARE_DEFAULT_COPY_CLASS(classname)
+
+/**
+    This macro can be used in a class declaration to enable declaring the
+    default copy constructor.
+
+    @since 3.1.4
+ */
+#define wxDECLARE_DEFAULT_COPY_CTOR(classname)
+
+/**
     A function which deletes and nulls the pointer.
 
     This function uses operator delete to free the pointer and also sets it to


### PR DESCRIPTION
A different solution for `= default`, see discussion here: https://github.com/wxWidgets/wxWidgets/commit/413fdfbfa47409af822021036b01f950ba3b2406#r38444880