### PR TITLE
OSX: Round frame sizes up, not down

### DIFF
--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -3448,8 +3448,8 @@ void wxWidgetCocoaImpl::GetBestRect( wxRect *r ) const
         [m_osxView sizeToFit];
         NSRect best = [m_osxView frame];
         [m_osxView setFrame:former];
-        r->width = (int)best.size.width;
-        r->height = (int)best.size.height;
+        r->width = (int)ceil(best.size.width);
+        r->height = (int)ceil(best.size.height);
     }
 }
 


### PR DESCRIPTION
On Retina display macs, those values can contain halves.  If you round them down, you end up cutting off content (e.g. cutting off the last letter in a text label)