### PR TITLE
CMake: fix monolithic build with webview

### DIFF
--- a/build/cmake/lib/CMakeLists.txt
+++ b/build/cmake/lib/CMakeLists.txt
@@ -99,6 +99,7 @@ if(wxBUILD_MONOLITHIC)
     foreach(file ${wxMONO_NONCOMPILED_CPP_FILES})
         set_source_files_properties(${file} PROPERTIES HEADER_FILE_ONLY TRUE)
     endforeach()
+    wx_webview_copy_webview2_loader(wxmono)
     wx_finalize_lib(wxmono)
 endif()
 

--- a/build/cmake/lib/webview/CMakeLists.txt
+++ b/build/cmake/lib/webview/CMakeLists.txt
@@ -9,6 +9,24 @@
 
 include(../../source_groups.cmake)
 
+function(wx_webview_copy_webview2_loader target)
+    if(NOT WXMSW OR NOT wxUSE_WEBVIEW_EDGE OR NOT TARGET ${target})
+        return()
+    endif()
+
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+        set(WEBVIEW2_ARCH x86)
+    else()
+        set(WEBVIEW2_ARCH x64)
+    endif()
+
+    add_custom_command(TARGET ${target} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+        "${WEBVIEW2_PACKAGE_DIR}/build/native/${WEBVIEW2_ARCH}/WebView2Loader.dll"
+        "$<TARGET_FILE_DIR:${target}>/WebView2Loader.dll")
+endfunction()
+
+
 wx_append_sources(WEBVIEW_FILES WEBVIEW_CMN)
 
 if(WXMSW)
@@ -77,18 +95,7 @@ elseif(WXMSW)
             endif()
         endif()
 
-        if (NOT wxBUILD_MONOLITHIC)
-            if (CMAKE_SIZEOF_VOID_P EQUAL 4)
-                set(WEBVIEW2_ARCH x86)
-            else()
-                set(WEBVIEW2_ARCH x64)
-            endif()
-
-            add_custom_command(TARGET wxwebview POST_BUILD
-                COMMAND ${CMAKE_COMMAND} -E copy
-                "${WEBVIEW2_PACKAGE_DIR}/build/native/${WEBVIEW2_ARCH}/WebView2Loader.dll"
-                "$<TARGET_FILE_DIR:wxwebview>/WebView2Loader.dll")
-        endif()
+        wx_webview_copy_webview2_loader(wxwebview)
     endif()
 elseif(WXGTK)
     if(LIBSOUP_FOUND)

--- a/build/cmake/lib/webview/CMakeLists.txt
+++ b/build/cmake/lib/webview/CMakeLists.txt
@@ -69,19 +69,23 @@ elseif(WXMSW)
         wx_lib_include_directories(wxwebview PRIVATE "${WEBVIEW2_PACKAGE_DIR}/build/native/include")
         if(NOT MSVC)
             wx_lib_include_directories(wxwebview PRIVATE "${wxSOURCE_DIR}/include/wx/msw/wrl")
-            target_compile_options(wxwebview PRIVATE -Wno-unknown-pragmas)
+            if (NOT wxBUILD_MONOLITHIC)
+                target_compile_options(wxwebview PRIVATE -Wno-unknown-pragmas)
+            endif()
         endif()
 
-        if (CMAKE_SIZEOF_VOID_P EQUAL 4)
-            set(WEBVIEW2_ARCH x86)
-        else()
-            set(WEBVIEW2_ARCH x64)
-        endif()
+        if (NOT wxBUILD_MONOLITHIC)
+            if (CMAKE_SIZEOF_VOID_P EQUAL 4)
+                set(WEBVIEW2_ARCH x86)
+            else()
+                set(WEBVIEW2_ARCH x64)
+            endif()
 
-        add_custom_command(TARGET wxwebview POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy
-            "${WEBVIEW2_PACKAGE_DIR}/build/native/${WEBVIEW2_ARCH}/WebView2Loader.dll"
-            "$<TARGET_FILE_DIR:wxwebview>/WebView2Loader.dll")
+            add_custom_command(TARGET wxwebview POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy
+                "${WEBVIEW2_PACKAGE_DIR}/build/native/${WEBVIEW2_ARCH}/WebView2Loader.dll"
+                "$<TARGET_FILE_DIR:wxwebview>/WebView2Loader.dll")
+        endif()
     endif()
 elseif(WXGTK)
     if(LIBSOUP_FOUND)

--- a/build/cmake/lib/webview/CMakeLists.txt
+++ b/build/cmake/lib/webview/CMakeLists.txt
@@ -44,13 +44,15 @@ elseif(WXMSW)
 
         set(WEBVIEW2_DEFAULT_PACKAGE_DIR "${CMAKE_BINARY_DIR}/packages/Microsoft.Web.WebView2.${WEBVIEW2_VERSION}")
 
+        if(NOT EXISTS ${WEBVIEW2_PACKAGE_DIR})
+            unset(WEBVIEW2_PACKAGE_DIR CACHE)
+        endif()
         find_path(WEBVIEW2_PACKAGE_DIR
             NAMES build/native/include/WebView2.h
             PATHS
                 "${PROJECT_SOURCE_DIR}/3rdparty/webview2"
                 ${WEBVIEW2_DEFAULT_PACKAGE_DIR}
         )
-        mark_as_advanced(WEBVIEW2_PACKAGE_DIR)
 
         if (NOT WEBVIEW2_PACKAGE_DIR)
             message(STATUS "WebView2 SDK not found locally, downloading...")
@@ -65,6 +67,7 @@ elseif(WXMSW)
                 WORKING_DIRECTORY ${WEBVIEW2_PACKAGE_DIR}
             )
         endif()
+        set(WEBVIEW2_PACKAGE_DIR ${WEBVIEW2_PACKAGE_DIR} CACHE INTERNAL "" FORCE)
 
         wx_lib_include_directories(wxwebview PRIVATE "${WEBVIEW2_PACKAGE_DIR}/build/native/include")
         if(NOT MSVC)


### PR DESCRIPTION
@TcT2k Did you intend for `WEBVIEW2_PACKAGE_DIR` to be available in the cache to the user, or is this because `find_path` adds it automatically to the cache?
If the first, I'll remove making it internal, but then I prefer prefixing it with `wxBUILD_`, just as all other wxWidgets variables.