### PR TITLE
macOS wxTextEntry::GetTextPeer fix for wxGenericComboCtrl

### DIFF
--- a/include/wx/generic/combo.h
+++ b/include/wx/generic/combo.h
@@ -92,7 +92,7 @@ protected:
     virtual GtkEntry *GetEntry() const wxOVERRIDE { return NULL; }
 #endif
 #elif defined(__WXMAC__)
-    // Looks like there's nothing we need to override here
+    virtual wxTextWidgetImpl * GetTextPeer() const wxOVERRIDE;
 #endif
 
     // For better transparent background rendering

--- a/include/wx/generic/combo.h
+++ b/include/wx/generic/combo.h
@@ -91,8 +91,11 @@ protected:
     virtual GtkEditable *GetEditable() const wxOVERRIDE { return NULL; }
     virtual GtkEntry *GetEntry() const wxOVERRIDE { return NULL; }
 #endif
-#elif defined(__WXMAC__)
-    virtual wxTextWidgetImpl * GetTextPeer() const wxOVERRIDE;
+#elif defined(__WXOSX__)
+    virtual wxTextWidgetImpl * GetTextPeer() const wxOVERRIDE
+    {
+        return m_text ? m_text->GetTextPeer() : NULL;
+    }
 #endif
 
     // For better transparent background rendering

--- a/include/wx/generic/combo.h
+++ b/include/wx/generic/combo.h
@@ -92,10 +92,7 @@ protected:
     virtual GtkEntry *GetEntry() const wxOVERRIDE { return NULL; }
 #endif
 #elif defined(__WXOSX__)
-    virtual wxTextWidgetImpl * GetTextPeer() const wxOVERRIDE
-    {
-        return m_text ? m_text->GetTextPeer() : NULL;
-    }
+    virtual wxTextWidgetImpl * GetTextPeer() const wxOVERRIDE;
 #endif
 
     // For better transparent background rendering

--- a/src/generic/combog.cpp
+++ b/src/generic/combog.cpp
@@ -458,6 +458,13 @@ bool wxGenericComboCtrl::IsKeyPopupToggle(const wxKeyEvent& event) const
     return false;
 }
 
+#if defined(__WXOSX__)
+wxTextWidgetImpl * wxGenericComboCtrl::GetTextPeer() const
+{
+    return m_text ? m_text->GetTextPeer() : NULL;
+}
+#endif
+
 #ifdef __WXUNIVERSAL__
 
 bool wxGenericComboCtrl::PerformAction(const wxControlAction& action,

--- a/src/generic/combog.cpp
+++ b/src/generic/combog.cpp
@@ -198,6 +198,13 @@ wxGenericComboCtrl::~wxGenericComboCtrl()
 {
 }
 
+#ifdef __WXOSX__
+wxTextWidgetImpl * wxGenericComboCtrl::GetTextPeer() const
+{
+    return m_text ? m_text->GetTextPeer() : NULL;
+}
+#endif
+
 bool wxGenericComboCtrl::HasTransparentBackground()
 {
 #if wxALWAYS_NATIVE_DOUBLE_BUFFER

--- a/src/generic/combog.cpp
+++ b/src/generic/combog.cpp
@@ -198,13 +198,6 @@ wxGenericComboCtrl::~wxGenericComboCtrl()
 {
 }
 
-#ifdef __WXOSX__
-wxTextWidgetImpl * wxGenericComboCtrl::GetTextPeer() const
-{
-    return m_text ? m_text->GetTextPeer() : NULL;
-}
-#endif
-
 bool wxGenericComboCtrl::HasTransparentBackground()
 {
 #if wxALWAYS_NATIVE_DOUBLE_BUFFER

--- a/src/generic/odcombo.cpp
+++ b/src/generic/odcombo.cpp
@@ -988,14 +988,7 @@ void wxOwnerDrawnComboBox::DoClear()
 
     // There is no text entry when using wxCB_READONLY style, so test for it.
     if ( GetTextCtrl() )
-    {
-#ifdef __WXOSX__
-        // this has to be rerouted to the text control explicitly on macOS
-        GetTextCtrl()->Clear();
-#else
         wxTextEntry::Clear();
-#endif
-    }
 }
 
 void wxOwnerDrawnComboBox::Clear()


### PR DESCRIPTION
Calling Clear on an wxOwnerDrawnComboBox led to an assertion unter macOS, because the generic control itself does not have a GetTextPeer. Attempt to correct things by overriding in the generic class.