### PR TITLE
Various WebView Edge improvements

### DIFF
--- a/include/wx/msw/private/webview_edge.h
+++ b/include/wx/msw/private/webview_edge.h
@@ -36,6 +36,8 @@ public:
     bool m_initialized;
     bool m_isBusy;
     wxString m_pendingURL;
+    int m_pendingContextMenuEnabled;
+    int m_pendingAccessToDevToolsEnabled;
 
     // WebView Events tokens
     EventRegistrationToken m_navigationStartingToken = { };

--- a/include/wx/msw/private/webview_edge.h
+++ b/include/wx/msw/private/webview_edge.h
@@ -65,7 +65,7 @@ public:
 
     ICoreWebView2Settings* GetSettings();
 
-    static int ms_isAvailable;
+    static bool ms_isInitialized;
     static wxDynamicLibrary ms_loaderDll;
 
     static bool Initialize();

--- a/include/wx/msw/webview_edge.h
+++ b/include/wx/msw/webview_edge.h
@@ -134,6 +134,8 @@ private:
 
     void OnSize(wxSizeEvent& event);
 
+    void OnShow(wxShowEvent& event);
+
     bool RunScriptSync(const wxString& javascript, wxString* output = NULL);
 
     wxDECLARE_DYNAMIC_CLASS(wxWebViewEdge);

--- a/include/wx/msw/webview_edge.h
+++ b/include/wx/msw/webview_edge.h
@@ -122,10 +122,6 @@ public:
 
     virtual void* GetNativeBackend() const wxOVERRIDE;
 
-    // ---- Edge-specific methods
-
-    static bool IsAvailable();
-
 protected:
     virtual void DoSetPage(const wxString& html, const wxString& baseUrl) wxOVERRIDE;
 
@@ -155,6 +151,7 @@ public:
     {
         return new wxWebViewEdge(parent, id, url, pos, size, style, name);
     }
+    virtual bool IsAvailable() wxOVERRIDE;
 };
 
 #endif // wxUSE_WEBVIEW && wxUSE_WEBVIEW_EDGE && defined(__WXMSW__)

--- a/include/wx/webview.h
+++ b/include/wx/webview.h
@@ -119,6 +119,7 @@ public:
                               const wxSize& size = wxDefaultSize,
                               long style = 0,
                               const wxString& name = wxASCII_STR(wxWebViewNameStr)) = 0;
+    virtual bool IsAvailable() { return true; }
 };
 
 WX_DECLARE_STRING_HASH_MAP(wxSharedPtr<wxWebViewFactory>, wxStringWebViewFactoryMap);

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -220,6 +220,17 @@ public:
                               const wxSize& size = wxDefaultSize,
                               long style = 0,
                               const wxString& name = wxWebViewNameStr) = 0;
+    /**
+        Function to check if the backend is available at runtime. The
+        wxWebView implementation can use this function to check all
+        runtime requirements without trying to create a wxWebView.
+
+        @return returns @true if the backend can be used or @false if it is
+            not available during runtime.
+
+        @since 3.1.5
+    */
+    virtual bool IsAvailable();
 };
 
 /**

--- a/src/common/webview.cpp
+++ b/src/common/webview.cpp
@@ -88,7 +88,10 @@ void wxWebView::RegisterFactory(const wxString& backend,
 bool wxWebView::IsBackendAvailable(const wxString& backend)
 {
     wxStringWebViewFactoryMap::iterator iter = FindFactory(backend);
-    return iter != m_factoryMap.end();
+    if (iter != m_factoryMap.end())
+        return iter->second->IsAvailable();
+    else
+        return false;
 }
 
 // static 
@@ -111,8 +114,7 @@ void wxWebView::InitFactoryMap()
 #endif
 
 #if wxUSE_WEBVIEW_EDGE
-    if (wxWebViewEdge::IsAvailable() &&
-        m_factoryMap.find(wxWebViewBackendEdge) == m_factoryMap.end())
+    if (m_factoryMap.find(wxWebViewBackendEdge) == m_factoryMap.end())
         RegisterFactory(wxWebViewBackendEdge, wxSharedPtr<wxWebViewFactory>
         (new wxWebViewFactoryEdge));
 #endif

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -76,6 +76,8 @@ bool wxWebViewEdgeImpl::Create()
 {
     m_initialized = false;
     m_isBusy = false;
+    m_pendingContextMenuEnabled = -1;
+    m_pendingAccessToDevToolsEnabled = -1;
 
     m_historyLoadingFromList = false;
     m_historyEnabled = true;
@@ -309,6 +311,18 @@ HRESULT wxWebViewEdgeImpl::OnWebViewCreated(HRESULT result, ICoreWebView2Control
         Callback<ICoreWebView2ContentLoadingEventHandler>(
             this, &wxWebViewEdgeImpl::OnContentLoading).Get(),
         &m_contentLoadingToken);
+
+    if (m_pendingContextMenuEnabled != -1)
+    {
+        m_ctrl->EnableContextMenu(m_pendingContextMenuEnabled == 1);
+        m_pendingContextMenuEnabled = -1;
+    }
+
+    if (m_pendingAccessToDevToolsEnabled != -1)
+    {
+        m_ctrl->EnableAccessToDevTools(m_pendingAccessToDevToolsEnabled == 1);
+        m_pendingContextMenuEnabled = -1;
+    }
 
     if (!m_pendingURL.empty())
     {
@@ -706,6 +720,8 @@ void wxWebViewEdge::EnableContextMenu(bool enable)
     wxCOMPtr<ICoreWebView2Settings> settings(m_impl->GetSettings());
     if (settings)
         settings->put_AreDefaultContextMenusEnabled(enable);
+    else
+        m_impl->m_pendingContextMenuEnabled = enable ? 1 : 0;
 }
 
 bool wxWebViewEdge::IsContextMenuEnabled() const
@@ -727,6 +743,8 @@ void wxWebViewEdge::EnableAccessToDevTools(bool enable)
     wxCOMPtr<ICoreWebView2Settings> settings(m_impl->GetSettings());
     if (settings)
         settings->put_AreDevToolsEnabled(enable);
+    else
+        m_impl->m_pendingAccessToDevToolsEnabled = enable ? 1 : 0;
 }
 
 bool wxWebViewEdge::IsAccessToDevToolsEnabled() const

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -364,6 +364,7 @@ bool wxWebViewEdge::IsAvailable()
 
 wxWebViewEdge::~wxWebViewEdge()
 {
+    Unbind(wxEVT_SHOW, &wxWebViewEdge::OnShow, this);
     delete m_impl;
 }
 
@@ -388,6 +389,7 @@ bool wxWebViewEdge::Create(wxWindow* parent,
     if (!m_impl->Create())
         return false;
     Bind(wxEVT_SIZE, &wxWebViewEdge::OnSize, this);
+    Bind(wxEVT_SHOW, &wxWebViewEdge::OnShow, this);
 
     LoadURL(url);
     return true;
@@ -396,6 +398,13 @@ bool wxWebViewEdge::Create(wxWindow* parent,
 void wxWebViewEdge::OnSize(wxSizeEvent& event)
 {
     m_impl->UpdateBounds();
+    event.Skip();
+}
+
+void wxWebViewEdge::OnShow(wxShowEvent& event)
+{
+    if (m_impl->m_webView)
+        m_impl->m_webViewController->put_IsVisible(event.IsShown());
     event.Skip();
 }
 


### PR DESCRIPTION
Some `wxWebViewEdge` fixes to issues I experienced while using in a real world application:

* Disable/Enable ContextMenu/DevTools during initialization
* Show/Hide during initialization
* Dynamically check for SDK during runtime (allows runtime installation without restarting the process)
