### PR TITLE
Fix newlines in Doxygen ALIASES

### DIFF
--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -60,44 +60,44 @@ LOOKUP_CACHE_SIZE      = 0
 #---------------------------------------------------------------------------
 
 # aliases to be used by classes which emit wxEvents (e.g. wxWindow, wxTextCtrl, etc):
-ALIASES = beginEventEmissionTable="\n<h2>Events emitted by this class</h2><p>Event macros for events emitted by this class:</p><div>"
-ALIASES += beginEventEmissionTable{1}="\n<h2>Events emitted by this class</h2><p>The following event handler macros redirect the events to member function handlers '<b>func</b>' with prototypes like: <div class='eventHandler'><span>void&nbsp;handlerFuncName(\1&&nbsp;event)</span></div></p>Event macros for events emitted by this class:<div>"
-ALIASES += beginEventEmissionTable{2}="\n<h2>Events emitted by this class</h2><p>The following event handler macros redirect the events to member function handlers '<b>func</b>' with prototypes like: <div class='eventHandler'><span>void&nbsp;handlerFuncName(\1&&nbsp;event)</span> or <span>void&nbsp;handlerFuncName(\2&&nbsp;event)</span></div></p>Event macros for events emitted by this class:<div>"
+ALIASES = beginEventEmissionTable=" ^^ <h2>Events emitted by this class</h2><p>Event macros for events emitted by this class:</p><div>"
+ALIASES += beginEventEmissionTable{1}=" ^^ <h2>Events emitted by this class</h2><p>The following event handler macros redirect the events to member function handlers '<b>func</b>' with prototypes like: <div class='eventHandler'><span>void&nbsp;handlerFuncName(\1&&nbsp;event)</span></div></p>Event macros for events emitted by this class:<div>"
+ALIASES += beginEventEmissionTable{2}=" ^^ <h2>Events emitted by this class</h2><p>The following event handler macros redirect the events to member function handlers '<b>func</b>' with prototypes like: <div class='eventHandler'><span>void&nbsp;handlerFuncName(\1&&nbsp;event)</span> or <span>void&nbsp;handlerFuncName(\2&&nbsp;event)</span></div></p>Event macros for events emitted by this class:<div>"
 
 # aliases to be used in wxEvent-derived classes:
-ALIASES += beginEventTable{1}="\n<h2>Events using this class</h2><p>The following event handler macros redirect the events to member function handlers '<b>func</b>' with prototypes like: <div class='eventHandler'><span>void&nbsp;handlerFuncName(\1&&nbsp;event)</span></div></p>Event macros:<div>"
-ALIASES += beginEventTable{2}="\n<h2>Events using this class</h2><p>The following event handler macros redirect the events to member function handlers '<b>func</b>' with prototypes like: <div class='eventHandler'><span>void&nbsp;handlerFuncName(\1&&nbsp;event)</span> or <span>void&nbsp;handlerFuncName(\2&&nbsp;event)</span></div></p>Event macros:<div>"
+ALIASES += beginEventTable{1}=" ^^ <h2>Events using this class</h2><p>The following event handler macros redirect the events to member function handlers '<b>func</b>' with prototypes like: <div class='eventHandler'><span>void&nbsp;handlerFuncName(\1&&nbsp;event)</span></div></p>Event macros:<div>"
+ALIASES += beginEventTable{2}=" ^^ <h2>Events using this class</h2><p>The following event handler macros redirect the events to member function handlers '<b>func</b>' with prototypes like: <div class='eventHandler'><span>void&nbsp;handlerFuncName(\1&&nbsp;event)</span> or <span>void&nbsp;handlerFuncName(\2&&nbsp;event)</span></div></p>Event macros:<div>"
 
 # common event aliases:
 ALIASES += event{1}="</div>\li <span class='event'>\1</span>:<div class='eventDesc'>"
 ALIASES += event{2}="</div>\li <span class='event'>\1, \2</span>:<div class='eventDesc'>"
 ALIASES += event{3}="</div>\li <span class='event'>\1, \2, \3</span>:<div class='eventDesc'>"
 ALIASES += event{4}="</div>\li <span class='event'>\1, \2, \3, \4</span>:<div class='eventDesc'>"
-ALIASES += endEventTable="</div>\n"
+ALIASES += endEventTable="</div> ^^ "
 
 # style aliases
-ALIASES += beginStyleTable="\n<h2>Styles</h2><p>This class supports the following styles:</p><div>"
+ALIASES += beginStyleTable=" ^^ <h2>Styles</h2><p>This class supports the following styles:</p><div>"
 ALIASES += style{1}="</div>\li <span class='style'>\1</span>:<div class='styleDesc'>"
-ALIASES += endStyleTable="</div>\n"
+ALIASES += endStyleTable="</div> ^^ "
 
 # extra style aliases
-ALIASES += beginExtraStyleTable="\n<hr><h2>Extra Styles</h2><p>This class supports the following extra styles:</p><div>"
-ALIASES += endExtraStyleTable="</div>\n"
+ALIASES += beginExtraStyleTable=" ^^ <hr><h2>Extra Styles</h2><p>This class supports the following extra styles:</p><div>"
+ALIASES += endExtraStyleTable="</div> ^^ "
 
 # flag aliases
 ALIASES += beginFlagTable="<div>"
 ALIASES += flag{1}="</div>\li <span class='flag'>\1</span>:<div class='flagDesc'>"
-ALIASES += endFlagTable="</div>\n"
+ALIASES += endFlagTable="</div> ^^ "
 
 # creates appearance section: this should be used for all main GUI controls
 # that look different in different ports. genericAppearance can be used for the
 # controls that always look the same.
-ALIASES += appearance{1}="\htmlonly<div class="appearance"><span class='appearance'>Appearance:</span><table><tr><td>\endhtmlonly\n\image html appear-\1-msw.png \"wxMSW Appearance\"\n\htmlonly</td><td>\endhtmlonly\n\image html appear-\1-gtk.png \"wxGTK Appearance\"\n\htmlonly</td><td>\endhtmlonly\n\image html appear-\1-mac.png \"wxOSX Appearance\"\n\htmlonly</td></tr></table></div>\endhtmlonly"
-ALIASES += genericAppearance{1}="\htmlonly<div class="appearance"><span class='appearance'>Appearance:</span><table class='appearance'><tr><td>\endhtmlonly\n\image html generic/\1.png \"Generic Appearance\"\n\htmlonly</td></tr></table></div>\endhtmlonly"
+ALIASES += appearance{1}="\htmlonly<div class="appearance"><span class='appearance'>Appearance:</span><table><tr><td>\endhtmlonly ^^ \image html appear-\1-msw.png \"wxMSW Appearance\" ^^ \htmlonly</td><td>\endhtmlonly ^^ \image html appear-\1-gtk.png \"wxGTK Appearance\" ^^ \htmlonly</td><td>\endhtmlonly ^^ \image html appear-\1-mac.png \"wxOSX Appearance\" ^^ \htmlonly</td></tr></table></div>\endhtmlonly"
+ALIASES += genericAppearance{1}="\htmlonly<div class="appearance"><span class='appearance'>Appearance:</span><table class='appearance'><tr><td>\endhtmlonly ^^ \image html generic/\1.png \"Generic Appearance\" ^^ \htmlonly</td></tr></table></div>\endhtmlonly"
 
 # these compact versions are only used on the screenshots page
-ALIASES += appearance_brief{2}="\htmlonly<div class="appearance_brief"><table><tr><td>\endhtmlonly\n\1\htmlonly</td><td>\endhtmlonly\n\image html appear-\2-msw.png\n\htmlonly</td><td>\endhtmlonly\n\image html appear-\2-gtk.png\n\htmlonly</td><td>\endhtmlonly\n\image html appear-\2-mac.png\n\htmlonly</td></tr></table></div>\endhtmlonly"
-ALIASES += genericAppearance_brief{2}="\htmlonly<div class="appearance_brief"><table><tr><td>\endhtmlonly\n\1\htmlonly</td><td>\endhtmlonly\n\image html generic/\2.png\n\htmlonly</td></tr></table></div>\endhtmlonly"
+ALIASES += appearance_brief{2}="\htmlonly<div class="appearance_brief"><table><tr><td>\endhtmlonly ^^ \1\htmlonly</td><td>\endhtmlonly ^^ \image html appear-\2-msw.png ^^ \htmlonly</td><td>\endhtmlonly ^^ \image html appear-\2-gtk.png ^^ \htmlonly</td><td>\endhtmlonly ^^ \image html appear-\2-mac.png ^^ \htmlonly</td></tr></table></div>\endhtmlonly"
+ALIASES += genericAppearance_brief{2}="\htmlonly<div class="appearance_brief"><table><tr><td>\endhtmlonly ^^ \1\htmlonly</td><td>\endhtmlonly ^^ \image html generic/\2.png ^^ \htmlonly</td></tr></table></div>\endhtmlonly"
 
 # aliases for the creation of "named member groups"
 # USAGE: the first argument must not contain spaces and be a unique identifier
@@ -113,9 +113,9 @@ ALIASES += ref_member_group{2}="<a href='#\1' class='el'>\2</a>"
 #---------------------------------------------------------------------------
 
 # aliases for additional wx-specific infos
-ALIASES += category{1}="\ingroup group_class_\1 \n<div><span class='category'>Category:</span>&nbsp;&nbsp;<span class='category_text'>\ref group_class_\1</span></div>"
-ALIASES += category{2}="\ingroup group_class_\1 group_class_\2 \n<div><span class='category'>Category:</span>&nbsp;&nbsp;<span class='category_text'>\ref group_class_\1, \ref group_class_\2</span></div>"
-ALIASES += category{3}="\ingroup group_class_\1 group_class_\2 group_class_\3 \n<div><span class='category'>Category:</span>&nbsp;&nbsp;<span class='category_text'>\ref group_class_\1, \ref group_class_\2, \ref group_class_\3</span></div>"
+ALIASES += category{1}="\ingroup group_class_\1  ^^ <div><span class='category'>Category:</span>&nbsp;&nbsp;<span class='category_text'>\ref group_class_\1</span></div>"
+ALIASES += category{2}="\ingroup group_class_\1 group_class_\2  ^^ <div><span class='category'>Category:</span>&nbsp;&nbsp;<span class='category_text'>\ref group_class_\1, \ref group_class_\2</span></div>"
+ALIASES += category{3}="\ingroup group_class_\1 group_class_\2 group_class_\3  ^^ <div><span class='category'>Category:</span>&nbsp;&nbsp;<span class='category_text'>\ref group_class_\1, \ref group_class_\2, \ref group_class_\3</span></div>"
 ALIASES += library{1}="<h2></h2><div><span class='lib'>Library:</span>&nbsp;&nbsp;<span class='lib_text'>\ref page_libs_\1</span></div>"
 ALIASES += nolibrary="<h2></h2><div><span class='lib'>Library:</span>&nbsp;&nbsp;<span class='lib_text'>None; this class implementation is entirely header-based.</span></div>"
 ALIASES += stdobjects="<span class='stdobj'>Predefined objects/pointers:</span>"
@@ -136,7 +136,7 @@ ALIASES += onlyfor{4}="<div><span class='avail'>Availability:</span>&nbsp;&nbsp;
 
 # Use this in grouped global functions, and macros since they
 # wouldn't otherwise indicate what header they are defined in.
-ALIASES += header{1}="Include file:\n \verbatim #include <\1> \endverbatim"
+ALIASES += header{1}="Include file: ^^  \verbatim #include <\1> \endverbatim"
 
 # some formatting aliases
 ALIASES += true="<span class='literal'>true</span>"
@@ -194,7 +194,7 @@ ALIASES += itemdef{8}="<tr><td><span class='itemdef'>\1</span></td> <td>\2,\3,\4
 ALIASES += itemdef{9}="<tr><td><span class='itemdef'>\1</span></td> <td>\2,\3,\4,\5,\6,\7,\8,\9</td></tr>"
 ALIASES += itemdef{10}="<tr><td><span class='itemdef'>\1</span></td> <td>\2,\3,\4,\5,\6,\7,\8,\9,\10</td></tr>"
 ALIASES += endDefList="</table>"
-ALIASES += stock{3}="<tr><td><span class='itemdef'>\1</span></td> <td> @image html gtk-\2.png\n</td><td>\3</td></tr>"
+ALIASES += stock{3}="<tr><td><span class='itemdef'>\1</span></td> <td> @image html gtk-\2.png ^^ </td><td>\3</td></tr>"
 
 # Aliases for documenting wxPerl/wxPython-specific parts
 #---------------------------------------------------------------------------


### PR DESCRIPTION
According to https://www.doxygen.nl/manual/custcmd.html, newlines which
should appear in the output have to be written as "Physical newlines",
i.e. "^^". Otherwise, line-commands like '\ingroup' and '\image' are not
terminated properly.

This fixes output with doxygen 1.8.20 (likely effects any version since
1.8.16).