### PR TITLE
Add more ignore paths for AppVeyor and GitHub CIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,12 @@ on:
       - 'distrib/**'
       - 'docs/**'
       - 'interface/**'
+      - 'include/msvc/**'
+      - 'include/wx/msw/**'
+      - 'src/wx/msw/**'
       - '*.md'
       - '*.yml'
+      - 'wxwidgets.props'
   pull_request:
     branches:
       - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ skip_commits:
     - src/unix/
     - include/wx/x11/
     - src/x11/
-    - '*.md'
+    - '**/*.md'
     - .github/workflows/
     - .travis.yml
     - build/tools/travis-ci.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,11 +7,25 @@ branches:
 
 skip_commits:
   files:
+    - demos/
     - docs/
     - interface/
     - misc/
+    - include/wx/dfb/
+    - src/dfb/
+    - include/wx/gtk/
+    - src/gtk/
+    - include/wx/gtk1/
+    - src/gtk1/
+    - include/wx/motif/
+    - src/motif/
     - include/wx/osx/
     - src/osx/
+    - include/wx/unix/
+    - src/unix/
+    - include/wx/x11/
+    - src/x11/
+    - '*.md'
     - .github/workflows/
     - .travis.yml
     - build/tools/travis-ci.sh


### PR DESCRIPTION
There is probably many more individual files or even folders that could be added (but perhaps with little return value), so this change may not be complete but I hope it is a step in the right direction.

_<Removed the part about samples, both CIs built at least some samples in some configurations>_