### PR TITLE
Fix wxRibbon Tooltip draw behaviour

### DIFF
--- a/src/ribbon/buttonbar.cpp
+++ b/src/ribbon/buttonbar.cpp
@@ -1298,7 +1298,8 @@ void wxRibbonButtonBar::OnMouseMove(wxMouseEvent& evt)
     }
     if(tooltipButton)
     {
-        SetToolTip(tooltipButton->base->help_string);
+        if (tooltipButton != m_hovered_button && !(tooltipButton->size & wxRIBBON_BUTTONBAR_BUTTON_DROPDOWN_ACTIVE))        
+            SetToolTip(tooltipButton->base->help_string);
     }
 #else
     wxUnusedVar(tooltipButton);
@@ -1374,7 +1375,10 @@ void wxRibbonButtonBar::OnMouseDown(wxMouseEvent& evt)
                 if(size.normal_region.Contains(cursor))
                     state = wxRIBBON_BUTTONBAR_BUTTON_NORMAL_ACTIVE;
                 else if(size.dropdown_region.Contains(cursor))
+                {
                     state = wxRIBBON_BUTTONBAR_BUTTON_DROPDOWN_ACTIVE;
+                    UnsetToolTip();
+                }
                 instance.base->state |= state;
                 Refresh(false);
                 break;

--- a/src/ribbon/toolbar.cpp
+++ b/src/ribbon/toolbar.cpp
@@ -1078,7 +1078,8 @@ void wxRibbonToolBar::OnMouseMove(wxMouseEvent& evt)
 #if wxUSE_TOOLTIPS
     if(new_hover)
     {
-        SetToolTip(new_hover->help_string);
+        if (new_hover != m_hover_tool && !(new_hover->state & wxRIBBON_TOOLBAR_TOOL_DROPDOWN_ACTIVE))
+            SetToolTip(new_hover->help_string);
     }
     else if(GetToolTip())
     {
@@ -1088,10 +1089,10 @@ void wxRibbonToolBar::OnMouseMove(wxMouseEvent& evt)
 
     if(new_hover && new_hover->state & wxRIBBON_TOOLBAR_TOOL_DISABLED)
     {
+        m_hover_tool = new_hover;
         new_hover = NULL; // A disabled tool can not be hilighted
     }
-
-    if(new_hover != m_hover_tool)
+    else if(new_hover != m_hover_tool)
     {
         if(m_hover_tool)
         {
@@ -1143,6 +1144,7 @@ void wxRibbonToolBar::OnMouseDown(wxMouseEvent& evt)
         m_active_tool = m_hover_tool;
         m_active_tool->state |=
             (m_active_tool->state & wxRIBBON_TOOLBAR_TOOL_HOVER_MASK) << 2;
+        UnsetToolTip();
         Refresh(false);
     }
 }


### PR DESCRIPTION
This commit changes both when and how often tooltips for wxRibbonToolBar and wxRibbonButtonBar are drawn.

Two main issues were fixed:
1. Previously, the tooltip would get re-drawn each time the mouse was moved. This was problematic both as it was non-standard behaviour (compared to other widgets, where the tooltip is only draw the first time the user hovers over the item, and stays drawn in that same location until they move away), and it was causing flickering.
2.  Previously, the tooltip would get drawn over a menu when a dropdown was present. This is undesirable as it covers the view of the menu, and is also non-standard.

Both changes were trivial, and simply involved either checking pointers or unsetting the tooltip.

Some minor re-structering was done in order for the changes to be compatible with the previous code.