### PR TITLE
Fix some reported DPI related bugs

### DIFF
--- a/src/common/combocmn.cpp
+++ b/src/common/combocmn.cpp
@@ -1457,7 +1457,7 @@ wxSize wxComboCtrlBase::DoGetSizeFromTextSize(int xlen, int ylen) const
     fhei += 2 * FOCUS_RING;
 
     // Calculate width
-    int fwid = xlen + FOCUS_RING + COMBO_MARGIN + DEFAULT_DROPBUTTON_WIDTH;
+    int fwid = GetNativeTextIndent() + xlen + FOCUS_RING + COMBO_MARGIN + m_btnArea.width;
 
     // Add the margins we have previously set
     wxPoint marg( GetMargins() );

--- a/src/html/winpars.cpp
+++ b/src/html/winpars.cpp
@@ -619,6 +619,10 @@ wxFont* wxHtmlWinParser::CreateCurrentFont()
         *encptr = m_OutputEnc;
 #endif
     }
+#ifdef __WXMSW__
+    if ( m_windowInterface && m_windowInterface->GetHTMLWindow() )
+        (*fontptr)->WXAdjustToPPI(m_windowInterface->GetHTMLWindow()->GetDPI());
+#endif
     m_DC->SetFont(**fontptr);
     return (*fontptr);
 }

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -4924,10 +4924,13 @@ static void UpdateSizerOnDPIChange(wxSizer* sizer, float scaleFactor)
             ScaleCoordIfSet(min.y, scaleFactor);
             sizerItem->SetMinSize(min);
 
-            wxSize size = sizerItem->GetSize();
-            ScaleCoordIfSet(size.x, scaleFactor);
-            ScaleCoordIfSet(size.y, scaleFactor);
-            sizerItem->SetDimension(wxDefaultPosition, size);
+            if ( sizerItem->IsSpacer() )
+            {
+                wxSize size = sizerItem->GetSize();
+                ScaleCoordIfSet(size.x, scaleFactor);
+                ScaleCoordIfSet(size.y, scaleFactor);
+                sizerItem->SetDimension(wxDefaultPosition, size);
+            }
 
             // Update any child sizers if this is a sizer
             UpdateSizerOnDPIChange(sizerItem->GetSizer(), scaleFactor);


### PR DESCRIPTION
Don't change sizer dimensions on DPI change ([#18969](https://trac.wxwidgets.org/ticket/18969)).

Return wxFont adjusted to DPI in wxHtmlWinParser::CreateCurrentFont() ([#18564](https://trac.wxwidgets.org/ticket/18564)).

Improve GetSizeFromText in wxComboCtrl ([#18930](https://trac.wxwidgets.org/ticket/18930)).