### PR TITLE
Remove support for gcc < 4

### DIFF
--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -481,10 +481,9 @@ typedef short int WXTYPE;
 
 #ifndef HAVE_WOSTREAM
     /*
-        Mingw <= 3.4 and all versions of Cygwin don't have std::wostream
+        Cygwin is the only platform which doesn't have std::wostream
      */
-    #if (!defined(__MINGW32__) || wxCHECK_GCC_VERSION(4, 0)) && \
-        !defined(__CYGWIN__)
+    #if !defined(__CYGWIN__)
         #define HAVE_WOSTREAM
     #endif
 #endif /* HAVE_WOSTREAM */
@@ -622,15 +621,11 @@ typedef short int WXTYPE;
  */
 #define wxDEPRECATED(x) wxDEPRECATED_DECL x
 
-#if defined(__GNUC__) && !wxCHECK_GCC_VERSION(3, 4)
-    /*
-        We need to add dummy "inline" to allow gcc < 3.4 to handle the
-        deprecation attribute on the constructors.
-    */
-    #define  wxDEPRECATED_CONSTRUCTOR(x) wxDEPRECATED( inline x)
-#else
-    #define  wxDEPRECATED_CONSTRUCTOR(x) wxDEPRECATED(x)
-#endif
+/*
+    This macro used to be defined differently for gcc < 3.4, but we don't
+    support it any more, so it's just the same thing as wxDEPRECATED now.
+ */
+#define wxDEPRECATED_CONSTRUCTOR(x) wxDEPRECATED(x)
 
 /*
    Macro which marks the function as being deprecated but also defines it

--- a/include/wx/wxcrt.h
+++ b/include/wx/wxcrt.h
@@ -460,20 +460,9 @@ WX_STRCMP_FUNC(wxStricmp, wxCRT_StricmpA, wxCRT_StricmpW, wxStricmp_String)
 
 #if defined(wxCRT_StrcollA) && defined(wxCRT_StrcollW)
 
-// GCC 3.4 and other compilers have a bug that causes it to fail compilation if
-// the template's implementation uses overloaded function declared later (see
-// the wxStrcoll() call in wxStrcoll_String<T>()), so we have to
-// forward-declare the template and implement it below WX_STRCMP_FUNC. OTOH,
-// this causes problems with GCC visibility in newer GCC versions.
-#if !(wxCHECK_GCC_VERSION(3,5) && !wxCHECK_GCC_VERSION(4,7)) || defined(__clang__)
-    #define wxNEEDS_DECL_BEFORE_TEMPLATE
-#endif
-
-#ifdef wxNEEDS_DECL_BEFORE_TEMPLATE
 template<typename T>
 inline int wxStrcoll_String(const wxString& s1, const T& s2);
 WX_STRCMP_FUNC(wxStrcoll, wxCRT_StrcollA, wxCRT_StrcollW, wxStrcoll_String)
-#endif // wxNEEDS_DECL_BEFORE_TEMPLATE
 
 template<typename T>
 inline int wxStrcoll_String(const wxString& s1, const T& s2)
@@ -488,12 +477,6 @@ inline int wxStrcoll_String(const wxString& s1, const T& s2)
     return wxStrcoll((const char*)s1.mb_str(), s2);
 #endif
 }
-
-#ifndef wxNEEDS_DECL_BEFORE_TEMPLATE
-// this is exactly the same WX_STRCMP_FUNC line as above, inside the
-// wxNEEDS_DECL_BEFORE_TEMPLATE case
-WX_STRCMP_FUNC(wxStrcoll, wxCRT_StrcollA, wxCRT_StrcollW, wxStrcoll_String)
-#endif
 
 #endif // defined(wxCRT_Strcoll[AW])
 


### PR DESCRIPTION
We probably could drop support for some gcc 4.x versions too, but we
definitely don't need to support gcc 3.x any longer and not doing it
simplifies the code a bit, so just assume gcc >= 4.