### PR TITLE
Suppress -Wsuggest-override warnings in user code for GCC the same as…

### DIFF
--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -710,8 +710,12 @@ typedef short int WXTYPE;
 
 /* Specific maros for -Wsuggest-override warning, new in gcc 5. */
 #if defined(__clang__)
-#   define wxWARNING_SUPPRESS_MISSING_OVERRIDE() wxCLANG_WARNING_SUPPRESS(suggest-override)
-#   define wxWARNING_RESTORE_MISSING_OVERRIDE() wxCLANG_WARNING_RESTORE(suggest-override)
+#   define wxWARNING_SUPPRESS_MISSING_OVERRIDE() \
+        wxCLANG_WARNING_SUPPRESS(suggest-override) \
+        wxCLANG_WARNING_SUPPRESS(inconsistent-missing-override)
+#   define wxWARNING_RESTORE_MISSING_OVERRIDE() \
+        wxCLANG_WARNING_RESTORE(inconsistent-missing-override) \
+        wxCLANG_WARNING_RESTORE(suggest-override)
 #elif wxCHECK_GCC_VERSION(5, 0)
 #   define wxWARNING_SUPPRESS_MISSING_OVERRIDE() wxGCC_WARNING_SUPPRESS(suggest-override)
 #   define wxWARNING_RESTORE_MISSING_OVERRIDE() wxGCC_WARNING_RESTORE(suggest-override)

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -708,6 +708,18 @@ typedef short int WXTYPE;
 #    define wxCLANG_WARNING_RESTORE(x)
 #endif
 
+/* Specific maros for -Wsuggest-override warning, new in gcc 5. */
+#if defined(__clang__)
+#   define wxWARNING_SUPPRESS_MISSING_OVERRIDE() wxCLANG_WARNING_SUPPRESS(suggest-override)
+#   define wxWARNING_RESTORE_MISSING_OVERRIDE() wxCLANG_WARNING_RESTORE(suggest-override)
+#elif wxCHECK_GCC_VERSION(5, 0)
+#   define wxWARNING_SUPPRESS_MISSING_OVERRIDE() wxGCC_WARNING_SUPPRESS(suggest-override)
+#   define wxWARNING_RESTORE_MISSING_OVERRIDE() wxGCC_WARNING_RESTORE(suggest-override)
+#else
+#   define wxWARNING_SUPPRESS_MISSING_OVERRIDE()
+#   define wxWARNING_RESTORE_MISSING_OVERRIDE()
+#endif
+
 /*
     Combination of the two variants above: should be used for deprecated
     functions which are defined inline and are used by wxWidgets itself.

--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -4273,12 +4273,10 @@ typedef void (wxEvtHandler::*wxPressAndTapEventFunction)(wxPressAndTapEvent&);
     private:                                                            \
         static const wxEventTableEntry sm_eventTableEntries[];          \
     protected:                                                          \
-        wxCLANG_WARNING_SUPPRESS(inconsistent-missing-override)         \
         wxWARNING_SUPPRESS_MISSING_OVERRIDE()                           \
         const wxEventTable* GetEventTable() const;                      \
         wxEventHashTable& GetEventHashTable() const;                    \
         wxWARNING_RESTORE_MISSING_OVERRIDE()                            \
-        wxCLANG_WARNING_RESTORE(inconsistent-missing-override)          \
         static const wxEventTable        sm_eventTable;                 \
         static wxEventHashTable          sm_eventHashTable
 

--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -4274,8 +4274,10 @@ typedef void (wxEvtHandler::*wxPressAndTapEventFunction)(wxPressAndTapEvent&);
         static const wxEventTableEntry sm_eventTableEntries[];          \
     protected:                                                          \
         wxCLANG_WARNING_SUPPRESS(inconsistent-missing-override)         \
+        wxGCC_WARNING_SUPPRESS(suggest-override)                        \
         const wxEventTable* GetEventTable() const;                      \
         wxEventHashTable& GetEventHashTable() const;                    \
+        wxGCC_WARNING_RESTORE(suggest-override)                         \
         wxCLANG_WARNING_RESTORE(inconsistent-missing-override)          \
         static const wxEventTable        sm_eventTable;                 \
         static wxEventHashTable          sm_eventHashTable

--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -4274,10 +4274,10 @@ typedef void (wxEvtHandler::*wxPressAndTapEventFunction)(wxPressAndTapEvent&);
         static const wxEventTableEntry sm_eventTableEntries[];          \
     protected:                                                          \
         wxCLANG_WARNING_SUPPRESS(inconsistent-missing-override)         \
-        wxGCC_WARNING_SUPPRESS(suggest-override)                        \
+        wxWARNING_SUPPRESS_MISSING_OVERRIDE()                           \
         const wxEventTable* GetEventTable() const;                      \
         wxEventHashTable& GetEventHashTable() const;                    \
-        wxGCC_WARNING_RESTORE(suggest-override)                         \
+        wxWARNING_RESTORE_MISSING_OVERRIDE()                            \
         wxCLANG_WARNING_RESTORE(inconsistent-missing-override)          \
         static const wxEventTable        sm_eventTable;                 \
         static wxEventHashTable          sm_eventHashTable

--- a/include/wx/richtext/richtextuicustomization.h
+++ b/include/wx/richtext/richtextuicustomization.h
@@ -104,13 +104,13 @@ protected:
 
 #define DECLARE_HELP_PROVISION() \
     wxCLANG_WARNING_SUPPRESS(inconsistent-missing-override) \
-    wxGCC_WARNING_SUPPRESS(suggest-override) \
+    wxWARNING_SUPPRESS_MISSING_OVERRIDE() \
     virtual long GetHelpId() const { return sm_helpInfo.GetHelpId(); } \
     virtual void SetHelpId(long id) { sm_helpInfo.SetHelpId(id); } \
     virtual wxRichTextUICustomization* GetUICustomization() const { return sm_helpInfo.GetUICustomization(); } \
     virtual void SetUICustomization(wxRichTextUICustomization* customization) { sm_helpInfo.SetUICustomization(customization); } \
     virtual bool ShowHelp(wxWindow* win) { return sm_helpInfo.ShowHelp(win); } \
-    wxGCC_WARNING_RESTORE(suggest-override) \
+    wxWARNING_RESTORE_MISSING_OVERRIDE() \
     wxCLANG_WARNING_RESTORE(inconsistent-missing-override) \
 public: \
     static wxRichTextHelpInfo& GetHelpInfo() { return sm_helpInfo; }\

--- a/include/wx/richtext/richtextuicustomization.h
+++ b/include/wx/richtext/richtextuicustomization.h
@@ -104,11 +104,13 @@ protected:
 
 #define DECLARE_HELP_PROVISION() \
     wxCLANG_WARNING_SUPPRESS(inconsistent-missing-override) \
+    wxGCC_WARNING_SUPPRESS(suggest-override) \
     virtual long GetHelpId() const { return sm_helpInfo.GetHelpId(); } \
     virtual void SetHelpId(long id) { sm_helpInfo.SetHelpId(id); } \
     virtual wxRichTextUICustomization* GetUICustomization() const { return sm_helpInfo.GetUICustomization(); } \
     virtual void SetUICustomization(wxRichTextUICustomization* customization) { sm_helpInfo.SetUICustomization(customization); } \
     virtual bool ShowHelp(wxWindow* win) { return sm_helpInfo.ShowHelp(win); } \
+    wxGCC_WARNING_RESTORE(suggest-override) \
     wxCLANG_WARNING_RESTORE(inconsistent-missing-override) \
 public: \
     static wxRichTextHelpInfo& GetHelpInfo() { return sm_helpInfo; }\

--- a/include/wx/richtext/richtextuicustomization.h
+++ b/include/wx/richtext/richtextuicustomization.h
@@ -103,7 +103,6 @@ protected:
 /// of the formatting dialog.
 
 #define DECLARE_HELP_PROVISION() \
-    wxCLANG_WARNING_SUPPRESS(inconsistent-missing-override) \
     wxWARNING_SUPPRESS_MISSING_OVERRIDE() \
     virtual long GetHelpId() const { return sm_helpInfo.GetHelpId(); } \
     virtual void SetHelpId(long id) { sm_helpInfo.SetHelpId(id); } \
@@ -111,7 +110,6 @@ protected:
     virtual void SetUICustomization(wxRichTextUICustomization* customization) { sm_helpInfo.SetUICustomization(customization); } \
     virtual bool ShowHelp(wxWindow* win) { return sm_helpInfo.ShowHelp(win); } \
     wxWARNING_RESTORE_MISSING_OVERRIDE() \
-    wxCLANG_WARNING_RESTORE(inconsistent-missing-override) \
 public: \
     static wxRichTextHelpInfo& GetHelpInfo() { return sm_helpInfo; }\
 protected: \

--- a/include/wx/rtti.h
+++ b/include/wx/rtti.h
@@ -141,9 +141,9 @@ WXDLLIMPEXP_BASE wxObject *wxCreateDynamicObject(const wxString& name);
     public:                                                                   \
         static wxClassInfo ms_classInfo;                                      \
         wxCLANG_WARNING_SUPPRESS(inconsistent-missing-override)               \
-        wxGCC_WARNING_SUPPRESS(suggest-override)                              \
+        wxWARNING_SUPPRESS_MISSING_OVERRIDE()                                 \
         virtual wxClassInfo *GetClassInfo() const;                            \
-        wxGCC_WARNING_RESTORE(suggest-override)                               \
+        wxWARNING_RESTORE_MISSING_OVERRIDE()                                  \
         wxCLANG_WARNING_RESTORE(inconsistent-missing-override)
 
 #define wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(name)                               \

--- a/include/wx/rtti.h
+++ b/include/wx/rtti.h
@@ -141,7 +141,9 @@ WXDLLIMPEXP_BASE wxObject *wxCreateDynamicObject(const wxString& name);
     public:                                                                   \
         static wxClassInfo ms_classInfo;                                      \
         wxCLANG_WARNING_SUPPRESS(inconsistent-missing-override)               \
-        virtual wxClassInfo *GetClassInfo() const                             \
+        wxGCC_WARNING_SUPPRESS(suggest-override)                              \
+        virtual wxClassInfo *GetClassInfo() const;                            \
+        wxGCC_WARNING_RESTORE(suggest-override)                               \
         wxCLANG_WARNING_RESTORE(inconsistent-missing-override)
 
 #define wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(name)                               \

--- a/include/wx/rtti.h
+++ b/include/wx/rtti.h
@@ -140,11 +140,9 @@ WXDLLIMPEXP_BASE wxObject *wxCreateDynamicObject(const wxString& name);
 #define wxDECLARE_ABSTRACT_CLASS(name)                                        \
     public:                                                                   \
         static wxClassInfo ms_classInfo;                                      \
-        wxCLANG_WARNING_SUPPRESS(inconsistent-missing-override)               \
         wxWARNING_SUPPRESS_MISSING_OVERRIDE()                                 \
         virtual wxClassInfo *GetClassInfo() const;                            \
-        wxWARNING_RESTORE_MISSING_OVERRIDE()                                  \
-        wxCLANG_WARNING_RESTORE(inconsistent-missing-override)
+        wxWARNING_RESTORE_MISSING_OVERRIDE()
 
 #define wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(name)                               \
     wxDECLARE_NO_ASSIGN_CLASS(name);                                          \


### PR DESCRIPTION
… as is done for -Winconsistent-override for clang

* This should be done also for clang when it gets the same warning in an
  actual release.