### PR TITLE
Add EXE extension to wxrc versioned executable

### DIFF
--- a/utils/wxrc/Makefile.in
+++ b/utils/wxrc/Makefile.in
@@ -25,6 +25,7 @@ CXX = @CXX@
 CXXFLAGS = @CXXFLAGS@
 CPPFLAGS = @CPPFLAGS@
 LDFLAGS = @LDFLAGS@
+WX_FLAVOUR = @WX_FLAVOUR@
 WX_LIB_FLAVOUR = @WX_LIB_FLAVOUR@
 TOOLKIT = @TOOLKIT@
 TOOLKIT_LOWERCASE = @TOOLKIT_LOWERCASE@
@@ -118,10 +119,10 @@ distclean: clean
 @COND_USE_XRC_1@install_wxrc: $(__wxrc___depname)
 @COND_USE_XRC_1@	$(INSTALL_DIR) $(DESTDIR)$(bindir)
 @COND_USE_XRC_1@	$(INSTALL_PROGRAM) wxrc$(EXEEXT) $(DESTDIR)$(bindir)
-@COND_USE_XRC_1@	rm -f $(DESTDIR)$(bindir)/wxrc$(EXEEXT) $(DESTDIR)$(bindir)/wxrc-$(WX_RELEASE)
+@COND_USE_XRC_1@	rm -f $(DESTDIR)$(bindir)/wxrc$(EXEEXT) $(DESTDIR)$(bindir)/wxrc-$(WX_RELEASE)$(WX_FLAVOUR)$(EXEEXT)
 @COND_USE_XRC_1@	$(INSTALL_PROGRAM) wxrc$(EXEEXT) $(DESTDIR)$(bindir)
-@COND_USE_XRC_1@	mv -f $(DESTDIR)$(bindir)/wxrc$(EXEEXT) $(DESTDIR)$(bindir)/wxrc-$(WX_RELEASE)
-@COND_USE_XRC_1@	(cd $(DESTDIR)$(bindir) && $(LN_S) wxrc-$(WX_RELEASE) wxrc$(EXEEXT))
+@COND_USE_XRC_1@	mv -f $(DESTDIR)$(bindir)/wxrc$(EXEEXT) $(DESTDIR)$(bindir)/wxrc-$(WX_RELEASE)$(WX_FLAVOUR)$(EXEEXT)
+@COND_USE_XRC_1@	(cd $(DESTDIR)$(bindir) && $(LN_S) wxrc-$(WX_RELEASE)$(WX_FLAVOUR)$(EXEEXT) wxrc$(EXEEXT))
 
 @COND_USE_XRC_1@uninstall_wxrc: 
 @COND_USE_XRC_1@	rm -f $(DESTDIR)$(bindir)/wxrc$(EXEEXT)

--- a/utils/wxrc/wxrc.bkl
+++ b/utils/wxrc/wxrc.bkl
@@ -17,7 +17,7 @@
              symlink pointing to it, so that users can use wxrc from different
              versions. -->
 
-        <set var="versioned_name">wxrc-$(WX_RELEASE)$(WX_FLAVOUR)</set>
+        <set var="versioned_name">wxrc-$(WX_RELEASE)$(WX_FLAVOUR)$(EXEEXT)</set>
         <modify-target target="install_wxrc">
             <command>
                 rm -f $(DESTDIR)$(BINDIR)/wxrc$(EXEEXT) $(DESTDIR)$(BINDIR)/$(versioned_name)


### PR DESCRIPTION
According to `utils/wxrc/wxrc.bkl`, the "versioned" executable for wxrc is not forced to end in ".exe", while its symlink is.

When cross-compiling to Windows from a Linux system, this gives in a Windows executable that does not end in ".exe" and IMHO it is confusing.

The Bakefile run also includes the modifications from PR #2013, because they were not applied yet.