### PR TITLE
Do not use wxRegEx in wxCmpNaturalGeneric()

### DIFF
--- a/interface/wx/arrstr.h
+++ b/interface/wx/arrstr.h
@@ -486,9 +486,6 @@ int wxCmpNatural(const wxString& s1, const wxString& s2);
 /**
     This is wxWidgets' own implementation of the natural sort comparison function.
 
-    Requires wxRegEx, if it is unavailable numbers within strings are not
-    recognised and only case-insensitive collation is performed.
-
     @see wxCmpNatural()
 
     @since 3.1.4

--- a/src/common/arrstr.cpp
+++ b/src/common/arrstr.cpp
@@ -20,7 +20,6 @@
 #endif
 
 #include "wx/arrstr.h"
-#include "wx/regex.h"
 #include "wx/scopedarray.h"
 #include "wx/wxcrt.h"
 
@@ -729,8 +728,6 @@ wxArrayString wxSplit(const wxString& str, const wxChar sep, const wxChar escape
     return ret;
 }
 
-#if wxUSE_REGEX
-
 namespace // helpers needed by wxCmpNaturalGeneric()
 {
 // Used for comparison of string parts
@@ -759,47 +756,48 @@ struct wxStringFragment
 
 wxStringFragment GetFragment(wxString& text)
 {
-    static const wxRegEx reSpaceOrPunct(wxS("^([[:space:]]|[[:punct:]])+"));
-    // Limit the length to make sure the value will fit into a wxUint64
-    static const wxRegEx reDigit(wxS("^[[:digit:]]{1,19}"));
-    static const wxRegEx reLetterOrSymbol("^[^[:space:]|[:punct:]|[:digit:]]+");
-
     if ( text.empty() )
         return wxStringFragment();
 
-    wxStringFragment fragment;
-    size_t           length = 0;
+    wxStringFragment   fragment;
+    wxString::iterator it;
 
-    // In attempt to minimize the number of wxRegEx.Matches() calls,
-    // try to do them from the most expected to the least expected
-    // string fragment type.
-    if ( reLetterOrSymbol.Matches(text) )
+    for ( it = text.begin(); it != text.end(); ++it )
     {
-        if ( reLetterOrSymbol.GetMatch(NULL, &length) )
+        const wxChar           ch = *it;
+        wxStringFragment::Type chType = wxStringFragment::Empty;
+
+        if ( wxIsspace(ch) || wxIspunct(ch) )
+            chType = wxStringFragment::SpaceOrPunct;
+        else if ( wxIsdigit(ch) )
+            chType = wxStringFragment::Digit;
+        else
+            chType = wxStringFragment::LetterOrSymbol;
+
+        // check if evaluating the first character
+        if ( fragment.type == wxStringFragment::Empty )
         {
-            fragment.type = wxStringFragment::LetterOrSymbol;
-            fragment.text = text.Left(length);
+            fragment.type = chType;
+            continue;
         }
-    }
-    else if ( reDigit.Matches(text) )
-    {
-        if ( reDigit.GetMatch(NULL, &length) )
+
+        // stop processing when the current character has a different
+        // string fragment type than the previously processed characters had
+        // or when there is a sequence of digits too long to fit in wxUint64
+        if ( fragment.type != chType ||
+              ( fragment.type == wxStringFragment::Digit
+                 && it - text.begin() == 19) )
         {
-            fragment.type = wxStringFragment::Digit;
-            fragment.text = text.Left(length);
-            fragment.text.ToULongLong(&fragment.value);
-        }
-    }
-    else if ( reSpaceOrPunct.Matches(text) )
-    {
-        if ( reSpaceOrPunct.GetMatch(NULL, &length) )
-        {
-            fragment.type = wxStringFragment::SpaceOrPunct;
-            fragment.text = text.Left(length);
+            break;
         }
     }
 
-    text.erase(0, length);
+    fragment.text.assign(text.begin(), it);
+    if ( fragment.type == wxStringFragment::Digit )
+        fragment.text.ToULongLong(&fragment.value);
+
+    text.erase(text.begin(), it);
+
     return fragment;
 }
 
@@ -892,15 +890,6 @@ int wxCMPFUNC_CONV wxCmpNaturalGeneric(const wxString& s1, const wxString& s2)
 
     return comparison;
 }
-
-#else
-
-int wxCMPFUNC_CONV wxCmpNaturalGeneric(const wxString& s1, const wxString& s2)
-{
-    return wxStrcoll_String(s1.Lower(), s2.Lower());
-}
-
-#endif // #if wxUSE_REGEX
 
 // ----------------------------------------------------------------------------
 // Declaration of StrCmpLogicalW()

--- a/src/common/arrstr.cpp
+++ b/src/common/arrstr.cpp
@@ -761,14 +761,14 @@ wxStringFragment GetFragment(wxString& text)
 
     // the maximum length of a sequence of digits that
     // can fit into wxUint64 when converted to a number
-    static const size_t maxDigitSequenceLength = 19;
+    static const ptrdiff_t maxDigitSequenceLength = 19;
 
     wxStringFragment         fragment;
     wxString::const_iterator it;
 
-    for ( it = text.begin(); it != text.end(); ++it )
+    for ( it = text.cbegin(); it != text.cend(); ++it )
     {
-        const wxUniChar        ch = *it;
+        const wxUniChar&       ch = *it;
         wxStringFragment::Type chType = wxStringFragment::Empty;
 
         if ( wxIsspace(ch) || wxIspunct(ch) )
@@ -790,17 +790,17 @@ wxStringFragment GetFragment(wxString& text)
         // or a sequence of digits is too long
         if ( fragment.type != chType
              || (fragment.type == wxStringFragment::Digit
-                 && it - text.begin() > maxDigitSequenceLength) )
+                 && it - text.cbegin() > maxDigitSequenceLength) )
         {
             break;
         }
     }
 
-    fragment.text.assign(text.begin(), it);
+    fragment.text.assign(text.cbegin(), it);
     if ( fragment.type == wxStringFragment::Digit )
         fragment.text.ToULongLong(&fragment.value);
 
-    text.erase(0, it - text.begin());
+    text.erase(0, it - text.cbegin());
 
     return fragment;
 }

--- a/src/common/arrstr.cpp
+++ b/src/common/arrstr.cpp
@@ -760,11 +760,11 @@ wxStringFragment GetFragment(wxString& text)
         return wxStringFragment();
 
     wxStringFragment   fragment;
-    wxString::iterator it;
+    wxString::const_iterator it;
 
     for ( it = text.begin(); it != text.end(); ++it )
     {
-        const wxChar           ch = *it;
+        const wxUniChar        ch = *it;
         wxStringFragment::Type chType = wxStringFragment::Empty;
 
         if ( wxIsspace(ch) || wxIspunct(ch) )
@@ -785,8 +785,7 @@ wxStringFragment GetFragment(wxString& text)
         // string fragment type than the previously processed characters had
         // or when there is a sequence of digits too long to fit in wxUint64
         if ( fragment.type != chType ||
-              ( fragment.type == wxStringFragment::Digit
-                 && it - text.begin() == 19) )
+             (fragment.type == wxStringFragment::Digit && it - text.begin() == 20) )
         {
             break;
         }
@@ -796,7 +795,7 @@ wxStringFragment GetFragment(wxString& text)
     if ( fragment.type == wxStringFragment::Digit )
         fragment.text.ToULongLong(&fragment.value);
 
-    text.erase(text.begin(), it);
+    text.erase(0, it - text.begin());
 
     return fragment;
 }

--- a/src/common/arrstr.cpp
+++ b/src/common/arrstr.cpp
@@ -759,7 +759,11 @@ wxStringFragment GetFragment(wxString& text)
     if ( text.empty() )
         return wxStringFragment();
 
-    wxStringFragment   fragment;
+    // the maximum length of a sequence of digits that
+    // can fit into wxUint64 when converted to a number
+    static const size_t maxDigitSequenceLength = 19;
+
+    wxStringFragment         fragment;
     wxString::const_iterator it;
 
     for ( it = text.begin(); it != text.end(); ++it )
@@ -783,9 +787,10 @@ wxStringFragment GetFragment(wxString& text)
 
         // stop processing when the current character has a different
         // string fragment type than the previously processed characters had
-        // or when there is a sequence of digits too long to fit in wxUint64
-        if ( fragment.type != chType ||
-             (fragment.type == wxStringFragment::Digit && it - text.begin() == 20) )
+        // or a sequence of digits is too long
+        if ( fragment.type != chType
+             || (fragment.type == wxStringFragment::Digit
+                 && it - text.begin() > maxDigitSequenceLength) )
         {
             break;
         }

--- a/tests/arrays/arrays.cpp
+++ b/tests/arrays/arrays.cpp
@@ -784,9 +784,6 @@ void ArraysTestCase::IndexFromEnd()
 
 TEST_CASE("wxNaturalStringComparisonGeneric()", "[wxString][compare]")
 {
-#if !wxUSE_REGEX
-    WARN("Skipping wxCmpNaturalGeneric() tests: wxRegEx not available");
-#else
     // simple string comparison
     CHECK(wxCmpNaturalGeneric("a", "a") == 0);
     CHECK(wxCmpNaturalGeneric("a", "z") < 0);
@@ -858,6 +855,5 @@ TEST_CASE("wxNaturalStringComparisonGeneric()", "[wxString][compare]")
     CHECK(wxCmpNaturalGeneric("a5th5", "a10th10") < 0);
     CHECK(wxCmpNaturalGeneric("a 10th 10", "a5th 5") < 0);
     CHECK(wxCmpNaturalGeneric("a5th 5", "a 10th 10") > 0);
-#endif // #if !wxUSE_REGEX
 }
 


### PR DESCRIPTION
Proposal based on the discussion here https://github.com/wxWidgets/wxWidgets/commit/371c4b13661641161f2c71ac2bc1044e48681705#commitcomment-41193189

TBH, I have not tested if `wxIsspace() `and `wxIspunct()` work properly with Unicode space and punctuation characters (besides checking `wxIsspace(L'\u2003') == true` on MSW), hoping that the CRT got it right...