### PR TITLE
Do not invoke PrepareForItem when Item has no value in generic wxDVC

### DIFF
--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -5950,9 +5950,15 @@ public:
         {
             item = m_clientArea->GetItemByRow(row);
         }
-
-        m_renderer->PrepareForItem(m_model, item, GetColumn());
-        UpdateWithWidth(m_renderer->GetSize().x + indent);
+        if ( m_model->HasValue(item, GetColumn()) )
+        {
+            m_renderer->PrepareForItem(m_model, item, GetColumn());
+            UpdateWithWidth(m_renderer->GetSize().x + indent);
+        }
+        else
+        {
+        	UpdateWithWidth(indent);
+        }
     }
 
 private:


### PR DESCRIPTION
This PR is for a bug fix in the generic dataview control. 

Background: When estimating the best width for a column in the generic dataview control, a few rows are sampled to find out their best width. This involves calling `PrepareForItem` on each of their column renderers and asking the renderer for its best width.

However, `PrepareForItem` will result in an assertion error if the cell has no value because the null variant cannot be converted to the expected type. This PR avoids calling `PrepareForItem` when the cell has no value and instead assumes the best width for such item is zero (plus the expander width if any) . This completely solves the problem and results in the correct behavior, which also matches the behavior of the native dataview controls.

For context: This PR is conceptually part of https://github.com/wxWidgets/wxWidgets/pull/1792