### PR TITLE
Fix dragging file in DnD sample

### DIFF
--- a/samples/dnd/dnd.cpp
+++ b/samples/dnd/dnd.cpp
@@ -1270,10 +1270,10 @@ void DnDFrame::OnUsePrimary(wxCommandEvent& event)
 
 #if wxUSE_DRAG_AND_DROP
 
-void DnDFrame::OnBeginDrag(wxTreeEvent& WXUNUSED(event))
+void DnDFrame::OnBeginDrag(wxTreeEvent& event)
 {
     wxFileDataObject data;
-    data.AddFile(m_ctrlDir->GetPath());
+    data.AddFile(m_ctrlDir->GetPath(event.GetItem()));
 
     wxDropSource dragSource(this);
     dragSource.SetData(data);


### PR DESCRIPTION
At least on Microsoft Windows, it is possible to start dragging an unselected
wxTreeCtrl item. Therefore, in wxEVT_TREE_BEGIN_DRAG handler do not use the
path that is currently selected in the control but the one that is actually
being dragged.