### PR TITLE
macOS wxNativeFontInfo changes

### DIFF
--- a/include/wx/fontutil.h
+++ b/include/wx/fontutil.h
@@ -173,6 +173,7 @@ public:
 
     static CGFloat GetCTWeight( CTFontRef font );
     static CGFloat GetCTWeight( CTFontDescriptorRef font );
+    static CGFloat GetCTwidth( CTFontDescriptorRef font );
     static CGFloat GetCTSlant( CTFontDescriptorRef font );
 
     CTFontDescriptorRef GetCTFontDescriptor() const;
@@ -182,6 +183,7 @@ private:
     // attributes for regenerating a CTFontDescriptor, stay close to native values
     // for better roundtrip fidelity
     CGFloat       m_ctWeight;
+    CGFloat       m_ctWidth;
     wxFontStyle   m_style;
     CGFloat       m_ctSize;
     wxFontFamily  m_family;

--- a/src/osx/carbon/font.cpp
+++ b/src/osx/carbon/font.cpp
@@ -1037,8 +1037,7 @@ bool wxNativeFontInfo::FromString(const wxString& s)
         wxFontEncoding encoding = (wxFontEncoding)l;
 
         wxString xml = tokenizer.GetString();
-        if ( !xml.StartsWith("<?xml"))
-            xml+=GetPListPrefix();
+        xml+=GetPListPrefix();
         wxCFStringRef plist(xml);
         wxCFDataRef listData(CFStringCreateExternalRepresentation(kCFAllocatorDefault,plist,kCFStringEncodingUTF8,0));
         wxCFDictionaryRef attributes((CFDictionaryRef) CFPropertyListCreateWithData(kCFAllocatorDefault, listData, 0, NULL, NULL));
@@ -1075,7 +1074,8 @@ wxString wxNativeFontInfo::ToString() const
             wxCFStringRef cfString( CFStringCreateFromExternalRepresentation( kCFAllocatorDefault, listData, kCFStringEncodingUTF8) );
             wxString xml = cfString.AsString();
             xml.Replace("\r",wxEmptyString,true);
-            xml.StartsWith(GetPListPrefix(), &xml);
+            xml.Replace("\t",wxEmptyString,true);
+            xml = xml.Mid(xml.Find("<plist"));
 
             s.Printf("%d;%d;%d;%d;%s",
                  2, // version

--- a/src/osx/carbon/font.cpp
+++ b/src/osx/carbon/font.cpp
@@ -1073,13 +1073,12 @@ wxString wxNativeFontInfo::ToString() const
             if ( xml.StartsWith(s_plistPrefix ))
                 xml = xml.Mid(s_plistPrefix.length());
 
-            s.Printf(wxT("%d;%d;%d;%d;"),
+            s.Printf("%d;%d;%d;%d;%s",
                  2, // version
                  GetUnderlined(),
                  GetStrikethrough(),
-                 (int)GetEncoding());
-
-            s += xml;
+                 (int)GetEncoding(),
+                 xml);
         }
     }
 

--- a/src/osx/carbon/font.cpp
+++ b/src/osx/carbon/font.cpp
@@ -935,8 +935,13 @@ CGFloat wxNativeFontInfo::GetCTSlant(CTFontDescriptorRef descr)
 }
 
 // common prefix of plist serializiation, gets removed and readded
-static const wxString s_plistPrefix = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE plist PUBLIC "
+
+static const wxString& GetPListPrefix()
+{
+    static const wxString s_plistPrefix = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE plist PUBLIC "
     "\"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">";
+    return s_plistPrefix;
+}
 
 bool wxNativeFontInfo::FromString(const wxString& s)
 {
@@ -1033,7 +1038,7 @@ bool wxNativeFontInfo::FromString(const wxString& s)
 
         wxString xml = tokenizer.GetString();
         if ( !xml.StartsWith("<?xml"))
-            xml+=s_plistPrefix;
+            xml+=GetPListPrefix();
         wxCFStringRef plist(xml);
         wxCFDataRef listData(CFStringCreateExternalRepresentation(kCFAllocatorDefault,plist,kCFStringEncodingUTF8,0));
         wxCFDictionaryRef attributes((CFDictionaryRef) CFPropertyListCreateWithData(kCFAllocatorDefault, listData, 0, NULL, NULL));
@@ -1070,7 +1075,7 @@ wxString wxNativeFontInfo::ToString() const
             wxCFStringRef cfString( CFStringCreateFromExternalRepresentation( kCFAllocatorDefault, listData, kCFStringEncodingUTF8) );
             wxString xml = cfString.AsString();
             xml.Replace("\r",wxEmptyString,true);
-            xml.StartsWith(s_plistPrefix, &xml);
+            xml.StartsWith(GetPListPrefix(), &xml);
 
             s.Printf("%d;%d;%d;%d;%s",
                  2, // version

--- a/src/osx/carbon/font.cpp
+++ b/src/osx/carbon/font.cpp
@@ -170,15 +170,15 @@ namespace
     const int kCTWeightsCount = 12;
     static CGFloat gCTWeights[kCTWeightsCount] = {
         -1.000, // 0
-        -0.800, // 100
-        -0.600, // 200
-        -0.400, // 300
-        0.000, // 400
-        0.230, // 500
-        0.300, // 600
-        0.400, // 700
-        0.560, // 800
-        0.620, // 900
+        -0.800, // 100, NSFontWeightUltraLight
+        -0.600, // 200, NSFontWeightThin
+        -0.400, // 300, NSFontWeightLight
+        0.000, // 400, NSFontWeightRegular
+        0.230, // 500, NSFontWeightMedium
+        0.300, // 600, NSFontWeightSemibold
+        0.400, // 700, NSFontWeightBold
+        0.560, // 800, NSFontWeightHeavy
+        0.620, // 900, NSFontWeightBlack
         0.750, // 1000
     };
 
@@ -947,6 +947,9 @@ CGFloat wxNativeFontInfo::GetCTSlant(CTFontDescriptorRef descr)
     return slant;
 }
 
+// recipe taken from
+// https://developer.apple.com/library/archive/documentation/StringsTextFonts/Conceptual/CoreText_Programming/FontOperations/FontOperations.html
+
 // common prefix of plist serializiation, gets removed and readded
 
 static const wxString& GetPListPrefix()
@@ -1050,7 +1053,7 @@ bool wxNativeFontInfo::FromString(const wxString& s)
         wxFontEncoding encoding = (wxFontEncoding)l;
 
         wxString xml = tokenizer.GetString();
-        xml+=GetPListPrefix();
+        xml = GetPListPrefix()+xml;
         wxCFStringRef plist(xml);
         wxCFDataRef listData(CFStringCreateExternalRepresentation(kCFAllocatorDefault,plist,kCFStringEncodingUTF8,0));
         wxCFDictionaryRef attributes((CFDictionaryRef) CFPropertyListCreateWithData(kCFAllocatorDefault, listData, 0, NULL, NULL));

--- a/src/osx/carbon/font.cpp
+++ b/src/osx/carbon/font.cpp
@@ -1070,8 +1070,7 @@ wxString wxNativeFontInfo::ToString() const
             wxCFStringRef cfString( CFStringCreateFromExternalRepresentation( kCFAllocatorDefault, listData, kCFStringEncodingUTF8) );
             wxString xml = cfString.AsString();
             xml.Replace("\r",wxEmptyString,true);
-            if ( xml.StartsWith(s_plistPrefix ))
-                xml = xml.Mid(s_plistPrefix.length());
+            xml.StartsWith(s_plistPrefix, &xml);
 
             s.Printf("%d;%d;%d;%d;%s",
                  2, // version

--- a/src/osx/carbon/font.cpp
+++ b/src/osx/carbon/font.cpp
@@ -1194,7 +1194,13 @@ void wxNativeFontInfo::SetStyle(wxFontStyle style_)
 
     if (formerIsItalic != newIsItalic)
     {
-        Free();
+        if ( m_descriptor )
+        {
+            if ( m_style != wxFONTSTYLE_NORMAL )
+                m_descriptor = CTFontDescriptorCreateCopyWithSymbolicTraits(m_descriptor, kCTFontItalicTrait, kCTFontItalicTrait);
+            else
+                m_descriptor = CTFontDescriptorCreateCopyWithSymbolicTraits(m_descriptor, 0, kCTFontItalicTrait);
+        }
     }
 }
 

--- a/src/osx/carbon/font.cpp
+++ b/src/osx/carbon/font.cpp
@@ -746,6 +746,7 @@ void wxNativeFontInfo::Init()
     m_encoding = wxFONTENCODING_UTF8;
 
     m_ctWeight = 0.0;
+    m_ctWidth = 0.0;
     m_style = wxFONTSTYLE_NORMAL;
     m_ctSize = 0.0;
     m_family = wxFONTFAMILY_DEFAULT;
@@ -765,6 +766,7 @@ void wxNativeFontInfo::Init(const wxNativeFontInfo& info)
     m_encoding = info.m_encoding;
 
     m_ctWeight = info.m_ctWeight;
+    m_ctWidth = info.m_ctWidth;
     m_style = info.m_style;
     m_ctSize = info.m_ctSize;
     m_family = info.m_family;
@@ -787,6 +789,7 @@ void wxNativeFontInfo::InitFromFontDescriptor(CTFontDescriptorRef desc)
     m_descriptor.reset(wxCFRetain(desc));
 
     m_ctWeight = GetCTWeight(desc);
+    m_ctWidth = GetCTwidth(desc);
     m_style = GetCTSlant(desc) > 0.01 ? wxFONTSTYLE_ITALIC : wxFONTSTYLE_NORMAL;
     wxCFTypeRef(CTFontDescriptorCopyAttribute(desc, kCTFontSizeAttribute)).GetValue(m_ctSize, CGFloat(0.0));
 
@@ -861,6 +864,7 @@ void wxNativeFontInfo::CreateCTFontDescriptor()
         traits.SetValue(kCTFontSymbolicTrait, kCTFontItalicTrait);
 
     traits.SetValue(kCTFontWeightTrait,m_ctWeight);
+    traits.SetValue(kCTFontWidthTrait,m_ctWidth);
 
     attributes.SetValue(kCTFontTraitsAttribute,traits.get());
     attributes.SetValue(kCTFontSizeAttribute, m_ctSize);
@@ -922,6 +926,15 @@ CGFloat wxNativeFontInfo::GetCTWeight(CTFontDescriptorRef descr)
     CFTypeRef fonttraitstype = CTFontDescriptorCopyAttribute(descr, kCTFontTraitsAttribute);
     wxCFDictionaryRef traits((CFDictionaryRef)fonttraitstype);
     traits.GetValue(kCTFontWeightTrait).GetValue(&weight, CGFloat(0.0));
+    return weight;
+}
+
+CGFloat wxNativeFontInfo::GetCTwidth(CTFontDescriptorRef descr)
+{
+    CGFloat weight;
+    CFTypeRef fonttraitstype = CTFontDescriptorCopyAttribute(descr, kCTFontTraitsAttribute);
+    wxCFDictionaryRef traits((CFDictionaryRef)fonttraitstype);
+    traits.GetValue(kCTFontWidthTrait).GetValue(&weight, CGFloat(0.0));
     return weight;
 }
 


### PR DESCRIPTION
The next version of macOS will break our font info serialization of UI fonts, the PostScript names of which are regarded as private. Therefore we switch to the Apple recommended way of serializing the native font scriptors.