### PR TITLE
Fix refcounting order in wxFileSystemWatcher::Add

### DIFF
--- a/src/common/fswatchercmn.cpp
+++ b/src/common/fswatchercmn.cpp
@@ -121,17 +121,17 @@ wxFileSystemWatcherBase::AddAny(const wxFileName& path,
     if (canonical.IsEmpty())
         return false;
 
-    // adding a path in a platform specific way
-    wxFSWatchInfo watch(canonical, events, type, filespec);
-    if ( !m_service->Add(watch) )
-        return false;
-
     // on success, either add path to our 'watch-list'
     // or, if already watched, inc the refcount. This may happen if
     // a dir is Add()ed, then later AddTree() is called on a parent dir
     wxFSWatchInfoMap::iterator it = m_watches.find(canonical);
     if ( it == m_watches.end() )
     {
+        // adding a path in a platform specific way
+        wxFSWatchInfo watch(canonical, events, type, filespec);
+        if ( !m_service->Add(watch) )
+            return false;
+
         wxFSWatchInfoMap::value_type val(canonical, watch);
         m_watches.insert(val);
     }


### PR DESCRIPTION
I think `wxFileSystemWatcher` refcounting (added in 76cfd1b in 2012) is incorrect:

The order of refcounting operations should be the opposite of what it was: first check if the path is not watched already and only if it is not call `m_service->Add()` to actually watch it. (Previously reference count was kept track of, but `m_service->Add()` was always called, i.e. the calls were repeated and unbalanced with `Remove()` calls.)

`Remove()` already has the correct order and only calls `m_service->Remove()` when the path's refcount reaches zero.