### PR TITLE
Fix compilation of GUI tests on VC10 (VS2010)

### DIFF
--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -554,7 +554,7 @@ TEST_CASE_METHOD(GridTestCase, "Grid::SelectionRange", "[grid]")
     REQUIRE( sel.begin() != sel.end() );
     CHECK( *sel.begin() == wxGridBlockCoords(1, 0, 3, 1) );
 
-#if __cplusplus >= 201103L || wxCHECK_VISUALC_VERSION(10)
+#if __cplusplus >= 201103L || wxCHECK_VISUALC_VERSION(11)
     m_grid->SelectBlock(4, 0, 7, 1, true);
     int index = 0;
     for ( const wxGridBlockCoords& block : m_grid->GetSelectedBlocks() )


### PR DESCRIPTION
VC10 does not support range-based for-loops, they were only introduced in
VC11 (VS2012): https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2012/hh409293(v=vs.110)