### PR TITLE
Generic treectrl cleanup

### DIFF
--- a/include/wx/generic/treectlg.h
+++ b/include/wx/generic/treectlg.h
@@ -352,8 +352,6 @@ protected:
     virtual wxSize DoGetBestSize() const wxOVERRIDE;
 
 private:
-    bool m_hasExplicitFont;
-
     void OnSysColourChanged(wxSysColourChangedEvent& WXUNUSED(event))
     {
         InitVisualAttributes();

--- a/include/wx/generic/treectlg.h
+++ b/include/wx/generic/treectlg.h
@@ -354,7 +354,14 @@ protected:
 private:
     bool m_hasExplicitFont;
 
-    void OnSysColourChanged(wxSysColourChangedEvent&);
+    void OnSysColourChanged(wxSysColourChangedEvent& WXUNUSED(event))
+    {
+        InitVisualAttributes();
+    }
+
+    // (Re)initialize colours, fonts, pens, brushes used by the control using
+    // the current system colours and font.
+    void InitVisualAttributes();
 
     // Reset the state of the last find (i.e. keyboard incremental search)
     // operation.

--- a/include/wx/generic/treectlg.h
+++ b/include/wx/generic/treectlg.h
@@ -13,8 +13,9 @@
 
 #if wxUSE_TREECTRL
 
-#include "wx/scrolwin.h"
+#include "wx/brush.h"
 #include "wx/pen.h"
+#include "wx/scrolwin.h"
 
 // -----------------------------------------------------------------------------
 // forward declaration
@@ -243,8 +244,8 @@ protected:
     unsigned short       m_indent;
     int                  m_lineHeight;
     wxPen                m_dottedPen;
-    wxBrush             *m_hilightBrush,
-                        *m_hilightUnfocusedBrush;
+    wxBrush              m_hilightBrush,
+                         m_hilightUnfocusedBrush;
     bool                 m_hasFocus;
     bool                 m_dirty;
     bool                 m_ownsImageListButtons;

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -937,8 +937,6 @@ void wxGenericTreeCtrl::Init()
     m_indent = 15;
     m_spacing = 18;
 
-    m_hilightBrush = NULL;
-    m_hilightUnfocusedBrush = NULL;
     m_imageListButtons = NULL;
     m_ownsImageListButtons = false;
 
@@ -995,9 +993,6 @@ bool wxGenericTreeCtrl::Create(wxWindow *parent,
 
 wxGenericTreeCtrl::~wxGenericTreeCtrl()
 {
-    delete m_hilightBrush;
-    delete m_hilightUnfocusedBrush;
-
     DeleteAllItems();
 
     delete m_renameTimer;
@@ -1020,10 +1015,8 @@ void wxGenericTreeCtrl::OnSysColourChanged(wxSysColourChangedEvent&)
     if (!m_hasExplicitFont)
         SetOwnFont(attr.font);
 
-    delete m_hilightBrush;
-    m_hilightBrush = new wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT));
-    delete m_hilightUnfocusedBrush;
-    m_hilightUnfocusedBrush = new wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNSHADOW));
+    m_hilightBrush = wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT));
+    m_hilightUnfocusedBrush = wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNSHADOW));
 
     m_dottedPen = wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT), 1, wxPENSTYLE_DOT);
 
@@ -2544,7 +2537,7 @@ void wxGenericTreeCtrl::PaintItem(wxGenericTreeItem *item, wxDC& dc)
 
     if ( item->IsSelected() )
     {
-        dc.SetBrush(*(m_hasFocus ? m_hilightBrush : m_hilightUnfocusedBrush));
+        dc.SetBrush(m_hasFocus ? m_hilightBrush : m_hilightUnfocusedBrush);
         drawItemBackground = true;
     }
     else

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -982,7 +982,6 @@ bool wxGenericTreeCtrl::Create(wxWindow *parent,
         m_spacing = 10;
     }
 
-    m_hasExplicitFont = m_hasFont;
     InitVisualAttributes();
 
     SetInitialSize(size);
@@ -1011,7 +1010,7 @@ void wxGenericTreeCtrl::InitVisualAttributes()
     const wxVisualAttributes attr(GetDefaultAttributes());
     SetOwnForegroundColour(attr.colFg);
     SetOwnBackgroundColour(attr.colBg);
-    if (!m_hasExplicitFont)
+    if (!m_hasFont)
         SetOwnFont(attr.font);
 
     m_hilightBrush = wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT));

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -983,8 +983,7 @@ bool wxGenericTreeCtrl::Create(wxWindow *parent,
     }
 
     m_hasExplicitFont = m_hasFont;
-    wxSysColourChangedEvent evt;
-    OnSysColourChanged(evt);
+    InitVisualAttributes();
 
     SetInitialSize(size);
 
@@ -1007,7 +1006,7 @@ void wxGenericTreeCtrl::EnableBellOnNoMatch( bool on )
     m_findBell = on;
 }
 
-void wxGenericTreeCtrl::OnSysColourChanged(wxSysColourChangedEvent&)
+void wxGenericTreeCtrl::InitVisualAttributes()
 {
     const wxVisualAttributes attr(GetDefaultAttributes());
     SetOwnForegroundColour(attr.colFg);

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -1007,11 +1007,30 @@ void wxGenericTreeCtrl::EnableBellOnNoMatch( bool on )
 
 void wxGenericTreeCtrl::InitVisualAttributes()
 {
+    // We want to use the default system colours/fonts here unless the user
+    // explicitly configured something different. We also need to reset the
+    // various m_hasXXX variables to false to prevent them from being left set
+    // to "true", as otherwise we wouldn't update the colours/fonts the next
+    // time the system colours change.
     const wxVisualAttributes attr(GetDefaultAttributes());
-    SetOwnForegroundColour(attr.colFg);
-    SetOwnBackgroundColour(attr.colBg);
-    if (!m_hasFont)
+    if ( !m_hasFgCol )
+    {
+        SetOwnForegroundColour(attr.colFg);
+        m_hasFgCol = false;
+    }
+
+    if ( !m_hasBgCol )
+    {
+        SetOwnBackgroundColour(attr.colBg);
+        m_hasBgCol = false;
+    }
+
+    if ( !m_hasFont )
+    {
         SetOwnFont(attr.font);
+        m_hasFont = false;
+    }
+
 
     m_hilightBrush = wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT));
     m_hilightUnfocusedBrush = wxBrush(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNSHADOW));


### PR DESCRIPTION
I'm not sure about the last commit, there must have been some reason for introducing `m_hasExplicitFont`, but I just don't see it. If you could please explain why is it needed, it could be reverted. The other 2 should still be applied IMO, but please let me know if you disagree. TIA!