### PR TITLE
Allow expanding an arbitrary column on OSX and not just the last one

### DIFF
--- a/include/wx/osx/cocoa/dataview.h
+++ b/include/wx/osx/cocoa/dataview.h
@@ -547,7 +547,7 @@ public:
     // Cocoa-specific helpers
     id GetItemAtRow(int row) const;
 
-    wxCocoaOutlineView *GetNativeControl() { return m_OutlineView; }
+    void SizeToFit() { [m_OutlineView sizeToFit]; }
 
     virtual void SetFont(const wxFont& font, const wxColour& foreground, long windowStyle, bool ignoreBlack = true);
 

--- a/include/wx/osx/cocoa/dataview.h
+++ b/include/wx/osx/cocoa/dataview.h
@@ -547,6 +547,8 @@ public:
     // Cocoa-specific helpers
     id GetItemAtRow(int row) const;
 
+    wxCocoaOutlineView *GetNativeControl() { return m_OutlineView; }
+
     virtual void SetFont(const wxFont& font, const wxColour& foreground, long windowStyle, bool ignoreBlack = true);
 
 private:

--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -989,7 +989,8 @@ wxDataViewCustomRendererBase::WXCallRender(wxRect rectCell, wxDC *dc, int state)
     const int align = GetEffectiveAlignment();
 
     const wxSize size = GetSize();
-
+    rectItem.width = size.GetWidth();
+    rectItem.height = size.GetHeight();
     // take alignment into account only if there is enough space, otherwise
     // show as much contents as possible
     //

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -384,7 +384,7 @@ NSTableColumn* CreateNativeColumn(const wxDataViewColumn *column)
     {
         wxCocoaDataViewControl *peer = static_cast<wxCocoaDataViewControl *>( column->GetOwner()->GetPeer() );
         if( peer )
-            [peer->GetNativeControl() sizeToFit];
+            peer->SizeToFit();
     }
 
     // setting the visibility:
@@ -3748,7 +3748,7 @@ void wxDataViewColumn::SetResizeable(bool resizable)
         return;
     wxCocoaDataViewControl *peer = static_cast<wxCocoaDataViewControl *>( GetOwner()->GetPeer() );
     if( peer )
-        [peer->GetNativeControl() sizeToFit];
+        peer->SizeToFit();
 }
 
 void wxDataViewColumn::UnsetAsSortKey()

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -3823,11 +3823,13 @@ void wxDataViewColumn::SetWidth(int width)
                 break;
 
         case wxCOL_WIDTH_DEFAULT:
-            width = wxDVC_DEFAULT_WIDTH;
-            wxFALLTHROUGH;
+            [m_NativeDataPtr->GetNativeColumnPtr() setWidth:wxDVC_DEFAULT_WIDTH];
+            break;
 
         default:
             [m_NativeDataPtr->GetNativeColumnPtr() setWidth:width];
+            [m_NativeDataPtr->GetNativeColumnPtr() setMinWidth:width];
+            [m_NativeDataPtr->GetNativeColumnPtr() setMaxWidth:width];
             break;
     }
 }

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2075,6 +2075,9 @@ void wxCocoaDataViewControl::InitOutlineView(long style)
 
     [m_OutlineView setImplementation:this];
     [m_OutlineView setFocusRingType:NSFocusRingTypeNone];
+    // According to the Apple docs in order to resize from the left to right columns
+    // we should be using NSTableViewReverseSequentialColumnAutoresizingStyle
+    // not sure if the RTL languages will need to use another option?
     [m_OutlineView setColumnAutoresizingStyle:NSTableViewReverseSequentialColumnAutoresizingStyle];
     [m_OutlineView setIndentationPerLevel:GetDataViewCtrl()->GetIndent()];
     NSUInteger maskGridStyle(NSTableViewGridNone);

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -3808,20 +3808,19 @@ void wxDataViewColumn::SetTitle(const wxString& title)
 
 void wxDataViewColumn::SetWidth(int width)
 {
-     m_width = width;
+    m_width = width;
 
     if ( !GetOwner() )
     {
         // can't set the real width yet
         return;
     }
-    wxCocoaDataViewControl *peer = static_cast<wxCocoaDataViewControl *>( GetOwner()->GetPeer() );
     switch ( width )
     {
         case wxCOL_WIDTH_AUTOSIZE:
-            {
+                // This will now be handled by the native control.
+                // So we don't need to do anything special here.
                 break;
-            }
 
         case wxCOL_WIDTH_DEFAULT:
             width = wxDVC_DEFAULT_WIDTH;

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2286,7 +2286,7 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos)
     }
 
     [column setWidth:calculator.GetMaxWidth()];
-    column.resizingMask = NSTableColumnAutoresizingMask;
+    [column setResizingMask:NSTableColumnAutoresizingMask];
     [m_OutlineView sizeToFit];
 }
 

--- a/tests/controls/dataviewctrltest.cpp
+++ b/tests/controls/dataviewctrltest.cpp
@@ -91,6 +91,28 @@ protected:
     wxDECLARE_NO_COPY_CLASS(MultiColumnsDataViewCtrlTestCase);
 };
 
+class AutosizeWithConstantWidthTestCase
+{
+public:
+    AutosizeWithConstantWidthTestCase();
+    ~AutosizeWithConstantWidthTestCase();
+
+protected:
+    // the dataview control itself
+    wxDataViewListCtrl *m_dvc;
+
+    // constants
+    const wxSize m_size;
+    const int m_firstColumnWidth;
+
+    // and the columns
+    wxDataViewColumn* m_firstColumn;
+    wxDataViewColumn* m_secondColumn;
+    wxDataViewColumn* m_lastColumn;
+
+    wxDECLARE_NO_COPY_CLASS(AutosizeWithConstantWidthTestCase);
+};
+
 // ----------------------------------------------------------------------------
 // test initialization
 // ----------------------------------------------------------------------------
@@ -138,6 +160,31 @@ MultiColumnsDataViewCtrlTestCase::MultiColumnsDataViewCtrlTestCase()
 }
 
 MultiColumnsDataViewCtrlTestCase::~MultiColumnsDataViewCtrlTestCase()
+{
+    delete m_dvc;
+}
+
+AutosizeWithConstantWidthTestCase::AutosizeWithConstantWidthTestCase()
+              : m_size(300, 100),
+              m_firstColumnWidth(50)
+{
+    m_dvc = new wxDataViewListCtrl(wxTheApp->GetTopWindow(), wxID_ANY);
+
+    m_firstColumn =
+    m_dvc->AppendTextColumn(wxString(), wxDATAVIEW_CELL_INERT, wxCOL_WIDTH_AUTOSIZE);
+    m_secondColumn =
+    m_dvc->AppendTextColumn(wxString(), wxDATAVIEW_CELL_INERT, m_firstColumnWidth);
+    m_lastColumn =
+    m_dvc->AppendTextColumn(wxString(), wxDATAVIEW_CELL_INERT);
+
+    // Set size after columns appending to extend size of the last column.
+    m_dvc->SetSize(m_size);
+    m_dvc->Layout();
+    m_dvc->Refresh();
+    m_dvc->Update();
+}
+
+AutosizeWithConstantWidthTestCase::~AutosizeWithConstantWidthTestCase()
 {
     delete m_dvc;
 }
@@ -352,6 +399,14 @@ TEST_CASE_METHOD(MultiColumnsDataViewCtrlTestCase,
     const int lastColumnMinWidth = lastColumnMaxWidth - 10;
     CHECK( m_lastColumn->GetWidth() <= lastColumnMaxWidth );
     CHECK( m_lastColumn->GetWidth() >= lastColumnMinWidth );
+}
+
+TEST_CASE_METHOD(AutosizeWithConstantWidthTestCase,
+"wxDVC::AppendAutosizedTextColumn",
+"[wxDataViewCtrl][column]")
+{
+    // Check the width of the first column.
+    CHECK( m_secondColumn->GetWidth() == m_firstColumnWidth );
 }
 
 #endif //wxUSE_DATAVIEWCTRL

--- a/tests/controls/dataviewctrltest.cpp
+++ b/tests/controls/dataviewctrltest.cpp
@@ -405,6 +405,19 @@ TEST_CASE_METHOD(AutosizeWithConstantWidthTestCase,
 "wxDVC::AppendAutosizedTextColumn",
 "[wxDataViewCtrl][column]")
 {
+#ifdef __WXGTK__
+    // Wait for the list control to be realized.
+    wxStopWatch sw;
+    while ( m_firstColumn->GetWidth() == 0 )
+    {
+        if ( sw.Time() > 500 )
+        {
+            WARN("Timed out waiting for wxDataViewListCtrl to be realized");
+            break;
+        }
+        wxYield();
+    }
+#endif
     // Check the width of the first column.
     CHECK( m_secondColumn->GetWidth() == m_firstColumnWidth );
 }


### PR DESCRIPTION
Hi, Vadim, Stefan,
This PR implements the behavior I requested in https://groups.google.com/forum/?fromgroups#!topic/wx-dev/9xunUIrDyKY.

As explained there, it already worked in both MSW and GTK{3} and now when this applied OSX will follow.

The changes were tested on wxWidgets 3.1.3 initially with OSX 10.8.

Please review and apply.

Thank you.

P.S.: Not sure if the documentation needs updating..
