### PR TITLE
iOS menu support

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -3537,7 +3537,6 @@ COND_TOOLKIT_OSX_IPHONE_GUI_HDR =  \
 	wx/generic/icon.h \
 	wx/generic/imaglist.h \
 	wx/osx/iphone/chkconf.h \
-	wx/osx/iphone/evtloop.h \
 	wx/osx/iphone/private.h \
 	wx/generic/region.h \
 	wx/osx/sound.h
@@ -5691,7 +5690,9 @@ COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS =  \
 	monodll_iphone_settings.o \
 	monodll_sound_osx.o \
 	monodll_core_sound.o \
-	monodll_iphone_statbmp.o
+	monodll_iphone_statbmp.o \
+	monodll_iphone_menuitem.o \
+	monodll_iphone_menu.o
 @COND_TOOLKIT_OSX_IPHONE@__GUI_SRC_OBJECTS = $(COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS)
 COND_TOOLKIT_QT___GUI_SRC_OBJECTS =  \
 	monodll_taskbarcmn.o \
@@ -7670,7 +7671,9 @@ COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS_1 =  \
 	monolib_iphone_settings.o \
 	monolib_sound_osx.o \
 	monolib_core_sound.o \
-	monolib_iphone_statbmp.o
+	monolib_iphone_statbmp.o \
+	monolib_iphone_menuitem.o \
+	monolib_iphone_menu.o
 @COND_TOOLKIT_OSX_IPHONE@__GUI_SRC_OBJECTS_1 = $(COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS_1)
 COND_TOOLKIT_QT___GUI_SRC_OBJECTS_1 =  \
 	monolib_taskbarcmn.o \
@@ -9795,7 +9798,9 @@ COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS_2 =  \
 	coredll_iphone_settings.o \
 	coredll_sound_osx.o \
 	coredll_core_sound.o \
-	coredll_iphone_statbmp.o
+	coredll_iphone_statbmp.o \
+	coredll_iphone_menuitem.o \
+	coredll_iphone_menu.o
 @COND_TOOLKIT_OSX_IPHONE@__GUI_SRC_OBJECTS_2 = $(COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS_2)
 COND_TOOLKIT_QT___GUI_SRC_OBJECTS_2 =  \
 	coredll_taskbarcmn.o \
@@ -11510,7 +11515,9 @@ COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS_3 =  \
 	corelib_iphone_settings.o \
 	corelib_sound_osx.o \
 	corelib_core_sound.o \
-	corelib_iphone_statbmp.o
+	corelib_iphone_statbmp.o \
+	corelib_iphone_menuitem.o \
+	corelib_iphone_menu.o
 @COND_TOOLKIT_OSX_IPHONE@__GUI_SRC_OBJECTS_3 = $(COND_TOOLKIT_OSX_IPHONE___GUI_SRC_OBJECTS_3)
 COND_TOOLKIT_QT___GUI_SRC_OBJECTS_3 =  \
 	corelib_taskbarcmn.o \
@@ -16658,6 +16665,12 @@ monodll_iphone_settings.o: $(srcdir)/src/osx/iphone/settings.mm $(MONODLL_ODEP)
 
 monodll_iphone_statbmp.o: $(srcdir)/src/osx/iphone/statbmp.mm $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/statbmp.mm
+
+monodll_iphone_menuitem.o: $(srcdir)/src/osx/iphone/menuitem.mm $(MONODLL_ODEP)
+	$(CXXC) -c -o $@ $(MONODLL_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/menuitem.mm
+
+monodll_iphone_menu.o: $(srcdir)/src/osx/iphone/menu.mm $(MONODLL_ODEP)
+	$(CXXC) -c -o $@ $(MONODLL_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/menu.mm
 
 monodll_qt_accel.o: $(srcdir)/src/qt/accel.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/qt/accel.cpp
@@ -21911,6 +21924,12 @@ monolib_iphone_settings.o: $(srcdir)/src/osx/iphone/settings.mm $(MONOLIB_ODEP)
 
 monolib_iphone_statbmp.o: $(srcdir)/src/osx/iphone/statbmp.mm $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/statbmp.mm
+
+monolib_iphone_menuitem.o: $(srcdir)/src/osx/iphone/menuitem.mm $(MONOLIB_ODEP)
+	$(CXXC) -c -o $@ $(MONOLIB_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/menuitem.mm
+
+monolib_iphone_menu.o: $(srcdir)/src/osx/iphone/menu.mm $(MONOLIB_ODEP)
+	$(CXXC) -c -o $@ $(MONOLIB_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/menu.mm
 
 monolib_qt_accel.o: $(srcdir)/src/qt/accel.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/qt/accel.cpp
@@ -27822,6 +27841,12 @@ coredll_iphone_settings.o: $(srcdir)/src/osx/iphone/settings.mm $(COREDLL_ODEP)
 coredll_iphone_statbmp.o: $(srcdir)/src/osx/iphone/statbmp.mm $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/statbmp.mm
 
+coredll_iphone_menuitem.o: $(srcdir)/src/osx/iphone/menuitem.mm $(COREDLL_ODEP)
+	$(CXXC) -c -o $@ $(COREDLL_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/menuitem.mm
+
+coredll_iphone_menu.o: $(srcdir)/src/osx/iphone/menu.mm $(COREDLL_ODEP)
+	$(CXXC) -c -o $@ $(COREDLL_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/menu.mm
+
 coredll_qt_accel.o: $(srcdir)/src/qt/accel.cpp $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/qt/accel.cpp
 
@@ -32063,6 +32088,12 @@ corelib_iphone_settings.o: $(srcdir)/src/osx/iphone/settings.mm $(CORELIB_ODEP)
 
 corelib_iphone_statbmp.o: $(srcdir)/src/osx/iphone/statbmp.mm $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/statbmp.mm
+
+corelib_iphone_menuitem.o: $(srcdir)/src/osx/iphone/menuitem.mm $(CORELIB_ODEP)
+	$(CXXC) -c -o $@ $(CORELIB_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/menuitem.mm
+
+corelib_iphone_menu.o: $(srcdir)/src/osx/iphone/menu.mm $(CORELIB_ODEP)
+	$(CXXC) -c -o $@ $(CORELIB_OBJCXXFLAGS) $(srcdir)/src/osx/iphone/menu.mm
 
 corelib_qt_accel.o: $(srcdir)/src/qt/accel.cpp $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/qt/accel.cpp

--- a/build/bakefiles/files.bkl
+++ b/build/bakefiles/files.bkl
@@ -2695,6 +2695,8 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     src/osx/sound_osx.cpp
     src/osx/core/sound.cpp
     src/osx/iphone/statbmp.mm
+    src/osx/iphone/menuitem.mm
+    src/osx/iphone/menu.mm
 </set>
 
 <set var="OSX_IPHONE_HDR" hints="files">

--- a/build/cmake/files.cmake
+++ b/build/cmake/files.cmake
@@ -2565,6 +2565,8 @@ set(OSX_IPHONE_SRC
     src/osx/sound_osx.cpp
     src/osx/core/sound.cpp
     src/osx/iphone/statbmp.mm
+    src/osx/iphone/menuitem.mm
+    src/osx/iphone/menu.mm
 )
 
 set(OSX_IPHONE_HDR

--- a/build/cmake/options.cmake
+++ b/build/cmake/options.cmake
@@ -377,7 +377,8 @@ wx_option(wxUSE_WIZARDDLG "use wxWizard")
 # misc GUI options
 # ---------------------------------------------------------------------------
 
-wx_option(wxUSE_MENUS "use wxMenu/wxMenuBar/wxMenuItem classes")
+wx_option(wxUSE_MENUS "use wxMenu and wxMenuItem classes")
+wx_option(wxUSE_MENUBAR "use wxMenuBar class")
 wx_option(wxUSE_MINIFRAME "use wxMiniFrame class")
 wx_option(wxUSE_TOOLTIPS "use wxToolTip class")
 wx_option(wxUSE_SPLINES "use spline drawing code")

--- a/build/cmake/samples/CMakeLists.txt
+++ b/build/cmake/samples/CMakeLists.txt
@@ -90,7 +90,7 @@ wx_add_sample(listctrl listtest.cpp listtest.h RES listtest.rc DEPENDS wxUSE_LIS
 wx_add_sample(mdi mdi.cpp mdi.h RES mdi.rc DEPENDS wxUSE_MDI wxUSE_DOC_VIEW_ARCHITECTURE wxUSE_MDI_ARCHITECTURE)
 wx_add_sample(mediaplayer LIBRARIES wxmedia DEPENDS wxUSE_MEDIACTRL)
 wx_add_sample(memcheck)
-wx_add_sample(menu DEPENDS wxUSE_MENUS)
+wx_add_sample(menu DEPENDS wxUSE_MENUS wxUSE_MENUBAR)
 wx_add_sample(minimal IMPORTANT)
 wx_add_sample(notebook notebook.cpp notebook.h LIBRARIES wxaui DEPENDS wxUSE_NOTEBOOK)
 if(wxUSE_OPENGL)

--- a/build/files
+++ b/build/files
@@ -2533,6 +2533,8 @@ OSX_IPHONE_SRC =
     src/osx/iphone/dialog.mm
     src/osx/iphone/evtloop.mm
     src/osx/iphone/gauge.mm
+    src/osx/iphone/menu.mm
+    src/osx/iphone/menuitem.mm
     src/osx/iphone/msgdlg.mm
     src/osx/iphone/nonownedwnd.mm
     src/osx/iphone/scrolbar.mm

--- a/build/osx/wxiphone.xcodeproj/project.pbxproj
+++ b/build/osx/wxiphone.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		00F1531404F832C6AE0748F2 /* spinbutt_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5E2F1BF8904635049BAFD6E1 /* spinbutt_osx.cpp */; };
 		014AF0BAB1783A5D9D75A7ED /* zstream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B9B5BC858CCF3477895D2786 /* zstream.cpp */; };
 		0164A65CDB7A334A8E9AA4BF /* dynload.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93BA27DFFB023F2EBD6295E3 /* dynload.cpp */; };
-		01D4C5F2147F3942A7CE91AA /* icon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5DAF1F49F0F3F41A427A21D /* icon.cpp */; };
 		01D4C5F2147F3942A7CE91AB /* icon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5DAF1F49F0F3F41A427A21E /* icon.cpp */; };
 		020BBB417207393F8C60EFB6 /* LexFortran.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 86A0C3603C8A343AAFBD2CE0 /* LexFortran.cxx */; };
 		026F90F7492C316A94128916 /* logg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C64705CE9398316D87BAB4DC /* logg.cpp */; };
@@ -678,12 +677,10 @@
 		CCE4ECA9CE883B008065C6FB /* jctrans.c in Sources */ = {isa = PBXBuildFile; fileRef = 725574EF98C4301989181CBF /* jctrans.c */; };
 		CCFD3144A22C3A87B67D88AB /* LexRebol.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 0D9828C9BD9633C1A8F4E0CD /* LexRebol.cxx */; };
 		CD241361D4693785A0B8939D /* StyleContext.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 9720FFA4490D3AC38E53BE03 /* StyleContext.cxx */; };
-		CD2A9111B8A83AFA8B5B97E5 /* overlay.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2128AD8BD12E3F33AD57478E /* overlay.cpp */; };
 		CD35A576FD363FD49C3AC4B3 /* LexAda.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 375E7A99FF4C38FA9E223772 /* LexAda.cxx */; };
 		CDC0FF253B503BA19693D68D /* xh_propdlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 49BF55FA3427335097F99A2C /* xh_propdlg.cpp */; };
 		CE17002B5B7E375582747639 /* xh_choic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 89EC3C6F9AEF3F6DA7CEB3B3 /* xh_choic.cpp */; };
 		CE2C937117FE3AB599DD30B9 /* sound_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A9B2316B32653DA0939A372D /* sound_osx.cpp */; };
-		EA10DA3199813E90B39C70D3 /* xh_infobar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 45C65E309F3A39598C043657 /* xh_infobar.cpp */; };
 		CEBAAB0C77983358A601BFFE /* jdmaster.c in Sources */ = {isa = PBXBuildFile; fileRef = ED19EF377E653F71B1876259 /* jdmaster.c */; };
 		CEC6430AEB6E3200BFA75D07 /* jfdctint.c in Sources */ = {isa = PBXBuildFile; fileRef = 90EC2A5B80EE3031BA4087B9 /* jfdctint.c */; };
 		CEE0D7A7D5D8323B9957A780 /* notifmsgg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 924AA3A156F834BCA1A57976 /* notifmsgg.cpp */; };
@@ -781,6 +778,7 @@
 		E92EB502F79638B0BE569EF4 /* CallTip.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 4F58B88D42A93BD0B74ADF75 /* CallTip.cxx */; };
 		E9EDB5C92D5D3B529E8D73B0 /* valgen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7440859617F3B47AF4D3817 /* valgen.cpp */; };
 		EA02FA6D3B003F8F8A2963C6 /* toolbar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE4B0CE56BA23002A5C8AEFF /* toolbar.cpp */; };
+		EA10DA3199813E90B39C70D3 /* xh_infobar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 45C65E309F3A39598C043657 /* xh_infobar.cpp */; };
 		EAA469E1A0CC33E4A21A3F7A /* gaugecmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 570D603125ED3A14848FA2E2 /* gaugecmn.cpp */; };
 		EAE02BA934B43EEE92C496C7 /* dcpsg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EEA0945B20913754A54D0FD9 /* dcpsg.cpp */; };
 		EB52C6A915943813932944FE /* control.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 12363D1F50FE301DAEE7F04A /* control.cpp */; };
@@ -960,7 +958,6 @@
 		1FBC6F8B4CA63A0081D6F34A /* tif_ojpeg.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_ojpeg.c; path = ../../src/tiff/libtiff/tif_ojpeg.c; sourceTree = "<group>"; };
 		20B922D61CDB3CCEB59A5194 /* convauto.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = convauto.cpp; path = ../../src/common/convauto.cpp; sourceTree = "<group>"; };
 		20E4A10BCD773C84AEC481A1 /* jdmarker.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jdmarker.c; path = ../../src/jpeg/jdmarker.c; sourceTree = "<group>"; };
-		2128AD8BD12E3F33AD57478E /* overlay.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = overlay.cpp; path = ../../src/osx/carbon/overlay.cpp; sourceTree = "<group>"; };
 		21A697F65B1E31168F0A7BD7 /* xh_tree.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_tree.cpp; path = ../../src/xrc/xh_tree.cpp; sourceTree = "<group>"; };
 		22D6E6D9712338C6906CFAA4 /* dcscreen.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = dcscreen.cpp; path = ../../src/osx/carbon/dcscreen.cpp; sourceTree = "<group>"; };
 		22D9626646773CED82449D5D /* persist.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = persist.cpp; path = ../../src/common/persist.cpp; sourceTree = "<group>"; };
@@ -1077,6 +1074,7 @@
 		4549845C0751356A907C23E0 /* jdtrans.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jdtrans.c; path = ../../src/jpeg/jdtrans.c; sourceTree = "<group>"; };
 		45860601270D318D93BEE1F3 /* LexMagik.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexMagik.cxx; path = ../../src/stc/scintilla/lexers/LexMagik.cxx; sourceTree = "<group>"; };
 		4592464D4868329897F3864D /* LexSpice.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexSpice.cxx; path = ../../src/stc/scintilla/lexers/LexSpice.cxx; sourceTree = "<group>"; };
+		45C65E309F3A39598C043657 /* xh_infobar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = xh_infobar.cpp; path = ../../src/xrc/xh_infobar.cpp; sourceTree = "<group>"; };
 		45D7558DF5E03A2EB41883F0 /* pngwutil.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pngwutil.c; path = ../../src/png/pngwutil.c; sourceTree = "<group>"; };
 		45E7EC6D0C0E3C878664C0A9 /* fldlgcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fldlgcmn.cpp; path = ../../src/common/fldlgcmn.cpp; sourceTree = "<group>"; };
 		47783A330B2A3B4EBB1CD95D /* fswatcherg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fswatcherg.cpp; path = ../../src/generic/fswatcherg.cpp; sourceTree = "<group>"; };
@@ -1553,7 +1551,6 @@
 		CD72950967F33809931D4968 /* LexAbaqus.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexAbaqus.cxx; path = ../../src/stc/scintilla/lexers/LexAbaqus.cxx; sourceTree = "<group>"; };
 		CDA232B9FFD33B7482E69B58 /* xh_tglbtn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_tglbtn.cpp; path = ../../src/xrc/xh_tglbtn.cpp; sourceTree = "<group>"; };
 		CDB4AB7CDABA3A54B4F8207B /* imaggif.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = imaggif.cpp; path = ../../src/common/imaggif.cpp; sourceTree = "<group>"; };
-		45C65E309F3A39598C043657 /* xh_infobar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = xh_infobar.cpp; path = ../../src/xrc/xh_infobar.cpp; sourceTree = "<group>"; };
 		CF23AF3EFC5731B2A5BCF4A3 /* choicdgg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = choicdgg.cpp; path = ../../src/generic/choicdgg.cpp; sourceTree = "<group>"; };
 		CF4F4F5211933057824B5621 /* button_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = button_osx.cpp; path = ../../src/osx/button_osx.cpp; sourceTree = "<group>"; };
 		CF502E0E4D853CBBBEC885EF /* LexerSimple.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexerSimple.cxx; path = ../../src/stc/scintilla/lexlib/LexerSimple.cxx; sourceTree = "<group>"; };
@@ -1681,7 +1678,6 @@
 		F4B85051B7C835A8BF4E3EE1 /* xh_panel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_panel.cpp; path = ../../src/xrc/xh_panel.cpp; sourceTree = "<group>"; };
 		F4C72C5C61A6335C8B418BA1 /* LexMetapost.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexMetapost.cxx; path = ../../src/stc/scintilla/lexers/LexMetapost.cxx; sourceTree = "<group>"; };
 		F52DCBC0442233738B39138E /* CaseFolder.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = CaseFolder.cxx; path = ../../src/stc/scintilla/src/CaseFolder.cxx; sourceTree = "<group>"; };
-		F5DAF1F49F0F3F41A427A21D /* icon.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = icon.cpp; path = ../../src/osx/carbon/icon.cpp; sourceTree = "<group>"; };
 		F5DAF1F49F0F3F41A427A21E /* icon.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = icon.cpp; path = ../../src/generic/icon.cpp; sourceTree = "<group>"; };
 		F6EA240B3DB93D398A990FAD /* tif_dirread.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_dirread.c; path = ../../src/tiff/libtiff/tif_dirread.c; sourceTree = "<group>"; };
 		F6F01A84F4DE3C9FB9849004 /* tif_jbig.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_jbig.c; path = ../../src/tiff/libtiff/tif_jbig.c; sourceTree = "<group>"; };
@@ -1990,7 +1986,6 @@
 				0BF1F491B8A8376E8E2E8182 /* cursor.cpp */,
 				18044326B5B13A98A49732DD /* fontdlg.cpp */,
 				377056CEB1FC3EEB8526E7A6 /* gdiobj.cpp */,
-				F5DAF1F49F0F3F41A427A21D /* icon.cpp */,
 				757B31FCCA1F381C95B30DF8 /* app.cpp */,
 				12363D1F50FE301DAEE7F04A /* control.cpp */,
 				271B4B77622B3411A7BF6634 /* dataobj.cpp */,
@@ -2002,7 +1997,6 @@
 				C3019BA65DD73F30A865365F /* frame.cpp */,
 				B568A7364ECA30288820CCE7 /* mdi.cpp */,
 				C2BB2949CC0B387AB6879539 /* metafile.cpp */,
-				2128AD8BD12E3F33AD57478E /* overlay.cpp */,
 				530DC2E26BF2313E8702AD43 /* popupwin.cpp */,
 				425BFA3FDB7D3EA7ADCE1087 /* renderer.cpp */,
 				E1F2E9C9052D3E53BBD17DE3 /* statbrma.cpp */,
@@ -2830,7 +2824,7 @@
 			isa = PBXProject;
 			attributes = {
 			};
-			buildConfigurationList = A66311F47C8832F6A58105B6 /* Build configuration list for PBXProject "wxiPhone" */;
+			buildConfigurationList = A66311F47C8832F6A58105B6 /* Build configuration list for PBXProject "wxiphone" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
@@ -3042,7 +3036,6 @@
 				5417332FE2DB3CD3A647B15D /* cursor.cpp in Sources */,
 				D66F5D4D204B3B789C7F76B9 /* fontdlg.cpp in Sources */,
 				692FCCABFB963696AFC1E122 /* gdiobj.cpp in Sources */,
-				01D4C5F2147F3942A7CE91AA /* icon.cpp in Sources */,
 				B0E94A59C83637C09FAAE71C /* app.cpp in Sources */,
 				EB52C6A915943813932944FE /* control.cpp in Sources */,
 				45AB45C6B24A3983B22E56A5 /* dataobj.cpp in Sources */,
@@ -3054,7 +3047,6 @@
 				BDAB44F5D017395D9D3A1F23 /* frame.cpp in Sources */,
 				27E2EABB117334CD89CFD2A4 /* mdi.cpp in Sources */,
 				73AA68AB9F1236ED9F1FBB2E /* metafile.cpp in Sources */,
-				CD2A9111B8A83AFA8B5B97E5 /* overlay.cpp in Sources */,
 				805CCAE64D023561AD334B53 /* popupwin.cpp in Sources */,
 				6832385DDBB33D1B90C73CBA /* renderer.cpp in Sources */,
 				F6A1AC5CF84E32C19F91A614 /* statbrma.cpp in Sources */,
@@ -3779,7 +3771,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		A66311F47C8832F6A58105B6 /* Build configuration list for PBXProject "wxiPhone" */ = {
+		A66311F47C8832F6A58105B6 /* Build configuration list for PBXProject "wxiphone" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				55C93151F6053EBCBDD70DF9 /* Debug */,

--- a/build/osx/wxiphone.xcodeproj/project.pbxproj
+++ b/build/osx/wxiphone.xcodeproj/project.pbxproj
@@ -227,6 +227,8 @@
 		3E99016BDE043A08B4D6B3CE /* htmprint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 194ADD28300E329E80F7892E /* htmprint.cpp */; };
 		3EB6B8528A0D3B6CADAE1256 /* archive.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 02D2E8B5C89939CE90B99E2B /* archive.cpp */; };
 		3ED6F4B64C283232A79423CF /* dircmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC9B6DFBF2F73917A99361C5 /* dircmn.cpp */; };
+		400DE11324A9D41800F526FE /* menuitem.mm in Sources */ = {isa = PBXBuildFile; fileRef = 400DE11124A9D41800F526FE /* menuitem.mm */; };
+		400DE11424A9D41800F526FE /* menu.mm in Sources */ = {isa = PBXBuildFile; fileRef = 400DE11224A9D41800F526FE /* menu.mm */; };
 		403FBA20CEFE3EAFB4E6B905 /* dir.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7332A03D93D3DABB050615D /* dir.cpp */; };
 		4040AE89BF9F34668091064A /* dragimgg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2A67053D16D63C588E555C84 /* dragimgg.cpp */; };
 		41943A8F82723027A151A468 /* fileconf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 61DA2A4C0D143CBE804BB8A1 /* fileconf.cpp */; };
@@ -1058,6 +1060,8 @@
 		3FB6D34C3029357EB64AECAA /* scrlwing.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = scrlwing.cpp; path = ../../src/generic/scrlwing.cpp; sourceTree = "<group>"; };
 		3FEBA7AC7F743EE88352AEBC /* htmlwin.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = htmlwin.cpp; path = ../../src/html/htmlwin.cpp; sourceTree = "<group>"; };
 		400275BE019D3E5BA47988BE /* inffast.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = inffast.c; path = ../../src/zlib/inffast.c; sourceTree = "<group>"; };
+		400DE11124A9D41800F526FE /* menuitem.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = menuitem.mm; path = ../../src/osx/iphone/menuitem.mm; sourceTree = "<group>"; };
+		400DE11224A9D41800F526FE /* menu.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = menu.mm; path = ../../src/osx/iphone/menu.mm; sourceTree = "<group>"; };
 		4048A3523EC03409BD899BEF /* xtixml.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xtixml.cpp; path = ../../src/common/xtixml.cpp; sourceTree = "<group>"; };
 		40586C8986443431A64EB066 /* LexLisp.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexLisp.cxx; path = ../../src/stc/scintilla/lexers/LexLisp.cxx; sourceTree = "<group>"; };
 		4071FF90F1D4336C836B2AE4 /* tif_pixarlog.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_pixarlog.c; path = ../../src/tiff/libtiff/tif_pixarlog.c; sourceTree = "<group>"; };
@@ -2024,6 +2028,8 @@
 				83B878A16ABC396E8C03A15E /* dialog.mm */,
 				8D2549709E0133C9A267E3A5 /* evtloop.mm */,
 				98A7F0605AAC3D28A8C9F253 /* gauge.mm */,
+				400DE11224A9D41800F526FE /* menu.mm */,
+				400DE11124A9D41800F526FE /* menuitem.mm */,
 				33CFE51FD6F0362092DF1A85 /* msgdlg.mm */,
 				AECB45CEAC093CE4AB4B7E45 /* nonownedwnd.mm */,
 				CC2E24773D853A77B9FEFA4C /* scrolbar.mm */,
@@ -2824,7 +2830,7 @@
 			isa = PBXProject;
 			attributes = {
 			};
-			buildConfigurationList = A66311F47C8832F6A58105B6 /* Build configuration list for PBXProject "wxiphone" */;
+			buildConfigurationList = A66311F47C8832F6A58105B6 /* Build configuration list for PBXProject "wxiPhone" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
@@ -3045,6 +3051,7 @@
 				774EB9F3F7E93A379E1F7551 /* graphics.cpp in Sources */,
 				5792675690843C6AA4125A72 /* font.cpp in Sources */,
 				BDAB44F5D017395D9D3A1F23 /* frame.cpp in Sources */,
+				400DE11324A9D41800F526FE /* menuitem.mm in Sources */,
 				27E2EABB117334CD89CFD2A4 /* mdi.cpp in Sources */,
 				73AA68AB9F1236ED9F1FBB2E /* metafile.cpp in Sources */,
 				805CCAE64D023561AD334B53 /* popupwin.cpp in Sources */,
@@ -3294,6 +3301,7 @@
 				8AA341CCFB8E3F6AB3523595 /* splash.cpp in Sources */,
 				98F52D5224B438DFA8887E06 /* timectrlg.cpp in Sources */,
 				77BC918AF05C30E8A0BD27F8 /* tipdlg.cpp in Sources */,
+				400DE11424A9D41800F526FE /* menu.mm in Sources */,
 				060E095718B03EF98C754799 /* treelist.cpp in Sources */,
 				82FA4AA043213728AC266700 /* wizard.cpp in Sources */,
 				EC3D181D65F33E09A675FFF2 /* addremovectrl.cpp in Sources */,
@@ -3771,7 +3779,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		A66311F47C8832F6A58105B6 /* Build configuration list for PBXProject "wxiphone" */ = {
+		A66311F47C8832F6A58105B6 /* Build configuration list for PBXProject "wxiPhone" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				55C93151F6053EBCBDD70DF9 /* Debug */,

--- a/build/osx/wxiphone.xcodeproj/xcshareddata/xcschemes/static.xcscheme
+++ b/build/osx/wxiphone.xcodeproj/xcshareddata/xcschemes/static.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0940"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BAB02EC06578349A9171CCAC"
+               BuildableName = "libwx_osx_iphone.a"
+               BlueprintName = "static"
+               ReferencedContainer = "container:wxiPhone.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BAB02EC06578349A9171CCAC"
+            BuildableName = "libwx_osx_iphone.a"
+            BlueprintName = "static"
+            ReferencedContainer = "container:wxiPhone.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BAB02EC06578349A9171CCAC"
+            BuildableName = "libwx_osx_iphone.a"
+            BlueprintName = "static"
+            ReferencedContainer = "container:wxiPhone.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/configure
+++ b/configure
@@ -36442,7 +36442,6 @@ fi
 
 if test "$wxUSE_MENUS" = "yes"; then
     $as_echo "#define wxUSE_MENUS 1" >>confdefs.h
-    $as_echo "#define wxUSE_MENUBAR 1" >>confdefs.h
 
     if test "$wxUSE_MENUBAR" = "yes"; then
         $as_echo "#define wxUSE_MENUBAR 1" >>confdefs.h

--- a/configure
+++ b/configure
@@ -1318,6 +1318,7 @@ enable_tipdlg
 enable_progressdlg
 enable_wizarddlg
 enable_menus
+enable_menubar
 enable_miniframe
 enable_tooltips
 enable_splines
@@ -2272,7 +2273,8 @@ Optional Features:
   --enable-tipdlg         use startup tips
   --enable-progressdlg    use wxProgressDialog
   --enable-wizarddlg      use wxWizard
-  --enable-menus          use wxMenu/wxMenuBar/wxMenuItem classes
+  --enable-menus          use wxMenu and wxMenuItem classes
+  --enable-menubar        use wxMenuBar class
   --enable-miniframe      use wxMiniFrame class
   --enable-tooltips       use wxToolTip class
   --enable-splines        use spline drawing code
@@ -11705,6 +11707,35 @@ fi
 
 
           eval "$wx_cv_use_menus"
+
+
+          enablestring=
+          defaultval=$wxUSE_ALL_FEATURES
+          if test -z "$defaultval"; then
+              if test x"$enablestring" = xdisable; then
+                  defaultval=yes
+              else
+                  defaultval=no
+              fi
+          fi
+
+          # Check whether --enable-menubar was given.
+if test "${enable_menubar+set}" = set; then :
+  enableval=$enable_menubar;
+                          if test "$enableval" = yes; then
+                            wx_cv_use_menubar='wxUSE_MENUBAR=yes'
+                          else
+                            wx_cv_use_menubar='wxUSE_MENUBAR=no'
+                          fi
+
+else
+
+                          wx_cv_use_menubar='wxUSE_MENUBAR=${'DEFAULT_wxUSE_MENUBAR":-$defaultval}"
+
+fi
+
+
+          eval "$wx_cv_use_menubar"
 
 
           enablestring=
@@ -36413,7 +36444,14 @@ if test "$wxUSE_MENUS" = "yes"; then
     $as_echo "#define wxUSE_MENUS 1" >>confdefs.h
     $as_echo "#define wxUSE_MENUBAR 1" >>confdefs.h
 
-    SAMPLES_SUBDIRS="$SAMPLES_SUBDIRS menu"
+    if test "$wxUSE_MENUBAR" = "yes"; then
+        $as_echo "#define wxUSE_MENUBAR 1" >>confdefs.h
+
+        SAMPLES_SUBDIRS="$SAMPLES_SUBDIRS menu"
+    fi
+elif test "$wxUSE_MENUBAR" = "yes"; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: wxMenuBar can't be used without wxMenu and will be disabled" >&5
+$as_echo "$as_me: WARNING: wxMenuBar can't be used without wxMenu and will be disabled" >&2;}
 fi
 
 if test "$wxUSE_MIMETYPE" = "yes"; then

--- a/configure
+++ b/configure
@@ -36411,6 +36411,7 @@ fi
 
 if test "$wxUSE_MENUS" = "yes"; then
     $as_echo "#define wxUSE_MENUS 1" >>confdefs.h
+    $as_echo "#define wxUSE_MENUBAR 1" >>confdefs.h
 
     SAMPLES_SUBDIRS="$SAMPLES_SUBDIRS menu"
 fi

--- a/configure.in
+++ b/configure.in
@@ -1014,7 +1014,8 @@ if test "$wxUSE_MSW" = 1 ; then
     DEFAULT_wxUSE_ACCESSIBILITY=yes
 fi
 
-WX_ARG_FEATURE(menus,       [  --enable-menus          use wxMenu/wxMenuBar/wxMenuItem classes], wxUSE_MENUS)
+WX_ARG_FEATURE(menus,       [  --enable-menus          use wxMenu and wxMenuItem classes], wxUSE_MENUS)
+WX_ARG_FEATURE(menubar,     [  --enable-menubar        use wxMenuBar class], wxUSE_MENUBAR)
 WX_ARG_FEATURE(miniframe,   [  --enable-miniframe      use wxMiniFrame class], wxUSE_MINIFRAME)
 WX_ARG_FEATURE(tooltips,    [  --enable-tooltips       use wxToolTip class], wxUSE_TOOLTIPS)
 WX_ARG_FEATURE(splines,     [  --enable-splines        use spline drawing code], wxUSE_SPLINES)
@@ -7197,7 +7198,12 @@ fi
 
 if test "$wxUSE_MENUS" = "yes"; then
     AC_DEFINE(wxUSE_MENUS)
-    SAMPLES_SUBDIRS="$SAMPLES_SUBDIRS menu"
+    if test "$wxUSE_MENUBAR" = "yes"; then
+        AC_DEFINE(wxUSE_MENUBAR)
+        SAMPLES_SUBDIRS="$SAMPLES_SUBDIRS menu"
+    fi
+elif test "$wxUSE_MENUBAR" = "yes"; then
+    AC_MSG_WARN([wxMenuBar can't be used without wxMenu and will be disabled])
 fi
 
 if test "$wxUSE_MIMETYPE" = "yes"; then

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -98,7 +98,7 @@
      */
     #pragma warning(disable: 4127) /*  conditional expression is constant */
 
-    /* There are too many false positives for this one, particularly when
+    /* There are too many false positivies for this one, particularly when
        using templates like wxVector<T> */
     /* class 'foo' needs to have dll-interface to be used by clients of
        class 'bar'" */
@@ -2777,6 +2777,8 @@ typedef WX_NSPasteboard OSXPasteboard;
 
 #elif wxOSX_USE_IPHONE
 
+DECLARE_WXCOCOA_OBJC_CLASS(UIMenu);
+DECLARE_WXCOCOA_OBJC_CLASS(UIMenuItem);
 DECLARE_WXCOCOA_OBJC_CLASS(UIWindow);
 DECLARE_WXCOCOA_OBJC_CLASS(UImage);
 DECLARE_WXCOCOA_OBJC_CLASS(UIView);
@@ -2791,6 +2793,7 @@ DECLARE_WXCOCOA_OBJC_CLASS(UIPasteboard);
 typedef WX_UIWindow WXWindow;
 typedef WX_UIView WXWidget;
 typedef WX_UIImage WXImage;
+typedef WX_UIMenu WXHMENU;
 typedef WX_EAGLContext WXGLContext;
 typedef WX_NSString WXGLPixelFormat;
 typedef WX_UIWebView OSXWebViewPtr;

--- a/include/wx/frame.h
+++ b/include/wx/frame.h
@@ -23,7 +23,9 @@ extern WXDLLIMPEXP_DATA_CORE(const char) wxStatusLineNameStr[];
 extern WXDLLIMPEXP_DATA_CORE(const char) wxToolBarNameStr[];
 
 class WXDLLIMPEXP_FWD_CORE wxFrame;
+#if wxUSE_MENUBAR
 class WXDLLIMPEXP_FWD_CORE wxMenuBar;
+#endif
 class WXDLLIMPEXP_FWD_CORE wxMenuItem;
 class WXDLLIMPEXP_FWD_CORE wxStatusBar;
 class WXDLLIMPEXP_FWD_CORE wxToolBar;
@@ -78,6 +80,7 @@ public:
     // ------------------
 
 #if wxUSE_MENUS
+#if wxUSE_MENUBAR
     virtual void SetMenuBar(wxMenuBar *menubar);
     virtual wxMenuBar *GetMenuBar() const { return m_frameMenuBar; }
 
@@ -85,7 +88,7 @@ public:
     // and exists mainly in order to be overridden in the MDI parent frame
     // which also looks at its active child menu bar
     virtual wxMenuItem *FindItemInMenuBar(int menuId) const;
-
+#endif
     // generate menu command corresponding to the given menu item
     //
     // returns true if processed
@@ -192,7 +195,7 @@ protected:
     // test whether this window makes part of the frame
     virtual bool IsOneOfBars(const wxWindow *win) const wxOVERRIDE;
 
-#if wxUSE_MENUS
+#if wxUSE_MENUBAR
     // override to update menu bar position when the frame size changes
     virtual void PositionMenuBar() { }
 
@@ -203,11 +206,13 @@ protected:
     // override to do something special when the menu bar is attached to the
     // frame
     virtual void AttachMenuBar(wxMenuBar *menubar);
-
+#endif
+    
     // Return true if we should update the menu item state from idle event
     // handler or false if we should delay it until the menu is opened.
     static bool ShouldUpdateMenuFromIdle();
 
+#if wxUSE_MENUBAR
     wxMenuBar *m_frameMenuBar;
 #endif // wxUSE_MENUS
 

--- a/include/wx/menu.h
+++ b/include/wx/menu.h
@@ -282,6 +282,7 @@ public:
     // handler to use for these events, but this should never be needed.
     void UpdateUI(wxEvtHandler* source = NULL);
 
+#if wxUSE_MENUBAR
     // get the menu bar this menu is attached to (may be NULL, always NULL for
     // popup menus).  Traverse up the menu hierarchy to find it.
     wxMenuBar *GetMenuBar() const;
@@ -292,6 +293,7 @@ public:
 
     // is the menu attached to a menu bar (or is it a popup one)?
     bool IsAttached() const { return GetMenuBar() != NULL; }
+#endif
 
     // set/get the parent of this menu
     void SetParent(wxMenu *parent) { m_menuParent = parent; }
@@ -443,6 +445,8 @@ WX_DECLARE_EXPORTED_LIST(wxMenuInfoHelper, wxMenuInfoHelperList );
 // wxMenuBar
 // ----------------------------------------------------------------------------
 
+#if wxUSE_MENUBAR
+
 class WXDLLIMPEXP_CORE wxMenuBarBase : public wxWindow
 {
 public:
@@ -584,6 +588,7 @@ protected:
 
     wxDECLARE_NO_COPY_CLASS(wxMenuBarBase);
 };
+#endif
 
 // ----------------------------------------------------------------------------
 // include the real class declaration

--- a/include/wx/osx/button.h
+++ b/include/wx/osx/button.h
@@ -46,6 +46,9 @@ public:
 
     // osx specific event handling common for all osx-ports
 
+#if wxOSX_USE_IPHONE
+    virtual void SetMenu( wxMenu* menu, bool isPrimaryAction = false);
+#endif
     virtual bool OSXHandleClicked(double timestampsec) wxOVERRIDE;
 
 #if wxOSX_USE_COCOA

--- a/include/wx/osx/button.h
+++ b/include/wx/osx/button.h
@@ -46,9 +46,6 @@ public:
 
     // osx specific event handling common for all osx-ports
 
-#if wxOSX_USE_IPHONE
-    virtual void SetMenu( wxMenu* menu, bool isPrimaryAction = false);
-#endif
     virtual bool OSXHandleClicked(double timestampsec) wxOVERRIDE;
 
 #if wxOSX_USE_COCOA

--- a/include/wx/osx/frame.h
+++ b/include/wx/osx/frame.h
@@ -90,7 +90,7 @@ protected:
     virtual void DoGetClientSize(int *width, int *height) const wxOVERRIDE;
     virtual void DoSetClientSize(int width, int height) wxOVERRIDE;
 
-#if wxUSE_MENUS
+#if wxUSE_MENUBAR
     virtual void DetachMenuBar() wxOVERRIDE;
     virtual void AttachMenuBar(wxMenuBar *menubar) wxOVERRIDE;
 #endif

--- a/include/wx/osx/iphone/chkconf.h
+++ b/include/wx/osx/iphone/chkconf.h
@@ -255,7 +255,12 @@
 
 #if wxUSE_MENUS
 #undef wxUSE_MENUS
-#define wxUSE_MENUS 0
+#define wxUSE_MENUS 1
+#endif
+
+#if wxUSE_MENUBAR
+#undef wxUSE_MENUBAR
+#define wxUSE_MENUBAR 0
 #endif
 
 /*

--- a/include/wx/osx/menu.h
+++ b/include/wx/osx/menu.h
@@ -102,7 +102,7 @@ private:
     wxDECLARE_DYNAMIC_CLASS(wxMenu);
 };
 
-#if wxOSX_USE_COCOA_OR_CARBON
+#if wxUSE_MENUBAR
 
 // the iphone only has popup-menus
 

--- a/include/wx/osx/private/available.h
+++ b/include/wx/osx/private/available.h
@@ -18,6 +18,9 @@
     #define WX_IS_MACOS_AVAILABLE(major, minor) \
         __builtin_available(macOS major ## . ## minor, *)
 
+    #define WX_IS_MACOS_OR_IOS_AVAILABLE(macmajor, macminor, imajor, iminor) \
+        __builtin_available(macOS macmajor ## . ## macminor, iOS imajor ##. ## iminor, *)
+
     #define WX_IS_MACOS_AVAILABLE_FULL(major, minor, micro) \
         __builtin_available(macOS major ## . ## minor ## . ## micro, *)
 
@@ -30,6 +33,14 @@
 
     #define WX_IS_MACOS_AVAILABLE(major, minor) \
         wxPlatformInfo::Get().CheckOSVersion(major, minor)
+
+#ifdef wxOSX_USE_IPHONE
+    #define WX_IS_MACOS_OR_IOS_AVAILABLE(macmajor, macminor, imajor, iminor) \
+        wxPlatformInfo::Get().CheckOSVersion(imajor, iminor)
+#else
+    #define WX_IS_MACOS_OR_IOS_AVAILABLE(macmajor, macminor, imajor, iminor) \
+        wxPlatformInfo::Get().CheckOSVersion(macmajor, macminor)
+#endif
 
     #define WX_IS_MACOS_AVAILABLE_FULL(major, minor, micro) \
         wxPlatformInfo::Get().CheckOSVersion(major, minor, micro)

--- a/samples/minimal/minimal.cpp
+++ b/samples/minimal/minimal.cpp
@@ -157,6 +157,7 @@ MyFrame::MyFrame(const wxString& title)
 
     fileMenu->Append(Minimal_Quit, "E&xit\tAlt-X", "Quit this program");
 
+#if wxUSE_MENUBAR
     // now append the freshly created menu to the menu bar...
     wxMenuBar *menuBar = new wxMenuBar();
     menuBar->Append(fileMenu, "&File");
@@ -164,6 +165,15 @@ MyFrame::MyFrame(const wxString& title)
 
     // ... and attach this menu bar to the frame
     SetMenuBar(menuBar);
+#else
+    wxSizer* sizer = new wxBoxSizer(wxHORIZONTAL);
+    wxButton* menuBtn = new wxButton(this, wxID_ANY, "Menu...");
+    helpMenu->SetInvokingWindow(this);
+    menuBtn->SetMenu((helpMenu));
+    sizer->Add(menuBtn, wxSizerFlags().Center());
+    SetSizer(sizer);
+#endif
+    
 #else // !wxUSE_MENUS
     // If menus are not available add a button to access the about box
     wxSizer* sizer = new wxBoxSizer(wxHORIZONTAL);

--- a/samples/minimal/minimal.cpp
+++ b/samples/minimal/minimal.cpp
@@ -165,13 +165,6 @@ MyFrame::MyFrame(const wxString& title)
 
     // ... and attach this menu bar to the frame
     SetMenuBar(menuBar);
-#else
-    wxSizer* sizer = new wxBoxSizer(wxHORIZONTAL);
-    wxButton* menuBtn = new wxButton(this, wxID_ANY, "Menu...");
-    helpMenu->SetInvokingWindow(this);
-    menuBtn->SetMenu((helpMenu));
-    sizer->Add(menuBtn, wxSizerFlags().Center());
-    SetSizer(sizer);
 #endif
     
 #else // !wxUSE_MENUS

--- a/samples/minimal/minimal_iphone.xcodeproj/project.pbxproj
+++ b/samples/minimal/minimal_iphone.xcodeproj/project.pbxproj
@@ -120,9 +120,9 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		1D6058900D05DD3D006BFB54 /* static */ = {
+		1D6058900D05DD3D006BFB54 /* app-static */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 1D6058960D05DD3E006BFB54 /* Build configuration list for PBXNativeTarget "static" */;
+			buildConfigurationList = 1D6058960D05DD3E006BFB54 /* Build configuration list for PBXNativeTarget "app-static" */;
 			buildPhases = (
 				1D60588D0D05DD3D006BFB54 /* Resources */,
 				1D60588E0D05DD3D006BFB54 /* Sources */,
@@ -132,7 +132,7 @@
 			);
 			dependencies = (
 			);
-			name = static;
+			name = "app-static";
 			productName = minimal_iphone;
 			productReference = 1D6058910D05DD3D006BFB54 /* minimal_iphone.app */;
 			productType = "com.apple.product-type.application";
@@ -164,7 +164,7 @@
 			);
 			projectRoot = "";
 			targets = (
-				1D6058900D05DD3D006BFB54 /* static */,
+				1D6058900D05DD3D006BFB54 /* app-static */,
 			);
 		};
 /* End PBXProject section */
@@ -245,7 +245,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		1D6058960D05DD3E006BFB54 /* Build configuration list for PBXNativeTarget "static" */ = {
+		1D6058960D05DD3E006BFB54 /* Build configuration list for PBXNativeTarget "app-static" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1D6058940D05DD3E006BFB54 /* Debug */,

--- a/samples/minimal/minimal_iphone.xcodeproj/xcshareddata/xcschemes/app-static.xcscheme
+++ b/samples/minimal/minimal_iphone.xcodeproj/xcshareddata/xcschemes/app-static.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0940"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1D6058900D05DD3D006BFB54"
+               BuildableName = "minimal_iphone.app"
+               BlueprintName = "app-static"
+               ReferencedContainer = "container:minimal_iphone.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1D6058900D05DD3D006BFB54"
+            BuildableName = "minimal_iphone.app"
+            BlueprintName = "app-static"
+            ReferencedContainer = "container:minimal_iphone.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1D6058900D05DD3D006BFB54"
+            BuildableName = "minimal_iphone.app"
+            BlueprintName = "app-static"
+            ReferencedContainer = "container:minimal_iphone.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1D6058900D05DD3D006BFB54"
+            BuildableName = "minimal_iphone.app"
+            BlueprintName = "app-static"
+            ReferencedContainer = "container:minimal_iphone.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/src/common/framecmn.cpp
+++ b/src/common/framecmn.cpp
@@ -148,7 +148,7 @@ wxCONSTRUCTOR_6( wxFrame, wxWindow*, Parent, wxWindowID, Id, wxString, Title, \
 
 wxFrameBase::wxFrameBase()
 {
-#if wxUSE_MENUS
+#if wxUSE_MENUBAR
     m_frameMenuBar = NULL;
 #endif // wxUSE_MENUS
 
@@ -183,7 +183,7 @@ wxFrame *wxFrameBase::New(wxWindow *parent,
 
 void wxFrameBase::DeleteAllBars()
 {
-#if wxUSE_MENUS
+#if wxUSE_MENUBAR
     wxDELETE(m_frameMenuBar);
 #endif // wxUSE_MENUS
 
@@ -198,7 +198,7 @@ void wxFrameBase::DeleteAllBars()
 
 bool wxFrameBase::IsOneOfBars(const wxWindow *win) const
 {
-#if wxUSE_MENUS
+#if wxUSE_MENUBAR
     if ( win == GetMenuBar() )
         return true;
 #endif // wxUSE_MENUS
@@ -258,11 +258,15 @@ wxPoint wxFrameBase::GetClientAreaOrigin() const
 
 bool wxFrameBase::ProcessCommand(int id)
 {
+#if wxUSE_MENUBAR
     wxMenuItem* const item = FindItemInMenuBar(id);
     if ( !item )
         return false;
 
     return ProcessCommand(item);
+#else
+    return false;
+#endif
 }
 
 bool wxFrameBase::ProcessCommand(wxMenuItem *item)
@@ -308,7 +312,7 @@ void wxFrameBase::UpdateWindowUI(long flags)
         GetToolBar()->UpdateWindowUI(flags);
 #endif
 
-#if wxUSE_MENUS
+#if wxUSE_MENUBAR
     if (GetMenuBar())
     {
         // If coming from an idle event, we only want to update the menus if
@@ -635,13 +639,17 @@ void wxFrameBase::DoMenuUpdates(wxMenu* menu)
     {
         menu->UpdateUI();
     }
+#if wxUSE_MENUBAR
     else
     {
         wxMenuBar* bar = GetMenuBar();
         if (bar != NULL)
             bar->UpdateMenus();
     }
+#endif
 }
+
+#if wxUSE_MENUBAR
 
 void wxFrameBase::DetachMenuBar()
 {
@@ -680,5 +688,7 @@ wxMenuItem *wxFrameBase::FindItemInMenuBar(int menuId) const
 
     return menuBar ? menuBar->FindItem(menuId) : NULL;
 }
+
+#endif // wxUSE_MENUBAR
 
 #endif // wxUSE_MENUS

--- a/src/common/menucmn.cpp
+++ b/src/common/menucmn.cpp
@@ -101,9 +101,10 @@ bool wxMenuBarStreamingCallback( const wxObject *WXUNUSED(object), wxObjectWrite
 }
 #endif
 
+#if wxUSE_MENUBAR
 wxIMPLEMENT_DYNAMIC_CLASS_XTI_CALLBACK(wxMenuBar, wxWindow, "wx/menu.h", \
                                        wxMenuBarStreamingCallback)
-
+#endif
 
 #if wxUSE_EXTENDED_RTTI
 WX_DEFINE_LIST( wxMenuInfoHelperList )
@@ -445,8 +446,10 @@ wxMenuItem *wxMenuBase::DoRemove(wxMenuItem *item)
     if ( submenu )
     {
         submenu->SetParent(NULL);
+#if wxUSE_MENUBAR
         if ( submenu->IsAttached() )
             submenu->Detach();
+#endif
     }
 
     return item;
@@ -648,8 +651,12 @@ bool wxMenuBase::DoProcessEvent(wxMenuBase* menu, wxEvent& event, wxWindow* win)
 {
     event.SetEventObject(menu);
 
+#if wxUSE_MENUBAR
     wxMenuBar* const mb = menu ? menu->GetMenuBar() : NULL;
-
+#else
+    bool mb = false;
+#endif
+    
     // Process event in the menu itself and all its parent menus, if it's a
     // submenu, first.
     for ( ; menu; menu = menu->GetParent() )
@@ -669,6 +676,7 @@ bool wxMenuBase::DoProcessEvent(wxMenuBase* menu, wxEvent& event, wxWindow* win)
         }
     }
 
+#if wxUSE_MENUBAR
     // If this menu is part of the menu bar, try the event there.
     if ( mb )
     {
@@ -681,7 +689,8 @@ bool wxMenuBase::DoProcessEvent(wxMenuBase* menu, wxEvent& event, wxWindow* win)
         if ( event.ShouldPropagate() )
             return false;
     }
-
+#endif
+    
     // Try the window the menu was popped up from.
     if ( win )
         return win->HandleWindowEvent(event);
@@ -712,6 +721,7 @@ wxMenuBase::ProcessMenuEvent(wxMenu* menu, wxMenuEvent& event, wxWindow* win)
 // wxMenu attaching/detaching to/from menu bar
 // ----------------------------------------------------------------------------
 
+#if wxUSE_MENUBAR
 wxMenuBar* wxMenuBase::GetMenuBar() const
 {
     if(GetParent())
@@ -737,6 +747,7 @@ void wxMenuBase::Detach()
 
     m_menuBar = NULL;
 }
+#endif
 
 // ----------------------------------------------------------------------------
 // wxMenu invoking window handling
@@ -746,9 +757,10 @@ void wxMenuBase::SetInvokingWindow(wxWindow *win)
 {
     wxASSERT_MSG( !GetParent(),
                     "should only be called for top level popup menus" );
+#if wxUSE_MENUBAR
     wxASSERT_MSG( !IsAttached(),
                     "menus attached to menu bar can't have invoking window" );
-
+#endif
     m_invokingWindow = win;
 }
 
@@ -762,8 +774,12 @@ wxWindow *wxMenuBase::GetWindow() const
         menu = menu->GetParent();
     }
 
+#if wxUSE_MENUBAR
     return menu->GetMenuBar() ? menu->GetMenuBar()->GetFrame()
                               : menu->GetInvokingWindow();
+#else
+    return menu->GetInvokingWindow();
+#endif
 }
 
 // ----------------------------------------------------------------------------
@@ -841,6 +857,8 @@ wxString wxMenuBase::GetHelpString( int itemid ) const
 
     return item->GetHelp();
 }
+
+#if wxUSE_MENUBAR
 
 // ----------------------------------------------------------------------------
 // wxMenuBarBase ctor and dtor
@@ -1109,5 +1127,7 @@ wxString wxMenuBarBase::GetLabelTop(size_t pos) const
     return GetMenuLabelText(pos);
 }
 #endif
+
+#endif // wxUSE_MENUBAR
 
 #endif // wxUSE_MENUS

--- a/src/common/utilscmn.cpp
+++ b/src/common/utilscmn.cpp
@@ -1261,15 +1261,15 @@ wxFindMenuItemId(wxFrame *frame,
                  const wxString& menuString,
                  const wxString& itemString)
 {
-#if wxUSE_MENUS
+#if wxUSE_MENUBAR
     wxMenuBar *menuBar = frame->GetMenuBar ();
     if ( menuBar )
         return menuBar->FindMenuItem (menuString, itemString);
-#else // !wxUSE_MENUS
+#else // !wxUSE_MENUBAR
     wxUnusedVar(frame);
     wxUnusedVar(menuString);
     wxUnusedVar(itemString);
-#endif // wxUSE_MENUS/!wxUSE_MENUS
+#endif // wxUSE_MENUBAR/!wxUSE_MENUBAR
 
     return wxNOT_FOUND;
 }

--- a/src/osx/carbon/app.cpp
+++ b/src/osx/carbon/app.cpp
@@ -412,7 +412,7 @@ void wxApp::OnIdle(wxIdleEvent& WXUNUSED(event))
     // either events to the threads other than main or events posted with
     // wxPostEvent() functions
 #ifndef __WXUNIVERSAL__
-#if wxUSE_MENUS
+#if wxUSE_MENUBAR
   if (!wxMenuBar::MacGetInstalledMenuBar() && wxMenuBar::MacGetCommonMenuBar())
     wxMenuBar::MacGetCommonMenuBar()->MacInstallMenuBar();
 #endif

--- a/src/osx/carbon/frame.cpp
+++ b/src/osx/carbon/frame.cpp
@@ -84,7 +84,7 @@ bool wxFrame::Enable(bool enable)
     if ( !wxWindow::Enable(enable) )
         return false;
 
-#if wxUSE_MENUS
+#if wxUSE_MENUBAR
     // we should always enable/disable the menubar, even if we are not current, otherwise
     // we might miss some state change later (happened eg in the docview sample after PrintPreview)
     if ( m_frameMenuBar /*&& m_frameMenuBar == wxMenuBar::MacGetInstalledMenuBar()*/)
@@ -156,7 +156,7 @@ void wxFrame::OnActivate(wxActivateEvent& event)
     }
     else
     {
-#if wxUSE_MENUS
+#if wxUSE_MENUBAR
         if (m_frameMenuBar != NULL)
         {
             m_frameMenuBar->MacInstallMenuBar();
@@ -180,7 +180,7 @@ void wxFrame::OnActivate(wxActivateEvent& event)
 #endif
 }
 
-#if wxUSE_MENUS
+#if wxUSE_MENUBAR
 void wxFrame::DetachMenuBar()
 {
     wxFrameBase::DetachMenuBar();
@@ -210,7 +210,7 @@ void wxFrame::AttachMenuBar( wxMenuBar *menuBar )
             m_frameMenuBar->MacInstallMenuBar();
     }
 }
-#endif
+#endif // wxUSE_MENUBAR
 
 void wxFrame::DoGetClientSize(int *x, int *y) const
 {
@@ -391,7 +391,7 @@ bool wxFrame::Show(bool show)
 {
     if ( !show )
     {
-#if wxUSE_MENUS
+#if wxUSE_MENUBAR
         if (m_frameMenuBar != NULL)
         {
           m_frameMenuBar->MacUninstallMenuBar();

--- a/src/osx/core/colour.cpp
+++ b/src/osx/core/colour.cpp
@@ -118,15 +118,13 @@ wxCGColorRefData::wxCGColorRefData(CGColorRef col)
     }
     else if (model != kCGColorSpaceModelRGB)
     {
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_11
-        if ( WX_IS_MACOS_AVAILABLE(10, 11) )
+        if ( WX_IS_MACOS_OR_IOS_AVAILABLE(10, 11, 9, 0) )
         {
             rgbacol = CGColorCreateCopyByMatchingToColorSpace(wxMacGetGenericRGBColorSpace(), kCGRenderingIntentDefault, col, NULL);
             noComp = CGColorGetNumberOfComponents(rgbacol);
             components = CGColorGetComponents(rgbacol);
         }
         else
-#endif
         {
             isRGB = false;
         }

--- a/src/osx/iphone/button.mm
+++ b/src/osx/iphone/button.mm
@@ -22,6 +22,13 @@
 
 #include "wx/osx/private.h"
 
+void wxButton::SetMenu( wxMenu* menu, bool isPrimaryAction )
+{
+    UIButton* native = (UIButton*) GetPeer()->GetWXWidget();
+    native.menu = menu->GetHMenu();
+    native.showsMenuAsPrimaryAction = isPrimaryAction;
+}
+
 @implementation wxUIButton
 
 + (void)initialize

--- a/src/osx/iphone/button.mm
+++ b/src/osx/iphone/button.mm
@@ -22,22 +22,6 @@
 
 #include "wx/osx/private.h"
 
-void wxButton::SetMenu( wxMenu* menu, bool isPrimaryAction )
-{
-    UIButton* native = (UIButton*) GetPeer()->GetWXWidget();
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
-    if ( wxCheckOsVersion(14))
-    {
-        native.menu = menu->GetHMenu();
-        native.showsMenuAsPrimaryAction = isPrimaryAction;
-    }
-    else
-#endif
-    {
-        
-    }
-}
-
 @implementation wxUIButton
 
 + (void)initialize

--- a/src/osx/iphone/button.mm
+++ b/src/osx/iphone/button.mm
@@ -25,8 +25,17 @@
 void wxButton::SetMenu( wxMenu* menu, bool isPrimaryAction )
 {
     UIButton* native = (UIButton*) GetPeer()->GetWXWidget();
-    native.menu = menu->GetHMenu();
-    native.showsMenuAsPrimaryAction = isPrimaryAction;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
+    if ( wxCheckOsVersion(14))
+    {
+        native.menu = menu->GetHMenu();
+        native.showsMenuAsPrimaryAction = isPrimaryAction;
+    }
+    else
+#endif
+    {
+        
+    }
 }
 
 @implementation wxUIButton

--- a/src/osx/iphone/menu.mm
+++ b/src/osx/iphone/menu.mm
@@ -1,0 +1,324 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        src/osx/iphone/menu.mm
+// Purpose:     wxMenu
+// Author:      Stefan Csomor
+// Modified by:
+// Created:     1998-01-01
+// Copyright:   (c) Stefan Csomor
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
+// ============================================================================
+// headers & declarations
+// ============================================================================
+
+// wxWidgets headers
+// -----------------
+
+#include "wx/wxprec.h"
+
+#ifndef WX_PRECOMP
+#include "wx/log.h"
+#include "wx/app.h"
+#include "wx/utils.h"
+#include "wx/frame.h"
+#include "wx/menuitem.h"
+#include "wx/dialog.h"
+#endif
+
+#include "wx/menu.h"
+
+#include "wx/osx/private.h"
+
+// other standard headers
+// ----------------------
+#include <string.h>
+/*
+@implementation wxUIMenu
+
+- (id) initWithTitle:(NSString*) title
+{
+    if ( self = [super initWithTitle:title] )
+    {
+        impl = NULL;
+    }
+    return self;
+}
+
+- (void)setImplementation: (wxMenuImpl *) theImplementation
+{
+    impl = theImplementation;
+}
+
+- (wxMenuImpl*) implementation
+{
+    return impl;
+}
+
+@end
+*/
+// this is more compatible, as it is also called for command-key shortcuts
+// and under 10.4, we are not getting a 'close' event however...
+#define wxOSX_USE_NEEDSUPDATE_HOOK 1
+
+@interface wxUIMenuController : NSObject //  TODO wxIOS <UIMenuDelegate>
+{
+}
+
+#if wxOSX_USE_NEEDSUPDATE_HOOK
+- (void)menuNeedsUpdate:(UIMenu*)smenu;
+#else
+- (void)menuWillOpen:(UIMenu *)menu;
+#endif
+- (void)menuDidClose:(UIMenu *)menu;
+- (void)menu:(UIMenu *)menu willHighlightItem:(UIMenuItem *)item;
+
+@end
+
+@implementation wxUIMenuController
+
+- (id) init
+{
+    self = [super init];
+    return self;
+}
+
+/*
+#if wxOSX_USE_NEEDSUPDATE_HOOK
+- (void)menuNeedsUpdate:(UIMenu*)smenu
+{
+    wxUIMenu* menu = (wxUIMenu*) smenu;
+    wxMenuImpl* menuimpl = [menu implementation];
+    if ( menuimpl )
+    {
+        wxMenu* wxpeer = (wxMenu*) menuimpl->GetWXPeer();
+        if ( wxpeer )
+            wxpeer->HandleMenuOpened();
+    }
+}
+#else
+- (void)menuWillOpen:(UIMenu *)smenu
+{
+    wxUIMenu* menu = (wxUIMenu*) smenu;
+    wxMenuImpl* menuimpl = [menu implementation];
+    if ( menuimpl )
+    {
+        wxMenu* wxpeer = (wxMenu*) menuimpl->GetWXPeer();
+        if ( wxpeer )
+            wxpeer->HandleMenuOpened();
+    }
+}
+#endif
+
+- (void)menuDidClose:(UIMenu *)smenu
+{
+    wxUIMenu* menu = (wxUIMenu*) smenu;
+    wxMenuImpl* menuimpl = [menu implementation];
+    if ( menuimpl )
+    {
+        wxMenu* wxpeer = (wxMenu*) menuimpl->GetWXPeer();
+        if ( wxpeer )
+            wxpeer->HandleMenuClosed();
+    }
+}
+
+- (void)menu:(UIMenu *)smenu willHighlightItem:(UIMenuItem *)item
+{
+    wxUIMenu* menu = (wxUIMenu*) smenu;
+    wxMenuImpl* menuimpl = [menu implementation];
+    if ( menuimpl )
+    {
+        wxMenuItem* menuitem = nullptr;
+        wxMenu* wxpeer = (wxMenu*) menuimpl->GetWXPeer();
+
+        if ( [ item isKindOfClass:[wxUIMenuItem class] ] )
+        {
+            wxMenuItemImpl* menuitemimpl = (wxMenuItemImpl*) [ (wxUIMenuItem*) item implementation ];
+            if ( menuitemimpl )
+            {
+                menuitem = menuitemimpl->GetWXPeer();
+            }
+        }
+
+        if ( wxpeer )
+        {
+            wxpeer->HandleMenuItemHighlighted( menuitem );
+        }
+    }
+}
+*/
+
+@end
+
+class wxMenuCocoaImpl : public wxMenuImpl
+{
+public :
+    wxMenuCocoaImpl( wxMenu* peer , UIMenu* menu) : wxMenuImpl(peer), m_osxMenu(wxCFRetain(menu))
+    {
+        /*
+        static wxUIMenuController* controller = NULL;
+        if ( controller == NULL )
+        {
+            controller = [[wxUIMenuController alloc] init];
+        }
+        [menu setDelegate:controller];
+        [m_osxMenu setImplementation:this];
+        // gc aware
+        if ( m_osxMenu )
+            CFRetain(m_osxMenu);
+        [m_osxMenu release];
+         */
+    }
+
+    virtual ~wxMenuCocoaImpl();
+
+    virtual void InsertOrAppend(wxMenuItem *pItem, size_t pos) wxOVERRIDE
+    {
+        UIMenuElement* uimenuitem = (UIMenuElement*) pItem->GetPeer()->GetHMenuItem();
+        m_children.push_back(uimenuitem);
+        /*
+        // make sure a call of SetSubMenu is also reflected (occurring after Create)
+        // update the native menu item accordingly
+        
+        if ( pItem->IsSubMenu() )
+        {
+            wxMenu* wxsubmenu = pItem->GetSubMenu();
+            WXHMENU nssubmenu = wxsubmenu->GetHMenu();
+            if ( [nsmenuitem submenu] != nssubmenu )
+            {
+                wxsubmenu->GetPeer()->SetTitle( pItem->GetItemLabelText() );
+                [nsmenuitem setSubmenu:nssubmenu];
+            }
+        }
+        
+        if ( pos == (size_t) -1 )
+            [m_osxMenu addItem:nsmenuitem ];
+        else
+            [m_osxMenu insertItem:nsmenuitem atIndex:pos];
+        */
+    }
+
+    virtual void Remove( wxMenuItem *pItem ) wxOVERRIDE
+    {
+        // [m_osxMenu removeItem:(UIMenuItem*) pItem->GetPeer()->GetHMenuItem()];
+    }
+        
+    virtual void MakeRoot() wxOVERRIDE
+    {
+    }
+
+    virtual void Enable( bool WXUNUSED(enable) )
+    {
+    }
+
+    virtual void SetTitle( const wxString& text ) wxOVERRIDE
+    {
+     //   wxCFStringRef cfText(text);
+     //   [m_osxMenu setTitle:cfText.AsNSString()];
+    }
+
+    virtual void PopUp( wxWindow *win, int x, int y ) wxOVERRIDE
+    {
+#if 0 //  TODO wxIOS
+        UIView *view = win->GetPeer()->GetWXWidget();
+
+        wxPoint screenPoint(x,y);
+        NSPoint pointInView = wxToNSPoint(view, win->ScreenToClient( screenPoint ));
+
+        // action and validation methods are not called from macos for modal dialogs
+        // when using popUpMenuPositioningItem therefore we fall back to the older method
+        if ( wxDialog::OSXHasModalDialogsOpen() )
+        {
+            // we don't want plug-ins interfering
+            m_osxMenu.allowsContextMenuPlugIns = NO;
+            
+            wxTopLevelWindow* tlw = static_cast<wxTopLevelWindow*>(wxGetTopLevelParent(win));
+            NSWindow* nsWindow = tlw->GetWXWindow();
+            NSRect nsrect = NSZeroRect;
+            nsrect.origin = wxToNSPoint( NULL, screenPoint );
+            nsrect = [nsWindow convertRectFromScreen:nsrect];
+
+            NSEvent* rightClick = [NSEvent mouseEventWithType:NSRightMouseDown
+                                                     location:nsrect.origin
+                                                modifierFlags:0
+                                                    timestamp:0
+                                                 windowNumber:[nsWindow windowNumber]
+                                                      context:nil
+                                                  eventNumber:0
+                                                   clickCount:1
+                                                     pressure:0];
+            
+            [UIMenu popUpContextMenu:m_osxMenu withEvent:rightClick forView:view];
+        }
+        else
+        {
+            [m_osxMenu popUpMenuPositioningItem:nil atLocation:pointInView inView:view];
+        }
+#endif
+    }
+    
+    virtual void GetMenuBarDimensions(int &x, int &y, int &width, int &height) const wxOVERRIDE
+    {
+#if 0 //  TODO wxIOS
+        NSRect r = [(NSScreen*)[[NSScreen screens] objectAtIndex:0] frame];
+        height = [m_osxMenu menuBarHeight];
+        x = r.origin.x;
+        y = r.origin.y;
+        width = r.size.width;
+#endif
+    }
+    
+    void DisableAutoEnable()
+    {
+        /*
+        [m_osxMenu setAutoenablesItems:NO];
+        
+        wxMenu* menu = GetWXPeer();
+        for ( wxMenuItemList::compatibility_iterator node = menu->GetMenuItems().GetFirst();
+              node;
+              node = node->GetNext() )
+        {
+            const wxMenuItem* const item = node->GetData();
+            if ( item->IsSubMenu() )
+            {
+                wxMenuCocoaImpl* subimpl = dynamic_cast<wxMenuCocoaImpl*>(item->GetSubMenu()->GetPeer());
+                if ( subimpl )
+                    subimpl->DisableAutoEnable();
+            }
+        }
+*/
+    }
+    
+    WXHMENU GetHMenu() wxOVERRIDE {
+        if ( m_osxMenu == nil )
+        {
+            m_osxMenu.reset( [UIMenu menuWithTitle:wxCFStringRef(m_peer->GetTitle()).AsNSString() children:m_children] );
+        }
+        return m_osxMenu;
+    }
+
+    static wxMenuImpl* Create( wxMenu* peer, const wxString& title );
+    static wxMenuImpl* CreateRootMenu( wxMenu* peer );
+protected :
+    wxCFRef<UIMenu*> m_osxMenu;
+    wxCFMutableArrayRef<UIMenuElement*> m_children;
+
+/*
+ UIMenu* menu = [[UIMenu menuWithTitle:cfText.AsNSString() children:];
+*/
+
+} ;
+
+wxMenuCocoaImpl::~wxMenuCocoaImpl()
+{
+    // [m_osxMenu setDelegate:nil];
+    // [m_osxMenu setImplementation:nil];
+    // gc aware
+}
+
+wxMenuImpl* wxMenuImpl::Create( wxMenu* peer, const wxString& title )
+{
+    wxCFStringRef cfText( title );
+    wxMenuImpl* c = new wxMenuCocoaImpl( peer, nil );
+    return c;
+ }

--- a/src/osx/iphone/menuitem.mm
+++ b/src/osx/iphone/menuitem.mm
@@ -1,0 +1,330 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        src/osx/iphone/menuitem.mm
+// Purpose:     wxMenuItem implementation
+// Author:      Stefan Csomor
+// Modified by:
+// Created:     1998-01-01
+// Copyright:   (c) Stefan Csomor
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#include "wx/wxprec.h"
+
+#include "wx/menuitem.h"
+#include "wx/stockitem.h"
+
+#ifndef WX_PRECOMP
+    #include "wx/app.h"
+    #include "wx/log.h"
+    #include "wx/menu.h"
+#endif // WX_PRECOMP
+
+#include "wx/osx/private.h"
+
+// a mapping from wx ids to standard osx actions in order to support the native menu item handling
+// if a new mapping is added, make sure the wxNonOwnedWindowController has a handler for this action as well
+
+struct Mapping
+{
+    int menuid;
+    SEL action;
+};
+
+Mapping sActionToWXMapping[] =
+{
+// as we don't have NSUndoManager support we must not use the native actions
+#if 0
+    { wxID_UNDO, @selector(undo:) },
+    { wxID_REDO, @selector(redo:) },
+#endif
+    { wxID_CUT, @selector(cut:) },
+    { wxID_COPY, @selector(copy:) },
+    { wxID_PASTE, @selector(paste:) },
+    { wxID_CLEAR, @selector(delete:) },
+    { wxID_SELECTALL, @selector(selectAll:) },
+    { 0, NULL }
+};
+
+int wxOSXGetIdFromSelector(SEL action )
+{
+    int i = 0 ;
+    while ( sActionToWXMapping[i].action != nil )
+    {
+        if ( sActionToWXMapping[i].action == action )
+            return sActionToWXMapping[i].menuid;
+        ++i;
+    }
+    
+    return 0;
+}
+
+SEL wxOSXGetSelectorFromID(int menuId )
+{
+    int i = 0 ;
+    while ( sActionToWXMapping[i].action != nil )
+    {
+        if ( sActionToWXMapping[i].menuid == menuId )
+            return sActionToWXMapping[i].action;
+        ++i;
+    }
+    
+    return nil;
+}
+
+/*
+void wxMacCocoaMenuItemSetAccelerator( UIMenuItem* menuItem, wxAcceleratorEntry* entry )
+{
+    if ( entry == NULL )
+    {
+        [menuItem setKeyEquivalent:@""];
+        return;
+    }
+
+#if 0 //  TODO wxIOS wxUSE_ACCEL
+    unsigned int modifiers = 0 ;
+    int key = entry->GetKeyCode() ;
+    if ( key )
+    {
+        if (entry->GetFlags() & wxACCEL_CTRL)
+            modifiers |= NSCommandKeyMask;
+
+        if (entry->GetFlags() & wxACCEL_RAW_CTRL)
+            modifiers |= NSControlKeyMask;
+        
+        if (entry->GetFlags() & wxACCEL_ALT)
+            modifiers |= NSAlternateKeyMask ;
+
+        // this may be ignored later for alpha chars
+
+        if (entry->GetFlags() & wxACCEL_SHIFT)
+            modifiers |= NSShiftKeyMask ;
+
+        unichar shortcut = 0;
+        if ( key >= WXK_F1 && key <= WXK_F15 )
+        {
+            shortcut = NSF1FunctionKey + ( key - WXK_F1 );
+        }
+        else
+        {
+            switch ( key )
+            {
+                case WXK_CLEAR :
+                    shortcut = NSDeleteCharacter ;
+                    break ;
+
+                case WXK_PAGEUP :
+                    shortcut = NSPageUpFunctionKey ;
+                    break ;
+
+                case WXK_PAGEDOWN :
+                    shortcut = NSPageDownFunctionKey ;
+                    break ;
+
+                case WXK_NUMPAD_LEFT :
+                    modifiers |= NSNumericPadKeyMask;
+                    wxFALLTHROUGH;
+                case WXK_LEFT :
+                    shortcut = NSLeftArrowFunctionKey ;
+                    break ;
+
+                case WXK_NUMPAD_UP :
+                    modifiers |= NSNumericPadKeyMask;
+                    wxFALLTHROUGH;
+                case WXK_UP :
+                    shortcut = NSUpArrowFunctionKey ;
+                    break ;
+
+                case WXK_NUMPAD_RIGHT :
+                    modifiers |= NSNumericPadKeyMask;
+                    wxFALLTHROUGH;
+                case WXK_RIGHT :
+                    shortcut = NSRightArrowFunctionKey ;
+                    break ;
+
+                case WXK_NUMPAD_DOWN :
+                    modifiers |= NSNumericPadKeyMask;
+                    wxFALLTHROUGH;
+                case WXK_DOWN :
+                    shortcut = NSDownArrowFunctionKey ;
+                    break ;
+
+                case WXK_HOME :
+                    shortcut = NSHomeFunctionKey ;
+                    break ;
+
+                case WXK_END :
+                    shortcut = NSEndFunctionKey ;
+                    break ;
+
+                case WXK_NUMPAD_ENTER :
+                    shortcut = NSEnterCharacter;
+                    break;
+                    
+                case WXK_BACK :
+                case WXK_RETURN :
+                case WXK_TAB :
+                case WXK_ESCAPE :
+                default :
+                    if(entry->GetFlags() & wxACCEL_SHIFT)
+                        shortcut = toupper(key);
+                    else
+                        shortcut = tolower(key);
+                    break ;
+            }
+        }
+
+        [menuItem setKeyEquivalent:[NSString stringWithCharacters:&shortcut length:1]];
+        [menuItem setKeyEquivalentModifierMask:modifiers];
+    }
+#endif // wxUSE_ACCEL
+}
+
+*/
+
+class wxMenuItemCocoaImpl : public wxMenuItemImpl
+{
+public :
+    wxMenuItemCocoaImpl( wxMenuItem* peer, UIMenuElement* item ) : wxMenuItemImpl(peer), m_osxMenuItem(wxCFRetain(item))
+    {
+    }
+
+    ~wxMenuItemCocoaImpl();
+
+    void SetBitmap( const wxBitmap& bitmap ) wxOVERRIDE
+    {
+    }
+
+    void Enable( bool enable ) wxOVERRIDE
+    {
+        UIMenuElement* menuElement = m_osxMenuItem.get();
+        if ( [menuElement isKindOfClass:UIAction.class] )
+        {
+            UIAction* action = (UIAction*) menuElement;
+            if ( enable )
+                action.attributes = action.attributes & ~UIMenuElementAttributesDisabled;
+            else
+                action.attributes = action.attributes | UIMenuElementAttributesDisabled;
+        }
+    }
+
+    void Check( bool check ) wxOVERRIDE
+    {
+        UIMenuElement* menuElement = m_osxMenuItem.get();
+        if ( [menuElement isKindOfClass:UIAction.class] )
+        {
+            UIAction* action = (UIAction*) menuElement;
+            action.state = check ? UIMenuElementStateOn : UIMenuElementStateOff;
+        }
+    }
+
+    void Hide( bool hide ) wxOVERRIDE
+    {
+        UIMenuElement* menuElement = m_osxMenuItem.get();
+        if ( [menuElement isKindOfClass:UIAction.class] )
+        {
+            UIAction* action = (UIAction*) menuElement;
+            if ( hide )
+                action.attributes = action.attributes | UIMenuElementAttributesHidden;
+            else
+                action.attributes = action.attributes & ~UIMenuElementAttributesHidden;
+        }
+    }
+
+    void SetLabel( const wxString& text, wxAcceleratorEntry *entry ) wxOVERRIDE
+    {
+        // recreate, it's readonly
+    }
+    
+    bool DoDefault() wxOVERRIDE;
+
+    void * GetHMenuItem() wxOVERRIDE { return m_osxMenuItem; }
+
+protected :
+    wxCFRef<UIMenuElement*> m_osxMenuItem ;
+} ;
+
+wxMenuItemCocoaImpl::~wxMenuItemCocoaImpl()
+{
+}
+
+bool wxMenuItemCocoaImpl::DoDefault()
+{
+    bool handled=false;
+    int menuid = m_peer->GetId();
+    
+#if 0 //  TODO wxIOS
+    NSApplication *theNSApplication = [NSApplication sharedApplication];
+    if (menuid == wxID_OSX_HIDE)
+    {
+        [theNSApplication hide:nil];
+        handled=true;
+    }
+    else if (menuid == wxID_OSX_HIDEOTHERS)
+    {
+        [theNSApplication hideOtherApplications:nil];
+        handled=true;
+    }
+    else if (menuid == wxID_OSX_SHOWALL)
+    {
+        [theNSApplication unhideAllApplications:nil];
+        handled=true;
+    }
+    else if (menuid == wxApp::s_macExitMenuItemId)
+    {
+        wxTheApp->ExitMainLoop();
+    }
+#endif
+    return handled;
+}
+
+wxMenuItemImpl* wxMenuItemImpl::Create( wxMenuItem* peer, wxMenu *pParentMenu,
+                       int menuid,
+                       const wxString& text,
+                       wxAcceleratorEntry *entry,
+                       const wxString& WXUNUSED(strHelp),
+                       wxItemKind kind,
+                       wxMenu *pSubMenu )
+{
+    wxMenuItemImpl* c = NULL;
+    UIMenuElement* item = nil;
+
+    if ( kind == wxITEM_SEPARATOR )
+    {
+        // TODO new version of item = [[UIMenuItem separatorItem] retain];
+    }
+    else
+    {
+        wxCFStringRef cfText(text);
+                        
+        if ( pSubMenu )
+        {
+            pSubMenu->GetPeer()->SetTitle( text );
+            UIMenu* submenu = pSubMenu->GetHMenu();
+            item = submenu;
+        }
+        else
+        {
+            // currently in the iOS 14 Beta UICommands trigger a layout violation so stick with UIActions for the time being
+            if ( entry )
+            {
+                //  TODO UIKeyCommand* command = [UIKeyCommand commandWithTitle ...]
+
+                UIAction* menuitem = [UIAction actionWithTitle:cfText.AsNSString() image:nil identifier:nil
+                                                   handler: ^( UIAction* action) { peer->GetMenu()->HandleCommandProcess(peer);} ];
+                item = menuitem;
+            }
+            else
+            {
+                /*
+                UICommand* command = [UICommand commandWithTitle:cfText.AsNSString() image:nil action:@selector(menuItemAction:) propertyList:nil];
+                 */
+                
+                UIAction* menuitem = [UIAction actionWithTitle:cfText.AsNSString() image:nil identifier:nil
+                                                   handler: ^( UIAction* action) { peer->GetMenu()->HandleCommandProcess(peer);} ];
+                item = menuitem;
+            }
+        }
+    }
+    c = new wxMenuItemCocoaImpl( peer, item );
+    return c;
+}

--- a/src/osx/menu_osx.cpp
+++ b/src/osx/menu_osx.cpp
@@ -66,13 +66,14 @@ void wxMenu::Init()
 
     m_peer = wxMenuImpl::Create( this, wxStripMenuCodes(m_title, wxStrip_Menu) );
 
-
-    // if we have a title, insert it in the beginning of the menu
+#if wxOSX_USE_COCOA
+    // under macOS there is no built-in title, so if we have a title, insert it in the beginning of the menu
     if ( !m_title.empty() )
     {
         Append(idMenuTitle, m_title) ;
         AppendSeparator() ;
     }
+#endif
 }
 
 wxMenu::~wxMenu()
@@ -151,10 +152,12 @@ bool wxMenu::DoInsertOrAppend(wxMenuItem *item, size_t pos)
         }
     }
 
+#if wxUSE_MENUBAR
     // if we're already attached to the menubar, we must update it
     if ( IsAttached() && GetMenuBar()->IsAttached() )
         GetMenuBar()->Refresh();
-
+#endif
+    
     if ( check )
         item->Check(true);
 
@@ -399,6 +402,8 @@ void wxMenu::HandleMenuClosed()
 {
     DoHandleMenuOpenedOrClosed(wxEVT_MENU_CLOSE);
 }
+
+#if wxUSE_MENUBAR
 
 // Menu Bar
 
@@ -707,5 +712,6 @@ void wxMenuBar::DoGetClientSize(int *width, int *height) const
     DoGetSize(width, height);
 }
 
+#endif // wxUSE_MENUBAR
 
 #endif // wxUSE_MENUS

--- a/src/xrc/xh_menu.cpp
+++ b/src/xrc/xh_menu.cpp
@@ -47,12 +47,14 @@ wxObject *wxMenuXmlHandler::DoCreateResource()
         CreateChildren(menu, true/*only this handler*/);
         m_insideMenu = oldins;
 
+#if wxUSE_MENUBAR
         wxMenuBar *p_bar = wxDynamicCast(m_parent, wxMenuBar);
         if (p_bar)
         {
             p_bar->Append(menu, title);
         }
         else
+#endif
         {
             wxMenu *p_menu = wxDynamicCast(m_parent, wxMenu);
             if (p_menu)
@@ -145,6 +147,8 @@ bool wxMenuXmlHandler::CanHandle(wxXmlNode *node)
            );
 }
 
+#if wxUSE_MENUBAR
+
 wxIMPLEMENT_DYNAMIC_CLASS(wxMenuBarXmlHandler, wxXmlResourceHandler);
 
 wxMenuBarXmlHandler::wxMenuBarXmlHandler() : wxXmlResourceHandler()
@@ -183,5 +187,7 @@ bool wxMenuBarXmlHandler::CanHandle(wxXmlNode *node)
 {
     return IsOfClass(node, wxT("wxMenuBar"));
 }
+
+#endif // wxUSE_MENUBAR
 
 #endif // wxUSE_XRC && wxUSE_MENUS

--- a/src/xrc/xmlrsall.cpp
+++ b/src/xrc/xmlrsall.cpp
@@ -140,7 +140,9 @@ void wxXmlResource::InitAllHandlers()
 #endif
 #if wxUSE_MENUS
     AddHandler(new wxMenuXmlHandler);
+#if wxUSE_MENUBAR
     AddHandler(new wxMenuBarXmlHandler);
+#endif
 #endif
 #if wxUSE_NOTEBOOK
     AddHandler(new wxNotebookXmlHandler);

--- a/tests/events/propagation.cpp
+++ b/tests/events/propagation.cpp
@@ -436,10 +436,11 @@ wxMenu* CreateTestMenu(wxFrame* frame)
 {
     wxMenu* const menu = new wxMenu;
     menu->Append(wxID_APPLY);
+#if wxUSE_MENUBAR
     wxMenuBar* const mb = new wxMenuBar;
     mb->Append(menu, "&Menu");
     frame->SetMenuBar(mb);
-
+#endif
     return menu;
 }
 
@@ -464,10 +465,11 @@ void EventPropagationTestCase::MenuEvent()
 
     // Create a minimal menu bar.
     wxMenu* const menu = CreateTestMenu(frame);
+#if wxUSE_MENUBAR
     wxMenuBar* const mb = menu->GetMenuBar();
     wxScopedPtr<wxMenuBar> ensureMenuBarDestruction(mb);
     wxON_BLOCK_EXIT_OBJ1( *frame, wxFrame::SetMenuBar, (wxMenuBar*)NULL );
-
+#endif
     // Check that wxApp gets the event exactly once.
     ASSERT_MENU_EVENT_RESULT( menu, "aA" );
 
@@ -491,13 +493,14 @@ void EventPropagationTestCase::MenuEvent()
                           wxEvtHandler::SetNextHandler, (wxEvtHandler*)NULL );
     ASSERT_MENU_EVENT_RESULT_FOR( wxID_ABOUT, submenu, "aosomA" );
 
+#if wxUSE_MENUBAR
     // Test that the event handler associated with the menu bar gets the event.
     TestMenuEvtHandler hb('b'); // 'b' for "menu Bar"
     mb->PushEventHandler(&hb);
     wxON_BLOCK_EXIT_OBJ1( *mb, wxWindow::PopEventHandler, false );
 
     ASSERT_MENU_EVENT_RESULT( menu, "aomobA" );
-
+#endif
 
     // Also test that the window to which the menu belongs gets the event.
     TestMenuEvtHandler hw('w'); // 'w' for "Window"

--- a/tests/menu/menu.cpp
+++ b/tests/menu/menu.cpp
@@ -12,7 +12,7 @@
 
 #include "testprec.h"
 
-#if wxUSE_MENUS
+#if wxUSE_MENUBAR
 
 #ifdef __BORLANDC__
     #pragma hdrstop


### PR DESCRIPTION
iOS does support menus since iOS 13, and even more in iOS 14 where they become a prominent element for different situations. But there is no menubar in iOS, therefore `wxUSE_MENUBAR` was introduced, to differentiate against `wxUSE_MENUS`, and will be used throughout wx for parts that depend on `wxMenuBar` being available.