### PR TITLE
Fix grid demo stars drawing

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -228,6 +228,13 @@ public:
 
     // create a new object which is the copy of this one
     virtual wxGridCellRenderer *Clone() const = 0;
+
+protected:
+    // set the text colours before drawing
+    void SetTextColoursAndFont(const wxGrid& grid,
+                               const wxGridCellAttr& attr,
+                               wxDC& dc,
+                               bool isSelected);
 };
 
 // Smart pointer to wxGridCellRenderer, calling DecRef() on it automatically.

--- a/include/wx/generic/gridctrl.h
+++ b/include/wx/generic/gridctrl.h
@@ -41,12 +41,6 @@ public:
         { return new wxGridCellStringRenderer; }
 
 protected:
-    // set the text colours before drawing
-    void SetTextColoursAndFont(const wxGrid& grid,
-                               const wxGridCellAttr& attr,
-                               wxDC& dc,
-                               bool isSelected);
-
     // calc the string extent for given string/font
     wxSize DoGetBestSize(const wxGridCellAttr& attr,
                          wxDC& dc,

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -110,6 +110,23 @@ public:
 
 protected:
     /**
+        Helper function setting the correct colours and font.
+
+        This function can be useful in the derived classes Draw()
+        implementation as it takes care of setting the appropriate colours and
+        font for @a dc depending on the global @a grid attributes, cell
+        attributions specified in @a attr and whether @a isSelected is @true.
+
+        Simply call it before doing any drawing in the derived class version to
+        use consistent colours and font for all cells.
+
+        @since 3.1.5
+     */
+    void SetTextColoursAndFont(const wxGrid& grid,
+                               const wxGridCellAttr& attr,
+                               wxDC& dc,
+                               bool isSelected);
+    /**
         The destructor is private because only DecRef() can delete us.
     */
     virtual ~wxGridCellRenderer();

--- a/samples/grid/griddemo.cpp
+++ b/samples/grid/griddemo.cpp
@@ -162,6 +162,8 @@ public:
     {
         wxGridCellRenderer::Draw(grid, attr, dc, rect, row, col, isSelected);
 
+        SetTextColoursAndFont(grid, attr, dc, isSelected);
+
         grid.DrawTextRectangle(dc, GetStarString(GetStarValue(grid, row, col)),
                                rect, attr);
     }

--- a/src/generic/gridctrl.cpp
+++ b/src/generic/gridctrl.cpp
@@ -69,6 +69,42 @@ void wxGridCellRenderer::Draw(wxGrid& grid,
     dc.DrawRectangle(rect);
 }
 
+void wxGridCellRenderer::SetTextColoursAndFont(const wxGrid& grid,
+                                               const wxGridCellAttr& attr,
+                                               wxDC& dc,
+                                               bool isSelected)
+{
+    dc.SetBackgroundMode( wxBRUSHSTYLE_TRANSPARENT );
+
+    // TODO some special colours for attr.IsReadOnly() case?
+
+    // different coloured text when the grid is disabled
+    if ( grid.IsThisEnabled() )
+    {
+        if ( isSelected )
+        {
+            wxColour clr;
+            if ( grid.HasFocus() )
+                clr = grid.GetSelectionBackground();
+            else
+                clr = wxSystemSettings::GetColour(wxSYS_COLOUR_BTNSHADOW);
+            dc.SetTextBackground( clr );
+            dc.SetTextForeground( grid.GetSelectionForeground() );
+        }
+        else
+        {
+            dc.SetTextBackground( attr.GetBackgroundColour() );
+            dc.SetTextForeground( attr.GetTextColour() );
+        }
+    }
+    else
+    {
+        dc.SetTextBackground(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
+        dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
+    }
+
+    dc.SetFont( attr.GetFont() );
+}
 
 // ----------------------------------------------------------------------------
 // wxGridCellDateTimeRenderer
@@ -572,43 +608,6 @@ wxGridCellAutoWrapStringRenderer::GetBestWidth(wxGrid& grid,
 // ----------------------------------------------------------------------------
 // wxGridCellStringRenderer
 // ----------------------------------------------------------------------------
-
-void wxGridCellStringRenderer::SetTextColoursAndFont(const wxGrid& grid,
-                                                     const wxGridCellAttr& attr,
-                                                     wxDC& dc,
-                                                     bool isSelected)
-{
-    dc.SetBackgroundMode( wxBRUSHSTYLE_TRANSPARENT );
-
-    // TODO some special colours for attr.IsReadOnly() case?
-
-    // different coloured text when the grid is disabled
-    if ( grid.IsThisEnabled() )
-    {
-        if ( isSelected )
-        {
-            wxColour clr;
-            if ( grid.HasFocus() )
-                clr = grid.GetSelectionBackground();
-            else
-                clr = wxSystemSettings::GetColour(wxSYS_COLOUR_BTNSHADOW);
-            dc.SetTextBackground( clr );
-            dc.SetTextForeground( grid.GetSelectionForeground() );
-        }
-        else
-        {
-            dc.SetTextBackground( attr.GetBackgroundColour() );
-            dc.SetTextForeground( attr.GetTextColour() );
-        }
-    }
-    else
-    {
-        dc.SetTextBackground(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
-        dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
-    }
-
-    dc.SetFont( attr.GetFont() );
-}
 
 wxSize wxGridCellStringRenderer::DoGetBestSize(const wxGridCellAttr& attr,
                                                wxDC& dc,


### PR DESCRIPTION
Reuse wxGridCellStringRenderer::SetTextColoursAndFont() to correctly set
up the font and colors before drawing the stars.