### PR TITLE
Generic wxDVC resorts nodes on Resort always when using custom sort criteria

### DIFF
--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -110,6 +110,8 @@ public:
 
     bool IsNone() const { return m_column == SortColumn_None; }
 
+    bool IsDefault() const { return m_column == SortColumn_Default; }
+
     int GetColumn() const { return m_column; }
     bool IsAscending() const { return m_ascending; }
 
@@ -1889,8 +1891,8 @@ void wxDataViewTreeNode::Resort(wxDataViewMainWindow* window)
         wxDataViewTreeNodes& nodes = m_branchData->children;
 
         // Only sort the children if they aren't already sorted by the wanted
-        // criteria.
-        if ( m_branchData->sortOrder != sortOrder )
+        // criterion. Or if the wanted criterion is default (a user custom order)
+        if ( m_branchData->sortOrder != sortOrder || sortOrder.IsDefault() )
         {
             std::sort(m_branchData->children.begin(),
                       m_branchData->children.end(),


### PR DESCRIPTION
This PR fixes a bug in the generic wxDVC.

When the user requests a resort in the model of a wxDVC and the model is sorted currently by a custom Default Compare, we cannot optimize away the resort, _even if the last resort was also using the custom default compare_ because the order in which nodes should be sorted can change between the previous resort and the current one, depending on the algorithm in the user's default compare. 

This PR checks for this condition and avoids the incorrect optimization in the generic implementation.