### PR TITLE
Deprecate wxTransformMatrix to prepare for its removal later

### DIFF
--- a/include/wx/matrix.h
+++ b/include/wx/matrix.h
@@ -11,7 +11,13 @@
 #ifndef _WX_MATRIXH__
 #define _WX_MATRIXH__
 
-//! headerfiles="matrix.h wx/object.h"
+#include "wx/defs.h"
+
+// Contents of this file is deprecated and shouldn't be used in the new code,
+// please see wxAffineMatrix2D instead.
+
+#if WXWIN_COMPATIBILITY_3_0
+
 #include "wx/object.h"
 #include "wx/math.h"
 
@@ -31,7 +37,11 @@
 //  at a certain coordinate and angle within another parent picture.
 //  At all times m_isIdentity is set if the matrix itself is an Identity matrix.
 //  It is used where possible to optimize calculations.
-class WXDLLIMPEXP_CORE wxTransformMatrix: public wxObject
+class
+#ifndef WXBUILDING
+wxDEPRECATED_MSG("use wxAffineMatrix2D instead")
+#endif
+WXDLLIMPEXP_CORE wxTransformMatrix: public wxObject
 {
 public:
     wxTransformMatrix();
@@ -226,9 +236,11 @@ inline bool wxTransformMatrix::IsIdentity1() const
 }
 
 // Calculates the determinant of a 2 x 2 matrix
-inline double wxCalculateDet(double a11, double a21, double a12, double a22)
-{
+wxDEPRECATED_BUT_USED_INTERNALLY_INLINE(
+    inline double wxCalculateDet(double a11, double a21, double a12, double a22),
     return a11 * a22 - a12 * a21;
-}
+)
+
+#endif // WXWIN_COMPATIBILITY_3_0
 
 #endif // _WX_MATRIXH__

--- a/src/common/matrix.cpp
+++ b/src/common/matrix.cpp
@@ -18,6 +18,8 @@
     #pragma hdrstop
 #endif
 
+#if WXWIN_COMPATIBILITY_3_0
+
 #include "wx/matrix.h"
 
 #ifndef WX_PRECOMP
@@ -598,3 +600,5 @@ void wxTransformMatrix::SetRotation(double rotation)
     Rotate(-GetRotation(), x, y);
     Rotate(rotation, x, y);
 }
+
+#endif // WXWIN_COMPATIBILITY_3_0

--- a/tests/allheaders.h
+++ b/tests/allheaders.h
@@ -217,7 +217,9 @@
 #include <wx/longlong.h>
 #include <wx/lzmastream.h>
 #include <wx/math.h>
+/* Intentionally excluded to avoid deprecation warnings.
 #include <wx/matrix.h>
+*/
 #include <wx/mdi.h>
 #include <wx/mediactrl.h>
 #include <wx/memconf.h>


### PR DESCRIPTION
This class is redundant with wxAffineMatrix2D, which is actually used by
the library itself and documented, so it gets to stay, while this one is
scheduled for removal.

Closes #13114.