### PR TITLE
Improve responsiveness of a wxGrid having plenty of attributes

### DIFF
--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -71,8 +71,9 @@ struct wxGridCellWithAttr
     wxGridCellAttr  *attr;
 };
 
-WX_DECLARE_OBJARRAY_WITH_DECL(wxGridCellWithAttr, wxGridCellWithAttrArray,
-                              class WXDLLIMPEXP_ADV);
+WX_DECLARE_HASH_MAP_WITH_DECL(wxLongLong_t, wxGridCellWithAttr*,
+                              wxIntegerHash, wxIntegerEqual,
+                              wxGridCoordsToAttrMap, class WXDLLIMPEXP_CORE);
 
 
 // ----------------------------------------------------------------------------
@@ -468,16 +469,18 @@ private:
 class WXDLLIMPEXP_ADV wxGridCellAttrData
 {
 public:
+    ~wxGridCellAttrData();
+
     void SetAttr(wxGridCellAttr *attr, int row, int col);
     wxGridCellAttr *GetAttr(int row, int col) const;
     void UpdateAttrRows( size_t pos, int numRows );
     void UpdateAttrCols( size_t pos, int numCols );
 
 private:
-    // searches for the attr for given cell, returns wxNOT_FOUND if not found
-    int FindIndex(int row, int col) const;
+    // Tries to search for the attr for given cell.
+    wxGridCoordsToAttrMap::iterator FindIndex(int row, int col) const;
 
-    wxGridCellWithAttrArray m_attrs;
+    mutable wxGridCoordsToAttrMap m_attrs;
 };
 
 // this class stores attributes set for rows or columns

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -24,54 +24,7 @@
 WX_DEFINE_ARRAY_WITH_DECL_PTR(wxGridCellAttr *, wxArrayAttrs,
                                  class WXDLLIMPEXP_ADV);
 
-struct wxGridCellWithAttr
-{
-    wxGridCellWithAttr(int row, int col, wxGridCellAttr *attr_)
-        : coords(row, col), attr(attr_)
-    {
-        wxASSERT( attr );
-    }
-
-    wxGridCellWithAttr(const wxGridCellWithAttr& other)
-        : coords(other.coords),
-          attr(other.attr)
-    {
-        attr->IncRef();
-    }
-
-    wxGridCellWithAttr& operator=(const wxGridCellWithAttr& other)
-    {
-        coords = other.coords;
-        if (attr != other.attr)
-        {
-            attr->DecRef();
-            attr = other.attr;
-            attr->IncRef();
-        }
-        return *this;
-    }
-
-    void ChangeAttr(wxGridCellAttr* new_attr)
-    {
-        if (attr != new_attr)
-        {
-            // "Delete" (i.e. DecRef) the old attribute.
-            attr->DecRef();
-            attr = new_attr;
-            // Take ownership of the new attribute, i.e. no IncRef.
-        }
-    }
-
-    ~wxGridCellWithAttr()
-    {
-        attr->DecRef();
-    }
-
-    wxGridCellCoords coords;
-    wxGridCellAttr  *attr;
-};
-
-WX_DECLARE_HASH_MAP_WITH_DECL(wxLongLong_t, wxGridCellWithAttr*,
+WX_DECLARE_HASH_MAP_WITH_DECL(wxLongLong_t, wxGridCellAttr*,
                               wxIntegerHash, wxIntegerEqual,
                               wxGridCoordsToAttrMap, class WXDLLIMPEXP_CORE);
 

--- a/samples/grid/griddemo.cpp
+++ b/samples/grid/griddemo.cpp
@@ -595,7 +595,7 @@ GridFrame::GridFrame()
 
     grid->GetTable()->SetAttrProvider(new CustomColumnHeadersProvider());
 
-    grid->AppendRows(100);
+    grid->AppendRows(1000);
     grid->AppendCols(100);
 
     int ir = grid->GetNumberRows();
@@ -632,11 +632,14 @@ GridFrame::GridFrame()
 
     grid->SetCellValue( 0, 5, "Press\nCtrl+arrow\nto skip over\ncells" );
 
-    grid->SetRowSize( 99, 4*grid->GetDefaultRowSize() );
-    grid->SetCellValue(98, 98, "Test background colour setting");
-    grid->SetCellBackgroundColour(98, 99, wxColour(255, 127, 127));
-    grid->SetCellBackgroundColour(99, 98, wxColour(255, 127, 127));
-    grid->SetCellValue( 99, 99, "Ctrl+End\nwill go to\nthis cell" );
+    const int endRow = grid->GetNumberRows() - 1,
+              endCol = grid->GetNumberCols() - 1;
+
+    grid->SetRowSize(endRow, 4 * grid->GetDefaultRowSize());
+    grid->SetCellValue(endRow - 1, endCol - 1, "Test background colour setting");
+    grid->SetCellBackgroundColour(endRow - 1, endCol, wxColour(255, 127, 127));
+    grid->SetCellBackgroundColour(endRow, endCol - 1, wxColour(255, 127, 127));
+    grid->SetCellValue(endRow, endCol, "Ctrl+End\nwill go to\nthis cell");
     grid->SetCellValue( 1, 0, "This default cell will overflow into neighboring cells, but not if you turn overflow off.");
 
     grid->SetCellValue(2, 0, "This one always overflows");

--- a/samples/grid/griddemo.h
+++ b/samples/grid/griddemo.h
@@ -49,6 +49,8 @@ class GridFrame : public wxFrame
     void AutoSizeCols( wxCommandEvent& );
     void CellOverflow( wxCommandEvent& );
     void ResizeCell( wxCommandEvent& );
+    void ToggleCheckeredCells( wxCommandEvent& );
+    void ToggleColouredCells( wxCommandEvent& );
     void SetLabelColour( wxCommandEvent& );
     void SetLabelTextColour( wxCommandEvent& );
     void SetLabelFont(wxCommandEvent &);
@@ -153,6 +155,8 @@ public:
         ID_TOGGLEGRIDLINES,
         ID_AUTOSIZECOLS,
         ID_CELLOVERFLOW,
+        ID_TOGGLE_CHECKERED_CELLS,
+        ID_TOGGLE_COLOURED_CELLS,
         ID_HIDECOL,
         ID_SHOWCOL,
         ID_HIDEROW,

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -124,7 +124,6 @@ const int GRID_TEXT_MARGIN = 1;
 #include "wx/arrimpl.cpp"
 
 WX_DEFINE_OBJARRAY(wxGridCellCoordsArray)
-WX_DEFINE_OBJARRAY(wxGridCellWithAttrArray)
 
 // ----------------------------------------------------------------------------
 // events
@@ -762,18 +761,51 @@ wxGridCellEditor* wxGridCellAttr::GetEditor(const wxGrid* grid, int row, int col
 // wxGridCellAttrData
 // ----------------------------------------------------------------------------
 
+namespace
+{
+
+// Helper functions to convert grid coords to a key for the attr map, and
+// vice versa.
+
+wxGridCoordsToAttrMap::key_type CoordsToKey(int row, int col)
+{
+    // Treat both row and col as unsigned to not cause havoc with (unsupported)
+    // negative coords.
+    return (static_cast<wxULongLong_t>(row) << 32) + static_cast<wxUint32>(col);
+}
+
+void KeyToCoords(wxGridCoordsToAttrMap::key_type key, int *pRow, int *pCol)
+{
+    *pRow = key >> 32;
+    *pCol = key & wxUINT32_MAX;
+}
+
+} // anonymous namespace
+
+wxGridCellAttrData::~wxGridCellAttrData()
+{
+    for ( wxGridCoordsToAttrMap::iterator it = m_attrs.begin();
+          it != m_attrs.end();
+          ++it )
+    {
+        delete it->second;
+    }
+
+    m_attrs.clear();
+}
+
 void wxGridCellAttrData::SetAttr(wxGridCellAttr *attr, int row, int col)
 {
     // Note: contrary to wxGridRowOrColAttrData::SetAttr, we must not
     //       touch attribute's reference counting explicitly, since this
     //       is managed by class wxGridCellWithAttr
-    int n = FindIndex(row, col);
-    if ( n == wxNOT_FOUND )
+    wxGridCoordsToAttrMap::iterator it = FindIndex(row, col);
+    if ( it == m_attrs.end() )
     {
         if ( attr )
         {
             // add the attribute
-            m_attrs.Add(new wxGridCellWithAttr(row, col, attr));
+            m_attrs[CoordsToKey(row, col)] = new wxGridCellWithAttr(row, col, attr);
         }
         //else: nothing to do
     }
@@ -782,12 +814,13 @@ void wxGridCellAttrData::SetAttr(wxGridCellAttr *attr, int row, int col)
         if ( attr )
         {
             // change the attribute
-            m_attrs[(size_t)n].ChangeAttr(attr);
+            it->second->ChangeAttr(attr);
         }
         else
         {
             // remove this attribute
-            m_attrs.RemoveAt((size_t)n);
+            delete it->second;
+            m_attrs.erase(it);
         }
     }
 }
@@ -796,10 +829,10 @@ wxGridCellAttr *wxGridCellAttrData::GetAttr(int row, int col) const
 {
     wxGridCellAttr *attr = NULL;
 
-    int n = FindIndex(row, col);
-    if ( n != wxNOT_FOUND )
+    wxGridCoordsToAttrMap::iterator it = FindIndex(row, col);
+    if ( it != m_attrs.end() )
     {
-        attr = m_attrs[(size_t)n].attr;
+        attr = it->second->attr;
         attr->IncRef();
     }
 
@@ -809,7 +842,7 @@ wxGridCellAttr *wxGridCellAttrData::GetAttr(int row, int col) const
 namespace
 {
 
-void UpdateCellAttrRowsOrCols(wxGridCellWithAttrArray& attrs, int editPos,
+void UpdateCellAttrRowsOrCols(wxGridCoordsToAttrMap& attrs, int editPos,
                               int editRowCount, int editColCount)
 {
     wxASSERT( !editRowCount || !editColCount );
@@ -817,17 +850,33 @@ void UpdateCellAttrRowsOrCols(wxGridCellWithAttrArray& attrs, int editPos,
     const bool isEditingRows = (editRowCount != 0);
     const int editCount = (isEditingRows ? editRowCount : editColCount);
 
-    size_t count = attrs.GetCount();
-    for ( size_t n = 0; n < count; n++ )
+    // Copy updated attributes to a new map instead of attempting to edit attrs
+    // map in-place. This requires more memory but greatly simplifies the code
+    // and any attempt with in-place editing would likely also require a lot
+    // more attr lookups.
+    // The updated copy will contain an attrs map with, if applicable: adjusted
+    // coords and cell size, newly inserted attributes (for multicells), and
+    // without now deleted attributes.
+    wxGridCoordsToAttrMap newAttrs;
+
+    for ( wxGridCoordsToAttrMap::iterator it = attrs.begin();
+          it != attrs.end();
+          ++it )
     {
-        wxGridCellAttr* cellAttr = attrs[n].attr;
+        const wxGridCoordsToAttrMap::key_type oldCoords = it->first;
+        wxGridCellWithAttr* cellWithAttr = it->second;
+        wxGridCellAttr* cellAttr = cellWithAttr->attr;
+
         int cellRows, cellCols;
         cellAttr->GetSize(&cellRows, &cellCols);
 
-        wxGridCellCoords& coords = attrs[n].coords;
-        const wxCoord cellRow = coords.GetRow(),
-                      cellCol = coords.GetCol(),
-                      cellPos = (isEditingRows ? cellRow : cellCol);
+        int cellRow, cellCol;
+        KeyToCoords(oldCoords, &cellRow, &cellCol);
+
+        wxGridCellCoords& coords = cellWithAttr->coords;
+        wxASSERT(wxGridCellCoords(cellRow, cellCol) == coords);
+
+        const int cellPos = isEditingRows ? cellRow : cellCol;
 
         if ( cellPos < editPos )
         {
@@ -894,6 +943,9 @@ void UpdateCellAttrRowsOrCols(wxGridCellWithAttrArray& attrs, int editPos,
                 }
             }
 
+            // Set attribute at old/unmodified coords.
+            newAttrs[oldCoords] = cellWithAttr;
+
             continue;
         }
 
@@ -901,18 +953,20 @@ void UpdateCellAttrRowsOrCols(wxGridCellWithAttrArray& attrs, int editPos,
         {
             // This row/col is deleted and the cell doesn't exist any longer:
             // Remove the attribute.
-            attrs.RemoveAt(n);
-            n--;
-            count--;
+            delete cellWithAttr;
 
             continue;
         }
+
+        const wxGridCoordsToAttrMap::key_type newCoords
+            = CoordsToKey(cellRow + editRowCount, cellCol + editColCount);
 
         if ( GetCellSpan(cellRows, cellCols) != wxGrid::CellSpan_Inside )
         {
             // Rows/cols inserted or deleted (and this cell still exists):
             // Adjust cell coords.
             coords.Set(cellRow + editRowCount, cellCol + editColCount);
+            newAttrs[newCoords] = cellWithAttr;
 
             // Nothing more to do: cell is not an inside cell of a multicell.
             continue;
@@ -928,9 +982,7 @@ void UpdateCellAttrRowsOrCols(wxGridCellWithAttrArray& attrs, int editPos,
             // On a position that still exists after deletion but main cell
             // of multicell is within deletion range so the multicell is gone:
             // Remove the attribute.
-            attrs.RemoveAt(n);
-            n--;
-            count--;
+            delete cellWithAttr;
 
             continue;
         }
@@ -938,6 +990,7 @@ void UpdateCellAttrRowsOrCols(wxGridCellWithAttrArray& attrs, int editPos,
         // Rows/cols inserted or deleted (and this inside cell still exists):
         // Adjust (inside) cell coords.
         coords.Set(cellRow + editRowCount, cellCol + editColCount);
+        newAttrs[newCoords] = cellWithAttr;
 
         if ( mainPos >= editPos )
         {
@@ -962,15 +1015,17 @@ void UpdateCellAttrRowsOrCols(wxGridCellWithAttrArray& attrs, int editPos,
                 wxGridCellAttr* attr = new wxGridCellAttr;
                 attr->SetSize(cellRows - adjustRows, cellCols - adjustCols);
 
-                attrs.Add(new wxGridCellWithAttr(cellRow + adjustRows,
-                                                  cellCol + adjustCols,
-                                                  attr));
+                const int row = cellRow + adjustRows,
+                          col = cellCol + adjustCols;
+                newAttrs[CoordsToKey(row, col)] = new wxGridCellWithAttr(row, col, attr);
             }
         }
 
         // Let this inside cell's size point to the main cell of the multicell.
         cellAttr->SetSize(cellRows - editRowCount, cellCols - editColCount);
     }
+
+    attrs = newAttrs;
 }
 
 } // anonymous namespace
@@ -985,19 +1040,10 @@ void wxGridCellAttrData::UpdateAttrCols( size_t pos, int numCols )
     UpdateCellAttrRowsOrCols(m_attrs, static_cast<int>(pos), 0, numCols);
 }
 
-int wxGridCellAttrData::FindIndex(int row, int col) const
+wxGridCoordsToAttrMap::iterator
+wxGridCellAttrData::FindIndex(int row, int col) const
 {
-    size_t count = m_attrs.GetCount();
-    for ( size_t n = 0; n < count; n++ )
-    {
-        const wxGridCellCoords& coords = m_attrs[n].coords;
-        if ( (coords.GetRow() == row) && (coords.GetCol() == col) )
-        {
-            return n;
-        }
-    }
-
-    return wxNOT_FOUND;
+    return m_attrs.find(CoordsToKey(row, col));
 }
 
 // ----------------------------------------------------------------------------

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -1691,6 +1691,10 @@ TEST_CASE_METHOD(GridTestCase, "Grid::CellAttribute", "[attr][cell][grid]")
         SetCellAttr(0, 0);
         CHECK_ATTR_COUNT( 1 );
 
+        // Overwrite existing attribute with another.
+        SetCellAttr(0, 0);
+        CHECK_ATTR_COUNT( 1 );
+
         m_grid->SetAttr(0, 0, NULL);
         CHECK_ATTR_COUNT( 0 );
 


### PR DESCRIPTION
Speed up grid attribute lookups by using a hash map instead of array.

Closes [#12764](https://trac.wxwidgets.org/ticket/12764).

--

Please see the referenced ticket for further details.

There's another optimization possible, before and still with this PR, by not always doing two lookups when getting a new attr in [wxGrid::GetOrCreateCellAttr](https://github.com/wxWidgets/wxWidgets/blob/36ab71301c5cd4390881ea901bbce7d4da6e5f9f/src/generic/grid.cpp#L9387-L9394). The first lookup is with `GetAttr()` then when that returns `NULL` there's another lookup through `SetAttr()`. It could be changed by having something like `SetNewAttr()` (twice, for `wxGridTableBase` and `wxGridCellAttrProvider`) and `wxGridCellAttrData::SetAttr()` getting a bool parameter `isConfirmedNewAttr` to skip lookup if true. However I don't know if it's worth the hassle because remaining backwards compatible would seem to require more changes, as there needs to be a way to know if a derived class handles `SetNewAttr()`. Probably by having a `virtual bool DoSetNewAttr()` (called by non-virtual `SetNewAttr()`), and calling `SetAttr()` like before if it returns false (not handled).