### PR TITLE
Remove references to PDP endianness

### DIFF
--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -1111,7 +1111,6 @@ typedef double wxDouble;
 
 #define  wxBIG_ENDIAN     4321
 #define  wxLITTLE_ENDIAN  1234
-#define  wxPDP_ENDIAN     3412
 
 #ifdef WORDS_BIGENDIAN
 #define  wxBYTE_ORDER  wxBIG_ENDIAN

--- a/include/wx/platinfo.h
+++ b/include/wx/platinfo.h
@@ -103,7 +103,6 @@ enum wxEndianness
 
     wxENDIAN_BIG,               // 4321
     wxENDIAN_LITTLE,            // 1234
-    wxENDIAN_PDP,               // 3412
 
     wxENDIAN_MAX
 };

--- a/src/common/platinfo.cpp
+++ b/src/common/platinfo.cpp
@@ -92,8 +92,7 @@ static const wxChar* const wxArchitectureNames[] =
 static const wxChar* const wxEndiannessNames[] =
 {
     wxT("Big endian"),
-    wxT("Little endian"),
-    wxT("PDP endian")
+    wxT("Little endian")
 };
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
There is no support for PDP endianness in either wxPlatformInfo nor the rest of
wx. The constant and macro are never used within wx itself. Doubtful if anyone
anywhere has ever used them.

Did anyone ever build wxWidgets on a PDP-11? Does the PDP-11 even have a GUI
in the first place?