### PR TITLE
Add missing wxRibbonMSWArtProvider::GetButtonBarButtonTextWidth interface

### DIFF
--- a/interface/wx/ribbon/art.h
+++ b/interface/wx/ribbon/art.h
@@ -1251,6 +1251,12 @@ public:
                         wxRect* normal_region,
                         wxRect* dropdown_region);
 
+    wxCoord GetButtonBarButtonTextWidth(
+                        wxDC& dc,
+                        const wxString& label,
+                        wxRibbonButtonKind kind,
+                        wxRibbonButtonBarButtonState size);
+
     wxSize GetMinimisedPanelMinimumSize(
                         wxDC& dc,
                         const wxRibbonPanel* wnd,


### PR DESCRIPTION
The missing override in the interface makes the inherited classes abstract
from the Phoenix SIP generators view.