### PR TITLE
Add header test to CMake and resolve warnings

### DIFF
--- a/build/cmake/tests/CMakeLists.txt
+++ b/build/cmake/tests/CMakeLists.txt
@@ -14,5 +14,6 @@ if(wxUSE_GUI AND wxBUILD_TESTS STREQUAL "ALL")
 
 add_subdirectory(drawing)
 add_subdirectory(gui)
+add_subdirectory(headers)
 
 endif()

--- a/build/cmake/tests/headers/CMakeLists.txt
+++ b/build/cmake/tests/headers/CMakeLists.txt
@@ -1,0 +1,25 @@
+#############################################################################
+# Name:        build/cmake/tests/headers/CMakeLists.txt
+# Purpose:     CMake file for headers test
+# Author:      Maarten Bent
+# Created:     2020-07-23
+# Copyright:   (c) 2020 wxWidgets development team
+# Licence:     wxWindows licence
+#############################################################################
+
+set(TEST_SRC
+    test.cpp
+    testableframe.cpp
+    allheaders.cpp
+
+    testprec.h
+    testableframe.h
+    allheaders.h
+    )
+
+wx_add_test(test_headers ${TEST_SRC})
+wx_exe_link_libraries(test_headers wxcore)
+if(wxUSE_SOCKETS)
+    wx_exe_link_libraries(test_headers wxnet)
+endif()
+wx_test_enable_precomp(test_headers)

--- a/demos/forty/scoredg.cpp
+++ b/demos/forty/scoredg.cpp
@@ -85,7 +85,7 @@ void ScoreCanvas::OnDraw(wxDC& dc)
 {
     dc.SetFont(* m_font);
 
-    const wxChar* str = m_text;
+    const wxChar* str = m_text.c_str();
     unsigned int tab = 0;
     unsigned int tabstops[] = { 5, 100, 150, 200 };
 
@@ -106,7 +106,7 @@ void ScoreCanvas::OnDraw(wxDC& dc)
         while (*str && *str >= ' ') *dest++ = *str++;
         *dest = '\0';
 
-        dc.DrawText(text, tabstops[tab], y);
+        dc.DrawText(text, FromDIP(tabstops[tab]), y);
 
         if (*str == '\t')
         {
@@ -131,8 +131,7 @@ wxEND_EVENT_TABLE()
 
 ScoreDialog::ScoreDialog(wxWindow* parent, ScoreFile* file) :
     wxDialog(parent, wxID_ANY, _("Scores"),
-            wxDefaultPosition, wxSize(400, 300)),
-    m_scoreFile(file)
+            wxDefaultPosition, wxSize(400, 300))
 {
     // create grid with players
     wxArrayString players;
@@ -177,7 +176,7 @@ ScoreDialog::ScoreDialog(wxWindow* parent, ScoreFile* file) :
     list->EnableEditing(false);
     sz.x = wxDefaultCoord;
 #else
-    ScoreCanvas* list = new ScoreCanvas(this, m_scoreFile, wxDefaultPosition, sz);
+    ScoreCanvas* list = new ScoreCanvas(this, file, wxDefaultPosition, sz);
 #endif
 
     list->SetInitialSize(sz);

--- a/demos/forty/scoredg.h
+++ b/demos/forty/scoredg.h
@@ -24,9 +24,6 @@ protected:
     void OnCloseWindow(wxCloseEvent& event);
 
 private:
-    ScoreFile* m_scoreFile;
-    wxButton* m_OK;
-
     wxDECLARE_EVENT_TABLE();
 };
 

--- a/include/wx/msw/nonownedwnd.h
+++ b/include/wx/msw/nonownedwnd.h
@@ -22,7 +22,7 @@ public:
     wxNonOwnedWindow();
     virtual ~wxNonOwnedWindow();
 
-    virtual bool Reparent(wxWindowBase* newParent);
+    virtual bool Reparent(wxWindowBase* newParent) wxOVERRIDE;
     virtual void InheritAttributes() wxOVERRIDE;
 
 protected:

--- a/tests/allheaders.h
+++ b/tests/allheaders.h
@@ -5,13 +5,17 @@
     Excluded headers:
 
     #include <wx/catch_cppunit.h>
+    #include <wx/dvrenderers.h>
     #include <wx/fmappriv.h>
     #include <wx/setup_inc.h>
     #include <wx/setup_redirect.h>
     #include <wx/variantbase.h>
-    #include <wx/xpmhand.h>
     #include <wx/vms_x_fix.h>
+    #include <wx/xpmhand.h>
 */
+
+#include <wx/beforestd.h>
+#include <wx/afterstd.h>
 
 #include <wx/aboutdlg.h>
 #include <wx/accel.h>
@@ -20,7 +24,6 @@
 #include <wx/addremovectrl.h>
 #include <wx/affinematrix2dbase.h>
 #include <wx/affinematrix2d.h>
-#include <wx/afterstd.h>
 #include <wx/anidecod.h>
 #include <wx/animate.h>
 #include <wx/animdecod.h>
@@ -36,7 +39,6 @@
 #include <wx/atomic.h>
 #include <wx/bannerwindow.h>
 #include <wx/base64.h>
-#include <wx/beforestd.h>
 #include <wx/bitmap.h>
 #include <wx/bmpbuttn.h>
 #include <wx/bmpcbox.h>


### PR DESCRIPTION
Add the new test from #1312 to CMake, and fix a warning for wrong order of includes.
Resolve a missing override warning.
Resolve some warnings and build issues in Forty demo.

And I added a (temporary) workaround for building with stl enabled in VS2019 16.6, see https://groups.google.com/forum/#!topic/wx-dev/ztNxkmqafMc for details.

