### PR TITLE
Improve wxComboCtrl popup position

### DIFF
--- a/include/wx/odcombo.h
+++ b/include/wx/odcombo.h
@@ -93,6 +93,7 @@ public:
     virtual void OnComboDoubleClick() wxOVERRIDE;
     virtual bool LazyCreate() wxOVERRIDE;
     virtual bool FindItem(const wxString& item, wxString* trueItem) wxOVERRIDE;
+    virtual void OnDPIChanged(wxDPIChangedEvent& event);
 
     // Item management
     void SetSelection( int item );

--- a/samples/combo/combo.cpp
+++ b/samples/combo/combo.cpp
@@ -252,10 +252,7 @@ public:
     virtual wxCoord OnMeasureItem( size_t item ) const wxOVERRIDE
     {
         // Simply demonstrate the ability to have variable-height items
-        if ( item & 1 )
-            return 36;
-        else
-            return 24;
+        return FromDIP( item & 1 ? 36 : 24 );
     }
 
     virtual wxCoord OnMeasureItemWidth( size_t WXUNUSED(item) ) const wxOVERRIDE

--- a/src/common/combocmn.cpp
+++ b/src/common/combocmn.cpp
@@ -2285,9 +2285,6 @@ void wxComboCtrlBase::ShowPopup()
 
     SetFocus();
 
-    int displayIdx = wxDisplay::GetFromWindow(this);
-    wxRect displayRect = wxDisplay(displayIdx != wxNOT_FOUND ? displayIdx : 0u).GetGeometry();
-
     // Space above and below
     int screenHeight;
     wxPoint scrPos;
@@ -2296,6 +2293,7 @@ void wxComboCtrlBase::ShowPopup()
     int maxHeightPopup;
     wxSize ctrlSz = GetSize();
 
+    wxRect displayRect = wxDisplay(this).GetGeometry();
     screenHeight = displayRect.GetHeight();
     scrPos = GetScreenPosition();
 

--- a/src/common/combocmn.cpp
+++ b/src/common/combocmn.cpp
@@ -2296,13 +2296,10 @@ void wxComboCtrlBase::ShowPopup()
     int maxHeightPopup;
     wxSize ctrlSz = GetSize();
 
-    // wxSystemSettings::GetMetric( wxSYS_SCREEN_Y, this ) returns a geometry of the primary display
-    // And it causes wrong calculation of the popuping on secondary monitor.
-    // So, let's make all calculation in respect to the display of the provided window.
-    screenHeight = displayRect.height;//wxSystemSettings::GetMetric( wxSYS_SCREEN_Y, this );
-    scrPos = GetScreenPosition() - displayRect.GetTopLeft();
+    screenHeight = displayRect.GetHeight();
+    scrPos = GetScreenPosition();
 
-    spaceAbove = scrPos.y;
+    spaceAbove = scrPos.y - displayRect.GetY();
     spaceBelow = screenHeight - spaceAbove - ctrlSz.y;
 
     maxHeightPopup = spaceBelow;
@@ -2364,20 +2361,20 @@ void wxComboCtrlBase::ShowPopup()
     wxSize szp = popup->GetSize();
 
     int popupX;
-    int popupY = scrPos.y + ctrlSz.y + displayRect.GetTop();
+    int popupY = scrPos.y + ctrlSz.y;
 
     // Default anchor is wxLEFT
     int anchorSide = m_anchorSide;
     if ( !anchorSide )
         anchorSide = wxLEFT;
 
-    int rightX = scrPos.x + ctrlSz.x + m_extRight - szp.x + displayRect.GetLeft();
-    int leftX = scrPos.x - m_extLeft + displayRect.GetLeft();
+    int rightX = scrPos.x + ctrlSz.x + m_extRight - szp.x;
+    int leftX = scrPos.x - m_extLeft;
 
     if ( wxTheApp->GetLayoutDirection() == wxLayout_RightToLeft )
         leftX -= ctrlSz.x;
 
-    int screenWidth = displayRect.width;// wxSystemSettings::GetMetric( wxSYS_SCREEN_X, this );
+    int screenWidth = displayRect.GetWidth();
 
     // If there is not enough horizontal space, anchor on the other side.
     // If there is no space even then, place the popup at x 0.
@@ -2414,7 +2411,7 @@ void wxComboCtrlBase::ShowPopup()
 
     if ( spaceBelow < szp.y )
     {
-        popupY = scrPos.y - szp.y + displayRect.GetTop();
+        popupY = scrPos.y - szp.y;
         showFlags |= ShowAbove;
     }
 

--- a/src/generic/odcombo.cpp
+++ b/src/generic/odcombo.cpp
@@ -84,6 +84,10 @@ bool wxVListBoxComboPopup::Create(wxWindow* parent)
     // TODO: Move this to SetFont
     m_itemHeight = m_combo->GetCharHeight();
 
+    // Bind to the DPI event of the combobox. We get our own once the popup
+    // is shown, but this is too late, m_itemHeight is already being used.
+    m_combo->Bind(wxEVT_DPI_CHANGED, &wxVListBoxComboPopup::OnDPIChanged, this);
+
     return true;
 }
 
@@ -102,6 +106,11 @@ void wxVListBoxComboPopup::SetFocus()
 #else
     wxVListBox::SetFocus();
 #endif
+}
+
+void wxVListBoxComboPopup::OnDPIChanged(wxDPIChangedEvent& WXUNUSED(event))
+{
+    m_itemHeight = m_combo->GetCharHeight();
 }
 
 bool wxVListBoxComboPopup::LazyCreate()

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -1716,8 +1716,7 @@ wxPoint wxPropertyGrid::GetGoodEditorDialogPosition( wxPGProperty* p,
 
     ImprovedClientToScreen( &x, &y );
 
-    int displayIdx = wxDisplay::GetFromWindow(this);
-    wxRect displayRect = wxDisplay(displayIdx != wxNOT_FOUND ? displayIdx : 0u).GetGeometry();
+    wxRect displayRect = wxDisplay(this).GetGeometry();
 
     x -= displayRect.GetX();
     y -= displayRect.GetY();

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -62,6 +62,7 @@
 #include "wx/timer.h"
 #include "wx/dcbuffer.h"
 #include "wx/scopeguard.h"
+#include "wx/display.h"
 
 // Two pics for the expand / collapse buttons.
 // Files are not supplied with this project (since it is
@@ -1715,27 +1716,30 @@ wxPoint wxPropertyGrid::GetGoodEditorDialogPosition( wxPGProperty* p,
 
     ImprovedClientToScreen( &x, &y );
 
-    int sw = wxSystemSettings::GetMetric( ::wxSYS_SCREEN_X, this );
-    int sh = wxSystemSettings::GetMetric( ::wxSYS_SCREEN_Y, this );
+    int displayIdx = wxDisplay::GetFromWindow(this);
+    wxRect displayRect = wxDisplay(displayIdx != wxNOT_FOUND ? displayIdx : 0u).GetGeometry();
+
+    x -= displayRect.GetX();
+    y -= displayRect.GetY();
 
     int new_x;
     int new_y;
 
-    if ( x > (sw/2) )
+    if ( x > (displayRect.GetWidth()/2) )
         // left
         new_x = x + (m_width-splitterX) - sz.x;
     else
         // right
         new_x = x;
 
-    if ( y > (sh/2) )
+    if ( y > (displayRect.GetHeight()/2) )
         // above
         new_y = y - sz.y;
     else
         // below
         new_y = y + m_lineHeight;
 
-    return wxPoint(new_x,new_y);
+    return wxPoint(new_x + displayRect.GetX(), new_y + displayRect.GetY());
 }
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
Some improvements to `wxOwnerDrawnComboBox`. 

Popup fix based on https://github.com/prusa3d/PrusaSlicer/issues/2999

Similar problem occurred when calculating  `wxPropertyGridEditor` position.

Also fix row-heights in the popup after DPI change.