### PR TITLE
Add wxGrid::GetSelectedRowBlocks() and GetSelectedColBlocks()

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -864,6 +864,8 @@ private:
     int m_rightCol;
 };
 
+typedef wxVector<wxGridBlockCoords> wxGridBlockCoordsVector;
+
 // ----------------------------------------------------------------------------
 // wxGridBlockDiffResult: The helper struct uses as a result type for difference
 // functions of wxGridBlockCoords class.
@@ -882,7 +884,7 @@ struct wxGridBlockDiffResult
 
 class wxGridBlocks
 {
-    typedef wxVector<wxGridBlockCoords>::const_iterator iterator_impl;
+    typedef wxGridBlockCoordsVector::const_iterator iterator_impl;
 
 public:
     class iterator
@@ -1997,7 +1999,13 @@ public:
     bool IsInSelection( const wxGridCellCoords& coords ) const
         { return IsInSelection( coords.GetRow(), coords.GetCol() ); }
 
+    // Efficient methods returning the selected blocks (there are few of those).
     wxGridBlocks GetSelectedBlocks() const;
+    wxGridBlockCoordsVector GetSelectedRowBlocks() const;
+    wxGridBlockCoordsVector GetSelectedColBlocks() const;
+
+    // Less efficient (but maybe more convenient methods) returning all
+    // selected cells, rows or columns -- there can be many and many of those.
     wxGridCellCoordsArray GetSelectedCells() const;
     wxGridCellCoordsArray GetSelectionBlockTopLeft() const;
     wxGridCellCoordsArray GetSelectionBlockBottomRight() const;

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -530,6 +530,12 @@ public:
     virtual int Select(const wxRect& r) const = 0;
     virtual int& Select(wxRect& r) const = 0;
 
+    // Return or set left/top or right/bottom component of a block.
+    virtual int SelectFirst(const wxGridBlockCoords& block) const = 0;
+    virtual int SelectLast(const wxGridBlockCoords& block) const = 0;
+    virtual void SetFirst(wxGridBlockCoords& block, int line) const = 0;
+    virtual void SetLast(wxGridBlockCoords& block, int line) const = 0;
+
     // Returns width or height of the rectangle
     virtual int& SelectSize(wxRect& r) const = 0;
 
@@ -642,6 +648,14 @@ public:
     virtual int Select(const wxSize& sz) const wxOVERRIDE { return sz.x; }
     virtual int Select(const wxRect& r) const wxOVERRIDE { return r.x; }
     virtual int& Select(wxRect& r) const wxOVERRIDE { return r.x; }
+    virtual int SelectFirst(const wxGridBlockCoords& block) const wxOVERRIDE
+        { return block.GetTopRow(); }
+    virtual int SelectLast(const wxGridBlockCoords& block) const wxOVERRIDE
+        { return block.GetBottomRow(); }
+    virtual void SetFirst(wxGridBlockCoords& block, int line) const wxOVERRIDE
+        { block.SetTopRow(line); }
+    virtual void SetLast(wxGridBlockCoords& block, int line) const wxOVERRIDE
+        { block.SetBottomRow(line); }
     virtual int& SelectSize(wxRect& r) const wxOVERRIDE { return r.width; }
     virtual wxSize MakeSize(int first, int second) const wxOVERRIDE
         { return wxSize(first, second); }
@@ -715,6 +729,14 @@ public:
     virtual int Select(const wxSize& sz) const wxOVERRIDE { return sz.y; }
     virtual int Select(const wxRect& r) const wxOVERRIDE { return r.y; }
     virtual int& Select(wxRect& r) const wxOVERRIDE { return r.y; }
+    virtual int SelectFirst(const wxGridBlockCoords& block) const wxOVERRIDE
+        { return block.GetLeftCol(); }
+    virtual int SelectLast(const wxGridBlockCoords& block) const wxOVERRIDE
+        { return block.GetRightCol(); }
+    virtual void SetFirst(wxGridBlockCoords& block, int line) const wxOVERRIDE
+        { block.SetLeftCol(line); }
+    virtual void SetLast(wxGridBlockCoords& block, int line) const wxOVERRIDE
+        { block.SetRightCol(line); }
     virtual int& SelectSize(wxRect& r) const wxOVERRIDE { return r.height; }
     virtual wxSize MakeSize(int first, int second) const wxOVERRIDE
         { return wxSize(second, first); }

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -4675,9 +4675,49 @@ public:
             }
         @endcode
 
+        Notice that the blocks returned by this method are not ordered in any
+        particular way and may overlap. For grids using rows or columns-only
+        selection modes, GetSelectedRowBlocks() or GetSelectedColBlocks() can
+        be more convenient, as they return ordered and non-overlapping blocks.
+
         @since 3.1.4
     */
     wxGridBlocks GetSelectedBlocks() const;
+
+    /**
+        Returns an ordered range of non-overlapping selected rows.
+
+        For the grids using wxGridSelectRows selection mode, returns the
+        possibly empty vector containing the coordinates of non-overlapping
+        selected row blocks in the natural order, i.e. from smallest to the
+        biggest row indices.
+
+        To see the difference between this method and GetSelectedBlocks(),
+        consider the case when the user selects rows 2..4 in the grid and then
+        also selects (using Ctrl/Shift keys) the rows 1..3. Iterating over the
+        result of GetSelectedBlocks() would yield two blocks directly
+        corresponding to the users selection, while this method returns a
+        vector with a single element corresponding to the rows 1..4.
+
+        This method returns empty vector for the other selection modes.
+
+        @see GetSelectedBlocks(), GetSelectedColBlocks()
+
+        @since 3.1.4
+     */
+    wxGridBlockCoordsVector GetSelectedRowBlocks() const;
+
+    /**
+        Returns an ordered range of non-overlapping selected columns.
+
+        This method is symmetric to GetSelectedRowBlocks(), but is useful only
+        in wxGridSelectColumns selection mode.
+
+        @see GetSelectedBlocks()
+
+        @since 3.1.4
+     */
+    wxGridBlockCoordsVector GetSelectedColBlocks() const;
 
     /**
         Returns an array of individually selected cells.

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -85,6 +85,30 @@ protected:
         CHECK( ++it == selected.end() );
     }
 
+    // Or specified ranges.
+    struct RowRange
+    {
+        RowRange(int top, int bottom) : top(top), bottom(bottom) { }
+
+        int top, bottom;
+    };
+
+    typedef wxVector<RowRange> RowRanges;
+
+    void CheckRowSelection(const RowRanges& ranges)
+    {
+        const wxGridBlockCoordsVector sel = m_grid->GetSelectedRowBlocks();
+        REQUIRE( sel.size() == ranges.size() );
+
+        for ( size_t n = 0; n < sel.size(); ++n )
+        {
+            INFO("n = " << n);
+
+            const RowRange& r = ranges[n];
+            CHECK( sel[n] == wxGridBlockCoords(r.top, 0, r.bottom, 1) );
+        }
+    }
+
     TestableGrid *m_grid;
 
     wxDECLARE_NO_COPY_CLASS(GridTestCase);
@@ -901,6 +925,47 @@ TEST_CASE_METHOD(GridTestCase, "Grid::SelectionMode", "[grid]")
     CHECK(selectedRows.Count() == 1);
     CHECK(selectedRows[0] == 3);
 
+    // Check that overlapping selection blocks are handled correctly.
+    m_grid->ClearSelection();
+    m_grid->SelectBlock(0, 0, 4, 1);
+    m_grid->SelectBlock(2, 0, 6, 1, true /* add to selection */);
+    CHECK( m_grid->GetSelectedRows().size() == 7 );
+
+    CHECK( m_grid->GetSelectedColBlocks().empty() );
+
+    RowRanges rowRanges;
+    rowRanges.push_back(RowRange(0, 6));
+    CheckRowSelection(rowRanges);
+
+    m_grid->SelectBlock(6, 0, 8, 1);
+    m_grid->SelectBlock(1, 0, 4, 1, true /* add to selection */);
+    m_grid->SelectBlock(0, 0, 2, 1, true /* add to selection */);
+    CHECK( m_grid->GetSelectedRows().size() == 8 );
+
+    rowRanges.clear();
+    rowRanges.push_back(RowRange(0, 4));
+    rowRanges.push_back(RowRange(6, 8));
+    CheckRowSelection(rowRanges);
+
+    // Select all odd rows.
+    m_grid->ClearSelection();
+    rowRanges.clear();
+    for ( int i = 1; i < m_grid->GetNumberRows(); i += 2 )
+    {
+        m_grid->SelectBlock(i, 0, i, 1, true);
+        rowRanges.push_back(RowRange(i, i));
+    }
+
+    CheckRowSelection(rowRanges);
+
+    // Now select another block overlapping 2 of them and bordering 2 others.
+    m_grid->SelectBlock(2, 0, 6, 1, true);
+
+    rowRanges.clear();
+    rowRanges.push_back(RowRange(1, 7));
+    rowRanges.push_back(RowRange(9, 9));
+    CheckRowSelection(rowRanges);
+
     CHECK(m_grid->GetSelectionMode() == wxGrid::wxGridSelectRows);
 
 
@@ -909,9 +974,15 @@ TEST_CASE_METHOD(GridTestCase, "Grid::SelectionMode", "[grid]")
     m_grid->SetSelectionMode(wxGrid::wxGridSelectColumns);
     m_grid->SelectBlock(3, 1, 3, 1);
 
+    CHECK( m_grid->GetSelectedRowBlocks().empty() );
+
     wxArrayInt selectedCols = m_grid->GetSelectedCols();
     CHECK(selectedCols.Count() == 1);
     CHECK(selectedCols[0] == 1);
+
+    wxGridBlockCoordsVector colBlocks = m_grid->GetSelectedColBlocks();
+    CHECK( colBlocks.size() == 1 );
+    CHECK( colBlocks.at(0) == wxGridBlockCoords(0, 1, 9, 1) );
 
     CHECK(m_grid->GetSelectionMode() == wxGrid::wxGridSelectColumns);
 }


### PR DESCRIPTION
These functions are much simpler to use in the application code using
wxGrid in row- or column-only selection mode than GetSelectedBlocks()
itself because they take care of deduplicating, ordering and squashing
together the adjacent ranges, so that the application can use their
results directly, unlike with GetSelectedBlocks().