### PR TITLE
Change AUI dockart to use system caption text color

### DIFF
--- a/src/aui/dockart.cpp
+++ b/src/aui/dockart.cpp
@@ -183,7 +183,7 @@ wxAuiDefaultDockArt::wxAuiDefaultDockArt()
     m_activeCaptionTextColour = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT);
     m_inactiveCaptionColour = darker1Colour;
     m_inactiveCaptionGradientColour = baseColour.ChangeLightness(97);
-    m_inactiveCaptionTextColour = *wxBLACK;
+    m_inactiveCaptionTextColour = wxSystemSettings::GetColour(wxSYS_COLOUR_INACTIVECAPTIONTEXT);
 
     m_sashBrush = wxBrush(baseColour);
     m_backgroundBrush = wxBrush(baseColour);


### PR DESCRIPTION
Backport part of #1791

Before:
![Capture d’écran du 2020-07-11 11-24-26](https://user-images.githubusercontent.com/8530546/87221073-a676b000-c369-11ea-8cc5-0a65af96a4a1.png)

After:
![Capture d’écran du 2020-07-11 11-25-49](https://user-images.githubusercontent.com/8530546/87221079-ab3b6400-c369-11ea-9f44-797e1970f103.png)
