### PR TITLE
Add DPI scaling factor and revert content scaling factor behaviour

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -86,7 +86,7 @@ Changes in behaviour not resulting in compilation errors
 
 - wxGLCanvas now uses physical pixels on high DPI displays under platforms
   where they're different from logical ones (wxGTK3, wxOSX). Multiply logical
-  coordinates, e.g. returned by wxWindow::GetSize() by GetOpenGLScaleFactor()
+  coordinates, e.g. returned by wxWindow::GetSize() by GetContentScaleFactor()
   before using them with OpenGL functions.
 
 - wxGTK now uses wxID_NONE item ID for wxEVT_MENU_HIGHLIGHT events sent when

--- a/include/wx/glcanvas.h
+++ b/include/wx/glcanvas.h
@@ -258,11 +258,6 @@ public:
     // as a parameter
     wxGLContextAttrs& GetGLCTXAttrs() { return m_GLCTXAttrs; }
 
-    // Return the factor to apply to transform window coordinates (e.g. sizes)
-    // to OpenGL coordinates: it can be different from 1 on the platforms where
-    // logical pixels are different from physical ones (i.e. wxGTK3 and wxOSX).
-    virtual double GetOpenGLScaleFactor() const;
-
     // deprecated methods using the implicit wxGLContext
 #if WXWIN_COMPATIBILITY_2_8
     wxDEPRECATED( wxGLContext* GetContext() const );

--- a/include/wx/gtk/glcanvas.h
+++ b/include/wx/gtk/glcanvas.h
@@ -60,8 +60,6 @@ public:
 
     virtual bool SetBackgroundStyle(wxBackgroundStyle style) wxOVERRIDE;
 
-    virtual double GetOpenGLScaleFactor() const wxOVERRIDE;
-
     // implement wxGLCanvasX11 methods
     // --------------------------------
 

--- a/include/wx/msw/dc.h
+++ b/include/wx/msw/dc.h
@@ -77,7 +77,6 @@ public:
     virtual bool CanGetTextExtent() const wxOVERRIDE;
     virtual int GetDepth() const wxOVERRIDE;
     virtual wxSize GetPPI() const wxOVERRIDE;
-    virtual double GetContentScaleFactor() const wxOVERRIDE;
 
 
     virtual void SetMapMode(wxMappingMode mode) wxOVERRIDE;

--- a/include/wx/osx/glcanvas.h
+++ b/include/wx/osx/glcanvas.h
@@ -100,7 +100,6 @@ public:
 
     // implement wxGLCanvasBase methods
     virtual bool SwapBuffers() wxOVERRIDE;
-    virtual double GetOpenGLScaleFactor() const wxOVERRIDE;
 
     // Mac-specific functions
     // ----------------------

--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -529,8 +529,10 @@ public:
         return wxSize( wxMax( client.x, best.x ), wxMax( client.y, best.y ) );
     }
 
-    // returns the magnification of the content of this window
-    // e.g. 2.0 for a window on a retina screen
+    // Return the magnification of the content of this window for the platforms
+    // using logical pixels different from physical ones, i.e. those for which
+    // wxHAVE_DPI_INDEPENDENT_PIXELS is defined. For the other ones, always
+    // returns 1, regardless of DPI scale factor returned by the function below.
     virtual double GetContentScaleFactor() const;
 
     // Return the ratio of the DPI used by this window to the standard DPI,

--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -533,6 +533,10 @@ public:
     // e.g. 2.0 for a window on a retina screen
     virtual double GetContentScaleFactor() const;
 
+    // Return the ratio of the DPI used by this window to the standard DPI,
+    // e.g. 1 for standard DPI screens and 2 for "200% scaling".
+    double GetDPIScaleFactor() const;
+
     // return the size of the left/right and top/bottom borders in x and y
     // components of the result respectively
     virtual wxSize GetWindowBorderSize() const;
@@ -957,7 +961,7 @@ public:
         // DPI-independent pixels, or DIPs, are pixel values for the standard
         // 96 DPI display, they are scaled to take the current resolution into
         // account (i.e. multiplied by the same factor as returned by
-        // GetContentScaleFactor()) if necessary for the current platform.
+        // GetDPIScaleFactor()) if necessary for the current platform.
         //
         // To support monitor-specific resolutions, prefer using the non-static
         // member functions or use a valid (non-null) window pointer.

--- a/interface/wx/glcanvas.h
+++ b/interface/wx/glcanvas.h
@@ -752,7 +752,7 @@ enum
     platforms where wxWindow uses logical pixels, affected by the coordinate
     scaling, on high DPI displays. Thus, if you want to set the OpenGL view
     port to the size of entire window, you must multiply the result returned by
-    wxWindow::GetClientSize() by wxGLCanvas::GetOpenGLScaleFactor() before
+    wxWindow::GetClientSize() by wxGLCanvas::GetContentScaleFactor() before
     passing it to @c glViewport(). Same considerations apply to other OpenGL
     functions and other coordinates, notably those retrieved from wxMouseEvent
     in the event handlers.
@@ -935,23 +935,6 @@ public:
         @return @false if an error occurred.
     */
     bool SetCurrent(const wxGLContext& context) const;
-
-    /**
-        Returns the scale factor for transformation between logical and
-        physical OpenGL coordinates.
-
-        This factor is always 1 on the platforms where logical pixels are the
-        same as physical ones, in any DPI (such as MSW), but can be different
-        from it on the platforms where logical and physical pixels may differ
-        due to DPI scaling (such as GTK 3 or macOS).
-
-        To handle the differences between the platforms, always multiply the
-        values expressed in window coordinates (window sizes, mouse position
-        etc) by this factor before passing them to OpenGL functions.
-
-        @since 3.1.4
-    */
-    double GetOpenGLScaleFactor() const;
 
     /**
         Swaps the double-buffer of this window, making the back-buffer the

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -1034,7 +1034,7 @@ public:
 
         A DPI-independent pixel is just a pixel at the standard 96 DPI
         resolution. To keep the same physical size at higher resolution, the
-        physical pixel value must be scaled by GetContentScaleFactor() but this
+        physical pixel value must be scaled by GetDPIScaleFactor() but this
         scaling may be already done by the underlying toolkit (GTK+, Cocoa,
         ...) automatically. This method performs the conversion only if it is
         not already done by the lower level toolkit and so by using it with
@@ -1110,7 +1110,7 @@ public:
 
     A DPI-independent pixel is just a pixel at the standard 96 DPI
     resolution. To keep the same physical size at higher resolution, the
-    physical pixel value must be scaled by GetContentScaleFactor() but this
+    physical pixel value must be scaled by GetDPIScaleFactor() but this
     scaling may be already done by the underlying toolkit (GTK+, Cocoa,
     ...) automatically. This method performs the conversion only if it is
     not already done by the lower level toolkit, For example, you may
@@ -1379,8 +1379,20 @@ public:
        Returns the magnification of the backing store of this window, eg 2.0
        for a window on a retina screen.
 
-       This factor should be used to determine the size of bitmaps and similar
-       "content-containing" windows appropriate for the current resolution.
+       @since 2.9.5
+    */
+    double GetContentScaleFactor() const;
+
+    /**
+       Returns the ratio of the DPI used by this window to the standard DPI.
+
+       The returned value is 1 for standard DPI screens or 2 for "200%
+       scaling".
+
+       This factor should be used to increase the size of icons and similar
+       windows whose best size is not based on text metrics when using DPI
+       scaling.
+
        E.g. the program may load a 32px bitmap if the content scale factor is
        1.0 or 64px version of the same bitmap if it is 2.0 or bigger.
 
@@ -1388,9 +1400,9 @@ public:
        are already scaled by this factor by the underlying toolkit under some
        platforms. Use FromDIP() for anything window-related instead.
 
-       @since 2.9.5
-    */
-    double GetContentScaleFactor() const;
+        @since 3.1.4
+     */
+    double GetDPIScaleFactor() const;
 
     /**
         Returns the size of the left/right and top/bottom borders of this window in x

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -1376,8 +1376,29 @@ public:
     virtual wxSize GetBestVirtualSize() const;
 
     /**
-       Returns the magnification of the backing store of this window, eg 2.0
-       for a window on a retina screen.
+       Returns the factor mapping logical pixels of this window to physical
+       pixels.
+
+       This function can be used to portably determine the number of physical
+       pixels in a window of the given size, by multiplying the window size by
+       the value returned from it. I.e. it returns the factor converting window
+       coordinates to "content view" coordinates, where the view can be just a
+       simple window displaying a wxBitmap or wxGLCanvas or any other kind of
+       window rendering arbitrary "content" on screen.
+
+       For the platforms not doing any pixel mapping, i.e. where logical and
+       physical pixels are one and the same, this function always returns 1.0
+       and so using it is, in principle, unnecessary and could be avoided by
+       using preprocessor check for @c wxHAVE_DPI_INDEPENDENT_PIXELS @e not
+       being defined, however using this function unconditionally under all
+       platforms is usually simpler and so preferable.
+
+       @note Current behaviour of this function is compatible with wxWidgets
+           3.0, but different from its behaviour in versions 3.1.0 to 3.1.3,
+           where it returned the same value as GetDPIScaleFactor(). Please use
+           the other function if you need to use a scaling factor greater than
+           1.0 even for the platforms without @c wxHAVE_DPI_INDEPENDENT_PIXELS,
+           such as wxMSW.
 
        @since 2.9.5
     */
@@ -1387,7 +1408,8 @@ public:
        Returns the ratio of the DPI used by this window to the standard DPI.
 
        The returned value is 1 for standard DPI screens or 2 for "200%
-       scaling".
+       scaling" and, unlike for GetContentScaleFactor(), is the same under all
+       platforms.
 
        This factor should be used to increase the size of icons and similar
        windows whose best size is not based on text metrics when using DPI
@@ -1396,9 +1418,10 @@ public:
        E.g. the program may load a 32px bitmap if the content scale factor is
        1.0 or 64px version of the same bitmap if it is 2.0 or bigger.
 
-       Notice that this method should @e not be used for window sizes, as they
-       are already scaled by this factor by the underlying toolkit under some
-       platforms. Use FromDIP() for anything window-related instead.
+       Notice that this method should @e not be used for window sizes expressed
+       in pixels, as they are already scaled by this factor by the underlying
+       toolkit under some platforms. Use FromDIP() for anything window-related
+       instead.
 
         @since 3.1.4
      */

--- a/samples/opengl/cube/cube.cpp
+++ b/samples/opengl/cube/cube.cpp
@@ -349,7 +349,7 @@ void TestGLCanvas::OnPaint(wxPaintEvent& WXUNUSED(event))
     // multiple canvases: If we updated the viewport in the wxSizeEvent
     // handler, changing the size of one canvas causes a viewport setting that
     // is wrong when next another canvas is repainted.
-    const wxSize ClientSize = GetClientSize() * GetOpenGLScaleFactor();
+    const wxSize ClientSize = GetClientSize() * GetContentScaleFactor();
 
     TestGLContext& canvas = wxGetApp().GetContext(this, m_useStereo);
     glViewport(0, 0, ClientSize.x, ClientSize.y);

--- a/samples/opengl/isosurf/isosurf.cpp
+++ b/samples/opengl/isosurf/isosurf.cpp
@@ -280,7 +280,7 @@ void TestGLCanvas::OnSize(wxSizeEvent& event)
     // This is OK here only because there is only one canvas that uses the
     // context. See the cube sample for that case that multiple canvases are
     // made current with one context.
-    const wxSize size = event.GetSize() * GetOpenGLScaleFactor();
+    const wxSize size = event.GetSize() * GetContentScaleFactor();
     glViewport(0, 0, size.x, size.y);
 }
 

--- a/samples/opengl/penguin/penguin.cpp
+++ b/samples/opengl/penguin/penguin.cpp
@@ -306,7 +306,7 @@ void TestGLCanvas::ResetProjectionMode()
     // or more than one wxGLContext in the application.
     SetCurrent(*m_glRC);
 
-    const wxSize ClientSize = GetClientSize() * GetOpenGLScaleFactor();
+    const wxSize ClientSize = GetClientSize() * GetContentScaleFactor();
 
     // It's up to the application code to update the OpenGL viewport settings.
     // In order to avoid extensive context switching, consider doing this in

--- a/samples/opengl/pyramid/pyramid.cpp
+++ b/samples/opengl/pyramid/pyramid.cpp
@@ -565,7 +565,7 @@ void MyGLCanvas::OnSize(wxSizeEvent& event)
     SetCurrent(*m_oglContext);
 
     // It's up to the application code to update the OpenGL viewport settings.
-    const wxSize size = event.GetSize() * GetOpenGLScaleFactor();
+    const wxSize size = event.GetSize() * GetContentScaleFactor();
     m_winHeight = size.y;
     m_oglManager->SetViewport(0, 0, size.x, m_winHeight);
 

--- a/src/aui/dockart.cpp
+++ b/src/aui/dockart.cpp
@@ -802,7 +802,7 @@ void wxAuiDefaultDockArt::DrawPaneButton(wxDC& dc,
             break;
     }
 
-    wxAuiScaleBitmap(bmp, window->GetContentScaleFactor());
+    wxAuiScaleBitmap(bmp, window->GetDPIScaleFactor());
 
     wxRect rect = _rect;
 

--- a/src/aui/tabart.cpp
+++ b/src/aui/tabart.cpp
@@ -578,7 +578,7 @@ void wxAuiGenericTabArt::DrawTab(wxDC& dc,
             bmp = m_activeCloseBmp;
         }
 
-        wxAuiScaleBitmap(bmp, wnd->GetContentScaleFactor());
+        wxAuiScaleBitmap(bmp, wnd->GetDPIScaleFactor());
 
         int offsetY = tab_y-1;
         if (m_flags & wxAUI_NB_BOTTOM)
@@ -755,7 +755,7 @@ void wxAuiGenericTabArt::DrawButton(wxDC& dc,
     if (!bmp.IsOk())
         return;
 
-    wxAuiScaleBitmap(bmp, wnd->GetContentScaleFactor());
+    wxAuiScaleBitmap(bmp, wnd->GetDPIScaleFactor());
 
     rect = in_rect;
 
@@ -1125,7 +1125,7 @@ void wxAuiSimpleTabArt::DrawTab(wxDC& dc,
         else
             bmp = m_disabledCloseBmp;
 
-        wxAuiScaleBitmap(bmp, wnd->GetContentScaleFactor());
+        wxAuiScaleBitmap(bmp, wnd->GetDPIScaleFactor());
 
         wxRect rect(tab_x + tab_width - bmp.GetScaledWidth() - 1,
                     tab_y + (tab_height/2) - (bmp.GetScaledHeight()/2) + 1,
@@ -1273,7 +1273,7 @@ void wxAuiSimpleTabArt::DrawButton(wxDC& dc,
     if (!bmp.IsOk())
         return;
 
-    wxAuiScaleBitmap(bmp, wnd->GetContentScaleFactor());
+    wxAuiScaleBitmap(bmp, wnd->GetDPIScaleFactor());
 
     rect = in_rect;
 

--- a/src/common/dcsvg.cpp
+++ b/src/common/dcsvg.cpp
@@ -358,7 +358,13 @@ wxString CreateBrushFill(const wxBrush& brush, wxSVGShapeRenderingMode mode)
 
 void SetScaledScreenDCFont(wxScreenDC& sDC, const wxFont& font)
 {
-    const double scale = sDC.GetContentScaleFactor();
+    // When using DPI-independent pixels, the results of GetTextExtent() and
+    // similar don't depend on DPI anyhow.
+#ifndef wxHAVE_DPI_INDEPENDENT_PIXELS
+    static const int SVG_DPI = 96;
+
+    const double screenDPI = sDC.GetPPI().y;
+    const double scale = screenDPI / SVG_DPI;
     if ( scale > 1 )
     {
         // wxScreenDC uses the DPI of the main screen to determine the text
@@ -373,6 +379,7 @@ void SetScaledScreenDCFont(wxScreenDC& sDC, const wxFont& font)
         sDC.SetFont(scaledFont);
     }
     else
+#endif // !wxHAVE_DPI_INDEPENDENT_PIXELS
     {
         sDC.SetFont(font);
     }

--- a/src/common/glcmn.cpp
+++ b/src/common/glcmn.cpp
@@ -376,11 +376,6 @@ bool wxGLCanvasBase::ParseAttribList(const int *attribList,
     return true;
 }
 
-double wxGLCanvasBase::GetOpenGLScaleFactor() const
-{
-    return 1.0;
-}
-
 // ============================================================================
 // compatibility layer for OpenGL 3 and OpenGL ES
 // ============================================================================

--- a/src/common/sizer.cpp
+++ b/src/common/sizer.cpp
@@ -111,7 +111,7 @@ float wxSizerFlags::DoGetDefaultBorderInPx()
     if ( s_defaultBorderInPx.HasChanged(win) )
     {
         s_defaultBorderInPx.SetAtNewDPI(
-            (float)(5 * (win ? win->GetContentScaleFactor() : 1)));
+            (float)(5 * (win ? win->GetDPIScaleFactor() : 1.0)));
     }
     return s_defaultBorderInPx.Get();
 }

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -101,9 +101,12 @@ bool IsInCaptureStack(wxWindowBase* win);
 
 } // wxMouseCapture
 
-// We consider 96 DPI to be the standard value, this is correct at least for
-// MSW, but could conceivably need adjustment for the other platforms.
+// Most platforms use 96 DPI by default, but Mac traditionally uses 72.
+#ifdef __WXOSX__
+static const int BASELINE_DPI = 72;
+#else
 static const int BASELINE_DPI = 96;
+#endif
 
 // ----------------------------------------------------------------------------
 // static data
@@ -808,6 +811,11 @@ static wxSize GetDPIHelper(const wxWindowBase* w)
 }
 
 double wxWindowBase::GetContentScaleFactor() const
+{
+    return GetDPIScaleFactor();
+}
+
+double wxWindowBase::GetDPIScaleFactor() const
 {
     const wxSize dpi = GetDPIHelper(this);
 

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -812,7 +812,12 @@ static wxSize GetDPIHelper(const wxWindowBase* w)
 
 double wxWindowBase::GetContentScaleFactor() const
 {
-    return GetDPIScaleFactor();
+    // By default, we assume that there is no mapping between logical and
+    // physical pixels and so the content scale factor is just 1. Only the
+    // platforms that do perform such mapping (currently ports for Apple
+    // platforms and GTK 3) override this function to return something
+    // different.
+    return 1.0;
 }
 
 double wxWindowBase::GetDPIScaleFactor() const

--- a/src/gtk/glcanvas.cpp
+++ b/src/gtk/glcanvas.cpp
@@ -271,13 +271,4 @@ void wxGLCanvas::GTKInitImplicitContext()
 
 #endif // WXWIN_COMPATIBILITY_2_8
 
-double wxGLCanvas::GetOpenGLScaleFactor() const
-{
-#ifdef __WXGTK3__
-    return GetContentScaleFactor();
-#else
-    return 1.0;
-#endif
-}
-
 #endif // wxUSE_GLCANVAS

--- a/src/html/htmlwin.cpp
+++ b/src/html/htmlwin.cpp
@@ -493,7 +493,7 @@ bool wxHtmlWindow::DoSetPage(const wxString& source)
 
     double pixelScale = 1.0;
 #ifndef wxHAVE_DPI_INDEPENDENT_PIXELS
-    pixelScale = GetContentScaleFactor();
+    pixelScale = GetDPIScaleFactor();
 #endif
 
     m_Parser->SetDC(&dc, pixelScale, 1.0);

--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -2555,11 +2555,6 @@ wxSize wxMSWDCImpl::GetPPI() const
     return ppi;
 }
 
-double wxMSWDCImpl::GetContentScaleFactor() const
-{
-    return GetPPI().y / 96.0;
-}
-
 // ----------------------------------------------------------------------------
 // DC caching
 // ----------------------------------------------------------------------------

--- a/src/osx/glcanvas_osx.cpp
+++ b/src/osx/glcanvas_osx.cpp
@@ -562,11 +562,6 @@ bool wxGLCanvas::IsAGLMultiSampleAvailable()
     return s_isMultiSampleAvailable != 0;
 }
 
-double wxGLCanvas::GetOpenGLScaleFactor() const
-{
-    return GetContentScaleFactor();
-}
-
 /* static */
 bool wxGLCanvasBase::IsDisplaySupported(const wxGLAttributes& dispAttrs)
 {

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -4610,7 +4610,7 @@ void wxPropertyGrid::OnResize( wxSizeEvent& event )
 
     if ( !HasExtraStyle(wxPG_EX_NATIVE_DOUBLE_BUFFERING) )
     {
-        double scaleFactor = GetContentScaleFactor();
+        double scaleFactor = GetDPIScaleFactor();
         int dblh = (m_lineHeight*2);
         if ( !m_doubleBuffer )
         {

--- a/src/richtext/richtextbuffer.cpp
+++ b/src/richtext/richtextbuffer.cpp
@@ -12687,11 +12687,8 @@ bool wxRichTextImage::LoadAndScaleImageCache(wxImage& image, const wxSize& sz, w
         else
         {
             double scaleFactor = 1.0;
-            // Scaled bitmaps only work on Mac currently
-#ifdef __WXOSX_COCOA__
             if (context.GetBuffer() && context.GetBuffer()->GetRichTextCtrl())
                 scaleFactor = context.GetBuffer()->GetRichTextCtrl()->GetContentScaleFactor();
-#endif
 
             // If the original width and height is small, e.g. 400 or below,
             // scale up and then down to improve image quality. This can make

--- a/src/stc/PlatWX.cpp
+++ b/src/stc/PlatWX.cpp
@@ -301,12 +301,8 @@ void SurfaceImpl::InitPixMap(int width, int height, Surface *surface, WindowID w
     hdcOwned = true;
     if (width < 1) width = 1;
     if (height < 1) height = 1;
-#ifdef __WXMSW__
-    bitmap = new wxBitmap(width, height);
-#else
     bitmap = new wxBitmap();
     bitmap->CreateScaled(width, height,wxBITMAP_SCREEN_DEPTH,(GETWIN(winid))->GetContentScaleFactor());
-#endif
     mdc->SelectObject(*bitmap);
 }
 


### PR DESCRIPTION
This reverts `wxWindow::GetContentScaleFactor()` back to what it did in 3.0 and adds new `GetDPIScalingFactor()` which can be used to retrieve the DPI scaling on all platforms.

This allows to get rid of some preprocessor checks (although not all, unfortunately).