### PR TITLE
Remove hardcoded max width from STC autocomplete listbox

### DIFF
--- a/src/stc/PlatWX.cpp
+++ b/src/stc/PlatWX.cpp
@@ -2647,6 +2647,7 @@ public:
 
     // Setters
     void SetContainerBorderSize(int);
+    void SetMaxListBoxWidth(int);
 
     // ListBoxImpl implementation
     virtual void SetListBoxFont(Font &font);
@@ -2698,6 +2699,7 @@ protected:
     int m_textHeight;
     int m_itemHeight;
     int m_textTopGap;
+    int m_maxBoxWidth;  // 0 means no max width
 
     // These drawing parameters are set internally and can be changed if needed
     // to better match the appearance of a list box on a specific platform.
@@ -2711,7 +2713,7 @@ wxSTCListBox::wxSTCListBox(wxWindow* parent, wxSTCListBoxVisualData* v, int ht)
               m_visualData(v), m_maxStrWidth(0), m_currentRow(wxNOT_FOUND),
               m_doubleClickAction(NULL), m_doubleClickActionData(NULL),
               m_aveCharWidth(8), m_textHeight(ht), m_itemHeight(ht),
-              m_textTopGap(0)
+              m_textTopGap(0), m_maxBoxWidth(350)
 {
     wxVListBox::Create(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                        wxBORDER_NONE, "AutoCompListBox");
@@ -2757,6 +2759,11 @@ void wxSTCListBox::SetContainerBorderSize(int s)
     m_borderSize = s;
 }
 
+void wxSTCListBox::SetMaxListBoxWidth(int maxWidth)
+{
+    m_maxBoxWidth = maxWidth;
+}
+
 void wxSTCListBox::SetListBoxFont(Font &font)
 {
     SetFont(*((wxFont*)font.GetID()));
@@ -2776,10 +2783,14 @@ PRectangle wxSTCListBox::GetDesiredRect() const
     int maxh ;
 
     // give it a default if there are no lines, and/or add a bit more
-    if (maxw == 0) maxw = 100;
+    if ( maxw == 0 )
+        maxw = 100;
+
     maxw += TextBoxFromClientEdge() + m_textBoxToTextGap + m_aveCharWidth * 3;
-    if (maxw > 350)
-        maxw = 350;
+
+    // m_maxBoxWidth == 0 or negative means no maximum
+    if ( ( m_maxBoxWidth > 0 ) && ( maxw > m_maxBoxWidth ) )
+        maxw = m_maxBoxWidth;
 
     // estimate a desired height
     const int count = Length();
@@ -3271,7 +3282,7 @@ void wxSTCListBoxWin::OnPaint(wxPaintEvent& WXUNUSED(evt))
 //----------------------------------------------------------------------
 
 ListBoxImpl::ListBoxImpl()
-            :m_listBox(NULL), m_visualData(new wxSTCListBoxVisualData(5))
+            :m_listBox(NULL), m_visualData(new wxSTCListBoxVisualData(5)), m_listBoxWidth(-1)
 {
 }
 
@@ -3290,6 +3301,19 @@ void ListBoxImpl::Create(Window &parent, int WXUNUSED(ctrlID),
                          bool WXUNUSED(unicodeMode_), int technology_) {
     wid = new wxSTCListBoxWin(GETWIN(parent.GetID()), &m_listBox, m_visualData,
                               lineHeight_, technology_);
+
+    if ( m_listBoxWidth >= -1 )
+        m_listBox->SetMaxListBoxWidth(m_listBoxWidth);
+}
+
+
+void ListBoxImpl::SetMaxListBoxWidth(int width) {
+    // Store the setting for future list box creations
+    m_listBoxWidth = width;
+
+    // Update the listbox if it currently exists, but allow this to be called before it is created
+    if ( m_listBox )
+        m_listBox->SetMaxListBoxWidth(m_listBoxWidth);
 }
 
 

--- a/src/stc/PlatWX.h
+++ b/src/stc/PlatWX.h
@@ -23,6 +23,10 @@ private:
     wxSTCListBox*           m_listBox;
     wxSTCListBoxVisualData* m_visualData;
 
+    // Allow the implementation to control the width of the underlying listbox.
+    // If this is negative, then the underlying listbox retains control over the max width.
+    int                     m_listBoxWidth;
+
 public:
     ListBoxImpl();
     ~ListBoxImpl();
@@ -30,6 +34,7 @@ public:
 
     virtual void SetFont(Font &font) wxOVERRIDE;
     virtual void Create(Window &parent, int ctrlID, Point location_, int lineHeight_, bool unicodeMode_, int technology_) wxOVERRIDE;
+            void SetMaxListBoxWidth(int width);
     virtual void SetAverageCharWidth(int width) wxOVERRIDE;
     virtual void SetVisibleRows(int rows) wxOVERRIDE;
     virtual int GetVisibleRows() const wxOVERRIDE;

--- a/src/stc/ScintillaWX.cpp
+++ b/src/stc/ScintillaWX.cpp
@@ -292,8 +292,11 @@ void ScintillaWX::Initialise() {
     kmap.AssignCmdKey(SCK_DOWN, SCI_CTRL, SCI_DOCUMENTEND);
 #endif // __WXMAC__
 
-    static_cast<ListBoxImpl*>(ac.lb)->SetListInfo(&listType, &(ac.posStart),
-                                                  &(ac.startLen));
+    ListBoxImpl* autoCompleteLB = static_cast<ListBoxImpl*>( ac.lb );
+
+    // Let the Scintilla autocomplete engine determine the max size for the listbox
+    autoCompleteLB->SetMaxListBoxWidth( 0 );
+    autoCompleteLB->SetListInfo( &listType, &(ac.posStart), &(ac.startLen) );
 }
 
 


### PR DESCRIPTION
The Scintilla engine will automatically truncate lines in the autocomplete listbox based on the call to AutoCompSetMaxWidth(). It is not good to do it in the wx implementation code as well, since then the meaning of `AutoCompSetMaxWidth(0)` (e.g. no truncation) is not valid and the list items will be truncated anyway.

This can be seen with this small diff to the `stc` sample:
```
diff --git a/samples/stc/edit.cpp b/samples/stc/edit.cpp
index 64b7b38f03..7a22725457 100644
--- a/samples/stc/edit.cpp
+++ b/samples/stc/edit.cpp
@@ -510,7 +510,8 @@ void Edit::OnCharAdded (wxStyledTextEvent &event) {
     }
     else if (chr == '#') {
         wxString s = "define?0 elif?0 else?0 endif?0 error?0 if?0 ifdef?0 "
-                     "ifndef?0 include?0 line?0 pragma?0 undef?0";
+                     "ifndef?0 include?0 line?0 pragma?0 undef?0 abdcef_123456789_123456789_123456789_123456789_123456789?0";
+        AutoCompSetMaxWidth( 0 );
         AutoCompShow(0,s);
     }
 }
```

Before this change, the autocomplete listbox will still truncate the long string (starting with `abcdef`) even though no truncation was requested (by calling `AutoCompSetMaxWidth( 0 )` it tells the control to ensure the autocomplete listbox is autosized to fit the longest item). After this change, the full string is shown properly.

Before:
![image](https://user-images.githubusercontent.com/2262453/109055175-b9f74100-76d6-11eb-9d68-97784c9d0b5f.png)

After:
![image](https://user-images.githubusercontent.com/2262453/109055080-9f24cc80-76d6-11eb-98db-3b5fd2b437b1.png)
