### PR TITLE
Make wxNumValidator::m_value protected rather than private

### DIFF
--- a/include/wx/valnum.h
+++ b/include/wx/valnum.h
@@ -238,6 +238,10 @@ protected:
                                                     : wxString();
     }
 
+    // This member is protected because it can be useful to the derived classes
+    // in their Transfer{From,To}Window() implementations.
+    ValueType * const m_value;
+
 private:
     // Just a helper which is a common part of TransferToWindow() and
     // NormalizeString(): returns string representation of a number honouring
@@ -257,8 +261,6 @@ private:
         return s;
     }
 
-
-    ValueType * const m_value;
 
     wxDECLARE_NO_ASSIGN_CLASS(wxNumValidator);
 };

--- a/interface/wx/valnum.h
+++ b/interface/wx/valnum.h
@@ -157,6 +157,57 @@ public:
         It does nothing if there is no associated variable.
      */
     virtual bool TransferFromWindow();
+
+protected:
+    /**
+        Pointer to the value associated with this validator.
+
+        This is the same pointer which is passed to the validator class ctor,
+        so please note that it can be null.
+
+        This field can be useful for the derived classes overriding the base
+        class TransferToWindow() and/or TransferFromWindow() methods, for
+        example here is a class which treats the absent value as @c 1
+        (similarly to how using wxNUM_VAL_ZERO_AS_BLANK would treat it as @c 0):
+
+        @code
+        class MyMultiplierValidator : public wxFloatingPointValidator<double>
+        {
+        public:
+            explicit MyMultiplierValidator(double& value)
+                : wxFloatingPointValidator(&value)
+            {
+                SetMin(0); // Multiplier is always positive.
+            }
+
+            bool TransferFromWindow() override
+            {
+                if ( GetTextEntry()->IsEmpty() )
+                {
+                    *m_value = 1.0;
+                    return true;
+                }
+
+                if ( !wxFloatingPointValidator<double>::TransferFromWindow() )
+                    return false;
+
+                // Multiplier must be strictly positive.
+                if ( *m_value == 0 )
+                    return false;
+
+                return true;
+            }
+
+            wxObject* Clone() const override
+            {
+                return new MyMultiplierValidator(*this);
+            }
+        };
+        @endcode
+
+        @since 3.1.5
+     */
+    ValueType* const m_value;
 };
 
 /**


### PR DESCRIPTION
This is useful for writing overridden TransferXXX() methods in the
derived validator classes, give a motivating example in the docs.

@AliKet you might be interested in this.