### PR TITLE
macOS tooltip

### DIFF
--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -901,6 +901,8 @@ static void SetDrawingEnabledIfFrozenRecursive(wxWidgetCocoaImpl *impl, bool ena
     }
 }
 
+#if 0
+
 - (NSTrackingRectTag)addTrackingRect:(NSRect)rect owner:(id)owner userData:(void *)data assumeInside:(BOOL)assumeInside
 {
     NSTrackingRectTag tag = [super addTrackingRect:rect owner:owner userData:data assumeInside:assumeInside];
@@ -923,6 +925,8 @@ static void SetDrawingEnabledIfFrozenRecursive(wxWidgetCocoaImpl *impl, bool ena
     }
     [super removeTrackingRect:tag];
 }
+
+#endif
 
 #if wxOSX_USE_NATIVE_FLIPPED
 - (BOOL)isFlipped


### PR DESCRIPTION
in newer systems tooltips were even less functional, strangely the problems seem to be related to functions present, but never called. So we must test against each macOS version …