### PR TITLE
Disable OpenGL functions deprecation warnings in wxOSX

### DIFF
--- a/include/wx/osx/glcanvas.h
+++ b/include/wx/osx/glcanvas.h
@@ -16,6 +16,9 @@
 #import <OpenGLES/ES1/glext.h>
 #define wxUSE_OPENGL_EMULATION 1
 #else
+#ifndef GL_SILENCE_DEPRECATION
+    #define GL_SILENCE_DEPRECATION
+#endif
 #include <OpenGL/gl.h>
 #endif
 


### PR DESCRIPTION
Don't generate dozens of deprecation warnings (one for each OpenGL
function used in the code) for any program using wxGLCanvas being built
using macOS 10.14 or later SDK.

---

Stefan, I don't t think it's useful to get all the warnings like this:
```
warning: 'glBegin' is deprecated: first deprecated in macOS 10.14 - OpenGL API deprecated. (Define GL_SILENCE_DEPRECATION to silence these warnings) [-Wdeprecated-declarations]
```
as we already know about them being deprecated, but still need to use them for now. But please let me know if you think that this isn't always appropriate.