### PR TITLE
Add a unit test for using bitmaps with image and empty label

### DIFF
--- a/tests/controls/buttontest.cpp
+++ b/tests/controls/buttontest.cpp
@@ -176,12 +176,17 @@ void ButtonTestCase::Bitmap()
     //We start with no bitmaps
     CPPUNIT_ASSERT(!m_button->GetBitmap().IsOk());
 
+    // Some bitmap, doesn't really matter which.
+    const wxBitmap bmp = wxArtProvider::GetBitmap(wxART_INFORMATION);
 
-    m_button->SetBitmap(wxArtProvider::GetIcon(wxART_INFORMATION,
-                                               wxART_OTHER,
-                                               wxSize(32, 32)));
+    m_button->SetBitmap(bmp);
 
     CPPUNIT_ASSERT(m_button->GetBitmap().IsOk());
+
+    // Check that resetting the button label doesn't result in problems when
+    // updating the bitmap later, as it used to be the case in wxGTK (#18898).
+    m_button->SetLabel(wxString());
+    CHECK_NOTHROW( m_button->Disable() );
 }
 
 #endif //wxUSE_BUTTON


### PR DESCRIPTION
This used to be broken, see #18898, and now that it is fixed by
5a70051c7e (Avoid assertion failure in wxButton with bitmap and empty
label, see #18898, 2020-08-21) add a unit test so that it stays fixed.

---

See https://trac.wxwidgets.org/ticket/18898