### PR TITLE
Make it possible to use controls inside wxComboPopup again

### DIFF
--- a/src/common/combocmn.cpp
+++ b/src/common/combocmn.cpp
@@ -454,7 +454,8 @@ public:
     wxComboPopupWindow( wxComboCtrlBase *parent,
                         int style )
     #if USES_WXPOPUPWINDOW || USES_WXPOPUPTRANSIENTWINDOW
-                       : wxComboPopupWindowBase(parent,style)
+                       : wxComboPopupWindowBase(parent,
+                                                style | wxPU_CONTAINS_CONTROLS)
     #else
                        : wxComboPopupWindowBase(parent,
                                                 wxID_ANY,


### PR DESCRIPTION
This should have been done together with the changes of 41410610ef
(Don't force wxPU_CONTAINS_CONTROLS on wxPopupTransientWindow,
2020-07-10) as without this style controls inside wxComboPopup couldn't
accept focus any more, which broke the previous behaviour.

---

I think we need to do it for compatibility, otherwise existing code putting editable controls inside `wxComboPopup` is completely broken. But please let me know if I'm mistaken.