### PR TITLE
Test fix gtk2

### DIFF
--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -4583,13 +4583,9 @@ void wxWindowGTK::SetFocus()
     if (gs_currentFocus != this)
         gs_pendingFocus = this;
 
-    // We can't do this under GTK 2 as it breaks the GUI tests suite, but GTK 3
-    // tests are robust enough to pass even if we do this.
-#ifdef __WXGTK3__
     wxWindow* tlw = wxGetTopLevelParent(static_cast<wxWindow*>(this));
     if (tlw && tlw->m_widget && !gtk_window_is_active(GTK_WINDOW(tlw->m_widget)))
         tlw->Raise();
-#endif // __WXGTK3__
 
     GtkWidget *widget = m_wxwindow ? m_wxwindow : m_focusWidget;
 

--- a/src/unix/uiactionx11.cpp
+++ b/src/unix/uiactionx11.cpp
@@ -178,7 +178,7 @@ protected:
         wxUnusedVar(win);
     #endif // platform
 
-        wxLogTrace("focus", "SetInputFocusToXWindow on Window 0x%ul.", focus);
+        wxLogTrace("focus", "SetInputFocusToXWindow on Window 0x%lu.", focus);
 
         XSetInputFocus(m_display, focus, RevertToPointerRoot, CurrentTime);
     }

--- a/tests/menu/menu.cpp
+++ b/tests/menu/menu.cpp
@@ -584,10 +584,6 @@ void MenuTestCase::Events()
     // Invoke the accelerator.
     m_frame->Show();
     m_frame->SetFocus();
-#ifdef __WXGTK__
-    // Without this, test fails when run with other tests under Xvfb.
-    m_frame->Raise();
-#endif
     wxYield();
 
     wxUIActionSimulator sim;

--- a/tests/validators/valnum.cpp
+++ b/tests/validators/valnum.cpp
@@ -211,16 +211,6 @@ void NumValidatorTestCase::Interactive()
         return;
 #endif // __WXMSW__
 
-#ifdef __WXGTK20__
-    // Travis CI fails without this!
-    if ( IsAutomaticTest() )
-    {
-        wxFrame* frame = wxDynamicCast(wxTheApp->GetTopWindow(), wxFrame);
-        frame->SetFocus();
-        frame->Raise();
-    }
-#endif // __WXGTK20__
-
     // Set a locale using comma as thousands separator character.
     wxLocale loc(wxLANGUAGE_ENGLISH_UK, wxLOCALE_DONT_LOAD_DEFAULT);
 


### PR DESCRIPTION
If i understand [this](https://github.com/Distrotech/gtk2/blob/5cb26cbab3291bee0d039eee4e56fe7c131cc0d6/docs/focus_tracking.txt) correctly, the failures of our tests on GTK2 is due to [this](https://github.com/Distrotech/gtk2/blob/5cb26cbab3291bee0d039eee4e56fe7c131cc0d6/docs/focus_tracking.txt#L115):

> Modification 1:
>    
>  When tracking has_pointer_focus(W), ignore all Focus
>  events with a mode of NotifyGrab or NotifyUngrab.
> 
>  Note that this means that with grabs, we don't perfectly.
>  track the delivery of keyboard events ... since we think
>  we are getting events in the case where
> 
>   has_pointer_focus(W) && !(G == None || G==W || G==descendant)
> 
>  But the X protocol doesn't provide sufficient information
>  to do this right... example:
> 
>    F=Ancestor, G=None   =>   F=Ancestor, G=Ancestor
> 
>  We stop getting events, but receive no notification.
> 	
>  The case of no window manager and keyboard grabs is pretty
>  rare in any case.
> 