### PR TITLE
catch doubleclick (item activation event) on non-item

### DIFF
--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -1679,6 +1679,9 @@ outlineView:(NSOutlineView*)outlineView
     wxDataViewCtrl* const dvc = implementation->GetDataViewCtrl();
     wxDataViewModel * const model = dvc->GetModel();
 
+    if ( self.clickedRow == -1 )
+        return;
+
     const wxDataViewItem item = wxDataViewItemFromItem([self itemAtRow:[self clickedRow]]);
 
     const NSInteger col = [self clickedColumn];


### PR DESCRIPTION
This PR fixes the issue reported in https://trac.wxwidgets.org/ticket/18984.
