### PR TITLE
Avoid UI functions in non-main thread in wxGStreamerMediaBackend

### DIFF
--- a/src/unix/mediactrl.cpp
+++ b/src/unix/mediactrl.cpp
@@ -209,6 +209,7 @@ class wxGStreamerMediaEventHandler : public wxEvtHandler
     }
 
     void OnMediaFinish(wxMediaEvent& event);
+    void NotifyMovieSizeChanged();
 
     wxGStreamerMediaBackend* m_be;
 };
@@ -633,14 +634,14 @@ bool wxGStreamerMediaBackend::QueryVideoSizeFromPad(GstPad* pad)
         gst_caps_unref (caps);
 #endif
 
-        NotifyMovieSizeChanged ();
+        m_eventHandler->CallAfter(&wxGStreamerMediaEventHandler::NotifyMovieSizeChanged);
 
         return true;
     } // end if caps
 
     m_videoSize = wxSize(0,0);
 
-    NotifyMovieSizeChanged ();
+    m_eventHandler->CallAfter(&wxGStreamerMediaEventHandler::NotifyMovieSizeChanged);
 
     return false; // not ready/massive failure
 }
@@ -893,6 +894,11 @@ void wxGStreamerMediaEventHandler::OnMediaFinish(wxMediaEvent& WXUNUSED(event))
         // Finally, queue the finish event
         m_be->QueueFinishEvent();
     }
+}
+
+void wxGStreamerMediaEventHandler::NotifyMovieSizeChanged()
+{
+    m_be->NotifyMovieSizeChanged();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
In aa2cd42, a couple of calls to NotifyMovieSizeChanged() were added, presumably for a good reason.  Unfortunately, NotifySizeChanged() makes UI calls on wxGTK, so this resulted in UI calls happening on a non-main thread because many of GStreamer's callbacks occur on arbitrary threads.  This is bad because it caused random X11 crashes.

Fix this by defining a new internal event type and queuing an event so that the main thread can call NotifyMovieSizeChanged().