### PR TITLE
Hitting a use after free on Windows with an app that has AUI

### DIFF
--- a/src/msw/toplevel.cpp
+++ b/src/msw/toplevel.cpp
@@ -1309,6 +1309,13 @@ void wxTopLevelWindowMSW::DoRestoreLastFocus()
 
 void wxTopLevelWindowMSW::OnActivate(wxActivateEvent& event)
 {
+    if ( IsBeingDeleted() )
+    {
+        // Ignore activations when being deleted #18790
+        event.Skip();
+        return;
+    }
+
     if ( event.GetActive() )
     {
         // We get WM_ACTIVATE before being restored from iconized state, so we


### PR DESCRIPTION
This is on the cases where destroying a frame causes the children to be destroyed, and if one the children frames attempts to reactivate the parent, we could be in a partially deleted state.  If we're trying to delete then we should just avoid Activation.