### PR TITLE
Make non-bundled apps work on mac

### DIFF
--- a/src/osx/cocoa/utils.mm
+++ b/src/osx/cocoa/utils.mm
@@ -72,6 +72,9 @@ void wxBell()
     wxUnusedVar(notification);
     [NSApp stop:nil];
     wxTheApp->OSXOnDidFinishLaunching();
+
+    [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+    [NSApp activateIgnoringOtherApps: YES];
 }
 
 - (void)application:(NSApplication *)sender openFiles:(NSArray *)fileNames
@@ -287,50 +290,6 @@ void wxBell()
 }
 @end
 
-
-// more on bringing non-bundled apps to the foreground
-// https://devforums.apple.com/thread/203753
-
-#if 0 
-
-// one possible solution is also quoted here
-// from https://stackoverflow.com/questions/7596643/when-calling-transformprocesstype-the-app-menu-doesnt-show-up
-
-@interface wxNSNonBundledAppHelper : NSObject {
-    
-}
-
-+ (void)transformToForegroundApplication;
-
-@end
-
-@implementation wxNSNonBundledAppHelper
-
-+ (void)transformToForegroundApplication {
-    for (NSRunningApplication * app in [NSRunningApplication runningApplicationsWithBundleIdentifier:@"com.apple.finder"]) {
-        [app activateWithOptions:NSApplicationActivateIgnoringOtherApps];
-        break;
-    }
-    [self performSelector:@selector(transformStep2) withObject:nil afterDelay:0.1];
-}
-
-+ (void)transformStep2
-{
-    ProcessSerialNumber psn = { 0, kCurrentProcess };
-    (void) TransformProcessType(&psn, kProcessTransformToForegroundApplication);
-    
-    [self performSelector:@selector(transformStep3) withObject:nil afterDelay:0.1];
-}
-
-+ (void)transformStep3
-{
-    [[NSRunningApplication currentApplication] activateWithOptions:NSApplicationActivateIgnoringOtherApps];
-}
-
-@end
-
-#endif
-
 // here we subclass NSApplication, for the purpose of being able to override sendEvent.
 @interface wxNSApplication : NSApplication
 {
@@ -352,16 +311,6 @@ void wxBell()
     }
     return self;
 }
-
-- (void) transformToForegroundApplication {
-    ProcessSerialNumber psn = { 0, kCurrentProcess };
-    TransformProcessType(&psn, kProcessTransformToForegroundApplication);
-    
-    [[NSRunningApplication currentApplication] activateWithOptions:
-        (NSApplicationActivateAllWindows | NSApplicationActivateIgnoringOtherApps)];
-}
-
-
 
 /* This is needed because otherwise we don't receive any key-up events for command-key
  combinations (an AppKit bug, apparently) */
@@ -391,20 +340,6 @@ bool wxApp::DoInitGui()
     if (!sm_isEmbedded)
     {
         [wxNSApplication sharedApplication];
-        
-        if ( OSXIsGUIApplication() )
-        {
-            CFURLRef url = CFBundleCopyBundleURL(CFBundleGetMainBundle() ) ;
-            CFStringRef path = CFURLCopyFileSystemPath ( url , kCFURLPOSIXPathStyle ) ;
-            CFRelease( url ) ;
-            wxString app = wxCFStringRef(path).AsString(wxLocale::GetSystemEncoding());
-            
-            // workaround is only needed for non-bundled apps
-            if ( !app.EndsWith(".app") )
-            {
-                [(wxNSApplication*) [wxNSApplication sharedApplication] transformToForegroundApplication];
-            }
-        }
 
         appcontroller = OSXCreateAppController();
         [[NSApplication sharedApplication] setDelegate:(id <NSApplicationDelegate>)appcontroller];

--- a/src/osx/cocoa/utils.mm
+++ b/src/osx/cocoa/utils.mm
@@ -73,8 +73,16 @@ void wxBell()
     [NSApp stop:nil];
     wxTheApp->OSXOnDidFinishLaunching();
 
-    [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-    [NSApp activateIgnoringOtherApps: YES];
+    CFURLRef url = CFBundleCopyBundleURL(CFBundleGetMainBundle() ) ;
+    CFStringRef path = CFURLCopyFileSystemPath ( url , kCFURLPOSIXPathStyle ) ;
+    CFRelease( url ) ;
+    wxString app = wxCFStringRef(path).AsString(wxLocale::GetSystemEncoding());
+    // Is only needed for non-bundled apps
+    if ( !app.EndsWith(".app") )
+    {
+        [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+        [NSApp activateIgnoringOtherApps: YES];
+    }
 }
 
 - (void)application:(NSApplication *)sender openFiles:(NSArray *)fileNames


### PR DESCRIPTION
Currently non-bundled apps don't work on Catalina and Big Sur, whats
worse is that old the code makes it impossible to make it work
in user code.

Remove the old "workaround", and make it proper.
Solution is what tcl/tk uses.

See [tcl/tk ](https://github.com/tcltk/tk/blob/main/macosx/tkMacOSXInit.c)

I don't know much about this mac stuff so please review carefully and check the tcl/tk solution,
for some comments there. 

Even if you don't apply this fix something needs to be done before next release because the current solution
hinders users to fix the problem in their code.
