### PR TITLE
Remove unused variable and consistent usage of NULL

### DIFF
--- a/include/wx/osx/dataobj2.h
+++ b/include/wx/osx/dataobj2.h
@@ -53,7 +53,6 @@ protected :
     void Clear() ;
 
     CFDataRef m_pictData ;
-    bool m_pictCreated ;
 };
 
 // ----------------------------------------------------------------------------

--- a/src/osx/carbon/dataobj.cpp
+++ b/src/osx/carbon/dataobj.cpp
@@ -91,27 +91,27 @@ wxDataFormat::NativeFormat wxDataFormat::GetFormatForType(wxDataFormatId type)
         case wxDF_TEXT:
             f = kUTTypeTraditionalMacText;
             break;
-
+            
         case wxDF_UNICODETEXT:
             f = kUTTypeUTF16PlainText;
             break;
-
+            
         case wxDF_HTML:
             f = kUTTypeHTML;
             break;
-
+            
         case wxDF_BITMAP:
             f = kUTTypeTIFF;
             break;
-
+            
         case wxDF_METAFILE:
             f = kUTTypePDF;
             break;
-
+            
         case wxDF_FILENAME:
             f = kUTTypeFileURL;
             break;
-
+            
         default:
             wxFAIL_MSG( wxS("unsupported data format") );
             break;
@@ -304,7 +304,7 @@ void wxDataObject::WriteToSink(wxOSXDataSink * datatransfer) const
                 if ( thisFormat.GetType() == wxDF_FILENAME )
                 {
                     wxString filenames;
-
+                    
 #if wxUSE_UNICODE
                     filenames = wxString( (const char*)buf, *wxConvFileName );
 #else
@@ -332,7 +332,7 @@ void wxDataObject::WriteToSink(wxOSXDataSink * datatransfer) const
 bool wxDataObject::ReadFromSource(wxDataObject * source)
 {
     bool transferred = false;
-
+    
     size_t formatcount = source->GetFormatCount();
     wxScopedArray<wxDataFormat> array(formatcount);
     source->GetAllFormats( array.get() );
@@ -343,7 +343,7 @@ bool wxDataObject::ReadFromSource(wxDataObject * source)
         {
             int size = source->GetDataSize( format );
             transferred = true;
-
+            
             if (size == 0)
             {
                 SetData( format, 0, 0 );
@@ -379,11 +379,11 @@ bool wxDataObject::ReadFromSource(wxOSXDataSource * source)
             wxCFMutableArrayRef<CFStringRef> typesarray;
             dataFormat.AddSupportedTypes(typesarray);
             size_t itemCount = source->GetItemCount();
-
+            
             for ( size_t itemIndex = 0; itemIndex < itemCount && !transferred; ++itemIndex)
             {
                 wxScopedPtr<const wxOSXDataSourceItem> sitem(source->GetItem(itemIndex));
-
+                
                 wxDataFormat::NativeFormat nativeFormat = sitem->AvailableType(typesarray);
                 CFDataRef flavorData = sitem->DoGetData(nativeFormat);
                 if (flavorData)
@@ -418,21 +418,21 @@ bool wxDataObject::ReadFromSource(wxOSXDataSource * source)
                                 databuf.UngetWriteBuf(flavorDataSize);
                             }
                         }
-
+                        
                         if (dataFormat.GetType() == wxDF_FILENAME)
                         {
                             // revert the translation and decomposition to arrive at a proper utf8 string again
-
+                            
                             wxCFRef<CFURLRef> url = CFURLCreateWithBytes(kCFAllocatorDefault, (UInt8*) buf, flavorDataSize, kCFStringEncodingUTF8, NULL);
                             wxCFStringRef cfString = CFURLCopyFileSystemPath(url, kCFURLPOSIXPathStyle);
-
+                                
                             CFMutableStringRef cfMutableString = CFStringCreateMutableCopy(NULL, 0, cfString);
                             CFStringNormalize(cfMutableString, kCFStringNormalizationFormC);
                             // cfMutableString is released by the wxCFStringRef
                             wxString path = wxCFStringRef(cfMutableString).AsString();
                             if (!path.empty())
                                 filenamesPassed += path + wxS("\n");
-
+                            
                             // if it's the last item, we set the wx data
                             if ( itemIndex + 1 == itemCount )
                             {
@@ -444,7 +444,7 @@ bool wxDataObject::ReadFromSource(wxOSXDataSource * source)
                         else
                         {
                             // because some data implementation expect trailing a trailing NUL, we add some headroom
-
+                            
                             if (dataFormat.GetType() == wxDF_TEXT)
                             {
                                 for (char* p = static_cast<char*>(buf); *p; p++)
@@ -474,7 +474,7 @@ wxDataFormat wxDataObject::GetSupportedFormatInSource(wxDataObject *source) cons
     wxDataFormat format;
     size_t formatcount = source->GetFormatCount();
     wxScopedArray<wxDataFormat> array(formatcount);
-
+    
     source->GetAllFormats( array.get() );
     for (size_t i = 0; i < formatcount; i++)
     {
@@ -492,23 +492,23 @@ wxDataFormat wxDataObject::GetSupportedFormatInSource(wxDataObject *source) cons
 wxDataFormat wxDataObject::GetSupportedFormatInSource(wxOSXDataSource *source) const
 {
     wxDataFormat format;
-
+    
     size_t formatcount = GetFormatCount(wxDataObject::Set);
     wxScopedArray<wxDataFormat> array(formatcount);
     GetAllFormats(array.get(), wxDataObject::Set);
-
+    
     for (size_t i = 0; i < formatcount; i++)
     {
         // go through the data in our order of preference
         wxDataFormat dataFormat = array[i];
-
+        
         if (source->IsSupported(dataFormat))
         {
             format = dataFormat;
             break;
         }
     }
-
+    
     return format;
 }
 
@@ -723,4 +723,3 @@ bool wxBitmapDataObject::SetData( size_t nSize, const void *pBuf )
 }
 
 #endif
-

--- a/src/osx/carbon/dataobj.cpp
+++ b/src/osx/carbon/dataobj.cpp
@@ -91,27 +91,27 @@ wxDataFormat::NativeFormat wxDataFormat::GetFormatForType(wxDataFormatId type)
         case wxDF_TEXT:
             f = kUTTypeTraditionalMacText;
             break;
-            
+
         case wxDF_UNICODETEXT:
             f = kUTTypeUTF16PlainText;
             break;
-            
+
         case wxDF_HTML:
             f = kUTTypeHTML;
             break;
-            
+
         case wxDF_BITMAP:
             f = kUTTypeTIFF;
             break;
-            
+
         case wxDF_METAFILE:
             f = kUTTypePDF;
             break;
-            
+
         case wxDF_FILENAME:
             f = kUTTypeFileURL;
             break;
-            
+
         default:
             wxFAIL_MSG( wxS("unsupported data format") );
             break;
@@ -304,7 +304,7 @@ void wxDataObject::WriteToSink(wxOSXDataSink * datatransfer) const
                 if ( thisFormat.GetType() == wxDF_FILENAME )
                 {
                     wxString filenames;
-                    
+
 #if wxUSE_UNICODE
                     filenames = wxString( (const char*)buf, *wxConvFileName );
 #else
@@ -332,7 +332,7 @@ void wxDataObject::WriteToSink(wxOSXDataSink * datatransfer) const
 bool wxDataObject::ReadFromSource(wxDataObject * source)
 {
     bool transferred = false;
-    
+
     size_t formatcount = source->GetFormatCount();
     wxScopedArray<wxDataFormat> array(formatcount);
     source->GetAllFormats( array.get() );
@@ -343,7 +343,7 @@ bool wxDataObject::ReadFromSource(wxDataObject * source)
         {
             int size = source->GetDataSize( format );
             transferred = true;
-            
+
             if (size == 0)
             {
                 SetData( format, 0, 0 );
@@ -379,11 +379,11 @@ bool wxDataObject::ReadFromSource(wxOSXDataSource * source)
             wxCFMutableArrayRef<CFStringRef> typesarray;
             dataFormat.AddSupportedTypes(typesarray);
             size_t itemCount = source->GetItemCount();
-            
+
             for ( size_t itemIndex = 0; itemIndex < itemCount && !transferred; ++itemIndex)
             {
                 wxScopedPtr<const wxOSXDataSourceItem> sitem(source->GetItem(itemIndex));
-                
+
                 wxDataFormat::NativeFormat nativeFormat = sitem->AvailableType(typesarray);
                 CFDataRef flavorData = sitem->DoGetData(nativeFormat);
                 if (flavorData)
@@ -418,21 +418,21 @@ bool wxDataObject::ReadFromSource(wxOSXDataSource * source)
                                 databuf.UngetWriteBuf(flavorDataSize);
                             }
                         }
-                        
+
                         if (dataFormat.GetType() == wxDF_FILENAME)
                         {
                             // revert the translation and decomposition to arrive at a proper utf8 string again
-                            
+
                             wxCFRef<CFURLRef> url = CFURLCreateWithBytes(kCFAllocatorDefault, (UInt8*) buf, flavorDataSize, kCFStringEncodingUTF8, NULL);
                             wxCFStringRef cfString = CFURLCopyFileSystemPath(url, kCFURLPOSIXPathStyle);
-                                
+
                             CFMutableStringRef cfMutableString = CFStringCreateMutableCopy(NULL, 0, cfString);
                             CFStringNormalize(cfMutableString, kCFStringNormalizationFormC);
                             // cfMutableString is released by the wxCFStringRef
                             wxString path = wxCFStringRef(cfMutableString).AsString();
                             if (!path.empty())
                                 filenamesPassed += path + wxS("\n");
-                            
+
                             // if it's the last item, we set the wx data
                             if ( itemIndex + 1 == itemCount )
                             {
@@ -444,7 +444,7 @@ bool wxDataObject::ReadFromSource(wxOSXDataSource * source)
                         else
                         {
                             // because some data implementation expect trailing a trailing NUL, we add some headroom
-                            
+
                             if (dataFormat.GetType() == wxDF_TEXT)
                             {
                                 for (char* p = static_cast<char*>(buf); *p; p++)
@@ -474,7 +474,7 @@ wxDataFormat wxDataObject::GetSupportedFormatInSource(wxDataObject *source) cons
     wxDataFormat format;
     size_t formatcount = source->GetFormatCount();
     wxScopedArray<wxDataFormat> array(formatcount);
-    
+
     source->GetAllFormats( array.get() );
     for (size_t i = 0; i < formatcount; i++)
     {
@@ -492,23 +492,23 @@ wxDataFormat wxDataObject::GetSupportedFormatInSource(wxDataObject *source) cons
 wxDataFormat wxDataObject::GetSupportedFormatInSource(wxOSXDataSource *source) const
 {
     wxDataFormat format;
-    
+
     size_t formatcount = GetFormatCount(wxDataObject::Set);
     wxScopedArray<wxDataFormat> array(formatcount);
     GetAllFormats(array.get(), wxDataObject::Set);
-    
+
     for (size_t i = 0; i < formatcount; i++)
     {
         // go through the data in our order of preference
         wxDataFormat dataFormat = array[i];
-        
+
         if (source->IsSupported(dataFormat))
         {
             format = dataFormat;
             break;
         }
     }
-    
+
     return format;
 }
 
@@ -659,7 +659,6 @@ void wxBitmapDataObject::SetBitmap( const wxBitmap& rBitmap )
 void wxBitmapDataObject::Init()
 {
     m_pictData = NULL;
-    m_pictCreated = false;
 }
 
 void wxBitmapDataObject::Clear()
@@ -669,7 +668,6 @@ void wxBitmapDataObject::Clear()
         CFRelease( m_pictData );
         m_pictData = NULL;
     }
-    m_pictCreated = false;
 }
 
 bool wxBitmapDataObject::GetDataHere( void *pBuf ) const
@@ -703,7 +701,7 @@ bool wxBitmapDataObject::SetData( size_t nSize, const void *pBuf )
     if ((pBuf == NULL) || (nSize == 0))
         return false;
 
-    CGImageRef cgImageRef = 0;
+    CGImageRef cgImageRef = NULL;
 
     CFDataRef data = CFDataCreate( kCFAllocatorDefault, (const UInt8*) pBuf, nSize);
     CGImageSourceRef source = CGImageSourceCreateWithData( data, NULL );
@@ -725,3 +723,4 @@ bool wxBitmapDataObject::SetData( size_t nSize, const void *pBuf )
 }
 
 #endif
+


### PR DESCRIPTION
Variable m_pictCreated was only initialised in Init and Clear methods, but never used anywhere else.
The other change is about consistency of NULL as initialisation value to cgImageRef variable.