### PR TITLE
Improve code examples in wxDataViewModel documentation

### DIFF
--- a/interface/wx/dataview.h
+++ b/interface/wx/dataview.h
@@ -73,9 +73,10 @@
     associating the model with a control like this:
 
     @code
-        wxDataViewCtrl *musicCtrl = new wxDataViewCtrl( this, wxID_ANY );
+        wxDataViewCtrl *musicCtrl = new wxDataViewCtrl(this, wxID_ANY);
         wxDataViewModel *musicModel = new MyMusicModel;
-        m_musicCtrl->AssociateModel( musicModel );
+
+        musicCtrl->AssociateModel(musicModel);
         musicModel->DecRef();  // avoid memory leak !!
 
         // add columns now
@@ -84,11 +85,10 @@
     A potentially better way to avoid memory leaks is to use wxObjectDataPtr
 
     @code
-        wxObjectDataPtr<MyMusicModel> musicModel;
-
-        wxDataViewCtrl *musicCtrl = new wxDataViewCtrl( this, wxID_ANY );
-        musicModel = new MyMusicModel;
-        m_musicCtrl->AssociateModel( musicModel.get() );
+        wxDataViewCtrl *musicCtrl = new wxDataViewCtrl(this, wxID_ANY);
+        wxObjectDataPtr<wxDataViewModel> musicModel(new MyMusicModel);
+        
+        musicCtrl->AssociateModel(musicModel.get());
 
         // add columns now
     @endcode


### PR DESCRIPTION
Fix variable name for the model.

Make the code using wxObjectDataPtr have the same flow as the
code using a raw pointer.

Format the code to be in accordance with the official guidelines.

Closes #18924.