### PR TITLE
Expose the scaled bitmap interface.

### DIFF
--- a/interface/wx/bitmap.h
+++ b/interface/wx/bitmap.h
@@ -350,8 +350,17 @@ public:
         @param depth
             Specifies the depth of the bitmap.
             If this is omitted, the display depth of the screen is used.
+        @param scale
+            Specifies the scale for a scaled bitmap. This corresponds to the size
+            of a device-independent standard pixel relative to that of a
+            device-dependent, actual pixel.
+            If this is omitted, 1.0 is used.
+
+            @since 3.1.0
+            NOTE: scale is ignored in wxMSW. In wxMSW, bitmap dpi awareness is
+                  specified per process via @see SetProcessDpiAwareness
     */
-    wxBitmap(const wxImage& img, int depth = wxBITMAP_SCREEN_DEPTH);
+    wxBitmap(const wxImage& img, int depth = wxBITMAP_SCREEN_DEPTH, double scale=1.0);
 
     /**
         Creates bitmap corresponding to the given cursor.
@@ -762,6 +771,31 @@ public:
             Bitmap width in pixels.
     */
     virtual void SetWidth(int width);
+
+    /**
+       Retrieves the size of a device-independent standard pixel relative to that
+       of a device-dependent, actual pixel for a scaled bitmap
+       @since 3.1.0
+    */
+    virtual double GetScaleFactor() const;
+
+    /**
+       Retrieves the width of a scaled bitmap in device-independent standard pixels
+       @since 3.1.0
+     */
+    virtual double GetScaledWidth() const;
+
+    /**
+       Retrieves the height of a scaled bitmap in device-independent standard pixels
+       @since 3.1.0
+    */
+    virtual double GetScaledHeight() const;
+
+    /**
+       Retrieves the size of a scaled bitmap in device-independent standard pixels
+       @since 3.1.0
+    */
+    virtual wxSize GetScaledSize() const;
 };
 
 /**
@@ -856,4 +890,3 @@ public:
     */
     wxBitmap GetBitmap() const;
 };
-

--- a/src/osx/core/bitmap.cpp
+++ b/src/osx/core/bitmap.cpp
@@ -238,6 +238,11 @@ bool wxBitmapRefData::Create(CGImageRef image, double scale)
         size_t width = CGImageGetWidth(image);
         size_t height = CGImageGetHeight(image);
 
+        wxASSERT_MSG(
+                     (int)((int)(width/scale)*scale)==width &&
+                     (int)((int)(height/scale)*scale)==height
+                     , "only scalefactors leading to integral dimensions are supported");
+
         m_hBitmap = NULL;
         m_scaleFactor = scale;
 
@@ -280,6 +285,12 @@ bool wxBitmapRefData::Create(int w, int h, int WXUNUSED(d), double logicalscale)
     size_t height = wxMax(1, h);
 
     m_scaleFactor = logicalscale;
+
+    wxASSERT_MSG(
+                 (int)((int)(width/logicalscale)*logicalscale)==width &&
+                 (int)((int)(height/logicalscale)*logicalscale)==height
+                 , "only scalefactors leading to integral dimensions are supported");
+
     m_hBitmap = NULL;
 
     size_t bytesPerRow = GetBestBytesPerRow(width * 4);


### PR DESCRIPTION
Hello Vadim and Robin,

This pull request is to expose the scaled bitmap interface. In particular so that it is available in wxPython. As you know, this interface enables creating bitmaps that are dpi aware. For a more in-depth discussion on the motivation for the pull request see https://discuss.wxpython.org/t/multiplatform-support-for-high-dpi-displays-in-particular-macos/34779

This pull request in particular enables creating a dpi aware bitmap from an image in python, for example as:

```
image = wx.Image('mytestimage.png')
scale = wx.GetApp().GetTopWindow().GetContentScaleFactor()
bitmap = wx.Bitmap(image, -1, scale)
```
Thank you.