### PR TITLE
Allow customizing text displayed in wxDatePickerCtrl without valid value

### DIFF
--- a/include/wx/datetimectrl.h
+++ b/include/wx/datetimectrl.h
@@ -32,6 +32,13 @@ public:
     // Set/get the date or time (in the latter case, time part is ignored).
     virtual void SetValue(const wxDateTime& dt) = 0;
     virtual wxDateTime GetValue() const = 0;
+
+    // For the controls with wxDP_ALLOWNONE style, set the string displayed
+    // when the control doesn't have any valid value. Currently this is only
+    // actually used under MSW, where it can be used to override the previous
+    // value which is still displayed by the control in this case, and ignored
+    // elsewhere.
+    virtual void SetNullText(const wxString& WXUNUSED(text)) { }
 };
 
 #if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)

--- a/include/wx/generic/timectrl.h
+++ b/include/wx/generic/timectrl.h
@@ -13,11 +13,13 @@
 #include "wx/containr.h"
 #include "wx/compositewin.h"
 
+typedef wxTimePickerCtrlCommonBase<wxDateTimePickerCtrlBase> wxTimePickerCtrlGenericBase;
+
 class WXDLLIMPEXP_ADV wxTimePickerCtrlGeneric
-    : public wxCompositeWindow< wxNavigationEnabled<wxTimePickerCtrlBase> >
+    : public wxCompositeWindow< wxNavigationEnabled<wxTimePickerCtrlGenericBase> >
 {
 public:
-    typedef wxCompositeWindow< wxNavigationEnabled<wxTimePickerCtrlBase> > Base;
+    typedef wxCompositeWindow< wxNavigationEnabled<wxTimePickerCtrlGenericBase> > Base;
 
     // Creating the control.
     wxTimePickerCtrlGeneric() { Init(); }

--- a/include/wx/msw/datetimectrl.h
+++ b/include/wx/msw/datetimectrl.h
@@ -46,39 +46,17 @@ protected:
                                  const wxValidator& validator,
                                  const wxString& name);
 
-    // Notice that the methods below must be overridden in all native MSW
-    // classes inheriting from this one but they can't be pure virtual because
-    // the generic implementations, not needing nor able to implement them, is
-    // also derived from this class currently. The real problem is, of course,
-    // this wrong class structure because the generic classes also inherit the
-    // wrong implementations of Set/GetValue() and DoGetBestSize() but as they
-    // override these methods anyhow, it does work -- but is definitely ugly
-    // and need to be changed (but how?) in the future.
-
 #if wxUSE_INTL
     // Override to return the date/time format used by this control.
-    virtual wxLocaleInfo MSWGetFormat() const /* = 0 */
-    {
-        wxFAIL_MSG( "Unreachable" );
-        return wxLOCALE_TIME_FMT;
-    }
+    virtual wxLocaleInfo MSWGetFormat() const = 0;
 #endif // wxUSE_INTL
 
     // Override to indicate whether we can have no date at all.
-    virtual bool MSWAllowsNone() const /* = 0 */
-    {
-        wxFAIL_MSG( "Unreachable" );
-        return false;
-    }
+    virtual bool MSWAllowsNone() const = 0;
 
     // Override to update m_date and send the event when the control contents
     // changes, return true if the event was handled.
-    virtual bool MSWOnDateTimeChange(const tagNMDATETIMECHANGE& dtch) /* = 0 */
-    {
-        wxUnusedVar(dtch);
-        wxFAIL_MSG( "Unreachable" );
-        return false;
-    }
+    virtual bool MSWOnDateTimeChange(const tagNMDATETIMECHANGE& dtch) = 0;
 
 
     // the date currently shown by the control, may be invalid

--- a/include/wx/msw/datetimectrl.h
+++ b/include/wx/msw/datetimectrl.h
@@ -26,6 +26,8 @@ public:
     virtual void SetValue(const wxDateTime& dt) wxOVERRIDE;
     virtual wxDateTime GetValue() const wxOVERRIDE;
 
+    virtual void SetNullText(const wxString& text) wxOVERRIDE;
+
     // returns true if the platform should explicitly apply a theme border
     virtual bool CanApplyThemeBorder() const wxOVERRIDE { return false; }
 
@@ -61,6 +63,19 @@ protected:
 
     // the date currently shown by the control, may be invalid
     wxDateTime m_date;
+
+private:
+    // Helper setting the appropriate format depending on the passed in state.
+    void MSWUpdateFormat(bool valid);
+
+    // Same thing, but only doing if the validity differs from the date
+    // validity, i.e. avoiding useless work if nothing needs to be done.
+    void MSWUpdateFormatIfNeeded(bool valid);
+
+
+    // shown when there is no valid value (so only used with wxDP_ALLOWNONE),
+    // always non-empty if SetNullText() was called, see the comments there
+    wxString m_nullText;
 };
 
 #endif // _WX_MSW_DATETIMECTRL_H_

--- a/include/wx/timectrl.h
+++ b/include/wx/timectrl.h
@@ -29,7 +29,10 @@ enum
 // wxTimePickerCtrl: Allow the user to enter the time.
 // ----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_ADV wxTimePickerCtrlBase : public wxDateTimePickerCtrl
+// The template argument must be a class deriving from wxDateTimePickerCtrlBase
+// (i.e. in practice either this class itself or wxDateTimePickerCtrl).
+template <typename Base>
+class wxTimePickerCtrlCommonBase : public Base
 {
 public:
     /*
@@ -67,7 +70,7 @@ public:
             return false;
         }
 
-        SetValue(dt);
+        this->SetValue(dt);
 
         return true;
     }
@@ -78,7 +81,7 @@ public:
         wxCHECK_MSG( hour && min && sec, false,
                      wxS("Time component pointers must be non-NULL") );
 
-        const wxDateTime::Tm tm = GetValue().GetTm();
+        const wxDateTime::Tm tm = this->GetValue().GetTm();
         *hour = tm.hour;
         *min = tm.min;
         *sec = tm.sec;
@@ -86,6 +89,10 @@ public:
         return true;
     }
 };
+
+// This class is defined mostly for compatibility and is used as the base class
+// by native wxTimePickerCtrl implementations.
+typedef wxTimePickerCtrlCommonBase<wxDateTimePickerCtrl> wxTimePickerCtrlBase;
 
 #if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
     #include "wx/msw/timectrl.h"

--- a/interface/wx/datectrl.h
+++ b/interface/wx/datectrl.h
@@ -169,6 +169,22 @@ public:
     virtual wxDateTime GetValue() const;
 
     /**
+        Set the text to show when there is no valid value.
+
+        For the controls with @c wxDP_ALLOWNONE style, set the string displayed
+        when the control doesn't have any valid value. Currently this is only
+        actually used under MSW, where it can be used to override the previous
+        value which is still displayed by the control in this case, and ignored
+        elsewhere.
+
+        Notably, @a text can be empty to completely hide the date if no valid
+        date is specified.
+
+        @since 3.1.5
+     */
+    void SetNullText(const wxString& text);
+
+    /**
         Sets the valid range for the date selection. If @a dt1 is valid, it
         becomes the earliest date (inclusive) accepted by the control. If
         @a dt2 is valid, it becomes the latest possible date.

--- a/misc/schema/xrc_schema.rnc
+++ b/misc/schema/xrc_schema.rnc
@@ -894,7 +894,8 @@ wxDatePickerCtrl =
     element object {
         attribute class { "wxDatePickerCtrl" } &
         stdObjectNodeAttributes &
-        stdWindowProperties
+        stdWindowProperties &
+        [xrc:p="o"] element null-text {_, t_text }*
     }
 
 

--- a/samples/widgets/datepick.cpp
+++ b/samples/widgets/datepick.cpp
@@ -54,6 +54,7 @@ enum
     DatePickerPage_Reset = wxID_HIGHEST,
     DatePickerPage_Set,
     DatePickerPage_SetRange,
+    DatePickerPage_SetNullText,
     DatePickerPage_Picker
 };
 
@@ -78,6 +79,7 @@ protected:
 
     void OnButtonSet(wxCommandEvent& event);
     void OnButtonSetRange(wxCommandEvent& event);
+    void OnButtonSetNullText(wxCommandEvent& event);
     void OnButtonReset(wxCommandEvent& event);
 
     // reset the date picker parameters
@@ -96,6 +98,7 @@ protected:
     wxTextCtrl *m_textCur;
     wxTextCtrl *m_textMin;
     wxTextCtrl *m_textMax;
+    wxTextCtrl *m_textNull;
 
     wxRadioBox* m_radioKind;
     wxCheckBox* m_chkStyleCentury;
@@ -117,6 +120,7 @@ wxBEGIN_EVENT_TABLE(DatePickerWidgetsPage, WidgetsPage)
     EVT_BUTTON(DatePickerPage_Reset, DatePickerWidgetsPage::OnButtonReset)
     EVT_BUTTON(DatePickerPage_Set, DatePickerWidgetsPage::OnButtonSet)
     EVT_BUTTON(DatePickerPage_SetRange, DatePickerWidgetsPage::OnButtonSetRange)
+    EVT_BUTTON(DatePickerPage_SetNullText, DatePickerWidgetsPage::OnButtonSetNullText)
 
     EVT_DATE_CHANGED(wxID_ANY, DatePickerWidgetsPage::OnDateChanged)
 wxEND_EVENT_TABLE()
@@ -195,6 +199,20 @@ void DatePickerWidgetsPage::CreateContent()
                      ),
                      wxSizerFlags().Expand().Border());
     sizerMiddle->Add(new wxButton(this, DatePickerPage_SetRange, "Set &range"),
+                     wxSizerFlags().Centre().Border());
+
+    sizerMiddle->AddSpacer(10);
+
+    sizerMiddle->Add(CreateSizerWithTextAndLabel
+                     (
+                        "&Null text",
+                        wxID_ANY,
+                        &m_textNull
+                     ),
+                     wxSizerFlags().Expand().Border());
+
+    sizerMiddle->Add(new wxButton(this, DatePickerPage_SetNullText,
+                                  "Set &null text"),
                      wxSizerFlags().Centre().Border());
 
 
@@ -325,6 +343,11 @@ void DatePickerWidgetsPage::OnButtonSetRange(wxCommandEvent& WXUNUSED(event))
 
         wxLogMessage("Date picker range updated");
     }
+}
+
+void DatePickerWidgetsPage::OnButtonSetNullText(wxCommandEvent& WXUNUSED(event))
+{
+    m_datePicker->SetNullText(m_textNull->GetValue());
 }
 
 // Helper function which has to be used here because the controls with

--- a/samples/widgets/datepick.cpp
+++ b/samples/widgets/datepick.cpp
@@ -327,11 +327,19 @@ void DatePickerWidgetsPage::OnButtonSetRange(wxCommandEvent& WXUNUSED(event))
     }
 }
 
+// Helper function which has to be used here because the controls with
+// wxDP_ALLOWNONE style can have invalid date, both in the control itself and
+// in the event it generates.
+static wxString FormatPossiblyInvalidDate(const wxDateTime& dt)
+{
+    return dt.IsValid() ? dt.FormatISOCombined() : wxString("[none]");
+}
+
 void DatePickerWidgetsPage::OnDateChanged(wxDateEvent& event)
 {
     wxLogMessage("Date changed, now is %s (control value is %s).",
-                 event.GetDate().FormatISOCombined(),
-                 m_datePicker->GetValue().FormatISOCombined());
+                 FormatPossiblyInvalidDate(event.GetDate()),
+                 FormatPossiblyInvalidDate(m_datePicker->GetValue()));
 }
 
 #endif // wxUSE_DATEPICKCTRL

--- a/src/xrc/xh_datectrl.cpp
+++ b/src/xrc/xh_datectrl.cpp
@@ -42,6 +42,10 @@ wxObject *wxDateCtrlXmlHandler::DoCreateResource()
 
     SetupWindow(picker);
 
+    // Note that we want to set this one even if it's empty.
+    if ( HasParam(wxS("null-text")) )
+        picker->SetNullText(GetText(wxS("null-text")));
+
     return picker;
 }
 


### PR DESCRIPTION
This allows to hide the date when it's not used, as it can be confusing/overwhelming when there are a lot of controls and it's not obvious to see at a glance whether they're used or not.

In principle, this could be extended to the other ports, but right now it's mostly useful in wxMSW which is the only port to show the date even when it's not used, so I don't plan to do it right now.