### PR TITLE
Add wxFontDialog::RestrictSelection() to disallow raster fonts

### DIFF
--- a/include/wx/fontdata.h
+++ b/include/wx/fontdata.h
@@ -12,6 +12,14 @@
 #include "wx/colour.h"
 #include "wx/encinfo.h"
 
+enum wxFontRestrictSelection
+{
+    wxFONTRESTRICT_NONE         = 0,
+    wxFONTRESTRICT_SCALABLE     = 1 << 0,
+    wxFONTRESTRICT_FIXEDPITCH   = 1 << 1,
+
+};
+
 class WXDLLIMPEXP_CORE wxFontData : public wxObject
 {
 public:
@@ -32,6 +40,9 @@ public:
 
     void EnableEffects(bool flag) { m_enableEffects = flag; }
     bool GetEnableEffects() const { return m_enableEffects; }
+
+    void RestrictSelection(int flags) { m_restrictSelection = flags; }
+    int  GetRestrictSelection() const { return m_restrictSelection; }
 
     void SetInitialFont(const wxFont& font) { m_initialFont = font; }
     wxFont GetInitialFont() const { return m_initialFont; }
@@ -63,6 +74,7 @@ public:
 private:
     wxFontEncoding       m_encoding;
     wxNativeEncodingInfo m_encodingInfo;
+    int                  m_restrictSelection;
 
     wxDECLARE_DYNAMIC_CLASS(wxFontData);
 };

--- a/interface/wx/fontdata.h
+++ b/interface/wx/fontdata.h
@@ -65,6 +65,23 @@ public:
     bool GetEnableEffects() const;
 
     /**
+        Returns the state of the flags restricting the selection.
+
+        Note that currently these flags are only effectively used in wxMSW.
+
+        @returns
+        - @c wxFONTRESTRICT_NONE If no restriction applies, or a combination of
+        the following flags:
+        - @c wxFONTRESTRICT_SCALABLE To show only scalable fonts - no raster fonts.
+        - @c wxFONTRESTRICT_FIXEDPITCH To show only monospaced fonts.
+
+        The default value is @c wxFONTRESTRICT_NONE.
+
+        @since 3.1.4
+    */
+    int GetRestrictSelection() const;
+
+    /**
         Gets the font that will be initially used by the font dialog. This
         should have previously been set by the application.
     */
@@ -76,6 +93,24 @@ public:
         The default value is @false.
     */
     bool GetShowHelp() const;
+
+    /**
+        Restricts the selection to a subset of the available fonts.
+
+        Note that currently these flags are only effectively used in wxMSW and
+        are ignored in the other ports.
+
+        Possible values are:
+
+        - @c wxFONTRESTRICT_NONE No restriction
+        - @c wxFONTRESTRICT_SCALABLE To show only scalable fonts - no raster fonts.
+        - @c wxFONTRESTRICT_FIXEDPITCH To show only monospaced fonts.
+
+        The default value is @c wxFONTRESTRICT_NONE.
+
+        @since 3.1.4
+    */
+    void RestrictSelection(int flags);
 
     /**
         Under Windows, determines whether symbol fonts can be selected. Has no

--- a/src/common/fontdata.cpp
+++ b/src/common/fontdata.cpp
@@ -26,6 +26,7 @@ wxFontData::wxFontData()
     m_maxSize = 0;
 
     m_encoding = wxFONTENCODING_SYSTEM;
+    m_restrictSelection = wxFONTRESTRICT_NONE;
 }
 
 wxFontData::~wxFontData()
@@ -43,7 +44,8 @@ wxFontData::wxFontData(const wxFontData& data)
       m_minSize(data.m_minSize),
       m_maxSize(data.m_maxSize),
       m_encoding(data.m_encoding),
-      m_encodingInfo(data.m_encodingInfo)
+      m_encodingInfo(data.m_encodingInfo),
+      m_restrictSelection(data.m_restrictSelection)
 {
 }
 
@@ -52,16 +54,17 @@ wxFontData& wxFontData::operator=(const wxFontData& data)
     if (&data != this)
     {
         wxObject::operator=(data);
-        m_fontColour     = data.m_fontColour;
-        m_showHelp       = data.m_showHelp;
-        m_allowSymbols   = data.m_allowSymbols;
-        m_enableEffects  = data.m_enableEffects;
-        m_initialFont    = data.m_initialFont;
-        m_chosenFont     = data.m_chosenFont;
-        m_minSize        = data.m_minSize;
-        m_maxSize        = data.m_maxSize;
-        m_encoding       = data.m_encoding;
-        m_encodingInfo   = data.m_encodingInfo;
+        m_fontColour        = data.m_fontColour;
+        m_showHelp          = data.m_showHelp;
+        m_allowSymbols      = data.m_allowSymbols;
+        m_enableEffects     = data.m_enableEffects;
+        m_initialFont       = data.m_initialFont;
+        m_chosenFont        = data.m_chosenFont;
+        m_minSize           = data.m_minSize;
+        m_maxSize           = data.m_maxSize;
+        m_encoding          = data.m_encoding;
+        m_encodingInfo      = data.m_encodingInfo;
+        m_restrictSelection = data.m_restrictSelection;
     }
     return *this;
 }

--- a/src/msw/fontdlg.cpp
+++ b/src/msw/fontdlg.cpp
@@ -140,6 +140,10 @@ int wxFontDialog::ShowModal()
       flags |= CF_EFFECTS;
     if ( m_fontData.GetShowHelp() )
       flags |= CF_SHOWHELP;
+    if ( m_fontData.GetRestrictSelection() & wxFONTRESTRICT_SCALABLE )
+      flags |= CF_SCALABLEONLY;
+    if ( m_fontData.GetRestrictSelection() & wxFONTRESTRICT_FIXEDPITCH )
+      flags |= CF_FIXEDPITCHONLY;
 
     if ( m_fontData.m_minSize != 0 || m_fontData.m_maxSize != 0 )
     {


### PR DESCRIPTION
Under MSW it is possible to restrict the native font dialog to showing
only scalable fonts only, disallowing the raster fonts, so add a method
to wxFontDialog exposing this functionality in wxWidgets API.

Closes [#16988](https://trac.wxwidgets.org/ticket/16988).