### PR TITLE
Set colour without changing font in wxOSX

### DIFF
--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -241,6 +241,10 @@ protected:
     // was the wx event for the current native key down event sent
     bool WasKeyDownSent() const;
 
+
+    // Return the view to apply the font/colour to.
+    NSView* GetViewWithText() const;
+
     NSEvent* m_lastKeyDownEvent;
     bool m_lastKeyDownWXSent;
 #if !wxOSX_USE_NATIVE_FLIPPED

--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -101,6 +101,7 @@ public :
 
     virtual void        SetBackgroundColour(const wxColour&) wxOVERRIDE;
     virtual bool        SetBackgroundStyle(wxBackgroundStyle style) wxOVERRIDE;
+    virtual void        SetForegroundColour(const wxColour& col) wxOVERRIDE;
 
     virtual void        GetContentArea( int &left, int &top, int &width, int &height ) const wxOVERRIDE;
     virtual void        Move(int x, int y, int width, int height) wxOVERRIDE;

--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -276,6 +276,7 @@ public :
 
     virtual void        SetBackgroundColour( const wxColour& col ) = 0;
     virtual bool        SetBackgroundStyle(wxBackgroundStyle style) = 0;
+    virtual void        SetForegroundColour( const wxColour& col ) = 0;
 
     // all coordinates in native parent widget relative coordinates
     virtual void        GetContentArea( int &left , int &top , int &width , int &height ) const = 0;

--- a/include/wx/osx/iphone/private.h
+++ b/include/wx/osx/iphone/private.h
@@ -56,6 +56,7 @@ public :
 
     virtual void        SetBackgroundColour( const wxColour& col ) ;
     virtual bool        SetBackgroundStyle(wxBackgroundStyle style) ;
+    virtual void        SetForegroundColour( const wxColour& col ) ;
 
     virtual void        GetContentArea( int &left , int &top , int &width , int &height ) const;
     virtual void        Move(int x, int y, int width, int height);

--- a/include/wx/osx/window.h
+++ b/include/wx/osx/window.h
@@ -342,7 +342,6 @@ protected:
     bool                MacHasScrollBarCorner() const;
     void                MacCreateScrollBars( long style ) ;
     void                MacRepositionScrollBars() ;
-    void                MacUpdateControlFont() ;
 
     // implement the base class pure virtuals
     virtual void DoGetTextExtent(const wxString& string,

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -3543,13 +3543,19 @@ void wxWidgetCocoaImpl::SetControlSize( wxWindowVariant variant )
     }
 }
 
+NSView* wxWidgetCocoaImpl::GetViewWithText() const
+{
+    if ( [m_osxView isKindOfClass:[NSScrollView class] ] )
+        return [(NSScrollView*) m_osxView documentView];
+    else if ( [m_osxView isKindOfClass:[NSBox class] ] )
+        return [(NSBox*) m_osxView titleCell];
+
+    return m_osxView;
+}
+
 void wxWidgetCocoaImpl::SetFont(wxFont const& font)
 {
-    NSView* targetView = m_osxView;
-    if ( [m_osxView isKindOfClass:[NSScrollView class] ] )
-        targetView = [(NSScrollView*) m_osxView documentView];
-    else if ( [m_osxView isKindOfClass:[NSBox class] ] )
-        targetView = [(NSBox*) m_osxView titleCell];
+    NSView* const targetView = GetViewWithText();
 
     if ([targetView respondsToSelector:@selector(setFont:)])
         [targetView setFont: font.OSXGetNSFont()];

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -3559,13 +3559,19 @@ void wxWidgetCocoaImpl::SetFont(wxFont const& font)
 
     if ([targetView respondsToSelector:@selector(setFont:)])
         [targetView setFont: font.OSXGetNSFont()];
+    if ([m_osxView respondsToSelector:@selector(setAttributedTitle:)])
+        SetLabel(wxStripMenuCodes(GetWXPeer()->GetLabel(), wxStrip_Mnemonics), GetWXPeer()->GetFont().GetEncoding());
+}
+
+void wxWidgetCocoaImpl::SetForegroundColour(const wxColour& col)
+{
+    NSView* const targetView = GetViewWithText();
+
     if ([targetView respondsToSelector:@selector(setTextColor:)])
     {
         wxColor col = GetWXPeer()->GetForegroundColour();
         [targetView setTextColor: col.OSXGetNSColor()];
     }
-    if ([m_osxView respondsToSelector:@selector(setAttributedTitle:)])
-        SetLabel(wxStripMenuCodes(GetWXPeer()->GetLabel(), wxStrip_Mnemonics), GetWXPeer()->GetFont().GetEncoding());
 }
 
 void wxWidgetCocoaImpl::SetToolTip(wxToolTip* tooltip)

--- a/src/osx/iphone/window.mm
+++ b/src/osx/iphone/window.mm
@@ -482,6 +482,11 @@ void wxWidgetIPhoneImpl::SetBackgroundColour( const wxColour &col )
     m_osxView.backgroundColor = [UIColor colorWithCGColor:col.GetCGColor()];
 }
 
+void wxWidgetIPhoneImpl::SetForegroundColour( const wxColour &col )
+{
+    // TODO: use textColor if available?
+}
+
 bool wxWidgetIPhoneImpl::SetBackgroundStyle(wxBackgroundStyle style) 
 {
     if ( style == wxBG_STYLE_PAINT )

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -504,33 +504,32 @@ void wxWindowMac::DoSetWindowVariant( wxWindowVariant variant )
     }
 }
 
-void wxWindowMac::MacUpdateControlFont()
-{
-    if ( GetPeer() )
-        GetPeer()->SetFont(GetFont()) ;
-
-    // do not trigger refreshes upon invisible and possible partly created objects
-    if ( IsShownOnScreen() )
-        Refresh() ;
-}
-
 bool wxWindowMac::SetFont(const wxFont& font)
 {
     bool retval = wxWindowBase::SetFont( font );
 
-    MacUpdateControlFont() ;
+    if (retval)
+    {
+        if ( GetPeer() )
+            GetPeer()->SetFont(GetFont()) ;
+
+        // do not trigger refreshes upon invisible and possible partly created objects
+        if ( IsShownOnScreen() )
+            Refresh() ;
+    }
 
     return retval;
 }
 
 bool wxWindowMac::SetForegroundColour(const wxColour& col )
 {
-    bool retval = wxWindowBase::SetForegroundColour( col );
+    if ( !wxWindowBase::SetForegroundColour( col ) )
+        return false;
 
-    if (retval)
-        MacUpdateControlFont();
+    if ( GetPeer() )
+        GetPeer()->SetForegroundColour(col);
 
-    return retval;
+    return true;
 }
 
 bool wxWindowMac::SetBackgroundStyle(wxBackgroundStyle style)


### PR DESCRIPTION
Stefan, I think this should have been done in #2103 because it's necessary to fix the problem [mentioned here](https://github.com/wxWidgets/wxWidgets/pull/2090#issuecomment-740215110), please let me know if I'm missing something.

Also, if you know of a way to quickly implement the new method in wxiOS, maybe it would be worth doing -- I think it should be simple, but I have no way to test it and I don't want to do it blindly.

Finally, I think there is a separate problem with `GetFont()`: clearly it doesn't return the font of the right size for `wxStaticBox`. But I didn't look at this, so I just mention this in case you also know a quick way to fix this too.

TIA!