### PR TITLE
Do not try to create bitmap for default constructed Caret

### DIFF
--- a/include/wx/caret.h
+++ b/include/wx/caret.h
@@ -153,6 +153,7 @@ protected:
         m_window = window;
         m_width = width;
         m_height = height;
+        DoSize();
 
         return true;
     }

--- a/src/generic/caret.cpp
+++ b/src/generic/caret.cpp
@@ -103,7 +103,8 @@ void wxCaret::InitGeneric()
 #ifndef wxHAS_CARET_USING_OVERLAYS
     m_xOld =
     m_yOld = -1;
-    m_bmpUnderCaret.Create(m_width, m_height);
+    if (m_width && m_height)
+        m_bmpUnderCaret.Create(m_width, m_height);
 #endif
 }
 
@@ -174,7 +175,10 @@ void wxCaret::DoSize()
     m_overlay.Reset();
 #else
     // Change bitmap size
-    m_bmpUnderCaret = wxBitmap(m_width, m_height);
+    if (m_width && m_height)
+        m_bmpUnderCaret = wxBitmap(m_width, m_height);
+    else
+        m_bmpUnderCaret = wxBitmap();
 #endif
     if (countVisible > 0)
     {


### PR DESCRIPTION
If a Caret is default-constructed, the width and height are still 0,
and the wxBitmap::Create implementations expect valid sizes.