### PR TITLE
Visual fixes to wxCheckListBox on macOS

### DIFF
--- a/src/osx/checklst_osx.cpp
+++ b/src/osx/checklst_osx.cpp
@@ -63,7 +63,7 @@ bool wxCheckListBox::Create(
     if ( !wxCheckListBoxBase::Create( parent, id, pos, size, n, choices, style & ~(wxHSCROLL | wxVSCROLL), validator, name ) )
         return false;
 
-    int colwidth = 30;
+    int colwidth = 18;
     // TODO adapt the width according to the window variant
     m_checkColumn = GetListPeer()->InsertCheckColumn(0, wxEmptyString, true, wxALIGN_CENTER, colwidth);
 

--- a/src/osx/cocoa/listbox.mm
+++ b/src/osx/cocoa/listbox.mm
@@ -648,6 +648,7 @@ wxWidgetImplType* wxWidgetImpl::CreateListBox( wxWindowMac* wxpeer,
 
     wxNSTableView* tableview = [[wxNSTableView alloc] init];
     [tableview setDelegate:tableview];
+    [tableview setFocusRingType:NSFocusRingTypeNone];
     // only one multi-select mode available
     if ( (style & wxLB_EXTENDED) || (style & wxLB_MULTIPLE) )
         [tableview setAllowsMultipleSelection:YES];

--- a/src/osx/cocoa/listbox.mm
+++ b/src/osx/cocoa/listbox.mm
@@ -473,7 +473,9 @@ wxListWidgetColumn* wxListWidgetCocoaImpl::InsertCheckColumn( unsigned pos , con
 
 void wxListWidgetCocoaImpl::AdaptColumnWidth ( int w )
 {
-    NSTableColumn *col = [[m_tableView tableColumns] objectAtIndex:0];
+    // Note that the table can have more than one column as it's also used by
+    // wxCheckListBox, but the column containing the text is always the last one.
+    NSTableColumn *col = [[m_tableView tableColumns] lastObject];
     [col setWidth:w];
     m_maxWidth = w;
 }
@@ -488,7 +490,7 @@ void wxListWidgetCocoaImpl::ListInsert( unsigned int n )
 
     if ( m_autoSize )
     {
-        NSCell *cell = [m_tableView preparedCellAtColumn:0 row:n];
+        NSCell *cell = [m_tableView preparedCellAtColumn:[m_tableView numberOfColumns]-1 row:n];
         NSSize size = [cell cellSize];
         int width = (int) ceil(size.width);
 


### PR DESCRIPTION
This fixes some visual issues in `wxCheckListBox`, ranging from minor to severe. The important bit is fixing truncated text, the rest are small improvements.

Before:

<img width="482" alt="Screen Shot 2021-03-07 at 17 03 23" src="https://user-images.githubusercontent.com/145881/110249107-c1d7a080-7f74-11eb-9e04-4f9531ec80cb.png">

After:

<img width="482" alt="Screen Shot 2021-03-07 at 17 04 09" src="https://user-images.githubusercontent.com/145881/110249109-c4d29100-7f74-11eb-819c-333278903301.png">
