### PR TITLE
Hide tooltips when style wxAUI_TB_NO_TOOLTIPS is provided

### DIFF
--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -2876,7 +2876,7 @@ void wxAuiToolBar::OnMotion(wxMouseEvent& evt)
         // tooltips handling
         wxAuiToolBarItem* packingHitItem;
         packingHitItem = FindToolByPositionWithPacking(evt.GetX(), evt.GetY());
-        if (packingHitItem)
+        if ( !HasFlag(wxAUI_TB_NO_TOOLTIPS) && packingHitItem )
         {
             if (packingHitItem != m_tipItem)
             {


### PR DESCRIPTION
This is a small fix to the wxAuiToolbar to actually hide the tooltips when the `wxAUI_TB_NO_TOOLTIPS` style is provided to the toolbar. Before, this style was not having any effect, so the tooltips were always displayed.