### PR TITLE
Remove obsolete Darwin-specific code in dynlib.*/dlunix.cpp

### DIFF
--- a/include/wx/dynlib.h
+++ b/include/wx/dynlib.h
@@ -18,11 +18,6 @@
 #include "wx/string.h"
 #include "wx/dynarray.h"
 
-// note that we have our own dlerror() implementation under Darwin
-#if defined(HAVE_DLERROR) || defined(__DARWIN__)
-    #define wxHAVE_DYNLIB_ERROR
-#endif
-
 class WXDLLIMPEXP_FWD_BASE wxDynamicLibraryDetailsCreator;
 
 // ----------------------------------------------------------------------------
@@ -31,9 +26,6 @@ class WXDLLIMPEXP_FWD_BASE wxDynamicLibraryDetailsCreator;
 
 #if defined(__WINDOWS__)
     typedef WXHMODULE           wxDllType;
-#elif defined(__DARWIN__)
-    // Don't include dlfcn.h on Darwin, we may be using our own replacements.
-    typedef void               *wxDllType;
 #elif defined(HAVE_DLOPEN)
     #include <dlfcn.h>
     typedef void               *wxDllType;
@@ -365,10 +357,10 @@ protected:
     // common part of GetSymbol() and HasSymbol()
     void* DoGetSymbol(const wxString& name, bool* success = NULL) const;
 
-#ifdef wxHAVE_DYNLIB_ERROR
+#ifdef HAVE_DLERROR
     // log the error after a dlxxx() function failure
     static void Error();
-#endif // wxHAVE_DYNLIB_ERROR
+#endif // HAVE_DLERROR
 
 
     // the handle to DLL or NULL

--- a/src/common/dynlib.cpp
+++ b/src/common/dynlib.cpp
@@ -86,7 +86,7 @@ bool wxDynamicLibrary::Load(const wxString& libnameOrig, int flags)
 
     if ( m_handle == 0 && !(flags & wxDL_QUIET) )
     {
-#ifdef wxHAVE_DYNLIB_ERROR
+#ifdef HAVE_DLERROR
         Error();
 #else
         wxLogSysError(_("Failed to load shared library '%s'"), libname.c_str());
@@ -114,7 +114,7 @@ void *wxDynamicLibrary::GetSymbol(const wxString& name, bool *success) const
     void *symbol = DoGetSymbol(name, success);
     if ( !symbol )
     {
-#ifdef wxHAVE_DYNLIB_ERROR
+#ifdef HAVE_DLERROR
         Error();
 #else
         wxLogSysError(_("Couldn't find symbol '%s' in a dynamic library"),

--- a/src/unix/dlunix.cpp
+++ b/src/unix/dlunix.cpp
@@ -36,10 +36,6 @@
     #include <dlfcn.h>
 #endif
 
-#ifdef __DARWIN__
-    #include <AvailabilityMacros.h>
-#endif
-
 // if some flags are not supported, just ignore them
 #ifndef RTLD_LAZY
     #define RTLD_LAZY 0
@@ -54,7 +50,7 @@
 #endif
 
 
-#if defined(HAVE_DLOPEN) || defined(__DARWIN__)
+#if defined(HAVE_DLOPEN)
     #define USE_POSIX_DL_FUNCS
 #elif !defined(HAVE_SHL_LOAD)
     #error "Don't know how to load dynamic libraries on this platform!"
@@ -112,7 +108,7 @@ wxDllType wxDynamicLibrary::RawLoad(const wxString& libname, int flags)
 /* static */
 void wxDynamicLibrary::Unload(wxDllType handle)
 {
-#ifdef wxHAVE_DYNLIB_ERROR
+#ifdef HAVE_DLERROR
     int rc =
 #endif
 
@@ -122,7 +118,7 @@ void wxDynamicLibrary::Unload(wxDllType handle)
     shl_unload(handle);
 #endif // USE_POSIX_DL_FUNCS/!USE_POSIX_DL_FUNCS
 
-#if defined(USE_POSIX_DL_FUNCS) && defined(wxHAVE_DYNLIB_ERROR)
+#if defined(USE_POSIX_DL_FUNCS) && defined(HAVE_DLERROR)
     if ( rc != 0 )
         Error();
 #endif
@@ -149,7 +145,7 @@ void *wxDynamicLibrary::RawGetSymbol(wxDllType handle, const wxString& name)
 // error handling
 // ----------------------------------------------------------------------------
 
-#ifdef wxHAVE_DYNLIB_ERROR
+#ifdef HAVE_DLERROR
 
 /* static */
 void wxDynamicLibrary::Error()
@@ -162,7 +158,7 @@ void wxDynamicLibrary::Error()
     wxLogError(wxT("%s"), err);
 }
 
-#endif // wxHAVE_DYNLIB_ERROR
+#endif // HAVE_DLERROR
 
 // ----------------------------------------------------------------------------
 // listing loaded modules


### PR DESCRIPTION
We don't have our own dlxxx() implementations under Darwin since
76c5594 (Remove our own dlxxx() functions emulation for OS X <= 10.3.,2013-10-17).

wxHAVE_DYNLIB_ERROR is reduced to being the same HAVE_DLERROR, so use
the latter one instead.