### PR TITLE
Remove obsolete code using sleep() in wxMicroSleep() for BeOS

### DIFF
--- a/configure
+++ b/configure
@@ -30411,20 +30411,10 @@ done
 
 fi
 
-HAVE_SOME_SLEEP_FUNC=0
-if test "$USE_BEOS" = 1; then
-            $as_echo "#define HAVE_SLEEP 1" >>confdefs.h
-
-    HAVE_SOME_SLEEP_FUNC=1
-fi
-
 if test "$USE_DARWIN" = 1; then
             $as_echo "#define HAVE_USLEEP 1" >>confdefs.h
 
-    HAVE_SOME_SLEEP_FUNC=1
-fi
-
-if test "$HAVE_SOME_SLEEP_FUNC" != 1; then
+else
         POSIX4_LINK=
     for ac_func in nanosleep
 do :
@@ -30533,8 +30523,7 @@ _ACEOF
 
     else
       :
-      { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: wxSleep() function will not work" >&5
-$as_echo "$as_me: WARNING: wxSleep() function will not work" >&2;}
+      as_fn_error $? "wxMicroSleep() can't be implemented" "$LINENO" 5
 
     fi
   done

--- a/configure.in
+++ b/configure.in
@@ -4516,22 +4516,11 @@ if test "$ac_cv_func_setenv" = "yes"; then
     AC_CHECK_FUNCS(unsetenv)
 fi
 
-HAVE_SOME_SLEEP_FUNC=0
-if test "$USE_BEOS" = 1; then
-    dnl BeOS has its own (wonder where did they get it from) sleep() function
-    dnl in unistd.h
-    AC_DEFINE(HAVE_SLEEP)
-    HAVE_SOME_SLEEP_FUNC=1
-fi
-
 if test "$USE_DARWIN" = 1; then
     dnl Mac OS X/Darwin has both nanosleep and usleep
     dnl but only usleep is defined in unistd.h
     AC_DEFINE(HAVE_USLEEP)
-    HAVE_SOME_SLEEP_FUNC=1
-fi
-
-if test "$HAVE_SOME_SLEEP_FUNC" != 1; then
+else
     dnl try nanosleep() in libc and libposix4, if this fails - usleep()
     POSIX4_LINK=
     AC_CHECK_FUNCS(nanosleep,
@@ -4544,7 +4533,7 @@ if test "$HAVE_SOME_SLEEP_FUNC" != 1; then
                 ],
                 [
                     WX_CHECK_FUNCS(usleep,,
-                                    AC_MSG_WARN([wxSleep() function will not work])
+                                   AC_MSG_ERROR([wxMicroSleep() can't be implemented])
                     )
                 ]
             )

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -192,9 +192,6 @@ void wxMicroSleep(unsigned long microseconds)
     #endif // Sun
 
     usleep(microseconds);
-#elif defined(HAVE_SLEEP)
-    // under BeOS sleep() takes seconds (what about other platforms, if any?)
-    sleep(microseconds * 1000000);
 #else // !sleep function
     #error "usleep() or nanosleep() function required for wxMicroSleep"
 #endif // sleep function


### PR DESCRIPTION
This code never worked (as proved by the conversion in it which was
wrong by a factor of 1e12) and should never be needed anyhow.

Simplify configure and give an error, not warning, if neither
nanosleep() nor usleep() are available, as otherwise we'd just get a
build error later when compiling utilsunx.cpp later.