### PR TITLE
Append WX_FLAVOUR to the name of wxrc executable

### DIFF
--- a/utils/wxrc/wxrc.bkl
+++ b/utils/wxrc/wxrc.bkl
@@ -13,11 +13,11 @@
 
     <if cond="FORMAT=='autoconf'">
 
-        <!-- Install wxrc as $prefix/bin/wxrc-$version with a wxrc symlink
-             pointing to it, so that users can use wxrc from different
+        <!-- Install wxrc as $prefix/bin/wxrc-$version$flavour with a wxrc
+             symlink pointing to it, so that users can use wxrc from different
              versions. -->
 
-        <set var="versioned_name">wxrc-$(WX_RELEASE)</set>
+        <set var="versioned_name">wxrc-$(WX_RELEASE)$(WX_FLAVOUR)</set>
         <modify-target target="install_wxrc">
             <command>
                 rm -f $(DESTDIR)$(BINDIR)/wxrc$(EXEEXT) $(DESTDIR)$(BINDIR)/$(versioned_name)

--- a/wx-config.in
+++ b/wx-config.in
@@ -45,7 +45,8 @@ usage()
  wx-config [--prefix[=DIR]] [--exec-prefix[=DIR]] [--release] [--version-full]
            [--list] [--selected-config] [--host=HOST] [--toolkit=TOOLKIT]
            [--universal[=yes|no]] [--unicode[=yes|no]] [--static[=yes|no]]
-           [--debug[=yes|no]] [--version[=VERSION]] [--basename] [--cc] [--cxx]
+           [--debug[=yes|no]] [--version[=VERSION]] [--flavour=FLAVOUR]
+           [--basename] [--cc] [--cxx]
            [--cppflags [base]] [--cxxflags [base]] [--cflags]
            [--rescomp] [--linkdeps] [--ld] [--utility=UTIL]
            [--libs [LIBS...]] [--optional-libs [LIBS...]]
@@ -54,19 +55,20 @@ usage()
   your system.  It may be used to retrieve the information required to build
   applications using these libraries using --cppflags, --cxxflags, --cflags,
   and --libs options. And you may query the properties of this configuration
-  using --query-{host,toolkit,widgetset,chartype,debugtype,version,linkage}.
+  using  --query-{host,toolkit,widgetset,chartype,debugtype,version,flavour,
+  linkage}.
 
     NOTE:    Usage of --debug and --query-debugtype are only relevant if you
   have any  versions prior to 2.9 installed  and use the --version option to
   select an earlier version.
 
     If multiple builds of wxWidgets  are available,  you can use the options
-  --prefix, --host, --toolkit, --unicode, --static, --universal or --version
-  to select from them.  The  --selected-config  option shows the name of the
-  current configuration and --list  shows available alternatives which match
-  specified criteria.  The  --utility  option returns the correct version of
-  UTIL to use with the selected build.  The  --linkdeps  option returns only
-  static libraries for your makefile link rule dependencies.
+  --prefix, --host, --toolkit,  --unicode, --static, --universal,  --version
+  or --flavour to select from them.  The --selected-config option shows  the
+  name of the current configuration and --list  shows available alternatives
+  which match specified criteria.  The --utility option  returns the correct
+  version of  UTIL to use with  the selected build.  The  --linkdeps  option
+  returns only static libraries for your makefile link rule dependencies.
 
     The LIBS arguments (comma or space separated) may be used to specify the
   wxWidgets libraries that  you wish to use. The "std" label may be used  to


### PR DESCRIPTION
The name of the wxrc executable does not contain the "flavour" that was indicated to the configure script.

As the libraries are named according to the flavour, it is IMHO a good idea to let the tools follow the same rule.

FYI the [FreeBSD wxWidgets port](https://svnweb.freebsd.org/ports/head/x11-toolkits/wxgtk31/files/patch-utils-wxrc-Makefile.in?view=markup) has been marking the wxrc executable since a long time.