### PR TITLE
Update WebView Edge min required version to 1.0.622.22

### DIFF
--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -304,7 +304,7 @@ public:
     This backend is not enabled by default, to build it follow these steps:
     - Visual Studio 2015, or newer, is required
     - Download the <a href="https://aka.ms/webviewnuget">WebView2 SDK</a>
-      nuget package (Version 0.9.488 or newer)
+      nuget package (Version 1.0.622.22 or newer)
     - Extract the package (it's a zip archive) to @c wxWidgets/3rdparty/webview2
       (you should have @c 3rdparty/webview2/build/native/include/WebView2.h
       file after unpacking it)


### PR DESCRIPTION
While technically it still builds with older versions,
version 1.0.622.22 ist the first non preview release which should
make the included webview loader DLL the most compatible for the
forseable future.