### PR TITLE
Update README.md to define macOS 10.10 as the lowest version supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This version of wxWidgets supports the following primary platforms:
 
 - Windows XP, Vista, 7, 8 and 10 (32/64 bits).
 - Most Unix variants using the GTK+ toolkit (version 2.6 or newer or 3.x).
-- macOS (10.7 or newer) using Cocoa (32/64 bits).
+- macOS (10.10 or newer) using Cocoa (32/64 bits).
 
 Most popular C++ compilers are supported including but not limited to:
 


### PR DESCRIPTION
Show that macOS 10.10 is lowest version supported by wxWidgets