### PR TITLE
Fix window background tinting on macOS 11

### DIFF
--- a/src/generic/splitter.cpp
+++ b/src/generic/splitter.cpp
@@ -31,6 +31,10 @@
     #include "wx/settings.h"
 #endif
 
+#ifdef __WXOSX__
+    #include "wx/osx/private/available.h"
+#endif
+
 #include "wx/renderer.h"
 
 #include <stdlib.h>
@@ -175,11 +179,23 @@ void wxSplitterWindow::OnPaint(wxPaintEvent& WXUNUSED(event))
 {
     wxPaintDC dc(this);
 #ifdef __WXOSX__
-    // as subpanels might have a transparent background we must erase the background
-    // at least on OSX, otherwise traces of the sash will remain
-    // test with: splitter sample->replace right window
-    dc.Clear();
-#endif
+  #if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_16
+    if ( WX_IS_MACOS_AVAILABLE(10, 16) )
+    {
+        // Nothing to do: since macOS 10.14, views are layer-backed or using a shared
+        // layer and explicitly clearing the background isn't needed. This only
+        // started mattering here with macOS 11 (aka 10.16 when built with older SDK),
+        // where we must avoid explicitly painting window backgrounds
+    }
+    else
+  #endif
+    {
+        // as subpanels might have a transparent background we must erase the background
+        // at least on OSX, otherwise traces of the sash will remain
+        // test with: splitter sample->replace right window
+        dc.Clear();
+    }
+#endif // __WXOSX__
 
     DrawSash(dc);
 }

--- a/src/osx/carbon/frame.cpp
+++ b/src/osx/carbon/frame.cpp
@@ -129,7 +129,6 @@ void wxFrame::PositionStatusBar()
 // Responds to colour changes, and passes event on to children.
 void wxFrame::OnSysColourChanged(wxSysColourChangedEvent& event)
 {
-    SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE));
     Refresh();
 
 #if wxUSE_STATUSBAR

--- a/src/osx/nonownedwnd_osx.cpp
+++ b/src/osx/nonownedwnd_osx.cpp
@@ -152,8 +152,6 @@ bool wxNonOwnedWindow::Create(wxWindow *parent,
     wxWindowCreateEvent event(this);
     HandleWindowEvent(event);
 
-    SetBackgroundColour(wxSystemSettings::GetColour( wxSYS_COLOUR_APPWORKSPACE ));
-
     if ( parent )
         parent->AddChild(this);
 


### PR DESCRIPTION
This is the last item on my list of core fixes for macOS 11; I was sitting on it for a while because I wasn't sure what I was doing (hence the request for reviews, particularly with a view towards inadvertent breakages). With a fresh look, I think I reduced the changes to the minimum needed, and the changes make sense to me (incl. the splitter one, where I verified the behavior as the comment says I should, and confirmed the old code is necessary on older OS X versions).

macOS 11 has an option (on by default) to tint window backgrounds with wallpaper colors. This means that standard window background color is not a constant anymore and can change as the window is moved across the screen. The key to supporting this is to _not set background color_ internally to what we think is the correct default color, or to repaint backgrounds. Let the OS handle the default behavior instead.

A similar situation happened with macOS 10.14's dark mode, but then it was sufficient (see 398e8744bdb48b78c3d9f690c861306c69b22313) to set the background color to the expected `NSWindow` instance, which handled the dynamic behavior. That doesn't appear to be the case now. 

To illustrate the issue, see this annotated screenshot:

![fixed](https://user-images.githubusercontent.com/145881/103412058-a36bb800-4b73-11eb-801a-8fbe3c9a4125.png)

The difference may be difficult to see (the bottom backgrounds, which are identical, don't _appear_ to be due to human eyes playing tricks; use a pixel sniping tool to confirm). It's easier to see in motion, and it is noticeable in use that something is subtly off about wx windows on Big Sur without this patch. 