### PR TITLE
Add wxGrid::wxGridSelectNone selection mode

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -1458,7 +1458,7 @@ public:
         wxGridSelectRows          = 1,  // allow selecting only entire rows
         wxGridSelectColumns       = 2,  // allow selecting only entire columns
         wxGridSelectRowsOrColumns = wxGridSelectRows | wxGridSelectColumns,
-        wxGridSelectNone          = 4,  // allow selecting nothing
+        wxGridSelectNone          = 4  // allow selecting nothing
     };
 
     // Different behaviour of the TAB key when the end (or the beginning, for

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -1457,7 +1457,8 @@ public:
         wxGridSelectCells         = 0,  // allow selecting anything
         wxGridSelectRows          = 1,  // allow selecting only entire rows
         wxGridSelectColumns       = 2,  // allow selecting only entire columns
-        wxGridSelectRowsOrColumns = wxGridSelectRows | wxGridSelectColumns
+        wxGridSelectRowsOrColumns = wxGridSelectRows | wxGridSelectColumns,
+        wxGridSelectNone          = 4,  // allow selecting nothing
     };
 
     // Different behaviour of the TAB key when the end (or the beginning, for

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -2945,7 +2945,14 @@ public:
 
             @since 2.9.1
          */
-        wxGridSelectRowsOrColumns
+        wxGridSelectRowsOrColumns,
+
+        /**
+            The selection mode allowing no selections to be made at all.
+
+            The user won't be able to select any cells in this mode.
+         */
+        wxGridSelectNone,
     };
 
     /**

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -2951,8 +2951,10 @@ public:
             The selection mode allowing no selections to be made at all.
 
             The user won't be able to select any cells in this mode.
+
+            @since 3.1.5
          */
-        wxGridSelectNone,
+        wxGridSelectNone
     };
 
     /**

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -4631,6 +4631,7 @@ wxGrid::DoGridCellLeftDown(wxMouseEvent& event,
                         // mode and is compatible with 2.8 behaviour (see #12062).
                         switch ( m_selection->GetSelectionMode() )
                         {
+                            case wxGridSelectNone:
                             case wxGridSelectCells:
                             case wxGridSelectRowsOrColumns:
                                 // nothing to do in these cases

--- a/src/generic/gridsel.cpp
+++ b/src/generic/gridsel.cpp
@@ -251,7 +251,7 @@ wxGridSelection::DeselectBlock(const wxGridBlockCoords& block,
                                wxEventType eventType)
 {
     // If we are in wxGridSelectNone mode, all blocks should already be deselected
-    if (m_selectionMode == wxGridSelectNone)
+    if (m_selectionMode == wxGrid::wxGridSelectNone)
     {
         return;
     }
@@ -527,7 +527,7 @@ bool wxGridSelection::ExtendCurrentBlock(const wxGridCellCoords& blockStart,
     wxASSERT( blockStart.GetRow() != -1 && blockStart.GetCol() != -1 &&
               blockEnd.GetRow() != -1 && blockEnd.GetCol() != -1 );
 
-    if (m_selectionMode == wxGridSelectNone)
+    if (m_selectionMode == wxGrid::wxGridSelectNone)
     {
         return false;
     }

--- a/src/generic/gridsel.cpp
+++ b/src/generic/gridsel.cpp
@@ -184,7 +184,7 @@ void wxGridSelection::SelectBlock( int topRow, int leftCol,
     // Fix the coordinates of the block if needed.
     int allowed = -1;
     switch ( m_selectionMode )
-    {       
+    {
         case wxGrid::wxGridSelectCells:
             // In this mode arbitrary blocks can be selected.
             allowed = 1;
@@ -214,7 +214,7 @@ void wxGridSelection::SelectBlock( int topRow, int leftCol,
             else
                 allowed = 0;
             break;
-        
+
         case wxGrid::wxGridSelectNone:
             allowed = 0;
             break;
@@ -255,7 +255,7 @@ wxGridSelection::DeselectBlock(const wxGridBlockCoords& block,
     {
         return;
     }
-    
+
     const wxGridBlockCoords canonicalizedBlock = block.Canonicalize();
 
     size_t count, n;
@@ -531,12 +531,12 @@ bool wxGridSelection::ExtendCurrentBlock(const wxGridCellCoords& blockStart,
     {
         return false;
     }
-    
+
     // If selection doesn't contain the current cell (which also covers the
     // special case of nothing being selected yet), we have to create a new
     // block containing it because it doesn't make sense to extend any existing
     // block to non-selected current cell.
-    
+
     if ( !IsInSelection(m_grid->GetGridCursorCoords()) )
     {
         SelectBlock(blockStart, blockEnd, kbd, eventType);

--- a/src/generic/gridsel.cpp
+++ b/src/generic/gridsel.cpp
@@ -98,6 +98,13 @@ void wxGridSelection::SetSelectionMode( wxGrid::wxGridSelectionModes selmode )
     if (selmode == m_selectionMode)
         return;
 
+    if (selmode == wxGrid::wxGridSelectNone)
+    {
+        ClearSelection();
+        m_selectionMode = selmode;
+        return;
+    }
+
     if ( m_selectionMode != wxGrid::wxGridSelectCells )
     {
         // if changing form row to column selection
@@ -127,6 +134,7 @@ void wxGridSelection::SetSelectionMode( wxGrid::wxGridSelectionModes selmode )
             switch ( selmode )
             {
                 case wxGrid::wxGridSelectCells:
+                case wxGrid::wxGridSelectNone:
                     wxFAIL_MSG("unreachable");
                     break;
 
@@ -321,6 +329,10 @@ wxGridSelection::DeselectBlock(const wxGridBlockCoords& block,
                 splitOrientation = wxHORIZONTAL;
             else
                 splitOrientation = wxVERTICAL;
+            break;
+
+        case wxGrid::wxGridSelectNone:
+            wxFAIL_MSG("unreachable");
             break;
         }
 
@@ -589,6 +601,10 @@ bool wxGridSelection::ExtendCurrentBlock(const wxGridCellCoords& blockStart,
                 canChangeRow =
                 canChangeCol = true;
             }
+            break;
+
+        case wxGrid::wxGridSelectNone:
+            wxFAIL_MSG("unreachable");
             break;
     }
 


### PR DESCRIPTION
Adds wxGridSelectNone option into wxGridSelectionModes enum to prevent the user from being able to select/highlight any cells whatsoever.