### PR TITLE
Implement various WebView macOS missing features

### DIFF
--- a/include/wx/osx/webview_webkit.h
+++ b/include/wx/osx/webview_webkit.h
@@ -71,6 +71,9 @@ public:
 
     virtual bool IsBusy() const wxOVERRIDE;
 
+    virtual bool IsAccessToDevToolsEnabled() const wxOVERRIDE;
+    virtual void EnableAccessToDevTools(bool enable = true) wxOVERRIDE;
+
     //History functions
     virtual void ClearHistory() wxOVERRIDE;
     virtual void EnableHistory(bool enable = true) wxOVERRIDE;

--- a/src/osx/webview_webkit.mm
+++ b/src/osx/webview_webkit.mm
@@ -123,6 +123,12 @@ bool wxWebViewWebKit::Create(wxWindow *parent,
 
     NSRect r = wxOSXGetFrameForControl( this, pos , size ) ;
     WKWebViewConfiguration* webViewConfig = [[WKWebViewConfiguration alloc] init];
+
+    // WebKit API available since macOS 10.11 and iOS 9.0
+    SEL fullScreenSelector = @selector(_setFullScreenEnabled:);
+    if ([webViewConfig.preferences respondsToSelector:fullScreenSelector])
+        [webViewConfig.preferences performSelector:fullScreenSelector withObject:[NSNumber numberWithBool:YES]];
+
     if (!m_handlers.empty())
     {
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_13
@@ -161,6 +167,11 @@ bool wxWebViewWebKit::Create(wxWindow *parent,
             [[WebViewUIDelegate alloc] initWithWxWindow: this];
 
     [m_webView setUIDelegate:uiDelegate];
+
+    // WebKit API available since macOS 10.13 and iOS 11.0
+    SEL fullScreenDelegateSelector = @selector(_setFullscreenDelegate:);
+    if ([m_webView respondsToSelector:fullScreenDelegateSelector])
+        [m_webView performSelector:fullScreenDelegateSelector withObject:uiDelegate];
 
     m_UIDelegate = uiDelegate;
 
@@ -940,6 +951,25 @@ WX_API_AVAILABLE_MACOS(10, 12)
 - (void)_webView:(WKWebView *)webView printFrame:(WKFrameInfo*)frame
 {
     webKitWindow->Print();
+}
+
+- (void)SendFullscreenChangedEvent:(int)status
+{
+    wxWebViewEvent event(wxEVT_WEBVIEW_FULLSCREEN_CHANGED, webKitWindow->GetId(),
+        webKitWindow->GetCurrentURL(), wxString());
+    event.SetEventObject(webKitWindow);
+    event.SetInt(status);
+    webKitWindow->HandleWindowEvent(event);
+}
+
+- (void)_webViewDidEnterFullscreen:(WKWebView *)webView
+{
+    [self SendFullscreenChangedEvent:1];
+}
+
+- (void)_webViewDidExitFullscreen:(WKWebView *)webView
+{
+    [self SendFullscreenChangedEvent:0];
 }
 
 @end

--- a/src/osx/webview_webkit.mm
+++ b/src/osx/webview_webkit.mm
@@ -933,6 +933,15 @@ WX_API_AVAILABLE_MACOS(10, 12)
 }
 #endif // __MAC_OS_X_VERSION_MAX_ALLOWED
 
+// The following WKUIDelegateMethods are undocumented as of macOS SDK 11.0,
+// but are documented in the WebKit cocoa interface headers:
+// https://github.com/WebKit/WebKit/blob/main/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
+
+- (void)_webView:(WKWebView *)webView printFrame:(WKFrameInfo*)frame
+{
+    webKitWindow->Print();
+}
+
 @end
 
 @implementation WebViewScriptMessageHandler

--- a/src/osx/webview_webkit.mm
+++ b/src/osx/webview_webkit.mm
@@ -308,6 +308,26 @@ bool wxWebViewWebKit::IsEditable() const
     return false;
 }
 
+bool wxWebViewWebKit::IsAccessToDevToolsEnabled() const
+{
+    // WebKit API available since macOS 10.11 and iOS 9.0
+    WKPreferences* prefs = m_webView.configuration.preferences;
+    SEL devToolsSelector = @selector(_developerExtrasEnabled);
+    id val = nil;
+    if ([prefs respondsToSelector:devToolsSelector])
+         val = [prefs performSelector:devToolsSelector];
+    return (val != nil);
+}
+
+void wxWebViewWebKit::EnableAccessToDevTools(bool enable)
+{
+    // WebKit API available since macOS 10.11 and iOS 9.0
+    WKPreferences* prefs = m_webView.configuration.preferences;
+    SEL devToolsSelector = @selector(_setDeveloperExtrasEnabled:);
+    if ([prefs respondsToSelector:devToolsSelector])
+        [prefs performSelector:devToolsSelector withObject:(id)enable];
+}
+
 void wxWebViewWebKit::SetZoomType(wxWebViewZoomType zoomType)
 {
     // there is only one supported zoom type at the moment so this setter


### PR DESCRIPTION
Implement various features currently missing from `wxWebView`

* Access to dev tools
* Javascript `window.print()`
* Javascript fullscreen API