### PR TITLE
Allow copying from read-only grid

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -893,10 +893,12 @@ public:
         typedef ptrdiff_t difference_type;
         typedef wxGridBlockCoords value_type;
         typedef const value_type& reference;
+        typedef const value_type* pointer;
 
         iterator() : m_it() { }
 
         reference operator*() const { return *m_it; }
+        pointer operator->() const { return &*m_it; }
 
         iterator& operator++()
             { ++m_it; return *this; }

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -2045,6 +2045,7 @@ public:
         iterator();
 
         const wxGridBlockCoords& operator*() const;
+        const wxGridBlockCoords* operator->() const;
 
         iterator& operator++();
         iterator operator++(int);


### PR DESCRIPTION
Fix for [Allow copying contents of wxGrid cells using the usual key combinations 13562](https://trac.wxwidgets.org/ticket/13562) ticket. 