### PR TITLE
Fix drawing of grid cells appearing inside a multicell

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -6235,13 +6235,15 @@ void wxGrid::DrawGridCellArea( wxDC& dc, const wxGridCellCoordsArray& cells )
                 {
                     if (!m_table->IsEmptyCell(row + l, j))
                     {
+                        wxGridCellAttrPtr attr = GetCellAttrPtr(row + l, j);
                         int numRows, numCols;
-                        if ( GetCellSize(row + l, j, &numRows, &numCols)
+                        attr->GetSize(&numRows, &numCols);
+                        if ( GetCellSpan(numRows, numCols)
                                  == wxGrid::CellSpan_Inside )
                             // As above: don't bother drawing inside cells.
                             continue;
 
-                        if ( GetCellAttrPtr(row + l, j)->CanOverflow() )
+                        if ( attr->CanOverflow() )
                         {
                             wxGridCellCoords cell(row + l, j);
                             bool marked = false;

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -158,6 +158,24 @@ wxDEFINE_EVENT( wxEVT_GRID_TABBING, wxGridEvent );
 // implementation
 // ============================================================================
 
+namespace
+{
+
+// Helper function for consistent cell span determination based on cell size.
+wxGrid::CellSpan GetCellSpan(int numRows, int numCols)
+{
+    if ( numRows == 1 && numCols == 1 )
+        return wxGrid::CellSpan_None; // just a normal cell
+
+    if ( numRows < 0 || numCols < 0 )
+        return wxGrid::CellSpan_Inside; // covered by a multi-span cell
+
+    // this cell spans multiple cells to its right/bottom
+    return wxGrid::CellSpan_Main;
+}
+
+} // anonymous namespace
+
 wxIMPLEMENT_ABSTRACT_CLASS(wxGridCellEditorEvtHandler, wxEvtHandler);
 
 wxBEGIN_EVENT_TABLE( wxGridCellEditorEvtHandler, wxEvtHandler )
@@ -9126,14 +9144,7 @@ wxGrid::GetCellSize( int row, int col, int *num_rows, int *num_cols ) const
 {
     GetCellAttrPtr(row, col)->GetSize( num_rows, num_cols );
 
-    if ( *num_rows == 1 && *num_cols == 1 )
-        return CellSpan_None; // just a normal cell
-
-    if ( *num_rows < 0 || *num_cols < 0 )
-        return CellSpan_Inside; // covered by a multi-span cell
-
-    // this cell spans multiple cells to its right/bottom
-    return CellSpan_Main;
+    return GetCellSpan(*num_rows, *num_cols);
 }
 
 wxGridCellRenderer* wxGrid::GetCellRenderer(int row, int col) const

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -6217,6 +6217,12 @@ void wxGrid::DrawGridCellArea( wxDC& dc, const wxGridCellCoordsArray& cells )
                 {
                     if (!m_table->IsEmptyCell(row + l, j))
                     {
+                        int numRows, numCols;
+                        if ( GetCellSize(row + l, j, &numRows, &numCols)
+                                 == wxGrid::CellSpan_Inside )
+                            // As above: don't bother drawing inside cells.
+                            continue;
+
                         if ( GetCellAttrPtr(row + l, j)->CanOverflow() )
                         {
                             wxGridCellCoords cell(row + l, j);

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -1423,6 +1423,32 @@ TEST_CASE_METHOD(GridTestCase, "Grid::AutoSizeColumn", "[grid]")
     }
 }
 
+TEST_CASE_METHOD(GridTestCase, "Grid::DrawInvalidCell", "[grid][multicell]")
+{
+    // Set up a multicell with inside an overflowing cell.
+    // This is artificial and normally inside cells are probably not expected
+    // to have a value but this is merely done to check if inside cells are
+    // drawn, which they shouldn't be.
+    m_grid->SetCellSize(0, 0, 2, 1);
+    m_grid->SetCellValue( 1, 0, wxString('W', 42) );
+
+    // Update()s, yields and sleep are needed to try to make the test fail with
+    // macOS, GTK and MSW.
+    // MSW needs just the yields (or updates), macOS in addition needs to sleep
+    // (doesn't work with updates) and for GTK it's usually enough to just do
+    // two updates (not yields). This test does all unconditionally.
+    m_grid->Update();
+    wxYield();
+    wxMilliSleep(20);
+
+    // Try to force redrawing of the inside cell: if it still draws there will
+    // be an infinite recursion.
+    m_grid->SetColSize(1, m_grid->GetColSize(1) + 1);
+
+    m_grid->Update();
+    wxYield();
+}
+
 // Test wxGridBlockCoords here because it'a a part of grid sources.
 
 std::ostream& operator<<(std::ostream& os, const wxGridBlockCoords& block) {


### PR DESCRIPTION
Grid cells are considered for redrawing solely based on having
a (text) value. This can lead to infinite recursion with overflowing
inside cells if `wxGridCellStringRenderer::Draw()` wants to draw cells
appearing after this one but instead visits the same cell again (because
of a negative cell size as opposed to expected default cell size of 1x1
or a larger spanning size) and calls `DrawCell()` again for this cell
which will call the renderer's `Draw()` again etc...

Fix by not taking inside cells into consideration for redrawing. This
is the right thing to do as earlier on in the same function a cell is
not drawn for the same reason. Also the aforementioned `Draw()` mentions
it shouldn't be called for cell sizes <= 0.

--

The last two commits are just related to refactoring which I would normally leave out but it helps get rid of a minor performance change introduced by the fix (which I wanted to keep minimal). I also didn't want to introduce any code changes prior to the fix, besides a test. Hence this commit order, if undesired let me know (or about anything else of course).

I also looked at `wxGridCellAttr::GetSize` returning `wxGrid::CellSpan` but the latter currently is declared after `wxGridCellAttr`. It didn't seem very useful to do anyway while the helper function `GetCellSpan(int, int)` can be used for later changes as well.