### PR TITLE
Set top-level window class name

### DIFF
--- a/include/wx/app.h
+++ b/include/wx/app.h
@@ -180,6 +180,11 @@ public:
         m_vendorDisplayName = name;
     }
 
+    // detect the filename of the application executable
+    //
+    // returns the empty string if it fails
+    wxString DetectExeName() const;
+
 
     // cmd line parsing stuff
     // ----------------------

--- a/src/common/appbase.cpp
+++ b/src/common/appbase.cpp
@@ -214,26 +214,7 @@ bool wxAppConsoleBase::Initialize(int& WXUNUSED(argc), wxChar **WXUNUSED(argv))
 
 wxString wxAppConsoleBase::GetAppName() const
 {
-    wxString name = m_appName;
-    if ( name.empty() )
-    {
-        if ( argv )
-        {
-            // the application name is, by default, the name of its executable file
-            wxFileName::SplitPath(argv[0], NULL, &name, NULL);
-        }
-#if wxUSE_STDPATHS
-        else // fall back to the executable file name, if we can determine it
-        {
-            const wxString pathExe = wxStandardPaths::Get().GetExecutablePath();
-            if ( !pathExe.empty() )
-            {
-                wxFileName::SplitPath(pathExe, NULL, &name, NULL);
-            }
-        }
-#endif // wxUSE_STDPATHS
-    }
-    return name;
+    return m_appName.empty() ? DetectExeName() : m_appName;
 }
 
 wxString wxAppConsoleBase::GetAppDisplayName() const
@@ -250,6 +231,26 @@ wxString wxAppConsoleBase::GetAppDisplayName() const
     // if neither is set, use the capitalized version of the program file as
     // it's the most reasonable default
     return GetAppName().Capitalize();
+}
+
+wxString wxAppConsoleBase::DetectExeName() const {
+    wxString name;
+    if ( argv )
+    {
+        // the application name is, by default, the name of its executable file
+        wxFileName::SplitPath(argv[0], NULL, &name, NULL);
+    }
+#if wxUSE_STDPATHS
+    else // fall back to the executable file name, if we can determine it
+    {
+        const wxString pathExe = wxStandardPaths::Get().GetExecutablePath();
+        if ( !pathExe.empty() )
+        {
+            wxFileName::SplitPath(pathExe, NULL, &name, NULL);
+        }
+    }
+#endif // wxUSE_STDPATHS
+    return name;
 }
 
 wxEventLoopBase *wxAppConsoleBase::CreateMainLoop()

--- a/src/gtk/toplevel.cpp
+++ b/src/gtk/toplevel.cpp
@@ -29,6 +29,7 @@
     #include "wx/log.h"
 #endif
 
+#include "wx/app.h"
 #include "wx/evtloop.h"
 #include "wx/sysopt.h"
 
@@ -688,6 +689,10 @@ bool wxTopLevelWindowGTK::Create( wxWindow *parent,
     if (!name.empty())
         gtk_window_set_role( GTK_WINDOW(m_widget), wxGTK_CONV( name ) );
 #endif
+
+    const wxString& appCls = wxTheApp->GetClassName();
+    if (!appCls.empty())
+        gtk_window_set_wmclass( GTK_WINDOW(m_widget), wxGTK_CONV( appCls ), wxGTK_CONV( appCls ) );
 
     gtk_window_set_title( GTK_WINDOW(m_widget), wxGTK_CONV( title ) );
     gtk_widget_set_can_focus(m_widget, false);

--- a/src/gtk/toplevel.cpp
+++ b/src/gtk/toplevel.cpp
@@ -690,9 +690,11 @@ bool wxTopLevelWindowGTK::Create( wxWindow *parent,
         gtk_window_set_role( GTK_WINDOW(m_widget), wxGTK_CONV( name ) );
 #endif
 
+    const wxString& exeName = wxTheApp->DetectExeName();
     const wxString& appCls = wxTheApp->GetClassName();
     if (!appCls.empty())
-        gtk_window_set_wmclass( GTK_WINDOW(m_widget), wxGTK_CONV( appCls ), wxGTK_CONV( appCls ) );
+        gtk_window_set_wmclass( GTK_WINDOW(m_widget), wxGTK_CONV( exeName ),
+                                wxGTK_CONV( appCls ) );
 
     gtk_window_set_title( GTK_WINDOW(m_widget), wxGTK_CONV( title ) );
     gtk_widget_set_can_focus(m_widget, false);


### PR DESCRIPTION
I'm developing an application for both macOS and Linux (specifically, Ubuntu 18.04). I noticed that the app name is not displayed properly in the task bar or in system menus: only its first character appears there.

In the case of macOS I managed to fix that by calling `SetAppName()` on startup. The Linux story was not so simple. It looks like gnome-shell relies, among other things, on the value of the WM_CLASS property of the top-level window. Indeed, an older version of the GTK-specific code used to set WM_CLASS.
https://github.com/wxWidgets/wxWidgets/blob/fb5c13ed00490bb61a7e77b7a21687381cd70efb/src/gtk1/toplevel.cpp#L538-L539

The function `gtk_window_set_wmclass()` was eventually deprecated. Still, no direct replacement seems to be available. I therefore suggest to reintroduce the call to allow the application to control its own name in the task bar. To make development easier, the actual string is taken from the `ClassName` attribute set on the global application object.

I think this is a low-risk update. Unless the user explicitly sets the application `ClassName`  wxWidgets behavior is not changing.