### PR TITLE
Close the cell editor when the editor's combobox is closed

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2827,7 +2827,6 @@ protected:
     void OnKeyDown( wxKeyEvent& );
     void OnKeyUp( wxKeyEvent& );
     void OnChar( wxKeyEvent& );
-    void OnHideEditor( wxCommandEvent& );
 
 
     bool SetCurrentCell( const wxGridCellCoords& coords );

--- a/include/wx/generic/grideditors.h
+++ b/include/wx/generic/grideditors.h
@@ -27,6 +27,8 @@ public:
     {
     }
 
+    void DismissEditor();
+
     void OnKillFocus(wxFocusEvent& event);
     void OnKeyDown(wxKeyEvent& event);
     void OnChar(wxKeyEvent& event);
@@ -335,8 +337,7 @@ public:
 protected:
     wxComboBox *Combo() const { return (wxComboBox *)m_control; }
 
-    void onComboCloseUp(wxCommandEvent& evt);
-    void onComboDropDown(wxCommandEvent& evt);
+    void OnComboCloseUp(wxCommandEvent& evt);
 
     wxString        m_value;
     wxArrayString   m_choices;

--- a/include/wx/generic/grideditors.h
+++ b/include/wx/generic/grideditors.h
@@ -335,6 +335,9 @@ public:
 protected:
     wxComboBox *Combo() const { return (wxComboBox *)m_control; }
 
+    void onComboCloseUp(wxCommandEvent& evt);
+    void onComboDropDown(wxCommandEvent& evt);
+
     wxString        m_value;
     wxArrayString   m_choices;
     bool            m_allowOthers;

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -17,10 +17,6 @@
 
 #include "wx/headerctrl.h"
 
-// Internally used (and hence intentionally not exported) event telling wxGrid
-// to hide the currently shown editor.
-wxDECLARE_EVENT( wxEVT_GRID_HIDE_EDITOR, wxCommandEvent );
-
 // ----------------------------------------------------------------------------
 // array classes
 // ----------------------------------------------------------------------------

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -2519,7 +2519,6 @@ wxBEGIN_EVENT_TABLE( wxGrid, wxScrolledCanvas )
     EVT_KEY_DOWN( wxGrid::OnKeyDown )
     EVT_KEY_UP( wxGrid::OnKeyUp )
     EVT_CHAR ( wxGrid::OnChar )
-    EVT_COMMAND(wxID_ANY, wxEVT_GRID_HIDE_EDITOR, wxGrid::OnHideEditor )
 wxEND_EVENT_TABLE()
 
 bool wxGrid::Create(wxWindow *parent, wxWindowID id,
@@ -7541,11 +7540,6 @@ void wxGrid::DoSaveEditControlValue()
                 SetCellValue(row, col, oldval);
             }
         }
-}
-
-void wxGrid::OnHideEditor(wxCommandEvent& WXUNUSED(event))
-{
-    DisableCellEditControl();
 }
 
 //


### PR DESCRIPTION
This PR makes it so the combobox grid editor is closed when the control loses focus. The loss of focus is now defined to be when the list closes, since the original KillFocus handler was never being called. This means that when the list is dismissed, the editor will close and apply the selection to the cell. Additionally, another handler needs to be added to capture the drop down event and reset the InSetFocus flag, otherwise the KillFocus handler won't function properly on GTK.

Closes [#16404](https://trac.wxwidgets.org/ticket/16404)