### PR TITLE
Fix static wxZipEntry::GetInternalName() function in documentation.

### DIFF
--- a/interface/wx/zipstrm.h
+++ b/interface/wx/zipstrm.h
@@ -310,9 +310,9 @@ public:
 
         @see @ref overview_archive_byname
     */
-    wxString GetInternalName(const wxString& name,
-                            wxPathFormat format = wxPATH_NATIVE,
-                            bool* pIsDir = NULL);
+    static wxString GetInternalName(const wxString& name,
+                                    wxPathFormat format = wxPATH_NATIVE,
+                                    bool* pIsDir = NULL);
     /**
         Returns the entry's filename in the internal format used within the archive.
         The name can include directory components, i.e. it can be a full path.


### PR DESCRIPTION
This overload function should be static in the documentation too.