### PR TITLE
Support arbitrary scale factors, not just 2, when loading bitmaps

### DIFF
--- a/src/osx/core/bitmap.cpp
+++ b/src/osx/core/bitmap.cpp
@@ -17,6 +17,7 @@
     #include "wx/dcmemory.h"
     #include "wx/icon.h"
     #include "wx/image.h"
+    #include "wx/math.h"
 #endif
 
 #include "wx/metafile.h"
@@ -1062,16 +1063,17 @@ bool wxBitmap::LoadFile(const wxString& filename, wxBitmapType type)
 
         if  ( type == wxBITMAP_TYPE_PNG )
         {
-            if ( wxOSXGetMainScreenContentScaleFactor() > 1.9 )
+            const int contentScaleFactor = wxRound(wxOSXGetMainScreenContentScaleFactor());
+            if ( contentScaleFactor > 1 )
             {
                 wxFileName fn(filename);
                 fn.MakeAbsolute();
-                fn.SetName(fn.GetName()+"@2x");
+                fn.SetName(fn.GetName()+wxString::Format("@%dx",contentScaleFactor));
 
                 if ( fn.Exists() )
                 {
                     fname = fn.GetFullPath();
-                    scale = 2.0;
+                    scale = contentScaleFactor;
                 }
             }
         }
@@ -1896,21 +1898,22 @@ bool wxBundleResourceHandler::LoadFile(wxBitmap *bitmap,
                                      int WXUNUSED(desiredHeight))
 {
     wxString ext = GetExtension().Lower();
-    wxCFStringRef resname(name);
-    wxCFStringRef resname2x(name+"@2x");
     wxCFStringRef restype(ext);
     double scale = 1.0;
     
     wxCFRef<CFURLRef> imageURL;
     
-    if ( wxOSXGetMainScreenContentScaleFactor() > 1.9 )
+    const int contentScaleFactor = wxRound(wxOSXGetMainScreenContentScaleFactor());
+    if ( contentScaleFactor > 1 )
     {
-        imageURL.reset(CFBundleCopyResourceURL(CFBundleGetMainBundle(), resname2x, restype, NULL));
-        scale = 2.0;
+        wxCFStringRef resname(wxString::Format("%s@%dx", name, contentScaleFactor));
+        imageURL.reset(CFBundleCopyResourceURL(CFBundleGetMainBundle(), resname, restype, NULL));
+        scale = contentScaleFactor;
     }
     
     if ( imageURL.get() == NULL )
     {
+        wxCFStringRef resname(name);
         imageURL.reset(CFBundleCopyResourceURL(CFBundleGetMainBundle(), resname, restype, NULL));
         scale = 1.0;
     }


### PR DESCRIPTION
This notably enables support for @3x icons used under iOS.