### PR TITLE
Determine display DPI from scaling factor

### DIFF
--- a/include/wx/display.h
+++ b/include/wx/display.h
@@ -102,6 +102,9 @@ public:
         return wxSize(GetStdPPIValue(), GetStdPPIValue());
     }
 
+    // get the scaling used by this display
+    double GetScaleFactor() const;
+
     // name may be empty
     wxString GetName() const;
 

--- a/include/wx/display.h
+++ b/include/wx/display.h
@@ -87,6 +87,21 @@ public:
     // get the resolution of this monitor in pixels per inch
     wxSize GetPPI() const;
 
+    // get the default resolution for displays on this platform
+    static int GetStdPPIValue()
+    {
+#ifdef __WXOSX__
+        return 72;
+#else
+        return 96;
+#endif
+    }
+
+    static wxSize GetStdPPI()
+    {
+        return wxSize(GetStdPPIValue(), GetStdPPIValue());
+    }
+
     // name may be empty
     wxString GetName() const;
 

--- a/include/wx/gtk/window.h
+++ b/include/wx/gtk/window.h
@@ -97,6 +97,7 @@ public:
     virtual int GetCharHeight() const wxOVERRIDE;
     virtual int GetCharWidth() const wxOVERRIDE;
     virtual double GetContentScaleFactor() const wxOVERRIDE;
+    virtual double GetDPIScaleFactor() const wxOVERRIDE;
 
     virtual void SetScrollbar( int orient, int pos, int thumbVisible,
                                int range, bool refresh = true ) wxOVERRIDE;

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -100,6 +100,8 @@ public:
     virtual bool Reparent(wxWindowBase *newParent) wxOVERRIDE;
 
     virtual wxSize GetDPI() const wxOVERRIDE;
+    virtual double GetDPIScaleFactor() const wxOVERRIDE;
+
 
     virtual void WarpPointer(int x, int y) wxOVERRIDE;
     virtual bool EnableTouchEvents(int eventsMask) wxOVERRIDE;

--- a/include/wx/osx/window.h
+++ b/include/wx/osx/window.h
@@ -121,6 +121,7 @@ public:
 #endif // wxUSE_HOTKEY
 
     virtual wxSize GetDPI() const wxOVERRIDE;
+    virtual double GetDPIScaleFactor() const wxOVERRIDE;
 
 #if wxUSE_DRAG_AND_DROP
     virtual void SetDropTarget( wxDropTarget *dropTarget ) wxOVERRIDE;

--- a/include/wx/private/display.h
+++ b/include/wx/private/display.h
@@ -115,13 +115,11 @@ public:
     // return the scale factor used to convert logical pixels to physical ones
     virtual double GetScaleFactor() const { return 1.0; }
 
-    // return the resolution of the display, uses GetSize(), GetScaleFactor()
-    // and GetSizeMM() by default but can be also overridden directly
-    virtual wxSize GetPPI() const;
+    // return the resolution of the display, by default uses GetScaleFactor(),
+    // but can be also overridden directly, as is done in wxMSW
+    virtual wxSize GetPPI() const { return wxDisplay::GetStdPPI()*GetScaleFactor(); }
 
-    // return the physical size of the display or (0, 0) if unknown: this is
-    // only used by GetPPI() implementation in the base class, so if GetPPI()
-    // is overridden, this one doesn't have to be implemented
+    // return the physical size of the display or (0, 0) if unknown
     virtual wxSize GetSizeMM() const { return wxSize(0, 0); }
 
     // return the name (may be empty)
@@ -148,11 +146,6 @@ public:
 protected:
     // create the object providing access to the display with the given index
     wxDisplayImpl(unsigned n) : m_index(n) { }
-
-    // Compute PPI from the sizes in pixels and mm.
-    //
-    // Return (0, 0) if physical size (in mm) is not known, i.e. 0.
-    static wxSize ComputePPI(int pxX, int pxY, int mmX, int mmY);
 
 
     // the index of this display (0 is always the primary one)

--- a/include/wx/private/display.h
+++ b/include/wx/private/display.h
@@ -119,9 +119,6 @@ public:
     // but can be also overridden directly, as is done in wxMSW
     virtual wxSize GetPPI() const { return wxDisplay::GetStdPPI()*GetScaleFactor(); }
 
-    // return the physical size of the display or (0, 0) if unknown
-    virtual wxSize GetSizeMM() const { return wxSize(0, 0); }
-
     // return the name (may be empty)
     virtual wxString GetName() const { return wxString(); }
 

--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -537,7 +537,7 @@ public:
 
     // Return the ratio of the DPI used by this window to the standard DPI,
     // e.g. 1 for standard DPI screens and 2 for "200% scaling".
-    double GetDPIScaleFactor() const;
+    virtual double GetDPIScaleFactor() const;
 
     // return the size of the left/right and top/bottom borders in x and y
     // components of the result respectively

--- a/interface/wx/display.h
+++ b/interface/wx/display.h
@@ -144,6 +144,19 @@ public:
     wxSize GetPPI() const;
 
     /**
+        Returns scaling factor used by this display.
+
+        The scaling factor is the ratio between GetPPI() and GetStdPPI()
+        (it is implicitly assumed that this ratio is the same for both
+        horizontal and vertical components).
+
+        @see wxWindow::GetContentScaleFactor(), wxWindow::GetDPIScaleFactor()
+
+        @since 3.1.5
+     */
+    double GetScaleFactor() const;
+
+    /**
         Returns default display resolution for the current platform in pixels
         per inch.
 

--- a/interface/wx/display.h
+++ b/interface/wx/display.h
@@ -144,6 +144,33 @@ public:
     wxSize GetPPI() const;
 
     /**
+        Returns default display resolution for the current platform in pixels
+        per inch.
+
+        This function mostly used internally, use GetPPI() to get the actual
+        display resolution.
+
+        Currently the standard PPI is the same in both horizontal and vertical
+        directions on all platforms and its value is 96 everywhere except under
+        Apple devices (those running macOS, iOS, watchOS etc), where it is 72.
+
+        @see GetStdPPI()
+
+        @since 3.1.5
+     */
+    static int GetStdPPIValue();
+
+    /**
+        Returns default display resolution for the current platform as wxSize.
+
+        This function is equivalent to constructing wxSize object with both
+        components set to GetStdPPIValue().
+
+        @since 3.1.5
+     */
+    static wxSize GetStdPPI();
+
+    /**
         Returns @true if the display is the primary display. The primary
         display is the one whose index is 0.
     */

--- a/samples/display/display.cpp
+++ b/samples/display/display.cpp
@@ -292,6 +292,11 @@ void MyFrame::PopuplateWithDisplayInfo()
         sizer->Add(new wxStaticText(page, wxID_ANY,
                                     wxString::Format("%d", display.GetDepth())));
 
+        sizer->Add(new wxStaticText(page, wxID_ANY, "Scaling: "));
+        sizer->Add(new wxStaticText(page, wxID_ANY,
+                                    wxString::Format("%.2f",
+                                                     display.GetScaleFactor())));
+
         sizer->Add(new wxStaticText(page, wxID_ANY, "Name: "));
         sizer->Add(new wxStaticText(page, wxID_ANY, display.GetName()));
 

--- a/src/common/dpycmn.cpp
+++ b/src/common/dpycmn.cpp
@@ -149,6 +149,25 @@ wxSize wxDisplay::GetPPI() const
     return m_impl->GetPPI();
 }
 
+double wxDisplay::GetScaleFactor() const
+{
+    wxCHECK_MSG( IsOk(), 0, wxT("invalid wxDisplay object") );
+
+#ifdef wxHAVE_DPI_INDEPENDENT_PIXELS
+    // Use wxDisplayImpl::GetScaleFactor() directly, it should be implemented
+    // correctly for the platforms doing pixel scaling and using it simpler and
+    // more efficient than using GetPPI().
+    return m_impl->GetScaleFactor();
+#else
+    // Under the other platforms, we just compute the DPI ratio ourselves.
+    //
+    // We use just the vertical component of the DPI because it's the one
+    // that counts most and, in practice, it's equal to the horizontal one
+    // anyhow.
+    return m_impl->GetPPI().y / (double)GetStdPPIValue();
+#endif
+}
+
 int wxDisplay::GetDepth() const
 {
     wxCHECK_MSG( IsOk(), 0, wxT("invalid wxDisplay object") );

--- a/src/common/dpycmn.cpp
+++ b/src/common/dpycmn.cpp
@@ -153,19 +153,7 @@ double wxDisplay::GetScaleFactor() const
 {
     wxCHECK_MSG( IsOk(), 0, wxT("invalid wxDisplay object") );
 
-#ifdef wxHAVE_DPI_INDEPENDENT_PIXELS
-    // Use wxDisplayImpl::GetScaleFactor() directly, it should be implemented
-    // correctly for the platforms doing pixel scaling and using it simpler and
-    // more efficient than using GetPPI().
     return m_impl->GetScaleFactor();
-#else
-    // Under the other platforms, we just compute the DPI ratio ourselves.
-    //
-    // We use just the vertical component of the DPI because it's the one
-    // that counts most and, in practice, it's equal to the horizontal one
-    // anyhow.
-    return m_impl->GetPPI().y / (double)GetStdPPIValue();
-#endif
 }
 
 int wxDisplay::GetDepth() const
@@ -224,35 +212,6 @@ bool wxDisplay::ChangeMode(const wxVideoMode& mode)
     }
 
     return *gs_factory;
-}
-
-// ============================================================================
-// wxDisplayImpl implementation
-// ============================================================================
-
-/* static */
-wxSize wxDisplayImpl::ComputePPI(int pxX, int pxY, int mmX, int mmY)
-{
-    if ( !mmX || !mmY )
-    {
-        // Physical size is unknown, return a special value indicating that we
-        // can't compute the resolution -- what else can we do?
-        return wxSize(0, 0);
-    }
-
-    return wxSize(wxRound((pxX * inches2mm) / mmX),
-                  wxRound((pxY * inches2mm) / mmY));
-}
-
-wxSize wxDisplayImpl::GetPPI() const
-{
-    const wxSize mm = GetSizeMM();
-
-    // We need physical pixels here, not logical ones returned by
-    // GetGeometry(), to compute the real DPI.
-    const wxSize pixels = GetGeometry().GetSize()*GetScaleFactor();
-
-    return ComputePPI(pixels.x, pixels.y, mm.x, mm.y);
 }
 
 // ============================================================================

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -101,13 +101,6 @@ bool IsInCaptureStack(wxWindowBase* win);
 
 } // wxMouseCapture
 
-// Most platforms use 96 DPI by default, but Mac traditionally uses 72.
-#ifdef __WXOSX__
-static const int BASELINE_DPI = 72;
-#else
-static const int BASELINE_DPI = 96;
-#endif
-
 // ----------------------------------------------------------------------------
 // static data
 // ----------------------------------------------------------------------------
@@ -805,7 +798,7 @@ static wxSize GetDPIHelper(const wxWindowBase* w)
     if ( !dpi.x || !dpi.y )
         dpi = wxScreenDC().GetPPI();
     if ( !dpi.x || !dpi.y )
-        dpi = wxSize(BASELINE_DPI, BASELINE_DPI);
+        dpi = wxDisplay::GetStdPPI();
 
     return dpi;
 }
@@ -829,7 +822,7 @@ double wxWindowBase::GetDPIScaleFactor() const
     // We use just the vertical component of the DPI because it's the one
     // that counts most and, in practice, it's equal to the horizontal one
     // anyhow.
-    return dpi.y / (double)BASELINE_DPI;
+    return dpi.y / (double)wxDisplay::GetStdPPIValue();
 }
 
 // helper of GetWindowBorderSize(): as many ports don't implement support for
@@ -2900,10 +2893,12 @@ wxWindowBase::FromDIP(const wxSize& sz, const wxWindowBase* w)
 {
     const wxSize dpi = GetDPIHelper(w);
 
+    const int baseline = wxDisplay::GetStdPPIValue();
+
     // Take care to not scale -1 because it has a special meaning of
     // "unspecified" which should be preserved.
-    return wxSize(sz.x == -1 ? -1 : wxMulDivInt32(sz.x, dpi.x, BASELINE_DPI),
-                  sz.y == -1 ? -1 : wxMulDivInt32(sz.y, dpi.y, BASELINE_DPI));
+    return wxSize(sz.x == -1 ? -1 : wxMulDivInt32(sz.x, dpi.x, baseline),
+                  sz.y == -1 ? -1 : wxMulDivInt32(sz.y, dpi.y, baseline));
 }
 
 /* static */
@@ -2912,10 +2907,12 @@ wxWindowBase::ToDIP(const wxSize& sz, const wxWindowBase* w)
 {
     const wxSize dpi = GetDPIHelper(w);
 
+    const int baseline = wxDisplay::GetStdPPIValue();
+
     // Take care to not scale -1 because it has a special meaning of
     // "unspecified" which should be preserved.
-    return wxSize(sz.x == -1 ? -1 : wxMulDivInt32(sz.x, BASELINE_DPI, dpi.x),
-                  sz.y == -1 ? -1 : wxMulDivInt32(sz.y, BASELINE_DPI, dpi.y));
+    return wxSize(sz.x == -1 ? -1 : wxMulDivInt32(sz.x, baseline, dpi.x),
+                  sz.y == -1 ? -1 : wxMulDivInt32(sz.y, baseline, dpi.y));
 }
 
 #endif // !wxHAVE_DPI_INDEPENDENT_PIXELS

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -786,25 +786,6 @@ wxSize wxWindowBase::DoGetBestSize() const
     return best;
 }
 
-namespace
-{
-
-static wxSize GetDPIHelper(const wxWindowBase* w)
-{
-    wxSize dpi;
-
-    if ( w )
-        dpi = w->GetDPI();
-    if ( !dpi.x || !dpi.y )
-        dpi = wxScreenDC().GetPPI();
-    if ( !dpi.x || !dpi.y )
-        dpi = wxDisplay::GetStdPPI();
-
-    return dpi;
-}
-
-}
-
 double wxWindowBase::GetContentScaleFactor() const
 {
     // By default, we assume that there is no mapping between logical and
@@ -817,12 +798,7 @@ double wxWindowBase::GetContentScaleFactor() const
 
 double wxWindowBase::GetDPIScaleFactor() const
 {
-    const wxSize dpi = GetDPIHelper(this);
-
-    // We use just the vertical component of the DPI because it's the one
-    // that counts most and, in practice, it's equal to the horizontal one
-    // anyhow.
-    return dpi.y / (double)wxDisplay::GetStdPPIValue();
+    return wxDisplay(static_cast<const wxWindow*>(this)).GetScaleFactor();
 }
 
 // helper of GetWindowBorderSize(): as many ports don't implement support for
@@ -2886,6 +2862,25 @@ wxSize wxWindowBase::GetDPI() const
 }
 
 #ifndef wxHAVE_DPI_INDEPENDENT_PIXELS
+
+namespace
+{
+
+static wxSize GetDPIHelper(const wxWindowBase* w)
+{
+    wxSize dpi;
+
+    if ( w )
+        dpi = w->GetDPI();
+    if ( !dpi.x || !dpi.y )
+        dpi = wxScreenDC().GetPPI();
+    if ( !dpi.x || !dpi.y )
+        dpi = wxDisplay::GetStdPPI();
+
+    return dpi;
+}
+
+}
 
 /* static */
 wxSize

--- a/src/gtk/display.cpp
+++ b/src/gtk/display.cpp
@@ -255,7 +255,6 @@ public:
 #if GTK_CHECK_VERSION(3,10,0)
     virtual double GetScaleFactor() const wxOVERRIDE;
 #endif // GTK+ 3.10
-    virtual wxSize GetPPI() const wxOVERRIDE;
     virtual wxSize GetSizeMM() const wxOVERRIDE;
 
 #if wxUSE_DISPLAY
@@ -350,36 +349,6 @@ double wxDisplayImplGTK::GetScaleFactor() const
 
     return 1.0;
 }
-
-wxSize wxDisplayImplGTK::GetPPI() const
-{
-    // The useful value of PPI is the scaled value of the default PPI and not
-    // the actual PPI computed by dividing the number of pixels by the physical
-    // screen size: this is what everyone else uses, and so we should do it
-    // too.
-    return wxDisplay::GetStdPPI()*GetScaleFactor();
-}
-
-#else // GTK+ < 3.10
-
-wxSize wxDisplayImplGTK::GetPPI() const
-{
-    // Try the base class version which uses our GetSizeMM() and returns
-    // per-display PPI value if it works.
-    wxSize ppi = wxDisplayImpl::GetPPI();
-
-    if ( !ppi.x || !ppi.y )
-    {
-        // But if it didn't work, fall back to the global DPI value common to
-        // all displays -- this is still better than nothing and more
-        // compatible with the previous wxWidgets versions.
-        ppi = ComputePPI(gdk_screen_width(), gdk_screen_height(),
-                         gdk_screen_width_mm(), gdk_screen_height_mm());
-    }
-
-    return ppi;
-}
-
 #endif // GTK+ 3.10
 
 wxSize wxDisplayImplGTK::GetSizeMM() const
@@ -403,9 +372,9 @@ wxSize wxDisplayImplGTK::GetSizeMM() const
     // When we have only a single display, we can use global GTK+ functions.
     // Note that at least in some configurations, these functions return valid
     // values when gdk_screen_get_monitor_xxx_mm() only return -1, so it's
-    // always worth fallng back on them, but we can't do it when using
+    // always worth falling back on them, but we can't do it when using
     // multiple displays because they combine the sizes of all displays in this
-    // case, which would result in a completely wrong value for GetPPI().
+    // case, which would result in a completely wrong value.
     if ( !(sizeMM.x && sizeMM.y) && gdk_screen_get_n_monitors(m_screen) == 1 )
     {
         sizeMM.x = gdk_screen_width_mm();

--- a/src/gtk/display.cpp
+++ b/src/gtk/display.cpp
@@ -350,7 +350,17 @@ double wxDisplayImplGTK::GetScaleFactor() const
 
     return 1.0;
 }
-#endif // GTK+ 3.10
+
+wxSize wxDisplayImplGTK::GetPPI() const
+{
+    // The useful value of PPI is the scaled value of the default PPI and not
+    // the actual PPI computed by dividing the number of pixels by the physical
+    // screen size: this is what everyone else uses, and so we should do it
+    // too.
+    return wxDisplay::GetStdPPI()*GetScaleFactor();
+}
+
+#else // GTK+ < 3.10
 
 wxSize wxDisplayImplGTK::GetPPI() const
 {
@@ -369,6 +379,8 @@ wxSize wxDisplayImplGTK::GetPPI() const
 
     return ppi;
 }
+
+#endif // GTK+ 3.10
 
 wxSize wxDisplayImplGTK::GetSizeMM() const
 {

--- a/src/gtk/display.cpp
+++ b/src/gtk/display.cpp
@@ -50,7 +50,6 @@ public:
     virtual wxRect GetClientArea() const wxOVERRIDE;
     virtual int GetDepth() const wxOVERRIDE;
     virtual double GetScaleFactor() const wxOVERRIDE;
-    virtual wxSize GetSizeMM() const wxOVERRIDE;
 
 #if wxUSE_DISPLAY
     virtual bool IsPrimary() const wxOVERRIDE;
@@ -151,15 +150,6 @@ double wxDisplayImplGTK::GetScaleFactor() const
     return gdk_monitor_get_scale_factor(m_monitor);
 }
 
-wxSize wxDisplayImplGTK::GetSizeMM() const
-{
-    return wxSize
-           (
-                gdk_monitor_get_width_mm(m_monitor),
-                gdk_monitor_get_height_mm(m_monitor)
-           );
-}
-
 #if wxUSE_DISPLAY
 bool wxDisplayImplGTK::IsPrimary() const
 {
@@ -255,7 +245,6 @@ public:
 #if GTK_CHECK_VERSION(3,10,0)
     virtual double GetScaleFactor() const wxOVERRIDE;
 #endif // GTK+ 3.10
-    virtual wxSize GetSizeMM() const wxOVERRIDE;
 
 #if wxUSE_DISPLAY
     virtual bool IsPrimary() const wxOVERRIDE;
@@ -350,39 +339,6 @@ double wxDisplayImplGTK::GetScaleFactor() const
     return 1.0;
 }
 #endif // GTK+ 3.10
-
-wxSize wxDisplayImplGTK::GetSizeMM() const
-{
-    wxSize sizeMM;
-#if GTK_CHECK_VERSION(2,14,0)
-    if ( wx_is_at_least_gtk2(14) )
-    {
-        // Take care not to return (-1, -1) from here, the caller expects us to
-        // return (0, 0) if we can't retrieve this information.
-        int rc = gdk_screen_get_monitor_width_mm(m_screen, m_index);
-        if ( rc != -1 )
-            sizeMM.x = rc;
-
-        rc = gdk_screen_get_monitor_height_mm(m_screen, m_index);
-        if ( rc != -1 )
-            sizeMM.y = rc;
-    }
-#endif // GTK+ 2.14
-
-    // When we have only a single display, we can use global GTK+ functions.
-    // Note that at least in some configurations, these functions return valid
-    // values when gdk_screen_get_monitor_xxx_mm() only return -1, so it's
-    // always worth falling back on them, but we can't do it when using
-    // multiple displays because they combine the sizes of all displays in this
-    // case, which would result in a completely wrong value.
-    if ( !(sizeMM.x && sizeMM.y) && gdk_screen_get_n_monitors(m_screen) == 1 )
-    {
-        sizeMM.x = gdk_screen_width_mm();
-        sizeMM.y = gdk_screen_height_mm();
-    }
-
-    return sizeMM;
-}
 
 #if wxUSE_DISPLAY
 bool wxDisplayImplGTK::IsPrimary() const

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -4363,6 +4363,13 @@ double wxWindowGTK::GetContentScaleFactor() const
     return scaleFactor;
 }
 
+double wxWindowGTK::GetDPIScaleFactor() const
+{
+    // Under GTK 3 DPI scale factor is the same as content scale factor, while
+    // under GTK 2 both are always 1, so they're still the same.
+    return GetContentScaleFactor();
+}
+
 void wxWindowGTK::GTKDisableFocusOutEvent()
 {
     g_signal_handlers_block_by_func( m_focusWidget,

--- a/src/msw/display.cpp
+++ b/src/msw/display.cpp
@@ -67,13 +67,6 @@ public:
     {
         return wxGetHDCDepth(ScreenHDC());
     }
-
-    virtual wxSize GetSizeMM() const wxOVERRIDE
-    {
-        ScreenHDC dc;
-
-        return wxSize(::GetDeviceCaps(dc, HORZSIZE), ::GetDeviceCaps(dc, VERTSIZE));
-    }
 };
 
 class wxDisplayFactorySingleMSW : public wxDisplayFactorySingle

--- a/src/msw/display.cpp
+++ b/src/msw/display.cpp
@@ -141,6 +141,7 @@ public:
     virtual wxRect GetClientArea() const wxOVERRIDE;
     virtual int GetDepth() const wxOVERRIDE;
     virtual wxSize GetPPI() const wxOVERRIDE;
+    virtual double GetScaleFactor() const wxOVERRIDE;
 
     virtual wxString GetName() const wxOVERRIDE;
     virtual bool IsPrimary() const wxOVERRIDE;
@@ -330,6 +331,12 @@ wxSize wxDisplayMSW::GetPPI() const
     }
 
     return IsPrimary() ? wxDisplayImplSingleMSW().GetPPI() : wxSize(0, 0);
+}
+
+double wxDisplayMSW::GetScaleFactor() const
+{
+    const int ppi = GetPPI().y;
+    return ppi ? ppi / (double)wxDisplay::GetStdPPIValue() : 1.0;
 }
 
 wxString wxDisplayMSW::GetName() const

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -105,6 +105,7 @@
 #include "wx/notebook.h"
 #include "wx/listctrl.h"
 #include "wx/dynlib.h"
+#include "wx/display.h"
 
 #include <string.h>
 
@@ -4856,6 +4857,11 @@ wxSize wxWindowMSW::GetDPI() const
     }
 
     return dpi;
+}
+
+double wxWindowMSW::GetDPIScaleFactor() const
+{
+    return GetDPI().y / (double)wxDisplay::GetStdPPIValue();
 }
 
 void wxWindowMSW::MSWUpdateFontOnDPIChange(const wxSize& newDPI)

--- a/src/osx/cocoa/utils.mm
+++ b/src/osx/cocoa/utils.mm
@@ -485,6 +485,24 @@ wxRect wxOSXGetMainDisplayClientArea()
     return wxFromNSRect( NULL, displayRect );
 }
 
+static NSScreen* wxOSXGetScreenFromDisplay( CGDirectDisplayID ID)
+{
+    for (NSScreen* screen in [NSScreen screens])
+    {
+        CGDirectDisplayID displayID = [[[screen deviceDescription] objectForKey:@"NSScreenNumber"] intValue];
+        if ( displayID == ID )
+            return screen;
+    }
+    return NULL;
+}
+
+extern // used from src/osx/core/display.cpp
+wxRect wxOSXGetDisplayClientArea(CGDirectDisplayID ID)
+{
+    NSRect displayRect = [wxOSXGetScreenFromDisplay(ID) visibleFrame];
+    return wxFromNSRect( NULL, displayRect );
+}
+
 void wxGetMousePosition( int* x, int* y )
 {
     wxPoint pt = wxFromNSPoint(NULL, [NSEvent mouseLocation]);

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -2648,7 +2648,10 @@ void wxWidgetCocoaImpl::SetVisibility( bool visible )
 double wxWidgetCocoaImpl::GetContentScaleFactor() const
 {
     NSWindow* tlw = [m_osxView window];
-    return [tlw backingScaleFactor];
+    if ( tlw )
+        return [tlw backingScaleFactor];
+    else
+        return wxOSXGetMainScreenContentScaleFactor();
 }
 
 // ----------------------------------------------------------------------------

--- a/src/osx/core/display.cpp
+++ b/src/osx/core/display.cpp
@@ -45,6 +45,14 @@ extern wxRect wxOSXGetDisplayClientArea(CGDirectDisplayID id);
 namespace
 {
 
+double wxGetScaleFactor( CGDirectDisplayID ID)
+{
+    wxCFRef<CGDisplayModeRef> mode = CGDisplayCopyDisplayMode(ID);
+    size_t width = CGDisplayModeGetWidth(mode);
+    size_t pixelsw = CGDisplayModeGetPixelWidth(mode);
+    return (double)pixelsw/width;
+}
+
 wxRect wxGetDisplayGeometry(CGDirectDisplayID id)
 {
     CGRect theRect = CGDisplayBounds(id);
@@ -257,10 +265,8 @@ int wxDisplayFactoryMacOSX::GetFromWindow(const wxWindow *window)
     for ( int i = 0 ; i < theCount; ++i )
     {
         // find a screen intersecting having the same contentScale as the window itself
-        wxCFRef<CGDisplayModeRef> mode = CGDisplayCopyDisplayMode(theIDs[i]);
-        size_t width = CGDisplayModeGetWidth(mode);
-        size_t pixelsw = CGDisplayModeGetPixelWidth(mode);
-        if ( fabs( (double)pixelsw / width - tlw->GetContentScaleFactor() ) < 0.01 )
+        double scale = wxGetScaleFactor(theIDs[i]);
+        if ( fabs(scale - tlw->GetContentScaleFactor() ) < 0.01 )
         {
             return wxOSXGetDisplayFromID(theIDs[i]);
         }
@@ -313,10 +319,7 @@ wxSize wxDisplayImplMacOSX::GetSizeMM() const
 
 double wxDisplayImplMacOSX::GetScaleFactor() const
 {
-    wxCFRef<CGDisplayModeRef> mode = CGDisplayCopyDisplayMode(m_id);
-    size_t width = CGDisplayModeGetWidth(mode);
-    size_t pixelsw = CGDisplayModeGetPixelWidth(mode);
-    return (double)pixelsw / width;
+    return wxGetScaleFactor(m_id);
 }
 
 static int wxOSXCGDisplayModeGetBitsPerPixel( CGDisplayModeRef theValue )

--- a/src/osx/core/display.cpp
+++ b/src/osx/core/display.cpp
@@ -255,11 +255,12 @@ int wxDisplayFactoryMacOSX::GetFromWindow(const wxWindow *window)
     err = CGGetDisplaysWithRect(r, theCount, theIDs.get(), &theCount);
     wxASSERT(err == CGDisplayNoErr);
 
+    const double scaleWindow = tlw->GetContentScaleFactor();
     for ( int i = 0 ; i < theCount; ++i )
     {
         // find a screen intersecting having the same contentScale as the window itself
         double scale = wxGetScaleFactor(theIDs[i]);
-        if ( fabs(scale - tlw->GetContentScaleFactor() ) < 0.01 )
+        if ( fabs(scale - scaleWindow) < 0.01 )
         {
             return wxOSXGetDisplayFromID(theIDs[i]);
         }

--- a/src/osx/core/display.cpp
+++ b/src/osx/core/display.cpp
@@ -85,12 +85,6 @@ int wxGetDisplayDepth(CGDirectDisplayID id)
     return theDepth;
 }
 
-wxSize wxGetDisplaySizeMM(CGDirectDisplayID id)
-{
-    const CGSize size = CGDisplayScreenSize(id);
-    return wxSize(wxRound(size.width), wxRound(size.height));
-}
-
 } // anonymous namespace
 
 #if wxUSE_DISPLAY
@@ -113,7 +107,6 @@ public:
     virtual wxRect GetGeometry() const wxOVERRIDE;
     virtual wxRect GetClientArea() const wxOVERRIDE;
     virtual int GetDepth() const wxOVERRIDE;
-    virtual wxSize GetSizeMM() const wxOVERRIDE;
     virtual double GetScaleFactor() const wxOVERRIDE;
 
     virtual wxArrayVideoModes GetModes(const wxVideoMode& mode) const wxOVERRIDE;
@@ -312,11 +305,6 @@ int wxDisplayImplMacOSX::GetDepth() const
     return wxGetDisplayDepth(m_id);
 }
 
-wxSize wxDisplayImplMacOSX::GetSizeMM() const
-{
-    return wxGetDisplaySizeMM(m_id);
-}
-
 double wxDisplayImplMacOSX::GetScaleFactor() const
 {
     return wxGetScaleFactor(m_id);
@@ -436,11 +424,6 @@ public:
     virtual int GetDepth() const wxOVERRIDE
     {
         return wxGetDisplayDepth(CGMainDisplayID());
-    }
-
-    virtual wxSize GetSizeMM() const wxOVERRIDE
-    {
-        return wxGetDisplaySizeMM(CGMainDisplayID());
     }
 };
 

--- a/src/osx/core/display.cpp
+++ b/src/osx/core/display.cpp
@@ -104,6 +104,7 @@ public:
     virtual wxRect GetClientArea() const wxOVERRIDE;
     virtual int GetDepth() const wxOVERRIDE;
     virtual wxSize GetSizeMM() const wxOVERRIDE;
+    virtual double GetScaleFactor() const wxOVERRIDE;
 
     virtual wxArrayVideoModes GetModes(const wxVideoMode& mode) const wxOVERRIDE;
     virtual wxVideoMode GetCurrentMode() const wxOVERRIDE;
@@ -268,6 +269,14 @@ int wxDisplayImplMacOSX::GetDepth() const
 wxSize wxDisplayImplMacOSX::GetSizeMM() const
 {
     return wxGetDisplaySizeMM(m_id);
+}
+
+double wxDisplayImplMacOSX::GetScaleFactor() const
+{
+    wxCFRef<CGDisplayModeRef> mode = CGDisplayCopyDisplayMode(m_id);
+    size_t width = CGDisplayModeGetWidth(mode);
+    size_t pixelsw = CGDisplayModeGetPixelWidth(mode);
+    return (double)pixelsw / width;
 }
 
 static int wxOSXCGDisplayModeGetBitsPerPixel( CGDisplayModeRef theValue )

--- a/src/osx/core/display.cpp
+++ b/src/osx/core/display.cpp
@@ -40,6 +40,7 @@
 
 // This one is defined in Objective C++ code.
 extern wxRect wxOSXGetMainDisplayClientArea();
+extern wxRect wxOSXGetDisplayClientArea(CGDirectDisplayID id);
 
 namespace
 {
@@ -297,13 +298,7 @@ wxRect wxDisplayImplMacOSX::GetGeometry() const
 
 wxRect wxDisplayImplMacOSX::GetClientArea() const
 {
-    // VZ: I don't know how to get client area for arbitrary display but
-    //     wxGetClientDisplayRect() does work correctly for at least the main
-    //     one (TODO: do it correctly for the other displays too)
-    if ( IsPrimary() )
-        return wxOSXGetMainDisplayClientArea();
-
-    return wxDisplayImpl::GetClientArea();
+    return wxOSXGetDisplayClientArea(m_id);
 }
 
 int wxDisplayImplMacOSX::GetDepth() const

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -2636,13 +2636,7 @@ wxSize wxWindowMac::GetDPI() const
 // on mac ContentScale and DPIScale are identical
 double wxWindowMac::GetDPIScaleFactor() const
 {
-    double scaleFactor;
-    if ( wxNonOwnedWindow* tlw = MacGetTopLevelWindow() )
-        scaleFactor = tlw->GetContentScaleFactor();
-    else
-        scaleFactor = wxOSXGetMainScreenContentScaleFactor();
-
-    return scaleFactor;
+    return GetContentScaleFactor();
 }
 
 

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -2630,14 +2630,21 @@ wxSize wxWindowMac::OSXMakeDPIFromScaleFactor(double scaleFactor)
 
 wxSize wxWindowMac::GetDPI() const
 {
+    return OSXMakeDPIFromScaleFactor(GetDPIScaleFactor());
+}
+
+// on mac ContentScale and DPIScale are identical
+double wxWindowMac::GetDPIScaleFactor() const
+{
     double scaleFactor;
     if ( wxNonOwnedWindow* tlw = MacGetTopLevelWindow() )
         scaleFactor = tlw->GetContentScaleFactor();
     else
         scaleFactor = wxOSXGetMainScreenContentScaleFactor();
 
-    return OSXMakeDPIFromScaleFactor(scaleFactor);
+    return scaleFactor;
 }
+
 
 //
 // wxWidgetImpl

--- a/src/qt/display.cpp
+++ b/src/qt/display.cpp
@@ -22,7 +22,6 @@ public:
     virtual wxRect GetGeometry() const wxOVERRIDE;
     virtual wxRect GetClientArea() const wxOVERRIDE;
     virtual int GetDepth() const wxOVERRIDE;
-    virtual wxSize GetSizeMM() const wxOVERRIDE;
 
 #if wxUSE_DISPLAY
     virtual wxArrayVideoModes GetModes(const wxVideoMode& mode) const wxOVERRIDE;
@@ -49,13 +48,6 @@ wxRect wxDisplayImplQt::GetClientArea() const
 int wxDisplayImplQt::GetDepth() const
 {
     return IsPrimary() ? QApplication::desktop()->depth() : 0;
-}
-
-wxSize wxDisplayImplQt::GetSizeMM() const
-{
-    return IsPrimary() ? wxSize(QApplication::desktop()->widthMM(),
-                                QApplication::desktop()->heightMM())
-                       : wxSize(0, 0);
 }
 
 #if wxUSE_DISPLAY

--- a/src/unix/displayx11.cpp
+++ b/src/unix/displayx11.cpp
@@ -76,11 +76,6 @@ public:
     {
         return wxGetMainScreenDepth();
     }
-
-    virtual wxSize GetSizeMM() const wxOVERRIDE
-    {
-        return wxGetMainScreenSizeMM();
-    }
 };
 
 class wxDisplayFactorySingleX11 : public wxDisplayFactorySingle
@@ -158,11 +153,6 @@ public:
             return mode.bpp;
 
         return wxGetMainScreenDepth();
-    }
-    virtual wxSize GetSizeMM() const wxOVERRIDE
-    {
-        // TODO: how to get physical size or resolution of the other monitors?
-        return IsPrimary() ? wxGetMainScreenSizeMM() : wxSize(0, 0);
     }
 
     virtual wxArrayVideoModes GetModes(const wxVideoMode& mode) const wxOVERRIDE;


### PR DESCRIPTION
See [#18855](https://trac.wxwidgets.org/ticket/18855): with these changes, the returned value of all of both `GetDPIScaleFactor()` and `GetContentScaleFactor()` is 2 when using high DPI screen. @paulcor do we care about always returning 1 here for GTK 3 < 3.10?

Note that this almost surely does *not* work under Mac, as `wxDisplayImpl::GetScaleFactor()` is not implemented there. @csomor Could you please add an implementation for it? It should be pretty simple, but I don't want to do it blindly. TIA! 
