### PR TITLE
Provide descriptions for WinHTTP error messages

### DIFF
--- a/include/wx/msw/private/webrequest_winhttp.h
+++ b/include/wx/msw/private/webrequest_winhttp.h
@@ -114,11 +114,15 @@ private:
 
     void CreateResponse();
 
-    // Retrieve the error message corresponding to the given error and set the
-    // state to failed with this message as error string.
-    void SetFailed(DWORD errorCode);
+    // Set the state to State_Failed with the error string including the
+    // provided description of the operation and the error message for this
+    // error code.
+    void SetFailed(const wxString& operation, DWORD errorCode);
 
-    void SetFailedWithLastError() { SetFailed(::GetLastError()); }
+    void SetFailedWithLastError(const wxString& operation)
+    {
+        SetFailed(operation, ::GetLastError());
+    }
 
     friend class wxWebAuthChallengeWinHTTP;
 


### PR DESCRIPTION
Just the error code is not very useful as it doesn't say anything about
what exactly failed, e.g. seeing "The buffers supplied to a function was
too small." doesn't help understanding which function was passed a too
small buffer, so add an extra parameter to SetFailed[WithLastError]() to
log this information too.

Also log the error code itself, because SEC_E_BUFFER_TOO_SMALL is
arguably more clear than its ungrammatical error message.

No real changes.

---

@TcT2k @MaartenBent please let me know if you have any other/better ideas about how to debug errors like [this one](https://ci.appveyor.com/project/wxWidgets/wxwidgets/builds/37777514/job/gw3ns0rm9aidpt6p#L1852).