### PR TITLE
Fix linking issue with wxCmpNatural() in static build

### DIFF
--- a/src/common/arrstr.cpp
+++ b/src/common/arrstr.cpp
@@ -912,7 +912,7 @@ int wxCMPFUNC_CONV wxCmpNaturalGeneric(const wxString& s1, const wxString& s2)
 //
 // If a native version of Natural sort is available, then use that, otherwise
 // use the generic version.
-inline int wxCMPFUNC_CONV wxCmpNatural(const wxString& s1, const wxString& s2)
+int wxCMPFUNC_CONV wxCmpNatural(const wxString& s1, const wxString& s2)
 {
 #if defined( __WINDOWS__ )
     return StrCmpLogicalW(s1.wc_str(), s2.wc_str());


### PR DESCRIPTION
wxCmpNatural() had "inline" function specifier in a .cpp file
which made the function inaccessible outside that file in static builds.

Fix this by removing "inline", the function character is such that the
overhead by a function call should have negligible impact on its performance.

Closes #18919.