### PR TITLE
Fix flickering when resizing MDI parent frame - see issue #18213

### DIFF
--- a/src/msw/mdi.cpp
+++ b/src/msw/mdi.cpp
@@ -198,7 +198,11 @@ bool wxMDIParentFrame::Create(wxWindow *parent,
   msflags &= ~WS_VSCROLL;
   msflags &= ~WS_HSCROLL;
 
-  if ( !wxWindow::MSWCreate(wxApp::GetRegisteredClassName(wxT("wxMDIFrame")),
+  if ( !wxWindow::MSWCreate(wxApp::GetRegisteredClassName(
+                                    wxT("wxMDIFrame"), -1, 0,
+                                    (style & wxFULL_REPAINT_ON_RESIZE) ? wxApp::RegClass_Default
+                                                                       : wxApp::RegClass_ReturnNR
+                                   ),
                             title.t_str(),
                             pos, size,
                             msflags,
@@ -842,10 +846,11 @@ bool wxMDIChildFrame::Create(wxMDIParentFrame *parent,
 
   MDICREATESTRUCT mcs;
 
-  wxString className =
-      wxApp::GetRegisteredClassName(wxT("wxMDIChildFrame"), COLOR_WINDOW);
-  if ( !(style & wxFULL_REPAINT_ON_RESIZE) )
-      className += wxApp::GetNoRedrawClassSuffix();
+  wxString className = wxApp::GetRegisteredClassName(
+                               wxT("wxMDIChildFrame"), COLOR_WINDOW, 0,
+                               (style & wxFULL_REPAINT_ON_RESIZE) ? wxApp::RegClass_Default
+                                                                  : wxApp::RegClass_ReturnNR
+                              );
 
   mcs.szClass = className.t_str();
   mcs.szTitle = title.t_str();


### PR DESCRIPTION
The `wxMDIParentFrame::Create()` function simply called `wxApp::GetRegisteredClassName(wxT("wxMDIFrame"))` without providing apropriate `flags` parameter depending on the presence/absence of the `wxFULL_REPAINT_ON_RESIZE` flag in `style`. Thus, the MDI parent frame was always created using the window class with the `CS_HREDRAW | CS_VREDRAW` style flags set. Choosing the appropriate value for the `flags` parameter of the `wxApp::GetRegisteredClassName()` function (like in the `wxWindowMSW::GetMSWClassName()` function) fixes the flicker issue. The `wxApp::GetRegisteredClassName()` call in `wxMDIChildFrame::Create()` is adapted as well just for the sake of consistency.