### PR TITLE
Draw wxTextCtrl focus ring natively on Mac

### DIFF
--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -111,6 +111,8 @@ public :
     virtual void        SetNeedsDisplay( const wxRect* where = NULL ) wxOVERRIDE;
     virtual bool        GetNeedsDisplay() const wxOVERRIDE;
 
+    virtual void        EnableFocusRing(bool enabled) wxOVERRIDE;
+
     virtual void        SetDrawingEnabled(bool enabled) wxOVERRIDE;
 
     virtual bool        CanFocus() const wxOVERRIDE;

--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -301,8 +301,7 @@ public :
     virtual void        SetNeedsDisplay( const wxRect* where = NULL ) = 0;
     virtual bool        GetNeedsDisplay() const = 0;
 
-    virtual bool        NeedsFocusRect() const;
-    virtual void        SetNeedsFocusRect( bool needs );
+    virtual void        EnableFocusRing(bool WXUNUSED(enabled)) {}
 
     virtual bool        NeedsFrame() const;
     virtual void        SetNeedsFrame( bool needs );
@@ -598,7 +597,6 @@ protected :
     bool                m_wantsUserKey;
     bool                m_wantsUserMouse;
     wxWindowMac*        m_wxPeer;
-    bool                m_needsFocusRect;
     bool                m_needsFrame;
     bool                m_shouldSendEvents;
 

--- a/include/wx/osx/window.h
+++ b/include/wx/osx/window.h
@@ -157,6 +157,7 @@ public:
     void MacOnScroll( wxScrollEvent&event );
 
     virtual bool AcceptsFocus() const wxOVERRIDE;
+    virtual void EnableVisibleFocus(bool enabled) wxOVERRIDE;
 
     virtual bool IsDoubleBuffered() const wxOVERRIDE { return true; }
 

--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -767,6 +767,9 @@ public:
         // call this when the return value of AcceptsFocus() changes
     virtual void SetCanFocus(bool WXUNUSED(canFocus)) { }
 
+        // call to customize visible focus indicator if possible in the port
+    virtual void EnableVisibleFocus(bool WXUNUSED(enabled)) { }
+
         // navigates inside this window
     bool NavigateIn(int flags = wxNavigationKeyEvent::IsForward)
         { return DoNavigateIn(flags); }

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -541,6 +541,22 @@ public:
     virtual void SetCanFocus(bool canFocus);
 
     /**
+        Enables or disables visible indication of keyboard focus.
+
+        By default, controls behave in platform-appropriate way and show focus
+        in the same way native applications do. In some very rare circumstances
+        it may be desirable to change the default (notably multiline text
+        controls don't normally have a focus indicator on Mac), which this
+        method allows. It should only be used if you have a good understanding
+        of the native platform's guidelines and user expectations.
+
+        This method is only implemented on Mac.
+
+        @since 3.1.5
+    */
+    virtual void EnableVisibleFocus(bool enable);
+
+    /**
         This sets the window to receive keyboard input.
 
         @see HasFocus(), wxFocusEvent, wxPanel::SetFocus,

--- a/src/generic/grideditors.cpp
+++ b/src/generic/grideditors.cpp
@@ -462,7 +462,7 @@ void wxGridCellTextEditor::DoCreate(wxWindow* parent,
 
 #ifdef __WXOSX__
     wxWidgetImpl* impl = m_control->GetPeer();
-    impl->SetNeedsFocusRect(false);
+    impl->EnableFocusRing(false);
 #endif
     // set max length allowed in the textctrl, if the parameter was set
     if ( m_maxChars != 0 )

--- a/src/generic/grideditors.cpp
+++ b/src/generic/grideditors.cpp
@@ -460,10 +460,6 @@ void wxGridCellTextEditor::DoCreate(wxWindow* parent,
     text->SetMargins(0, 0);
     m_control = text;
 
-#ifdef __WXOSX__
-    wxWidgetImpl* impl = m_control->GetPeer();
-    impl->EnableFocusRing(false);
-#endif
     // set max length allowed in the textctrl, if the parameter was set
     if ( m_maxChars != 0 )
     {

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -1590,7 +1590,7 @@ wxWidgetImplType* wxWidgetImpl::CreateTextControl( wxTextCtrl* wxpeer,
         v = [[wxNSTextScrollView alloc] initWithFrame:r];
         wxNSTextViewControl* t = new wxNSTextViewControl( wxpeer, v, style );
         c = t;
-        c->SetNeedsFocusRect( true );
+        c->EnableFocusRing( true );
 
         t->SetStringValue(str);
     }

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -1590,7 +1590,6 @@ wxWidgetImplType* wxWidgetImpl::CreateTextControl( wxTextCtrl* wxpeer,
         v = [[wxNSTextScrollView alloc] initWithFrame:r];
         wxNSTextViewControl* t = new wxNSTextViewControl( wxpeer, v, style );
         c = t;
-        c->EnableFocusRing( true );
 
         t->SetStringValue(str);
     }

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -3849,10 +3849,6 @@ void wxWidgetCocoaImpl::DoNotifyFocusLost()
 void wxWidgetCocoaImpl::DoNotifyFocusEvent(bool receivedFocus, wxWidgetImpl* otherWindow)
 {
     wxWindow* thisWindow = GetWXPeer();
-    if ( thisWindow->MacGetTopLevelWindow() && NeedsFocusRect() )
-    {
-        thisWindow->MacInvalidateBorders();
-    }
 
     if ( receivedFocus )
     {
@@ -3924,6 +3920,11 @@ void wxWidgetCocoaImpl::SetFlipped(bool flipped)
 }
 
 #endif
+
+void wxWidgetCocoaImpl::EnableFocusRing(bool enabled)
+{
+    [m_osxView setFocusRingType:enabled ? NSFocusRingTypeExterior : NSFocusRingTypeNone];
+}
 
 void wxWidgetCocoaImpl::SetDrawingEnabled(bool enabled)
 {

--- a/src/osx/iphone/window.mm
+++ b/src/osx/iphone/window.mm
@@ -642,10 +642,6 @@ void wxWidgetIPhoneImpl::InstallEventHandler( WXWidget control )
 void wxWidgetIPhoneImpl::DoNotifyFocusEvent(bool receivedFocus, wxWidgetImpl* otherWindow)
 {
     wxWindow* thisWindow = GetWXPeer();
-    if ( thisWindow->MacGetTopLevelWindow() && NeedsFocusRect() )
-    {
-        thisWindow->MacInvalidateBorders();
-    }
 
     if ( receivedFocus )
     {

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -938,9 +938,6 @@ void wxWindowMac::MacInvalidateBorders()
 
     int outerBorder = MacGetLeftBorderSize() ;
 
-    if ( GetPeer()->NeedsFocusRect() )
-        outerBorder += 4 ;
-
     if ( outerBorder == 0 )
         return ;
 
@@ -1578,8 +1575,6 @@ void wxWindowMac::MacPaintBorders( int WXUNUSED(leftOrigin) , int WXUNUSED(right
 
 #if wxOSX_USE_COCOA_OR_CARBON
     {
-        const bool hasFocus = GetPeer()->NeedsFocusRect() && HasFocus();
-
         CGRect cgrect = CGRectMake( tx-1 , ty-1 , tw+2 ,
             th+2 ) ;
 
@@ -1594,7 +1589,6 @@ void wxWindowMac::MacPaintBorders( int WXUNUSED(leftOrigin) , int WXUNUSED(right
             info.version = 0 ;
             info.kind = 0 ;
             info.state = IsEnabled() ? kThemeStateActive : kThemeStateInactive ;
-            info.isFocused = hasFocus ;
 
             if ( HasFlag(wxRAISED_BORDER) || HasFlag(wxSUNKEN_BORDER) || HasFlag(wxDOUBLE_BORDER) )
             {
@@ -1606,11 +1600,6 @@ void wxWindowMac::MacPaintBorders( int WXUNUSED(leftOrigin) , int WXUNUSED(right
                 info.kind = kHIThemeFrameListBox ;
                 HIThemeDrawFrame( &cgrect , &info , cgContext , kHIThemeOrientationNormal ) ;
             }
-        }
-
-        if ( hasFocus )
-        {
-            HIThemeDrawFocusRect( &cgrect , true , cgContext , kHIThemeOrientationNormal ) ;
         }
     }
 #endif // wxOSX_USE_COCOA_OR_CARBON
@@ -2746,18 +2735,7 @@ void wxWidgetImpl::Init()
     m_wantsUserKey = false;
     m_wantsUserMouse = false;
     m_wxPeer = NULL;
-    m_needsFocusRect = false;
     m_needsFrame = true;
-}
-
-void wxWidgetImpl::SetNeedsFocusRect( bool needs )
-{
-    m_needsFocusRect = needs;
-}
-
-bool wxWidgetImpl::NeedsFocusRect() const
-{
-    return m_needsFocusRect;
 }
 
 void wxWidgetImpl::SetNeedsFrame( bool needs )

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -2171,6 +2171,11 @@ bool wxWindowMac::AcceptsFocus() const
         return GetPeer()->CanFocus();
 }
 
+void wxWindowMac::EnableVisibleFocus(bool enabled)
+{
+    GetPeer()->EnableFocusRing(enabled);
+}
+
 void wxWindowMac::MacSuperChangedPosition()
 {
     // only window-absolute structures have to be moved i.e. controls


### PR DESCRIPTION
`NSTextView` doesn't display focus ring by default, which is why wxOSX did draw it manually, but this behavior can be overriden since OS X 10.3 with `NSView.focusRingType` property.

The HITheme-based rendering suffered from a number of non-nativeness issues:
1. didn't respect macOS 10.14+ accent colors
2. not animated as the native focus ring
3. subtly different shape of the outline
4. _noticeably_ different outline shape on macOS 11

The PR fixes this by removing `NeedsFocusRect()` and associated workaround for manually drawing focus ring inside `NSTextView` (i.e. multiline text controls) and replacing it with a way to override default focus ring type. This private interface was only used for wxTextCtrl and nothing else, so this shouldn't have any impact elsewhere.