### PR TITLE
wxGTK: Expose GtkTreeView drop position

### DIFF
--- a/include/wx/dataview.h
+++ b/include/wx/dataview.h
@@ -930,8 +930,10 @@ public:
 
     void SetColumn( int col ) { m_col = col; }
     void SetEditCancelled() { m_editCancelled = true; }
+#if wxUSE_DRAG_AND_DROP
     void SetDropPos(int pos) {  m_droppos = pos; }
     int GetDropPos() {  return m_droppos; }
+#endif
 
 protected:
     wxDataViewItem      m_item;

--- a/include/wx/dataview.h
+++ b/include/wx/dataview.h
@@ -930,6 +930,8 @@ public:
 
     void SetColumn( int col ) { m_col = col; }
     void SetEditCancelled() { m_editCancelled = true; }
+    void SetDropPos(int pos) {  m_droppos = pos; }
+    int GetDropPos() {  return m_droppos; }
 
 protected:
     wxDataViewItem      m_item;
@@ -952,6 +954,7 @@ protected:
     int                 m_dragFlags;
     wxDragResult        m_dropEffect;
     int                 m_proposedDropIndex;
+    int                 m_droppos;
 #endif // wxUSE_DRAG_AND_DROP
 
 private:

--- a/include/wx/dataview.h
+++ b/include/wx/dataview.h
@@ -930,10 +930,6 @@ public:
 
     void SetColumn( int col ) { m_col = col; }
     void SetEditCancelled() { m_editCancelled = true; }
-#if wxUSE_DRAG_AND_DROP
-    void SetDropPos(int pos) {  m_droppos = pos; }
-    int GetDropPos() {  return m_droppos; }
-#endif
 
 protected:
     wxDataViewItem      m_item;
@@ -956,7 +952,6 @@ protected:
     int                 m_dragFlags;
     wxDragResult        m_dropEffect;
     int                 m_proposedDropIndex;
-    int                 m_droppos;
 #endif // wxUSE_DRAG_AND_DROP
 
 private:

--- a/include/wx/dataview.h
+++ b/include/wx/dataview.h
@@ -864,6 +864,7 @@ public:
         m_dataBuffer(event.m_dataBuffer),
         m_dataSize(event.m_dataSize),
         m_dragFlags(event.m_dragFlags),
+        m_dropFlags(event.m_dropFlags),
         m_dropEffect(event.m_dropEffect),
         m_proposedDropIndex(event.m_proposedDropIndex)
 #endif
@@ -905,7 +906,9 @@ public:
     void SetDataBuffer( void* buf ) { m_dataBuffer = buf;}
     void *GetDataBuffer() const { return m_dataBuffer; }
     void SetDragFlags( int flags ) { m_dragFlags = flags; }
+    void SetDropFlags( int flags ) { m_dropFlags = flags; }
     int GetDragFlags() const { return m_dragFlags; }
+    int GetDropFlags() const { return m_dropFlags; }
     void SetDropEffect( wxDragResult effect ) { m_dropEffect = effect; }
     wxDragResult GetDropEffect() const { return m_dropEffect; }
     // For platforms (currently generic and OSX) that support Drag/Drop
@@ -950,6 +953,7 @@ protected:
     size_t              m_dataSize;
 
     int                 m_dragFlags;
+    int                 m_dropFlags;
     wxDragResult        m_dropEffect;
     int                 m_proposedDropIndex;
 #endif // wxUSE_DRAG_AND_DROP

--- a/include/wx/dnd.h
+++ b/include/wx/dnd.h
@@ -50,7 +50,7 @@ enum wxDropFlags
 {
     wxDrop_Before = 0x01,
     wxDrop_After = 0x02,
-    wxDrop_Onto  = 0x04,
+    wxDrop_Onto  = 0x04
 };
 
 // return true if res indicates that something was done during a dnd operation,

--- a/include/wx/dnd.h
+++ b/include/wx/dnd.h
@@ -44,6 +44,15 @@ enum wxDragResult
     wxDragCancel    // the operation was cancelled by user (not an error)
 };
 
+// Flags for wxDataViewEvent::GetDragFlags() with wxEVT_DATAVIEW_DROP
+// Note: 0x05 & 0x06 are valid combinations!
+enum wxDropFlags
+{
+    wxDrop_Before = 0x01,
+    wxDrop_After = 0x02,
+    wxDrop_Onto  = 0x04,
+};
+
 // return true if res indicates that something was done during a dnd operation,
 // i.e. is neither error nor none nor cancel
 WXDLLIMPEXP_CORE bool wxIsDragResultOk(wxDragResult res);

--- a/include/wx/dnd.h
+++ b/include/wx/dnd.h
@@ -44,8 +44,9 @@ enum wxDragResult
     wxDragCancel    // the operation was cancelled by user (not an error)
 };
 
-// Flags for wxDataViewEvent::GetDragFlags() with wxEVT_DATAVIEW_DROP
-// Note: 0x05 & 0x06 are valid combinations!
+// Flags for wxDataViewEvent::GetDropFlags() with wxEVT_DATAVIEW_DROP
+// Note: 0x05 & 0x06 are valid combinations as they represent drops
+// onto the upper and lower part respectively of the target row.
 enum wxDropFlags
 {
     wxDrop_Before = 0x01,

--- a/interface/wx/dataview.h
+++ b/interface/wx/dataview.h
@@ -3964,7 +3964,6 @@ public:
     void SetDataBuffer( void* buf );
     int GetDragFlags() const;
     void SetDropEffect( wxDragResult effect );
-    void SetDropPos(int pos);
 };
 
 

--- a/interface/wx/dataview.h
+++ b/interface/wx/dataview.h
@@ -3964,6 +3964,7 @@ public:
     void SetDataBuffer( void* buf );
     int GetDragFlags() const;
     void SetDropEffect( wxDragResult effect );
+    void SetDropPos(int pos);
 };
 
 

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -2383,6 +2383,14 @@ bool wxDataViewMainWindow::OnDrop( wxDataFormat format, wxCoord x, wxCoord y )
     wxDataViewEvent event(wxEVT_DATAVIEW_ITEM_DROP_POSSIBLE, m_owner, dropItemInfo.m_item);
     event.SetProposedDropIndex(dropItemInfo.m_proposedDropIndex);
     event.SetDataFormat( format );
+
+    if( dropItemInfo.m_proposedDropIndex == wxNOT_FOUND )
+        event.SetDropFlags(wxDrop_Onto);
+    else if( dropItemInfo.m_proposedDropIndex == 0)
+        event.SetDropFlags(wxDrop_Before);
+    else
+        event.SetDropFlags(wxDrop_After);
+
     if (!m_owner->HandleWindowEvent( event ) || !event.IsAllowed())
         return false;
 
@@ -2402,6 +2410,14 @@ wxDragResult wxDataViewMainWindow::OnData( wxDataFormat format, wxCoord x, wxCoo
     event.SetDataSize( obj->GetSize() );
     event.SetDataBuffer( obj->GetData() );
     event.SetDropEffect( def );
+
+    if( dropItemInfo.m_proposedDropIndex == wxNOT_FOUND )
+        event.SetDropFlags(wxDrop_Onto);
+    else if( dropItemInfo.m_proposedDropIndex == 0)
+        event.SetDropFlags(wxDrop_Before);
+    else
+        event.SetDropFlags(wxDrop_After);
+
     if ( !m_owner->HandleWindowEvent( event ) || !event.IsAllowed() )
         return wxDragNone;
 

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -3826,7 +3826,7 @@ wxDataViewCtrlInternal::drag_data_received(GtkTreeDragDest *WXUNUSED(drag_dest),
 {
     wxDataViewItem item(GetOwner()->GTKPathToItem(path));
     int drop_flags = 0;
-    int drop_pos = wxNOT_FOUND;
+    int drop_idx = wxNOT_FOUND;
     int *path_indices;
     int path_depth;
 
@@ -3834,35 +3834,36 @@ wxDataViewCtrlInternal::drag_data_received(GtkTreeDragDest *WXUNUSED(drag_dest),
         {
         path_indices = gtk_tree_path_get_indices(path);
         path_depth = gtk_tree_path_get_depth(path);
-        drop_pos = path_indices[path_depth - 1] + 1;
+        drop_idx = path_indices[path_depth - 1] + 1;
         }
     switch(pos)
         {
         case GTK_TREE_VIEW_DROP_BEFORE:
             drop_flags = wxDrop_Before;
-            if(drop_pos == 1)
+            if(drop_idx == 1)
                 {
                 // For compatibility with wxGeneric, a position of 0
                 // is a special case meaning before first item.
-                drop_pos = 0;
+                drop_idx = 0;
                 }
             break;
         case GTK_TREE_VIEW_DROP_INTO_OR_BEFORE:
             drop_flags = wxDrop_Onto | wxDrop_Before;
-            drop_pos = wxNOT_FOUND;
+            drop_idx = wxNOT_FOUND;
             break;
         case GTK_TREE_VIEW_DROP_INTO_OR_AFTER:
             drop_flags = wxDrop_Onto | wxDrop_After;
-            drop_pos = wxNOT_FOUND;
+            drop_idx = wxNOT_FOUND;
             break;
         case GTK_TREE_VIEW_DROP_AFTER:
             drop_flags = wxDrop_After;
             break;
         }
 
-    if(path && drop_pos != wxNOT_FOUND)
+    if(path && drop_idx != wxNOT_FOUND)
         {
-        // I'd rather use GetParent() but it ain't available here..
+        // If drop is between rows, return parent row.
+        // GetParent() isn't available here, so use GTK functions.
         if( gtk_tree_path_up(path) )
             {
             wxDataViewItem newitem(GetOwner()->GTKPathToItem(path));
@@ -3877,7 +3878,7 @@ wxDataViewCtrlInternal::drag_data_received(GtkTreeDragDest *WXUNUSED(drag_dest),
     event.SetDataFormat(gtk_selection_data_get_target(selection_data));
     event.SetDataSize(gtk_selection_data_get_length(selection_data));
     event.SetDataBuffer(const_cast<guchar*>(gtk_selection_data_get_data(selection_data)));
-    event.SetProposedDropIndex( drop_pos );
+    event.SetProposedDropIndex( drop_idx );
     if (!m_owner->HandleWindowEvent( event ))
         return FALSE;
 
@@ -3893,18 +3894,20 @@ wxDataViewCtrlInternal::row_drop_possible(GtkTreeDragDest *WXUNUSED(drag_dest),
                                           GtkSelectionData *selection_data)
 {
     wxDataViewItem item(GetOwner()->GTKPathToItem(path));
-    int drop_pos = wxNOT_FOUND;
+    int drop_idx = wxNOT_FOUND;
 
     if(path)
         {
         int *path_indices = gtk_tree_path_get_indices(path);
         int path_depth = gtk_tree_path_get_depth(path);
-        drop_pos = path_indices[path_depth - 1] + 1;
+        drop_idx = path_indices[path_depth - 1] + 1;
         }
+    // Ideally would also fill in event.SetDropFlags() but the required
+    // GtkTreeViewDropPosition data is not available..
     wxDataViewEvent event(wxEVT_DATAVIEW_ITEM_DROP_POSSIBLE, m_owner, item);
     event.SetDataFormat(gtk_selection_data_get_target(selection_data));
     event.SetDataSize(gtk_selection_data_get_length(selection_data));
-    event.SetProposedDropIndex( drop_pos );
+    event.SetProposedDropIndex( drop_idx );
     if (!m_owner->HandleWindowEvent( event ))
         return FALSE;
 
@@ -4693,7 +4696,7 @@ static void gtk_dataview_drag_data_received_callback(GtkWidget *widget,
      GtkTreePath *path;
      GtkTreeView *tree = (GtkTreeView*)widget;
      GtkTreeViewDropPosition pos;
-     gtk_tree_view_get_dest_row_at_pos((GtkTreeView*)widget,x,y, &path, &pos);
+     gtk_tree_view_get_dest_row_at_pos((GtkTreeView*)widget, x, y, &path, &pos);
      GtkWxTreeModel *wxtree_model = (GtkWxTreeModel *) gtk_tree_view_get_model(tree);
      wxtree_model->internal->drag_data_received(NULL, path, selection_data, pos );
 }

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -3834,6 +3834,14 @@ wxDataViewCtrlInternal::drag_data_received(GtkTreeDragDest *WXUNUSED(drag_dest),
     wxDataViewItem item(GetOwner()->GTKPathToItem(path));
     wxDataViewEvent event(wxEVT_DATAVIEW_ITEM_DROP, m_owner, item);
     int drop_flags = 0;
+    int drop_pos = wxNOT_FOUND;
+
+    if(path)
+        {
+        int *path_indices = gtk_tree_path_get_indices(path);
+        int path_depth = gtk_tree_path_get_depth(path);
+        drop_pos = path_indices[path_depth - 1] + 1;
+        }
     switch(pos)
         {
         case GTK_TREE_VIEW_DROP_BEFORE:
@@ -3841,9 +3849,11 @@ wxDataViewCtrlInternal::drag_data_received(GtkTreeDragDest *WXUNUSED(drag_dest),
             break;
         case GTK_TREE_VIEW_DROP_INTO_OR_BEFORE:
             drop_flags = wxDrop_Onto | wxDrop_Before;
+            drop_pos = wxNOT_FOUND;
             break;
         case GTK_TREE_VIEW_DROP_INTO_OR_AFTER:
             drop_flags = wxDrop_Onto | wxDrop_After;
+            drop_pos = wxNOT_FOUND;
             break;
         case GTK_TREE_VIEW_DROP_AFTER:
             drop_flags = wxDrop_After;
@@ -3853,6 +3863,7 @@ wxDataViewCtrlInternal::drag_data_received(GtkTreeDragDest *WXUNUSED(drag_dest),
     event.SetDataFormat(gtk_selection_data_get_target(selection_data));
     event.SetDataSize(gtk_selection_data_get_length(selection_data));
     event.SetDataBuffer(const_cast<guchar*>(gtk_selection_data_get_data(selection_data)));
+    event.SetProposedDropIndex( drop_pos );
     if (!m_owner->HandleWindowEvent( event ))
         return FALSE;
 
@@ -3868,10 +3879,18 @@ wxDataViewCtrlInternal::row_drop_possible(GtkTreeDragDest *WXUNUSED(drag_dest),
                                           GtkSelectionData *selection_data)
 {
     wxDataViewItem item(GetOwner()->GTKPathToItem(path));
+    int drop_pos = wxNOT_FOUND;
 
+    if(path)
+        {
+        int *path_indices = gtk_tree_path_get_indices(path);
+        int path_depth = gtk_tree_path_get_depth(path);
+        drop_pos = path_indices[path_depth - 1] + 1;
+        }
     wxDataViewEvent event(wxEVT_DATAVIEW_ITEM_DROP_POSSIBLE, m_owner, item);
     event.SetDataFormat(gtk_selection_data_get_target(selection_data));
     event.SetDataSize(gtk_selection_data_get_length(selection_data));
+    event.SetProposedDropIndex( drop_pos );
     if (!m_owner->HandleWindowEvent( event ))
         return FALSE;
 

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -966,8 +966,8 @@ wxgtk_tree_model_drag_data_get (GtkTreeDragSource *drag_source,
 
 static gboolean
 wxgtk_tree_model_drag_data_received (GtkTreeDragDest  *drag_dest,
-                                     GtkTreePath      *dest,
-                                     GtkSelectionData *selection_data)
+                                     GtkTreePath      *WXUNUSED(dest),
+                                     GtkSelectionData *WXUNUSED(selection_data))
 {
     GtkWxTreeModel *wxtree_model = (GtkWxTreeModel *) drag_dest;
     g_return_val_if_fail (GTK_IS_WX_TREE_MODEL (wxtree_model), FALSE);
@@ -4634,8 +4634,8 @@ gtk_dataview_motion_notify_callback( GtkWidget *WXUNUSED(widget),
     return FALSE;
 }
 
-static void evtDragDataGet(GtkWidget *widget, GdkDragContext *context,
-    GtkSelectionData *selection_data, guint i, guint t)
+static void evtDragDataGet(GtkWidget *widget, GdkDragContext *WXUNUSED(context),
+    GtkSelectionData *selection_data, guint WXUNUSED(i), guint WXUNUSED(t))
 {
     GtkTreeView *tree = (GtkTreeView*)widget;
     GtkWxTreeModel *wxtree_model = (GtkWxTreeModel *) gtk_tree_view_get_model(tree);
@@ -4646,8 +4646,9 @@ static void evtDragDataGet(GtkWidget *widget, GdkDragContext *context,
     wxtree_model->internal->drag_data_get((GtkTreeDragSource*)1, path, selection_data );
 }
 
-static void evtDragDataRecv(GtkWidget *widget, GdkDragContext *context, gint x, gint y,
-    GtkSelectionData *selection_data, guint i, guint t)
+static void evtDragDataRecv(GtkWidget *widget, GdkDragContext *WXUNUSED(context),
+    gint x, gint y, GtkSelectionData *selection_data, guint WXUNUSED(i),
+    guint WXUNUSED(t))
 {
      GtkTreePath *path;
      GtkTreeView *tree = (GtkTreeView*)widget;


### PR DESCRIPTION
Within a wxDataViewCtrl drag-and-drop the underlying GtkTreeView
in wxGTK provides visual hints whether the drop is before/on/after
the destination row, but this information is not exposed to the
end developer. This proof-of-concept adds this functionality.

The main change is connecting to the drag-data-get and
drag-data-received signals which as far as I know were introduced
in GTK3, and are able to provide more information then
GtkTreeDragSourceIface and GtkTreeDragDestIface.