### PR TITLE
An event to make it easier to receive messages posted by web content

### DIFF
--- a/include/wx/gtk/webview_webkit.h
+++ b/include/wx/gtk/webview_webkit.h
@@ -146,6 +146,8 @@ protected:
 
     virtual GdkWindow *GTKGetWindow(wxArrayGdkWindows& windows) const wxOVERRIDE;
 
+    virtual void RegisterScriptMessageHandler() wxOVERRIDE;
+
 private:
 
     void ZoomIn();

--- a/include/wx/msw/private/webview_edge.h
+++ b/include/wx/msw/private/webview_edge.h
@@ -13,7 +13,7 @@
 #include "wx/dynlib.h"
 #include "wx/msw/private/comptr.h"
 
-#include <Webview2.h>
+#include <WebView2.h>
 
 #ifndef __ICoreWebView2Environment_INTERFACE_DEFINED__
     #error "WebView2 SDK version 0.9.430 or newer is required"
@@ -45,6 +45,7 @@ public:
     EventRegistrationToken m_newWindowRequestedToken = { };
     EventRegistrationToken m_documentTitleChangedToken = { };
     EventRegistrationToken m_contentLoadingToken = { };
+    EventRegistrationToken m_webMessageReceivedToken = { };
 
     // WebView Event handlers
     HRESULT OnNavigationStarting(ICoreWebView2* sender, ICoreWebView2NavigationStartingEventArgs* args);
@@ -52,6 +53,10 @@ public:
     HRESULT OnNewWindowRequested(ICoreWebView2* sender, ICoreWebView2NewWindowRequestedEventArgs* args);
     HRESULT OnDocumentTitleChanged(ICoreWebView2* sender, IUnknown* args);
     HRESULT OnContentLoading(ICoreWebView2* sender, ICoreWebView2ContentLoadingEventArgs* args);
+
+    wxString m_sJsName;
+    void RegisterScriptMessageHandler();
+    HRESULT OnWebMessageReceived(ICoreWebView2 *sender, ICoreWebView2WebMessageReceivedEventArgs *args);
 
     HRESULT OnEnvironmentCreated(HRESULT result, ICoreWebView2Environment* environment);
     HRESULT OnWebViewCreated(HRESULT result, ICoreWebView2Controller* webViewController);

--- a/include/wx/msw/webview_edge.h
+++ b/include/wx/msw/webview_edge.h
@@ -125,6 +125,8 @@ public:
 protected:
     virtual void DoSetPage(const wxString& html, const wxString& baseUrl) wxOVERRIDE;
 
+    virtual void RegisterScriptMessageHandler() wxOVERRIDE;
+
 private:
     wxWebViewEdgeImpl* m_impl;
 

--- a/include/wx/webview.h
+++ b/include/wx/webview.h
@@ -289,12 +289,12 @@ class WXDLLIMPEXP_WEBVIEW wxJSValue
 {
 #if defined(__WXGTK__)
 public:
-    wxJSValue(_WebKitJavascriptResult *jsResult) { // a sink
+    wxJSValue(_WebKitJavascriptResult *jsResult) : m_val(jsResult) // a sink
+    {
         /**
          * The caller is supposed to give ownership of the argument to us, so
          * don't need to increase ref count here.
          */
-        m_val = jsResult;
     }
 private:
     _WebKitJavascriptResult *m_val;

--- a/src/common/webview.cpp
+++ b/src/common/webview.cpp
@@ -48,6 +48,7 @@ wxDEFINE_EVENT( wxEVT_WEBVIEW_LOADED, wxWebViewEvent );
 wxDEFINE_EVENT( wxEVT_WEBVIEW_ERROR, wxWebViewEvent );
 wxDEFINE_EVENT( wxEVT_WEBVIEW_NEWWINDOW, wxWebViewEvent );
 wxDEFINE_EVENT( wxEVT_WEBVIEW_TITLE_CHANGED, wxWebViewEvent );
+wxDEFINE_EVENT( wxEVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED, wxWebViewEvent );
 
 wxStringWebViewFactoryMap wxWebView::m_factoryMap;
 


### PR DESCRIPTION
Assume we have a code block like this:
```
enum {ID_WEBVIEW = wxID_HIGHEST};
...
wxWebView *widget = wxWebView::New(frame, ID_WEBVIEW, "http://www.wxwidgets.org/");
widget->SetJSName("wx");
...
wxBEGIN_EVENT_TABLE(CFrame, wxFrame)
	EVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED(ID_WEBVIEW, CFrame::OnWebviewScriptMessageReceived)
wxEND_EVENT_TABLE()
```
whenever the web content executes a JavaScript statement like `window.wx.postMessage(foo);`, the callback `CFrame::OnWebviewScriptMessageReceived` gets called. In the callback, we can receive the message like this:
```
void CFrame::OnWebviewScriptMessageReceived(wxWebViewEvent& evt)
{
	const wxJSValue *msg = evt.GetScriptMessage();
	wxString&& json = msg->AsJSON();
	wxString&& str = msg->AsString();
	int a = msg->AsInteger();
	bool b = msg->AsBoolean();
	double d = msg->AsDouble();
}
```
There are also error-checking version of the getter methods. For instance,
```
double pi;
bool success = msg->AsDouble(&pi);
```

Additionally, several templates are added for GNU C++ and Clang C++ to compile without errors when `wxUSE_WEBVIEW_EDGE` is true. See https://github.com/wxWidgets/wxWidgets/pull/2171 for details. The steps obviously shall be on document, but I don't know how to access the document.

Please note that `wxWebViewIE` and Mac port are both ignored in this branch. Therefore, it's very likely that compile time errors will happen if try to build them. Some discussion would be needed, because I'm not interested in and also have no idea of how to implement them.