### PR TITLE
 wxGrid: Fix potential infinite loop with auto-wrapped multi-line cells

### DIFF
--- a/src/generic/gridctrl.cpp
+++ b/src/generic/gridctrl.cpp
@@ -546,10 +546,16 @@ wxGridCellAutoWrapStringRenderer::GetBestWidth(wxGrid& grid,
 {
     const int lineHeight = dc.GetCharHeight();
 
-    // Maximal number of lines that fully fit but at least 1.
-    const size_t maxLines = height - AUTOWRAP_Y_MARGIN < lineHeight
-                                ? 1
-                                : (height - AUTOWRAP_Y_MARGIN)/lineHeight;
+    // Base the maximal number of lines either on how many fit or how many
+    // (new)lines the cell's text contains, whichever results in the most lines.
+    //
+    // It's important to take the newlines into account as GetTextLines() splits
+    // based on them and the number of lines returned can never drop below that,
+    // resulting in the while loop below never exiting if there are already more
+    // lines in the text than can fit in the available height.
+    const size_t maxLines = wxMax(
+                              (height - AUTOWRAP_Y_MARGIN)/lineHeight,
+                              1 + grid.GetCellValue(row, col).Freq(wxS('\n')));
 
     // Increase width until all the text fits.
     //

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -1405,6 +1405,22 @@ TEST_CASE_METHOD(GridTestCase, "Grid::AutoSizeColumn", "[grid]")
         // so just calculate the maximum width.
         CheckFirstColAutoSize( wxMax(labelWidth, cellWidth) );
     }
+
+    SECTION("Column with auto wrapping contents taller than row")
+    {
+        // Verify row height remains unchanged with an auto-wrapping multi-line
+        // cell.
+        // Also shouldn't continuously try to fit the multi-line content into
+        // a single line, which is not possible. See
+        // https://trac.wxwidgets.org/ticket/15943 .
+
+        m_grid->SetCellValue(0, 0, multilineStr);
+        m_grid->SetCellRenderer(0 , 0, new wxGridCellAutoWrapStringRenderer);
+        m_grid->AutoSizeColumn(0);
+
+        wxYield();
+        CHECK( m_grid->GetRowSize(0) == m_grid->GetDefaultRowSize() );
+    }
 }
 
 // Test wxGridBlockCoords here because it'a a part of grid sources.


### PR DESCRIPTION
See [#15943](https://trac.wxwidgets.org/ticket/15943).

Suggestion for git note:

```All (GUI): Fix potential infinite loop with auto-wrapped multi-line cells in wxGrid.```
