### PR TITLE
Fix configure arguments for builtin libtiff

### DIFF
--- a/configure
+++ b/configure
@@ -1028,7 +1028,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -1455,7 +1454,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1708,15 +1706,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1854,7 +1843,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -2007,7 +1996,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -21854,13 +21842,6 @@ fi
     fi
 fi
 
-if test "$wxUSE_LIBTIFF" = "builtin"; then
-    ac_configure_args="$ac_configure_args --disable-webp --disable-zstd"
-    if test "$wxUSE_LIBLZMA" = "no"; then
-        ac_configure_args="$ac_configure_args --disable-lzma"
-    fi
-fi
-
 
 JBIG_LINK=
 if test "$wxUSE_LIBJBIG" = "yes"; then
@@ -22135,6 +22116,10 @@ $as_echo "$as_me: WARNING: system tiff library not found, will use built-in inst
         fi
     fi
     if test "$wxUSE_LIBTIFF" = "builtin" ; then
+                                        ac_configure_args="$ac_configure_args --disable-webp --disable-zstd"
+        if test "$wxUSE_LIBLZMA" = "no"; then
+            ac_configure_args="$ac_configure_args --disable-lzma"
+        fi
         if test "$wxUSE_LIBJPEG" = "no"; then
                                                                                     ac_configure_args="$ac_configure_args --disable-jpeg"
         fi

--- a/configure
+++ b/configure
@@ -21885,8 +21885,6 @@ if test "x$ac_cv_lib_jbig_jbg_dec_init" = xyes; then :
   JBIG_LINK=" -ljbig"
 fi
 
-else
-    ac_configure_args="$ac_configure_args --disable-jbig"
 fi
 
 
@@ -22123,6 +22121,7 @@ $as_echo "$as_me: WARNING: system tiff library not found, will use built-in inst
         if test "$wxUSE_LIBJPEG" = "no"; then
                                                                                     ac_configure_args="$ac_configure_args --disable-jpeg"
         fi
+                        ac_configure_args="$ac_configure_args --disable-jbig"
 
 
 subdirs="$subdirs src/tiff"

--- a/configure.in
+++ b/configure.in
@@ -2629,8 +2629,6 @@ dnl ------------------------------------------------------------------------
 JBIG_LINK=
 if test "$wxUSE_LIBJBIG" = "yes"; then
     AC_CHECK_LIB(jbig, jbg_dec_init, JBIG_LINK=" -ljbig")
-else
-    ac_configure_args="$ac_configure_args --disable-jbig"
 fi
 
 dnl ------------------------------------------------------------------------
@@ -2710,6 +2708,9 @@ if test "$wxUSE_LIBTIFF" != "no" ; then
             dnl we need to hack around this
             ac_configure_args="$ac_configure_args --disable-jpeg"
         fi
+        dnl We don't provide a built-in version of the libjbig library, so
+        dnl disable it for the builtin libtiff.
+        ac_configure_args="$ac_configure_args --disable-jbig"
         AC_CONFIG_SUBDIRS([src/tiff])
     fi
 fi

--- a/configure.in
+++ b/configure.in
@@ -2622,17 +2622,6 @@ if test "$wxUSE_LIBLZMA" != "no"; then
     fi
 fi
 
-dnl Disable the use of lzma, webp and zstd in built-in libtiff explicitly, as
-dnl otherwise we'd depend on the system libraries, which is typically
-dnl undesirable when using builtin libraries. If we use lzma ourselves, keep it
-dnl enabled.
-if test "$wxUSE_LIBTIFF" = "builtin"; then
-    ac_configure_args="$ac_configure_args --disable-webp --disable-zstd"
-    if test "$wxUSE_LIBLZMA" = "no"; then
-        ac_configure_args="$ac_configure_args --disable-lzma"
-    fi
-fi
-
 dnl ------------------------------------------------------------------------
 dnl Check for jbig library
 dnl ------------------------------------------------------------------------
@@ -2704,6 +2693,14 @@ if test "$wxUSE_LIBTIFF" != "no" ; then
         fi
     fi
     if test "$wxUSE_LIBTIFF" = "builtin" ; then
+        dnl Disable the use of lzma, webp and zstd in built-in libtiff explicitly, as
+        dnl otherwise we'd depend on the system libraries, which is typically
+        dnl undesirable when using builtin libraries. If we use lzma ourselves, keep it
+        dnl enabled.
+        ac_configure_args="$ac_configure_args --disable-webp --disable-zstd"
+        if test "$wxUSE_LIBLZMA" = "no"; then
+            ac_configure_args="$ac_configure_args --disable-lzma"
+        fi
         if test "$wxUSE_LIBJPEG" = "no"; then
             dnl we have to prevent the builtin libtiff configure from building the
             dnl library with JPEG support as this was explicitly disabled by user,


### PR DESCRIPTION
We need to ensure the configure arguments to disable features are passed in immediately before calling, because the builtin is the fallback if the system library is not found. In the previous location, these disable arguments were not being set for the library when it was used after failing to find the system libtiff library. This led to linker errors later on for the ZSTD symbols.

I am not sure what the changes to `runstatedir` are, but they were made when I ran `./autogen.sh` on my machine (I have autotools version 2.69).

Fixes [#18791](https://trac.wxwidgets.org/ticket/18791)