### PR TITLE
Fixed an issue concerning the ExtendRulesAndAlternateColour feature.

### DIFF
--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -2188,7 +2188,7 @@ void wxListMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
                 int x_pos = x - dev_x;
                 if (col < GetColumnCount()-1) x_pos -= 2;
 
-                int ruleHeight = m_extendRulesAndAlternateColour
+                int ruleHeight = m_extendRulesAndAlternateColour && visibleEnd > visibleTo
                                     ? clientHeight
                                     : lastItemRect.GetBottom() + 1 - dev_y;
 


### PR DESCRIPTION
When the ExtendRulesAndAlternateColour feature was set to "true" and there were more than lines-per-page rows in the ListCtrl, then from the second page on the vertical rules were not being shown anymore. This one-line piece of code fixes the issue.