### PR TITLE
configure: Fix failing libpng and zlib detection

### DIFF
--- a/configure
+++ b/configure
@@ -21547,13 +21547,13 @@ else
                     int main()
                     {
                         FILE *f=fopen("conftestval", "w");
-                        if (!f) exit(1);
+                        if (!f) return 1;
                         fprintf(f, "%s",
                                 ZLIB_VERSION[0] == '1' &&
                                 (ZLIB_VERSION[2] > '1' ||
                                 (ZLIB_VERSION[2] == '1' &&
                                  ZLIB_VERSION[4] >= '4')) ? "yes" : "no");
-                        exit(0);
+                        return 0;
                     }
 
 _ACEOF
@@ -21686,10 +21686,10 @@ else
                     int main()
                     {
                         FILE *f=fopen("conftestval", "w");
-                        if (!f) exit(1);
+                        if (!f) return 1;
                         fprintf(f, "%s",
                                  PNG_LIBPNG_VER > 90 ? "yes" : "no");
-                        exit(0);
+                        return 0;
                     }
 
 _ACEOF

--- a/configure.in
+++ b/configure.in
@@ -2451,13 +2451,13 @@ if test "$wxUSE_ZLIB" != "no" ; then
                     int main()
                     {
                         FILE *f=fopen("conftestval", "w");
-                        if (!f) exit(1);
+                        if (!f) return 1;
                         fprintf(f, "%s",
                                 ZLIB_VERSION[0] == '1' &&
                                 (ZLIB_VERSION[2] > '1' ||
                                 (ZLIB_VERSION[2] == '1' &&
                                  ZLIB_VERSION[4] >= '4')) ? "yes" : "no");
-                        exit(0);
+                        return 0;
                     }
                 ],
                 ac_cv_header_zlib_h=`cat conftestval`,
@@ -2536,10 +2536,10 @@ if test "$wxUSE_LIBPNG" != "no" ; then
                     int main()
                     {
                         FILE *f=fopen("conftestval", "w");
-                        if (!f) exit(1);
+                        if (!f) return 1;
                         fprintf(f, "%s",
                                  PNG_LIBPNG_VER > 90 ? "yes" : "no");
-                        exit(0);
+                        return 0;
                     }
                 ],
                 ac_cv_header_png_h=`cat conftestval`,


### PR DESCRIPTION
Since Apple clang version 12 implicit function declarations by default
are (rightfully) an error resulting in failure to compile the configure
tests for libpng and zlib, which make implicit use of exit.

Fix by using return statements (another solution is including stdlib.h).