### PR TITLE
macOS SetFont cleanup

### DIFF
--- a/include/wx/osx/cocoa/dataview.h
+++ b/include/wx/osx/cocoa/dataview.h
@@ -548,7 +548,7 @@ public:
     // Cocoa-specific helpers
     id GetItemAtRow(int row) const;
 
-    virtual void SetFont(const wxFont& font, const wxColour& foreground, long windowStyle, bool ignoreBlack = true);
+    virtual void SetFont(const wxFont& font);
 
 private:
     void InitOutlineView(long style);

--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -150,7 +150,7 @@ public :
     void                PulseGauge() wxOVERRIDE;
     void                SetScrollThumb( wxInt32 value, wxInt32 thumbSize ) wxOVERRIDE;
 
-    void                SetFont( const wxFont & font, const wxColour& foreground, long windowStyle, bool ignoreBlack = true ) wxOVERRIDE;
+    void                SetFont(const wxFont & font) wxOVERRIDE;
     void                SetToolTip( wxToolTip* tooltip ) wxOVERRIDE;
 
     void                InstallEventHandler( WXWidget control = NULL ) wxOVERRIDE;

--- a/include/wx/osx/cocoa/private/textimpl.h
+++ b/include/wx/osx/cocoa/private/textimpl.h
@@ -118,7 +118,7 @@ public:
     virtual long XYToPosition(long x, long y) const wxOVERRIDE;
     virtual void ShowPosition(long pos) wxOVERRIDE;
     virtual void WriteText(const wxString& str) wxOVERRIDE ;
-    virtual void SetFont( const wxFont & font , const wxColour& foreground , long windowStyle, bool ignoreBlack = true ) wxOVERRIDE;
+    virtual void SetFont(const wxFont & font) wxOVERRIDE;
 
     virtual bool GetStyle(long position, wxTextAttr& style) wxOVERRIDE;
     virtual void SetStyle(long start, long end, const wxTextAttr& style) wxOVERRIDE;

--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -348,7 +348,7 @@ public :
     virtual void        PulseGauge() = 0;
     virtual void        SetScrollThumb( wxInt32 value, wxInt32 thumbSize ) = 0;
 
-    virtual void        SetFont( const wxFont & font , const wxColour& foreground , long windowStyle, bool ignoreBlack = true ) = 0;
+    virtual void        SetFont(const wxFont & font) = 0;
 
     virtual void        SetToolTip(wxToolTip* WXUNUSED(tooltip)) { }
 

--- a/include/wx/osx/iphone/private.h
+++ b/include/wx/osx/iphone/private.h
@@ -102,7 +102,7 @@ public :
     void                PulseGauge();
     void                SetScrollThumb( wxInt32 value, wxInt32 thumbSize );
 
-    void                SetFont( const wxFont & font , const wxColour& foreground , long windowStyle, bool ignoreBlack = true );
+    void                SetFont(const wxFont & font);
 
     void                InstallEventHandler( WXWidget control = NULL );
     bool                EnableTouchEvents(int WXUNUSED(eventsMask)) { return false; }

--- a/include/wx/osx/iphone/private/textimpl.h
+++ b/include/wx/osx/iphone/private/textimpl.h
@@ -62,7 +62,7 @@ public:
     virtual void GetSelection( long* from, long* to) const ;
     virtual void SetSelection( long from , long to );
     virtual void WriteText(const wxString& str) ;
-    virtual void SetFont( const wxFont & font , const wxColour& foreground , long windowStyle, bool ignoreBlack = true );
+    virtual void SetFont(const wxFont & font);
 
     virtual bool GetStyle(long position, wxTextAttr& style);
     virtual void SetStyle(long start, long end, const wxTextAttr& style);

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2719,9 +2719,9 @@ id wxCocoaDataViewControl::GetItemAtRow(int row) const
     return [m_OutlineView itemAtRow:row];
 }
 
-void wxCocoaDataViewControl::SetFont(const wxFont& font, const wxColour& foreground, long windowStyle, bool ignoreBlack)
+void wxCocoaDataViewControl::SetFont(const wxFont& font)
 {
-    wxWidgetCocoaImpl::SetFont(font, foreground, windowStyle, ignoreBlack);
+    wxWidgetCocoaImpl::SetFont(font);
     SetRowHeight(0/*will use default/minimum height*/);
 }
 

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -1021,7 +1021,7 @@ void wxNSTextViewControl::DoUpdateTextStyle()
     }
 }
 
-void wxNSTextViewControl::SetFont( const wxFont & font , const wxColour& WXUNUSED(foreground) , long WXUNUSED(windowStyle), bool WXUNUSED(ignoreBlack) )
+void wxNSTextViewControl::SetFont(const wxFont & font)
 {
     if ([m_textView respondsToSelector:@selector(setFont:)])
         [m_textView setFont: font.OSXGetNSFont()];

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -3593,7 +3593,7 @@ void wxWidgetCocoaImpl::SetControlSize( wxWindowVariant variant )
     }
 }
 
-void wxWidgetCocoaImpl::SetFont(wxFont const& font, wxColour const&col, long, bool)
+void wxWidgetCocoaImpl::SetFont(wxFont const& font)
 {
     NSView* targetView = m_osxView;
     if ( [m_osxView isKindOfClass:[NSScrollView class] ] )
@@ -3604,7 +3604,10 @@ void wxWidgetCocoaImpl::SetFont(wxFont const& font, wxColour const&col, long, bo
     if ([targetView respondsToSelector:@selector(setFont:)])
         [targetView setFont: font.OSXGetNSFont()];
     if ([targetView respondsToSelector:@selector(setTextColor:)])
+    {
+        wxColor col = GetWXPeer()->GetForegroundColour();
         [targetView setTextColor: col.OSXGetNSColor()];
+    }
     if ([m_osxView respondsToSelector:@selector(setAttributedTitle:)])
         SetLabel(wxStripMenuCodes(GetWXPeer()->GetLabel(), wxStrip_Mnemonics), GetWXPeer()->GetFont().GetEncoding());
 }

--- a/src/osx/iphone/textctrl.mm
+++ b/src/osx/iphone/textctrl.mm
@@ -426,7 +426,7 @@ void wxUITextViewControl::WriteText(const wxString& str)
     [m_textView setText:subst];
 }
 
-void wxUITextViewControl::SetFont( const wxFont & font , const wxColour& WXUNUSED(foreground) , long WXUNUSED(windowStyle), bool WXUNUSED(ignoreBlack) )
+void wxUITextViewControl::SetFont(const wxFont & font)
 {
     if ([m_textView respondsToSelector:@selector(setFont:)])
         [m_textView setFont: font.OSXGetUIFont()];

--- a/src/osx/iphone/window.mm
+++ b/src/osx/iphone/window.mm
@@ -622,7 +622,7 @@ double wxWidgetIPhoneImpl::GetContentScaleFactor() const
         return 1.0;
 }
 
-void wxWidgetIPhoneImpl::SetFont( const wxFont & font , const wxColour& foreground , long windowStyle, bool ignoreBlack )
+void wxWidgetIPhoneImpl::SetFont(const wxFont & font)
 {
 }
 

--- a/src/osx/textctrl_osx.cpp
+++ b/src/osx/textctrl_osx.cpp
@@ -150,7 +150,7 @@ bool wxTextCtrl::SetFont( const wxFont& font )
     if ( !wxTextCtrlBase::SetFont( font ) )
         return false ;
 
-    GetPeer()->SetFont( font , GetForegroundColour() , GetWindowStyle(), false /* dont ignore black */ ) ;
+    GetPeer()->SetFont(font) ;
 
     return true ;
 }

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -507,7 +507,7 @@ void wxWindowMac::DoSetWindowVariant( wxWindowVariant variant )
 void wxWindowMac::MacUpdateControlFont()
 {
     if ( GetPeer() )
-        GetPeer()->SetFont( GetFont() , GetForegroundColour() , GetWindowStyle() ) ;
+        GetPeer()->SetFont(GetFont()) ;
 
     // do not trigger refreshes upon invisible and possible partly created objects
     if ( IsShownOnScreen() )


### PR DESCRIPTION
The SetFont method on the native control implementations had several obsolete parameters, they have been removed in this PR