### PR TITLE
OSX: Pad bitmap button size when using non-square bezel

### DIFF
--- a/src/osx/bmpbuttn_osx.cpp
+++ b/src/osx/bmpbuttn_osx.cpp
@@ -58,11 +58,13 @@ wxSize wxBitmapButton::DoGetBestSize() const
 
     if ( GetBitmapLabel().IsOk() )
     {
-        // Hack to stop 16x16 bitmap being clipped
-        if (GetBitmapLabel().GetScaledSize().x == 16)
+        wxSize bitmapSize = GetBitmapLabel().GetScaledSize();
+        best += bitmapSize;
+
+        // The NSRoundedBezelStyle and NSTexturedRoundedBezelStyle used when the image is less than 20
+        // tall have a small border on x that cuts off the image
+        if ( bitmapSize.y <= 20 )
             best += wxSize(4,0);
-            
-        best += GetBitmapLabel().GetScaledSize();
     }
 
     return best;


### PR DESCRIPTION
This is a minor fix that cleans-up a previous hack. The bitmap button on OSX has a small border when it uses the `NSRoundedBezelStyle` and `NSTexturedRoundedBezelStyle` styles, so the additional x size should be added whenever those bezels are used (which for a `wxBitmapButton` is when the image is less than 20 tall), and not just if the bitmap is 16 wide (since bitmaps smaller than 20 are cutoff).