### PR TITLE
Avoid recommending deprecated wxNewId()

### DIFF
--- a/docs/doxygen/mainpages/const_stdevtid.h
+++ b/docs/doxygen/mainpages/const_stdevtid.h
@@ -15,8 +15,8 @@ the following two situations:
 
 @li when creating a new window you may specify @c wxID_ANY to let
     wxWidgets assign an unused identifier to it automatically
-@li when installing an event handler using either the event table
-    macros or wxEvtHandler::Connect,
+@li when installing an event handler using wxEvtHandler::Bind,
+    wxEvtHandler::Connect or the event table macros,
     you may use it to indicate that you want to handle the events
     coming from any control, regardless of its identifier
 
@@ -27,7 +27,8 @@ wxWidgets also defines a few standard command identifiers which may be used by
 the user code and also are sometimes used by wxWidgets itself. These reserved
 identifiers are all in the range between @c wxID_LOWEST and
 @c wxID_HIGHEST and, accordingly, the user code should avoid defining its
-own constants in this range (e.g. by using wxNewId()).
+own constants in this range (e.g. by using @c wxID_ANY and retrieving the
+control's id after it was created).
 
 Refer to @ref page_stockitems "the list of stock items" for the subset of standard IDs
 which are stock IDs as well.

--- a/docs/doxygen/overviews/eventhandling.h
+++ b/docs/doxygen/overviews/eventhandling.h
@@ -873,9 +873,6 @@ positive.
 See @ref page_stdevtid for the list of standard identifiers available.
 You can use wxID_HIGHEST to determine the number above which it is safe to
 define your own identifiers. Or, you can use identifiers below wxID_LOWEST.
-Finally, you can allocate identifiers dynamically using wxNewId() function too.
-If you use wxNewId() consistently in your application, you can be sure that
-your identifiers don't conflict accidentally.
 
 
 @subsection overview_events_with_mouse_capture Event Handlers and Mouse Capture

--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -482,6 +482,8 @@ int wxFindMenuItemId(wxFrame* frame, const wxString& menuString,
 
     Generates an integer identifier unique to this run of the program.
 
+    @see wxRegisterId()
+
     @header{wx/utils.h}
 */
 wxWindowID wxNewId();


### PR DESCRIPTION
Since wxNewId() was deprecated, maybe it should no longer be recommended by the docs.
Alternatively, it should probably not be deprecated, and maybe advice using wxRegisterId() along with it.