### PR TITLE
OSX: Fixes for readonly text fields

### DIFF
--- a/src/osx/cocoa/combobox.mm
+++ b/src/osx/cocoa/combobox.mm
@@ -330,11 +330,11 @@ void wxNSComboBoxControl::Dismiss()
 
 void wxNSComboBoxControl::SetEditable(bool editable)
 {
-    // TODO: unfortunately this does not work, setEditable just means the same as CB_READONLY
-    // I don't see a way to access the text field directly
-    
-    // Behavior NONE <- SELECTECTABLE
     [m_comboBox setEditable:editable];
+
+    // When the combobox isn't editable, make sure it is still selectable so the text can be copied
+    if ( !editable )
+        [m_comboBox setSelectable:YES];
 }
 
 wxWidgetImplType* wxWidgetImpl::CreateComboBox( wxComboBox* wxpeer, 
@@ -352,9 +352,12 @@ wxWidgetImplType* wxWidgetImpl::CreateComboBox( wxComboBox* wxpeer,
         [v setNumberOfVisibleItems:999];
     else
         [v setNumberOfVisibleItems:13];
-    if (style & wxCB_READONLY)
-        [v setEditable:NO];
+
     wxNSComboBoxControl* c = new wxNSComboBoxControl( wxpeer, v );
+
+    if (style & wxCB_READONLY)
+        c->SetEditable(false);
+
     return c;
 }
 

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -844,7 +844,13 @@ bool wxNSTextViewControl::CanPaste() const
 void wxNSTextViewControl::SetEditable(bool editable)
 {
     if (m_textView)
+    {
         [m_textView setEditable: editable];
+
+        // When the field isn't editable, make sure it is still selectable so the text can be copied
+        if ( !editable )
+            [m_textView setSelectable:YES];
+    }
 }
 
 long wxNSTextViewControl::GetLastPosition() const
@@ -1374,6 +1380,10 @@ bool wxNSTextFieldControl::CanPaste() const
 void wxNSTextFieldControl::SetEditable(bool editable)
 {
     [m_textField setEditable:editable];
+
+    // When the field isn't editable, make sure it is still selectable so the text can be copied
+    if ( !editable )
+        [m_textField setSelectable:YES];
 }
 
 long wxNSTextFieldControl::GetLastPosition() const


### PR DESCRIPTION
OSX textfields have two different flags: editable and selectable. When the editable flag is set, the field is also selectable. However, if the editable flag is not set and no explicit call to set the selectable flag was made it could be in a weird selection state (so selection may not be possible).  This can be seen in the widgets sample on the combobox page. On that page, when the combobox is made readonly the text in the text field can't be selected, but the text in the readonly insertion point field can be selected (neither of these fields call `setSelectable`). This PR adds explicit calls to `setSelectable` for the combobox and textfields to ensure the text is always selectable even when it is not editable (if it isn't selectable, copy cannot be done on it).

Before:
![Screen Recording 2020-09-14 at 22 25 09](https://user-images.githubusercontent.com/2262453/93144493-02e7aa00-f6e2-11ea-8fa8-1ef66e45a774.gif)

After:
![Screen Recording 2020-09-14 at 23 04 54](https://user-images.githubusercontent.com/2262453/93144507-0b3fe500-f6e2-11ea-93e1-ee63fcf4d111.gif)


@csomor I noticed you had left a comment in `wxNSComboBoxControl::SetEditable` about accessing the text field directly, but from my experiments calling `setEditable` and `sestSelectable` on the combobox object did change the properties of the text field in the combobox, so I am not quite sure what you thought was wrong - but it seems to be working properly to me.