### PR TITLE
Fix building wxMSW using GCC 10.1 with C++20 standard

### DIFF
--- a/include/wx/msw/ole/dataform.h
+++ b/include/wx/msw/ole/dataform.h
@@ -41,6 +41,8 @@ public:
     bool operator!=(wxDataFormatId format) const;
     bool operator==(const wxDataFormat& format) const;
     bool operator!=(const wxDataFormat& format) const;
+    bool operator==(NativeFormat format) const;
+    bool operator!=(NativeFormat format) const;
 
     // explicit and implicit conversions to NativeFormat which is one of
     // standard data types (implicit conversion is useful for preserving the

--- a/src/msw/ole/dataobj.cpp
+++ b/src/msw/ole/dataobj.cpp
@@ -369,6 +369,16 @@ bool wxDataFormat::operator!=(const wxDataFormat& format) const
     return !(*this == format);
 }
 
+bool wxDataFormat::operator==(NativeFormat format) const
+{
+    return HtmlFormatFixup(*this).m_format == format;
+}
+
+bool wxDataFormat::operator!=(NativeFormat format) const
+{
+    return !(*this == format);
+}
+
 void wxDataFormat::SetId(const wxString& format)
 {
     m_format = (wxDataFormat::NativeFormat)::RegisterClipboardFormat(format.t_str());


### PR DESCRIPTION
Add comparison operator overloads using NativeFormat to wxDataFormat
to prevent ambiguous operator overload errors.

It may be because it is way too late but I am not sure if it is a correct solution nor why it is needed when `wxDataFormat` has `operator NativeFormat() const`?