### PR TITLE
Don't use windres --use-temp-file option

### DIFF
--- a/build/bakefiles/config.bkl
+++ b/build/bakefiles/config.bkl
@@ -519,7 +519,7 @@ Set the version of your Mingw installation here.
             </description>
         </option>
         <option name="WINDRES">
-            <default-value>windres --use-temp-file</default-value>
+            <default-value>windres</default-value>
             <description>
 Windows resource compiler to use, possibly including extra options.
 For example, add "-F pe-i386" here if using 64 bit windres for 32 bit build.

--- a/build/msw/config.gcc
+++ b/build/msw/config.gcc
@@ -145,5 +145,5 @@ GCC_VERSION ?= 3
 
 # Windows resource compiler to use, possibly including extra options.
 # For example, add "-F pe-i386" here if using 64 bit windres for 32 bit build. 
-WINDRES ?= windres --use-temp-file
+WINDRES ?= windres
 


### PR DESCRIPTION
According to the manual, it should only be needed for Win9x systems not
supported since a long time anyhow and this option is apparently buggy
in recent MinGW binutils as it results in build errors when used, see
https://github.com/msys2/MINGW-packages/issues/6558