### PR TITLE
Add wxGetCpuArchitectureName() for finding out CPU architecture

### DIFF
--- a/include/wx/utils.h
+++ b/include/wx/utils.h
@@ -153,6 +153,9 @@ WXDLLIMPEXP_BASE bool wxIsPlatformLittleEndian();
 // Get platform architecture
 WXDLLIMPEXP_BASE bool wxIsPlatform64Bit();
 
+// Get machine CPU architecture
+WXDLLIMPEXP_BASE wxString wxGetCpuArchitectureName();
+
 #ifdef __LINUX__
 // Get linux-distro information
 WXDLLIMPEXP_BASE wxLinuxDistributionInfo wxGetLinuxDistributionInfo();

--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -992,6 +992,15 @@ bool wxIsPlatform64Bit();
 bool wxIsPlatformLittleEndian();
 
 /**
+    Returns the CPU architecture name. This can be, for example, "x86_64",
+    "arm64", or "i86pc". The name for the same CPU running on the same
+    hardware can vary across operating systems.
+
+    @since 3.1.5
+*/
+wxString wxGetCpuArchitectureName();
+
+/**
     Returns a structure containing information about the currently running
     Linux distribution.
 

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -86,6 +86,10 @@
     #include <shellapi.h>
 #endif
 
+#ifndef PROCESSOR_ARCHITECTURE_ARM64
+#define PROCESSOR_ARCHITECTURE_ARM64 12
+#endif
+
 #include <errno.h>
 
 // For wxKillAllChildren
@@ -1267,6 +1271,34 @@ wxWinVersion wxGetWinVersion()
     }
 
     return wxWinVersion_Unknown;
+}
+
+wxString wxGetCpuArchitectureName()
+{
+    SYSTEM_INFO si;
+    GetNativeSystemInfo(&si);
+
+    switch (si.wProcessorArchitecture)
+    {
+    case PROCESSOR_ARCHITECTURE_AMD64:
+        return "x64";
+
+    case PROCESSOR_ARCHITECTURE_ARM:
+        return "ARM";
+
+    case PROCESSOR_ARCHITECTURE_ARM64:
+        return "ARM64";
+
+    case PROCESSOR_ARCHITECTURE_IA64:
+        return "Itanium";
+
+    case PROCESSOR_ARCHITECTURE_INTEL:
+        return "x86";
+
+    case PROCESSOR_ARCHITECTURE_UNKNOWN:
+    default:
+        return "Unknown";
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -1079,13 +1079,18 @@ bool wxIsPlatform64Bit()
     (void)wxGetCommandOutput;
     return true;  // 64-bit programs run only on 64-bit platforms
 #else
-    const wxString machine = wxGetCommandOutput(wxT("uname -m"));
+    const wxString machine = wxGetCpuArchitectureName();
 
     // the test for "64" is obviously not 100% reliable but seems to work fine
     // in practice
     return machine.Contains(wxT("64")) ||
                 machine.Contains(wxT("alpha"));
 #endif
+}
+
+wxString wxGetCpuArchitectureName()
+{
+    return wxGetCommandOutput(wxT("uname -m"));
 }
 
 #ifdef __LINUX__


### PR DESCRIPTION
The returned value is OS-dependent and can be something
like: "x86_64", "x86", "arm64".