### PR TITLE
some improvisation fixes building wxGTK on msys2 and mingw32 host/target

### DIFF
--- a/include/wx/utils.h
+++ b/include/wx/utils.h
@@ -782,7 +782,7 @@ void WXDLLIMPEXP_CORE wxGetMousePosition( int* x, int* y );
 // X11 Display access
 // ----------------------------------------------------------------------------
 
-#if defined(__X__) || defined(__WXGTK__)
+#if defined(__X__) || defined(__WXGTK__) && defined(__UNIX__)
 
 #ifdef __WXGTK__
     WXDLLIMPEXP_CORE void *wxGetDisplay();

--- a/src/gtk/utilsgtk.cpp
+++ b/src/gtk/utilsgtk.cpp
@@ -71,7 +71,7 @@ void wxBell()
 // ----------------------------------------------------------------------------
 // display characteristics
 // ----------------------------------------------------------------------------
-
+#if defined(__UNIX__)
 void *wxGetDisplay()
 {
     return wxGetDisplayInfo().dpy;
@@ -97,6 +97,7 @@ wxDisplayInfo wxGetDisplayInfo()
 #endif
     return info;
 }
+#endif
 
 wxWindow* wxFindWindowAtPoint(const wxPoint& pt)
 {


### PR DESCRIPTION
An improvisation fix that let us build wxGTK 3/2 on msys2 with mingw32.

configure command args used:

export PKG_CONFIG_PATH=/mingw32/lib/pkgconfig:$PKG_CONFIG_PATH
./configure --build=i686-w64-mingw32 --host=i686-w64-mingw32 --with-gtk=3
