### PR TITLE
Fix numbered list in wxMenuEvent docs

### DIFF
--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -4479,7 +4479,6 @@ public:
     wxMenuBar, attached to wxFrame, and popup menus shown by
     wxWindow::PopupMenu(). They are sent to the following objects until one of
     them handles the event:
-
         -# The menu object itself, as returned by GetMenu(), if any.
         -# The wxMenuBar to which this menu is attached, if any.
         -# The window associated with the menu, e.g. the one calling


### PR DESCRIPTION
Just remove the empty line which prevented doxygen from generating a numbered list.

The list for [the event ](https://docs.wxwidgets.org/trunk/classwx_menu_event.html) now looks like this
![menuevent-incorrect](https://user-images.githubusercontent.com/12495521/105643372-c302b180-5e8f-11eb-99b3-1f5f30f670d2.png)
