### PR TITLE
Don't hard code grid lines colour in wxGrid

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -2844,7 +2844,7 @@ void wxGrid::Init()
     m_minAcceptableColWidth  =
     m_minAcceptableRowHeight = 0;
 
-    m_gridLineColour = wxColour( 192,192,192 );
+    m_gridLineColour = wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE);
     m_gridLinesEnabled = true;
     m_gridLinesClipHorz =
     m_gridLinesClipVert = true;


### PR DESCRIPTION
Use wxSYS_COLOUR_BTNFACE instead of the hardcoded value of this colour
in "Windows Classic" theme, which was probably used back when the commit
73145b0ed1 (Applied patches by Scott Pleiter:, 2002-12-09), which was
supposed to change wxGrid to use system colours (among other things),
was done.

Nowadays wxSYS_COLOUR_BTNFACE is 0xF0F0F0 rather than 0xC0C0C0, which is
quite different visually, but it still seems better to use the system
colour rather than the fixed value, especially for platforms with dark
mode support.

---

Does anybody mind changing the default colour of the grid lines like this?