### PR TITLE
wxWidgetCocoaImpl::SetDropTarget fix.

### DIFF
--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -3225,7 +3225,11 @@ void wxWidgetCocoaImpl::SetDropTarget(wxDropTarget* target)
     if (dobj)
     {
         wxCFMutableArrayRef<CFStringRef> typesarray;
-        dobj->AddSupportedTypes(typesarray, wxDataObjectBase::Direction::Get);
+        /*
+            In macOS the view controls the types we can drop onto it, so we have to collect
+            all formats that can be put into dataObject instead of only ones that can be get.
+        */
+        dobj->AddSupportedTypes(typesarray, wxDataObjectBase::Direction::Set);
         NSView* targetView = m_osxView;
         if ([m_osxView isKindOfClass:[NSScrollView class]])
             targetView = [(NSScrollView*)m_osxView documentView];


### PR DESCRIPTION
Under macOS the `kUTTypeUTF16PlainText` type is used for `wxDF_UNICODETEXT` as native format. On the other hand it seems that many apps use `kUTTypeUTF8PlainText` when dragging text. In this case text can't be dropped from 3rd party apps e.g. Sublime Text. So our view for which we setup drop target has to accept all native formats that can be put into given data object instead only ones we can get from it.

Stefan @csomor can you review my fix, please?