### PR TITLE
Fix wxMediaCtrl::Seek() on macOS for sub-second resolution

### DIFF
--- a/src/osx/cocoa/mediactrl.mm
+++ b/src/osx/cocoa/mediactrl.mm
@@ -495,7 +495,7 @@ bool wxAVMediaBackend::SetPlaybackRate(double dRate)
 
 bool wxAVMediaBackend::SetPosition(wxLongLong where)
 {
-    [m_player seekToTime:CMTimeMakeWithSeconds(where.GetValue() / 1000.0, 1)
+    [m_player seekToTime:CMTimeMakeWithSeconds(where.GetValue() / 1000.0, 60000)
               toleranceBefore:kCMTimeZero toleranceAfter:kCMTimeZero];
 
     return true;


### PR DESCRIPTION
On macOS, wxMediaCtrl::Seek() currently only works to the nearest second.
For example, Seek(5033) will actually seek to an offset of 5000.  This is
because the timescale was being set to 1, meaning 1 possible timeslice per
second.  The fix is to set the timescale to 60000, which means that there are
60000 timeslices per second.  This is probably overkill since the API for seek
is an integer in milliseconds, but should be fine.

References:
https://stackoverflow.com/questions/22666190/using-seconds-in-avplayer-seektotime
http://warrenmoore.net/understanding-cmtime