### PR TITLE
Make props file work for builds using any prefix/DLL combinations

### DIFF
--- a/docs/msw/install.md
+++ b/docs/msw/install.md
@@ -529,8 +529,15 @@ Building Applications Using wxWidgets  {#msw_build_apps}
 =====================================
 
 If you use MSVS 2010 or later IDE for building your project, simply add
-`wxwidgets.props` property sheet to (all) your project(s) using wxWidgets.
-You don't need to do anything else.
+`wxwidgets.props` property sheet to (all) your project(s) using wxWidgets
+by using "View|Property Manager" menu item to open the property manager
+window and then selecting "Add Existing Property Sheet..." from the context
+menu in this window.
+
+If you've created a new empty project (i.e. chose "Empty Project" in the
+"Create a new project" window shown by MSVS rather than "Windows Desktop"),
+you need to change "Linker|System|SubSystem" in the project properties to
+"Windows", from the default "Console". You don't need to do anything else.
 
 If you want to use CMake for building your project, please see
 @ref overview_cmake.

--- a/wxwidgets.props
+++ b/wxwidgets.props
@@ -3,28 +3,127 @@
     This is a property sheet to be included in MSVS projects of the applications
     using wxWidgets. Use "View|Property Manager" and choose "Add Existing
     Property Sheet..." from the context menu to add it from the IDE or edit your
-    .vcxproj file directly and add <Import Project="path\to\wxwidgets.props">
+    .vcxproj file directly and add <Import Project="$(WXWIN)\wxwidgets.props">
     tag to it.
   -->
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" InitialTargets="CheckWXLibs" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="PropertySheets">
     <Import Project="build/msw/wx_setup.props" />
     <Import Project="build/msw/wx_local.props" Condition="exists('build/msw/wx_local.props')" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros" Condition="'$(Configuration)'=='DLL Debug' or '$(Configuration)'=='DLL Release'">
+
+  <PropertyGroup Label="UserMacros">
+    <!--
+      We have several possible choices for the compiler prefix:
+
+      - Default one is "vc", we want to use this to allow building this project
+        when wx was built from source with the default options.
+      - Version-specific prefix of the form "vcNNN", which is used in some other
+        projects.
+      - Version-specific but ABI-compatible prefix which differs from the
+        previous value in that it's the same "vc14x" for MSVS 2015/2017/2019
+        which are ABI-compatible with each other. This is used by official wx
+        binaries, so we want to check this one too.
+      -->
+    <wxToolsetVersion Condition="'$(VisualStudioVersion)' == '10.0'">100</wxToolsetVersion>
+    <wxToolsetVersion Condition="'$(VisualStudioVersion)' == '11.0'">110</wxToolsetVersion>
+    <wxToolsetVersion Condition="'$(VisualStudioVersion)' == '12.0'">120</wxToolsetVersion>
+    <wxToolsetVersion Condition="'$(VisualStudioVersion)' == '14.0'">140</wxToolsetVersion>
+    <wxToolsetVersion Condition="'$(VisualStudioVersion)' == '15.0'">141</wxToolsetVersion>
+    <wxToolsetVersion Condition="'$(VisualStudioVersion)' == '16.0'">142</wxToolsetVersion>
+
+    <wxToolsetVerABICompat Condition="'$(VisualStudioVersion)' == '10.0'">100</wxToolsetVerABICompat>
+    <wxToolsetVerABICompat Condition="'$(VisualStudioVersion)' == '11.0'">110</wxToolsetVerABICompat>
+    <wxToolsetVerABICompat Condition="'$(VisualStudioVersion)' == '12.0'">120</wxToolsetVerABICompat>
+    <wxToolsetVerABICompat Condition="'$(VisualStudioVersion)' == '14.0'">14x</wxToolsetVerABICompat>
+    <wxToolsetVerABICompat Condition="'$(VisualStudioVersion)' == '15.0'">14x</wxToolsetVerABICompat>
+    <wxToolsetVerABICompat Condition="'$(VisualStudioVersion)' == '16.0'">14x</wxToolsetVerABICompat>
+  </PropertyGroup>
+
+  <!--
+    Try to find some existing wxWidgets libraries.
+
+    Note that we use wxBaseLibNamePrefix for both static libs and DLL cases,
+    it's simpler than constructing the DLL name and still works as we must have
+    the import library with this name in the DLL directory too.
+    -->
+  <Choose>
+    <When Condition="Exists('$(MSBuildThisFileDirectory)lib\vc$(wxToolsetVerABICompat)$(wxArchSuffix)_dll$(wxCfg)\$(wxBaseLibNamePrefix).lib')">
+      <PropertyGroup Label="UserMacros">
+        <wxUsingVersionABICompat>1</wxUsingVersionABICompat>
+        <wxUsingDll>1</wxUsingDll>
+        <wxLibOrDllDir>$(MSBuildThisFileDirectory)lib\vc$(wxToolsetVerABICompat)$(wxArchSuffix)_dll$(wxCfg)</wxLibOrDllDir>
+      </PropertyGroup>
+    </When>
+
+    <When Condition="Exists('$(MSBuildThisFileDirectory)lib\vc$(wxToolsetVerABICompat)$(wxArchSuffix)_lib$(wxCfg)\$(wxBaseLibNamePrefix).lib')">
+      <PropertyGroup Label="UserMacros">
+        <wxUsingVersionABICompat>1</wxUsingVersionABICompat>
+        <wxUsingLib>1</wxUsingLib>
+        <wxLibOrDllDir>$(MSBuildThisFileDirectory)lib\vc$(wxToolsetVerABICompat)$(wxArchSuffix)_lib$(wxCfg)</wxLibOrDllDir>
+      </PropertyGroup>
+    </When>
+
+    <When Condition="Exists('$(MSBuildThisFileDirectory)lib\vc$(wxToolsetVersion)$(wxArchSuffix)_dll$(wxCfg)\$(wxBaseLibNamePrefix).lib')">
+      <PropertyGroup Label="UserMacros">
+        <wxUsingVersion>1</wxUsingVersion>
+        <wxUsingDll>1</wxUsingDll>
+        <wxLibOrDllDir>$(MSBuildThisFileDirectory)lib\vc$(wxToolsetVersion)$(wxArchSuffix)_dll$(wxCfg)</wxLibOrDllDir>
+      </PropertyGroup>
+    </When>
+
+    <When Condition="Exists('$(MSBuildThisFileDirectory)lib\vc$(wxToolsetVersion)$(wxArchSuffix)_lib$(wxCfg)\$(wxBaseLibNamePrefix).lib')">
+      <PropertyGroup Label="UserMacros">
+        <wxUsingVersion>1</wxUsingVersion>
+        <wxUsingLib>1</wxUsingLib>
+        <wxLibOrDllDir>$(MSBuildThisFileDirectory)lib\vc$(wxToolsetVersion)$(wxArchSuffix)_lib$(wxCfg)</wxLibOrDllDir>
+      </PropertyGroup>
+    </When>
+
+    <When Condition="Exists('$(MSBuildThisFileDirectory)lib\vc$(wxArchSuffix)_dll$(wxCfg)\$(wxBaseLibNamePrefix).lib')">
+      <PropertyGroup Label="UserMacros">
+        <wxUsingDll>1</wxUsingDll>
+        <wxLibOrDllDir>$(MSBuildThisFileDirectory)lib\vc$(wxArchSuffix)_dll$(wxCfg)</wxLibOrDllDir>
+      </PropertyGroup>
+    </When>
+
+    <When Condition="Exists('$(MSBuildThisFileDirectory)lib\vc$(wxArchSuffix)_lib$(wxCfg)\$(wxBaseLibNamePrefix).lib')">
+      <PropertyGroup Label="UserMacros">
+        <wxUsingLib>1</wxUsingLib>
+        <wxLibOrDllDir>$(MSBuildThisFileDirectory)lib\vc$(wxArchSuffix)_lib$(wxCfg)</wxLibOrDllDir>
+      </PropertyGroup>
+    </When>
+  </Choose>
+
+  <PropertyGroup Label="UserMacros" Condition="$(wxUsingVersionABICompat) != ''">
+    <wxVersionDefine>wxMSVC_VERSION_AUTO;wxMSVC_VERSION_ABI_COMPAT</wxVersionDefine>
+  </PropertyGroup>
+
+  <PropertyGroup Label="UserMacros" Condition="$(wxUsingVersion) != ''">
+    <wxVersionDefine>wxMSVC_VERSION_AUTO</wxVersionDefine>
+  </PropertyGroup>
+
+  <PropertyGroup Label="UserMacros" Condition="$(wxUsingDll) != ''">
     <wxUsingDllDefine>WXUSINGDLL</wxUsingDllDefine>
   </PropertyGroup>
+
+  <Target Name="CheckWXLibs">
+    <Error
+      Condition="'$(wxUsingDll)$(wxUsingLib)' == ''"
+      Text="wxWidgets libraries not found under &quot;$(MSBuildThisFileDirectory)lib&quot;." />
+  </Target>
+
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>__WXMSW__;$(wxUsingDllDefine);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__WXMSW__;$(wxUsingDllDefine);$(wxVersionDefine);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)include\msvc;$(MSBuildThisFileDirectory)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>__WXMSW__;$(wxUsingDllDefine);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)lib\$(wxOutDirName)\$(wxToolkitPrefix)$(wxSuffix);$(MSBuildThisFileDirectory)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(wxLibOrDllDir)\$(wxToolkitPrefix)$(wxSuffix);$(MSBuildThisFileDirectory)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(MSBuildThisFileDirectory)lib\$(wxOutDirName);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(wxLibOrDllDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
The existing wxwidgets.props wasn't particularly useful as it couldn't
be used with with wx DLLs when the user project configuration were not
called "DLL Debug" or "DLL Release" (and it makes little sense for the
user application to use "DLL" in its configuration names just because it
happens to use wx as DLL, of course).

It also couldn't be used with the libraries built using nmake with a
custom COMPILER_PREFIX, which, significantly, includes the official MSW
binaries.

Try to fix both problems by checking for the actually existing libraries
and using whichever ones we find. This is somewhat surprising for a
project file to do, but it seems like it should result in the most
useful behaviour in practice as it allows user projects importing this
file to work out of the box in all of the following situations:

  - Using official wxMSW binaries.
  - Building wxMSW from source without any customization.
  - Building wxMSW from source using reasonable custom compiler prefix.

---

I'm rather ashamed to admit this, but it turns out that the advice for building wx applications with MSVC I was giving since quite some time didn't actually work with our own official binaries and not just for one, but for 2 reasons:

1. It didn't use the DLLs unless the application project configuration happened to be called "DLL Debug/Release" which is, of course, not the case by default (and shouldn't be required).
1. It didn't look for the libraries under the right directory anyhow, as it always used `lib\vc_lib` instead of `lib\vc14x_dll`.

I started fixing this by creating a `.props` file for the official DLLs, but then realized that we could actually do everything from the same file, using MSBuild `Exists()` condition. I don't know if I didn't create a monster here, but at least this seems to work fine in all situations (and I've tested it with a few). So what do you think of doing it like this?