### PR TITLE
BUG FIX - wxTextCtrl dirty flag not set when text changes

### DIFF
--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -2423,7 +2423,10 @@ void wxWidgetCocoaImpl::controlTextDidChange()
         wxTextCtrl *tc = wxDynamicCast( wxpeer , wxTextCtrl );
         wxComboBox *cb = wxDynamicCast( wxpeer , wxComboBox );
         if ( tc )
+        {
+            tc->MarkDirty();
             tc->SendTextUpdatedEventIfAllowed();
+        }
         else if ( cb )
             cb->SendTextUpdatedEventIfAllowed();
         else 


### PR DESCRIPTION
The headline already says it. The bug can be shown by using wxWidget's sample on macOS:

- select Spin
- change max to 100
- increase wxSpinCtrl value using spin buttons to 11
- remove the last "1" in spin's text control and immediately press the up button
- result is 12 (although "2" is expected).
