### PR TITLE
Fixing syntax error in interface headers

### DIFF
--- a/interface/wx/defs.h
+++ b/interface/wx/defs.h
@@ -1577,7 +1577,7 @@ typedef double wxDouble;
 
     @header{wx/defs.h}
 */
-template <typename T> wxDELETE(T*& ptr);
+template <typename T> void wxDELETE(T*& ptr);
 
 /**
     A function which deletes and nulls the pointer.
@@ -1597,7 +1597,7 @@ template <typename T> wxDELETE(T*& ptr);
 
     @header{wx/defs.h}
 */
-template <typename T> wxDELETEA(T*& array);
+template <typename T> void wxDELETEA(T*& array);
 
 /**
     Generate deprecation warning with the given message when a function is
@@ -1796,7 +1796,7 @@ template <typename T> wxDELETEA(T*& array);
         wxASSERT( x == 4 && y == 3 );
     @endcode
  */
-template <typename T> wxSwap(T& first, T& second);
+template <typename T> void wxSwap(T& first, T& second);
 
 /**
     This macro is the same as the standard C99 @c va_copy for the compilers

--- a/interface/wx/filesys.h
+++ b/interface/wx/filesys.h
@@ -493,7 +493,7 @@ public:
 
         Use wxStreamBase::IsOk() to verify if the constructor succeeded.
     */
-    wxFileInputStream(const wxString& filename, int flags = 0);
+    wxFSInputStream(const wxString& filename, int flags = 0);
 
     /**
         Returns @true if the stream is initialized and ready.

--- a/interface/wx/list.h
+++ b/interface/wx/list.h
@@ -99,18 +99,18 @@ public:
     /**
         Default constructor.
     */
-    wxList<T>();
+    wxList();
 
     /**
         Constructor which initialized the list with an array of @a count elements.
     */
-    wxList<T>(size_t count, T* elements[]);
+    wxList(size_t count, T* elements[]);
 
     /**
         Destroys the list, but does not delete the objects stored in the list
         unless you called DeleteContents(@true ).
     */
-    ~wxList<T>();
+    ~wxList();
 
     /**
         Appends the pointer to @a object to the list.

--- a/interface/wx/object.h
+++ b/interface/wx/object.h
@@ -583,19 +583,19 @@ public:
         @a ptr is a pointer to the reference counted object to which this class points.
         If @a ptr is not NULL @b T::IncRef() will be called on the object.
     */
-    wxObjectDataPtr<T>(T* ptr = NULL);
+    wxObjectDataPtr(T* ptr = NULL);
 
     /**
         This copy constructor increases the count of the reference counted object to
         which @a tocopy points and then this class will point to, as well.
     */
-    wxObjectDataPtr<T>(const wxObjectDataPtr<T>& tocopy);
+    wxObjectDataPtr(const wxObjectDataPtr<T>& tocopy);
 
 
     /**
         Decreases the reference count of the object to which this class points.
     */
-    ~wxObjectDataPtr<T>();
+    ~wxObjectDataPtr();
 
     /**
         Gets a pointer to the reference counted object to which this class points.

--- a/interface/wx/propgrid/editors.h
+++ b/interface/wx/propgrid/editors.h
@@ -251,7 +251,7 @@ public:
 class wxPGChoiceEditor : public wxPGEditor
 {
 public:
-    wxPGChoiceEditor()
+    wxPGChoiceEditor();
     virtual ~wxPGChoiceEditor();
 
     virtual wxPGWindowList CreateControls(wxPropertyGrid* propgrid,

--- a/interface/wx/propgrid/propgrid.h
+++ b/interface/wx/propgrid/propgrid.h
@@ -1403,7 +1403,7 @@ public:
                  accessible even after the associated property or
                  the property grid has been deleted.
     */
-    wxVariant GetPropertyValue() const
+    wxVariant GetPropertyValue() const;
 
     /**
         Returns value of the associated property.

--- a/interface/wx/propgrid/propgridpagestate.h
+++ b/interface/wx/propgrid/propgridpagestate.h
@@ -376,7 +376,7 @@ public:
     */
     inline unsigned int GetActualVirtualHeight() const;
 
-    unsigned int GetColumnCount() const'
+    unsigned int GetColumnCount() const;
 
     int GetColumnMinWidth( int column ) const;
 
@@ -524,4 +524,4 @@ public:
     bool DoExpand( wxPGProperty* p );
 
     void CalculateFontAndBitmapStuff( int vspacing );
-}:
+};

--- a/interface/wx/ribbon/toolbar.h
+++ b/interface/wx/ribbon/toolbar.h
@@ -305,7 +305,7 @@ public:
 
         @since 2.9.4
     */
-    wxRibbonToolBarToolBase* GetToolByPos(size_t pos)const
+    wxRibbonToolBarToolBase* GetToolByPos(size_t pos)const;
 
     /**
         Returns the number of tools in the toolbar.

--- a/interface/wx/richtext/richtextprint.h
+++ b/interface/wx/richtext/richtextprint.h
@@ -173,7 +173,7 @@ public:
     /**
         Assignment operator.
     */
-    void operator operator=(const wxRichTextHeaderFooterData& data);
+    void operator=(const wxRichTextHeaderFooterData& data);
 };
 
 

--- a/interface/wx/tarstrm.h
+++ b/interface/wx/tarstrm.h
@@ -400,6 +400,6 @@ public:
     /**
         Assignment operator.
     */
-    wxTarEntry& operator operator=(const wxTarEntry& entry);
+    wxTarEntry& operator=(const wxTarEntry& entry);
 };
 


### PR DESCRIPTION
Few headers of interface/wx folder have syntax error, they are easy to fix and this pull request contains those changes.