### PR TITLE
Miscellaneous DPI Improvements

### DIFF
--- a/include/wx/msw/private/dpiaware.h
+++ b/include/wx/msw/private/dpiaware.h
@@ -22,13 +22,14 @@ namespace wxMSWImpl
 {
 
 // ----------------------------------------------------------------------------
-// Temporarily change the DPI Awareness context to System
+// Temporarily change the DPI Awareness context to GDIScaled or System
 // ----------------------------------------------------------------------------
 
 class AutoSystemDpiAware
 {
-    #define WXDPI_AWARENESS_CONTEXT_UNAWARE      ((WXDPI_AWARENESS_CONTEXT)-1)
-    #define WXDPI_AWARENESS_CONTEXT_SYSTEM_AWARE ((WXDPI_AWARENESS_CONTEXT)-2)
+    #define WXDPI_AWARENESS_CONTEXT_UNAWARE           ((WXDPI_AWARENESS_CONTEXT)-1)
+    #define WXDPI_AWARENESS_CONTEXT_SYSTEM_AWARE      ((WXDPI_AWARENESS_CONTEXT)-2)
+    #define WXDPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED ((WXDPI_AWARENESS_CONTEXT)-5)
     typedef WXDPI_AWARENESS_CONTEXT
             (WINAPI *SetThreadDpiAwarenessContext_t)(WXDPI_AWARENESS_CONTEXT);
 
@@ -46,7 +47,12 @@ public:
         if ( m_pfnSetThreadDpiAwarenessContext )
         {
             m_prevContext = m_pfnSetThreadDpiAwarenessContext(
-                                WXDPI_AWARENESS_CONTEXT_SYSTEM_AWARE);
+                                    WXDPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED);
+            if ( !m_prevContext )
+            {
+                m_prevContext = m_pfnSetThreadDpiAwarenessContext(
+                                    WXDPI_AWARENESS_CONTEXT_SYSTEM_AWARE);
+            }
         }
 
     }

--- a/samples/dataview/dataview.cpp
+++ b/samples/dataview/dataview.cpp
@@ -262,7 +262,7 @@ public:
 
     virtual wxSize GetSize() const wxOVERRIDE
     {
-        return wxSize(60,20);
+        return GetView()->FromDIP(wxSize(60, 20));
     }
 
     virtual bool SetValue( const wxVariant &value ) wxOVERRIDE

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -429,17 +429,6 @@ void wxListCtrl::MSWUpdateFontOnDPIChange(const wxSize& newDPI)
 {
     wxListCtrlBase::MSWUpdateFontOnDPIChange(newDPI);
 
-    for ( int i = 0; i < GetItemCount(); i++ )
-    {
-        wxMSWListItemData *data = MSWGetItemData(i);
-        if ( data && data->attr && data->attr->HasFont() )
-        {
-            wxFont f = data->attr->GetFont();
-            f.WXAdjustToPPI(newDPI);
-            SetItemFont(i, f);
-        }
-    }
-
     if ( m_headerCustomDraw && m_headerCustomDraw->m_attr.HasFont() )
     {
         wxItemAttr item(m_headerCustomDraw->m_attr);
@@ -1014,13 +1003,6 @@ bool wxListCtrl::SetItem(wxListItem& info)
                 data->attr->AssignFrom(attrNew);
             else
                 data->attr = new wxItemAttr(attrNew);
-
-            if ( data->attr->HasFont() )
-            {
-                wxFont f = data->attr->GetFont();
-                f.WXAdjustToPPI(GetDPI());
-                data->attr->SetFont(f);
-            }
         }
     }
 
@@ -3182,6 +3164,7 @@ static WXLPARAM HandleItemPrepaint(wxListCtrl *listctrl,
     if ( attr->HasFont() )
     {
         wxFont font = attr->GetFont();
+        font.WXAdjustToPPI(listctrl->GetDPI());
         if ( font.GetEncoding() != wxFONTENCODING_SYSTEM )
         {
             // the standard control ignores the font encoding/charset, at least


### PR DESCRIPTION
- Use GDI Scaling for dpi-unaware system dialogs. Fall back to system scaling when GDI scaling fails or is unavailable.
Scaling from 100% to 175%, System vs GDI:
<a href="https://user-images.githubusercontent.com/8088070/90682004-9b664800-e264-11ea-9ffc-b422e10e6cd9.png"><img src="https://user-images.githubusercontent.com/8088070/90682004-9b664800-e264-11ea-9ffc-b422e10e6cd9.png" width="250" alt="System"/></a> <a href="https://user-images.githubusercontent.com/8088070/90682007-9c977500-e264-11ea-889e-389132b8c370.png"><img src="https://user-images.githubusercontent.com/8088070/90682007-9c977500-e264-11ea-889e-389132b8c370.png" width="250" alt="GDI"/></a>

- Make custom renderer in dataview sample DPI Aware

- Don't iterate all item of wxListCtrl on DPI change. This can take multiple seconds in big lists, meanwhile the UI is frozen at the
display border. Adjust the font of the attribute to the DPI when it is used for drawing.