### PR TITLE
Monochrome bitmap support (bug #18888)

### DIFF
--- a/include/wx/msw/dib.h
+++ b/include/wx/msw/dib.h
@@ -154,14 +154,14 @@ public:
     // can be used with ::AlphaBlend() but it is also possible to disable
     // pre-multiplication for the DIB to be usable with ImageList_Draw() which
     // does pre-multiplication internally.
-    wxDIB(const wxImage& image, PixelFormat pf = PixelFormat_PreMultiplied)
+    wxDIB(const wxImage& image, PixelFormat pf = PixelFormat_PreMultiplied, int depth = -1)
     {
         Init();
-        (void)Create(image, pf);
+        (void)Create(image, pf, depth);
     }
 
     // same as the above ctor but with the return code
-    bool Create(const wxImage& image, PixelFormat pf = PixelFormat_PreMultiplied);
+    bool Create(const wxImage& image, PixelFormat pf = PixelFormat_PreMultiplied, int depth = -1);
 
     // create wxImage having the same data as this DIB
 

--- a/include/wx/msw/dib.h
+++ b/include/wx/msw/dib.h
@@ -41,8 +41,8 @@ public:
 
 #ifdef __WXMSW__
     // create a DIB from the DDB
-    wxDIB(const wxBitmap& bmp)
-        { Init(); (void)Create(bmp); }
+    wxDIB(const wxBitmap& bmp, int depth = -1)
+        { Init(); (void)Create(bmp, depth); }
 #endif // __WXMSW__
 
     // create a DIB from the Windows DDB
@@ -58,9 +58,9 @@ public:
     // same as the corresponding ctors but with return value
     bool Create(int width, int height, int depth);
 #ifdef __WXMSW__
-    bool Create(const wxBitmap& bmp) { return Create(GetHbitmapOf(bmp)); }
+    bool Create(const wxBitmap& bmp, int depth = -1) { return Create(GetHbitmapOf(bmp), depth); }
 #endif
-    bool Create(HBITMAP hbmp);
+    bool Create(HBITMAP hbmp, int depth = -1);
     bool Load(const wxString& filename);
 
     // dtor is not virtual, this class is not meant to be used polymorphically

--- a/include/wx/rawbmp.h
+++ b/include/wx/rawbmp.h
@@ -715,14 +715,14 @@ struct wxPixelDataOut<wxBitmap>
             public:
                 Reference& operator=(bool b)
                 {
-                    wxByte mask = 1 << m_bit;
-                    wxByte value = b << m_bit;
+                    wxByte mask = static_cast<wxByte>(1 << m_bit);
+                    wxByte value = static_cast<wxByte>(b << m_bit);
                     (*m_ptr &= ~mask) |= value;
                     return *this;
                 }
                 operator bool() const
                 {
-                    wxByte mask = 1 << m_bit;
+                    wxByte mask = static_cast<wxByte>(1 << m_bit);
                     return (*m_ptr & mask) != 0;
                 }
 

--- a/include/wx/rawbmp.h
+++ b/include/wx/rawbmp.h
@@ -735,7 +735,7 @@ struct wxPixelDataOut<wxBitmap>
 
                 wxByte* m_ptr;
                 wxInt8 m_bit;
-                friend Iterator;
+                friend class Iterator;
             };
 
             class Iterator

--- a/include/wx/rawbmp.h
+++ b/include/wx/rawbmp.h
@@ -699,6 +699,7 @@ struct wxPixelDataOut<wxBitmap>
         }
     };
 
+#if defined(__WXMSW__)
     template <>
     class wxPixelDataIn<wxNativeMonoPixelFormat> : public wxPixelDataBase
     {
@@ -910,6 +911,7 @@ struct wxPixelDataOut<wxBitmap>
             m_height = sz.y;
         }
     };
+#endif
 };
 
 #endif //wxUSE_GUI

--- a/include/wx/rawbmp.h
+++ b/include/wx/rawbmp.h
@@ -170,7 +170,7 @@ typedef wxPixelFormat<unsigned char, 24, 0, 1, 2> wxImagePixelFormat;
         // doesn't cover the case of wxImage which stores alpha separately)
         enum { HasAlpha = false };
     };
-    typedef wxPixelFormat<void, 1, -1, -1, -1, -1, bool> wxNativeMonoPixelFormat;
+    typedef wxPixelFormat<void, 1, -1, -1, -1, -1, bool> wxMonoPixelFormat;
 #elif defined(__WXMAC__)
     // under Mac, first component is unused but still present, hence we use
     // 32bpp, not 24
@@ -702,7 +702,7 @@ struct wxPixelDataOut<wxBitmap>
 
     #if defined(__WXMSW__)
         template <>
-        struct wxPixelDataOut<wxBitmap>::wxPixelDataIn<wxNativeMonoPixelFormat> : public wxPixelDataBase
+        struct wxPixelDataOut<wxBitmap>::wxPixelDataIn<wxMonoPixelFormat> : public wxPixelDataBase
         {
         public:
             // the type of the class we're working with
@@ -742,7 +742,7 @@ struct wxPixelDataOut<wxBitmap>
             {
             public:
                 // emulate unspecialized template
-                typedef wxNativeMonoPixelFormat Format;
+                typedef wxMonoPixelFormat Format;
 
                 // the pixel format we use
                 typedef Format PixelFormat;
@@ -945,7 +945,7 @@ typedef wxPixelData<wxBitmap, wxNativePixelFormat> wxNativePixelData;
 typedef wxPixelData<wxBitmap, wxAlphaPixelFormat> wxAlphaPixelData;
 
 #if defined(__WXMSW__)
-typedef wxPixelData<wxBitmap, wxNativeMonoPixelFormat> wxNativeMonoPixelData;
+typedef wxPixelData<wxBitmap, wxMonoPixelFormat> wxMonoPixelData;
 #endif
 
 #endif //wxUSE_GUI

--- a/include/wx/rawbmp.h
+++ b/include/wx/rawbmp.h
@@ -153,6 +153,24 @@ typedef wxPixelFormat<unsigned char, 24, 0, 1, 2> wxImagePixelFormat;
     typedef wxPixelFormat<unsigned char, 24, 2, 1, 0> wxNativePixelFormat;
 
     #define wxPIXEL_FORMAT_ALPHA 3
+
+    template<>
+    struct wxPixelFormat<void, 1, -1, -1, -1, -1, bool>
+    {
+        // the type which may hold the entire pixel value
+        typedef bool PixelType;
+
+        // size of one pixel in bits
+        static const int BitsPerPixel = 1;
+
+        // size of one pixel in ChannelType units (usually bytes)
+        static const int SizePixel = 1;
+
+        // true if we have an alpha channel (together with the other channels, this
+        // doesn't cover the case of wxImage which stores alpha separately)
+        enum { HasAlpha = false };
+    };
+    typedef wxPixelFormat<void, 1, -1, -1, -1, -1, bool> wxNativeMonoPixelFormat;
 #elif defined(__WXMAC__)
     // under Mac, first component is unused but still present, hence we use
     // 32bpp, not 24
@@ -680,6 +698,218 @@ struct wxPixelDataOut<wxBitmap>
             m_height = sz.y;
         }
     };
+
+    template <>
+    class wxPixelDataIn<wxNativeMonoPixelFormat> : public wxPixelDataBase
+    {
+    public:
+        // the type of the class we're working with
+        typedef wxBitmap ImageType;
+
+        // Reference emulates ChannelType& for monochrome bitmap
+        class Iterator;
+        class Reference
+        {
+        public:
+            Reference& operator=(bool b)
+            {
+                wxByte mask = 1 << m_bit;
+                wxByte value = b << m_bit;
+                (*m_ptr &= ~mask) |= value;
+                return *this;
+            }
+            operator bool() const
+            {
+                wxByte mask = 1 << m_bit;
+                return (*m_ptr & mask) != 0;
+            }
+
+        private:
+            Reference(const Iterator& i) :
+                m_ptr(i.m_ptr),
+                m_bit(i.m_bit)
+            {
+            }
+
+            wxByte* m_ptr;
+            wxInt8 m_bit;
+            friend Iterator;
+        };
+
+        class Iterator
+        {
+        public:
+            // emulate unspecialized template
+            typedef wxNativeMonoPixelFormat Format;
+
+            // the pixel format we use
+            typedef Format PixelFormat;
+
+            // the pixel data we're working with
+            typedef wxPixelDataOut<wxBitmap>::wxPixelDataIn<Format> PixelData;
+
+
+            // go back to (0, 0)
+            void Reset(const PixelData& data)
+            {
+                *this = data.GetPixels();
+            }
+
+            // initializes the iterator to point to the origin of the given
+            // pixel data
+            Iterator(PixelData& data)
+            {
+                Reset(data);
+            }
+
+            // initializes the iterator to point to the origin of the given
+            // bitmap
+            Iterator(wxBitmap& bmp, PixelData& data)
+            {
+                // using cast here is ugly but it should be safe as
+                // GetRawData() real return type should be consistent with
+                // BitsPerPixel (which is in turn defined by ChannelType) and
+                // this is the only thing we can do without making GetRawData()
+                // a template function which is undesirable
+                m_ptr = (wxByte*)
+                    bmp.GetRawData(data, PixelFormat::BitsPerPixel);
+                m_bit = 7;
+            }
+
+            // default constructor
+            Iterator()
+            {
+                m_ptr = NULL;
+                // m_bit doesn't need to be set until m_ptr != NULL
+            }
+
+            // return true if this iterator is valid
+            bool IsOk() const { return m_ptr != NULL; }
+
+
+            // navigation
+            // ----------
+
+            // advance the iterator to the next pixel, prefix version
+            Iterator& operator++()
+            {
+                --m_bit;
+                m_ptr += (m_bit < 0);
+                m_bit &= 0x7;
+
+                return *this;
+            }
+
+            // postfix (hence less efficient -- don't use it unless you
+            // absolutely must) version
+            Iterator operator++(int)
+            {
+                Iterator p(*this);
+                ++* this;
+                return p;
+            }
+
+            // move x pixels to the right and y down
+            //
+            // note that the rows don't wrap!
+            void Offset(const PixelData& data, int x, int y)
+            {
+                m_ptr += data.GetRowStride() * y;
+                x += 7 - m_bit;
+                m_ptr += x >> 3;
+                m_bit = 7 - (x & 0x7);
+            }
+
+            // move x pixels to the right (again, no row wrapping)
+            void OffsetX(const PixelData& WXUNUSED(data), int x)
+            {
+                x += 7 - m_bit;
+                m_ptr += x >> 3;
+                m_bit = 7 - (x & 0x7);
+            }
+
+            // move y rows to the bottom
+            void OffsetY(const PixelData& data, int y)
+            {
+                m_ptr += data.GetRowStride() * y;
+            }
+
+            // go to the given position
+            void MoveTo(const PixelData& data, int x, int y)
+            {
+                Reset(data);
+                Offset(data, x, y);
+            }
+
+
+            // data access
+            // -----------
+
+            // access to individual pixels
+            Reference Pixel() { return Reference(*this); }
+
+        // private: -- see comment in the beginning of the file
+
+            // I don't see a way to bit-twiddle without two fields
+            wxByte* m_ptr;
+            wxInt8 m_bit;
+        };
+
+        // ctor associates this pointer with a bitmap and locks the bitmap for
+        // raw access, it will be unlocked only by our dtor and so these
+        // objects should normally be only created on the stack, i.e. have
+        // limited life-time
+        wxPixelDataIn(wxBitmap& bmp) : m_bmp(bmp), m_pixels(bmp, *this)
+        {
+        }
+
+        wxPixelDataIn(wxBitmap& bmp, const wxRect& rect)
+            : m_bmp(bmp), m_pixels(bmp, *this)
+        {
+            InitRect(rect.GetPosition(), rect.GetSize());
+        }
+
+        wxPixelDataIn(wxBitmap& bmp, const wxPoint& pt, const wxSize& sz)
+            : m_bmp(bmp), m_pixels(bmp, *this)
+        {
+            InitRect(pt, sz);
+        }
+
+        // we evaluate to true only if we could get access to bitmap data
+        // successfully
+        operator bool() const { return m_pixels.IsOk(); }
+
+        // get the iterator pointing to the origin
+        Iterator GetPixels() const { return m_pixels; }
+
+        // dtor unlocks the bitmap
+        ~wxPixelDataIn()
+        {
+            if (m_pixels.IsOk())
+            {
+                m_bmp.UngetRawData(*this);
+            }
+            // else: don't call UngetRawData() if GetRawData() failed
+        }
+
+    // private: -- see comment in the beginning of the file
+
+        // the bitmap we're associated with
+        wxBitmap m_bmp;
+
+        // the iterator pointing to the image origin
+        Iterator m_pixels;
+
+    private:
+        void InitRect(const wxPoint& pt, const wxSize& sz)
+        {
+            m_pixels.Offset(*this, pt.x, pt.y);
+
+            m_ptOrigin = pt;
+            m_width = sz.x;
+            m_height = sz.y;
+        }
+    };
 };
 
 #endif //wxUSE_GUI
@@ -711,6 +941,10 @@ typedef wxPixelData<wxImage> wxImagePixelData;
 #if wxUSE_GUI
 typedef wxPixelData<wxBitmap, wxNativePixelFormat> wxNativePixelData;
 typedef wxPixelData<wxBitmap, wxAlphaPixelFormat> wxAlphaPixelData;
+
+#if defined(__WXMSW__)
+typedef wxPixelData<wxBitmap, wxNativeMonoPixelFormat> wxNativeMonoPixelData;
+#endif
 
 #endif //wxUSE_GUI
 

--- a/src/msw/bitmap.cpp
+++ b/src/msw/bitmap.cpp
@@ -1272,7 +1272,7 @@ void wxBitmap::MSWBlendMaskWithAlpha()
 
     {
         wxBitmap bmpMask = GetMask()->GetBitmap();
-        wxNativeMonoPixelData maskData(bmpMask);
+        wxMonoPixelData maskData(bmpMask);
         wxCHECK_RET(maskData, "No access to bitmap mask data");
 
         wxAlphaPixelData bmpData(*this);
@@ -1281,11 +1281,11 @@ void wxBitmap::MSWBlendMaskWithAlpha()
         const int w = GetWidth();
         const int h = GetHeight();
 
-        wxNativeMonoPixelData::Iterator maskRowStart(maskData);
+        wxMonoPixelData::Iterator maskRowStart(maskData);
         wxAlphaPixelData::Iterator bmpRowStart(bmpData);
         for ( int y = 0; y < h; y++ )
         {
-            wxNativeMonoPixelData::Iterator pMask = maskRowStart;
+            wxMonoPixelData::Iterator pMask = maskRowStart;
             wxAlphaPixelData::Iterator pBmp = bmpRowStart;
             for ( int x = 0; x < w; x++, ++pBmp, ++pMask )
             {

--- a/src/msw/bitmap.cpp
+++ b/src/msw/bitmap.cpp
@@ -848,7 +848,7 @@ bool wxBitmap::CreateFromImage(const wxImage& image, int depth, WXHDC hdc)
     const int h = image.GetHeight();
     const int w = image.GetWidth();
 
-    wxDIB dib(image);
+    wxDIB dib(image, wxDIB::PixelFormat_PreMultiplied, depth);
     if ( !dib.IsOk() )
         return false;
 

--- a/src/msw/bitmap.cpp
+++ b/src/msw/bitmap.cpp
@@ -1272,7 +1272,7 @@ void wxBitmap::MSWBlendMaskWithAlpha()
 
     {
         wxBitmap bmpMask = GetMask()->GetBitmap();
-        wxNativePixelData maskData(bmpMask);
+        wxNativeMonoPixelData maskData(bmpMask);
         wxCHECK_RET(maskData, "No access to bitmap mask data");
 
         wxAlphaPixelData bmpData(*this);
@@ -1281,17 +1281,17 @@ void wxBitmap::MSWBlendMaskWithAlpha()
         const int w = GetWidth();
         const int h = GetHeight();
 
-        wxNativePixelData::Iterator maskRowStart(maskData);
+        wxNativeMonoPixelData::Iterator maskRowStart(maskData);
         wxAlphaPixelData::Iterator bmpRowStart(bmpData);
         for ( int y = 0; y < h; y++ )
         {
-            wxNativePixelData::Iterator pMask = maskRowStart;
+            wxNativeMonoPixelData::Iterator pMask = maskRowStart;
             wxAlphaPixelData::Iterator pBmp = bmpRowStart;
             for ( int x = 0; x < w; x++, ++pBmp, ++pMask )
             {
                 // Masked pixel is not drawn i.e. is transparent,
                 // non-masked pixel is untouched.
-                if ( pMask.Red() == 0 )
+                if ( pMask.Pixel() == 0 )
                 {
                     pBmp.Red() = pBmp.Green() = pBmp.Blue() = 0; // pre-multiplied
                     pBmp.Alpha() = wxALPHA_TRANSPARENT;

--- a/src/msw/dib.cpp
+++ b/src/msw/dib.cpp
@@ -823,9 +823,9 @@ wxImage wxDIB::ConvertToImage(ConversionFlags flags) const
     {
         // copy one DIB line
         const unsigned char *src = srcLineStart;
-        for ( int x = 0; x < w; x++ )
+        if ( bpp != 1 )
         {
-            if ( bpp != 1 )
+            for ( int x = 0; x < w; x++ )
             {
                 dst[2] = *src++;
                 dst[1] = *src++;
@@ -865,8 +865,13 @@ wxImage wxDIB::ConvertToImage(ConversionFlags flags) const
 
                     src++;
                 }
+
+                dst += 3;
             }
-            else
+        }
+        else
+        {
+            for ( int x = 0; x < w; x++ )
             {
                 unsigned char value = MonochromeLineReadBit(srcLineStart, x)
                                         ? 255
@@ -875,8 +880,6 @@ wxImage wxDIB::ConvertToImage(ConversionFlags flags) const
                 dst[1] = value;
                 dst[0] = value;
             }
-
-            dst += 3;
         }
 
         // pass to the previous line in the image

--- a/src/msw/dib.cpp
+++ b/src/msw/dib.cpp
@@ -719,7 +719,7 @@ bool wxDIB::Create(const wxImage& image, PixelFormat pf, int depth)
         {
             for ( int x = 0; x < w; x++ )
             {
-                if (bpp != 1)
+                if ( bpp != 1 )
                 {
                     *dst++ = src[2];
                     *dst++ = src[1];
@@ -793,7 +793,7 @@ wxImage wxDIB::ConvertToImage(ConversionFlags flags) const
         const unsigned char *src = srcLineStart;
         for ( int x = 0; x < w; x++ )
         {
-            if (bpp != 1)
+            if ( bpp != 1 )
             {
                 dst[2] = *src++;
                 dst[1] = *src++;

--- a/src/msw/dib.cpp
+++ b/src/msw/dib.cpp
@@ -54,7 +54,8 @@
 // private functions
 // ----------------------------------------------------------------------------
 
-namespace {
+namespace
+{
 
 // calculate the number of palette entries needed for the bitmap with this
 // number of bits per pixel
@@ -83,6 +84,7 @@ inline bool MonochromeLineReadBit(const unsigned char* srcLineStart, int index)
     unsigned char mask = 1 << bit;
     return (*byte & mask) != 0;
 }
+
 inline void MonochromeLineWriteBit(unsigned char* dstLineStart, int index, bool value)
 {
     unsigned char* byte = dstLineStart + (index >> 3);

--- a/src/msw/dib.cpp
+++ b/src/msw/dib.cpp
@@ -881,6 +881,8 @@ wxImage wxDIB::ConvertToImage(ConversionFlags flags) const
                 dst[2] = value;
                 dst[1] = value;
                 dst[0] = value;
+
+                dst += 3;
             }
         }
 

--- a/src/msw/dib.cpp
+++ b/src/msw/dib.cpp
@@ -151,7 +151,7 @@ bool wxDIB::Create(int width, int height, int depth)
     return true;
 }
 
-bool wxDIB::Create(HBITMAP hbmp)
+bool wxDIB::Create(HBITMAP hbmp, int depth /* = -1 */)
 {
     wxCHECK_MSG( hbmp, false, wxT("wxDIB::Create(): invalid bitmap") );
 
@@ -183,7 +183,7 @@ bool wxDIB::Create(HBITMAP hbmp)
             return false;
         }
 
-        int d = bm.bmBitsPixel;
+        int d = depth >= 1 ? depth : bm.bmBitsPixel;
         if ( d <= 0 )
             d = wxDisplayDepth();
 

--- a/src/msw/dib.cpp
+++ b/src/msw/dib.cpp
@@ -673,12 +673,11 @@ bool wxDIB::Create(const wxImage& image, PixelFormat pf, int depth)
         wxScopedPtr<wxPalette> palette(tempPalette);
         eightBitData.reset(tempEightBitData);
 
-        // try to use palette's colors in result bitmap
+        // use palette's colors in result bitmap
         MemoryHDC hDC;
         SelectInHDC sDC(hDC, m_handle);
-        RGBQUAD colorTable[256];
-        UINT colors = GetDIBColorTable(hDC, 0, 256, colorTable);
-        for ( UINT i = 0; i < colors; ++i )
+        RGBQUAD colorTable[2];
+        for ( UINT i = 0; i < WXSIZEOF(colorTable); ++i )
         {
             if ( !palette->GetRGB(i,
                                     &colorTable[i].rgbRed,
@@ -689,14 +688,11 @@ bool wxDIB::Create(const wxImage& image, PixelFormat pf, int depth)
             }
             colorTable[i].rgbReserved = 0;
         }
-        UINT rc = SetDIBColorTable(hDC, 0, colors, colorTable);
-        if ( rc != colors )
+        UINT rc = SetDIBColorTable(hDC, 0, WXSIZEOF(colorTable), colorTable);
+        if ( rc != WXSIZEOF(colorTable))
         {
             wxLogLastError(wxT("SetDIBColorTable"));
-#if 0   // KLUDGE:  SetDIBColorTable always fails for me,
-        // so allow bitmap to stay black/white
             return false;
-#endif
         }
     }
 

--- a/src/msw/dib.cpp
+++ b/src/msw/dib.cpp
@@ -53,9 +53,11 @@
 // private functions
 // ----------------------------------------------------------------------------
 
+namespace {
+
 // calculate the number of palette entries needed for the bitmap with this
 // number of bits per pixel
-static inline WORD GetNumberOfColours(WORD bitsPerPixel)
+inline WORD GetNumberOfColours(WORD bitsPerPixel)
 {
     // only 1, 4 and 8bpp bitmaps use palettes (well, they could be used with
     // 24bpp ones too but we don't support this as I think it's quite uncommon)
@@ -63,7 +65,7 @@ static inline WORD GetNumberOfColours(WORD bitsPerPixel)
 }
 
 // wrapper around ::GetObject() for DIB sections
-static inline bool GetDIBSection(HBITMAP hbmp, DIBSECTION *ds)
+inline bool GetDIBSection(HBITMAP hbmp, DIBSECTION *ds)
 {
     // note that GetObject() may return sizeof(DIBSECTION) for a bitmap
     // which is *not* a DIB section and the way to check for it is
@@ -73,14 +75,14 @@ static inline bool GetDIBSection(HBITMAP hbmp, DIBSECTION *ds)
 }
 
 // for monochrome bitmaps, need bit twiddling functions to get at pixels
-static inline bool MonochromeLineReadBit(const unsigned char* srcLineStart, int index)
+inline bool MonochromeLineReadBit(const unsigned char* srcLineStart, int index)
 {
     const unsigned char* byte = srcLineStart + (index >> 3);
     int bit = 7 - (index & 7);
     unsigned char mask = 1 << bit;
-    return *byte & mask;
+    return (*byte & mask) != 0;
 }
-static inline void MonochromeLineWriteBit(unsigned char* dstLineStart, int index, bool value)
+inline void MonochromeLineWriteBit(unsigned char* dstLineStart, int index, bool value)
 {
     unsigned char* byte = dstLineStart + (index >> 3);
     int bit = 7 - (index & 7);
@@ -89,6 +91,7 @@ static inline void MonochromeLineWriteBit(unsigned char* dstLineStart, int index
     (*byte &= mask) |= newValue;
 }
 
+}
 // ============================================================================
 // implementation
 // ============================================================================

--- a/src/msw/dib.cpp
+++ b/src/msw/dib.cpp
@@ -764,7 +764,6 @@ bool wxDIB::Create(const wxImage& image, PixelFormat pf, int dstDepth)
             {
                 for ( int x = 0; x < w; x++ )
                 {
-                    wxASSERT(src[0] == 0 || src[0] == 1);
                     MonochromeLineWriteBit(dstLineStart, x, src[0] != 0);
                     ++src;
                 }

--- a/src/msw/dib.cpp
+++ b/src/msw/dib.cpp
@@ -276,9 +276,9 @@ bool wxDIB::Save(const wxString& filename)
             if ( ds.dsBmih.biBitCount == 1 )
             {
                 memset(monoBmiColors, 128, sizeof(monoBmiColors));
-                MemoryHDC dc;
-                SelectInHDC(dc, m_handle);
-                UINT rc = GetDIBColorTable(dc, 0, WXSIZEOF(monoBmiColors), monoBmiColors);
+                MemoryHDC hDC;
+                SelectInHDC sDC(hDC, m_handle);
+                UINT rc = GetDIBColorTable(hDC, 0, WXSIZEOF(monoBmiColors), monoBmiColors);
                 if ( rc != 2 )
                 {
                     wxLogLastError(wxT("GetDIBColorTable"));
@@ -688,7 +688,7 @@ bool wxDIB::Create(const wxImage& image, PixelFormat pf, int depth)
 
         // try to use palette's colors in result bitmap
         MemoryHDC hDC;
-        SelectInHDC(hDC, m_handle);
+        SelectInHDC sDC(hDC, m_handle);
         RGBQUAD colorTable[256];
         UINT colors = GetDIBColorTable(hDC, 0, 256, colorTable);
         for ( UINT i = 0; i < colors; ++i )

--- a/src/msw/dib.cpp
+++ b/src/msw/dib.cpp
@@ -750,19 +750,22 @@ bool wxDIB::Create(const wxImage& image, PixelFormat pf, int depth)
         }
         else // no alpha channel
         {
-            for ( int x = 0; x < w; x++ )
+            if ( bpp != 1 )
             {
-                if ( bpp != 1 )
+                for ( int x = 0; x < w; x++ )
                 {
                     *dst++ = src[2];
                     *dst++ = src[1];
                     *dst++ = src[0];
                     src += 3;
                 }
-                else
+            }
+            else
+            {
+                for ( int x = 0; x < w; x++ )
                 {
                     wxASSERT(src[0] == 0 || src[0] == 1);
-                    MonochromeLineWriteBit(dstLineStart, x, src[0]);
+                    MonochromeLineWriteBit(dstLineStart, x, src[0] != 0);
                     ++src;
                 }
             }

--- a/src/msw/dib.cpp
+++ b/src/msw/dib.cpp
@@ -646,11 +646,7 @@ bool wxDIB::Create(const wxImage& image, PixelFormat pf, int depth)
     // a 24bpp RGB is sufficient
     // but use monochrome if requested (to support wxMask)
     const bool hasAlpha = image.HasAlpha();
-    // monochrome DIBs can't express alpha
-    if ( hasAlpha && depth == 1 ) {
-        wxLogError( _("can't convert image with alpha to monochrome") );
-        return false;
-    }
+    wxCHECK_MSG(!hasAlpha || depth != 1, false, "alpha not supported in monochrome bitmaps");
     const int bpp = depth != -1 ? depth : hasAlpha ? 32 : 24;
 
     if ( !Create(w, h, bpp) )

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -67,10 +67,11 @@ TEST_CASE("BitmapTestCase::Monochrome", "[bitmap][monochrome]")
 
     wxImage imgQuant = color.ConvertToImage();
     wxBitmap bmpQuant(imgQuant, 1);
-    bmpQuant.SaveFile("quantize.bmp", wxBITMAP_TYPE_BMP);
+    REQUIRE(bmpQuant.GetDepth() == 1);
+    REQUIRE(bmpQuant.SaveFile("quantize.bmp", wxBITMAP_TYPE_BMP));
 
     wxBitmap mono;
-    mono.LoadFile("quantize.bmp", wxBITMAP_TYPE_BMP);
+    REQUIRE(mono.LoadFile("quantize.bmp", wxBITMAP_TYPE_BMP));
     REQUIRE(mono.IsOk());
     REQUIRE(mono.GetDepth() == 1);
 }

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -80,7 +80,7 @@ TEST_CASE("BitmapTestCase::Monochrome", "[bitmap][monochrome]")
     REQUIRE(mono.GetDepth() == 1);
 
 #if !defined(__WXMSW__)
-    WARN("wxNativeMonoPixelData only exists in wxMSW")
+    WARN("wxNativeMonoPixelData only exists in wxMSW");
 #else
     // draw lines on top and left, but leaving blank top and left lines
     {

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -78,6 +78,26 @@ TEST_CASE("BitmapTestCase::Monochrome", "[bitmap][monochrome]")
     REQUIRE(mono.LoadFile(mono_horse.GetName(), wxBITMAP_TYPE_BMP));
     REQUIRE(mono.IsOk());
     REQUIRE(mono.GetDepth() == 1);
+
+    // draw lines on top and left, but leaving blank top and left lines
+    {
+        wxNativeMonoPixelData data(mono);
+        wxNativeMonoPixelData::Iterator p(data);
+        p.OffsetY(data, 1);
+        for ( int i = 0; i < data.GetWidth() - 2; ++i )
+        {
+            ++p;
+            p.Pixel() = 0;
+        }
+        p.MoveTo(data, 1, 1);
+        for ( int i = 0; i < data.GetHeight() - 3; ++i )
+        {
+            p.OffsetY(data, 1);
+            p.Pixel() = 1;
+        }
+    }
+    TempFile mono_lines_horse("mono_lines_horse.bmp");
+    REQUIRE(mono.SaveFile(mono_lines_horse.GetName(), wxBITMAP_TYPE_BMP));
 #endif
 }
 
@@ -747,32 +767,32 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
     }
 
     // Check sub bitmap mask
-    wxColour maskClrTopLeft;
-    wxColour maskClrTopRight;
-    wxColour maskClrBottomLeft;
-    wxColour maskClrBottomRight;
+    bool maskValueTopLeft;
+    bool maskValueTopRight;
+    bool maskValueBottomLeft;
+    bool maskValueBottomRight;
     // Fetch sample original mask pixels
     {
-        wxNativePixelData data(bmpMask);
+        wxNativeMonoPixelData data(bmpMask);
         REQUIRE(data);
-        wxNativePixelData::Iterator p(data);
+        wxNativeMonoPixelData::Iterator p(data);
         p.OffsetY(data, h / 4);
-        wxNativePixelData::Iterator rowStart = p;
+        wxNativeMonoPixelData::Iterator rowStart = p;
         p.OffsetX(data, w / 4); // top-left point
-        maskClrTopLeft = wxColour(p.Red(), p.Green(), p.Blue());
+        maskValueTopLeft = p.Pixel();
         p.OffsetX(data, w / 2); // top-right point
-        maskClrTopRight = wxColour(p.Red(), p.Green(), p.Blue());
+        maskValueTopRight = p.Pixel();
         p = rowStart;
         p.OffsetY(data, h / 2);
         p.OffsetX(data, w / 4); // bottom-left point
-        maskClrBottomLeft = wxColour(p.Red(), p.Green(), p.Blue());
+        maskValueBottomLeft = p.Pixel();
         p.OffsetX(data, w / 2); // bottom-right point
-        maskClrBottomRight = wxColour(p.Red(), p.Green(), p.Blue());
+        maskValueBottomRight = p.Pixel();
     }
-    CHECK(maskClrTopLeft == *wxWHITE);
-    CHECK(maskClrTopRight == *wxWHITE);
-    CHECK(maskClrBottomLeft == *wxBLACK);
-    CHECK(maskClrBottomRight == *wxBLACK);
+    CHECK(maskValueTopLeft == true);
+    CHECK(maskValueTopRight == true);
+    CHECK(maskValueBottomLeft == false);
+    CHECK(maskValueBottomRight == false);
 
     wxBitmap subBmpMask = subBmp.GetMask()->GetBitmap();
     // Check sub bitmap mask attributes
@@ -785,21 +805,21 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
     REQUIRE_FALSE(subBmpMask.GetMask());
     // Check sub bitmap mask pixels
     {
-        wxNativePixelData data(subBmpMask);
+        wxNativeMonoPixelData data(subBmpMask);
         REQUIRE(data);
-        wxNativePixelData::Iterator p(data);
+        wxNativeMonoPixelData::Iterator p(data);
         p.OffsetY(data, h2 / 4);
-        wxNativePixelData::Iterator rowStart = p;
+        wxNativeMonoPixelData::Iterator rowStart = p;
         p.OffsetX(data, w2 / 4); // top-left point
-        ASSERT_EQUAL_COLOUR_RGB(p, maskClrTopLeft);
+        CHECK(p.Pixel() == maskValueTopLeft);
         p.OffsetX(data, w2 / 2); // top-right point
-        ASSERT_EQUAL_COLOUR_RGB(p, maskClrTopRight);
+        CHECK(p.Pixel() == maskValueTopRight);
         p = rowStart;
         p.OffsetY(data, h2 / 2);
         p.OffsetX(data, w2 / 4); // bottom-left point
-        ASSERT_EQUAL_COLOUR_RGB(p, maskClrBottomLeft);
+        CHECK(p.Pixel() == maskValueBottomLeft);
         p.OffsetX(data, w2 / 2); // bottom-right point
-        ASSERT_EQUAL_COLOUR_RGB(p, maskClrBottomRight);
+        CHECK(p.Pixel() == maskValueBottomRight);
     }
 }
 
@@ -891,32 +911,32 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
     }
 
     // Check sub bitmap mask
-    wxColour maskClrTopLeft;
-    wxColour maskClrTopRight;
-    wxColour maskClrBottomLeft;
-    wxColour maskClrBottomRight;
+    bool maskValueTopLeft;
+    bool maskValueTopRight;
+    bool maskValueBottomLeft;
+    bool maskValueBottomRight;
     // Fetch sample original mask pixels
     {
-        wxNativePixelData data(bmpMask);
+        wxNativeMonoPixelData data(bmpMask);
         REQUIRE(data);
-        wxNativePixelData::Iterator p(data);
+        wxNativeMonoPixelData::Iterator p(data);
         p.OffsetY(data, h / 4);
-        wxNativePixelData::Iterator rowStart = p;
+        wxNativeMonoPixelData::Iterator rowStart = p;
         p.OffsetX(data, w / 4); // top-left point
-        maskClrTopLeft = wxColour(p.Red(), p.Green(), p.Blue());
+        maskValueTopLeft = p.Pixel();
         p.OffsetX(data, w / 2); // top-right point
-        maskClrTopRight = wxColour(p.Red(), p.Green(), p.Blue());
+        maskValueTopRight = p.Pixel();
         p = rowStart;
         p.OffsetY(data, h / 2);
         p.OffsetX(data, w / 4); // bottom-left point
-        maskClrBottomLeft = wxColour(p.Red(), p.Green(), p.Blue());
+        maskValueBottomLeft = p.Pixel();
         p.OffsetX(data, w / 2); // bottom-right point
-        maskClrBottomRight = wxColour(p.Red(), p.Green(), p.Blue());
+        maskValueBottomRight = p.Pixel();
     }
-    CHECK(maskClrTopLeft == *wxWHITE);
-    CHECK(maskClrTopRight == *wxWHITE);
-    CHECK(maskClrBottomLeft == *wxBLACK);
-    CHECK(maskClrBottomRight == *wxBLACK);
+    CHECK(maskValueTopLeft == true);
+    CHECK(maskValueTopRight == true);
+    CHECK(maskValueBottomLeft == false);
+    CHECK(maskValueBottomRight == false);
 
     wxBitmap subBmpMask = subBmp.GetMask()->GetBitmap();
     // Check sub bitmap mask attributes
@@ -929,21 +949,21 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
     REQUIRE_FALSE(subBmpMask.GetMask());
     // Check sub bitmap mask pixels
     {
-        wxNativePixelData data(subBmpMask);
+        wxNativeMonoPixelData data(subBmpMask);
         REQUIRE(data);
-        wxNativePixelData::Iterator p(data);
+        wxNativeMonoPixelData::Iterator p(data);
         p.OffsetY(data, h2 / 4);
-        wxNativePixelData::Iterator rowStart = p;
+        wxNativeMonoPixelData::Iterator rowStart = p;
         p.OffsetX(data, w2 / 4); // top-left point
-        ASSERT_EQUAL_RGB(p, maskClrTopLeft.Red(), maskClrTopLeft.Green(), maskClrTopLeft.Blue());
+        CHECK(p.Pixel() == maskValueTopLeft);
         p.OffsetX(data, w2 / 2); // top-right point
-        ASSERT_EQUAL_RGB(p, maskClrTopRight.Red(), maskClrTopRight.Green(), maskClrTopRight.Blue());
+        CHECK(p.Pixel() == maskValueTopRight);
         p = rowStart;
         p.OffsetY(data, h2 / 2);
         p.OffsetX(data, w2 / 4); // bottom-left point
-        ASSERT_EQUAL_RGB(p, maskClrBottomLeft.Red(), maskClrBottomLeft.Green(), maskClrBottomLeft.Blue());
+        CHECK(p.Pixel() == maskValueBottomLeft);
         p.OffsetX(data, w2 / 2); // bottom-right point
-        ASSERT_EQUAL_RGB(p, maskClrBottomRight.Red(), maskClrBottomRight.Green(), maskClrBottomRight.Blue());
+        CHECK(p.Pixel() == maskValueBottomRight);
     }
 }
 

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -80,12 +80,12 @@ TEST_CASE("BitmapTestCase::Monochrome", "[bitmap][monochrome]")
     REQUIRE(mono.GetDepth() == 1);
 
 #if !defined(__WXMSW__)
-    WARN("wxNativeMonoPixelData only exists in wxMSW");
+    WARN("wxMonoPixelData only exists in wxMSW");
 #else
     // draw lines on top and left, but leaving blank top and left lines
     {
-        wxNativeMonoPixelData data(mono);
-        wxNativeMonoPixelData::Iterator p(data);
+        wxMonoPixelData data(mono);
+        wxMonoPixelData::Iterator p(data);
         p.OffsetY(data, 1);
         for ( int i = 0; i < data.GetWidth() - 2; ++i )
         {
@@ -805,11 +805,11 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
     bool maskValueBottomRight;
     // Fetch sample original mask pixels
     {
-        wxNativeMonoPixelData data(bmpMask);
+        wxMonoPixelData data(bmpMask);
         REQUIRE(data);
-        wxNativeMonoPixelData::Iterator p(data);
+        wxMonoPixelData::Iterator p(data);
         p.OffsetY(data, h / 4);
-        wxNativeMonoPixelData::Iterator rowStart = p;
+        wxMonoPixelData::Iterator rowStart = p;
         p.OffsetX(data, w / 4); // top-left point
         maskValueTopLeft = p.Pixel();
         p.OffsetX(data, w / 2); // top-right point
@@ -857,11 +857,11 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
     }
 #else
     {
-        wxNativeMonoPixelData data(subBmpMask);
+        wxMonoPixelData data(subBmpMask);
         REQUIRE(data);
-        wxNativeMonoPixelData::Iterator p(data);
+        wxMonoPixelData::Iterator p(data);
         p.OffsetY(data, h2 / 4);
-        wxNativeMonoPixelData::Iterator rowStart = p;
+        wxMonoPixelData::Iterator rowStart = p;
         p.OffsetX(data, w2 / 4); // top-left point
         CHECK(p.Pixel() == maskValueTopLeft);
         p.OffsetX(data, w2 / 2); // top-right point
@@ -998,11 +998,11 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
     bool maskValueBottomRight;
     // Fetch sample original mask pixels
     {
-        wxNativeMonoPixelData data(bmpMask);
+        wxMonoPixelData data(bmpMask);
         REQUIRE(data);
-        wxNativeMonoPixelData::Iterator p(data);
+        wxMonoPixelData::Iterator p(data);
         p.OffsetY(data, h / 4);
-        wxNativeMonoPixelData::Iterator rowStart = p;
+        wxMonoPixelData::Iterator rowStart = p;
         p.OffsetX(data, w / 4); // top-left point
         maskValueTopLeft = p.Pixel();
         p.OffsetX(data, w / 2); // top-right point
@@ -1050,11 +1050,11 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
     }
 #else
     {
-        wxNativeMonoPixelData data(subBmpMask);
+        wxMonoPixelData data(subBmpMask);
         REQUIRE(data);
-        wxNativeMonoPixelData::Iterator p(data);
+        wxMonoPixelData::Iterator p(data);
         p.OffsetY(data, h2 / 4);
-        wxNativeMonoPixelData::Iterator rowStart = p;
+        wxMonoPixelData::Iterator rowStart = p;
         p.OffsetX(data, w2 / 4); // top-left point
         CHECK(p.Pixel() == maskValueTopLeft);
         p.OffsetX(data, w2 / 2); // top-right point

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -771,6 +771,34 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
     }
 
     // Check sub bitmap mask
+#if !defined(__WXMSW__)
+    wxColour maskClrTopLeft;
+    wxColour maskClrTopRight;
+    wxColour maskClrBottomLeft;
+    wxColour maskClrBottomRight;
+    // Fetch sample original mask pixels
+    {
+        wxNativePixelData data(bmpMask);
+        REQUIRE(data);
+        wxNativePixelData::Iterator p(data);
+        p.OffsetY(data, h / 4);
+        wxNativePixelData::Iterator rowStart = p;
+        p.OffsetX(data, w / 4); // top-left point
+        maskClrTopLeft = wxColour(p.Red(), p.Green(), p.Blue());
+        p.OffsetX(data, w / 2); // top-right point
+        maskClrTopRight = wxColour(p.Red(), p.Green(), p.Blue());
+        p = rowStart;
+        p.OffsetY(data, h / 2);
+        p.OffsetX(data, w / 4); // bottom-left point
+        maskClrBottomLeft = wxColour(p.Red(), p.Green(), p.Blue());
+        p.OffsetX(data, w / 2); // bottom-right point
+        maskClrBottomRight = wxColour(p.Red(), p.Green(), p.Blue());
+    }
+    CHECK(maskClrTopLeft == *wxWHITE);
+    CHECK(maskClrTopRight == *wxWHITE);
+    CHECK(maskClrBottomLeft == *wxBLACK);
+    CHECK(maskClrBottomRight == *wxBLACK);
+#else
     bool maskValueTopLeft;
     bool maskValueTopRight;
     bool maskValueBottomLeft;
@@ -797,6 +825,7 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
     CHECK(maskValueTopRight == true);
     CHECK(maskValueBottomLeft == false);
     CHECK(maskValueBottomRight == false);
+#endif
 
     wxBitmap subBmpMask = subBmp.GetMask()->GetBitmap();
     // Check sub bitmap mask attributes
@@ -808,6 +837,25 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
     REQUIRE_FALSE(subBmpMask.HasAlpha());
     REQUIRE_FALSE(subBmpMask.GetMask());
     // Check sub bitmap mask pixels
+#if !defined(__WXMSW__)
+    {
+        wxNativePixelData data(subBmpMask);
+        REQUIRE(data);
+        wxNativePixelData::Iterator p(data);
+        p.OffsetY(data, h2 / 4);
+        wxNativePixelData::Iterator rowStart = p;
+        p.OffsetX(data, w2 / 4); // top-left point
+        ASSERT_EQUAL_COLOUR_RGB(p, maskClrTopLeft);
+        p.OffsetX(data, w2 / 2); // top-right point
+        ASSERT_EQUAL_COLOUR_RGB(p, maskClrTopRight);
+        p = rowStart;
+        p.OffsetY(data, h2 / 2);
+        p.OffsetX(data, w2 / 4); // bottom-left point
+        ASSERT_EQUAL_COLOUR_RGB(p, maskClrBottomLeft);
+        p.OffsetX(data, w2 / 2); // bottom-right point
+        ASSERT_EQUAL_COLOUR_RGB(p, maskClrBottomRight);
+    }
+#else
     {
         wxNativeMonoPixelData data(subBmpMask);
         REQUIRE(data);
@@ -825,6 +873,7 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
         p.OffsetX(data, w2 / 2); // bottom-right point
         CHECK(p.Pixel() == maskValueBottomRight);
     }
+#endif
 }
 
 TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][withmask]")
@@ -915,6 +964,34 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
     }
 
     // Check sub bitmap mask
+#if !defined(__WXMSW__)
+    wxColour maskClrTopLeft;
+    wxColour maskClrTopRight;
+    wxColour maskClrBottomLeft;
+    wxColour maskClrBottomRight;
+    // Fetch sample original mask pixels
+    {
+        wxNativePixelData data(bmpMask);
+        REQUIRE(data);
+        wxNativePixelData::Iterator p(data);
+        p.OffsetY(data, h / 4);
+        wxNativePixelData::Iterator rowStart = p;
+        p.OffsetX(data, w / 4); // top-left point
+        maskClrTopLeft = wxColour(p.Red(), p.Green(), p.Blue());
+        p.OffsetX(data, w / 2); // top-right point
+        maskClrTopRight = wxColour(p.Red(), p.Green(), p.Blue());
+        p = rowStart;
+        p.OffsetY(data, h / 2);
+        p.OffsetX(data, w / 4); // bottom-left point
+        maskClrBottomLeft = wxColour(p.Red(), p.Green(), p.Blue());
+        p.OffsetX(data, w / 2); // bottom-right point
+        maskClrBottomRight = wxColour(p.Red(), p.Green(), p.Blue());
+    }
+    CHECK(maskClrTopLeft == *wxWHITE);
+    CHECK(maskClrTopRight == *wxWHITE);
+    CHECK(maskClrBottomLeft == *wxBLACK);
+    CHECK(maskClrBottomRight == *wxBLACK);
+#else
     bool maskValueTopLeft;
     bool maskValueTopRight;
     bool maskValueBottomLeft;
@@ -941,6 +1018,7 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
     CHECK(maskValueTopRight == true);
     CHECK(maskValueBottomLeft == false);
     CHECK(maskValueBottomRight == false);
+#endif
 
     wxBitmap subBmpMask = subBmp.GetMask()->GetBitmap();
     // Check sub bitmap mask attributes
@@ -952,6 +1030,25 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
     REQUIRE_FALSE(subBmpMask.HasAlpha());
     REQUIRE_FALSE(subBmpMask.GetMask());
     // Check sub bitmap mask pixels
+#if !defined(__WXMSW__)
+    {
+        wxNativePixelData data(subBmpMask);
+        REQUIRE(data);
+        wxNativePixelData::Iterator p(data);
+        p.OffsetY(data, h2 / 4);
+        wxNativePixelData::Iterator rowStart = p;
+        p.OffsetX(data, w2 / 4); // top-left point
+        ASSERT_EQUAL_RGB(p, maskClrTopLeft.Red(), maskClrTopLeft.Green(), maskClrTopLeft.Blue());
+        p.OffsetX(data, w2 / 2); // top-right point
+        ASSERT_EQUAL_RGB(p, maskClrTopRight.Red(), maskClrTopRight.Green(), maskClrTopRight.Blue());
+        p = rowStart;
+        p.OffsetY(data, h2 / 2);
+        p.OffsetX(data, w2 / 4); // bottom-left point
+        ASSERT_EQUAL_RGB(p, maskClrBottomLeft.Red(), maskClrBottomLeft.Green(), maskClrBottomLeft.Blue());
+        p.OffsetX(data, w2 / 2); // bottom-right point
+        ASSERT_EQUAL_RGB(p, maskClrBottomRight.Red(), maskClrBottomRight.Green(), maskClrBottomRight.Blue());
+    }
+#else
     {
         wxNativeMonoPixelData data(subBmpMask);
         REQUIRE(data);
@@ -969,6 +1066,7 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
         p.OffsetX(data, w2 / 2); // bottom-right point
         CHECK(p.Pixel() == maskValueBottomRight);
     }
+#endif
 }
 
 namespace Catch

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -79,6 +79,9 @@ TEST_CASE("BitmapTestCase::Monochrome", "[bitmap][monochrome]")
     REQUIRE(mono.IsOk());
     REQUIRE(mono.GetDepth() == 1);
 
+#if !defined(__WXMSW__)
+    WARN("wxNativeMonoPixelData only exists in wxMSW")
+#else
     // draw lines on top and left, but leaving blank top and left lines
     {
         wxNativeMonoPixelData data(mono);
@@ -98,7 +101,8 @@ TEST_CASE("BitmapTestCase::Monochrome", "[bitmap][monochrome]")
     }
     TempFile mono_lines_horse("mono_lines_horse.bmp");
     REQUIRE(mono.SaveFile(mono_lines_horse.GetName(), wxBITMAP_TYPE_BMP));
-#endif
+#endif      // __WXMSW__
+#endif      // !__WXGTK__
 }
 
 TEST_CASE("BitmapTestCase::Mask", "[bitmap][mask]")

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -25,6 +25,7 @@
 #include "wx/graphics.h"
 #endif // wxUSE_GRAPHICS_CONTEXT
 
+#include "testfile.h"
 #include "testimage.h"
 
 #define ASSERT_EQUAL_RGB(c, r, g, b) \
@@ -70,10 +71,11 @@ TEST_CASE("BitmapTestCase::Monochrome", "[bitmap][monochrome]")
     wxImage imgQuant = color.ConvertToImage();
     wxBitmap bmpQuant(imgQuant, 1);
     REQUIRE(bmpQuant.GetDepth() == 1);
-    REQUIRE(bmpQuant.SaveFile("quantize.bmp", wxBITMAP_TYPE_BMP));
+    TempFile mono_horse("mono_horse.bmp");
+    REQUIRE(bmpQuant.SaveFile(mono_horse.GetName(), wxBITMAP_TYPE_BMP));
 
     wxBitmap mono;
-    REQUIRE(mono.LoadFile("quantize.bmp", wxBITMAP_TYPE_BMP));
+    REQUIRE(mono.LoadFile(mono_horse.GetName(), wxBITMAP_TYPE_BMP));
     REQUIRE(mono.IsOk());
     REQUIRE(mono.GetDepth() == 1);
 #endif

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -24,7 +24,6 @@
 #if wxUSE_GRAPHICS_CONTEXT
 #include "wx/graphics.h"
 #endif // wxUSE_GRAPHICS_CONTEXT
-#include "wx/quantize.h"
 
 #include "testimage.h"
 

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -61,7 +61,7 @@ typedef wxNativePixelData wxNative32PixelData;
 TEST_CASE("BitmapTestCase::Monochrome", "[bitmap][monochrome]")
 {
 #ifdef __WXGTK__
-    WARN("Skipping test known not to work in wxGTK.")
+    WARN("Skipping test known not to work in wxGTK.");
 #else
     wxBitmap color;
     color.LoadFile("horse.bmp", wxBITMAP_TYPE_BMP);

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -79,9 +79,8 @@ TEST_CASE("BitmapTestCase::Monochrome", "[bitmap][monochrome]")
     REQUIRE(mono.IsOk());
     REQUIRE(mono.GetDepth() == 1);
 
-#if !defined(__WXMSW__)
-    WARN("wxMonoPixelData only exists in wxMSW");
-#else
+    // wxMonoPixelData only exists in wxMSW
+#if defined(__WXMSW__)
     // draw lines on top and left, but leaving blank top and left lines
     {
         wxMonoPixelData data(mono);
@@ -771,13 +770,13 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
     }
 
     // Check sub bitmap mask
-#if !defined(__WXMSW__)
     wxColour maskClrTopLeft;
     wxColour maskClrTopRight;
     wxColour maskClrBottomLeft;
     wxColour maskClrBottomRight;
     // Fetch sample original mask pixels
     {
+        REQUIRE(bmpMask.GetDepth() == 1);
         wxNativePixelData data(bmpMask);
         REQUIRE(data);
         wxNativePixelData::Iterator p(data);
@@ -794,17 +793,21 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
         p.OffsetX(data, w / 2); // bottom-right point
         maskClrBottomRight = wxColour(p.Red(), p.Green(), p.Blue());
     }
+    REQUIRE(bmpMask.GetDepth() == 1);
     CHECK(maskClrTopLeft == *wxWHITE);
     CHECK(maskClrTopRight == *wxWHITE);
     CHECK(maskClrBottomLeft == *wxBLACK);
     CHECK(maskClrBottomRight == *wxBLACK);
-#else
+
+    // wxMonoPixelData only exists in wxMSW
+#if defined(__WXMSW__)
     bool maskValueTopLeft;
     bool maskValueTopRight;
     bool maskValueBottomLeft;
     bool maskValueBottomRight;
     // Fetch sample original mask pixels
     {
+        REQUIRE(bmpMask.GetDepth() == 1);
         wxMonoPixelData data(bmpMask);
         REQUIRE(data);
         wxMonoPixelData::Iterator p(data);
@@ -821,11 +824,12 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
         p.OffsetX(data, w / 2); // bottom-right point
         maskValueBottomRight = p.Pixel();
     }
+    REQUIRE(bmpMask.GetDepth() == 1);
     CHECK(maskValueTopLeft == true);
     CHECK(maskValueTopRight == true);
     CHECK(maskValueBottomLeft == false);
     CHECK(maskValueBottomRight == false);
-#endif
+#endif      // __WXMSW__
 
     wxBitmap subBmpMask = subBmp.GetMask()->GetBitmap();
     // Check sub bitmap mask attributes
@@ -837,8 +841,8 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
     REQUIRE_FALSE(subBmpMask.HasAlpha());
     REQUIRE_FALSE(subBmpMask.GetMask());
     // Check sub bitmap mask pixels
-#if !defined(__WXMSW__)
     {
+        REQUIRE(subBmpMask.GetDepth() == 1);
         wxNativePixelData data(subBmpMask);
         REQUIRE(data);
         wxNativePixelData::Iterator p(data);
@@ -855,8 +859,12 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
         p.OffsetX(data, w2 / 2); // bottom-right point
         ASSERT_EQUAL_COLOUR_RGB(p, maskClrBottomRight);
     }
-#else
+    REQUIRE(subBmpMask.GetDepth() == 1);
+
+    // wxMonoPixelData only exists in wxMSW
+#if defined(__WXMSW__)
     {
+        REQUIRE(subBmpMask.GetDepth() == 1);
         wxMonoPixelData data(subBmpMask);
         REQUIRE(data);
         wxMonoPixelData::Iterator p(data);
@@ -873,7 +881,8 @@ TEST_CASE("BitmapTestCase::SubBitmapNonAlphaWithMask", "[bitmap][subbitmap][nona
         p.OffsetX(data, w2 / 2); // bottom-right point
         CHECK(p.Pixel() == maskValueBottomRight);
     }
-#endif
+    REQUIRE(subBmpMask.GetDepth() == 1);
+#endif      // __WXMSW__
 }
 
 TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][withmask]")
@@ -964,13 +973,13 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
     }
 
     // Check sub bitmap mask
-#if !defined(__WXMSW__)
     wxColour maskClrTopLeft;
     wxColour maskClrTopRight;
     wxColour maskClrBottomLeft;
     wxColour maskClrBottomRight;
     // Fetch sample original mask pixels
     {
+        REQUIRE(bmpMask.GetDepth() == 1);
         wxNativePixelData data(bmpMask);
         REQUIRE(data);
         wxNativePixelData::Iterator p(data);
@@ -987,17 +996,21 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
         p.OffsetX(data, w / 2); // bottom-right point
         maskClrBottomRight = wxColour(p.Red(), p.Green(), p.Blue());
     }
+    REQUIRE(bmpMask.GetDepth() == 1);
     CHECK(maskClrTopLeft == *wxWHITE);
     CHECK(maskClrTopRight == *wxWHITE);
     CHECK(maskClrBottomLeft == *wxBLACK);
     CHECK(maskClrBottomRight == *wxBLACK);
-#else
+
+    // wxMonoPixelData only exists in wxMSW
+#if defined(__WXMSW__)
     bool maskValueTopLeft;
     bool maskValueTopRight;
     bool maskValueBottomLeft;
     bool maskValueBottomRight;
     // Fetch sample original mask pixels
     {
+        REQUIRE(bmpMask.GetDepth() == 1);
         wxMonoPixelData data(bmpMask);
         REQUIRE(data);
         wxMonoPixelData::Iterator p(data);
@@ -1014,11 +1027,12 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
         p.OffsetX(data, w / 2); // bottom-right point
         maskValueBottomRight = p.Pixel();
     }
+    REQUIRE(bmpMask.GetDepth() == 1);
     CHECK(maskValueTopLeft == true);
     CHECK(maskValueTopRight == true);
     CHECK(maskValueBottomLeft == false);
     CHECK(maskValueBottomRight == false);
-#endif
+#endif      // __WXMSW__
 
     wxBitmap subBmpMask = subBmp.GetMask()->GetBitmap();
     // Check sub bitmap mask attributes
@@ -1030,8 +1044,8 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
     REQUIRE_FALSE(subBmpMask.HasAlpha());
     REQUIRE_FALSE(subBmpMask.GetMask());
     // Check sub bitmap mask pixels
-#if !defined(__WXMSW__)
     {
+        REQUIRE(subBmpMask.GetDepth() == 1);
         wxNativePixelData data(subBmpMask);
         REQUIRE(data);
         wxNativePixelData::Iterator p(data);
@@ -1048,8 +1062,12 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
         p.OffsetX(data, w2 / 2); // bottom-right point
         ASSERT_EQUAL_RGB(p, maskClrBottomRight.Red(), maskClrBottomRight.Green(), maskClrBottomRight.Blue());
     }
-#else
+    REQUIRE(subBmpMask.GetDepth() == 1);
+
+    // wxMonoPixelData only exists in wxMSW
+#if defined(__WXMSW__)
     {
+        REQUIRE(subBmpMask.GetDepth() == 1);
         wxMonoPixelData data(subBmpMask);
         REQUIRE(data);
         wxMonoPixelData::Iterator p(data);
@@ -1066,7 +1084,8 @@ TEST_CASE("BitmapTestCase::SubBitmapAlphaWithMask", "[bitmap][subbitmap][alpha][
         p.OffsetX(data, w2 / 2); // bottom-right point
         CHECK(p.Pixel() == maskValueBottomRight);
     }
-#endif
+    REQUIRE(subBmpMask.GetDepth() == 1);
+#endif      // __WXMSW__
 }
 
 namespace Catch

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -24,6 +24,7 @@
 #if wxUSE_GRAPHICS_CONTEXT
 #include "wx/graphics.h"
 #endif // wxUSE_GRAPHICS_CONTEXT
+#include "wx/quantize.h"
 
 #include "testimage.h"
 
@@ -56,6 +57,23 @@ typedef wxNativePixelData wxNative32PixelData;
 // ----------------------------------------------------------------------------
 // tests
 // ----------------------------------------------------------------------------
+
+TEST_CASE("BitmapTestCase::Monochrome", "[bitmap][monochrome]")
+{
+    wxBitmap color;
+    color.LoadFile("horse.bmp", wxBITMAP_TYPE_BMP);
+    REQUIRE(color.IsOk());
+    REQUIRE(color.GetDepth() == 32);
+
+    wxImage imgQuant = color.ConvertToImage();
+    wxBitmap bmpQuant(imgQuant, 1);
+    bmpQuant.SaveFile("quantize.bmp", wxBITMAP_TYPE_BMP);
+
+    wxBitmap mono;
+    mono.LoadFile("quantize.bmp", wxBITMAP_TYPE_BMP);
+    REQUIRE(mono.IsOk());
+    REQUIRE(mono.GetDepth() == 1);
+}
 
 TEST_CASE("BitmapTestCase::Mask", "[bitmap][mask]")
 {

--- a/tests/graphics/bitmap.cpp
+++ b/tests/graphics/bitmap.cpp
@@ -60,6 +60,9 @@ typedef wxNativePixelData wxNative32PixelData;
 
 TEST_CASE("BitmapTestCase::Monochrome", "[bitmap][monochrome]")
 {
+#ifdef __WXGTK__
+    WARN("Skipping test known not to work in wxGTK.")
+#else
     wxBitmap color;
     color.LoadFile("horse.bmp", wxBITMAP_TYPE_BMP);
     REQUIRE(color.IsOk());
@@ -74,6 +77,7 @@ TEST_CASE("BitmapTestCase::Monochrome", "[bitmap][monochrome]")
     REQUIRE(mono.LoadFile("quantize.bmp", wxBITMAP_TYPE_BMP));
     REQUIRE(mono.IsOk());
     REQUIRE(mono.GetDepth() == 1);
+#endif
 }
 
 TEST_CASE("BitmapTestCase::Mask", "[bitmap][mask]")


### PR DESCRIPTION
Here is a an attempt to provide basic support for monochrome bitmaps, in particular loading from and saving to files.  I also make wxBitmap(const wxImage&, depth 1) generate a monochrome bitmap.  The resulting bitmap is generated by wxQuantize.  I tried to preserve the colors selected by wxQuantize, but was unable to SetDIBColorTable() work.  Therefore, the resulting bitmap is currently always black-and-white.  Does anyone have any insight into what I am doing wrong with SetDIBColorTable()?

I have also included a basic unit test.