### PR TITLE
wxDataViewDropSource shouldn't be created at all in wxDataViewMainWin…

### DIFF
--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -4657,6 +4657,9 @@ void wxDataViewMainWindow::OnMouse( wxMouseEvent &event )
             m_owner->CalcUnscrolledPosition( m_dragStart.x, m_dragStart.y,
                                              &m_dragStart.x, &m_dragStart.y );
             unsigned int drag_item_row = GetLineAt( m_dragStart.y );
+            if (drag_item_row >= GetRowCount() || m_dragStart.x > GetEndOfLastCol())
+                return;
+
             wxDataViewItem itemDragged = GetItemByRow( drag_item_row );
 
             // Notify cell about drag


### PR DESCRIPTION
…dow::OnMouse() if the row is invalid because why could dragging nothing be ever useful anyhow? (acc**o**rding to conversation in PR #1822)