### PR TITLE
some fixes building without X stuff.

### DIFF
--- a/src/gtk/display.cpp
+++ b/src/gtk/display.cpp
@@ -175,7 +175,7 @@ bool wxDisplayImplGTK::ChangeMode(const wxVideoMode& WXUNUSED(mode))
 
 #else // !__WXGTK4__
 
-#ifdef __WXGTK3__
+#if defined(__WXGTK3__) && defined(GDK_WINDOWING_X11)
 
 static inline bool wxIsX11GDKScreen(GdkScreen* screen)
 {

--- a/src/gtk/glcanvas.cpp
+++ b/src/gtk/glcanvas.cpp
@@ -260,8 +260,12 @@ bool wxGLCanvas::SetBackgroundStyle(wxBackgroundStyle /* style */)
 
 unsigned long wxGLCanvas::GetXWindow() const
 {
+#if defined(GDK_WINDOWING_X11)
     GdkWindow* window = GTKGetDrawingWindow();
     return window ? GDK_WINDOW_XID(window) : 0;
+#else
+    return 0;
+#endif
 }
 
 void wxGLCanvas::GTKHandleRealized()

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -2460,7 +2460,7 @@ wxWindow *wxGetActiveWindow()
 
 // Under Unix this is implemented using X11 functions in utilsx11.cpp but we
 // need to have this function under Windows too, so provide at least a stub.
-#ifndef GDK_WINDOWING_X11
+#ifdef GDK_WINDOWING_WIN32
 bool wxGetKeyState(wxKeyCode WXUNUSED(key))
 {
     wxFAIL_MSG(wxS("Not implemented under Windows"));

--- a/src/unix/utilsx11.cpp
+++ b/src/unix/utilsx11.cpp
@@ -2636,15 +2636,17 @@ static bool wxGetKeyStateGTK(wxKeyCode key)
 bool wxGetKeyState(wxKeyCode key)
 {
 #ifdef wxHAS_GETKEYSTATE_GTK
+    bool ret = false;
     GdkDisplay* display = gdk_window_get_display(wxGetTopLevelGDK());
     const char* name = g_type_name(G_TYPE_FROM_INSTANCE(display));
     if (strcmp(name, "GdkX11Display") != 0)
     {
-        return wxGetKeyStateGTK(key);
+        ret = wxGetKeyStateGTK(key);
     }
-#endif // GTK+ 3.4+
-
+    return ret;
+#else
     return wxGetKeyStateX11(key);
+#endif // GTK+ 3.4+
 }
 
 // ----------------------------------------------------------------------------

--- a/src/unix/utilsx11.cpp
+++ b/src/unix/utilsx11.cpp
@@ -50,9 +50,11 @@ GdkWindow* wxGetTopLevelGDK();
 GtkWidget* wxGetTopLevelGTK();
 #endif
 
+#ifdef GTK_CHECK_VERSION
 #if GTK_CHECK_VERSION(3,4,0)
 #define wxHAS_GETKEYSTATE_GTK
 #endif //GTK+ 3.4
+#endif
 
 // Only X11 backend is supported for wxGTK here (GTK < 2 has no others)
 #if !defined(__WXGTK__) || \

--- a/src/unix/utilsx11.cpp
+++ b/src/unix/utilsx11.cpp
@@ -50,6 +50,10 @@ GdkWindow* wxGetTopLevelGDK();
 GtkWidget* wxGetTopLevelGTK();
 #endif
 
+#if GTK_CHECK_VERSION(3,4,0)
+#define wxHAS_GETKEYSTATE_GTK
+#endif //GTK+ 3.4
+
 // Only X11 backend is supported for wxGTK here (GTK < 2 has no others)
 #if !defined(__WXGTK__) || \
     (!defined(__WXGTK20__) || defined(GDK_WINDOWING_X11))
@@ -2544,6 +2548,7 @@ int wxUnicodeCharXToWX(WXKeySym keySym)
 // check current state of a key
 // ----------------------------------------------------------------------------
 
+#ifndef wxHAS_GETKEYSTATE_GTK
 static bool wxGetKeyStateX11(wxKeyCode key)
 {
     wxASSERT_MSG(key != WXK_LBUTTON && key != WXK_RBUTTON && key !=
@@ -2588,6 +2593,7 @@ static bool wxGetKeyStateX11(wxKeyCode key)
     XQueryKeymap(pDisplay, key_vector);
     return (key_vector[keyCode >> 3] & (1 << (keyCode & 7))) != 0;
 }
+#endif
 
 #endif // !defined(__WXGTK__) || defined(GDK_WINDOWING_X11)
 
@@ -2596,9 +2602,8 @@ static bool wxGetKeyStateX11(wxKeyCode key)
 #ifdef __WXGTK__
 
 // gdk_keymap_get_modifier_state() is only available since 3.4
-#if GTK_CHECK_VERSION(3,4,0)
 
-#define wxHAS_GETKEYSTATE_GTK
+#ifdef wxHAS_GETKEYSTATE_GTK
 
 static bool wxGetKeyStateGTK(wxKeyCode key)
 {
@@ -2629,8 +2634,8 @@ static bool wxGetKeyStateGTK(wxKeyCode key)
     }
     return (state & mask) != 0;
 }
+#endif // wxHAS_GETKEYSTATE_GTK
 
-#endif // GTK+ 3.4
 #endif // __WXGTK__
 
 bool wxGetKeyState(wxKeyCode key)


### PR DESCRIPTION
Tested and working wxWidgets natively on wayland with drm backend and Opengl ES 2.0 with a Raspberry Pi2.

Examples working:

- isosurf    OK
- penguin  OK
- cube       OK

pyramid  example throw an error beacause Opengl version mismatch.