### PR TITLE
Pass pre-adjusted cairo context to wxGraphicsContext::CreateFromNative()

### DIFF
--- a/include/wx/gtk/dc.h
+++ b/include/wx/gtk/dc.h
@@ -42,6 +42,9 @@ protected:
     // Set m_size from the given (valid) GdkWindow.
     void InitSize(GdkWindow* window);
 
+    // Adjust cairo context for RTL.
+    void AdjustCairoContext(cairo_t* cr);
+
     wxSize m_size;
     wxLayoutDirection m_layoutDir;
 

--- a/samples/widgets/widgets.cpp
+++ b/samples/widgets/widgets.cpp
@@ -459,6 +459,8 @@ WidgetsFrame::WidgetsFrame(const wxString& title)
     menuWidget->AppendSeparator();
     menuWidget->AppendCheckItem(Widgets_LayoutDirection,
                                 "Toggle &layout direction\tCtrl-L");
+    menuWidget->Check(Widgets_LayoutDirection,
+                      GetLayoutDirection() == wxLayout_RightToLeft);
 
     menuWidget->AppendSeparator();
     menuWidget->AppendCheckItem(Widgets_GlobalBusyCursor,

--- a/samples/widgets/widgets.h
+++ b/samples/widgets/widgets.h
@@ -95,7 +95,7 @@ struct WidgetAttributes
 #endif // wxUSE_TOOLTIPS
         m_enabled = true;
         m_show = true;
-        m_dir = wxLayout_LeftToRight;
+        m_dir = wxLayout_Default;
         m_variant = wxWINDOW_VARIANT_NORMAL;
         m_cursor = wxNullCursor;
         m_defaultFlags = wxBORDER_DEFAULT;


### PR DESCRIPTION
It took me awhile to figure out that `wxGTKCairoDCImpl::SetLayoutDirection()` has no effect, but to set the `m_layoutDir` only!
and that we should pass to `wxGraphicsContext::CreateFromNative()` a pre adjusted cairo context for things to work properly.

you can test these samples (with master):
 - drawing
 - griddemo
 - splitter

try some interactions with them and see what happens!

**drawing sample for ex.:**
- the canvas keeps flipping whenever you click inside!
- the rubber-band is not working correctly!

@paulcor thanks in advance for your help on this.