### PR TITLE
Fix possible invalid array access in wxIsAbsolutePath()

### DIFF
--- a/src/common/filefn.cpp
+++ b/src/common/filefn.cpp
@@ -254,12 +254,13 @@ wxIsAbsolutePath (const wxString& filename)
         if (filename[0] == wxT('/'))
             return true;
 #ifdef __VMS__
-        if ((filename[0] == wxT('[') && filename[1] != wxT('.')))
+        if (filename.size() > 1 && (filename[0] == wxT('[') && filename[1] != wxT('.')))
             return true;
 #endif
 #if defined(__WINDOWS__)
         // MSDOS like
-        if (filename[0] == wxT('\\') || (wxIsalpha (filename[0]) && filename[1] == wxT(':')))
+        if (filename[0] == wxT('\\') ||
+            (filename.size() > 1 && (wxIsalpha (filename[0]) && filename[1] == wxT(':'))))
             return true;
 #endif
     }

--- a/tests/file/filefn.cpp
+++ b/tests/file/filefn.cpp
@@ -525,6 +525,12 @@ void FileFunctionsTestCase::IsAbsolutePath()
     CPPUNIT_ASSERT( filename.MakeAbsolute() );
     // wxFileName::GetFullPath returns absolute path
     CPPUNIT_ASSERT_MESSAGE( msg, wxIsAbsolutePath(filename.GetFullPath()));
+
+#ifdef __WINDOWS__
+    CPPUNIT_ASSERT( wxIsAbsolutePath("\\"));
+    CPPUNIT_ASSERT( wxIsAbsolutePath("c:"));
+    CPPUNIT_ASSERT( !wxIsAbsolutePath("c"));
+#endif
 }
 
 void FileFunctionsTestCase::PathOnly()


### PR DESCRIPTION
This is an attempt following PR #2253 by @owenwengerd-hexagon. I am not happy about testing the length twice but I could not figure out a better solution.

BTW, looking at the function code and then at its description
> Returns true if the argument is an absolute filename, i.e. with a slash or drive name at the beginning. 

I can see that the definition of "absolute" does not match [the Microsoft's](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#fully-qualified-vs-relative-paths) (who use the term "fully qualified" when distinguishing from "relative" which is relative to the CWD)? 

For example, by MS definition `c:path` is not "a fully qualified path", only `c:\path` is; i.e., the semicolon must be followed by the slash. The absolute path also should not contain double dots. Additionally, the UNC paths (starting with ` \\`) are not considered in `wxIsAbsolutePath()` either. `wxFileName::IsAbsolute()` probably behaves similarly.

While this is probably by design, perhaps it could be documented somehow, as the difference between wxWidgets' and OS definitions (e.g., vs. `::PathIsRelative()` on MSW) may be surprising to some?
