### PR TITLE
Don't work with wxGrid selection in resizing mode

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -3003,7 +3003,6 @@ private:
     void DoGridProcessTab(wxKeyboardState& kbdState);
 
     // common implementations of methods defined for both rows and columns
-    bool DoEndDragResizeLine(const wxGridOperations& oper, wxGridWindow *gridWindow);
     int PosToLinePos(int pos, bool clipToMinMax,
                      const wxGridOperations& oper,
                      wxGridWindow *gridWindow) const;

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -4714,14 +4714,14 @@ wxGrid::DoGridMouseMoveEvent(wxMouseEvent& WXUNUSED(event),
     // cell corner, as this is a more common operation.
     if ( dragCol >= 0 && CanDragGridColEdges() && CanDragColSize(dragCol) )
     {
-        if ( m_cursorMode == WXGRID_CURSOR_SELECT_CELL )
+        if ( m_cursorMode != WXGRID_CURSOR_RESIZE_COL )
         {
             ChangeCursorMode(WXGRID_CURSOR_RESIZE_COL, gridWindow, false);
         }
     }
     else if ( dragRow >= 0 && CanDragGridRowEdges() && CanDragRowSize(dragRow) )
     {
-        if ( m_cursorMode == WXGRID_CURSOR_SELECT_CELL )
+        if ( m_cursorMode != WXGRID_CURSOR_RESIZE_ROW)
         {
             ChangeCursorMode(WXGRID_CURSOR_RESIZE_ROW, gridWindow, false);
         }


### PR DESCRIPTION
We should not work with the selection if we currently in the resizing mode.
So check for resizing ability at first and only then for Shift modifier.

Note that this commit is best viewed with "git diff -w" to see how little
has really changed.