### PR TITLE
Don't call GetBestSize() from DoGetSizeFromTextSize() in wxOSX

### DIFF
--- a/include/wx/osx/cocoa/private/textimpl.h
+++ b/include/wx/osx/cocoa/private/textimpl.h
@@ -32,6 +32,12 @@ public :
     virtual ~wxNSTextBase() { }
 
     virtual bool ShouldHandleKeyNavigation(const wxKeyEvent &event) const wxOVERRIDE;
+
+    virtual void SetInitialLabel(const wxString& WXUNUSED(title), wxFontEncoding WXUNUSED(encoding)) wxOVERRIDE
+    {
+        // Don't do anything here, text controls don't have any label and
+        // setting it would overwrite the string value set when creating it.
+    }
 };
 
 // implementation exposed, so that search control can pull it

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -1556,7 +1556,7 @@ void wxNSTextFieldControl::SetJustification()
 wxWidgetImplType* wxWidgetImpl::CreateTextControl( wxTextCtrl* wxpeer,
                                     wxWindowMac* WXUNUSED(parent),
                                     wxWindowID WXUNUSED(id),
-                                    const wxString& WXUNUSED(str),
+                                    const wxString& str,
                                     const wxPoint& pos,
                                     const wxSize& size,
                                     long style,
@@ -1569,8 +1569,11 @@ wxWidgetImplType* wxWidgetImpl::CreateTextControl( wxTextCtrl* wxpeer,
     {
         wxNSTextScrollView* v = nil;
         v = [[wxNSTextScrollView alloc] initWithFrame:r];
-        c = new wxNSTextViewControl( wxpeer, v, style );
+        wxNSTextViewControl* t = new wxNSTextViewControl( wxpeer, v, style );
+        c = t;
         c->SetNeedsFocusRect( true );
+
+        t->SetStringValue(str);
     }
     else
     {
@@ -1593,7 +1596,8 @@ wxWidgetImplType* wxWidgetImpl::CreateTextControl( wxTextCtrl* wxpeer,
         [cell setWraps:NO];
         [cell setScrollable:YES];
 
-        c = new wxNSTextFieldControl( wxpeer, wxpeer, v );
+        wxNSTextFieldControl* t = new wxNSTextFieldControl( wxpeer, wxpeer, v );
+        c = t;
 
         if ( (style & wxNO_BORDER) || (style & wxSIMPLE_BORDER) )
         {
@@ -1608,6 +1612,8 @@ wxWidgetImplType* wxWidgetImpl::CreateTextControl( wxTextCtrl* wxpeer,
             // use native border
             c->SetNeedsFrame(false);
         }
+
+        t->SetStringValue(str);
     }
 
     return c;

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -1222,9 +1222,9 @@ void wxNSTextViewControl::EnableAutomaticDashSubstitution(bool enable)
 
 wxSize wxNSTextViewControl::GetBestSize() const
 {
-    if (m_textView && [m_textView layoutManager])
+    if ( NSLayoutManager* const layoutManager = [m_textView layoutManager] )
     {
-        NSRect rect = [[m_textView layoutManager] usedRectForTextContainer: [m_textView textContainer]];
+        NSRect rect = [layoutManager usedRectForTextContainer: [m_textView textContainer]];
         return wxSize((int)(rect.size.width + [m_textView textContainerInset].width),
                       (int)(rect.size.height + [m_textView textContainerInset].height));
     }

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -1222,13 +1222,25 @@ void wxNSTextViewControl::EnableAutomaticDashSubstitution(bool enable)
 
 wxSize wxNSTextViewControl::GetBestSize() const
 {
+    wxSize size;
     if ( NSLayoutManager* const layoutManager = [m_textView layoutManager] )
     {
-        NSRect rect = [layoutManager usedRectForTextContainer: [m_textView textContainer]];
-        return wxSize((int)(rect.size.width + [m_textView textContainerInset].width),
-                      (int)(rect.size.height + [m_textView textContainerInset].height));
+        // We could have used usedRectForTextContainer: here to compute the
+        // total rectangle needed for the current text, but this is actually
+        // not too helpful for determining the best size of the control, as we
+        // don't always want to fit it to its text: e.g. if it contains 1000
+        // lines, we definitely don't want to make it higher than display.
+        //
+        // So instead we just get the height of a single line (which works for
+        // any non-empty control) and then multiply it by the number of lines
+        // we want to have by default, which is currently just hardcoded as 5
+        // for compatibility with the behaviour of the previous versions.
+        NSRect rect = [layoutManager lineFragmentRectForGlyphAtIndex: 0
+                                     effectiveRange: nil];
+        size.y = (int)(5*rect.size.height + [m_textView textContainerInset].height);
     }
-    return wxSize(0,0);
+
+    return size;
 }
 
 void wxNSTextViewControl::SetJustification()

--- a/src/osx/textctrl_osx.cpp
+++ b/src/osx/textctrl_osx.cpp
@@ -105,12 +105,6 @@ bool wxTextCtrl::Create( wxWindow *parent,
 
     MacPostControlCreate(pos, size) ;
 
-#if wxOSX_USE_COCOA
-    // under carbon everything can already be set before the MacPostControlCreate embedding takes place
-    // but under cocoa for single line textfields this only works after everything has been set up
-    GetTextPeer()->SetStringValue(str);
-#endif
-
     // only now the embedding is correct and we can do a positioning update
 
     MacSuperChangedPosition() ;


### PR DESCRIPTION
This could easily result in infinite recursion, as it is very natural to
implement DoGetBestSize() in terms of GetSizeFromTextSize() and, in
fact, our own implementation of the generic wxSpinCtrl did exactly this.

Avoid such problems by only calling GetSizeFromTextSize() from
DoGetBestSize(), but not in the other direction.

This shouldn't have any effect on the returned size values.

---

@wangqr Please let me know if I broke your recent fixes with this.