### PR TITLE
Speed up wxDataViewCtrl::SetSelections() on macOS

### DIFF
--- a/include/wx/osx/cocoa/dataview.h
+++ b/include/wx/osx/cocoa/dataview.h
@@ -514,6 +514,7 @@ public:
     virtual int  GetSelections(wxDataViewItemArray& sel)   const;
     virtual bool IsSelected(const wxDataViewItem& item) const;
     virtual void Select(const wxDataViewItem& item);
+    virtual void Select(const wxDataViewItemArray& items);
     virtual void SelectAll();
     virtual void Unselect(const wxDataViewItem& item);
     virtual void UnselectAll();

--- a/include/wx/osx/core/dataview.h
+++ b/include/wx/osx/core/dataview.h
@@ -90,6 +90,7 @@ public:
   virtual int  GetSelections(wxDataViewItemArray& sel)   const = 0; // returns all selected items in the native control
   virtual bool IsSelected   (wxDataViewItem const& item) const = 0; // checks if the passed item is selected in the native control
   virtual void Select       (wxDataViewItem const& item)       = 0; // selects the passed item in the native control
+  virtual void Select       (wxDataViewItemArray const& items) = 0; // selects the passed items in the native control
   virtual void SelectAll()                                     = 0; // selects all items in the native control
   virtual void Unselect     (wxDataViewItem const& item)       = 0; // unselects the passed item in the native control
   virtual void UnselectAll()                                   = 0; // unselects all items in the native control

--- a/interface/wx/dataview.h
+++ b/interface/wx/dataview.h
@@ -1675,6 +1675,9 @@ public:
 
     /**
         Sets the selection to the array of wxDataViewItems.
+
+        Note that if @a sel contains any invalid items, they are simply
+        ignored.
     */
     virtual void SetSelections(const wxDataViewItemArray& sel);
 

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2508,6 +2508,20 @@ void wxCocoaDataViewControl::Select(const wxDataViewItem& item)
             byExtendingSelection:GetDataViewCtrl()->HasFlag(wxDV_MULTIPLE) ? YES : NO];
 }
 
+void wxCocoaDataViewControl::Select(const wxDataViewItemArray& items)
+{
+    NSMutableIndexSet *selection = [[NSMutableIndexSet alloc] init];
+
+    for ( const auto& i: items )
+    {
+        if ( i.IsOk() )
+            [selection addIndex:[m_OutlineView rowForItem:[m_DataSource getDataViewItemFromBuffer:i]]];
+    }
+
+    [m_OutlineView selectRowIndexes:selection byExtendingSelection:NO];
+    [selection release];
+}
+
 void wxCocoaDataViewControl::SelectAll()
 {
     [m_OutlineView selectAll:m_OutlineView];

--- a/src/osx/dataview_osx.cpp
+++ b/src/osx/dataview_osx.cpp
@@ -647,9 +647,8 @@ void wxDataViewCtrl::SetSelections(wxDataViewItemArray const& sel)
         last_parent = parent;
     }
 
-   // finally select the items:
-    for (i=0; i<noOfSelections; ++i)
-      dataViewWidgetPtr->Select(sel[i]);
+    // finally select the items:
+    dataViewWidgetPtr->Select(sel);
 }
 
 void wxDataViewCtrl::Unselect(wxDataViewItem const& item)

--- a/tests/controls/dataviewctrltest.cpp
+++ b/tests/controls/dataviewctrltest.cpp
@@ -147,6 +147,30 @@ MultiColumnsDataViewCtrlTestCase::~MultiColumnsDataViewCtrlTestCase()
 // ----------------------------------------------------------------------------
 
 TEST_CASE_METHOD(MultiSelectDataViewCtrlTestCase,
+                 "wxDVC::Selection",
+                 "[wxDataViewCtrl][select]")
+{
+    // Check selection round-trip.
+    wxDataViewItemArray sel;
+    sel.push_back(m_child1);
+    sel.push_back(m_grandchild);
+    REQUIRE_NOTHROW( m_dvc->SetSelections(sel) );
+
+    wxDataViewItemArray sel2;
+    CHECK( m_dvc->GetSelections(sel2) == sel.size() );
+
+    CHECK( sel2 == sel );
+
+    // Invalid items in GetSelections() input are supposed to be just skipped.
+    sel.clear();
+    sel.push_back(wxDataViewItem());
+    REQUIRE_NOTHROW( m_dvc->SetSelections(sel) );
+
+    CHECK( m_dvc->GetSelections(sel2) == 0 );
+    CHECK( sel2.empty() );
+}
+
+TEST_CASE_METHOD(MultiSelectDataViewCtrlTestCase,
                  "wxDVC::DeleteSelected",
                  "[wxDataViewCtrl][delete]")
 {


### PR DESCRIPTION
Don't make many single-item selection adjustments in `SetSelections()` in wxOSX and instead implement it with a single native call to `selectRowIndexes:byExtendingSelection:`

This has a dramatic, orders of magnitude effect on this call's performance when selecting many items: selecting 10 thousand items goes from minutes of runtime and gigabytes of RAM  to unobservable impact in both.

I swear I'm not making it up, the RAM impact of ten thousand single-row Select() calls was enormous (and it was neither leaks nor wx code):

<img width="1037" alt="Screen Shot 2020-10-11 at 18 19 01" src="https://user-images.githubusercontent.com/145881/95684035-0d1c9b80-0bef-11eb-9654-8cbfc654883a.png">
