### PR TITLE
Try to make wxWebRequest CI tests more reliable

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -76,8 +76,14 @@ before_test:
     Write-Output "Getting and launching httpbin."
     C:\Python35\Scripts\pip.exe --disable-pip-version-check --no-warn-script-location install httpbin
     Start-Job -Name wx_httpbin { C:\Python35\python.exe -m httpbin.core 2>&1 > c:\projects\wxwidgets\httpbin.log }
-    curl http://127.0.0.1:5000/ip
-    $env:WX_TEST_WEBREQUEST_URL="http://127.0.0.1:5000"
+    Start-Sleep -Seconds 5
+    if (curl -s http://127.0.0.1:5000/ip > $null) {
+        $env:WX_TEST_WEBREQUEST_URL="http://127.0.0.1:5000"
+    }
+    else {
+        Write-Error "Disabling wxWebRequest tests as launching httpbin failed."
+        $env:WX_TEST_WEBREQUEST_URL="0"
+    }
 
 test_script: c:\projects\wxwidgets\build\tools\appveyor-test.bat
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -78,7 +78,7 @@ before_test:
     pip.exe --disable-pip-version-check install httpbin
     Start-Job -Name wx_httpbin { python.exe -m httpbin.core 2>&1 > c:\projects\wxwidgets\httpbin.log }
     Start-Sleep -Seconds 5
-    if (curl -s http://127.0.0.1:5000/ip > $null) {
+    if (curl.exe -s http://127.0.0.1:5000/ip > $null) {
         $env:WX_TEST_WEBREQUEST_URL="http://127.0.0.1:5000"
     }
     else {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,7 +75,7 @@ before_test:
 - ps: |
     Write-Output "Getting and launching httpbin."
     C:\Python35\Scripts\pip.exe --disable-pip-version-check --no-warn-script-location install httpbin
-    Start-Job -Name wx_httpbin { C:\Python35\python.exe -m httpbin.core > c:\projects\wxwidgets\httpbin.log }
+    Start-Job -Name wx_httpbin { C:\Python35\python.exe -m httpbin.core 2>&1 > c:\projects\wxwidgets\httpbin.log }
     curl http://127.0.0.1:5000/ip
     $env:WX_TEST_WEBREQUEST_URL="http://127.0.0.1:5000"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,7 +74,7 @@ build_script: c:\projects\wxwidgets\build\tools\appveyor.bat
 before_test:
 - ps: |
     Write-Output "Getting and launching httpbin."
-    C:\Python35\Scripts\pip.exe --disable-pip-version-check --no-warn-script-location install httpbin
+    C:\Python35\Scripts\pip.exe --disable-pip-version-check install httpbin
     Start-Job -Name wx_httpbin { C:\Python35\python.exe -m httpbin.core 2>&1 > c:\projects\wxwidgets\httpbin.log }
     Start-Sleep -Seconds 5
     if (curl -s http://127.0.0.1:5000/ip > $null) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,8 +74,8 @@ build_script: c:\projects\wxwidgets\build\tools\appveyor.bat
 before_test:
 - ps: |
     Write-Output "Getting and launching httpbin."
-    pip install httpbin
-    Start-Job -Name wx_httpbin { python -m httpbin.core > c:\projects\wxwidgets\httpbin.log }
+    C:\Python35\Scripts\pip.exe --disable-pip-version-check install httpbin
+    Start-Job -Name wx_httpbin { C:\Python35\python.exe -m httpbin.core > c:\projects\wxwidgets\httpbin.log }
     curl http://127.0.0.1:5000/ip
     $env:WX_TEST_WEBREQUEST_URL="http://127.0.0.1:5000"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -84,6 +84,3 @@ test_script: c:\projects\wxwidgets\build\tools\appveyor-test.bat
 after_test:
 - ps: |
     Stop-Job -Name wx_httpbin
-    Write-Output "--- httpbin output ---"
-    Get-Content c:\projects\wxwidgets\httpbin.log
-    Write-Output "--- httpbin output end ---"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,8 +74,9 @@ build_script: c:\projects\wxwidgets\build\tools\appveyor.bat
 before_test:
 - ps: |
     Write-Output "Getting and launching httpbin."
-    C:\Python35\Scripts\pip.exe --disable-pip-version-check install httpbin
-    Start-Job -Name wx_httpbin { C:\Python35\python.exe -m httpbin.core 2>&1 > c:\projects\wxwidgets\httpbin.log }
+    $env:PATH = "C:\Python35;C:\Python35\Scripts;" + $env:PATH
+    pip.exe --disable-pip-version-check install httpbin
+    Start-Job -Name wx_httpbin { python.exe -m httpbin.core 2>&1 > c:\projects\wxwidgets\httpbin.log }
     Start-Sleep -Seconds 5
     if (curl -s http://127.0.0.1:5000/ip > $null) {
         $env:WX_TEST_WEBREQUEST_URL="http://127.0.0.1:5000"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,4 +71,19 @@ before_build:
 
 build_script: c:\projects\wxwidgets\build\tools\appveyor.bat
 
+before_test:
+- ps: |
+    Write-Output "Getting and launching httpbin."
+    pip install httpbin
+    Start-Job -Name wx_httpbin { python -m httpbin.core > c:\projects\wxwidgets\httpbin.log }
+    curl http://127.0.0.1:5000/ip
+    $env:WX_TEST_WEBREQUEST_URL="http://127.0.0.1:5000"
+
 test_script: c:\projects\wxwidgets\build\tools\appveyor-test.bat
+
+after_test:
+- ps: |
+    Stop-Job -Name wx_httpbin
+    Write-Output "--- httpbin output ---"
+    Get-Content c:\projects\wxwidgets\httpbin.log
+    Write-Output "--- httpbin output end ---"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,7 +74,7 @@ build_script: c:\projects\wxwidgets\build\tools\appveyor.bat
 before_test:
 - ps: |
     Write-Output "Getting and launching httpbin."
-    C:\Python35\Scripts\pip.exe --disable-pip-version-check install httpbin
+    C:\Python35\Scripts\pip.exe --disable-pip-version-check --no-warn-script-location install httpbin
     Start-Job -Name wx_httpbin { C:\Python35\python.exe -m httpbin.core > c:\projects\wxwidgets\httpbin.log }
     curl http://127.0.0.1:5000/ip
     $env:WX_TEST_WEBREQUEST_URL="http://127.0.0.1:5000"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -78,7 +78,8 @@ before_test:
     pip.exe --disable-pip-version-check install httpbin
     Start-Job -Name wx_httpbin { python.exe -m httpbin.core 2>&1 > c:\projects\wxwidgets\httpbin.log }
     Start-Sleep -Seconds 5
-    if (curl.exe -s http://127.0.0.1:5000/ip > $null) {
+    curl.exe -s http://127.0.0.1:5000/ip > $null
+    if ($lastExitCode -eq "0") {
         $env:WX_TEST_WEBREQUEST_URL="http://127.0.0.1:5000"
     }
     else {

--- a/build/tools/appveyor-test.bat
+++ b/build/tools/appveyor-test.bat
@@ -1,13 +1,4 @@
 echo.
-echo --- Running httpbin...
-echo.
-
-pip install httpbin
-start /b python -m httpbin.core
-set WX_TEST_WEBREQUEST_URL=http://127.0.0.1:5000
-curl http://127.0.0.1:5000/ip
-
-echo.
 echo --- Running tests.
 echo.
 

--- a/build/tools/appveyor-test.bat
+++ b/build/tools/appveyor-test.bat
@@ -1,4 +1,13 @@
 echo.
+echo --- Running httpbin...
+echo.
+
+pip install httpbin
+start /b python -m httpbin.core
+set WX_TEST_WEBREQUEST_URL="http://127.0.0.1:5000"
+curl http://127.0.0.1:5000/ip
+
+echo.
 echo --- Running tests.
 echo.
 

--- a/build/tools/appveyor-test.bat
+++ b/build/tools/appveyor-test.bat
@@ -62,4 +62,4 @@ echo.
 echo --- httpbin output ---
 type c:\projects\wxwidgets\httpbin.log
 echo --- httpbin output end ---
-goto :eof
+exit /b 1

--- a/build/tools/appveyor-test.bat
+++ b/build/tools/appveyor-test.bat
@@ -59,4 +59,7 @@ goto :eof
 echo.
 echo !!! Non-GUI test failed.
 echo.
+echo --- httpbin output ---
+type c:\projects\wxwidgets\httpbin.log
+echo --- httpbin output end ---
 goto :eof

--- a/build/tools/appveyor-test.bat
+++ b/build/tools/appveyor-test.bat
@@ -4,7 +4,7 @@ echo.
 
 pip install httpbin
 start /b python -m httpbin.core
-set WX_TEST_WEBREQUEST_URL="http://127.0.0.1:5000"
+set WX_TEST_WEBREQUEST_URL=http://127.0.0.1:5000
 curl http://127.0.0.1:5000/ip
 
 echo.

--- a/build/tools/travis-ci.sh
+++ b/build/tools/travis-ci.sh
@@ -14,10 +14,21 @@ export NO_AT_BRIDGE=1
 
 launch_httpbin() {
     echo 'travis_fold:start:httpbin'
-    echo 'Running httpbin container...'
-    docker pull kennethreitz/httpbin
-    docker run -d -p 80:80 kennethreitz/httpbin
-    WX_TEST_WEBREQUEST_URL="http://localhost"
+    echo 'Running httpbin...'
+
+    # Prefer to use docker if it's available as it's more robust than dealing
+    # with pip -- but we need to have a fallback as at least Mac builds don't
+    # have docker.
+    if command -v docker; then
+        docker pull kennethreitz/httpbin
+        docker run -d -p 80:80 kennethreitz/httpbin
+        WX_TEST_WEBREQUEST_URL="http://localhost"
+    else
+        pip install httpbin
+        python -m httpbin.core &
+        WX_TEST_WEBREQUEST_URL="http://localhost:5000"
+    fi
+
     export WX_TEST_WEBREQUEST_URL
     echo 'travis_fold:end:httpbin'
 }

--- a/build/tools/travis-ci.sh
+++ b/build/tools/travis-ci.sh
@@ -12,6 +12,16 @@ wxBUILD_ARGS="-j$wxPROC_COUNT"
 # messages from WebKit tests that we're not interested in.
 export NO_AT_BRIDGE=1
 
+launch_httpbin() {
+    echo 'travis_fold:start:httpbin'
+    echo 'Running httpbin container...'
+    docker pull kennethreitz/httpbin
+    docker run -d -p 80:80 kennethreitz/httpbin
+    WX_TEST_WEBREQUEST_URL="http://localhost"
+    export WX_TEST_WEBREQUEST_URL
+    echo 'travis_fold:end:httpbin'
+}
+
 case $wxTOOLSET in
     cmake)
         if [ -z $wxCMAKE_TESTS ]; then wxCMAKE_TESTS=CONSOLE_ONLY; fi
@@ -42,6 +52,8 @@ case $wxTOOLSET in
         echo 'travis_fold:end:install'
 
         if [ "$wxCMAKE_TESTS" != "OFF" ]; then
+            launch_httpbin
+
             echo 'travis_fold:start:testing'
             echo 'Testing...'
             ctest -V -C Debug -E "test_drawing" --output-on-failure --interactive-debug-mode 0 .
@@ -123,6 +135,8 @@ case $wxTOOLSET in
             echo 'Skipping running tests'
             exit 0
         fi
+
+        launch_httpbin
 
         echo 'travis_fold:start:testing'
         echo 'Testing...'

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -50,8 +50,19 @@ public:
     // it returns false, as this indicates that web requests tests are disabled.
     bool InitBaseURL()
     {
-        if ( !wxGetEnv("WX_TEST_WEBREQUEST_URL", &baseURL) )
+        if ( wxGetEnv("WX_TEST_WEBREQUEST_URL", &baseURL) )
+        {
+            static bool s_shown = false;
+            if ( !s_shown )
+            {
+                s_shown = true;
+                WARN("Using non-default root URL " << baseURL);
+            }
+        }
+        else
+        {
             baseURL = WX_TEST_WEBREQUEST_URL_DEFAULT;
+        }
 
         return baseURL != "0";
     }

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -247,24 +247,14 @@ TEST_CASE_METHOD(RequestFixture,
     if ( !InitBaseURL() )
         return;
 
-    // We can't use the same httpbin.org server that we use for the other tests
-    // for this one because it doesn't return anything in the body when
-    // returning an error status code, so use another one.
-    CreateAbs("https://httpstat.us/418");
+    Create("/status/418");
     Run(wxWebRequest::State_Failed, 0);
 
-    // For some reason, this test doesn't work with libcurl included in Ubuntu
-    // 14.04, so skip it.
-    const int status = request.GetResponse().GetStatus();
-    if ( status == 0 )
-    {
-        WARN("Status code not returned.");
-    }
-    else
-    {
-        CHECK( status == 418 );
-        CHECK( request.GetResponse().AsString() == "418 I'm a teapot" );
-    }
+    CHECK( request.GetResponse().GetStatus() == 418 );
+
+    const wxString& response = request.GetResponse().AsString();
+    INFO( "Response: " << response);
+    CHECK( response.Contains("teapot") );
 }
 
 TEST_CASE_METHOD(RequestFixture,

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -27,11 +27,15 @@
 #include "wx/filename.h"
 #include "wx/wfstream.h"
 
-// This test uses https://httpbin.org by default, but this can be overridden by
-// setting WX_TEST_WEBREQUEST_URL, e.g. when running httpbin locally in a
-// docker container. This variable can also be set to a special value "0" to
-// disable running the test entirely.
-static const char* WX_TEST_WEBREQUEST_URL_DEFAULT = "https://httpbin.org";
+// This test uses httpbin service and by default uses the mirror at the
+// location below, which seems to be more reliable than the main site at
+// https://httpbin.org. Any other mirror, including a local one, which can be
+// set by running kennethreitz/httpbin Docker container, can be used by setting
+// WX_TEST_WEBREQUEST_URL environment variable to its URL.
+//
+// This variable can also be set to a special value "0" to disable running the
+// test entirely.
+static const char* WX_TEST_WEBREQUEST_URL_DEFAULT = "https://nghttp2.org/httpbin";
 
 class RequestFixture : public wxTimer
 {

--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -111,7 +111,7 @@ public:
 
     void RunLoopWithTimeout()
     {
-        StartOnce(10000); // Ensure that we exit the loop after 10s.
+        StartOnce(30000); // Ensure that we exit the loop after 30s.
         loop.Run();
         Stop();
     }


### PR DESCRIPTION
In fact, using Docker might be the best thing to do, actually -- it seems to be available everywhere, so if this still doesn't work, I think I'm going to try doing  this next. These tests are too useful to sacrifice running them automatically entirely...