### PR TITLE
Add wxRibbonToolBar GetToolByPos and GetToolRect coord functions

### DIFF
--- a/include/wx/ribbon/toolbar.h
+++ b/include/wx/ribbon/toolbar.h
@@ -131,6 +131,7 @@ public:
 
     virtual wxRibbonToolBarToolBase* FindById(int tool_id)const;
     virtual wxRibbonToolBarToolBase* GetToolByPos(size_t pos)const;
+    virtual wxRibbonToolBarToolBase* GetToolByPos(wxCoord x, wxCoord y)const;
     virtual size_t GetToolCount() const;
     virtual int GetToolId(const wxRibbonToolBarToolBase* tool)const;
 
@@ -139,6 +140,7 @@ public:
     virtual wxString GetToolHelpString(int tool_id)const;
     virtual wxRibbonButtonKind GetToolKind(int tool_id)const;
     virtual int GetToolPos(int tool_id)const;
+    virtual wxRect GetToolRect(int tool_id)const;
     virtual bool GetToolState(int tool_id)const;
 
     virtual bool Realize() wxOVERRIDE;

--- a/interface/wx/ribbon/toolbar.h
+++ b/interface/wx/ribbon/toolbar.h
@@ -308,6 +308,16 @@ public:
     wxRibbonToolBarToolBase* GetToolByPos(size_t pos)const;
 
     /**
+    Return the opaque pointer corresponding to the given tool, given specified coordinates.
+
+    @return an opaque pointer, NULL if is not found.
+
+    @since 2.9.4
+    */
+    virtual wxRibbonToolBarToolBase* GetToolByPos(wxCoord x, wxCoord y)const;
+
+
+    /**
         Returns the number of tools in the toolbar.
 
         @since 2.9.4
@@ -379,6 +389,18 @@ public:
         @since 2.9.4
     */
     virtual int GetToolPos(int tool_id)const;
+
+    /**
+        Returns the rect in the toolbar, or a default-constructed rect if the tool
+        is not found.
+
+        @param tool_id
+            ID of the tool in question, as passed to AddTool().
+
+        @since 3.1.5
+    */
+    virtual wxRect GetToolRect(int tool_id)const;
+
 
     /**
         Gets the on/off state of a toggle tool.

--- a/interface/wx/ribbon/toolbar.h
+++ b/interface/wx/ribbon/toolbar.h
@@ -312,7 +312,7 @@ public:
 
     @return an opaque pointer, NULL if is not found.
 
-    @since 2.9.4
+    @since 3.1.5
     */
     virtual wxRibbonToolBarToolBase* GetToolByPos(wxCoord x, wxCoord y)const;
 

--- a/src/ribbon/toolbar.cpp
+++ b/src/ribbon/toolbar.cpp
@@ -432,15 +432,14 @@ wxRibbonToolBarToolBase* wxRibbonToolBar::GetToolByPos(size_t pos)const
 wxRibbonToolBarToolBase* wxRibbonToolBar::GetToolByPos(wxCoord x, wxCoord y)const
 {
     size_t group_count = m_groups.GetCount();
-    size_t g, t;
-    for(g = 0; g < group_count; ++g)
+    for ( size_t g = 0; g < group_count; ++g )
     {
         wxRibbonToolBarToolGroup* group = m_groups.Item(g);
         size_t tool_count = group->tools.GetCount();
-        for(t = 0; t < tool_count; ++t)
+        for ( size_t t = 0; t < tool_count; ++t )
         {
             wxRibbonToolBarToolBase* tool = group->tools.Item(t);
-            wxRect rect(tool->position.x, tool->position.y, tool->size.GetWidth(), tool->size.GetHeight());
+            wxRect rect(tool->position, tool->size);
             if(rect.Contains(x, y))
             {
                 return tool;

--- a/src/ribbon/toolbar.cpp
+++ b/src/ribbon/toolbar.cpp
@@ -429,6 +429,27 @@ wxRibbonToolBarToolBase* wxRibbonToolBar::GetToolByPos(size_t pos)const
     return NULL;
 }
 
+wxRibbonToolBarToolBase* wxRibbonToolBar::GetToolByPos(wxCoord x, wxCoord y)const
+{
+    size_t group_count = m_groups.GetCount();
+    size_t g, t;
+    for(g = 0; g < group_count; ++g)
+    {
+        wxRibbonToolBarToolGroup* group = m_groups.Item(g);
+        size_t tool_count = group->tools.GetCount();
+        for(t = 0; t < tool_count; ++t)
+        {
+            wxRibbonToolBarToolBase* tool = group->tools.Item(t);
+            wxRect rect(tool->position.x, tool->position.y, tool->size.GetWidth(), tool->size.GetHeight());
+            if(rect.Contains(x, y))
+            {
+                return tool;
+            }
+        }
+    }
+    return NULL;
+}
+
 size_t wxRibbonToolBar::GetToolCount() const
 {
     size_t count = 0;
@@ -499,6 +520,30 @@ int wxRibbonToolBar::GetToolPos(int tool_id)const
         ++pos; // Increment pos for group separator.
     }
     return wxNOT_FOUND;
+}
+
+wxRect wxRibbonToolBar::GetToolRect(int tool_id)const
+{
+    size_t group_count = m_groups.GetCount();
+    size_t g, t;
+    int pos = 0;
+    for(g = 0; g < group_count; ++g)
+    {
+        wxRibbonToolBarToolGroup* group = m_groups.Item(g);
+        size_t tool_count = group->tools.GetCount();
+        for(t = 0; t < tool_count; ++t)
+        {
+            wxRibbonToolBarToolBase* tool = group->tools.Item(t);
+            if (tool->id == tool_id)
+            {
+                wxRect rect(tool->position.x, tool->position.y, tool->size.GetWidth(), tool->size.GetHeight());
+                return rect;
+            }
+            ++pos;
+        }
+        ++pos; // Increment pos for group separator.
+    }
+    return wxRect();
 }
 
 bool wxRibbonToolBar::GetToolState(int tool_id)const


### PR DESCRIPTION
This commit adds the following functions to wxRibbonToolBar:
- wxGetToolByPos accepts two wxCoords (x and y) and returns the opaque tool pointer after a recursive search through all the tools for any tool that contains those coords
- wxGetRect accepts a tool index and returns the rect representing the top left and bottom right points of the relevant tool

These functions were available in wxAuiToolBar but were not available in wxRibbonToolBar, and we found that they were necessary for our project, hence this commit.