### PR TITLE
Generate Enter/Tab events even in readonly MSW wxTextCtrl

### DIFF
--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -2166,7 +2166,7 @@ void wxTextCtrl::OnChar(wxKeyEvent& event)
             // the right thing to do would, of course, be to understand what
             // the hell is IsDialogMessage() doing but this is beyond my feeble
             // forces at the moment unfortunately
-            if ( !(m_windowStyle & wxTE_PROCESS_TAB))
+            if ( !(m_windowStyle & wxTE_PROCESS_TAB) || !IsEditable() )
             {
                 if ( ::GetFocus() == GetHwnd() )
                 {
@@ -2334,35 +2334,23 @@ wxTextCtrl::MSWHandleMessage(WXLRESULT *rc,
                 // in a read only control
                 long lDlgCode = DLGC_WANTCHARS | DLGC_WANTARROWS;
 
-                if ( IsEditable() )
-                {
-                    // we may have several different cases:
-                    // 1. normal: both TAB and ENTER are used for navigation
-                    // 2. ctrl wants TAB for itself: ENTER is used to pass to
-                    //    the next control in the dialog
-                    // 3. ctrl wants ENTER for itself: TAB is used for dialog
-                    //    navigation
-                    // 4. ctrl wants both TAB and ENTER: Ctrl-ENTER is used to
-                    //    go to the next control (we need some way to do it)
+                // we may have several different cases:
+                // 1. normal: both TAB and ENTER are used for navigation
+                // 2. ctrl wants TAB for itself: ENTER is used to pass to
+                //    the next control in the dialog
+                // 3. ctrl wants ENTER for itself: TAB is used for dialog
+                //    navigation
+                // 4. ctrl wants both TAB and ENTER: Ctrl-ENTER is used to
+                //    go to the next control (we need some way to do it)
 
-                    // multiline controls should always get ENTER for themselves
-                    if ( HasFlag(wxTE_PROCESS_ENTER) || HasFlag(wxTE_MULTILINE) )
-                        lDlgCode |= DLGC_WANTMESSAGE;
+                // multiline controls should always get ENTER for themselves
+                if ( HasFlag(wxTE_PROCESS_ENTER) || HasFlag(wxTE_MULTILINE) )
+                    lDlgCode |= DLGC_WANTMESSAGE;
 
-                    if ( HasFlag(wxTE_PROCESS_TAB) )
-                        lDlgCode |= DLGC_WANTTAB;
+                if ( HasFlag(wxTE_PROCESS_TAB) )
+                    lDlgCode |= DLGC_WANTTAB;
 
-                    *rc |= lDlgCode;
-                }
-                else // !editable
-                {
-                    // NB: use "=", not "|=" as the base class version returns
-                    //     the same flags in the disabled state as usual (i.e.
-                    //     including DLGC_WANTMESSAGE). This is strange (how
-                    //     does it work in the native Win32 apps?) but for now
-                    //     live with it.
-                    *rc = lDlgCode;
-                }
+                *rc |= lDlgCode;
 
                 if ( IsMultiLine() )
                 {


### PR DESCRIPTION
Respect wxTE_PROCESS_TAB and wxTE_PROCESS_ENTER flags even for readonly
text controls. Previously there were ignored for them due to the changes
of 080c709f70 (fix for handling TAB presses in readonly text controls,
2002-09-07), but there doesn't seem to be any good reason to do this, so
revert the changes of that commit by removing IsEditable() check from
our WM_GETDLGCODE handler.

We also need to avoid inserting TABs into readonly controls ourselves in
the default wxEVT_CHAR handler, so add a check for IsEditable() there to
compensate for the fact that these events are now received even for the
readonly controls.

This commit is best viewed ignoring whitespace-only changes.

Closes [#19064](https://trac.wxwidgets.org/ticket/19064).