### PR TITLE
Correcting @since comment on notifymsg.h

### DIFF
--- a/interface/wx/notifmsg.h
+++ b/interface/wx/notifmsg.h
@@ -50,7 +50,7 @@
            selects on of the actions added by AddAction()
     @endEventTable
 
-    @since 2.9.0
+    @since 3.1.0
     @library{wxcore}
     @category{misc}
 */


### PR DESCRIPTION
The wxNotificationMessage events have been introduced in 3.1.0 and not in 2.9.0 as wrongly annotated