### PR TITLE
[wxGtk] After a call to wxTextCtrl::WriteText() scroll to cursor was broken

### DIFF
--- a/samples/widgets/textctrl.cpp
+++ b/samples/widgets/textctrl.cpp
@@ -904,11 +904,17 @@ void TextWidgetsPage::OnButtonAdd(wxCommandEvent& WXUNUSED(event))
 
 void TextWidgetsPage::OnButtonInsert(wxCommandEvent& WXUNUSED(event))
 {
-    m_text->WriteText("Is there anybody going to listen to my story");
+    wxString str = "Is there anybody going to listen to my story";
+
     if ( m_text->GetWindowStyle() & wxTE_MULTILINE )
     {
-        m_text->WriteText("\nall about the girl who came to stay");
+        str += "\nall about the girl who came to stay";
+
+        for ( int i = 0; i < 5; i++ )
+            str += str;
     }
+
+    m_text->WriteText(str);
 }
 
 void TextWidgetsPage::OnButtonClear(wxCommandEvent& WXUNUSED(event))


### PR DESCRIPTION
See this ticket [#18864](https://trac.wxwidgets.org/ticket/18864#comment:10)

N.B. I tested this PR against GTK3 only !!