### PR TITLE
Fix broken non-Unicode MSW build

### DIFF
--- a/include/wx/msw/winundef.h
+++ b/include/wx/msw/winundef.h
@@ -268,7 +268,7 @@
    #else
    inline int StartDoc(HDC h, CONST DOCINFOA* info)
    {
-      return StartDocA(h, const_cast<DOCINFOA*>(info);
+      return StartDocA(h, const_cast<DOCINFOA*>(info));
    }
    #endif
 #endif


### PR DESCRIPTION
Add a missing parenthesis in a non-Unicode StartDoc() definition (broken in 948ddc6).