### PR TITLE
macOS: fixed getting decimal separator.

### DIFF
--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -1762,6 +1762,12 @@ wxString wxLocale::GetInfo(wxLocaleInfo index, wxLocaleCategory WXUNUSED(cat))
             break;
 
         case wxLOCALE_DECIMAL_POINT:
+            // If user did not set specific locale all funcs work in standard C locale.
+            if (!wxGetLocale())
+                return wxString(".");
+
+            // This returns system specific separator for user's region, e.g. comma ',' for Russia,
+            // even if user did not specify locale and all funcs work with C locale...
             cfstr = (CFStringRef) CFLocaleGetValue(userLocaleRef, kCFLocaleDecimalSeparator);
             break;
 

--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -1766,7 +1766,7 @@ wxString wxLocale::GetInfo(wxLocaleInfo index, wxLocaleCategory WXUNUSED(cat))
             if (!wxGetLocale())
                 return wxString(".");
 
-            // This returns system specific separator for user's region, e.g. comma ',' for Russia,
+            // Use this only with explicit wxLocale specified. Otherwise it returns system specific separator for user's region, e.g. comma ',' for Russia,
             // even if user did not specify locale and all funcs work with C locale...
             cfstr = (CFStringRef) CFLocaleGetValue(userLocaleRef, kCFLocaleDecimalSeparator);
             break;


### PR DESCRIPTION
Under macOS all C string-related functions work in **C locale** by default even if OS region use other locale (e.g. in Russia). This leads to runtime checks failure when processing localised strings w/o explicitly setting `wxLocale`. For example, generic `wxSpinCtrlDouble` uses `wxFloatingPointValidator` for user input checking where check for locale-dependent _decimal separator_ occurs. W/o this fix `wxNumberFormatter::GetDecimalSeparator()` could return '**,**' but `wxIntegerValidatorBase::FromString` would fail with that string-to-double conversion.

PS
I'd like to notice that on macOS, w/o explicitly setting wxLocale for user's current region, `wxString::FromDouble` will return string in C locale and `wxString::ToDouble` _will fail_ if we pass localised string like "120,034" which may be _correct_ for user's locale. I wrote macOS specific functions for conversion in that cases (not included in this PR) but I don't know is it a good practise to wxString locale-specific functions etc w/o wxLocale setup. I did not found any comments on this in the documentation.