### PR TITLE
Fix system UI font handling on macOS 11

### DIFF
--- a/src/osx/carbon/font.cpp
+++ b/src/osx/carbon/font.cpp
@@ -1062,6 +1062,17 @@ wxString wxNativeFontInfo::GetPostScriptName() const
     // if not explicitly set, obtain it from the font descriptor
     wxString ps;
     wxCFTypeRef(CTFontDescriptorCopyAttribute(GetCTFontDescriptor(), kCTFontNameAttribute)).GetValue(ps);
+
+    if ( WX_IS_MACOS_AVAILABLE(10, 16) )
+    {
+        // the PostScript names reported in macOS start with a dot for System Fonts, this has to be corrected
+        // otherwise round-trips are not possible, resulting in a Times Fallback, therefore we replace these with
+        // their official PostScript Name
+        wxString rest;
+        if ( ps.StartsWith(".SFNS", &rest) )
+            return "SFPro" + rest;
+    }
+
     return ps;
 }
 

--- a/src/osx/carbon/font.cpp
+++ b/src/osx/carbon/font.cpp
@@ -27,6 +27,7 @@
 #include "wx/tokenzr.h"
 
 #include "wx/osx/private.h"
+#include "wx/osx/private/available.h"
 
 #include <map>
 #include <string>
@@ -324,10 +325,6 @@ void wxFontRefData::AllocIfNeeded() const
 void wxFontRefData::Alloc()
 {
     wxCHECK_RET(m_info.GetPointSize() > 0, wxT("Point size should not be zero."));
-
-    // make sure the font descriptor has been processed properly
-    // otherwise the Post Script Name may not be valid yet
-    m_info.RealizeResource();
     
     // use font caching, we cache a font with a certain size and a font with just any size for faster creation
     wxString lookupnameNoSize = wxString::Format("%s_%d_%d", m_info.GetPostScriptName(), (int)m_info.GetStyle(), m_info.GetNumericWeight());
@@ -818,7 +815,6 @@ void wxNativeFontInfo::InitFromFontDescriptor(CTFontDescriptorRef desc)
     }
 
     wxCFTypeRef(CTFontDescriptorCopyAttribute(m_descriptor, kCTFontFamilyNameAttribute)).GetValue(m_familyName);
-    wxCFTypeRef(CTFontDescriptorCopyAttribute(m_descriptor, kCTFontNameAttribute)).GetValue(m_postScriptName);
 }
 
 void wxNativeFontInfo::Free()
@@ -876,7 +872,6 @@ void wxNativeFontInfo::CreateCTFontDescriptor()
     m_descriptor = descriptor;
     
     wxCFTypeRef(CTFontDescriptorCopyAttribute(m_descriptor, kCTFontFamilyNameAttribute)).GetValue(m_familyName);
-    wxCFTypeRef(CTFontDescriptorCopyAttribute(m_descriptor, kCTFontNameAttribute)).GetValue(m_postScriptName);
 
 #if wxDEBUG_LEVEL >= 2
     // for debugging: show all different font names
@@ -1022,10 +1017,6 @@ bool wxNativeFontInfo::FromString(const wxString& s)
 
 wxString wxNativeFontInfo::ToString() const
 {
-    // make sure the font descriptor has been processed properly
-    // otherwise the Post Script Name may not be valid yet
-    RealizeResource();
-    
     wxString s;
 
     s.Printf(wxT("%d;%s;%d;%d;%d;%d;%d;%s;%d"),
@@ -1064,7 +1055,14 @@ bool wxNativeFontInfo::GetUnderlined() const
 
 wxString wxNativeFontInfo::GetPostScriptName() const
 {
-    return m_postScriptName;
+    // return user-set PostScript name as-is
+    if ( !m_postScriptName.empty() )
+        return m_postScriptName;
+
+    // if not explicitly set, obtain it from the font descriptor
+    wxString ps;
+    wxCFTypeRef(CTFontDescriptorCopyAttribute(GetCTFontDescriptor(), kCTFontNameAttribute)).GetValue(ps);
+    return ps;
 }
 
 wxString wxNativeFontInfo::GetFaceName() const


### PR DESCRIPTION
This is an alternative to b494443 from PR #1995 that I think works (tested in Poedit). 

See what it does in the commit description, let me explain here how I arrived to it from #1995:

The b494443 (fonts fixes) commit still has problems: 

1. The font shouldn't be "SFProDisplay" (which is for large texts like titles and produces bad glyphs at small sizes like typically encountered in GUI code) nor "SFProText" (for small text), but "SFPro" — on macOS 11 that's the font dynamically choosing between the former two and the actual system font. That would be trivial to fix.

2. More troublingly, it's not enough: something as simple as `statictext->SetFont(statictext->GetFont().Bold());` doesn't work  in that the font remains with its normal weight. This is because the PostScript name changed in a way that breaks wx's expectations: in macOS 10.14, `m_postScriptName` was ".SFNSText" for the system font. In macOS 11, it is ".SFNS-Regular" — i.e. a specific weight. b494443 translates this into (with 1. applied) "SFPro-Regular", and that is then kept and used in `CreateCTFontDescriptor` regardless of the provided weight value. Making everything was stuck with the regular weight.

This is problematic to fix, because the PostScript name is part of public `wxNativeFontInfo` API, and there's really no guarantee how it's structured. For the same reason, clearing it on any weight, style etc. change is ill-advised.

I was about to propose to fix the immediate concern regarding the system font in #1995 like this instead:

```cpp
void wxNativeFontInfo::OSXAdjustPostScriptName()
{
    if ( WX_IS_MACOS_AVAILABLE(11, 0) )
    {
        if ( m_familyName == ".AppleSystemUIFont" )
            m_postScriptName.clear();
    }
}
```
(The check is for 11.0 because it only affects builds with the new SDK, which identifies the OS as 11.0, not the backward-compatible 10.16 number;  ".AppleSystemUIFont" seems new-ish too, it was ".SF NS Text" in 10.14.)

I finished with a remark that aspirationally, I think it would be best to not store `m_postScriptName` at all — use it just to create the descriptor or obtain from it when requested, but don't use it as *ground truth* as it is not being used.

But then I realized that this would break serialization in `ToString` and also some caching (which I don't quite understand). So I took a step back and did the "aspirational" thing. PostScript name is still being kept if provided by the user.

