### PR TITLE
Prevent configure failures when trying to use gtk=2 and GCC's address…

### DIFF
--- a/build/aclocal/gtk-2.0.m4
+++ b/build/aclocal/gtk-2.0.m4
@@ -80,8 +80,10 @@ main ()
   tmp_version = g_strdup("$min_gtk_version");
   if (sscanf(tmp_version, "%d.%d.%d", &major, &minor, &micro) != 3) {
      printf("%s, bad version string\n", "$min_gtk_version");
+     g_free(tmp_version);
      exit(1);
    }
+  g_free(tmp_version);
 
   if ((gtk_major_version != $gtk_config_major_version) ||
       (gtk_minor_version != $gtk_config_minor_version) ||

--- a/build/aclocal/gtk.m4
+++ b/build/aclocal/gtk.m4
@@ -78,9 +78,11 @@ main ()
   /* HP/UX 9 (%@#!) writes to sscanf strings */
   tmp_version = g_strdup("$min_gtk_version");
   if (sscanf(tmp_version, "%d.%d.%d", &major, &minor, &micro) != 3) {
+     g_free(tmp_version);
      printf("%s, bad version string\n", "$min_gtk_version");
      exit(1);
    }
+  g_free(tmp_version);
 
   if ((gtk_major_version != $gtk_config_major_version) ||
       (gtk_minor_version != $gtk_config_minor_version) ||

--- a/configure
+++ b/configure
@@ -23440,8 +23440,10 @@ main ()
   tmp_version = g_strdup("$min_gtk_version");
   if (sscanf(tmp_version, "%d.%d.%d", &major, &minor, &micro) != 3) {
      printf("%s, bad version string\n", "$min_gtk_version");
+     g_free(tmp_version);
      exit(1);
    }
+  g_free(tmp_version);
 
   if ((gtk_major_version != $gtk_config_major_version) ||
       (gtk_minor_version != $gtk_config_minor_version) ||
@@ -23966,9 +23968,11 @@ main ()
   /* HP/UX 9 (%@#!) writes to sscanf strings */
   tmp_version = g_strdup("$min_gtk_version");
   if (sscanf(tmp_version, "%d.%d.%d", &major, &minor, &micro) != 3) {
+     g_free(tmp_version);
      printf("%s, bad version string\n", "$min_gtk_version");
      exit(1);
    }
+  g_free(tmp_version);
 
   if ((gtk_major_version != $gtk_config_major_version) ||
       (gtk_minor_version != $gtk_config_minor_version) ||
@@ -24238,9 +24242,11 @@ main ()
   /* HP/UX 9 (%@#!) writes to sscanf strings */
   tmp_version = g_strdup("$min_gtk_version");
   if (sscanf(tmp_version, "%d.%d.%d", &major, &minor, &micro) != 3) {
+     g_free(tmp_version);
      printf("%s, bad version string\n", "$min_gtk_version");
      exit(1);
    }
+  g_free(tmp_version);
 
   if ((gtk_major_version != $gtk_config_major_version) ||
       (gtk_minor_version != $gtk_config_minor_version) ||


### PR DESCRIPTION
… sanitizer

* I'm using this condifure command:
  ../git/configure \
    CXXFLAGS="-fsanitize=address -Werror=address -Og" \
    CFLAGS="-fsanitize=address -Werror=address -Og" \
    LDFLAGS="-fsanitize=address" \
    --enable-debug --with-gtk=2
* GCC version 9.3.0 on linux
* The failure happens because there are leaks which cause the configure
  executable to fail.