### PR TITLE
Handle wxToolBars created with wxTB_HORIZONTAL | wxTB_BOTTOM style

### DIFF
--- a/include/wx/tbarbase.h
+++ b/include/wx/tbarbase.h
@@ -482,6 +482,10 @@ public:
     // return true if this is a vertical toolbar, otherwise false
     bool IsVertical() const;
 
+    // returns one of wxTB_TOP, wxTB_BOTTOM, wxTB_LEFT, wxTB_RIGHT
+    // indicating where the toolbar is placed in the associated frame
+    int GetDirection() const;
+
     // these methods allow to access tools by their index in the toolbar
     size_t GetToolsCount() const { return m_tools.GetCount(); }
     wxToolBarToolBase *GetToolByPos(int pos) { return m_tools[pos]; }

--- a/src/common/tbarbase.cpp
+++ b/src/common/tbarbase.cpp
@@ -628,6 +628,24 @@ bool wxToolBarBase::IsVertical() const
     return HasFlag(wxTB_LEFT | wxTB_RIGHT);
 }
 
+// wxTB_HORIZONTAL is same as wxTB_TOP and wxTB_VERTICAL is same as wxTB_LEFT,
+// so a toolbar created with wxTB_HORIZONTAL | wxTB_BOTTOM style can have set both
+// wxTB_TOP and wxTB_BOTTOM, similarly wxTB_VERTICAL | wxTB_RIGHT == wxTB_LEFT | wxTB_RIGHT.
+// GetDirection() makes things less confusing and returns just one of wxTB_TOP, wxTB_BOTTOM,
+// wxTB_LEFT, wxTB_RIGHT indicating where the toolbar is placed in the associated frame.
+int wxToolBarBase::GetDirection() const
+{
+    if ( HasFlag(wxTB_BOTTOM) )
+        return wxTB_BOTTOM;
+
+    if ( HasFlag(wxTB_RIGHT) )
+        return wxTB_RIGHT;
+
+    if ( HasFlag(wxTB_LEFT) )
+        return wxTB_LEFT;
+
+    return wxTB_TOP;
+}
 
 // ----------------------------------------------------------------------------
 // event processing

--- a/src/msw/frame.cpp
+++ b/src/msw/frame.cpp
@@ -321,13 +321,12 @@ void wxFrame::PositionStatusBar()
 
         if ( toolbar->HasFlag(wxTB_LEFT | wxTB_RIGHT) )
         {
-            if ( toolbar->HasFlag(wxTB_LEFT) )
+            if ( !toolbar->HasFlag(wxTB_RIGHT) )
                 x -= sizeTB.x;
 
             w += sizeTB.x;
         }
-        else
-        if ( toolbar->HasFlag(wxTB_BOTTOM) )
+        else if ( toolbar->HasFlag(wxTB_BOTTOM) )
         {
             // we need to position the status bar below the toolbar
             h += sizeTB.y;
@@ -943,7 +942,7 @@ wxPoint wxFrame::GetClientAreaOrigin() const
         {
             pt.y += sizeTB.y;
         }
-        else if ( toolbar->HasFlag(wxTB_LEFT) )
+        else if ( toolbar->HasFlag(wxTB_LEFT) && !toolbar->HasFlag(wxTB_RIGHT) )
         {
             pt.x += sizeTB.x;
         }

--- a/src/msw/frame.cpp
+++ b/src/msw/frame.cpp
@@ -315,7 +315,7 @@ void wxFrame::PositionStatusBar()
     int x = 0;
 #if wxUSE_TOOLBAR
     wxToolBar * const toolbar = GetToolBar();
-    if ( toolbar && !toolbar->HasFlag(wxTB_TOP) )
+    if ( toolbar )
     {
         const wxSize sizeTB = toolbar->GetSize();
 
@@ -326,13 +326,14 @@ void wxFrame::PositionStatusBar()
 
             w += sizeTB.x;
         }
-        else // wxTB_BOTTOM
+        else
+        if ( toolbar->HasFlag(wxTB_BOTTOM) )
         {
             // we need to position the status bar below the toolbar
             h += sizeTB.y;
         }
+        //else: no adjustments necessary for the toolbar on top
     }
-    //else: no adjustments necessary for the toolbar on top
 #endif // wxUSE_TOOLBAR
 
     // GetSize returns the height of the clientSize in which the statusbar
@@ -933,7 +934,12 @@ wxPoint wxFrame::GetClientAreaOrigin() const
     {
         const wxSize sizeTB = toolbar->GetSize();
 
-        if ( toolbar->HasFlag(wxTB_TOP) )
+        // wxTB_TOP has the same value as wxTB_HORIZONTAL so HasFlag(wxTB_TOP)
+        // returns true for a toolbar created with wxTB_HORIZONTAL | wxTB_BOTTOM
+        // style despite the toolbar being on the frame bottom and not affecting
+        // the client area origin. We therefore need to check here not only for
+        // presence of wxTB_TOP but also for absence of wxTB_BOTTOM.
+        if ( toolbar->HasFlag(wxTB_TOP) && !toolbar->HasFlag(wxTB_BOTTOM) )
         {
             pt.y += sizeTB.y;
         }

--- a/src/msw/frame.cpp
+++ b/src/msw/frame.cpp
@@ -318,15 +318,16 @@ void wxFrame::PositionStatusBar()
     if ( toolbar )
     {
         const wxSize sizeTB = toolbar->GetSize();
+        const int directionTB = toolbar->GetDirection();
 
-        if ( toolbar->HasFlag(wxTB_LEFT | wxTB_RIGHT) )
+        if ( toolbar->IsVertical() )
         {
-            if ( !toolbar->HasFlag(wxTB_RIGHT) )
+            if ( directionTB == wxTB_LEFT )
                 x -= sizeTB.x;
 
             w += sizeTB.x;
         }
-        else if ( toolbar->HasFlag(wxTB_BOTTOM) )
+        else if ( directionTB == wxTB_BOTTOM )
         {
             // we need to position the status bar below the toolbar
             h += sizeTB.y;
@@ -932,17 +933,13 @@ wxPoint wxFrame::GetClientAreaOrigin() const
     if ( toolbar && toolbar->IsShown() )
     {
         const wxSize sizeTB = toolbar->GetSize();
+        const int directionTB = toolbar->GetDirection();
 
-        // wxTB_TOP has the same value as wxTB_HORIZONTAL so HasFlag(wxTB_TOP)
-        // returns true for a toolbar created with wxTB_HORIZONTAL | wxTB_BOTTOM
-        // style despite the toolbar being on the frame bottom and not affecting
-        // the client area origin. We therefore need to check here not only for
-        // presence of wxTB_TOP but also for absence of wxTB_BOTTOM.
-        if ( toolbar->HasFlag(wxTB_TOP) && !toolbar->HasFlag(wxTB_BOTTOM) )
+        if ( directionTB == wxTB_TOP )
         {
             pt.y += sizeTB.y;
         }
-        else if ( toolbar->HasFlag(wxTB_LEFT) && !toolbar->HasFlag(wxTB_RIGHT) )
+        else if ( directionTB == wxTB_LEFT )
         {
             pt.x += sizeTB.x;
         }

--- a/src/osx/carbon/frame.cpp
+++ b/src/osx/carbon/frame.cpp
@@ -62,11 +62,11 @@ wxPoint wxFrame::GetClientAreaOrigin() const
         int w, h;
         toolbar->GetSize(&w, &h);
 
-        if ( toolbar->HasFlag(wxTB_LEFT) )
+        if ( toolbar->HasFlag(wxTB_LEFT) && !toolbar->HasFlag(wxTB_RIGHT) )
         {
             pt.x += w;
         }
-        else if ( toolbar->HasFlag(wxTB_TOP) )
+        else if ( toolbar->HasFlag(wxTB_TOP) && !toolbar->HasFlag(wxTB_BOTTOM) )
         {
 #if !wxOSX_USE_NATIVE_TOOLBAR
             pt.y += h;
@@ -342,19 +342,24 @@ void wxFrame::PositionToolBar()
 
         tx = ty = 0 ;
         GetToolBar()->GetSize(&tw, &th);
-        if (GetToolBar()->HasFlag(wxTB_LEFT))
-        {
-            // Use the 'real' position. wxSIZE_NO_ADJUSTMENTS
-            // means, pretend we don't have toolbar/status bar, so we
-            // have the original client size.
-            GetToolBar()->SetSize(tx , ty , tw, ch , wxSIZE_NO_ADJUSTMENTS );
-        }
-        else if (GetToolBar()->HasFlag(wxTB_RIGHT))
+
+        // Note: we need to test for wxTB_RIGHT before wxTB_LEFT, as the latter
+        // is the same as wxTB_VERTICAL and it's possible to combine wxTB_RIGHT
+        // with wxTB_VERTICAL, so testing for wxTB_LEFT could be true for a
+        // right-aligned toolbar (while the reverse is, luckily, impossible).
+        if (GetToolBar()->HasFlag(wxTB_RIGHT))
         {
             // Use the 'real' position. wxSIZE_NO_ADJUSTMENTS
             // means, pretend we don't have toolbar/status bar, so we
             // have the original client size.
             tx = cw - tw;
+            GetToolBar()->SetSize(tx , ty , tw, ch , wxSIZE_NO_ADJUSTMENTS );
+        }
+        else if (GetToolBar()->HasFlag(wxTB_LEFT))
+        {
+            // Use the 'real' position. wxSIZE_NO_ADJUSTMENTS
+            // means, pretend we don't have toolbar/status bar, so we
+            // have the original client size.
             GetToolBar()->SetSize(tx , ty , tw, ch , wxSIZE_NO_ADJUSTMENTS );
         }
         else if (GetToolBar()->HasFlag(wxTB_BOTTOM))

--- a/src/osx/carbon/frame.cpp
+++ b/src/osx/carbon/frame.cpp
@@ -59,14 +59,15 @@ wxPoint wxFrame::GetClientAreaOrigin() const
     wxToolBar *toolbar = GetToolBar();
     if ( toolbar && toolbar->IsShown() )
     {
+        const int direction = toolbar->GetDirection();
         int w, h;
         toolbar->GetSize(&w, &h);
 
-        if ( toolbar->HasFlag(wxTB_LEFT) && !toolbar->HasFlag(wxTB_RIGHT) )
+        if ( direction == wxTB_LEFT )
         {
             pt.x += w;
         }
-        else if ( toolbar->HasFlag(wxTB_TOP) && !toolbar->HasFlag(wxTB_BOTTOM) )
+        else if ( direction == wxTB_TOP )
         {
 #if !wxOSX_USE_NATIVE_TOOLBAR
             pt.y += h;
@@ -338,16 +339,20 @@ void wxFrame::PositionToolBar()
 
     if (GetToolBar())
     {
+        const int direction = GetToolBar()->GetDirection();
         int tx, ty, tw, th;
 
         tx = ty = 0 ;
         GetToolBar()->GetSize(&tw, &th);
 
-        // Note: we need to test for wxTB_RIGHT before wxTB_LEFT, as the latter
-        // is the same as wxTB_VERTICAL and it's possible to combine wxTB_RIGHT
-        // with wxTB_VERTICAL, so testing for wxTB_LEFT could be true for a
-        // right-aligned toolbar (while the reverse is, luckily, impossible).
-        if (GetToolBar()->HasFlag(wxTB_RIGHT))
+        if (direction == wxTB_LEFT)
+        {
+            // Use the 'real' position. wxSIZE_NO_ADJUSTMENTS
+            // means, pretend we don't have toolbar/status bar, so we
+            // have the original client size.
+            GetToolBar()->SetSize(tx , ty , tw, ch , wxSIZE_NO_ADJUSTMENTS );
+        }
+        else if (direction == wxTB_RIGHT)
         {
             // Use the 'real' position. wxSIZE_NO_ADJUSTMENTS
             // means, pretend we don't have toolbar/status bar, so we
@@ -355,14 +360,7 @@ void wxFrame::PositionToolBar()
             tx = cw - tw;
             GetToolBar()->SetSize(tx , ty , tw, ch , wxSIZE_NO_ADJUSTMENTS );
         }
-        else if (GetToolBar()->HasFlag(wxTB_LEFT))
-        {
-            // Use the 'real' position. wxSIZE_NO_ADJUSTMENTS
-            // means, pretend we don't have toolbar/status bar, so we
-            // have the original client size.
-            GetToolBar()->SetSize(tx , ty , tw, ch , wxSIZE_NO_ADJUSTMENTS );
-        }
-        else if (GetToolBar()->HasFlag(wxTB_BOTTOM))
+        else if (direction == wxTB_BOTTOM)
         {
             tx = 0;
             ty = ch - th;

--- a/src/osx/cocoa/toolbar.mm
+++ b/src/osx/cocoa/toolbar.mm
@@ -1688,10 +1688,14 @@ void wxToolBar::OnPaint(wxPaintEvent& event)
         }
         
         dc.SetPen( wxPen( wxColour( 0x51,0x51,0x51 ) ) );
-        if ( HasFlag(wxTB_LEFT) )
-            dc.DrawLine(w-1, 0, w-1, h);
-        else if ( HasFlag(wxTB_RIGHT) )
+
+        // Note that testing this is in the "reverse" order, i.e. right before
+        // left and bottom before top because these flags can actually be
+        // combined because left/top are the same as vertical/horizontal
+        if ( HasFlag(wxTB_RIGHT) )
             dc.DrawLine(0, 0, 0, h);
+        else if ( HasFlag(wxTB_LEFT) )
+            dc.DrawLine(w-1, 0, w-1, h);
         else if ( HasFlag(wxTB_BOTTOM) )
             dc.DrawLine(0, 0, w, 0);
         else if ( HasFlag(wxTB_TOP) )

--- a/src/osx/cocoa/toolbar.mm
+++ b/src/osx/cocoa/toolbar.mm
@@ -1670,6 +1670,7 @@ void wxToolBar::OnPaint(wxPaintEvent& event)
     else
 #endif
     {
+        const int direction = GetDirection();
         int w, h;
         GetSize( &w, &h );
 
@@ -1689,16 +1690,13 @@ void wxToolBar::OnPaint(wxPaintEvent& event)
         
         dc.SetPen( wxPen( wxColour( 0x51,0x51,0x51 ) ) );
 
-        // Note that testing this is in the "reverse" order, i.e. right before
-        // left and bottom before top because these flags can actually be
-        // combined because left/top are the same as vertical/horizontal
-        if ( HasFlag(wxTB_RIGHT) )
+        if ( direction == wxTB_RIGHT )
             dc.DrawLine(0, 0, 0, h);
-        else if ( HasFlag(wxTB_LEFT) )
+        else if ( direction == wxTB_LEFT )
             dc.DrawLine(w-1, 0, w-1, h);
-        else if ( HasFlag(wxTB_BOTTOM) )
+        else if ( direction == wxTB_BOTTOM )
             dc.DrawLine(0, 0, w, 0);
-        else if ( HasFlag(wxTB_TOP) )
+        else if ( direction == wxTB_TOP )
             dc.DrawLine(0, h-1, w, h-1);
     }
     event.Skip();


### PR DESCRIPTION
wxToolBar created with wxTB_HORIZONTAL | wxTB_BOTTOM had two issues:
(1) There was a toolbar-high gap below the menu bar.
(2) The status bar was not positioned correctly.

Fix both issues by taking into account that wxTB_TOP is an alias for wxTB_HORIZONTAL
and so a wxToolBar can have quite counter-intuitively set both wxTB_TOP and wxTB_BOTTOM.

In such cases it means that the toolbar is horizontal and on the frame bottom,
this needs to be accounted for when computing the origin of the frame client
area as well as the status bar position.

Closes #18760