### PR TITLE
Change fractional point size from float to double

### DIFF
--- a/include/wx/dfb/font.h
+++ b/include/wx/dfb/font.h
@@ -74,7 +74,7 @@ public:
     bool Create(const wxNativeFontInfo& fontinfo);
 
     // implement base class pure virtuals
-    virtual float GetFractionalPointSize() const;
+    virtual double GetFractionalPointSize() const;
     virtual wxFontStyle GetStyle() const;
     virtual int GetNumericWeight() const;
     virtual wxString GetFaceName() const;
@@ -83,7 +83,7 @@ public:
     virtual bool IsFixedWidth() const;
     virtual const wxNativeFontInfo *GetNativeFontInfo() const;
 
-    virtual void SetFractionalPointSize(float pointSize);
+    virtual void SetFractionalPointSize(double pointSize);
     virtual void SetFamily(wxFontFamily family);
     virtual void SetStyle(wxFontStyle style);
     virtual void SetNumericWeight(int weight);

--- a/include/wx/font.h
+++ b/include/wx/font.h
@@ -129,22 +129,28 @@ public:
     // Default ctor uses the default font size appropriate for the current
     // platform.
     wxFontInfo()
-        { InitPointSize(-1.0f); }
+        : m_pointSize(-1.0)
+        , m_pixelSize(wxDefaultSize)
+    {
+        Init();
+    }
 
     // These ctors specify the font size, either in points or in pixels.
-    // Point size is a floating point number, however we also accept all
-    // integer sizes using the simple template ctor below.
-    explicit wxFontInfo(float pointSize)
-        { InitPointSize(pointSize); }
-    explicit wxFontInfo(const wxSize& pixelSize) : m_pixelSize(pixelSize)
-        { Init(); }
-
-    // Need to define this one to avoid casting double to int too.
     explicit wxFontInfo(double pointSize)
-        { InitPointSize(static_cast<float>(pointSize)); }
-    template <typename T>
-    explicit wxFontInfo(T pointSize)
-        { InitPointSize(ToFloatPointSize(pointSize)); }
+        : m_pointSize(pointSize >= 0.0 ? pointSize : -1.0)
+        , m_pixelSize(wxDefaultSize)
+    {
+        Init();
+        if (!wxIsSameDouble(m_pointSize, pointSize))
+            wxFAIL_MSG("Invalid font point size");
+    }
+    explicit wxFontInfo(const wxSize& pixelSize)
+        : m_pointSize(-1.0)
+        , m_pixelSize(pixelSize)
+    {
+        Init();
+    }
+    // Default copy ctor, assignment operator and dtor are OK
 
     // Setters for the various attributes. All of them return the object itself
     // so that the calls to them could be chained.
@@ -185,7 +191,6 @@ public:
     wxFontInfo& Encoding(wxFontEncoding encoding)
         { m_encoding = encoding; return *this; }
 
-
     // Set all flags at once.
     wxFontInfo& AllFlags(int flags)
     {
@@ -200,13 +205,12 @@ public:
         return *this;
     }
 
-
     // Accessors are mostly meant to be used by wxFont itself to extract the
     // various pieces of the font description.
 
     bool IsUsingSizeInPixels() const { return m_pixelSize != wxDefaultSize; }
-    float GetFractionalPointSize() const { return m_pointSize; }
-    int GetPointSize() const { return ToIntPointSize(m_pointSize); }
+    double GetFractionalPointSize() const { return m_pointSize; }
+    int GetPointSize() const { return wxRound(m_pointSize); }
     wxSize GetPixelSize() const { return m_pixelSize; }
 
     // If face name is not empty, it has priority, otherwise use family.
@@ -250,28 +254,6 @@ public:
 
     wxFontEncoding GetEncoding() const { return m_encoding; }
 
-
-    // Default copy ctor, assignment operator and dtor are OK.
-
-
-    // Helper functions for converting between integer and fractional sizes.
-    static int ToIntPointSize(float pointSize) { return wxRound(pointSize); }
-    static float ToFloatPointSize(int pointSize)
-    {
-        wxCHECK_MSG( pointSize == -1 || pointSize >= 0,
-                     -1, "Invalid font point size" );
-
-        // Huge values are not exactly representable as floats, so don't accept
-        // those neither as they can only be due to a mistake anyhow: nobody
-        // could possibly need a font of size 16777217pt (which is the first
-        // value for which this fails).
-        const float f = static_cast<float>(pointSize);
-        wxCHECK_MSG( static_cast<int>(f) == pointSize,
-                     -1, "Font point size out of range" );
-
-        return f;
-    }
-
     // Another helper for converting arbitrary numeric weight to the closest
     // value of wxFontWeight enum. It should be avoided in the new code (also
     // note that the function for the conversion in the other direction is
@@ -296,19 +278,10 @@ public:
 private:
     void Init()
     {
-        m_pointSize = -1;
         m_family = wxFONTFAMILY_DEFAULT;
         m_flags = wxFONTFLAG_DEFAULT;
         m_weight = wxFONTWEIGHT_NORMAL;
         m_encoding = wxFONTENCODING_DEFAULT;
-    }
-
-    void InitPointSize(float pointSize)
-    {
-        Init();
-
-        m_pointSize = pointSize;
-        m_pixelSize = wxDefaultSize;
     }
 
     // Turn on or off the given bit in m_flags depending on the value of the
@@ -324,7 +297,7 @@ private:
     // The size information: if m_pixelSize is valid (!= wxDefaultSize), then
     // it is used. Otherwise m_pointSize is used, except if it is < 0, which
     // means that the platform dependent font size should be used instead.
-    float m_pointSize;
+    double m_pointSize;
     wxSize m_pixelSize;
 
     wxFontFamily m_family;
@@ -425,7 +398,7 @@ public:
 
     // accessors: get the font characteristics
     virtual int GetPointSize() const;
-    virtual float GetFractionalPointSize() const = 0;
+    virtual double GetFractionalPointSize() const = 0;
     virtual wxSize GetPixelSize() const;
     virtual bool IsUsingSizeInPixels() const;
     wxFontFamily GetFamily() const;
@@ -447,7 +420,7 @@ public:
 
     // change the font characteristics
     virtual void SetPointSize( int pointSize );
-    virtual void SetFractionalPointSize( float pointSize ) = 0;
+    virtual void SetFractionalPointSize( double pointSize ) = 0;
     virtual void SetPixelSize( const wxSize& pixelSize );
     virtual void SetFamily( wxFontFamily family ) = 0;
     virtual void SetStyle( wxFontStyle style ) = 0;

--- a/include/wx/fontutil.h
+++ b/include/wx/fontutil.h
@@ -132,18 +132,18 @@ public:
 
     // MSW-specific: get point size from LOGFONT height using specified DPI,
     // or screen DPI when 0.
-    static float GetPointSizeAtPPI(int lfHeight, int ppi = 0);
+    static double GetPointSizeAtPPI(int lfHeight, int ppi = 0);
 
     // MSW-specific: get the height value in pixels using LOGFONT convention
     // (i.e. negative) corresponding to the given size in points and DPI.
-    static int GetLogFontHeightAtPPI(float size, int ppi);
+    static int GetLogFontHeightAtPPI(double size, int ppi);
 
     LOGFONT      lf;
 
     // MSW only has limited support for fractional point sizes and we need to
     // store the fractional point size separately if it was initially specified
     // as we can't losslessly recover it from LOGFONT later.
-    float        pointSize;
+    double       pointSize;
 #elif defined(__WXOSX__)
 public:
     wxNativeFontInfo(const wxNativeFontInfo& info) { Init(info); }
@@ -208,7 +208,7 @@ public :
     //
     #define wxNO_NATIVE_FONTINFO
 
-    float         pointSize;
+    double        pointSize;
     wxFontFamily  family;
     wxFontStyle   style;
     int           weight;
@@ -280,7 +280,7 @@ public:
 
     // accessors and modifiers for the font elements
     int GetPointSize() const;
-    float GetFractionalPointSize() const;
+    double GetFractionalPointSize() const;
     wxSize GetPixelSize() const;
     wxFontStyle GetStyle() const;
     wxFontWeight GetWeight() const;
@@ -292,7 +292,7 @@ public:
     wxFontEncoding GetEncoding() const;
 
     void SetPointSize(int pointsize);
-    void SetFractionalPointSize(float pointsize);
+    void SetFractionalPointSize(double pointsize);
     void SetPixelSize(const wxSize& pixelSize);
     void SetStyle(wxFontStyle style);
     void SetNumericWeight(int weight);
@@ -305,7 +305,7 @@ public:
 
     // Helper used in many ports: use the normal font size if the input is
     // negative, as we handle -1 as meaning this for compatibility.
-    void SetSizeOrDefault(float size)
+    void SetSizeOrDefault(double size)
     {
         SetFractionalPointSize
         (

--- a/include/wx/gtk/font.h
+++ b/include/wx/gtk/font.h
@@ -64,7 +64,7 @@ public:
     virtual ~wxFont();
 
     // implement base class pure virtuals
-    virtual float GetFractionalPointSize() const wxOVERRIDE;
+    virtual double GetFractionalPointSize() const wxOVERRIDE;
     virtual wxFontStyle GetStyle() const wxOVERRIDE;
     virtual int GetNumericWeight() const wxOVERRIDE;
     virtual wxString GetFaceName() const wxOVERRIDE;
@@ -74,7 +74,7 @@ public:
     virtual const wxNativeFontInfo *GetNativeFontInfo() const wxOVERRIDE;
     virtual bool IsFixedWidth() const wxOVERRIDE;
 
-    virtual void SetFractionalPointSize(float pointSize) wxOVERRIDE;
+    virtual void SetFractionalPointSize(double pointSize) wxOVERRIDE;
     virtual void SetFamily(wxFontFamily family) wxOVERRIDE;
     virtual void SetStyle(wxFontStyle style) wxOVERRIDE;
     virtual void SetNumericWeight(int weight) wxOVERRIDE;

--- a/include/wx/gtk1/font.h
+++ b/include/wx/gtk1/font.h
@@ -90,7 +90,7 @@ public:
     virtual ~wxFont();
 
     // implement base class pure virtuals
-    virtual float GetFractionalPointSize() const;
+    virtual double GetFractionalPointSize() const;
     virtual wxFontStyle GetStyle() const;
     virtual int GetNumericWeight() const;
     virtual wxString GetFaceName() const;
@@ -99,7 +99,7 @@ public:
     virtual const wxNativeFontInfo *GetNativeFontInfo() const;
     virtual bool IsFixedWidth() const;
 
-    virtual void SetFractionalPointSize(float pointSize);
+    virtual void SetFractionalPointSize(double pointSize);
     virtual void SetFamily(wxFontFamily family);
     virtual void SetStyle(wxFontStyle style);
     virtual void SetNumericWeight(int weight);

--- a/include/wx/motif/font.h
+++ b/include/wx/motif/font.h
@@ -72,7 +72,7 @@ public:
     virtual ~wxFont();
 
     // implement base class pure virtuals
-    virtual float GetFractionalPointSize() const;
+    virtual double GetFractionalPointSize() const;
     virtual wxFontStyle GetStyle() const;
     virtual int GetNumericWeight() const;
     virtual bool GetUnderlined() const;
@@ -80,7 +80,7 @@ public:
     virtual wxFontEncoding GetEncoding() const;
     virtual const wxNativeFontInfo *GetNativeFontInfo() const;
 
-    virtual void SetFractionalPointSize(float pointSize);
+    virtual void SetFractionalPointSize(double pointSize);
     virtual void SetFamily(wxFontFamily family);
     virtual void SetStyle(wxFontStyle style);
     virtual void SetNumericWeight(int weight);

--- a/include/wx/msw/font.h
+++ b/include/wx/msw/font.h
@@ -95,7 +95,7 @@ public:
     virtual ~wxFont();
 
     // implement base class pure virtuals
-    virtual float GetFractionalPointSize() const wxOVERRIDE;
+    virtual double GetFractionalPointSize() const wxOVERRIDE;
     virtual wxSize GetPixelSize() const wxOVERRIDE;
     virtual bool IsUsingSizeInPixels() const wxOVERRIDE;
     virtual wxFontStyle GetStyle() const wxOVERRIDE;
@@ -106,7 +106,7 @@ public:
     virtual wxFontEncoding GetEncoding() const wxOVERRIDE;
     virtual const wxNativeFontInfo *GetNativeFontInfo() const wxOVERRIDE;
 
-    virtual void SetFractionalPointSize(float pointSize) wxOVERRIDE;
+    virtual void SetFractionalPointSize(double pointSize) wxOVERRIDE;
     virtual void SetPixelSize(const wxSize& pixelSize) wxOVERRIDE;
     virtual void SetFamily(wxFontFamily family) wxOVERRIDE;
     virtual void SetStyle(wxFontStyle style) wxOVERRIDE;

--- a/include/wx/osx/font.h
+++ b/include/wx/osx/font.h
@@ -88,7 +88,7 @@ public:
     virtual ~wxFont();
 
     // implement base class pure virtuals
-    virtual float GetFractionalPointSize() const wxOVERRIDE;
+    virtual double GetFractionalPointSize() const wxOVERRIDE;
     virtual wxSize GetPixelSize() const wxOVERRIDE;
     virtual wxFontStyle GetStyle() const wxOVERRIDE;
     virtual int GetNumericWeight() const wxOVERRIDE;
@@ -100,7 +100,7 @@ public:
 
     virtual bool IsFixedWidth() const wxOVERRIDE;
 
-    virtual void SetFractionalPointSize(float pointSize) wxOVERRIDE;
+    virtual void SetFractionalPointSize(double pointSize) wxOVERRIDE;
     virtual void SetFamily(wxFontFamily family) wxOVERRIDE;
     virtual void SetStyle(wxFontStyle style) wxOVERRIDE;
     virtual void SetNumericWeight(int weight) wxOVERRIDE;

--- a/include/wx/private/fontmgr.h
+++ b/include/wx/private/fontmgr.h
@@ -218,7 +218,7 @@ public:
 
     const wxNativeFontInfo *GetNativeFontInfo() const { return &m_info; }
 
-    float GetFractionalPointSize() const { return m_info.pointSize; }
+    double GetFractionalPointSize() const { return m_info.pointSize; }
     wxString GetFaceName() const { return m_info.faceName; }
     wxFontFamily GetFamily() const { return m_info.family; }
     wxFontStyle GetStyle() const { return m_info.style; }
@@ -226,7 +226,7 @@ public:
     bool GetUnderlined() const { return m_info.underlined; }
     wxFontEncoding GetEncoding() const { return m_info.encoding; }
 
-    void SetFractionalPointSize(float pointSize);
+    void SetFractionalPointSize(double pointSize);
     void SetFamily(wxFontFamily family);
     void SetStyle(wxFontStyle style);
     void SetNumericWeight(int weight);

--- a/include/wx/qt/font.h
+++ b/include/wx/qt/font.h
@@ -51,7 +51,7 @@ public:
 
     // accessors: get the font characteristics
     virtual int GetPointSize() const wxOVERRIDE;
-    virtual float GetFractionalPointSize() const wxOVERRIDE;
+    virtual double GetFractionalPointSize() const wxOVERRIDE;
     virtual wxSize GetPixelSize() const wxOVERRIDE;
     virtual wxFontStyle GetStyle() const wxOVERRIDE;
     virtual int GetNumericWeight() const wxOVERRIDE;
@@ -62,7 +62,7 @@ public:
     virtual bool GetStrikethrough() const wxOVERRIDE;
 
     // change the font characteristics
-    virtual void SetFractionalPointSize(float pointSize) wxOVERRIDE;
+    virtual void SetFractionalPointSize(double pointSize) wxOVERRIDE;
     virtual void SetPixelSize(const wxSize& pixelSize) wxOVERRIDE;
     virtual void SetFamily( wxFontFamily family ) wxOVERRIDE;
     virtual void SetStyle( wxFontStyle style ) wxOVERRIDE;

--- a/include/wx/unix/fontutil.h
+++ b/include/wx/unix/fontutil.h
@@ -21,7 +21,7 @@
 
 // returns the handle of the nearest available font or 0
 extern wxNativeFont
-wxLoadQueryNearestFont(float pointSize,
+wxLoadQueryNearestFont(double pointSize,
                        wxFontFamily family,
                        wxFontStyle style,
                        int weight,

--- a/include/wx/x11/font.h
+++ b/include/wx/x11/font.h
@@ -81,7 +81,7 @@ public:
     virtual ~wxFont();
 
     // implement base class pure virtuals
-    virtual float GetFractionalPointSize() const;
+    virtual double GetFractionalPointSize() const;
     virtual wxFontStyle GetStyle() const;
     virtual int GetNumericWeight() const;
     virtual bool GetUnderlined() const;
@@ -92,7 +92,7 @@ public:
 
     virtual bool IsFixedWidth() const;
 
-    virtual void SetFractionalPointSize(float pointSize);
+    virtual void SetFractionalPointSize(double pointSize);
     virtual void SetFamily(wxFontFamily family);
     virtual void SetStyle(wxFontStyle style);
     virtual void SetNumericWeight(int weight);

--- a/interface/wx/font.h
+++ b/interface/wx/font.h
@@ -322,16 +322,11 @@ public:
     /**
         Constructor setting the font size in points to use.
 
-        The canonical type of @a pointSize argument is @c float, however any
-        other integer type, as well as @c double, is also accepted for
-        compatibility.
-
-        Notice that until wxWidgets 3.1.2, the type could only be @c int.
+        Note that until wxWidgets 3.1.2, the type of @a pointSize was @c int.
 
         @see wxFont::SetPointSize()
      */
-    template <typename T>
-    explicit wxFontInfo(T pointSize);
+    explicit wxFontInfo(double pointSize);
 
     /**
         Constructor setting the font size in pixels to use.
@@ -786,7 +781,7 @@ public:
 
         @since 3.1.2
     */
-    virtual float  GetFractionalPointSize() const;
+    virtual double GetFractionalPointSize() const;
 
     /**
         Gets the pixel size.
@@ -1139,7 +1134,7 @@ public:
 
         @since 3.1.2
     */
-    virtual void SetFractionalPointSize(float pointSize);
+    virtual void SetFractionalPointSize(double pointSize);
 
     /**
         Sets the pixel size.

--- a/src/common/fontcmn.cpp
+++ b/src/common/fontcmn.cpp
@@ -44,8 +44,6 @@
 
 #include "wx/tokenzr.h"
 
-#include <float.h>       // for FLT_MAX
-
 // debugger helper: this function can be called from a debugger to show what
 // the date really is
 extern const char *wxDumpFont(const wxFont *font)
@@ -254,7 +252,7 @@ int wxFontBase::GetNumericWeightOf(wxFontWeight weight_)
 
 int wxFontBase::GetPointSize() const
 {
-    return wxFontInfo::ToIntPointSize(GetFractionalPointSize());
+    return wxRound(GetFractionalPointSize());
 }
 
 
@@ -279,7 +277,7 @@ bool wxFontBase::IsUsingSizeInPixels() const
 
 void wxFontBase::SetPointSize(int pointSize)
 {
-    SetFractionalPointSize(wxFontInfo::ToFloatPointSize(pointSize));
+    SetFractionalPointSize(pointSize);
 }
 
 void wxFontBase::SetPixelSize( const wxSize& pixelSize )
@@ -688,7 +686,7 @@ wxFont& wxFont::MakeStrikethrough()
 
 wxFont& wxFont::Scale(float x)
 {
-    SetFractionalPointSize(x*GetFractionalPointSize());
+    SetFractionalPointSize(double(x) * GetFractionalPointSize());
     return *this;
 }
 
@@ -727,12 +725,12 @@ void wxNativeFontInfo::SetFaceName(const wxArrayString& facenames)
 
 int wxNativeFontInfo::GetPointSize() const
 {
-    return wxFontInfo::ToIntPointSize(GetFractionalPointSize());
+    return wxRound(GetFractionalPointSize());
 }
 
 void wxNativeFontInfo::SetPointSize(int pointsize)
 {
-    SetFractionalPointSize(wxFontInfo::ToFloatPointSize(pointsize));
+    SetFractionalPointSize(pointsize);
 }
 
 #ifdef wxNO_NATIVE_FONTINFO
@@ -760,9 +758,9 @@ bool wxNativeFontInfo::FromString(const wxString& s)
     token = tokenizer.GetNextToken();
     if ( !token.ToCDouble(&d) )
         return false;
-    if ( d < 0 || d > FLT_MAX )
+    if ( d < 0 )
         return false;
-    pointSize = static_cast<float>(d);
+    pointSize = d;
 
     token = tokenizer.GetNextToken();
     if ( !token.ToLong(&l) )
@@ -839,7 +837,7 @@ void wxNativeFontInfo::Init()
     encoding = wxFONTENCODING_DEFAULT;
 }
 
-float wxNativeFontInfo::GetFractionalPointSize() const
+double wxNativeFontInfo::GetFractionalPointSize() const
 {
     return pointSize;
 }
@@ -879,7 +877,7 @@ wxFontEncoding wxNativeFontInfo::GetEncoding() const
     return encoding;
 }
 
-void wxNativeFontInfo::SetFractionalPointSize(float pointsize)
+void wxNativeFontInfo::SetFractionalPointSize(double pointsize)
 {
     pointSize = pointsize;
 }

--- a/src/common/fontmgrcmn.cpp
+++ b/src/common/fontmgrcmn.cpp
@@ -280,7 +280,7 @@ wxFontMgrFontRefData::GetFontInstance(float scale, bool antialiased) const
                                        antialiased);
 }
 
-void wxFontMgrFontRefData::SetFractionalPointSize(float pointSize)
+void wxFontMgrFontRefData::SetFractionalPointSize(double pointSize)
 {
     m_info.pointSize = pointSize;
     m_fontValid = false;

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -1036,22 +1036,22 @@ void wxWindowBase::DoSetWindowVariant( wxWindowVariant variant )
     // adjust the font height to correspond to our new variant (notice that
     // we're only called if something really changed)
     wxFont font = GetFont();
-    float size = font.GetFractionalPointSize();
+    double size = font.GetFractionalPointSize();
     switch ( variant )
     {
         case wxWINDOW_VARIANT_NORMAL:
             break;
 
         case wxWINDOW_VARIANT_SMALL:
-            size /= 1.2f;
+            size /= 1.2;
             break;
 
         case wxWINDOW_VARIANT_MINI:
-            size /= 1.2f * 1.2f;
+            size /= 1.2 * 1.2;
             break;
 
         case wxWINDOW_VARIANT_LARGE:
-            size *= 1.2f;
+            size *= 1.2;
             break;
 
         default:

--- a/src/dfb/font.cpp
+++ b/src/dfb/font.cpp
@@ -94,7 +94,7 @@ wxIDirectFBFontPtr wxFont::GetDirectFBFont(bool antialiased) const
     return i ? i->GetDirectFBFont() : wxIDirectFBFontPtr();
 }
 
-float wxFont::GetFractionalPointSize() const
+double wxFont::GetFractionalPointSize() const
 {
     wxCHECK_MSG( IsOk(), 0, wxT("invalid font") );
 
@@ -160,7 +160,7 @@ const wxNativeFontInfo *wxFont::GetNativeFontInfo() const
 // change font attributes
 // ----------------------------------------------------------------------------
 
-void wxFont::SetFractionalPointSize(float pointSize)
+void wxFont::SetFractionalPointSize(double pointSize)
 {
     AllocExclusive();
     M_FONTDATA->SetFractionalPointSize(pointSize);

--- a/src/gtk/font.cpp
+++ b/src/gtk/font.cpp
@@ -49,7 +49,7 @@ public:
 
     // setters: all of them also take care to modify m_nativeFontInfo if we
     // have it so as to not lose the information not carried by our fields
-    void SetFractionalPointSize(float pointSize);
+    void SetFractionalPointSize(double pointSize);
     void SetFamily(wxFontFamily family);
     void SetStyle(wxFontStyle style);
     void SetWeight(wxFontWeight weight);
@@ -134,7 +134,7 @@ wxFontRefData::wxFontRefData(const wxString& nativeFontInfoString)
 // wxFontRefData SetXXX()
 // ----------------------------------------------------------------------------
 
-void wxFontRefData::SetFractionalPointSize(float pointSize)
+void wxFontRefData::SetFractionalPointSize(double pointSize)
 {
     m_nativeFontInfo.SetFractionalPointSize(pointSize);
 }
@@ -283,7 +283,7 @@ wxFont::~wxFont()
 // accessors
 // ----------------------------------------------------------------------------
 
-float wxFont::GetFractionalPointSize() const
+double wxFont::GetFractionalPointSize() const
 {
     wxCHECK_MSG( IsOk(), 0, wxT("invalid font") );
 
@@ -356,7 +356,7 @@ bool wxFont::IsFixedWidth() const
 // change font attributes
 // ----------------------------------------------------------------------------
 
-void wxFont::SetFractionalPointSize(float pointSize)
+void wxFont::SetFractionalPointSize(double pointSize)
 {
     AllocExclusive();
 

--- a/src/gtk1/font.cpp
+++ b/src/gtk1/font.cpp
@@ -77,7 +77,7 @@ public:
 
     // setters: all of them also take care to modify m_nativeFontInfo if we
     // have it so as to not lose the information not carried by our fields
-    void SetFractionalPointSize(float pointSize);
+    void SetFractionalPointSize(double pointSize);
     void SetFamily(wxFontFamily family);
     void SetStyle(wxFontStyle style);
     void SetNumericWeight(int weight);
@@ -108,7 +108,7 @@ private:
     // the map of font sizes to "GdkFont *"
     wxScaledFontList  m_scaled_xfonts;
 
-    float           m_pointSize;
+    double          m_pointSize;
     wxFontFamily    m_family;
     wxFontStyle     m_style;
     int             m_weight;
@@ -311,7 +311,7 @@ wxFontRefData::~wxFontRefData()
 // wxFontRefData SetXXX()
 // ----------------------------------------------------------------------------
 
-void wxFontRefData::SetFractionalPointSize(float pointSize)
+void wxFontRefData::SetFractionalPointSize(double pointSize)
 {
     m_pointSize = pointSize;
 
@@ -485,7 +485,7 @@ wxGDIRefData *wxFont::CloneGDIRefData(const wxGDIRefData *data) const
 // accessors
 // ----------------------------------------------------------------------------
 
-float wxFont::GetFractionalPointSize() const
+double wxFont::GetFractionalPointSize() const
 {
     wxCHECK_MSG( IsOk(), 0, wxT("invalid font") );
 
@@ -568,7 +568,7 @@ bool wxFont::IsFixedWidth() const
 // change font attributes
 // ----------------------------------------------------------------------------
 
-void wxFont::SetFractionalPointSize(float pointSize)
+void wxFont::SetFractionalPointSize(double pointSize)
 {
     Unshare();
 

--- a/src/motif/font.cpp
+++ b/src/motif/font.cpp
@@ -93,7 +93,7 @@ public:
 
 protected:
     // common part of all ctors
-    void Init(float size,
+    void Init(double size,
               wxFontFamily family,
               wxFontStyle style,
               int weight,
@@ -102,7 +102,7 @@ protected:
               wxFontEncoding encoding);
 
     // font attributes
-    float         m_pointSize;
+    double        m_pointSize;
     wxFontFamily  m_family;
     wxFontStyle   m_style;
     int           m_weight;
@@ -163,7 +163,7 @@ wxXFont::~wxXFont()
 // wxFontRefData
 // ----------------------------------------------------------------------------
 
-void wxFontRefData::Init(float pointSize,
+void wxFontRefData::Init(double pointSize,
                          wxFontFamily family,
                          wxFontStyle style,
                          int weight,
@@ -381,7 +381,7 @@ void wxFont::Unshare()
     }
 }
 
-void wxFont::SetFractionalPointSize(float pointSize)
+void wxFont::SetFractionalPointSize(double pointSize)
 {
     Unshare();
 
@@ -449,7 +449,7 @@ void wxFont::DoSetNativeFontInfo(const wxNativeFontInfo& info)
 // query font attributes
 // ----------------------------------------------------------------------------
 
-float wxFont::GetFractionalPointSize() const
+double wxFont::GetFractionalPointSize() const
 {
     wxCHECK_MSG( IsOk(), 0, wxT("invalid font") );
 

--- a/src/msw/font.cpp
+++ b/src/msw/font.cpp
@@ -43,8 +43,6 @@
 #include "wx/scopeguard.h"
 #include "wx/tokenzr.h"
 
-#include <float.h>       // for FLT_MAX
-
 // ----------------------------------------------------------------------------
 // constants
 // ----------------------------------------------------------------------------
@@ -79,7 +77,7 @@ public:
     void Free();
 
     // all wxFont accessors
-    float GetFractionalPointSize() const
+    double GetFractionalPointSize() const
     {
         return m_nativeFontInfo.GetFractionalPointSize();
     }
@@ -168,7 +166,7 @@ public:
     // ... and setters: notice that all of them invalidate the currently
     // allocated HFONT, if any, so that the next call to GetHFONT() recreates a
     // new one
-    void SetFractionalPointSize(float pointSize)
+    void SetFractionalPointSize(double pointSize)
     {
         Free();
 
@@ -411,18 +409,18 @@ wxNativeFontInfo::wxNativeFontInfo(const LOGFONT& lf_, const wxWindow* win)
 { }
 
 /* static */
-float wxNativeFontInfo::GetPointSizeAtPPI(int lfHeight, int ppi)
+double wxNativeFontInfo::GetPointSizeAtPPI(int lfHeight, int ppi)
 {
     if ( ppi == 0 )
         ppi = ::GetDeviceCaps(ScreenHDC(), LOGPIXELSY);
 
-    return abs(lfHeight) * 72.0f / ppi;
+    return abs(lfHeight) * 72.0 / ppi;
 }
 
 /* static */
-int wxNativeFontInfo::GetLogFontHeightAtPPI(float size, int ppi)
+int wxNativeFontInfo::GetLogFontHeightAtPPI(double size, int ppi)
 {
-    return -wxRound(size * ppi / 72.0f);
+    return -wxRound(size * ppi / 72.0);
 }
 
 void wxNativeFontInfo::Init()
@@ -437,10 +435,10 @@ void wxNativeFontInfo::Init()
                     ? DEFAULT_QUALITY
                     : PROOF_QUALITY;
 
-    pointSize = 0.0f;
+    pointSize = 0;
 }
 
-float wxNativeFontInfo::GetFractionalPointSize() const
+double wxNativeFontInfo::GetFractionalPointSize() const
 {
     return pointSize;
 }
@@ -523,7 +521,7 @@ wxFontEncoding wxNativeFontInfo::GetEncoding() const
     return wxGetFontEncFromCharSet(lf.lfCharSet);
 }
 
-void wxNativeFontInfo::SetFractionalPointSize(float pointSizeNew)
+void wxNativeFontInfo::SetFractionalPointSize(double pointSizeNew)
 {
     // We don't have the correct DPI to use here, so use that of the
     // primary screen and rely on WXAdjustToPPI() changing it later if
@@ -694,11 +692,7 @@ bool wxNativeFontInfo::FromString(const wxString& s)
                 // lfHeight, as with v0 strings.
                 if ( !wxIsNullDouble(d) )
                 {
-                    if ( d < 0 || d > FLT_MAX )
-                        return false;
-
-                    pointSize = static_cast<float>(d);
-
+                    pointSize = d;
                     setPointSizeFromHeight = false;
                 }
             }
@@ -901,7 +895,7 @@ bool wxFont::IsFree() const
 // change font attribute: we recreate font when doing it
 // ----------------------------------------------------------------------------
 
-void wxFont::SetFractionalPointSize(float pointSize)
+void wxFont::SetFractionalPointSize(double pointSize)
 {
     AllocExclusive();
 
@@ -998,7 +992,7 @@ void wxFont::DoSetNativeFontInfo(const wxNativeFontInfo& info)
 // accessors
 // ----------------------------------------------------------------------------
 
-float wxFont::GetFractionalPointSize() const
+double wxFont::GetFractionalPointSize() const
 {
     wxCHECK_MSG( IsOk(), 0, wxT("invalid font") );
 

--- a/src/msw/graphics.cpp
+++ b/src/msw/graphics.cpp
@@ -1148,9 +1148,9 @@ wxGDIPlusFontData::wxGDIPlusFontData( wxGraphicsRenderer* renderer,
     if ( font.GetWeight() == wxFONTWEIGHT_BOLD )
         style |= FontStyleBold;
 
-    REAL fontSize = (REAL)(!dpi.y
-        ? font.GetPixelSize().GetHeight()
-        : (font.GetFractionalPointSize() * dpi.y / 72.0f));
+    REAL fontSize = !dpi.y
+        ? REAL(font.GetPixelSize().GetHeight())
+        : REAL(font.GetFractionalPointSize()) * dpi.y / 72.0f;
 
     Init(font.GetFaceName(), fontSize, style, col);
 }

--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -3104,9 +3104,9 @@ wxD2DFontData::wxD2DFontData(wxGraphicsRenderer* renderer, const wxFont& font, c
     hr = familyNames->GetString(0, name, length+1);
     wxCHECK_HRESULT_RET(hr);
 
-    FLOAT fontSize = (FLOAT)(!dpi.y
-        ? font.GetPixelSize().GetHeight()
-        : (font.GetFractionalPointSize() * dpi.y / 72.0f));
+    FLOAT fontSize = !dpi.y
+        ? FLOAT(font.GetPixelSize().GetHeight())
+        : FLOAT(font.GetFractionalPointSize()) * dpi.y / 72.0f;
 
     hr = wxDWriteFactory()->CreateTextFormat(
         name,

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -3383,7 +3383,7 @@ bool wxTextCtrl::GetStyle(long position, wxTextAttr& style)
     // Determine the pointSize that was used in SetStyle. Don't worry about
     // lfHeight or PPI, style.SetFont() will lose this information anyway.
     wxFont font(wxNativeFontInfo(lf, this));
-    font.SetFractionalPointSize(cf.yHeight / 20.0f); // 1 pt = 20 twips
+    font.SetFractionalPointSize(cf.yHeight / 20.0); // 1 pt = 20 twips
     if (font.IsOk())
     {
         style.SetFont(font);

--- a/src/osx/carbon/font.cpp
+++ b/src/osx/carbon/font.cpp
@@ -49,7 +49,7 @@ public:
 
     wxFontRefData(CTFontRef font);
 
-    float GetFractionalPointSize() const { return m_info.GetFractionalPointSize(); }
+    double GetFractionalPointSize() const { return m_info.GetFractionalPointSize(); }
 
     wxFontFamily GetFamily() const { return m_info.GetFamily(); }
 
@@ -75,7 +75,7 @@ public:
 
     const wxNativeFontInfo& GetNativeFontInfo() const;
 
-    void SetFractionalPointSize(float size)
+    void SetFractionalPointSize(double size)
     {
         if (GetFractionalPointSize() != size)
         {
@@ -569,7 +569,7 @@ wxGDIRefData* wxFont::CloneGDIRefData(const wxGDIRefData* data) const
     return new wxFontRefData(*static_cast<const wxFontRefData*>(data));
 }
 
-void wxFont::SetFractionalPointSize(float pointSize)
+void wxFont::SetFractionalPointSize(double pointSize)
 {
     AllocExclusive();
 
@@ -626,7 +626,7 @@ void wxFont::SetStrikethrough(bool strikethrough)
 
 // TODO: insert checks everywhere for M_FONTDATA == NULL!
 
-float wxFont::GetFractionalPointSize() const
+double wxFont::GetFractionalPointSize() const
 {
     wxCHECK_MSG(IsOk(), 0, wxT("invalid font"));
 
@@ -1040,7 +1040,7 @@ wxString wxNativeFontInfo::ToString() const
     return s;
 }
 
-float wxNativeFontInfo::GetFractionalPointSize() const
+double wxNativeFontInfo::GetFractionalPointSize() const
 {
     return m_ctSize;
 }
@@ -1087,7 +1087,7 @@ bool wxNativeFontInfo::GetStrikethrough() const
 
 // changing the font descriptor
 
-void wxNativeFontInfo::SetFractionalPointSize(float pointsize)
+void wxNativeFontInfo::SetFractionalPointSize(double pointsize)
 {
     if (GetFractionalPointSize() != pointsize)
     {

--- a/src/qt/font.cpp
+++ b/src/qt/font.cpp
@@ -241,7 +241,7 @@ int wxFont::GetPointSize() const
     return M_FONTDATA.wxNativeFontInfo::GetPointSize();
 }
 
-float wxFont::GetFractionalPointSize() const
+double wxFont::GetFractionalPointSize() const
 {
     return M_FONTDATA.GetFractionalPointSize();
 }
@@ -287,7 +287,7 @@ bool wxFont::GetStrikethrough() const
 }
 
 
-void wxFont::SetFractionalPointSize(float pointSize)
+void wxFont::SetFractionalPointSize(double pointSize)
 {
     AllocExclusive();
 
@@ -390,7 +390,7 @@ void wxNativeFontInfo::Init()
 {
 }
 
-float wxNativeFontInfo::GetFractionalPointSize() const
+double wxNativeFontInfo::GetFractionalPointSize() const
 {
     return m_qtFont.pointSizeF();
 }
@@ -501,7 +501,7 @@ wxFontEncoding wxNativeFontInfo::GetEncoding() const
     return wxFONTENCODING_UTF8;
 }
 
-void wxNativeFontInfo::SetFractionalPointSize(float pointsize)
+void wxNativeFontInfo::SetFractionalPointSize(double pointsize)
 {
     m_qtFont.setPointSizeF(pointsize);
 }

--- a/src/unix/fontutil.cpp
+++ b/src/unix/fontutil.cpp
@@ -91,9 +91,9 @@ void wxNativeFontInfo::Free()
         pango_font_description_free(description);
 }
 
-float wxNativeFontInfo::GetFractionalPointSize() const
+double wxNativeFontInfo::GetFractionalPointSize() const
 {
-    return ((float) pango_font_description_get_size( description )) / PANGO_SCALE;
+    return double(pango_font_description_get_size(description)) / PANGO_SCALE;
 }
 
 wxFontStyle wxNativeFontInfo::GetStyle() const
@@ -215,7 +215,7 @@ wxFontEncoding wxNativeFontInfo::GetEncoding() const
     return wxFONTENCODING_SYSTEM;
 }
 
-void wxNativeFontInfo::SetFractionalPointSize(float pointsize)
+void wxNativeFontInfo::SetFractionalPointSize(double pointsize)
 {
     pango_font_description_set_size( description, wxRound(pointsize * PANGO_SCALE) );
 }
@@ -489,7 +489,7 @@ static wxHashTable *g_fontHash = NULL;
 
 static bool wxTestFontSpec(const wxString& fontspec);
 
-static wxNativeFont wxLoadQueryFont(float pointSize,
+static wxNativeFont wxLoadQueryFont(double pointSize,
                                     wxFontFamily family,
                                     wxFontStyle style,
                                     int weight,
@@ -693,7 +693,7 @@ void wxNativeFontInfo::SetXFontName(const wxString& xFontName_)
     m_isDefault = false;
 }
 
-float wxNativeFontInfo::GetFractionalPointSize() const
+double wxNativeFontInfo::GetFractionalPointSize() const
 {
     const wxString s = GetXFontComponent(wxXLFD_POINTSIZE);
 
@@ -785,7 +785,7 @@ wxFontEncoding wxNativeFontInfo::GetEncoding() const
     return wxFONTENCODING_MAX;
 }
 
-void wxNativeFontInfo::SetFractionalPointSize(float pointsize)
+void wxNativeFontInfo::SetFractionalPointSize(double pointsize)
 {
     wxString s;
     if ( pointsize < 0 )
@@ -1029,7 +1029,7 @@ bool wxTestFontEncoding(const wxNativeEncodingInfo& info)
 // X-specific functions
 // ----------------------------------------------------------------------------
 
-wxNativeFont wxLoadQueryNearestFont(float pointSize,
+wxNativeFont wxLoadQueryNearestFont(double pointSize,
                                     wxFontFamily family,
                                     wxFontStyle style,
                                     int weight,
@@ -1252,7 +1252,7 @@ static bool wxTestFontSpec(const wxString& fontspec)
     }
 }
 
-static wxNativeFont wxLoadQueryFont(float pointSize,
+static wxNativeFont wxLoadQueryFont(double pointSize,
                                     wxFontFamily family,
                                     wxFontStyle style,
                                     int weight,

--- a/src/x11/font.cpp
+++ b/src/x11/font.cpp
@@ -138,7 +138,7 @@ public:
 
     // setters: all of them also take care to modify m_nativeFontInfo if we
     // have it so as to not lose the information not carried by our fields
-    void SetFractionalPointSize(float pointSize);
+    void SetFractionalPointSize(double pointSize);
     void SetFamily(wxFontFamily family);
     void SetStyle(wxFontStyle style);
     void SetNumericWeight(int weight);
@@ -250,7 +250,7 @@ void wxFontRefData::Init(int pointSize,
     m_nativeFontInfo.SetUnderlined(underlined);
 #endif // wxUSE_UNICODE
 
-    SetFractionalPointSize(static_cast<float>(pointSize));
+    SetFractionalPointSize(pointSize);
 }
 
 void wxFontRefData::InitFromNative()
@@ -426,7 +426,7 @@ wxFontRefData::~wxFontRefData()
 // wxFontRefData SetXXX()
 // ----------------------------------------------------------------------------
 
-void wxFontRefData::SetFractionalPointSize(float pointSize)
+void wxFontRefData::SetFractionalPointSize(double pointSize)
 {
     // NB: Pango doesn't support point sizes less than 1
     m_pointSize = pointSize == wxDEFAULT || pointSize < 1 ? wxDEFAULT_FONT_SIZE
@@ -692,7 +692,7 @@ void wxFont::Unshare()
 // accessors
 // ----------------------------------------------------------------------------
 
-float wxFont::GetFractionalPointSize() const
+double wxFont::GetFractionalPointSize() const
 {
     wxCHECK_MSG( IsOk(), 0, wxT("invalid font") );
 
@@ -799,7 +799,7 @@ bool wxFont::IsFixedWidth() const
 // change font attributes
 // ----------------------------------------------------------------------------
 
-void wxFont::SetFractionalPointSize(float pointSize)
+void wxFont::SetFractionalPointSize(double pointSize)
 {
     Unshare();
 

--- a/tests/font/fonttest.cpp
+++ b/tests/font/fonttest.cpp
@@ -454,7 +454,7 @@ TEST_CASE("wxFont::NativeFontInfoUserDesc", "[font][fontinfo]")
     // strings (see #18590).
     wxFont font(*wxNORMAL_FONT);
 
-    static const float sizes[] = { 12.0f, 10.5f, 13.8f, 10.123f, 11.1f };
+    static const double sizes[] = { 12.0, 10.5, 13.8, 10.123, 11.1 };
     for ( unsigned n = 0; n < WXSIZEOF(sizes); n++ )
     {
         font.SetFractionalPointSize(sizes[n]);
@@ -462,7 +462,7 @@ TEST_CASE("wxFont::NativeFontInfoUserDesc", "[font][fontinfo]")
         // Just setting the font can slightly change it because of rounding
         // errors, so don't expect the actual size to be exactly equal to what
         // we used -- but close enough.
-        const float sizeUsed = font.GetFractionalPointSize();
+        const double sizeUsed = font.GetFractionalPointSize();
         CHECK( sizeUsed == Approx(sizes[n]).epsilon(0.001) );
 
         const wxString& desc = font.GetNativeFontInfoDesc();


### PR DESCRIPTION
There doesn't seem to be any compelling reason to use float. Using double
is simpler, and avoids otherwise unnecessary float<->double conversions.