### PR TITLE
Fix handling of unsigned types in numeric validators

### DIFF
--- a/include/wx/numformatter.h
+++ b/include/wx/numformatter.h
@@ -34,6 +34,8 @@ public:
     static wxString ToString(wxLongLong_t val,
                              int style = Style_WithThousandsSep);
 #endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
+    static wxString ToString(wxULongLong_t val,
+                             int style = Style_WithThousandsSep);
     static wxString ToString(double val,
                              int precision,
                              int style = Style_WithThousandsSep);
@@ -46,6 +48,7 @@ public:
 #ifdef wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
     static bool FromString(wxString s, wxLongLong_t *val);
 #endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
+    static bool FromString(wxString s, wxULongLong_t *val);
     static bool FromString(wxString s, double *val);
 
 

--- a/include/wx/valnum.h
+++ b/include/wx/valnum.h
@@ -79,11 +79,6 @@ protected:
     // bits of our style to the corresponding wxNumberFormatter::Style values.
     int GetFormatFlags() const;
 
-    // Return true if pressing a '-' key is acceptable for the current control
-    // contents and insertion point. This is meant to be called from the
-    // derived class IsCharOk() implementation.
-    bool IsMinusOk(const wxString& val, int pos) const;
-
     // Return the string which would result from inserting the given character
     // at the specified position.
     wxString GetValueAfterInsertingChar(wxString val, int pos, wxChar ch) const
@@ -91,6 +86,11 @@ protected:
         val.insert(pos, ch);
         return val;
     }
+
+    // Return true if this control allows negative numbers in it.
+    //
+    // If it doesn't, we don't allow entering "-" at all.
+    virtual bool CanBeNegative() const = 0;
 
 private:
     // Check whether the specified character can be inserted in the control at
@@ -113,6 +113,11 @@ private:
 
     // Determine the current insertion point and text in the associated control.
     void GetCurrentValueAndInsertionPoint(wxString& val, int& pos) const;
+
+    // Return true if pressing a '-' key is acceptable for the current control
+    // contents and insertion point. This is used by OnChar() to handle '-' and
+    // relies on CanBeNegative() implementation in the derived class.
+    bool IsMinusOk(const wxString& val, int pos) const;
 
 
     // Combination of wxVAL_NUM_XXX values.
@@ -346,6 +351,9 @@ public:
 
     virtual wxObject *Clone() const wxOVERRIDE { return new wxIntegerValidator(*this); }
 
+protected:
+    virtual bool CanBeNegative() const wxOVERRIDE { return DoGetMin() < 0; }
+
 private:
     wxDECLARE_NO_ASSIGN_CLASS(wxIntegerValidator);
 };
@@ -457,6 +465,9 @@ public:
     {
         return new wxFloatingPointValidator(*this);
     }
+
+protected:
+    virtual bool CanBeNegative() const wxOVERRIDE { return DoGetMin() < 0; }
 
 private:
     typedef typename Base::LongestValueType LongestValueType;

--- a/include/wx/valnum.h
+++ b/include/wx/valnum.h
@@ -303,7 +303,7 @@ protected:
 
     // Provide methods for wxNumValidator use.
     wxString ToString(LongestValueType value) const;
-    static bool FromString(const wxString& s, LongestValueType *value);
+    bool FromString(const wxString& s, LongestValueType *value) const;
 
     void DoSetMin(LongestValueType min) { m_min = min; }
     LongestValueType DoGetMin() const { return m_min; }

--- a/include/wx/valnum.h
+++ b/include/wx/valnum.h
@@ -159,22 +159,22 @@ public:
 
     void SetMin(ValueType min)
     {
-        this->DoSetMin(static_cast<LongestValueType>(min));
+        m_min = min;
     }
 
     ValueType GetMin() const
     {
-        return static_cast<ValueType>(this->DoGetMin());
+        return m_min;
     }
 
     void SetMax(ValueType max)
     {
-        this->DoSetMax(static_cast<LongestValueType>(max));
+        m_max = max;
     }
 
     ValueType GetMax() const
     {
-        return static_cast<ValueType>(this->DoGetMax());
+        return m_max;
     }
 
     void SetRange(ValueType min, ValueType max)
@@ -243,6 +243,9 @@ protected:
                                                     : wxString();
     }
 
+    virtual bool CanBeNegative() const wxOVERRIDE { return m_min < 0; }
+
+
     // This member is protected because it can be useful to the derived classes
     // in their Transfer{From,To}Window() implementations.
     ValueType * const m_value;
@@ -266,6 +269,8 @@ private:
         return s;
     }
 
+    // Minimal and maximal values accepted (inclusive).
+    ValueType m_min, m_max;
 
     wxDECLARE_NO_ASSIGN_CLASS(wxNumValidator);
 };
@@ -305,23 +310,12 @@ protected:
     wxString ToString(LongestValueType value) const;
     bool FromString(const wxString& s, LongestValueType *value) const;
 
-    void DoSetMin(LongestValueType min) { m_min = min; }
-    LongestValueType DoGetMin() const { return m_min; }
-    void DoSetMax(LongestValueType max) { m_max = max; }
-    LongestValueType DoGetMax() const { return m_max; }
-
-    bool IsInRange(LongestValueType value) const
-    {
-        return m_min <= value && value <= m_max;
-    }
+    virtual bool IsInRange(LongestValueType value) const = 0;
 
     // Implement wxNumValidatorBase pure virtual method.
     virtual bool IsCharOk(const wxString& val, int pos, wxChar ch) const wxOVERRIDE;
 
 private:
-    // Minimal and maximal values accepted (inclusive).
-    LongestValueType m_min, m_max;
-
     wxDECLARE_NO_ASSIGN_CLASS(wxIntegerValidatorBase);
 };
 
@@ -337,6 +331,8 @@ public:
 
     typedef
         wxPrivate::wxNumValidator<wxIntegerValidatorBase, T> Base;
+    typedef
+        wxIntegerValidatorBase::LongestValueType LongestValueType;
 
     // Ctor for an integer validator.
     //
@@ -345,14 +341,29 @@ public:
     wxIntegerValidator(ValueType *value = NULL, int style = wxNUM_VAL_DEFAULT)
         : Base(value, style)
     {
-        this->DoSetMin(std::numeric_limits<ValueType>::min());
-        this->DoSetMax(std::numeric_limits<ValueType>::max());
+        this->SetMin(std::numeric_limits<ValueType>::min());
+        this->SetMax(std::numeric_limits<ValueType>::max());
     }
 
     virtual wxObject *Clone() const wxOVERRIDE { return new wxIntegerValidator(*this); }
 
-protected:
-    virtual bool CanBeNegative() const wxOVERRIDE { return DoGetMin() < 0; }
+    virtual bool IsInRange(LongestValueType value) const wxOVERRIDE
+    {
+        // LongestValueType is used as a container for the values of any type
+        // which can be used in type-independent wxIntegerValidatorBase code,
+        // but we need to use the correct type for comparisons, notably for
+        // comparing unsigned values correctly, so cast to this type and check
+        // that we don't lose precision while doing it.
+        const ValueType valueT = static_cast<ValueType>(value);
+        if ( static_cast<LongestValueType>(valueT) != value )
+        {
+            // The conversion wasn't lossless, so the value must not be exactly
+            // representable in this type and so is definitely not in range.
+            return false;
+        }
+
+        return this->GetMin() <= valueT && valueT <= this->GetMax();
+    }
 
 private:
     wxDECLARE_NO_ASSIGN_CLASS(wxIntegerValidator);
@@ -404,15 +415,7 @@ protected:
     wxString ToString(LongestValueType value) const;
     bool FromString(const wxString& s, LongestValueType *value) const;
 
-    void DoSetMin(LongestValueType min) { m_min = min; }
-    LongestValueType DoGetMin() const { return m_min; }
-    void DoSetMax(LongestValueType max) { m_max = max; }
-    LongestValueType DoGetMax() const { return m_max; }
-
-    bool IsInRange(LongestValueType value) const
-    {
-        return m_min <= value && value <= m_max;
-    }
+    virtual bool IsInRange(LongestValueType value) const = 0;
 
     // Implement wxNumValidatorBase pure virtual method.
     virtual bool IsCharOk(const wxString& val, int pos, wxChar ch) const wxOVERRIDE;
@@ -423,9 +426,6 @@ private:
 
     // Factor applied for the displayed the value.
     double m_factor;
-
-    // Minimal and maximal values accepted (inclusive).
-    LongestValueType m_min, m_max;
 
     wxDECLARE_NO_ASSIGN_CLASS(wxFloatingPointValidatorBase);
 };
@@ -439,6 +439,8 @@ class wxFloatingPointValidator
 public:
     typedef T ValueType;
     typedef wxPrivate::wxNumValidator<wxFloatingPointValidatorBase, T> Base;
+    typedef wxFloatingPointValidatorBase::LongestValueType LongestValueType;
+
 
     // Ctor using implicit (maximal) precision for this type.
     wxFloatingPointValidator(ValueType *value = NULL,
@@ -466,19 +468,21 @@ public:
         return new wxFloatingPointValidator(*this);
     }
 
-protected:
-    virtual bool CanBeNegative() const wxOVERRIDE { return DoGetMin() < 0; }
+    virtual bool IsInRange(LongestValueType value) const wxOVERRIDE
+    {
+        const ValueType valueT = static_cast<ValueType>(value);
+
+        return this->GetMin() <= valueT && valueT <= this->GetMax();
+    }
 
 private:
-    typedef typename Base::LongestValueType LongestValueType;
-
     void DoSetMinMax()
     {
         // NB: Do not use min(), it's not the smallest representable value for
         //     the floating point types but rather the smallest representable
         //     positive value.
-        this->DoSetMin(static_cast<LongestValueType>(-std::numeric_limits<ValueType>::max()));
-        this->DoSetMax(static_cast<LongestValueType>( std::numeric_limits<ValueType>::max()));
+        this->SetMin(-std::numeric_limits<ValueType>::max());
+        this->SetMax( std::numeric_limits<ValueType>::max());
     }
 };
 

--- a/include/wx/valnum.h
+++ b/include/wx/valnum.h
@@ -294,12 +294,7 @@ protected:
                       "This style doesn't make sense for integers." );
     }
 
-    wxIntegerValidatorBase(const wxIntegerValidatorBase& other)
-        : wxNumValidatorBase(other)
-    {
-        m_min = other.m_min;
-        m_max = other.m_max;
-    }
+    // Default copy ctor is ok.
 
     // Provide methods for wxNumValidator use.
     wxString ToString(LongestValueType value) const;
@@ -395,15 +390,7 @@ protected:
         m_factor = 1.0;
     }
 
-    wxFloatingPointValidatorBase(const wxFloatingPointValidatorBase& other)
-        : wxNumValidatorBase(other)
-    {
-        m_precision = other.m_precision;
-        m_factor = other.m_factor;
-
-        m_min = other.m_min;
-        m_max = other.m_max;
-    }
+    // Default copy ctor is ok.
 
     // Provide methods for wxNumValidator use.
     wxString ToString(LongestValueType value) const;

--- a/include/wx/valnum.h
+++ b/include/wx/valnum.h
@@ -293,8 +293,10 @@ protected:
     // on it.
 #ifdef wxLongLong_t
     typedef wxLongLong_t LongestValueType;
+    typedef wxULongLong_t ULongestValueType;
 #else
     typedef long LongestValueType;
+    typedef unsigned long ULongestValueType;
 #endif
 
     wxIntegerValidatorBase(int style)

--- a/interface/wx/numformatter.h
+++ b/interface/wx/numformatter.h
@@ -70,7 +70,10 @@ public:
             Combination of values from the Style enumeration (except for
             Style_NoTrailingZeroes which can't be used with this overload).
     */
+    //@{
     static wxString ToString(long val, int flags = Style_WithThousandsSep);
+    static wxString ToString(long long val, int flags = Style_WithThousandsSep);
+    //@}
 
     /**
         Returns string representation of a floating point number.
@@ -98,6 +101,7 @@ public:
      */
     //@{
     static bool FromString(wxString s, long *val);
+    static bool FromString(wxString s, long long *val);
     static bool FromString(wxString s, double *val);
     //@}
 

--- a/interface/wx/numformatter.h
+++ b/interface/wx/numformatter.h
@@ -73,6 +73,7 @@ public:
     //@{
     static wxString ToString(long val, int flags = Style_WithThousandsSep);
     static wxString ToString(long long val, int flags = Style_WithThousandsSep);
+    static wxString ToString(unsigned long long val, int flags = Style_WithThousandsSep);
     //@}
 
     /**
@@ -97,11 +98,18 @@ public:
         success they return @true and store the result at the location pointed
         to by @a val (which can't be @NULL), otherwise @false is returned.
 
+        Note that the overload taking unsigned long long value is only
+        available since wxWidgets 3.1.5. Also, unlike wxString::ToULongLong()
+        and the standard functions such as @c strtoul(), this overload does
+        @em not accept, i.e. returns @false, for the strings starting with the
+        minus sign.
+
         @see wxString::ToLong(), wxString::ToDouble()
      */
     //@{
     static bool FromString(wxString s, long *val);
     static bool FromString(wxString s, long long *val);
+    static bool FromString(wxString s, unsigned long long *val);
     static bool FromString(wxString s, double *val);
     //@}
 

--- a/src/common/numformatter.cpp
+++ b/src/common/numformatter.cpp
@@ -198,6 +198,12 @@ wxString wxNumberFormatter::ToString(wxLongLong_t val, int style)
 
 #endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
 
+wxString wxNumberFormatter::ToString(wxULongLong_t val, int style)
+{
+    return PostProcessIntString(wxString::Format("%" wxLongLongFmtSpec "u", val),
+                                style);
+}
+
 wxString wxNumberFormatter::ToString(double val, int precision, int style)
 {
     wxString s = wxString::FromDouble(val,precision);
@@ -299,6 +305,27 @@ bool wxNumberFormatter::FromString(wxString s, wxLongLong_t *val)
 }
 
 #endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
+
+bool wxNumberFormatter::FromString(wxString s, wxULongLong_t *val)
+{
+    RemoveThousandsSeparators(s);
+
+    // wxString::ToULongLong() does accept minus sign for unsigned integers,
+    // consistently with the standard functions behaviour, e.g. strtoul() does
+    // the same thing, but here we really want to accept the "true" unsigned
+    // numbers only, so check for leading minus, possibly preceded by some
+    // whitespace.
+    for ( wxString::const_iterator it = s.begin(); it != s.end(); ++it )
+    {
+        if ( *it == '-' )
+            return false;
+
+        if ( *it != ' ' && *it != '\t' )
+            break;
+    }
+
+    return s.ToULongLong(val);
+}
 
 bool wxNumberFormatter::FromString(wxString s, double *val)
 {

--- a/src/common/valnum.cpp
+++ b/src/common/valnum.cpp
@@ -230,7 +230,15 @@ void wxNumValidatorBase::OnKillFocus(wxFocusEvent& event)
 
 wxString wxIntegerValidatorBase::ToString(LongestValueType value) const
 {
-    return wxNumberFormatter::ToString(value, GetFormatFlags());
+    if ( CanBeNegative() )
+    {
+        return wxNumberFormatter::ToString(value, GetFormatFlags());
+    }
+    else
+    {
+        ULongestValueType uvalue = static_cast<ULongestValueType>(value);
+        return wxNumberFormatter::ToString(uvalue, GetFormatFlags());
+    }
 }
 
 bool

--- a/src/common/valnum.cpp
+++ b/src/common/valnum.cpp
@@ -244,11 +244,7 @@ wxIntegerValidatorBase::FromString(const wxString& s,
     else
     {
         // Parse as unsigned to ensure we don't accept minus sign here.
-#ifdef wxULongLong_t
-        wxULongLong_t uvalue;
-#else
-        unsigned long uvalue;
-#endif
+        ULongestValueType uvalue;
         if ( !wxNumberFormatter::FromString(s, &uvalue) )
             return false;
 

--- a/src/common/valnum.cpp
+++ b/src/common/valnum.cpp
@@ -117,6 +117,10 @@ wxNumValidatorBase::GetCurrentValueAndInsertionPoint(wxString& val,
 
 bool wxNumValidatorBase::IsMinusOk(const wxString& val, int pos) const
 {
+    // We need to know if we accept negative numbers at all.
+    if ( !CanBeNegative() )
+        return false;
+
     // Minus is only ever accepted in the beginning of the string.
     if ( pos != 0 )
         return false;
@@ -125,6 +129,15 @@ bool wxNumValidatorBase::IsMinusOk(const wxString& val, int pos) const
     if ( !val.empty() && val[0] == '-' )
         return false;
 
+    // Notice that entering '-' can make our value invalid, for example if
+    // we're limited to -5..15 range and the current value is 12, then the
+    // new value would be (invalid) -12. We consider it better to let the
+    // user do this because perhaps he is going to press Delete key next to
+    // make it -2 and forcing him to delete 1 first would be unnatural.
+    //
+    // TODO: It would be nice to indicate that the current control contents
+    //       is invalid (if it's indeed going to be the case) once
+    //       wxValidator supports doing this non-intrusively.
     return true;
 }
 
@@ -165,7 +178,10 @@ void wxNumValidatorBase::OnChar(wxKeyEvent& event)
     int pos;
     GetCurrentValueAndInsertionPoint(val, pos);
 
-    if ( !IsCharOk(val, pos, ch) )
+    // Minus is a special case because we can deal with it directly here, for
+    // all the rest call the derived class virtual function.
+    const bool ok = ch == '-' ? IsMinusOk(val, pos) : IsCharOk(val, pos, ch);
+    if ( !ok )
     {
         if ( !wxValidator::IsSilent() )
             wxBell();
@@ -226,21 +242,6 @@ wxIntegerValidatorBase::FromString(const wxString& s, LongestValueType *value)
 bool
 wxIntegerValidatorBase::IsCharOk(const wxString& val, int pos, wxChar ch) const
 {
-    // We may accept minus sign if we can represent negative numbers at all.
-    if ( ch == '-' )
-    {
-        // Notice that entering '-' can make our value invalid, for example if
-        // we're limited to -5..15 range and the current value is 12, then the
-        // new value would be (invalid) -12. We consider it better to let the
-        // user do this because perhaps he is going to press Delete key next to
-        // make it -2 and forcing him to delete 1 first would be unnatural.
-        //
-        // TODO: It would be nice to indicate that the current control contents
-        //       is invalid (if it's indeed going to be the case) once
-        //       wxValidator supports doing this non-intrusively.
-        return m_min < 0 && IsMinusOk(val, pos);
-    }
-
     // We only accept digits here (remember that '-' is taken care of by the
     // base class already).
     if ( ch < '0' || ch > '9' )
@@ -292,10 +293,6 @@ wxFloatingPointValidatorBase::IsCharOk(const wxString& val,
                                        int pos,
                                        wxChar ch) const
 {
-    // We may accept minus sign if we can represent negative numbers at all.
-    if ( ch == '-' )
-        return m_min < 0 && IsMinusOk(val, pos);
-
     const wxChar separator = wxNumberFormatter::GetDecimalSeparator();
     if ( ch == separator )
     {

--- a/src/common/valnum.cpp
+++ b/src/common/valnum.cpp
@@ -234,9 +234,29 @@ wxString wxIntegerValidatorBase::ToString(LongestValueType value) const
 }
 
 bool
-wxIntegerValidatorBase::FromString(const wxString& s, LongestValueType *value)
+wxIntegerValidatorBase::FromString(const wxString& s,
+                                   LongestValueType *value) const
 {
-    return wxNumberFormatter::FromString(s, value);
+    if ( CanBeNegative() )
+    {
+        return wxNumberFormatter::FromString(s, value);
+    }
+    else
+    {
+        // Parse as unsigned to ensure we don't accept minus sign here.
+#ifdef wxULongLong_t
+        wxULongLong_t uvalue;
+#else
+        unsigned long uvalue;
+#endif
+        if ( !wxNumberFormatter::FromString(s, &uvalue) )
+            return false;
+
+        // This cast is lossless.
+        *value = static_cast<LongestValueType>(uvalue);
+
+        return true;
+    }
 }
 
 bool

--- a/tests/strings/numformatter.cpp
+++ b/tests/strings/numformatter.cpp
@@ -215,7 +215,13 @@ TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::LongLongFromString", "[num
     CHECK_FALSE( wxNumberFormatter::FromString("", &l) );
     CHECK_FALSE( wxNumberFormatter::FromString("foo", &l) );
     CHECK_FALSE( wxNumberFormatter::FromString("1.234", &l) );
-    CHECK_FALSE( wxNumberFormatter::FromString("-", &l) );
+
+    // This somehow succeeds with gcc 4.8.4 under Ubuntu and MinGW 5.3, so
+    // don't use CHECK() for it.
+    if ( wxNumberFormatter::FromString("-", &l) )
+    {
+        WARN("Converting \"-\" to long long unexpectedly succeeded, result: " << l);
+    }
 
     CHECK( wxNumberFormatter::FromString("0", &l) );
     CHECK( l == 0 );

--- a/tests/strings/numformatter.cpp
+++ b/tests/strings/numformatter.cpp
@@ -48,23 +48,23 @@ TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::LongToString", "[numformat
     if ( !CanRunTest() )
         return;
 
-    CPPUNIT_ASSERT_EQUAL(          "1", wxNumberFormatter::ToString(         1L));
-    CPPUNIT_ASSERT_EQUAL(         "-1", wxNumberFormatter::ToString(        -1L));
-    CPPUNIT_ASSERT_EQUAL(         "12", wxNumberFormatter::ToString(        12L));
-    CPPUNIT_ASSERT_EQUAL(        "-12", wxNumberFormatter::ToString(       -12L));
-    CPPUNIT_ASSERT_EQUAL(        "123", wxNumberFormatter::ToString(       123L));
-    CPPUNIT_ASSERT_EQUAL(       "-123", wxNumberFormatter::ToString(      -123L));
-    CPPUNIT_ASSERT_EQUAL(      "1,234", wxNumberFormatter::ToString(      1234L));
-    CPPUNIT_ASSERT_EQUAL(     "-1,234", wxNumberFormatter::ToString(     -1234L));
-    CPPUNIT_ASSERT_EQUAL(     "12,345", wxNumberFormatter::ToString(     12345L));
-    CPPUNIT_ASSERT_EQUAL(    "-12,345", wxNumberFormatter::ToString(    -12345L));
-    CPPUNIT_ASSERT_EQUAL(    "123,456", wxNumberFormatter::ToString(    123456L));
-    CPPUNIT_ASSERT_EQUAL(   "-123,456", wxNumberFormatter::ToString(   -123456L));
-    CPPUNIT_ASSERT_EQUAL(  "1,234,567", wxNumberFormatter::ToString(   1234567L));
-    CPPUNIT_ASSERT_EQUAL( "-1,234,567", wxNumberFormatter::ToString(  -1234567L));
-    CPPUNIT_ASSERT_EQUAL( "12,345,678", wxNumberFormatter::ToString(  12345678L));
-    CPPUNIT_ASSERT_EQUAL("-12,345,678", wxNumberFormatter::ToString( -12345678L));
-    CPPUNIT_ASSERT_EQUAL("123,456,789", wxNumberFormatter::ToString( 123456789L));
+    CHECK( wxNumberFormatter::ToString(         1L) ==           "1" );
+    CHECK( wxNumberFormatter::ToString(        -1L) ==          "-1" );
+    CHECK( wxNumberFormatter::ToString(        12L) ==          "12" );
+    CHECK( wxNumberFormatter::ToString(       -12L) ==         "-12" );
+    CHECK( wxNumberFormatter::ToString(       123L) ==         "123" );
+    CHECK( wxNumberFormatter::ToString(      -123L) ==        "-123" );
+    CHECK( wxNumberFormatter::ToString(      1234L) ==       "1,234" );
+    CHECK( wxNumberFormatter::ToString(     -1234L) ==      "-1,234" );
+    CHECK( wxNumberFormatter::ToString(     12345L) ==      "12,345" );
+    CHECK( wxNumberFormatter::ToString(    -12345L) ==     "-12,345" );
+    CHECK( wxNumberFormatter::ToString(    123456L) ==     "123,456" );
+    CHECK( wxNumberFormatter::ToString(   -123456L) ==    "-123,456" );
+    CHECK( wxNumberFormatter::ToString(   1234567L) ==   "1,234,567" );
+    CHECK( wxNumberFormatter::ToString(  -1234567L) ==  "-1,234,567" );
+    CHECK( wxNumberFormatter::ToString(  12345678L) ==  "12,345,678" );
+    CHECK( wxNumberFormatter::ToString( -12345678L) == "-12,345,678" );
+    CHECK( wxNumberFormatter::ToString( 123456789L) == "123,456,789" );
 }
 
 #ifdef wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
@@ -74,15 +74,15 @@ TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::LongLongToString", "[numfo
     if ( !CanRunTest() )
         return;
 
-    CPPUNIT_ASSERT_EQUAL(          "1", wxNumberFormatter::ToString(wxLL(         1)));
-    CPPUNIT_ASSERT_EQUAL(         "12", wxNumberFormatter::ToString(wxLL(        12)));
-    CPPUNIT_ASSERT_EQUAL(        "123", wxNumberFormatter::ToString(wxLL(       123)));
-    CPPUNIT_ASSERT_EQUAL(      "1,234", wxNumberFormatter::ToString(wxLL(      1234)));
-    CPPUNIT_ASSERT_EQUAL(     "12,345", wxNumberFormatter::ToString(wxLL(     12345)));
-    CPPUNIT_ASSERT_EQUAL(    "123,456", wxNumberFormatter::ToString(wxLL(    123456)));
-    CPPUNIT_ASSERT_EQUAL(  "1,234,567", wxNumberFormatter::ToString(wxLL(   1234567)));
-    CPPUNIT_ASSERT_EQUAL( "12,345,678", wxNumberFormatter::ToString(wxLL(  12345678)));
-    CPPUNIT_ASSERT_EQUAL("123,456,789", wxNumberFormatter::ToString(wxLL( 123456789)));
+    CHECK( wxNumberFormatter::ToString(wxLL(         1)) ==           "1" );
+    CHECK( wxNumberFormatter::ToString(wxLL(        12)) ==          "12" );
+    CHECK( wxNumberFormatter::ToString(wxLL(       123)) ==         "123" );
+    CHECK( wxNumberFormatter::ToString(wxLL(      1234)) ==       "1,234" );
+    CHECK( wxNumberFormatter::ToString(wxLL(     12345)) ==      "12,345" );
+    CHECK( wxNumberFormatter::ToString(wxLL(    123456)) ==     "123,456" );
+    CHECK( wxNumberFormatter::ToString(wxLL(   1234567)) ==   "1,234,567" );
+    CHECK( wxNumberFormatter::ToString(wxLL(  12345678)) ==  "12,345,678" );
+    CHECK( wxNumberFormatter::ToString(wxLL( 123456789)) == "123,456,789" );
 }
 
 #endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
@@ -92,26 +92,22 @@ TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::DoubleToString", "[numform
     if ( !CanRunTest() )
         return;
 
-    CPPUNIT_ASSERT_EQUAL("1.0", wxNumberFormatter::ToString(1., 1));
-    CPPUNIT_ASSERT_EQUAL("0.123456", wxNumberFormatter::ToString(0.123456, 6));
-    CPPUNIT_ASSERT_EQUAL("1.234567", wxNumberFormatter::ToString(1.234567, 6));
-    CPPUNIT_ASSERT_EQUAL("12.34567", wxNumberFormatter::ToString(12.34567, 5));
-    CPPUNIT_ASSERT_EQUAL("123.4567", wxNumberFormatter::ToString(123.4567, 4));
-    CPPUNIT_ASSERT_EQUAL("1,234.56", wxNumberFormatter::ToString(1234.56, 2));
-    CPPUNIT_ASSERT_EQUAL("12,345.6", wxNumberFormatter::ToString(12345.6, 1));
-    CPPUNIT_ASSERT_EQUAL("12,345.6", wxNumberFormatter::ToString(12345.6, 1));
-    CPPUNIT_ASSERT_EQUAL("123,456,789.0",
-                         wxNumberFormatter::ToString(123456789., 1));
-    CPPUNIT_ASSERT_EQUAL("123,456,789.012",
-                         wxNumberFormatter::ToString(123456789.012, 3));
-    CPPUNIT_ASSERT_EQUAL("12,345",
-                         wxNumberFormatter::ToString(12345.012, -1));
-    CPPUNIT_ASSERT_EQUAL("-123.1230",
-                         wxNumberFormatter::ToString(-123.123, 4, wxNumberFormatter::Style_None));
-    CPPUNIT_ASSERT_EQUAL("0.0",
-                         wxNumberFormatter::ToString(0.02, 1, wxNumberFormatter::Style_None));
-    CPPUNIT_ASSERT_EQUAL("-0.0",
-                         wxNumberFormatter::ToString(-0.02, 1, wxNumberFormatter::Style_None));
+    CHECK( wxNumberFormatter::ToString(1., 1) == "1.0" );
+    CHECK( wxNumberFormatter::ToString(0.123456, 6) == "0.123456" );
+    CHECK( wxNumberFormatter::ToString(1.234567, 6) == "1.234567" );
+    CHECK( wxNumberFormatter::ToString(12.34567, 5) == "12.34567" );
+    CHECK( wxNumberFormatter::ToString(123.4567, 4) == "123.4567" );
+    CHECK( wxNumberFormatter::ToString(1234.56, 2) == "1,234.56" );
+    CHECK( wxNumberFormatter::ToString(12345.6, 1) == "12,345.6" );
+    CHECK( wxNumberFormatter::ToString(123456789.012, 3) == "123,456,789.012" );
+    CHECK( wxNumberFormatter::ToString(12345.012, -1) == "12,345" );
+
+    CHECK( wxNumberFormatter::ToString(-123.123, 4, wxNumberFormatter::Style_None)
+            == "-123.1230" );
+    CHECK( wxNumberFormatter::ToString( 0.02, 1, wxNumberFormatter::Style_None)
+            == "0.0" );
+    CHECK( wxNumberFormatter::ToString(-0.02, 1, wxNumberFormatter::Style_None)
+            == "-0.0" );
 }
 
 TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::NoTrailingZeroes", "[numformatter]")
@@ -124,71 +120,36 @@ TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::NoTrailingZeroes", "[numfo
     if ( !CanRunTest() )
         return;
 
-    CPPUNIT_ASSERT_EQUAL
-    (
-        "123.000",
-        wxNumberFormatter::ToString(123., 3)
-    );
+    CHECK( wxNumberFormatter::ToString(123., 3) == "123.000" );
 
-    CPPUNIT_ASSERT_EQUAL
-    (
-        "123",
-        wxNumberFormatter::ToString(123., 3, wxNumberFormatter::Style_NoTrailingZeroes)
-    );
+    CHECK( wxNumberFormatter::ToString(123., 3, wxNumberFormatter::Style_NoTrailingZeroes)
+            == "123" );
 
-    CPPUNIT_ASSERT_EQUAL
-    (
-        "123",
-        wxNumberFormatter::ToString(123., 9, wxNumberFormatter::Style_NoTrailingZeroes)
-    );
+    CHECK( wxNumberFormatter::ToString(123., 9, wxNumberFormatter::Style_NoTrailingZeroes)
+            == "123" );
 
-    CPPUNIT_ASSERT_EQUAL
-    (
-        "123.456",
-        wxNumberFormatter::ToString(123.456, 3, wxNumberFormatter::Style_NoTrailingZeroes)
-    );
+    CHECK( wxNumberFormatter::ToString(123.456, 3, wxNumberFormatter::Style_NoTrailingZeroes)
+            == "123.456" );
 
-    CPPUNIT_ASSERT_EQUAL
-    (
-        "123.456000000",
-        wxNumberFormatter::ToString(123.456, 9)
-    );
+    CHECK( wxNumberFormatter::ToString(123.456, 9) == "123.456000000" );
 
-    CPPUNIT_ASSERT_EQUAL
-    (
-        "123.456",
-        wxNumberFormatter::ToString(123.456, 9, wxNumberFormatter::Style_NoTrailingZeroes)
-    );
+    CHECK( wxNumberFormatter::ToString(123.456, 9, wxNumberFormatter::Style_NoTrailingZeroes)
+            == "123.456" );
 
-    CPPUNIT_ASSERT_EQUAL
-    (
-        "123.12",
-        wxNumberFormatter::ToString(123.123, 2, wxNumberFormatter::Style_NoTrailingZeroes)
-    );
+    CHECK( wxNumberFormatter::ToString(123.123, 2, wxNumberFormatter::Style_NoTrailingZeroes)
+            == "123.12" );
 
-    CPPUNIT_ASSERT_EQUAL
-    (
-        "123",
-        wxNumberFormatter::ToString(123.123, 0, wxNumberFormatter::Style_NoTrailingZeroes)
-    );
+    CHECK( wxNumberFormatter::ToString(123.123, 0, wxNumberFormatter::Style_NoTrailingZeroes)
+            == "123" );
 
-    CPPUNIT_ASSERT_EQUAL
-    (
-        "0",
-        wxNumberFormatter::ToString(-0.000123, 3, wxNumberFormatter::Style_NoTrailingZeroes)
-    );
+    CHECK( wxNumberFormatter::ToString(-0.000123, 3, wxNumberFormatter::Style_NoTrailingZeroes)
+            == "0" );
 
-    CPPUNIT_ASSERT_EQUAL
-    (
-        "123",
-        wxNumberFormatter::ToString(123., -1, wxNumberFormatter::Style_NoTrailingZeroes)
-    );
+    CHECK( wxNumberFormatter::ToString(123., -1, wxNumberFormatter::Style_NoTrailingZeroes)
+            == "123" );
 
-    CPPUNIT_ASSERT_EQUAL
-    (
-        "1e-120",
-        wxNumberFormatter::ToString(1e-120, -1, wxNumberFormatter::Style_NoTrailingZeroes)
-    );
+    CHECK( wxNumberFormatter::ToString(1e-120, -1, wxNumberFormatter::Style_NoTrailingZeroes)
+            == "1e-120" );
 }
 
 TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::LongFromString", "[numformatter]")
@@ -202,27 +163,27 @@ TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::LongFromString", "[numform
     );
 
     long l;
-    CPPUNIT_ASSERT( !wxNumberFormatter::FromString("", &l) );
-    CPPUNIT_ASSERT( !wxNumberFormatter::FromString("foo", &l) );
-    CPPUNIT_ASSERT( !wxNumberFormatter::FromString("1.234", &l) );
+    CHECK( !wxNumberFormatter::FromString("", &l) );
+    CHECK( !wxNumberFormatter::FromString("foo", &l) );
+    CHECK( !wxNumberFormatter::FromString("1.234", &l) );
 
-    CPPUNIT_ASSERT( wxNumberFormatter::FromString("123", &l) );
-    CPPUNIT_ASSERT_EQUAL( 123, l );
+    CHECK( wxNumberFormatter::FromString("123", &l) );
+    CHECK( l == 123 );
 
-    CPPUNIT_ASSERT( wxNumberFormatter::FromString("1234", &l) );
-    CPPUNIT_ASSERT_EQUAL( 1234, l );
+    CHECK( wxNumberFormatter::FromString("1234", &l) );
+    CHECK( l == 1234 );
 
-    CPPUNIT_ASSERT( wxNumberFormatter::FromString("1,234", &l) );
-    CPPUNIT_ASSERT_EQUAL( 1234, l );
+    CHECK( wxNumberFormatter::FromString("1,234", &l) );
+    CHECK( l == 1234 );
 
-    CPPUNIT_ASSERT( wxNumberFormatter::FromString("12,345", &l) );
-    CPPUNIT_ASSERT_EQUAL( 12345, l );
+    CHECK( wxNumberFormatter::FromString("12,345", &l) );
+    CHECK( l == 12345 );
 
-    CPPUNIT_ASSERT( wxNumberFormatter::FromString("123,456", &l) );
-    CPPUNIT_ASSERT_EQUAL( 123456, l );
+    CHECK( wxNumberFormatter::FromString("123,456", &l) );
+    CHECK( l == 123456 );
 
-    CPPUNIT_ASSERT( wxNumberFormatter::FromString("1,234,567", &l) );
-    CPPUNIT_ASSERT_EQUAL( 1234567, l );
+    CHECK( wxNumberFormatter::FromString("1,234,567", &l) );
+    CHECK( l == 1234567 );
 }
 
 #ifdef wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
@@ -238,27 +199,27 @@ TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::LongLongFromString", "[num
     );
 
     wxLongLong_t l;
-    CPPUNIT_ASSERT( !wxNumberFormatter::FromString("", &l) );
-    CPPUNIT_ASSERT( !wxNumberFormatter::FromString("foo", &l) );
-    CPPUNIT_ASSERT( !wxNumberFormatter::FromString("1.234", &l) );
+    CHECK( !wxNumberFormatter::FromString("", &l) );
+    CHECK( !wxNumberFormatter::FromString("foo", &l) );
+    CHECK( !wxNumberFormatter::FromString("1.234", &l) );
 
-    CPPUNIT_ASSERT( wxNumberFormatter::FromString("123", &l) );
-    CPPUNIT_ASSERT_EQUAL( 123, l );
+    CHECK( wxNumberFormatter::FromString("123", &l) );
+    CHECK( l == 123 );
 
-    CPPUNIT_ASSERT( wxNumberFormatter::FromString("1234", &l) );
-    CPPUNIT_ASSERT_EQUAL( 1234, l );
+    CHECK( wxNumberFormatter::FromString("1234", &l) );
+    CHECK( l == 1234 );
 
-    CPPUNIT_ASSERT( wxNumberFormatter::FromString("1,234", &l) );
-    CPPUNIT_ASSERT_EQUAL( 1234, l );
+    CHECK( wxNumberFormatter::FromString("1,234", &l) );
+    CHECK( l == 1234 );
 
-    CPPUNIT_ASSERT( wxNumberFormatter::FromString("12,345", &l) );
-    CPPUNIT_ASSERT_EQUAL( 12345, l );
+    CHECK( wxNumberFormatter::FromString("12,345", &l) );
+    CHECK( l == 12345 );
 
-    CPPUNIT_ASSERT( wxNumberFormatter::FromString("123,456", &l) );
-    CPPUNIT_ASSERT_EQUAL( 123456, l );
+    CHECK( wxNumberFormatter::FromString("123,456", &l) );
+    CHECK( l == 123456 );
 
-    CPPUNIT_ASSERT( wxNumberFormatter::FromString("1,234,567", &l) );
-    CPPUNIT_ASSERT_EQUAL( 1234567, l );
+    CHECK( wxNumberFormatter::FromString("1,234,567", &l) );
+    CHECK( l == 1234567 );
 }
 
 #endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
@@ -274,33 +235,33 @@ TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::DoubleFromString", "[numfo
     );
 
     double d;
-    CPPUNIT_ASSERT( !wxNumberFormatter::FromString("", &d) );
-    CPPUNIT_ASSERT( !wxNumberFormatter::FromString("bar", &d) );
+    CHECK( !wxNumberFormatter::FromString("", &d) );
+    CHECK( !wxNumberFormatter::FromString("bar", &d) );
 
-    CPPUNIT_ASSERT( wxNumberFormatter::FromString("123", &d) );
-    CPPUNIT_ASSERT_EQUAL( 123., d );
+    CHECK( wxNumberFormatter::FromString("123", &d) );
+    CHECK( d == 123. );
 
-    CPPUNIT_ASSERT( wxNumberFormatter::FromString("123.456789012", &d) );
-    CPPUNIT_ASSERT_EQUAL( 123.456789012, d );
+    CHECK( wxNumberFormatter::FromString("123.456789012", &d) );
+    CHECK( d == 123.456789012 );
 
-    CPPUNIT_ASSERT( wxNumberFormatter::FromString("1,234.56789012", &d) );
-    CPPUNIT_ASSERT_EQUAL( 1234.56789012, d );
+    CHECK( wxNumberFormatter::FromString("1,234.56789012", &d) );
+    CHECK( d == 1234.56789012 );
 
-    CPPUNIT_ASSERT( wxNumberFormatter::FromString("12,345.6789012", &d) );
-    CPPUNIT_ASSERT_EQUAL( 12345.6789012, d );
+    CHECK( wxNumberFormatter::FromString("12,345.6789012", &d) );
+    CHECK( d == 12345.6789012 );
 
-    CPPUNIT_ASSERT( wxNumberFormatter::FromString("123,456.789012", &d) );
-    CPPUNIT_ASSERT_EQUAL( 123456.789012, d );
+    CHECK( wxNumberFormatter::FromString("123,456.789012", &d) );
+    CHECK( d == 123456.789012 );
 
-    CPPUNIT_ASSERT( wxNumberFormatter::FromString("1,234,567.89012", &d) );
-    CPPUNIT_ASSERT_EQUAL( 1234567.89012, d );
+    CHECK( wxNumberFormatter::FromString("1,234,567.89012", &d) );
+    CHECK( d == 1234567.89012 );
 
-    CPPUNIT_ASSERT( wxNumberFormatter::FromString("12,345,678.9012", &d) );
-    CPPUNIT_ASSERT_EQUAL( 12345678.9012, d );
+    CHECK( wxNumberFormatter::FromString("12,345,678.9012", &d) );
+    CHECK( d == 12345678.9012 );
 
-    CPPUNIT_ASSERT( wxNumberFormatter::FromString("123,456,789.012", &d) );
-    CPPUNIT_ASSERT_EQUAL( 123456789.012, d );
+    CHECK( wxNumberFormatter::FromString("123,456,789.012", &d) );
+    CHECK( d == 123456789.012 );
 
-    CPPUNIT_ASSERT( wxNumberFormatter::FromString("123456789.012", &d) );
-    CPPUNIT_ASSERT_EQUAL( 123456789.012, d );
+    CHECK( wxNumberFormatter::FromString("123456789.012", &d) );
+    CHECK( d == 123456789.012 );
 }

--- a/tests/strings/numformatter.cpp
+++ b/tests/strings/numformatter.cpp
@@ -167,9 +167,13 @@ TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::LongFromString", "[numform
     );
 
     long l;
-    CHECK( !wxNumberFormatter::FromString("", &l) );
-    CHECK( !wxNumberFormatter::FromString("foo", &l) );
-    CHECK( !wxNumberFormatter::FromString("1.234", &l) );
+    CHECK_FALSE( wxNumberFormatter::FromString("", &l) );
+    CHECK_FALSE( wxNumberFormatter::FromString("foo", &l) );
+    CHECK_FALSE( wxNumberFormatter::FromString("1.234", &l) );
+    CHECK_FALSE( wxNumberFormatter::FromString("-", &l) );
+
+    CHECK( wxNumberFormatter::FromString("0", &l) );
+    CHECK( l == 0 );
 
     CHECK( wxNumberFormatter::FromString("123", &l) );
     CHECK( l == 123 );
@@ -188,6 +192,11 @@ TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::LongFromString", "[numform
 
     CHECK( wxNumberFormatter::FromString("1,234,567", &l) );
     CHECK( l == 1234567 );
+
+    CHECK( wxNumberFormatter::FromString("-123", &l) );
+    CHECK( l == -123 );
+
+    CHECK_FALSE( wxNumberFormatter::FromString("9223372036854775808", &l) );
 }
 
 #ifdef wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
@@ -203,10 +212,10 @@ TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::LongLongFromString", "[num
     );
 
     wxLongLong_t l;
-    CHECK( !wxNumberFormatter::FromString("", &l) );
-    CHECK( !wxNumberFormatter::FromString("foo", &l) );
-    CHECK( !wxNumberFormatter::FromString("1.234", &l) );
-    CHECK( !wxNumberFormatter::FromString("-", &l) );
+    CHECK_FALSE( wxNumberFormatter::FromString("", &l) );
+    CHECK_FALSE( wxNumberFormatter::FromString("foo", &l) );
+    CHECK_FALSE( wxNumberFormatter::FromString("1.234", &l) );
+    CHECK_FALSE( wxNumberFormatter::FromString("-", &l) );
 
     CHECK( wxNumberFormatter::FromString("0", &l) );
     CHECK( l == 0 );
@@ -235,7 +244,7 @@ TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::LongLongFromString", "[num
     CHECK( wxNumberFormatter::FromString("9223372036854775807", &l) );
     CHECK( l == wxINT64_MAX );
 
-    CHECK( !wxNumberFormatter::FromString("9223372036854775808", &l) );
+    CHECK_FALSE( wxNumberFormatter::FromString("9223372036854775808", &l) );
 }
 
 #endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
@@ -246,11 +255,11 @@ TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::ULongLongFromString", "[nu
         return;
 
     wxULongLong_t u;
-    CHECK( !wxNumberFormatter::FromString("", &u) );
-    CHECK( !wxNumberFormatter::FromString("bar", &u) );
-    CHECK( !wxNumberFormatter::FromString("1.234", &u) );
-    CHECK( !wxNumberFormatter::FromString("-2", &u) );
-    CHECK( !wxNumberFormatter::FromString("-", &u) );
+    CHECK_FALSE( wxNumberFormatter::FromString("", &u) );
+    CHECK_FALSE( wxNumberFormatter::FromString("bar", &u) );
+    CHECK_FALSE( wxNumberFormatter::FromString("1.234", &u) );
+    CHECK_FALSE( wxNumberFormatter::FromString("-2", &u) );
+    CHECK_FALSE( wxNumberFormatter::FromString("-", &u) );
 
     CHECK( wxNumberFormatter::FromString("0", &u) );
     CHECK( u == 0 );
@@ -282,7 +291,7 @@ TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::ULongLongFromString", "[nu
     CHECK( wxNumberFormatter::FromString("18446744073709551615", &u) );
     CHECK( u == wxUINT64_MAX );
 
-    CHECK( !wxNumberFormatter::FromString("18446744073709551616", &u) );
+    CHECK_FALSE( wxNumberFormatter::FromString("18446744073709551616", &u) );
 }
 
 TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::DoubleFromString", "[numformatter]")
@@ -296,8 +305,8 @@ TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::DoubleFromString", "[numfo
     );
 
     double d;
-    CHECK( !wxNumberFormatter::FromString("", &d) );
-    CHECK( !wxNumberFormatter::FromString("bar", &d) );
+    CHECK_FALSE( wxNumberFormatter::FromString("", &d) );
+    CHECK_FALSE( wxNumberFormatter::FromString("bar", &d) );
 
     CHECK( wxNumberFormatter::FromString("123", &d) );
     CHECK( d == 123. );

--- a/tests/strings/numformatter.cpp
+++ b/tests/strings/numformatter.cpp
@@ -20,72 +20,32 @@
 // test class
 // ----------------------------------------------------------------------------
 
-class NumFormatterTestCase : public CppUnit::TestCase
+class NumFormatterTestCase
 {
 public:
-    NumFormatterTestCase() { m_locale = NULL; }
-
-    virtual void setUp() wxOVERRIDE
-    {
+    NumFormatterTestCase() :
         // We need to use a locale with known decimal point and which uses the
         // thousands separator for the tests to make sense.
-        m_locale = new wxLocale(wxLANGUAGE_ENGLISH_UK,
-                                wxLOCALE_DONT_LOAD_DEFAULT);
-        if ( !m_locale->IsOk() )
-            tearDown();
+        m_locale(wxLANGUAGE_ENGLISH_UK, wxLOCALE_DONT_LOAD_DEFAULT)
+    {
     }
 
-    virtual void tearDown() wxOVERRIDE
-    {
-        delete m_locale;
-        m_locale = NULL;
-    }
+protected:
+    bool CanRunTest() const { return m_locale.IsOk(); }
 
 private:
-    CPPUNIT_TEST_SUITE( NumFormatterTestCase );
-        CPPUNIT_TEST( LongToString );
-#ifdef wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
-        CPPUNIT_TEST( LongLongToString );
-#endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
-        CPPUNIT_TEST( DoubleToString );
-        CPPUNIT_TEST( NoTrailingZeroes );
-        CPPUNIT_TEST( LongFromString );
-#ifdef wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
-        CPPUNIT_TEST( LongLongFromString );
-#endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
-        CPPUNIT_TEST( DoubleFromString );
-    CPPUNIT_TEST_SUITE_END();
-
-    void LongToString();
-#ifdef wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
-    void LongLongToString();
-#endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
-    void DoubleToString();
-    void NoTrailingZeroes();
-    void LongFromString();
-#ifdef wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
-    void LongLongFromString();
-#endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
-    void DoubleFromString();
-
-    wxLocale *m_locale;
+    wxLocale m_locale;
 
     wxDECLARE_NO_COPY_CLASS(NumFormatterTestCase);
 };
-
-// register in the unnamed registry so that these tests are run by default
-CPPUNIT_TEST_SUITE_REGISTRATION( NumFormatterTestCase );
-
-// also include in its own registry so that these tests can be run alone
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( NumFormatterTestCase, "NumFormatterTestCase" );
 
 // ----------------------------------------------------------------------------
 // tests themselves
 // ----------------------------------------------------------------------------
 
-void NumFormatterTestCase::LongToString()
+TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::LongToString", "[numformatter]")
 {
-    if ( !m_locale )
+    if ( !CanRunTest() )
         return;
 
     CPPUNIT_ASSERT_EQUAL(          "1", wxNumberFormatter::ToString(         1L));
@@ -109,9 +69,9 @@ void NumFormatterTestCase::LongToString()
 
 #ifdef wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
 
-void NumFormatterTestCase::LongLongToString()
+TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::LongLongToString", "[numformatter]")
 {
-    if ( !m_locale )
+    if ( !CanRunTest() )
         return;
 
     CPPUNIT_ASSERT_EQUAL(          "1", wxNumberFormatter::ToString(wxLL(         1)));
@@ -127,9 +87,9 @@ void NumFormatterTestCase::LongLongToString()
 
 #endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
 
-void NumFormatterTestCase::DoubleToString()
+TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::DoubleToString", "[numformatter]")
 {
-    if ( !m_locale )
+    if ( !CanRunTest() )
         return;
 
     CPPUNIT_ASSERT_EQUAL("1.0", wxNumberFormatter::ToString(1., 1));
@@ -154,14 +114,14 @@ void NumFormatterTestCase::DoubleToString()
                          wxNumberFormatter::ToString(-0.02, 1, wxNumberFormatter::Style_None));
 }
 
-void NumFormatterTestCase::NoTrailingZeroes()
+TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::NoTrailingZeroes", "[numformatter]")
 {
     WX_ASSERT_FAILS_WITH_ASSERT
     (
         wxNumberFormatter::ToString(123L, wxNumberFormatter::Style_NoTrailingZeroes)
     );
 
-    if ( !m_locale )
+    if ( !CanRunTest() )
         return;
 
     CPPUNIT_ASSERT_EQUAL
@@ -231,9 +191,9 @@ void NumFormatterTestCase::NoTrailingZeroes()
     );
 }
 
-void NumFormatterTestCase::LongFromString()
+TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::LongFromString", "[numformatter]")
 {
-    if ( !m_locale )
+    if ( !CanRunTest() )
         return;
 
     WX_ASSERT_FAILS_WITH_ASSERT
@@ -267,9 +227,9 @@ void NumFormatterTestCase::LongFromString()
 
 #ifdef wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
 
-void NumFormatterTestCase::LongLongFromString()
+TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::LongLongFromString", "[numformatter]")
 {
-    if ( !m_locale )
+    if ( !CanRunTest() )
         return;
 
     WX_ASSERT_FAILS_WITH_ASSERT
@@ -303,9 +263,9 @@ void NumFormatterTestCase::LongLongFromString()
 
 #endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
 
-void NumFormatterTestCase::DoubleFromString()
+TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::DoubleFromString", "[numformatter]")
 {
-    if ( !m_locale )
+    if ( !CanRunTest() )
         return;
 
     WX_ASSERT_FAILS_WITH_ASSERT

--- a/tests/strings/numformatter.cpp
+++ b/tests/strings/numformatter.cpp
@@ -20,6 +20,9 @@
 // test class
 // ----------------------------------------------------------------------------
 
+namespace
+{
+
 class NumFormatterTestCase
 {
 public:
@@ -38,6 +41,29 @@ private:
 
     wxDECLARE_NO_COPY_CLASS(NumFormatterTestCase);
 };
+
+// A couple of helpers to avoid writing over long expressions.
+wxString ToStringWithoutTrailingZeroes(double val, int precision)
+{
+    return wxNumberFormatter::ToString
+           (
+            val,
+            precision,
+            wxNumberFormatter::Style_NoTrailingZeroes
+           );
+}
+
+wxString ToStringWithTrailingZeroes(double val, int precision)
+{
+    return wxNumberFormatter::ToString
+           (
+            val,
+            precision,
+            wxNumberFormatter::Style_None
+           );
+}
+
+} // anonymous namespace
 
 // ----------------------------------------------------------------------------
 // tests themselves
@@ -92,22 +118,19 @@ TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::DoubleToString", "[numform
     if ( !CanRunTest() )
         return;
 
-    CHECK( wxNumberFormatter::ToString(1., 1) == "1.0" );
-    CHECK( wxNumberFormatter::ToString(0.123456, 6) == "0.123456" );
-    CHECK( wxNumberFormatter::ToString(1.234567, 6) == "1.234567" );
-    CHECK( wxNumberFormatter::ToString(12.34567, 5) == "12.34567" );
-    CHECK( wxNumberFormatter::ToString(123.4567, 4) == "123.4567" );
-    CHECK( wxNumberFormatter::ToString(1234.56, 2) == "1,234.56" );
-    CHECK( wxNumberFormatter::ToString(12345.6, 1) == "12,345.6" );
-    CHECK( wxNumberFormatter::ToString(123456789.012, 3) == "123,456,789.012" );
-    CHECK( wxNumberFormatter::ToString(12345.012, -1) == "12,345" );
+    CHECK( wxNumberFormatter::ToString(           1.,  1) ==             "1.0" );
+    CHECK( wxNumberFormatter::ToString(     0.123456,  6) ==        "0.123456" );
+    CHECK( wxNumberFormatter::ToString(     1.234567,  6) ==        "1.234567" );
+    CHECK( wxNumberFormatter::ToString(     12.34567,  5) ==        "12.34567" );
+    CHECK( wxNumberFormatter::ToString(     123.4567,  4) ==        "123.4567" );
+    CHECK( wxNumberFormatter::ToString(      1234.56,  2) ==        "1,234.56" );
+    CHECK( wxNumberFormatter::ToString(      12345.6,  1) ==        "12,345.6" );
+    CHECK( wxNumberFormatter::ToString(123456789.012,  3) == "123,456,789.012" );
+    CHECK( wxNumberFormatter::ToString(    12345.012, -1) ==          "12,345" );
 
-    CHECK( wxNumberFormatter::ToString(-123.123, 4, wxNumberFormatter::Style_None)
-            == "-123.1230" );
-    CHECK( wxNumberFormatter::ToString( 0.02, 1, wxNumberFormatter::Style_None)
-            == "0.0" );
-    CHECK( wxNumberFormatter::ToString(-0.02, 1, wxNumberFormatter::Style_None)
-            == "-0.0" );
+    CHECK( ToStringWithTrailingZeroes(-123.123, 4) == "-123.1230" );
+    CHECK( ToStringWithTrailingZeroes(    0.02, 1) ==       "0.0" );
+    CHECK( ToStringWithTrailingZeroes(   -0.02, 1) ==      "-0.0" );
 }
 
 TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::NoTrailingZeroes", "[numformatter]")
@@ -120,36 +143,17 @@ TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::NoTrailingZeroes", "[numfo
     if ( !CanRunTest() )
         return;
 
-    CHECK( wxNumberFormatter::ToString(123., 3) == "123.000" );
-
-    CHECK( wxNumberFormatter::ToString(123., 3, wxNumberFormatter::Style_NoTrailingZeroes)
-            == "123" );
-
-    CHECK( wxNumberFormatter::ToString(123., 9, wxNumberFormatter::Style_NoTrailingZeroes)
-            == "123" );
-
-    CHECK( wxNumberFormatter::ToString(123.456, 3, wxNumberFormatter::Style_NoTrailingZeroes)
-            == "123.456" );
-
-    CHECK( wxNumberFormatter::ToString(123.456, 9) == "123.456000000" );
-
-    CHECK( wxNumberFormatter::ToString(123.456, 9, wxNumberFormatter::Style_NoTrailingZeroes)
-            == "123.456" );
-
-    CHECK( wxNumberFormatter::ToString(123.123, 2, wxNumberFormatter::Style_NoTrailingZeroes)
-            == "123.12" );
-
-    CHECK( wxNumberFormatter::ToString(123.123, 0, wxNumberFormatter::Style_NoTrailingZeroes)
-            == "123" );
-
-    CHECK( wxNumberFormatter::ToString(-0.000123, 3, wxNumberFormatter::Style_NoTrailingZeroes)
-            == "0" );
-
-    CHECK( wxNumberFormatter::ToString(123., -1, wxNumberFormatter::Style_NoTrailingZeroes)
-            == "123" );
-
-    CHECK( wxNumberFormatter::ToString(1e-120, -1, wxNumberFormatter::Style_NoTrailingZeroes)
-            == "1e-120" );
+    CHECK( ToStringWithTrailingZeroes   (      123., 3) ==       "123.000" );
+    CHECK( ToStringWithoutTrailingZeroes(      123., 3) ==           "123" );
+    CHECK( ToStringWithoutTrailingZeroes(      123., 9) ==           "123" );
+    CHECK( ToStringWithoutTrailingZeroes(   123.456, 3) ==       "123.456" );
+    CHECK( ToStringWithTrailingZeroes   (   123.456, 9) == "123.456000000" );
+    CHECK( ToStringWithoutTrailingZeroes(   123.456, 9) ==       "123.456" );
+    CHECK( ToStringWithoutTrailingZeroes(   123.123, 2) ==        "123.12" );
+    CHECK( ToStringWithoutTrailingZeroes(   123.123, 0) ==           "123" );
+    CHECK( ToStringWithoutTrailingZeroes( -0.000123, 3) ==             "0" );
+    CHECK( ToStringWithoutTrailingZeroes(     123., -1) ==           "123" );
+    CHECK( ToStringWithoutTrailingZeroes(   1e-120, -1) ==        "1e-120" );
 }
 
 TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::LongFromString", "[numformatter]")

--- a/tests/strings/numformatter.cpp
+++ b/tests/strings/numformatter.cpp
@@ -206,6 +206,10 @@ TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::LongLongFromString", "[num
     CHECK( !wxNumberFormatter::FromString("", &l) );
     CHECK( !wxNumberFormatter::FromString("foo", &l) );
     CHECK( !wxNumberFormatter::FromString("1.234", &l) );
+    CHECK( !wxNumberFormatter::FromString("-", &l) );
+
+    CHECK( wxNumberFormatter::FromString("0", &l) );
+    CHECK( l == 0 );
 
     CHECK( wxNumberFormatter::FromString("123", &l) );
     CHECK( l == 123 );
@@ -224,9 +228,62 @@ TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::LongLongFromString", "[num
 
     CHECK( wxNumberFormatter::FromString("1,234,567", &l) );
     CHECK( l == 1234567 );
+
+    CHECK( wxNumberFormatter::FromString("-123", &l) );
+    CHECK( l == -123 );
+
+    CHECK( wxNumberFormatter::FromString("9223372036854775807", &l) );
+    CHECK( l == wxINT64_MAX );
+
+    CHECK( !wxNumberFormatter::FromString("9223372036854775808", &l) );
 }
 
 #endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
+
+TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::ULongLongFromString", "[numformatter]")
+{
+    if ( !CanRunTest() )
+        return;
+
+    wxULongLong_t u;
+    CHECK( !wxNumberFormatter::FromString("", &u) );
+    CHECK( !wxNumberFormatter::FromString("bar", &u) );
+    CHECK( !wxNumberFormatter::FromString("1.234", &u) );
+    CHECK( !wxNumberFormatter::FromString("-2", &u) );
+    CHECK( !wxNumberFormatter::FromString("-", &u) );
+
+    CHECK( wxNumberFormatter::FromString("0", &u) );
+    CHECK( u == 0 );
+
+    CHECK( wxNumberFormatter::FromString("123", &u) );
+    CHECK( u == 123 );
+
+    CHECK( wxNumberFormatter::FromString("1234", &u) );
+    CHECK( u == 1234 );
+
+    CHECK( wxNumberFormatter::FromString("1,234", &u) );
+    CHECK( u == 1234 );
+
+    CHECK( wxNumberFormatter::FromString("12,345", &u) );
+    CHECK( u == 12345 );
+
+    CHECK( wxNumberFormatter::FromString("123,456", &u) );
+    CHECK( u == 123456 );
+
+    CHECK( wxNumberFormatter::FromString("1,234,567", &u) );
+    CHECK( u == 1234567 );
+
+    CHECK( wxNumberFormatter::FromString("9223372036854775807", &u) );
+    CHECK( u == static_cast<wxULongLong_t>(wxINT64_MAX) );
+
+    CHECK( wxNumberFormatter::FromString("9223372036854775808", &u) );
+    CHECK( u == static_cast<wxULongLong_t>(wxINT64_MAX) + 1 );
+
+    CHECK( wxNumberFormatter::FromString("18446744073709551615", &u) );
+    CHECK( u == wxUINT64_MAX );
+
+    CHECK( !wxNumberFormatter::FromString("18446744073709551616", &u) );
+}
 
 TEST_CASE_METHOD(NumFormatterTestCase, "NumFormatter::DoubleFromString", "[numformatter]")
 {

--- a/tests/validators/valnum.cpp
+++ b/tests/validators/valnum.cpp
@@ -99,6 +99,8 @@ TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::TransferUnsigned", "[valnum]")
     m_text->ChangeValue("4294967295"); // == ULONG_MAX in 32 bits
     CHECK( valUnsigned.TransferFromWindow() );
     CHECK( value == wxUINT32_MAX );
+    CHECK( valUnsigned.TransferToWindow() );
+    CHECK( m_text->GetValue() == "4294967295" );
 
     m_text->ChangeValue("4294967296"); // == ULONG_MAX + 1
     CHECK( !valUnsigned.TransferFromWindow() );
@@ -116,20 +118,41 @@ TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::TransferULL", "[valnum]")
     wxIntegerValidator<unsigned long long> valULL(&value);
     valULL.SetWindow(m_text);
 
-    m_text->ChangeValue("9223372036854775807"); // == LLONG_MAX
-    CHECK( valULL.TransferFromWindow() );
-    CHECK( value == static_cast<wxULongLong_t>(wxINT64_MAX) );
+    SECTION("LLONG_MAX")
+    {
+        m_text->ChangeValue("9223372036854775807"); // == LLONG_MAX
+        REQUIRE( valULL.TransferFromWindow() );
+        CHECK( value == static_cast<wxULongLong_t>(wxINT64_MAX) );
 
-    m_text->ChangeValue("9223372036854775808"); // == LLONG_MAX + 1
-    CHECK( valULL.TransferFromWindow() );
-    CHECK( value == static_cast<wxULongLong_t>(wxINT64_MAX) + 1 );
+        REQUIRE( valULL.TransferToWindow() );
+        CHECK( m_text->GetValue() == "9223372036854775807" );
+    }
 
-    m_text->ChangeValue("18446744073709551615"); // == ULLONG_MAX
-    CHECK( valULL.TransferFromWindow() );
-    CHECK( value == wxUINT64_MAX );
+    SECTION("LLONG_MAX+1")
+    {
+        m_text->ChangeValue("9223372036854775808"); // == LLONG_MAX + 1
+        REQUIRE( valULL.TransferFromWindow() );
+        CHECK( value == static_cast<wxULongLong_t>(wxINT64_MAX) + 1 );
 
-    m_text->ChangeValue("18446744073709551616"); // == ULLONG_MAX + 1
-    CHECK( !valULL.TransferFromWindow() );
+        REQUIRE( valULL.TransferToWindow() );
+        CHECK( m_text->GetValue() == "9223372036854775808" );
+    }
+
+    SECTION("ULLONG_MAX")
+    {
+        m_text->ChangeValue("18446744073709551615"); // == ULLONG_MAX
+        REQUIRE( valULL.TransferFromWindow() );
+        CHECK( value == wxUINT64_MAX );
+
+        REQUIRE( valULL.TransferToWindow() );
+        CHECK( m_text->GetValue() == "18446744073709551615" );
+    }
+
+    SECTION("ULLONG_MAX+1")
+    {
+        m_text->ChangeValue("18446744073709551616"); // == ULLONG_MAX + 1
+        CHECK( !valULL.TransferFromWindow() );
+    }
 }
 
 TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::TransferFloat", "[valnum]")

--- a/tests/validators/valnum.cpp
+++ b/tests/validators/valnum.cpp
@@ -96,11 +96,40 @@ TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::TransferUnsigned", "[valnum]")
     CHECK( valUnsigned.TransferFromWindow() );
     CHECK( value == 234 );
 
+    m_text->ChangeValue("4294967295"); // == ULONG_MAX in 32 bits
+    CHECK( valUnsigned.TransferFromWindow() );
+    CHECK( value == wxUINT32_MAX );
+
+    m_text->ChangeValue("4294967296"); // == ULONG_MAX + 1
+    CHECK( !valUnsigned.TransferFromWindow() );
+
     m_text->ChangeValue("18446744073709551616"); // == ULLONG_MAX + 1
     CHECK( !valUnsigned.TransferFromWindow() );
 
     m_text->Clear();
     CHECK( !valUnsigned.TransferFromWindow() );
+}
+
+TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::TransferULL", "[valnum]")
+{
+    unsigned long long value = 0;
+    wxIntegerValidator<unsigned long long> valULL(&value);
+    valULL.SetWindow(m_text);
+
+    m_text->ChangeValue("9223372036854775807"); // == LLONG_MAX
+    CHECK( valULL.TransferFromWindow() );
+    CHECK( value == static_cast<wxULongLong_t>(wxINT64_MAX) );
+
+    m_text->ChangeValue("9223372036854775808"); // == LLONG_MAX + 1
+    CHECK( valULL.TransferFromWindow() );
+    CHECK( value == static_cast<wxULongLong_t>(wxINT64_MAX) + 1 );
+
+    m_text->ChangeValue("18446744073709551615"); // == ULLONG_MAX
+    CHECK( valULL.TransferFromWindow() );
+    CHECK( value == wxUINT64_MAX );
+
+    m_text->ChangeValue("18446744073709551616"); // == ULLONG_MAX + 1
+    CHECK( !valULL.TransferFromWindow() );
 }
 
 TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::TransferFloat", "[valnum]")

--- a/tests/validators/valnum.cpp
+++ b/tests/validators/valnum.cpp
@@ -50,26 +50,26 @@ TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::TransferInt", "[valnum]")
     wxIntegerValidator<int> valInt(&value);
     valInt.SetWindow(m_text);
 
-    CPPUNIT_ASSERT( valInt.TransferToWindow() );
-    CPPUNIT_ASSERT_EQUAL( "0", m_text->GetValue() );
+    CHECK( valInt.TransferToWindow() );
+    CHECK( m_text->GetValue() == "0" );
 
     value = 17;
-    CPPUNIT_ASSERT( valInt.TransferToWindow() );
-    CPPUNIT_ASSERT_EQUAL( "17", m_text->GetValue() );
+    CHECK( valInt.TransferToWindow() );
+    CHECK( m_text->GetValue() == "17" );
 
 
     m_text->ChangeValue("foobar");
-    CPPUNIT_ASSERT( !valInt.TransferFromWindow() );
+    CHECK( !valInt.TransferFromWindow() );
 
     m_text->ChangeValue("-234");
-    CPPUNIT_ASSERT( valInt.TransferFromWindow() );
-    CPPUNIT_ASSERT_EQUAL( -234, value );
+    CHECK( valInt.TransferFromWindow() );
+    CHECK( value == -234 );
 
     m_text->ChangeValue("9223372036854775808"); // == LLONG_MAX + 1
-    CPPUNIT_ASSERT( !valInt.TransferFromWindow() );
+    CHECK( !valInt.TransferFromWindow() );
 
     m_text->Clear();
-    CPPUNIT_ASSERT( !valInt.TransferFromWindow() );
+    CHECK( !valInt.TransferFromWindow() );
 }
 
 TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::TransferUnsigned", "[valnum]")
@@ -78,29 +78,29 @@ TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::TransferUnsigned", "[valnum]")
     wxIntegerValidator<unsigned> valUnsigned(&value);
     valUnsigned.SetWindow(m_text);
 
-    CPPUNIT_ASSERT( valUnsigned.TransferToWindow() );
-    CPPUNIT_ASSERT_EQUAL( "0", m_text->GetValue() );
+    CHECK( valUnsigned.TransferToWindow() );
+    CHECK( m_text->GetValue() == "0" );
 
     value = 17;
-    CPPUNIT_ASSERT( valUnsigned.TransferToWindow() );
-    CPPUNIT_ASSERT_EQUAL( "17", m_text->GetValue() );
+    CHECK( valUnsigned.TransferToWindow() );
+    CHECK( m_text->GetValue() == "17" );
 
 
     m_text->ChangeValue("foobar");
-    CPPUNIT_ASSERT( !valUnsigned.TransferFromWindow() );
+    CHECK( !valUnsigned.TransferFromWindow() );
 
     m_text->ChangeValue("-234");
-    CPPUNIT_ASSERT( !valUnsigned.TransferFromWindow() );
+    CHECK( !valUnsigned.TransferFromWindow() );
 
     m_text->ChangeValue("234");
-    CPPUNIT_ASSERT( valUnsigned.TransferFromWindow() );
-    CPPUNIT_ASSERT_EQUAL( 234, value );
+    CHECK( valUnsigned.TransferFromWindow() );
+    CHECK( value == 234 );
 
     m_text->ChangeValue("18446744073709551616"); // == ULLONG_MAX + 1
-    CPPUNIT_ASSERT( !valUnsigned.TransferFromWindow() );
+    CHECK( !valUnsigned.TransferFromWindow() );
 
     m_text->Clear();
-    CPPUNIT_ASSERT( !valUnsigned.TransferFromWindow() );
+    CHECK( !valUnsigned.TransferFromWindow() );
 }
 
 TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::TransferFloat", "[valnum]")
@@ -112,27 +112,27 @@ TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::TransferFloat", "[valnum]")
     wxFloatingPointValidator<float> valFloat(3, &value);
     valFloat.SetWindow(m_text);
 
-    CPPUNIT_ASSERT( valFloat.TransferToWindow() );
-    CPPUNIT_ASSERT_EQUAL( "0.000", m_text->GetValue() );
+    CHECK( valFloat.TransferToWindow() );
+    CHECK( m_text->GetValue() == "0.000" );
 
     value = 1.234f;
-    CPPUNIT_ASSERT( valFloat.TransferToWindow() );
-    CPPUNIT_ASSERT_EQUAL( "1.234", m_text->GetValue() );
+    CHECK( valFloat.TransferToWindow() );
+    CHECK( m_text->GetValue() == "1.234" );
 
     value = 1.2345678f;
-    CPPUNIT_ASSERT( valFloat.TransferToWindow() );
-    CPPUNIT_ASSERT_EQUAL( "1.235", m_text->GetValue() );
+    CHECK( valFloat.TransferToWindow() );
+    CHECK( m_text->GetValue() == "1.235" );
 
 
     m_text->ChangeValue("foobar");
-    CPPUNIT_ASSERT( !valFloat.TransferFromWindow() );
+    CHECK( !valFloat.TransferFromWindow() );
 
     m_text->ChangeValue("-234.567");
-    CPPUNIT_ASSERT( valFloat.TransferFromWindow() );
-    CPPUNIT_ASSERT_EQUAL( -234.567f, value );
+    CHECK( valFloat.TransferFromWindow() );
+    CHECK( value == -234.567f );
 
     m_text->Clear();
-    CPPUNIT_ASSERT( !valFloat.TransferFromWindow() );
+    CHECK( !valFloat.TransferFromWindow() );
 }
 
 TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::ZeroAsBlank", "[valnum]")
@@ -143,12 +143,12 @@ TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::ZeroAsBlank", "[valnum]")
 
     wxValidator * const val = m_text->GetValidator();
 
-    CPPUNIT_ASSERT( val->TransferToWindow() );
-    CPPUNIT_ASSERT_EQUAL( "", m_text->GetValue() );
+    CHECK( val->TransferToWindow() );
+    CHECK( m_text->GetValue() == "" );
 
     value++;
-    CPPUNIT_ASSERT( val->TransferFromWindow() );
-    CPPUNIT_ASSERT_EQUAL( 0, value );
+    CHECK( val->TransferFromWindow() );
+    CHECK( value == 0 );
 }
 
 TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::NoTrailingZeroes", "[valnum]")
@@ -162,12 +162,12 @@ TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::NoTrailingZeroes", "[valnum]")
 
     wxValidator * const val = m_text->GetValidator();
 
-    CPPUNIT_ASSERT( val->TransferToWindow() );
-    CPPUNIT_ASSERT_EQUAL( "1.2", m_text->GetValue() );
+    CHECK( val->TransferToWindow() );
+    CHECK( m_text->GetValue() == "1.2" );
 
     value = 1.234;
-    CPPUNIT_ASSERT( val->TransferToWindow() );
-    CPPUNIT_ASSERT_EQUAL( "1.234", m_text->GetValue() );
+    CHECK( val->TransferToWindow() );
+    CHECK( m_text->GetValue() == "1.234" );
 }
 
 #if wxUSE_UIACTIONSIMULATOR
@@ -202,12 +202,12 @@ TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::Interactive", "[valnum]")
     m_text->SetFocus();
     sim.Char('-');
     wxYield();
-    CPPUNIT_ASSERT_EQUAL( "", m_text->GetValue() );
+    CHECK( m_text->GetValue() == "" );
 
     // Neither is entering '.' or any non-digit character.
     sim.Text(".a+/");
     wxYield();
-    CPPUNIT_ASSERT_EQUAL( "", m_text->GetValue() );
+    CHECK( m_text->GetValue() == "" );
 
     // Entering digits should work though and after leaving the control the
     // contents should be normalized.
@@ -216,43 +216,43 @@ TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::Interactive", "[valnum]")
     text2->SetFocus();
     wxYield();
     if ( loc.IsOk() )
-        CPPUNIT_ASSERT_EQUAL( "1,234,567", m_text->GetValue() );
+        CHECK( m_text->GetValue() == "1,234,567" );
     else
-        CPPUNIT_ASSERT_EQUAL( "1234567", m_text->GetValue() );
+        CHECK( m_text->GetValue() == "1234567" );
 
 
     // Entering both '-' and '.' in this control should work but only in the
     // correct order.
     sim.Char('-');
     wxYield();
-    CPPUNIT_ASSERT_EQUAL( "-", text2->GetValue() );
+    CHECK( text2->GetValue() == "-" );
 
     text2->SetInsertionPoint(0);
     sim.Char('.');
     wxYield();
-    CPPUNIT_ASSERT_EQUAL( "-", text2->GetValue() );
+    CHECK( text2->GetValue() == "-" );
 
     text2->SetInsertionPointEnd();
     sim.Char('.');
     wxYield();
-    CPPUNIT_ASSERT_EQUAL( "-.", text2->GetValue() );
+    CHECK( text2->GetValue() == "-." );
 
     // Adding up to three digits after the point should work.
     sim.Text("987");
     wxYield();
-    CPPUNIT_ASSERT_EQUAL( "-.987", text2->GetValue() );
+    CHECK( text2->GetValue() == "-.987" );
 
     // But no more.
     sim.Text("654");
     wxYield();
-    CPPUNIT_ASSERT_EQUAL( "-.987", text2->GetValue() );
+    CHECK( text2->GetValue() == "-.987" );
 
     // We can remove one digit and another one though.
     sim.Char(WXK_BACK);
     sim.Char(WXK_BACK);
     sim.Char('6');
     wxYield();
-    CPPUNIT_ASSERT_EQUAL( "-.96", text2->GetValue() );
+    CHECK( text2->GetValue() == "-.96" );
 
 
     // Also test the range constraint.
@@ -260,11 +260,11 @@ TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::Interactive", "[valnum]")
 
     sim.Char('9');
     wxYield();
-    CPPUNIT_ASSERT_EQUAL( "9", text2->GetValue() );
+    CHECK( text2->GetValue() == "9" );
 
     sim.Char('9');
     wxYield();
-    CPPUNIT_ASSERT_EQUAL( "9", text2->GetValue() );
+    CHECK( text2->GetValue() == "9" );
 }
 
 #endif // wxUSE_UIACTIONSIMULATOR

--- a/tests/validators/valnum.cpp
+++ b/tests/validators/valnum.cpp
@@ -22,55 +22,29 @@
 #include "testableframe.h"
 #include "wx/uiaction.h"
 
-class NumValidatorTestCase : public CppUnit::TestCase
+class NumValidatorTestCase
 {
 public:
-    NumValidatorTestCase() { }
+    NumValidatorTestCase();
+    ~NumValidatorTestCase();
 
-    void setUp() wxOVERRIDE;
-    void tearDown() wxOVERRIDE;
-
-private:
-    CPPUNIT_TEST_SUITE( NumValidatorTestCase );
-        CPPUNIT_TEST( TransferInt );
-        CPPUNIT_TEST( TransferUnsigned );
-        CPPUNIT_TEST( TransferFloat );
-        CPPUNIT_TEST( ZeroAsBlank );
-        CPPUNIT_TEST( NoTrailingZeroes );
-        WXUISIM_TEST( Interactive );
-    CPPUNIT_TEST_SUITE_END();
-
-    void TransferInt();
-    void TransferUnsigned();
-    void TransferFloat();
-    void ZeroAsBlank();
-    void NoTrailingZeroes();
-#if wxUSE_UIACTIONSIMULATOR
-    void Interactive();
-#endif // wxUSE_UIACTIONSIMULATOR
-
-    wxTextCtrl *m_text;
+protected:
+    wxTextCtrl* const m_text;
 
     wxDECLARE_NO_COPY_CLASS(NumValidatorTestCase);
 };
 
-// register in the unnamed registry so that these tests are run by default
-CPPUNIT_TEST_SUITE_REGISTRATION( NumValidatorTestCase );
-
-// also include in its own registry so that these tests can be run alone
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( NumValidatorTestCase, "NumValidatorTestCase" );
-
-void NumValidatorTestCase::setUp()
+NumValidatorTestCase::NumValidatorTestCase()
+    : m_text(new wxTextCtrl(wxTheApp->GetTopWindow(), wxID_ANY))
 {
-    m_text = new wxTextCtrl(wxTheApp->GetTopWindow(), wxID_ANY);
 }
 
-void NumValidatorTestCase::tearDown()
+NumValidatorTestCase::~NumValidatorTestCase()
 {
-    wxTheApp->GetTopWindow()->DestroyChildren();
+    delete m_text;
 }
 
-void NumValidatorTestCase::TransferInt()
+TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::TransferInt", "[valnum]")
 {
     int value = 0;
     wxIntegerValidator<int> valInt(&value);
@@ -98,7 +72,7 @@ void NumValidatorTestCase::TransferInt()
     CPPUNIT_ASSERT( !valInt.TransferFromWindow() );
 }
 
-void NumValidatorTestCase::TransferUnsigned()
+TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::TransferUnsigned", "[valnum]")
 {
     unsigned value = 0;
     wxIntegerValidator<unsigned> valUnsigned(&value);
@@ -129,7 +103,7 @@ void NumValidatorTestCase::TransferUnsigned()
     CPPUNIT_ASSERT( !valUnsigned.TransferFromWindow() );
 }
 
-void NumValidatorTestCase::TransferFloat()
+TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::TransferFloat", "[valnum]")
 {
     // We need a locale with point as decimal separator.
     wxLocale loc(wxLANGUAGE_ENGLISH_UK, wxLOCALE_DONT_LOAD_DEFAULT);
@@ -161,7 +135,7 @@ void NumValidatorTestCase::TransferFloat()
     CPPUNIT_ASSERT( !valFloat.TransferFromWindow() );
 }
 
-void NumValidatorTestCase::ZeroAsBlank()
+TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::ZeroAsBlank", "[valnum]")
 {
     long value = 0;
     m_text->SetValidator(
@@ -177,7 +151,7 @@ void NumValidatorTestCase::ZeroAsBlank()
     CPPUNIT_ASSERT_EQUAL( 0, value );
 }
 
-void NumValidatorTestCase::NoTrailingZeroes()
+TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::NoTrailingZeroes", "[valnum]")
 {
     // We need a locale with point as decimal separator.
     wxLocale loc(wxLANGUAGE_ENGLISH_UK, wxLOCALE_DONT_LOAD_DEFAULT);
@@ -198,7 +172,7 @@ void NumValidatorTestCase::NoTrailingZeroes()
 
 #if wxUSE_UIACTIONSIMULATOR
 
-void NumValidatorTestCase::Interactive()
+TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::Interactive", "[valnum]")
 {
 #ifdef __WXMSW__
     // FIXME: This test fails on MSW buildbot slaves although works fine on


### PR DESCRIPTION
This is still a bit ugly and we probably should get rid of all this `LongestValueType` stuff completely and just work with strings as "value containers" instead, but it's not more complicated than before (I'd even say it's slightly simpler) and does allow the new unit tests to pass, so seems like an improvement.

@AliKet please let me know if you see anything wrong with this.