### PR TITLE
wxAUI's FrameManager: redundant Repaint removed; Late repaint of deco…

### DIFF
--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -2536,6 +2536,11 @@ void wxAuiManager::Update()
         }
     }
 
+#ifdef __WXMSW__
+    // freeze managed window before layouting
+    if (!wxAuiManager_HasLiveResize(*this))
+        m_frame->Freeze();
+#endif
 
     // delete old sizer first
     m_frame->SetSizer(NULL);
@@ -2640,7 +2645,6 @@ void wxAuiManager::Update()
     DoFrameLayout();
 
 
-
     // now that the frame layout is done, we need to check
     // the new pane rectangles against the old rectangles that
     // we saved a few lines above here.  If the rectangles have
@@ -2660,6 +2664,12 @@ void wxAuiManager::Update()
 
 
     Repaint();
+
+#ifdef __WXMSW__
+    // thaw managed window after layouting
+    if (!wxAuiManager_HasLiveResize(*this))
+        m_frame->Thaw();
+#endif
 
     // set frame's minimum size
 
@@ -4250,7 +4260,6 @@ bool wxAuiManager::DoEndResizeAction(wxMouseEvent& event)
         }
 
         Update();
-        Repaint(NULL);
     }
     else if (m_actionPart &&
         m_actionPart->type == wxAuiDockUIPart::typePaneSizer)
@@ -4418,10 +4427,7 @@ bool wxAuiManager::DoEndResizeAction(wxMouseEvent& event)
         dock.panes.Item(borrow_pane)->dock_proportion = prop_borrow;
         pane.dock_proportion = new_proportion;
 
-
-        // repaint
         Update();
-        Repaint(NULL);
     }
 
     return true;


### PR DESCRIPTION
…rations fixed by freezing managed window (win32, non live update only)