### PR TITLE
Fix typo in settings.h and wxListCtrl Class Reference

### DIFF
--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -906,7 +906,7 @@ public:
     long InsertItem(wxListItem& info);
 
     /**
-        Insert an string item.
+        Insert a string item.
 
         @param index
             Index of the new item, supplied by the application
@@ -1972,4 +1972,3 @@ public:
     */
     void SetWidth(int width);
 };
-

--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -1972,3 +1972,4 @@ public:
     */
     void SetWidth(int width);
 };
+

--- a/interface/wx/settings.h
+++ b/interface/wx/settings.h
@@ -78,14 +78,14 @@ enum wxSystemColour
     wxSYS_COLOUR_HOTLIGHT,            //!< Colour for a hyperlink or hot-tracked item.
 
     /**
-        Right side colour in the color gradient of an active window's title bar.
-        @c wxSYS_COLOUR_ACTIVECAPTION specifies the left side color.
+        Right side colour in the colour gradient of an active window's title
+        bar. @c wxSYS_COLOUR_ACTIVECAPTION specifies the left side colour.
     */
     wxSYS_COLOUR_GRADIENTACTIVECAPTION,
 
     /**
-        Right side colour in the color gradient of an inactive window's title bar.
-        @c wxSYS_COLOUR_INACTIVECAPTION specifies the left side color.
+        Right side colour in the colour gradient of an inactive window's title
+        bar. @c wxSYS_COLOUR_INACTIVECAPTION specifies the left side colour.
     */
     wxSYS_COLOUR_GRADIENTINACTIVECAPTION,
 
@@ -97,7 +97,7 @@ enum wxSystemColour
 
     /**
         The background colour for the menu bar when menus appear as flat menus.
-        However, @c wxSYS_COLOUR_MENU continues to specify the background color of the menu popup.
+        However, @c wxSYS_COLOUR_MENU continues to specify the background colour of the menu popup.
     */
     wxSYS_COLOUR_MENUBAR,
 
@@ -389,4 +389,3 @@ public:
     */
     static bool HasFeature(wxSystemFeature index);
 };
-

--- a/interface/wx/settings.h
+++ b/interface/wx/settings.h
@@ -389,3 +389,4 @@ public:
     */
     static bool HasFeature(wxSystemFeature index);
 };
+


### PR DESCRIPTION
An insignificant correction of typos in settings.h and listctrl.h.
Changes:
- an to a
- color to colour
