### PR TITLE
[wxGTK] mark_set() handler fixup

### DIFF
--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -626,7 +626,12 @@ extern "C" {
 static void mark_set(GtkTextBuffer*, GtkTextIter*, GtkTextMark* mark, GSList** markList)
 {
     if (gtk_text_mark_get_name(mark) == NULL)
+    {
         *markList = g_slist_prepend(*markList, mark);
+        wxLogDebug("m_anonymousMarkList size: %lu", g_slist_length(*markList));
+    }
+
+    wxLogDebug("Inside mark_set() handler");
 }
 }
 


### PR DESCRIPTION
_This PR is made for discussion purposes and to present my thoughts about mark_set() handler._

Seeing the [gtk_text_buffer_move_mark](https://developer.gnome.org/gtk3/stable/GtkTextBuffer.html#gtk-text-buffer-move-mark) documentation which clearly states:

> .... Emits the “mark-set” signal as notification of the move.

So after a call to `gtk_text_buffer_move_mark` the “mark-set” signal should be emitted which is not the case with the old code! (83a5ac8 commit proves it)

Now, if the code changed like the 1b00288 commit does, everything will work correctly.
But what i don't understand is... what is the purpose of `m_anonymousMarkList` ?
Whenever the cursor (which is an anonymous mark) position changed, the “mark-set” signal is emitted as expected, and the `m_anonymousMarkList` got filled with **duplicate** marks (here, with the same cursor again and again) !?

Am i missing something here ?

TIA.