### PR TITLE
Fix wxWindowId parameter type and name in wxHtmlHelpWindow

### DIFF
--- a/include/wx/html/helpwnd.h
+++ b/include/wx/html/helpwnd.h
@@ -80,7 +80,7 @@ class WXDLLIMPEXP_HTML wxHtmlHelpWindow : public wxWindow
 
 public:
     wxHtmlHelpWindow(wxHtmlHelpData* data = NULL) { Init(data); }
-    wxHtmlHelpWindow(wxWindow* parent, wxWindowID wxWindowID,
+    wxHtmlHelpWindow(wxWindow* parent, wxWindowID id,
                     const wxPoint& pos = wxDefaultPosition,
                     const wxSize& size = wxDefaultSize,
                     int style = wxTAB_TRAVERSAL|wxNO_BORDER,

--- a/interface/wx/html/helpwnd.h
+++ b/interface/wx/html/helpwnd.h
@@ -77,7 +77,7 @@ public:
         For the values of @a helpStyle, please see the documentation for
         wxHtmlHelpController.
     */
-    wxHtmlHelpWindow(wxWindow* parent, int wxWindowID,
+    wxHtmlHelpWindow(wxWindow* parent, wxWindowID id,
                      const wxPoint& pos = wxDefaultPosition,
                      const wxSize& size = wxDefaultSize,
                      int style = wxTAB_TRAVERSAL|wxBORDER_NONE,


### PR DESCRIPTION
The type obviously should be wxWindowID, not int.

Rename the parameter, as it is the only instance where the id is not
named 'id', the implementation already uses 'id', and for Phoenix naming
it id is also preferred, as the name is used for mangling.

The naming change causes no further breakage for Phoenix, as the generator
is currently broken anyway for this case.