### PR TITLE
Check headers compilation with max warning level

### DIFF
--- a/include/wx/debug.h
+++ b/include/wx/debug.h
@@ -371,7 +371,7 @@ extern void WXDLLIMPEXP_BASE wxAbort();
         wxFAIL_COND_MSG(#cond, msg);                                      \
         op;                                                               \
     }                                                                     \
-    struct wxDummyCheckStruct /* just to force a semicolon */
+    struct wxMAKE_UNIQUE_NAME(wxDummyCheckStruct) /* to force a semicolon */
 
 // check which returns with the specified return code if the condition fails
 #define wxCHECK_MSG(cond, rc, msg)   wxCHECK2_MSG(cond, return rc, msg)

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -662,6 +662,9 @@ typedef short int WXTYPE;
         wxGCC_WARNING_SUPPRESS(float-equal)
         inline bool wxIsSameDouble(double x, double y) { return x == y; }
         wxGCC_WARNING_RESTORE(float-equal)
+
+   Note that these macros apply to both gcc and clang, even though they only
+   have "GCC" in their names.
  */
 #if defined(__clang__) || wxCHECK_GCC_VERSION(4, 6)
 #   define wxGCC_WARNING_SUPPRESS(x) \
@@ -672,6 +675,17 @@ typedef short int WXTYPE;
 #else /* gcc < 4.6 or not gcc and not clang at all */
 #   define wxGCC_WARNING_SUPPRESS(x)
 #   define wxGCC_WARNING_RESTORE(x)
+#endif
+
+/*
+    Similar macros but for gcc-specific warnings.
+ */
+#ifdef __GNUC__
+#   define wxGCC_ONLY_WARNING_SUPPRESS(x) wxGCC_WARNING_SUPPRESS(x)
+#   define wxGCC_ONLY_WARNING_RESTORE(x) wxGCC_WARNING_RESTORE(x)
+#else
+#   define wxGCC_ONLY_WARNING_SUPPRESS(x)
+#   define wxGCC_ONLY_WARNING_RESTORE(x)
 #endif
 
 /* Specific macros for -Wcast-function-type warning new in gcc 8. */

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -542,12 +542,14 @@ typedef short int WXTYPE;
 /*  ---------------------------------------------------------------------------- */
 
 /*  Printf-like attribute definitions to obtain warnings with GNU C/C++ */
+#if defined(__GNUC__) && !wxUSE_UNICODE
+#    define WX_ATTRIBUTE_FORMAT(like, m, n) __attribute__ ((__format__ (like, m, n)))
+#else
+#    define WX_ATTRIBUTE_FORMAT(like, m, n)
+#endif
+
 #ifndef WX_ATTRIBUTE_PRINTF
-#   if defined(__GNUC__) && !wxUSE_UNICODE
-#       define WX_ATTRIBUTE_PRINTF(m, n) __attribute__ ((__format__ (__printf__, m, n)))
-#   else
-#       define WX_ATTRIBUTE_PRINTF(m, n)
-#   endif
+#   define WX_ATTRIBUTE_PRINTF(m, n) WX_ATTRIBUTE_FORMAT(__printf__, m, n)
 
 #   define WX_ATTRIBUTE_PRINTF_1 WX_ATTRIBUTE_PRINTF(1, 2)
 #   define WX_ATTRIBUTE_PRINTF_2 WX_ATTRIBUTE_PRINTF(2, 3)

--- a/include/wx/dfb/dfbptr.h
+++ b/include/wx/dfb/dfbptr.h
@@ -23,7 +23,7 @@
  */
 #define wxDFB_DECLARE_INTERFACE(name)            \
     class wx##name;                              \
-    typedef wxDfbPtr<wx##name> wx##name##Ptr;
+    typedef wxDfbPtr<wx##name> wx##name##Ptr
 
 
 //-----------------------------------------------------------------------------

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -1140,9 +1140,9 @@ private:
     {
     }
 
-    wxGridBlocks(iterator_impl begin, iterator_impl end) :
-        m_begin(begin),
-        m_end(end)
+    wxGridBlocks(iterator_impl ibegin, iterator_impl iend) :
+        m_begin(ibegin),
+        m_end(iend)
     {
     }
 

--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -274,6 +274,12 @@ extern WXDLLIMPEXP_DATA_CORE(wxGraphicsMatrix) wxNullGraphicsMatrix;
 // and how they are spread out in a gradient
 // ----------------------------------------------------------------------------
 
+// gcc 9 gives a nonsensical warning about implicitly generated move ctor not
+// throwing but not being noexcept, suppress it.
+#if wxCHECK_GCC_VERSION(9, 1) && !wxCHECK_GCC_VERSION(10, 0)
+wxGCC_WARNING_SUPPRESS(noexcept)
+#endif
+
 // Describes a single gradient stop.
 class wxGraphicsGradientStop
 {
@@ -305,6 +311,10 @@ private:
     // Its starting position: 0 is the beginning and 1 is the end.
     float m_pos;
 };
+
+#if wxCHECK_GCC_VERSION(9, 1) && !wxCHECK_GCC_VERSION(10, 0)
+wxGCC_WARNING_RESTORE(noexcept)
+#endif
 
 // A collection of gradient stops ordered by their positions (from lowest to
 // highest). The first stop (index 0, position 0.0) is always the starting

--- a/include/wx/hashmap.h
+++ b/include/wx/hashmap.h
@@ -497,15 +497,15 @@ private:
 
 public:
     wxIntegerHash() { }
-    size_t operator()( long x ) const { return longHash( x ); }
-    size_t operator()( unsigned long x ) const { return ulongHash( x ); }
-    size_t operator()( int x ) const { return intHash( x ); }
-    size_t operator()( unsigned int x ) const { return uintHash( x ); }
-    size_t operator()( short x ) const { return shortHash( x ); }
-    size_t operator()( unsigned short x ) const { return ushortHash( x ); }
+    size_t operator()( long x ) const wxNOEXCEPT { return longHash( x ); }
+    size_t operator()( unsigned long x ) const wxNOEXCEPT { return ulongHash( x ); }
+    size_t operator()( int x ) const wxNOEXCEPT { return intHash( x ); }
+    size_t operator()( unsigned int x ) const wxNOEXCEPT { return uintHash( x ); }
+    size_t operator()( short x ) const wxNOEXCEPT { return shortHash( x ); }
+    size_t operator()( unsigned short x ) const wxNOEXCEPT { return ushortHash( x ); }
 #ifdef wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
-    size_t operator()( wxLongLong_t x ) const { return longlongHash(x); }
-    size_t operator()( wxULongLong_t x ) const { return longlongHash(x); }
+    size_t operator()( wxLongLong_t x ) const wxNOEXCEPT { return longlongHash(x); }
+    size_t operator()( wxULongLong_t x ) const wxNOEXCEPT { return longlongHash(x); }
 #endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
 
     wxIntegerHash& operator=(const wxIntegerHash&) { return *this; }
@@ -517,15 +517,15 @@ public:
 struct WXDLLIMPEXP_BASE wxIntegerHash
 {
     wxIntegerHash() { }
-    unsigned long operator()( long x ) const { return (unsigned long)x; }
-    unsigned long operator()( unsigned long x ) const { return x; }
-    unsigned long operator()( int x ) const { return (unsigned long)x; }
-    unsigned long operator()( unsigned int x ) const { return x; }
-    unsigned long operator()( short x ) const { return (unsigned long)x; }
-    unsigned long operator()( unsigned short x ) const { return x; }
+    unsigned long operator()( long x ) const wxNOEXCEPT { return (unsigned long)x; }
+    unsigned long operator()( unsigned long x ) const wxNOEXCEPT { return x; }
+    unsigned long operator()( int x ) const wxNOEXCEPT { return (unsigned long)x; }
+    unsigned long operator()( unsigned int x ) const wxNOEXCEPT { return x; }
+    unsigned long operator()( short x ) const wxNOEXCEPT { return (unsigned long)x; }
+    unsigned long operator()( unsigned short x ) const wxNOEXCEPT { return x; }
 #ifdef wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
-    wxULongLong_t operator()( wxLongLong_t x ) const { return static_cast<wxULongLong_t>(x); }
-    wxULongLong_t operator()( wxULongLong_t x ) const { return x; }
+    wxULongLong_t operator()( wxLongLong_t x ) const wxNOEXCEPT { return static_cast<wxULongLong_t>(x); }
+    wxULongLong_t operator()( wxULongLong_t x ) const wxNOEXCEPT { return x; }
 #endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
 };
 
@@ -552,27 +552,27 @@ struct WXDLLIMPEXP_BASE wxPointerHash
     wxPointerHash() { }
 
 #ifdef wxNEEDS_WX_HASH_MAP
-    wxUIntPtr operator()( const void* k ) const { return wxPtrToUInt(k); }
+    wxUIntPtr operator()( const void* k ) const wxNOEXCEPT { return wxPtrToUInt(k); }
 #else
-    size_t operator()( const void* k ) const { return (size_t)k; }
+    size_t operator()( const void* k ) const wxNOEXCEPT { return (size_t)k; }
 #endif
 };
 
 struct WXDLLIMPEXP_BASE wxPointerEqual
 {
     wxPointerEqual() { }
-    bool operator()( const void* a, const void* b ) const { return a == b; }
+    bool operator()( const void* a, const void* b ) const wxNOEXCEPT { return a == b; }
 };
 
 // wxString, char*, wchar_t*
 struct WXDLLIMPEXP_BASE wxStringHash
 {
     wxStringHash() {}
-    unsigned long operator()( const wxString& x ) const
+    unsigned long operator()( const wxString& x ) const wxNOEXCEPT
         { return stringHash( x.wx_str() ); }
-    unsigned long operator()( const wchar_t* x ) const
+    unsigned long operator()( const wchar_t* x ) const wxNOEXCEPT
         { return stringHash( x ); }
-    unsigned long operator()( const char* x ) const
+    unsigned long operator()( const char* x ) const wxNOEXCEPT
         { return stringHash( x ); }
 
 #if WXWIN_COMPATIBILITY_2_8
@@ -591,12 +591,12 @@ struct WXDLLIMPEXP_BASE wxStringHash
 struct WXDLLIMPEXP_BASE wxStringEqual
 {
     wxStringEqual() {}
-    bool operator()( const wxString& a, const wxString& b ) const
+    bool operator()( const wxString& a, const wxString& b ) const wxNOEXCEPT
         { return a == b; }
-    bool operator()( const wxChar* a, const wxChar* b ) const
+    bool operator()( const wxChar* a, const wxChar* b ) const wxNOEXCEPT
         { return wxStrcmp( a, b ) == 0; }
 #if wxUSE_UNICODE
-    bool operator()( const char* a, const char* b ) const
+    bool operator()( const char* a, const char* b ) const wxNOEXCEPT
         { return strcmp( a, b ) == 0; }
 #endif // wxUSE_UNICODE
 };

--- a/include/wx/motif/cursor.h
+++ b/include/wx/motif/cursor.h
@@ -63,7 +63,5 @@ private:
     wxDECLARE_DYNAMIC_CLASS(wxCursor);
 };
 
-extern WXDLLIMPEXP_CORE void wxSetCursor(const wxCursor& cursor);
-
 #endif
 // _WX_CURSOR_H_

--- a/include/wx/motif/statbmp.h
+++ b/include/wx/motif/statbmp.h
@@ -52,7 +52,7 @@ public:
     wxIcon GetIcon() const
     {
         // don't use wxDynamicCast, icons and bitmaps are really the same thing
-        return *(wxIcon*)&m_messageBitmap;
+        return *(const wxIcon*)&m_messageBitmap;
     }
 
     // for compatibility with wxMSW

--- a/include/wx/msw/stackwalk.h
+++ b/include/wx/msw/stackwalk.h
@@ -49,21 +49,21 @@ public:
         m_addrFrame = addrFrame;
     }
 
-    virtual size_t GetParamCount() const
+    virtual size_t GetParamCount() const wxOVERRIDE
     {
         ConstCast()->OnGetParam();
         return DoGetParamCount();
     }
 
     virtual bool
-    GetParam(size_t n, wxString *type, wxString *name, wxString *value) const;
+    GetParam(size_t n, wxString *type, wxString *name, wxString *value) const wxOVERRIDE;
 
     // callback used by OnGetParam(), don't call directly
     void OnParam(wxSYMBOL_INFO *pSymInfo);
 
 protected:
-    virtual void OnGetName();
-    virtual void OnGetLocation();
+    virtual void OnGetName() wxOVERRIDE;
+    virtual void OnGetLocation() wxOVERRIDE;
 
     void OnGetParam();
 
@@ -96,9 +96,9 @@ public:
     // only
     wxStackWalker(const char * WXUNUSED(argv0) = NULL) { }
 
-    virtual void Walk(size_t skip = 1, size_t maxDepth = wxSTACKWALKER_MAX_DEPTH);
+    virtual void Walk(size_t skip = 1, size_t maxDepth = wxSTACKWALKER_MAX_DEPTH) wxOVERRIDE;
 #if wxUSE_ON_FATAL_EXCEPTION
-    virtual void WalkFromException(size_t maxDepth = wxSTACKWALKER_MAX_DEPTH);
+    virtual void WalkFromException(size_t maxDepth = wxSTACKWALKER_MAX_DEPTH) wxOVERRIDE;
 #endif // wxUSE_ON_FATAL_EXCEPTION
 
 

--- a/include/wx/osx/cursor.h
+++ b/include/wx/osx/cursor.h
@@ -47,6 +47,4 @@ private:
     wxDECLARE_DYNAMIC_CLASS(wxCursor);
 };
 
-extern WXDLLIMPEXP_CORE void wxSetCursor(const wxCursor& cursor);
-
 #endif // _WX_CURSOR_H_

--- a/include/wx/qt/anybutton.h
+++ b/include/wx/qt/anybutton.h
@@ -29,7 +29,7 @@ public:
 
     // implementation only
     void QtUpdateState();
-    virtual int GetEventType() const = 0;
+    virtual int QtGetEventType() const = 0;
 
 protected:
     virtual wxBitmap DoGetBitmap(State state) const wxOVERRIDE;

--- a/include/wx/qt/bitmap.h
+++ b/include/wx/qt/bitmap.h
@@ -22,7 +22,6 @@ class WXDLLIMPEXP_CORE wxBitmap : public wxBitmapBase
 public:
     wxBitmap();
     wxBitmap(QPixmap pix);
-    wxBitmap(const wxBitmap& bmp);
     wxBitmap(const char bits[], int width, int height, int depth = 1);
     wxBitmap(int width, int height, int depth = wxBITMAP_SCREEN_DEPTH);
     wxBitmap(const wxSize& sz, int depth = wxBITMAP_SCREEN_DEPTH);

--- a/include/wx/qt/button.h
+++ b/include/wx/qt/button.h
@@ -32,7 +32,7 @@ public:
    virtual wxWindow *SetDefault() wxOVERRIDE;
 
     // implementation only
-    virtual int GetEventType() const wxOVERRIDE { return wxEVT_BUTTON; }
+    virtual int QtGetEventType() const wxOVERRIDE { return wxEVT_BUTTON; }
 
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxButton);

--- a/include/wx/qt/menuitem.h
+++ b/include/wx/qt/menuitem.h
@@ -36,7 +36,7 @@ public:
     virtual bool IsChecked() const wxOVERRIDE;
 
     virtual void SetBitmap(const wxBitmap& bitmap);
-    virtual const wxBitmap& GetBitmap() const { return m_bitmap; };
+    virtual const wxBitmap& GetBitmap() const { return m_bitmap; }
 
     virtual QAction *GetHandle() const;
 

--- a/include/wx/qt/tglbtn.h
+++ b/include/wx/qt/tglbtn.h
@@ -36,7 +36,7 @@ public:
     virtual bool GetValue() const wxOVERRIDE;
 
     // implementation only
-    virtual int GetEventType() const wxOVERRIDE { return wxEVT_TOGGLEBUTTON; }
+    virtual int QtGetEventType() const wxOVERRIDE { return wxEVT_TOGGLEBUTTON; }
 
 private:
     wxDECLARE_DYNAMIC_CLASS(wxToggleButton);

--- a/include/wx/rtti.h
+++ b/include/wx/rtti.h
@@ -139,10 +139,10 @@ WXDLLIMPEXP_BASE wxObject *wxCreateDynamicObject(const wxString& name);
 
 #define wxDECLARE_ABSTRACT_CLASS(name)                                        \
     public:                                                                   \
-        static wxClassInfo ms_classInfo;                                      \
         wxWARNING_SUPPRESS_MISSING_OVERRIDE()                                 \
         virtual wxClassInfo *GetClassInfo() const;                            \
-        wxWARNING_RESTORE_MISSING_OVERRIDE()
+        wxWARNING_RESTORE_MISSING_OVERRIDE()                                  \
+        static wxClassInfo ms_classInfo
 
 #define wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(name)                               \
     wxDECLARE_NO_ASSIGN_CLASS(name);                                          \

--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -554,12 +554,20 @@ private:
       if ( cacheBegin == NULL )
         return NULL;
 #endif
+
+      // gcc 7 warns about not being able to optimize this loop because of
+      // possible loop variable overflow, really not sure what to do about
+      // this, so just disable this warnings for now
+      wxGCC_ONLY_WARNING_SUPPRESS(unsafe-loop-optimizations)
+
       Cache::Element * const cacheEnd = GetCacheEnd();
       for ( Cache::Element *c = cacheBegin; c != cacheEnd; c++ )
       {
           if ( c->str == this )
               return c;
       }
+
+      wxGCC_ONLY_WARNING_RESTORE(unsafe-loop-optimizations)
 
       return NULL;
   }

--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -569,6 +569,12 @@ private:
   // its corresponding index in the byte string or not
   Cache::Element *GetCacheElement() const
   {
+      // gcc warns about cacheBegin and c inside the loop being possibly null,
+      // but this shouldn't actually be the case
+#if wxCHECK_GCC_VERSION(6,1)
+      wxGCC_ONLY_WARNING_SUPPRESS(null-dereference)
+#endif
+
       Cache::Element * const cacheBegin = GetCacheBegin();
       Cache::Element * const cacheEnd = GetCacheEnd();
       Cache::Element * const cacheStart = cacheBegin + LastUsedCacheElement();
@@ -598,6 +604,10 @@ private:
       }
 
       return c;
+
+#if wxCHECK_GCC_VERSION(6,1)
+      wxGCC_ONLY_WARNING_RESTORE(null-dereference)
+#endif
   }
 
   size_t DoPosToImpl(size_t pos) const

--- a/include/wx/strvararg.h
+++ b/include/wx/strvararg.h
@@ -31,6 +31,10 @@
 class WXDLLIMPEXP_FWD_BASE wxCStrData;
 class WXDLLIMPEXP_FWD_BASE wxString;
 
+// There are a lot of structs with intentionally private ctors in this file,
+// suppress gcc warnings about this.
+wxGCC_WARNING_SUPPRESS(ctor-dtor-privacy)
+
 // ----------------------------------------------------------------------------
 // WX_DEFINE_VARARG_FUNC* macros
 // ----------------------------------------------------------------------------
@@ -1247,5 +1251,7 @@ private:
 #define _WX_VARARG_DEFINE_FUNC_NOP_N0(name, numfixed, fixed)                  \
     inline void name(_WX_VARARG_FIXED_UNUSED_EXPAND(numfixed, fixed))         \
     {}
+
+wxGCC_WARNING_RESTORE(ctor-dtor-privacy)
 
 #endif // _WX_STRVARARG_H_

--- a/include/wx/univ/control.h
+++ b/include/wx/univ/control.h
@@ -79,7 +79,10 @@ public:
         return m_indexAccel == -1 ? wxT('\0') : (wxChar)m_label[m_indexAccel];
     }
 
-    virtual wxWindow *GetInputWindow() const wxOVERRIDE { return (wxWindow*)this; }
+    virtual wxWindow *GetInputWindow() const wxOVERRIDE
+    {
+        return const_cast<wxControl*>(this);
+    }
 
 protected:
     // common part of all ctors

--- a/include/wx/wxcrt.h
+++ b/include/wx/wxcrt.h
@@ -1052,9 +1052,16 @@ inline wchar_t* wxGetenv(const wxScopedWCharBuffer& name) { return wxCRT_GetenvW
 // ----------------------------------------------------------------------------
 
 #ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
+WX_ATTRIBUTE_FORMAT(__strftime__, 3, 4)
 inline size_t wxStrftime(char *s, size_t max,
                          const wxString& format, const struct tm *tm)
-    { return wxCRT_StrftimeA(s, max, format.mb_str(), tm); }
+    {
+        wxGCC_ONLY_WARNING_SUPPRESS(format-nonliteral)
+
+        return wxCRT_StrftimeA(s, max, format.mb_str(), tm);
+
+        wxGCC_ONLY_WARNING_RESTORE(format-nonliteral)
+    }
 #endif // wxNO_IMPLICIT_WXSTRING_ENCODING
 
 inline size_t wxStrftime(wchar_t *s, size_t max,

--- a/include/wx/wxcrtvararg.h
+++ b/include/wx/wxcrtvararg.h
@@ -276,6 +276,8 @@
 #endif
 
 
+wxGCC_ONLY_WARNING_SUPPRESS(format-nonliteral)
+
 WX_DEFINE_VARARG_FUNC_SANS_N0(int, wxPrintf, 1, (const wxFormatString&),
                               wxCRT_PrintfNative, wxCRT_PrintfA)
 inline int wxPrintf(const wxFormatString& s)
@@ -289,6 +291,8 @@ inline int wxFprintf(FILE *f, const wxFormatString& s)
 {
     return wxFprintf(f, wxASCII_STR("%s"), s.InputAsString());
 }
+
+wxGCC_ONLY_WARNING_RESTORE(format-nonliteral)
 
 // va_list versions of printf functions simply forward to the respective
 // CRT function; note that they assume that va_list was created using

--- a/src/qt/anybutton.cpp
+++ b/src/qt/anybutton.cpp
@@ -45,7 +45,7 @@ void wxQtPushButton::clicked(bool checked)
     wxAnyButton *handler = GetHandler();
     if ( handler )
     {
-        wxCommandEvent event( handler->GetEventType(), handler->GetId() );
+        wxCommandEvent event( handler->QtGetEventType(), handler->GetId() );
         if ( isCheckable() ) // toggle buttons
         {
             event.SetInt(checked);

--- a/src/qt/bitmap.cpp
+++ b/src/qt/bitmap.cpp
@@ -174,11 +174,6 @@ wxBitmap::wxBitmap(QPixmap pix)
     m_refData = new wxBitmapRefData(pix);
 }
 
-wxBitmap::wxBitmap(const wxBitmap& bmp)
-{
-    Ref(bmp);
-}
-
 wxBitmap::wxBitmap(const char bits[], int width, int height, int depth )
 {
     wxASSERT(depth == 1);

--- a/tests/allheaders.cpp
+++ b/tests/allheaders.cpp
@@ -84,6 +84,10 @@
 
 #include "catch.hpp"
 
+#if defined(__WXQT__)
+    #include <QtGui/QFont>
+#endif
+
 #ifdef GCC_TURN_OFF
     #pragma GCC diagnostic pop
 #endif

--- a/tests/allheaders.cpp
+++ b/tests/allheaders.cpp
@@ -86,6 +86,14 @@
 
 #if defined(__WXMSW__)
     #include <windows.h>
+
+    // Avoid warnings about redeclaring standard functions such as chmod() in
+    // various standard headers when using MinGW/Cygwin.
+    #if defined(__MINGW32__) || defined(__CYGWIN__)
+        #include <stdio.h>
+        #include <unistd.h>
+        #include <sys/stat.h>
+    #endif
 #elif defined(__WXQT__)
     #include <QtGui/QFont>
 #endif

--- a/tests/allheaders.cpp
+++ b/tests/allheaders.cpp
@@ -379,6 +379,10 @@
     GCC_TURN_OFF(abi-tag)
 #endif // 4.8
 
+    // This can be used to ask the compiler to explain why some function is not
+    // inlined, but it's perfectly normal for some functions not to be inlined.
+    GCC_TURN_OFF(inline)
+
     // All those are about using perfectly normal C++ features that are
     // actually used in our code.
     GCC_TURN_OFF(aggregate-return)

--- a/tests/allheaders.cpp
+++ b/tests/allheaders.cpp
@@ -10,11 +10,6 @@
 // headers
 // ----------------------------------------------------------------------------
 
-// Avoid pre-compiled headers at all
-#ifdef __BORLANDC__
-    #pragma hdrstop
-#endif
-
 #include "wx/setup.h"
 
 #if !wxUSE_UTF8_LOCALE_ONLY

--- a/tests/allheaders.cpp
+++ b/tests/allheaders.cpp
@@ -42,6 +42,7 @@
 
     GCC_TURN_OFF(aggregate-return)
     GCC_TURN_OFF(conversion)
+    GCC_TURN_OFF(format)
     GCC_TURN_OFF(padded)
     GCC_TURN_OFF(parentheses)
     GCC_TURN_OFF(sign-compare)

--- a/tests/allheaders.cpp
+++ b/tests/allheaders.cpp
@@ -10,7 +10,391 @@
 // headers
 // ----------------------------------------------------------------------------
 
+// Note: can't use wxCHECK_GCC_VERSION() here as it's not defined yet.
+#if defined(__GNUC__)
+    #define CHECK_GCC_VERSION(major, minor) \
+      (__GNUC__ > (major) || (__GNUC__ == (major) && __GNUC_MINOR__ >= (minor)))
+#else
+    #define CHECK_GCC_VERSION(major, minor) 0
+#endif
+
+#if CHECK_GCC_VERSION(4, 6)
+    // As above, we can't reuse wxCONCAT() and wxSTRINGIZE macros from wx/cpp.h
+    // here, so define their equivalents here.
+    #define CONCAT_HELPER(x, y) x ## y
+    #define CONCAT(x1, x2)      CONCAT_HELPER(x1, x2)
+
+    #define STRINGIZE_HELPER(x) #x
+    #define STRINGIZE(x)        STRINGIZE_HELPER(x)
+
+    #define GCC_TURN_ON(warn) \
+        _Pragma(STRINGIZE(GCC diagnostic error STRINGIZE(CONCAT(-W,warn))))
+    #define GCC_TURN_OFF(warn) \
+        _Pragma(STRINGIZE(GCC diagnostic ignored STRINGIZE(CONCAT(-W,warn))))
+#endif
+
+// Due to what looks like a bug in gcc, some warnings enabled after including
+// the standard headers still result in warnings being given when instantiating
+// some functions defined in these headers later and we need to explicitly
+// disable these warnings to avoid them, even if they're not enabled yet.
+#ifdef GCC_TURN_OFF
+    #pragma GCC diagnostic push
+
+    GCC_TURN_OFF(aggregate-return)
+    GCC_TURN_OFF(conversion)
+    GCC_TURN_OFF(padded)
+    GCC_TURN_OFF(parentheses)
+    GCC_TURN_OFF(sign-compare)
+    GCC_TURN_OFF(sign-conversion)
+    GCC_TURN_OFF(unused-parameter)
+    GCC_TURN_OFF(zero-as-null-pointer-constant)
+#endif
+
+// We have to include this one first in order to check for HAVE_XXX below.
 #include "wx/setup.h"
+
+// Include all standard headers that are used in wx headers before enabling the
+// warnings below.
+#include <algorithm>
+#include <cmath>
+#include <exception>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <list>
+#include <locale>
+#include <map>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#if defined(HAVE_STD_UNORDERED_MAP)
+    #include <unordered_map>
+#endif
+#if defined(HAVE_STD_UNORDERED_SET)
+    #include <unordered_set>
+#endif
+
+#if defined(HAVE_DLOPEN)
+    #include <dlfcn.h>
+#endif
+#include <fcntl.h>
+
+#include "catch.hpp"
+
+#ifdef GCC_TURN_OFF
+    #pragma GCC diagnostic pop
+#endif
+
+// Enable max warning level for headers if possible, using gcc pragmas.
+#ifdef GCC_TURN_ON
+    // Enable all the usual "maximal" warnings.
+    GCC_TURN_ON(all)
+    GCC_TURN_ON(extra)
+    GCC_TURN_ON(pedantic)
+
+    // Enable all the individual warnings not enabled by one of the warnings
+    // above.
+
+    // Start of semi-auto-generated part, don't modify it manually.
+    //
+    // Manual changes:
+    //  - Globally replace HANDLE_GCC_WARNING with GCC_TURN_ON.
+    //  - Add v6 check for -Wabi, gcc < 6 don't seem to support turning it off
+    //    once it's turned on and gives it for the standard library symbols.
+    // {{{
+#if CHECK_GCC_VERSION(6,1)
+    GCC_TURN_ON(abi)
+#endif // 6.1
+#if CHECK_GCC_VERSION(4,8)
+    GCC_TURN_ON(abi-tag)
+#endif // 4.8
+    GCC_TURN_ON(address)
+    GCC_TURN_ON(aggregate-return)
+#if CHECK_GCC_VERSION(7,1)
+    GCC_TURN_ON(alloc-zero)
+#endif // 7.1
+#if CHECK_GCC_VERSION(7,1)
+    GCC_TURN_ON(alloca)
+#endif // 7.1
+#if CHECK_GCC_VERSION(10,1)
+    GCC_TURN_ON(arith-conversion)
+#endif // 10.1
+    GCC_TURN_ON(array-bounds)
+    GCC_TURN_ON(builtin-macro-redefined)
+    GCC_TURN_ON(cast-align)
+#if CHECK_GCC_VERSION(8,1)
+    GCC_TURN_ON(cast-align=strict)
+#endif // 8.1
+    GCC_TURN_ON(cast-qual)
+    GCC_TURN_ON(char-subscripts)
+#if CHECK_GCC_VERSION(9,1)
+    GCC_TURN_ON(chkp)
+#endif // 9.1
+#if CHECK_GCC_VERSION(8,1)
+    GCC_TURN_ON(class-memaccess)
+#endif // 8.1
+    GCC_TURN_ON(clobbered)
+#if CHECK_GCC_VERSION(10,1)
+    GCC_TURN_ON(comma-subscript)
+#endif // 10.1
+    GCC_TURN_ON(comment)
+#if CHECK_GCC_VERSION(4,9)
+    GCC_TURN_ON(conditionally-supported)
+#endif // 4.9
+    GCC_TURN_ON(conversion)
+    GCC_TURN_ON(ctor-dtor-privacy)
+#if CHECK_GCC_VERSION(4,9)
+    GCC_TURN_ON(date-time)
+#endif // 4.9
+#if CHECK_GCC_VERSION(4,7)
+    GCC_TURN_ON(delete-non-virtual-dtor)
+#endif // 4.7
+#if CHECK_GCC_VERSION(9,1)
+    GCC_TURN_ON(deprecated-copy)
+#endif // 9.1
+#if CHECK_GCC_VERSION(9,1)
+    GCC_TURN_ON(deprecated-copy-dtor)
+#endif // 9.1
+    GCC_TURN_ON(disabled-optimization)
+    GCC_TURN_ON(double-promotion)
+#if CHECK_GCC_VERSION(7,1)
+    GCC_TURN_ON(duplicated-branches)
+#endif // 7.1
+#if CHECK_GCC_VERSION(6,1)
+    GCC_TURN_ON(duplicated-cond)
+#endif // 6.1
+    GCC_TURN_ON(empty-body)
+    GCC_TURN_ON(endif-labels)
+    GCC_TURN_ON(enum-compare)
+#if CHECK_GCC_VERSION(8,1)
+    GCC_TURN_ON(extra-semi)
+#endif // 8.1
+    GCC_TURN_ON(float-equal)
+    GCC_TURN_ON(format)
+    GCC_TURN_ON(format-contains-nul)
+    GCC_TURN_ON(format-extra-args)
+    GCC_TURN_ON(format-nonliteral)
+    GCC_TURN_ON(format-security)
+#if CHECK_GCC_VERSION(5,1)
+    GCC_TURN_ON(format-signedness)
+#endif // 5.1
+#if CHECK_GCC_VERSION(4,7)
+    GCC_TURN_ON(format-zero-length)
+#endif // 4.7
+    GCC_TURN_ON(ignored-qualifiers)
+    GCC_TURN_ON(init-self)
+    GCC_TURN_ON(inline)
+    GCC_TURN_ON(invalid-pch)
+#if CHECK_GCC_VERSION(4,8)
+    GCC_TURN_ON(literal-suffix)
+#endif // 4.8
+#if CHECK_GCC_VERSION(6,1)
+    GCC_TURN_ON(logical-op)
+#endif // 6.1
+    GCC_TURN_ON(long-long)
+    GCC_TURN_ON(main)
+#if CHECK_GCC_VERSION(4,7)
+    GCC_TURN_ON(maybe-uninitialized)
+#endif // 4.7
+#if CHECK_GCC_VERSION(10,1)
+    GCC_TURN_ON(mismatched-tags)
+#endif // 10.1
+    GCC_TURN_ON(missing-braces)
+    GCC_TURN_ON(missing-declarations)
+    GCC_TURN_ON(missing-field-initializers)
+    GCC_TURN_ON(missing-format-attribute)
+    GCC_TURN_ON(missing-include-dirs)
+    GCC_TURN_ON(missing-noreturn)
+    GCC_TURN_ON(multichar)
+#if CHECK_GCC_VERSION(6,1)
+    GCC_TURN_ON(namespaces)
+#endif // 6.1
+#if CHECK_GCC_VERSION(4,7)
+    GCC_TURN_ON(narrowing)
+#endif // 4.7
+    GCC_TURN_ON(noexcept)
+#if CHECK_GCC_VERSION(7,1)
+    GCC_TURN_ON(noexcept-type)
+#endif // 7.1
+    GCC_TURN_ON(non-virtual-dtor)
+#if CHECK_GCC_VERSION(4,7)
+    GCC_TURN_ON(nonnull)
+#endif // 4.7
+#if CHECK_GCC_VERSION(6,1)
+    GCC_TURN_ON(null-dereference)
+#endif // 6.1
+    GCC_TURN_ON(old-style-cast)
+    GCC_TURN_ON(overlength-strings)
+    GCC_TURN_ON(overloaded-virtual)
+    GCC_TURN_ON(packed)
+    GCC_TURN_ON(packed-bitfield-compat)
+    GCC_TURN_ON(padded)
+    GCC_TURN_ON(parentheses)
+#if CHECK_GCC_VERSION(9,1)
+    GCC_TURN_ON(pessimizing-move)
+#endif // 9.1
+    GCC_TURN_ON(pointer-arith)
+    GCC_TURN_ON(redundant-decls)
+#if CHECK_GCC_VERSION(10,1)
+    GCC_TURN_ON(redundant-tags)
+#endif // 10.1
+#if CHECK_GCC_VERSION(7,1)
+    GCC_TURN_ON(register)
+#endif // 7.1
+    GCC_TURN_ON(reorder)
+#if CHECK_GCC_VERSION(7,1)
+    GCC_TURN_ON(restrict)
+#endif // 7.1
+    GCC_TURN_ON(return-type)
+    GCC_TURN_ON(sequence-point)
+    GCC_TURN_ON(shadow)
+#if CHECK_GCC_VERSION(6,1)
+    GCC_TURN_ON(shift-negative-value)
+#endif // 6.1
+    GCC_TURN_ON(sign-compare)
+    GCC_TURN_ON(sign-conversion)
+    GCC_TURN_ON(sign-promo)
+    GCC_TURN_ON(stack-protector)
+    GCC_TURN_ON(strict-aliasing)
+    GCC_TURN_ON(strict-null-sentinel)
+    GCC_TURN_ON(strict-overflow)
+#if CHECK_GCC_VERSION(10,1)
+    GCC_TURN_ON(string-compare)
+#endif // 10.1
+#if CHECK_GCC_VERSION(8,1)
+    GCC_TURN_ON(stringop-truncation)
+#endif // 8.1
+#if CHECK_GCC_VERSION(8,1)
+    GCC_TURN_ON(suggest-attribute=cold)
+#endif // 8.1
+    GCC_TURN_ON(suggest-attribute=const)
+#if CHECK_GCC_VERSION(4,8)
+    GCC_TURN_ON(suggest-attribute=format)
+#endif // 4.8
+#if CHECK_GCC_VERSION(8,1)
+    GCC_TURN_ON(suggest-attribute=malloc)
+#endif // 8.1
+    GCC_TURN_ON(suggest-attribute=noreturn)
+    GCC_TURN_ON(suggest-attribute=pure)
+#if CHECK_GCC_VERSION(5,1)
+    GCC_TURN_ON(suggest-final-methods)
+#endif // 5.1
+#if CHECK_GCC_VERSION(5,1)
+    GCC_TURN_ON(suggest-final-types)
+#endif // 5.1
+#if CHECK_GCC_VERSION(5,1)
+    GCC_TURN_ON(suggest-override)
+#endif // 5.1
+    GCC_TURN_ON(switch)
+    GCC_TURN_ON(switch-default)
+    GCC_TURN_ON(switch-enum)
+    GCC_TURN_ON(synth)
+    GCC_TURN_ON(system-headers)
+#if CHECK_GCC_VERSION(6,1)
+    GCC_TURN_ON(templates)
+#endif // 6.1
+    GCC_TURN_ON(trampolines)
+    GCC_TURN_ON(trigraphs)
+    GCC_TURN_ON(type-limits)
+    GCC_TURN_ON(undef)
+    GCC_TURN_ON(uninitialized)
+    GCC_TURN_ON(unknown-pragmas)
+    GCC_TURN_ON(unreachable-code)
+    GCC_TURN_ON(unsafe-loop-optimizations)
+    GCC_TURN_ON(unused)
+    GCC_TURN_ON(unused-but-set-parameter)
+    GCC_TURN_ON(unused-but-set-variable)
+    GCC_TURN_ON(unused-function)
+    GCC_TURN_ON(unused-label)
+#if CHECK_GCC_VERSION(4,7)
+    GCC_TURN_ON(unused-local-typedefs)
+#endif // 4.7
+    GCC_TURN_ON(unused-macros)
+    GCC_TURN_ON(unused-parameter)
+    GCC_TURN_ON(unused-value)
+    GCC_TURN_ON(unused-variable)
+#if CHECK_GCC_VERSION(4,8)
+    GCC_TURN_ON(useless-cast)
+#endif // 4.8
+    GCC_TURN_ON(variadic-macros)
+#if CHECK_GCC_VERSION(4,7)
+    GCC_TURN_ON(vector-operation-performance)
+#endif // 4.7
+#if CHECK_GCC_VERSION(6,1)
+    GCC_TURN_ON(virtual-inheritance)
+#endif // 6.1
+    GCC_TURN_ON(vla)
+#if CHECK_GCC_VERSION(10,1)
+    GCC_TURN_ON(volatile)
+#endif // 10.1
+    GCC_TURN_ON(volatile-register-var)
+    GCC_TURN_ON(write-strings)
+#if CHECK_GCC_VERSION(4,7)
+    GCC_TURN_ON(zero-as-null-pointer-constant)
+#endif // 4.7
+    // }}}
+
+    #undef GCC_TURN_ON
+
+    /*
+        Some warnings still must be disabled, so turn them back off explicitly:
+    */
+
+    // Those are potentially useful warnings, but there are just too many
+    // occurrences of them in our code currently.
+    GCC_TURN_OFF(conversion)
+    GCC_TURN_OFF(sign-compare)
+    GCC_TURN_OFF(sign-conversion)
+
+    GCC_TURN_OFF(old-style-cast)
+#if CHECK_GCC_VERSION(4,8)
+    GCC_TURN_OFF(useless-cast)
+#endif // 4.8
+
+#if CHECK_GCC_VERSION(10,1)
+    GCC_TURN_OFF(redundant-tags) // "struct tm" triggers this
+#endif // 10.1
+
+    // This one is given for NULL, and not just literal 0, up to gcc 10, and so
+    // has to remain disabled for as long as we use any NULLs in our code.
+#if CHECK_GCC_VERSION(4,7) && !CHECK_GCC_VERSION(10,1)
+    GCC_TURN_OFF(zero-as-null-pointer-constant)
+#endif
+
+    // wxWARNING_SUPPRESS_MISSING_OVERRIDE() inside wxRTTI macros is just
+    // ignored by gcc up to 9.x for some reason, so we have no choice but to
+    // disable it.
+#if CHECK_GCC_VERSION(5,1) && !CHECK_GCC_VERSION(9,0)
+    GCC_TURN_OFF(suggest-override)
+#endif
+
+    // The rest are the warnings that we don't ever want to enable.
+
+    // This one is given whenever inheriting from std:: classes without using
+    // C++11 ABI tag explicitly, probably harmless.
+#if CHECK_GCC_VERSION(4,8)
+    GCC_TURN_OFF(abi-tag)
+#endif // 4.8
+
+    // All those are about using perfectly normal C++ features that are
+    // actually used in our code.
+    GCC_TURN_OFF(aggregate-return)
+    GCC_TURN_OFF(long-long)
+#if CHECK_GCC_VERSION(6,1)
+    GCC_TURN_OFF(namespaces)
+    GCC_TURN_OFF(multiple-inheritance)
+    GCC_TURN_OFF(templates)
+#endif // 6.1
+
+    // This warns about missing "default" label in exhaustive switches over
+    // enums, so it's completely useless.
+    GCC_TURN_OFF(switch-default)
+
+    // We don't care about padding being added to our structs.
+    GCC_TURN_OFF(padded)
+#endif // gcc >= 4.6
 
 #if !wxUSE_UTF8_LOCALE_ONLY
 #define wxNO_IMPLICIT_WXSTRING_ENCODING
@@ -19,6 +403,11 @@
 #include "testprec.h"
 
 #include "allheaders.h"
+
+#ifdef GCC_TURN_OFF
+    // Just using REQUIRE() below triggers -Wparentheses, so avoid it.
+    GCC_TURN_OFF(parentheses)
+#endif
 
 TEST_CASE("wxNO_IMPLICIT_WXSTRING_ENCODING", "[string]")
 {

--- a/tests/allheaders.cpp
+++ b/tests/allheaders.cpp
@@ -368,6 +368,13 @@
     GCC_TURN_OFF(zero-as-null-pointer-constant)
 #endif
 
+    // These ones could be useful to explore, but for now we don't use "final"
+    // at all anywhere.
+#if CHECK_GCC_VERSION(5,1)
+    GCC_TURN_OFF(suggest-final-methods)
+    GCC_TURN_OFF(suggest-final-types)
+#endif // 5.1
+
     // wxWARNING_SUPPRESS_MISSING_OVERRIDE() inside wxRTTI macros is just
     // ignored by gcc up to 9.x for some reason, so we have no choice but to
     // disable it.

--- a/tests/allheaders.cpp
+++ b/tests/allheaders.cpp
@@ -84,7 +84,9 @@
 
 #include "catch.hpp"
 
-#if defined(__WXQT__)
+#if defined(__WXMSW__)
+    #include <windows.h>
+#elif defined(__WXQT__)
     #include <QtGui/QFont>
 #endif
 


### PR DESCRIPTION
This is not the first time our headers got broken with `-pedantic`, but hopefully it could be the last one.

See [#18901](https://trac.wxwidgets.org/ticket/18901).