### PR TITLE
Explain in wxPlatformInfo docs that it means bitness when it says architecture

### DIFF
--- a/include/wx/platinfo.h
+++ b/include/wx/platinfo.h
@@ -82,7 +82,7 @@ enum wxPortId
     wxPORT_QT       = 1 << 10       // wxQT, using Qt 5+
 };
 
-// architecture of the operating system
+// architecture bitness of the operating system
 // (regardless of the build environment of wxWidgets library - see
 // wxIsPlatform64bit documentation for more info)
 enum wxArchitecture
@@ -134,7 +134,7 @@ struct wxLinuxDistributionInfo
 // ----------------------------------------------------------------------------
 
 // Information about the toolkit that the app is running under and some basic
-// platform and architecture info
+// platform and architecture bitness info
 class WXDLLIMPEXP_BASE wxPlatformInfo
 {
 public:
@@ -359,7 +359,7 @@ protected:
     // others
     // -----------------
 
-    // architecture of the OS/machine
+    // architecture bitness of the OS/machine
     wxArchitecture m_arch;
 
     // endianness of the machine

--- a/include/wx/platinfo.h
+++ b/include/wx/platinfo.h
@@ -85,15 +85,24 @@ enum wxPortId
 // architecture bitness of the operating system
 // (regardless of the build environment of wxWidgets library - see
 // wxIsPlatform64bit documentation for more info)
-enum wxArchitecture
+
+enum wxBitness
 {
-    wxARCH_INVALID = -1,        // returned on error
+    wxBITNESS_INVALID = -1,     // returned on error
 
-    wxARCH_32,                  // 32 bit
-    wxARCH_64,
+    wxBITNESS_32,
+    wxBITNESS_64,
 
-    wxARCH_MAX
+    wxBITNESS_MAX
 };
+
+typedef wxBitness wxArchitecture;
+
+const wxArchitecture
+    wxARCH_INVALID = wxBITNESS_INVALID,
+    wxARCH_32 = wxBITNESS_32,
+    wxARCH_64 = wxBITNESS_64,
+    wxARCH_MAX = wxBITNESS_MAX;
 
 
 // endian-ness of the machine
@@ -143,7 +152,7 @@ public:
                    int tkMajor = -1, int tkMinor = -1,
                    wxOperatingSystemId id = wxOS_UNKNOWN,
                    int osMajor = -1, int osMinor = -1,
-                   wxArchitecture arch = wxARCH_INVALID,
+                   wxBitness bitness = wxBITNESS_INVALID,
                    wxEndianness endian = wxENDIAN_INVALID,
                    bool usingUniversal = false);
 
@@ -166,6 +175,8 @@ public:
     static wxOperatingSystemId GetOperatingSystemId(const wxString &name);
     static wxPortId GetPortId(const wxString &portname);
 
+    static wxBitness GetBitness(const wxString &bitness);
+    wxDEPRECATED_MSG("Use GetBitness() instead")
     static wxArchitecture GetArch(const wxString &arch);
     static wxEndianness GetEndianness(const wxString &end);
 
@@ -177,6 +188,8 @@ public:
     static wxString GetPortIdName(wxPortId port, bool usingUniversal);
     static wxString GetPortIdShortName(wxPortId port, bool usingUniversal);
 
+    static wxString GetBitnessName(wxBitness bitness);
+    wxDEPRECATED_MSG("Use GetBitnessName() instead")
     static wxString GetArchName(wxArchitecture arch);
     static wxString GetEndiannessName(wxEndianness end);
 
@@ -220,8 +233,11 @@ public:
         { return m_ldi; }
     wxPortId GetPortId() const
         { return m_port; }
+    wxBitness GetBitness() const
+        { return m_bitness; }
+    wxDEPRECATED_MSG("Use GetBitness() instead")
     wxArchitecture GetArchitecture() const
-        { return m_arch; }
+        { return GetBitness(); }
     wxEndianness GetEndianness() const
         { return m_endian; }
 
@@ -237,8 +253,11 @@ public:
         { return GetPortIdName(m_port, m_usingUniversal); }
     wxString GetPortIdShortName() const
         { return GetPortIdShortName(m_port, m_usingUniversal); }
+    wxString GetBitnessName() const
+        { return GetBitnessName(m_bitness); }
+    wxDEPRECATED_MSG("Use GetBitnessName() instead")
     wxString GetArchName() const
-        { return GetArchName(m_arch); }
+        { return GetBitnessName(); }
     wxString GetEndiannessName() const
         { return GetEndiannessName(m_endian); }
     wxString GetOperatingSystemDescription() const
@@ -275,8 +294,11 @@ public:
         { m_osDesc = desc; }
     void SetPortId(wxPortId n)
         { m_port = n; }
-    void SetArchitecture(wxArchitecture n)
-        { m_arch = n; }
+    void SetBitness(wxBitness n)
+        { m_bitness = n; }
+    wxDEPRECATED_MSG("Use SetBitness() instead")
+    void SetArchitecture(wxBitness n)
+        { SetBitness(n); }
     void SetEndianness(wxEndianness n)
         { m_endian = n; }
 
@@ -298,7 +320,7 @@ public:
                m_tkVersionMajor != -1 && m_tkVersionMinor != -1 &&
                m_tkVersionMicro != -1 &&
                m_port != wxPORT_UNKNOWN &&
-               m_arch != wxARCH_INVALID &&
+               m_bitness != wxBITNESS_INVALID &&
                m_endian != wxENDIAN_INVALID;
 
                // do not check linux-specific info; it's ok to have them empty
@@ -360,7 +382,7 @@ protected:
     // -----------------
 
     // architecture bitness of the OS/machine
-    wxArchitecture m_arch;
+    wxBitness m_bitness;
 
     // endianness of the machine
     wxEndianness m_endian;

--- a/include/wx/utils.h
+++ b/include/wx/utils.h
@@ -150,7 +150,7 @@ WXDLLIMPEXP_BASE bool wxCheckOsVersion(int majorVsn, int minorVsn = 0, int micro
 // Get platform endianness
 WXDLLIMPEXP_BASE bool wxIsPlatformLittleEndian();
 
-// Get platform architecture
+// Get platform architecture bitness
 WXDLLIMPEXP_BASE bool wxIsPlatform64Bit();
 
 // Get machine CPU architecture

--- a/interface/wx/platinfo.h
+++ b/interface/wx/platinfo.h
@@ -74,7 +74,7 @@ enum wxPortId
 
 
 /**
-    The architecture of the operating system
+    The architecture bitness of the operating system
     (regardless of the build environment of wxWidgets library - see ::wxIsPlatform64Bit()
     documentation for more info).
 */
@@ -126,7 +126,7 @@ struct wxLinuxDistributionInfo
     @class wxPlatformInfo
 
     This class holds information about the operating system, the toolkit and the
-    basic architecture of the machine where the application is currently running.
+    basic architecture bitness of the machine where the application is currently running.
 
     This class does not only have @e getters for the information above, it also has
     @e setters. This allows you to e.g. save the current platform information in a
@@ -227,7 +227,7 @@ public:
 
     /**
         Converts the given string to a wxArchitecture enum value or to
-        @c wxARCH_INVALID if the given string is not a valid architecture string
+        @c wxARCH_INVALID if the given string is not a valid architecture bitness string
         (i.e. does not contain nor @c 32 nor @c 64 strings).
     */
     static wxArchitecture GetArch(const wxString& arch);
@@ -322,7 +322,7 @@ public:
     //@{
 
     /**
-        Returns the architecture ID of this wxPlatformInfo instance.
+        Returns the architecture bitness ID of this wxPlatformInfo instance.
     */
     wxArchitecture GetArchitecture() const;
 
@@ -440,7 +440,7 @@ public:
     //@{
 
     /**
-        Returns the name for the architecture of this wxPlatformInfo instance.
+        Returns the name for the architecture bitness of this wxPlatformInfo instance.
     */
     wxString GetArchName() const;
 
@@ -483,7 +483,7 @@ public:
     //@{
 
     /**
-        Sets the architecture enum value associated with this wxPlatformInfo instance.
+        Sets the architecture bitness enum value associated with this wxPlatformInfo instance.
     */
     void SetArchitecture(wxArchitecture n);
 

--- a/interface/wx/platinfo.h
+++ b/interface/wx/platinfo.h
@@ -77,6 +77,22 @@ enum wxPortId
     The architecture bitness of the operating system
     (regardless of the build environment of wxWidgets library - see ::wxIsPlatform64Bit()
     documentation for more info).
+
+    @since 3.1.5
+*/
+enum wxBitness
+{
+    wxBITNESS_INVALID = -1,        //!< returned on error
+
+    wxBITNESS_32,                  //!< 32 bit
+    wxBITNESS_64,                  //!< 64 bit
+
+    wxBITNESS_MAX
+};
+
+
+/**
+    @deprecated Use wxBitness instead.
 */
 enum wxArchitecture
 {
@@ -172,7 +188,7 @@ public:
                    wxOperatingSystemId id = wxOS_UNKNOWN,
                    int osMajor = -1,
                    int osMinor = -1,
-                   wxArchitecture arch = wxARCH_INVALID,
+                   wxBitness bitness = wxBITNESS_INVALID,
                    wxEndianness endian = wxENDIAN_INVALID);
 
 
@@ -226,9 +242,16 @@ public:
     //@{
 
     /**
-        Converts the given string to a wxArchitecture enum value or to
-        @c wxARCH_INVALID if the given string is not a valid architecture bitness string
+        Converts the given string to a wxBitness enum value or to
+        @c wxBITNESS_INVALID if the given string is not a valid architecture bitness string
         (i.e. does not contain nor @c 32 nor @c 64 strings).
+
+        @since 3.1.5
+    */
+    static wxBitness GetBitness(const wxString& bitness);
+
+    /**
+        @deprecated Use GetBitness() instead.
     */
     static wxArchitecture GetArch(const wxString& arch);
 
@@ -263,9 +286,16 @@ public:
     //@{
 
     /**
-        Returns the name for the given wxArchitecture enumeration value.
+        @deprecated Use GetBitnessName() instead.
     */
     static wxString GetArchName(wxArchitecture arch);
+
+    /**
+        Returns the name for the given wxBitness enumeration value.
+
+        @since 3.1.5
+    */
+    static wxString GetBitnessName(wxBitness bitness);
 
     /**
         Returns name for the given wxEndianness enumeration value.
@@ -322,9 +352,16 @@ public:
     //@{
 
     /**
-        Returns the architecture bitness ID of this wxPlatformInfo instance.
+        @deprecated Use GetBitness() instead.
     */
     wxArchitecture GetArchitecture() const;
+
+    /**
+        Returns the architecture bitness ID of this wxPlatformInfo instance.
+
+        @since 3.1.5
+    */
+    wxBitness GetBitness() const;
 
     /**
         Returns the endianness ID of this wxPlatformInfo instance.
@@ -440,9 +477,16 @@ public:
     //@{
 
     /**
-        Returns the name for the architecture bitness of this wxPlatformInfo instance.
+        @deprecated Use GetBitnessName() instead.
     */
     wxString GetArchName() const;
+
+    /**
+        Returns the name for the architecture bitness of this wxPlatformInfo instance.
+
+        @since 3.1.5
+    */
+    wxString GetBitnessName() const;
 
     /**
         Returns the name for the endianness of this wxPlatformInfo instance.
@@ -483,9 +527,16 @@ public:
     //@{
 
     /**
-        Sets the architecture bitness enum value associated with this wxPlatformInfo instance.
+        @deprecated Use SetBitness() instead.
     */
     void SetArchitecture(wxArchitecture n);
+
+    /**
+        Sets the architecture bitness enum value associated with this wxPlatformInfo instance.
+
+        @since 3.1.5
+    */
+    void SetBitness(wxBitness n);
 
     /**
         Sets the endianness enum value associated with this wxPlatformInfo instance.

--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -970,12 +970,11 @@ bool wxCheckOsVersion(int majorVsn, int minorVsn = 0, int microVsn = 0);
     bit. The check is performed at run-time and may differ from the value
     available at compile-time (at compile-time you can just check if
     <tt>sizeof(void*) == 8</tt>) since the program could be running in
-    emulation mode or in a mixed 32/64 bit system (bi-architecture operating
-    system).
+    emulation mode or in a mixed 32/64 bit system.
 
     @note This function is not 100% reliable on some systems given the fact
           that there isn't always a standard way to do a reliable check on the
-          OS architecture.
+          OS bitness.
 
     @header{wx/utils.h}
 */

--- a/src/common/platinfo.cpp
+++ b/src/common/platinfo.cpp
@@ -83,7 +83,7 @@ static const wxChar* const wxPortIdNames[] =
     wxT("wxQT")
 };
 
-static const wxChar* const wxArchitectureNames[] =
+static const wxChar* const wxBitnessNames[] =
 {
     wxT("32 bit"),
     wxT("64 bit")
@@ -130,7 +130,7 @@ wxPlatformInfo::wxPlatformInfo()
 
 wxPlatformInfo::wxPlatformInfo(wxPortId pid, int tkMajor, int tkMinor,
                                wxOperatingSystemId id, int osMajor, int osMinor,
-                               wxArchitecture arch,
+                               wxBitness bitness,
                                wxEndianness endian,
                                bool usingUniversal)
 {
@@ -148,7 +148,7 @@ wxPlatformInfo::wxPlatformInfo(wxPortId pid, int tkMajor, int tkMinor,
     m_osVersionMicro = -1;
 
     m_endian = endian;
-    m_arch = arch;
+    m_bitness = bitness;
 }
 
 bool wxPlatformInfo::operator==(const wxPlatformInfo &t) const
@@ -165,7 +165,7 @@ bool wxPlatformInfo::operator==(const wxPlatformInfo &t) const
            m_desktopEnv == t.m_desktopEnv &&
            m_port == t.m_port &&
            m_usingUniversal == t.m_usingUniversal &&
-           m_arch == t.m_arch &&
+           m_bitness == t.m_bitness &&
            m_endian == t.m_endian;
 }
 
@@ -196,7 +196,7 @@ void wxPlatformInfo::InitForCurrentPlatform()
     m_os = wxGetOsVersion(&m_osVersionMajor, &m_osVersionMinor, &m_osVersionMicro);
     m_osDesc = wxGetOsDescription();
     m_endian = wxIsPlatformLittleEndian() ? wxENDIAN_LITTLE : wxENDIAN_BIG;
-    m_arch = wxIsPlatform64Bit() ? wxARCH_64 : wxARCH_32;
+    m_bitness = wxIsPlatform64Bit() ? wxBITNESS_64 : wxBITNESS_32;
 
 #ifdef __LINUX__
     m_ldi = wxGetLinuxDistributionInfo();
@@ -287,12 +287,12 @@ wxString wxPlatformInfo::GetPortIdShortName(wxPortId port, bool usingUniversal)
     return ret;
 }
 
-wxString wxPlatformInfo::GetArchName(wxArchitecture arch)
+wxString wxPlatformInfo::GetBitnessName(wxBitness bitness)
 {
-    wxCOMPILE_TIME_ASSERT( WXSIZEOF(wxArchitectureNames) == wxARCH_MAX,
-                           wxArchitectureNamesMismatch );
+    wxCOMPILE_TIME_ASSERT( WXSIZEOF(wxBitnessNames) == wxBITNESS_MAX,
+                           wxBitnessNamesMismatch );
 
-    return wxArchitectureNames[arch];
+    return wxBitnessNames[bitness];
 }
 
 wxString wxPlatformInfo::GetEndiannessName(wxEndianness end)

--- a/tests/interactive/output.cpp
+++ b/tests/interactive/output.cpp
@@ -280,7 +280,7 @@ void InteractiveOutputTestCase::TestPlatformInfo()
     wxPrintf(wxT("Operating system name is: %s\n"), plat.GetOperatingSystemIdName());
     wxPrintf(wxT("Port ID name is: %s\n"), plat.GetPortIdName());
     wxPrintf(wxT("Port ID short name is: %s\n"), plat.GetPortIdShortName());
-    wxPrintf(wxT("Architecture bitness is: %s\n"), plat.GetArchName());
+    wxPrintf(wxT("Architecture bitness is: %s\n"), plat.GetBitnessName());
     wxPrintf(wxT("Endianness is: %s\n"), plat.GetEndiannessName());
 
     wxPuts(wxEmptyString);

--- a/tests/interactive/output.cpp
+++ b/tests/interactive/output.cpp
@@ -280,7 +280,7 @@ void InteractiveOutputTestCase::TestPlatformInfo()
     wxPrintf(wxT("Operating system name is: %s\n"), plat.GetOperatingSystemIdName());
     wxPrintf(wxT("Port ID name is: %s\n"), plat.GetPortIdName());
     wxPrintf(wxT("Port ID short name is: %s\n"), plat.GetPortIdShortName());
-    wxPrintf(wxT("Architecture is: %s\n"), plat.GetArchName());
+    wxPrintf(wxT("Architecture bitness is: %s\n"), plat.GetArchName());
     wxPrintf(wxT("Endianness is: %s\n"), plat.GetEndiannessName());
 
     wxPuts(wxEmptyString);


### PR DESCRIPTION
In the context of wxPlatformInfo, 'architecture' means either '32 bit' or
'64 bit'. Anywhere outside the context of wxPlatformInfo, this concept is
known as 'bitness'.

For the rest of the world, 'architecture' generally refers to the CPU
instruction set architecture, i.e. something like x86, x86_64, arm64, whereas
'operating system architecture' refers to the design of separating kernel
space, user space, etc.