### PR TITLE
Fix wrong step size in wximage paste

### DIFF
--- a/src/common/image.cpp
+++ b/src/common/image.cpp
@@ -1764,7 +1764,7 @@ wxImage::Paste(const wxImage & image, int x, int y,
                 // Make all the copied pixels fully opaque
                 if (alpha_target_data != NULL)
                 {
-                    memset(alpha_target_data, wxALPHA_OPAQUE, target_alpha_step);
+                    memset(alpha_target_data, wxALPHA_OPAQUE, width);
                     alpha_target_data += target_alpha_step;
                 }
             }

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1839,6 +1839,21 @@ TEST_CASE("wxImage::Paste", "[image][paste]")
         CHECK_THAT(actual, CenterAlphaPixelEquals(255));
         CHECK_THAT(actual, RGBSameAs(black));
     }
+    SECTION("Paste large image with negative vertical offset")
+    {
+        wxImage target(442, 249);
+        wxImage to_be_pasted(345, 24900);
+        target.InitAlpha();
+        target.Paste(to_be_pasted, 48, -12325, wxIMAGE_ALPHA_BLEND_COMPOSE);
+    }
+    SECTION("Paste large image with negative horizontal offset")
+    {
+        wxImage target(249, 442);
+        wxImage to_be_pasted(24900, 345);
+        target.InitAlpha();
+        target.Paste(to_be_pasted, -12325, 48, wxIMAGE_ALPHA_BLEND_COMPOSE);
+    }
+
 }
 
 /*


### PR DESCRIPTION
Wrong step size used caused memory corruption.
Test (the one with the large negative vertical offset) reproduced this 100%.