### PR TITLE
Avoid buffer size wrap-around in function DoStringPrintfV

### DIFF
--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -3894,7 +3894,7 @@ public:
 
         size_t len;
         const wxCharTypeBuffer<CharType> buf(str.tchar_str<CharType>(&len));
-        if ( buf )
+        if ( buf && m_buf.data() )
         {
             if ( len > lenWanted )
             {

--- a/src/common/string.cpp
+++ b/src/common/string.cpp
@@ -2081,10 +2081,14 @@ static int DoStringPrintfV(wxString& str,
             // If errno was set to one of the two well-known hard errors
             // then fail immediately to avoid an infinite loop.
                 return -1;
-            else
-            // still not enough, as we don't know how much we need, double the
-            // current size of the buffer
-                size *= 2;
+            else {
+                // still not enough, as we don't know how much we
+                // need, double the current size of the buffer
+                int newSize = size * 2;
+                if (newSize < size) // Overflow
+                    return -1;
+                size = newSize;
+            }
 #endif // wxUSE_WXVSNPRINTF/!wxUSE_WXVSNPRINTF
         }
         else if ( len >= size )
@@ -2093,7 +2097,11 @@ static int DoStringPrintfV(wxString& str,
             // we know that our own implementation of wxVsnprintf() returns
             // size+1 when there's not enough space but that's not the size
             // of the required buffer!
-            size *= 2;      // so we just double the current size of the buffer
+            // So we just double the current size of the buffer
+            int newSize = size * 2;
+            if (newSize < size)
+                return -1; // Overflow
+            size = newSize;
 #else
             // some vsnprintf() implementations NUL-terminate the buffer and
             // some don't in len == size case, to be safe always add 1

--- a/src/common/string.cpp
+++ b/src/common/string.cpp
@@ -2023,7 +2023,7 @@ template<typename BufferType>
 static int DoStringPrintfV(wxString& str,
                            const wxString& format, va_list argptr)
 {
-    int size = 1024;
+    size_t size = 1024;
 
     for ( ;; )
     {
@@ -2084,21 +2084,21 @@ static int DoStringPrintfV(wxString& str,
             else {
                 // still not enough, as we don't know how much we
                 // need, double the current size of the buffer
-                int newSize = size * 2;
+                size_t newSize = size * 2;
                 if (newSize < size) // Overflow
                     return -1;
                 size = newSize;
             }
 #endif // wxUSE_WXVSNPRINTF/!wxUSE_WXVSNPRINTF
         }
-        else if ( len >= size )
+        else if ( static_cast<size_t>(len) >= size )
         {
 #if wxUSE_WXVSNPRINTF
             // we know that our own implementation of wxVsnprintf() returns
             // size+1 when there's not enough space but that's not the size
             // of the required buffer!
             // So we just double the current size of the buffer
-            int newSize = size * 2;
+            size_t newSize = size * 2;
             if (newSize < size)
                 return -1; // Overflow
             size = newSize;


### PR DESCRIPTION
This PR addresses [bug #18921](https://trac.wxwidgets.org/ticket/18921)

The reasoning is simple: because we do not have any information on why the error happened, the logic "just double the buffer size" is kept, but it is checked against wrap-around.

When applying this patch, the test program attached to issue #18921 does not segfault any more, but rather shows a failed assertion.