### PR TITLE
Various wxWebView improvements

### DIFF
--- a/include/wx/gtk/webview_webkit.h
+++ b/include/wx/gtk/webview_webkit.h
@@ -114,7 +114,7 @@ public:
     virtual wxString GetSelectedSource() const wxOVERRIDE;
     virtual void ClearSelection() wxOVERRIDE;
 
-    virtual bool RunScript(const wxString& javascript, wxString* output = NULL) wxOVERRIDE;
+    virtual bool RunScript(const wxString& javascript, wxString* output = NULL) const wxOVERRIDE;
 
     //Virtual Filesystem Support
     virtual void RegisterHandler(wxSharedPtr<wxWebViewHandler> handler) wxOVERRIDE;
@@ -161,7 +161,7 @@ private:
     bool CanExecuteEditingCommand(const gchar* command) const;
     void SetupWebExtensionServer();
     GDBusProxy *GetExtensionProxy() const;
-    bool RunScriptSync(const wxString& javascript, wxString* output = NULL);
+    bool RunScriptSync(const wxString& javascript, wxString* output = NULL) const;
 #endif
 
     WebKitWebView *m_web_view;

--- a/include/wx/gtk/webview_webkit.h
+++ b/include/wx/gtk/webview_webkit.h
@@ -198,6 +198,9 @@ public:
                               long style = 0,
                               const wxString& name = wxASCII_STR(wxWebViewNameStr)) wxOVERRIDE
     { return new wxWebViewWebKit(parent, id, url, pos, size, style, name); }
+#if wxUSE_WEBVIEW_WEBKIT2
+    virtual wxVersionInfo GetVersionInfo() wxOVERRIDE;
+#endif
 };
 
 

--- a/include/wx/gtk/webview_webkit.h
+++ b/include/wx/gtk/webview_webkit.h
@@ -82,9 +82,7 @@ public:
     void SetZoomType(wxWebViewZoomType) wxOVERRIDE;
     wxWebViewZoomType GetZoomType() const wxOVERRIDE;
     bool CanSetZoomType(wxWebViewZoomType) const wxOVERRIDE;
-    virtual wxWebViewZoom GetZoom() const wxOVERRIDE;
     virtual float GetZoomFactor() const wxOVERRIDE;
-    virtual void SetZoom(wxWebViewZoom) wxOVERRIDE;
     virtual void SetZoomFactor(float) wxOVERRIDE;
 
     //Clipboard functions

--- a/include/wx/msw/private/webview_edge.h
+++ b/include/wx/msw/private/webview_edge.h
@@ -67,6 +67,7 @@ public:
 
     static wxDynamicLibrary ms_loaderDll;
     static wxString ms_browserExecutableDir;
+    static wxString ms_version;
 
     static bool Initialize();
 

--- a/include/wx/msw/private/webview_edge.h
+++ b/include/wx/msw/private/webview_edge.h
@@ -66,6 +66,7 @@ public:
     ICoreWebView2Settings* GetSettings();
 
     static wxDynamicLibrary ms_loaderDll;
+    static wxString ms_browserExecutableDir;
 
     static bool Initialize();
 

--- a/include/wx/msw/webview_edge.h
+++ b/include/wx/msw/webview_edge.h
@@ -122,6 +122,8 @@ public:
 
     virtual void* GetNativeBackend() const wxOVERRIDE;
 
+    static void MSWSetBrowserExecutableDir(const wxString& path);
+
 protected:
     virtual void DoSetPage(const wxString& html, const wxString& baseUrl) wxOVERRIDE;
 

--- a/include/wx/msw/webview_edge.h
+++ b/include/wx/msw/webview_edge.h
@@ -89,7 +89,7 @@ public:
     virtual void EnableAccessToDevTools(bool enable = true) wxOVERRIDE;
     virtual bool IsAccessToDevToolsEnabled() const wxOVERRIDE;
 
-    virtual bool RunScript(const wxString& javascript, wxString* output = NULL) wxOVERRIDE;
+    virtual bool RunScript(const wxString& javascript, wxString* output = NULL) const wxOVERRIDE;
 
     virtual void RegisterHandler(wxSharedPtr<wxWebViewHandler> handler) wxOVERRIDE;
 
@@ -107,7 +107,7 @@ private:
 
     void OnShow(wxShowEvent& event);
 
-    bool RunScriptSync(const wxString& javascript, wxString* output = NULL);
+    bool RunScriptSync(const wxString& javascript, wxString* output = NULL) const;
 
     wxDECLARE_DYNAMIC_CLASS(wxWebViewEdge);
 };

--- a/include/wx/msw/webview_edge.h
+++ b/include/wx/msw/webview_edge.h
@@ -60,9 +60,6 @@ public:
     virtual void Stop() wxOVERRIDE;
     virtual void Reload(wxWebViewReloadFlags flags = wxWEBVIEW_RELOAD_DEFAULT) wxOVERRIDE;
 
-    virtual wxString GetPageSource() const wxOVERRIDE;
-    virtual wxString GetPageText() const wxOVERRIDE;
-
     virtual bool IsBusy() const wxOVERRIDE;
     virtual wxString GetCurrentURL() const wxOVERRIDE;
     virtual wxString GetCurrentTitle() const wxOVERRIDE;
@@ -73,18 +70,8 @@ public:
 
     virtual void Print() wxOVERRIDE;
 
-    virtual wxWebViewZoom GetZoom() const wxOVERRIDE;
     virtual float GetZoomFactor() const wxOVERRIDE;
-    virtual void SetZoom(wxWebViewZoom zoom) wxOVERRIDE;
     virtual void SetZoomFactor(float zoom) wxOVERRIDE;
-
-    //Clipboard functions
-    virtual bool CanCut() const wxOVERRIDE;
-    virtual bool CanCopy() const wxOVERRIDE;
-    virtual bool CanPaste() const wxOVERRIDE;
-    virtual void Cut() wxOVERRIDE;
-    virtual void Copy() wxOVERRIDE;
-    virtual void Paste() wxOVERRIDE;
 
     //Undo / redo functionality
     virtual bool CanUndo() const wxOVERRIDE;
@@ -92,29 +79,15 @@ public:
     virtual void Undo() wxOVERRIDE;
     virtual void Redo() wxOVERRIDE;
 
-    //Find function
-    virtual long Find(const wxString& text, int flags = wxWEBVIEW_FIND_DEFAULT) wxOVERRIDE;
-
     //Editing functions
     virtual void SetEditable(bool enable = true) wxOVERRIDE;
     virtual bool IsEditable() const wxOVERRIDE;
-
-    //Selection
-    virtual void SelectAll() wxOVERRIDE;
-    virtual bool HasSelection() const wxOVERRIDE;
-    virtual void DeleteSelection() wxOVERRIDE;
-    virtual wxString GetSelectedText() const wxOVERRIDE;
-    virtual wxString GetSelectedSource() const wxOVERRIDE;
-    virtual void ClearSelection() wxOVERRIDE;
 
     virtual void EnableContextMenu(bool enable = true) wxOVERRIDE;
     virtual bool IsContextMenuEnabled() const wxOVERRIDE;
 
     virtual void EnableAccessToDevTools(bool enable = true) wxOVERRIDE;
     virtual bool IsAccessToDevToolsEnabled() const wxOVERRIDE;
-
-    bool QueryCommandEnabled(const wxString& command) const;
-    void ExecCommand(const wxString& command);
 
     virtual bool RunScript(const wxString& javascript, wxString* output = NULL) wxOVERRIDE;
 

--- a/include/wx/msw/webview_edge.h
+++ b/include/wx/msw/webview_edge.h
@@ -154,6 +154,7 @@ public:
         return new wxWebViewEdge(parent, id, url, pos, size, style, name);
     }
     virtual bool IsAvailable() wxOVERRIDE;
+    virtual wxVersionInfo GetVersionInfo() wxOVERRIDE;
 };
 
 #endif // wxUSE_WEBVIEW && wxUSE_WEBVIEW_EDGE && defined(__WXMSW__)

--- a/include/wx/msw/webview_ie.h
+++ b/include/wx/msw/webview_ie.h
@@ -192,6 +192,7 @@ public:
                               long style = 0,
                               const wxString& name = wxASCII_STR(wxWebViewNameStr)) wxOVERRIDE
     { return new wxWebViewIE(parent, id, url, pos, size, style, name); }
+    virtual wxVersionInfo GetVersionInfo() wxOVERRIDE;
 };
 
 #endif // wxUSE_WEBVIEW && wxUSE_WEBVIEW_IE && defined(__WXMSW__)

--- a/include/wx/msw/webview_ie.h
+++ b/include/wx/msw/webview_ie.h
@@ -131,7 +131,7 @@ public:
     virtual wxString GetSelectedSource() const wxOVERRIDE;
     virtual void ClearSelection() wxOVERRIDE;
 
-    virtual bool RunScript(const wxString& javascript, wxString* output = NULL) wxOVERRIDE;
+    virtual bool RunScript(const wxString& javascript, wxString* output = NULL) const wxOVERRIDE;
 
     //Virtual Filesystem Support
     virtual void RegisterHandler(wxSharedPtr<wxWebViewHandler> handler) wxOVERRIDE;

--- a/include/wx/osx/webview_webkit.h
+++ b/include/wx/osx/webview_webkit.h
@@ -56,17 +56,13 @@ public:
     virtual void GoForward() wxOVERRIDE;
     virtual void Reload(wxWebViewReloadFlags flags = wxWEBVIEW_RELOAD_DEFAULT) wxOVERRIDE;
     virtual void Stop() wxOVERRIDE;
-    virtual wxString GetPageSource() const wxOVERRIDE;
-    virtual wxString GetPageText() const wxOVERRIDE;
 
     virtual void Print() wxOVERRIDE;
 
     virtual void LoadURL(const wxString& url) wxOVERRIDE;
     virtual wxString GetCurrentURL() const wxOVERRIDE;
     virtual wxString GetCurrentTitle() const wxOVERRIDE;
-    virtual wxWebViewZoom GetZoom() const wxOVERRIDE;
     virtual float GetZoomFactor() const wxOVERRIDE;
-    virtual void SetZoom(wxWebViewZoom zoom) wxOVERRIDE;
     virtual void SetZoomFactor(float zoom) wxOVERRIDE;
 
     virtual void SetZoomType(wxWebViewZoomType zoomType) wxOVERRIDE;
@@ -88,33 +84,9 @@ public:
     virtual void Undo() wxOVERRIDE;
     virtual void Redo() wxOVERRIDE;
 
-    //Find function
-    virtual long Find(const wxString& text, int flags = wxWEBVIEW_FIND_DEFAULT) wxOVERRIDE
-    {
-        wxUnusedVar(text);
-        wxUnusedVar(flags);
-        return wxNOT_FOUND;
-    }
-
-    //Clipboard functions
-    virtual bool CanCut() const wxOVERRIDE { return true; }
-    virtual bool CanCopy() const wxOVERRIDE { return true; }
-    virtual bool CanPaste() const wxOVERRIDE { return true; }
-    virtual void Cut() wxOVERRIDE;
-    virtual void Copy() wxOVERRIDE;
-    virtual void Paste() wxOVERRIDE;
-
     //Editing functions
     virtual void SetEditable(bool enable = true) wxOVERRIDE;
     virtual bool IsEditable() const wxOVERRIDE;
-
-    //Selection
-    virtual void DeleteSelection() wxOVERRIDE;
-    virtual bool HasSelection() const wxOVERRIDE;
-    virtual void SelectAll() wxOVERRIDE;
-    virtual wxString GetSelectedText() const wxOVERRIDE;
-    virtual wxString GetSelectedSource() const wxOVERRIDE;
-    virtual void ClearSelection() wxOVERRIDE;
 
     bool RunScript(const wxString& javascript, wxString* output = NULL) wxOVERRIDE;
 
@@ -136,8 +108,6 @@ private:
     WX_NSObject m_UIDelegate;
 
     bool RunScriptSync(const wxString& javascript, wxString* output = NULL);
-    bool QueryCommandEnabled(const wxString& command) const;
-    void ExecCommand(const wxString& command);
 };
 
 class WXDLLIMPEXP_WEBVIEW wxWebViewFactoryWebKit : public wxWebViewFactory

--- a/include/wx/osx/webview_webkit.h
+++ b/include/wx/osx/webview_webkit.h
@@ -88,7 +88,7 @@ public:
     virtual void SetEditable(bool enable = true) wxOVERRIDE;
     virtual bool IsEditable() const wxOVERRIDE;
 
-    bool RunScript(const wxString& javascript, wxString* output = NULL) wxOVERRIDE;
+    bool RunScript(const wxString& javascript, wxString* output = NULL) const wxOVERRIDE;
 
     //Virtual Filesystem Support
     virtual void RegisterHandler(wxSharedPtr<wxWebViewHandler> handler) wxOVERRIDE;
@@ -107,7 +107,7 @@ private:
     WX_NSObject m_navigationDelegate;
     WX_NSObject m_UIDelegate;
 
-    bool RunScriptSync(const wxString& javascript, wxString* output = NULL);
+    bool RunScriptSync(const wxString& javascript, wxString* output = NULL) const;
 };
 
 class WXDLLIMPEXP_WEBVIEW wxWebViewFactoryWebKit : public wxWebViewFactory

--- a/include/wx/private/json.h
+++ b/include/wx/private/json.h
@@ -22,6 +22,7 @@ bool DecodeString(const wxString& in, wxString* out)
     // String has to chart with a quote
     if (*(ch++) != '"')
         return false;
+    out->clear();
     out->reserve(buf.length());
     const wchar_t* end = buf.data() + buf.length() - 1;
     for (; ch < end; ++ch)

--- a/include/wx/webview.h
+++ b/include/wx/webview.h
@@ -160,7 +160,7 @@ public:
     static void RegisterFactory(const wxString& backend,
                                 wxSharedPtr<wxWebViewFactory> factory);
     static bool IsBackendAvailable(const wxString& backend);
-    static wxVersionInfo GetBackendVersionInfo(const wxString& backend);
+    static wxVersionInfo GetBackendVersionInfo(const wxString& backend = wxASCII_STR(wxWebViewBackendDefault));
 
     // General methods
     virtual void EnableContextMenu(bool enable = true)

--- a/include/wx/webview.h
+++ b/include/wx/webview.h
@@ -171,8 +171,8 @@ public:
     virtual wxString GetCurrentTitle() const = 0;
     virtual wxString GetCurrentURL() const = 0;
     // TODO: handle choosing a frame when calling GetPageSource()?
-    virtual wxString GetPageSource() const = 0;
-    virtual wxString GetPageText() const = 0;
+    virtual wxString GetPageSource() const;
+    virtual wxString GetPageText() const;
     virtual bool IsBusy() const = 0;
     virtual bool IsContextMenuEnabled() const { return m_showMenu; }
     virtual bool IsAccessToDevToolsEnabled() const { return false; }
@@ -208,28 +208,28 @@ public:
 
     //Zoom
     virtual bool CanSetZoomType(wxWebViewZoomType type) const = 0;
-    virtual wxWebViewZoom GetZoom() const = 0;
+    virtual wxWebViewZoom GetZoom() const;
     virtual float GetZoomFactor() const = 0;
     virtual wxWebViewZoomType GetZoomType() const = 0;
-    virtual void SetZoom(wxWebViewZoom zoom) = 0;
+    virtual void SetZoom(wxWebViewZoom zoom);
     virtual void SetZoomFactor(float zoom) = 0;
     virtual void SetZoomType(wxWebViewZoomType zoomType) = 0;
 
     //Selection
-    virtual void SelectAll() = 0;
-    virtual bool HasSelection() const = 0;
-    virtual void DeleteSelection() = 0;
-    virtual wxString GetSelectedText() const = 0;
-    virtual wxString GetSelectedSource() const = 0;
-    virtual void ClearSelection() = 0;
+    virtual void SelectAll() ;
+    virtual bool HasSelection() const;
+    virtual void DeleteSelection();
+    virtual wxString GetSelectedText() const;
+    virtual wxString GetSelectedSource() const;
+    virtual void ClearSelection();
 
     //Clipboard functions
-    virtual bool CanCut() const = 0;
-    virtual bool CanCopy() const = 0;
-    virtual bool CanPaste() const = 0;
-    virtual void Cut() = 0;
-    virtual void Copy() = 0;
-    virtual void Paste() = 0;
+    virtual bool CanCut() const;
+    virtual bool CanCopy() const;
+    virtual bool CanPaste() const;
+    virtual void Cut();
+    virtual void Copy();
+    virtual void Paste();
 
     //Undo / redo functionality
     virtual bool CanUndo() const = 0;
@@ -240,10 +240,13 @@ public:
     //Get the pointer to the underlying native engine.
     virtual void* GetNativeBackend() const = 0;
     //Find function
-    virtual long Find(const wxString& text, int flags = wxWEBVIEW_FIND_DEFAULT) = 0;
+    virtual long Find(const wxString& text, int flags = wxWEBVIEW_FIND_DEFAULT);
 
 protected:
     virtual void DoSetPage(const wxString& html, const wxString& baseUrl) = 0;
+
+    bool QueryCommandEnabled(const wxString& command) const;
+    void ExecCommand(const wxString& command);
 
     // Count the number of calls to RunScript() in order to prevent
     // the_same variable from being used twice in more than one call.

--- a/include/wx/webview.h
+++ b/include/wx/webview.h
@@ -181,7 +181,7 @@ public:
     virtual void Print() = 0;
     virtual void RegisterHandler(wxSharedPtr<wxWebViewHandler> handler) = 0;
     virtual void Reload(wxWebViewReloadFlags flags = wxWEBVIEW_RELOAD_DEFAULT) = 0;
-    virtual bool RunScript(const wxString& javascript, wxString* output = NULL) = 0;
+    virtual bool RunScript(const wxString& javascript, wxString* output = NULL) const = 0;
     virtual void SetEditable(bool enable = true) = 0;
     void SetPage(const wxString& html, const wxString& baseUrl)
     {
@@ -250,7 +250,7 @@ protected:
 
     // Count the number of calls to RunScript() in order to prevent
     // the_same variable from being used twice in more than one call.
-    int m_runScriptCount;
+    mutable int m_runScriptCount;
 
 private:
     static void InitFactoryMap();

--- a/include/wx/webview.h
+++ b/include/wx/webview.h
@@ -18,6 +18,7 @@
 #include "wx/sstream.h"
 #include "wx/sharedptr.h"
 #include "wx/vector.h"
+#include "wx/versioninfo.h"
 
 #if defined(__WXOSX__)
     #include "wx/osx/webviewhistoryitem_webkit.h"
@@ -120,6 +121,7 @@ public:
                               long style = 0,
                               const wxString& name = wxASCII_STR(wxWebViewNameStr)) = 0;
     virtual bool IsAvailable() { return true; }
+    virtual wxVersionInfo GetVersionInfo() { return wxVersionInfo(); }
 };
 
 WX_DECLARE_STRING_HASH_MAP(wxSharedPtr<wxWebViewFactory>, wxStringWebViewFactoryMap);
@@ -158,6 +160,7 @@ public:
     static void RegisterFactory(const wxString& backend,
                                 wxSharedPtr<wxWebViewFactory> factory);
     static bool IsBackendAvailable(const wxString& backend);
+    static wxVersionInfo GetBackendVersionInfo(const wxString& backend);
 
     // General methods
     virtual void EnableContextMenu(bool enable = true)

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -231,6 +231,13 @@ public:
         @since 3.1.5
     */
     virtual bool IsAvailable();
+
+    /**
+        Retrieve the version information about this backend implementation.
+
+        @since 3.1.5
+    */
+    virtual wxVersionInfo GetVersionInfo(const wxString& backend);
 };
 
 /**
@@ -492,6 +499,12 @@ public:
     */
     static bool IsBackendAvailable(const wxString& backend);
 
+    /**
+        Retrieve the version information about the backend implementation.
+
+        @since 3.1.5
+    */
+    static wxVersionInfo GetBackendVersionInfo(const wxString& backend);
 
     /**
         Get the title of the current web page, or its URL/path if title is not

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -330,6 +330,12 @@ public:
     - Make sure to add a note about using the WebView2 SDK to your application
       documentation, as required by its licence
 
+    If your application should use a
+    <a href="https://docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution#fixed-version-distribution-mode">
+    fixed version</a> of the WebView2 runtime you must use
+    wxWebViewEdge::MSWSetBrowserExecutableDir() to specify its usage before
+    using the edge backend.
+
     @par wxWEBVIEW_WEBKIT (GTK)
 
     Under GTK the WebKit backend uses

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -337,6 +337,10 @@ public:
     - Make sure to add a note about using the WebView2 SDK to your application
       documentation, as required by its licence
 
+    If enabled and available at runtime edge will be selected as the default
+    backend. If you require the IE backend use @c wxWEBVIEW_BACKEND_IE when
+    using wxWebView::New().
+
     If your application should use a
     <a href="https://docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution#fixed-version-distribution-mode">
     fixed version</a> of the WebView2 runtime you must use
@@ -504,7 +508,7 @@ public:
 
         @since 3.1.5
     */
-    static wxVersionInfo GetBackendVersionInfo(const wxString& backend);
+    static wxVersionInfo GetBackendVersionInfo(const wxString& backend = wxWebViewBackendDefault);
 
     /**
         Get the title of the current web page, or its URL/path if title is not

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -660,7 +660,7 @@ public:
             version 3.1.1.
         @return @true if there is a result, @false if there is an error.
     */
-    virtual bool RunScript(const wxString& javascript, wxString* output = NULL) = 0;
+    virtual bool RunScript(const wxString& javascript, wxString* output = NULL) const = 0;
 
     /**
         Set the editable property of the web control. Enabling allows the user

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -550,12 +550,12 @@ public:
         @return The HTML source code, or an empty string if no page is currently
                 shown.
     */
-    virtual wxString GetPageSource() const = 0;
+    virtual wxString GetPageSource() const;
 
     /**
         Get the text of the current page.
     */
-    virtual wxString GetPageText() const = 0;
+    virtual wxString GetPageText() const;
 
     /**
         Returns whether the web control is currently busy (e.g.\ loading a page).
@@ -702,36 +702,36 @@ public:
 
         @note This always returns @c true on the macOS WebKit backend.
     */
-    virtual bool CanCopy() const = 0;
+    virtual bool CanCopy() const;
 
     /**
         Returns @true if the current selection can be cut.
 
          @note This always returns @c true on the macOS WebKit backend.
     */
-    virtual bool CanCut() const = 0;
+    virtual bool CanCut() const;
 
     /**
         Returns @true if data can be pasted.
 
         @note This always returns @c true on the macOS WebKit backend.
     */
-    virtual bool CanPaste() const = 0;
+    virtual bool CanPaste() const;
 
     /**
         Copies the current selection.
     */
-    virtual void Copy() = 0;
+    virtual void Copy();
 
     /**
         Cuts the current selection.
     */
-    virtual void Cut() = 0;
+    virtual void Cut();
 
     /**
         Pastes the current data.
     */
-    virtual void Paste() = 0;
+    virtual void Paste();
 
     /**
         @name Context Menu
@@ -842,34 +842,34 @@ public:
     /**
         Clears the current selection.
     */
-    virtual void ClearSelection() = 0;
+    virtual void ClearSelection();
 
     /**
         Deletes the current selection. Note that for @c wxWEBVIEW_BACKEND_WEBKIT
         the selection must be editable, either through SetEditable or the
         correct HTML attribute.
     */
-    virtual void DeleteSelection() = 0;
+    virtual void DeleteSelection();
 
     /**
         Returns the currently selected source, if any.
     */
-    virtual wxString GetSelectedSource() const = 0;
+    virtual wxString GetSelectedSource() const;
 
     /**
         Returns the currently selected text, if any.
     */
-    virtual wxString GetSelectedText() const = 0;
+    virtual wxString GetSelectedText() const;
 
     /**
         Returns @true if there is a current selection.
     */
-    virtual bool HasSelection() const = 0;
+    virtual bool HasSelection() const;
 
     /**
         Selects the entire page.
     */
-    virtual void SelectAll() = 0;
+    virtual void SelectAll();
 
     /**
         @name Undo / Redo
@@ -917,7 +917,7 @@ public:
               on the macOS WebKit backend.
         @since 2.9.5
     */
-    virtual long Find(const wxString& text, wxWebViewFindFlags flags = wxWEBVIEW_FIND_DEFAULT) = 0;
+    virtual long Find(const wxString& text, wxWebViewFindFlags flags = wxWEBVIEW_FIND_DEFAULT);
 
     /**
         @name Zoom
@@ -937,7 +937,7 @@ public:
         as provided by @c wxWebViewZoom.
         @return The current level of zoom.
     */
-    virtual wxWebViewZoom GetZoom() const = 0;
+    virtual wxWebViewZoom GetZoom() const;
 
     /**
         Get the zoom factor of the page.
@@ -958,7 +958,7 @@ public:
         steps provided by @c wxWebViewZoom.
         @param zoom How much to zoom (scale) the HTML document.
     */
-    virtual void SetZoom(wxWebViewZoom zoom) = 0;
+    virtual void SetZoom(wxWebViewZoom zoom);
 
     /**
         Set the zoom factor of the page.

--- a/samples/webview/webview.cpp
+++ b/samples/webview/webview.cpp
@@ -374,9 +374,7 @@ WebFrame::WebFrame(const wxString& url) :
     // Create a log window
     new wxLogWindow(this, _("Logging"), true, false);
 
-    // Create the webview
-    wxString backend = wxWebViewBackendDefault;
-#ifdef __WXMSW__
+#if wxUSE_WEBVIEW_EDGE
     // Check if a fixed version of edge is present in
     // $executable_path/edge_fixed and use it
     wxFileName edgeFixedDir(wxStandardPaths::Get().GetExecutablePath());
@@ -387,18 +385,12 @@ WebFrame::WebFrame(const wxString& url) :
         wxWebViewEdge::MSWSetBrowserExecutableDir(edgeFixedDir.GetFullPath());
         wxLogMessage("Using fixed edge version");
     }
-    if (wxWebView::IsBackendAvailable(wxWebViewBackendEdge))
-    {
-        wxLogMessage("Using Edge backend");
-        backend = wxWebViewBackendEdge;
-    }
-    else
-    {
-        wxLogMessage("Edge backend not available");
-    }
 #endif
-    m_browser = wxWebView::New(backend);
-    wxLogMessage("Backend version: %s", wxWebView::GetBackendVersionInfo(backend).ToString());
+    // Create the webview
+    m_browser = wxWebView::New();
+    // Log backend information
+    wxLogMessage("Backend: %s Version: %s", m_browser->GetClassInfo()->GetClassName(),
+        wxWebView::GetBackendVersionInfo().ToString());
 #ifdef __WXMAC__
     // With WKWebView handlers need to be registered before creation
     m_browser->RegisterHandler(wxSharedPtr<wxWebViewHandler>(new wxWebViewArchiveHandler("wxfs")));

--- a/samples/webview/webview.cpp
+++ b/samples/webview/webview.cpp
@@ -398,6 +398,7 @@ WebFrame::WebFrame(const wxString& url) :
     }
 #endif
     m_browser = wxWebView::New(backend);
+    wxLogMessage("Backend version: %s", wxWebView::GetBackendVersionInfo(backend).ToString());
 #ifdef __WXMAC__
     // With WKWebView handlers need to be registered before creation
     m_browser->RegisterHandler(wxSharedPtr<wxWebViewHandler>(new wxWebViewArchiveHandler("wxfs")));

--- a/samples/webview/webview.cpp
+++ b/samples/webview/webview.cpp
@@ -30,6 +30,9 @@
 #if wxUSE_WEBVIEW_IE
 #include "wx/msw/webview_ie.h"
 #endif
+#if wxUSE_WEBVIEW_EDGE
+#include "wx/msw/webview_edge.h"
+#endif
 #include "wx/webviewarchivehandler.h"
 #include "wx/webviewfshandler.h"
 #include "wx/numdlg.h"
@@ -37,6 +40,7 @@
 #include "wx/filesys.h"
 #include "wx/fs_arc.h"
 #include "wx/fs_mem.h"
+#include "wx/stdpaths.h"
 
 #ifndef wxHAS_IMAGES_IN_RESOURCES
     #include "../sample.xpm"
@@ -373,6 +377,16 @@ WebFrame::WebFrame(const wxString& url) :
     // Create the webview
     wxString backend = wxWebViewBackendDefault;
 #ifdef __WXMSW__
+    // Check if a fixed version of edge is present in
+    // $executable_path/edge_fixed and use it
+    wxFileName edgeFixedDir(wxStandardPaths::Get().GetExecutablePath());
+    edgeFixedDir.SetFullName("");
+    edgeFixedDir.AppendDir("edge_fixed");
+    if (edgeFixedDir.DirExists())
+    {
+        wxWebViewEdge::MSWSetBrowserExecutableDir(edgeFixedDir.GetFullPath());
+        wxLogMessage("Using fixed edge version");
+    }
     if (wxWebView::IsBackendAvailable(wxWebViewBackendEdge))
     {
         wxLogMessage("Using Edge backend");

--- a/src/common/webview.cpp
+++ b/src/common/webview.cpp
@@ -112,7 +112,7 @@ void wxWebView::SetZoom(wxWebViewZoom zoom)
 bool wxWebView::QueryCommandEnabled(const wxString& command) const
 {
     wxString resultStr;
-    const_cast<wxWebView*>(this)->RunScript(
+    RunScript(
         wxString::Format("function f(){ return document.queryCommandEnabled('%s'); } f();", command), &resultStr);
     return resultStr.IsSameAs("true", false);
 }
@@ -125,14 +125,14 @@ void wxWebView::ExecCommand(const wxString& command)
 wxString wxWebView::GetPageSource() const
 {
     wxString text;
-    const_cast<wxWebView*>(this)->RunScript("document.documentElement.outerHTML;", &text);
+    RunScript("document.documentElement.outerHTML;", &text);
     return text;
 }
 
 wxString wxWebView::GetPageText() const
 {
     wxString text;
-    const_cast<wxWebView*>(this)->RunScript("document.body.innerText;", &text);
+    RunScript("document.body.innerText;", &text);
     return text;
 }
 
@@ -169,7 +169,7 @@ void wxWebView::Paste()
 wxString wxWebView::GetSelectedText() const
 {
     wxString text;
-    const_cast<wxWebView*>(this)->RunScript("window.getSelection().toString();", &text);
+    RunScript("window.getSelection().toString();", &text);
     return text;
 }
 
@@ -187,7 +187,7 @@ void wxWebView::DeleteSelection()
 bool wxWebView::HasSelection() const
 {
     wxString rangeCountStr;
-    const_cast<wxWebView*>(this)->RunScript("window.getSelection().rangeCount;", &rangeCountStr);
+    RunScript("window.getSelection().rangeCount;", &rangeCountStr);
     return rangeCountStr != "0";
 }
 

--- a/src/common/webview.cpp
+++ b/src/common/webview.cpp
@@ -34,7 +34,7 @@ extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewBackendEdge[] = "wxWebViewE
 extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewBackendWebKit[] = "wxWebViewWebKit";
 
 #ifdef __WXMSW__
-extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewBackendDefault[] = "wxWebViewIE";
+extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewBackendDefault[] = "";
 #else
 extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewBackendDefault[] = "wxWebViewWebKit";
 #endif
@@ -269,7 +269,22 @@ wxStringWebViewFactoryMap::iterator wxWebView::FindFactory(const wxString &backe
     // Initialise the map, it checks internally for existing factories
     InitFactoryMap();
 
-    return m_factoryMap.find(backend);
+#ifdef __WXMSW__
+    // Use edge as default backend on MSW if available
+    if (backend.empty())
+    {
+        wxStringWebViewFactoryMap::iterator defaultBackend =
+            m_factoryMap.find(wxWebViewBackendIE);
+#if wxUSE_WEBVIEW_EDGE
+        wxStringWebViewFactoryMap::iterator edgeFactory = m_factoryMap.find(wxWebViewBackendEdge);
+        if (edgeFactory->second->IsAvailable())
+            return edgeFactory;
+#endif
+        return defaultBackend;
+    }
+    else
+#endif
+        return m_factoryMap.find(backend);
 }
 
 // static

--- a/src/common/webview.cpp
+++ b/src/common/webview.cpp
@@ -94,6 +94,15 @@ bool wxWebView::IsBackendAvailable(const wxString& backend)
         return false;
 }
 
+wxVersionInfo wxWebView::GetBackendVersionInfo(const wxString& backend)
+{
+    wxStringWebViewFactoryMap::iterator iter = FindFactory(backend);
+    if (iter != m_factoryMap.end())
+        return iter->second->GetVersionInfo();
+    else
+        return wxVersionInfo();
+}
+
 // static 
 wxStringWebViewFactoryMap::iterator wxWebView::FindFactory(const wxString &backend)
 {

--- a/src/common/webview.cpp
+++ b/src/common/webview.cpp
@@ -78,7 +78,7 @@ wxWebViewZoom wxWebView::GetZoom() const
     }
 
     // to shut up compilers, this can never be reached logically
-    wxASSERT(false);
+    wxFAIL_MSG("unreachable");
     return wxWEBVIEW_ZOOM_MEDIUM;
 }
 
@@ -106,9 +106,6 @@ void wxWebView::SetZoom(wxWebViewZoom zoom)
         case wxWEBVIEW_ZOOM_LARGEST:
             SetZoomFactor(1.6f);
             break;
-
-        default:
-            wxASSERT(false);
     }
 }
 

--- a/src/common/webview.cpp
+++ b/src/common/webview.cpp
@@ -51,6 +51,166 @@ wxDEFINE_EVENT( wxEVT_WEBVIEW_TITLE_CHANGED, wxWebViewEvent );
 
 wxStringWebViewFactoryMap wxWebView::m_factoryMap;
 
+wxWebViewZoom wxWebView::GetZoom() const
+{
+    float zoom = GetZoomFactor();
+
+    // arbitrary way to map float zoom to our common zoom enum
+    if (zoom <= 0.55)
+    {
+        return wxWEBVIEW_ZOOM_TINY;
+    }
+    else if (zoom > 0.55 && zoom <= 0.85)
+    {
+        return wxWEBVIEW_ZOOM_SMALL;
+    }
+    else if (zoom > 0.85 && zoom <= 1.15)
+    {
+        return wxWEBVIEW_ZOOM_MEDIUM;
+    }
+    else if (zoom > 1.15 && zoom <= 1.45)
+    {
+        return wxWEBVIEW_ZOOM_LARGE;
+    }
+    else if (zoom > 1.45)
+    {
+        return wxWEBVIEW_ZOOM_LARGEST;
+    }
+
+    // to shut up compilers, this can never be reached logically
+    wxASSERT(false);
+    return wxWEBVIEW_ZOOM_MEDIUM;
+}
+
+void wxWebView::SetZoom(wxWebViewZoom zoom)
+{
+    // arbitrary way to map our common zoom enum to float zoom
+    switch (zoom)
+    {
+        case wxWEBVIEW_ZOOM_TINY:
+            SetZoomFactor(0.4f);
+            break;
+
+        case wxWEBVIEW_ZOOM_SMALL:
+            SetZoomFactor(0.7f);
+            break;
+
+        case wxWEBVIEW_ZOOM_MEDIUM:
+            SetZoomFactor(1.0f);
+            break;
+
+        case wxWEBVIEW_ZOOM_LARGE:
+            SetZoomFactor(1.3f);
+            break;
+
+        case wxWEBVIEW_ZOOM_LARGEST:
+            SetZoomFactor(1.6f);
+            break;
+
+        default:
+            wxASSERT(false);
+    }
+}
+
+bool wxWebView::QueryCommandEnabled(const wxString& command) const
+{
+    wxString resultStr;
+    const_cast<wxWebView*>(this)->RunScript(
+        wxString::Format("function f(){ return document.queryCommandEnabled('%s'); } f();", command), &resultStr);
+    return resultStr.IsSameAs("true", false);
+}
+
+void wxWebView::ExecCommand(const wxString& command)
+{
+    RunScript(wxString::Format("document.execCommand('%s');", command));
+}
+
+wxString wxWebView::GetPageSource() const
+{
+    wxString text;
+    const_cast<wxWebView*>(this)->RunScript("document.documentElement.outerHTML;", &text);
+    return text;
+}
+
+wxString wxWebView::GetPageText() const
+{
+    wxString text;
+    const_cast<wxWebView*>(this)->RunScript("document.body.innerText;", &text);
+    return text;
+}
+
+bool wxWebView::CanCut() const
+{
+    return QueryCommandEnabled("cut");
+}
+
+bool wxWebView::CanCopy() const
+{
+    return QueryCommandEnabled("copy");
+}
+
+bool wxWebView::CanPaste() const
+{
+    return QueryCommandEnabled("paste");
+}
+
+void wxWebView::Cut()
+{
+    ExecCommand("cut");
+}
+
+void wxWebView::Copy()
+{
+    ExecCommand("copy");
+}
+
+void wxWebView::Paste()
+{
+    ExecCommand("paste");
+}
+
+wxString wxWebView::GetSelectedText() const
+{
+    wxString text;
+    const_cast<wxWebView*>(this)->RunScript("window.getSelection().toString();", &text);
+    return text;
+}
+
+wxString wxWebView::GetSelectedSource() const
+{
+    // TODO: could probably be implemented by script similar to GetSelectedText()
+    return wxString();
+}
+
+void wxWebView::DeleteSelection()
+{
+    ExecCommand("delete");
+}
+
+bool wxWebView::HasSelection() const
+{
+    wxString rangeCountStr;
+    const_cast<wxWebView*>(this)->RunScript("window.getSelection().rangeCount;", &rangeCountStr);
+    return rangeCountStr != "0";
+}
+
+void wxWebView::ClearSelection()
+{
+    //We use javascript as selection isn't exposed at the moment in webkit
+    RunScript("window.getSelection().removeAllRanges();");
+}
+
+void wxWebView::SelectAll()
+{
+    RunScript("window.getSelection().selectAllChildren(document.body);");
+}
+
+long wxWebView::Find(const wxString& WXUNUSED(text), int WXUNUSED(flags))
+{
+    // TODO: could probably be implemented by script
+    return -1;
+}
+
 // static
 wxWebView* wxWebView::New(const wxString& backend)
 {
@@ -103,7 +263,7 @@ wxVersionInfo wxWebView::GetBackendVersionInfo(const wxString& backend)
         return wxVersionInfo();
 }
 
-// static 
+// static
 wxStringWebViewFactoryMap::iterator wxWebView::FindFactory(const wxString &backend)
 {
     // Initialise the map, it checks internally for existing factories

--- a/src/gtk/webview_webkit.cpp
+++ b/src/gtk/webview_webkit.cpp
@@ -750,66 +750,11 @@ wxString wxWebViewWebKit::GetPageSource() const
 }
 
 
-wxWebViewZoom wxWebViewWebKit::GetZoom() const
-{
-    float zoom = GetWebkitZoom();
-
-    // arbitrary way to map float zoom to our common zoom enum
-    if (zoom <= 0.65)
-    {
-        return wxWEBVIEW_ZOOM_TINY;
-    }
-    if (zoom <= 0.90)
-    {
-        return wxWEBVIEW_ZOOM_SMALL;
-    }
-    if (zoom <= 1.15)
-    {
-        return wxWEBVIEW_ZOOM_MEDIUM;
-    }
-    if (zoom <= 1.45)
-    {
-        return wxWEBVIEW_ZOOM_LARGE;
-    }
-    return wxWEBVIEW_ZOOM_LARGEST;
-}
-
-
 float wxWebViewWebKit::GetZoomFactor() const
 {
     return GetWebkitZoom();
 }
 
-
-void wxWebViewWebKit::SetZoom(wxWebViewZoom zoom)
-{
-    // arbitrary way to map our common zoom enum to float zoom
-    switch (zoom)
-    {
-        case wxWEBVIEW_ZOOM_TINY:
-            SetWebkitZoom(0.6f);
-            break;
-
-        case wxWEBVIEW_ZOOM_SMALL:
-            SetWebkitZoom(0.8f);
-            break;
-
-        case wxWEBVIEW_ZOOM_MEDIUM:
-            SetWebkitZoom(1.0f);
-            break;
-
-        case wxWEBVIEW_ZOOM_LARGE:
-            SetWebkitZoom(1.3);
-            break;
-
-        case wxWEBVIEW_ZOOM_LARGEST:
-            SetWebkitZoom(1.6);
-            break;
-
-        default:
-            wxFAIL;
-    }
-}
 
 void wxWebViewWebKit::SetZoomFactor(float zoom)
 {

--- a/src/gtk/webview_webkit.cpp
+++ b/src/gtk/webview_webkit.cpp
@@ -920,7 +920,7 @@ wxString wxWebViewWebKit::GetPageText() const
                     wxConvUTF8);
 }
 
-bool wxWebViewWebKit::RunScript(const wxString& javascript, wxString* output)
+bool wxWebViewWebKit::RunScript(const wxString& javascript, wxString* output) const
 {
     wxCHECK_MSG( m_web_view, false,
         wxS("wxWebView must be created before calling RunScript()") );

--- a/src/gtk/webview_webkit2.cpp
+++ b/src/gtk/webview_webkit2.cpp
@@ -508,6 +508,16 @@ wxgtk_authorize_authenticated_peer_cb(GDBusAuthObserver *,
 } // extern "C"
 
 //-----------------------------------------------------------------------------
+// wxWebViewFactoryWebKit
+//-----------------------------------------------------------------------------
+
+wxVersionInfo wxWebViewFactoryWebKit::GetVersionInfo()
+{
+    return wxVersionInfo("webkit2", webkit_get_major_version(),
+        webkit_get_minor_version(), webkit_get_micro_version());
+}
+
+//-----------------------------------------------------------------------------
 // wxWebViewWebKit
 //-----------------------------------------------------------------------------
 

--- a/src/gtk/webview_webkit2.cpp
+++ b/src/gtk/webview_webkit2.cpp
@@ -909,63 +909,9 @@ wxString wxWebViewWebKit::GetPageSource() const
 }
 
 
-wxWebViewZoom wxWebViewWebKit::GetZoom() const
-{
-    float zoom = GetWebkitZoom();
-
-    // arbitrary way to map float zoom to our common zoom enum
-    if (zoom <= 0.65f)
-    {
-        return wxWEBVIEW_ZOOM_TINY;
-    }
-    if (zoom <= 0.90f)
-    {
-        return wxWEBVIEW_ZOOM_SMALL;
-    }
-    if (zoom <= 1.15f)
-    {
-        return wxWEBVIEW_ZOOM_MEDIUM;
-    }
-    if (zoom <= 1.45f)
-    {
-        return wxWEBVIEW_ZOOM_LARGE;
-    }
-    return wxWEBVIEW_ZOOM_LARGEST;
-}
-
 float wxWebViewWebKit::GetZoomFactor() const
 {
     return GetWebkitZoom();
-}
-
-void wxWebViewWebKit::SetZoom(wxWebViewZoom zoom)
-{
-    // arbitrary way to map our common zoom enum to float zoom
-    switch (zoom)
-    {
-        case wxWEBVIEW_ZOOM_TINY:
-            SetWebkitZoom(0.6f);
-            break;
-
-        case wxWEBVIEW_ZOOM_SMALL:
-            SetWebkitZoom(0.8f);
-            break;
-
-        case wxWEBVIEW_ZOOM_MEDIUM:
-            SetWebkitZoom(1.0f);
-            break;
-
-        case wxWEBVIEW_ZOOM_LARGE:
-            SetWebkitZoom(1.3);
-            break;
-
-        case wxWEBVIEW_ZOOM_LARGEST:
-            SetWebkitZoom(1.6);
-            break;
-
-        default:
-            wxFAIL;
-    }
 }
 
 void wxWebViewWebKit::SetZoomFactor(float zoom)

--- a/src/gtk/webview_webkit2.cpp
+++ b/src/gtk/webview_webkit2.cpp
@@ -1130,7 +1130,7 @@ static void wxgtk_run_javascript_cb(GObject *,
 } // extern "C"
 
 // Run the given script synchronously and return its result in output.
-bool wxWebViewWebKit::RunScriptSync(const wxString& javascript, wxString* output)
+bool wxWebViewWebKit::RunScriptSync(const wxString& javascript, wxString* output) const
 {
     GAsyncResult *result = NULL;
     webkit_web_view_run_javascript(m_web_view,
@@ -1193,7 +1193,7 @@ bool wxWebViewWebKit::RunScriptSync(const wxString& javascript, wxString* output
     return true;
 }
 
-bool wxWebViewWebKit::RunScript(const wxString& javascript, wxString* output)
+bool wxWebViewWebKit::RunScript(const wxString& javascript, wxString* output) const
 {
     wxJSScriptWrapper wrapJS(javascript, &m_runScriptCount);
 
@@ -1240,7 +1240,7 @@ long wxWebViewWebKit::Find(const wxString& text, int flags)
 {
     WebKitFindController* findctrl = webkit_web_view_get_find_controller(m_web_view);
     bool newSearch = false;
-    if(text != m_findText || 
+    if(text != m_findText ||
        (flags & wxWEBVIEW_FIND_MATCH_CASE) != (m_findFlags & wxWEBVIEW_FIND_MATCH_CASE))
     {
         newSearch = true;

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -651,7 +651,7 @@ void wxWebViewEdge::MSWSetBrowserExecutableDir(const wxString & path)
     wxWebViewEdgeImpl::ms_browserExecutableDir = path;
 }
 
-bool wxWebViewEdge::RunScriptSync(const wxString& javascript, wxString* output)
+bool wxWebViewEdge::RunScriptSync(const wxString& javascript, wxString* output) const
 {
     bool scriptExecuted = false;
 
@@ -687,7 +687,7 @@ bool wxWebViewEdge::RunScriptSync(const wxString& javascript, wxString* output)
         return true;
 }
 
-bool wxWebViewEdge::RunScript(const wxString& javascript, wxString* output)
+bool wxWebViewEdge::RunScript(const wxString& javascript, wxString* output) const
 {
     wxJSScriptWrapper wrapJS(javascript, &m_runScriptCount);
 

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -741,14 +741,18 @@ bool wxWebViewFactoryEdge::IsAvailable()
 wxVersionInfo wxWebViewFactoryEdge::GetVersionInfo()
 {
     IsAvailable(); // Make sure ms_version string is initialized (if available)
-    long versions[3] = { 0, 0, 0 };
-    wxArrayString tokens = wxStringTokenize(wxWebViewEdgeImpl::ms_version, ". ");
-    for (size_t i = 0; i < 3; i++)
-    {
-        if (tokens.size() > i)
-            tokens[i].ToLong(&versions[i]);
-    }
-    return wxVersionInfo("Microsoft Edge WebView2", versions[0], versions[1], versions[2]);
+    long major = 0,
+         minor = 0,
+         micro = 0;
+    wxStringTokenizer tk(wxWebViewEdgeImpl::ms_version, ". ");
+    // Ignore the return value because if the version component is missing
+    // or invalid (i.e. non-numeric), the only thing we can do is to ignore
+    // it anyhow.
+    tk.GetNextToken().ToLong(&major);
+    tk.GetNextToken().ToLong(&minor);
+    tk.GetNextToken().ToLong(&micro);
+
+    return wxVersionInfo("Microsoft Edge WebView2", major, minor, micro);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -19,6 +19,7 @@
 #include "wx/log.h"
 #include "wx/stdpaths.h"
 #include "wx/thread.h"
+#include "wx/tokenzr.h"
 #include "wx/private/jsscriptwrapper.h"
 #include "wx/private/json.h"
 #include "wx/msw/private.h"
@@ -53,6 +54,7 @@ GetAvailableCoreWebView2BrowserVersionString_t wxGetAvailableCoreWebView2Browser
 
 wxDynamicLibrary wxWebViewEdgeImpl::ms_loaderDll;
 wxString wxWebViewEdgeImpl::ms_browserExecutableDir;
+wxString wxWebViewEdgeImpl::ms_version;
 
 wxWebViewEdgeImpl::wxWebViewEdgeImpl(wxWebViewEdge* webview):
     m_ctrl(webview)
@@ -135,6 +137,7 @@ bool wxWebViewEdgeImpl::Initialize()
         wxLogApiError("GetCoreWebView2BrowserVersionInfo", hr);
         return false;
     }
+    ms_version = versionStr;
 
     ms_loaderDll.Attach(loaderDll.Detach());
 
@@ -876,6 +879,18 @@ bool wxWebViewFactoryEdge::IsAvailable()
     return wxWebViewEdgeImpl::Initialize();
 }
 
+wxVersionInfo wxWebViewFactoryEdge::GetVersionInfo()
+{
+    IsAvailable(); // Make sure ms_version string is initialized (if available)
+    long versions[3] = { 0, 0, 0 };
+    wxArrayString tokens = wxStringTokenize(wxWebViewEdgeImpl::ms_version, ". ");
+    for (size_t i = 0; i < 3; i++)
+    {
+        if (tokens.size() > i)
+            tokens[i].ToLong(&versions[i]);
+    }
+    return wxVersionInfo("Microsoft Edge WebView2", versions[0], versions[1], versions[2]);
+}
 
 // ----------------------------------------------------------------------------
 // Module ensuring all global/singleton objects are destroyed on shutdown.

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -508,20 +508,6 @@ void wxWebViewEdge::Reload(wxWebViewReloadFlags WXUNUSED(flags))
         m_impl->m_webView->Reload();
 }
 
-wxString wxWebViewEdge::GetPageSource() const
-{
-    wxString text;
-    const_cast<wxWebViewEdge*>(this)->RunScript("document.documentElement.outerHTML;", &text);
-    return text;
-}
-
-wxString wxWebViewEdge::GetPageText() const
-{
-    wxString text;
-    const_cast<wxWebViewEdge*>(this)->RunScript("document.body.innerText;", &text);
-    return text;
-}
-
 bool wxWebViewEdge::IsBusy() const
 {
     return m_impl->m_isBusy;
@@ -565,21 +551,6 @@ void wxWebViewEdge::Print()
     RunScript("window.print();");
 }
 
-wxWebViewZoom wxWebViewEdge::GetZoom() const
-{
-    double old_zoom_factor = 0.0;
-    m_impl->m_webViewController->get_ZoomFactor(&old_zoom_factor);
-    if (old_zoom_factor > 1.7)
-        return wxWEBVIEW_ZOOM_LARGEST;
-    if (old_zoom_factor > 1.3)
-        return wxWEBVIEW_ZOOM_LARGE;
-    if (old_zoom_factor > 0.8)
-        return wxWEBVIEW_ZOOM_MEDIUM;
-    if (old_zoom_factor > 0.6)
-        return wxWEBVIEW_ZOOM_SMALL;
-    return wxWEBVIEW_ZOOM_TINY;
-}
-
 float wxWebViewEdge::GetZoomFactor() const
 {
     double old_zoom_factor = 0.0;
@@ -587,67 +558,9 @@ float wxWebViewEdge::GetZoomFactor() const
     return old_zoom_factor;
 }
 
-void wxWebViewEdge::SetZoom(wxWebViewZoom zoom)
-{
-    double old_zoom_factor = 0.0;
-    m_impl->m_webViewController->get_ZoomFactor(&old_zoom_factor);
-    double zoom_factor = 1.0;
-    switch (zoom)
-    {
-    case wxWEBVIEW_ZOOM_LARGEST:
-        zoom_factor = 2.0;
-        break;
-    case wxWEBVIEW_ZOOM_LARGE:
-        zoom_factor = 1.5;
-        break;
-    case wxWEBVIEW_ZOOM_MEDIUM:
-        zoom_factor = 1.0;
-        break;
-    case wxWEBVIEW_ZOOM_SMALL:
-        zoom_factor = 0.75;
-        break;
-    case wxWEBVIEW_ZOOM_TINY:
-        zoom_factor = 0.5;
-        break;
-    default:
-        break;
-    }
-    SetZoomFactor(zoom_factor);
-}
-
 void wxWebViewEdge::SetZoomFactor(float zoom)
 {
     m_impl->m_webViewController->put_ZoomFactor(zoom);
-}
-
-bool wxWebViewEdge::CanCut() const
-{
-    return QueryCommandEnabled("cut");
-}
-
-bool wxWebViewEdge::CanCopy() const
-{
-    return QueryCommandEnabled("copy");
-}
-
-bool wxWebViewEdge::CanPaste() const
-{
-    return QueryCommandEnabled("paste");
-}
-
-void wxWebViewEdge::Cut()
-{
-    ExecCommand("cut");
-}
-
-void wxWebViewEdge::Copy()
-{
-    ExecCommand("copy");
-}
-
-void wxWebViewEdge::Paste()
-{
-    ExecCommand("paste");
 }
 
 bool wxWebViewEdge::CanUndo() const
@@ -670,12 +583,6 @@ void wxWebViewEdge::Redo()
     ExecCommand("redo");
 }
 
-long wxWebViewEdge::Find(const wxString& WXUNUSED(text), int WXUNUSED(flags))
-{
-    // TODO: not implemented in SDK (could probably be implemented by script)
-    return -1;
-}
-
 //Editing functions
 void wxWebViewEdge::SetEditable(bool WXUNUSED(enable))
 {
@@ -685,41 +592,6 @@ void wxWebViewEdge::SetEditable(bool WXUNUSED(enable))
 bool wxWebViewEdge::IsEditable() const
 {
     return false;
-}
-
-void wxWebViewEdge::SelectAll()
-{
-    RunScript("window.getSelection().selectAllChildren(document);");
-}
-
-bool wxWebViewEdge::HasSelection() const
-{
-    wxString rangeCountStr;
-    const_cast<wxWebViewEdge*>(this)->RunScript("window.getSelection().rangeCount;", &rangeCountStr);
-    return rangeCountStr != "0";
-}
-
-void wxWebViewEdge::DeleteSelection()
-{
-    ExecCommand("delete");
-}
-
-wxString wxWebViewEdge::GetSelectedText() const
-{
-    wxString selectedText;
-    const_cast<wxWebViewEdge*>(this)->RunScript("window.getSelection().toString();", &selectedText);
-    return selectedText;
-}
-
-wxString wxWebViewEdge::GetSelectedSource() const
-{
-    // TODO: not implemented in SDK (could probably be implemented by script)
-    return wxString();
-}
-
-void wxWebViewEdge::ClearSelection()
-{
-    RunScript("window.getSelection().empty();");
 }
 
 void wxWebViewEdge::EnableContextMenu(bool enable)
@@ -772,19 +644,6 @@ bool wxWebViewEdge::IsAccessToDevToolsEnabled() const
 void* wxWebViewEdge::GetNativeBackend() const
 {
     return m_impl->m_webView;
-}
-
-bool wxWebViewEdge::QueryCommandEnabled(const wxString& command) const
-{
-    wxString resultStr;
-    const_cast<wxWebViewEdge*>(this)->RunScript(
-        wxString::Format("function f(){ return document.queryCommandEnabled('%s'); } f();", command), &resultStr);
-    return resultStr.IsSameAs("true", false);
-}
-
-void wxWebViewEdge::ExecCommand(const wxString& command)
-{
-    RunScript(wxString::Format("document.execCommand('%s');", command));
 }
 
 void wxWebViewEdge::MSWSetBrowserExecutableDir(const wxString & path)

--- a/src/msw/webview_ie.cpp
+++ b/src/msw/webview_ie.cpp
@@ -19,6 +19,7 @@
 #include "wx/filesys.h"
 #include "wx/dynlib.h"
 #include "wx/scopeguard.h"
+#include "wx/tokenzr.h"
 
 #include "wx/msw/missing.h"
 #include "wx/msw/private.h"
@@ -49,6 +50,22 @@ enum //Internal find flags
     wxWEBVIEW_FIND_REMOVE_HIGHLIGHT =  0x0002
 };
 
+}
+
+// wxWebViewFactoryIE
+wxVersionInfo wxWebViewFactoryIE::GetVersionInfo()
+{
+    wxRegKey key(wxRegKey::HKLM, "Software\\Microsoft\\Internet Explorer");
+    wxString value;
+    key.QueryValue("Version", value);
+    long versions[3] = { 0, 0, 0 };
+    wxArrayString tokens = wxStringTokenize(value, ". ");
+    for (size_t i = 0; i < 3; i++)
+    {
+        if (tokens.size() > i)
+            tokens[i].ToLong(&versions[i]);
+    }
+    return wxVersionInfo("Internet Explorer", versions[0], versions[1], versions[2]);
 }
 
 //Convenience function for error conversion

--- a/src/msw/webview_ie.cpp
+++ b/src/msw/webview_ie.cpp
@@ -58,14 +58,17 @@ wxVersionInfo wxWebViewFactoryIE::GetVersionInfo()
     wxRegKey key(wxRegKey::HKLM, "Software\\Microsoft\\Internet Explorer");
     wxString value;
     key.QueryValue("Version", value);
-    long versions[3] = { 0, 0, 0 };
-    wxArrayString tokens = wxStringTokenize(value, ". ");
-    for (size_t i = 0; i < 3; i++)
-    {
-        if (tokens.size() > i)
-            tokens[i].ToLong(&versions[i]);
-    }
-    return wxVersionInfo("Internet Explorer", versions[0], versions[1], versions[2]);
+    long major = 0,
+         minor = 0,
+         micro = 0;
+    wxStringTokenizer tk(value, ". ");
+    // Ignore the return value because if the version component is missing
+    // or invalid (i.e. non-numeric), the only thing we can do is to ignore
+    // it anyhow.
+    tk.GetNextToken().ToLong(&major);
+    tk.GetNextToken().ToLong(&minor);
+    tk.GetNextToken().ToLong(&micro);
+    return wxVersionInfo("Internet Explorer", major, minor, micro);
 }
 
 //Convenience function for error conversion

--- a/src/msw/webview_ie.cpp
+++ b/src/msw/webview_ie.cpp
@@ -1029,7 +1029,7 @@ bool CallEval(const wxString& code,
     return scriptAO.Invoke("eval", DISPATCH_METHOD, *varResult, 1, &varCode);
 }
 
-bool wxWebViewIE::RunScript(const wxString& javascript, wxString* output)
+bool wxWebViewIE::RunScript(const wxString& javascript, wxString* output) const
 {
     wxCOMPtr<IHTMLDocument2> document(m_impl->GetDocument());
     if ( !document )

--- a/src/osx/webview_webkit.mm
+++ b/src/osx/webview_webkit.mm
@@ -222,13 +222,6 @@ void wxWebViewWebKit::Stop()
     [m_webView stopLoading];
 }
 
-wxString wxWebViewWebKit::GetPageSource() const
-{
-    wxString text;
-    const_cast<wxWebViewWebKit*>(this)->RunScript("document.documentElement.outerHTML;", &text);
-    return text;
-}
-
 void wxWebViewWebKit::Print()
 {
 
@@ -307,13 +300,6 @@ bool wxWebViewWebKit::CanSetZoomType(wxWebViewZoomType type) const
         default:
             return false;
     }
-}
-
-wxString wxWebViewWebKit::GetSelectedText() const
-{
-    wxString text;
-    const_cast<wxWebViewWebKit*>(this)->RunScript("window.getSelection().toString();", &text);
-    return text;
 }
 
 bool wxWebViewWebKit::RunScriptSync(const wxString& javascript, wxString* output)
@@ -404,70 +390,9 @@ wxString wxWebViewWebKit::GetCurrentTitle() const
     return wxCFStringRef::AsString(m_webView.title);
 }
 
-wxWebViewZoom wxWebViewWebKit::GetZoom() const
-{
-    float zoom = GetZoomFactor();
-
-    // arbitrary way to map float zoom to our common zoom enum
-    if (zoom <= 0.55)
-    {
-        return wxWEBVIEW_ZOOM_TINY;
-    }
-    else if (zoom > 0.55 && zoom <= 0.85)
-    {
-        return wxWEBVIEW_ZOOM_SMALL;
-    }
-    else if (zoom > 0.85 && zoom <= 1.15)
-    {
-        return wxWEBVIEW_ZOOM_MEDIUM;
-    }
-    else if (zoom > 1.15 && zoom <= 1.45)
-    {
-        return wxWEBVIEW_ZOOM_LARGE;
-    }
-    else if (zoom > 1.45)
-    {
-        return wxWEBVIEW_ZOOM_LARGEST;
-    }
-
-    // to shut up compilers, this can never be reached logically
-    wxASSERT(false);
-    return wxWEBVIEW_ZOOM_MEDIUM;
-}
-
 float wxWebViewWebKit::GetZoomFactor() const
 {
     return m_webView.magnification;
-}
-
-void wxWebViewWebKit::SetZoom(wxWebViewZoom zoom)
-{
-    // arbitrary way to map our common zoom enum to float zoom
-    switch (zoom)
-    {
-        case wxWEBVIEW_ZOOM_TINY:
-            SetZoomFactor(0.4f);
-            break;
-
-        case wxWEBVIEW_ZOOM_SMALL:
-            SetZoomFactor(0.7f);
-            break;
-
-        case wxWEBVIEW_ZOOM_MEDIUM:
-            SetZoomFactor(1.0f);
-            break;
-
-        case wxWEBVIEW_ZOOM_LARGE:
-            SetZoomFactor(1.3);
-            break;
-
-        case wxWEBVIEW_ZOOM_LARGEST:
-            SetZoomFactor(1.6);
-            break;
-
-        default:
-            wxASSERT(false);
-    }
 }
 
 void wxWebViewWebKit::SetZoomFactor(float zoom)
@@ -483,57 +408,6 @@ void wxWebViewWebKit::DoSetPage(const wxString& src, const wxString& baseUrl)
     [m_webView loadHTMLString:wxCFStringRef( src ).AsNSString()
                                   baseURL:[NSURL URLWithString:
                                     wxCFStringRef( baseUrl ).AsNSString()]];
-}
-
-void wxWebViewWebKit::Cut()
-{
-    ExecCommand("cut");
-}
-
-void wxWebViewWebKit::Copy()
-{
-    ExecCommand("copy");
-}
-
-void wxWebViewWebKit::Paste()
-{
-    ExecCommand("paste");
-}
-
-void wxWebViewWebKit::DeleteSelection()
-{
-    ExecCommand("delete");
-}
-
-bool wxWebViewWebKit::HasSelection() const
-{
-    wxString rangeCountStr;
-    const_cast<wxWebViewWebKit*>(this)->RunScript("window.getSelection().rangeCount;", &rangeCountStr);
-    return rangeCountStr != "0";
-}
-
-void wxWebViewWebKit::ClearSelection()
-{
-    //We use javascript as selection isn't exposed at the moment in webkit
-    RunScript("window.getSelection().removeAllRanges();");
-}
-
-void wxWebViewWebKit::SelectAll()
-{
-    RunScript("window.getSelection().selectAllChildren(document.body);");
-}
-
-wxString wxWebViewWebKit::GetSelectedSource() const
-{
-    // TODO: not implemented in SDK (could probably be implemented by script)
-    return wxString();
-}
-
-wxString wxWebViewWebKit::GetPageText() const
-{
-    wxString text;
-    const_cast<wxWebViewWebKit*>(this)->RunScript("document.body.innerText;", &text);
-    return text;
 }
 
 void wxWebViewWebKit::EnableHistory(bool enable)
@@ -613,19 +487,6 @@ void wxWebViewWebKit::Redo()
 void wxWebViewWebKit::RegisterHandler(wxSharedPtr<wxWebViewHandler> handler)
 {
     m_handlers[handler->GetName()] = handler;
-}
-
-bool wxWebViewWebKit::QueryCommandEnabled(const wxString& command) const
-{
-    wxString resultStr;
-    const_cast<wxWebViewWebKit*>(this)->RunScript(
-        wxString::Format("function f(){ return document.queryCommandEnabled('%s'); } f();", command), &resultStr);
-    return resultStr.IsSameAs("true", false);
-}
-
-void wxWebViewWebKit::ExecCommand(const wxString& command)
-{
-    RunScript(wxString::Format("document.execCommand('%s');", command));
 }
 
 //------------------------------------------------------------

--- a/src/osx/webview_webkit.mm
+++ b/src/osx/webview_webkit.mm
@@ -302,7 +302,7 @@ bool wxWebViewWebKit::CanSetZoomType(wxWebViewZoomType type) const
     }
 }
 
-bool wxWebViewWebKit::RunScriptSync(const wxString& javascript, wxString* output)
+bool wxWebViewWebKit::RunScriptSync(const wxString& javascript, wxString* output) const
 {
     __block bool scriptExecuted = false;
     __block wxString outputStr;
@@ -345,7 +345,7 @@ bool wxWebViewWebKit::RunScriptSync(const wxString& javascript, wxString* output
     return scriptSuccess;
 }
 
-bool wxWebViewWebKit::RunScript(const wxString& javascript, wxString* output)
+bool wxWebViewWebKit::RunScript(const wxString& javascript, wxString* output) const
 {
     wxJSScriptWrapper wrapJS(javascript, &m_runScriptCount);
 

--- a/tests/controls/webtest.cpp
+++ b/tests/controls/webtest.cpp
@@ -174,7 +174,7 @@ TEST_CASE_METHOD(WebViewTestCase, "WebView", "[wxWebView]")
         CHECK(m_browser->GetBackwardHistory().size() == 2);
     }
 
-#if !defined(__WXOSX__)
+#if !defined(__WXOSX__) && (!defined(wxUSE_WEBVIEW_EDGE) || !wxUSE_WEBVIEW_EDGE)
     SECTION("Editable")
     {
         CHECK(!m_browser->IsEditable());
@@ -209,7 +209,7 @@ TEST_CASE_METHOD(WebViewTestCase, "WebView", "[wxWebView]")
         CHECK(m_browser->HasSelection());
         CHECK(m_browser->GetSelectedText() == "Some strong text");
 
-#if !defined(__WXOSX__)
+#if !defined(__WXOSX__) && (!defined(wxUSE_WEBVIEW_EDGE) || !wxUSE_WEBVIEW_EDGE)
         // The web engine doesn't necessarily represent the HTML in the same way as
         // we used above, e.g. IE uses upper case for all the tags while WebKit
         // under OS X inserts plenty of its own <span> tags, so don't test for
@@ -258,7 +258,7 @@ TEST_CASE_METHOD(WebViewTestCase, "WebView", "[wxWebView]")
         ENSURE_LOADED;
 
         wxString result;
-    #if wxUSE_WEBVIEW_IE
+    #if wxUSE_WEBVIEW_IE && !wxUSE_WEBVIEW_EDGE
         CHECK(wxWebViewIE::MSWSetModernEmulationLevel());
 
         // Define a specialized scope guard ensuring that we reset the emulation


### PR DESCRIPTION
A [fixed version](https://docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution#fixed-version-distribution-mode) may be distributed with the application (no installation required)
and `wxWebViewEdge::MSWSetBrowserExecutableDir()` allows
it's usage with `wxWebViewEdge`.

Additionally:
* Use the Edge backend as default if enabled and available at runtime
* add `wxWebView::GetBackendVersionInformation()` to get backend version information.
This is currently implemented for IE, edge and webkit2.
I don't think it can be implemented for macOS or iOS as WKWebView is just bound to the system.
* Move common `wxWebView` code to base class