### PR TITLE
Support bitmaps in sizers

### DIFF
--- a/include/wx/sizer.h
+++ b/include/wx/sizer.h
@@ -1151,6 +1151,7 @@ public:
     virtual bool Detach( wxWindow *window ) wxOVERRIDE;
     virtual bool Detach( wxSizer *sizer ) wxOVERRIDE { return wxBoxSizer::Detach(sizer); }
     virtual bool Detach( int index ) wxOVERRIDE { return wxBoxSizer::Detach(index); }
+    virtual bool Detach( const wxSharedPtr<wxBitmap>& bmp ) wxOVERRIDE { return wxBoxSizer::Detach(bmp); }
 
 protected:
     wxStaticBox   *m_staticBox;

--- a/include/wx/sizer.h
+++ b/include/wx/sizer.h
@@ -14,6 +14,7 @@
 #include "wx/defs.h"
 
 #include "wx/window.h"
+#include "wx/sharedptr.h"
 
 //---------------------------------------------------------------------------
 // classes
@@ -268,7 +269,7 @@ private:
 class WXDLLIMPEXP_CORE wxBmpSpacer : public wxSizerSpacer
 {
 public:
-    wxBmpSpacer(const wxSharedPtr<wxBitmap>& bmp) : wxSizerSpacer(bmp->GetSize()), m_bmp(bmp) { }
+    wxBmpSpacer(const wxSharedPtr<wxBitmap>& bmp);
 
     const wxSharedPtr<wxBitmap>& GetBitmap() const { return m_bmp; }
 

--- a/include/wx/sizer.h
+++ b/include/wx/sizer.h
@@ -270,11 +270,12 @@ class WXDLLIMPEXP_CORE wxBmpSpacer : public wxSizerSpacer
 {
 public:
     wxBmpSpacer(const wxSharedPtr<wxBitmap>& bmp);
+    ~wxBmpSpacer();
 
-    const wxSharedPtr<wxBitmap>& GetBitmap() const { return m_bmp; }
+    const wxSharedPtr<wxBitmap>& GetBitmap() const { return *m_bmp; }
 
 private:
-    wxSharedPtr<wxBitmap> m_bmp;
+    wxSharedPtr<wxBitmap>* m_bmp;
 };
 
 // ----------------------------------------------------------------------------
@@ -423,8 +424,7 @@ public:
             return m_bmpSpacer->GetBitmap();
         else
         {
-            static wxSharedPtr<wxBitmap> dummy;
-            return dummy;
+            return GetDummyBmpSharedPtr();
         }
     }
 
@@ -542,6 +542,8 @@ protected:
     wxObject    *m_userData;
 
 private:
+    const wxSharedPtr<wxBitmap>& GetDummyBmpSharedPtr() const;
+
     wxDECLARE_CLASS(wxSizerItem);
     wxDECLARE_NO_COPY_CLASS(wxSizerItem);
 };

--- a/src/common/bmpbase.cpp
+++ b/src/common/bmpbase.cpp
@@ -234,6 +234,8 @@ bool wxMaskBase::Create(const wxBitmap& bitmap)
 // ----------------------------------------------------------------------------
 // wxSizer support for wxBitmap
 // ----------------------------------------------------------------------------
+#include "wx/sizer.h"
+#include "wx/sharedptr.h"
 
 // define this here to avoid including bitmap.h in sizer.h
 wxBmpSpacer::wxBmpSpacer(const wxSharedPtr<wxBitmap>& bmp) : wxSizerSpacer(bmp->GetSize()), m_bmp(new wxSharedPtr<wxBitmap>(bmp))

--- a/src/common/bmpbase.cpp
+++ b/src/common/bmpbase.cpp
@@ -229,3 +229,24 @@ bool wxMaskBase::Create(const wxBitmap& bitmap)
 
     return InitFromMonoBitmap(bitmap);
 }
+
+
+// ----------------------------------------------------------------------------
+// wxSizer support for wxBitmap
+// ----------------------------------------------------------------------------
+
+// define this here to avoid including bitmap.h in sizer.h
+wxBmpSpacer::wxBmpSpacer(const wxSharedPtr<wxBitmap>& bmp) : wxSizerSpacer(bmp->GetSize()), m_bmp(new wxSharedPtr<wxBitmap>(bmp))
+{}
+
+wxBmpSpacer::~wxBmpSpacer()
+{
+    delete m_bmp;
+}
+
+const wxSharedPtr<wxBitmap>& wxSizerItem::GetDummyBmpSharedPtr() const
+{
+    static wxSharedPtr<wxBitmap> dummy;
+
+    return dummy;
+}

--- a/src/common/sizer.cpp
+++ b/src/common/sizer.cpp
@@ -120,6 +120,14 @@ float wxSizerFlags::DoGetDefaultBorderInPx()
 #endif // wxNEEDS_BORDER_IN_PX
 
 // ----------------------------------------------------------------------------
+// wxBmpSpacer
+// ----------------------------------------------------------------------------
+
+// define this here to avoid including bitmap.h in sizer.h
+wxBmpSpacer::wxBmpSpacer(const wxSharedPtr<wxBitmap>& bmp) : wxSizerSpacer(bmp->GetSize()), m_bmp(bmp)
+{}
+
+// ----------------------------------------------------------------------------
 // wxSizerItem
 // ----------------------------------------------------------------------------
 

--- a/src/common/sizer.cpp
+++ b/src/common/sizer.cpp
@@ -120,14 +120,6 @@ float wxSizerFlags::DoGetDefaultBorderInPx()
 #endif // wxNEEDS_BORDER_IN_PX
 
 // ----------------------------------------------------------------------------
-// wxBmpSpacer
-// ----------------------------------------------------------------------------
-
-// define this here to avoid including bitmap.h in sizer.h
-wxBmpSpacer::wxBmpSpacer(const wxSharedPtr<wxBitmap>& bmp) : wxSizerSpacer(bmp->GetSize()), m_bmp(bmp)
-{}
-
-// ----------------------------------------------------------------------------
 // wxSizerItem
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
_[This is not supposed to be merged (well, not yet), but making the PR might trigger some testing and receiving some needed help.]_

The goal here was to allow `wxSizer`s to contain `wxBitmap`s, so that the latter can be easily embedded into layouts and painted automatically, without any user code.
A `wxSizerItem` containing a `wxBitmap` will behave like a `spacer` when no painting will be performed.
And it works surprisingly well so far. The only problem is when the window is resized after it has been scrolled. For the life of me I can't understand what is different after a resize of a scrolled window. Any help with this would be great.

Another question would be, what is the best way to trigger the painting? My test class in the minimal sample is working, and something like that could be added to wxW, but there should probably be a more user-friendly way to do it, and not restricted to inheriting from `wxScrolled<>`.

Other considerents:
- A `wxSizer[Item]` will take a `wxSharedPtr<wxBitmap>`. This is inconsistent with other overloads taking `wxWindow *` and `wxSizer *`, but those are managed by wxW, while the bitmap pointers would be in the user's hands, so why not make them use more modern technique. Another reason in favor of the shared pointer is that the same bitmap can be reused in multiple sizers.
- I thought about having implementations of `wxSizer` that use either `wxBitmap` or `wxWindow`. It was easier like this, and it might not be a bad thing in the end, as excluding each other would only help with painting.
- Testing this is really simple: just build this branch, and run `minimal` sample.