### PR TITLE
Remove typecasting of CGContextRef

### DIFF
--- a/src/osx/carbon/utilscocoa.mm
+++ b/src/osx/carbon/utilscocoa.mm
@@ -46,8 +46,7 @@ wxMacAutoreleasePool::~wxMacAutoreleasePool()
 
 CGContextRef wxOSXGetContextFromCurrentContext()
 {
-    CGContextRef context = (CGContextRef)[[NSGraphicsContext currentContext]
-                                          CGContext];
+    CGContextRef context = [[NSGraphicsContext currentContext] CGContext];
     return context;
 }
 


### PR DESCRIPTION
Forgot to remove typecast of CGContextRef in a previous commit which replaces deprecated methods in utilscocoa.mm.