### PR TITLE
Fix displaying Flush() in wxClipboard docs note

### DIFF
--- a/interface/wx/clipbrd.h
+++ b/interface/wx/clipbrd.h
@@ -57,7 +57,7 @@
           the end-user's machine. In order for the clipboard data to persist after
           the window closes, a clipboard manager must be installed. Some clipboard
           managers will automatically flush the clipboard after each new piece of
-          data is added, while others will not. The @Flush() function will force
+          data is added, while others will not. The Flush() function will force
           the clipboard manager to flush the data.
 
     @library{wxcore}


### PR DESCRIPTION
Just remove the '@' which was probably there by accident but
made the function name disappear:
![doc-clipboard-note](https://user-images.githubusercontent.com/12495521/94308244-82913680-ff76-11ea-89b9-c187278c56bc.png)
