### PR TITLE
Always use pip for installing httpbin in Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
     include:
         - dist: trusty
           compiler: gcc
-          env: wxGTK_VERSION=2 wxUSE_XVFB=1 wxUSE_DOCKER_HTTPBIN=1
+          env: wxGTK_VERSION=2 wxUSE_XVFB=1
           name: wxGTK 2 Ubuntu 14.04
         - dist: bionic
           compiler: gcc

--- a/build/tools/travis-ci.sh
+++ b/build/tools/travis-ci.sh
@@ -16,17 +16,9 @@ launch_httpbin() {
     echo 'travis_fold:start:httpbin'
     echo 'Running httpbin...'
 
-    # Use docker if configured to do so, this works around Python/pip problems
-    # on some platforms.
-    if [ "$wxUSE_DOCKER_HTTPBIN" = 1 ]; then
-        docker pull kennethreitz/httpbin
-        docker run -d -p 80:80 kennethreitz/httpbin
-        WX_TEST_WEBREQUEST_URL="http://localhost"
-    else
-        pip install httpbin
-        python -m httpbin.core &
-        WX_TEST_WEBREQUEST_URL="http://localhost:5000"
-    fi
+    pip install httpbin --user
+    python -m httpbin.core &
+    WX_TEST_WEBREQUEST_URL="http://localhost:5000"
 
     export WX_TEST_WEBREQUEST_URL
     echo 'travis_fold:end:httpbin'


### PR DESCRIPTION
Using Docker just doesn't work: simply running "docker pull" fails due
to the pull rate limits all the time, see e.g.

https://travis-ci.org/github/wxWidgets/wxWidgets/jobs/759810039#L2628

while following Travis own instructions for dealing with this problem at

	https://blog.travis-ci.com/docker-rate-limits

results in the build failure due to secret environment variables not
being accessible from the PRs for security reasons, see

	https://travis-ci.org/github/wxWidgets/wxWidgets/jobs/759820694

So use pip everywhere, even under Ubuntu 14.04, where it doesn't work
out of the box as it tries to install globally when it doesn't have the
permissions to do it.