### PR TITLE
mediactrl: introduce runtime checks for GDK_WINDOWING

### DIFF
--- a/include/wx/gtk/private/mediactrl.h
+++ b/include/wx/gtk/private/mediactrl.h
@@ -1,0 +1,54 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/gtk/private/mediactrl.h
+// Purpose:     Wrap runtime checks to manage GTK windows with Wayland and X11
+// Author:      Pierluigi Passaro
+// Created:     2021-03-18
+// Copyright:   (c) 2021 Pierluigi Passaro <pierluigi.p@variscite.com>
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_GTK_PRIVATE_MEDIACTRL_H_
+#define _WX_GTK_PRIVATE_MEDIACTRL_H_
+
+#ifdef GDK_WINDOWING_X11
+    #include <gdk/gdkx.h>
+#endif
+#ifdef GDK_WINDOWING_WAYLAND
+    #include <gdk/gdkwayland.h>
+#endif
+
+//-----------------------------------------------------------------------------
+// "wxGtkGetIdFromWidget" from widget
+//
+// Get the windows_id performing run-time checks If the window wasn't realized
+// when Load was called, this is the callback for when it is - the purpose of
+// which is to tell GStreamer to play the video in our control
+//-----------------------------------------------------------------------------
+extern "C" {
+inline gpointer wxGtkGetIdFromWidget(GtkWidget* widget)
+{
+    gdk_flush();
+
+    GdkWindow* window = gtk_widget_get_window(widget);
+    wxASSERT(window);
+
+#ifdef GDK_WINDOWING_X11
+#ifdef __WXGTK3__
+    if ( GDK_IS_X11_WINDOW(window) )
+#endif
+    {
+        return (gpointer)GDK_WINDOW_XID(window);
+    }
+#endif
+#ifdef GDK_WINDOWING_WAYLAND
+    if ( GDK_IS_WAYLAND_WINDOW(window) )
+    {
+        return (gpointer)gdk_wayland_window_get_wl_surface(window);
+    }
+#endif
+
+    return (gpointer)NULL;
+}
+}
+
+#endif // _WX_GTK_PRIVATE_MEDIACTRL_H_

--- a/src/unix/mediactrl_gstplayer.cpp
+++ b/src/unix/mediactrl_gstplayer.cpp
@@ -27,7 +27,7 @@
 
 #ifdef __WXGTK__
     #include "wx/gtk/private/wrapgtk.h"
-    #include <gdk/gdkx.h>
+    #include "wx/gtk/private/mediactrl.h"
 #endif
 
 wxGCC_WARNING_SUPPRESS(cast-qual)
@@ -175,13 +175,8 @@ expose_event_callback(GtkWidget* widget, GdkEventExpose* event, wxGStreamerMedia
 extern "C" {
 static void realize_callback(GtkWidget* widget, wxGStreamerMediaBackend* be)
 {
-    gdk_flush();
-
-    GdkWindow* window = gtk_widget_get_window(widget);
-    wxASSERT(window);
-
     gst_player_video_overlay_video_renderer_set_window_handle(GST_PLAYER_VIDEO_OVERLAY_VIDEO_RENDERER(be->m_video_renderer),
-                                (gpointer) GDK_WINDOW_XID(window)
+                                wxGtkGetIdFromWidget(widget)
                                 );
     GtkWidget* w = be->GetControl()->m_wxwindow;
 #ifdef __WXGTK3__
@@ -326,9 +321,7 @@ bool wxGStreamerMediaBackend::CreateControl(wxControl* ctrl, wxWindow* parent,
     }
     else
     {
-        GdkWindow* window = gtk_widget_get_window(m_ctrl->m_wxwindow);
-        wxASSERT(window);
-        window_handle = (gpointer) GDK_WINDOW_XID(window);
+        window_handle = wxGtkGetIdFromWidget(m_ctrl->m_wxwindow);
 
         GtkWidget* w = m_ctrl->m_wxwindow;
 #ifdef __WXGTK3__


### PR DESCRIPTION
For GTK, the current implementation assumes X11 is the only window option.
Introduce runtime checks to manage Wayland too.

Signed-off-by: Pierluigi Passaro <pierluigi.p@variscite.com>