### PR TITLE
Remove useless code from IsShownOnScreen() in wxOSX

### DIFF
--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -2422,20 +2422,6 @@ bool wxWindowMac::IsShownOnScreen() const
 {
     if ( GetPeer() && GetPeer()->IsOk() )
     {
-        bool peerVis = GetPeer()->IsVisible();
-        bool wxVis = wxWindowBase::IsShownOnScreen();
-        if( peerVis != wxVis )
-        {
-            // CS : put a breakpoint here to investigate differences
-            // between native an wx visibilities
-            // the only place where I've encountered them until now
-            // are the hiding/showing sequences where the vis-changed event is
-            // first sent to the innermost control, while wx does things
-            // from the outmost control
-            wxVis = wxWindowBase::IsShownOnScreen();
-            return wxVis;
-        }
-
         return GetPeer()->IsVisible();
     }
     return wxWindowBase::IsShownOnScreen();


### PR DESCRIPTION
There is no need to call wxWindowBase::IsShownOnScreen() if we have a
valid peer, as we can just use its IsVisible() directly.

This shouldn't change anything, but should significantly speed up this
function by avoiding a lot of useless work.

Closes [#18645](https://trac.wxwidgets.org/ticket/18645).

---

@csomor Do you mind removing this? Apparently it's taking noticeable time (see the ticket link above).