### PR TITLE
Change capitalization of stock label "&CD-Rom" to "&CD-ROM"

### DIFF
--- a/docs/doxygen/mainpages/const_stockitems.h
+++ b/docs/doxygen/mainpages/const_stockitems.h
@@ -27,7 +27,7 @@ Also note that you can retrieve stock bitmaps using wxArtProvider.
 @stock{wxID_BOLD,bold,&Bold}
 @stock{wxID_BOTTOM,goto-bottom,&Bottom}
 @stock{wxID_CANCEL,cancel,&Cancel}
-@stock{wxID_CDROM,cdrom,&CD-Rom}
+@stock{wxID_CDROM,cdrom,&CD-ROM}
 @stock{wxID_CLEAR,clear,&Clear}
 @stock{wxID_CLOSE,close,&Close}
 @stock{wxID_CONVERT,convert,&Convert}

--- a/src/common/stockitem.cpp
+++ b/src/common/stockitem.cpp
@@ -149,7 +149,7 @@ wxString wxGetStockLabel(wxWindowID id, long flags)
         STOCKITEM(wxID_BOLD,                _("&Bold"),               _("Bold"));
         STOCKITEM(wxID_BOTTOM,              _("&Bottom"),             _("Bottom"));
         STOCKITEM(wxID_CANCEL,              _("&Cancel"),             _("Cancel"));
-        STOCKITEM(wxID_CDROM,               _("&CD-Rom"),             _("CD-Rom"));
+        STOCKITEM(wxID_CDROM,               _("&CD-ROM"),             _("CD-ROM"));
         STOCKITEM(wxID_CLEAR,               _("&Clear"),              _("Clear"));
         STOCKITEM(wxID_CLOSE,               _("&Close"),              _("Close"));
         STOCKITEM(wxID_CONVERT,             _("&Convert"),            _("Convert"));


### PR DESCRIPTION
Is the mixed capitalization "CD-Rom" used anywhere outside of wx?