### PR TITLE
Don't allow using GetPath/GetFilename with wxFD_MULTIPLE

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -96,7 +96,7 @@ Changes in behaviour not resulting in compilation errors
 - wxAuiNotebook::RemovePage() now hides the removed page, so it needs to be
   shown again if it is reused in another place.
 
-- wxFileDialog::GetPath and wxFileDialog::GetFilename now assert and return
+- wxFileDialog::GetPath() and wxFileDialog::GetFilename() now assert and return
   an empty string if called on dialogs with the wxFD_MULTIPLE style.
 
 

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -96,6 +96,9 @@ Changes in behaviour not resulting in compilation errors
 - wxAuiNotebook::RemovePage() now hides the removed page, so it needs to be
   shown again if it is reused in another place.
 
+- wxFileDialog::GetPath and wxFileDialog::GetFilename now assert and return
+  an empty string if called on dialogs with the wxFD_MULTIPLE style.
+
 
 Changes in behaviour which may result in build errors
 -----------------------------------------------------

--- a/include/wx/filedlg.h
+++ b/include/wx/filedlg.h
@@ -106,7 +106,7 @@ public:
     virtual wxString GetMessage() const { return m_message; }
     virtual wxString GetPath() const
     {
-        wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxEmptyString, wxT("GetPath called when wxFD_MULTIPLE defined") );
+        wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxString(), "When using wxFD_MULTIPLE, must call GetPaths() instead" );
         return m_path;
     }
 
@@ -114,7 +114,7 @@ public:
     virtual wxString GetDirectory() const { return m_dir; }
     virtual wxString GetFilename() const
     {
-        wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxEmptyString, wxT("GetFilename called when wxFD_MULTIPLE defined") );
+        wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxString(), "When using wxFD_MULTIPLE, must call GetFilenames() instead" );
         return m_fileName;
     }
     virtual void GetFilenames(wxArrayString& files) const { files.Empty(); files.Add(m_fileName); }

--- a/include/wx/filedlg.h
+++ b/include/wx/filedlg.h
@@ -104,10 +104,19 @@ public:
     virtual void SetFilterIndex(int filterIndex) { m_filterIndex = filterIndex; }
 
     virtual wxString GetMessage() const { return m_message; }
-    virtual wxString GetPath() const { return m_path; }
+    virtual wxString GetPath() const
+    {
+        wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxEmptyString, wxT("GetPath called when wxFD_MULTIPLE defined") );
+        return m_path;
+    }
+
     virtual void GetPaths(wxArrayString& paths) const { paths.Empty(); paths.Add(m_path); }
     virtual wxString GetDirectory() const { return m_dir; }
-    virtual wxString GetFilename() const { return m_fileName; }
+    virtual wxString GetFilename() const
+    {
+        wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxEmptyString, wxT("GetFilename called when wxFD_MULTIPLE defined") );
+        return m_fileName;
+    }
     virtual void GetFilenames(wxArrayString& files) const { files.Empty(); files.Add(m_fileName); }
     virtual wxString GetWildcard() const { return m_wildCard; }
     virtual int GetFilterIndex() const { return m_filterIndex; }

--- a/include/wx/generic/filedlgg.h
+++ b/include/wx/generic/filedlgg.h
@@ -74,7 +74,7 @@ public:
 
     virtual wxString GetPath() const wxOVERRIDE
         {
-            wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxEmptyString, wxT("GetPath called when wxFD_MULTIPLE defined") );
+            wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxString(), "When using wxFD_MULTIPLE, must call GetPaths() instead" );
             return m_filectrl->GetPath();
         }
     virtual void GetPaths(wxArrayString& paths) const wxOVERRIDE
@@ -83,7 +83,7 @@ public:
         { return m_filectrl->GetDirectory(); }
     virtual wxString GetFilename() const wxOVERRIDE
         {
-            wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxEmptyString, wxT("GetFilename called when wxFD_MULTIPLE defined") );
+            wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxString(), "When using wxFD_MULTIPLE, must call GetFilenames() instead" );
             return m_filectrl->GetFilename();
         }
     virtual void GetFilenames(wxArrayString& files) const wxOVERRIDE

--- a/include/wx/generic/filedlgg.h
+++ b/include/wx/generic/filedlgg.h
@@ -73,13 +73,19 @@ public:
         { m_filectrl->SetWildcard(wildCard); }
 
     virtual wxString GetPath() const wxOVERRIDE
-        { return m_filectrl->GetPath(); }
+        {
+            wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxEmptyString, wxT("GetPath called when wxFD_MULTIPLE defined") );
+            return m_filectrl->GetPath();
+        }
     virtual void GetPaths(wxArrayString& paths) const wxOVERRIDE
         { m_filectrl->GetPaths(paths); }
     virtual wxString GetDirectory() const wxOVERRIDE
         { return m_filectrl->GetDirectory(); }
     virtual wxString GetFilename() const wxOVERRIDE
-        { return m_filectrl->GetFilename(); }
+        {
+            wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxEmptyString, wxT("GetFilename called when wxFD_MULTIPLE defined") );
+            return m_filectrl->GetFilename();
+        }
     virtual void GetFilenames(wxArrayString& files) const wxOVERRIDE
         { m_filectrl->GetFilenames(files); }
     virtual wxString GetWildcard() const wxOVERRIDE

--- a/interface/wx/filedlg.h
+++ b/interface/wx/filedlg.h
@@ -265,7 +265,7 @@ public:
     /**
         Returns the default filename.
 
-        @note This function should not be used with dialogs which have the @c wxFD_MULTIPLE style,
+        @note This function can't be used with dialogs which have the @c wxFD_MULTIPLE style,
               use GetFilenames() instead.
     */
     virtual wxString GetFilename() const;
@@ -302,7 +302,7 @@ public:
     /**
         Returns the full path (directory and filename) of the selected file.
 
-        @note This function should not be used with dialogs which have the @c wxFD_MULTIPLE style,
+        @note This function can't be used with dialogs which have the @c wxFD_MULTIPLE style,
               use GetPaths() instead.
     */
     virtual wxString GetPath() const;

--- a/interface/wx/filedlg.h
+++ b/interface/wx/filedlg.h
@@ -264,6 +264,9 @@ public:
 
     /**
         Returns the default filename.
+
+        @note This function should not be used with dialogs which have the @c wxFD_MULTIPLE style,
+              use GetFilenames() instead.
     */
     virtual wxString GetFilename() const;
 
@@ -298,6 +301,9 @@ public:
 
     /**
         Returns the full path (directory and filename) of the selected file.
+
+        @note This function should not be used with dialogs which have the @c wxFD_MULTIPLE style,
+              use GetPaths() instead.
     */
     virtual wxString GetPath() const;
 

--- a/src/gtk/filedlg.cpp
+++ b/src/gtk/filedlg.cpp
@@ -396,7 +396,7 @@ void wxFileDialog::OnSize(wxSizeEvent&)
 
 wxString wxFileDialog::GetPath() const
 {
-    wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxEmptyString, wxT("GetPath called when wxFD_MULTIPLE defined") );
+    wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxString(), "When using wxFD_MULTIPLE, must call GetPaths() instead" );
     return m_fc.GetPath();
 }
 
@@ -464,7 +464,7 @@ void wxFileDialog::SetFilename(const wxString& name)
 
 wxString wxFileDialog::GetFilename() const
 {
-    wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxEmptyString, wxT("GetFilename called when wxFD_MULTIPLE defined") );
+    wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxString(), "When using wxFD_MULTIPLE, must call GetFilenames() instead" );
 
     wxString currentFilename( m_fc.GetFilename() );
     if (currentFilename.empty())

--- a/src/gtk/filedlg.cpp
+++ b/src/gtk/filedlg.cpp
@@ -396,6 +396,7 @@ void wxFileDialog::OnSize(wxSizeEvent&)
 
 wxString wxFileDialog::GetPath() const
 {
+    wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxEmptyString, wxT("GetPath called when wxFD_MULTIPLE defined") );
     return m_fc.GetPath();
 }
 
@@ -463,6 +464,8 @@ void wxFileDialog::SetFilename(const wxString& name)
 
 wxString wxFileDialog::GetFilename() const
 {
+    wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxEmptyString, wxT("GetFilename called when wxFD_MULTIPLE defined") );
+
     wxString currentFilename( m_fc.GetFilename() );
     if (currentFilename.empty())
     {

--- a/src/qt/filedlg.cpp
+++ b/src/qt/filedlg.cpp
@@ -103,7 +103,7 @@ bool wxFileDialog::Create(wxWindow *parent,
 
 wxString wxFileDialog::GetPath() const
 {
-    wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxEmptyString, wxT("GetPath called when wxFD_MULTIPLE defined") );
+    wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxString(), "When using wxFD_MULTIPLE, must call GetPaths() instead" );
 
     wxArrayString paths;
     GetPaths(paths);
@@ -122,7 +122,7 @@ void wxFileDialog::GetPaths(wxArrayString& paths) const
 
 wxString wxFileDialog::GetFilename() const
 {
-    wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxEmptyString, wxT("GetFilename called when wxFD_MULTIPLE defined") );
+    wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxString(), "When using wxFD_MULTIPLE, must call GetFilenames() instead" );
 
     wxArrayString filenames;
     GetFilenames(filenames);

--- a/src/qt/filedlg.cpp
+++ b/src/qt/filedlg.cpp
@@ -103,6 +103,8 @@ bool wxFileDialog::Create(wxWindow *parent,
 
 wxString wxFileDialog::GetPath() const
 {
+    wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxEmptyString, wxT("GetPath called when wxFD_MULTIPLE defined") );
+
     wxArrayString paths;
     GetPaths(paths);
     if (paths.empty())
@@ -120,6 +122,8 @@ void wxFileDialog::GetPaths(wxArrayString& paths) const
 
 wxString wxFileDialog::GetFilename() const
 {
+    wxCHECK_MSG( !HasFlag(wxFD_MULTIPLE), wxEmptyString, wxT("GetFilename called when wxFD_MULTIPLE defined") );
+
     wxArrayString filenames;
     GetFilenames(filenames);
     if ( filenames.empty() )


### PR DESCRIPTION
This PR adds checks to the `GetPath` and `GetFilename` functions to ensure they aren't called when the multiple selection style (`wxFD_MULTIPLE`) is used in the dialog. If they are, then they just return an empty string instead of the platform-inconsistent string they had been returning.

This change was discussed in https://trac.wxwidgets.org/ticket/18736.