### PR TITLE
Make wxRound() compile for all integer types again

### DIFF
--- a/include/wx/math.h
+++ b/include/wx/math.h
@@ -164,18 +164,26 @@ inline int wxRound(float x)
 
 inline int wxRound(long double x) { return wxRound(double(x)); }
 
-// For compatibility purposes, define wxRound() overloads for integer types
-// too, as this used to compile with wx 3.0.
+// For compatibility purposes, make wxRound() work with integer types too, as
+// this used to compile with wx 3.0.
 #if WXWIN_COMPATIBILITY_3_0
 
+template <typename T>
 wxDEPRECATED_MSG("rounding an integer is useless")
-inline int wxRound(int x) { return x; }
+inline int wxRound(T x)
+{
+    // We have to disable this warning for the unsigned types. We do handle
+    // them correctly in this comparison due to "x > 0" below (removing it
+    // would make this fail for them!).
+    wxGCC_WARNING_SUPPRESS(sign-compare)
 
-wxDEPRECATED_MSG("rounding an integer is useless")
-inline int wxRound(short x) { return x; }
+    wxASSERT_MSG((x > 0 || x > INT_MIN) && x < INT_MAX,
+        "argument out of supported range");
 
-wxDEPRECATED_MSG("rounding an integer is useless")
-inline int wxRound(long x) { return static_cast<int>(x); }
+    wxGCC_WARNING_RESTORE(sign-compare)
+
+    return int(x);
+}
 
 #endif // WXWIN_COMPATIBILITY_3_0
 

--- a/tests/misc/misctests.cpp
+++ b/tests/misc/misctests.cpp
@@ -158,3 +158,32 @@ TEST_CASE("wxCTZ", "[math]")
 
     WX_ASSERT_FAILS_WITH_ASSERT( wxCTZ(0) );
 }
+
+TEST_CASE("wxRound", "[math]")
+{
+    CHECK( wxRound(2.3) == 2 );
+    CHECK( wxRound(3.7) == 4 );
+    CHECK( wxRound(-0.5f) == -1 );
+
+    WX_ASSERT_FAILS_WITH_ASSERT( wxRound(2.0*INT_MAX) );
+    WX_ASSERT_FAILS_WITH_ASSERT( wxRound(1.1*INT_MIN) );
+
+    // For compatibility reasons, we allow using wxRound() with integer types
+    // as well, even if this doesn't really make sense/
+#if WXWIN_COMPATIBILITY_3_0
+    #ifdef __VISUALC__
+        #pragma warning(push)
+        #pragma warning(disable:4996)
+    #endif
+    wxGCC_WARNING_SUPPRESS(deprecated-declarations)
+
+    CHECK( wxRound(-9) == -9 );
+    CHECK( wxRound((size_t)17) == 17 );
+    CHECK( wxRound((short)289) == 289 );
+
+    wxGCC_WARNING_RESTORE(deprecated-declarations)
+    #ifdef __VISUALC__
+        #pragma warning(pop)
+    #endif
+#endif // WXWIN_COMPATIBILITY_3_0
+}


### PR DESCRIPTION
Replace the overloads added in c2e5f3520a (Add a wxRound() overload for
int, 2020-11-05) and 1cf7c47934 (Add more wxRound() compatibility
overloads and improve docs, 2020-11-05) with a template function that
should work for all integer types.

This fixes compilation of existing code using wxRound() with size_t
values: while this doesn't make any sense, it doesn't make much less
sense than using it with int, so let people avoid having to change their
code when upgrading to wx 3.2.

Also add at least some minimal tests for this function.