### PR TITLE
Draw expander in generic wxDVC when required even when item doesn't have a value

### DIFF
--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -2790,6 +2790,7 @@ void wxDataViewMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
             wxDataViewTreeNode *node = NULL;
             wxDataViewItem dataitem;
             const int line_height = GetLineHeight(item);
+            bool hasValue = true;
 
             if (!IsVirtualList())
             {
@@ -2802,12 +2803,9 @@ void wxDataViewMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
 
                 dataitem = node->GetItem();
 
-                // Skip al columns  that do not have values
                 if ( !model->HasValue(dataitem, col->GetModelColumn()) )
-                {
-                    cell_rect.y += line_height;
-                    continue;
-                }
+                    hasValue = false;
+
             }
             else
             {
@@ -2824,7 +2822,8 @@ void wxDataViewMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
                 state |= wxDATAVIEW_CELL_SELECTED;
 
             cell->SetState(state);
-            cell->PrepareForItem(model, dataitem, col->GetModelColumn());
+            if (hasValue)
+                cell->PrepareForItem(model, dataitem, col->GetModelColumn());
 
             // draw the background
             if ( !selected )
@@ -2905,7 +2904,8 @@ void wxDataViewMainWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
             //       make its own renderer and thus we cannot be sure of that.
             wxDCClipper clip(dc, item_rect);
 
-            cell->WXCallRender(item_rect, &dc, state);
+            if (hasValue)
+                cell->WXCallRender(item_rect, &dc, state);
 
             cell_rect.y += line_height;
         }


### PR DESCRIPTION
This PR is for a feature in the generic dataview control: To draw the expander when relevant _even if the item does not have values_. (This should have been part of https://github.com/wxWidgets/wxWidgets/pull/1792 but I missed it). The proposed behavior for the generic dataview control matches the behavior of the native controls.

The following images illustrate the issue: The first example is from the `wxDataViewCtrl sample` in which the first column has been marked as having no values.

This is how it appears in the native gtk control (Notice the expander triangles in the first, otherwise blank, column).
![image](https://user-images.githubusercontent.com/23492126/102168578-52568700-3e45-11eb-9832-eefc2d085a68.png)

and this is how it appears in the generic control before this PR. (The expander triangles are missing).
![image](https://user-images.githubusercontent.com/23492126/102169375-e8d77800-3e46-11eb-88dd-6e191ee0447e.png)

and this is how it appears in the generic control after this PR (The expander triangles are back)
![image](https://user-images.githubusercontent.com/23492126/102168176-a1e88300-3e44-11eb-8e44-78e8bb00ec2e.png)

The above example is artificial and one might be left wondering whether there are reasonable cases where the expander column has no values.

The following example is from a custom application where the first column uses a bool renderer that makes sense in some nodes but not in others (which are groups) and illustrates a real use:

Generic control before this PR. Expander triangles are missing and don't show tree structure.
![image](https://user-images.githubusercontent.com/23492126/102437421-5c0bf600-3fcf-11eb-9f8c-54b1d8e45f7d.png)

Native control (on GTK). The expander triangles in grouping nodes provide the intended UX:
![image](https://user-images.githubusercontent.com/23492126/102170768-f2aeaa80-3e49-11eb-86f5-4ff68c861f35.png)

Generic control after this PR  (The expander triangles are back)
![image](https://user-images.githubusercontent.com/23492126/102698149-14b08000-41f0-11eb-9e18-c7c72415e753.png)


