### PR TITLE
wxPreferencesEditor  support for macOS 11

### DIFF
--- a/src/osx/carbon/utilscocoa.mm
+++ b/src/osx/carbon/utilscocoa.mm
@@ -183,6 +183,16 @@ wxBitmap wxOSXCreateSystemBitmap(const wxString& name, const wxString &client, c
 WXImage wxOSXGetSystemImage(const wxString& name)
 {
     wxCFStringRef cfname(name);
+
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_16
+    if ( WX_IS_MACOS_AVAILABLE(11, 0) )
+    {
+        NSImage *symbol = [NSImage imageWithSystemSymbolName:cfname.AsNSString() accessibilityDescription:nil];
+        if ( symbol )
+            return symbol;
+    }
+#endif
+    
     NSImage* nsimage = [NSImage imageNamed:cfname.AsNSString()];
     return nsimage;
 }

--- a/src/osx/cocoa/preferences.mm
+++ b/src/osx/cocoa/preferences.mm
@@ -35,6 +35,7 @@
 #include "wx/weakref.h"
 #include "wx/windowid.h"
 #include "wx/osx/private.h"
+#include "wx/osx/private/available.h"
 
 #import <AppKit/NSWindow.h>
 
@@ -62,6 +63,13 @@ public:
           m_toolbarRealized(false),
           m_visiblePage(NULL)
     {
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_16
+        if ( WX_IS_MACOS_AVAILABLE(11,0) )
+        {
+            NSWindow *win = GetWXWindow();
+            [win setToolbarStyle:NSWindowToolbarStylePreference];
+        }
+#endif
         m_toolbar = new wxToolBar(this, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                                   wxTB_FLAT | wxTB_TEXT);
         m_toolbar->SetToolBitmapSize(wxSize(32,32));

--- a/src/osx/cocoa/preferences.mm
+++ b/src/osx/cocoa/preferences.mm
@@ -42,6 +42,19 @@
 
 wxBitmap wxStockPreferencesPage::GetLargeIcon() const
 {
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_16
+    if ( WX_IS_MACOS_AVAILABLE(11, 0) )
+    {
+        switch ( m_kind )
+        {
+            case Kind_General:
+                return wxBitmap([NSImage imageWithSystemSymbolName:@"gearshape" accessibilityDescription:nil]);
+            case Kind_Advanced:
+                return wxBitmap([NSImage imageWithSystemSymbolName:@"gearshape.2" accessibilityDescription:nil]);
+        }
+    }
+#endif
+
     switch ( m_kind )
     {
         case Kind_General:
@@ -49,6 +62,7 @@ wxBitmap wxStockPreferencesPage::GetLargeIcon() const
         case Kind_Advanced:
             return wxBitmap([NSImage imageNamed:NSImageNameAdvanced]);
     }
+
     return wxBitmap(); // silence compiler warning
 }
 


### PR DESCRIPTION
(This is still not all, but is the end of my Big Sur spamming spree _for now_.)

macOS 11 changes how preferences windows look ([see HIG update](https://developer.apple.com/design/human-interface-guidelines/macos/overview/whats-new-in-macos/#bxlabels-toolbar-prefs)):

1. A very different artistic style (not our concern here)
2. The toolbar is different from now-normal toolbars and requires special treatment in the code to have the right look (i.e. not be right-aligned and merged with the titlebar)
3. Icons are centered now and windows don't change width anymore when switching to differently-sized tab; instead, all tabs have the same width and only change window's height

This PR addresses this. Point 1 is partially addressed w.r.t. stock pages in b6bc50d; acf02be (SF Symbols support) is not strictly about preferences, but a prereq for that; it will be generally useful to developers needing to port to macOS 11.
