### PR TITLE
slidertest: enable _Thumb_ test under GTK

### DIFF
--- a/tests/controls/slidertest.cpp
+++ b/tests/controls/slidertest.cpp
@@ -188,7 +188,7 @@ void SliderTestCase::Range()
 
 void SliderTestCase::Thumb()
 {
-#if wxUSE_UIACTIONSIMULATOR && !defined(__WXGTK__)
+#if wxUSE_UIACTIONSIMULATOR
     EventCounter track(m_slider, wxEVT_SCROLL_THUMBTRACK);
     EventCounter release(m_slider, wxEVT_SCROLL_THUMBRELEASE);
     EventCounter changed(m_slider, wxEVT_SCROLL_CHANGED);
@@ -197,12 +197,14 @@ void SliderTestCase::Thumb()
 
     m_slider->SetValue(0);
 
-    sim.MouseDragDrop(m_slider->ClientToScreen(wxPoint(10, 10)),m_slider->ClientToScreen(wxPoint(50, 10)));
+    // use the slider real position for dragging the mouse.
+    const int ypos = m_slider->GetSize().y / 2;
+    sim.MouseDragDrop(m_slider->ClientToScreen(wxPoint(10, ypos)),m_slider->ClientToScreen(wxPoint(50, ypos)));
     wxYield();
 
     CPPUNIT_ASSERT(track.GetCount() != 0);
     CPPUNIT_ASSERT_EQUAL(1, release.GetCount());
-#ifdef __WXMSW__
+#if defined(__WXMSW__) || defined(__WXGTK__)
     CPPUNIT_ASSERT_EQUAL(1, changed.GetCount());
 #endif
 #endif


### PR DESCRIPTION
Should wxSlider override DoGetBestSize() ?

**Before:**
![slidertest_before](https://user-images.githubusercontent.com/7704771/88309802-c19cd480-cd06-11ea-96ac-80ece1eb07c6.png)

**After:**
![slidertest_after](https://user-images.githubusercontent.com/7704771/88309820-c9f50f80-cd06-11ea-967f-3fd011208579.png)
