### PR TITLE
Send wxEVT_SLIDER event only when slider value actually changes

### DIFF
--- a/src/msw/slider.cpp
+++ b/src/msw/slider.cpp
@@ -313,11 +313,11 @@ bool wxSlider::MSWOnScroll(int WXUNUSED(orientation),
     SetValue(newPos);
 
     wxScrollEvent event(scrollEvent, m_windowId);
-    bool          result = false;
+    bool          processed = false;
 
     event.SetPosition(newPos);
     event.SetEventObject( this );
-    result = HandleWindowEvent(event);
+    processed = HandleWindowEvent(event);
 
     // Do not generate wxEVT_SLIDER when the native scroll message
     // parameter is SB_ENDSCROLL, which always follows only after
@@ -331,10 +331,10 @@ bool wxSlider::MSWOnScroll(int WXUNUSED(orientation),
         cevent.SetInt( newPos );
         cevent.SetEventObject( this );
 
-        result = HandleWindowEvent( cevent );
+        processed = HandleWindowEvent( cevent );
     }
 
-    return result;
+    return processed;
 }
 
 void wxSlider::Command (wxCommandEvent & event)

--- a/src/msw/slider.cpp
+++ b/src/msw/slider.cpp
@@ -313,15 +313,28 @@ bool wxSlider::MSWOnScroll(int WXUNUSED(orientation),
     SetValue(newPos);
 
     wxScrollEvent event(scrollEvent, m_windowId);
+    bool          result = false;
+
     event.SetPosition(newPos);
     event.SetEventObject( this );
-    HandleWindowEvent(event);
+    result = HandleWindowEvent(event);
 
-    wxCommandEvent cevent( wxEVT_SLIDER, GetId() );
-    cevent.SetInt( newPos );
-    cevent.SetEventObject( this );
+    // Do not generate wxEVT_SLIDER when the native scroll message
+    // parameter is SB_ENDSCROLL, which always follows only after
+    // another scroll message which already changed the slider value.
+    // Therefore, sending wxEVT_SLIDER after SB_ENDSCROLL
+    // would result into two wxEVT_SLIDER events with the same value.
+    if ( wParam != SB_ENDSCROLL )
+    {
+        wxCommandEvent cevent( wxEVT_SLIDER, GetId() );
 
-    return HandleWindowEvent( cevent );
+        cevent.SetInt( newPos );
+        cevent.SetEventObject( this );
+
+        result = HandleWindowEvent( cevent );
+    }
+
+    return result;
 }
 
 void wxSlider::Command (wxCommandEvent & event)

--- a/src/msw/slider.cpp
+++ b/src/msw/slider.cpp
@@ -313,15 +313,28 @@ bool wxSlider::MSWOnScroll(int WXUNUSED(orientation),
     SetValue(newPos);
 
     wxScrollEvent event(scrollEvent, m_windowId);
+    bool          result = false;
+
     event.SetPosition(newPos);
     event.SetEventObject( this );
-    HandleWindowEvent(event);
+    result = HandleWindowEvent(event);
 
-    wxCommandEvent cevent( wxEVT_SLIDER, GetId() );
-    cevent.SetInt( newPos );
-    cevent.SetEventObject( this );
+    // Do not generate wxEVT_SLIDER when the scroll event
+    // is wxEVT_SCROLL_CHANGED. wxEVT_SCROLL_CHANGED always
+    // follows only after another scroll event which already changed
+    // the value. Therefore, sending wxEVT_SLIDER after wxEVT_SCROLL_CHANGED
+    // would result into two wxEVT_SLIDER events with the same value.
+    if ( scrollEvent != wxEVT_SCROLL_CHANGED )
+    {
+        wxCommandEvent cevent( wxEVT_SLIDER, GetId() );
 
-    return HandleWindowEvent( cevent );
+        cevent.SetInt( newPos );
+        cevent.SetEventObject( this );
+
+        result = HandleWindowEvent( cevent );
+    }
+
+    return result;
 }
 
 void wxSlider::Command (wxCommandEvent & event)

--- a/src/msw/slider.cpp
+++ b/src/msw/slider.cpp
@@ -323,7 +323,7 @@ bool wxSlider::MSWOnScroll(int WXUNUSED(orientation),
     // parameter is SB_ENDSCROLL, which always follows only after
     // another scroll message which already changed the slider value.
     // Therefore, sending wxEVT_SLIDER after SB_ENDSCROLL
-    // would result into two wxEVT_SLIDER events with the same value.
+    // would result in two wxEVT_SLIDER events with the same value.
     if ( wParam != SB_ENDSCROLL )
     {
         wxCommandEvent cevent( wxEVT_SLIDER, GetId() );

--- a/tests/controls/slidertest.cpp
+++ b/tests/controls/slidertest.cpp
@@ -35,6 +35,7 @@ private:
 #ifndef __WXOSX__
         WXUISIM_TEST( PageUpDown );
         WXUISIM_TEST( LineUpDown );
+        WXUISIM_TEST( EvtSlider );
         WXUISIM_TEST( LinePageSize );
 #endif
         CPPUNIT_TEST( Value );
@@ -47,6 +48,7 @@ private:
 
     void PageUpDown();
     void LineUpDown();
+    void EvtSlider();
     void LinePageSize();
     void Value();
     void Range();
@@ -122,6 +124,24 @@ void SliderTestCase::LineUpDown()
 
     CPPUNIT_ASSERT_EQUAL(1, lineup.GetCount());
     CPPUNIT_ASSERT_EQUAL(1, linedown.GetCount());
+#endif
+}
+
+void SliderTestCase::EvtSlider()
+{
+#if wxUSE_UIACTIONSIMULATOR
+    EventCounter slider(m_slider, wxEVT_SLIDER);
+
+    wxUIActionSimulator sim;
+    wxYield();
+    m_slider->SetFocus();
+
+    sim.Char(WXK_UP);
+    sim.Char(WXK_DOWN);
+
+    wxYield();
+
+    CPPUNIT_ASSERT_EQUAL(2, slider.GetCount());
 #endif
 }
 


### PR DESCRIPTION
Due to wxMSW implementation detail, two wxEVT_SLIDER events were always
generated for one change in the slider value. Do not do this anymore,
generate wxEVT_SLIDER only when the slider value actually changes.

See [ticket 18929](https://trac.wxwidgets.org/ticket/18929).

**EDIT**
The first "fix" was wrong, checking for `wxEVT_SCROLL_CHANGED` instead of `SB_ENDSCROLL`. It hopefully works as intended now; however, as always I failed to squash the commits.