### PR TITLE
replacing __Verify_noErr on macOS, generic implementation

### DIFF
--- a/include/wx/debug.h
+++ b/include/wx/debug.h
@@ -398,6 +398,8 @@ extern void WXDLLIMPEXP_BASE wxAbort();
 //     to begin with...)
 #define wxCHECK_RET(cond, msg)       wxCHECK2_MSG(cond, return, msg)
 
+#if wxDEBUG_LEVEL && wxUSE_UNICODE
+
 // This macro checks if the evaluation of cond, having a return value of
 // OS Error type, is zero, ie no error occurred, and calls the assert handler
 // with the provided message if it isn't and finally traps if the special flag
@@ -416,6 +418,15 @@ extern void WXDLLIMPEXP_BASE wxAbort();
             wxTrap();                                                     \
         }                                                                 \
     wxSTATEMENT_MACRO_END
+
+#else
+
+#define wxVERIFY_NOERR_MSG_AT(cond, msg, file, line, func)                \
+    wxSTATEMENT_MACRO_BEGIN                                               \
+        cond;                                                             \
+    wxSTATEMENT_MACRO_END
+
+#endif
 
 // A version asserting at the current location.
 #define wxVERIFY_NOERR_MSG(cond, msg) \

--- a/include/wx/debug.h
+++ b/include/wx/debug.h
@@ -186,13 +186,6 @@ extern WXDLLIMPEXP_BASE void wxOnAssert(const char *file,
                                         const char *cond,
                                         const char *msg);
 
-extern WXDLLIMPEXP_BASE void wxOnAssertWithErrorCode(const char *file,
-                                        int line,
-                                        const char *func,
-                                        unsigned long errorCode,
-                                        const char *cond,
-                                        const char *msg);
-
 extern WXDLLIMPEXP_BASE void wxOnAssert(const char *file,
                                         int line,
                                         const char *func,
@@ -335,7 +328,6 @@ extern WXDLLIMPEXP_BASE void wxOnAssert(const char *file,
 
     #define wxASSERT(cond)
     #define wxASSERT_MSG(cond, msg)
-
     #define wxFAIL
     #define wxFAIL_MSG(msg)
     #define wxFAIL_COND_MSG(cond, msg)
@@ -398,43 +390,32 @@ extern void WXDLLIMPEXP_BASE wxAbort();
 //     to begin with...)
 #define wxCHECK_RET(cond, msg)       wxCHECK2_MSG(cond, return, msg)
 
-#if wxDEBUG_LEVEL && wxUSE_UNICODE
+#if wxDEBUG_LEVEL
 
 // This macro checks if the evaluation of cond, having a return value of
 // OS Error type, is zero, ie no error occurred, and calls the assert handler
 // with the provided message if it isn't and finally traps if the special flag
 // indicating that it should do it was set by the handler.
-#define wxVERIFY_NOERR_MSG_AT(cond, msg, file, line, func)                \
+#define wxVERIFY_NOERR(cond)                \
     wxSTATEMENT_MACRO_BEGIN                                               \
         unsigned long evalOnceErrorCode = (cond);                         \
         if ( evalOnceErrorCode == 0 )                                     \
         {                                                                 \
         }                                                                 \
-        else if ( wxTheAssertHandler &&                                   \
-                (wxOnAssertWithErrorCode(file, line, func,                \
-                 evalOnceErrorCode, #cond, msg), wxTrapInAssert) )        \
+        else                                                              \
         {                                                                 \
-            wxTrapInAssert = false;                                       \
-            wxTrap();                                                     \
+            wxFAIL_COND_MSG(#cond, wxSysErrorMsgStr(cond));               \
         }                                                                 \
     wxSTATEMENT_MACRO_END
 
 #else
 
-#define wxVERIFY_NOERR_MSG_AT(cond, msg, file, line, func)                \
+#define wxVERIFY_NOERR(cond)                                              \
     wxSTATEMENT_MACRO_BEGIN                                               \
         cond;                                                             \
     wxSTATEMENT_MACRO_END
 
 #endif
-
-// A version asserting at the current location.
-#define wxVERIFY_NOERR_MSG(cond, msg) \
-    wxVERIFY_NOERR_MSG_AT(cond, msg, __FILE__, __LINE__, __WXFUNCTION__)
-
-// a version without any additional message, don't use unless condition
-// itself is fully self-explanatory
-#define wxVERIFY_NOERR(cond) wxVERIFY_NOERR_MSG(cond, (const char*)NULL)
 
 // ----------------------------------------------------------------------------
 // Compile time asserts

--- a/include/wx/debug.h
+++ b/include/wx/debug.h
@@ -186,6 +186,13 @@ extern WXDLLIMPEXP_BASE void wxOnAssert(const char *file,
                                         const char *cond,
                                         const char *msg);
 
+extern WXDLLIMPEXP_BASE void wxOnAssertWithErrorCode(const char *file,
+                                        int line,
+                                        const char *func,
+                                        unsigned long errorCode,
+                                        const char *cond,
+                                        const char *msg);
+
 extern WXDLLIMPEXP_BASE void wxOnAssert(const char *file,
                                         int line,
                                         const char *func,
@@ -328,6 +335,7 @@ extern WXDLLIMPEXP_BASE void wxOnAssert(const char *file,
 
     #define wxASSERT(cond)
     #define wxASSERT_MSG(cond, msg)
+
     #define wxFAIL
     #define wxFAIL_MSG(msg)
     #define wxFAIL_COND_MSG(cond, msg)
@@ -390,6 +398,32 @@ extern void WXDLLIMPEXP_BASE wxAbort();
 //     to begin with...)
 #define wxCHECK_RET(cond, msg)       wxCHECK2_MSG(cond, return, msg)
 
+// This macro checks if the evaluation of cond, having a return value of
+// OS Error type, is zero, ie no error occurred, and calls the assert handler
+// with the provided message if it isn't and finally traps if the special flag
+// indicating that it should do it was set by the handler.
+#define wxVERIFY_NOERR_MSG_AT(cond, msg, file, line, func)                \
+    wxSTATEMENT_MACRO_BEGIN                                               \
+        unsigned long evalOnceErrorCode = (cond);                         \
+        if ( evalOnceErrorCode == 0 )                                     \
+        {                                                                 \
+        }                                                                 \
+        else if ( wxTheAssertHandler &&                                   \
+                (wxOnAssertWithErrorCode(file, line, func,                \
+                 evalOnceErrorCode, #cond, msg), wxTrapInAssert) )        \
+        {                                                                 \
+            wxTrapInAssert = false;                                       \
+            wxTrap();                                                     \
+        }                                                                 \
+    wxSTATEMENT_MACRO_END
+
+// A version asserting at the current location.
+#define wxVERIFY_NOERR_MSG(cond, msg) \
+    wxVERIFY_NOERR_MSG_AT(cond, msg, __FILE__, __LINE__, __WXFUNCTION__)
+
+// a version without any additional message, don't use unless condition
+// itself is fully self-explanatory
+#define wxVERIFY_NOERR(cond) wxVERIFY_NOERR_MSG(cond, (const char*)NULL)
 
 // ----------------------------------------------------------------------------
 // Compile time asserts

--- a/src/common/appbase.cpp
+++ b/src/common/appbase.cpp
@@ -1264,30 +1264,6 @@ void wxOnAssert(const char *file,
     wxTheAssertHandler(file, line, func, cond, msg);
 }
 
-void wxOnAssertWithErrorCode(const char *file,
-                int line,
-                const char *func,
-                unsigned long errorCode,
-                const char *cond,
-                const char *msg)
-{
-    wxString message;
-    if ( msg && *msg )
-        message = wxString::Format("%s ", msg);
-    wxString osError = wxSysErrorMsgStr(errorCode);
-#if defined(__WXMSW__)
-    // native error code type is unsigned 32 on msw, but signed on others
-    message += wxString::Format("(Error %lu", errorCode);
-#else
-    message += wxString::Format("(Error %ld", static_cast<long>(errorCode));
-#endif
-    if ( !osError.IsEmpty() )
-        message += wxString::Format(", %s", osError);
-    message += ")";
-
-    wxTheAssertHandler(file, line, func, cond, message);
-}
-
 #endif // wxUSE_UNICODE
 
 #endif // wxDEBUG_LEVEL

--- a/src/common/appbase.cpp
+++ b/src/common/appbase.cpp
@@ -1263,6 +1263,31 @@ void wxOnAssert(const char *file,
 {
     wxTheAssertHandler(file, line, func, cond, msg);
 }
+
+void wxOnAssertWithErrorCode(const char *file,
+                int line,
+                const char *func,
+                unsigned long errorCode,
+                const char *cond,
+                const char *msg)
+{
+    wxString message;
+    if ( msg && *msg )
+        message = wxString::Format("%s ", msg);
+    wxString osError = wxSysErrorMsgStr(errorCode);
+#if defined(__WXMSW__)
+    // native error code type is unsigned 32 on msw, but signed on others
+    message += wxString::Format("(Error %lu", errorCode);
+#else
+    message += wxString::Format("(Error %ld", static_cast<long>(errorCode));
+#endif
+    if ( !osError.IsEmpty() )
+        message += wxString::Format(", %s", osError);
+    message += ")";
+
+    wxTheAssertHandler(file, line, func, cond, message);
+}
+
 #endif // wxUSE_UNICODE
 
 #endif // wxDEBUG_LEVEL

--- a/src/common/appbase.cpp
+++ b/src/common/appbase.cpp
@@ -1263,7 +1263,6 @@ void wxOnAssert(const char *file,
 {
     wxTheAssertHandler(file, line, func, cond, msg);
 }
-
 #endif // wxUSE_UNICODE
 
 #endif // wxDEBUG_LEVEL

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -58,6 +58,10 @@
     #include "wx/msw/private.h" // includes windows.h
 #endif
 
+#if defined(__WXOSX__)
+    #include "wx/osx/private.h" // for GetMacOSStatusErrorString
+#endif
+
 #undef wxLOG_COMPONENT
 const char *wxLOG_COMPONENT = "";
 
@@ -1121,6 +1125,12 @@ static const wxChar* GetSysErrorMsg(wxChar* szBuf, size_t sizeBuf, unsigned long
         errorMsg = strerror_r((int)nErrCode, buffer, sizeof(buffer));
 #elif defined( __VMS )
         errorMsg = strerror((int)nErrCode);
+#elif defined(__WXOSX_COCOA__)
+        int iErrorCode = (int)nErrCode;
+        if ( iErrorCode < 0 )
+            strncpy(buffer,GetMacOSStatusErrorString(iErrorCode), sizeof(buffer));
+        else
+            strerror_r(iErrorCode, buffer, sizeof(buffer));
 #else // XSI-compliant strerror_r
         strerror_r((int)nErrCode, buffer, sizeof(buffer));
 #endif

--- a/src/osx/carbon/region.cpp
+++ b/src/osx/carbon/region.cpp
@@ -1036,7 +1036,7 @@ bool wxRegion::DoOffset(wxCoord x, wxCoord y)
 
     AllocExclusive();
 
-    __Verify_noErr(HIShapeOffset( M_REGION , x , y )) ;
+    wxVERIFY_NOERR(HIShapeOffset( M_REGION , x , y )) ;
 
     return true ;
 }
@@ -1091,11 +1091,11 @@ bool wxRegion::DoCombine(const wxRegion& region, wxRegionOp op)
     switch (op)
     {
         case wxRGN_AND:
-            __Verify_noErr(HIShapeIntersect( M_REGION , OTHER_M_REGION(region) , M_REGION ));
+            wxVERIFY_NOERR(HIShapeIntersect( M_REGION , OTHER_M_REGION(region) , M_REGION ));
             break ;
 
         case wxRGN_OR:
-            __Verify_noErr(HIShapeUnion( M_REGION , OTHER_M_REGION(region) , M_REGION ));
+            wxVERIFY_NOERR(HIShapeUnion( M_REGION , OTHER_M_REGION(region) , M_REGION ));
             break ;
 
         case wxRGN_XOR:
@@ -1103,12 +1103,12 @@ bool wxRegion::DoCombine(const wxRegion& region, wxRegionOp op)
                 // XOR is defined as the difference between union and intersection
                 wxCFRef< HIShapeRef > unionshape( HIShapeCreateUnion( M_REGION , OTHER_M_REGION(region) ) );
                 wxCFRef< HIShapeRef > intersectionshape( HIShapeCreateIntersection( M_REGION , OTHER_M_REGION(region) ) );
-                __Verify_noErr(HIShapeDifference( unionshape, intersectionshape, M_REGION ));
+                wxVERIFY_NOERR(HIShapeDifference( unionshape, intersectionshape, M_REGION ));
             }
             break ;
 
         case wxRGN_DIFF:
-            __Verify_noErr(HIShapeDifference( M_REGION , OTHER_M_REGION(region) , M_REGION )) ;
+            wxVERIFY_NOERR(HIShapeDifference( M_REGION , OTHER_M_REGION(region) , M_REGION )) ;
             break ;
 
         case wxRGN_COPY:

--- a/src/osx/core/bitmap.cpp
+++ b/src/osx/core/bitmap.cpp
@@ -893,7 +893,7 @@ IconRef wxBitmap::GetIconRef() const
 IconRef wxBitmap::CreateIconRef() const
 {
     IconRef icon = GetIconRef();
-    __Verify_noErr(AcquireIconRef(icon));
+    wxVERIFY_NOERR(AcquireIconRef(icon));
     return icon;
 }
 #endif
@@ -1866,7 +1866,7 @@ bool wxICNSResourceHandler::LoadFile(wxBitmap *bitmap,
     {
         IconRef iconRef = NULL ;
         
-        __Verify_noErr(GetIconRef( kOnSystemDisk, kSystemIconsCreator, theId, &iconRef )) ;
+        wxVERIFY_NOERR(GetIconRef( kOnSystemDisk, kSystemIconsCreator, theId, &iconRef )) ;
         img = wxOSXGetNSImageFromIconRef(iconRef);
     }
     else


### PR DESCRIPTION
macros for verifying methods don’t fail with native error codes