### PR TITLE
Change documentation references from OS X to macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ This version of wxWidgets supports the following primary platforms:
 
 - Windows XP, Vista, 7, 8 and 10 (32/64 bits).
 - Most Unix variants using the GTK+ toolkit (version 2.6 or newer or 3.x).
-- OS X (10.7 or newer) using Cocoa (32/64 bits).
+- macOS (10.7 or newer) using Cocoa (32/64 bits).
 
 Most popular C++ compilers are supported including but not limited to:
 
 - Microsoft Visual C++ 2003 or later (up to 2019).
 - g++ 3.4 or later, including MinGW/MinGW-64/TDM under Windows.
-- Clang under OS X and Linux.
+- Clang under macOS and Linux.
 - Intel icc compiler.
 - Oracle (ex-Sun) CC.
 

--- a/docs/base/readme.txt
+++ b/docs/base/readme.txt
@@ -30,7 +30,7 @@ executing simultaneously (portably!) and so on.
 --------------------------------------
 
  wxBase can be compiled and used under Win32, mostly any modern Unix system
-(including OS X), VMS and BeOS (this release couldn't be tested under
+(including macOS), VMS and BeOS (this release couldn't be tested under
 these platforms so you might encounter some problems but they should be easy
 to solve -- please contact us in this case!)
 

--- a/docs/doxygen/groups/funcmacro_atomic.h
+++ b/docs/doxygen/groups/funcmacro_atomic.h
@@ -14,7 +14,7 @@ When using multi-threaded applications, it is often required to access or
 modify memory which is shared between threads. Atomic integer and pointer
 operations are an efficient way to handle this issue (another, less efficient,
 way is to use a wxMutex or wxCriticalSection). A native implementation exists
-for Windows, Linux, Solaris and OS X; for others, a wxCriticalSection is
+for Windows, Linux, Solaris and macOS; for others, a wxCriticalSection is
 used to protect the data.
 
 One particular application is reference counting (used by so-called

--- a/docs/doxygen/mainpages/const_cpp.h
+++ b/docs/doxygen/mainpages/const_cpp.h
@@ -39,9 +39,9 @@ Notice that for compatibility reasons, this symbol is defined for console
 applications under Windows as well, but it should only be used in the GUI code
 while <tt>__WINDOWS__</tt> should be used for the platform tests.}
 @itemdef{__WXOSX__, OS X GUI using any Apple widget framework (AppKit or UIKit)}
-@itemdef{__WXOSX_IPHONE__, OS X iPhone (UIKit)}
-@itemdef{__WXOSX_COCOA__, OS X using Cocoa (AppKit)}
-@itemdef{__WXOSX_MAC__, OS X (Cocoa)}
+@itemdef{__WXOSX_IPHONE__, iPhone (UIKit)}
+@itemdef{__WXOSX_COCOA__, macOS using Cocoa (AppKit)}
+@itemdef{__WXOSX_MAC__, macOS (Cocoa)}
 @itemdef{__WXPM__, OS/2 native Presentation Manager (not used any longer).}
 @itemdef{__WXSTUBS__, Stubbed version ('template' wxWin implementation)}
 @itemdef{__WXXT__, Xt; mutually exclusive with WX_MOTIF, not implemented in wxWidgets 2.x}
@@ -59,7 +59,7 @@ versions: Cocoa for the desktop and a very early iPhone port. To summarize:
     <tt>__WXOSX_MAC__</tt>.
 @li If you want to test for wxOSX on the iPhone, use
     <tt>__WXOSX_IPHONE__</tt>.
-@li If you want to test for any port under OS X, including, for
+@li If you want to test for any port under macOS, including, for
     example, wxGTK and also wxBase, use <tt>__DARWIN__</tt> (see below).
 
 The convention is to use the <tt>__WX</tt> prefix for these

--- a/docs/doxygen/mainpages/devtips.h
+++ b/docs/doxygen/mainpages/devtips.h
@@ -114,7 +114,7 @@ include: Microsoft Visual C++ (.vc), Borland C++ (.bcc) and MinGW/Cygwin
 (.gcc). Makefiles are provided for the wxWidgets library itself, samples,
 demos, and utilities.
 
-On Linux and OS X, you use the @c 'configure' command to generate the
+On Linux and macOS, you use the @c 'configure' command to generate the
 necessary makefiles. You should also use this method when building with
 MinGW/Cygwin on Windows.
 
@@ -127,7 +127,7 @@ On Windows using a compiler other than MinGW/Cygwin, you would build the
 wxWidgets library from the @c "build/msw" directory which contains the relevant
 makefiles.
 
-On Windows using MinGW/Cygwin, and on Unix and OS X, you invoke
+On Windows using MinGW/Cygwin, and on Unix and macOS, you invoke
 'configure' (found in the top-level of the wxWidgets source hierarchy), from
 within a suitable empty directory for containing makefiles, object files and
 libraries.

--- a/docs/doxygen/mainpages/introduction.h
+++ b/docs/doxygen/mainpages/introduction.h
@@ -91,7 +91,7 @@ NetBSD, Solaris, AIX, ...) and require GTK+ 2.6 or later or GTK+ 3.x. The
 primary supported compiler is GNU g++.
 
 @li wxOSX/Cocoa: This is the native port for Apple computers. wxOSX/Cocoa
-supports 32 or 64 bit Intel Macs running OS X 10.7 or later. The port can be
+supports 32 or 64 bit Intel Macs running macOS 10.7 or later. The port can be
 built either with g++ or clang.
 
 Other platforms (e.g. iOS - with a minimum requirement of iOS 9), compilers (Borland C++

--- a/docs/doxygen/mainpages/platdetails.h
+++ b/docs/doxygen/mainpages/platdetails.h
@@ -52,8 +52,8 @@ starting with 3.1.4. Use @c configure option @c \--with-gtk=2 to use GTK 2.
 
 @section page_port_wxosx wxOSX/Cocoa
 
-wxOSX/Cocoa is the port of wxWidgets for the OS X platform. It requires
-OS X 10.7 or later and fully supports 64 bit builds.
+wxOSX/Cocoa is the port of wxWidgets for the macOS platform. It requires
+macOS 10.7 or later and fully supports 64 bit builds.
 
 @subpage plat_osx_install "Build and Install Instructions"
 

--- a/docs/doxygen/mainpages/samples.h
+++ b/docs/doxygen/mainpages/samples.h
@@ -652,7 +652,7 @@ first argument of @c save, @c load or @c delete, followed by the "service" and
 "user" arguments as used by wxSecretStore methods. After storing some password,
 you can check that it can be retrieved later and also that it can be seen in
 the OS-provided password manager (e.g. credential manager under MSW or keychain
-utility under OS X).
+utility under macOS).
 
 @sampledir{secretstore}
 

--- a/docs/doxygen/overviews/backwardcompatibility.h
+++ b/docs/doxygen/overviews/backwardcompatibility.h
@@ -108,7 +108,7 @@ compatible but can also be binary compatible.
 
 Binary compatibility makes it possible to get the maximum benefit from using
 shared libraries, also known as dynamic link libraries (DLLs) on Windows or
-dynamic shared libraries on OS X.
+dynamic shared libraries on macOS.
 
 For example, suppose several applications are installed on a system requiring
 wxWidgets 2.6.0, 2.6.1 and 2.6.2. Since 2.6.2 is backward compatible with the

--- a/docs/doxygen/overviews/bitmap.h
+++ b/docs/doxygen/overviews/bitmap.h
@@ -82,7 +82,7 @@ XPM nor BMP formats are appropriate as they don't have support for alpha and
 another format, typically PNG, should be used. wxWidgets provides a similar
 helper for PNG bitmaps called wxBITMAP_PNG() that can be used to either load
 PNG files embedded in resources (meaning either Windows resource section of the
-executable file or OS X "Resource" subdirectory of the application bundle) or
+executable file or macOS "Resource" subdirectory of the application bundle) or
 arrays containing PNG data included into the program code itself.
 
 @see @ref group_class_gdi

--- a/docs/doxygen/overviews/cmake.md
+++ b/docs/doxygen/overviews/cmake.md
@@ -5,7 +5,7 @@ CMake Overview                         {#overview_cmake}
 CMake allows building wxWidgets on various platforms with your preferred build
 system.
 
-Most linux distributions contain CMake as a package on Windows and OS X you can
+Most linux distributions contain CMake as a package on Windows and macOS you can
 download an installer at the [CMake Page](https://cmake.org).
 
 Using the CMake GUI                    {#cmake_gui}
@@ -30,7 +30,7 @@ Using the CMake Command Line           {#cmake_cli}
 
 Run `cmake --help` to see a list of available generators on your platform.
 These can than be specified using the -G command line option. On Windows it
-is recommended to use Visual Studio and on OS X Xcode is recommended.
+is recommended to use Visual Studio and on macOS Xcode is recommended.
 Various build options can be specified using -D see
 [available options](#cmake_options).
 

--- a/docs/doxygen/overviews/internationalization.h
+++ b/docs/doxygen/overviews/internationalization.h
@@ -80,12 +80,12 @@ locations when possible.
 
 Depending on the platform, the default location differs. On Windows, it is
 alongside the executable. On Unix, translations are expected to be in
-"$prefix/share/locale". On OS X, application bundle's @em Resources subdirectory
+"$prefix/share/locale". On macOS, application bundle's @em Resources subdirectory
 is used.
 
 In all cases, translations are searched for in subdirectories named using the
 languages codes from ISO 639. The .mo file(s) should be located either directly
-in that directory or in LC_MESSAGES subdirectory. On OS X, ".lproj" extension
+in that directory or in LC_MESSAGES subdirectory. On macOS, ".lproj" extension
 is used for the per-languages Resources subdirectories.
 
 Here's how an app would typically install the files on Unix:
@@ -94,7 +94,7 @@ Here's how an app would typically install the files on Unix:
 /usr/share/locale/de/LC_MESSAGES/myapp.mo
 /usr/share/locale/fr/LC_MESSAGES/myapp.mo
 @endcode
-And on OS X:
+And on macOS:
 @code
 MyApp.app/Contents/MacOS/MyApp
 MyApp.app/Contents/Resources/de.lproj/myapp.mo

--- a/docs/doxygen/overviews/richtextctrl.h
+++ b/docs/doxygen/overviews/richtextctrl.h
@@ -42,7 +42,7 @@ list styles with a renumber option.
 There are a few disadvantages to using wxRichTextCtrl. It is not native, so
 does not behave exactly as a native wxTextCtrl, although common editing
 conventions are followed. Users may miss the built-in spelling correction on
-OS X, or any special character input that may be provided by the native
+macOS, or any special character input that may be provided by the native
 control. It would also be a poor choice if intended users rely on screen
 readers that would be not work well with non-native text input implementation.
 You might mitigate this by providing the choice between wxTextCtrl and
@@ -495,7 +495,7 @@ tables, text boxes, and floating images, in addition to a simplified-HTML mode f
 
 There are also things that could be done to take advantage of the underlying
 text capabilities of the platform; higher-level text formatting APIs are
-available on some platforms, such as OS X, and some of translation from
+available on some platforms, such as macOS, and some of translation from
 high level to low level wxDC API is unnecessary. However this would require
 additions to the wxWidgets API.
 

--- a/docs/doxygen/overviews/string.h
+++ b/docs/doxygen/overviews/string.h
@@ -135,7 +135,7 @@ to buffer overflows. At last, C++ has a standard string class (@c std::string). 
 why the need for wxString? There are several advantages:
 
 @li <b>Efficiency:</b> Since wxWidgets 3.0 wxString uses @c std::string (in UTF8
-    mode under Linux, Unix and OS X) or @c std::wstring (in UTF16 mode under Windows)
+    mode under Linux, Unix and macOS) or @c std::wstring (in UTF16 mode under Windows)
     internally by default to store its contents. wxString will therefore inherit the
     performance characteristics from @c std::string.
 @li <b>Compatibility:</b> This class tries to combine almost full compatibility

--- a/docs/doxygen/overviews/unicode.h
+++ b/docs/doxygen/overviews/unicode.h
@@ -182,7 +182,7 @@ aware of the potential problems covered by the following section.
 wxWidgets uses the system @c wchar_t in wxString implementation by default
 under all systems. Thus, under Microsoft Windows, UCS-2 (simplified version of
 UTF-16 without support for surrogate characters) is used as @c wchar_t is 2
-bytes on this platform. Under Unix systems, including OS X, UCS-4 (also
+bytes on this platform. Under Unix systems, including macOS, UCS-4 (also
 known as UTF-32) is used by default, however it is also possible to build
 wxWidgets to use UTF-8 internally by passing @c \--enable-utf8 option to
 configure.

--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -2663,15 +2663,15 @@ should be processed on. It is filtered out and ignored on any other platforms.
 Possible elemental values are:
 @beginDefList
 @itemdef{ @c win, Windows }
-@itemdef{ @c mac, OS X (or Mac Classic in wxWidgets version supporting it) }
-@itemdef{ @c unix, Any Unix platform @em except OS X }
+@itemdef{ @c mac, macOS (or Mac Classic in wxWidgets version supporting it) }
+@itemdef{ @c unix, Any Unix platform @em except macOS }
 @endDefList
 
 Examples:
 @code
 <label platform="win">Windows</label>
 <label platform="unix">Unix</label>
-<label platform="mac">OS X</label>
+<label platform="mac">macOS</label>
 <help platform="mac|unix">Not a Windows machine</help>
 @endcode
 

--- a/docs/ios/install.md
+++ b/docs/ios/install.md
@@ -5,7 +5,7 @@ wxiOS is far from a full supported port, but can be used
 as base for simple applications and future improvements.
 
 It requires Xcode with iOS SDK 9.0 or later. Xcode is available
-for free in the OS X app store.
+for free in the macOS app store.
 
 To build wxiOS you should use Xcode to open the minimal samples
 Xcode project file located at:

--- a/docs/osx/install.md
+++ b/docs/osx/install.md
@@ -1,4 +1,4 @@
-wxWidgets for OS X installation        {#plat_osx_install}
+wxWidgets for macOS installation        {#plat_osx_install}
 -----------------------------------
 
 [TOC]
@@ -33,7 +33,7 @@ After the compilation completes, use Finder to run the samples and demos
 * The source code for the samples is in wxWidgets/samples
 * The source code for the demos is in wxWidgets/demos
 
-More information about building on OS X is available in the wxWiki.
+More information about building on macOS is available in the wxWiki.
 Here are two useful links
   * https://wiki.wxwidgets.org/Guides_%26_Tutorials
   * https://wiki.wxwidgets.org/Development:_wxMac

--- a/docs/readme.txt
+++ b/docs/readme.txt
@@ -97,7 +97,7 @@ This version of wxWidgets supports the following primary platforms:
 
 * Windows XP, Vista, 7, 8 and 10 (32/64 bits).
 * Most Unix variants using the GTK+ toolkit (version 2.6 or newer)
-* OS X (10.7 or newer) using Cocoa (32/64 bits)
+* macOS (10.7 or newer) using Cocoa (32/64 bits)
 
 There is some support for the following platforms:
 
@@ -116,7 +116,7 @@ Files
 wxWidgets is distributed in source form in several archive formats. ZIP and 7z
 archives are for Microsoft Windows users and contain the files with DOS/Windows
 line endings while the compressed tar archives are for Unix systems (including
-OS X) and contain the files with Unix line endings. Please notice that some
+macOS) and contain the files with Unix line endings. Please notice that some
 Windows tools still don't accept files with Unix line endings and that compiling
 sources with DOS line endings under Unix will fail, so please choose the correct
 file for your system.

--- a/interface/wx/aboutdlg.h
+++ b/interface/wx/aboutdlg.h
@@ -230,7 +230,7 @@ public:
         "Version " to @a version).
 
         The generic about dialog and native GTK+ dialog use @a version only,
-        as a suffix to the program name. The native MSW and OS X about dialogs
+        as a suffix to the program name. The native MSW and macOS about dialogs
         use the long version.
     */
     void SetVersion(const wxString& version, const wxString& longVersion = wxString());

--- a/interface/wx/accel.h
+++ b/interface/wx/accel.h
@@ -15,13 +15,13 @@ enum wxAcceleratorEntryFlags
     /** hold Alt key down */
     wxACCEL_ALT,
 
-    /** hold Ctrl key down, corresponds to Command key on OS X */
+    /** hold Ctrl key down, corresponds to Command key on macOS */
     wxACCEL_CTRL,
 
     /** hold Shift key down */
     wxACCEL_SHIFT,
 
-    /** corresponds to real Ctrl key on OS X, identic to @c wxACCEL_CTRL on other platforms */
+    /** corresponds to real Ctrl key on macOS, identic to @c wxACCEL_CTRL on other platforms */
     wxACCEL_RAW_CTRL,
 
     /** deprecated, identic to @c wxACCEL_CTRL on all platforms. */

--- a/interface/wx/addremovectrl.h
+++ b/interface/wx/addremovectrl.h
@@ -95,8 +95,8 @@ public:
     using this control instead of just creating and managing the buttons
     directly is that the correct buttons and layout for the current platform
     are used by this class. E.g. the buttons are positioned under the list
-    control under OS X and GTK+ but to its right under MSW and the buttons
-    themselves use system-specific bitmaps under OS X.
+    control under macOS and GTK+ but to its right under MSW and the buttons
+    themselves use system-specific bitmaps under macOS.
 
     This class is always used in conjunction with wxAddRemoveAdaptor which is
     used to actually add items to or remove them from the control containing

--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -756,7 +756,7 @@ public:
         @endcode
         but be warned that locale support in C++ standard library can be poor
         or worse under some platforms, e.g. the above line results in an
-        immediate crash under OS X up to the version 10.8.2.
+        immediate crash under macOS up to the version 10.8.2.
 
         @since 2.9.5
      */
@@ -772,7 +772,7 @@ public:
 
         Under Windows and Linux/Unix, you should parse the command line
         arguments and check for files to be opened when starting your
-        application. Under OS X, you need to override MacOpenFiles()
+        application. Under macOS, you need to override MacOpenFiles()
         since command line arguments are used differently there.
 
         You may use the wxCmdLineParser to parse command line arguments.
@@ -1055,7 +1055,7 @@ public:
 
     /**
         May be overridden to indicate that the application is not a foreground
-        GUI application under OS X.
+        GUI application under macOS.
 
         This method is called during the application startup and returns @true
         by default. In this case, wxWidgets ensures that the application is ran

--- a/interface/wx/appprogress.h
+++ b/interface/wx/appprogress.h
@@ -9,7 +9,7 @@
     @class wxAppProgressIndicator
 
     A helper class that can be used to update the progress bar in the taskbar
-    button on Windows and the dock icon on OS X.
+    button on Windows and the dock icon on macOS.
 
     @library{wxcore}
     @category{misc}

--- a/interface/wx/bitmap.h
+++ b/interface/wx/bitmap.h
@@ -665,7 +665,7 @@ public:
         @endcode
         in your application startup code.
 
-        However under OS X this function uses native image loading and so
+        However under macOS this function uses native image loading and so
         doesn't require wxWidgets PNG support.
 
         @since 2.9.5

--- a/interface/wx/bookctrl.h
+++ b/interface/wx/bookctrl.h
@@ -12,7 +12,7 @@
     bits is set if point is over a tab.
     Notice that wxOSX currently only returns wxBK_HITTEST_ONLABEL or
     wxBK_HITTEST_NOWHERE and never the other values, so you should only test
-    for these two in the code that should be portable under OS X.
+    for these two in the code that should be portable under macOS.
  */
 enum
 {

--- a/interface/wx/button.h
+++ b/interface/wx/button.h
@@ -32,7 +32,7 @@
 
     A button may have either a single image for all states or different images
     for the following states (different images are not currently supported
-    under OS X where the normal image is used for all states):
+    under macOS where the normal image is used for all states):
     @li @b normal: the default state
     @li @b disabled: bitmap shown when the button is disabled.
     @li @b pressed: bitmap shown when the button is pushed (e.g. while the user
@@ -115,7 +115,7 @@ public:
         @ref page_stockitems "this list", a standard label will be used. In
         other words, if you use a predefined @c wxID_XXX constant, just omit
         the label completely rather than specifying it. In particular, help
-        buttons (the ones with @a id of @c wxID_HELP) under OS X can't
+        buttons (the ones with @a id of @c wxID_HELP) under macOS can't
         display any label at all and while wxButton will detect if the standard
         "Help" label is used and ignore it, using any other label will prevent
         the button from correctly appearing as a help button and so should be

--- a/interface/wx/chartype.h
+++ b/interface/wx/chartype.h
@@ -125,7 +125,7 @@ typedef wxUSE_UNICODE_dependent wxUChar;
     \- @c wchar_t when <tt>wxUSE_UNICODE_WCHAR==1</tt> and <tt>wxUSE_UNICODE==1</tt>
 
     The @c wxUSE_UNICODE_WCHAR symbol is defined to @c 1 when building on
-    Windows while it's defined to @c 0 when building on Unix, Linux or OS X.
+    Windows while it's defined to @c 0 when building on Unix, Linux or macOS.
     (Note that @c wxUSE_UNICODE_UTF8 symbol is defined as the opposite of
     @c wxUSE_UNICODE_WCHAR.)
 

--- a/interface/wx/combo.h
+++ b/interface/wx/combo.h
@@ -730,7 +730,7 @@ public:
         Sets a hint shown in an empty unfocused combo control.
 
         Notice that hints are known as <em>cue banners</em> under MSW or
-        <em>placeholder strings</em> under OS X.
+        <em>placeholder strings</em> under macOS.
 
         @see wxTextEntry::SetHint()
 

--- a/interface/wx/cshelp.h
+++ b/interface/wx/cshelp.h
@@ -182,7 +182,7 @@ public:
       so that this button is only added to a dialog for non-Windows platforms
       (use wxDIALOG_EX_CONTEXTHELP on Windows).
 
-    Note that on OS X, the cursor does not change when in context-sensitive
+    Note that on macOS, the cursor does not change when in context-sensitive
     help mode.
 
     @library{wxcore}

--- a/interface/wx/cursor.h
+++ b/interface/wx/cursor.h
@@ -140,7 +140,7 @@ public:
             - under MacOS, it defaults to @c wxBITMAP_TYPE_MACCURSOR_RESOURCE;
               when specifying a string resource name, first the color cursors 'crsr'
               and then the black/white cursors 'CURS' in the resource chain are scanned
-              through. Note that resource forks are deprecated on OS X so this
+              through. Note that resource forks are deprecated on macOS so this
               is only available for legacy reasons and should not be used in
               new code.
             - under GTK, it defaults to @c wxBITMAP_TYPE_XPM.

--- a/interface/wx/dataview.h
+++ b/interface/wx/dataview.h
@@ -613,9 +613,9 @@ public:
     wxDataViewVirtualListModel is a specialized data model which lets you address
     an item by its position (row) rather than its wxDataViewItem and as such offers
     the exact same interface as wxDataViewIndexListModel.
-    The important difference is that under platforms other than OS X, using this
+    The important difference is that under platforms other than macOS, using this
     model will result in a truly virtual control able to handle millions of items
-    as the control doesn't store any item (a feature not supported by OS X).
+    as the control doesn't store any item (a feature not supported by macOS).
 
     @see wxDataViewListModel for the API.
 
@@ -733,7 +733,7 @@ public:
         text.
 
         Currently this attribute is only supported in the generic version of
-        wxDataViewCtrl and GTK and ignored by the native OS X implementations.
+        wxDataViewCtrl and GTK and ignored by the native macOS implementations.
 
         @since 3.1.2
     */
@@ -981,7 +981,7 @@ wxEventType wxEVT_DATAVIEW_ITEM_DROP;
            Process a @c wxEVT_DATAVIEW_COLUMN_HEADER_CLICK event.
     @event{EVT_DATAVIEW_COLUMN_HEADER_RIGHT_CLICK(id, func)}
            Process a @c wxEVT_DATAVIEW_COLUMN_HEADER_RIGHT_CLICK event.
-           Notice that currently this event is not generated in the native OS X
+           Notice that currently this event is not generated in the native macOS
            versions of the control.
     @event{EVT_DATAVIEW_COLUMN_SORTED(id, func)}
            Process a @c wxEVT_DATAVIEW_COLUMN_SORTED event.
@@ -1433,8 +1433,8 @@ public:
         style as in the case of single selection it returns the same thing as
         GetSelection().
 
-        Notice that under all platforms except OS X the currently focused
-        item may be selected or not but under OS X the current item is always
+        Notice that under all platforms except macOS the currently focused
+        item may be selected or not but under macOS the current item is always
         selected.
 
         @see SetCurrentItem(), GetCurrentColumn()
@@ -1639,7 +1639,7 @@ public:
         In single selection mode, calling this method is the same as calling
         Select() and is thus not very useful. In multiple selection mode this
         method only moves the current item however without changing the
-        selection except under OS X where the current item is always selected,
+        selection except under macOS where the current item is always selected,
         so calling SetCurrentItem() selects @a item if it hadn't been selected
         before.
 
@@ -1695,7 +1695,7 @@ public:
         This function can only be used when all rows have the same height, i.e.
         when wxDV_VARIABLE_LINE_HEIGHT flag is not used.
 
-        Currently this is implemented in the generic and native GTK and OS X
+        Currently this is implemented in the generic and native GTK and macOS
         (since 3.1.1) versions.
 
         Also notice that this method can only be used to increase the row
@@ -2030,7 +2030,7 @@ public:
         The default value of @c wxDVR_DEFAULT_ALIGNMENT indicates that the content
         should have the same alignment as the column header.
 
-        The method is not implemented under OS X and the renderer always aligns
+        The method is not implemented under macOS and the renderer always aligns
         its contents as the column header on that platform. The other platforms
         support both vertical and horizontal alignment.
     */
@@ -3822,7 +3822,7 @@ public:
 
         Currently support for setting this field and for vetoing the change is
         only available in the generic version of wxDataViewCtrl, i.e. under MSW
-        but not GTK nor OS X.
+        but not GTK nor macOS.
 
         @since 2.9.3
      */
@@ -3883,7 +3883,7 @@ public:
         moved) and ::wxDrag_DefaultMove.
 
         Currently it is only honoured by the generic version of wxDataViewCtrl
-        (used e.g. under MSW) and not supported by the native GTK and OS X
+        (used e.g. under MSW) and not supported by the native GTK and macOS
         versions.
 
         @see GetDropEffect()
@@ -3903,7 +3903,7 @@ public:
 
         Currently this is only available when using the generic version of
         wxDataViewCtrl (used e.g. under MSW) and always returns ::wxDragNone in
-        the GTK and OS X native versions.
+        the GTK and macOS native versions.
 
         @since 2.9.4
     */

--- a/interface/wx/dc.h
+++ b/interface/wx/dc.h
@@ -164,7 +164,7 @@ struct wxFontMetrics
     In general wxDC methods don't support alpha transparency and the alpha
     component of wxColour is simply ignored and you need to use wxGraphicsContext
     for full transparency support. There are, however, a few exceptions: first,
-    under OS X and GTK+ 3 colours with alpha channel are supported in all the normal
+    under macOS and GTK+ 3 colours with alpha channel are supported in all the normal
     wxDC-derived classes as they use wxGraphicsContext internally. Second,
     under all platforms wxSVGFileDC also fully supports alpha channel. In both
     of these cases the instances of wxPen or wxBrush that are built from
@@ -173,7 +173,7 @@ struct wxFontMetrics
 
     @section dc_transform_support Support for Transformation Matrix
 
-    On some platforms (currently under MSW, GTK+ 3, OS X) wxDC has support for
+    On some platforms (currently under MSW, GTK+ 3, macOS) wxDC has support for
     applying an arbitrary affine transformation matrix to its coordinate system
     (since 3.1.1 this feature is also supported by wxGCDC in all ports).
     Call CanUseTransformMatrix() to check if this support is available and then
@@ -1640,7 +1640,7 @@ public:
        context, if this wxDC has something that could be thought of in that
        way.  (Not all of them do.)
 
-       For example, on Windows the return value is an HDC, on OS X it is a
+       For example, on Windows the return value is an HDC, on macOS it is a
        CGContextRef and on wxGTK it will be a GdkDrawable.  If the DC is a
        wxGCDC then the return value will be the value returned from
        wxGraphicsContext::GetNativeContext.  A value of NULL is returned if

--- a/interface/wx/dcbuffer.h
+++ b/interface/wx/dcbuffer.h
@@ -40,7 +40,7 @@
     backing store for the window contents. In this case, the associated @e DC
     may be @NULL but a valid backing store bitmap should be specified.
 
-    Finally, please note that GTK+ 2.0 as well as OS X provide double buffering
+    Finally, please note that GTK+ 2.0 as well as macOS provide double buffering
     themselves natively. You can either use wxWindow::IsDoubleBuffered() to
     determine whether you need to use buffering or not, or use
     wxAutoBufferedPaintDC to avoid needless double buffering on the systems

--- a/interface/wx/defs.h
+++ b/interface/wx/defs.h
@@ -931,13 +931,13 @@ enum wxKeyCode
     WXK_CLEAR,
     WXK_SHIFT,
     WXK_ALT,
-    /** Note that under OS X, to improve compatibility with other
+    /** Note that under macOS, to improve compatibility with other
       * systems, 'WXK_CONTROL' represents the 'Command' key. Use this
       * constant to work with keyboard shortcuts. See 'WXK_RAW_CONTROL'
       * to get the state of the actual 'Control' key.
       */
     WXK_CONTROL,
-    /** Under OS X, where the 'Command' key is mapped to 'Control'
+    /** Under macOS, where the 'Command' key is mapped to 'Control'
       * to improve compatibility with other systems, WXK_RAW_CONTROL may
       * be used to obtain the state of the actual 'Control' key
       * ('WXK_CONTROL' would obtain the status of the 'Command' key).
@@ -1035,7 +1035,7 @@ enum wxKeyCode
     WXK_WINDOWS_RIGHT,
     WXK_WINDOWS_MENU ,
 
-    /** This special key code was used to represent the key used for keyboard shortcuts. Under OS X,
+    /** This special key code was used to represent the key used for keyboard shortcuts. Under macOS,
       * this key maps to the 'Command' (aka logo or 'Apple') key, whereas on Linux/Windows/others
       * this is the Control key, with the new semantic of WXK_CONTROL, WXK_COMMAND is not needed anymore
       */
@@ -1089,14 +1089,14 @@ enum wxKeyModifier
 {
     wxMOD_NONE      = 0x0000,
     wxMOD_ALT       = 0x0001,
-    /** Ctlr Key, corresponds to Command key on OS X */
+    /** Ctlr Key, corresponds to Command key on macOS */
     wxMOD_CONTROL   = 0x0002,
     wxMOD_ALTGR     = wxMOD_ALT | wxMOD_CONTROL,
     wxMOD_SHIFT     = 0x0004,
     wxMOD_META      = 0x0008,
     wxMOD_WIN       = wxMOD_META,
 
-    /** used to describe the true Ctrl Key under OS X,
+    /** used to describe the true Ctrl Key under macOS,
     identic to @c wxMOD_CONTROL on other platforms */
     wxMOD_RAW_CONTROL,
 

--- a/interface/wx/dialog.h
+++ b/interface/wx/dialog.h
@@ -126,7 +126,7 @@ enum wxDialogLayoutAdaptationMode
            calling SetExtraStyle() before Create is called (two-step
            construction).
     @style{wxDIALOG_EX_METAL}
-           On OS X, frames with this style will be shown with a metallic
+           On macOS, frames with this style will be shown with a metallic
            look. This is an extra style.
     @endStyleTable
 

--- a/interface/wx/dynlib.h
+++ b/interface/wx/dynlib.h
@@ -123,7 +123,7 @@ public:
         is included.
 
         For example, on Windows @c ".dll" is returned, and either @c ".dylib"
-        or @c ".bundle" on OS X.
+        or @c ".bundle" on macOS.
     */
     static wxString GetDllExt(wxDynamicLibraryCategory cat = wxDL_LIBRARY);
 

--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -1574,7 +1574,7 @@ public:
         Under GTK, the raw key code is the @c keyval field of the corresponding
         GDK event.
 
-        Under OS X, the raw key code is the @c keyCode field of the
+        Under macOS, the raw key code is the @c keyCode field of the
         corresponding NSEvent.
 
         @note Currently the raw key codes are not supported by all ports, use
@@ -1594,7 +1594,7 @@ public:
         Under GTK, the raw flags contain the @c hardware_keycode field of the
         corresponding GDK event.
 
-        Under OS X, the raw flags contain the modifiers state.
+        Under macOS, the raw flags contain the modifiers state.
 
         @note Currently the raw key flags are not supported by all ports, use
               @ifdef_ wxHAS_RAW_KEY_CODES to determine if this feature is available.
@@ -2784,7 +2784,7 @@ public:
         (or zoom in), a negative value means we should shrink (or zoom out).
 
         This method is only valid to call for @c wxEVT_MAGNIFY events which are
-        currently only generated under OS X.
+        currently only generated under macOS.
 
         @see Magnify()
 
@@ -2877,7 +2877,7 @@ public:
     /**
         Returns @true if the event is a magnify (i.e.\ pinch to zoom) event.
 
-        Such events are currently generated only under OS X.
+        Such events are currently generated only under macOS.
 
         @see GetMagnification()
 

--- a/interface/wx/filedlg.h
+++ b/interface/wx/filedlg.h
@@ -108,7 +108,7 @@ const char wxFileSelectorDefaultWildcardStr[];
     descriptive test; "BMP files (*.bmp)|*.bmp" is displayed as "*.bmp", and both
     "BMP files (*.bmp)|*.bmp|GIF files (*.gif)|*.gif" and "Image files|*.bmp;*.gif"
     are errors.
-    On Mac OS X in the open file dialog the filter choice box is not shown by default.
+    On Mac macOS in the open file dialog the filter choice box is not shown by default.
     Instead all given wildcards are appplied at the same time: So in the above
     example all bmp, gif and png files are displayed. To enforce the
     display of the filter choice set the corresponding wxSystemOptions before calling
@@ -117,7 +117,7 @@ const char wxFileSelectorDefaultWildcardStr[];
          wxSystemOptions::SetOption(wxOSX_FILEDIALOG_ALWAYS_SHOW_TYPES, 1)
     @endcode
     But in contrast to Windows and Unix, where the file type choice filters only
-    the selected files, on Mac OS X even in this case the dialog shows all files
+    the selected files, on Mac macOS even in this case the dialog shows all files
     matching all file types. The files which does not match the currently selected
     file type are greyed out and are not selectable.
 
@@ -143,9 +143,9 @@ const char wxFileSelectorDefaultWildcardStr[];
            3.1.0.
     @style{wxFD_FILE_MUST_EXIST}
            For open dialog only: the user may only select files that actually
-           exist. Notice that under OS X the file dialog with @c wxFD_OPEN
+           exist. Notice that under macOS the file dialog with @c wxFD_OPEN
            style always behaves as if this style was specified, because it is
-           impossible to choose a file that doesn't exist from a standard OS X
+           impossible to choose a file that doesn't exist from a standard macOS
            file dialog.
     @style{wxFD_MULTIPLE}
            For open dialog only: allows selecting multiple files.

--- a/interface/wx/font.h
+++ b/interface/wx/font.h
@@ -739,7 +739,7 @@ public:
         This method can be used to allow this application to use the font from
         the given file even if it is not globally installed on the system.
 
-        Under OS X this method actually doesn't do anything other than check
+        Under macOS this method actually doesn't do anything other than check
         for the existence of the file in the "Fonts" subdirectory of the
         application bundle "Resources" directory. You are responsible for
         actually making the font file available in this directory and setting

--- a/interface/wx/frame.h
+++ b/interface/wx/frame.h
@@ -119,7 +119,7 @@
            frames having this style (the dialogs don't have a minimize or a
            maximize box by default)
     @style{wxFRAME_EX_METAL}
-           On OS X, frames with this style will be shown with a metallic
+           On macOS, frames with this style will be shown with a metallic
            look. This is an extra style.
     @endExtraStyleTable
 

--- a/interface/wx/fswatcher.h
+++ b/interface/wx/fswatcher.h
@@ -14,10 +14,10 @@
     system changes.
 
     @note Implementation limitations: this class is currently implemented for
-          MSW, OS X and GTK ports but doesn't detect all changes correctly
+          MSW, macOS and GTK ports but doesn't detect all changes correctly
           everywhere: under MSW accessing the file is not detected (only
-          modifying it is) and under OS X neither accessing nor modifying is
-          detected (only creating and deleting files is). Moreover, OS X
+          modifying it is) and under macOS neither accessing nor modifying is
+          detected (only creating and deleting files is). Moreover, macOS
           version doesn't currently collapse pairs of create/delete events in a
           rename event, unlike the other ones.
 
@@ -85,7 +85,7 @@ public:
         Additionally a file mask can be specified to include only files
         matching that particular mask.
 
-        This method is implemented efficiently on MSW and OS X >= 10.7, but
+        This method is implemented efficiently on MSW and macOS >= 10.7, but
         should be used with care on other platforms for directories with lots
         of children (e.g. the root directory) as it calls Add() for each
         subdirectory, potentially creating a lot of watches and taking a long
@@ -250,7 +250,7 @@ enum wxFSWFlags
         Notice that under MSW this event is sometimes -- although not always --
         followed by a ::wxFSW_EVENT_MODIFY for the new file.
 
-        Under OS X this event is only detected when watching entire trees. When
+        Under macOS this event is only detected when watching entire trees. When
         watching directories, separate ::wxFSW_EVENT_CREATE and
         ::wxFSW_EVENT_DELETE events are detected instead.
      */
@@ -262,7 +262,7 @@ enum wxFSWFlags
         Depending on the program doing the file modification, multiple such
         events can be reported for a single logical file update.
 
-        Under OS X this event is only detected when watching entire trees.
+        Under macOS this event is only detected when watching entire trees.
      */
     wxFSW_EVENT_MODIFY = 0x08,
 
@@ -276,8 +276,8 @@ enum wxFSWFlags
     /**
         The item's metadata was changed, e.g.\ its permissions or timestamps.
 
-        This event is currently only detected under Linux and OS X.
-        Under OS X this event is only detected when watching entire trees.
+        This event is currently only detected under Linux and macOS.
+        Under macOS this event is only detected when watching entire trees.
 
         @since 2.9.5
      */
@@ -289,8 +289,8 @@ enum wxFSWFlags
         wxFSW_EVENT_UNMOUNT cannot be set; unmount events are produced automatically. This flag
         is therefore not included in wxFSW_EVENT_ALL.
 
-        This event is currently only detected under Linux and OS X.
-        Under OS X this event is only detected when watching entire trees.
+        This event is currently only detected under Linux and macOS.
+        Under macOS this event is only detected when watching entire trees.
 
         @since 2.9.5
     */

--- a/interface/wx/gauge.h
+++ b/interface/wx/gauge.h
@@ -55,7 +55,7 @@
            This flag is only available in wxWidgets 3.1.0 and later.
     @style{wxGA_PROGRESS}
            Reflect the value of gauge in the application taskbar button under
-           Windows 7 and later and the dock icon under OS X, ignored under
+           Windows 7 and later and the dock icon under macOS, ignored under
            the other platforms.
            This flag is only available in wxWidgets 3.1.0 and later.
 

--- a/interface/wx/gdicmn.h
+++ b/interface/wx/gdicmn.h
@@ -1131,7 +1131,7 @@ const wxSize wxDefaultSize;
     @endcode
     to be able to use @c wxBITMAP_PNG(mybitmap) in the code.
 
-    Under OS X the file with the specified name and "png" extension must be
+    Under macOS the file with the specified name and "png" extension must be
     present in the "Resources" subdirectory of the application bundle.
 
     Under the other platforms, this is equivalent to wxBITMAP_PNG_FROM_DATA()
@@ -1175,7 +1175,7 @@ const wxSize wxDefaultSize;
 
     You can use wxBITMAP_PNG() to load the PNG bitmaps from resources on the
     platforms that support this and only fall back to loading them from data
-    under the other ones (i.e. not Windows and not OS X).
+    under the other ones (i.e. not Windows and not macOS).
 
     @header{wx/gdicmn.h}
 

--- a/interface/wx/glcanvas.h
+++ b/interface/wx/glcanvas.h
@@ -144,7 +144,7 @@ class wxGLAttributes : public wxGLAttribsBase
 public:
     /**
         Use true colour instead of colour index rendering for each pixel.
-        It makes no effect for OS X.
+        It makes no effect for macOS.
     */
     wxGLAttributes& RGBA();
 
@@ -158,7 +158,7 @@ public:
     wxGLAttributes& BufferSize(int val);
 
     /**
-        Specifies the framebuffer level. It makes no effect for OS X.
+        Specifies the framebuffer level. It makes no effect for macOS.
 
         @param val
         0 for main buffer, >0 for overlay, <0 for underlay.
@@ -246,7 +246,7 @@ public:
     wxGLAttributes& Samplers(int val);
 
     /**
-        Used to request a frame buffer sRGB capable. It makes no effect for OS X.
+        Used to request a frame buffer sRGB capable. It makes no effect for macOS.
     */
     wxGLAttributes& FrameBuffersRGB();
 
@@ -315,7 +315,7 @@ public:
         @param val
         The major version number requested.
 
-        It has no effect under OS X where specifying CoreProfile() will
+        It has no effect under macOS where specifying CoreProfile() will
         result in using OpenGL version at least 3.2.
     */
     wxGLContextAttrs& MajorVersion(int val);
@@ -326,7 +326,7 @@ public:
         @param val
         The minor version number requested, e.g. 2 if OpenGL 3.2 is requested.
 
-        It has no effect under OS X where specifying CoreProfile() will
+        It has no effect under macOS where specifying CoreProfile() will
         result in using OpenGL version at least 3.2.
     */
     wxGLContextAttrs& MinorVersion(int val);
@@ -340,7 +340,7 @@ public:
         @param vminor
         The minor version number requested, e.g. 5 if OpenGL 4.5 is requested.
 
-        It has no effect under OS X where specifying CoreProfile() will
+        It has no effect under macOS where specifying CoreProfile() will
         result in using OpenGL version at least 3.2.
     */
     wxGLContextAttrs& OGLVersion(int vmayor, int vminor);
@@ -358,7 +358,7 @@ public:
         later. They must not support functionality marked as deprecated or
         removed by the requested version of the OpenGL API.
 
-        It has no effect under OS X.
+        It has no effect under macOS.
     */
     wxGLContextAttrs& ForwardCompatible();
 
@@ -367,7 +367,7 @@ public:
         subsets of OpenGL, lacking some features of the full specification.
         Used mainly in embedded devices such as mobile phones.
 
-        It has no effect under OS X.
+        It has no effect under macOS.
     */
     wxGLContextAttrs& ES2();
 
@@ -376,7 +376,7 @@ public:
         some logs are enabled and also allows OGL to send debug messages through
         a callback function.
 
-        It has no effect under OS X.
+        It has no effect under macOS.
     */
     wxGLContextAttrs& DebugCtx();
 
@@ -384,14 +384,14 @@ public:
         Request robustness, or how OpenGL handles out-of-bounds buffer object
         accesses and graphics reset notification behaviours.
 
-        It has no effect under OS X.
+        It has no effect under macOS.
     */
     wxGLContextAttrs& Robust();
 
     /**
         With robustness enabled, never deliver notification of reset events.
 
-        It has no effect under OS X.
+        It has no effect under macOS.
     */
     wxGLContextAttrs& NoResetNotify();
 
@@ -399,7 +399,7 @@ public:
         With robustness enabled, if graphics reset happens, all context state is
         lost.
 
-        It has no effect under OS X.
+        It has no effect under macOS.
     */
     wxGLContextAttrs& LoseOnReset();
 
@@ -407,7 +407,7 @@ public:
         Request OpenGL to protect other applications or shared contexts from reset
         side-effects.
 
-        It has no effect under OS X.
+        It has no effect under macOS.
     */
     wxGLContextAttrs& ResetIsolation();
 
@@ -419,7 +419,7 @@ public:
         @param val
         0 for not flushing, 1 (wxWidgets default) for flushing pending commands.
 
-        It has no effect under OS X.
+        It has no effect under macOS.
     */
     wxGLContextAttrs& ReleaseFlush(int val = 1);
 
@@ -620,7 +620,7 @@ enum
         This attribute should be followed by the major version number
         requested.
 
-        It has no effect under OS X where specifying ::WX_GL_CORE_PROFILE will
+        It has no effect under macOS where specifying ::WX_GL_CORE_PROFILE will
         result in using OpenGL version at least 3.2 but can still be used
         there for portability.
 
@@ -769,7 +769,7 @@ enum
     parameter) but it's discouraged.
 
     @note
-        On those platforms which use a configure script (e.g. Linux and OS X)
+        On those platforms which use a configure script (e.g. Linux and macOS)
         OpenGL support is automatically enabled if the relative headers and
         libraries are found.
         To switch it on under the other platforms (e.g. Windows), you need to edit

--- a/interface/wx/graphics.h
+++ b/interface/wx/graphics.h
@@ -1327,7 +1327,7 @@ public:
         Creates wxGraphicsBitmap from a native bitmap handle.
 
         @a bitmap meaning is platform-dependent. Currently it's a GDI+ @c
-        Bitmap pointer under MSW, @c CGImage pointer under OS X or a @c
+        Bitmap pointer under MSW, @c CGImage pointer under macOS or a @c
         cairo_surface_t pointer when using Cairo under any platform.
 
         Notice that this method takes ownership of @a bitmap, i.e. it will be
@@ -1478,7 +1478,7 @@ public:
         and end colours could be specified.
 
         The ability to apply a transformation matrix to the gradient was added in 3.1.3
-        
+
     */
     virtual wxGraphicsBrush CreateLinearGradientBrush(wxDouble x1,
                                                       wxDouble y1,
@@ -1534,7 +1534,7 @@ public:
 
         Currently this function returns "gdiplus" for Windows GDI+
         implementation, "direct2d" for Windows Direct2D implementation,
-        "cairo" for Cairo implementation and "cg" for OS X CoreGraphics
+        "cairo" for Cairo implementation and "cg" for macOS CoreGraphics
         implementation.
 
         @remarks The string returned by this method is not user-readable and is
@@ -1559,7 +1559,7 @@ public:
     virtual void GetVersion(int* major, int* minor = NULL, int* micro=NULL) const = 0;
 
     /**
-        Returns the default renderer on this platform. On OS X this is the Core
+        Returns the default renderer on this platform. On macOS this is the Core
         Graphics (a.k.a. Quartz 2D) renderer, on MSW the GDIPlus renderer, and
         on GTK we currently default to the Cairo renderer.
     */
@@ -1660,25 +1660,25 @@ public:
 
     wxGraphicsPenInfo& Cap(wxPenCap cap);
 
-    wxGraphicsPenInfo& 
+    wxGraphicsPenInfo&
     LinearGradient(wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2,
                    const wxColour& c1, const wxColour& c2,
                    const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix);
 
-    wxGraphicsPenInfo& 
+    wxGraphicsPenInfo&
     LinearGradient(wxDouble x1, wxDouble y1, wxDouble x2, wxDouble y2,
                    const wxGraphicsGradientStops& stops,
                    const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix);
 
-    wxGraphicsPenInfo& 
+    wxGraphicsPenInfo&
     RadialGradient(wxDouble startX, wxDouble startY,
-                   wxDouble endX, wxDouble endY, wxDouble radius, 
+                   wxDouble endX, wxDouble endY, wxDouble radius,
                    const wxColour& oColor, const wxColour& cColor,
                    const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix);
 
-    wxGraphicsPenInfo& 
+    wxGraphicsPenInfo&
     RadialGradient(wxDouble startX, wxDouble startY,
-                   wxDouble endX, wxDouble endY, 
+                   wxDouble endX, wxDouble endY,
                    wxDouble radius, const wxGraphicsGradientStops& stops,
                    const wxGraphicsMatrix& matrix = wxNullGraphicsMatrix);
 
@@ -1690,7 +1690,7 @@ public:
     int GetDashes(wxDash **ptr);
     int GetDashCount() const;
     wxDash* GetDash() const;
-    bool IsTransparent() const;    
+    bool IsTransparent() const;
     wxDouble GetWidth() const;
     wxGradientType GetGradientType() const;
     wxDouble GetX1() const;

--- a/interface/wx/headercol.h
+++ b/interface/wx/headercol.h
@@ -18,8 +18,8 @@ enum
     /**
         Size the column automatically to fit all values.
 
-        @note On OS X, this style is only implemented in the Cocoa build on
-              OS X >= 10.5; it behaves identically to wxCOL_WIDTH_DEFAULT otherwise.
+        @note On macOS, this style is only implemented in the Cocoa build on
+              macOS >= 10.5; it behaves identically to wxCOL_WIDTH_DEFAULT otherwise.
      */
     wxCOL_WIDTH_AUTOSIZE = -2
 };

--- a/interface/wx/html/webkit.h
+++ b/interface/wx/html/webkit.h
@@ -20,7 +20,7 @@
     RunScript return a value, which is a very critical feature in many web
     embedding scenarios.
 
-    This class is only available on OS X.
+    This class is only available on macOS.
 **/
 
 class wxWebKitCtrl : public wxControl

--- a/interface/wx/intl.h
+++ b/interface/wx/intl.h
@@ -131,7 +131,7 @@ enum wxLocaleInfo
         Short date format.
 
         Notice that short and long date formats may be the same under POSIX
-        systems currently but may, and typically are, different under MSW or OS X.
+        systems currently but may, and typically are, different under MSW or macOS.
 
         @since 2.9.0
      */

--- a/interface/wx/kbdstate.h
+++ b/interface/wx/kbdstate.h
@@ -85,7 +85,7 @@ public:
     /**
         Returns true if Control or Alt are pressed.
 
-        Checks if Control, Alt or, under OS X only, Command key are pressed
+        Checks if Control, Alt or, under macOS only, Command key are pressed
         (notice that the real Control key is still taken into account under OS
         X too).
 
@@ -97,7 +97,7 @@ public:
     bool HasModifiers() const;
 
     /**
-        Returns true if the Control key or Apple/Command key under OS X is pressed.
+        Returns true if the Control key or Apple/Command key under macOS is pressed.
 
         This function doesn't distinguish between right and left control keys.
 
@@ -106,7 +106,7 @@ public:
     bool ControlDown() const;
 
     /**
-        Returns true if the Control key (also under OS X).
+        Returns true if the Control key (also under macOS).
 
         This function doesn't distinguish between right and left control keys.
 

--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -588,7 +588,7 @@ public:
         Returns @NULL if no label is being edited.
 
         @note It is currently only implemented for wxMSW and the generic version,
-              not for the native OS X version.
+              not for the native macOS version.
     */
     wxTextCtrl* GetEditControl() const;
 

--- a/interface/wx/mdi.h
+++ b/interface/wx/mdi.h
@@ -251,7 +251,7 @@ public:
         and this function can be used to retrieve it. Notice that the default
         menu can be replaced by calling SetWindowMenu().
 
-        This function is currently not available under OS X.
+        This function is currently not available under macOS.
 
         @return The current Window menu or @NULL.
     */
@@ -320,7 +320,7 @@ public:
         All of which are handled by wxMDIParentFrame itself. If any other
         commands are used in the menu, the derived frame should handle them.
 
-        This function is currently not available under OS X.
+        This function is currently not available under macOS.
 
         @param menu
             The menu to be used instead of the standard MDI Window menu or @NULL.

--- a/interface/wx/menu.h
+++ b/interface/wx/menu.h
@@ -445,8 +445,8 @@ public:
     @note
     Please note that @e wxID_ABOUT and @e wxID_EXIT are predefined by wxWidgets
     and have a special meaning since entries using these IDs will be taken out
-    of the normal menus under OS X and will be inserted into the system menu
-    (following the appropriate OS X interface guideline).
+    of the normal menus under macOS and will be inserted into the system menu
+    (following the appropriate macOS interface guideline).
 
     Menu items may be either @e normal items, @e check items or @e radio items.
     Normal items don't have any special properties while the check items have a

--- a/interface/wx/menuitem.h
+++ b/interface/wx/menuitem.h
@@ -418,7 +418,7 @@ public:
         "ALT" and @c "SHIFT" strings (case doesn't matter) separated by either
         @c '-' or @c '+' characters and followed by the accelerator itself.
         Notice that @c CTRL corresponds to the "Ctrl" key on most platforms but
-        not under OS X where it is mapped to "Cmd" key on Mac keyboard.
+        not under macOS where it is mapped to "Cmd" key on Mac keyboard.
         Usually this is exactly what you want in portable code but if you
         really need to use the (rarely used for this purpose) "Ctrl" key even
         under Mac, you may use @c RAWCTRL to prevent this mapping. Under the

--- a/interface/wx/msgdlg.h
+++ b/interface/wx/msgdlg.h
@@ -56,7 +56,7 @@ const char wxMessageBoxCaptionStr[] = "Message";
         Displays a warning icon in the dialog. This style should be used for
         informative warnings or, in combination with @c wxYES_NO or @c wxCANCEL,
         for questions that have potentially serious consequences (caution
-        icon is used on OS X in this case).
+        icon is used on macOS in this case).
     @style{wxICON_QUESTION}
         Displays a question mark symbol. This icon is automatically used
         with @c wxYES_NO so it's usually unnecessary to specify it explicitly.

--- a/interface/wx/notifmsg.h
+++ b/interface/wx/notifmsg.h
@@ -10,7 +10,7 @@
 
     This class allows showing the user a message non intrusively.
 
-    Currently it is implemented natively for Windows, OS X, GTK and uses
+    Currently it is implemented natively for Windows, macOS, GTK and uses
     generic toast notifications under the other platforms. It's not recommended
     but @c wxGenericNotificationMessage can be used instead of the native ones.
     This might make sense if your application requires features not available in
@@ -30,8 +30,8 @@
     recommended to call MSWUseToasts() before showing the first notification
     message.
 
-    @par OS X
-    The OS X implementation uses Notification Center to display native notifications.
+    @par macOS
+    The macOS implementation uses Notification Center to display native notifications.
     In order to use actions your notifications must use the alert style. This can
     be enabled by the user in system settings or by setting the
     @c NSUserNotificationAlertStyle value in Info.plist to @c alert. Please note

--- a/interface/wx/platinfo.h
+++ b/interface/wx/platinfo.h
@@ -23,7 +23,7 @@ enum wxOperatingSystemId
     wxOS_UNKNOWN = 0,                 //!< returned on error
 
     wxOS_MAC_OS         = 1 << 0,     //!< Apple Mac OS 8/9/X with Mac paths
-    wxOS_MAC_OSX_DARWIN = 1 << 1,     //!< Apple OS X with Unix paths
+    wxOS_MAC_OSX_DARWIN = 1 << 1,     //!< Apple macOS with Unix paths
 
     //! A combination of all @c wxOS_MAC_* values previously listed.
     wxOS_MAC = wxOS_MAC_OS|wxOS_MAC_OSX_DARWIN,

--- a/interface/wx/power.h
+++ b/interface/wx/power.h
@@ -106,7 +106,7 @@ wxEventType wxEVT_POWER_RESUME;
     powering off the screen and Acquire() method can be used to do this.
 
     Notice that currently this functionality is only implemented for MSW and
-    OS X.
+    macOS.
 
     If possible, use wxPowerResourceBlocker class to ensure that Release() is
     called instead of calling it manually.

--- a/interface/wx/preferences.h
+++ b/interface/wx/preferences.h
@@ -12,8 +12,8 @@
 
     This class encapsulates the differences -- both in appearance and
     behaviour -- between preferences dialogs on different platforms.  In
-    particular, OS X preferences look very different from the typical notebook
-    control used on other platforms, and both OS X and GTK+ preferences windows
+    particular, macOS preferences look very different from the typical notebook
+    control used on other platforms, and both macOS and GTK+ preferences windows
     are modeless unlike Windows options dialogs that are typically modal.
 
     wxPreferencesEditor is able to hide the differences by hiding the creation
@@ -90,7 +90,7 @@ public:
         Returns whether changes to values in preferences pages should be
         applied immediately or only when the user clicks the OK button.
 
-        Currently, changes are applied immediately on OS X and GTK+.
+        Currently, changes are applied immediately on macOS and GTK+.
 
         The preprocessor macro `wxHAS_PREF_EDITOR_APPLY_IMMEDIATELY` is defined
         in this case as well.
@@ -149,10 +149,10 @@ public:
     /**
         Return 32x32 icon used for the page on some platforms.
 
-        Currently only used on OS X.
+        Currently only used on macOS.
 
         @note This method is only pure virtual on platforms that require it
-              (OS X). On other platforms, it has default implementation that
+              (macOS). On other platforms, it has default implementation that
               returns an invalid bitmap. The preprocessor symbol
               `wxHAS_PREF_EDITOR_ICONS` is defined if this method must be
               implemented.
@@ -182,7 +182,7 @@ public:
     Specialization of wxPreferencesPage useful for certain commonly used
     preferences page.
 
-    On OS X, preferences pages named "General" and "Advanced" are commonly used
+    On macOS, preferences pages named "General" and "Advanced" are commonly used
     in apps and the OS provides stock icons for them that should be used.
     Instead of reimplementing this behaviour yourself, you can inherit from
     wxStockPreferencesPage and get correct title and icon.
@@ -214,6 +214,6 @@ public:
 
     /// Reimplemented to return suitable name for the page's kind.
     virtual wxString GetName() const;
-    /// Reimplemented to return stock icon on OS X.
+    /// Reimplemented to return stock icon on macOS.
     virtual wxBitmap GetLargeIcon() const;
 };

--- a/interface/wx/print.h
+++ b/interface/wx/print.h
@@ -290,7 +290,7 @@ public:
     created. In particular, printing code relying on wxDC::GetTextExtent()
     heavily (for example, wxHtmlEasyPrinting and other wxHTML classes do) is
     affected. It is recommended to use native preview functionality on
-    platforms that offer it (OS X, GTK+).
+    platforms that offer it (macOS, GTK+).
 
     @library{wxcore}
     @category{printing}
@@ -805,7 +805,7 @@ public:
         page rectangle, or page margins rectangle to perform your own scaling.
 
         @note
-        While the underlying drawing model of OS X is floating-point,
+        While the underlying drawing model of macOS is floating-point,
         wxWidgets's drawing model scales from integer coordinates.
     */
     void MapScreenSizeToDevice();

--- a/interface/wx/propdlg.h
+++ b/interface/wx/propdlg.h
@@ -49,7 +49,7 @@ enum wxPropertySheetDialogFlags
 
     /**
         Shrinks the dialog window to fit the currently selected page
-        (common behaviour for property sheets on OS X).
+        (common behaviour for property sheets on macOS).
     */
     wxPROPSHEET_SHRINKTOFIT = 0x0100,
 };

--- a/interface/wx/rawbmp.h
+++ b/interface/wx/rawbmp.h
@@ -14,7 +14,7 @@
     possible to extend this class (interface) to other types of
     image content.
 
-    Implemented on Windows, GTK+ and OS X:
+    Implemented on Windows, GTK+ and macOS:
        @li wxNativePixelData: Class to access to wxBitmap's internal data
            without alpha channel (RGB).
        @li wxAlphaPixelData: Class to access to wxBitmap's internal data with

--- a/interface/wx/renderer.h
+++ b/interface/wx/renderer.h
@@ -520,7 +520,7 @@ public:
     /**
         Draw a title bar button in the given state.
 
-        This function is currently only available under MSW and OS X (and only
+        This function is currently only available under MSW and macOS (and only
         for wxTITLEBAR_BUTTON_CLOSE under the latter), its best replacement for
         the other platforms is to use wxArtProvider to retrieve the bitmaps for
         @c wxART_HELP and @c wxART_CLOSE (but not any other title bar buttons

--- a/interface/wx/secretstore.h
+++ b/interface/wx/secretstore.h
@@ -139,7 +139,7 @@ public:
     A collection of secrets, sometimes called a key chain.
 
     This class provides access to the secrets stored in the OS-provided
-    facility, e.g. credentials manager under MSW, keychain under OS X or
+    facility, e.g. credentials manager under MSW, keychain under macOS or
     Freedesktop-compliant password storage mechanism such as GNOME keyring
     under Unix systems.
 
@@ -155,7 +155,7 @@ public:
     included in the string to allow storing passwords for more than one server.
 
     Notice that this class is always available under MSW (except when using
-    MinGW32 which doesn't provide the required @c wincred.h header) and OS X
+    MinGW32 which doesn't provide the required @c wincred.h header) and macOS
     but requires libsecret (see https://developer.gnome.org/libsecret/) under
     Unix and may not be compiled in if it wasn't found. You can check @c
     wxUSE_SECRETSTORE to test for this. Moreover, retrieving the default

--- a/interface/wx/sizer.h
+++ b/interface/wx/sizer.h
@@ -969,7 +969,7 @@ public:
     and ordering defined by the platform or toolkit's user interface guidelines
     (if such things exist). By using this class, you can ensure that all your
     standard dialogs look correct on all major platforms. Currently it conforms to
-    the Windows, GTK+ and OS X human interface guidelines.
+    the Windows, GTK+ and macOS human interface guidelines.
 
     When there aren't interface guidelines defined for a particular platform or
     toolkit, wxStdDialogButtonSizer reverts to the Windows implementation.
@@ -980,9 +980,9 @@ public:
     and then call Realize in order to create the actual button layout used.
     Other than these special operations, this sizer works like any other sizer.
 
-    If you add a button with wxID_SAVE, on OS X the button will be renamed to
+    If you add a button with wxID_SAVE, on macOS the button will be renamed to
     "Save" and the wxID_NO button will be renamed to "Don't Save" in accordance
-    with the OS X Human Interface Guidelines.
+    with the macOS Human Interface Guidelines.
 
     @library{wxcore}
     @category{winlayout}

--- a/interface/wx/socket.h
+++ b/interface/wx/socket.h
@@ -664,7 +664,7 @@ enum wxSocketEventFlags
     This option can have surprising platform dependent behaviour, so check the
     documentation for your platform's implementation of setsockopt().
 
-    Note that on BSD-based systems(e.g. OS X), use of
+    Note that on BSD-based systems(e.g. macOS), use of
     @b wxSOCKET_REUSEADDR implies @b SO_REUSEPORT in addition to
     @b SO_REUSEADDR to be consistent with Windows.
 

--- a/interface/wx/stdpaths.h
+++ b/interface/wx/stdpaths.h
@@ -19,7 +19,7 @@
     methods.
 
     In the description of the methods below, the example return values are given
-    for the Unix, Windows and OS X systems, however please note that these are
+    for the Unix, Windows and macOS systems, however please note that these are
     just the examples and the actual values may differ. For example, under Windows:
     the system administrator may change the standard directories locations, e.g.
     the Windows directory may be named @c "W:\Win2003" instead of
@@ -310,7 +310,7 @@ public:
         specified category for the given language.
 
         In general this is just the same as @a lang subdirectory of GetResourcesDir()
-        (or @c lang.lproj under OS X) but is something quite different for
+        (or @c lang.lproj under macOS) but is something quite different for
         message catalog category under Unix where it returns the standard
         @c prefix/share/locale/lang/LC_MESSAGES directory.
 
@@ -337,7 +337,7 @@ public:
         The resources are the auxiliary data files needed for the application to run
         and include, for example, image and sound files it might use.
 
-        This function is the same as GetDataDir() for all platforms except OS X.
+        This function is the same as GetDataDir() for all platforms except macOS.
         Example return values:
         - Unix: @c prefix/share/appinfo
         - Windows: the directory where the executable file is located

--- a/interface/wx/string.h
+++ b/interface/wx/string.h
@@ -681,7 +681,7 @@ public:
 
     /**
         Converts the strings contents to the wide character representation
-        and returns it as a temporary wxWCharBuffer object (Unix and OS X)
+        and returns it as a temporary wxWCharBuffer object (Unix and macOS)
         or returns a pointer to the internal string contents in wide character
         mode (Windows).
 

--- a/interface/wx/sysopt.h
+++ b/interface/wx/sysopt.h
@@ -111,7 +111,7 @@
     @flag{mac.textcontrol-use-spell-checker}
         If 1 activates the spell checking in wxTextCtrl.
     @flag{osx.openfiledialog.always-show-types}
-        Per default a wxFileDialog with wxFD_OPEN does not show a types-popup on OS X but allows
+        Per default a wxFileDialog with wxFD_OPEN does not show a types-popup on macOS but allows
         the selection of files from any of the supported types. Setting this to 1 shows a wxChoice
         for selection (if there is more than one supported filetype).
     @endFlagTable

--- a/interface/wx/taskbar.h
+++ b/interface/wx/taskbar.h
@@ -144,7 +144,7 @@ public:
         Returns true if system tray is available in the desktop environment the
         app runs under.
 
-        On Windows and OS X, the tray is always available and this function
+        On Windows and macOS, the tray is always available and this function
         simply returns true.
 
         On Unix, X11 environment may or may not provide the tray, depending on

--- a/interface/wx/textentry.h
+++ b/interface/wx/textentry.h
@@ -461,10 +461,10 @@ public:
         controls which are initially empty.
 
         Notice that hints are known as <em>cue banners</em> under MSW or
-        <em>placeholder strings</em> under OS X.
+        <em>placeholder strings</em> under macOS.
 
         @remarks Currently implemented natively on Windows (Vista and later
-            only), OS X and GTK+ (3.2 and later).
+            only), macOS and GTK+ (3.2 and later).
 
             For the platforms without native hints support, the implementation
             has several known limitations. Notably, the hint display will not

--- a/interface/wx/toolbook.h
+++ b/interface/wx/toolbook.h
@@ -28,7 +28,7 @@ wxEventType wxEVT_TOOLBOOK_PAGE_CHANGING;
 
     @beginStyleTable
     @style{wxTBK_BUTTONBAR}
-        Use wxButtonToolBar-based implementation under OS X (ignored under
+        Use wxButtonToolBar-based implementation under macOS (ignored under
         other platforms).
     @style{wxTBK_HORZ_LAYOUT}
         Shows the text and the icons alongside, not vertically stacked (only

--- a/interface/wx/toplevel.h
+++ b/interface/wx/toplevel.h
@@ -594,7 +594,7 @@ public:
     virtual bool ShouldPreventAppExit() const;
 
     /**
-        This function sets the wxTopLevelWindow's modified state on OS X,
+        This function sets the wxTopLevelWindow's modified state on macOS,
         which currently draws a black dot in the wxTopLevelWindow's close button.
         On other platforms, this method does nothing.
 
@@ -603,7 +603,7 @@ public:
     virtual void OSXSetModified(bool modified);
 
     /**
-        Returns the current modified state of the wxTopLevelWindow on OS X.
+        Returns the current modified state of the wxTopLevelWindow on macOS.
         On other platforms, this method does nothing.
 
         @see OSXSetModified()
@@ -613,7 +613,7 @@ public:
     /**
         Sets the file name represented by this wxTopLevelWindow.
 
-        Under OS X, this file name is used to set the "proxy icon", which
+        Under macOS, this file name is used to set the "proxy icon", which
         appears in the window title bar near its title, corresponding to this
         file name. Under other platforms it currently doesn't do anything but
         it is harmless to call it now and it might be implemented to do
@@ -633,7 +633,7 @@ public:
 
     /**
         Enables the maximize button to toggle full screen mode. Prior to
-        OS X 10.10 a full screen button is added to the right upper corner
+        macOS 10.10 a full screen button is added to the right upper corner
         of a window's title bar.
 
         Currently only available for wxOSX/Cocoa.
@@ -646,7 +646,7 @@ public:
         under another OS.
 
         @note Having the button is also required to let ShowFullScreen()
-        make use of the full screen API available since OS X 10.7: a full
+        make use of the full screen API available since macOS 10.7: a full
         screen window gets its own space and entering and exiting the mode
         is animated.
         If the button is not present the old way of switching to full screen

--- a/interface/wx/translation.h
+++ b/interface/wx/translation.h
@@ -96,7 +96,7 @@ public:
         list the user configured in the OS. Notice that this may or may not
         correspond to the default @em locale as obtained from
         wxLocale::GetSystemLanguage(); modern operation systems (Windows
-        Vista+, OS X) have separate language and regional (= locale) settings.
+        Vista+, macOS) have separate language and regional (= locale) settings.
 
         @param domain
             The catalog domain to look for.
@@ -119,7 +119,7 @@ public:
         list the user configured in the OS. Notice that this may or may not
         correspond to the default @em locale as obtained from
         wxLocale::GetSystemLanguage(); modern operation systems (Windows
-        Vista+, OS X) have separate language and regional (= locale) settings.
+        Vista+, macOS) have separate language and regional (= locale) settings.
 
         @param domain
             The catalog domain to look for.
@@ -333,7 +333,7 @@ public:
 
     Catalogs are searched for in standard places (system locales directory,
     `LC_PATH` on Unix systems, Resources subdirectory of the application bundle
-    on OS X, executable's directory on Windows), but you may also prepend
+    on macOS, executable's directory on Windows), but you may also prepend
     additional directories to the search path with
     AddCatalogLookupPathPrefix().
 

--- a/interface/wx/treectrl.h
+++ b/interface/wx/treectrl.h
@@ -14,7 +14,7 @@
     wxTreeItemId handles, which may be tested for validity by calling
     wxTreeItemId::IsOk().
 
-    A similar control with a fully native implementation for GTK+ and OS X
+    A similar control with a fully native implementation for GTK+ and macOS
     as well is wxDataViewTreeCtrl.
 
     To intercept events from a tree control, use the event table macros

--- a/interface/wx/uiaction.h
+++ b/interface/wx/uiaction.h
@@ -109,7 +109,7 @@ public:
         Press a key.
 
         If you are using modifiers then it needs to be paired with an identical
-        KeyUp or the modifiers will not be released (MSW and OS X).
+        KeyUp or the modifiers will not be released (MSW and macOS).
 
         @param keycode
             Key to operate on, as an integer. It is interpreted as a wxKeyCode.

--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -922,9 +922,9 @@ wxString wxGetOsDescription();
     numbers (as returned by the 'uname -r' command); e.g. "4", "1", and "4" if
     the machine is using kernel 4.1.4.
 
-    For OS X systems (@c wxOS_MAC) the major and minor version integers are the
+    For macOS systems (@c wxOS_MAC) the major and minor version integers are the
     natural version numbers associated with the OS; e.g. "10", "11" and "2" if
-    the machine is using OS X El Capitan 10.11.2.
+    the machine is using macOS El Capitan 10.11.2.
 
     For Windows-like systems (@c wxOS_WINDOWS) the major and minor version integers will
     contain the following values:

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -261,7 +261,7 @@ public:
     It is designed to allow the creation of multiple backends for each port,
     although currently just one is available. It differs from wxHtmlWindow in
     that each backend is actually a full rendering engine, Trident on MSW and
-    Webkit on OS X and GTK. This allows the correct viewing of complex pages with
+    Webkit on macOS and GTK. This allows the correct viewing of complex pages with
     javascript and css.
 
     @section descriptions Backend Descriptions
@@ -324,7 +324,7 @@ public:
 
     @par wxWEBVIEW_WEBKIT (OSX)
 
-    The OS X WebKit backend uses Apple's
+    The macOS WebKit backend uses Apple's
     <a href="http://developer.apple.com/library/mac/#documentation/Cocoa/Reference/WebKit/Classes/WebView_Class/Reference/Reference.html#//apple_ref/doc/uid/20001903">WebView</a>
     class. This backend has full support for custom schemes and virtual file
     systems.
@@ -478,7 +478,7 @@ public:
         This method can be used to retrieve the pointer to the native rendering
         engine used by this control. The return value needs to be down-casted
         to the appropriate type depending on the platform: under Windows, it's
-        a pointer to IWebBrowser2 interface, under OS X it's a WebView pointer
+        a pointer to IWebBrowser2 interface, under macOS it's a WebView pointer
         and under GTK it's a WebKitWebView.
 
         For example, you could set the WebKit options using this method:
@@ -650,21 +650,21 @@ public:
     /**
         Returns @true if the current selection can be copied.
 
-        @note This always returns @c true on the OS X WebKit backend.
+        @note This always returns @c true on the macOS WebKit backend.
     */
     virtual bool CanCopy() const = 0;
 
     /**
         Returns @true if the current selection can be cut.
 
-         @note This always returns @c true on the OS X WebKit backend.
+         @note This always returns @c true on the macOS WebKit backend.
     */
     virtual bool CanCut() const = 0;
 
     /**
         Returns @true if data can be pasted.
 
-        @note This always returns @c true on the OS X WebKit backend.
+        @note This always returns @c true on the macOS WebKit backend.
     */
     virtual bool CanPaste() const = 0;
 
@@ -864,7 +864,7 @@ public:
               are changed, since this will require a new search. To reset the
               search, for example resetting the highlights call the function
               with an empty search phrase. This always returns @c wxNOT_FOUND
-              on the OS X WebKit backend.
+              on the macOS WebKit backend.
         @since 2.9.5
     */
     virtual long Find(const wxString& text, wxWebViewFindFlags flags = wxWEBVIEW_FIND_DEFAULT) = 0;

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -3237,9 +3237,9 @@ public:
         Chooses a different variant of the window display to use.
 
         Window variants currently just differ in size, as can be seen from
-        ::wxWindowVariant documentation. Under all platforms but OS X, this
+        ::wxWindowVariant documentation. Under all platforms but macOS, this
         function does nothing more than change the font used by the window.
-        However under OS X it is implemented natively and selects the
+        However under macOS it is implemented natively and selects the
         appropriate variant of the native widget, which has better appearance
         than just scaled down or up version of the normal variant, so it should
         be preferred to directly tweaking the font size.
@@ -3799,7 +3799,7 @@ public:
 
         @remarks Use EVT_HOTKEY(hotkeyId, fnc) in the event table to capture the
                  event. This function is currently only implemented under MSW
-                 and OS X and always returns false in the other ports.
+                 and macOS and always returns false in the other ports.
 
         @see UnregisterHotKey()
     */

--- a/interface/wx/xlocale.h
+++ b/interface/wx/xlocale.h
@@ -30,7 +30,7 @@
 
     This class is fully implemented only under the platforms where xlocale POSIX
     API or equivalent is available. Currently the xlocale API is available under
-    most of the recent Unix systems (including Linux, various BSD and OS X) and
+    most of the recent Unix systems (including Linux, various BSD and macOS) and
     Microsoft Visual C++ standard library provides a similar API starting from
     version 8 (Visual Studio 2005).
 


### PR DESCRIPTION
Since OS X 10.12 it has been named macOS so it makes sense
to reference it in documentation as such, even when it
sometimes refers to older versions which were called (Mac) OS X.

BTW if the minimum target gets updated, there are quite a few places referencing 10.7 as minimum.