### PR TITLE
Fix WinHTTP GET parameter

### DIFF
--- a/src/msw/webrequest_winhttp.cpp
+++ b/src/msw/webrequest_winhttp.cpp
@@ -330,7 +330,7 @@ void wxWebRequestWinHTTP::Start()
 
     wxString objectName(urlComps.lpszUrlPath, urlComps.dwUrlPathLength);
     if ( urlComps.dwExtraInfoLength )
-        objectName += "?" + wxString(urlComps.lpszExtraInfo, urlComps.dwExtraInfoLength);
+        objectName += wxString(urlComps.lpszExtraInfo, urlComps.dwExtraInfoLength);
 
     // Open a request
     static const wchar_t* acceptedTypes[] = { L"*/*", NULL };


### PR DESCRIPTION
An additional ? was send to the server, resulting in ignoring the first get parameter