### PR TITLE
Fix search in wxSortedArrayString with custom compare function

### DIFF
--- a/include/wx/arrstr.h
+++ b/include/wx/arrstr.h
@@ -398,6 +398,9 @@ private:
   // (if the old buffer is big enough, just return NULL).
   wxString *Grow(size_t nIncrement);
 
+  // Binary search in the sorted array
+  size_t BinarySearch(const wxString& str, bool equal = false) const;
+
   size_t  m_nSize,    // current size of the array
           m_nCount;   // current number of elements
 

--- a/include/wx/dynarray.h
+++ b/include/wx/dynarray.h
@@ -255,6 +255,9 @@ public:
         Add(item);
     }
 
+protected:
+    SCMPFUNC GetCompareFunction() const wxNOEXCEPT { return m_fnCompare; }
+
 private:
     SCMPFUNC m_fnCompare;
 };

--- a/src/common/arrstr.cpp
+++ b/src/common/arrstr.cpp
@@ -198,15 +198,16 @@ int wxSortedArrayString::Index(const wxString& str,
     wxASSERT_MSG( bCase && !bFromEnd,
                   "search parameters ignored for sorted array" );
 
+    SCMPFUNC function = GetCompareFunction();
     wxSortedArrayString::const_iterator
         it = std::lower_bound(begin(), end(), str,
 #if __cplusplus >= 201103L || wxCHECK_VISUALC_VERSION(14)
-                              [](const wxString& s1, const wxString& s2)
+                              [function](const wxString& s1, const wxString& s2)
                               {
-                                  return s1 < s2;
+                                  return function(s1, s2) < 0;
                               }
 #else // C++98 version
-                              wxStringCompare(wxStringCmp())
+                              wxStringCompare(function)
 #endif // C++11/C++98
                               );
 

--- a/tests/arrays/arrays.cpp
+++ b/tests/arrays/arrays.cpp
@@ -399,6 +399,11 @@ void ArraysTestCase::SortedArray()
     ad.Add("Aa");
     CPPUNIT_ASSERT_EQUAL( "a", ad[0] );
     CPPUNIT_ASSERT_EQUAL( "Aa", ad[1] );
+    CPPUNIT_ASSERT_EQUAL( 0, ad.Index("a") );
+    CPPUNIT_ASSERT_EQUAL( 1, ad.Index("Aa") );
+    CPPUNIT_ASSERT_EQUAL( 2, ad.Index("AB") );
+    CPPUNIT_ASSERT_EQUAL( wxNOT_FOUND, ad.Index("A") );
+    CPPUNIT_ASSERT_EQUAL( wxNOT_FOUND, ad.Index("z") );
 }
 
 void ArraysTestCase::wxStringArraySplitTest()


### PR DESCRIPTION
Take the custom compare function into account in wxArrayString::Index(), move duplicated binary search code to BinarySearch() and add tests.