### PR TITLE
Fix wxTreeCtrl background painting in wxOSX

### DIFF
--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -1251,14 +1251,14 @@ void wxOSX_drawRect(NSView* self, SEL _cmd, NSRect rect)
     {
         if ( impl->IsUserPane() )
         {
-            wxWindow* win = impl->GetWXPeer();
-            if ( win->UseBgCol() )
+            const wxColour colBg = impl->GetWXPeer()->GetBackgroundColour();
+            if ( colBg.IsOk() )
             {
                 
                 CGContextRef context = [[NSGraphicsContext currentContext] CGContext];
                 CGContextSaveGState( context );
 
-                CGContextSetFillColorWithColor( context, win->GetBackgroundColour().GetCGColor());
+                CGContextSetFillColorWithColor( context, colBg.GetCGColor());
                 CGRect r = CGRectMake(rect.origin.x, rect.origin.y, rect.size.width, rect.size.height);
                 CGContextFillRect( context, r );
 

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -1950,9 +1950,10 @@ bool wxWindowMac::MacDoRedraw( long time )
                         break;
                 }
 
-                if ( UseBgCol() )
+                const wxColour colBg = GetBackgroundColour();
+                if ( colBg.IsOk() )
                 {
-                    dc.SetBackground(GetBackgroundColour());
+                    dc.SetBackground(colBg);
                     dc.Clear();
                 }
             }


### PR DESCRIPTION
Always erase non-native windows background, even if the background
colour wasn't explicitly changed, as it happened for wxTreeCtrl since
9cd3ab5ebd (Improve wxGenericTreeCtrl colours/fonts updating on theme
change, 2020-07-14).

This seems to make sense: background must be erased anyhow, whether we
use a custom or default background colour.

Closes [#18940](https://trac.wxwidgets.org/ticket/18940).