### PR TITLE
Update webview_edge.h

### DIFF
--- a/include/wx/msw/private/webview_edge.h
+++ b/include/wx/msw/private/webview_edge.h
@@ -13,7 +13,7 @@
 #include "wx/dynlib.h"
 #include "wx/msw/private/comptr.h"
 
-#include <Webview2.h>
+#include <WebView2.h>
 
 #ifndef __ICoreWebView2Environment_INTERFACE_DEFINED__
     #error "WebView2 SDK version 0.9.430 or newer is required"


### PR DESCRIPTION
The filenames in the file-systems on Linux are usually case-sensitive, so we'd better not change the filename case randomly. When cross-compiling, the host platform could be Linux.