### PR TITLE
Use wxGtkValue RAII wrapper in wxGTK code

### DIFF
--- a/include/wx/gtk/private/value.h
+++ b/include/wx/gtk/private/value.h
@@ -18,14 +18,14 @@ class wxGtkValue
 {
 public:
     explicit wxGtkValue()
-        : m_val(G_VALUE_INIT)
     {
+        memset(&m_val, 0, sizeof(m_val));
     }
 
     // Initialize the value of the specified type.
     explicit wxGtkValue(GType gtype)
-        : m_val(G_VALUE_INIT)
     {
+        memset(&m_val, 0, sizeof(m_val));
         g_value_init(&m_val, gtype);
     }
 

--- a/include/wx/gtk/private/value.h
+++ b/include/wx/gtk/private/value.h
@@ -17,6 +17,11 @@
 class wxGtkValue
 {
 public:
+    explicit wxGtkValue()
+        : m_val(G_VALUE_INIT)
+    {
+    }
+
     // Initialize the value of the specified type.
     explicit wxGtkValue(GType gtype)
         : m_val(G_VALUE_INIT)

--- a/src/gtk/bmpcbox.cpp
+++ b/src/gtk/bmpcbox.cpp
@@ -27,6 +27,7 @@
 #endif
 
 #include "wx/gtk/private.h"
+#include "wx/gtk/private/value.h"
 
 // ============================================================================
 // implementation
@@ -197,12 +198,10 @@ void wxBitmapComboBox::SetItemBitmap(unsigned int n, const wxBitmap& bitmap)
 
         if ( gtk_tree_model_iter_nth_child( model, &iter, NULL, n ) )
         {
-            GValue value0 = G_VALUE_INIT;
-            g_value_init( &value0, G_TYPE_OBJECT );
-            g_value_set_object( &value0, bitmap.GetPixbuf() );
+            wxGtkValue value0( G_TYPE_OBJECT );
+            g_value_set_object( value0, bitmap.GetPixbuf() );
             gtk_list_store_set_value( GTK_LIST_STORE(model), &iter,
-                                      m_bitmapCellIndex, &value0 );
-            g_value_unset( &value0 );
+                                      m_bitmapCellIndex, value0 );
         }
     }
 }
@@ -217,16 +216,15 @@ wxBitmap wxBitmapComboBox::GetItemBitmap(unsigned int n) const
 
     if (gtk_tree_model_iter_nth_child (model, &iter, NULL, n))
     {
-        GValue value = G_VALUE_INIT;
+        wxGtkValue value;
         gtk_tree_model_get_value( model, &iter,
-                                  m_bitmapCellIndex, &value );
-        GdkPixbuf* pixbuf = (GdkPixbuf*) g_value_get_object( &value );
+                                  m_bitmapCellIndex, value );
+        GdkPixbuf* pixbuf = (GdkPixbuf*) g_value_get_object( value );
         if ( pixbuf )
         {
             g_object_ref( pixbuf );
             bitmap = wxBitmap(pixbuf);
         }
-        g_value_unset( &value );
     }
 
     return bitmap;
@@ -295,11 +293,9 @@ void wxBitmapComboBox::GTKInsertComboBoxTextItem( unsigned int n, const wxString
 
     gtk_list_store_insert( store, &iter, n );
 
-    GValue value = G_VALUE_INIT;
-    g_value_init( &value, G_TYPE_STRING );
-    g_value_set_string( &value, wxGTK_CONV( text ) );
-    gtk_list_store_set_value( store, &iter, m_stringCellIndex, &value );
-    g_value_unset( &value );
+    wxGtkValue value( G_TYPE_STRING );
+    g_value_set_string( value, wxGTK_CONV( text ) );
+    gtk_list_store_set_value( store, &iter, m_stringCellIndex, value );
 }
 
 // ----------------------------------------------------------------------------

--- a/src/gtk/choice.cpp
+++ b/src/gtk/choice.cpp
@@ -18,6 +18,7 @@
 
 #include "wx/gtk/private.h"
 #include "wx/gtk/private/eventsdisabler.h"
+#include "wx/gtk/private/value.h"
 
 // ----------------------------------------------------------------------------
 // GTK callbacks
@@ -233,10 +234,9 @@ int wxChoice::FindString( const wxString &item, bool bCase ) const
     int count = 0;
     do
     {
-        GValue value = G_VALUE_INIT;
-        gtk_tree_model_get_value( model, &iter, m_stringCellIndex, &value );
-        wxString str = wxGTK_CONV_BACK( g_value_get_string( &value ) );
-        g_value_unset( &value );
+        wxGtkValue value;
+        gtk_tree_model_get_value( model, &iter, m_stringCellIndex, value );
+        wxString str = wxGTK_CONV_BACK( g_value_get_string( value ) );
 
         if (item.IsSameAs( str, bCase ) )
             return count;
@@ -264,11 +264,9 @@ void wxChoice::SetString(unsigned int n, const wxString &text)
     GtkTreeIter iter;
     if (gtk_tree_model_iter_nth_child (model, &iter, NULL, n))
     {
-        GValue value = G_VALUE_INIT;
-        g_value_init( &value, G_TYPE_STRING );
-        g_value_set_string( &value, wxGTK_CONV( text ) );
-        gtk_list_store_set_value( GTK_LIST_STORE(model), &iter, m_stringCellIndex, &value );
-        g_value_unset( &value );
+        wxGtkValue value(G_TYPE_STRING);
+        g_value_set_string( value, wxGTK_CONV( text ) );
+        gtk_list_store_set_value( GTK_LIST_STORE(model), &iter, m_stringCellIndex, value );
     }
 
     InvalidateBestSize();
@@ -287,11 +285,9 @@ wxString wxChoice::GetString(unsigned int n) const
         return wxString();
     }
 
-    GValue value = G_VALUE_INIT;
-    gtk_tree_model_get_value( model, &iter, m_stringCellIndex, &value );
-    wxString tmp = wxGTK_CONV_BACK( g_value_get_string( &value ) );
-    g_value_unset( &value );
-    return tmp;
+    wxGtkValue value;
+    gtk_tree_model_get_value( model, &iter, m_stringCellIndex, value );
+    return wxGTK_CONV_BACK( g_value_get_string( value ) );
 }
 
 unsigned int wxChoice::GetCount() const

--- a/src/gtk/renderer.cpp
+++ b/src/gtk/renderer.cpp
@@ -41,6 +41,7 @@
 
 #include "wx/gtk/private.h"
 #include "wx/gtk/private/stylecontext.h"
+#include "wx/gtk/private/value.h"
 
 #if defined(__WXGTK3__) && !GTK_CHECK_VERSION(3,14,0)
     #define GTK_STATE_FLAG_CHECKED (1 << 11)
@@ -583,20 +584,17 @@ struct CheckBoxInfo
         }
         else
         {
-            GValue value = G_VALUE_INIT;
-            g_value_init(&value, G_TYPE_INT);
+            wxGtkValue value( G_TYPE_INT);
 
-            gtk_style_context_get_style_property(sc, "indicator-size", &value);
+            gtk_style_context_get_style_property(sc, "indicator-size", value);
             indicator_width =
-            indicator_height = g_value_get_int(&value);
+            indicator_height = g_value_get_int(value);
 
-            gtk_style_context_get_style_property(sc, "indicator-spacing", &value);
+            gtk_style_context_get_style_property(sc, "indicator-spacing", value);
             margin_left =
             margin_top =
             margin_right =
-            margin_bottom = g_value_get_int(&value);
-
-            g_value_unset(&value);
+            margin_bottom = g_value_get_int(value);
         }
     }
 #else // !__WXGTK3__
@@ -1112,12 +1110,10 @@ void wxRendererGTK::DrawRadioBitmap(wxWindow*, wxDC& dc, const wxRect& rect, int
     }
     else
     {
-        GValue value = G_VALUE_INIT;
-        g_value_init(&value, G_TYPE_INT);
-        gtk_style_context_get_style_property(sc, "indicator-size", &value);
-        min_width = g_value_get_int(&value);
+        wxGtkValue value( G_TYPE_INT);
+        gtk_style_context_get_style_property(sc, "indicator-size", value);
+        min_width = g_value_get_int(value);
         min_height = min_width;
-        g_value_unset(&value);
     }
 
     // need save/restore for GTK+ 3.6 & 3.8

--- a/src/gtk/settings.cpp
+++ b/src/gtk/settings.cpp
@@ -24,6 +24,7 @@
 #include "wx/gtk/private/gtk3-compat.h"
 #include "wx/gtk/private/win_gtk.h"
 #include "wx/gtk/private/stylecontext.h"
+#include "wx/gtk/private/value.h"
 
 bool wxGetFrameExtents(GdkWindow* window, int* left, int* right, int* top, int* bottom);
 
@@ -562,15 +563,13 @@ wxColour wxSystemSettingsNative::GetColour(wxSystemColour index)
         else
         {
             wxGCC_WARNING_SUPPRESS(deprecated-declarations)
-            GValue value = G_VALUE_INIT;
-            g_value_init(&value, GDK_TYPE_COLOR);
-            gtk_style_context_get_style_property(sc, "link-color", &value);
-            GdkColor* link_color = static_cast<GdkColor*>(g_value_get_boxed(&value));
+            wxGtkValue value( GDK_TYPE_COLOR);
+            gtk_style_context_get_style_property(sc, "link-color", value);
+            GdkColor* link_color = static_cast<GdkColor*>(g_value_get_boxed(value));
             GdkColor gdkColor = { 0, 0, 0, 0xeeee };
             if (link_color)
                 gdkColor = *link_color;
             color = wxColour(gdkColor);
-            g_value_unset(&value);
             wxGCC_WARNING_RESTORE()
         }
 #endif


### PR DESCRIPTION
wxGtkValue class was added back in 3f84cb17ca (Add wxActivityIndicator
control., 2015-03-06), but somehow never used. Start using it now
(better late than never...) as it makes the code simpler, shorter and
more robust.

No real changes.