### PR TITLE
Make --disable-sys-libs configure option less drastic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           - name: Ubuntu 18.04 wxGTK 3 with clang
             runner: ubuntu-18.04
             compiler: clang
-            configure_flags: --disable-sys-libs --with-libcurl
+            configure_flags: --disable-sys-libs
             use_xvfb: true
           - name: Ubuntu 20.04 wxGTK ANSI
             runner: ubuntu-20.04
@@ -57,7 +57,7 @@ jobs:
             skip_samples: true
           - name: Ubuntu 20.04 wxGTK with ASAN
             runner: ubuntu-20.04
-            configure_flags: --disable-compat30 --disable-sys-libs --with-libcurl --disable-webview
+            configure_flags: --disable-compat30 --disable-sys-libs --disable-webview
             skip_samples: true
             use_asan: true
             use_xvfb: true

--- a/configure
+++ b/configure
@@ -2071,7 +2071,7 @@ Optional Features:
   --enable-official_build official build of wxWidgets (win32 DLL only)
   --enable-vendor=VENDOR  vendor name (win32 DLL only)
   --disable-all-features  disable all optional features to build minimal library
-  --disable-sys-libs      disable all use of system libraries, use only built-in ones
+  --disable-sys-libs      disable use of system libraries for which built-in versions are available
   --disable-tests         disable building tests
   --enable-universal      use wxWidgets GUI controls instead of native ones
   --enable-nanox          use NanoX
@@ -22113,16 +22113,15 @@ fi
 
 
 if test "$wxUSE_LIBLZMA" != "no"; then
-            if test "$wxUSE_SYS_LIBS" != "no"; then
-        ac_fn_c_check_header_mongrel "$LINENO" "lzma.h" "ac_cv_header_lzma_h" "$ac_includes_default"
+    ac_fn_c_check_header_mongrel "$LINENO" "lzma.h" "ac_cv_header_lzma_h" "$ac_includes_default"
 if test "x$ac_cv_header_lzma_h" = xyes; then :
 
 fi
 
 
 
-        if test "$ac_cv_header_lzma_h" = "yes"; then
-            { $as_echo "$as_me:${as_lineno-$LINENO}: checking for lzma_code in -llzma" >&5
+    if test "$ac_cv_header_lzma_h" = "yes"; then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for lzma_code in -llzma" >&5
 $as_echo_n "checking for lzma_code in -llzma... " >&6; }
 if ${ac_cv_lib_lzma_lzma_code+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -22160,14 +22159,13 @@ fi
 $as_echo "$ac_cv_lib_lzma_lzma_code" >&6; }
 if test "x$ac_cv_lib_lzma_lzma_code" = xyes; then :
 
-                    LZMA_LINK="-llzma"
-                    LIBS="$LZMA_LINK $LIBS"
-                    $as_echo "#define wxUSE_LIBLZMA 1" >>confdefs.h
+                LZMA_LINK="-llzma"
+                LIBS="$LZMA_LINK $LIBS"
+                $as_echo "#define wxUSE_LIBLZMA 1" >>confdefs.h
 
 
 fi
 
-        fi
     fi
 
     if test -z "$LZMA_LINK"; then
@@ -22982,7 +22980,6 @@ fi
 
 
 if test "$wxUSE_WEBREQUEST" = "yes" -a "$wxUSE_LIBCURL" != "no"; then
-            if test "$wxUSE_SYS_LIBS" != "no" -o "$wxUSE_LIBCURL" = "yes"; then
 
 pkg_failed=no
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for LIBCURL" >&5
@@ -23043,15 +23040,15 @@ fi
 	echo "$LIBCURL_PKG_ERRORS" >&5
 
 
-                wxUSE_LIBCURL=no
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
+            wxUSE_LIBCURL=no
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
 $as_echo "not found" >&6; }
 
 
 elif test $pkg_failed = untried; then
 
-                wxUSE_LIBCURL=no
-                { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
+            wxUSE_LIBCURL=no
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
 $as_echo "not found" >&6; }
 
 
@@ -23061,17 +23058,11 @@ else
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 
-                wxUSE_LIBCURL=yes
-                CXXFLAGS="$LIBCURL_CFLAGS $CXXFLAGS"
-                LIBS="$LIBCURL_LIBS $LIBS"
+            wxUSE_LIBCURL=yes
+            CXXFLAGS="$LIBCURL_CFLAGS $CXXFLAGS"
+            LIBS="$LIBCURL_LIBS $LIBS"
 
 fi
-    else
-                                if test "$USE_WIN32" != 1 -a "$USE_DARWIN" != 1; then
-            { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Support for libcurl disabled due to --disable-sys-libs, use --with-libcurl explicitly if necessary" >&5
-$as_echo "$as_me: WARNING: Support for libcurl disabled due to --disable-sys-libs, use --with-libcurl explicitly if necessary" >&2;}
-        fi
-    fi
 fi
 
 

--- a/configure.in
+++ b/configure.in
@@ -402,7 +402,7 @@ if test "x$VENDOR" = "x"; then
 fi
 
 WX_ARG_DISABLE(all-features,[  --disable-all-features  disable all optional features to build minimal library], wxUSE_ALL_FEATURES)
-WX_ARG_DISABLE(sys-libs,    [  --disable-sys-libs      disable all use of system libraries, use only built-in ones], wxUSE_SYS_LIBS)
+WX_ARG_DISABLE(sys-libs,    [  --disable-sys-libs      disable use of system libraries for which built-in versions are available], wxUSE_SYS_LIBS)
 WX_ARG_DISABLE(tests,       [  --disable-tests         disable building tests], wxUSE_TESTS_SUBDIR)
 
 if test "$wxUSE_ALL_FEATURES" = "no"; then
@@ -2712,19 +2712,15 @@ dnl Check for lzma library
 dnl ------------------------------------------------------------------------
 
 if test "$wxUSE_LIBLZMA" != "no"; then
-    dnl We shouldn't depend on the external liblzma if system libraries are
-    dnl explicitly disabled.
-    if test "$wxUSE_SYS_LIBS" != "no"; then
-        AC_CHECK_HEADER(lzma.h,,,[])
+    AC_CHECK_HEADER(lzma.h,,,[])
 
-        if test "$ac_cv_header_lzma_h" = "yes"; then
-            AC_CHECK_LIB(lzma, lzma_code,
-                [
-                    LZMA_LINK="-llzma"
-                    LIBS="$LZMA_LINK $LIBS"
-                    AC_DEFINE(wxUSE_LIBLZMA)
-                ])
-        fi
+    if test "$ac_cv_header_lzma_h" = "yes"; then
+        AC_CHECK_LIB(lzma, lzma_code,
+            [
+                LZMA_LINK="-llzma"
+                LIBS="$LZMA_LINK $LIBS"
+                AC_DEFINE(wxUSE_LIBLZMA)
+            ])
     fi
 
     if test -z "$LZMA_LINK"; then
@@ -2946,28 +2942,17 @@ dnl Check for libcurl
 dnl ------------------------------------------------------------------------
 
 if test "$wxUSE_WEBREQUEST" = "yes" -a "$wxUSE_LIBCURL" != "no"; then
-    dnl We shouldn't depend on the external libcurl if system libraries are
-    dnl explicitly disabled, unless it is explicitly requested.
-    if test "$wxUSE_SYS_LIBS" != "no" -o "$wxUSE_LIBCURL" = "yes"; then
-        PKG_CHECK_MODULES(LIBCURL, [libcurl],
-            [
-                wxUSE_LIBCURL=yes
-                CXXFLAGS="$LIBCURL_CFLAGS $CXXFLAGS"
-                LIBS="$LIBCURL_LIBS $LIBS"
-            ],
-            [
-                wxUSE_LIBCURL=no
-                AC_MSG_RESULT([not found])
-            ]
-        )
-    else
-        dnl Under Win32/macOS we have other backends for wxWebRequest, but
-        dnl under Unix it will be disabled without libcurl, so warn about it as
-        dnl this could be an unexpected consequence of disabling sys libs.
-        if test "$USE_WIN32" != 1 -a "$USE_DARWIN" != 1; then
-            AC_MSG_WARN([Support for libcurl disabled due to --disable-sys-libs, use --with-libcurl explicitly if necessary])
-        fi
-    fi
+    PKG_CHECK_MODULES(LIBCURL, [libcurl],
+        [
+            wxUSE_LIBCURL=yes
+            CXXFLAGS="$LIBCURL_CFLAGS $CXXFLAGS"
+            LIBS="$LIBCURL_LIBS $LIBS"
+        ],
+        [
+            wxUSE_LIBCURL=no
+            AC_MSG_RESULT([not found])
+        ]
+    )
 fi
 
 dnl ----------------------------------------------------------------

--- a/docs/gtk/install.md
+++ b/docs/gtk/install.md
@@ -127,10 +127,11 @@ libraries, wxWidgets also provides built-in versions, that can be
 linked into wx libraries themselves, which can be useful to
 minimize external dependencies.
 
-    --disable-sys-libs      Don't use system libraries at all.
-                            Use built-in ones when possible or
-                            disable support for the corresponding
-                            feature otherwise.
+    --disable-sys-libs      Don't use system libraries when there is
+                            a built-in version included in wxWidgets.
+                            Note that other system libraries can,
+                            and typically will, still be used if
+                            found.
 
     --without-libpng        Disables PNG image format code.
                             Don't use libpng (although GTK


### PR DESCRIPTION
Only disable using the system libraries when a built-in version is
available, otherwise still use the system library as this seems more
useful than disabling the use of only some system libraries (liblzma and
libcurl), while still possibly depending on dozens more via GTK.

Update the documentation and remove the now unnecessary --with-libcurl
from the CI script.