### PR TITLE
Don't use ID2D1Bitmap::GetSize() to get source bitmap size

### DIFF
--- a/src/msw/graphicsd2d.cpp
+++ b/src/msw/graphicsd2d.cpp
@@ -4494,11 +4494,11 @@ void wxD2DContext::DrawBitmap(const wxGraphicsBitmap& bmp, wxDouble x, wxDouble 
 
     wxD2DBitmapData* bitmapData = wxGetD2DBitmapData(bmp);
     bitmapData->Bind(this);
-    D2D1_SIZE_F imgSize = bitmapData->GetD2DBitmap()->GetSize();
+    wxBitmap const& bitmap = static_cast<wxD2DBitmapData::NativeType*>(bitmapData->GetNativeBitmap())->GetSourceBitmap();
 
     m_renderTargetHolder->DrawBitmap(
         bitmapData->GetD2DBitmap(),
-        D2D1::RectF(0, 0, imgSize.width, imgSize.height),
+        D2D1::RectF(0, 0, bitmap.GetWidth(), bitmap.GetHeight()),
         D2D1::RectF(x, y, x + w, y + h),
         GetInterpolationQuality(),
         GetCompositionMode());


### PR DESCRIPTION
See [#17171](https://trac.wxwidgets.org/ticket/17171), [#18686](https://trac.wxwidgets.org/ticket/18686)