### PR TITLE
Added a provision parameter to the wxHTMLDataObject ctor, and provisi…

### DIFF
--- a/include/wx/dataobj.h
+++ b/include/wx/dataobj.h
@@ -334,13 +334,51 @@ private:
 class WXDLLIMPEXP_CORE wxHTMLDataObject : public wxDataObjectSimple
 {
 public:
+    /**
+        Provision values to be passed to the constructor to determine what
+        portion of the content is passed to or retrieved from the data object.
+     */
+     
+    enum
+    {
+        /**
+            All content is set or retrieved, including any header information.
+         */
+        Raw,
+
+        /**
+            All HTML content is set or retrieved (the default for non-Windows).
+         */
+        HTML,
+
+        /**
+            Just the relevant fragment is set or retrieved (the default for Windows).
+         */
+        Fragment,
+        
+        /**
+            The default provision (platform-specific)
+         */
+        DefaultProvision = 
+#ifdef __WXMSW__
+                    Fragment
+#else
+                    HTML
+#endif
+    };
+    
     // ctor: you can specify the text here or in SetText(), or override
     // GetText()
-    wxHTMLDataObject(const wxString& html = wxEmptyString)
+    wxHTMLDataObject(const wxString& html = wxEmptyString, int provision = DefaultProvision)
         : wxDataObjectSimple(wxDF_HTML),
-          m_html(html)
+          m_html(html),
+          m_provision(provision)
         {
         }
+
+    // Determine what part of the HTML will be passed or returned
+    void SetProvision(int provision) { m_provision = provision; }
+    int GetProvision() const { return m_provision; }
 
     // virtual functions which you may override if you want to provide text on
     // demand only - otherwise, the trivial default versions will be used
@@ -368,6 +406,7 @@ public:
 
 private:
     wxString m_html;
+    int      m_provision;
 };
 
 class WXDLLIMPEXP_CORE wxTextDataObject : public wxDataObjectSimple

--- a/interface/wx/dataobj.h
+++ b/interface/wx/dataobj.h
@@ -824,6 +824,17 @@ public:
     @class wxHTMLDataObject
 
     wxHTMLDataObject is used for working with HTML-formatted text.
+    
+    The form of content that will be set or retrieved is set by the optional @a provision argument passed to the constructor.
+    To retrieve all content, including any platform-specific header, pass @c wxHTMLDataObject::Raw.
+    To retrieve just the HTML, pass @c wxHTMLDataObject::HTML.
+    To retrieve just the relevant fragment, pass @c wxHTMLDataObject::Fragment.
+    
+    Similarly, if you are setting clipboard data, and you pass @c wxHTMLDataObject::Fragment, then
+    the HTML you pass will be treated as a fragment and will be wrapped in HTML tags.
+    
+    On Windows, the default is @c wxHTMLDataObject::Fragment. On other platforms, it's
+    @c wxHTMLDataObject::HTML, for compatibility with existing code.
 
     @library{wxcore}
     @category{dnd}
@@ -834,9 +845,43 @@ class wxHTMLDataObject : public wxDataObjectSimple
 {
 public:
     /**
-        Constructor.
+        Provision values to be passed to the constructor to determine what
+        portion of the content is passed to or retrieved from the data object.
+     */
+     
+    enum
+    {
+        /**
+            All content is set or retrieved, including any header information.
+         */
+        Raw,
+
+        /**
+            All HTML content is set or retrieved (the default for non-Windows).
+         */
+        HTML,
+
+        /**
+            Just the relevant fragment is set or retrieved (the default for Windows).
+         */
+        Fragment,
+        
+        /**
+            The default provision (platform-specific)
+         */
+        DefaultProvision = 
+#ifdef __WXMSW__
+                    Fragment
+#else
+                    HTML
+#endif
+    };
+
+    /**
+        Constructor. Optionally specify the kind of provision - the kind of content that will
+        be passed or retrieved.
     */
-    wxHTMLDataObject(const wxString& html = wxEmptyString);
+    wxHTMLDataObject(const wxString& html = wxEmptyString, int provision = DefaultProvision);
 
     /**
         Returns the HTML string.
@@ -847,4 +892,14 @@ public:
         Sets the HTML string.
     */
     virtual void SetHTML(const wxString& html);
+    
+    /**
+        Set the type of content that will be passed or returned: Raw, HTML or Fragment.
+    */
+    void SetProvision(int provision);
+
+    /**
+        Returns the type of content that will be passed or returned: Raw, HTML or Fragment.
+    */
+    int GetProvision() const;
 };

--- a/samples/clipboard/clipboard.cpp
+++ b/samples/clipboard/clipboard.cpp
@@ -48,6 +48,10 @@ public:
     void OnQuit(wxCommandEvent&event);
     void OnAbout(wxCommandEvent&event);
     void OnFlush(wxCommandEvent &event);
+    void OnPasteHTML_Raw(wxCommandEvent &event);
+    void OnPasteHTML_HTML(wxCommandEvent &event);
+    void OnPasteHTML_Fragment(wxCommandEvent &event);
+    void OnUpdatePasteHTML(wxUpdateUIEvent &event);
     void OnWriteClipboardContents(wxCommandEvent&event);
     void OnUpdateUI(wxUpdateUIEvent&event);
 #if USE_ASYNCHRONOUS_CLIPBOARD_REQUEST
@@ -70,13 +74,23 @@ enum
     ID_About  = wxID_ABOUT,
     ID_Write  = 100,
     ID_Text   = 101,
-    ID_Flush  = 102
+    ID_Flush  = 102,
+
+    ID_PasteHTML_Raw  = 103,
+    ID_PasteHTML_HTML  = 104,
+    ID_PasteHTML_Fragment  = 105
 };
 
 wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(ID_Quit,  MyFrame::OnQuit)
     EVT_MENU(ID_About, MyFrame::OnAbout)
     EVT_MENU(ID_Flush, MyFrame::OnFlush)
+    EVT_MENU(ID_PasteHTML_Raw, MyFrame::OnPasteHTML_Raw)
+    EVT_MENU(ID_PasteHTML_HTML, MyFrame::OnPasteHTML_HTML)
+    EVT_MENU(ID_PasteHTML_Fragment, MyFrame::OnPasteHTML_Fragment)
+    EVT_UPDATE_UI(ID_PasteHTML_Raw, MyFrame::OnUpdatePasteHTML)
+    EVT_UPDATE_UI(ID_PasteHTML_HTML, MyFrame::OnUpdatePasteHTML)
+    EVT_UPDATE_UI(ID_PasteHTML_Fragment, MyFrame::OnUpdatePasteHTML)
     EVT_BUTTON(ID_Write, MyFrame::OnWriteClipboardContents)
     EVT_UPDATE_UI(ID_Write, MyFrame::OnUpdateUI)
 #if USE_ASYNCHRONOUS_CLIPBOARD_REQUEST
@@ -117,6 +131,11 @@ MyFrame::MyFrame(const wxString& title)
     helpMenu->Append(ID_About, "&About\tF1", "Show about dialog");
 
     fileMenu->Append(ID_Flush, "Flush the clipboard" );
+    fileMenu->AppendSeparator();
+    fileMenu->Append(ID_PasteHTML_HTML, "Paste HTML" );
+    fileMenu->Append(ID_PasteHTML_Raw, "Paste HTML (Raw)" );
+    fileMenu->Append(ID_PasteHTML_Fragment, "Paste HTML (Fragment)" );    
+    fileMenu->AppendSeparator();
     fileMenu->Append(ID_Quit, "E&xit\tAlt-X", "Quit this program");
 
     // now append the freshly created menu to the menu bar...
@@ -163,6 +182,62 @@ void MyFrame::OnFlush(wxCommandEvent &WXUNUSED(event))
 
     m_textctrl->AppendText("Clipboard flushed successfully, you should now "
                            "be able to paste text even after closing the sample.");
+}
+
+void MyFrame::OnPasteHTML_Raw(wxCommandEvent & WXUNUSED(event))
+{
+   if (wxTheClipboard->Open())
+   {
+        if (wxTheClipboard->IsSupported( wxDF_HTML))
+        {
+            wxHTMLDataObject data(wxEmptyString, wxHTMLDataObject::Raw);
+            wxTheClipboard->GetData(data);
+            m_textctrl->SetValue(data.GetHTML());
+        }
+        
+        wxTheClipboard->Close();
+   }
+}
+
+void MyFrame::OnPasteHTML_HTML(wxCommandEvent & WXUNUSED(event))
+{
+   if (wxTheClipboard->Open())
+   {
+        if (wxTheClipboard->IsSupported( wxDF_HTML))
+        {
+            wxHTMLDataObject data(wxEmptyString, wxHTMLDataObject::HTML);
+            wxTheClipboard->GetData(data);
+            m_textctrl->SetValue(data.GetHTML());
+        }
+        
+        wxTheClipboard->Close();
+   }
+}
+
+void MyFrame::OnPasteHTML_Fragment(wxCommandEvent & WXUNUSED(event))
+{
+   if (wxTheClipboard->Open())
+   {
+        if (wxTheClipboard->IsSupported( wxDF_HTML))
+        {
+            wxHTMLDataObject data(wxEmptyString, wxHTMLDataObject::Fragment);
+            wxTheClipboard->GetData(data);
+            m_textctrl->SetValue(data.GetHTML());
+        }
+        
+        wxTheClipboard->Close();
+   }
+}
+
+void MyFrame::OnUpdatePasteHTML(wxUpdateUIEvent &event)
+{
+   if (wxTheClipboard->Open())
+   {
+        event.Enable(wxTheClipboard->IsSupported( wxDF_HTML));
+        wxTheClipboard->Close();
+   }
+   else
+        event.Enable(false);
 }
 
 void MyFrame::OnWriteClipboardContents(wxCommandEvent& WXUNUSED(event))

--- a/src/common/dobjcmn.cpp
+++ b/src/common/dobjcmn.cpp
@@ -452,11 +452,11 @@ size_t wxHTMLDataObject::GetDataSize() const
 
     size_t size = buffer.length();
 
-#ifdef __WXMSW__
     // On Windows we need to add some stuff to the string to satisfy
     // its clipboard format requirements.
+    // On other platforms, we may also be passing a fragment
+    // and wrapping in further HTML tags
     size += 400;
-#endif
 
     return size;
 }
@@ -473,50 +473,73 @@ bool wxHTMLDataObject::GetDataHere(void *buf) const
         return false;
 
     char* const buffer = static_cast<char*>(buf);
+    memset(buf, 0, GetDataSize(wxDF_HTML));
 
 #ifdef __WXMSW__
     // add the extra info that the MSW clipboard format requires.
 
-        // Create a template string for the HTML header...
-    strcpy(buffer,
-        "Version:0.9\r\n"
-        "StartHTML:00000000\r\n"
-        "EndHTML:00000000\r\n"
-        "StartFragment:00000000\r\n"
-        "EndFragment:00000000\r\n"
-        "<html><body>\r\n"
-        "<!--StartFragment -->\r\n");
+    // Create a template string for the HTML header...
+    if (GetProvision() == HTML || GetProvision() == Fragment)
+        strcat(buffer,
+            "Version:0.9\r\n"
+            "StartHTML:00000000\r\n"
+            "EndHTML:00000000\r\n"
+            "StartFragment:00000000\r\n"
+            "EndFragment:00000000\r\n");
+#endif
+
+    if (GetProvision() == Fragment)
+    {
+        strcat(buffer,
+            "<html><body>\r\n"
+            "<!--StartFragment -->\r\n");
+    }
 
     // Append the HTML...
     strcat(buffer, html);
-    strcat(buffer, "\r\n");
-    // Finish up the HTML format...
-    strcat(buffer,
-        "<!--EndFragment-->\r\n"
-        "</body>\r\n"
-        "</html>");
 
+    // Finish up the HTML format...
+    if (GetProvision() == Fragment)
+    {
+        strcat(buffer, "\r\n");
+        strcat(buffer,
+            "<!--EndFragment-->\r\n"
+            "</body>\r\n"
+            "</html>");
+    }
+
+#ifdef __WXMSW__
     // Now go back, calculate all the lengths, and write out the
     // necessary header information. Note, wsprintf() truncates the
     // string when you overwrite it so you follow up with code to replace
     // the 0 appended at the end with a '\r'...
     char *ptr = strstr(buffer, "StartHTML");
-    sprintf(ptr+10, "%08u", (unsigned)(strstr(buffer, "<html>") - buffer));
-    *(ptr+10+8) = '\r';
+    if (ptr)
+    {
+        sprintf(ptr+10, "%08u", (unsigned)(strstr(buffer, "<html>") - buffer));
+        *(ptr+10+8) = '\r';
+    }
 
     ptr = strstr(buffer, "EndHTML");
-    sprintf(ptr+8, "%08u", (unsigned)strlen(buffer));
-    *(ptr+8+8) = '\r';
+    if (ptr)
+    {
+        sprintf(ptr+8, "%08u", (unsigned)strlen(buffer));
+        *(ptr+8+8) = '\r';
+    }
 
     ptr = strstr(buffer, "StartFragment");
-    sprintf(ptr+14, "%08u", (unsigned)(strstr(buffer, "<!--StartFrag") - buffer));
-    *(ptr+14+8) = '\r';
+    if (ptr)
+    {
+        sprintf(ptr+14, "%08u", (unsigned)(strstr(buffer, "<!--StartFrag") - buffer));
+        *(ptr+14+8) = '\r';
+    }
 
     ptr = strstr(buffer, "EndFragment");
-    sprintf(ptr+12, "%08u", (unsigned)(strstr(buffer, "<!--EndFrag") - buffer));
-    *(ptr+12+8) = '\r';
-#else
-    strcpy(buffer, html);
+    if (ptr)
+    {
+        sprintf(ptr+12, "%08u", (unsigned)(strstr(buffer, "<!--EndFrag") - buffer));
+        *(ptr+12+8) = '\r';
+    }
 #endif // __WXMSW__
 
     return true;
@@ -530,21 +553,58 @@ bool wxHTMLDataObject::SetData(size_t WXUNUSED(len), const void *buf)
     // Windows and Mac always use UTF-8, and docs suggest GTK does as well.
     wxString html = wxString::FromUTF8(static_cast<const char*>(buf));
 
-#ifdef __WXMSW__
-    // To be consistent with other platforms, we only add the Fragment part
-    // of the Windows HTML clipboard format to the data object.
-    int fragmentStart = html.rfind("StartFragment");
-    int fragmentEnd = html.rfind("EndFragment");
+    // Although some applications such as Word may pass the correctly-sized buffer, let's
+    // ensure we can read the HTML even if there's garbage at the end. For example,
+    // on Windows, LibreOffice includes extraneous terminating characters, as can be seen via a
+    // clipboard viewer such as Free Clipboard Viewer.
+    if (html.IsEmpty())
+        html = wxString((const char *) buf, wxMBConvUTF8(wxMBConvUTF8::MAP_INVALID_UTF8_TO_OCTAL), wxString::npos);
 
-    if (fragmentStart != wxNOT_FOUND && fragmentEnd != wxNOT_FOUND)
+    if (GetProvision() == Fragment)
     {
-        int startCommentEnd = html.find("-->", fragmentStart) + 3;
-        int endCommentStart = html.rfind("<!--", fragmentEnd);
+        // Only retrieve the Fragment part of the Windows HTML clipboard format.
+        // This is the default behaviour, but pass HTML or Raw to the object ctor
+        // if you need more or all of the original content.
+        int fragmentStart = html.rfind("StartFragment");
+        int fragmentEnd = html.rfind("EndFragment");
 
-        if (startCommentEnd != wxNOT_FOUND && endCommentStart != wxNOT_FOUND)
-            html = html.Mid(startCommentEnd, endCommentStart - startCommentEnd);
+        bool success = false;
+        if (fragmentStart != wxNOT_FOUND && fragmentEnd != wxNOT_FOUND)
+        {
+            int startCommentEnd = html.find("-->", fragmentStart) + 3;
+            int endCommentStart = html.rfind("<!--", fragmentEnd);
+
+            if (startCommentEnd != wxNOT_FOUND && endCommentStart != wxNOT_FOUND)
+            {
+                html = html.Mid(startCommentEnd, endCommentStart - startCommentEnd);
+                success = true;
+            }
+        }
+        if (!success)
+        {
+            // Find the text inside the body
+            int fragmentStart = html.rfind("<body");
+            int fragmentEnd = html.rfind("</body>");
+            if (fragmentStart != wxNOT_FOUND && fragmentEnd != wxNOT_FOUND)
+            {
+                while ((fragmentStart < int(html.Length()-1)) && html[fragmentStart] != wxT('>'))
+                    fragmentStart ++;
+                if (fragmentStart < int(html.Length()-1))
+                    fragmentStart ++;
+                    
+                html = html.Mid(fragmentStart, fragmentEnd - fragmentStart);
+            }
+        }
     }
-#endif // __WXMSW__
+    else if (GetProvision() == HTML)
+    {
+        int fragmentStart = html.rfind("<html");
+        int fragmentEnd = html.rfind("</html>");
+        if (fragmentStart != wxNOT_FOUND && fragmentEnd != wxNOT_FOUND)
+            html = html.Mid(fragmentStart, fragmentEnd - fragmentStart + 7);
+        else if (fragmentStart != wxNOT_FOUND)
+            html = html.Mid(fragmentStart);
+    }
 
     SetHTML( html );
 

--- a/src/msw/ole/dataobj.cpp
+++ b/src/msw/ole/dataobj.cpp
@@ -717,6 +717,8 @@ STDMETHODIMP wxIDataObject::SetData(FORMATETC *pformatetc,
                 switch ( format )
                 {
                     case wxDF_HTML:
+                        size = ::GlobalSize(pmedium->hGlobal);
+                        break;
                     case CF_TEXT:
                     case CF_OEMTEXT:
                         size = strlen((const char *)ptr.Get());


### PR DESCRIPTION
…on accessors. This allows the application to specify whether the provided or retrieved HTML is an HTML fragment, full HTML, or the raw platform-dependent clipboard data.

On Windows, the data size is found from the global data handle as otherwise we could get garbage at the end of data copied from Word (the data size computed from the string was too long and the conversion from UTF-8 failed). A relaxed UTF-8 conversion is done if the strict conversion failed due to garbage (for example, LibreOffice adds extra data to the end).
Finally, the clipboard sample adds 3 menu commands for testing the Raw, HTML, and Fragment modes for wxHTMLDataObject when pasting from the clipboard.