### PR TITLE
Spelling fixes

### DIFF
--- a/include/wx/affinematrix2dbase.h
+++ b/include/wx/affinematrix2dbase.h
@@ -44,7 +44,7 @@ public:
     // sets the matrix to the respective values
     virtual void Set(const wxMatrix2D& mat2D, const wxPoint2DDouble& tr) = 0;
 
-    // gets the component valuess of the matrix
+    // gets the component values of the matrix
     virtual void Get(wxMatrix2D* mat2D, wxPoint2DDouble* tr) const = 0;
 
     // concatenates the matrix

--- a/include/wx/aui/dockart.h
+++ b/include/wx/aui/dockart.h
@@ -26,7 +26,7 @@
 
 // dock art provider code - a dock provider provides all drawing
 // functionality to the wxAui dock manager.  This allows the dock
-// manager to have plugable look-and-feels
+// manager to have pluggable look-and-feels
 
 class WXDLLIMPEXP_AUI wxAuiDockArt
 {

--- a/include/wx/clrpicker.h
+++ b/include/wx/clrpicker.h
@@ -74,7 +74,7 @@ protected:
 // under the name "wxColourPickerWidget".
 // NOTE: wxColourPickerCtrl allocates a wxColourPickerWidget and relies on the
 //       fact that all classes being mapped as wxColourPickerWidget have the
-//       same prototype for their contructor (and also explains why we use
+//       same prototype for their constructor (and also explains why we use
 //       define instead of a typedef)
 // since GTK > 2.4, there is GtkColorButton
 #if defined(__WXGTK20__) && !defined(__WXUNIVERSAL__)

--- a/include/wx/datetime.h
+++ b/include/wx/datetime.h
@@ -723,7 +723,7 @@ public:
         // get the broken down date/time representation in the given timezone
         //
         // If you wish to get several time components (day, month and year),
-        // consider getting the whole Tm strcuture first and retrieving the
+        // consider getting the whole Tm structure first and retrieving the
         // value from it - this is much more efficient
     Tm GetTm(const TimeZone& tz = Local) const;
 
@@ -861,7 +861,7 @@ public:
         return m_time != dt.m_time;
     }
 
-    // arithmetics with dates (see also below for more operators)
+    // arithmetic with dates (see also below for more operators)
     // ------------------------------------------------------------------------
 
         // return the sum of the date with a time span (positive or negative)
@@ -1207,7 +1207,7 @@ public:
 
         // no dtor
 
-    // arithmetics with time spans (see also below for more operators)
+    // arithmetic with time spans (see also below for more operators)
     // ------------------------------------------------------------------------
 
         // return the sum of two timespans
@@ -1448,7 +1448,7 @@ public:
         // returns 7*GetWeeks() + GetDays()
     int GetTotalDays() const { return 7*m_weeks + m_days; }
 
-    // arithmetics with date spans (see also below for more operators)
+    // arithmetic with date spans (see also below for more operators)
     // ------------------------------------------------------------------------
 
         // return sum of two date spans
@@ -1848,7 +1848,7 @@ inline bool wxDateTime::IsEqualUpTo(const wxDateTime& dt,
 }
 
 // ----------------------------------------------------------------------------
-// wxDateTime arithmetics
+// wxDateTime arithmetic
 // ----------------------------------------------------------------------------
 
 inline wxDateTime wxDateTime::Add(const wxTimeSpan& diff) const
@@ -1997,7 +1997,7 @@ inline int wxTimeSpan::GetWeeks() const
 }
 
 // ----------------------------------------------------------------------------
-// wxTimeSpan arithmetics
+// wxTimeSpan arithmetic
 // ----------------------------------------------------------------------------
 
 inline wxTimeSpan wxTimeSpan::Add(const wxTimeSpan& diff) const

--- a/include/wx/dc.h
+++ b/include/wx/dc.h
@@ -528,7 +528,7 @@ public:
 
     virtual void ComputeScaleAndOrigin();
 
-    // this needs to overidden if the axis is inverted
+    // this needs to overridden if the axis is inverted
     virtual void SetAxisOrientation(bool xLeftRight, bool yBottomUp);
 
     virtual double GetContentScaleFactor() const { return m_contentScaleFactor; }

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -98,7 +98,7 @@
      */
     #pragma warning(disable: 4127) /*  conditional expression is constant */
 
-    /* There are too many false positivies for this one, particularly when
+    /* There are too many false positives for this one, particularly when
        using templates like wxVector<T> */
     /* class 'foo' needs to have dll-interface to be used by clients of
        class 'bar'" */

--- a/include/wx/dialup.h
+++ b/include/wx/dialup.h
@@ -118,7 +118,7 @@ public:
     // set misc wxDialUpManager options
     // --------------------------------
 
-    // enable automatical checks for the connection status and sending of
+    // enable automatic checks for the connection status and sending of
     // wxEVT_DIALUP_CONNECTED/wxEVT_DIALUP_DISCONNECTED events. The interval
     // parameter is only for Unix where we do the check manually: under
     // Windows, the notification about the change of connection status is

--- a/include/wx/dnd.h
+++ b/include/wx/dnd.h
@@ -187,9 +187,9 @@ public:
     virtual bool GetData() = 0;
 
     // sets the default action for drag and drop:
-    // use wxDragMove or wxDragCopy to set deafult action to move or copy
+    // use wxDragMove or wxDragCopy to set default action to move or copy
     // and use wxDragNone (default) to set default action specified by
-    // initialization of draging (see wxDropSourceBase::DoDragDrop())
+    // initialization of dragging (see wxDropSourceBase::DoDragDrop())
     void SetDefaultAction(wxDragResult action)
         { m_defaultAction = action; }
 

--- a/include/wx/dynload.h
+++ b/include/wx/dynload.h
@@ -39,7 +39,7 @@ typedef wxDLManifest wxDLImports;
 //       wxDL is not virtual and we deliberately hide some of it's
 //       methods here.
 //
-//       Unless you know exacty why you need to, you probably shouldn't
+//       Unless you know exactly why you need to, you probably shouldn't
 //       instantiate this class directly anyway, use wxPluginManager
 //       instead.
 

--- a/include/wx/encconv.h
+++ b/include/wx/encconv.h
@@ -96,7 +96,7 @@ class WXDLLIMPEXP_BASE wxEncodingConverter : public wxObject
             bool Convert(wchar_t* str) const { return Convert(str, str); }
 
             // Return equivalent(s) for given font that are used
-            // under given platform. wxPLATFORM_CURRENT means the plaform
+            // under given platform. wxPLATFORM_CURRENT means the platform
             // this binary was compiled for
             //
             // Examples:

--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -2190,7 +2190,7 @@ public:
             *ypos = GetY();
     }
 
-    // This version if provided only for backwards compatiblity, don't use.
+    // This version if provided only for backwards compatibility, don't use.
     void GetPosition(long *xpos, long *ypos) const
     {
         if (xpos)

--- a/include/wx/eventfilter.h
+++ b/include/wx/eventfilter.h
@@ -59,7 +59,7 @@ public:
 
 private:
     // Objects of this class are made to be stored in a linked list in
-    // wxEvtHandler so put the next node ponter directly in the class itself.
+    // wxEvtHandler so put the next node pointer directly in the class itself.
     wxEventFilter* m_next;
 
     // And provide access to it for wxEvtHandler [only].

--- a/include/wx/fdrepdlg.h
+++ b/include/wx/fdrepdlg.h
@@ -26,7 +26,7 @@ class WXDLLIMPEXP_FWD_CORE wxFindReplaceDialogImpl;
 // Flags for wxFindReplaceData.Flags
 // ----------------------------------------------------------------------------
 
-// flages used by wxFindDialogEvent::GetFlags()
+// flags used by wxFindDialogEvent::GetFlags()
 enum wxFindReplaceFlags
 {
     // downward search/replace selected (otherwise - upwards)

--- a/include/wx/filename.h
+++ b/include/wx/filename.h
@@ -133,7 +133,7 @@ public:
     wxFileName(const wxFileName& filepath) { Assign(filepath); }
 
         // from a full filename: if it terminates with a '/', a directory path
-        // is contructed (the name will be empty), otherwise a file name and
+        // is constructed (the name will be empty), otherwise a file name and
         // extension are extracted from it
     wxFileName( const wxString& fullpath, wxPathFormat format = wxPATH_NATIVE )
         { Assign( fullpath, format ); m_dontFollowLinks = false; }

--- a/include/wx/filepicker.h
+++ b/include/wx/filepicker.h
@@ -126,7 +126,7 @@ protected:
 // under the name "wxFilePickerWidget" and "wxDirPickerWidget".
 // NOTE: wxFileDirPickerCtrlBase will allocate a wx{File|Dir}PickerWidget and this
 //       requires that all classes being mapped as wx{File|Dir}PickerWidget have the
-//       same prototype for the contructor...
+//       same prototype for the constructor...
 // since GTK >= 2.6, there is GtkFileButton
 #if defined(__WXGTK20__) && !defined(__WXUNIVERSAL__)
     #include "wx/gtk/filepicker.h"

--- a/include/wx/frame.h
+++ b/include/wx/frame.h
@@ -18,7 +18,7 @@
 #include "wx/toplevel.h"      // the base class
 #include "wx/statusbr.h"
 
-// the default names for various classs
+// the default names for various classes
 extern WXDLLIMPEXP_DATA_CORE(const char) wxStatusLineNameStr[];
 extern WXDLLIMPEXP_DATA_CORE(const char) wxToolBarNameStr[];
 

--- a/include/wx/gauge.h
+++ b/include/wx/gauge.h
@@ -24,7 +24,7 @@
 #define wxGA_HORIZONTAL      wxHORIZONTAL
 #define wxGA_VERTICAL        wxVERTICAL
 
-// Available since Windows 7 only. With this style, the value of guage will
+// Available since Windows 7 only. With this style, the value of gauge will
 // reflect on the taskbar button.
 #define wxGA_PROGRESS        0x0010
 // Win32 only, is default (and only) on some other platforms

--- a/include/wx/gdicmn.h
+++ b/include/wx/gdicmn.h
@@ -224,7 +224,7 @@ enum wxEllipsizeMode
 #endif // platform
 
 /* Another macro: this one is for portable creation of bitmaps. We assume that
-   under Unix bitmaps live in XPMs and under Windows they're in ressources.
+   under Unix bitmaps live in XPMs and under Windows they're in resources.
  */
 
 #if defined(__WINDOWS__) && wxUSE_WXDIB

--- a/include/wx/generic/dcpsg.h
+++ b/include/wx/generic/dcpsg.h
@@ -90,7 +90,7 @@ public:
 
     void PsPrint( const wxString& psdata );
 
-    // Overrridden for wxPrinterDC Impl
+    // Overridden for wxPrinterDC Impl
 
     virtual int GetResolution() const wxOVERRIDE;
     virtual wxRect GetPaperRect() const wxOVERRIDE;

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -302,7 +302,7 @@ public:
     // version only checks that the event has no modifiers. The derived
     // classes are supposed to do "if ( base::IsAcceptedKey() && ... )" in
     // their IsAcceptedKey() implementation, although, of course, it is not a
-    // mandatory requirment.
+    // mandatory requirement.
     //
     // NB: if the key is F2 (special), editing will always start and this
     //     method will not be called at all (but StartingKey() will)

--- a/include/wx/generic/grideditors.h
+++ b/include/wx/generic/grideditors.h
@@ -210,7 +210,7 @@ public:
         { return new wxGridCellFloatEditor(m_width, m_precision); }
 
     // parameters string format is "width[,precision[,format]]"
-    // format to choose beween f|e|g|E|G (f is used by default)
+    // format to choose between f|e|g|E|G (f is used by default)
     virtual void SetParameters(const wxString& params) wxOVERRIDE;
 
 protected:

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -140,7 +140,7 @@ private:
     int m_col;
 };
 
-// header control retreiving column information from the grid
+// header control retrieving column information from the grid
 class wxGridHeaderCtrl : public wxHeaderCtrl
 {
 public:

--- a/include/wx/generic/progdlgg.h
+++ b/include/wx/generic/progdlgg.h
@@ -120,7 +120,7 @@ protected:
     // called to disable the other windows while this dialog is shown
     void DisableOtherWindows();
 
-    // must be called to reenable the other windows temporarily disabled while
+    // must be called to re-enable the other windows temporarily disabled while
     // the dialog was shown
     void ReenableOtherWindows();
 

--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -104,7 +104,7 @@ class WXDLLIMPEXP_FWD_CORE wxGraphicsBitmap;
 /*
  * notes about the graphics context apis
  *
- * angles : are measured in radians, 0.0 being in direction of positiv x axis, PI/2 being
+ * angles : are measured in radians, 0.0 being in direction of positive x axis, PI/2 being
  * in direction of positive y axis.
  */
 
@@ -218,7 +218,7 @@ public:
     virtual void Set(wxDouble a=1.0, wxDouble b=0.0, wxDouble c=0.0, wxDouble d=1.0,
         wxDouble tx=0.0, wxDouble ty=0.0);
 
-    // gets the component valuess of the matrix
+    // gets the component values of the matrix
     virtual void Get(wxDouble* a=NULL, wxDouble* b=NULL,  wxDouble* c=NULL,
                      wxDouble* d=NULL, wxDouble* tx=NULL, wxDouble* ty=NULL) const;
 

--- a/include/wx/gtk/dcclient.h
+++ b/include/wx/gtk/dcclient.h
@@ -97,7 +97,7 @@ public:
     virtual wxSize GetPPI() const wxOVERRIDE;
     virtual int GetDepth() const wxOVERRIDE;
 
-    // overrriden here for RTL
+    // overridden here for RTL
     virtual void SetDeviceOrigin( wxCoord x, wxCoord y ) wxOVERRIDE;
     virtual void SetAxisOrientation( bool xLeftRight, bool yBottomUp ) wxOVERRIDE;
 

--- a/include/wx/gtk/toplevel.h
+++ b/include/wx/gtk/toplevel.h
@@ -124,7 +124,7 @@ public:
     };
     DecorSize m_decorSize;
 
-    // private gtk_timeout_add result for mimicing wxUSER_ATTENTION_INFO and
+    // private gtk_timeout_add result for mimicking wxUSER_ATTENTION_INFO and
     // wxUSER_ATTENTION_ERROR difference, -2 for no hint, -1 for ERROR hint, rest for GtkTimeout handle.
     int m_urgency_hint;
     // timer for detecting WM with broken _NET_REQUEST_FRAME_EXTENTS handling

--- a/include/wx/gtk1/dataobj2.h
+++ b/include/wx/gtk1/dataobj2.h
@@ -45,7 +45,7 @@ protected:
     void DoConvertToPng();
 
 private:
-    // virtual function hiding supression
+    // virtual function hiding suppression
     size_t GetDataSize(const wxDataFormat& format) const
         { return(wxDataObjectSimple::GetDataSize(format)); }
     bool GetDataHere(const wxDataFormat& format, void* pBuf) const
@@ -71,7 +71,7 @@ public:
     virtual bool SetData(size_t len, const void *buf);
 
 private:
-    // virtual function hiding supression
+    // virtual function hiding suppression
     size_t GetDataSize(const wxDataFormat& format) const
         { return(wxDataObjectSimple::GetDataSize(format)); }
     bool GetDataHere(const wxDataFormat& format, void* pBuf) const

--- a/include/wx/gtk1/toplevel.h
+++ b/include/wx/gtk1/toplevel.h
@@ -101,7 +101,7 @@ public:
     long          m_gdkFunc,
                   m_gdkDecor;
 
-    // private gtk_timeout_add result for mimicing wxUSER_ATTENTION_INFO and
+    // private gtk_timeout_add result for mimicking wxUSER_ATTENTION_INFO and
     // wxUSER_ATTENTION_ERROR difference, -2 for no hint, -1 for ERROR hint, rest for GtkTimeout handle.
     int m_urgency_hint;
 

--- a/include/wx/gtk1/treectrl.h
+++ b/include/wx/gtk1/treectrl.h
@@ -317,7 +317,7 @@ public:
 
         // sort the children of this item using the specified callback function
         // (it should return -1, 0 or +1 as usual), if it's not specified
-        // alphabetical comparaison is performed.
+        // alphabetical comparison is performed.
         //
         // NB: this function is not reentrant!
     void SortChildren(const wxTreeItemId& item,

--- a/include/wx/gtk1/window.h
+++ b/include/wx/gtk1/window.h
@@ -211,7 +211,7 @@ public:
     bool                 m_needsStyleChange:1;  // May not be able to change
                                                 // background style until OnIdle
 
-    // C++ has no virtual methods in the constrcutor of any class but we need
+    // C++ has no virtual methods in the constructor of any class but we need
     // different methods of inserting a child window into a wxFrame,
     // wxMDIFrame, wxNotebook etc. this is the callback that will get used.
     wxInsertChildFunction  m_insertCallback;

--- a/include/wx/hash.h
+++ b/include/wx/hash.h
@@ -119,7 +119,7 @@ private:
     void DoRemoveNode( wxHashTableBase_Node* node );
 
     // destroys data contained in the node if appropriate:
-    // deletes the key if it is a string and destrys
+    // deletes the key if it is a string and destroys
     // the value if m_deleteContents is true
     void DoDestroyNode( wxHashTableBase_Node* node );
 

--- a/include/wx/html/helpdata.h
+++ b/include/wx/html/helpdata.h
@@ -203,7 +203,7 @@ protected:
     wxHtmlBookRecArray m_bookRecords;
 
     wxHtmlHelpDataItems m_contents; // list of all available books and pages
-    wxHtmlHelpDataItems m_index; // list of index itesm
+    wxHtmlHelpDataItems m_index; // list of index items
 
 protected:
     // Imports .hhp files (MS HTML Help Workshop)

--- a/include/wx/html/htmlfilt.h
+++ b/include/wx/html/htmlfilt.h
@@ -45,7 +45,7 @@ public:
 //--------------------------------------------------------------------------------
 // wxHtmlFilterPlainText
 //                  This filter is used as default filter if no other can
-//                  be used (= uknown type of file). It is used by
+//                  be used (= unknown type of file). It is used by
 //                  wxHtmlWindow itself.
 //--------------------------------------------------------------------------------
 

--- a/include/wx/html/htmlpars.h
+++ b/include/wx/html/htmlpars.h
@@ -163,7 +163,7 @@ protected:
     // Adds tag and proceeds it. Parse() may (and usually is) called from this method.
     // This is called from Parse() and may be overridden.
     // Default behaviour is that it looks for proper handler in m_Handlers. The tag is
-    // ignored if no hander is found.
+    // ignored if no handler is found.
     // Derived class is *responsible* for filling in m_Handlers table.
     virtual void AddTag(const wxHtmlTag& tag);
 
@@ -236,7 +236,7 @@ public:
     //   is capable of handling italic, bold, font and paragraph tags
     virtual wxString GetSupportedTags() = 0;
 
-    // This is hadling core method. It does all the Steps 1-3.
+    // This is handling core method. It does all the Steps 1-3.
     // To process step 2, you can call ParseInner()
     // returned value : true if it called ParseInner(),
     //                  false etherwise
@@ -282,7 +282,7 @@ public:
     // (with respect to output encoding)
     wxString Parse(const wxString& input) const;
 
-    // Returns character for given entity or 0 if the enity is unknown
+    // Returns character for given entity or 0 if the entity is unknown
     wxChar GetEntityChar(const wxString& entity) const;
 
     // Returns character that represents given Unicode code

--- a/include/wx/html/htmlwin.h
+++ b/include/wx/html/htmlwin.h
@@ -260,7 +260,7 @@ public:
 
     // Set HTML page and display it. !! source is HTML document itself,
     // it is NOT address/filename of HTML document. If you want to
-    // specify document location, use LoadPage() istead
+    // specify document location, use LoadPage() instead
     // Return value : false if an error occurred, true otherwise
     virtual bool SetPage(const wxString& source);
 
@@ -503,8 +503,8 @@ protected:
     bool m_makingSelection;
 
 #if wxUSE_CLIPBOARD
-    // time of the last doubleclick event, used to detect tripleclicks
-    // (tripleclicks are used to select whole line):
+    // time of the last double-click event, used to detect triple clicks
+    // (triple clicks are used to select whole line):
     wxMilliClock_t m_lastDoubleClick;
 
     // helper class to automatically scroll the window if the user is selecting

--- a/include/wx/html/winpars.h
+++ b/include/wx/html/winpars.h
@@ -249,7 +249,7 @@ private:
 
 //-----------------------------------------------------------------------------
 // wxHtmlWinTagHandler
-//                  This is basicly wxHtmlTagHandler except
+//                  This is basically wxHtmlTagHandler except
 //                  it is extended with protected member m_Parser pointing to
 //                  the wxHtmlWinParser object
 //-----------------------------------------------------------------------------

--- a/include/wx/image.h
+++ b/include/wx/image.h
@@ -401,7 +401,7 @@ public:
     // (actually shades of grey) typically when you draw anti-
     // aliased text into a bitmap. The DC drawinf routines
     // draw grey values on the black background although they
-    // actually mean to draw white with differnt alpha values.
+    // actually mean to draw white with different alpha values.
     // This method reverses it, assuming a black (!) background
     // and white text (actually only the red channel is read).
     // The method will then fill up the whole image with the

--- a/include/wx/log.h
+++ b/include/wx/log.h
@@ -804,7 +804,7 @@ public:
     // change the new log target
     void SetLog(wxLog *logger);
 
-    // this can be used to temporarily disable (and then reenable) passing
+    // this can be used to temporarily disable (and then re-enable) passing
     // messages to the old logger (by default we do pass them)
     void PassMessages(bool bDoPass) { m_bPassMessages = bDoPass; }
 

--- a/include/wx/longlong.h
+++ b/include/wx/longlong.h
@@ -707,7 +707,7 @@ public:
     wxLongLongWx operator-() const;
     wxLongLongWx& Negate();
 
-        // subraction
+        // subtraction
     wxLongLongWx operator-(const wxLongLongWx& ll) const;
     wxLongLongWx& operator-=(const wxLongLongWx& ll);
 

--- a/include/wx/meta/movable.h
+++ b/include/wx/meta/movable.h
@@ -15,7 +15,7 @@
 
 // Helper to decide if an object of type T is "movable", i.e. if it can be
 // copied to another memory location using memmove() or realloc() C functions.
-// C++ only gurantees that POD types (including primitive types) are
+// C++ only guarantees that POD types (including primitive types) are
 // movable.
 template<typename T>
 struct wxIsMovable

--- a/include/wx/mimetype.h
+++ b/include/wx/mimetype.h
@@ -32,7 +32,7 @@ class WXDLLIMPEXP_FWD_BASE wxIconLocation;
 class WXDLLIMPEXP_FWD_BASE wxFileTypeImpl;
 class WXDLLIMPEXP_FWD_BASE wxMimeTypesManagerImpl;
 
-// these constants define the MIME informations source under UNIX and are used
+// these constants define the MIME information source under UNIX and are used
 // by wxMimeTypesManager::Initialize()
 enum wxMailcapStyle
 {

--- a/include/wx/motif/choice.h
+++ b/include/wx/motif/choice.h
@@ -102,7 +102,7 @@ public:
 protected:
     // minimum size for the text ctrl
     wxSize GetItemsSize() const;
-    // common part of all contructors
+    // common part of all constructors
     void Init();
 
     WXWidget      m_menuWidget;

--- a/include/wx/motif/window.h
+++ b/include/wx/motif/window.h
@@ -310,7 +310,7 @@ private:
 // undesired effects.
 //
 // Usage: create an instance of this class on the stack to disable the size
-// optimisation, it will be reenabled as soon as the object goes out
+// optimisation, it will be re-enabled as soon as the object goes out
 // from scope.
 // ----------------------------------------------------------------------------
 

--- a/include/wx/msw/clipbrd.h
+++ b/include/wx/msw/clipbrd.h
@@ -13,7 +13,7 @@
 
 #if wxUSE_CLIPBOARD
 
-// These functions superceded by wxClipboard, but retained in order to
+// These functions superseded by wxClipboard, but retained in order to
 // implement wxClipboard, and for compatibility.
 
 // open/close the clipboard

--- a/include/wx/msw/dib.h
+++ b/include/wx/msw/dib.h
@@ -125,7 +125,7 @@ public:
                                    const void *bits = NULL);
 
     // create a plain DIB (not a DIB section) from a DDB, the caller is
-    // responsable for freeing it using ::GlobalFree()
+    // responsible for freeing it using ::GlobalFree()
     static HGLOBAL ConvertFromBitmap(HBITMAP hbmp);
 
     // creates a DIB from the given DDB or calculates the space needed by it:

--- a/include/wx/msw/listctrl.h
+++ b/include/wx/msw/listctrl.h
@@ -414,7 +414,7 @@ protected:
     // get the internal data object for this item (may return NULL)
     wxMSWListItemData *MSWGetItemData(long item) const;
 
-    // get the item attribute, either by quering it for virtual control, or by
+    // get the item attribute, either by querying it for virtual control, or by
     // returning the one previously set using setter methods for a normal one
     wxItemAttr *DoGetItemColumnAttr(long item, long column) const;
 

--- a/include/wx/msw/menu.h
+++ b/include/wx/msw/menu.h
@@ -136,7 +136,7 @@ private:
     // It is initially NULL and only allocated if we have any radio items.
     wxMenuRadioItemsData *m_radioData;
 
-    // if true, insert a breal before appending the next item
+    // if true, insert a break before appending the next item
     bool m_doBreak;
 
     // the menu handle of this menu

--- a/include/wx/msw/mimetype.h
+++ b/include/wx/msw/mimetype.h
@@ -83,7 +83,7 @@ public:
     // temporarily suppress multiple notifications that would be generated for
     // them and generate a single one at the end using MSWNotifyShell()
     // explicitly.
-    void MSWSuppressNotifications(bool supress);
+    void MSWSuppressNotifications(bool suppress);
 
     wxString
     GetExpandedCommand(const wxString& verb,

--- a/include/wx/msw/ole/comimpl.h
+++ b/include/wx/msw/ole/comimpl.h
@@ -56,7 +56,7 @@ extern WXDLLIMPEXP_CORE bool IsIidFromList(REFIID riid, const IID *aIids[], size
  */
 
 /*
-  wxAutoULong: this class is used for automatically initalising m_cRef to 0
+  wxAutoULong: this class is used for automatically initialising m_cRef to 0
 */
 class wxAutoULong
 {

--- a/include/wx/msw/private/graphicsd2d.h
+++ b/include/wx/msw/private/graphicsd2d.h
@@ -1,6 +1,6 @@
 /////////////////////////////////////////////////////////////////////////////
 // Name:        wx/msw/private/graphicsd2d.h
-// Purpose:     Allow functions from graphicsd2d.cpp to be used in othe files
+// Purpose:     Allow functions from graphicsd2d.cpp to be used in other files
 // Author:      New Pagodi
 // Created:     2017-10-31
 // Copyright:   (c) 2017 wxWidgets development team

--- a/include/wx/msw/private/webview_edge.h
+++ b/include/wx/msw/private/webview_edge.h
@@ -68,7 +68,7 @@ public:
 
     static bool Initialize();
 
-    static void Uninitalize();
+    static void Uninitialize();
 
     friend class wxWebViewEdgeModule;
 };

--- a/include/wx/msw/progdlg.h
+++ b/include/wx/msw/progdlg.h
@@ -64,7 +64,7 @@ private:
     // generic version does. This is done as part of DoNativeBeforeUpdate().
     void DispatchEvents();
 
-    // Updates the various timing informations for both determinate
+    // Updates the various timing information for both determinate
     // and indeterminate modes. Requires the shared object to have
     // been entered.
     void UpdateExpandedInformation(int value);

--- a/include/wx/msw/uxtheme.h
+++ b/include/wx/msw/uxtheme.h
@@ -33,8 +33,8 @@
 // ----------------------------------------------------------------------------
 // Definitions for legacy Windows SDKs
 // ----------------------------------------------------------------------------
-// Some defintions introduced with Windows Vista might be missing in older SDKs
-// Missing defintions are added here for compatiblity
+// Some definitions introduced with Windows Vista might be missing in older SDKs
+// Missing definitions are added here for compatibility
 
 #ifndef VSCLASS_LISTVIEW
 #define LISS_NORMAL 1

--- a/include/wx/odcombo.h
+++ b/include/wx/odcombo.h
@@ -369,7 +369,7 @@ protected:
     // NULL popup can be used to indicate default interface
     virtual void DoSetPopupControl(wxComboPopup* popup) wxOVERRIDE;
 
-    // clears all allocated client datas
+    // clears all allocated client data
     void ClearClientDatas();
 
     wxVListBoxComboPopup* GetVListBoxComboPopup() const

--- a/include/wx/osx/app.h
+++ b/include/wx/osx/app.h
@@ -77,7 +77,7 @@ public:
     { m_macCurrentEvent = event ; m_macCurrentEventHandlerCallRef = handler ; }
 
     // adding a CFType object to be released only at the end of the current event cycle (increases the
-    // refcount of the object passed), needed in case we are in the middle of an event concering an object
+    // refcount of the object passed), needed in case we are in the middle of an event concerning an object
     // we want to delete and cannot do it immediately
     // TODO change semantics to be in line with cocoa (make autrelease NOT increase the count)
     void                  MacAddToAutorelease( void* cfrefobj );

--- a/include/wx/osx/core/dataview.h
+++ b/include/wx/osx/core/dataview.h
@@ -59,7 +59,7 @@ public:
  // item related methods
  //
   virtual bool         Add          (wxDataViewItem const& parent, wxDataViewItem const& item)       = 0; // adds an item to the native control
-  virtual bool         Add          (wxDataViewItem const& parent, wxDataViewItemArray const& itesm) = 0; // adds a items to the native control
+  virtual bool         Add          (wxDataViewItem const& parent, wxDataViewItemArray const& items) = 0; // adds items to the native control
   virtual void         Collapse     (wxDataViewItem const& item)                                     = 0; // collapses the passed item in the native control
   virtual void         EnsureVisible(wxDataViewItem const& item, wxDataViewColumn const* columnPtr)  = 0; // ensures that the passed item's value in the passed column is visible (column pointer can be NULL)
   virtual unsigned int GetCount() const                                                              = 0; // returns the number of items in the native control
@@ -103,12 +103,12 @@ public:
  //
  // other methods
  //
-  virtual void DoSetIndent (int indent)                                                                     = 0; // sets the indention in the native control
+  virtual void DoSetIndent (int indent)                                                                     = 0; // sets the indentation in the native control
   virtual void DoExpand    (wxDataViewItem const& item)                                                     = 0; // expands the passed item in the native control
 
   virtual void HitTest     (wxPoint const& point, wxDataViewItem& item, wxDataViewColumn*& columnPtr) const = 0; // return the item and column pointer that contains with the passed point
   virtual void SetRowHeight(int height)                                                                     = 0; // sets the height of all rows
-  virtual void SetRowHeight(wxDataViewItem const& item, unsigned int height)                                = 0; // sets the height of the row containg the passed item in the native control
+  virtual void SetRowHeight(wxDataViewItem const& item, unsigned int height)                                = 0; // sets the height of the row containing the passed item in the native control
   virtual void OnSize()                                                                                     = 0; // updates the layout of the native control after a size event
   virtual void StartEditor( const wxDataViewItem & item, unsigned int column )                              = 0; // starts editing the passed in item and column
 };

--- a/include/wx/popupwin.h
+++ b/include/wx/popupwin.h
@@ -176,7 +176,7 @@ public:
     virtual void Popup(wxWindow *focus = NULL) wxOVERRIDE;
     virtual void Dismiss() wxOVERRIDE;
 
-    // Overridden to grab the input on some plaforms
+    // Overridden to grab the input on some platforms
     virtual bool Show( bool show = true ) wxOVERRIDE;
 
 protected:

--- a/include/wx/private/fswatcher.h
+++ b/include/wx/private/fswatcher.h
@@ -62,7 +62,7 @@ public:
         if (!DoAdd(watch))
             return false;
 
-        // add watch to our map (always succeedes, checked above)
+        // add watch to our map (always succeeds, checked above)
         wxFSWatchEntries::value_type val(watch->GetPath(), watch);
         return m_watches.insert(val).second;
     }

--- a/include/wx/private/graphics.h
+++ b/include/wx/private/graphics.h
@@ -54,7 +54,7 @@ public :
        virtual void Set(wxDouble a=1.0, wxDouble b=0.0, wxDouble c=0.0, wxDouble d=1.0,
            wxDouble tx=0.0, wxDouble ty=0.0) = 0;
 
-       // gets the component valuess of the matrix
+       // gets the component values of the matrix
        virtual void Get(wxDouble* a=NULL, wxDouble* b=NULL,  wxDouble* c=NULL,
                         wxDouble* d=NULL, wxDouble* tx=NULL, wxDouble* ty=NULL) const = 0;
 

--- a/include/wx/private/window.h
+++ b/include/wx/private/window.h
@@ -76,7 +76,7 @@ public:
         }
 
         // Ensure that we return true the first time we're called,
-        // asuming that the value will always be set to a non-default value.
+        // assuming that the value will always be set to a non-default value.
         return m_value == T();
     }
 

--- a/include/wx/propgrid/property.h
+++ b/include/wx/propgrid/property.h
@@ -1037,7 +1037,7 @@ public:
                                 wxPGValidationInfo& validationInfo ) const;
 
     // Converts text into wxVariant value appropriate for this property.
-    // Prameters:
+    // Parameters:
     // variant - On function entry this is the old value (should not be
     //   wxNullVariant in normal cases). Translated value must be assigned
     //   back to it.

--- a/include/wx/propgrid/propgrid.h
+++ b/include/wx/propgrid/propgrid.h
@@ -593,7 +593,7 @@ enum wxPG_INTERNAL_FLAGS
 // used to do the very same thing, but it hasn't been updated for a while
 // and it is currently deprecated.
 // Please note that most member functions are inherited and as such not
-// documented heree. This means you will probably also want to read
+// documented here. This means you will probably also want to read
 // wxPropertyGridInterface class reference.
 // To process input from a propertygrid control, use these event handler
 // macros to direct input to member functions that take a wxPropertyGridEvent

--- a/include/wx/propgrid/propgridiface.h
+++ b/include/wx/propgrid/propgridiface.h
@@ -540,7 +540,7 @@ public:
 
     // Hides or reveals a property.
     // hide - If true, hides property, otherwise reveals it.
-    // flags - By default changes are applied recursively. Set this paramter
+    // flags - By default changes are applied recursively. Set this parameter
     //   wxPG_DONT_RECURSE to prevent this.
     bool HideProperty( wxPGPropArg id,
                        bool hide = true,

--- a/include/wx/qt/private/winevent.h
+++ b/include/wx/qt/private/winevent.h
@@ -54,7 +54,7 @@ public:
         : Widget( parent != NULL ? parent->GetHandle() : NULL )
         , wxQtSignalHandler< Handler >( handler )
     {
-        // Set immediatelly as it is used to check if wxWindow is alive
+        // Set immediately as it is used to check if wxWindow is alive
         wxWindow::QtStoreWindowPointer( this, handler );
 
         // Handle QWidget destruction signal AFTER it gets deleted

--- a/include/wx/qt/window.h
+++ b/include/wx/qt/window.h
@@ -50,7 +50,7 @@ class WXDLLIMPEXP_FWD_CORE wxQtShortcutHandler;
  * found in winevent_qt.(h|cpp) to send all Qt events here to QtHandleXXXEvent()
  * methods. All these methods receive the Qt event and the handler. This is
  * done because events of the containers (the scrolled part of the window) are
- * sent to the same wxWindow instance, that must be able to differenciate them
+ * sent to the same wxWindow instance, that must be able to differentiate them
  * as some events need different handling (paintEvent) depending on that.
  * We pass the QWidget pointer to all event handlers for consistency.
  */

--- a/include/wx/selstore.h
+++ b/include/wx/selstore.h
@@ -57,7 +57,7 @@ public:
     // several items at once, return true if any of them were selected
     bool OnItemsDeleted(unsigned item, unsigned numItems);
 
-    // select one item, use SelectRange() insted if possible!
+    // select one item, use SelectRange() instead if possible!
     //
     // returns true if the items selection really changed
     bool SelectItem(unsigned item, bool select = true);

--- a/include/wx/stackwalk.h
+++ b/include/wx/stackwalk.h
@@ -143,7 +143,7 @@ public:
 #endif // wxUSE_ON_FATAL_EXCEPTION
 
 protected:
-    // this function must be overrided to process the given frame
+    // this function must be overridden to process the given frame
     virtual void OnStackFrame(const wxStackFrame& frame) = 0;
 };
 

--- a/include/wx/stc/stc.h
+++ b/include/wx/stc/stc.h
@@ -3074,7 +3074,7 @@ public:
     // Set the background colour used for a particular marker number when its folding block is selected.
     void MarkerSetBackgroundSelected(int markerNumber, const wxColour& back);
 
-    // Enable/disable highlight for current folding bloc (smallest one that contains the caret)
+    // Enable/disable highlight for current folding block (smallest one that contains the caret)
     void MarkerEnableHighlight(bool enabled);
 
     // Add a marker to a line, returning an ID which can be used to find or delete the marker.

--- a/include/wx/testing.h
+++ b/include/wx/testing.h
@@ -320,7 +320,7 @@ public:
 
     // Called to verify that all expectations were met. This cannot be done in
     // the destructor, because ReportFailure() may throw (either because it's
-    // overriden or because wx's assertions handling is, globally). And
+    // overridden or because wx's assertions handling is, globally). And
     // throwing from the destructor would introduce all sort of problems,
     // including messing up the order of errors in some cases.
     void CheckUnmetExpectations()

--- a/include/wx/treebook.h
+++ b/include/wx/treebook.h
@@ -195,7 +195,7 @@ private:
     // from m_tree (wxTreeCtrl) component.
     int DoInternalFindPageById(wxTreeItemId page) const;
 
-    // Updates page and wxTreeItemId correspondance.
+    // Updates page and wxTreeItemId correspondence.
     void DoInternalAddPage(size_t newPos, wxWindow *page, wxTreeItemId pageId);
 
     // Removes the page from internal structure.

--- a/include/wx/unichar.h
+++ b/include/wx/unichar.h
@@ -121,7 +121,7 @@ public:
     wxUint16 LowSurrogate() const { return LowSurrogate(m_value); }
 
     // Conversions to char and wchar_t types: all of those are needed to be
-    // able to pass wxUniChars to verious standard narrow and wide character
+    // able to pass wxUniChars to various standard narrow and wide character
     // functions
     operator char() const { return To8bit(m_value); }
     operator unsigned char() const { return (unsigned char)To8bit(m_value); }

--- a/include/wx/univ/renderer.h
+++ b/include/wx/univ/renderer.h
@@ -360,7 +360,7 @@ public:
     // ------------------
 
     // get the dimensions of the border: rect.x/y contain the width/height of
-    // the left/top side, width/heigh - of the right/bottom one
+    // the left/top side, width/height - of the right/bottom one
     virtual wxRect GetBorderDimensions(wxBorder border) const = 0;
 
     // the scrollbars may be drawn either inside the window border or outside
@@ -397,7 +397,7 @@ public:
 
 #if wxUSE_TEXTCTRL
     // convert between text rectangle and client rectangle for text controls:
-    // the former is typicall smaller to leave margins around text
+    // the former is typically smaller to leave margins around text
     virtual wxRect GetTextTotalArea(const wxTextCtrl *text,
                                     const wxRect& rectText) const = 0;
 

--- a/include/wx/univ/scrolbar.h
+++ b/include/wx/univ/scrolbar.h
@@ -131,7 +131,7 @@ protected:
     virtual void DoDraw(wxControlRenderer *renderer) wxOVERRIDE;
     virtual wxBorder GetDefaultBorder() const wxOVERRIDE { return wxBORDER_NONE; }
 
-    // forces update of thumb's visual appearence (does nothing if m_dirty=false)
+    // forces update of thumb's visual appearance (does nothing if m_dirty=false)
     void UpdateThumb();
 
     // SetThumbPosition() helper

--- a/include/wx/univ/stdrend.h
+++ b/include/wx/univ/stdrend.h
@@ -269,7 +269,7 @@ protected:
         // draw complete rectangle
     void DrawRect(wxDC& dc, wxRect *rect, const wxPen& pen);
 
-        // draw the rectange using the first pen for the left and top sides
+        // draw the rectangle using the first pen for the left and top sides
         // and the second one for the bottom and right ones
     void DrawShadedRect(wxDC& dc, wxRect *rect,
                         const wxPen& pen1, const wxPen& pen2);

--- a/include/wx/utils.h
+++ b/include/wx/utils.h
@@ -154,7 +154,7 @@ WXDLLIMPEXP_BASE bool wxIsPlatformLittleEndian();
 WXDLLIMPEXP_BASE bool wxIsPlatform64Bit();
 
 #ifdef __LINUX__
-// Get linux-distro informations
+// Get linux-distro information
 WXDLLIMPEXP_BASE wxLinuxDistributionInfo wxGetLinuxDistributionInfo();
 #endif
 
@@ -178,7 +178,7 @@ WXDLLIMPEXP_CORE bool wxGetKeyState(wxKeyCode key);
 // in wxMSW.
 WXDLLIMPEXP_CORE bool wxSetDetectableAutoRepeat( bool flag );
 
-// Returns the current state of the mouse position, buttons and modifers
+// Returns the current state of the mouse position, buttons and modifiers
 WXDLLIMPEXP_CORE wxMouseState wxGetMouseState();
 
 #endif // wxUSE_GUI
@@ -802,7 +802,7 @@ inline struct _XDisplay *wxGetX11Display()
 // wxYield(): these functions are obsolete, please use wxApp methods instead!
 // ----------------------------------------------------------------------------
 
-// avoid redeclaring this function here if it had been already declated by
+// avoid redeclaring this function here if it had been already declared by
 // wx/app.h, this results in warnings from g++ with -Wredundant-decls
 #ifndef wx_YIELD_DECLARED
 #define wx_YIELD_DECLARED

--- a/include/wx/vscroll.h
+++ b/include/wx/vscroll.h
@@ -133,7 +133,7 @@ public:
     void HandleOnMouseWheel(wxMouseEvent& event);
 #endif // wxUSE_MOUSEWHEEL
 
-    // these functions must be overidden in the derived class to return
+    // these functions must be overridden in the derived class to return
     // orientation specific data (e.g. the width for vertically scrolling
     // derivatives in the case of GetOrientationTargetSize())
     virtual int GetOrientationTargetSize() const = 0;

--- a/include/wx/wxcrt.h
+++ b/include/wx/wxcrt.h
@@ -490,7 +490,7 @@ inline int wxStrcoll_String(const wxString& s1, const T& s2)
 }
 
 #ifndef wxNEEDS_DECL_BEFORE_TEMPLATE
-// this is exactly the same WX_STRCMP_FUNC line as above, insde the
+// this is exactly the same WX_STRCMP_FUNC line as above, inside the
 // wxNEEDS_DECL_BEFORE_TEMPLATE case
 WX_STRCMP_FUNC(wxStrcoll, wxCRT_StrcollA, wxCRT_StrcollW, wxStrcoll_String)
 #endif

--- a/include/wx/x11/window.h
+++ b/include/wx/x11/window.h
@@ -203,7 +203,7 @@ private:
 // undesired effects.
 //
 // Usage: create an instance of this class on the stack to disable the size
-// optimisation, it will be reenabled as soon as the object goes out from scope.
+// optimisation, it will be re-enabled as soon as the object goes out from scope.
 // ----------------------------------------------------------------------------
 
 class WXDLLIMPEXP_CORE wxNoOptimize

--- a/include/wx/xml/xml.h
+++ b/include/wx/xml/xml.h
@@ -171,7 +171,7 @@ public:
     void SetAttributes(wxXmlAttribute *attr) { m_attrs = attr; }
     virtual void AddAttribute(wxXmlAttribute *attr);
 
-    // If true, don't do encoding conversion to improve efficiency - node content is ACII text
+    // If true, don't do encoding conversion to improve efficiency - node content is ASCII text
     bool GetNoConversion() const { return m_noConversion; }
     void SetNoConversion(bool noconversion) { m_noConversion = noconversion; }
 

--- a/include/wx/xtistrm.h
+++ b/include/wx/xtistrm.h
@@ -233,7 +233,7 @@ public:
     // The return value is the root object ID, which can
     // then be used to ask the depersister about that object
     // if there was a problem you will get back wxInvalidObjectID and the current
-    // error log will carry the problems encoutered
+    // error log will carry the problems encountered
     virtual int ReadObject( const wxString &name, wxObjectReaderCallback *readercallback ) = 0;
 
 private:

--- a/include/wx/xtitypes.h
+++ b/include/wx/xtitypes.h
@@ -263,7 +263,7 @@ void wxFlagsToString( wxString &s, const e& data )
 //  The first characterization is done by wxTypeKind. All enums up to and including
 //  wxT_CUSTOM represent so called simple types. These cannot be divided any further.
 //  They can be converted to and from wxStrings, that's all.
-//  Other wxTypeKinds can instead be splitted recursively into smaller parts until
+//  Other wxTypeKinds can instead be split recursively into smaller parts until
 //  the simple types are reached.
 
 enum wxTypeKind

--- a/interface/wx/aui/auibar.h
+++ b/interface/wx/aui/auibar.h
@@ -90,7 +90,7 @@ enum wxAuiToolBarStyle
 enum wxAuiToolBarArtSetting
 {
     /**
-      wxAuiToolBar seperator size.
+      wxAuiToolBar separator size.
     */
     wxAUI_TBART_SEPARATOR_SIZE = 0,
 

--- a/interface/wx/bitmap.h
+++ b/interface/wx/bitmap.h
@@ -445,7 +445,7 @@ public:
         @param height
             The height of the bitmap in pixels, must be strictly positive.
         @param dc
-            DC from wich the scaling factor is inherited
+            DC from which the scaling factor is inherited
 
         @return @true if the creation was successful.
 

--- a/interface/wx/config.h
+++ b/interface/wx/config.h
@@ -894,7 +894,7 @@ public:
 
     For example:
     @code
-    // this function loads somes settings from the given wxConfig object;
+    // this function loads some settings from the given wxConfig object;
     // the path selected inside it is left unchanged
     bool LoadMySettings(wxConfigBase* cfg)
     {

--- a/interface/wx/datetime.h
+++ b/interface/wx/datetime.h
@@ -489,7 +489,7 @@ public:
 
         Here are the trivial accessors. Other functions, which might have to
         perform some more complicated calculations to find the answer are under
-        the "Date Arithmetics" section.
+        the "Date Arithmetic" section.
     */
     //@{
 
@@ -738,10 +738,10 @@ public:
 
 
     /**
-        @name Date Arithmetics
+        @name Date Arithmetic
 
         These functions carry out
-        @ref overview_datetime_arithmetics "arithmetics" on the wxDateTime
+        @ref overview_datetime_arithmetics "arithmetic" on the wxDateTime
         objects. As explained in the overview, either wxTimeSpan or wxDateSpan
         may be added to wxDateTime, hence all functions are overloaded to
         accept both arguments.

--- a/interface/wx/dnd.h
+++ b/interface/wx/dnd.h
@@ -146,7 +146,7 @@ public:
     /**
        Sets the default action for drag and drop.  Use wxDragMove or
        wxDragCopy to set default action to move or copy and use wxDragNone
-       (default) to set default action specified by initialization of draging
+       (default) to set default action specified by initialization of dragging
        (see wxDropSource::DoDragDrop())
     */
     void SetDefaultAction(wxDragResult action);

--- a/interface/wx/gauge.h
+++ b/interface/wx/gauge.h
@@ -13,7 +13,7 @@
 #define wxGA_HORIZONTAL      wxHORIZONTAL
 #define wxGA_VERTICAL        wxVERTICAL
 
-// Available since Windows 7 only. With this style, the value of guage will
+// Available since Windows 7 only. With this style, the value of gauge will
 // reflect on the taskbar button.
 #define wxGA_PROGRESS        0x0010
 // Win32 only, is default (and only) on some other platforms

--- a/interface/wx/generic/aboutdlgg.h
+++ b/interface/wx/generic/aboutdlgg.h
@@ -22,7 +22,7 @@
     To instantiate an object from your wxGenericAboutDialog-based class, you
     can use either the default constructor followed by a call to Create(), or
     directly using the alternate constructor. In either case, you have to
-    prepare a wxAboutDialogInfo containing standard informations to display in
+    prepare a wxAboutDialogInfo containing standard information to display in
     an about-box.
 
     Example of usage, MyAboutDlg being a class derived from wxGenericAboutDialog:

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -99,7 +99,7 @@ public:
         GetBestSize() should be called for each cell individually.
 
         Note that this method will only be used if
-        wxGridTableBase::CanMeasureColUsingSameAttr() is overriden to return
+        wxGridTableBase::CanMeasureColUsingSameAttr() is overridden to return
         @true.
 
         @since 3.1.4
@@ -1326,7 +1326,7 @@ public:
         Returns @true if the cell will draw an overflowed text into the
         neighbouring cells.
 
-        Note that only left aligned cells currenty can overflow. It means that
+        Note that only left aligned cells currently can overflow. It means that
         GetFitMode().IsOverflow() should returns true and GetAlignment should
         returns wxALIGN_LEFT for hAlign parameter.
 

--- a/interface/wx/log.h
+++ b/interface/wx/log.h
@@ -668,7 +668,7 @@ public:
         By default, the log messages are passed to the previously active log target.
         Calling this function with @false parameter disables this behaviour
         (presumably temporarily, as you shouldn't use wxLogChain at all otherwise) and
-        it can be reenabled by calling it again with @a passMessages set to @true.
+        it can be re-enabled by calling it again with @a passMessages set to @true.
     */
     void PassMessages(bool passMessages);
 

--- a/interface/wx/object.h
+++ b/interface/wx/object.h
@@ -625,7 +625,7 @@ public:
 
     /**
         Conversion to a boolean expression (in a variant which is not
-        convertable to anything but a boolean expression).
+        convertible to anything but a boolean expression).
 
         If this class contains a valid pointer it will return @true, if it contains
         a @NULL pointer it will return @false.

--- a/interface/wx/propgrid/property.h
+++ b/interface/wx/propgrid/property.h
@@ -469,7 +469,7 @@ wxPG_PROP_CLASS_SPECIFIC_3          = 0x00400000
     @subsection wxIntProperty
 
     It derives from wxNumericProperty and displays value as a signed long integer.
-    wxIntProperty seamlessly supports 64-bit integers (i.e. wxLongLong) on overlfow.
+    wxIntProperty seamlessly supports 64-bit integers (i.e. wxLongLong) on overflow.
     To safely convert variant to integer, use code like this:
 
     @code
@@ -1397,7 +1397,7 @@ public:
         Returns property attribute value, null variant if not found.
 
         @remarks
-        For built-in atrribute returns null variant if extra style
+        For built-in attribute returns null variant if extra style
         ::wxPG_EX_WRITEONLY_BUILTIN_ATTRIBUTES is set.
     */
     wxVariant GetAttribute( const wxString& name ) const;
@@ -1405,7 +1405,7 @@ public:
     /** Returns named attribute, as string, if found. Otherwise @a defVal is returned.
 
         @remarks
-        For built-in atrribute returns @a defVal if extra style
+        For built-in attribute returns @a defVal if extra style
         ::wxPG_EX_WRITEONLY_BUILTIN_ATTRIBUTES is set.
     */
     wxString GetAttribute( const wxString& name, const wxString& defVal ) const;
@@ -1413,7 +1413,7 @@ public:
     /** Returns named attribute, as long, if found. Otherwise @a defVal is returned.
 
         @remarks
-        For built-in atrribute returns @a defVal if extra style
+        For built-in attribute returns @a defVal if extra style
         ::wxPG_EX_WRITEONLY_BUILTIN_ATTRIBUTES is set.
     */
     long GetAttributeAsLong( const wxString& name, long defVal ) const;
@@ -1421,7 +1421,7 @@ public:
     /** Returns named attribute, as double, if found. Otherwise @a defVal is returned.
 
         @remarks
-        For built-in atrribute returns @a defVal if extra style
+        For built-in attribute returns @a defVal if extra style
         ::wxPG_EX_WRITEONLY_BUILTIN_ATTRIBUTES is set.
     */
     double GetAttributeAsDouble( const wxString& name, double defVal ) const;

--- a/interface/wx/ribbon/toolbar.h
+++ b/interface/wx/ribbon/toolbar.h
@@ -315,7 +315,7 @@ public:
     virtual size_t GetToolCount() const;
 
     /**
-        Return the id assciated to the tool opaque structure.
+        Return the id associated to the tool opaque structure.
 
         The structure pointer must not be @NULL.
 

--- a/interface/wx/richtext/richtextctrl.h
+++ b/interface/wx/richtext/richtextctrl.h
@@ -1206,7 +1206,7 @@ public:
     bool EndParagraphSpacing();
 
     /**
-        Begins appling line spacing. @e spacing is a multiple, where 10 means
+        Begins applying line spacing. @e spacing is a multiple, where 10 means
         single-spacing, 15 means 1.5 spacing, and 20 means double spacing.
 
         The ::wxTextAttrLineSpacing constants are defined for convenience.

--- a/interface/wx/stackwalk.h
+++ b/interface/wx/stackwalk.h
@@ -86,7 +86,7 @@ public:
 
 protected:
     /**
-        This function must be overidden to process the given frame.
+        This function must be overridden to process the given frame.
     */
     virtual void OnStackFrame(const wxStackFrame& frame) = 0;
 };

--- a/interface/wx/stc/stc.h
+++ b/interface/wx/stc/stc.h
@@ -5324,7 +5324,7 @@ public:
     void MarkerSetBackgroundSelected(int markerNumber, const wxColour& back);
 
     /**
-        Enable/disable highlight for current folding bloc (smallest one that contains the caret)
+        Enable/disable highlight for current folding block (smallest one that contains the caret)
     */
     void MarkerEnableHighlight(bool enabled);
 
@@ -7927,7 +7927,7 @@ public:
     @section event_types Event Types
 
     The following is a brief description of when the control generates these
-    events and a list of which methods provide relevent information.  Additional
+    events and a list of which methods provide relevant information.  Additional
     details can be found in the Scintilla documentation
     (http://www.scintilla.org/ScintillaDoc.html#Notifications).
 

--- a/interface/wx/treelist.h
+++ b/interface/wx/treelist.h
@@ -90,7 +90,7 @@ public:
     /**
         Default constructor.
 
-        Notice that this class is not copyable, comparators are not passed by
+        Notice that this class is not copiable, comparators are not passed by
         value.
      */
     wxTreeListItemComparator();

--- a/interface/wx/ustring.h
+++ b/interface/wx/ustring.h
@@ -19,7 +19,7 @@
 
     The main purpose of wxUString is a to give users a Unicode string
     class that has O(1) access to its content, to be identical on all
-    platforms and to be easily convertable to wxString as well as other
+    platforms and to be easily convertible to wxString as well as other
     ways to store strings (C string literals, wide character
     string literals, character buffer, etc) by providing several overloads
     and built-in conversions to and from the various string formats.

--- a/interface/wx/valtext.h
+++ b/interface/wx/valtext.h
@@ -62,7 +62,7 @@ enum wxTextValidatorStyle
     /// wxFILTER_ASCII, wxFILTER_ALPHA, wxFILTER_ALPHANUMERIC, wxFILTER_DIGITS,
     /// wxFILTER_XDIGITS, wxFILTER_NUMERIC it just extends the character class
     /// denoted by the aforementioned styles with those specified in the include
-    /// char list. If set alone, then the charactes allowed to be in the user input
+    /// char list. If set alone, then the characters allowed to be in the user input
     /// are restricted to those, and only those, present in the include char list.
     wxFILTER_INCLUDE_CHAR_LIST,
 

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -164,7 +164,7 @@ class wxWebViewHistoryItem
 {
 public:
     /**
-        Construtor.
+        Constructor.
     */
     wxWebViewHistoryItem(const wxString& url, const wxString& title);
 

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -1964,7 +1964,7 @@ public:
         Freezes the window or, in other words, prevents any updates from taking
         place on screen, the window is not redrawn at all.
 
-        Thaw() must be called to reenable window redrawing. Calls to these two
+        Thaw() must be called to re-enable window redrawing. Calls to these two
         functions may be nested but to ensure that the window is properly
         repainted again, you must thaw it exactly as many times as you froze it.
 
@@ -2855,7 +2855,7 @@ public:
 
     /**
         Enable or disable the window for user input. Note that when a parent window is
-        disabled, all of its children are disabled as well and they are reenabled again
+        disabled, all of its children are disabled as well and they are re-enabled again
         when the parent is.
 
         A window can be created initially disabled by calling this method on it

--- a/misc/scripts/codespell.ignore
+++ b/misc/scripts/codespell.ignore
@@ -1,0 +1,6 @@
+convertor
+malcom
+ot
+othere
+seh
+ser

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -135,7 +135,7 @@ bool wxWebViewEdgeImpl::Initialize()
     return false;
 }
 
-void wxWebViewEdgeImpl::Uninitalize()
+void wxWebViewEdgeImpl::Uninitialize()
 {
     if (ms_isAvailable == 1)
     {
@@ -861,7 +861,7 @@ public:
 
     virtual void OnExit() wxOVERRIDE
     {
-        wxWebViewEdgeImpl::Uninitalize();
+        wxWebViewEdgeImpl::Uninitialize();
     }
 
 private:


### PR DESCRIPTION
I don't know how I had never heard about it before, but there is a tool that can spell checking of just the comments and identifier names, but respecting their camel case. I've run it over our headers and corrected the mistakes it found.

Unfortunately we can't integrate it with our CI yet because we need some resolution to this https://github.com/codespell-project/codespell/issues/1212 first and we also have to have some rather strange exceptions due to https://github.com/codespell-project/codespell/issues/1578, but overall it seems very useful.