### PR TITLE
Add more wxRound() compatibility overloads and improve docs

### DIFF
--- a/include/wx/math.h
+++ b/include/wx/math.h
@@ -164,8 +164,20 @@ inline int wxRound(float x)
 
 inline int wxRound(long double x) { return wxRound(double(x)); }
 
+// For compatibility purposes, define wxRound() overloads for integer types
+// too, as this used to compile with wx 3.0.
+#if WXWIN_COMPATIBILITY_3_0
+
 wxDEPRECATED_MSG("rounding an integer is useless")
 inline int wxRound(int x) { return x; }
+
+wxDEPRECATED_MSG("rounding an integer is useless")
+inline int wxRound(short x) { return x; }
+
+wxDEPRECATED_MSG("rounding an integer is useless")
+inline int wxRound(long x) { return static_cast<int>(x); }
+
+#endif // WXWIN_COMPATIBILITY_3_0
 
 // Convert between degrees and radians.
 inline double wxDegToRad(double deg) { return (deg * M_PI) / 180.0; }

--- a/interface/wx/math.h
+++ b/interface/wx/math.h
@@ -89,9 +89,18 @@ double wxRadToDeg(double rad);
 unsigned int wxCTZ(wxUint32 x);
 
 /**
-    Small wrapper around round().
+    Small wrapper around std::lround().
+
+    This function exists for compatibility, as it was more convenient than
+    std::round() before C++11. Use std::lround() in the new code.
+
+    It is defined for all floating point types @c T and can be also used with
+    integer types for compatibility, but such use is deprecated -- simply
+    remove the calls to wxRound() from your code if you're using it with
+    integer types, it is unnecessary in this case.
 */
-int wxRound(double x);
+template <typename T>
+int wxRound(T x);
 
 /**
    Returns true if both double values are identical. This is


### PR DESCRIPTION
Make the overloads added for compatibility available only when
WXWIN_COMPATIBILITY_3_0 is on and add two more of them, to cover all the
interer types (except char but, honestly, who rounds those?).

Also improve the documentation and make it clear that this function is
not needed at all in the new code.