### PR TITLE
Fix size and postion of STC popups with DirectWrite

### DIFF
--- a/src/stc/PlatWX.cpp
+++ b/src/stc/PlatWX.cpp
@@ -3175,8 +3175,8 @@ public:
         wxString ellipsizedLabel = label;
 
         wxCharBuffer buffer = wx2stc(ellipsizedLabel);
-        int curWidth = surface.WidthText(tempFont, buffer.data(),
-                                         wx2stclen(wxString(), buffer));
+        int ellipsizedLen = wx2stclen(ellipsizedLabel, buffer);
+        int curWidth = surface.WidthText(tempFont, buffer.data(),ellipsizedLen);
 
         for ( int i = label.length(); curWidth > rect.GetWidth() && i; --i )
         {
@@ -3184,8 +3184,8 @@ public:
             ellipsizedLabel << "...";
 
             buffer = wx2stc(ellipsizedLabel);
-            curWidth = surface.WidthText(tempFont, buffer.data(),
-                                          wx2stclen(wxString(), buffer));
+            ellipsizedLen = wx2stclen(ellipsizedLabel, buffer);
+            curWidth = surface.WidthText(tempFont, buffer.data(),ellipsizedLen);
         }
 
         PRectangle prect = PRectangleFromwxRect(rect);
@@ -3194,7 +3194,7 @@ public:
         XYPOSITION ybase = rect.GetTop() + m_surfaceFontData->GetAscent();
 
         surface.DrawTextTransparent(prect, tempFont, ybase, buffer.data(),
-                                    wx2stclen(wxString(), buffer), fore);
+                                    ellipsizedLen, fore);
         tempFont.Release();
         surface.Release();
     }

--- a/src/stc/PlatWX.cpp
+++ b/src/stc/PlatWX.cpp
@@ -2384,7 +2384,7 @@ private:
 };
 
 wxSTCListBoxVisualData::wxSTCListBoxVisualData(int d):m_desiredVisibleRows(d),
-                        m_imgAreaSize(0,0), m_useDefaultBgColour(true),
+                        m_useDefaultBgColour(true),
                         m_useDefaultTextColour(true),
                         m_useDefaultHighlightBgColour(true),
                         m_useDefaultHighlightTextColour(true),
@@ -3178,24 +3178,14 @@ public:
         int curWidth = surface.WidthText(tempFont, buffer.data(),
                                          wx2stclen(wxString(), buffer));
 
-        if ( curWidth > rect.GetWidth() )
+        for ( int i = label.length(); curWidth > rect.GetWidth() && i; --i )
         {
-            int len = label.Length();
+            ellipsizedLabel = label.Left(i);
+            ellipsizedLabel << "...";
 
-            for ( int i = len; i >= 0; --i )
-            {
-                ellipsizedLabel = label.Left(i);
-                ellipsizedLabel << "...";
-
-                buffer = wx2stc(ellipsizedLabel);
-                curWidth = surface.WidthText(tempFont, buffer.data(),
-                                              wx2stclen(wxString(), buffer));
-
-                if ( curWidth <= rect.GetWidth() )
-                {
-                    break;
-                }
-            }
+            buffer = wx2stc(ellipsizedLabel);
+            curWidth = surface.WidthText(tempFont, buffer.data(),
+                                          wx2stclen(wxString(), buffer));
         }
 
         PRectangle prect = PRectangleFromwxRect(rect);

--- a/src/stc/PlatWX.cpp
+++ b/src/stc/PlatWX.cpp
@@ -3223,15 +3223,17 @@ wxSTCListBoxWin::wxSTCListBoxWin(wxWindow* parent, wxSTCListBox** lb,
                                  wxSTCListBoxVisualData* v, int h, int tech)
                 :wxSTCPopupWindow(parent)
 {
+    switch ( tech )
+    {
 #ifdef HAVE_DIRECTWRITE_TECHNOLOGY
-    if ( tech == wxSTC_TECHNOLOGY_DIRECTWRITE )
-    {
-        *lb = new wxSTCListBoxD2D(this, v, h);
-    }
-    else
+        case wxSTC_TECHNOLOGY_DIRECTWRITE:
+            *lb = new wxSTCListBoxD2D(this, v, h);
+            break;
 #endif
-    {
-        *lb = new wxSTCListBox(this, v, h);
+        case wxSTC_TECHNOLOGY_DEFAULT:
+            wxFALLTHROUGH;
+        default:
+            *lb = new wxSTCListBox(this, v, h);
     }
 
     // Use the background of this window to form a frame around the listbox

--- a/src/stc/PlatWX.cpp
+++ b/src/stc/PlatWX.cpp
@@ -3181,7 +3181,12 @@ public:
         for ( int i = label.length(); curWidth > rect.GetWidth() && i; --i )
         {
             ellipsizedLabel = label.Left(i);
-            ellipsizedLabel << "...";
+            #if wxUSE_UNICODE
+                // Add the "Horizontal Ellipsis" character (U+2026).
+                ellipsizedLabel << wxUniChar(0x2026);
+            #else
+                ellipsizedLabel << "...";
+            #endif
 
             buffer = wx2stc(ellipsizedLabel);
             ellipsizedLen = wx2stclen(ellipsizedLabel, buffer);

--- a/src/stc/ScintillaWX.cpp
+++ b/src/stc/ScintillaWX.cpp
@@ -1510,13 +1510,8 @@ void ScintillaWX::ImeStartComposition() {
             int sizeZoomed = vs.styles[styleHere].size + vs.zoomLevel * SC_FONT_SIZE_MULTIPLIER;
             if (sizeZoomed <= 2 * SC_FONT_SIZE_MULTIPLIER)	// Hangs if sizeZoomed <= 1
                 sizeZoomed = 2 * SC_FONT_SIZE_MULTIPLIER;
-            AutoSurface surface(this);
-            int deviceHeight = sizeZoomed;
-            if (surface) {
-                deviceHeight = (sizeZoomed * surface->LogPixelsY()) / 72;
-            }
             // The negative is to allow for leading
-            lf.lfHeight = -(std::abs(deviceHeight / SC_FONT_SIZE_MULTIPLIER));
+            lf.lfHeight = -::MulDiv(sizeZoomed, stc->GetDPI().y, 72 * SC_FONT_SIZE_MULTIPLIER);
             lf.lfWeight = vs.styles[styleHere].weight;
             lf.lfItalic = static_cast<BYTE>(vs.styles[styleHere].italic ? 1 : 0);
             lf.lfCharSet = DEFAULT_CHARSET;


### PR DESCRIPTION
As discussed in PR #1904, this is a 2 fixes for the size and position of the STC popup.  I also tried to pull cccea8f from that PR.

First, the popup was positioned incorrectly when images were used.  The text in the popup is supposed to be immediately below the text in the editor, but instead the images are below the text:

![incorrectwithimages](https://user-images.githubusercontent.com/10080894/85631319-ebe17080-b63a-11ea-8b84-228cbf368eec.png)

This was due to me not realizing that Scintilla positions the popup before adding the items to it.  To fix the issue, the images are tracked as they are registered for use with the popup, and the information is used to help Scintilla position the popup.

-----

Second, when D2D was used to do the drawing, the font in the popup could be too large:

![incorrectd2d](https://user-images.githubusercontent.com/10080894/85631503-45e23600-b63b-11ea-9897-599d8df4d030.png)

The effect was comically bad when the screen scaling was set higher than 100%.  At 200% it looks like this:

![incorrectd2d200](https://user-images.githubusercontent.com/10080894/85631586-6f02c680-b63b-11ea-87a2-5b692bc39e88.png)

This was due a confusion because font sizes with D2D are specified in DIPs instead of points.  To fix the issue, I used the same functions for drawing the popup that are used for drawing the editor instead of wxDC functions. 