### PR TITLE
Add Tool colours into case statements for wxRibbonArtProvider

### DIFF
--- a/src/ribbon/art_msw.cpp
+++ b/src/ribbon/art_msw.cpp
@@ -942,6 +942,30 @@ wxColour wxRibbonMSWArtProvider::GetColour(int id) const
            return m_tab_highlight_colour;
         case wxRIBBON_ART_BUTTON_BAR_LABEL_HIGHLIGHT_GRADIENT_COLOUR:
            return m_tab_highlight_gradient_colour;
+        case wxRIBBON_ART_TOOL_BACKGROUND_TOP_COLOUR:
+            return m_tool_background_top_colour;
+        case wxRIBBON_ART_TOOL_BACKGROUND_TOP_GRADIENT_COLOUR:
+            return m_tool_background_top_gradient_colour;        
+        case wxRIBBON_ART_TOOL_BACKGROUND_COLOUR:
+            return m_tool_background_colour;        
+        case wxRIBBON_ART_TOOL_BACKGROUND_GRADIENT_COLOUR:
+            return m_tool_background_gradient_colour;        
+        case wxRIBBON_ART_TOOL_HOVER_BACKGROUND_TOP_COLOUR:
+            return m_tool_hover_background_top_colour;        
+        case wxRIBBON_ART_TOOL_HOVER_BACKGROUND_TOP_GRADIENT_COLOUR:
+            return m_tool_hover_background_top_gradient_colour;        
+        case wxRIBBON_ART_TOOL_HOVER_BACKGROUND_COLOUR:
+            return m_tool_hover_background_colour;        
+        case wxRIBBON_ART_TOOL_HOVER_BACKGROUND_GRADIENT_COLOUR:
+            return m_tool_hover_background_gradient_colour;        
+        case wxRIBBON_ART_TOOL_ACTIVE_BACKGROUND_TOP_COLOUR:
+            return m_tool_active_background_top_colour;        
+        case wxRIBBON_ART_TOOL_ACTIVE_BACKGROUND_TOP_GRADIENT_COLOUR:
+            return m_tool_active_background_top_gradient_colour;        
+        case wxRIBBON_ART_TOOL_ACTIVE_BACKGROUND_COLOUR:
+            return m_tool_active_background_colour;        
+        case wxRIBBON_ART_TOOL_ACTIVE_BACKGROUND_GRADIENT_COLOUR:
+            return m_tool_active_background_gradient_colour;
         default:
             wxFAIL_MSG(wxT("Invalid Metric Ordinal"));
             break;
@@ -1247,6 +1271,42 @@ void wxRibbonMSWArtProvider::SetColour(int id, const wxColor& colour)
         case wxRIBBON_ART_BUTTON_BAR_LABEL_HIGHLIGHT_GRADIENT_COLOUR:
            m_tab_highlight_gradient_colour = colour;
            break;
+        case wxRIBBON_ART_TOOL_BACKGROUND_TOP_COLOUR:
+            m_tool_background_top_colour = colour;
+            break;
+        case wxRIBBON_ART_TOOL_BACKGROUND_TOP_GRADIENT_COLOUR:
+            m_tool_background_top_gradient_colour = colour;
+            break;        
+        case wxRIBBON_ART_TOOL_BACKGROUND_COLOUR:
+            m_tool_background_colour = colour;
+            break;        
+        case wxRIBBON_ART_TOOL_BACKGROUND_GRADIENT_COLOUR:
+            m_tool_background_gradient_colour = colour;
+            break;        
+        case wxRIBBON_ART_TOOL_HOVER_BACKGROUND_TOP_COLOUR:
+            m_tool_hover_background_top_colour = colour;
+            break;        
+        case wxRIBBON_ART_TOOL_HOVER_BACKGROUND_TOP_GRADIENT_COLOUR:
+            m_tool_hover_background_top_gradient_colour = colour;
+            break;        
+        case wxRIBBON_ART_TOOL_HOVER_BACKGROUND_COLOUR:
+            m_tool_hover_background_colour = colour;
+            break;        
+        case wxRIBBON_ART_TOOL_HOVER_BACKGROUND_GRADIENT_COLOUR:
+            m_tool_hover_background_gradient_colour = colour;
+            break;        
+        case wxRIBBON_ART_TOOL_ACTIVE_BACKGROUND_TOP_COLOUR:
+            m_tool_active_background_top_colour = colour;
+            break;        
+        case wxRIBBON_ART_TOOL_ACTIVE_BACKGROUND_TOP_GRADIENT_COLOUR:
+            m_tool_active_background_top_gradient_colour = colour;
+            break;        
+        case wxRIBBON_ART_TOOL_ACTIVE_BACKGROUND_COLOUR:
+            m_tool_active_background_colour = colour;
+            break;        
+        case wxRIBBON_ART_TOOL_ACTIVE_BACKGROUND_GRADIENT_COLOUR:
+            m_tool_active_background_gradient_colour = colour;
+            break;        
         default:
             wxFAIL_MSG(wxT("Invalid Metric Ordinal"));
             break;


### PR DESCRIPTION
For some reason, the case statements in wxRibbonMSWArtProvider::SetColour and wxRibbonMSWArtProvider::GetColour did not contain checks for any of the wxRIBBON_ART_TOOL_xxx enums, even though they are clearly implemented internally.

This pr simply adds these colours into the case statements.