### PR TITLE
wxMSW: wxImage loading using Windows Imaging Component

### DIFF
--- a/build/bakefiles/files.bkl
+++ b/build/bakefiles/files.bkl
@@ -262,6 +262,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     wx/msw/ole/oleutils.h
     wx/msw/ole/comimpl.h
     wx/msw/ole/uuid.h
+    wx/msw/ole/stream.h
 </set>
 
 <set var="QT_PLATFORM_SRC" hints="files">
@@ -2081,6 +2082,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     src/msw/ole/uuid.cpp
     src/msw/evtloop.cpp
     src/msw/ole/access.cpp
+    src/msw/image_wic.cpp
 </set>
 <set var="MSW_LOWLEVEL_HDR" hints="files">
     wx/msw/nonownedwnd.h
@@ -2094,6 +2096,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     wx/msw/sound.h
     wx/msw/joystick.h
     wx/msw/evtloop.h
+    wx/msw/image_wic.h
 </set>
 
 <set var="MSW_SRC" hints="files">

--- a/build/cmake/files.cmake
+++ b/build/cmake/files.cmake
@@ -185,6 +185,7 @@ set(QT_WIN32_HDR
     wx/msw/sound.h
     wx/msw/ole/oleutils.h
     wx/msw/ole/comimpl.h
+    wx/msw/ole/stream.h
 )
 
 set(QT_HDR
@@ -1955,6 +1956,7 @@ set(MSW_LOWLEVEL_SRC
     src/msw/richtooltip.cpp
     src/msw/evtloop.cpp
     src/msw/ole/access.cpp
+    src/msw/image_wic.cpp
 )
 
 set(MSW_LOWLEVEL_HDR
@@ -1969,6 +1971,7 @@ set(MSW_LOWLEVEL_HDR
     wx/msw/helpwin.h
     wx/msw/taskbar.h
     wx/msw/evtloop.h
+    wx/msw/image_wic.h
 )
 
 set(MSW_DESKTOP_LOWLEVEL_SRC

--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -536,7 +536,7 @@ set(wxTHIRD_PARTY_LIBRARIES)
 function(wx_add_thirdparty_library var_name lib_name help_str)
     cmake_parse_arguments(THIRDPARTY "" "DEFAULT;DEFAULT_APPLE;DEFAULT_WIN32" "" ${ARGN})
 
-    if(THIRDPARTY_DEFAULT)
+    if(DEFINED THIRDPARTY_DEFAULT)
         set(thirdparty_lib_default ${THIRDPARTY_DEFAULT})
     elseif(THIRDPARTY_DEFAULT_APPLE AND APPLE)
         set(thirdparty_lib_default ${THIRDPARTY_DEFAULT_APPLE})

--- a/build/cmake/options.cmake
+++ b/build/cmake/options.cmake
@@ -90,12 +90,21 @@ wx_option(wxUSE_REPRODUCIBLE_BUILD "enable reproducable build" OFF)
 # external libraries
 # ---------------------------------------------------------------------------
 
+if(WIN32)
+    wx_option(wxUSE_WIC "use Windows Imaging Component")
+endif()
+
 wx_add_thirdparty_library(wxUSE_REGEX REGEX "enable support for wxRegEx class" DEFAULT builtin)
 wx_add_thirdparty_library(wxUSE_ZLIB ZLIB "use zlib for LZW compression" DEFAULT_APPLE sys)
 wx_add_thirdparty_library(wxUSE_EXPAT EXPAT "use expat for XML parsing" DEFAULT_APPLE sys)
-wx_add_thirdparty_library(wxUSE_LIBJPEG JPEG "use libjpeg (JPEG file format)")
-wx_add_thirdparty_library(wxUSE_LIBPNG PNG "use libpng (PNG image format)")
-wx_add_thirdparty_library(wxUSE_LIBTIFF TIFF "use libtiff (TIFF file format)")
+if(WIN32 AND wxUSE_WIC)
+    set(wxIMAGELIB_DEFAULT OFF)
+else()
+    set(wxIMAGELIB_DEFAULT builtin)
+endif()
+wx_add_thirdparty_library(wxUSE_LIBJPEG JPEG "use libjpeg (JPEG file format)" DEFAULT ${wxIMAGELIB_DEFAULT})
+wx_add_thirdparty_library(wxUSE_LIBPNG PNG "use libpng (PNG image format)" DEFAULT ${wxIMAGELIB_DEFAULT})
+wx_add_thirdparty_library(wxUSE_LIBTIFF TIFF "use libtiff (TIFF file format)" DEFAULT ${wxIMAGELIB_DEFAULT})
 
 wx_option(wxUSE_LIBLZMA "use LZMA compression" OFF)
 set(wxTHIRD_PARTY_LIBRARIES ${wxTHIRD_PARTY_LIBRARIES} wxUSE_LIBLZMA "use liblzma for LZMA compression")

--- a/build/cmake/setup.h.in
+++ b/build/cmake/setup.h.in
@@ -697,6 +697,8 @@
     #cmakedefine01 wxUSE_WEBREQUEST_WINHTTP
 #endif
 
+#define wxUSE_WIC	1
+
 
 #cmakedefine01 wxUSE_OLE
 

--- a/build/files
+++ b/build/files
@@ -205,6 +205,7 @@ QT_WIN32_HDR=
     wx/msw/ole/comimpl.h
     wx/msw/ole/oleutils.h
     wx/msw/ole/safearray.h
+    wx/msw/ole/stream.h
     wx/msw/ole/uuid.h
     wx/msw/dib.h
     wx/msw/joystick.h
@@ -1922,6 +1923,7 @@ MSW_LOWLEVEL_SRC =
     src/msw/helpchm.cpp
     src/msw/helpwin.cpp
     src/msw/icon.cpp
+	src/msw/image_wic.cpp
     src/msw/imaglist.cpp
     src/msw/joystick.cpp
     src/msw/minifram.cpp
@@ -1964,6 +1966,7 @@ MSW_LOWLEVEL_HDR =
     wx/msw/helpchm.h
     wx/msw/helpwin.h
     wx/msw/htmlhelp.h
+	wx/msw/image_wic.h
     wx/msw/joystick.h
     wx/msw/nonownedwnd.h
     wx/msw/ole/activex.h

--- a/build/msw/wx_core.vcxproj
+++ b/build/msw/wx_core.vcxproj
@@ -1067,6 +1067,7 @@
     <ClCompile Include="..\..\src\common\bmpcboxcmn.cpp" />
     <ClCompile Include="..\..\src\generic\rowheightcache.cpp" />
     <ClCompile Include="..\..\src\generic\creddlgg.cpp" />
+    <ClCompile Include="..\..\src\msw\image_wic.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\src\msw\version.rc">
@@ -1505,6 +1506,7 @@
     <ClInclude Include="..\..\include\wx\dcbuffer.h" />
     <ClInclude Include="..\..\include\wx\creddlg.h" />
     <ClInclude Include="..\..\include\wx\generic\creddlgg.h" />
+    <ClInclude Include="..\..\include\wx\msw\image_wic.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/build/msw/wx_core.vcxproj.filters
+++ b/build/msw/wx_core.vcxproj.filters
@@ -852,6 +852,9 @@
     <ClCompile Include="..\..\src\msw\icon.cpp">
       <Filter>MSW Sources</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\msw\image_wic.cpp">
+      <Filter>MSW Sources</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\msw\imaglist.cpp">
       <Filter>MSW Sources</Filter>
     </ClCompile>
@@ -1802,6 +1805,9 @@
       <Filter>MSW Headers</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\wx\msw\icon.h">
+      <Filter>MSW Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\wx\msw\image_wic.h">
       <Filter>MSW Headers</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\wx\msw\imaglist.h">

--- a/build/msw/wx_vc7_core.vcproj
+++ b/build/msw/wx_vc7_core.vcproj
@@ -1135,6 +1135,9 @@
 			<File
 				RelativePath="..\..\src\msw\window.cpp">
 			</File>
+			<File
+				RelativePath="..\..\src\msw\image_wic.cpp">
+			</File>
 		</Filter>
 		<Filter
 			Name="Generic Sources"
@@ -1807,6 +1810,9 @@
 			</File>
 			<File
 				RelativePath="..\..\include\wx\msw\window.h">
+			</File>
+			<File
+				RelativePath="..\..\include\wx\msw\image_wic.h">
 			</File>
 		</Filter>
 		<Filter

--- a/build/msw/wx_vc8_core.vcproj
+++ b/build/msw/wx_vc8_core.vcproj
@@ -1926,6 +1926,10 @@
 				RelativePath="..\..\src\msw\window.cpp"
 				>
 			</File>
+			<File
+				RelativePath="..\..\src\msw\image_wic.cpp"
+				>
+			</File>
 		</Filter>
 		<Filter
 			Name="Generic Sources"
@@ -2911,6 +2915,10 @@
 			</File>
 			<File
 				RelativePath="..\..\include\wx\msw\window.h"
+				>
+			</File>
+			<File
+				RelativePath="..\..\include\wx\msw\image_wic.h"
 				>
 			</File>
 		</Filter>

--- a/build/msw/wx_vc9_core.vcproj
+++ b/build/msw/wx_vc9_core.vcproj
@@ -1922,6 +1922,10 @@
 				RelativePath="..\..\src\msw\window.cpp"
 				>
 			</File>
+			<File
+				RelativePath="..\..\src\msw\image_wic.cpp"
+				>
+			</File>
 		</Filter>
 		<Filter
 			Name="Generic Sources"
@@ -2907,6 +2911,10 @@
 			</File>
 			<File
 				RelativePath="..\..\include\wx\msw\window.h"
+				>
+			</File>
+			<File
+				RelativePath="..\..\include\wx\msw\image_wic.h"
 				>
 			</File>
 		</Filter>

--- a/include/wx/chkconf.h
+++ b/include/wx/chkconf.h
@@ -1808,7 +1808,7 @@
 
 /* common dependencies */
 #if wxUSE_ARTPROVIDER_TANGO
-#   if !(wxUSE_STREAMS && wxUSE_IMAGE && wxUSE_LIBPNG)
+#   if !(wxUSE_STREAMS && wxUSE_IMAGE && (wxUSE_LIBPNG || (defined(wxUSE_WIC) && wxUSE_WIC) ))
 #       ifdef wxABORT_ON_CONFIG_ERROR
 #           error "Tango art provider requires wxImage with streams and PNG support"
 #       else
@@ -2269,7 +2269,7 @@
 #   endif
 #endif /* wxUSE_SVG */
 
-#if wxUSE_SVG && !wxUSE_LIBPNG
+#if wxUSE_SVG && !wxUSE_LIBPNG && (!defined(wxUSE_WIC) && !wxUSE_WIC)
 #   ifdef wxABORT_ON_CONFIG_ERROR
 #       error "wxUSE_SVG requires wxUSE_LIBPNG"
 #   else

--- a/include/wx/gtk/setup0.h
+++ b/include/wx/gtk/setup0.h
@@ -1656,6 +1656,13 @@
     #define wxUSE_WEBREQUEST_WINHTTP 0
 #endif
 
+// wxImage loading based on Windows Imaging Component
+//
+// Default is 1
+//
+// Recommended setting: 1
+#define wxUSE_WIC	1
+
 // ----------------------------------------------------------------------------
 // Windows-only settings
 // ----------------------------------------------------------------------------

--- a/include/wx/msw/chkconf.h
+++ b/include/wx/msw/chkconf.h
@@ -125,6 +125,14 @@
 #    endif
 #endif  /* wxUSE_UXTHEME */
 
+#ifndef wxUSE_WIC
+#    ifdef wxABORT_ON_CONFIG_ERROR
+#        error "wxUSE_WIC must be defined."
+#    else
+#        define wxUSE_WIC 0
+#    endif
+#endif  /* wxUSE_WIC */
+
 #ifndef wxUSE_WINSOCK2
 #    ifdef wxABORT_ON_CONFIG_ERROR
 #        error "wxUSE_WINSOCK2 must be defined."

--- a/include/wx/msw/image_wic.h
+++ b/include/wx/msw/image_wic.h
@@ -11,9 +11,6 @@
 #ifndef _WX_IMAGE_WIC_H_
 #define _WX_IMAGE_WIC_H_
 
-//TODO: Move to defs
-#define wxUSE_WIC 1 
-
 #include "wx/defs.h"
 
 #ifdef wxUSE_WIC

--- a/include/wx/msw/image_wic.h
+++ b/include/wx/msw/image_wic.h
@@ -1,0 +1,47 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        include/wx/msw/image_wic.h
+// Purpose:     Implementation of wxImageHandler using
+//              Windows Imaging Component
+// Author:      Tobias Taschner
+// Created:     2021-01-15
+// Copyright:   (c) 2021 wxWidgets development team
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_IMAGE_WIC_H_
+#define _WX_IMAGE_WIC_H_
+
+//TODO: Move to defs
+#define wxUSE_WIC 1 
+
+#include "wx/defs.h"
+
+#ifdef wxUSE_WIC
+
+#include "wx/image.h"
+
+class WXDLLIMPEXP_CORE wxImageHandlerWIC : public wxImageHandler
+{
+public:
+    wxImageHandlerWIC() { }
+    wxImageHandlerWIC(wxBitmapType bitmapType);
+
+    static void InitAllSupportedHandlers();
+
+#if wxUSE_STREAMS
+    virtual bool LoadFile(wxImage *image, wxInputStream& stream, bool verbose = true, int index = -1) wxOVERRIDE;
+    virtual bool SaveFile(wxImage *image, wxOutputStream& stream, bool verbose = true) wxOVERRIDE;
+protected:
+    virtual bool DoCanRead(wxInputStream& stream) wxOVERRIDE;
+#endif
+
+private:
+    const GUID* m_containerFormat;
+
+    wxDECLARE_DYNAMIC_CLASS(wxImageHandlerWIC);
+};
+
+
+#endif // wxUSE_WIC
+
+#endif // _WX_IMAGE_WIC_H_

--- a/include/wx/msw/private/comstream.h
+++ b/include/wx/msw/private/comstream.h
@@ -1,0 +1,177 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/msw/private/comstream.h
+// Purpose:     COM Stream adapter to wxStreamBase based streams
+// Created:     2021-01-15
+// Copyright:   (c) 2021 wxWidgets team
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef WX_COMSTREAM_H
+#define WX_COMSTREAM_H
+
+#include "wx/stream.h"
+#include "wx/msw/ole/comimpl.h"
+
+class wxCOMBaseStreamAdapter : public IStream
+{
+public:
+    wxCOMBaseStreamAdapter(wxStreamBase* stream):
+        m_stream(stream)
+    { }
+
+    DECLARE_IUNKNOWN_METHODS;
+
+    // IStream
+    virtual HRESULT STDMETHODCALLTYPE Seek(
+        LARGE_INTEGER WXUNUSED(dlibMove), DWORD WXUNUSED(dwOrigin),
+        ULARGE_INTEGER *WXUNUSED(plibNewPosition)) wxOVERRIDE
+    {
+        return E_NOTIMPL;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE SetSize(ULARGE_INTEGER WXUNUSED(libNewSize))
+    {
+        return E_NOTIMPL;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE CopyTo(IStream *WXUNUSED(pstm),
+        ULARGE_INTEGER WXUNUSED(cb), ULARGE_INTEGER *WXUNUSED(pcbRead),
+        ULARGE_INTEGER *WXUNUSED(pcbWritten)) wxOVERRIDE
+    {
+        return E_NOTIMPL;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE Commit(DWORD WXUNUSED(grfCommitFlags)) wxOVERRIDE
+    {
+        return E_NOTIMPL;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE Revert(void) wxOVERRIDE
+    {
+        return E_NOTIMPL;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE LockRegion(ULARGE_INTEGER WXUNUSED(libOffset),
+        ULARGE_INTEGER WXUNUSED(cb), DWORD WXUNUSED(dwLockType)) wxOVERRIDE
+    {
+        return E_NOTIMPL;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE UnlockRegion(ULARGE_INTEGER WXUNUSED(libOffset),
+        ULARGE_INTEGER WXUNUSED(cb), DWORD WXUNUSED(dwLockType)) wxOVERRIDE
+    {
+        return E_NOTIMPL;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE Stat(STATSTG *pstatstg, DWORD WXUNUSED(grfStatFlag)) wxOVERRIDE
+    {
+        pstatstg->type = STGTY_STREAM;
+        pstatstg->cbSize.QuadPart = m_stream->GetSize();
+
+        return S_OK;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE Clone(IStream **WXUNUSED(ppstm)) wxOVERRIDE
+    {
+        return E_NOTIMPL;
+    }
+
+    // ISequentialStream
+
+    virtual HRESULT STDMETHODCALLTYPE Read(void *WXUNUSED(pv),
+        ULONG WXUNUSED(cb), ULONG *WXUNUSED(pcbRead)) wxOVERRIDE
+    {
+        return E_NOTIMPL;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE Write(const void *WXUNUSED(pv),
+        ULONG WXUNUSED(cb), ULONG *WXUNUSED(pcbWritten)) wxOVERRIDE
+    {
+        return E_NOTIMPL;
+    }
+
+
+protected:
+    wxStreamBase* m_stream;
+
+    static wxSeekMode OriginToSeekMode(DWORD origin)
+    {
+        switch (origin)
+        {
+        case STREAM_SEEK_SET:
+            return wxFromStart;
+        case STREAM_SEEK_CUR:
+            return wxFromCurrent;
+        case STREAM_SEEK_END:
+            return wxFromEnd;
+        }
+
+        return wxFromStart;
+    }
+};
+
+class wxCOMInputStreamAdapter : public wxCOMBaseStreamAdapter
+{
+public:
+    wxCOMInputStreamAdapter(wxInputStream* stream):
+        wxCOMBaseStreamAdapter(stream)
+    {
+
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE Seek(
+        LARGE_INTEGER dlibMove, DWORD dwOrigin,
+        ULARGE_INTEGER *plibNewPosition) wxOVERRIDE
+    {
+        wxFileOffset newOffset = reinterpret_cast<wxInputStream*>(m_stream)->SeekI(dlibMove.QuadPart, OriginToSeekMode(dwOrigin));
+        if (plibNewPosition)
+            plibNewPosition->QuadPart = newOffset;
+        return S_OK;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE Read(void *pv, ULONG cb, ULONG *pcbRead) wxOVERRIDE
+    {
+        wxInputStream* inputStr = reinterpret_cast<wxInputStream*>(m_stream);
+        inputStr->Read(pv, cb);
+        *pcbRead = inputStr->LastRead();
+        return S_OK;
+    }
+
+};
+
+class wxCOMOutputStreamAdapter : public wxCOMBaseStreamAdapter
+{
+public:
+    wxCOMOutputStreamAdapter(wxOutputStream* stream) :
+        wxCOMBaseStreamAdapter(stream)
+    { }
+
+    virtual HRESULT STDMETHODCALLTYPE Seek(
+        LARGE_INTEGER dlibMove, DWORD dwOrigin,
+        ULARGE_INTEGER *plibNewPosition) wxOVERRIDE
+    {
+        wxFileOffset newOffset = reinterpret_cast<wxOutputStream*>(m_stream)->SeekO(dlibMove.QuadPart, OriginToSeekMode(dwOrigin));
+        if (plibNewPosition)
+            plibNewPosition->QuadPart = newOffset;
+        return S_OK;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE Write(const void *pv, ULONG cb, ULONG *pcbWritten) wxOVERRIDE
+    {
+        wxOutputStream* outputStr = reinterpret_cast<wxOutputStream*>(m_stream);
+        outputStr->Write(pv, cb);
+        *pcbWritten = outputStr->LastWrite();
+        return S_OK;
+    }
+
+};
+
+BEGIN_IID_TABLE(wxCOMBaseStreamAdapter)
+ADD_IID(Unknown)
+ADD_IID(SequentialStream)
+ADD_IID(Stream)
+END_IID_TABLE;
+
+IMPLEMENT_IUNKNOWN_METHODS(wxCOMBaseStreamAdapter);
+
+#endif // WX_COMSTREAM_H

--- a/include/wx/msw/setup0.h
+++ b/include/wx/msw/setup0.h
@@ -1656,6 +1656,13 @@
     #define wxUSE_WEBREQUEST_WINHTTP 0
 #endif
 
+// wxImage loading based on Windows Imaging Component
+//
+// Default is 1
+//
+// Recommended setting: 1
+#define wxUSE_WIC	1
+
 // ----------------------------------------------------------------------------
 // Windows-only settings
 // ----------------------------------------------------------------------------

--- a/include/wx/msw/setup_inc.h
+++ b/include/wx/msw/setup_inc.h
@@ -50,6 +50,13 @@
     #define wxUSE_WEBREQUEST_WINHTTP 0
 #endif
 
+// wxImage loading based on Windows Imaging Component
+//
+// Default is 1
+//
+// Recommended setting: 1
+#define wxUSE_WIC	1
+
 // ----------------------------------------------------------------------------
 // Windows-only settings
 // ----------------------------------------------------------------------------

--- a/samples/image/canvas.cpp
+++ b/samples/image/canvas.cpp
@@ -77,7 +77,7 @@ MyCanvas::MyCanvas( wxWindow *parent, wxWindowID id,
 
     wxImage image = bitmap.ConvertToImage();
 
-#if wxUSE_LIBPNG
+#if wxUSE_LIBPNG || wxUSE_WIC
     if ( !image.SaveFile( dir + "test.png", wxBITMAP_TYPE_PNG ))
     {
         wxLogError("Can't save file");
@@ -119,7 +119,7 @@ MyCanvas::MyCanvas( wxWindow *parent, wxWindowID id,
 
 #endif // wxUSE_LIBPNG
 
-#if wxUSE_LIBJPEG
+#if wxUSE_LIBJPEG || wxUSE_WIC
     image.Destroy();
 
     if ( !image.LoadFile( dir + "horse.jpg") )
@@ -237,7 +237,7 @@ MyCanvas::MyCanvas( wxWindow *parent, wxWindowID id,
     }
 #endif
 
-#if wxUSE_LIBTIFF
+#if wxUSE_LIBTIFF || wxUSE_WIC
     image.Destroy();
 
     if ( !image.LoadFile( dir + "horse.tif", wxBITMAP_TYPE_TIFF ) )

--- a/setup.h.in
+++ b/setup.h.in
@@ -697,6 +697,8 @@
     #define wxUSE_WEBREQUEST_WINHTTP 0
 #endif
 
+#define wxUSE_WIC	1
+
 
 #define wxUSE_OLE           0
 

--- a/src/common/arttango.cpp
+++ b/src/common/arttango.cpp
@@ -288,8 +288,10 @@ wxTangoArtProvider::CreateBitmap(const wxArtID& id,
         {
             // Of course, if the user code did add it already, we have nothing
             // to do.
+#if !(defined(wxUSE_WIC) && wxUSE_WIC)
             if ( !wxImage::FindHandler(wxBITMAP_TYPE_PNG) )
                 wxImage::AddHandler(new wxPNGHandler);
+#endif
 
             // In any case, no need to do it again.
             m_imageHandledAdded = true;

--- a/src/common/bmpbase.cpp
+++ b/src/common/bmpbase.cpp
@@ -19,7 +19,7 @@
     #include "wx/image.h"
 #endif // WX_PRECOMP
 
-#if wxUSE_IMAGE && wxUSE_LIBPNG && wxUSE_STREAMS
+#if wxUSE_IMAGE && (wxUSE_LIBPNG || wxUSE_WIC) && wxUSE_STREAMS
     #define wxHAS_PNG_LOAD
 
     #include "wx/mstream.h"

--- a/src/common/dcsvg.cpp
+++ b/src/common/dcsvg.cpp
@@ -399,8 +399,10 @@ wxSVGBitmapEmbedHandler::ProcessBitmap(const wxBitmap& bmp,
 {
     static int sub_images = 0;
 
+#if !(defined(wxUSE_WIC) && wxUSE_WIC)
     if ( wxImage::FindHandler(wxBITMAP_TYPE_PNG) == NULL )
         wxImage::AddHandler(new wxPNGHandler);
+#endif
 
     // write the bitmap as a PNG to a memory stream and Base64 encode
     wxMemoryOutputStream mem;
@@ -444,8 +446,10 @@ wxSVGBitmapFileHandler::ProcessBitmap(const wxBitmap& bmp,
 {
     static int sub_images = 0;
 
+#if !(defined(wxUSE_WIC) && wxUSE_WIC)
     if ( wxImage::FindHandler(wxBITMAP_TYPE_PNG) == NULL )
         wxImage::AddHandler(new wxPNGHandler);
+#endif
 
     // find a suitable file name
     wxFileName sPNG = m_path;

--- a/src/common/imagall.cpp
+++ b/src/common/imagall.cpp
@@ -16,6 +16,10 @@
     #include "wx/image.h"
 #endif
 
+#ifdef __WXMSW__
+#include "wx/msw/image_wic.h"
+#endif
+
 //-----------------------------------------------------------------------------
 // This function allows dynamic access to all image handlers compile within
 // the library. This function should be in a separate file as some compilers
@@ -23,13 +27,16 @@
 
 void wxInitAllImageHandlers()
 {
-#if wxUSE_LIBPNG
+#if wxUSE_WIC
+  wxImageHandlerWIC::InitAllSupportedHandlers();
+#endif
+#if wxUSE_LIBPNG && !wxUSE_WIC
   wxImage::AddHandler( new wxPNGHandler );
 #endif
-#if wxUSE_LIBJPEG
+#if wxUSE_LIBJPEG && !wxUSE_WIC
   wxImage::AddHandler( new wxJPEGHandler );
 #endif
-#if wxUSE_LIBTIFF
+#if wxUSE_LIBTIFF && !wxUSE_WIC
   wxImage::AddHandler( new wxTIFFHandler );
 #endif
 #if wxUSE_GIF

--- a/src/msw/gdiimage.cpp
+++ b/src/msw/gdiimage.cpp
@@ -39,7 +39,7 @@
 // loading PNG images in the library. This symbol could be predefined as 0 to
 // avoid doing this if anybody ever needs to do it for some reason.
 #if !defined(wxUSE_PNG_RESOURCE_HANDLER)
-    #define wxUSE_PNG_RESOURCE_HANDLER wxUSE_LIBPNG && wxUSE_IMAGE
+    #define wxUSE_PNG_RESOURCE_HANDLER (wxUSE_LIBPNG || wxUSE_WIC) && wxUSE_IMAGE
 #endif
 
 #if wxUSE_PNG_RESOURCE_HANDLER

--- a/src/msw/image_wic.cpp
+++ b/src/msw/image_wic.cpp
@@ -1,0 +1,255 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        src/msw/image_wic.cpp
+// Purpose:     Implementation of wxImageHandler using
+//              Windows Imaging Component
+// Author:      Tobias Taschner
+// Created:     2021-01-15
+// Copyright:   (c) 2021 wxWidgets development team
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
+// ----------------------------------------------------------------------------
+// headers
+// ----------------------------------------------------------------------------
+
+// For compilers that support precompilation, includes "wx.h".
+#include "wx/wxprec.h"
+
+#include "wx/msw/image_wic.h"
+
+#if wxUSE_IMAGE && wxUSE_WIC
+
+// For MSVC we can link in the required library explicitly, for the other
+// compilers (e.g. MinGW) this needs to be done at makefiles level.
+#ifdef __VISUALC__
+#pragma comment(lib, "windowscodecs")
+#endif
+
+#include "wx/msw/private/comptr.h"
+#include "wx/msw/private/comstream.h"
+
+#include <wincodec.h>
+
+// ----------------------------------------------------------------------------
+// local functions
+// ----------------------------------------------------------------------------
+
+#define wxCOM_CHECK(name, params) hr = name params; \
+    if (FAILED(hr)) \
+    {\
+        wxLogApiError(wxS("Windows Imaging Component: "#name), hr); \
+        return false; \
+    }   
+
+static
+bool wxWICCopyPixels(IWICBitmapSource* bmpSource, wxMemoryBuffer& buffer,
+    wxUint32 width, wxUint32 height, wxUint32 bitsPerPixel)
+{
+    HRESULT hr;
+
+    size_t memSize = width * height * (bitsPerPixel / 8);
+    wxCOM_CHECK(bmpSource->CopyPixels,
+        (NULL,
+            width * (bitsPerPixel / 8), memSize,
+            (BYTE*)buffer.GetWriteBuf(memSize)
+            )
+    );
+    buffer.SetDataLen(memSize);
+
+    return true;
+}
+
+static
+bool wxWICConvertAndCopyPixels(IWICBitmapSource* bmpSource, REFWICPixelFormatGUID pixelFormat,
+    wxMemoryBuffer& buffer, wxUint32 width, wxUint32 height, wxUint32 bitsPerPixel)
+{
+    HRESULT hr;
+    wxCOMPtr<IWICBitmapSource> dstSource;
+    wxCOM_CHECK(WICConvertBitmapSource, (pixelFormat, bmpSource, &dstSource));
+    return wxWICCopyPixels(dstSource, buffer, width, height, bitsPerPixel);
+}
+
+// ============================================================================
+// wxImageHandlerWIC implementation
+// ============================================================================
+
+wxIMPLEMENT_DYNAMIC_CLASS(wxImageHandlerWIC, wxImageHandler);
+
+wxImageHandlerWIC::wxImageHandlerWIC(wxBitmapType bitmapType)
+{
+    m_type = bitmapType;
+
+    switch (m_type)
+    {
+    case wxBITMAP_TYPE_PNG:
+        m_name = wxT("PNG file");
+        m_extension = wxT("png");
+        m_mime = wxT("image/png");
+        m_containerFormat = &GUID_ContainerFormatPng;
+        break;
+    case wxBITMAP_TYPE_JPEG:
+        m_name = wxT("JPEG file");
+        m_extension = wxT("jpg");
+        m_altExtensions.Add(wxT("jpeg"));
+        m_altExtensions.Add(wxT("jpe"));
+        m_mime = wxT("image/jpeg");
+        m_containerFormat = &GUID_ContainerFormatJpeg;
+        break;
+    case wxBITMAP_TYPE_TIFF:
+        m_name = wxT("TIFF file");
+        m_extension = wxT("tif");
+        m_altExtensions.Add(wxT("tiff"));
+        m_mime = wxT("image/tiff");
+        m_containerFormat = &GUID_ContainerFormatTiff;
+        break;
+    default:
+        wxASSERT_MSG(FALSE, "Unsupported bitmap type");
+        break;
+    }
+}
+
+void wxImageHandlerWIC::InitAllSupportedHandlers()
+{
+    wxImage::AddHandler(new wxImageHandlerWIC(wxBITMAP_TYPE_PNG));
+    wxImage::AddHandler(new wxImageHandlerWIC(wxBITMAP_TYPE_JPEG));
+    wxImage::AddHandler(new wxImageHandlerWIC(wxBITMAP_TYPE_TIFF));
+}
+
+bool wxImageHandlerWIC::LoadFile(wxImage *image, wxInputStream& stream,
+    bool WXUNUSED(verbose), int index)
+{
+    UINT frameIndex = index < 0 ? 0 : index;
+
+    HRESULT hr;
+
+    // Create the COM imaging factory
+    wxCOMPtr<IWICImagingFactory> imgFactory;
+    wxCOM_CHECK(::CoCreateInstance, (
+        CLSID_WICImagingFactory,
+        NULL,
+        CLSCTX_INPROC_SERVER,
+        wxIID_PPV_ARGS(IWICImagingFactory, &imgFactory)
+    ));
+
+    // Create decoder
+    wxCOMPtr<IWICBitmapDecoder> decoder;
+    wxCOM_CHECK(imgFactory->CreateDecoder,
+        (*m_containerFormat, NULL, &decoder));
+    wxCOM_CHECK(decoder->Initialize, (new wxCOMInputStreamAdapter(&stream),
+        WICDecodeMetadataCacheOnDemand));
+
+    // Get frame bitmap
+    UINT frameCount = 0;
+    wxCOM_CHECK(decoder->GetFrameCount, (&frameCount));
+    if (frameCount < frameIndex)
+        return false;
+    wxCOMPtr<IWICBitmapFrameDecode> frameBitmap;
+    wxCOM_CHECK(decoder->GetFrame, (frameIndex, &frameBitmap));
+
+    // Get bitmap information
+    WICPixelFormatGUID formatGUID;
+    wxCOM_CHECK(frameBitmap->GetPixelFormat, (&formatGUID));
+    wxCOMPtr<IWICComponentInfo> compInfo;
+    wxCOM_CHECK(imgFactory->CreateComponentInfo, (formatGUID, &compInfo));
+    wxCOMPtr<IWICPixelFormatInfo> formatInfo;
+    wxCOM_CHECK(compInfo->QueryInterface,
+        (wxIID_PPV_ARGS(IWICPixelFormatInfo, &formatInfo)));
+    UINT bitsPerPixel = 0;
+    wxCOM_CHECK(formatInfo->GetBitsPerPixel, (&bitsPerPixel));
+    UINT imgWidth, imgHeight;
+    wxCOM_CHECK(frameBitmap->GetSize, (&imgWidth, &imgHeight));
+    double resX, resY;
+    wxCOM_CHECK(frameBitmap->GetResolution, (&resX, &resY));
+
+    // Set metadata
+    image->SetOption(wxIMAGE_OPTION_RESOLUTIONX,
+        wxString::FromCDouble(resX * imgWidth, 2));
+    image->SetOption(wxIMAGE_OPTION_RESOLUTIONY,
+        wxString::FromCDouble(resY * imgHeight, 2));
+    image->SetOption(wxIMAGE_OPTION_RESOLUTIONUNIT, wxIMAGE_RESOLUTION_INCHES);
+
+    // Extract and or convert pixel data
+    wxMemoryBuffer imgData;
+    wxMemoryBuffer alphaData;
+    if (!wxWICConvertAndCopyPixels(frameBitmap, GUID_WICPixelFormat24bppRGB,
+        imgData, imgWidth, imgHeight, 24))
+        return false;
+
+    if (!wxWICConvertAndCopyPixels(frameBitmap, GUID_WICPixelFormat8bppAlpha,
+        alphaData, imgWidth, imgHeight, 8))
+        alphaData.Clear();
+
+    // Init wxImage from pixel data
+    bool success = image->Create(imgWidth, imgHeight,
+        (unsigned char*)imgData.release(), false);
+    if (success && !alphaData.IsEmpty())
+        image->SetAlpha((unsigned char*)alphaData.release());
+
+    return success;
+}
+
+bool wxImageHandlerWIC::SaveFile(wxImage *image, wxOutputStream& stream,
+    bool WXUNUSED(verbose))
+{
+    HRESULT hr;
+
+    // Create the COM imaging factory
+    wxCOMPtr<IWICImagingFactory> imgFactory;
+    wxCOM_CHECK(::CoCreateInstance, (
+        CLSID_WICImagingFactory,
+        NULL,
+        CLSCTX_INPROC_SERVER,
+        wxIID_PPV_ARGS(IWICImagingFactory, &imgFactory)
+        ));
+
+    // Create and initalize encoder
+    wxCOMPtr<IWICBitmapEncoder> encoder;
+    wxCOM_CHECK(imgFactory->CreateEncoder,
+        (*m_containerFormat, NULL, &encoder));
+    wxCOM_CHECK(encoder->Initialize, (new wxCOMOutputStreamAdapter(&stream), WICBitmapEncoderNoCache));
+
+    // Create frame
+    wxCOMPtr<IPropertyBag2> encodeOptions;
+    wxCOMPtr<IWICBitmapFrameEncode> frameEncode;
+    wxCOM_CHECK(encoder->CreateNewFrame, (&frameEncode, &encodeOptions));
+
+    // Init frame
+    wxCOM_CHECK(frameEncode->Initialize, (encodeOptions));
+    wxCOM_CHECK(frameEncode->SetSize, (image->GetWidth(), image->GetHeight()));
+    WICPixelFormatGUID formatGUID = GUID_WICPixelFormat24bppRGB;
+    wxCOM_CHECK(frameEncode->SetPixelFormat, (&formatGUID));
+
+    // Copy pixel data
+    int bitsPerPixel = 24;
+    size_t memSize = image->GetWidth() * image->GetHeight() * (bitsPerPixel / 8);
+    wxCOM_CHECK(frameEncode->WritePixels, (image->GetHeight(), image->GetWidth() * (bitsPerPixel / 8), memSize, image->GetData()));
+
+    // Commit data to file
+    wxCOM_CHECK(frameEncode->Commit, ());
+    wxCOM_CHECK(encoder->Commit, ());
+
+    return true;
+}
+
+bool wxImageHandlerWIC::DoCanRead(wxInputStream& stream)
+{
+    unsigned char hdr[4];
+
+    if (!stream.Read(hdr, WXSIZEOF(hdr)))     // it's ok to modify the stream position here
+        return false;
+
+    switch (m_type)
+    {
+        case wxBITMAP_TYPE_PNG:
+            return memcmp(hdr, "\211PNG", WXSIZEOF(hdr)) == 0;
+        case wxBITMAP_TYPE_JPEG:
+            return hdr[0] == 0xFF && hdr[1] == 0xD8;
+        case wxBITMAP_TYPE_TIFF:
+            return (hdr[0] == 'I' && hdr[1] == 'I') ||
+                (hdr[0] == 'M' && hdr[1] == 'M');
+        default:
+            return false;
+    }
+}
+
+#endif // wxUSE_WIC

--- a/src/msw/image_wic.cpp
+++ b/src/msw/image_wic.cpp
@@ -234,7 +234,21 @@ bool wxImageHandlerWIC::LoadFile(wxImage *image, wxInputStream& stream,
     bool success = image->Create(imgWidth, imgHeight,
         (unsigned char*)imgData.release(), false);
     if (success && !alphaData.IsEmpty())
-        image->SetAlpha((unsigned char*)alphaData.release());
+    {
+        // See if alpha is required
+        bool needsAlpha = false;
+        char* ap = (char*) alphaData.GetData();
+        for (int ai = 0; ai < alphaData.GetDataLen(); ai++)
+        {
+            needsAlpha = *ap != '\xff';
+            if (needsAlpha)
+                break;
+            ap++;
+        }
+
+        if (needsAlpha)
+            image->SetAlpha((unsigned char*)alphaData.release());
+    }
 
     if (success)
     {


### PR DESCRIPTION
This is very much a proof of concept/WIP for now, just wanted to gather interest before pursuing it further.

This adds a new `wxImageHandler` based on **Windows Imaging Component** for wxMSW.
Windows Imaging Component are available since WinXP SP2 and allows loading and writing of various image formats.
This removes the dependency on libpng, libtiff and libjpeg. It could also replace a wxWidgets internal loaders for other formats such as GIF. It would also allow other formats such as JPEG XR, DDS.

The current implementation can run the **images sample** without issues except the CMYK JPEG.
I haven't tested further but there are surly many open issues.

As always any **feedback** is welcome.

Documentation is available at:
https://docs.microsoft.com/en-us/windows/win32/wic/
