### PR TITLE
wxAUI repaint optimizations

### DIFF
--- a/include/wx/aui/framemanager.h
+++ b/include/wx/aui/framemanager.h
@@ -412,6 +412,8 @@ public:
 
     void SetFlags(unsigned int flags);
     unsigned int GetFlags() const;
+
+    static bool AlwaysUsesLiveResize();
     bool HasLiveResize() const;
 
     void SetManagedWindow(wxWindow* managedWnd);

--- a/include/wx/aui/framemanager.h
+++ b/include/wx/aui/framemanager.h
@@ -412,6 +412,7 @@ public:
 
     void SetFlags(unsigned int flags);
     unsigned int GetFlags() const;
+    bool HasLiveResize() const;
 
     void SetManagedWindow(wxWindow* managedWnd);
     wxWindow* GetManagedWindow() const;

--- a/include/wx/wupdlock.h
+++ b/include/wx/wupdlock.h
@@ -19,12 +19,29 @@
 class wxWindowUpdateLocker
 {
 public:
+    // Prefer using the ctor below if possible, this ctor is only useful if
+    // Lock() must be called only conditionally.
+    wxWindowUpdateLocker() : m_win(NULL) { }
+
     // create an object preventing updates of the given window (which must have
     // a lifetime at least as great as ours)
     explicit wxWindowUpdateLocker(wxWindow *win) : m_win(win) { win->Freeze(); }
 
+    // May be called only for the object constructed using the default ctor.
+    void Lock(wxWindow *win)
+    {
+        wxASSERT( !m_win );
+
+        m_win = win;
+        win->Freeze();
+    }
+
     // dtor thaws the window to permit updates again
-    ~wxWindowUpdateLocker() { m_win->Thaw(); }
+    ~wxWindowUpdateLocker()
+    {
+        if ( m_win )
+            m_win->Thaw();
+    }
 
 private:
     wxWindow *m_win;

--- a/include/wx/wupdlock.h
+++ b/include/wx/wupdlock.h
@@ -21,7 +21,7 @@ class wxWindowUpdateLocker
 public:
     // create an object preventing updates of the given window (which must have
     // a lifetime at least as great as ours)
-    wxWindowUpdateLocker(wxWindow *win) : m_win(win) { win->Freeze(); }
+    explicit wxWindowUpdateLocker(wxWindow *win) : m_win(win) { win->Freeze(); }
 
     // dtor thaws the window to permit updates again
     ~wxWindowUpdateLocker() { m_win->Thaw(); }

--- a/interface/wx/aui/framemanager.h
+++ b/interface/wx/aui/framemanager.h
@@ -213,8 +213,8 @@ public:
         If this function returns true, ::wxAUI_MGR_LIVE_RESIZE flag is ignored
         and live resize is always used, whether it's specified or not.
 
-        Currently this is the case for wxOSX port, as live resizing is the only
-        implemented method there.
+        Currently this is the case for wxOSX and wxGTK3 ports, as live resizing
+        is the only implemented method there.
 
         @since 3.1.4
      */

--- a/interface/wx/aui/framemanager.h
+++ b/interface/wx/aui/framemanager.h
@@ -208,6 +208,19 @@ public:
     //@}
 
     /**
+        Returns true if live resize is always used on the current platform.
+
+        If this function returns true, ::wxAUI_MGR_LIVE_RESIZE flag is ignored
+        and live resize is always used, whether it's specified or not.
+
+        Currently this is the case for wxOSX port, as live resizing is the only
+        implemented method there.
+
+        @since 3.1.4
+     */
+    static bool AlwaysUsesLiveResize();
+
+    /**
         This function is used by controls to calculate the drop hint rectangle.
 
         The method first calls DoDrop() to determine the exact position the
@@ -313,9 +326,9 @@ public:
     /**
         Returns true if windows are resized live.
 
-        Live resizing behaviour is specified by wxAUI_MGR_LIVE_RESIZE flag,
-        however some platforms (currently wxOSX) ignore it and always use live
-        resizing because this is the only implemented resize mode.
+        This function combines the check for AlwaysUsesLiveResize() and, for
+        the platforms where live resizing is optional, the check for
+        wxAUI_MGR_LIVE_RESIZE flag.
 
         Using this accessor allows to verify whether live resizing is being
         actually used.

--- a/interface/wx/aui/framemanager.h
+++ b/interface/wx/aui/framemanager.h
@@ -311,6 +311,20 @@ public:
     //@}
 
     /**
+        Returns true if windows are resized live.
+
+        Live resizing behaviour is specified by wxAUI_MGR_LIVE_RESIZE flag,
+        however some platforms (currently wxOSX) ignore it and always use live
+        resizing because this is the only implemented resize mode.
+
+        Using this accessor allows to verify whether live resizing is being
+        actually used.
+
+        @since 3.1.4
+    */
+    bool HasLiveResize() const;
+
+    /**
         HideHint() hides any docking hint that may be visible.
     */
     virtual void HideHint();

--- a/interface/wx/wupdlock.h
+++ b/interface/wx/wupdlock.h
@@ -40,7 +40,7 @@ public:
         The parameter must be non-@NULL and the window must exist for longer than
         wxWindowUpdateLocker object itself.
     */
-    wxWindowUpdateLocker(wxWindow* win);
+    explicit wxWindowUpdateLocker(wxWindow* win);
 
     /**
         Destructor reenables updates for the window this object is associated with.

--- a/interface/wx/wupdlock.h
+++ b/interface/wx/wupdlock.h
@@ -36,11 +36,34 @@ class wxWindowUpdateLocker
 {
 public:
     /**
+        Default constructor doesn't do anything.
+
+        Prefer using the non-default constructor if possible, this constructor
+        is only useful if Lock() must be called conditionally, i.e. if it may
+        or not be called depending on some run-time condition.
+
+        @since 3.1.4
+     */
+    wxWindowUpdateLocker();
+
+    /**
         Creates an object preventing the updates of the specified @e win.
         The parameter must be non-@NULL and the window must exist for longer than
         wxWindowUpdateLocker object itself.
     */
     explicit wxWindowUpdateLocker(wxWindow* win);
+
+    /**
+        Really lock window updates.
+
+        This method can only be called on an object initialized using the
+        default constructor.
+
+        @param win Non-@NULL window which must exist for longer than this object.
+
+        @since 3.1.4
+     */
+    void Lock(wxWindow *win);
 
     /**
         Destructor reenables updates for the window this object is associated with.

--- a/samples/aui/auidemo.cpp
+++ b/samples/aui/auidemo.cpp
@@ -709,7 +709,9 @@ MyFrame::MyFrame(wxWindow* parent,
     options_menu->AppendCheckItem(ID_NoVenetianFade, _("Disable Venetian Blinds Hint Fade-in"));
     options_menu->AppendCheckItem(ID_TransparentDrag, _("Transparent Drag"));
     options_menu->AppendCheckItem(ID_AllowActivePane, _("Allow Active Pane"));
-    options_menu->AppendCheckItem(ID_LiveUpdate, _("Live Resize Update"));
+    // Only show "live resize" toggle if it's actually functional.
+    if ( !wxAuiManager::AlwaysUsesLiveResize() )
+        options_menu->AppendCheckItem(ID_LiveUpdate, _("Live Resize Update"));
     options_menu->AppendSeparator();
     options_menu->AppendRadioItem(ID_NoGradient, _("No Caption Gradient"));
     options_menu->AppendRadioItem(ID_VerticalGradient, _("Vertical Caption Gradient"));

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -4250,7 +4250,6 @@ bool wxAuiManager::DoEndResizeAction(wxMouseEvent& event)
         }
 
         Update();
-        Repaint(NULL);
     }
     else if (m_actionPart &&
         m_actionPart->type == wxAuiDockUIPart::typePaneSizer)
@@ -4418,10 +4417,7 @@ bool wxAuiManager::DoEndResizeAction(wxMouseEvent& event)
         dock.panes.Item(borrow_pane)->dock_proportion = prop_borrow;
         pane.dock_proportion = new_proportion;
 
-
-        // repaint
         Update();
-        Repaint(NULL);
     }
 
     return true;

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -772,9 +772,9 @@ unsigned int wxAuiManager::GetFlags() const
     return m_flags;
 }
 
-// With Core Graphics on Mac, it's not possible to show sash feedback,
+// With Core Graphics on Mac or GTK 3, it's not possible to show sash feedback,
 // so we'll always use live update instead.
-#if defined(__WXMAC__)
+#if defined(__WXMAC__) || defined(__WXGTK3__)
     #define wxUSE_AUI_LIVE_RESIZE_ALWAYS 1
 #else
     #define wxUSE_AUI_LIVE_RESIZE_ALWAYS 0

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -772,11 +772,22 @@ unsigned int wxAuiManager::GetFlags() const
     return m_flags;
 }
 
+// With Core Graphics on Mac, it's not possible to show sash feedback,
+// so we'll always use live update instead.
+#if defined(__WXMAC__)
+    #define wxUSE_AUI_LIVE_RESIZE_ALWAYS 1
+#else
+    #define wxUSE_AUI_LIVE_RESIZE_ALWAYS 0
+#endif
+
+/* static */ bool wxAuiManager::AlwaysUsesLiveResize()
+{
+    return wxUSE_AUI_LIVE_RESIZE_ALWAYS;
+}
+
 bool wxAuiManager::HasLiveResize() const
 {
-    // With Core Graphics on Mac, it's not possible to show sash feedback,
-    // so we'll always use live update instead.
-#if defined(__WXMAC__)
+#if wxUSE_AUI_LIVE_RESIZE_ALWAYS
     return true;
 #else
     return (GetFlags() & wxAUI_MGR_LIVE_RESIZE) == wxAUI_MGR_LIVE_RESIZE;

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -771,17 +771,14 @@ unsigned int wxAuiManager::GetFlags() const
     return m_flags;
 }
 
-// Convenience function
-static
-bool wxAuiManager_HasLiveResize(wxAuiManager& manager)
+bool wxAuiManager::HasLiveResize() const
 {
     // With Core Graphics on Mac, it's not possible to show sash feedback,
     // so we'll always use live update instead.
 #if defined(__WXMAC__)
-    wxUnusedVar(manager);
     return true;
 #else
-    return (manager.GetFlags() & wxAUI_MGR_LIVE_RESIZE) == wxAUI_MGR_LIVE_RESIZE;
+    return (GetFlags() & wxAUI_MGR_LIVE_RESIZE) == wxAUI_MGR_LIVE_RESIZE;
 #endif
 }
 
@@ -4429,13 +4426,13 @@ void wxAuiManager::OnLeftUp(wxMouseEvent& event)
     {
         m_frame->ReleaseMouse();
 
-        if (!wxAuiManager_HasLiveResize(*this))
+        if (!HasLiveResize())
         {
             // get rid of the hint rectangle
             wxScreenDC dc;
             DrawResizeHint(dc, m_actionHintRect);
         }
-        if (m_currentDragItem != -1 && wxAuiManager_HasLiveResize(*this))
+        if (m_currentDragItem != -1 && HasLiveResize())
             m_actionPart = & (m_uiParts.Item(m_currentDragItem));
 
         DoEndResizeAction(event);
@@ -4539,7 +4536,7 @@ void wxAuiManager::OnMotion(wxMouseEvent& event)
             else
                 pos.x = wxMax(0, event.m_x - m_actionOffset.x);
 
-            if (wxAuiManager_HasLiveResize(*this))
+            if (HasLiveResize())
             {
                 m_frame->ReleaseMouse();
                 DoEndResizeAction(event);


### PR DESCRIPTION
Optimize repaint under MSW (see #1865) and always use live resize mode for GTK3.