### PR TITLE
Improve handling of default locale under Unix and other enhancements

### DIFF
--- a/interface/wx/intl.h
+++ b/interface/wx/intl.h
@@ -459,9 +459,11 @@ public:
         try to translate the messages using the message catalogs for this locale.
 
         @param language
-            ::wxLanguage identifier of the locale.
-            @c wxLANGUAGE_DEFAULT has special meaning -- wxLocale will use system's
-            default language (see GetSystemLanguage()).
+            ::wxLanguage identifier of the locale. It can be either some
+            concrete language, e.g. @c wxLANGUAGE_ESPERANTO, or a special value
+            @c wxLANGUAGE_DEFAULT which means that wxLocale should use system's
+            default language (see GetSystemLanguage()). Notice that the value
+            @c wxLANGUAGE_UNKNOWN is not allowed here.
         @param flags
             Combination of the following:
             - wxLOCALE_LOAD_DEFAULT: Load the message catalog for the given locale

--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -89,15 +89,12 @@ namespace
 {
 
 #if defined(__UNIX__)
+
 // get just the language part ("en" in "en_GB")
 inline wxString ExtractLang(const wxString& langFull)
 {
     return langFull.BeforeFirst('_');
 }
-#endif
-
-// helper functions of GetSystemLanguage()
-#ifdef __UNIX__
 
 // get everything else (including the leading '_')
 inline wxString ExtractNotLang(const wxString& langFull)

--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -50,6 +50,9 @@
     #ifndef LOCALE_SNAME
     #define LOCALE_SNAME 0x5c
     #endif
+    #ifndef LOCALE_CUSTOM_UI_DEFAULT
+    #define LOCALE_CUSTOM_UI_DEFAULT 0x1400
+    #endif
 #endif
 
 #include "wx/file.h"
@@ -768,11 +771,11 @@ inline bool wxGetNonEmptyEnvVar(const wxString& name, wxString* value)
         }
     }
 #elif defined(__WIN32__)
-    LCID lcid = GetUserDefaultLCID();
-    if ( lcid != 0 )
+    const LANGID langid = ::GetUserDefaultUILanguage();
+    if ( langid != LOCALE_CUSTOM_UI_DEFAULT )
     {
-        wxUint32 lang = PRIMARYLANGID(LANGIDFROMLCID(lcid));
-        wxUint32 sublang = SUBLANGID(LANGIDFROMLCID(lcid));
+        wxUint32 lang = PRIMARYLANGID(langid);
+        wxUint32 sublang = SUBLANGID(langid);
 
         for ( i = 0; i < count; i++ )
         {

--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -547,10 +547,14 @@ bool wxLocale::Init(int lang, int flags)
 
 #elif defined(__WIN32__)
     const char *retloc;
-    if ( !info )
+    if ( lang == wxLANGUAGE_DEFAULT )
     {
-        // We're using the system language, but we don't know what it is, so
-        // just use setlocale() to deal with it.
+        ::SetThreadLocale(LOCALE_USER_DEFAULT);
+        wxMSWSetThreadUILanguage(LANG_USER_DEFAULT);
+
+        // We're using the system language, so let setlocale() deal with it: it
+        // does it better than we do and we might not even know about this
+        // language in the first place.
         retloc = wxSetlocale(LC_ALL, "");
     }
     else if ( info->WinLang == 0 )

--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -952,6 +952,9 @@ const wxLanguageInfo *wxLocale::GetLanguageInfo(int lang)
     if ( lang == wxLANGUAGE_DEFAULT )
         lang = GetSystemLanguage();
 
+    if ( lang == wxLANGUAGE_UNKNOWN )
+        return NULL;
+
     const size_t count = ms_languagesDB->GetCount();
     for ( size_t i = 0; i < count; i++ )
     {

--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -434,6 +434,10 @@ bool wxLocale::Init(int lang, int flags)
                   wxS("wxLOCALE_CONV_ENCODING is no longer supported, add charset to your catalogs") );
 #endif
 
+    wxCHECK_MSG( lang != wxLANGUAGE_UNKNOWN, false,
+                 wxS("Initializing unknown locale doesn't make sense, did you ")
+                 wxS("mean to use wxLANGUAGE_DEFAULT perhaps?") );
+
     wxString name, shortName;
 
     const wxLanguageInfo *info = GetLanguageInfo(lang);

--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -732,7 +732,7 @@ inline bool wxGetNonEmptyEnvVar(const wxString& name, wxString* value)
     {
         for ( i = 0; i < count; i++ )
         {
-            if ( ms_languagesDB->Item(i).CanonicalName == lang )
+            if ( ExtractLang(ms_languagesDB->Item(i).CanonicalName) == lang )
             {
                 break;
             }

--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -461,11 +461,11 @@ bool wxLocale::Init(int language, int flags)
 
     // Set the locale:
 #if defined(__UNIX__)
-    const wxString& locale = info->CanonicalName;
+    const wxString& shortName = info->CanonicalName;
 
     const char *retloc = wxSetlocaleTryUTF8(LC_ALL, locale);
 
-    const wxString langOnly = ExtractLang(locale);
+    const wxString langOnly = ExtractLang(shortName);
     if ( !retloc )
     {
         // Some C libraries don't like xx_YY form and require xx only
@@ -478,11 +478,11 @@ bool wxLocale::Init(int language, int flags)
         // so will translate the abbrev for them
         wxString localeAlt;
         if ( langOnly == wxS("he") )
-            localeAlt = wxS("iw") + ExtractNotLang(locale);
+            localeAlt = wxS("iw") + ExtractNotLang(shortName);
         else if ( langOnly == wxS("id") )
-            localeAlt = wxS("in") + ExtractNotLang(locale);
+            localeAlt = wxS("in") + ExtractNotLang(shortName);
         else if ( langOnly == wxS("yi") )
-            localeAlt = wxS("ji") + ExtractNotLang(locale);
+            localeAlt = wxS("ji") + ExtractNotLang(shortName);
         else if ( langOnly == wxS("nb") )
             localeAlt = wxS("no_NO");
         else if ( langOnly == wxS("nn") )

--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -471,26 +471,6 @@ bool wxLocale::Init(int language, int flags)
         retloc = wxSetlocaleTryUTF8(LC_ALL, langOnly);
     }
 
-#if wxUSE_FONTMAP
-    // some systems (e.g. FreeBSD and HP-UX) don't have xx_YY aliases but
-    // require the full xx_YY.encoding form, so try using UTF-8 because this is
-    // the only thing we can do generically
-    //
-    // TODO: add encodings applicable to each language to the lang DB and try
-    //       them all in turn here
-    if ( !retloc )
-    {
-        const wxChar **names =
-            wxFontMapperBase::GetAllEncodingNames(wxFONTENCODING_UTF8);
-        while ( *names )
-        {
-            retloc = wxSetlocale(LC_ALL, locale + wxS('.') + *names++);
-            if ( retloc )
-                break;
-        }
-    }
-#endif // wxUSE_FONTMAP
-
     if ( !retloc )
     {
         // Some C libraries (namely glibc) still use old ISO 639,

--- a/tests/intl/intltest.cpp
+++ b/tests/intl/intltest.cpp
@@ -226,4 +226,11 @@ void IntlTestCase::IsAvailable()
     CPPUNIT_ASSERT_EQUAL( origLocale, setlocale(LC_ALL, NULL) );
 }
 
+TEST_CASE("wxLocale::Default", "[locale]")
+{
+    wxLocale loc;
+
+    REQUIRE( loc.Init(wxLANGUAGE_DEFAULT, wxLOCALE_DONT_LOAD_DEFAULT) );
+}
+
 #endif // wxUSE_INTL

--- a/tests/intl/intltest.cpp
+++ b/tests/intl/intltest.cpp
@@ -226,11 +226,17 @@ void IntlTestCase::IsAvailable()
     CPPUNIT_ASSERT_EQUAL( origLocale, setlocale(LC_ALL, NULL) );
 }
 
+// The test may fail in ANSI builds because of unsupported encoding, but we
+// don't really care about this build anyhow, so just skip it there.
+#if wxUSE_UNICODE
+
 TEST_CASE("wxLocale::Default", "[locale]")
 {
     wxLocale loc;
 
     REQUIRE( loc.Init(wxLANGUAGE_DEFAULT, wxLOCALE_DONT_LOAD_DEFAULT) );
 }
+
+#endif // wxUSE_UNICODE
 
 #endif // wxUSE_INTL


### PR DESCRIPTION
This addresses both problems of [#19082](https://trac.wxwidgets.org/ticket/19082):

1. Always allow initializing locale to system default.
2. Fix the existing, but broken, fallback from `ll_LL` to `ll` when the former is unknown.

@andriybyelikov Pinging you as you wrote that you'd be curious to see how this would be addressed.

Of course, any other reviews would be welcome as usual too.