### PR TITLE
Implement wxSYS_COLOUR_HOTLIGHT on macOS

### DIFF
--- a/src/osx/cocoa/settings.mm
+++ b/src/osx/cocoa/settings.mm
@@ -163,11 +163,13 @@ wxColour wxSystemSettingsNative::GetColour(wxSystemColour index)
         sysColor = [NSColor windowBackgroundColor];
         break;
     case wxSYS_COLOUR_HOTLIGHT:
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_10
         if ( WX_IS_MACOS_AVAILABLE(10, 10) )
         {
             sysColor = [NSColor linkColor];
         }
         else
+#endif
         {
             // OSX doesn't change color on mouse hover
             sysColor = [NSColor controlTextColor];

--- a/src/osx/cocoa/settings.mm
+++ b/src/osx/cocoa/settings.mm
@@ -163,8 +163,15 @@ wxColour wxSystemSettingsNative::GetColour(wxSystemColour index)
         sysColor = [NSColor windowBackgroundColor];
         break;
     case wxSYS_COLOUR_HOTLIGHT:
-        // OSX doesn't change color on mouse hover
-        sysColor = [NSColor controlTextColor];
+        if ( WX_IS_MACOS_AVAILABLE(10, 10) )
+        {
+            sysColor = [NSColor linkColor];
+        }
+        else
+        {
+            // OSX doesn't change color on mouse hover
+            sysColor = [NSColor controlTextColor];
+        }
         break;
     case wxSYS_COLOUR_MENUHILIGHT:
         sysColor = [NSColor selectedMenuItemColor];


### PR DESCRIPTION
* There is linkColor avaiable since 10.10. Just use it.
* https://developer.apple.com/documentation/appkit/nscolor/2998828-linkcolor
* https://developer.apple.com/design/human-interface-guidelines/macos/visual-design/color/