### PR TITLE
Macos native statusbar

### DIFF
--- a/include/wx/generic/statusbr.h
+++ b/include/wx/generic/statusbr.h
@@ -70,7 +70,7 @@ protected:
     void OnSysColourChanged(wxSysColourChangedEvent& event);
 
 protected:
-
+    virtual int GetEffectiveFieldStyle(int i) const { return m_panes[i].GetStyle(); }
     virtual void DrawFieldText(wxDC& dc, const wxRect& rc, int i, int textHeight);
     virtual void DrawField(wxDC& dc, int i, int textHeight);
 

--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -329,6 +329,8 @@ public :
 
     virtual void SetRepresentedFilename(const wxString& filename) wxOVERRIDE;
 
+    virtual void SetBottomBorderThickness(int thickness) wxOVERRIDE;
+
     wxNonOwnedWindow*   GetWXPeer() { return m_wxPeer; }
 
     CGWindowLevel   GetWindowLevel() const wxOVERRIDE { return m_macWindowLevel; }

--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -984,6 +984,8 @@ public :
 
     virtual void SetRepresentedFilename(const wxString& WXUNUSED(filename)) { }
 
+    virtual void SetBottomBorderThickness(int WXUNUSED(thickness)) { }
+
 #if wxOSX_USE_IPHONE
     virtual CGFloat GetWindowLevel() const { return 0.0; }
 #else

--- a/include/wx/osx/frame.h
+++ b/include/wx/osx/frame.h
@@ -71,6 +71,8 @@ public:
                                            long style = wxSTB_DEFAULT_STYLE,
                                            wxWindowID id = 0,
                                            const wxString& name = wxASCII_STR(wxStatusLineNameStr)) wxOVERRIDE;
+
+    virtual void SetStatusBar(wxStatusBar *statbar) wxOVERRIDE;
 #endif // wxUSE_STATUSBAR
 
     void PositionBars();

--- a/include/wx/osx/statusbr.h
+++ b/include/wx/osx/statusbr.h
@@ -38,9 +38,7 @@ protected:
     virtual void InitColours() wxOVERRIDE;
 
 private:
-    wxColour m_textActive, m_textInactive,
-             m_bgActiveFrom, m_bgActiveTo,
-             m_borderActive, m_borderInactive;
+    wxColour m_textActive, m_textInactive;
 
     wxDECLARE_DYNAMIC_CLASS(wxStatusBarMac);
     wxDECLARE_EVENT_TABLE();

--- a/include/wx/osx/statusbr.h
+++ b/include/wx/osx/statusbr.h
@@ -31,9 +31,7 @@ public:
     void OnPaint(wxPaintEvent& event);
 
 protected:
-    virtual void DrawFieldText(wxDC& dc, const wxRect& rc, int i, int textHeight) wxOVERRIDE;
-    virtual void DrawField(wxDC& dc, int i, int textHeight) wxOVERRIDE;
-    virtual void DoUpdateStatusText(int number = 0) wxOVERRIDE;
+    virtual int GetEffectiveFieldStyle(int WXUNUSED(i)) const wxOVERRIDE { return wxSB_NORMAL; }
 
     virtual void InitColours() wxOVERRIDE;
 

--- a/src/generic/splitter.cpp
+++ b/src/generic/splitter.cpp
@@ -31,6 +31,10 @@
     #include "wx/settings.h"
 #endif
 
+#ifdef __WXOSX__
+    #include "wx/osx/private/available.h"
+#endif
+
 #include "wx/renderer.h"
 
 #include <stdlib.h>
@@ -175,11 +179,23 @@ void wxSplitterWindow::OnPaint(wxPaintEvent& WXUNUSED(event))
 {
     wxPaintDC dc(this);
 #ifdef __WXOSX__
-    // as subpanels might have a transparent background we must erase the background
-    // at least on OSX, otherwise traces of the sash will remain
-    // test with: splitter sample->replace right window
-    dc.Clear();
-#endif
+  #if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_16
+    if ( WX_IS_MACOS_AVAILABLE(10, 16) )
+    {
+        // Nothing to do: since macOS 10.14, views are layer-backed or using a shared
+        // layer and explicitly clearing the background isn't needed. This only
+        // started mattering here with macOS 11 (aka 10.16 when built with older SDK),
+        // where we must avoid explicitly painting window backgrounds
+    }
+    else
+  #endif
+    {
+        // as subpanels might have a transparent background we must erase the background
+        // at least on OSX, otherwise traces of the sash will remain
+        // test with: splitter sample->replace right window
+        dc.Clear();
+    }
+#endif // __WXOSX__
 
     DrawSash(dc);
 }

--- a/src/generic/statusbr.cpp
+++ b/src/generic/statusbr.cpp
@@ -265,9 +265,11 @@ void wxStatusBarGeneric::DrawFieldText(wxDC& dc, const wxRect& rect, int i, int 
         SetEllipsizedFlag(i, text != GetStatusText(i));
     }
 
-#if defined( __WXGTK__ ) || defined(__WXMAC__)
+#if defined( __WXGTK__ )
     xpos++;
     ypos++;
+#elif defined(__WXMAC__)
+    xpos++;
 #endif
 
     // draw the text
@@ -285,7 +287,7 @@ void wxStatusBarGeneric::DrawField(wxDC& dc, int i, int textHeight)
     if (rect.GetWidth() <= 0)
         return;     // happens when the status bar is shrunk in a very small area!
 
-    int style = m_panes[i].GetStyle();
+    int style = GetEffectiveFieldStyle(i);
     if (style == wxSB_RAISED || style == wxSB_SUNKEN)
     {
         // Draw border

--- a/src/osx/carbon/frame.cpp
+++ b/src/osx/carbon/frame.cpp
@@ -129,7 +129,6 @@ void wxFrame::PositionStatusBar()
 // Responds to colour changes, and passes event on to children.
 void wxFrame::OnSysColourChanged(wxSysColourChangedEvent& event)
 {
-    SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE));
     Refresh();
 
 #if wxUSE_STATUSBAR

--- a/src/osx/carbon/frame.cpp
+++ b/src/osx/carbon/frame.cpp
@@ -24,13 +24,27 @@
 #endif // WX_PRECOMP
 
 #include "wx/osx/private.h"
+#include "wx/osx/private/available.h"
+
+namespace
+{
+
+int GetMacStatusbarHeight()
+{
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_16
+    if ( WX_IS_MACOS_AVAILABLE(10, 16) )
+        return 28;
+    else
+#endif
+        return 24;
+}
+
+} // anonymous namespace
 
 wxBEGIN_EVENT_TABLE(wxFrame, wxFrameBase)
   EVT_ACTIVATE(wxFrame::OnActivate)
   EVT_SYS_COLOUR_CHANGED(wxFrame::OnSysColourChanged)
 wxEND_EVENT_TABLE()
-
-#define WX_MAC_STATUSBAR_HEIGHT 24
 
 // ----------------------------------------------------------------------------
 // creation/destruction
@@ -106,7 +120,7 @@ wxStatusBar *wxFrame::OnCreateStatusBar(int number, long style, wxWindowID id,
     wxStatusBar *statusBar;
 
     statusBar = new wxStatusBar(this, id, style, name);
-    statusBar->SetSize(100, WX_MAC_STATUSBAR_HEIGHT);
+    statusBar->SetSize(100, GetMacStatusbarHeight());
     statusBar->SetFieldsCount(number);
 
     return statusBar;
@@ -115,7 +129,7 @@ wxStatusBar *wxFrame::OnCreateStatusBar(int number, long style, wxWindowID id,
 void wxFrame::SetStatusBar(wxStatusBar *statbar)
 {
     wxFrameBase::SetStatusBar(statbar);
-    m_nowpeer->SetBottomBorderThickness(statbar ? WX_MAC_STATUSBAR_HEIGHT : 0);
+    m_nowpeer->SetBottomBorderThickness(statbar ? GetMacStatusbarHeight() : 0);
 }
 
 void wxFrame::PositionStatusBar()
@@ -127,7 +141,7 @@ void wxFrame::PositionStatusBar()
 
         // Since we wish the status bar to be directly under the client area,
         // we use the adjusted sizes without using wxSIZE_NO_ADJUSTMENTS.
-        m_frameStatusBar->SetSize(0, h, w, WX_MAC_STATUSBAR_HEIGHT);
+        m_frameStatusBar->SetSize(0, h, w, GetMacStatusbarHeight());
     }
 }
 #endif // wxUSE_STATUSBAR
@@ -223,7 +237,7 @@ void wxFrame::DoGetClientSize(int *x, int *y) const
 
 #if wxUSE_STATUSBAR
     if ( GetStatusBar() && GetStatusBar()->IsShown() && y )
-        *y -= WX_MAC_STATUSBAR_HEIGHT;
+        *y -= GetMacStatusbarHeight();
 #endif
 
 #if wxUSE_TOOLBAR

--- a/src/osx/carbon/frame.cpp
+++ b/src/osx/carbon/frame.cpp
@@ -112,6 +112,12 @@ wxStatusBar *wxFrame::OnCreateStatusBar(int number, long style, wxWindowID id,
     return statusBar;
 }
 
+void wxFrame::SetStatusBar(wxStatusBar *statbar)
+{
+    wxFrameBase::SetStatusBar(statbar);
+    m_nowpeer->SetBottomBorderThickness(statbar ? WX_MAC_STATUSBAR_HEIGHT : 0);
+}
+
 void wxFrame::PositionStatusBar()
 {
     if (m_frameStatusBar && m_frameStatusBar->IsShown() )

--- a/src/osx/carbon/statbrma.cpp
+++ b/src/osx/carbon/statbrma.cpp
@@ -97,51 +97,6 @@ void wxStatusBarMac::InitColours()
     }
 }
 
-void wxStatusBarMac::DrawFieldText(wxDC& dc, const wxRect& rect, int i, int textHeight)
-{
-    int w, h;
-    GetSize( &w , &h );
-
-    wxString text(GetStatusText( i ));
-
-    int xpos = rect.x + wxFIELD_TEXT_MARGIN + 1;
-    int ypos = 2 + (rect.height - textHeight) / 2;
-
-    if ( MacGetTopLevelWindow()->GetExtraStyle() & wxFRAME_EX_METAL )
-        ypos++;
-
-    dc.SetClippingRegion(rect.x, 0, rect.width, h);
-    dc.DrawText(text, xpos, ypos);
-    dc.DestroyClippingRegion();
-}
-
-void wxStatusBarMac::DrawField(wxDC& dc, int i, int textHeight)
-{
-    wxRect rect;
-    GetFieldRect(i, rect);
-
-    DrawFieldText(dc, rect, i, textHeight);
-}
-
-void wxStatusBarMac::DoUpdateStatusText(int number)
-{
-    wxRect rect;
-    GetFieldRect(number, rect);
-
-    int w, h;
-    GetSize( &w, &h );
-
-    rect.y = 0;
-    rect.height = h ;
-
-    Refresh( true, &rect );
-    // we should have to force the update here
-    // TODO Remove if no regressions occur
-#if 0
-    Update();
-#endif
-}
-
 void wxStatusBarMac::OnPaint(wxPaintEvent& WXUNUSED(event))
 {
     wxPaintDC dc(this);

--- a/src/osx/carbon/statbrma.cpp
+++ b/src/osx/carbon/statbrma.cpp
@@ -78,42 +78,22 @@ void wxStatusBarMac::InitColours()
 {
     if ( WX_IS_MACOS_AVAILABLE(10, 14) )
     {
-        // FIXME: None of this is correct and is only very loose
-        //        approximation. 10.14's dark mode uses dynamic colors that
-        //        use desktop tinting. The only correct way to render the
-        //        statusbar is to use windowBackgroundColor in a NSBox.
-        wxColour bg = wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE);
-        m_textActive = wxSystemSettings::GetColour(wxSYS_COLOUR_BTNTEXT);
-        m_textInactive = wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT);
-
         if ( wxSystemSettings::GetAppearance().IsDark() )
         {
-            // dark mode appearance
-            m_textActive = wxColour(0xB0, 0xB0, 0xB0);
-            m_bgActiveFrom = wxColour(0x32, 0x32, 0x34);
-            m_bgActiveTo = wxColour(0x29, 0x29, 0x2A);
-            m_borderActive = wxColour(0x00, 0x00, 0x00);
-            m_borderInactive = wxColour(0x00, 0x00, 0x00);
+            m_textActive = wxColour(0xA9, 0xA9, 0xA9);
+            m_textInactive = wxColour(0x67, 0x67, 0x67);
         }
         else
         {
-            m_bgActiveFrom = wxColour(0xE9, 0xE7, 0xEA);
-            m_bgActiveTo = wxColour(0xCD, 0xCB, 0xCE);
-            m_borderActive = wxColour(0xBA, 0xB8, 0xBB);
-            m_borderInactive = wxColour(0xC3, 0xC3, 0xC3);
+            m_textActive = wxColour(0x4B, 0x4B, 0x4B);
+            m_textInactive = wxColour(0xB1, 0xB1, 0xB1);
         }
-        SetBackgroundColour(bg); // inactive bg
     }
-    else
+    else // 10.10 Yosemite to 10.13:
     {
-        // 10.10 Yosemite to 10.13 :
+
         m_textActive = wxColour(0x40, 0x40, 0x40);
         m_textInactive = wxColour(0x4B, 0x4B, 0x4B);
-        m_bgActiveFrom = wxColour(0xE9, 0xE7, 0xEA);
-        m_bgActiveTo = wxColour(0xCD, 0xCB, 0xCE);
-        m_borderActive = wxColour(0xBA, 0xB8, 0xBB);
-        m_borderInactive = wxColour(0xC3, 0xC3, 0xC3);
-        SetBackgroundColour(wxColour(0xF4, 0xF4, 0xF4)); // inactive bg
     }
 }
 
@@ -165,10 +145,6 @@ void wxStatusBarMac::DoUpdateStatusText(int number)
 void wxStatusBarMac::OnPaint(wxPaintEvent& WXUNUSED(event))
 {
     wxPaintDC dc(this);
-    dc.Clear();
-
-    int w, h;
-    GetSize( &w, &h );
 
     // Notice that wxOSXGetKeyWindow (aka [NSApp keyWindow] used below is
     // subtly different from IsActive() (aka [NSWindow iskeyWindow]): the
@@ -188,22 +164,9 @@ void wxStatusBarMac::OnPaint(wxPaintEvent& WXUNUSED(event))
             break;
     }
 
-    if ( tlw == keyWindow )
-    {
-        dc.GradientFillLinear(dc.GetSize(), m_bgActiveFrom, m_bgActiveTo, wxBOTTOM);
+    // Don't paint any background, that's handled by the OS. Only draw text:
 
-        // Finder statusbar border color
-        dc.SetPen(wxPen(m_borderActive, 2, wxPENSTYLE_SOLID));
-        dc.SetTextForeground(m_textActive);
-    }
-    else
-    {
-        // Finder statusbar border color
-        dc.SetPen(wxPen(m_borderInactive, 2, wxPENSTYLE_SOLID));
-        dc.SetTextForeground(m_textInactive);
-    }
-
-    dc.DrawLine(0, 0, w, 0);
+    dc.SetTextForeground(tlw == keyWindow ? m_textActive : m_textInactive);
 
     if ( GetFont().IsOk() )
         dc.SetFont(GetFont());

--- a/src/osx/cocoa/nonownedwnd.mm
+++ b/src/osx/cocoa/nonownedwnd.mm
@@ -1288,6 +1288,12 @@ void wxNonOwnedWindowCocoaImpl::SetRepresentedFilename(const wxString& filename)
     [m_macWindow setRepresentedFilename:wxCFStringRef(filename).AsNSString()];
 }
 
+void wxNonOwnedWindowCocoaImpl::SetBottomBorderThickness(int thickness)
+{
+    [m_macWindow setAutorecalculatesContentBorderThickness:(thickness ? NO : YES) forEdge:NSMinYEdge];
+    [m_macWindow setContentBorderThickness:thickness forEdge:NSMinYEdge];
+}
+
 void wxNonOwnedWindowCocoaImpl::RestoreWindowLevel()
 {
     if ( [m_macWindow level] != m_macWindowLevel )

--- a/src/osx/nonownedwnd_osx.cpp
+++ b/src/osx/nonownedwnd_osx.cpp
@@ -152,8 +152,6 @@ bool wxNonOwnedWindow::Create(wxWindow *parent,
     wxWindowCreateEvent event(this);
     HandleWindowEvent(event);
 
-    SetBackgroundColour(wxSystemSettings::GetColour( wxSYS_COLOUR_APPWORKSPACE ));
-
     if ( parent )
         parent->AddChild(this);
 


### PR DESCRIPTION
This PR removes generic code to mimic native macOS status bars, which we had to update in the past for new OS X versions (typically with a significant delay). Instead, it does what is apparently the "official" way of having status bar: set large bottom content border thickness, which makes the OS render the desired background, and draw status items on it.

Thus, we remove some code *and* get perfect match to the native look (with a Big Sur-sized caveat below). 

This PR depends on PR #2158, so has an extra commit in it (5ebd76c). The subject matter commits are only these:
- e687d0c - Render statusbar natively on macOS 
- d28771c - Tweak wxStatusBar size for macOS 11

Notice that this is only possible thanks to #2158. Without it, the background would be rendered as solid-color because wx would unconditionally set the background color on `wxFrame`.

Also notice that the Big Sur commit adjusts statusbar size to match Finder (as was done previously too; bottom border default in Interface Builder is only 22pt, not 24), but doesn't change rendering method. It uses the same native bottom border rendering, which Apple did not, as of macOS 11.1, update for the new visuals. Finder in macOS 11 does *not* use bottom border anymore, but renders the status bar same as path bar, in only the content side of the window. This means there's pretty much no presence of native statusbar in macOS now. It *also* means that it is entirely possible Apple won't fix bottom border rendering (because they discourage statusbars altogether) and consequently that there's an argument for rejecting this PR.