### PR TITLE
WebView Edge: Disable status bar

### DIFF
--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -330,6 +330,10 @@ HRESULT wxWebViewEdgeImpl::OnWebViewCreated(HRESULT result, ICoreWebView2Control
         m_pendingContextMenuEnabled = -1;
     }
 
+    wxCOMPtr<ICoreWebView2Settings> settings(GetSettings());
+    if (settings)
+        settings->put_IsStatusBarEnabled(false);
+
     if (!m_pendingURL.empty())
     {
         m_ctrl->LoadURL(m_pendingURL);


### PR DESCRIPTION
No other webview backend shows it's own integrated status bar
it's safe to assume applications would not expect it.