### PR TITLE
Take number of digits into account in GTK wxSpinCtrlDouble

### DIFF
--- a/include/wx/gtk/spinctrl.h
+++ b/include/wx/gtk/spinctrl.h
@@ -71,8 +71,9 @@ protected:
     void GtkDisableEvents();
     void GtkEnableEvents();
 
-    // Update the number of digits used to match our range (and base).
-    void GtkSetEntryWidth();
+    // Update the width of the entry field to fit the current range (and also
+    // base or number of digits depending on the derived class).
+    virtual void GtkSetEntryWidth() = 0;
 
     virtual wxSize DoGetSizeFromTextSize(int xlen, int ylen = -1) const wxOVERRIDE;
     virtual GdkWindow *GTKGetWindow(wxArrayGdkWindows& windows) const wxOVERRIDE;
@@ -135,6 +136,9 @@ public:
 
     virtual int GetBase() const wxOVERRIDE { return m_base; }
     virtual bool SetBase(int base) wxOVERRIDE;
+
+protected:
+    virtual void GtkSetEntryWidth() wxOVERRIDE;
 
 private:
     // Common part of all ctors.
@@ -200,6 +204,9 @@ public:
 
     virtual int GetBase() const wxOVERRIDE { return 10; }
     virtual bool SetBase(int WXUNUSED(base)) wxOVERRIDE { return false; }
+
+protected:
+    virtual void GtkSetEntryWidth() wxOVERRIDE;
 
     wxDECLARE_DYNAMIC_CLASS(wxSpinCtrlDouble);
 };

--- a/src/gtk/spinctrl.cpp
+++ b/src/gtk/spinctrl.cpp
@@ -354,18 +354,6 @@ GdkWindow *wxSpinCtrlGTKBase::GTKGetWindow(wxArrayGdkWindows& windows) const
     return NULL;
 }
 
-void wxSpinCtrlGTKBase::GtkSetEntryWidth()
-{
-    const int minVal = static_cast<int>(DoGetMin());
-    const int maxVal = static_cast<int>(DoGetMax());
-
-    gtk_entry_set_width_chars
-    (
-        GTK_ENTRY(m_widget),
-        wxSpinCtrlImpl::GetMaxValueLength(minVal, maxVal, GetBase())
-    );
-}
-
 wxSize wxSpinCtrlGTKBase::DoGetSizeFromTextSize(int xlen, int ylen) const
 {
     wxASSERT_MSG( m_widget, wxS("GetSizeFromTextSize called before creation") );
@@ -437,6 +425,18 @@ wx_gtk_spin_output(GtkSpinButton* spin, wxSpinCtrl* win)
 
 } // extern "C"
 
+void wxSpinCtrl::GtkSetEntryWidth()
+{
+    const int minVal = static_cast<int>(DoGetMin());
+    const int maxVal = static_cast<int>(DoGetMax());
+
+    gtk_entry_set_width_chars
+    (
+        GTK_ENTRY(m_widget),
+        wxSpinCtrlImpl::GetMaxValueLength(minVal, maxVal, GetBase())
+    );
+}
+
 bool wxSpinCtrl::SetBase(int base)
 {
     // Currently we only support base 10 and 16. We could add support for base
@@ -486,6 +486,15 @@ bool wxSpinCtrl::SetBase(int base)
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxSpinCtrlDouble, wxSpinCtrlGTKBase);
 
+void wxSpinCtrlDouble::GtkSetEntryWidth()
+{
+    const unsigned digits = GetDigits();
+    const int lenMin = wxString::Format("%.*f", digits, GetMin()).length();
+    const int lenMax = wxString::Format("%.*f", digits, GetMax()).length();
+
+    gtk_entry_set_width_chars(GTK_ENTRY(m_widget), wxMax(lenMin, lenMax));
+}
+
 unsigned wxSpinCtrlDouble::GetDigits() const
 {
     wxCHECK_MSG( m_widget, 0, "invalid spin button" );
@@ -499,6 +508,10 @@ void wxSpinCtrlDouble::SetDigits(unsigned digits)
 
     wxSpinCtrlEventDisabler disable(this);
     gtk_spin_button_set_digits( GTK_SPIN_BUTTON(m_widget), digits);
+
+    InvalidateBestSize();
+
+    GtkSetEntryWidth();
 }
 
 #endif // wxUSE_SPINCTRL


### PR DESCRIPTION
When determining the entry width in wxSpinCtrlDouble, we need to account
not only for the width of the integer part, but also for the number of
digits that determines the width of the fractional part.

Do it in the overridden version of (now virtual) GtkSetEntryWidth().

Closes [#18734](https://github.com/vadz/wxWidgets/pull/new/spin-double-width).