### PR TITLE
allow wx/utils.h to be included on its own

### DIFF
--- a/include/wx/utils.h
+++ b/include/wx/utils.h
@@ -15,6 +15,7 @@
 // headers
 // ----------------------------------------------------------------------------
 
+#include "wx/defs.h"
 #include "wx/windowid.h"
 #include "wx/object.h"
 #include "wx/list.h"


### PR DESCRIPTION
This is a follow-up of PR #1682 
It should allow to include `wx/utils.h` on its own again.
This is required, for example, by [a file in the Audacity project](https://github.com/audacity/audacity/blob/master/src/MemoryX.h#L388).