### PR TITLE
Make wxMenu::MSWCommand virtual

### DIFF
--- a/include/wx/msw/menu.h
+++ b/include/wx/msw/menu.h
@@ -58,7 +58,7 @@ public:
     // implementation only from now on
     // -------------------------------
 
-    bool MSWCommand(WXUINT param, WXWORD id);
+    virtual bool MSWCommand(WXUINT param, WXWORD id);
 
     // get the native menu handle
     WXHMENU GetHMenu() const { return m_hMenu; }

--- a/interface/wx/menu.h
+++ b/interface/wx/menu.h
@@ -932,6 +932,28 @@ public:
     bool IsEnabled(int id) const;
 
     /**
+        Allows for handling Menu command messages sent by MSW.
+
+        This is a low-level function which allows handling MSW commands sent
+        to a wxMenu. It is partically useful for a Menu whose owner is not a
+        wxFrame, as specific handling can then be done in a wxMenu-derived
+        class directly, instead of in the wxWindow-derived owner class.
+
+        @param param
+            The MSW command parameter.
+
+        @param id
+            The id of the command.
+
+        @return
+            @true if the command was handled, @false otherwise.
+
+        @onlyfor{wxMSW}
+        @since 3.1.5
+    */
+    virtual bool MSWCommand(WXUINT param, WXWORD id);
+    
+    /**
         Inserts the given @a item at position 0, i.e.\ before all the other
         existing items.
 


### PR DESCRIPTION
This commit simply makes wxMenu::MSWCommand a virtual function.

In a specific instance, we found we needed to handle the MSWCommand for a wxMenu. (https://github.com/wxWidgets/wxWidgets/pull/2145#issuecomment-752134557). The easiest way for us to do this would be to override MSWCommand, however this was not an option - hence this PR.

I couldn't find anything else that needed to be changed besides simply adding the "virtual" keyword, but if there is let me know and I will make another commit.