### PR TITLE
Add checks to 3rdparty libraries availability

### DIFF
--- a/configure
+++ b/configure
@@ -1059,6 +1059,7 @@ enable_official_build
 enable_vendor
 enable_all_features
 enable_sys_libs
+enable_tests
 with_dpi
 enable_universal
 with_themes
@@ -2040,6 +2041,7 @@ Optional Features:
   --enable-vendor=VENDOR  vendor name (win32 DLL only)
   --disable-all-features  disable all optional features to build minimal library
   --disable-sys-libs      disable all use of system libraries, use only built-in ones
+  --disable-tests         disable tests configuration
   --enable-universal      use wxWidgets GUI controls instead of native ones
   --enable-nanox          use NanoX
   --enable-gpe            use GNOME PDA Environment features if possible
@@ -4290,6 +4292,35 @@ fi
 
 
           eval "$wx_cv_use_sys_libs"
+
+
+          enablestring=disable
+          defaultval=
+          if test -z "$defaultval"; then
+              if test x"$enablestring" = xdisable; then
+                  defaultval=yes
+              else
+                  defaultval=no
+              fi
+          fi
+
+          # Check whether --enable-tests was given.
+if test "${enable_tests+set}" = set; then :
+  enableval=$enable_tests;
+                          if test "$enableval" = yes; then
+                            wx_cv_use_tests='wxUSE_TESTS_SUBDIR=yes'
+                          else
+                            wx_cv_use_tests='wxUSE_TESTS_SUBDIR=no'
+                          fi
+
+else
+
+                          wx_cv_use_tests='wxUSE_TESTS_SUBDIR=${'DEFAULT_wxUSE_TESTS_SUBDIR":-$defaultval}"
+
+fi
+
+
+          eval "$wx_cv_use_tests"
 
 
 if test "$wxUSE_ALL_FEATURES" = "no"; then
@@ -21525,6 +21556,21 @@ $as_echo "$as_me: WARNING: zlib library not found or too old, will use built-in 
                         wxUSE_ZLIB=sys
         fi
     fi
+
+                if test "$wxUSE_ZLIB" = "builtin" ; then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether zlib.h file exists" >&5
+$as_echo_n "checking whether zlib.h file exists... " >&6; }
+        if ! test -f "$ac_confdir/src/zlib/zlib.h" ; then
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+            as_fn_error $? "
+    Configured to use built-in zlib library, but couldn't find required
+    header. You probably need to run: git submodule update --init src/zlib" "$LINENO" 5
+        else
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+        fi
+    fi
 fi
 
 
@@ -21639,6 +21685,21 @@ $as_echo "$as_me: WARNING: system png library not found or too old, will use bui
             fi
         else
                         wxUSE_LIBPNG=sys
+        fi
+    fi
+
+                if test "$wxUSE_LIBPNG" = "builtin" ; then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether png.c file exists" >&5
+$as_echo_n "checking whether png.c file exists... " >&6; }
+        if ! test -f "$ac_confdir/src/png/png.c" ; then
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+            as_fn_error $? "
+    Configured to use built-in png library, but couldn't find required source
+    file. You probably need to run: git submodule update --init src/png" "$LINENO" 5
+        else
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
         fi
     fi
 fi
@@ -21794,6 +21855,21 @@ _ACEOF
 fi
 
             fi
+        fi
+    fi
+
+                if test "$wxUSE_LIBJPEG" = "builtin" ; then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether jpeglib.h file exists" >&5
+$as_echo_n "checking whether jpeglib.h file exists... " >&6; }
+        if ! test -f "$ac_confdir/src/jpeg/jpeglib.h" ; then
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+            as_fn_error $? "
+    Configured to use built-in jpeg library, but couldn't find required
+    header. You probably need to run: git submodule update --init src/jpeg" "$LINENO" 5
+        else
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
         fi
     fi
 fi
@@ -22134,6 +22210,19 @@ $as_echo "$as_me: WARNING: system tiff library not found, will use built-in inst
         fi
     fi
     if test "$wxUSE_LIBTIFF" = "builtin" ; then
+                { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether tiff.h file exists" >&5
+$as_echo_n "checking whether tiff.h file exists... " >&6; }
+        if ! test -f "$ac_confdir/src/tiff/libtiff/tiff.h" ; then
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+            as_fn_error $? "
+    Configured to use built-in tiff library, but couldn't find required
+    header. You probably need to run: git submodule update --init src/tiff" "$LINENO" 5
+        else
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+        fi
+
                                         ac_configure_args="$ac_configure_args --disable-webp --disable-zstd"
         if test "$wxUSE_LIBLZMA" = "no"; then
             ac_configure_args="$ac_configure_args --disable-lzma"
@@ -22263,6 +22352,19 @@ $as_echo "$as_me: WARNING: system expat library not found, will use built-in ins
         fi
     fi
     if test "$wxUSE_EXPAT" = "builtin" ; then
+                { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether expat.h file exists" >&5
+$as_echo_n "checking whether expat.h file exists... " >&6; }
+        if ! test -f "$ac_confdir/src/expat/expat/lib/expat.h" ; then
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+            as_fn_error $? "
+    Configured to use built-in expat library, but couldn't find required
+    header. You probably need to run: git submodule update --init src/expat" "$LINENO" 5
+        else
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+        fi
+
                         save_CC="$CC"
            { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CC option to accept ISO C99" >&5
 $as_echo_n "checking for $CC option to accept ISO C99... " >&6; }
@@ -40448,7 +40550,23 @@ if test "$wxUSE_GUI" = "yes"; then
 else
             SUBDIRS="samples utils"
 fi
-SUBDIRS="$SUBDIRS tests"
+
+if test "$wxUSE_TESTS_SUBDIR" != "no"; then
+        SUBDIRS="$SUBDIRS tests"
+
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether catch.hpp file exists" >&5
+$as_echo_n "checking whether catch.hpp file exists... " >&6; }
+    if ! test -f "$ac_confdir/3rdparty/catch/include/catch.hpp" ; then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+        as_fn_error $? "
+    catch (C++ Automated Test Cases in Headers) is required, but couldn't find
+    header. Probably need to run: git submodule update --init 3rdparty/catch" "$LINENO" 5
+    else
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+    fi
+fi
 
 for subdir in $SUBDIRS; do
     if test -d ${srcdir}/${subdir} ; then

--- a/configure.in
+++ b/configure.in
@@ -402,6 +402,7 @@ fi
 
 WX_ARG_DISABLE(all-features,[  --disable-all-features  disable all optional features to build minimal library], wxUSE_ALL_FEATURES)
 WX_ARG_DISABLE(sys-libs,    [  --disable-sys-libs      disable all use of system libraries, use only built-in ones], wxUSE_SYS_LIBS)
+WX_ARG_DISABLE(tests,       [  --disable-tests         disable tests configuration], wxUSE_TESTS_SUBDIR)
 
 if test "$wxUSE_ALL_FEATURES" = "no"; then
     dnl this is a bit ugly but currently we have no choice but to manually
@@ -2487,6 +2488,21 @@ if test "$wxUSE_ZLIB" != "no" ; then
             wxUSE_ZLIB=sys
         fi
     fi
+
+    dnl We should test if built-in zlib library is avalable, preferably
+    dnl downloaded through --recurse-submodules option if cloned from git.
+    dnl Would be available when downloaded as a zipped or tarball release.
+    if test "$wxUSE_ZLIB" = "builtin" ; then
+        AC_MSG_CHECKING([whether zlib.h file exists])
+        if ! test -f "$ac_confdir/src/zlib/zlib.h" ; then
+            AC_MSG_RESULT([no])
+            AC_MSG_ERROR([
+    Configured to use built-in zlib library, but couldn't find required
+    header. You probably need to run: git submodule update --init src/zlib])
+        else
+            AC_MSG_RESULT([yes])
+        fi
+    fi    
 fi
 
 dnl ------------------------------------------------------------------------
@@ -2547,6 +2563,21 @@ if test "$wxUSE_LIBPNG" != "no" ; then
             wxUSE_LIBPNG=sys
         fi
     fi
+
+    dnl We should test if built-in png library is avalable, preferably
+    dnl downloaded through --recurse-submodules option if cloned from git.
+    dnl Would be available when downloaded as a zipped or tarball release.
+    if test "$wxUSE_LIBPNG" = "builtin" ; then
+        AC_MSG_CHECKING([whether png.c file exists])
+        if ! test -f "$ac_confdir/src/png/png.c" ; then
+            AC_MSG_RESULT([no])
+            AC_MSG_ERROR([
+    Configured to use built-in png library, but couldn't find required source
+    file. You probably need to run: git submodule update --init src/png])
+        else
+            AC_MSG_RESULT([yes])
+        fi
+    fi    
 fi
 
 dnl ------------------------------------------------------------------------
@@ -2619,6 +2650,21 @@ if test "$wxUSE_LIBJPEG" != "no" ; then
             fi
         fi
     fi
+
+    dnl We should test if built-in jpeg library is avalable, preferably
+    dnl downloaded through --recurse-submodules option if cloned from git.
+    dnl Would be available when downloaded as a zipped or tarball release.
+    if test "$wxUSE_LIBJPEG" = "builtin" ; then
+        AC_MSG_CHECKING([whether jpeglib.h file exists])
+        if ! test -f "$ac_confdir/src/jpeg/jpeglib.h" ; then
+            AC_MSG_RESULT([no])
+            AC_MSG_ERROR([
+    Configured to use built-in jpeg library, but couldn't find required
+    header. You probably need to run: git submodule update --init src/jpeg])
+        else
+            AC_MSG_RESULT([yes])
+        fi
+    fi    
 fi
 
 dnl ------------------------------------------------------------------------
@@ -2715,6 +2761,17 @@ if test "$wxUSE_LIBTIFF" != "no" ; then
         fi
     fi
     if test "$wxUSE_LIBTIFF" = "builtin" ; then
+        dnl Test for built-in tiff library avalability.
+        AC_MSG_CHECKING([whether tiff.h file exists])
+        if ! test -f "$ac_confdir/src/tiff/libtiff/tiff.h" ; then
+            AC_MSG_RESULT([no])
+            AC_MSG_ERROR([
+    Configured to use built-in tiff library, but couldn't find required
+    header. You probably need to run: git submodule update --init src/tiff])
+        else
+            AC_MSG_RESULT([yes])
+        fi
+
         dnl Disable the use of lzma, webp and zstd in built-in libtiff explicitly, as
         dnl otherwise we'd depend on the system libraries, which is typically
         dnl undesirable when using builtin libraries. If we use lzma ourselves, keep it
@@ -2780,6 +2837,17 @@ if test "$wxUSE_EXPAT" != "no"; then
         fi
     fi
     if test "$wxUSE_EXPAT" = "builtin" ; then
+        dnl Test for built-in expat library avalability.
+        AC_MSG_CHECKING([whether expat.h file exists])
+        if ! test -f "$ac_confdir/src/expat/expat/lib/expat.h" ; then
+            AC_MSG_RESULT([no])
+            AC_MSG_ERROR([
+    Configured to use built-in expat library, but couldn't find required
+    header. You probably need to run: git submodule update --init src/expat])
+        else
+            AC_MSG_RESULT([yes])
+        fi
+
         dnl Expat requires C99 compiler, so define wxCFLAGS_C99 variable which
         dnl is used when compiling it in our makefiles.
         save_CC="$CC"
@@ -8445,7 +8513,22 @@ else
     dnl there are no wxBase programs in demos
     SUBDIRS="samples utils"
 fi
-SUBDIRS="$SUBDIRS tests"
+
+if test "$wxUSE_TESTS_SUBDIR" != "no"; then
+    dnl Configure tests directory
+    SUBDIRS="$SUBDIRS tests"
+    
+    dnl Check for catch (C++ Automated Test Cases in Headers) availability.
+    AC_MSG_CHECKING([whether catch.hpp file exists])
+    if ! test -f "$ac_confdir/3rdparty/catch/include/catch.hpp" ; then
+        AC_MSG_RESULT([no])
+        AC_MSG_ERROR([
+    catch (C++ Automated Test Cases in Headers) is required, but couldn't find
+    header. Probably need to run: git submodule update --init 3rdparty/catch])
+    else
+        AC_MSG_RESULT([yes])
+    fi
+fi
 
 for subdir in $SUBDIRS; do
     if test -d ${srcdir}/${subdir} ; then


### PR DESCRIPTION
Availability of built-in libraries should be checked while
configuring for compilation, and configuration process
should be stopped if those libraries are not found.
This is to avoid surprises especially for developers downloading
wxWidgets through git clone. Without this check, configuration
will almost always turns out as successful, while later **make**
would show incomplete expected libraries.
This behaviour is similar to what **cmake** does in wxWidgets.