### PR TITLE
fix cmdline arguments iteration

### DIFF
--- a/src/common/cmdline.cpp
+++ b/src/common/cmdline.cpp
@@ -1203,7 +1203,7 @@ int wxCmdLineParser::Parse(bool showUsage)
     if ( ok )
     {
         size_t countOpt = m_data->m_options.GetCount();
-        for ( size_t n = 0; ok && (n < countOpt); n++ )
+        for ( size_t n = 0; n < countOpt; n++ )
         {
             wxCmdLineOption& opt = m_data->m_options[n];
             if ( (opt.flags & wxCMD_LINE_OPTION_MANDATORY) && !opt.HasValue() )


### PR DESCRIPTION
**iteration against command line arguments only ran once**
Iteration prematurely terminated after one count, because for loop depended upon ok && (n < countOpt), but boolean variable ok is set to false after the first value error. Therefore error message only shows the first MANDATORY option.
Can be tested against a slightly modified sample found in wxWidgest wiki:
[https://wiki.wxwidgets.org/Command-Line_Arguments](https://wiki.wxwidgets.org/Command-Line_Arguments)

Modified sample has 2 wxCMD_LINE_OPTION_MANDATORY
```
static const wxCmdLineEntryDesc g_cmdLineDesc [] =
{
     { wxCMD_LINE_SWITCH,
		  static_cast<const char*>("h"),
		  static_cast<const char*>("help"),
		  static_cast<const char*>("displays help on the command line parameters"),
          wxCMD_LINE_VAL_NONE, wxCMD_LINE_OPTION_HELP
	 },
     { wxCMD_LINE_SWITCH,
		  static_cast<const char*>("t"),
		  static_cast<const char*>("test"),
		  static_cast<const char*>("test switch"),
          wxCMD_LINE_VAL_NONE, wxCMD_LINE_OPTION_MANDATORY
	 },
     { wxCMD_LINE_SWITCH,
		  static_cast<const char*>("x"),
		  static_cast<const char*>("justx"),
		  static_cast<const char*>("any value"),
          wxCMD_LINE_VAL_NONE, wxCMD_LINE_OPTION_MANDATORY
	 },
     { wxCMD_LINE_SWITCH,
		  static_cast<const char*>("s"),
		  static_cast<const char*>("silent"),
		  static_cast<const char*>("disables the GUI") },

     { wxCMD_LINE_NONE }
};
```