### PR TITLE
fixes a strange issue on OSX concerning the state of nodes being expandables or not

### DIFF
--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -573,7 +573,7 @@ outlineView:(NSOutlineView*)outlineView
         // Note that returning "NO" here would result in currently expanded
         // branches not being expanded any more, while returning "YES" doesn't
         // seem to have any ill effects, even though this is clearly bogus.
-        return YES;
+        // return YES;
     }
 
     wxCHECK_MSG( model, 0, "Valid model in data source does not exist." );


### PR DESCRIPTION
On OSX 10.11.6 when deleting a node of a dataviewctrl with a tree model, other nodes are marked as being expandable even if they are not. This happens only if the DataViewCtrl has just a single column.

Before delete:
![Screen Shot 2020-12-14 at 10 47 25](https://user-images.githubusercontent.com/12586486/102088802-2bbf2e80-3dfa-11eb-85bb-8852c678b858.png)
After delete:
![Screen Shot 2020-12-14 at 10 47 33](https://user-images.githubusercontent.com/12586486/102088819-337ed300-3dfa-11eb-922d-e4123cb53232.png)

This PR seems to fix this issue, but honestly I do not understand what the lines I deleted where meant for. Someone with more insight needs to verify please.