### PR TITLE
Add wxWindow::WXAdjustFontToOwnPPI()

### DIFF
--- a/include/wx/font.h
+++ b/include/wx/font.h
@@ -476,13 +476,6 @@ public:
     // account as well.
     static int GetNumericWeightOf(wxFontWeight weight);
 
-    // Some ports need to modify the font object when the DPI of the window it
-    // is used with changes, this function can be used to do it.
-    //
-    // Currently it is only used in wxMSW and is not considered to be part of
-    // wxWidgets public API.
-    virtual void WXAdjustToPPI(const wxSize& WXUNUSED(ppi)) { }
-
     // this doesn't do anything and is kept for compatibility only
 #if WXWIN_COMPATIBILITY_2_8
     wxDEPRECATED_INLINE(void SetNoAntiAliasing(bool no = true), wxUnusedVar(no);)

--- a/include/wx/msw/font.h
+++ b/include/wx/msw/font.h
@@ -120,7 +120,11 @@ public:
 
     virtual bool IsFixedWidth() const wxOVERRIDE;
 
-    virtual void WXAdjustToPPI(const wxSize& ppi) wxOVERRIDE;
+    // MSW needs to modify the font object when the DPI of the window it
+    // is used with changes, this function can be used to do it.
+    //
+    // This method is not considered to be part of wxWidgets public API.
+    void WXAdjustToPPI(const wxSize& ppi);
 
     wxDEPRECATED_MSG("use wxFONT{FAMILY,STYLE,WEIGHT}_XXX constants ie: wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD")
     wxFont(int size,

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -599,6 +599,8 @@ public:
     void MSWUpdateOnDPIChange(const wxSize& oldDPI, const wxSize& newDPI);
 
 protected:
+    virtual void WXAdjustFontToOwnPPI(wxFont& font) const wxOVERRIDE;
+
     // Called from MSWUpdateOnDPIChange() specifically to update the control
     // font, as this may need to be done differently for some specific native
     // controls. The default version updates m_font of this window.

--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -964,6 +964,13 @@ public:
         // Get the DPI used by the given window or wxSize(0, 0) if unknown.
     virtual wxSize GetDPI() const;
 
+    // Some ports need to modify the font object when the DPI of the window it
+    // is used with changes, this function can be used to do it.
+    //
+    // Currently it is only used in wxMSW and is not considered to be part of
+    // wxWidgets public API.
+    virtual void WXAdjustFontToOwnPPI(wxFont& WXUNUSED(font)) const { }
+
         // DPI-independent pixels, or DIPs, are pixel values for the standard
         // 96 DPI display, they are scaled to take the current resolution into
         // account (i.e. multiplied by the same factor as returned by

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -1710,7 +1710,7 @@ wxFont wxWindowBase::GetFont() const
         if ( !font.IsOk() )
             font = GetClassDefaultAttributes().font;
 
-        font.WXAdjustToPPI(GetDPI());
+        WXAdjustFontToOwnPPI(font);
 
         return font;
     }
@@ -1731,7 +1731,7 @@ bool wxWindowBase::SetFont(const wxFont& font)
     m_inheritFont = m_hasFont;
 
     if ( m_hasFont )
-        m_font.WXAdjustToPPI(GetDPI());
+        WXAdjustFontToOwnPPI(m_font);
 
     InvalidateBestSize();
 

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -4864,6 +4864,11 @@ double wxWindowMSW::GetDPIScaleFactor() const
     return GetDPI().y / (double)wxDisplay::GetStdPPIValue();
 }
 
+void wxWindowMSW::WXAdjustFontToOwnPPI(wxFont& font) const
+{
+    font.WXAdjustToPPI(GetDPI());
+}
+
 void wxWindowMSW::MSWUpdateFontOnDPIChange(const wxSize& newDPI)
 {
     if ( m_font.IsOk() )


### PR DESCRIPTION
Avoid calling GeTDPI() in font.WXAdjustToPPI(GetDPI()); invocations in
common code on platforms that don't need any adjustment (i.e. anything
other than MSW).

This fixes wxOSX crashes when GetFont() is called too early during
window creation, but is the right thing to do regardless.

/cc @MaartenBent @csomor