### PR TITLE
macOS wxFileDialog improvements

### DIFF
--- a/include/wx/filedlg.h
+++ b/include/wx/filedlg.h
@@ -181,6 +181,9 @@ protected:
         { return m_extraControlCreator != NULL; }
     // get the size of the extra control by creating and deleting it
     wxSize GetExtraControlSize();
+    // Helper function for native file dialog usage where no wx events
+    // are processed.
+    void UpdateExtraControlUI();
 
 private:
     ExtraControlCreatorFunction m_extraControlCreator;

--- a/interface/wx/filedlg.h
+++ b/interface/wx/filedlg.h
@@ -236,10 +236,11 @@ public:
         control to update its state depending on the currently selected file
         type filter.
 
-        Currently this function is fully implemented only under MSW and
+        Currently this function is fully implemented under macOS and MSW and
         always returns @c wxNOT_FOUND elsewhere.
 
-        @since 3.1.3
+        @since 3.1.3 - MSW
+        @since 3.1.5 - macOS
 
         @return The 0-based index of the currently selected file type filter or
             wxNOT_FOUND if nothing is selected.

--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -203,6 +203,7 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(DIALOGS_FILES_OPEN_WINDOW_MODAL,       MyFrame::FilesOpenWindowModal)
     EVT_MENU(DIALOGS_FILE_SAVE,                     MyFrame::FileSave)
     EVT_MENU(DIALOGS_FILE_SAVE_WINDOW_MODAL,        MyFrame::FileSaveWindowModal)
+    EVT_MENU(DIALOGS_MAC_TOGGLE_ALWAYS_SHOW_TYPES,  MyFrame::MacToggleAlwaysShowTypes)
 #endif // wxUSE_FILEDLG
 
 #if USE_FILEDLG_GENERIC
@@ -503,6 +504,13 @@ bool MyApp::OnInit()
     filedlg_menu->Append(DIALOGS_FILES_OPEN_GENERIC, "Open &files (generic)");
     filedlg_menu->Append(DIALOGS_FILE_SAVE_GENERIC, "Sa&ve file (generic)");
 #endif // USE_FILEDLG_GENERIC
+
+#ifdef __WXOSX_COCOA__
+    filedlg_menu->AppendSeparator();
+    filedlg_menu->AppendCheckItem(DIALOGS_MAC_TOGGLE_ALWAYS_SHOW_TYPES,
+                                  "macOS only: Toggle open file "
+                                    "\"Always show types\"\tRawCtrl+Ctrl+S");
+#endif
 
     menuDlg->Append(wxID_ANY,"&File operations",filedlg_menu);
 
@@ -1852,6 +1860,16 @@ void MyFrame::FileSaveWindowModalClosed(wxWindowModalDialogEvent& event)
 }
 
 #endif // wxUSE_FILEDLG
+
+void MyFrame::MacToggleAlwaysShowTypes(wxCommandEvent& event)
+{
+#ifdef wxOSX_FILEDIALOG_ALWAYS_SHOW_TYPES
+    wxSystemOptions::SetOption(wxOSX_FILEDIALOG_ALWAYS_SHOW_TYPES,
+                               event.IsChecked());
+#else
+    wxUnusedVar(event);
+#endif
+}
 
 #if USE_FILEDLG_GENERIC
 void MyFrame::FileOpenGeneric(wxCommandEvent& WXUNUSED(event) )

--- a/samples/dialogs/dialogs.h
+++ b/samples/dialogs/dialogs.h
@@ -433,6 +433,7 @@ public:
     void FileSave(wxCommandEvent& event);
     void FileSaveWindowModal(wxCommandEvent& event);
     void FileSaveWindowModalClosed(wxWindowModalDialogEvent& event);
+    void MacToggleAlwaysShowTypes(wxCommandEvent& event);
 #endif // wxUSE_FILEDLG
 
 #if USE_FILEDLG_GENERIC
@@ -616,6 +617,7 @@ enum
     DIALOGS_FILE_OPEN_GENERIC,
     DIALOGS_FILES_OPEN_GENERIC,
     DIALOGS_FILE_SAVE_GENERIC,
+    DIALOGS_MAC_TOGGLE_ALWAYS_SHOW_TYPES,
     DIALOGS_DIR_CHOOSE,
     DIALOGS_DIR_CHOOSE_WINDOW_MODAL,
     DIALOGS_DIRNEW_CHOOSE,

--- a/src/common/fldlgcmn.cpp
+++ b/src/common/fldlgcmn.cpp
@@ -192,6 +192,12 @@ wxSize wxFileDialogBase::GetExtraControlSize()
     return (*m_extraControlCreator)(&dlg)->GetSize();
 }
 
+void wxFileDialogBase::UpdateExtraControlUI()
+{
+    if ( m_extraControl )
+        m_extraControl->UpdateWindowUI(wxUPDATE_UI_RECURSE);
+}
+
 void wxFileDialogBase::SetPath(const wxString& path)
 {
     wxString ext;

--- a/src/gtk/filedlg.cpp
+++ b/src/gtk/filedlg.cpp
@@ -496,8 +496,7 @@ void wxFileDialog::GTKSelectionChanged(const wxString& filename)
 {
     m_currentlySelectedFilename = filename;
 
-    if (m_extraControl)
-        m_extraControl->UpdateWindowUI(wxUPDATE_UI_RECURSE);
+    UpdateExtraControlUI();
 }
 
 #endif // wxUSE_FILEDLG

--- a/src/msw/filedlg.cpp
+++ b/src/msw/filedlg.cpp
@@ -353,8 +353,7 @@ void wxFileDialog::MSWOnSelChange(WXHWND hDlg)
     else
         m_currentlySelectedFilename.clear();
 
-    if ( m_extraControl )
-        m_extraControl->UpdateWindowUI(wxUPDATE_UI_RECURSE);
+    UpdateExtraControlUI();
 }
 
 void wxFileDialog::MSWOnTypeChange(WXHWND WXUNUSED(hDlg), int nFilterIndex)
@@ -364,8 +363,7 @@ void wxFileDialog::MSWOnTypeChange(WXHWND WXUNUSED(hDlg), int nFilterIndex)
     // circumstances, so take care before decrementing it.
     m_currentlySelectedFilterIndex = nFilterIndex ? nFilterIndex - 1 : 0;
 
-    if ( m_extraControl )
-        m_extraControl->UpdateWindowUI(wxUPDATE_UI_RECURSE);
+    UpdateExtraControlUI();
 }
 
 // helper used below in ShowCommFileDialog(): style is used to determine

--- a/src/osx/cocoa/filedlg.mm
+++ b/src/osx/cocoa/filedlg.mm
@@ -261,10 +261,12 @@ wxWindow* wxFileDialog::CreateFilterPanel(wxWindow *extracontrol)
     {
         wxBoxSizer *horizontalSizer = new wxBoxSizer(wxHORIZONTAL);
         verticalSizer->Add(horizontalSizer, 0, wxEXPAND, 0);
+        horizontalSizer->AddStretchSpacer();
         wxStaticText *stattext = new wxStaticText( extrapanel, wxID_ANY, _("File type:") );
         horizontalSizer->Add(stattext, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
         m_filterChoice = new wxChoice(extrapanel, wxID_ANY);
-        horizontalSizer->Add(m_filterChoice, 1, wxALIGN_CENTER_VERTICAL|wxALL, 5);
+        horizontalSizer->Add(m_filterChoice, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
+        horizontalSizer->AddStretchSpacer();
         m_filterChoice->Append(m_filterNames);
         if( m_filterNames.GetCount() > 0)
         {

--- a/src/osx/cocoa/filedlg.mm
+++ b/src/osx/cocoa/filedlg.mm
@@ -295,6 +295,10 @@ void wxFileDialog::DoOnFilterSelected(int index)
     NSArray* types = GetTypesFromExtension(m_filterExtensions[index],m_currentExtensions);
     NSSavePanel* panel = (NSSavePanel*) GetWXWindow();
     [panel setAllowedFileTypes:types];
+
+    m_currentlySelectedFilterIndex = index;
+
+    UpdateExtraControlUI();
 }
 
 // An item has been selected in the file filter wxChoice:


### PR DESCRIPTION
This PR mainly consists of two fixes:

5cc2f6ce9f - Fix width of file type wxChoice in open dialogs on macOS
f048a03ea6 - Fix parent of extra control not being a wxFileDialogBase on macOS

and one enhancement:

40422db37d - Add wxMac wxFileDialog::GetCurrentlySelectedFilterIndex() support

Tested on 10.10, 10.12 and 11.0.