### PR TITLE
Warn about using XIM as input method with wxGTK

### DIFF
--- a/src/gtk/app.cpp
+++ b/src/gtk/app.cpp
@@ -27,6 +27,7 @@
 
 #include "wx/apptrait.h"
 #include "wx/fontmap.h"
+#include "wx/msgout.h"
 
 #include "wx/gtk/private.h"
 
@@ -337,6 +338,18 @@ bool wxApp::Initialize(int& argc_, wxChar **argv_)
     wxConvFileName = &fileconv;
 #endif // __UNIX__
 
+
+    // Using XIM results in many problems, so try to warn people about it.
+    wxString inputMethod;
+    if ( wxGetEnv("GTK_IM_MODULE", &inputMethod) && inputMethod == "xim" )
+    {
+        wxMessageOutputStderr().Output
+        (
+            _("WARNING: using XIM input method is unsupported and may result "
+              "in problems with input handling and flickering. Consider "
+              "unsetting GTK_IM_MODULE or setting to \"ibus\".")
+        );
+    }
 
     bool init_result;
 


### PR DESCRIPTION
This results in various problems, including both the problems with
handling keyboard input (see #16840) and, even less expectedly,
graphical issues with flickering (see #18462).

Fixing or working around these issues doesn't seem to be easily
possible, but we can at least warn people about the problem.