### PR TITLE
Some more simplifications to wxGrid

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2908,8 +2908,11 @@ private:
                 );
     }
 
-    // Accept the changes in the edit control, if it's currently shown, and
-    // dismiss it.
+    // Accept the changes in the edit control, i.e. save them to the table and
+    // dismiss the editor.
+    void DoAcceptCellEditControl();
+
+    // As above, but do nothing if the control is not currently shown.
     void AcceptCellEditControlIfShown();
 
     // Unlike the public SaveEditControlValue(), this method doesn't check if

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -1509,7 +1509,7 @@ public:
 
     bool IsCurrentCellReadOnly() const;
 
-    void ShowCellEditControl();
+    void ShowCellEditControl(); // Use EnableCellEditControl() instead.
     void HideCellEditControl();
     void SaveEditControlValue();
 
@@ -2907,6 +2907,9 @@ private:
                     m_currentCellCoords.GetCol()
                 );
     }
+
+    // Show the cell editor for the current cell unconditionally.
+    void DoShowCellEditControl();
 
     // Accept the changes in the edit control, i.e. save them to the table and
     // dismiss the editor.

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2908,11 +2908,12 @@ private:
                 );
     }
 
-    // Show the cell editor for the current cell unconditionally.
+    // Show/hide the cell editor for the current cell unconditionally.
     void DoShowCellEditControl();
+    void DoHideCellEditControl();
 
     // Accept the changes in the edit control, i.e. save them to the table and
-    // dismiss the editor.
+    // dismiss the editor. Also reset m_cellEditCtrlEnabled.
     void DoAcceptCellEditControl();
 
     // As above, but do nothing if the control is not currently shown.

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -1504,7 +1504,7 @@ public:
     void EnableCellEditControl( bool enable = true );
     void DisableCellEditControl() { EnableCellEditControl(false); }
     bool CanEnableCellControl() const;
-    bool IsCellEditControlEnabled() const;
+    bool IsCellEditControlEnabled() const { return m_cellEditCtrlEnabled; }
     bool IsCellEditControlShown() const;
 
     bool IsCurrentCellReadOnly() const;

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2908,6 +2908,10 @@ private:
                 );
     }
 
+    // Accept the changes in the edit control, if it's currently shown, and
+    // dismiss it.
+    void AcceptCellEditControlIfShown();
+
     // Unlike the public SaveEditControlValue(), this method doesn't check if
     // the edit control is shown, but just supposes that it is.
     void DoSaveEditControlValue();

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2520,7 +2520,6 @@ protected:
     wxGridCellAttr*     m_defaultCellAttr;
 
 
-    bool m_inOnKeyDown;
     int  m_batchCount;
 
 

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2897,6 +2897,17 @@ private:
     void SetNativeHeaderColCount();
     void SetNativeHeaderColOrder();
 
+    // Return the editor which should be used for the current cell.
+    wxGridCellEditorPtr GetCurrentCellEditorPtr() const
+    {
+        return GetCellAttrPtr(m_currentCellCoords)->GetEditorPtr
+                (
+                    this,
+                    m_currentCellCoords.GetRow(),
+                    m_currentCellCoords.GetCol()
+                );
+    }
+
     // Unlike the public SaveEditControlValue(), this method doesn't check if
     // the edit control is shown, but just supposes that it is.
     void DoSaveEditControlValue();

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2912,6 +2912,14 @@ private:
     void DoShowCellEditControl();
     void DoHideCellEditControl();
 
+    // Unconditionally try showing the editor for the current cell.
+    //
+    // Returns false if the user code vetoed wxEVT_GRID_EDITOR_SHOWN.
+    bool DoEnableCellEditControl();
+
+    // Unconditionally disable (accepting the changes) the editor.
+    void DoDisableCellEditControl();
+
     // Accept the changes in the edit control, i.e. save them to the table and
     // dismiss the editor. Also reset m_cellEditCtrlEnabled.
     void DoAcceptCellEditControl();

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -3827,8 +3827,9 @@ public:
         Displays the active in-place cell edit control for the current cell
         after it was hidden.
 
-        Note that this method does @em not start editing the cell, this is only
-        done by EnableCellEditControl().
+        This method should only be called after calling HideCellEditControl(),
+        to start editing the current grid cell use EnableCellEditControl()
+        instead.
     */
     void ShowCellEditControl();
 

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -3440,6 +3440,9 @@ public:
         currently show, otherwise the @c wxEVT_GRID_EDITOR_HIDDEN event is
         generated but, unlike the "shown" event, it can't be vetoed and the
         in-place editor is dismissed unconditionally.
+
+        Note that it is an error to call this function if the current cell is
+        read-only, use CanEnableCellControl() to check for this precondition.
     */
     void EnableCellEditControl(bool enable = true);
 

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -3437,7 +3437,7 @@ public:
         allows the user to change the cell value.
 
         Disabling in-place editing does nothing if the in-place editor isn't
-        currently show, otherwise the @c wxEVT_GRID_EDITOR_HIDDEN event is
+        currently shown, otherwise the @c wxEVT_GRID_EDITOR_HIDDEN event is
         generated but, unlike the "shown" event, it can't be vetoed and the
         in-place editor is dismissed unconditionally.
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -5696,13 +5696,14 @@ void wxGrid::OnKeyDown( wxKeyEvent& event )
                 }
                 else
                 {
-                    if ( !MoveCursorDown( event.ShiftDown() ) )
-                    {
-                        // Normally this would be done by MoveCursorDown(), but
-                        // if it failed to move the cursor, e.g. because we're
-                        // at the bottom of a column, do it here.
-                        DisableCellEditControl();
-                    }
+                    // We want to accept the changes in the editor when Enter
+                    // is pressed in any case, so do it (note that in many
+                    // cases this would be done by MoveCursorDown() itself, but
+                    // not always, e.g. it wouldn't do it when editing the
+                    // cells in the last row or when using Shift-Enter).
+                    DisableCellEditControl();
+
+                    MoveCursorDown( event.ShiftDown() );
                 }
                 break;
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -4663,12 +4663,6 @@ wxGrid::DoGridCellLeftUp(wxMouseEvent& event,
 
             m_waitForSlowClick = false;
         }
-        else if ( m_selection && m_selection->IsSelection() )
-        {
-            // Show the edit control, if it has been hidden for
-            // drag-shrinking.
-            ShowCellEditControl();
-        }
     }
     else if ( m_cursorMode == WXGRID_CURSOR_RESIZE_ROW )
     {

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -5222,8 +5222,7 @@ void wxGrid::ClearGrid()
 {
     if ( m_table )
     {
-        if (IsCellEditControlEnabled())
-            DisableCellEditControl();
+        DisableCellEditControl();
 
         m_table->Clear();
         if ( ShouldRefresh() )
@@ -5240,8 +5239,7 @@ wxGrid::DoModifyLines(bool (wxGridTableBase::*funcModify)(size_t, size_t),
     if ( !m_table )
         return false;
 
-    if ( IsCellEditControlEnabled() )
-        DisableCellEditControl();
+    DisableCellEditControl();
 
     return (m_table->*funcModify)(pos, num);
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -2887,7 +2887,6 @@ void wxGrid::Init()
 
     m_editable = true;  // default for whole grid
 
-    m_inOnKeyDown = false;
     m_batchCount = 0;
 
     m_extraWidth =
@@ -5639,15 +5638,6 @@ void wxGrid::OnDPIChanged(wxDPIChangedEvent& event)
 
 void wxGrid::OnKeyDown( wxKeyEvent& event )
 {
-    if ( m_inOnKeyDown )
-    {
-        // shouldn't be here - we are going round in circles...
-        //
-        wxFAIL_MSG( wxT("wxGrid::OnKeyDown called while already active") );
-    }
-
-    m_inOnKeyDown = true;
-
     // propagate the event up and see if it gets processed
     wxWindow *parent = GetParent();
     wxKeyEvent keyEvt( event );
@@ -5954,8 +5944,6 @@ void wxGrid::OnKeyDown( wxKeyEvent& event )
                 break;
         }
     }
-
-    m_inOnKeyDown = false;
 }
 
 void wxGrid::OnKeyUp( wxKeyEvent& WXUNUSED(event) )

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -7149,11 +7149,11 @@ void wxGrid::EnableCellEditControl( bool enable )
     {
         if ( enable )
         {
+            // this should be checked by the caller!
+            wxCHECK_RET( CanEnableCellControl(), wxT("can't enable editing for this cell!") );
+
             if ( SendEvent(wxEVT_GRID_EDITOR_SHOWN) == -1 )
                 return;
-
-            // this should be checked by the caller!
-            wxASSERT_MSG( CanEnableCellControl(), wxT("can't enable editing for this cell!") );
 
             // do it before ShowCellEditControl()
             m_cellEditCtrlEnabled = enable;
@@ -7179,13 +7179,6 @@ bool wxGrid::CanEnableCellControl() const
 {
     return m_editable && (m_currentCellCoords != wxGridNoCellCoords) &&
         !IsCurrentCellReadOnly();
-}
-
-bool wxGrid::IsCellEditControlEnabled() const
-{
-    // the cell edit control might be disable for all cells or just for the
-    // current one if it's read only
-    return m_cellEditCtrlEnabled ? !IsCurrentCellReadOnly() : false;
 }
 
 bool wxGrid::IsCellEditControlShown() const

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -7170,15 +7170,7 @@ void wxGrid::EnableCellEditControl( bool enable )
         {
             SendEvent(wxEVT_GRID_EDITOR_HIDDEN);
 
-            HideCellEditControl();
-
-            // do it after HideCellEditControl() but before invoking
-            // user-defined handlers invoked by DoSaveEditControlValue() to
-            // ensure that we don't enter infinite loop if any of them try to
-            // disable the edit control again.
-            m_cellEditCtrlEnabled = false;
-
-            DoSaveEditControlValue();
+            DoAcceptCellEditControl();
         }
     }
 }
@@ -7415,9 +7407,22 @@ void wxGrid::AcceptCellEditControlIfShown()
 {
     if ( IsCellEditControlShown() )
     {
-        HideCellEditControl();
-        DoSaveEditControlValue();
+        DoAcceptCellEditControl();
     }
+}
+
+void wxGrid::DoAcceptCellEditControl()
+{
+    HideCellEditControl();
+
+    // do it after HideCellEditControl() but before invoking
+    // user-defined handlers invoked by DoSaveEditControlValue() to
+    // ensure that we don't enter infinite loop if any of them try to
+    // disable the edit control again by calling DisableCellEditControl()
+    // from which we can be called
+    m_cellEditCtrlEnabled = false;
+
+    DoSaveEditControlValue();
 }
 
 void wxGrid::SaveEditControlValue()

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -3710,6 +3710,7 @@ void wxGrid::ProcessRowLabelMouseEvent( wxMouseEvent& event, wxGridRowLabelWindo
         row = YToEdgeOfRow(pos.y);
         if ( row != wxNOT_FOUND && CanDragRowSize(row) )
         {
+            DoStartResizeRowOrCol(row);
             ChangeCursorMode(WXGRID_CURSOR_RESIZE_ROW, rowLabelWin);
         }
         else // not a request to start resizing
@@ -3847,7 +3848,6 @@ void wxGrid::ProcessRowLabelMouseEvent( wxMouseEvent& event, wxGridRowLabelWindo
             {
                 if ( CanDragRowSize(dragRowOrCol) )
                 {
-                    DoStartResizeRowOrCol(dragRowOrCol);
                     ChangeCursorMode(WXGRID_CURSOR_RESIZE_ROW, rowLabelWin, false);
                 }
             }
@@ -4107,6 +4107,7 @@ void wxGrid::ProcessColLabelMouseEvent( wxMouseEvent& event, wxGridColLabelWindo
         int colEdge = XToEdgeOfCol(x);
         if ( colEdge != wxNOT_FOUND && CanDragColSize(colEdge) )
         {
+            DoStartResizeRowOrCol(colEdge);
             ChangeCursorMode(WXGRID_CURSOR_RESIZE_COL, colLabelWin);
         }
         else // not a request to start resizing
@@ -4298,7 +4299,6 @@ void wxGrid::ProcessColLabelMouseEvent( wxMouseEvent& event, wxGridColLabelWindo
             {
                 if ( CanDragColSize(dragRowOrCol) )
                 {
-                    DoStartResizeRowOrCol(dragRowOrCol);
                     ChangeCursorMode(WXGRID_CURSOR_RESIZE_COL, colLabelWin, false);
                 }
             }
@@ -4566,11 +4566,18 @@ wxGrid::DoGridCellLeftDown(wxMouseEvent& event,
         // it being disabled for a particular row/column as it would be
         // surprising to have different mouse behaviour in different parts of
         // the same grid, so we only check for it being globally disabled).
-        if ( CanDragGridColEdges() && XToEdgeOfCol(pos.x) != wxNOT_FOUND )
-            return;
+        int dragRowOrCol = wxNOT_FOUND;
+        if ( CanDragGridColEdges() )
+            dragRowOrCol = XToEdgeOfCol(pos.x);
 
-        if ( CanDragGridRowEdges() && YToEdgeOfRow(pos.y) != wxNOT_FOUND )
+        if ( dragRowOrCol == wxNOT_FOUND && CanDragGridRowEdges() )
+            dragRowOrCol = YToEdgeOfRow(pos.y);
+
+        if ( dragRowOrCol != wxNOT_FOUND )
+        {
+            DoStartResizeRowOrCol(dragRowOrCol);
             return;
+        }
 
         DisableCellEditControl();
         MakeCellVisible( coords );
@@ -4701,7 +4708,6 @@ wxGrid::DoGridMouseMoveEvent(wxMouseEvent& WXUNUSED(event),
     {
         if ( m_cursorMode == WXGRID_CURSOR_SELECT_CELL )
         {
-            DoStartResizeRowOrCol(dragCol);
             ChangeCursorMode(WXGRID_CURSOR_RESIZE_COL, gridWindow, false);
         }
     }
@@ -4709,7 +4715,6 @@ wxGrid::DoGridMouseMoveEvent(wxMouseEvent& WXUNUSED(event),
     {
         if ( m_cursorMode == WXGRID_CURSOR_SELECT_CELL )
         {
-            DoStartResizeRowOrCol(dragRow);
             ChangeCursorMode(WXGRID_CURSOR_RESIZE_ROW, gridWindow, false);
         }
     }

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -3966,11 +3966,7 @@ void wxGrid::DoStartResizeRowOrCol(int col)
 {
     // Hide the editor if it's currently shown to avoid any weird interactions
     // with it while dragging the row/column separator.
-    if ( IsCellEditControlShown() )
-    {
-        HideCellEditControl();
-        SaveEditControlValue();
-    }
+    AcceptCellEditControlIfShown();
 
     m_dragRowOrCol = col;
 }
@@ -4481,11 +4477,7 @@ wxGrid::DoGridCellDrag(wxMouseEvent& event,
     if ( isFirstDrag )
     {
         // Hide the edit control, so it won't interfere with drag-shrinking.
-        if ( IsCellEditControlShown() )
-        {
-            HideCellEditControl();
-            SaveEditControlValue();
-        }
+        AcceptCellEditControlIfShown();
 
         switch ( event.GetModifiers() )
         {
@@ -7419,6 +7411,15 @@ void wxGrid::HideCellEditControl()
     }
 }
 
+void wxGrid::AcceptCellEditControlIfShown()
+{
+    if ( IsCellEditControlShown() )
+    {
+        HideCellEditControl();
+        DoSaveEditControlValue();
+    }
+}
+
 void wxGrid::SaveEditControlValue()
 {
     if ( IsCellEditControlEnabled() )
@@ -9951,9 +9952,7 @@ wxGrid::AutoSizeColOrRow(int colOrRow, bool setAsMin, wxGridDirection direction)
 
     wxClientDC dc(m_gridWin);
 
-    // cancel editing of cell
-    HideCellEditControl();
-    SaveEditControlValue();
+    AcceptCellEditControlIfShown();
 
     // initialize both of them just to avoid compiler warnings even if only
     // really needs to be initialized here
@@ -10272,11 +10271,7 @@ void wxGrid::AutoSizeRowLabelSize( int row )
 {
     // Hide the edit control, so it
     // won't interfere with drag-shrinking.
-    if ( IsCellEditControlShown() )
-    {
-        HideCellEditControl();
-        SaveEditControlValue();
-    }
+    AcceptCellEditControlIfShown();
 
     // autosize row height depending on label text
     SetRowSize(row, -1);
@@ -10288,11 +10283,7 @@ void wxGrid::AutoSizeColLabelSize( int col )
 {
     // Hide the edit control, so it
     // won't interfere with drag-shrinking.
-    if ( IsCellEditControlShown() )
-    {
-        HideCellEditControl();
-        SaveEditControlValue();
-    }
+    AcceptCellEditControlIfShown();
 
     // autosize column width depending on label text
     SetColSize(col, -1);

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -2012,7 +2012,7 @@ void wxGridRowLabelWindow::OnMouseEvent( wxMouseEvent& event )
 
 void wxGridRowLabelWindow::OnMouseWheel( wxMouseEvent& event )
 {
-    if (!m_owner->GetEventHandler()->ProcessEvent( event ))
+    if (!m_owner->ProcessWindowEvent( event ))
         event.Skip();
 }
 
@@ -2061,7 +2061,7 @@ void wxGridColLabelWindow::OnMouseEvent( wxMouseEvent& event )
 
 void wxGridColLabelWindow::OnMouseWheel( wxMouseEvent& event )
 {
-    if (!m_owner->GetEventHandler()->ProcessEvent( event ))
+    if (!m_owner->ProcessWindowEvent( event ))
         event.Skip();
 }
 
@@ -2087,7 +2087,7 @@ void wxGridCornerLabelWindow::OnMouseEvent( wxMouseEvent& event )
 
 void wxGridCornerLabelWindow::OnMouseWheel( wxMouseEvent& event )
 {
-    if (!m_owner->GetEventHandler()->ProcessEvent(event))
+    if (!m_owner->ProcessWindowEvent(event))
         event.Skip();
 }
 
@@ -2450,7 +2450,7 @@ void wxGridWindow::OnMouseEvent( wxMouseEvent& event )
 
 void wxGridWindow::OnMouseWheel( wxMouseEvent& event )
 {
-    if (!m_owner->GetEventHandler()->ProcessEvent( event ))
+    if (!m_owner->ProcessWindowEvent( event ))
         event.Skip();
 }
 
@@ -2459,19 +2459,19 @@ void wxGridWindow::OnMouseWheel( wxMouseEvent& event )
 //
 void wxGridWindow::OnKeyDown( wxKeyEvent& event )
 {
-    if ( !m_owner->GetEventHandler()->ProcessEvent( event ) )
+    if ( !m_owner->ProcessWindowEvent( event ) )
         event.Skip();
 }
 
 void wxGridWindow::OnKeyUp( wxKeyEvent& event )
 {
-    if ( !m_owner->GetEventHandler()->ProcessEvent( event ) )
+    if ( !m_owner->ProcessWindowEvent( event ) )
         event.Skip();
 }
 
 void wxGridWindow::OnChar( wxKeyEvent& event )
 {
-    if ( !m_owner->GetEventHandler()->ProcessEvent( event ) )
+    if ( !m_owner->ProcessWindowEvent( event ) )
         event.Skip();
 }
 
@@ -2501,7 +2501,7 @@ void wxGridWindow::OnFocus(wxFocusEvent& event)
             Refresh(true, &cursor);
     }
 
-    if ( !m_owner->GetEventHandler()->ProcessEvent( event ) )
+    if ( !m_owner->ProcessWindowEvent( event ) )
         event.Skip();
 }
 
@@ -5294,7 +5294,7 @@ wxGrid::SendGridSizeEvent(wxEventType type,
            mouseEv.GetY() + GetColLabelSize(),
            mouseEv);
 
-   return GetEventHandler()->ProcessEvent(gridEvt);
+   return ProcessWindowEvent(gridEvt);
 }
 
 // Process the event and return
@@ -5303,7 +5303,7 @@ wxGrid::SendGridSizeEvent(wxEventType type,
 //   0 if the event wasn't handled
 int wxGrid::DoSendEvent(wxGridEvent& gridEvt)
 {
-    const bool claimed = GetEventHandler()->ProcessEvent(gridEvt);
+    const bool claimed = ProcessWindowEvent(gridEvt);
 
     // A Veto'd event may not be `claimed' so test this first
     if ( !gridEvt.IsAllowed() )
@@ -5664,7 +5664,7 @@ void wxGrid::OnKeyDown( wxKeyEvent& event )
     wxKeyEvent keyEvt( event );
     keyEvt.SetEventObject( parent );
 
-    if ( !parent->GetEventHandler()->ProcessEvent( keyEvt ) )
+    if ( !parent->ProcessWindowEvent( keyEvt ) )
     {
         if (GetLayoutDirection() == wxLayout_RightToLeft)
         {
@@ -7291,7 +7291,7 @@ void wxGrid::ShowCellEditControl()
                                              row,
                                              col,
                                              editorWindow);
-                GetEventHandler()->ProcessEvent(evt);
+                ProcessWindowEvent(evt);
             }
             else if ( editor->GetWindow() &&
                       editor->GetWindow()->GetParent() != gridWindow )


### PR DESCRIPTION
Try to make `wxGrid` code a bit less convoluted. It's definitely still not ideal, but hopefully the logic of hiding/showing/enabling/disabling cell editors is a bit easier to follow after these changes.

There are no real changes here yet, but this should make it simpler to implement further (user-visible) improvements.