### PR TITLE
wxDVC: support DnD for multiple formats at once.

### DIFF
--- a/include/wx/dataview.h
+++ b/include/wx/dataview.h
@@ -535,6 +535,10 @@ private:
 // wxDataViewCtrlBase
 // ---------------------------------------------------------
 
+#if wxUSE_DRAG_AND_DROP
+WX_DEFINE_ARRAY(wxDataFormat,wxDataFormatArray);
+#endif
+
 #define wxDV_SINGLE                  0x0000     // for convenience
 #define wxDV_MULTIPLE                0x0001     // can select multiple items
 
@@ -759,8 +763,21 @@ public:
 #if wxUSE_DRAG_AND_DROP
     virtual bool EnableDragSource(const wxDataFormat& WXUNUSED(format))
         { return false; }
-    virtual bool EnableDropTarget(const wxDataFormat& WXUNUSED(format))
-        { return false; }
+
+    bool EnableDropTarget(const wxDataFormatArray& formats)
+        { return DoEnableDropTarget(formats); }
+
+    bool EnableDropTarget(const wxDataFormat& format)
+    {
+        wxDataFormatArray formats;
+        if (format.GetType() != wxDF_INVALID)
+        {
+            formats.Add(format);
+        }
+
+        return EnableDropTarget(formats);
+    }
+
 #endif // wxUSE_DRAG_AND_DROP
 
     // define control visual attributes
@@ -790,6 +807,14 @@ public:
 protected:
     virtual void DoSetExpanderColumn() = 0 ;
     virtual void DoSetIndent() = 0;
+
+#if wxUSE_DRAG_AND_DROP
+    virtual wxDataObject* CreateDataObject(const wxDataFormatArray& formats);
+
+    virtual bool DoEnableDropTarget(const wxDataFormatArray& WXUNUSED(formats))
+        { return false; }
+
+#endif // wxUSE_DRAG_AND_DROP
 
     // Just expand this item assuming it is already shown, i.e. its parent has
     // been already expanded using ExpandAncestors().

--- a/include/wx/generic/dataview.h
+++ b/include/wx/generic/dataview.h
@@ -278,7 +278,7 @@ public:
 
 #if wxUSE_DRAG_AND_DROP
     virtual bool EnableDragSource( const wxDataFormat &format ) wxOVERRIDE;
-    virtual bool EnableDropTarget( const wxDataFormat &format ) wxOVERRIDE;
+    virtual bool DoEnableDropTarget(const wxDataFormatArray& formats) wxOVERRIDE;
 #endif // wxUSE_DRAG_AND_DROP
 
     virtual wxBorder GetDefaultBorder() const wxOVERRIDE;

--- a/include/wx/gtk/dataview.h
+++ b/include/wx/gtk/dataview.h
@@ -166,7 +166,7 @@ public:
     virtual bool IsExpanded( const wxDataViewItem & item ) const wxOVERRIDE;
 
     virtual bool EnableDragSource( const wxDataFormat &format ) wxOVERRIDE;
-    virtual bool EnableDropTarget( const wxDataFormat &format ) wxOVERRIDE;
+    virtual bool DoEnableDropTarget( const wxDataFormatArray& formats ) wxOVERRIDE;
 
     virtual wxDataViewColumn *GetCurrentColumn() const wxOVERRIDE;
 

--- a/include/wx/osx/cocoa/dataview.h
+++ b/include/wx/osx/cocoa/dataview.h
@@ -541,10 +541,6 @@ public:
 
     virtual void StartEditor( const wxDataViewItem & item, unsigned int column );
 
-    // drag & drop helper methods
-    wxDataFormat GetDnDDataFormat(wxDataObjectComposite* dataObjects);
-    wxDataObjectComposite* GetDnDDataObjects(NSData* dataObject) const;
-
     // Cocoa-specific helpers
     id GetItemAtRow(int row) const;
 

--- a/include/wx/osx/dataview.h
+++ b/include/wx/osx/dataview.h
@@ -120,6 +120,7 @@ WX_DEFINE_ARRAY(wxDataViewColumn*,wxDataViewColumnPtrArrayType);
 // ---------------------------------------------------------
 // wxDataViewCtrl
 // ---------------------------------------------------------
+
 class WXDLLIMPEXP_ADV wxDataViewCtrl: public wxDataViewCtrlBase
 {
 public:
@@ -207,6 +208,10 @@ public:
   void FinishCustomItemEditing();
 
   virtual void EditItem(const wxDataViewItem& item, const wxDataViewColumn *column) wxOVERRIDE;
+
+#if wxUSE_DRAG_AND_DROP
+  virtual bool DoEnableDropTarget( const wxDataFormatArray& formats ) wxOVERRIDE;
+#endif // wxUSE_DRAG_AND_DROP
 
  // returns the n-th pointer to a column;
  // this method is different from GetColumn(unsigned int pos) because here 'n' is not a position in the control but the n-th
@@ -315,4 +320,3 @@ private:
 };
 
 #endif // _WX_DATAVIEWCTRL_OSX_H_
-

--- a/include/wx/qt/dataview.h
+++ b/include/wx/qt/dataview.h
@@ -120,7 +120,7 @@ public:
     virtual bool IsExpanded( const wxDataViewItem & item ) const;
 
     virtual bool EnableDragSource( const wxDataFormat &format );
-    virtual bool EnableDropTarget( const wxDataFormat &format );
+    virtual bool DoEnableDropTarget( const wxDataFormatArray& formats ) wxOVERRIDE;
 
     static wxVisualAttributes
     GetClassDefaultAttributes(wxWindowVariant variant = wxWINDOW_VARIANT_NORMAL);

--- a/interface/wx/dataview.h
+++ b/interface/wx/dataview.h
@@ -1380,9 +1380,23 @@ public:
     virtual bool EnableDragSource( const wxDataFormat &format );
 
     /**
-       Enable drop operations using the given @a format.
+        Enable drop operations for each @a format from passed array.
+        Currently this is fully implemented in the generic and native macOS versions.
+        On GTK the only first element of array will be used.
+
+        @note Passing empty array disables drop operations at all.
+
+        @since 3.1.5
     */
-    virtual bool EnableDropTarget( const wxDataFormat &format );
+    bool EnableDropTarget(const wxDataFormatArray& formats);
+
+    /**
+        Enable drop operations using the given @a format.
+        Under the hood just calls overloaded EnableDropTarget() with an array holds single passed format.
+
+        @note Since 3.1.5 wxDF_INVALID can be passed to disable drop operations at all.
+    */
+    bool EnableDropTarget( const wxDataFormat &format );
 
     /**
         Call this to ensure that the given item is visible.

--- a/samples/dataview/dataview.cpp
+++ b/samples/dataview/dataview.cpp
@@ -1291,21 +1291,20 @@ void MyFrame::OnDrop( wxDataViewEvent &event )
         return;
     }
 
-    wxTextDataObject obj;
-    obj.SetData( wxDF_UNICODETEXT, event.GetDataSize(), event.GetDataBuffer() );
+    wxTextDataObject* obj = static_cast<wxTextDataObject*>(event.GetDataObject());
 
     if ( item.IsOk() )
     {
         if (m_music_model->IsContainer(item))
         {
             wxLogMessage("Text '%s' dropped in container '%s' (proposed index = %i)",
-                         obj.GetText(), m_music_model->GetTitle(item), event.GetProposedDropIndex());
+                         obj->GetText(), m_music_model->GetTitle(item), event.GetProposedDropIndex());
         }
         else
-            wxLogMessage("Text '%s' dropped on item '%s'", obj.GetText(), m_music_model->GetTitle(item));
+            wxLogMessage("Text '%s' dropped on item '%s'", obj->GetText(), m_music_model->GetTitle(item));
     }
     else
-        wxLogMessage("Text '%s' dropped on background (proposed index = %i)", obj.GetText(), event.GetProposedDropIndex());
+        wxLogMessage("Text '%s' dropped on background (proposed index = %i)", obj->GetText(), event.GetProposedDropIndex());
 }
 
 #endif // wxUSE_DRAG_AND_DROP

--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -1669,6 +1669,64 @@ void wxDataViewCtrlBase::StartEditor(const wxDataViewItem& item, unsigned int co
     EditItem(item, GetColumn(column));
 }
 
+#if wxUSE_DRAG_AND_DROP
+
+wxDataObject* wxDataViewCtrlBase::CreateDataObject(const wxDataFormatArray& formats)
+{
+    if (formats.GetCount() == 0)
+    {
+         return NULL;
+    }
+
+    wxDataObjectComposite *dataObject(new wxDataObjectComposite);
+    for (size_t i = 0; i < formats.GetCount(); ++i)
+    {
+        switch (formats.Item(i).GetType())
+        {
+            case wxDF_TEXT:
+            case wxDF_OEMTEXT:
+            case wxDF_UNICODETEXT:
+                dataObject->Add(new wxTextDataObject);
+                break;
+
+            case wxDF_BITMAP:
+                dataObject->Add(new wxBitmapDataObject);
+                break;
+
+            case wxDF_FILENAME:
+                dataObject->Add(new wxFileDataObject);
+                break;
+
+            case wxDF_HTML:
+                dataObject->Add(new wxHTMLDataObject);
+                break;
+
+            case wxDF_METAFILE:
+            case wxDF_SYLK:
+            case wxDF_DIF:
+            case wxDF_TIFF:
+            case wxDF_DIB:
+            case wxDF_PALETTE:
+            case wxDF_PENDATA:
+            case wxDF_RIFF:
+            case wxDF_WAVE:
+            case wxDF_ENHMETAFILE:
+            case wxDF_LOCALE:
+            case wxDF_PRIVATE:
+                dataObject->Add(new wxCustomDataObject(formats.Item(i)));
+                break;
+
+            case wxDF_INVALID:
+            case wxDF_MAX:
+                break;
+        }
+    }
+
+    return dataObject;
+}
+
+#endif // wxUSE_DRAG_AND_DROP
+
 // ---------------------------------------------------------
 // wxDataViewEvent
 // ---------------------------------------------------------

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -907,7 +907,6 @@ public:
     };
 
     bool EnableDragSource( const wxDataFormat &format );
-    bool EnableDropTarget( const wxDataFormat &format );
 
     void RefreshDropHint();
     void RemoveDropHint();
@@ -1014,8 +1013,6 @@ private:
     bool                        m_dragEnabled;
     wxDataFormat                m_dragFormat;
 
-    bool                        m_dropEnabled;
-    wxDataFormat                m_dropFormat;
     DropItemInfo                m_dropItemInfo;
 #endif // wxUSE_DRAG_AND_DROP
 
@@ -2057,7 +2054,6 @@ wxDataViewMainWindow::wxDataViewMainWindow( wxDataViewCtrl *parent, wxWindowID i
     m_dragStart = wxPoint(0,0);
 
     m_dragEnabled = false;
-    m_dropEnabled = false;
     m_dropItemInfo = DropItemInfo();
 #endif // wxUSE_DRAG_AND_DROP
 
@@ -2109,17 +2105,6 @@ bool wxDataViewMainWindow::EnableDragSource( const wxDataFormat &format )
 {
     m_dragFormat = format;
     m_dragEnabled = format != wxDF_INVALID;
-
-    return true;
-}
-
-bool wxDataViewMainWindow::EnableDropTarget( const wxDataFormat &format )
-{
-    m_dropFormat = format;
-    m_dropEnabled = format != wxDF_INVALID;
-
-    if (m_dropEnabled)
-        SetDropTarget( new wxDataViewDropTarget( new wxCustomDataObject( format ), this ) );
 
     return true;
 }
@@ -2375,13 +2360,13 @@ wxDragResult wxDataViewMainWindow::OnData( wxDataFormat format, wxCoord x, wxCoo
 {
     DropItemInfo dropItemInfo = GetDropItemInfo(x, y);
 
-    wxCustomDataObject *obj = (wxCustomDataObject *) GetDropTarget()->GetDataObject();
+    wxDataObjectComposite *obj = static_cast<wxDataObjectComposite*>(GetDropTarget()->GetDataObject());
 
     wxDataViewEvent event(wxEVT_DATAVIEW_ITEM_DROP, m_owner, dropItemInfo.m_item);
     event.SetProposedDropIndex(dropItemInfo.m_proposedDropIndex);
     event.SetDataFormat( format );
-    event.SetDataSize( obj->GetSize() );
-    event.SetDataBuffer( obj->GetData() );
+    event.SetDataSize(obj->GetDataSize(format));
+    event.SetDataObject(obj->GetObject(format));
     event.SetDropEffect( def );
     if ( !m_owner->HandleWindowEvent( event ) || !event.IsAllowed() )
         return wxDragNone;
@@ -5718,9 +5703,17 @@ bool wxDataViewCtrl::EnableDragSource( const wxDataFormat &format )
     return m_clientArea->EnableDragSource( format );
 }
 
-bool wxDataViewCtrl::EnableDropTarget( const wxDataFormat &format )
+bool wxDataViewCtrl::DoEnableDropTarget( const wxDataFormatArray &formats )
 {
-    return m_clientArea->EnableDropTarget( format );
+    wxDataViewDropTarget* dt = NULL;
+    if (wxDataObject* dataObject = CreateDataObject(formats))
+    {
+        dt = new wxDataViewDropTarget(dataObject, m_clientArea);
+    }
+
+    m_clientArea->SetDropTarget(dt);
+
+    return true;
 }
 
 #endif // wxUSE_DRAG_AND_DROP

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -210,7 +210,7 @@ public:
     // dnd iface
 
     bool EnableDragSource( const wxDataFormat &format );
-    bool EnableDropTarget( const wxDataFormat &format );
+    bool EnableDropTarget( const wxDataFormatArray &formats );
 
     gboolean row_draggable( GtkTreeDragSource *drag_source, GtkTreePath *path );
     gboolean drag_data_delete( GtkTreeDragSource *drag_source, GtkTreePath* path );
@@ -3814,9 +3814,16 @@ bool wxDataViewCtrlInternal::EnableDragSource( const wxDataFormat &format )
     return true;
 }
 
-bool wxDataViewCtrlInternal::EnableDropTarget( const wxDataFormat &format )
+bool wxDataViewCtrlInternal::EnableDropTarget( const wxDataFormatArray& formats )
 {
-    wxGtkString atom_str( gdk_atom_name( format  ) );
+    if (formats.GetCount() == 0)
+    {
+        gtk_tree_view_unset_rows_drag_dest(GTK_TREE_VIEW(m_owner->GtkGetTreeView()));
+
+        return true;
+    }
+
+    wxGtkString atom_str( gdk_atom_name( formats.Item(0) ) );
     m_dropTargetTargetEntryTarget = wxCharBuffer( atom_str );
 
     m_dropTargetTargetEntry.target =  m_dropTargetTargetEntryTarget.data();
@@ -4933,10 +4940,10 @@ bool wxDataViewCtrl::EnableDragSource( const wxDataFormat &format )
     return m_internal->EnableDragSource( format );
 }
 
-bool wxDataViewCtrl::EnableDropTarget( const wxDataFormat &format )
+bool wxDataViewCtrl::DoEnableDropTarget( const wxDataFormatArray& formats )
 {
     wxCHECK_MSG( m_internal, false, "model must be associated before calling EnableDragTarget" );
-    return m_internal->EnableDropTarget( format );
+    return m_internal->EnableDropTarget( formats );
 }
 
 bool wxDataViewCtrl::AppendColumn( wxDataViewColumn *col )

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -26,6 +26,7 @@
 
 #include "wx/osx/private.h"
 #include "wx/osx/private/available.h"
+#include "wx/osx/private/datatransfer.h"
 #include "wx/osx/cocoa/dataview.h"
 #include "wx/renderer.h"
 #include "wx/stopwatch.h"
@@ -707,71 +708,77 @@ outlineView:(NSOutlineView*)outlineView
     return [self setupAndCallDataViewEvents:wxEVT_DATAVIEW_ITEM_DROP_POSSIBLE dropInfo:info item:item proposedChildIndex:index];
 }
 
--(NSDragOperation) callDataViewEvents:(wxEventType)eventType dataObjects:(wxDataObjectComposite*)dataObjects item:(id)item
-                   proposedChildIndex:(NSInteger)index
+-(NSDragOperation) setupAndCallDataViewEvents:(wxEventType)eventType dropInfo:(id<NSDraggingInfo>)info item:(id)item
+                           proposedChildIndex:(NSInteger)index
 {
-    NSDragOperation dragOperation = NSDragOperationNone;
     wxDataViewCtrl* const dvc(implementation->GetDataViewCtrl());
+
+    wxDropTarget* dt = dvc->GetDropTarget();
+    if (!dt)
+        return NSDragOperationNone;
+
+    NSPasteboard* pasteboard([info draggingPasteboard]);
+    wxOSXPasteboard wxPastboard(pasteboard);
+    dt->SetCurrentDragSource(&wxPastboard);
+
+    wxDataFormat format = dt->GetMatchingPair();
+    if (format == wxDF_INVALID)
+        return NSDragOperationNone;
+
+    // Create event
     wxDataViewEvent event(eventType, dvc, wxDataViewItemFromItem(item));
-    if (dataObjects && (dataObjects->GetFormatCount() > 0))
+
+    // Retrieve data info if user released mouse buttton (drop occured)
+    if (eventType == wxEVT_DATAVIEW_ITEM_DROP)
     {
-        // copy data into data object:
-        event.SetDataObject(dataObjects);
-        event.SetDataFormat(implementation->GetDnDDataFormat(dataObjects));
-        event.SetProposedDropIndex(index);
-        if (index == -1)
-        {
-            event.SetDropEffect(wxDragCopy);
-        }
-        else
-        {
-            //if index is not -1, we're going to set the default
-            //for the drop effect to None to be compatible with
-            //the other wxPlatforms that don't support it.  In the
-            //user code for for the event, they can set this to
-            //copy/move or similar to support it.
-            event.SetDropEffect(wxDragNone);
-        }
-        wxDataFormatId formatId = event.GetDataFormat().GetType();
-        wxMemoryBuffer buffer;
+        if (!dt->GetData())
+            return NSDragOperationNone;
 
-        // copy data into buffer:
-        if ( formatId != wxDF_INVALID)
-        {
-            size_t size = dataObjects->GetDataSize(formatId);
+        wxDataObjectComposite *obj = static_cast<wxDataObjectComposite*>(dt->GetDataObject());
+        event.SetDataSize(obj->GetDataSize(format));
+        event.SetDataObject(obj->GetObject(format));
+    }
 
-            event.SetDataSize(size);
-            dataObjects->GetDataHere(formatId,buffer.GetWriteBuf(size));
-            buffer.UngetWriteBuf(size);
-            event.SetDataBuffer(buffer.GetData());
-        }
+    // Setup other event properties
+    event.SetProposedDropIndex(index);
+    event.SetDataFormat(format);
+    if (index == -1)
+    {
+        event.SetDropEffect(wxDragCopy);
+    }
+    else
+    {
+        //if index is not -1, we're going to set the default
+        //for the drop effect to None to be compatible with
+        //the other wxPlatforms that don't support it.  In the
+        //user code for for the event, they can set this to
+        //copy/move or similar to support it.
+        event.SetDropEffect(wxDragNone);
+    }
 
-        // finally, send event:
-        if (dvc->HandleWindowEvent(event) && event.IsAllowed())
+    NSDragOperation dragOperation = NSDragOperationNone;
+
+    // finally, send event:
+    if (dvc->HandleWindowEvent(event) && event.IsAllowed())
+    {
+        switch (event.GetDropEffect())
         {
-            switch (event.GetDropEffect())
-            {
-                case wxDragCopy:
-                    dragOperation = NSDragOperationCopy;
-                    break;
-                case wxDragMove:
-                    dragOperation = NSDragOperationMove;
-                    break;
-                case wxDragLink:
-                    dragOperation = NSDragOperationLink;
-                    break;
-                case wxDragNone:
-                case wxDragCancel:
-                case wxDragError:
-                    dragOperation = NSDragOperationNone;
-                    break;
-                default:
-                    dragOperation = NSDragOperationEvery;
-            }
-        }
-        else
-        {
-            dragOperation = NSDragOperationNone;
+            case wxDragCopy:
+                dragOperation = NSDragOperationCopy;
+                break;
+            case wxDragMove:
+                dragOperation = NSDragOperationMove;
+                break;
+            case wxDragLink:
+                dragOperation = NSDragOperationLink;
+                break;
+            case wxDragNone:
+            case wxDragCancel:
+            case wxDragError:
+                dragOperation = NSDragOperationNone;
+                break;
+            default:
+                dragOperation = NSDragOperationEvery;
         }
     }
     else
@@ -782,201 +789,40 @@ outlineView:(NSOutlineView*)outlineView
     return dragOperation;
 }
 
--(NSDragOperation) setupAndCallDataViewEvents:(wxEventType)eventType dropInfo:(id<NSDraggingInfo>)info item:(id)item
-                           proposedChildIndex:(NSInteger)index
-{
-    NSArray* supportedTypes(
-                            [NSArray arrayWithObjects:DataViewPboardType,NSStringPboardType,nil]
-                            );
-
-    NSPasteboard* pasteboard([info draggingPasteboard]);
-
-    NSString* bestType([pasteboard availableTypeFromArray:supportedTypes]);
-
-    if ( bestType == nil )
-        return NSDragOperationNone;
-
-    NSDragOperation dragOperation = NSDragOperationNone;
-    wxDataViewCtrl* const dvc(implementation->GetDataViewCtrl());
-
-    wxCHECK_MSG(dvc, false, "Pointer to data view control not set correctly.");
-    wxCHECK_MSG(dvc->GetModel(), false, "Pointer to model not set correctly.");
-
-    // wxDataViewEvent event(eventType, dvc, wxDataViewItemFromItem(item));
-    if ([bestType compare:DataViewPboardType] == NSOrderedSame)
-    {
-        NSArray*               dataArray((NSArray*)[pasteboard propertyListForType:DataViewPboardType]);
-        NSUInteger             indexDraggedItem, noOfDraggedItems([dataArray count]);
-
-        indexDraggedItem = 0;
-        while (indexDraggedItem < noOfDraggedItems)
-        {
-            wxDataObjectComposite* dataObjects(implementation->GetDnDDataObjects((NSData*)[dataArray objectAtIndex:indexDraggedItem]));
-
-            dragOperation = [self callDataViewEvents:eventType dataObjects:dataObjects item:item proposedChildIndex:index];
-
-            if ( dragOperation != NSDragOperationNone )
-                ++indexDraggedItem;
-            else
-                indexDraggedItem = noOfDraggedItems;
-
-            // clean-up:
-            delete dataObjects;
-        }
-    }
-    else
-    {
-        // needed to convert internally used UTF-16 representation to a UTF-8
-        // representation
-        CFDataRef              osxData;
-        wxDataObjectComposite* dataObjects   (new wxDataObjectComposite());
-        wxTextDataObject*      textDataObject(new wxTextDataObject());
-
-        osxData = ::CFStringCreateExternalRepresentation(kCFAllocatorDefault,(CFStringRef)[pasteboard stringForType:NSStringPboardType],
-#if defined(wxNEEDS_UTF16_FOR_TEXT_DATAOBJ)
-                                                         kCFStringEncodingUTF16,
-#else
-                                                         kCFStringEncodingUTF8,
-#endif
-                                                         32);
-        if (textDataObject->SetData(::CFDataGetLength(osxData),::CFDataGetBytePtr(osxData)))
-            dataObjects->Add(textDataObject);
-        else
-            delete textDataObject;
-        // send event if data could be copied:
-
-        dragOperation = [self callDataViewEvents:eventType dataObjects:dataObjects item:item proposedChildIndex:index];
-
-        // clean up:
-        ::CFRelease(osxData);
-        delete dataObjects;
-    }
-
-    return dragOperation;
-}
-
 -(BOOL) outlineView:(NSOutlineView*)outlineView writeItems:(NSArray*)writeItems toPasteboard:(NSPasteboard*)pasteboard
 {
     wxUnusedVar(outlineView);
 
-    // the pasteboard will be filled up with an array containing the data as
-    // returned by the events (including the data type) and a concatenation of
-    // text (string) data; the text data will only be put onto the pasteboard
-    // if for all items a string representation exists
     wxDataViewCtrl* const dvc = implementation->GetDataViewCtrl();
-
-    wxDataViewItemArray dataViewItems;
-
 
     wxCHECK_MSG(dvc, false,"Pointer to data view control not set correctly.");
     wxCHECK_MSG(dvc->GetModel(),false,"Pointer to model not set correctly.");
 
+    BOOL result = NO;
     if ([writeItems count] > 0)
     {
-        bool            dataStringAvailable(true); // a flag indicating if for all items a data string is available
-        NSMutableArray* dataArray = [NSMutableArray arrayWithCapacity:[writeItems count]]; // data of all items
-        wxString        dataString; // contains the string data of all items
+        // Send a begin drag event for the first selected item and send wxEVT_DATAVIEW_ITEM_BEGIN_DRAG.
+        // If there are several items selected, user can process each in event handler and
+        // fill up the corresponding wxDataObject the way he wants.
+        const wxDataViewItem item = wxDataViewItemFromItem([writeItems objectAtIndex:0]);
+        wxDataViewEvent event(wxEVT_DATAVIEW_ITEM_BEGIN_DRAG, dvc, item);
 
-        // send a begin drag event for all selected items and proceed with
-        // dragging unless the event is vetoed:
-        for (size_t itemCounter=0; itemCounter<[writeItems count]; ++itemCounter)
+        // check if event has not been vetoed:
+        if (dvc->HandleWindowEvent(event) && event.IsAllowed() && event.GetDataObject())
         {
-            bool                   itemStringAvailable(false);              // a flag indicating if for the current item a string is available
-            wxDataObjectComposite* itemObject(new wxDataObjectComposite()); // data object for current item
-            wxString               itemString;                              // contains the TAB concatenated data of an item
+            wxDataObject *dataObject = event.GetDataObject();
 
-            const wxDataViewItem item = wxDataViewItemFromItem([writeItems objectAtIndex:itemCounter]);
-            wxDataViewEvent event(wxEVT_DATAVIEW_ITEM_BEGIN_DRAG, dvc, item);
-            itemString = ::ConcatenateDataViewItemValues(dvc, item);
-            itemObject->Add(new wxTextDataObject(itemString));
-            event.SetDataObject(itemObject);
-            // check if event has not been vetoed:
-            if (dvc->HandleWindowEvent(event) && event.IsAllowed() && (event.GetDataObject()->GetFormatCount() > 0))
-            {
-                size_t const noOfFormats = event.GetDataObject()->GetFormatCount();
-                wxDataFormat* dataFormats(new wxDataFormat[noOfFormats]);
+            wxOSXPasteboard wxPastboard(pasteboard);
 
-                event.GetDataObject()->GetAllFormats(dataFormats,wxDataObject::Get);
-                for (size_t formatCounter=0; formatCounter<noOfFormats; ++formatCounter)
-                {
-                    // constant definitions for abbreviational purposes:
-                    wxDataFormatId const idDataFormat = dataFormats[formatCounter].GetType();
-                    size_t const dataSize       = event.GetDataObject()->GetDataSize(idDataFormat);
-                    size_t const dataBufferSize = sizeof(wxDataFormatId)+dataSize;
-                    // variable definitions (used in all case statements):
-                    // give additional headroom for trailing NULL
-                    wxMemoryBuffer dataBuffer(dataBufferSize+4);
+            wxPastboard.Clear();
+            dataObject->WriteToSink(&wxPastboard);
+            wxPastboard.Flush();
 
-                    dataBuffer.AppendData(&idDataFormat,sizeof(wxDataFormatId));
-                    switch (idDataFormat)
-                    {
-                        case wxDF_TEXT:
-                            // otherwise wxDF_UNICODETEXT already filled up
-                            // the string; and the UNICODE representation has
-                            // priority
-                            if (!itemStringAvailable)
-                            {
-                                event.GetDataObject()->GetDataHere(wxDF_TEXT,dataBuffer.GetAppendBuf(dataSize));
-                                dataBuffer.UngetAppendBuf(dataSize);
-                                [dataArray addObject:[NSData dataWithBytes:dataBuffer.GetData() length:dataBufferSize]];
-                                itemString = wxString(static_cast<char const*>(dataBuffer.GetData())+sizeof(wxDataFormatId),wxConvLocal);
-                                itemStringAvailable = true;
-                            }
-                            break;
-                        case wxDF_UNICODETEXT:
-                            {
-                                event.GetDataObject()->GetDataHere(wxDF_UNICODETEXT,dataBuffer.GetAppendBuf(dataSize));
-                                dataBuffer.UngetAppendBuf(dataSize);
-                                if (itemStringAvailable) // does an object already exist as an ASCII text (see wxDF_TEXT case statement)?
-                                    [dataArray replaceObjectAtIndex:itemCounter withObject:[NSData dataWithBytes:dataBuffer.GetData() length:dataBufferSize]];
-                                else
-                                    [dataArray addObject:[NSData dataWithBytes:dataBuffer.GetData() length:dataBufferSize]];
-                                itemString = wxString::FromUTF8(static_cast<char const*>(dataBuffer.GetData())+sizeof(wxDataFormatId),dataSize);
-                                itemStringAvailable = true;
-                            } /* block */
-                            break;
-                        default:
-                            wxFAIL_MSG("Data object has invalid or unsupported data format");
-                            return NO;
-                    }
-                }
-                delete[] dataFormats;
-                delete itemObject;
-                if (dataStringAvailable)
-                {
-                    if (itemStringAvailable)
-                    {
-                        if (itemCounter > 0)
-                            dataString << wxT('\n');
-                        dataString << itemString;
-                    }
-                    else
-                        dataStringAvailable = false;
-                }
-            }
-            else
-            {
-                delete itemObject;
-                return NO; // dragging was vetoed or no data available
-            }
+            result = YES;
         }
-        if (dataStringAvailable)
-        {
-            wxCFStringRef osxString(dataString);
-
-            [pasteboard declareTypes:[NSArray arrayWithObjects:DataViewPboardType,NSStringPboardType,nil] owner:nil];
-            [pasteboard setPropertyList:dataArray forType:DataViewPboardType];
-            [pasteboard setString:osxString.AsNSString() forType:NSStringPboardType];
-        }
-        else
-        {
-            [pasteboard declareTypes:[NSArray arrayWithObject:DataViewPboardType] owner:nil];
-            [pasteboard setPropertyList:dataArray forType:DataViewPboardType];
-        }
-        return YES;
     }
-    else
-        return NO; // no items to drag (should never occur)
+
+    return result;
 }
 
 //
@@ -1643,7 +1489,6 @@ outlineView:(NSOutlineView*)outlineView
         currentlyEditedColumn =
             currentlyEditedRow = -1;
 
-        [self registerForDraggedTypes:[NSArray arrayWithObjects:DataViewPboardType,NSStringPboardType,nil]];
         [self setDelegate:self];
         [self setDoubleAction:@selector(actionDoubleClick:)];
         [self setDraggingSourceOperationMask:NSDragOperationEvery forLocal:NO];
@@ -2621,97 +2466,6 @@ void wxCocoaDataViewControl::SetRowHeight(const wxDataViewItem& WXUNUSED(item), 
 void wxCocoaDataViewControl::OnSize()
 {
     [m_OutlineView sizeLastColumnToFit];
-}
-
-//
-// drag & drop helper methods
-//
-wxDataFormat wxCocoaDataViewControl::GetDnDDataFormat(wxDataObjectComposite* dataObjects)
-{
-    wxDataFormat resultFormat;
-    if ( !dataObjects )
-        return resultFormat;
-
-    bool compatible(true);
-
-    size_t const noOfFormats = dataObjects->GetFormatCount();
-    size_t       indexFormat;
-
-    wxDataFormat* formats;
-
-    // get all formats and check afterwards if the formats are compatible; if
-    // they are compatible the preferred format is returned otherwise
-    // wxDF_INVALID is returned;
-    // currently compatible types (ordered by priority are):
-    //  - wxDF_UNICODETEXT - wxDF_TEXT
-    formats = new wxDataFormat[noOfFormats];
-    dataObjects->GetAllFormats(formats);
-    indexFormat = 0;
-    while ((indexFormat < noOfFormats) && compatible)
-    {
-        switch (resultFormat.GetType())
-        {
-            case wxDF_INVALID:
-                resultFormat.SetType(formats[indexFormat].GetType()); // first format (should only be reached if indexFormat == 0)
-                break;
-            case wxDF_TEXT:
-                if (formats[indexFormat].GetType() == wxDF_UNICODETEXT)
-                    resultFormat.SetType(wxDF_UNICODETEXT);
-                else // incompatible
-                {
-                    resultFormat.SetType(wxDF_INVALID);
-                    compatible = false;
-                }
-                break;
-            case wxDF_UNICODETEXT:
-                if (formats[indexFormat].GetType() != wxDF_TEXT)
-                {
-                    resultFormat.SetType(wxDF_INVALID);
-                    compatible = false;
-                }
-                break;
-            default:
-                resultFormat.SetType(wxDF_INVALID); // not (yet) supported format
-                compatible = false;
-        }
-        ++indexFormat;
-    }
-
-    delete[] formats;
-
-    return resultFormat;
-}
-
-wxDataObjectComposite* wxCocoaDataViewControl::GetDnDDataObjects(NSData* dataObject) const
-{
-    wxDataFormatId dataFormatID;
-
-
-    [dataObject getBytes:&dataFormatID length:sizeof(wxDataFormatId)];
-    switch (dataFormatID)
-    {
-        case wxDF_TEXT:
-        case wxDF_UNICODETEXT:
-            {
-                wxTextDataObject* textDataObject(new wxTextDataObject());
-
-                if (textDataObject->SetData(wxDataFormat(dataFormatID),[dataObject length]-sizeof(wxDataFormatId),static_cast<char const*>([dataObject bytes])+sizeof(wxDataFormatId)))
-                {
-                    wxDataObjectComposite* dataObjectComposite(new wxDataObjectComposite());
-
-                    dataObjectComposite->Add(textDataObject);
-                    return dataObjectComposite;
-                }
-                else
-                {
-                    delete textDataObject;
-                    return NULL;
-                }
-            }
-            break;
-        default:
-            return NULL;
-    }
 }
 
 id wxCocoaDataViewControl::GetItemAtRow(int row) const

--- a/src/osx/dataview_osx.cpp
+++ b/src/osx/dataview_osx.cpp
@@ -684,6 +684,23 @@ void wxDataViewCtrl::EditItem(const wxDataViewItem& item, const wxDataViewColumn
     GetDataViewPeer()->StartEditor(item, GetColumnPosition(column));
 }
 
+#if wxUSE_DRAG_AND_DROP
+
+bool wxDataViewCtrl::DoEnableDropTarget(const wxDataFormatArray &formats)
+{
+    wxDropTarget* dt = NULL;
+    if (wxDataObject* dataObject = CreateDataObject(formats))
+    {
+        dt = new wxDropTarget(dataObject);
+    }
+
+    SetDropTarget(dt);
+
+    return true;
+}
+
+#endif // wxUSE_DRAG_AND_DROP
+
 void wxDataViewCtrl::FinishCustomItemEditing()
 {
   if (GetCustomRendererItem().IsOk())

--- a/src/qt/dataview.cpp
+++ b/src/qt/dataview.cpp
@@ -285,7 +285,7 @@ bool wxDataViewCtrl::EnableDragSource( const wxDataFormat &format )
     return false;
 }
 
-bool wxDataViewCtrl::EnableDropTarget( const wxDataFormat &format )
+bool wxDataViewCtrl::DoEnableDropTarget( const wxDataFormatArray &formats )
 {
     return false;
 }


### PR DESCRIPTION
In generic wxDVC `EnableDropTarget( const wxDataFormat &format )` method worked correctly only with formats which internal data may be copied with `memcpy` (`wxCustomDataObject `restriction). Moreover it enabled support for only one format at the same time, althouh method's name means to _enable_ support for format w/o removing support for other _enabled_ formats (btw, maybe I'm wrong).

There is support for multiple formats at once with this patch. (What about `disabling `specific format?).

Also there are at least two unused vars in code: `m_dropEnabled`, `m_dropFormat`, do we really need them?

When we are ready for the wxEVT_DATAVIEW_ITEM_DROP event, I place dropObject (`wxDataObjectComposite`) into event and still copy the data to event, do we really need it? We always can copy data from dropObject if needed. The same happens in the wxOSX port.