### PR TITLE
Check usability of inotify before selecting it

### DIFF
--- a/configure
+++ b/configure
@@ -1028,6 +1028,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -1454,6 +1455,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1706,6 +1708,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1843,7 +1854,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1996,6 +2007,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -32969,7 +32981,10 @@ if test "$wxUSE_FSWATCHER" = "yes"; then
         if test "$wxUSE_UNIX" = "yes"; then
                                                 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether inotify is usable" >&5
 $as_echo_n "checking whether inotify is usable... " >&6; }
-            cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+if ${wx_cv_inotify_usable+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 int main() { return inotify_init(); }
 _ACEOF
@@ -32982,7 +32997,9 @@ else
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
-            { $as_echo "$as_me:${as_lineno-$LINENO}: result: $wx_cv_inotify_usable" >&5
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $wx_cv_inotify_usable" >&5
 $as_echo "$wx_cv_inotify_usable" >&6; }
             if test "$wx_cv_inotify_usable" = "no"; then
                 for ac_header in sys/event.h

--- a/configure
+++ b/configure
@@ -32967,23 +32967,24 @@ fi
 if test "$wxUSE_FSWATCHER" = "yes"; then
                 if test "$USE_WIN32" != 1; then
         if test "$wxUSE_UNIX" = "yes"; then
-            for ac_header in sys/inotify.h
-do :
-  ac_fn_c_check_header_compile "$LINENO" "sys/inotify.h" "ac_cv_header_sys_inotify_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_sys_inotify_h" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_SYS_INOTIFY_H 1
+                                                { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether inotify is usable" >&5
+$as_echo_n "checking whether inotify is usable... " >&6; }
+            cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+int main() { return inotify_init(); }
 _ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  wx_cv_inotify_usable=yes; $as_echo "#define wxHAS_INOTIFY 1" >>confdefs.h
+
+else
+  wx_cv_inotify_usable=no
 
 fi
-
-done
-
-            if test "$ac_cv_header_sys_inotify_h" = "yes"; then
-                $as_echo "#define wxHAS_INOTIFY 1" >>confdefs.h
-
-            else
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: $wx_cv_inotify_usable" >&5
+$as_echo "$wx_cv_inotify_usable" >&6; }
+            if test "$wx_cv_inotify_usable" = "no"; then
                 for ac_header in sys/event.h
 do :
   ac_fn_c_check_header_compile "$LINENO" "sys/event.h" "ac_cv_header_sys_event_h" "$ac_includes_default

--- a/configure.in
+++ b/configure.in
@@ -5476,10 +5476,17 @@ if test "$wxUSE_FSWATCHER" = "yes"; then
     dnl includes OS X which does have kqueue but no other platforms)
     if test "$USE_WIN32" != 1; then
         if test "$wxUSE_UNIX" = "yes"; then
-            AC_CHECK_HEADERS(sys/inotify.h,,, [AC_INCLUDES_DEFAULT()])
-            if test "$ac_cv_header_sys_inotify_h" = "yes"; then
-                AC_DEFINE(wxHAS_INOTIFY)
-            else
+            dnl inotify header may be present from a compatibility library so
+            dnl check that the function is usable. We don't try to link with,
+            dnl e.g. -linotify so native kqueue support is used in preference.
+            AC_MSG_CHECKING([whether inotify is usable])
+            AC_LINK_IFELSE(
+                [AC_LANG_SOURCE([int main() { return inotify_init(); }])],
+                [wx_cv_inotify_usable=yes; AC_DEFINE(wxHAS_INOTIFY) ],
+                [wx_cv_inotify_usable=no]
+            )
+            AC_MSG_RESULT($wx_cv_inotify_usable)
+            if test "$wx_cv_inotify_usable" = "no"; then
                 AC_CHECK_HEADERS(sys/event.h,,, [AC_INCLUDES_DEFAULT()])
                 if test "$ac_cv_header_sys_event_h" = "yes"; then
                     AC_DEFINE(wxHAS_KQUEUE)

--- a/configure.in
+++ b/configure.in
@@ -5479,13 +5479,15 @@ if test "$wxUSE_FSWATCHER" = "yes"; then
             dnl inotify header may be present from a compatibility library so
             dnl check that the function is usable. We don't try to link with,
             dnl e.g. -linotify so native kqueue support is used in preference.
-            AC_MSG_CHECKING([whether inotify is usable])
-            AC_LINK_IFELSE(
-                [AC_LANG_SOURCE([int main() { return inotify_init(); }])],
-                [wx_cv_inotify_usable=yes; AC_DEFINE(wxHAS_INOTIFY) ],
-                [wx_cv_inotify_usable=no]
+            AC_CACHE_CHECK(
+                [whether inotify is usable],
+                wx_cv_inotify_usable,
+                AC_LINK_IFELSE(
+                    [AC_LANG_SOURCE([int main() { return inotify_init(); }])],
+                    [wx_cv_inotify_usable=yes; AC_DEFINE(wxHAS_INOTIFY) ],
+                    [wx_cv_inotify_usable=no]
+                )
             )
-            AC_MSG_RESULT($wx_cv_inotify_usable)
             if test "$wx_cv_inotify_usable" = "no"; then
                 AC_CHECK_HEADERS(sys/event.h,,, [AC_INCLUDES_DEFAULT()])
                 if test "$ac_cv_header_sys_event_h" = "yes"; then


### PR DESCRIPTION
A libinotify compatibility library exists for BSD systems. If this is installed, configure finds sys/inotify.h, tries to use inotify and consequently the build fails to link. By also checking for inotify_init() this problem can be avoided. AC_CHECK_FUNCS seems to be sufficient – it is returning no on FreeBSD and yes on Linux. I've included the change against the generated configure file in the pull request as this appears to be consistent with the project's practices.

Note that a kqueue compatibility library for Linux also appears to exist so the presence of both sys/event.h and sys/inotify.h could come about on Linux. On Linux with this change, configure would still not bother looking for event.h. I've verified this change on Linux. I'm not aware of other compatibility libraries that might be relevant. Solaris has event ports and no compatibility library exists to my knowledge.

Given that there is native support for kqueue, there is no need to handle linking with libinotify. If you strongly believe that it should be used if installed then let me know and I can try a different approach. I can't see why you would want that when the native support exists.

See #18729.