### PR TITLE
Missing cast when returning value for wxRound

### DIFF
--- a/include/wx/math.h
+++ b/include/wx/math.h
@@ -68,7 +68,7 @@
         wxASSERT_MSG(x > (double)INT_MIN - 0.5 && x < (double)INT_MAX + 0.5,
             wxT("argument out of supported range"));
 
-        return std::lround(x);
+        return static_cast<int>(std::lround(x));
     }
 #else /* C++98 */
 


### PR DESCRIPTION
wxRound returns an int value but std::lround(..) provides a long value. The internal checking against overflow is correctly done using min. and max. int values, therefore, a static_cast can securely be applied.