### PR TITLE
Ensure the clipboard contents are stored properly on GTK

### DIFF
--- a/interface/wx/clipbrd.h
+++ b/interface/wx/clipbrd.h
@@ -53,6 +53,13 @@
     }
     @endcode
 
+    @note On GTK, the clipboard behavior can vary depending on the configuration of
+          the end-user's machine. In order for the clipboard data to persist after
+          the window closes, a clipboard manager must be installed. Some clipboard
+          managers will automatically flush the clipboard after each new piece of
+          data is added, while others will not. The @Flush() function will force
+          the clipboard manager to flush the data.
+
     @library{wxcore}
     @category{dnd}
 
@@ -98,6 +105,10 @@ public:
 
         Currently this method is implemented in MSW and GTK and always returns @false
         otherwise.
+
+        @note On GTK, only the non-primary selection can be flushed. Calling this function
+              when the clipboard is using the primary selection will return @false and not
+              make any data available after the program exits.
 
         @return @false if the operation is unsuccessful for any reason.
     */

--- a/samples/clipboard/clipboard.cpp
+++ b/samples/clipboard/clipboard.cpp
@@ -151,7 +151,8 @@ void MyFrame::OnFlush(wxCommandEvent &WXUNUSED(event))
         return;
     }
 
-    if ( !wxTheClipboard->AddData(new wxTextDataObject("Text from wx clipboard sample")) )
+    wxString clipData = wxString::Format("Text from wx clipboard sample at %s" , wxDateTime::Now().Format());
+    if ( !wxTheClipboard->AddData(new wxTextDataObject(clipData)) )
     {
         m_textctrl->AppendText("Failed to put text on clipboard.\n");
         return;

--- a/src/gtk/clipbrd.cpp
+++ b/src/gtk/clipbrd.cpp
@@ -41,7 +41,6 @@ typedef wxScopedArray<wxDataFormat> wxDataFormatArray;
 // data
 // ----------------------------------------------------------------------------
 
-static GdkAtom  g_clipboardAtom   = 0;
 static GdkAtom  g_targetsAtom     = 0;
 static GdkAtom  g_timestampAtom   = 0;
 
@@ -231,7 +230,7 @@ selection_clear_clip( GtkWidget *WXUNUSED(widget), GdkEventSelection *event )
 
         kind = wxClipboard::Primary;
     }
-    else if (event->selection == g_clipboardAtom)
+    else if ( event->selection == GDK_SELECTION_CLIPBOARD )
     {
         wxLogTrace(TRACE_CLIPBOARD, wxT("Lost clipboard" ));
 
@@ -471,8 +470,6 @@ wxClipboard::wxClipboard()
                       G_CALLBACK (selection_clear_clip), NULL);
 
     // initialize atoms we use if not done yet
-    if ( !g_clipboardAtom )
-        g_clipboardAtom = gdk_atom_intern( "CLIPBOARD", FALSE );
     if ( !g_targetsAtom )
         g_targetsAtom = gdk_atom_intern ("TARGETS", FALSE);
     if ( !g_timestampAtom )
@@ -494,7 +491,7 @@ wxClipboard::~wxClipboard()
 GdkAtom wxClipboard::GTKGetClipboardAtom() const
 {
     return m_usePrimary ? (GdkAtom)GDK_SELECTION_PRIMARY
-                        : g_clipboardAtom;
+                        : (GdkAtom)GDK_SELECTION_CLIPBOARD;
 }
 
 void wxClipboard::GTKClearData(Kind kind)
@@ -775,7 +772,7 @@ wxDataObject* wxClipboard::GTKGetDataObject( GdkAtom atom )
 
         return Data( wxClipboard::Primary );
     }
-    else if ( atom == g_clipboardAtom )
+    else if ( atom == GDK_SELECTION_CLIPBOARD )
     {
         wxLogTrace(TRACE_CLIPBOARD, wxT("Clipboard data requested" ));
 


### PR DESCRIPTION
This PR adds the function call to tell GTK that the clipboard data can be stored. This must be done before the actual store call for the data to properly persist in some cases.

Also, this PR documents that the clipboard behavior on GTK is very dependent on the configuration of the user's machine. On my machine when testing this I noticed that the clipboard didn't persist (even with these store calls) before I installed a clipboard manager for my desktop environment. Also, in my experiments some clipboard managers (such as gpaste) will automatically treat any piece of data added to the clipboard as being persisted - making the call to `Flush` extraneous. I left a small note about that in the documentation so that developers are warned it can happen.

Closes [#10515](https://trac.wxwidgets.org/ticket/10515)