### PR TITLE
Point to wxWebView Class Reference as an alternative to wxHTML.

### DIFF
--- a/docs/doxygen/overviews/html.h
+++ b/docs/doxygen/overviews/html.h
@@ -13,7 +13,7 @@
 
 The wxHTML library provides classes for parsing and displaying HTML.
 It is not intended to be a high-end HTML browser. If you are looking for
-something like that try <http://www.mozilla.org/>.
+something like that use wxWebView.
 
 wxHTML can be used as a generic rich text viewer - for example to display
 a nice About Box (like those of GNOME apps) or to display the result of


### PR DESCRIPTION
Currently documentation of **wxHTML Overview** refers to http://www.mozilla.org/
as a high-end HTML browser engine, while already available wxWebView doesn't
get the attention it deserves.
Note: Maybe we need to create a wxWebView Overview document at a later date.