### PR TITLE
Add null check in wxAuiToolBar event handler

### DIFF
--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -2839,7 +2839,7 @@ void wxAuiToolBar::OnMotion(wxMouseEvent& evt)
     const bool button_pressed = HasCapture();
 
     // start a drag event
-    if (!m_dragging && button_pressed &&
+    if (!m_dragging && button_pressed && m_actionItem &&
         abs(evt.GetX() - m_actionPos.x) + abs(evt.GetY() - m_actionPos.y) > 5)
     {
         // TODO: sending this event only makes sense if there is an 'END_DRAG'


### PR DESCRIPTION
I noticed in some code I was writing that if I showed a `wxPopupTransientWindow` using a drag event as a trigger (even not actually showing it during the drag event and using a `CallAfter` to show it) that I would get a crash on OSX when the toolbar tried to run its `OnMotion` handler because `m_actionItem` was null in the handler after the popup window was shown. Every other place that dereferences `m_actionItem` is guarded by a null check, so this adds a null check to it and will set the ID for the event to -1 if the item is null (this is the same value used in other handlers to indicate an invalid tool ID).