### PR TITLE
Fix IsEnabled() for TLWs under MSW

### DIFF
--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -94,6 +94,8 @@ public:
         return MSWShowWithEffect(false, effect, timeout);
     }
 
+    virtual bool IsThisEnabled() const wxOVERRIDE;
+
     virtual void SetFocus() wxOVERRIDE;
     virtual void SetFocusFromKbd() wxOVERRIDE;
 

--- a/include/wx/utils.h
+++ b/include/wx/utils.h
@@ -25,6 +25,7 @@
 #if wxUSE_GUI
     #include "wx/gdicmn.h"
     #include "wx/mousestate.h"
+    #include "wx/vector.h"
 #endif
 
 class WXDLLIMPEXP_FWD_BASE wxArrayString;
@@ -51,7 +52,6 @@ class WXDLLIMPEXP_FWD_BASE wxArrayInt;
 class WXDLLIMPEXP_FWD_BASE wxProcess;
 class WXDLLIMPEXP_FWD_CORE wxFrame;
 class WXDLLIMPEXP_FWD_CORE wxWindow;
-class wxWindowList;
 class WXDLLIMPEXP_FWD_CORE wxEventLoop;
 
 // ----------------------------------------------------------------------------
@@ -733,7 +733,7 @@ private:
 #if defined(__WXOSX__) && wxOSX_USE_COCOA
     wxEventLoop* m_modalEventLoop;
 #endif
-    wxWindowList *m_winDisabled;
+    wxVector<wxWindow*> m_winDisabled;
     bool m_disabled;
 
     wxDECLARE_NO_COPY_CLASS(wxWindowDisabler);

--- a/include/wx/vector.h
+++ b/include/wx/vector.h
@@ -26,6 +26,12 @@ inline void wxVectorSort(wxVector<T>& v)
     std::sort(v.begin(), v.end());
 }
 
+template<typename T>
+inline bool wxVectorContains(const wxVector<T>& v, const T& obj)
+{
+    return std::find(v.begin(), v.end(), obj) != v.end();
+}
+
 #else // !wxUSE_STD_CONTAINERS
 
 #include "wx/scopeguard.h"
@@ -688,7 +694,17 @@ void wxVectorSort(wxVector<T>& v)
             wxPrivate::wxVectorComparator<T>::Compare, NULL);
 }
 
+template<typename T>
+inline bool wxVectorContains(const wxVector<T>& v, const T& obj)
+{
+    for ( size_t n = 0; n < v.size(); ++n )
+    {
+        if ( v[n] == obj )
+            return true;
+    }
 
+    return false;
+}
 
 #endif // wxUSE_STD_CONTAINERS/!wxUSE_STD_CONTAINERS
 

--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -655,7 +655,7 @@ public:
         // state, i.e. the state in which the window would be if all its
         // parents were enabled (use IsEnabled() above to get the effective
         // window state)
-    bool IsThisEnabled() const { return m_isEnabled; }
+    virtual bool IsThisEnabled() const { return m_isEnabled; }
 
     // returns true if the window is visible, i.e. IsShown() returns true
     // if called on it and all its parents up to the first TLW

--- a/interface/wx/vector.h
+++ b/interface/wx/vector.h
@@ -307,3 +307,13 @@ public:
 */
 template<typename T>
 void wxVectorSort(wxVector<T>& v);
+
+/**
+    Returns true if the vector contains the given value.
+
+    This is just a trivial wrapper around std::find().
+
+    @since 3.1.5
+ */
+template<typename T>
+bool wxVectorContains(const wxVector<T>& v, const T& value);

--- a/src/common/utilscmn.cpp
+++ b/src/common/utilscmn.cpp
@@ -1530,8 +1530,6 @@ void wxWindowDisabler::DoDisable(wxWindow *winToSkip)
 {
     // remember the top level windows which were already disabled, so that we
     // don't reenable them later
-    m_winDisabled = NULL;
-
     wxWindowList::compatibility_iterator node;
     for ( node = wxTopLevelWindows.GetFirst(); node; node = node->GetNext() )
     {
@@ -1546,12 +1544,7 @@ void wxWindowDisabler::DoDisable(wxWindow *winToSkip)
         }
         else
         {
-            if ( !m_winDisabled )
-            {
-                m_winDisabled = new wxWindowList;
-            }
-
-            m_winDisabled->Append(winTop);
+            m_winDisabled.push_back(winTop);
         }
     }
 }
@@ -1565,14 +1558,12 @@ wxWindowDisabler::~wxWindowDisabler()
     for ( node = wxTopLevelWindows.GetFirst(); node; node = node->GetNext() )
     {
         wxWindow *winTop = node->GetData();
-        if ( !m_winDisabled || !m_winDisabled->Find(winTop) )
+        if ( !wxVectorContains(m_winDisabled, winTop) )
         {
             winTop->Enable();
         }
         //else: had been already disabled, don't reenable
     }
-
-    delete m_winDisabled;
 }
 
 #endif

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -627,6 +627,16 @@ wxWindow *wxWindowBase::DoFindFocus()
     return NULL;
 }
 
+bool wxWindowMSW::IsThisEnabled() const
+{
+    // Under MSW we use the actual window state rather than the value of
+    // m_isEnabled because the latter might be out of sync, notably for TLWs
+    // disabled while showing a native modal dialog, as native code just calls
+    // ::EnableWindow() on them without updating m_isEnabled and we have no way
+    // to be notified about this.
+    return !(::GetWindowLong(GetHwnd(), GWL_STYLE) & WS_DISABLED);
+}
+
 void wxWindowMSW::DoEnable( bool enable )
 {
     MSWEnableHWND(GetHwnd(), enable);

--- a/tests/vectors/vectors.cpp
+++ b/tests/vectors/vectors.cpp
@@ -288,6 +288,22 @@ TEST_CASE("wxVector::Sort", "[vector][sort]")
     }
 }
 
+TEST_CASE("wxVector::Contains", "[vector][contains]")
+{
+    wxVector<int> v;
+    CHECK( !wxVectorContains(v, 0) );
+
+    v.push_back(3);
+    CHECK( wxVectorContains(v, 3) );
+
+    v.push_back(2);
+    v.push_back(3);
+
+    CHECK( wxVectorContains(v, 2) );
+    CHECK( wxVectorContains(v, 3) );
+    CHECK( !wxVectorContains(v, 1) );
+}
+
 TEST_CASE("wxVector::operator==", "[vector][compare]")
 {
     wxVector<wxString> v1, v2;


### PR DESCRIPTION
The important commit here is the first one, the other ones are trivial.

Hopefully this doesn't break something else, the only change I can see is that `IsThisEnabled()` is going to return `false` for the children of a disabled non-TLW parent now, but this shouldn't be that important as `IsEnabled()` already returned `false` for them.

We could also optimize `IsEnabled()` now that we can trust the window state, but I'm not sure if it's worth it.