### PR TITLE
Fix the initial wxTextCtrl size in wxGTK

### DIFF
--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -817,7 +817,14 @@ bool wxTextCtrl::Create( wxWindow *parent,
     if (!value.empty())
     {
         ChangeValue(value);
-        InvalidateBestSize();
+
+        // The call to SetInitialSize() from inside PostCreation() didn't take
+        // the value into account because it hadn't been set yet when it was
+        // called (and setting it earlier wouldn't have been correct neither,
+        // as the appropriate size depends on the presence of the borders,
+        // which are configured in PostCreation()), so recompute the initial
+        // size again now that we have set it.
+        SetInitialSize(size);
     }
 
     if (style & wxTE_PASSWORD)


### PR DESCRIPTION
We need to explicitly call SetInitialSize() after setting the value of
the control (if it's not empty), as the first call, done from inside of
PostCreation(), doesn't take the initial control contents into account
and so doesn't allocate the height correctly for multiline text controls
containing more than 2 lines of text, for example.

---

Paul: this is a pretty trivial change, of course, and it does improve the behaviour, so I think it can be merged, but I just wonder if you see some better way of doing it, avoiding duplicate calls to `SetInitialSize()`. I don't think there is any, but I could be missing something...