### PR TITLE
Fix wxRibbonToolBar Coord functions

### DIFF
--- a/interface/wx/ribbon/toolbar.h
+++ b/interface/wx/ribbon/toolbar.h
@@ -308,7 +308,8 @@ public:
     wxRibbonToolBarToolBase* GetToolByPos(size_t pos)const;
 
     /**
-        Return the opaque pointer for the tool at the given coordinates.
+        Returns the opaque pointer for the tool at the given coordinates,
+        which are relative to the toolbar's parent.
 
         @return an opaque pointer, NULL if is not found.
 
@@ -391,8 +392,8 @@ public:
     virtual int GetToolPos(int tool_id)const;
 
     /**
-        Returns the rect in the toolbar, or a default-constructed rect if the tool
-        is not found.
+        Returns the tool's rect with coordinates relative to the toolbar's parent,
+        or a default-constructed rect if the tool is not found.
 
         @param tool_id
             ID of the tool in question, as passed to AddTool().

--- a/src/ribbon/toolbar.cpp
+++ b/src/ribbon/toolbar.cpp
@@ -439,7 +439,7 @@ wxRibbonToolBarToolBase* wxRibbonToolBar::GetToolByPos(wxCoord x, wxCoord y)cons
         for ( size_t t = 0; t < tool_count; ++t )
         {
             wxRibbonToolBarToolBase* tool = group->tools.Item(t);
-            wxRect rect(tool->position, tool->size);
+            wxRect rect(tool->position + group->position, tool->size);
             if(rect.Contains(x, y))
             {
                 return tool;
@@ -535,7 +535,7 @@ wxRect wxRibbonToolBar::GetToolRect(int tool_id)const
             wxRibbonToolBarToolBase* tool = group->tools.Item(t);
             if (tool->id == tool_id)
             {
-                wxRect rect(tool->position.x, tool->position.y, tool->size.GetWidth(), tool->size.GetHeight());
+                wxRect rect(tool->position + group->position, tool->size);
                 return rect;
             }
             ++pos;


### PR DESCRIPTION
Previously, wxRibbonToolBar::GetToolByPos and wxRibbonToolBar::GetToolRect worked with co-ordinates relative to the group that the tool is in. This is fine if there is only a single group, however the obvious desired behaviour when using these functions is for the tool's coords to be relative to the parent of the toolbar e.g. their position in a wxRibbonPanel.

This PR changes these coord functions to work with coords that have taken into account the group that the tool is in (i.e. offsets values by the x and y of the tool's group). It also adds clarification on this to the documentation.