### PR TITLE
Add missing QPainterPath include required with Qt 5.15

### DIFF
--- a/src/qt/dc.cpp
+++ b/src/qt/dc.cpp
@@ -15,6 +15,7 @@
 #include <QtGui/QBitmap>
 #include <QtGui/QPen>
 #include <QtGui/QPainter>
+#include <QtGui/QPainterPath>
 
 #ifndef WX_PRECOMP
     #include "wx/icon.h"

--- a/src/qt/graphics.cpp
+++ b/src/qt/graphics.cpp
@@ -19,6 +19,7 @@
 #include <QApplication>
 #include <QDesktopWidget>
 #include <QPainter>
+#include <QPainterPath>
 #include <QPicture>
 
 #ifndef WX_PRECOMP


### PR DESCRIPTION
The header is no longer pulled in by QPainter, omitting it causes
failing builds due to incomplete type QPainterPath.