### PR TITLE
wxOSX: wxKeyEvent propagation in native implementation of wxDVC.

### DIFF
--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -1709,12 +1709,18 @@ outlineView:(NSOutlineView*)outlineView
     dvc->GetEventHandler()->ProcessEvent(event);
 }
 
+// User can define behaviour for any key.
 // Default enter key behaviour is to begin cell editing. Subclass keyDown to
 // provide a keyboard wxEVT_DATAVIEW_ITEM_ACTIVATED event and allow the NSEvent
 // to pass if the wxEvent is not processed.
 - (void)keyDown:(NSEvent *)event
 {
-    if( [[event charactersIgnoringModifiers]
+    // Propagate key event to wxDVC
+    if (implementation->DoHandleKeyEvent(event))
+    {
+        // Nothing to do: user redefined default behaviour
+    }
+    else if( [[event charactersIgnoringModifiers]
          characterAtIndex: 0] == NSCarriageReturnCharacter )
     {
         wxDataViewCtrl* const dvc = implementation->GetDataViewCtrl();


### PR DESCRIPTION
Underlying `wxCocoaOutlineView` handles _NSEvent_ key event in `keyDown` and may call its super class' handler but anyway does not propagate event to wxWidgets so connecting wxDVC to handle `wxKeyEvent`s does not make sense.

With this update we can handle key events (`EVT_CHAR_HOOK`, `EVT_CHAR` etc) by ourself and redefine behaviour for any key. Also if we need default behaviour we can just skip event in our handler or do not create our handler at all.