### PR TITLE
Fix wxStatusBar::SetMinHeight() in wxMSW

### DIFF
--- a/misc/git/ignore_revs
+++ b/misc/git/ignore_revs
@@ -10,6 +10,9 @@
 # Remove (most) occurrences of wxT() macro from the samples, 2018-09-23
 f58ea625968953ca93585ea7f93dcc07ad032d8f
 
+# Remove trailing whitespace from several files, 2018-04-11
+496da2e550ce1f562f727230babc363da190530e
+
 # Globally replace _T() with wxT()., 2009-07-23
 9a83f860948059b0273b5cc6d9e43fadad3ebfca
 

--- a/src/msw/statusbar.cpp
+++ b/src/msw/statusbar.cpp
@@ -423,9 +423,12 @@ void wxStatusBar::SetMinHeight(int height)
     // statbar sample gets truncated otherwise.
     height += 4*GetBorderY();
 
-    // We need to set the size and not the size to reflect the height because
-    // wxFrame uses our size and not the minimal size as it assumes that the
-    // size of a status bar never changes anyhow.
+    // Ensure that the min height is respected when the status bar is resized
+    // automatically, like the status bar managed by wxFrame.
+    SetMinSize(wxSize(m_minWidth, height));
+
+    // And also update the size immediately, which may be useful for the status
+    // bars not managed by wxFrame.
     SetSize(-1, height);
 
     SendMessage(GetHwnd(), SB_SETMINHEIGHT, height, 0);


### PR DESCRIPTION
This was broken, possibly by 25c9b032a8 (Don't call CacheBestSize() from
DoGetBestSize() implementations, 2016-04-03), as it didn't change the
min size of the status bar and so it was resized to it when it was
managed by wxFrame.

Closes [#18996](https://trac.wxwidgets.org/ticket/18996).