### PR TITLE
Fix wrong font size in wxSTC popup with DirectWrite

### DIFF
--- a/src/stc/PlatWX.h
+++ b/src/stc/PlatWX.h
@@ -22,6 +22,7 @@ class ListBoxImpl : public ListBox {
 private:
     wxSTCListBox*           m_listBox;
     wxSTCListBoxVisualData* m_visualData;
+    int                     m_technology;
 
 public:
     ListBoxImpl();

--- a/src/stc/ScintillaWX.cpp
+++ b/src/stc/ScintillaWX.cpp
@@ -1510,13 +1510,8 @@ void ScintillaWX::ImeStartComposition() {
             int sizeZoomed = vs.styles[styleHere].size + vs.zoomLevel * SC_FONT_SIZE_MULTIPLIER;
             if (sizeZoomed <= 2 * SC_FONT_SIZE_MULTIPLIER)	// Hangs if sizeZoomed <= 1
                 sizeZoomed = 2 * SC_FONT_SIZE_MULTIPLIER;
-            AutoSurface surface(this);
-            int deviceHeight = sizeZoomed;
-            if (surface) {
-                deviceHeight = (sizeZoomed * surface->LogPixelsY()) / 72;
-            }
             // The negative is to allow for leading
-            lf.lfHeight = -(std::abs(deviceHeight / SC_FONT_SIZE_MULTIPLIER));
+            lf.lfHeight = -::MulDiv(sizeZoomed, stc->GetDPI().y, 72 * SC_FONT_SIZE_MULTIPLIER);
             lf.lfWeight = vs.styles[styleHere].weight;
             lf.lfItalic = static_cast<BYTE>(vs.styles[styleHere].italic ? 1 : 0);
             lf.lfCharSet = DEFAULT_CHARSET;


### PR DESCRIPTION
`DeviceHeightFont` returned the wrong value, resulting in a wrong internal font point size (x2 on 200% scaling). This was not visible in the default text area, because D2D/DirectWrite did not scale the font to its DPI. But the popup (`wxListBox`) adjusted the font again to the DPI, resulting in a wrong font size.
~Fix this by returning the expected `DeviceHeightFont`, and adjust the font to the DPI in `CreateTextFormat` (same as in `wxD2DFontData`).
A disadvantage is that this requires modifying the Scintilla sources, so the DPI can be passed to the font creation function.~
Fix this by determining the correct font size.

Fix the DPI in wxSTC IME window. This same modification was made to the Scintilla/SciTE source.

