### PR TITLE
OSX fix duplicate key down event

### DIFF
--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -231,7 +231,7 @@ protected:
     // allow executing text changes without triggering key down events
 
     // is currently processing a native key down event
-    bool IsInNativeKeyDown();
+    bool IsInNativeKeyDown() const;
     // the native key event
     NSEvent* GetLastNativeKeyDownEvent();
     // did send the wx event for the current native key down event

--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -48,7 +48,25 @@ WXWindow WXDLLIMPEXP_CORE wxOSXGetKeyWindow();
 
 class WXDLLIMPEXP_FWD_CORE wxDialog;
 
-struct WXDLLIMPEXP_FWD_CORE wxWidgetCocoaKeyDownEvent;
+class WXDLLIMPEXP_FWD_CORE wxWidgetCocoaImpl;
+
+// a class which disables sending wx keydown events useful when adding text programmatically, for wx-internal use only
+class wxWidgetCocoaNativeKeyDownSuspender
+{
+public:
+    // stops sending keydown events for text inserted into this widget
+    wxWidgetCocoaNativeKeyDownSuspender(wxWidgetCocoaImpl *target);
+    
+    // resumes sending keydown events
+    ~wxWidgetCocoaNativeKeyDownSuspender();
+    
+private:
+    wxWidgetCocoaImpl *m_target;
+    NSEvent* m_nsevent;
+    bool m_wxsent;
+
+    wxDECLARE_NO_COPY_CLASS(wxWidgetCocoaNativeKeyDownSuspender);
+};
 
 class WXDLLIMPEXP_CORE wxWidgetCocoaImpl : public wxWidgetImpl
 {
@@ -211,9 +229,7 @@ protected:
     // done with the current native key down event
     void EndNativeKeyDownEvent();
     // allow executing text changes without triggering key down events
-    void PauseNativeKeyDownEvent(wxWidgetCocoaKeyDownEvent* &token);
-    // resume normal key down processing
-    void ResumeNativeKeyDownEvent(wxWidgetCocoaKeyDownEvent* token);
+
     // is currently processing a native key down event
     bool IsInNativeKeyDown();
     // the native key event
@@ -224,7 +240,7 @@ protected:
     bool WasKeyDownSent();
 
     NSEvent* m_lastKeyDownEvent;
-    int m_lastKeyDownWXSent;
+    bool m_lastKeyDownWXSent;
 #if !wxOSX_USE_NATIVE_FLIPPED
     bool m_isFlipped;
 #endif
@@ -232,6 +248,8 @@ protected:
     // events, don't resend them
     bool m_hasEditor;
 
+    friend class wxWidgetCocoaNativeKeyDownSuspender;
+    
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxWidgetCocoaImpl);
 };
 

--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -48,6 +48,8 @@ WXWindow WXDLLIMPEXP_CORE wxOSXGetKeyWindow();
 
 class WXDLLIMPEXP_FWD_CORE wxDialog;
 
+struct WXDLLIMPEXP_FWD_CORE wxWidgetCocoaKeyDownEvent;
+
 class WXDLLIMPEXP_CORE wxWidgetCocoaImpl : public wxWidgetImpl
 {
 public :
@@ -203,7 +205,26 @@ public :
 
 protected:
     WXWidget m_osxView;
+    
+    // begins processing of native key down event, storing the native event for later wx event generation
+    void BeginNativeKeyDownEvent( NSEvent* event );
+    // done with the current native key down event
+    void EndNativeKeyDownEvent();
+    // allow executing text changes without triggering key down events
+    void PauseNativeKeyDownEvent(wxWidgetCocoaKeyDownEvent* &token);
+    // resume normal key down processing
+    void ResumeNativeKeyDownEvent(wxWidgetCocoaKeyDownEvent* token);
+    // is currently processing a native key down event
+    bool IsInNativeKeyDown();
+    // the native key event
+    NSEvent* GetLastNativeKeyDownEvent();
+    // did send the wx event for the current native key down event
+    void SetKeyDownSent();
+    // was the wx event for the current native key down event sent
+    bool WasKeyDownSent();
+
     NSEvent* m_lastKeyDownEvent;
+    int m_lastKeyDownWXSent;
 #if !wxOSX_USE_NATIVE_FLIPPED
     bool m_isFlipped;
 #endif

--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -55,7 +55,7 @@ class wxWidgetCocoaNativeKeyDownSuspender
 {
 public:
     // stops sending keydown events for text inserted into this widget
-    wxWidgetCocoaNativeKeyDownSuspender(wxWidgetCocoaImpl *target);
+    explicit wxWidgetCocoaNativeKeyDownSuspender(wxWidgetCocoaImpl *target);
     
     // resumes sending keydown events
     ~wxWidgetCocoaNativeKeyDownSuspender();
@@ -573,4 +573,3 @@ private:
 
 #endif
     // _WX_PRIVATE_COCOA_H_
-

--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -237,7 +237,7 @@ protected:
     // did send the wx event for the current native key down event
     void SetKeyDownSent();
     // was the wx event for the current native key down event sent
-    bool WasKeyDownSent();
+    bool WasKeyDownSent() const;
 
     NSEvent* m_lastKeyDownEvent;
     bool m_lastKeyDownWXSent;

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -988,10 +988,8 @@ void wxNSTextViewControl::WriteText(const wxString& str)
 {
     wxString st(wxMacConvertNewlines10To13(str));
     wxMacEditHelper helper(m_textView);
-    wxWidgetCocoaKeyDownEvent* formerEvent = NULL;
-    PauseNativeKeyDownEvent(formerEvent);
+    wxWidgetCocoaNativeKeyDownSuspender suspend(this);
     [m_textView insertText:wxCFStringRef( st , m_wxPeer->GetFont().GetEncoding() ).AsNSString()];
-    ResumeNativeKeyDownEvent(formerEvent);
     // Some text styles have to be updated manually.
     DoUpdateTextStyle();
 }
@@ -1467,8 +1465,7 @@ void wxNSTextFieldControl::ShowPosition(long pos)
 
 void wxNSTextFieldControl::WriteText(const wxString& str)
 {
-    wxWidgetCocoaKeyDownEvent* formerEvent = NULL;
-    PauseNativeKeyDownEvent(formerEvent);
+    wxWidgetCocoaNativeKeyDownSuspender suspend(this);
     NSText* editor = [m_textField currentEditor];
     if ( editor )
     {
@@ -1490,7 +1487,6 @@ void wxNSTextFieldControl::WriteText(const wxString& str)
         SetStringValue( val ) ;
         SetSelection( start + str.length() , start + str.length() ) ;
     }
-    ResumeNativeKeyDownEvent(formerEvent);
 }
 
 void wxNSTextFieldControl::controlAction(WXWidget WXUNUSED(slf),

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -781,7 +781,7 @@ bool wxNSTextViewControl::CanFocus() const
 void wxNSTextViewControl::insertText(NSString* str, WXWidget slf, void *_cmd)
 {
     NSString *text = [str isKindOfClass:[NSAttributedString class]] ? [(id)str string] : str;
-    if ( m_lastKeyDownEvent ==NULL || !DoHandleCharEvent(m_lastKeyDownEvent, text) )
+    if ( !IsInNativeKeyDown() || !DoHandleCharEvent(GetLastNativeKeyDownEvent(), text) )
     {
         wxOSX_TextEventHandlerPtr superimpl = (wxOSX_TextEventHandlerPtr) [[slf superclass] instanceMethodForSelector:(SEL)_cmd];
         superimpl(slf, (SEL)_cmd, str);
@@ -988,10 +988,10 @@ void wxNSTextViewControl::WriteText(const wxString& str)
 {
     wxString st(wxMacConvertNewlines10To13(str));
     wxMacEditHelper helper(m_textView);
-    NSEvent* formerEvent = m_lastKeyDownEvent;
-    m_lastKeyDownEvent = nil;
+    wxWidgetCocoaKeyDownEvent* formerEvent = NULL;
+    PauseNativeKeyDownEvent(formerEvent);
     [m_textView insertText:wxCFStringRef( st , m_wxPeer->GetFont().GetEncoding() ).AsNSString()];
-    m_lastKeyDownEvent = formerEvent;
+    ResumeNativeKeyDownEvent(formerEvent);
     // Some text styles have to be updated manually.
     DoUpdateTextStyle();
 }
@@ -1467,8 +1467,8 @@ void wxNSTextFieldControl::ShowPosition(long pos)
 
 void wxNSTextFieldControl::WriteText(const wxString& str)
 {
-    NSEvent* formerEvent = m_lastKeyDownEvent;
-    m_lastKeyDownEvent = nil;
+    wxWidgetCocoaKeyDownEvent* formerEvent = NULL;
+    PauseNativeKeyDownEvent(formerEvent);
     NSText* editor = [m_textField currentEditor];
     if ( editor )
     {
@@ -1490,7 +1490,7 @@ void wxNSTextFieldControl::WriteText(const wxString& str)
         SetStringValue( val ) ;
         SetSelection( start + str.length() , start + str.length() ) ;
     }
-    m_lastKeyDownEvent = formerEvent;
+    ResumeNativeKeyDownEvent(formerEvent);
 }
 
 void wxNSTextFieldControl::controlAction(WXWidget WXUNUSED(slf),

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -2592,13 +2592,14 @@ void wxWidgetCocoaImpl::EndNativeKeyDownEvent()
     m_lastKeyDownWXSent = false;
 }
 
-bool wxWidgetCocoaImpl::IsInNativeKeyDown()
+bool wxWidgetCocoaImpl::IsInNativeKeyDown() const
 {
     return m_lastKeyDownEvent != nil;
 }
 
 NSEvent* wxWidgetCocoaImpl::GetLastNativeKeyDownEvent()
 {
+    wxASSERT( m_lastKeyDownEvent != nil);
     return m_lastKeyDownEvent;
 }
 
@@ -2608,7 +2609,7 @@ void wxWidgetCocoaImpl::SetKeyDownSent()
     m_lastKeyDownWXSent = true;
 }
 
-bool wxWidgetCocoaImpl::WasKeyDownSent()
+bool wxWidgetCocoaImpl::WasKeyDownSent() const
 {
     return m_lastKeyDownWXSent;
 }


### PR DESCRIPTION
Ctrl-O on mac is translated automatically to the bash-equivalent of execute and move back in history, since this results in two commands, Ctrl-O was sent twice as a wx key down event. This PR should fix this and similar problems and wraps up the handling into a small API.