### PR TITLE
Include macOS 11 name in wxGetOsDescription()

### DIFF
--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -108,6 +108,15 @@ wxString wxGetOsDescription()
                 break;
         };
     }
+    else if (majorVer > 10)
+    {
+        switch (majorVer)
+        {
+            case 11:
+                osName = "Big Sur";
+                break;
+        }
+    }
 #else
     wxString osBrand = "iOS";
     wxString osName;


### PR DESCRIPTION
I would assume that from here on macOS will follow apples other operation systems and use a major version for the yearly releases.

![Screenshot 2020-06-30 at 14 52 25](https://user-images.githubusercontent.com/5075894/86128357-8df0d500-bae1-11ea-8105-43d9a82faa67.png)

This screenshot is taken running the _minimal_ sample on macOS 11 ARM.