### PR TITLE
Unicode key as accelerator

### DIFF
--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -518,7 +518,7 @@ void wxWidgetCocoaImpl::SetupKeyEvent(wxKeyEvent &wxevent , NSEvent * nsEvent, N
         }
     }
 
-    if ( !keyval )
+    if ( !keyval && aunichar < 256) // only for ASCII characters
     {
         if ( wxevent.GetEventType() == wxEVT_KEY_UP || wxevent.GetEventType() == wxEVT_KEY_DOWN )
             keyval = wxToupper( aunichar ) ;

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -518,7 +518,7 @@ void wxWidgetCocoaImpl::SetupKeyEvent(wxKeyEvent &wxevent , NSEvent * nsEvent, N
         }
     }
 
-    if ( !keyval && aunichar < 256) // only for ASCII characters
+    if ( !keyval && aunichar < 256 ) // only for ASCII characters
     {
         if ( wxevent.GetEventType() == wxEVT_KEY_UP || wxevent.GetEventType() == wxEVT_KEY_DOWN )
             keyval = wxToupper( aunichar ) ;

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -2573,7 +2573,7 @@ bool wxWindowMac::OSXHandleKeyEvent( wxKeyEvent& event )
     // moved the ordinary key event sending AFTER the accel evaluation
 
 #if wxUSE_ACCEL
-    if (event.GetEventType() == wxEVT_KEY_DOWN)
+    if (event.GetEventType() == wxEVT_KEY_DOWN && event.GetUnicodeKey() == WXK_NONE)
     {
         wxWindow *ancestor = this;
         while (ancestor)

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -2573,7 +2573,7 @@ bool wxWindowMac::OSXHandleKeyEvent( wxKeyEvent& event )
     // moved the ordinary key event sending AFTER the accel evaluation
 
 #if wxUSE_ACCEL
-    if (event.GetEventType() == wxEVT_KEY_DOWN && event.GetUnicodeKey() == WXK_NONE)
+    if (event.GetEventType() == wxEVT_KEY_DOWN)
     {
         wxWindow *ancestor = this;
         while (ancestor)


### PR DESCRIPTION
The problem can be reproduced when using a sample with accelerator table (e.g. `mdi`) and setting F11 as accelerator.
When typing the Turkish 'ş' character (which has the same 350 value as wx's `WXK_F11`) the F11 accelerator command is triggered.
The difference with gtk is also visible with the `keyboard` sample. Unicode key events have both the key code and the Unicode value set for the event.

PS: There are unintended committed and reverted commits in this PR. They do not affect the overall diff. Is this a problem?