### PR TITLE
Add option to send wxEVT_MENU even when item is reselected

### DIFF
--- a/include/wx/menu.h
+++ b/include/wx/menu.h
@@ -360,6 +360,17 @@ public:
         Insert(0u, itemid, text, help, isCheckable);
     }
 
+    // Sets if the wxEVT_MENU command event should be sent even when IsChecked() returns true (e.g for Radio). False by default.
+    void SendCommandEvenIfChecked(bool sendAlways = true)
+    {
+        m_isSendCommandEvenIfChecked = sendAlways;
+    }
+
+    bool IsSendCommandEvenIfChecked() const
+    {
+        return m_isSendCommandEvenIfChecked;
+    }
+
     static void LockAccels(bool locked)
     {
         ms_locked = locked;
@@ -399,6 +410,7 @@ protected:
 
     static bool      ms_locked;
 
+    bool          m_isSendCommandEvenIfChecked; // if wxEVT_MENU should be sent even if IsChecked() returns true
 
 protected:
     // Common part of SendEvent() and ProcessMenuEvent(): sends the event to

--- a/interface/wx/menu.h
+++ b/interface/wx/menu.h
@@ -298,6 +298,11 @@ public:
     bool IsEnabled(int id) const;
 
     /**
+        Returns @true if wxEVT_MENU command events should be sent even when IsChecked() returns @true.
+    */
+    bool IsSendCommandEvenIfChecked() const;
+
+    /**
         Redraw the menu bar
     */
     virtual void Refresh(bool eraseBackground = true, const wxRect* rect = NULL);
@@ -327,6 +332,11 @@ public:
         @see Insert(), Remove()
     */
     virtual wxMenu* Replace(size_t pos, wxMenu* menu, const wxString& title);
+
+    /**
+        Sets if the wxEVT_MENU command event should be sent even when IsChecked() returns @true (e.g for Radio). @false by default.
+    */
+    void SendCommandEvenIfChecked(bool sendAlways = true);
 
     /**
         Sets the help string associated with a menu item.

--- a/src/msw/menu.cpp
+++ b/src/msw/menu.cpp
@@ -782,7 +782,12 @@ bool wxMenu::MSWCommand(WXUINT WXUNUSED(param), WXWORD id_)
         if ( item )
         {
             if ( item->IsRadio() && item->IsChecked() )
+            {
+                if ( IsSendCommandEvenIfChecked() )
+                    item->GetMenu()->SendEvent(id, 1);
+
                 return true;
+            }
 
             if ( item->IsCheckable() )
             {


### PR DESCRIPTION
This pull request adds two functions to wxMenu:
- SendCommandEvenIfChecked(bool sendAlways)
- IsSendCommandEvenIfChecked()

These allow for the user to receive a wxEVT_MENU command event when an item that is already checked has been rechecked/reselected. We found that we required this functionality in a very specific use case in our application.

Unfortunately we have only been able to implement this on wxMSW as we do not build on other platforms and wouldn't want to risk creating build errors, however the implementations for other platforms would most likely be trivial.