### PR TITLE
Fixed errors I came across during closing multiple wxApps from task bar

### DIFF
--- a/include/wx/tracker.h
+++ b/include/wx/tracker.h
@@ -80,7 +80,9 @@ protected:
         {
             wxTrackerNode * const first = m_first;
             m_first = first->m_nxt;
-            first->OnObjectDestroy();
+            if (first) {
+                first->OnObjectDestroy();
+            }
         }
     }
 


### PR DESCRIPTION
I had a problem with handling multpile apps closing from windows taskbar. When i close them one-by-one everyting worked fine, but when i right-clicked on a group of this applications and selected close, almost 80% crashed saying something like "Error occured  during exit, calling abort()". When i checked that in my debuger (Visual studio 2019), it said that in ~wxTrackable() I tried to invoke OnObjectDestroy() on NULL. I couldn't find any solution on the Internet so i tried puting it if statement, checking if current object is not NULL. After that the same error (talking about abort()) occured but now VC points that problem is in event.cpp file. It said the same thing - I tried to do something with object that is NULL. So i added another if statement and that fixed it.