### PR TITLE
Fix ANSI build on GCC older than 4.6

### DIFF
--- a/include/wx/wxcrt.h
+++ b/include/wx/wxcrt.h
@@ -1052,7 +1052,10 @@ inline wchar_t* wxGetenv(const wxScopedWCharBuffer& name) { return wxCRT_GetenvW
 // ----------------------------------------------------------------------------
 
 #ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
+// suppressing warnings (errors) isn't possible with GCC <4.6, so don't cause warnings
+#if wxCHECK_GCC_VERSION(4, 6)
 WX_ATTRIBUTE_FORMAT(__strftime__, 3, 4)
+#endif
 inline size_t wxStrftime(char *s, size_t max,
                          const wxString& format, const struct tm *tm)
     {


### PR DESCRIPTION
GCC 4 is supported, and ANSI build is "supported", so have both work together.

Compilation error detected with GCC 4.4.7 on CentOS 6.

I don't use ANSI build myself, I just sometimes compile it out of curiosity. IIRC, not too long ago, the ANSI build was broken on master for more than a year and nobody noticed or cared.