### PR TITLE
Don't check for DrawThemeTextEx availability every DrawItemText()

### DIFF
--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -1044,11 +1044,17 @@ void wxRendererXP::DrawItemText(wxWindow* win,
 
     typedef HRESULT(__stdcall *DrawThemeTextEx_t)(HTHEME, HDC, int, int, const wchar_t *, int, DWORD, RECT *, const WXDTTOPTS *);
     static DrawThemeTextEx_t s_DrawThemeTextEx = NULL;
+    static bool s_initDone = false;
 
-    if (wxGetWinVersion() >= wxWinVersion_Vista)
+    if ( !s_initDone )
     {
-        wxLoadedDLL dllUxTheme(wxS("uxtheme.dll"));
-        wxDL_INIT_FUNC(s_, DrawThemeTextEx, dllUxTheme);
+        if (wxGetWinVersion() >= wxWinVersion_Vista)
+        {
+            wxLoadedDLL dllUxTheme(wxS("uxtheme.dll"));
+            wxDL_INIT_FUNC(s_, DrawThemeTextEx, dllUxTheme);
+        }
+
+        s_initDone = true;
     }
 
     if ( s_DrawThemeTextEx && // Might be not available if we're under XP


### PR DESCRIPTION
Check for DrawThemeTextEx availability only once, which also seems to be
what ddceaab001 (Remove MSW wxUxThemeEngine class, 2017-10-27) intended
to do here by already introducing a static function pointer. Simply add
an init guard, also because the repeated check is not a cheap operation
(judging by comparing performance with drawing short texts).

--

Note: An init-once approach like in 5b1985a920 was considered but I slightly preferred the `bool` way in the end (for readability I guess).
