### PR TITLE
Improve Widgets sample

### DIFF
--- a/samples/widgets/dirctrl.cpp
+++ b/samples/widgets/dirctrl.cpp
@@ -263,7 +263,7 @@ void DirCtrlWidgetsPage::CreateDirCtrl()
     wxGenericDirCtrl *dirCtrl = new wxGenericDirCtrl(
         this,
         DirCtrlPage_Ctrl,
-        wxDirDialogDefaultFolderStr,
+        m_dirCtrl->GetPath(),
         wxDefaultPosition,
         wxDefaultSize,
         style

--- a/samples/widgets/dirctrl.cpp
+++ b/samples/widgets/dirctrl.cpp
@@ -118,7 +118,7 @@ protected:
     void Reset();
 
     // (re)create the m_dirCtrl
-    void CreateDirCtrl();
+    void CreateDirCtrl(bool defaultPath = false);
 
     // the controls
     // ------------
@@ -231,18 +231,32 @@ void DirCtrlWidgetsPage::CreateContent()
     sizerTop->Add(m_radioStdPath, 0, wxGROW | wxALL , 10);
     sizerTop->Add(m_dirCtrl, 1, wxGROW | (wxALL & ~wxRIGHT), 10);
 
+    SetSizer(sizerTop);
+
     // final initializations
     Reset();
-
-    SetSizer(sizerTop);
 }
 
 void DirCtrlWidgetsPage::Reset()
 {
-    m_path->SetValue(m_dirCtrl->GetPath());
+    m_path->Clear();
+
+    m_chkDirOnly->SetValue(false);
+    m_chk3D->SetValue(false);
+    m_chkFirst->SetValue(false);
+    m_chkFilters->SetValue(false);
+    m_chkLabels->SetValue(false);
+    m_chkMulti->SetValue(false);
+
+    m_radioStdPath->SetSelection(0);
+
+    for ( size_t i = 0; i < WXSIZEOF(m_fltr); ++i )
+        m_fltr[i]->SetValue(false);
+
+    CreateDirCtrl(true);
 }
 
-void DirCtrlWidgetsPage::CreateDirCtrl()
+void DirCtrlWidgetsPage::CreateDirCtrl(bool defaultPath)
 {
     wxWindowUpdateLocker noUpdates(this);
 
@@ -260,10 +274,11 @@ void DirCtrlWidgetsPage::CreateDirCtrl()
     if ( m_chkMulti->IsChecked() )
         style |= wxDIRCTRL_MULTIPLE;
 
+
     wxGenericDirCtrl *dirCtrl = new wxGenericDirCtrl(
         this,
         DirCtrlPage_Ctrl,
-        m_dirCtrl->GetPath(),
+        defaultPath ? wxDirDialogDefaultFolderStr : m_dirCtrl->GetPath(),
         wxDefaultPosition,
         wxDefaultSize,
         style

--- a/samples/widgets/filectrl.cpp
+++ b/samples/widgets/filectrl.cpp
@@ -83,7 +83,7 @@ protected:
     void OnButtonSetFilename( wxCommandEvent& event );
     void OnButtonReset( wxCommandEvent& event );
     void OnCheckBox( wxCommandEvent& event );
-    void OnRadioBox( wxCommandEvent& event );
+    void OnSwitchMode( wxCommandEvent& event );
     void OnFileCtrl( wxFileCtrlEvent& event );
 
     // reset the control parameters
@@ -127,7 +127,7 @@ wxBEGIN_EVENT_TABLE( FileCtrlWidgetsPage, WidgetsPage )
     EVT_BUTTON( FileCtrlPage_SetPath, FileCtrlWidgetsPage::OnButtonSetPath )
     EVT_BUTTON( FileCtrlPage_SetFilename, FileCtrlWidgetsPage::OnButtonSetFilename )
     EVT_CHECKBOX( wxID_ANY, FileCtrlWidgetsPage::OnCheckBox )
-    EVT_RADIOBOX( wxID_ANY, FileCtrlWidgetsPage::OnRadioBox )
+    EVT_RADIOBOX( wxID_ANY, FileCtrlWidgetsPage::OnSwitchMode )
 
     EVT_FILECTRL_FILTERCHANGED( wxID_ANY, FileCtrlWidgetsPage::OnFileCtrl )
     EVT_FILECTRL_FOLDERCHANGED( wxID_ANY, FileCtrlWidgetsPage::OnFileCtrl )
@@ -228,11 +228,22 @@ void FileCtrlWidgetsPage::CreateFileCtrl()
     wxWindowUpdateLocker noUpdates( this );
 
     long style = GetAttrs().m_defaultFlags;
-    style |= m_radioFileCtrlMode->GetSelection() == FileCtrlMode_Open
-                ? wxFC_OPEN
-                : wxFC_SAVE;
-    if ( m_chkMultiple->IsChecked() )
-        style |= wxFC_MULTIPLE;
+
+    if ( m_radioFileCtrlMode->GetSelection() == FileCtrlMode_Open )
+    {
+        style |= wxFC_OPEN;
+        m_chkMultiple->Enable();
+        if ( m_chkMultiple->IsChecked() )
+            style |= wxFC_MULTIPLE;
+    }
+    else
+    {
+        style |= wxFC_SAVE;
+        // wxFC_SAVE is incompatible with wxFC_MULTIPLE
+        m_chkMultiple->SetValue(false);
+        m_chkMultiple->Enable(false);
+    }
+
     if ( m_chkNoShowHidden->IsChecked() )
         style |= wxFC_NOSHOWHIDDEN;
 
@@ -301,7 +312,7 @@ void FileCtrlWidgetsPage::OnCheckBox( wxCommandEvent& WXUNUSED( event ) )
     CreateFileCtrl();
 }
 
-void FileCtrlWidgetsPage::OnRadioBox( wxCommandEvent& WXUNUSED( event ) )
+void FileCtrlWidgetsPage::OnSwitchMode( wxCommandEvent& WXUNUSED( event ) )
 {
     CreateFileCtrl();
 }


### PR DESCRIPTION
Disallow invalid flag combination for wxFileCtrl (avoids showing an assert).
Preserve the path when changing flags for wxDirCtrl.

I do not understand the logic behind [DirCtrlWidgetsPage::Reset()](https://github.com/wxWidgets/wxWidgets/blob/master/samples/widgets/dirctrl.cpp#L240). I would expect this method
to recreate `m_dirCtrl` with the default options (same as in the `DirCtrlWidgetsPage` ctor). But it
just sets the value of a `wxTextCtrl` allowing set a custom path to a path from `m_dirCtrl`?