### PR TITLE
Better support for RTL mode under GTK3

### DIFF
--- a/include/wx/dc.h
+++ b/include/wx/dc.h
@@ -537,6 +537,14 @@ public:
     // this needs to overridden if the axis is inverted
     virtual void SetAxisOrientation(bool xLeftRight, bool yBottomUp);
 
+    void GetAxisOrientation(int* signX, int* signY) const
+    {
+        if (signX)
+            *signX = m_signX;
+        if (signY)
+            *signY = m_signY;
+    }
+
     virtual double GetContentScaleFactor() const { return m_contentScaleFactor; }
 
 #ifdef __WXMSW__
@@ -1070,6 +1078,8 @@ public:
 
     void SetAxisOrientation(bool xLeftRight, bool yBottomUp)
         { m_pimpl->SetAxisOrientation(xLeftRight, yBottomUp); }
+    void GetAxisOrientation(int* signX, int* signY) const
+        { m_pimpl->GetAxisOrientation(signX, signY); }
 
 #if wxUSE_DC_TRANSFORM_MATRIX
     bool CanUseTransformMatrix() const

--- a/src/generic/scrlwing.cpp
+++ b/src/generic/scrlwing.cpp
@@ -655,7 +655,7 @@ int wxScrollHelperBase::CalcScrollInc(wxScrollWinEvent& event)
 void wxScrollHelperBase::DoPrepareDC(wxDC& dc)
 {
     wxPoint pt = dc.GetDeviceOrigin();
-#ifdef __WXGTK__
+#if defined(__WXGTK__) && !defined(__WXGTK3__)
     // It may actually be correct to always query
     // the m_sign from the DC here, but I leave the
     // #ifdef GTK for now.

--- a/src/generic/scrlwing.cpp
+++ b/src/generic/scrlwing.cpp
@@ -655,13 +655,15 @@ int wxScrollHelperBase::CalcScrollInc(wxScrollWinEvent& event)
 void wxScrollHelperBase::DoPrepareDC(wxDC& dc)
 {
     wxPoint pt = dc.GetDeviceOrigin();
-#if defined(__WXGTK__) && !defined(__WXGTK3__)
-    // It may actually be correct to always query
-    // the m_sign from the DC here, but I leave the
-    // #ifdef GTK for now.
+#if defined(__WXGTK__)
     if (m_win->GetLayoutDirection() == wxLayout_RightToLeft)
-        dc.SetDeviceOrigin( pt.x + m_xScrollPosition * m_xScrollPixelsPerLine,
+    {
+        int signX;
+        dc.GetAxisOrientation(&signX, NULL);
+
+        dc.SetDeviceOrigin( pt.x - m_xScrollPosition * m_xScrollPixelsPerLine * signX,
                             pt.y - m_yScrollPosition * m_yScrollPixelsPerLine );
+    }
     else
 #endif
         dc.SetDeviceOrigin( pt.x - m_xScrollPosition * m_xScrollPixelsPerLine,

--- a/src/gtk/dc.cpp
+++ b/src/gtk/dc.cpp
@@ -258,6 +258,13 @@ wxWindowDCImpl::wxWindowDCImpl(wxWindowDC* owner, wxWindow* window)
     GtkWidget* widget = window->m_wxwindow;
     if (widget == NULL)
         widget = window->m_widget;
+#ifdef __WXGTK3__
+    else if (window->GetLayoutDirection() == wxLayout_RightToLeft)
+    {
+        m_signX = -1;
+        m_deviceOriginX = window->GetClientSize().x;
+    }
+#endif // __WXGTK3__
     GdkWindow* gdkWindow = NULL;
     if (widget)
     {
@@ -304,6 +311,13 @@ wxClientDCImpl::wxClientDCImpl(wxClientDC* owner, wxWindow* window)
     GtkWidget* widget = window->m_wxwindow;
     if (widget == NULL)
         widget = window->m_widget;
+#ifdef __WXGTK3__
+    else if (window->GetLayoutDirection() == wxLayout_RightToLeft)
+    {
+        m_signX = -1;
+        m_deviceOriginX = window->GetClientSize().x;
+    }
+#endif // __WXGTK3__
     GdkWindow* gdkWindow = NULL;
     if (widget)
     {
@@ -342,6 +356,7 @@ wxPaintDCImpl::wxPaintDCImpl(wxPaintDC* owner, wxWindow* window)
     : wxGTKCairoDCImpl(owner, window)
     , m_clip(window->m_nativeUpdateRegion)
 {
+    // N.B. The dc is flipped (mirrored) in RTL mode under GTK3
     cairo_t* cr = window->GTKPaintContext();
     wxCHECK_RET(cr, "using wxPaintDC without being in a native paint event");
     InitSize(gtk_widget_get_window(window->m_wxwindow));

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -5077,6 +5077,14 @@ void wxWindowGTK::GTKSendPaintEvents(const GdkRegion* region)
 #endif
 {
 #ifdef __WXGTK3__
+    if ( GetLayoutDirection() == wxLayout_RightToLeft )
+    {
+        const int width = gdk_window_get_width(GTKGetDrawingWindow());
+
+        cairo_translate(cr, width, 0);
+        cairo_scale(cr, -1, 1);
+    }
+
     GdkRectangle rect;
     if ( !gdk_cairo_get_clip_rectangle(cr, &rect) )
       return;
@@ -5097,9 +5105,12 @@ void wxWindowGTK::GTKSendPaintEvents(const GdkRegion* region)
 
     m_nativeUpdateRegion = m_updateRegion;
 
+#ifndef __WXGTK3__
     if (GetLayoutDirection() == wxLayout_RightToLeft)
     {
-        // Transform m_updateRegion under RTL
+        // Transform m_updateRegion under RTL.
+        // Notice that under GTK3 the dc is flipped (mirrored)
+        // and we don't have to de anything here.
         m_updateRegion.Clear();
 
         const int width = gdk_window_get_width(GTKGetDrawingWindow());
@@ -5119,6 +5130,7 @@ void wxWindowGTK::GTKSendPaintEvents(const GdkRegion* region)
             ++upd;
         }
     }
+#endif // __WXGTK3__
 
     switch ( GetBackgroundStyle() )
     {

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -5077,22 +5077,15 @@ void wxWindowGTK::GTKSendPaintEvents(const GdkRegion* region)
 #endif
 {
 #ifdef __WXGTK3__
-    {
-        cairo_region_t* region = gdk_window_get_clip_region(gtk_widget_get_window(m_wxwindow));
-        cairo_rectangle_int_t rect;
-        cairo_region_get_extents(region, &rect);
-        cairo_region_destroy(region);
-        cairo_rectangle(cr, rect.x, rect.y, rect.width, rect.height);
-        cairo_clip(cr);
-    }
-    double x1, y1, x2, y2;
-    cairo_clip_extents(cr, &x1, &y1, &x2, &y2);
+    GdkRectangle rect;
+    if ( !gdk_cairo_get_clip_rectangle(cr, &rect) )
+      return;
 
-    if (x1 >= x2 || y1 >= y2)
-        return;
+    gdk_cairo_rectangle(cr, &rect);
+    cairo_clip(cr);
 
     m_paintContext = cr;
-    m_updateRegion = wxRegion(int(x1), int(y1), int(x2 - x1), int(y2 - y1));
+    m_updateRegion = wxRegion(rect.x, rect.y, rect.width, rect.height);
 #else // !__WXGTK3__
     m_updateRegion = wxRegion(region);
 #if wxGTK_HAS_COMPOSITING_SUPPORT

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -2627,7 +2627,13 @@ void wxWindowGTK::GTKCreateScrolledWindowWith(GtkWidget* view)
 
     m_scrollBar[ScrollDir_Horz] = GTK_RANGE(gtk_scrolled_window_get_hscrollbar(scrolledWindow));
     m_scrollBar[ScrollDir_Vert] = GTK_RANGE(gtk_scrolled_window_get_vscrollbar(scrolledWindow));
-    if (GetLayoutDirection() == wxLayout_RightToLeft)
+
+    // Don't just call GetLayoutDirection() here as the layout direction is not initialized yet
+    // for this window, and thus gtk_range_set_inverted() won't be called at all.
+    const wxWindow *const parent = GetParent();
+    const bool isRTL = parent ? parent->GetLayoutDirection() == wxLayout_RightToLeft
+                              : wxTheApp->GetLayoutDirection() == wxLayout_RightToLeft;
+    if ( isRTL )
         gtk_range_set_inverted( m_scrollBar[ScrollDir_Horz], TRUE );
 
     gtk_container_add( GTK_CONTAINER(m_widget), view );

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -5093,7 +5093,6 @@ void wxWindowGTK::GTKSendPaintEvents(const GdkRegion* region)
 
     m_paintContext = cr;
     m_updateRegion = wxRegion(int(x1), int(y1), int(x2 - x1), int(y2 - y1));
-    m_nativeUpdateRegion = m_updateRegion;
 #else // !__WXGTK3__
     m_updateRegion = wxRegion(region);
 #if wxGTK_HAS_COMPOSITING_SUPPORT


### PR DESCRIPTION
Replaced by #2194

I am doing thing PR to call for help!

### Motivation:

As i noticed that the **RTL** support is broken with some `wxControl`s (e.g. `wxGrid`)
when custom drawing is in play to draw the client area, and failing to de anything about it
with the current implementation, i tried with the mirrored DC approach and guess? it worked
like a charm! (more work to be done to get this ready, however).

### The problem: (now fixed by bb9c0fe and 281b736)

Even if everything looks right to me so far, I'm going crazy with one thing: **the srolling nightmare**!

To better understand what i am talking about, here is a patch to be applied to the **internat** sample:

1. Assuming you have chosen an RTL language (e.g. Arabic)
2. Try to scroll to the last column (by pressing LEFT key repeatedly)
3. The grid is correctly scrolled off to the right.
4. Now try to press the RIGHT key...
5. See the artifact caused by the scrolling!!

Sure, i'm missing something fundamental here about how scrolling should be setup to make things work as expected, so i need some guidance on how to achieve this with this PR.

TIA!

### The patch:
```
diff --git a/samples/internat/internat.cpp b/samples/internat/internat.cpp
index 7296519e3f..119842f432 100644
--- a/samples/internat/internat.cpp
+++ b/samples/internat/internat.cpp
@@ -30,6 +30,7 @@
 
 #include "wx/intl.h"
 #include "wx/file.h"
+#include "wx/grid.h"
 #include "wx/log.h"
 #include "wx/cmdline.h"
 
@@ -74,6 +75,8 @@ public:
     void OnTest3(wxCommandEvent& event);
     void OnTestMsgBox(wxCommandEvent& event);
 
+    void OnGrid(wxGridEvent& event);
+
     wxDECLARE_EVENT_TABLE();
 
     wxLocale& m_locale;
@@ -171,6 +174,8 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(INTERNAT_TEST_2, MyFrame::OnTest2)
     EVT_MENU(INTERNAT_TEST_3, MyFrame::OnTest3)
     EVT_MENU(INTERNAT_TEST_MSGBOX, MyFrame::OnTestMsgBox)
+
+    EVT_GRID_SELECT_CELL(MyFrame::OnGrid)
 wxEND_EVENT_TABLE()
 
 wxIMPLEMENT_APP(MyApp);
@@ -337,11 +342,23 @@ MyFrame::MyFrame(wxLocale& locale)
     CreateStatusBar(1);
 
     // this demonstrates RTL layout mirroring for Arabic locales
+#if 0
     wxSizer *sizer = new wxBoxSizer(wxHORIZONTAL);
     sizer->Add(new wxStaticText(this, wxID_ANY, _("First")),
                 wxSizerFlags().Border());
     sizer->Add(new wxStaticText(this, wxID_ANY, _("Second")),
                 wxSizerFlags().Border());
+#endif
+    wxSizer *sizer = new wxBoxSizer(wxVERTICAL);
+
+    wxGrid* grid = new wxGrid(this, wxID_ANY);
+    grid->CreateGrid(5, 5);
+    grid->SetDefaultCellOverflow(false);
+    sizer->Add(grid, wxSizerFlags().Border());
+
+    grid->SetCellBackgroundColour(1, 1, *wxRED);
+
     SetSizer(sizer);
 }
 
@@ -541,3 +558,9 @@ void MyFrame::OnTestMsgBox(wxCommandEvent& WXUNUSED(event))
         wxMessageBox(_("Please report the details of your platform to us."));
     }
 }
+
+void MyFrame::OnGrid(wxGridEvent& event)
+{
+    event.Skip();
+    wxLogDebug("Cell(%d, %d)", event.GetRow(), event.GetCol());
+}
```