### PR TITLE
Bitmapcombobox getstringselection osx

### DIFF
--- a/include/wx/bmpcbox.h
+++ b/include/wx/bmpcbox.h
@@ -44,7 +44,6 @@ public:
 
     // Sets the image for the given item.
     virtual void SetItemBitmap(unsigned int n, const wxBitmap& bitmap) = 0;
-    virtual wxString GetStringSelection() = 0;
 
 #if !defined(wxBITMAPCOMBOBOX_OWNERDRAWN_BASED)
 

--- a/include/wx/bmpcbox.h
+++ b/include/wx/bmpcbox.h
@@ -44,6 +44,7 @@ public:
 
     // Sets the image for the given item.
     virtual void SetItemBitmap(unsigned int n, const wxBitmap& bitmap) = 0;
+    virtual wxString GetStringSelection() = 0;
 
 #if !defined(wxBITMAPCOMBOBOX_OWNERDRAWN_BASED)
 

--- a/include/wx/generic/bmpcbox.h
+++ b/include/wx/generic/bmpcbox.h
@@ -83,7 +83,7 @@ public:
                 const wxString& name = wxASCII_STR(wxBitmapComboBoxNameStr));
 
     virtual ~wxBitmapComboBox();
-    virtual wxString GetStringSelection() wxOVERRIDE;
+    virtual wxString GetStringSelection() const wxOVERRIDE;
     // Adds item with image to the end of the combo box.
     int Append(const wxString& item, const wxBitmap& bitmap = wxNullBitmap);
     int Append(const wxString& item, const wxBitmap& bitmap, void *clientData);

--- a/include/wx/generic/bmpcbox.h
+++ b/include/wx/generic/bmpcbox.h
@@ -83,7 +83,7 @@ public:
                 const wxString& name = wxASCII_STR(wxBitmapComboBoxNameStr));
 
     virtual ~wxBitmapComboBox();
-
+    virtual wxString GetStringSelection() wxOVERRIDE;
     // Adds item with image to the end of the combo box.
     int Append(const wxString& item, const wxBitmap& bitmap = wxNullBitmap);
     int Append(const wxString& item, const wxBitmap& bitmap, void *clientData);

--- a/include/wx/generic/bmpcbox.h
+++ b/include/wx/generic/bmpcbox.h
@@ -83,7 +83,9 @@ public:
                 const wxString& name = wxASCII_STR(wxBitmapComboBoxNameStr));
 
     virtual ~wxBitmapComboBox();
+
     virtual wxString GetStringSelection() const wxOVERRIDE;
+
     // Adds item with image to the end of the combo box.
     int Append(const wxString& item, const wxBitmap& bitmap = wxNullBitmap);
     int Append(const wxString& item, const wxBitmap& bitmap, void *clientData);

--- a/src/generic/bmpcboxg.cpp
+++ b/src/generic/bmpcboxg.cpp
@@ -135,9 +135,9 @@ wxBitmapComboBox::~wxBitmapComboBox()
     DoClear();
 }
 
-wxString wxBitmapComboBox::GetStringSelection()
+wxString wxBitmapComboBox::GetStringSelection() const
 {
-    return dynamic_cast<wxItemContainerImmutable *>( this )->GetStringSelection();
+    return wxItemContainer::GetStringSelection();
 }
 
 // ----------------------------------------------------------------------------

--- a/src/generic/bmpcboxg.cpp
+++ b/src/generic/bmpcboxg.cpp
@@ -135,6 +135,11 @@ wxBitmapComboBox::~wxBitmapComboBox()
     DoClear();
 }
 
+wxString wxBitmapComboBox::GetStringSelection()
+{
+    return dynamic_cast<wxItemContainerImmutable *>( this )->GetStringSelection();
+}
+
 // ----------------------------------------------------------------------------
 // Item manipulation
 // ----------------------------------------------------------------------------

--- a/tests/controls/bitmapcomboboxtest.cpp
+++ b/tests/controls/bitmapcomboboxtest.cpp
@@ -79,13 +79,9 @@ void BitmapComboBoxTestCase::Bitmap()
     wxArrayString items;
     items.push_back("item 0");
     items.push_back("item 1");
-#if defined __WXMSW__ || defined __WXGTK__
-    //We need this otherwise MSVC complains as it cannot find a suitable append
-    static_cast<wxComboBox*>(m_combo)->Append(items);
-#else
+    // TODO: Add wxBitmapComboBoxBase::Append(wxArrayString )
     for( unsigned int i = 0; i < items.size(); ++i )
         m_combo->Append(items[i]);
-#endif
 
     CPPUNIT_ASSERT(!m_combo->GetItemBitmap(0).IsOk());
 

--- a/tests/controls/bitmapcomboboxtest.cpp
+++ b/tests/controls/bitmapcomboboxtest.cpp
@@ -79,7 +79,7 @@ void BitmapComboBoxTestCase::Bitmap()
     wxArrayString items;
     items.push_back("item 0");
     items.push_back("item 1");
-#ifdef __WXMSW__
+#if defined __WXMSW__ || defined __WXGTK__
     //We need this otherwise MSVC complains as it cannot find a suitable append
     static_cast<wxComboBox*>(m_combo)->Append(items);
 #else

--- a/tests/controls/bitmapcomboboxtest.cpp
+++ b/tests/controls/bitmapcomboboxtest.cpp
@@ -83,7 +83,7 @@ void BitmapComboBoxTestCase::Bitmap()
     //We need this otherwise MSVC complains as it cannot find a suitable append
     static_cast<wxComboBox*>(m_combo)->Append(items);
 #else
-    for( int i = 0; i < items.size(); ++i )
+    for( unsigned int i = 0; i < items.size(); ++i )
         m_combo->Append(items[i]);
 #endif
 

--- a/tests/controls/bitmapcomboboxtest.cpp
+++ b/tests/controls/bitmapcomboboxtest.cpp
@@ -24,9 +24,6 @@
 #include "itemcontainertest.h"
 #include "asserthelper.h"
 
-//Test only if we are based off of wxComboBox
-#ifndef wxGENERIC_BITMAPCOMBOBOX
-
 class BitmapComboBoxTestCase : public TextEntryTestCase,
                                public ItemContainerTestCase,
                                public CppUnit::TestCase
@@ -82,9 +79,13 @@ void BitmapComboBoxTestCase::Bitmap()
     wxArrayString items;
     items.push_back("item 0");
     items.push_back("item 1");
-
+#ifdef __WXMSW__
     //We need this otherwise MSVC complains as it cannot find a suitable append
     static_cast<wxComboBox*>(m_combo)->Append(items);
+#else
+    for( int i = 0; i < items.size(); ++i )
+        m_combo->Append(items[i]);
+#endif
 
     CPPUNIT_ASSERT(!m_combo->GetItemBitmap(0).IsOk());
 
@@ -104,8 +105,10 @@ void BitmapComboBoxTestCase::Bitmap()
     CPPUNIT_ASSERT(m_combo->GetItemBitmap(0).IsOk());
 
     CPPUNIT_ASSERT_EQUAL(wxSize(16, 16), m_combo->GetBitmapSize());
-}
 
-#endif //wxGENERIC_BITMAPCOMBOBOX
+    m_combo->SetSelection( 1 );
+
+    CPPUNIT_ASSERT_EQUAL( m_combo->GetStringSelection(), "item with bitmap" );
+}
 
 #endif //wxUSE_BITMAPCOMBOBOX


### PR DESCRIPTION
Hi, ALL,
This PR does 2 things:

1. It adds the GetStringSelection() to generic version of wxBitmapComboBox with the testing
2. It enables testing of generic wxBitmapComboBox

Let me know if this needs the documentation changes.

wxBitmapComboBox is documented as "comtains wxComboBox API" this function was not available for OSX/generic version and user code had to have a conditional compilation.

Please review and apply.

Thank you.

