### PR TITLE
Make the wxUIActionSimulator::Text implementation match the interface

### DIFF
--- a/include/wx/uiaction.h
+++ b/include/wx/uiaction.h
@@ -60,6 +60,7 @@ public:
     bool Char(int keycode, int modifiers = wxMOD_NONE);
 
     bool Text(const char *text);
+    bool Text(const wxString& text);
 
     // Select the item with the given text in the currently focused control.
     bool Select(const wxString& text);

--- a/src/common/uiactioncmn.cpp
+++ b/src/common/uiactioncmn.cpp
@@ -161,6 +161,12 @@ static bool MapUnshifted(char& ch)
     return true;
 }
 
+bool wxUIActionSimulator::Text(const wxString& text)
+{
+    const wxScopedCharBuffer ascii = text.ToAscii();
+    return Text(ascii.data());
+}
+
 bool wxUIActionSimulator::Text(const char *s)
 {
     while ( *s != '\0' )


### PR DESCRIPTION
interface/uiaction.h declares the parameter as 'const wxString&'. For
non-STL variants, this just makes the char* conversion explicit, while
for STL variants this actually allows to pass a wxString to the method.

This also fixes a compile error when building wxPython with a system
wxWidgets library which has been built with wxUSE_STL=1.