### PR TITLE
Make wxChoice::GetString() consistently assert in all ports when given invalid index

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -107,6 +107,8 @@ Changes in behaviour not resulting in compilation errors
 
 - wxGetInstallPrefix() now returns wxString.
 
+- wxChoice::GetString() now consistently asserts when passed an invalid index.
+
 
 Changes in behaviour which may result in build errors
 -----------------------------------------------------

--- a/interface/wx/ctrlsub.h
+++ b/interface/wx/ctrlsub.h
@@ -51,11 +51,14 @@ public:
     /**
         Returns the label of the item with the given index.
 
+        The index must be valid, i.e. less than the value returned by
+        GetCount(), otherwise an assert is triggered. Notably, this function
+        can't be called if the control is empty.
+
         @param n
             The zero-based index.
 
-        @return The label of the item or an empty string if the position was
-                invalid.
+        @return The label of the item.
     */
     virtual wxString GetString(unsigned int n) const = 0;
 

--- a/src/gtk/choice.cpp
+++ b/src/gtk/choice.cpp
@@ -278,21 +278,20 @@ wxString wxChoice::GetString(unsigned int n) const
 {
     wxCHECK_MSG( m_widget != NULL, wxEmptyString, wxT("invalid control") );
 
-    wxString str;
-
     GtkComboBox* combobox = GTK_COMBO_BOX( m_widget );
     GtkTreeModel *model = gtk_combo_box_get_model( combobox );
     GtkTreeIter iter;
-    if (gtk_tree_model_iter_nth_child (model, &iter, NULL, n))
+    if (!gtk_tree_model_iter_nth_child (model, &iter, NULL, n))
     {
-        GValue value = G_VALUE_INIT;
-        gtk_tree_model_get_value( model, &iter, m_stringCellIndex, &value );
-        wxString tmp = wxGTK_CONV_BACK( g_value_get_string( &value ) );
-        g_value_unset( &value );
-        return tmp;
+        wxFAIL_MSG( "invalid index" );
+        return wxString();
     }
 
-    return str;
+    GValue value = G_VALUE_INIT;
+    gtk_tree_model_get_value( model, &iter, m_stringCellIndex, &value );
+    wxString tmp = wxGTK_CONV_BACK( g_value_get_string( &value ) );
+    g_value_unset( &value );
+    return tmp;
 }
 
 unsigned int wxChoice::GetCount() const

--- a/src/msw/choice.cpp
+++ b/src/msw/choice.cpp
@@ -362,10 +362,13 @@ void wxChoice::SetString(unsigned int n, const wxString& s)
 
 wxString wxChoice::GetString(unsigned int n) const
 {
-    int len = (int)::SendMessage(GetHwnd(), CB_GETLBTEXTLEN, n, 0);
+    const int len = (int)::SendMessage(GetHwnd(), CB_GETLBTEXTLEN, n, 0);
 
     wxString str;
-    if ( len != CB_ERR && len > 0 )
+
+    wxCHECK_MSG( len != CB_ERR, str, wxS("Invalid index") );
+
+    if ( len > 0 )
     {
         if ( ::SendMessage
                (

--- a/tests/controls/itemcontainertest.cpp
+++ b/tests/controls/itemcontainertest.cpp
@@ -71,6 +71,7 @@ void ItemContainerTestCase::Count()
     wxItemContainer * const container = GetContainer();
 
     CPPUNIT_ASSERT(container->IsEmpty());
+    WX_ASSERT_FAILS_WITH_ASSERT( container->GetString(0) );
 
     wxArrayString testitems;
     testitems.Add("item 0");
@@ -95,6 +96,7 @@ void ItemContainerTestCase::Count()
     container->Insert(testitems, 1);
 
     CPPUNIT_ASSERT_EQUAL(5, container->GetCount());
+    WX_ASSERT_FAILS_WITH_ASSERT( container->GetString(10) );
 }
 
 void ItemContainerTestCase::ItemSelection()


### PR DESCRIPTION
See [#18852](https://trac.wxwidgets.org/ticket/18852).