### PR TITLE
Inherit art provider in wxAuiFloatingFrame by default

### DIFF
--- a/include/wx/aui/dockart.h
+++ b/include/wx/aui/dockart.h
@@ -35,6 +35,7 @@ public:
     wxAuiDockArt() { }
     virtual ~wxAuiDockArt() { }
 
+    virtual wxAuiDockArt* Clone() = 0;
     virtual int GetMetric(int id) = 0;
     virtual void SetMetric(int id, int newVal) = 0;
     virtual void SetFont(int id, const wxFont& font) = 0;
@@ -92,6 +93,7 @@ public:
 
     wxAuiDefaultDockArt();
 
+    wxAuiDockArt* Clone() wxOVERRIDE;
     int GetMetric(int metricId) wxOVERRIDE;
     void SetMetric(int metricId, int newVal) wxOVERRIDE;
     wxColour GetColour(int id) wxOVERRIDE;

--- a/include/wx/aui/floatpane.h
+++ b/include/wx/aui/floatpane.h
@@ -46,6 +46,8 @@ public:
     // Allow processing accelerators to the parent frame
     virtual bool IsTopNavigationDomain(NavigationKind kind) const wxOVERRIDE;
 
+    wxAuiManager& GetAuiManager()  { return m_mgr; }
+
 protected:
     virtual void OnMoveStart();
     virtual void OnMoving(const wxRect& windowRect, wxDirection dir);

--- a/interface/wx/aui/floatpane.h
+++ b/interface/wx/aui/floatpane.h
@@ -23,6 +23,13 @@ public:
     void SetPaneWindow(const wxAuiPaneInfo& pane);
     wxAuiManager* GetOwnerManager() const;
 
+    /**
+       Returns the embedded wxAuiManager managing this floating pane's contents.
+
+       @since 3.1.5
+    */
+    wxAuiManager& GetAuiManager();
+
 protected:
     virtual void OnMoveStart();
     virtual void OnMoving(const wxRect& windowRect, wxDirection dir);

--- a/src/aui/dockart.cpp
+++ b/src/aui/dockart.cpp
@@ -252,6 +252,11 @@ wxAuiDefaultDockArt::wxAuiDefaultDockArt()
     InitBitmaps();
 }
 
+wxAuiDockArt* wxAuiDefaultDockArt::Clone()
+{
+    return new wxAuiDefaultDockArt(*this);
+}
+
 void
 wxAuiDefaultDockArt::InitBitmaps ()
 {

--- a/src/aui/floatpane.cpp
+++ b/src/aui/floatpane.cpp
@@ -56,6 +56,7 @@ wxAuiFloatingFrame::wxAuiFloatingFrame(wxWindow* parent,
 {
     m_moving = false;
     m_mgr.SetManagedWindow(this);
+    m_mgr.SetArtProvider(owner_mgr->GetArtProvider()->Clone());
     m_solidDrag = true;
 
     // find out if the system supports solid window drag.


### PR DESCRIPTION
Use the same art provider for a floating frame detached from an existing
wxAuiManager as was used by the original wxAuiManager itself, to ensure
that the appearance of this frame is consistent with the appearance of
its parent.

Implementing this required adding wxAuiDockArt::Clone() to allow copying
it in the new frame and this patch also adds GetAuiManager() to
wxAuiFloatingFrame, similar to the existing method in wxAuiNotebook, in
order to allow changing the dock art from the application code if
desired.

Closes [#18882](https://trac.wxwidgets.org/ticket/18882).