### PR TITLE
CMake: add more stl checks and enable them in setup.h

### DIFF
--- a/build/cmake/setup.cmake
+++ b/build/cmake/setup.cmake
@@ -156,25 +156,57 @@ if(wxUSE_STL AND NOT wxHAS_CXX11)
     if(NOT wxTEST_STL)
         message(FATAL_ERROR "Can't use wxUSE_STL as basic STL functionality is missing")
     endif()
-
-    wx_check_cxx_source_compiles("
-        std::string foo, bar;
-        foo.compare(bar);
-        foo.compare(1, 1, bar);
-        foo.compare(1, 1, bar, 1, 1);
-        foo.compare(\"\");
-        foo.compare(1, 1, \"\");
-        foo.compare(1, 1, \"\", 2);"
-        HAVE_STD_STRING_COMPARE
-        string
-        )
-
-    wx_check_cxx_source_compiles(
-        "std::wstring s;"
-        HAVE_STD_WSTRING
-        string
-        )
 endif()
+
+wx_check_cxx_source_compiles("
+    std::string foo, bar;
+    foo.compare(bar);
+    foo.compare(1, 1, bar);
+    foo.compare(1, 1, bar, 1, 1);
+    foo.compare(\"\");
+    foo.compare(1, 1, \"\");
+    foo.compare(1, 1, \"\", 2);"
+    HAVE_STD_STRING_COMPARE
+    string
+    )
+
+wx_check_cxx_source_compiles(
+    "std::wstring s;"
+    HAVE_STD_WSTRING
+    string
+    )
+
+wx_check_cxx_source_compiles("
+    std::hash_map<double*, char*, std::hash<double*>, std::equal_to<double*> > test1;
+    std::hash_set<char*, std::hash<char*>, std::equal_to<char*> > test2;"
+    HAVE_HASH_MAP
+    hash_map hash_set
+    )
+set(HAVE_STD_HASH_MAP ${HAVE_HASH_MAP})
+
+wx_check_cxx_source_compiles("
+    __gnu_cxx::hash_map<double*, char*, __gnu_cxx::hash<double*>, std::equal_to<double*> > test1;
+    __gnu_cxx::hash_set<char*, __gnu_cxx::hash<char*>, std::equal_to<char*> > test2;"
+    HAVE_EXT_HASH_MAP
+    ext/hash_map ext/hash_set
+    )
+set(HAVE_GNU_CXX_HASH_MAP ${HAVE_EXT_HASH_MAP})
+
+wx_check_cxx_source_compiles("
+    std::unordered_map<double*, char*> test1;
+    std::unordered_set<char*> test2;"
+    HAVE_STD_UNORDERED_MAP
+    unordered_map unordered_set
+    )
+set(HAVE_STD_UNORDERED_SET ${HAVE_STD_UNORDERED_MAP})
+
+wx_check_cxx_source_compiles("
+    std::tr1::unordered_map<double*, char*> test1;
+    std::tr1::unordered_set<char*> test2;"
+    HAVE_TR1_UNORDERED_MAP
+    tr1/unordered_map tr1/unordered_set
+    )
+set(HAVE_TR1_UNORDERED_SET ${HAVE_TR1_UNORDERED_MAP})
 
 # Check for availability of GCC's atomic operations builtins.
 wx_check_c_source_compiles("
@@ -544,8 +576,6 @@ check_struct_has_member("struct passwd" pw_gecos pwd.h HAVE_PW_GECOS)
 # Check for functions
 # ---------------------------------------------------------------------------
 
-# TODO: wcslen
-
 # Check various string symbols
 foreach(func
     ftime
@@ -554,6 +584,7 @@ foreach(func
     wcsdup wcsnlen wcscasecmp wcsncasecmp
     wcsrctombs
     wcstoull
+    wcslen
     )
     string(TOUPPER ${func} func_upper)
     check_symbol_exists(${func} wchar.h HAVE_${func_upper})


### PR DESCRIPTION
I noticed these where missing when trying and confirming the xhash error.