### PR TITLE
Fix compilation with curl <7.21.6

### DIFF
--- a/src/common/webrequest_curl.cpp
+++ b/src/common/webrequest_curl.cpp
@@ -37,6 +37,11 @@
     #define wxCURL_HAVE_MULTI_WAIT 0
 #endif
 
+// The new name was introduced in curl 7.21.6.
+#ifndef CURLOPT_ACCEPT_ENCODING
+    #define CURLOPT_ACCEPT_ENCODING CURLOPT_ENCODING
+#endif
+
 //
 // wxWebResponseCURL
 //


### PR DESCRIPTION
According to cURL documentation, the CURLOPT_ACCEPT_ENCODING symbol
was called CURLOPT_ENCODING earlier.

Fixes compilation on CentOS 6.