### PR TITLE
configure: Use -fpermissive option with CXXFLAGS variable.

### DIFF
--- a/configure
+++ b/configure
@@ -33364,7 +33364,7 @@ if test "$GCC" = "yes" ; then
         WXCONFIG_CXXFLAGS="$WXCONFIG_CXXFLAGS -fno-exceptions"
     fi
     if test "$wxUSE_PERMISSIVE" = "yes" ; then
-        WXCONFIG_CFLAGS="$WXCONFIG_CFLAGS -fpermissive"
+        WXCONFIG_CXXFLAGS="$WXCONFIG_CXXFLAGS -fpermissive"
     fi
 
                                                 case "${host}" in

--- a/configure.in
+++ b/configure.in
@@ -5462,7 +5462,7 @@ if test "$GCC" = "yes" ; then
         WXCONFIG_CXXFLAGS="$WXCONFIG_CXXFLAGS -fno-exceptions"
     fi
     if test "$wxUSE_PERMISSIVE" = "yes" ; then
-        WXCONFIG_CFLAGS="$WXCONFIG_CFLAGS -fpermissive"
+        WXCONFIG_CXXFLAGS="$WXCONFIG_CXXFLAGS -fpermissive"
     fi
 
     dnl Ian Brown <ian.brown@printsoft.de> reports that versions of gcc before


### PR DESCRIPTION
When configured with --enable-permissive option, the warning is shown:
cc1.exe: warning: command-line option '-fpermissive' is valid for C++/ObjC++ but not for C
This change fixes the issue.