### PR TITLE
Change wxHtmlWindow to use system colors

### DIFF
--- a/src/html/htmlwin.cpp
+++ b/src/html/htmlwin.cpp
@@ -488,7 +488,7 @@ bool wxHtmlWindow::DoSetPage(const wxString& source)
     // ...and run the parser on it:
     wxClientDC dc(this);
     dc.SetMapMode(wxMM_TEXT);
-    SetBackgroundColour(wxColour(0xFF, 0xFF, 0xFF));
+    SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
     SetBackgroundImage(wxNullBitmap);
 
     double pixelScale = 1.0;

--- a/src/html/winpars.cpp
+++ b/src/html/winpars.cpp
@@ -211,8 +211,8 @@ void wxHtmlWinParser::InitParser(const wxString& source)
 
     m_UseLink = false;
     m_Link = wxHtmlLinkInfo( wxEmptyString );
-    m_LinkColor.Set(0, 0, 0xFF);
-    m_ActualColor.Set(0, 0, 0);
+    m_LinkColor = wxSystemSettings::GetColour(wxSYS_COLOUR_HOTLIGHT);
+    m_ActualColor = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
     const wxColour windowColour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW) ;
     m_ActualBackgroundColor = m_windowInterface
                             ? m_windowInterface->GetHTMLBackgroundColour()


### PR DESCRIPTION
I know that this might be controversial. I think that most apps aren't setting custom colors. The white background is burning my eyes. I think that it would be better to automatically set colors.
Some users might not like this because they expect that if they don't set colors, background will always be white, text black and links blue.