### PR TITLE
Make virtual lists send DESELECTED events consistently on both implementations

### DIFF
--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -1442,7 +1442,7 @@ protected:
         control itself when this event is generated, see @ref
         overview_events_with_mouse_capture "event handling overview".
     @event{EVT_LIST_ITEM_DESELECTED(id, func)}
-        The item has been deselected.
+        The item has been deselected. GetIndex() may be -1 with virtual lists.
     @event{EVT_LIST_ITEM_ACTIVATED(id, func)}
         The item has been activated (ENTER or double click).
     @event{EVT_LIST_ITEM_FOCUSED(id, func)}

--- a/samples/listctrl/listtest.cpp
+++ b/samples/listctrl/listtest.cpp
@@ -53,6 +53,8 @@
 // Constants and globals
 // ----------------------------------------------------------------------------
 
+wxButton *m_button;
+
 const wxChar *SMALL_VIRTUAL_VIEW_ITEMS[][2] =
 {
     { wxT("Cat"), wxT("meow") },
@@ -308,8 +310,12 @@ MyFrame::MyFrame(const wxString& title)
     CreateStatusBar();
 #endif // wxUSE_STATUSBAR
 
+	m_button = new wxButton(m_panel, wxID_ANY, "Do something with the selected item");
+	m_button->Enable(false);
+
     wxBoxSizer* const sizer = new wxBoxSizer(wxVERTICAL);
     sizer->Add(m_listCtrl, wxSizerFlags(2).Expand().Border());
+	sizer->Add(m_button, wxSizerFlags(2));
     sizer->Add(m_logWindow, wxSizerFlags(1).Expand().Border());
     m_panel->SetSizer(sizer);
 
@@ -1184,7 +1190,9 @@ void MyListCtrl::OnDeleteAllItems(wxListEvent& event)
 
 void MyListCtrl::OnSelected(wxListEvent& event)
 {
-    LogEvent(event, "OnSelected");
+	m_button->Enable(true);
+
+	LogEvent(event, "OnSelected");
 
     if ( GetWindowStyle() & wxLC_REPORT )
     {
@@ -1206,6 +1214,8 @@ void MyListCtrl::OnSelected(wxListEvent& event)
 
 void MyListCtrl::OnDeselected(wxListEvent& event)
 {
+	if (GetSelectedItemCount() == 0)
+		m_button->Enable(false);
     LogEvent(event, "OnDeselected");
 }
 
@@ -1258,7 +1268,7 @@ void MyListCtrl::OnListKeyDown(wxListEvent& event)
 
     if ( !wxGetKeyState(WXK_SHIFT) )
     {
-        LogEvent(event, "OnListKeyDown");
+        //LogEvent(event, "OnListKeyDown");
         event.Skip();
     }
 
@@ -1409,7 +1419,7 @@ void MyListCtrl::OnListKeyDown(wxListEvent& event)
             wxFALLTHROUGH;
 
         default:
-            LogEvent(event, "OnListKeyDown");
+            //LogEvent(event, "OnListKeyDown");
 
             event.Skip();
     }

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -2447,7 +2447,8 @@ void wxListMainWindow::OnMouse( wxMouseEvent &event )
     else
         m_dragCount = 0;
 
-    // The only mouse event that can be generated without any valid item is
+    // The only mouse events that can be generated without any valid item are
+    // wxEVT_LIST_ITEM_DESELECTED for virtual lists, and
     // wxEVT_LIST_ITEM_RIGHT_CLICK as it can be useful to have a global
     // popup menu for the list control itself which should be shown even when
     // the user clicks outside of any item.
@@ -2467,6 +2468,10 @@ void wxListMainWindow::OnMouse( wxMouseEvent &event )
         {
             // reset the selection and bail out
             HighlightAll(false);
+            // generate a DESELECTED event for
+            // virtual multi-selection lists
+            if ( IsVirtual() && !IsSingleSel() )
+                SendNotify( m_lineLastClicked, wxEVT_LIST_ITEM_DESELECTED );
         }
 
         return;

--- a/tests/controls/listbasetest.cpp
+++ b/tests/controls/listbasetest.cpp
@@ -203,6 +203,7 @@ void ListBaseTestCase::ItemClick()
     EventCounter focused(list, wxEVT_LIST_ITEM_FOCUSED);
     EventCounter activated(list, wxEVT_LIST_ITEM_ACTIVATED);
     EventCounter rclick(list, wxEVT_LIST_ITEM_RIGHT_CLICK);
+    EventCounter deselected(list, wxEVT_LIST_ITEM_DESELECTED);
 
     wxUIActionSimulator sim;
 
@@ -224,6 +225,15 @@ void ListBaseTestCase::ItemClick()
     sim.MouseClick(wxMOUSE_BTN_RIGHT);
     wxYield();
 
+    // We want a point within the listctrl but below any items
+    point = list->ClientToScreen(pos.GetPosition()) + wxPoint(10, 50);
+
+    sim.MouseMove(point);
+    wxYield();
+
+    sim.MouseClick();
+    wxYield();
+
     // when the first item was selected the focus changes to it, but not
     // on subsequent clicks
 
@@ -234,6 +244,7 @@ void ListBaseTestCase::ItemClick()
 #ifndef _WX_GENERIC_LISTCTRL_H_
     CPPUNIT_ASSERT_EQUAL(1, focused.GetCount());
     CPPUNIT_ASSERT_EQUAL(1, selected.GetCount());
+    CPPUNIT_ASSERT_EQUAL(1, deselected.GetCount());
 #endif
     CPPUNIT_ASSERT_EQUAL(1, activated.GetCount());
     CPPUNIT_ASSERT_EQUAL(1, rclick.GetCount());

--- a/tests/controls/virtlistctrltest.cpp
+++ b/tests/controls/virtlistctrltest.cpp
@@ -23,6 +23,8 @@
 #endif // WX_PRECOMP
 
 #include "wx/listctrl.h"
+#include "testableframe.h"
+#include "wx/uiaction.h"
 
 // ----------------------------------------------------------------------------
 // test class
@@ -39,9 +41,11 @@ public:
 private:
     CPPUNIT_TEST_SUITE( VirtListCtrlTestCase );
         CPPUNIT_TEST( UpdateSelection );
+        WXUISIM_TEST( DeselectedEvent );
     CPPUNIT_TEST_SUITE_END();
 
     void UpdateSelection();
+    void DeselectedEvent();
 
     wxListCtrl *m_list;
 
@@ -103,6 +107,44 @@ void VirtListCtrlTestCase::UpdateSelection()
     // more.
     m_list->SetItemCount(5);
     CPPUNIT_ASSERT_EQUAL( 1, m_list->GetSelectedItemCount() );
+}
+
+void VirtListCtrlTestCase::DeselectedEvent()
+{
+#if wxUSE_UIACTIONSIMULATOR
+	m_list->AppendColumn("Col0");
+    m_list->SetItemCount(1);
+    wxListCtrl* const list = m_list;
+
+    EventCounter selected(list, wxEVT_LIST_ITEM_SELECTED);
+    EventCounter deselected(list, wxEVT_LIST_ITEM_DESELECTED);
+
+    wxUIActionSimulator sim;
+
+    wxRect pos;
+    list->GetItemRect(0, pos);
+
+    //We move in slightly so we are not on the edge
+    wxPoint point = list->ClientToScreen(pos.GetPosition()) + wxPoint(10, 10);
+
+    sim.MouseMove(point);
+    wxYield();
+
+    sim.MouseClick();
+    wxYield();
+
+    // We want a point within the listctrl but below any items
+    point = list->ClientToScreen(pos.GetPosition()) + wxPoint(10, 50);
+
+    sim.MouseMove(point);
+    wxYield();
+
+    sim.MouseClick();
+    wxYield();
+
+    CPPUNIT_ASSERT_EQUAL(1, selected.GetCount());
+    CPPUNIT_ASSERT_EQUAL(1, deselected.GetCount());
+#endif
 }
 
 #endif // wxUSE_LISTCTRL


### PR DESCRIPTION
In the case when a listctrl is clicked outside of any item, the item is
visually deselected, and it is logical that a DESELECTED is sent.

For non-virtual lists this would happen, but for virtual lists it would
either happen or not happen depending on implementation (MSW/generic)
and mode (single/multi). From now on the DESELECTED event is always sent.

The first commit is not to be merged, it just demonstrates the behavior and
use case in listctrl sample.