### PR TITLE
Remeasure magic values for wxTextCtrl's border width on wxOSX

### DIFF
--- a/include/wx/osx/textctrl.h
+++ b/include/wx/osx/textctrl.h
@@ -139,6 +139,7 @@ protected:
     void Init();
 
     virtual wxSize DoGetBestSize() const wxOVERRIDE;
+    virtual wxSize DoGetSizeFromTextSize(int xlen, int ylen) const wxOVERRIDE;
 
     // flag is set to true when the user edits the controls contents
     bool m_dirty;

--- a/src/generic/spinctlg.cpp
+++ b/src/generic/spinctlg.cpp
@@ -278,6 +278,10 @@ wxSize wxSpinCtrlGenericBase::DoGetBestSize() const
 
 wxSize wxSpinCtrlGenericBase::DoGetSizeFromTextSize(int xlen, int ylen) const
 {
+#ifdef __WXOSX__
+    wxSize sizeBtn = m_spinButton->GetBestSize(), sizeText = m_textCtrl->GetSizeFromTextSize(xlen, ylen);
+    return wxSize(sizeBtn.GetWidth() + sizeText.GetWidth() + MARGIN, wxMax(sizeBtn.GetHeight(), sizeText.GetHeight()));
+#else
     wxSize sizeBtn  = m_spinButton->GetBestSize();
     wxSize totalS( m_textCtrl->GetBestSize() );
 
@@ -293,6 +297,7 @@ wxSize wxSpinCtrlGenericBase::DoGetSizeFromTextSize(int xlen, int ylen) const
         tsize.IncBy(0, ylen - GetCharHeight());
 
     return tsize;
+#endif
 }
 
 void wxSpinCtrlGenericBase::DoMoveWindow(int x, int y, int width, int height)

--- a/src/osx/textctrl_osx.cpp
+++ b/src/osx/textctrl_osx.cpp
@@ -206,19 +206,19 @@ wxSize wxTextCtrl::DoGetBestSize() const
         switch ( m_windowVariant )
         {
             case wxWINDOW_VARIANT_NORMAL :
-                hText = 22 - 6 ;
+                hText = 22 - 5 ;
                 break ;
 
             case wxWINDOW_VARIANT_SMALL :
-                hText = 19 - 6 ;
+                hText = 19 - 5 ;
                 break ;
 
             case wxWINDOW_VARIANT_MINI :
-                hText = 15 - 6 ;
+                hText = 15 - 5 ;
                 break ;
 
             default :
-                hText = 22 - 6;
+                hText = 22 - 5;
                 break ;
         }
     }
@@ -229,9 +229,17 @@ wxSize wxTextCtrl::DoGetBestSize() const
          hText *= 5 ;
 
     if ( !HasFlag(wxNO_BORDER) )
-        hText += 6 ;
+        hText += 5 ;
 
     return wxSize(wText, hText);
+}
+
+wxSize wxTextCtrl::DoGetSizeFromTextSize(int xlen, int ylen) const
+{
+    wxSize size = wxDefaultSize;
+    if (xlen > 0) size.SetWidth(HasFlag(wxNO_BORDER) ? xlen + 4 : xlen + 9);
+    if (ylen > 0) size.SetHeight(HasFlag(wxNO_BORDER) ? ylen + 2 : ylen + 7);
+    return size;
 }
 
 bool wxTextCtrl::GetStyle(long position, wxTextAttr& style)


### PR DESCRIPTION
The original code assumes the best height for wxTextCtrl is 22px and border height is 6px. However with wxNO_BORDER, the wxTextCtrl is 1px lower than best size, and the text inside it will move up and down when selecting with mouse. Reduce the border height to 5px (so that wxTextCtrl(wxNO_BORDER) will be 17 px high instead of 16px) will fix this issue.

The comment says these values are from HIG. I'm not sure what HIG is, but [Apple Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/macos/fields-and-labels/text-fields/) does not provide any info on best size or border size. So I assume it is measured manually.

Values in this PR are measured on macOS Catalina 10.15.5. I have verified all 8 combinations of single line / multi line, and with / without border, on 1x and 2x HiDPI scaling.

This PR also measured and implemented GetSizeFromTextSize. #1757 is no longer needed after this PR.