### PR TITLE
Remove unneeded code for wxSTC auto-complete listbox width

### DIFF
--- a/src/stc/PlatWX.cpp
+++ b/src/stc/PlatWX.cpp
@@ -2647,7 +2647,6 @@ public:
 
     // Setters
     void SetContainerBorderSize(int);
-    void SetMaxListBoxWidth(int);
 
     // ListBoxImpl implementation
     virtual void SetListBoxFont(Font &font);
@@ -2699,7 +2698,6 @@ protected:
     int m_textHeight;
     int m_itemHeight;
     int m_textTopGap;
-    int m_maxBoxWidth;  // 0 means no max width
 
     // These drawing parameters are set internally and can be changed if needed
     // to better match the appearance of a list box on a specific platform.
@@ -2713,7 +2711,7 @@ wxSTCListBox::wxSTCListBox(wxWindow* parent, wxSTCListBoxVisualData* v, int ht)
               m_visualData(v), m_maxStrWidth(0), m_currentRow(wxNOT_FOUND),
               m_doubleClickAction(NULL), m_doubleClickActionData(NULL),
               m_aveCharWidth(8), m_textHeight(ht), m_itemHeight(ht),
-              m_textTopGap(0), m_maxBoxWidth(350)
+              m_textTopGap(0)
 {
     wxVListBox::Create(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                        wxBORDER_NONE, "AutoCompListBox");
@@ -2759,11 +2757,6 @@ void wxSTCListBox::SetContainerBorderSize(int s)
     m_borderSize = s;
 }
 
-void wxSTCListBox::SetMaxListBoxWidth(int maxWidth)
-{
-    m_maxBoxWidth = maxWidth;
-}
-
 void wxSTCListBox::SetListBoxFont(Font &font)
 {
     SetFont(*((wxFont*)font.GetID()));
@@ -2787,10 +2780,6 @@ PRectangle wxSTCListBox::GetDesiredRect() const
         maxw = 100;
 
     maxw += TextBoxFromClientEdge() + m_textBoxToTextGap + m_aveCharWidth * 3;
-
-    // m_maxBoxWidth == 0 or negative means no maximum
-    if ( ( m_maxBoxWidth > 0 ) && ( maxw > m_maxBoxWidth ) )
-        maxw = m_maxBoxWidth;
 
     // estimate a desired height
     const int count = Length();
@@ -3282,7 +3271,7 @@ void wxSTCListBoxWin::OnPaint(wxPaintEvent& WXUNUSED(evt))
 //----------------------------------------------------------------------
 
 ListBoxImpl::ListBoxImpl()
-            :m_listBox(NULL), m_visualData(new wxSTCListBoxVisualData(5)), m_listBoxWidth(-1)
+            :m_listBox(NULL), m_visualData(new wxSTCListBoxVisualData(5))
 {
 }
 
@@ -3301,19 +3290,6 @@ void ListBoxImpl::Create(Window &parent, int WXUNUSED(ctrlID),
                          bool WXUNUSED(unicodeMode_), int technology_) {
     wid = new wxSTCListBoxWin(GETWIN(parent.GetID()), &m_listBox, m_visualData,
                               lineHeight_, technology_);
-
-    if ( m_listBoxWidth >= 0 )
-        m_listBox->SetMaxListBoxWidth(m_listBoxWidth);
-}
-
-
-void ListBoxImpl::SetMaxListBoxWidth(int width) {
-    // Store the setting for future list box creations
-    m_listBoxWidth = width;
-
-    // Update the listbox if it currently exists, but allow this to be called before it is created
-    if ( m_listBox )
-        m_listBox->SetMaxListBoxWidth(m_listBoxWidth);
 }
 
 

--- a/src/stc/PlatWX.h
+++ b/src/stc/PlatWX.h
@@ -37,7 +37,6 @@ public:
     virtual int CaretFromEdge() wxOVERRIDE;
     virtual void Clear() wxOVERRIDE;
     virtual void Append(char *s, int type = -1) wxOVERRIDE;
-            void Append(const wxString& text, int type);
     virtual int Length() wxOVERRIDE;
     virtual void Select(int n) wxOVERRIDE;
     virtual int GetSelection() wxOVERRIDE;

--- a/src/stc/PlatWX.h
+++ b/src/stc/PlatWX.h
@@ -23,10 +23,6 @@ private:
     wxSTCListBox*           m_listBox;
     wxSTCListBoxVisualData* m_visualData;
 
-    // Allow the implementation to control the width of the underlying listbox.
-    // If this is negative, then the underlying listbox retains control over the max width.
-    int                     m_listBoxWidth;
-
 public:
     ListBoxImpl();
     ~ListBoxImpl();
@@ -34,7 +30,6 @@ public:
 
     virtual void SetFont(Font &font) wxOVERRIDE;
     virtual void Create(Window &parent, int ctrlID, Point location_, int lineHeight_, bool unicodeMode_, int technology_) wxOVERRIDE;
-            void SetMaxListBoxWidth(int width);
     virtual void SetAverageCharWidth(int width) wxOVERRIDE;
     virtual void SetVisibleRows(int rows) wxOVERRIDE;
     virtual int GetVisibleRows() const wxOVERRIDE;

--- a/src/stc/ScintillaWX.cpp
+++ b/src/stc/ScintillaWX.cpp
@@ -293,9 +293,6 @@ void ScintillaWX::Initialise() {
 #endif // __WXMAC__
 
     ListBoxImpl* autoCompleteLB = static_cast<ListBoxImpl*>( ac.lb );
-
-    // Let the Scintilla autocomplete engine determine the max size for the listbox
-    autoCompleteLB->SetMaxListBoxWidth( 0 );
     autoCompleteLB->SetListInfo( &listType, &(ac.posStart), &(ac.startLen) );
 }
 


### PR DESCRIPTION
#2250 removed the maximum width of wxSTC auto-complete listbox. It added some code to keep the original width of 350px in case this listbox was used by something else besides auto-complete. Since this is not the case, I think it is not needed to keep this extra complexity.