### PR TITLE
Implement wxImageDataObject

### DIFF
--- a/include/wx/dataobj.h
+++ b/include/wx/dataobj.h
@@ -36,7 +36,9 @@
    wxTextDataObject    |     wxBitmapDataObject
                        |
                wxCustomDataObject
-
+                       |
+                       |
+               wxImageDataObject
 */
 // ============================================================================
 
@@ -543,6 +545,22 @@ private:
     void  *m_data;
 
     wxDECLARE_NO_COPY_CLASS(wxCustomDataObject);
+};
+
+// ----------------------------------------------------------------------------
+// wxImageDataObject - data object for wxImage
+// ----------------------------------------------------------------------------
+
+class WXDLLIMPEXP_CORE wxImageDataObject : public wxCustomDataObject
+{
+public:
+    explicit wxImageDataObject(const wxImage& image = wxNullImage);
+
+    void SetImage(const wxImage& image);
+    wxImage GetImage() const;
+
+private:
+    wxDECLARE_NO_COPY_CLASS(wxImageDataObject);
 };
 
 // ----------------------------------------------------------------------------

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -2153,6 +2153,7 @@ enum wxDataFormatId
     wxDF_LOCALE =           16,
     wxDF_PRIVATE =          20,
     wxDF_HTML =             30, /* Note: does not correspond to CF_ constant */
+    wxDF_PNG =              31, /* Note: does not correspond to CF_ constant */
     wxDF_MAX
 };
 

--- a/interface/wx/dataobj.h
+++ b/interface/wx/dataobj.h
@@ -35,7 +35,8 @@
     @itemdef{wxDF_HTML,
              An HTML string. This is currently only valid on Mac and MSW.}
     @itemdef{wxDF_PNG,
-             A PNG file. This is valid only on MSW.}
+             A PNG file. This is valid only on MSW. This constant is available
+             since wxWidgets 3.1.5.}
     @endDefList
 
     As mentioned above, these standard formats may be passed to any function
@@ -618,6 +619,42 @@ public:
         override this function.
     */
     virtual void SetBitmap(const wxBitmap& bitmap);
+};
+
+
+
+/**
+    @class wxImageDataObject
+
+    wxImageDataObject is a specialization of wxDataObject for image data.
+    It can be used e.g. when you need to put on and retrieve from the clipboard
+    a wxImage with its metadata (like image resolution).
+
+    @since 3.1.5
+
+    @library{wxcore}
+    @category{dnd}
+
+    @see @ref overview_dnd, wxDataObject, wxCustomDataObject, wxBitmapDataObject
+*/
+class wxImageDataObject : public wxCustomDataObject
+{
+public:
+    /**
+        Constructor, optionally passing an image (otherwise use SetImage()
+        later).
+    */
+    explicit wxImageDataObject(const wxImage& image = wxNullImage);
+
+    /**
+        Returns the image associated with the data object.
+    */
+    wxImage GetImage() const;
+
+    /**
+        Sets the image stored by the data object.
+    */
+    void SetImage(const wxImage& image);
 };
 
 

--- a/interface/wx/dataobj.h
+++ b/interface/wx/dataobj.h
@@ -34,6 +34,8 @@
              A list of filenames.}
     @itemdef{wxDF_HTML,
              An HTML string. This is currently only valid on Mac and MSW.}
+    @itemdef{wxDF_PNG,
+             A PNG file. This is valid only on MSW.}
     @endDefList
 
     As mentioned above, these standard formats may be passed to any function

--- a/samples/image/image.cpp
+++ b/samples/image/image.cpp
@@ -91,6 +91,8 @@ public:
 #if wxUSE_CLIPBOARD
     void OnCopy(wxCommandEvent& event);
     void OnPaste(wxCommandEvent& event);
+    void OnCopyImage(wxCommandEvent& evt);
+    void OnPasteImage(wxCommandEvent& evt);
 #endif // wxUSE_CLIPBOARD
 
     MyCanvas         *m_canvas;
@@ -124,8 +126,39 @@ class MyImageFrame : public wxFrame
 public:
     MyImageFrame(wxFrame *parent, const wxString& desc, const wxImage& image, double scale = 1.0)
     {
-        Create(parent, desc, wxBitmap(image, wxBITMAP_SCREEN_DEPTH, scale),
-            image.GetImageCount(desc));
+        // Retrieve image info
+        wxString info;
+        int xres, yres;
+        switch ( GetResolutionFromOptions(image, &xres, &yres) )
+        {
+            case wxIMAGE_RESOLUTION_NONE:
+                break;
+
+            case wxIMAGE_RESOLUTION_CM:
+                // convert to DPI
+                xres = wxRound(xres / 10.0 * inches2mm);
+                yres = wxRound(yres / 10.0 * inches2mm);
+                wxFALLTHROUGH;
+
+            case wxIMAGE_RESOLUTION_INCHES:
+                info = wxString::Format("DPI %i x %i", xres, yres);
+                break;
+
+            default:
+                wxFAIL_MSG("unexpected image resolution units");
+                break;
+        }
+
+        int numImages = desc.StartsWith("Clipboard") ? 1 : image.GetImageCount(desc);
+        if ( numImages > 1 )
+        {
+            if ( !info.empty() )
+                info += ", ";
+
+            info += wxString::Format("%d images", numImages);
+        }
+
+        Create(parent, desc, wxBitmap(image, wxBITMAP_SCREEN_DEPTH, scale), info);
     }
 
     MyImageFrame(wxFrame *parent, const wxString& desc, const wxBitmap& bitmap)
@@ -137,7 +170,7 @@ private:
     bool Create(wxFrame *parent,
                 const wxString& desc,
                 const wxBitmap& bitmap,
-                int numImages = 1)
+                wxString info = wxString())
     {
         if ( !wxFrame::Create(parent, wxID_ANY,
                               wxString::Format("Image from %s", desc),
@@ -169,8 +202,7 @@ private:
         mbar->Check(ID_PAINT_BG, true);
 
         CreateStatusBar(2);
-        if ( numImages != 1 )
-            SetStatusText(wxString::Format("%d images", numImages), 1);
+        SetStatusText(info, 1);
 
         SetClientSize(bitmap.GetWidth(), bitmap.GetHeight());
 
@@ -439,6 +471,41 @@ private:
         Refresh();
     }
 
+    // This is a copy of protected wxImageHandler::GetResolutionFromOptions()
+    static wxImageResolution GetResolutionFromOptions(const wxImage& image, int* x, int* y)
+    {
+        wxCHECK_MSG(x && y, wxIMAGE_RESOLUTION_NONE, wxT("NULL pointer"));
+
+        if ( image.HasOption(wxIMAGE_OPTION_RESOLUTIONX) &&
+            image.HasOption(wxIMAGE_OPTION_RESOLUTIONY) )
+        {
+            *x = image.GetOptionInt(wxIMAGE_OPTION_RESOLUTIONX);
+            *y = image.GetOptionInt(wxIMAGE_OPTION_RESOLUTIONY);
+        }
+        else if ( image.HasOption(wxIMAGE_OPTION_RESOLUTION) )
+        {
+            *x =
+            *y = image.GetOptionInt(wxIMAGE_OPTION_RESOLUTION);
+        }
+        else // no resolution options specified
+        {
+            *x =
+            *y = 0;
+
+            return wxIMAGE_RESOLUTION_NONE;
+        }
+
+        // get the resolution unit too
+        int resUnit = image.GetOptionInt(wxIMAGE_OPTION_RESOLUTIONUNIT);
+        if ( !resUnit )
+        {
+            // this is the default
+            resUnit = wxIMAGE_RESOLUTION_INCHES;
+        }
+
+        return (wxImageResolution)resUnit;
+    }
+
     wxBitmap m_bitmap;
     double m_zoom;
 
@@ -631,7 +698,9 @@ enum
     ID_INFO,
     ID_SHOWRAW,
     ID_GRAPHICS,
-    ID_SHOWTHUMBNAIL
+    ID_SHOWTHUMBNAIL,
+    ID_COPY_IMAGE,
+    ID_PASTE_IMAGE
 };
 
 wxIMPLEMENT_DYNAMIC_CLASS( MyFrame, wxFrame );
@@ -651,6 +720,8 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
 #if wxUSE_CLIPBOARD
     EVT_MENU(wxID_COPY, MyFrame::OnCopy)
     EVT_MENU(wxID_PASTE, MyFrame::OnPaste)
+    EVT_MENU(ID_COPY_IMAGE, MyFrame::OnCopyImage)
+    EVT_MENU(ID_PASTE_IMAGE, MyFrame::OnPasteImage)
 #endif // wxUSE_CLIPBOARD
     EVT_UPDATE_UI(ID_NEW_HIDPI, MyFrame::OnUpdateNewFrameHiDPI)
 wxEND_EVENT_TABLE()
@@ -686,8 +757,11 @@ MyFrame::MyFrame()
 
 #if wxUSE_CLIPBOARD
     wxMenu *menuClipboard = new wxMenu;
-    menuClipboard->Append(wxID_COPY, "&Copy test image\tCtrl-C");
-    menuClipboard->Append(wxID_PASTE, "&Paste image\tCtrl-V");
+    menuClipboard->Append(wxID_COPY, "&Copy test image as wxBitmap\tCtrl-C");
+    menuClipboard->Append(wxID_PASTE, "&Paste image as wxBitmap\tCtrl-V");
+    menuClipboard->AppendSeparator();
+    menuClipboard->Append(ID_COPY_IMAGE, "Copy image as wxImage");
+    menuClipboard->Append(ID_PASTE_IMAGE, "Paste image as wxImage");
     menu_bar->Append(menuClipboard, "&Clipboard");
 #endif // wxUSE_CLIPBOARD
 
@@ -943,6 +1017,38 @@ void MyFrame::OnPaste(wxCommandEvent& WXUNUSED(event))
         new MyImageFrame(this, "Clipboard", dobjBmp.GetBitmap());
     }
     wxTheClipboard->Close();
+}
+
+void MyFrame::OnCopyImage(wxCommandEvent& WXUNUSED(evt))
+{
+    wxImage img;
+    wxString filename = LoadUserImage(img);
+    if ( filename.empty() )
+        return;
+
+    wxImageDataObject* dobjImage = new wxImageDataObject;
+    dobjImage->SetImage(img);
+
+    wxClipboardLocker clipOpener;
+    if ( !wxTheClipboard->SetData(dobjImage) )
+    {
+        wxLogError("Failed to copy wxImage to clipboard");
+    }
+}
+
+void MyFrame::OnPasteImage(wxCommandEvent& WXUNUSED(evt))
+{
+    wxImageDataObject dobjImage;
+
+    wxClipboardLocker clipOpener;
+    if ( !wxTheClipboard->GetData(dobjImage) )
+    {
+        wxLogMessage("No wxImage data in the clipboard");
+    }
+    else
+    {
+        new MyImageFrame(this, "Clipboard (wxImage)", dobjImage.GetImage());
+    }
 }
 
 #endif // wxUSE_CLIPBOARD

--- a/src/common/dobjcmn.cpp
+++ b/src/common/dobjcmn.cpp
@@ -20,6 +20,7 @@
     #include "wx/app.h"
 #endif
 
+#include "wx/mstream.h"
 #include "wx/textbuf.h"
 
 // ----------------------------------------------------------------------------
@@ -618,6 +619,59 @@ bool wxCustomDataObject::SetData(size_t size, const void *buf)
     memcpy( m_data, buf, m_size );
 
     return true;
+}
+
+// ----------------------------------------------------------------------------
+// wxImageDataObject
+// ----------------------------------------------------------------------------
+
+#if defined(__WXMSW__)
+#define wxIMAGE_FORMAT_DATA wxDF_PNG
+#define wxIMAGE_FORMAT_BITMAP_TYPE wxBITMAP_TYPE_PNG
+#define wxIMAGE_FORMAT_NAME "PNG"
+#elif defined(__WXGTK__)
+#define wxIMAGE_FORMAT_DATA wxDF_BITMAP
+#define wxIMAGE_FORMAT_BITMAP_TYPE wxBITMAP_TYPE_PNG
+#define wxIMAGE_FORMAT_NAME "PNG"
+#elif defined(__WXOSX__)
+#define wxIMAGE_FORMAT_DATA wxDF_BITMAP
+#define wxIMAGE_FORMAT_BITMAP_TYPE wxBITMAP_TYPE_TIFF
+#define wxIMAGE_FORMAT_NAME "TIFF"
+#else
+#define wxIMAGE_FORMAT_DATA wxDF_BITMAP
+#define wxIMAGE_FORMAT_BITMAP_TYPE wxBITMAP_TYPE_PNG
+#define wxIMAGE_FORMAT_NAME "PNG"
+#endif
+
+wxImageDataObject::wxImageDataObject(const wxImage& image)
+    : wxCustomDataObject(wxIMAGE_FORMAT_DATA)
+{
+    if ( image.IsOk() )
+    {
+        SetImage(image);
+    }
+}
+
+void wxImageDataObject::SetImage(const wxImage& image)
+{
+    wxCHECK_RET(wxImage::FindHandler(wxIMAGE_FORMAT_BITMAP_TYPE) != NULL,
+        wxIMAGE_FORMAT_NAME " image handler must be installed to use clipboard with image");
+
+    wxMemoryOutputStream mem;
+    image.SaveFile(mem, wxIMAGE_FORMAT_BITMAP_TYPE);
+
+    SetData(mem.GetLength(), mem.GetOutputStreamBuffer()->GetBufferStart());
+}
+
+wxImage wxImageDataObject::GetImage() const
+{
+    wxCHECK_MSG(wxImage::FindHandler(wxIMAGE_FORMAT_BITMAP_TYPE) != NULL, wxNullImage,
+        wxIMAGE_FORMAT_NAME " image handler must be installed to use clipboard with image");
+
+    wxMemoryInputStream mem(GetData(), GetSize());
+    wxImage image;
+    image.LoadFile(mem, wxIMAGE_FORMAT_BITMAP_TYPE);
+    return image;
 }
 
 // ============================================================================


### PR DESCRIPTION
 We need a way to store images with metadata (especially image resolution) to clipboard - see [17631](https://trac.wxwidgets.org/ticket/17631). wxImage contains this extra information (unlike to wxBitmap) so we could use it for this purposes by implementing a new data object for wxImage data.
For wxGTK and wxOSX we can use their native PNG/TIFF clipboard data formats to store the image and its metadata but for wxMSW we need to implement a custom PNG data handler. It's non-standard but it is supported by several applications like MS Excel, MS PowerPoint or GIMP.