### PR TITLE
Ignore GCC version and architecture tagged library output folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -217,10 +217,12 @@
 /lib/evc_armv4_lib
 /lib/evc_emulator_lib
 /lib/expat*.lib
-/lib/gcc_dll
+/lib/gcc*_dll
+/lib/gcc*_x64_dll
 /lib/gcc_dll32
 /lib/gcc_dll64
-/lib/gcc_lib
+/lib/gcc*_lib
+/lib/gcc*_x64_lib
 /lib/gcc_lib32
 /lib/gcc_lib64
 /lib/jpeg*.lib


### PR DESCRIPTION
Add patterns to ignore the directory structure of the library release version for GCC
like it is already done for MSVC.

I didn't touch the ignores with the bit depth at end because i don't know what produces them and if it's necessary there.