### PR TITLE
WebView allow custom user agent

### DIFF
--- a/include/wx/gtk/webview_webkit.h
+++ b/include/wx/gtk/webview_webkit.h
@@ -81,6 +81,7 @@ public:
 #if wxUSE_WEBVIEW_WEBKIT2
     virtual void EnableAccessToDevTools(bool enable = true) wxOVERRIDE;
     virtual bool IsAccessToDevToolsEnabled() const wxOVERRIDE;
+    virtual bool SetUserAgent(const wxString& userAgent) wxOVERRIDE;
 #endif
 
     void SetZoomType(wxWebViewZoomType) wxOVERRIDE;
@@ -176,6 +177,7 @@ private:
 #endif
 
     WebKitWebView *m_web_view;
+    wxString m_customUserAgent;
     int m_historyLimit;
 
     wxVector<wxSharedPtr<wxWebViewHandler> > m_handlerList;

--- a/include/wx/msw/private/webview_edge.h
+++ b/include/wx/msw/private/webview_edge.h
@@ -58,6 +58,7 @@ public:
     wxVector<wxString> m_pendingUserScripts;
     wxVector<wxString> m_userScriptIds;
     wxString m_scriptMsgHandlerName;
+    wxString m_customUserAgent;
 
     // WebView Events tokens
     EventRegistrationToken m_navigationStartingToken = { };

--- a/include/wx/msw/webview_edge.h
+++ b/include/wx/msw/webview_edge.h
@@ -23,7 +23,7 @@ class WXDLLIMPEXP_WEBVIEW wxWebViewEdge : public wxWebView
 {
 public:
 
-    wxWebViewEdge() {}
+    wxWebViewEdge();
 
     wxWebViewEdge(wxWindow* parent,
         wxWindowID id,
@@ -31,10 +31,7 @@ public:
         const wxPoint& pos = wxDefaultPosition,
         const wxSize& size = wxDefaultSize,
         long style = 0,
-        const wxString& name = wxWebViewNameStr)
-    {
-        Create(parent, id, url, pos, size, style, name);
-    }
+        const wxString& name = wxWebViewNameStr);
 
     ~wxWebViewEdge();
 

--- a/include/wx/msw/webview_edge.h
+++ b/include/wx/msw/webview_edge.h
@@ -86,6 +86,8 @@ public:
     virtual void EnableAccessToDevTools(bool enable = true) wxOVERRIDE;
     virtual bool IsAccessToDevToolsEnabled() const wxOVERRIDE;
 
+    virtual bool SetUserAgent(const wxString& userAgent) wxOVERRIDE;
+
     virtual bool RunScript(const wxString& javascript, wxString* output = NULL) const wxOVERRIDE;
     virtual bool AddScriptMessageHandler(const wxString& name) wxOVERRIDE;
     virtual bool RemoveScriptMessageHandler(const wxString& name) wxOVERRIDE;

--- a/include/wx/osx/webview_webkit.h
+++ b/include/wx/osx/webview_webkit.h
@@ -73,6 +73,7 @@ public:
 
     virtual bool IsAccessToDevToolsEnabled() const wxOVERRIDE;
     virtual void EnableAccessToDevTools(bool enable = true) wxOVERRIDE;
+    virtual bool SetUserAgent(const wxString& userAgent) wxOVERRIDE;
 
     //History functions
     virtual void ClearHistory() wxOVERRIDE;
@@ -111,6 +112,7 @@ protected:
 private:
     OSXWebViewPtr m_webView;
     wxStringToWebHandlerMap m_handlers;
+    wxString m_customUserAgent;
 
     WX_NSObject m_navigationDelegate;
     WX_NSObject m_UIDelegate;

--- a/include/wx/webview.h
+++ b/include/wx/webview.h
@@ -187,6 +187,8 @@ public:
     virtual void Print() = 0;
     virtual void RegisterHandler(wxSharedPtr<wxWebViewHandler> handler) = 0;
     virtual void Reload(wxWebViewReloadFlags flags = wxWEBVIEW_RELOAD_DEFAULT) = 0;
+    virtual bool SetUserAgent(const wxString& userAgent) { wxUnusedVar(userAgent); return false; }
+    virtual wxString GetUserAgent() const;
 
     // Script
     virtual bool RunScript(const wxString& javascript, wxString* output = NULL) const = 0;

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -890,6 +890,28 @@ public:
     virtual bool IsAccessToDevToolsEnabled() const;
 
     /**
+        Specify a custom user agent string for the web view.
+        Returns @true the user agent could be set.
+
+        If your first request should already use the custom user agent
+        please use two step creation and call SetUserAgent() before Create().
+
+        @note This is not implemented for IE. For Edge SetUserAgent()
+            MUST be called before Create().
+
+        @since 3.1.5
+    */
+    virtual bool SetUserAgent(const wxString& userAgent);
+
+    /**
+        Returns the current user agent string for the web view.
+
+        @since 3.1.5
+    */
+    virtual wxString GetUserAgent() const;
+
+
+    /**
         @name History
     */
 

--- a/samples/webview/webview.cpp
+++ b/samples/webview/webview.cpp
@@ -161,6 +161,7 @@ public:
     void OnRunScriptMessage(wxCommandEvent& evt);
     void OnRunScriptCustom(wxCommandEvent& evt);
     void OnAddUserScript(wxCommandEvent& evt);
+    void OnSetCustomUserAgent(wxCommandEvent& evt);
     void OnClearSelection(wxCommandEvent& evt);
     void OnDeleteSelection(wxCommandEvent& evt);
     void OnSelectAll(wxCommandEvent& evt);
@@ -393,9 +394,6 @@ WebFrame::WebFrame(const wxString& url) :
 #endif
     // Create the webview
     m_browser = wxWebView::New();
-    // Log backend information
-    wxLogMessage("Backend: %s Version: %s", m_browser->GetClassInfo()->GetClassName(),
-        wxWebView::GetBackendVersionInfo().ToString());
 #ifdef __WXMAC__
     // With WKWebView handlers need to be registered before creation
     m_browser->RegisterHandler(wxSharedPtr<wxWebViewHandler>(new wxWebViewArchiveHandler("wxfs")));
@@ -403,6 +401,11 @@ WebFrame::WebFrame(const wxString& url) :
 #endif
     m_browser->Create(this, wxID_ANY, url, wxDefaultPosition, wxDefaultSize);
     topsizer->Add(m_browser, wxSizerFlags().Expand().Proportion(1));
+
+    // Log backend information
+    wxLogMessage("Backend: %s Version: %s", m_browser->GetClassInfo()->GetClassName(),
+        wxWebView::GetBackendVersionInfo().ToString());
+    wxLogMessage("User Agent: %s", m_browser->GetUserAgent());
 
 #ifndef __WXMAC__
     //We register the wxfs:// protocol for testing purposes
@@ -493,6 +496,7 @@ WebFrame::WebFrame(const wxString& url) :
     m_script_custom = script_menu->Append(wxID_ANY, "Custom script");
     m_tools_menu->AppendSubMenu(script_menu, _("Run Script"));
     wxMenuItem* addUserScript = m_tools_menu->Append(wxID_ANY, _("Add user script"));
+    wxMenuItem* setCustomUserAgent = m_tools_menu->Append(wxID_ANY, _("Set custom user agent"));
 
     //Selection menu
     wxMenu* selection = new wxMenu();
@@ -593,6 +597,7 @@ WebFrame::WebFrame(const wxString& url) :
     Bind(wxEVT_MENU, &WebFrame::OnRunScriptMessage, this, m_script_message->GetId());
     Bind(wxEVT_MENU, &WebFrame::OnRunScriptCustom, this, m_script_custom->GetId());
     Bind(wxEVT_MENU, &WebFrame::OnAddUserScript, this, addUserScript->GetId());
+    Bind(wxEVT_MENU, &WebFrame::OnSetCustomUserAgent, this, setCustomUserAgent->GetId());
     Bind(wxEVT_MENU, &WebFrame::OnClearSelection, this, m_selection_clear->GetId());
     Bind(wxEVT_MENU, &WebFrame::OnDeleteSelection, this, m_selection_delete->GetId());
     Bind(wxEVT_MENU, &WebFrame::OnSelectAll, this, selectall->GetId());
@@ -1228,6 +1233,24 @@ void WebFrame::OnAddUserScript(wxCommandEvent & WXUNUSED(evt))
 
     if (!m_browser->AddUserScript(dialog.GetValue()))
         wxLogError("Could not add user script");
+}
+
+void WebFrame::OnSetCustomUserAgent(wxCommandEvent& WXUNUSED(evt))
+{
+    wxString customUserAgent = "Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.1 Mobile/15E148 Safari/604.1";
+    wxTextEntryDialog dialog
+    (
+        this,
+        "Enter the custom user agent string you would like to use.",
+        wxGetTextFromUserPromptStr,
+        customUserAgent,
+        wxOK | wxCANCEL | wxCENTRE
+    );
+    if (dialog.ShowModal() != wxID_OK)
+        return;
+
+    if (!m_browser->SetUserAgent(customUserAgent))
+        wxLogError("Could not set custom user agent");
 }
 
 void WebFrame::OnClearSelection(wxCommandEvent& WXUNUSED(evt))

--- a/src/common/webview.cpp
+++ b/src/common/webview.cpp
@@ -217,6 +217,13 @@ long wxWebView::Find(const wxString& text, int flags)
         return 1;
 }
 
+wxString wxWebView::GetUserAgent() const
+{
+    wxString userAgent;
+    RunScript("navigator.userAgent", &userAgent);
+    return userAgent;
+}
+
 // static
 wxWebView* wxWebView::New(const wxString& backend)
 {

--- a/src/gtk/webview_webkit2.cpp
+++ b/src/gtk/webview_webkit2.cpp
@@ -651,6 +651,9 @@ bool wxWebViewWebKit::Create(wxWindow *parent,
     GTKCreateScrolledWindowWith(GTK_WIDGET(m_web_view));
     g_object_ref(m_widget);
 
+    if (!m_customUserAgent.empty())
+        SetUserAgent(m_customUserAgent);
+
     g_signal_connect(m_web_view, "decide-policy",
                      G_CALLBACK(wxgtk_webview_webkit_decide_policy),
                      this);
@@ -754,6 +757,18 @@ bool wxWebViewWebKit::IsAccessToDevToolsEnabled() const
 {
     WebKitSettings* settings = webkit_web_view_get_settings(m_web_view);
     return webkit_settings_get_enable_developer_extras(settings);
+}
+
+bool wxWebViewWebKit::SetUserAgent(const wxString& userAgent)
+{
+    if (m_web_view)
+    {
+        WebKitSettings* settings = webkit_web_view_get_settings(m_web_view);
+        webkit_settings_set_user_agent(settings, userAgent.utf8_str());
+    }
+    else
+        m_customUserAgent = userAgent;
+    return true;
 }
 
 void wxWebViewWebKit::Stop()

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -476,6 +476,24 @@ ICoreWebView2Settings* wxWebViewEdgeImpl::GetSettings()
     return settings;
 }
 
+wxWebViewEdge::wxWebViewEdge():
+    m_impl(new wxWebViewEdgeImpl(this))
+{
+
+}
+
+wxWebViewEdge::wxWebViewEdge(wxWindow* parent,
+    wxWindowID id,
+    const wxString& url,
+    const wxPoint& pos,
+    const wxSize& size,
+    long style,
+    const wxString& name):
+    m_impl(new wxWebViewEdgeImpl(this))
+{
+    Create(parent, id, url, pos, size, style, name);
+}
+
 wxWebViewEdge::~wxWebViewEdge()
 {
     wxWindow* topLevelParent = wxGetTopLevelParent(this);
@@ -501,7 +519,6 @@ bool wxWebViewEdge::Create(wxWindow* parent,
         return false;
     }
 
-    m_impl = new wxWebViewEdgeImpl(this);
     if (!m_impl->Create())
         return false;
     Bind(wxEVT_SIZE, &wxWebViewEdge::OnSize, this);
@@ -774,6 +791,8 @@ void wxWebViewEdge::MSWSetBrowserExecutableDir(const wxString & path)
 bool wxWebViewEdge::RunScriptSync(const wxString& javascript, wxString* output) const
 {
     bool scriptExecuted = false;
+    if (!m_impl->m_webView)
+        return false;
 
     // Start script execution
     HRESULT executionResult = m_impl->m_webView->ExecuteScript(javascript.wc_str(), Callback<ICoreWebView2ExecuteScriptCompletedHandler>(

--- a/src/osx/webview_webkit.mm
+++ b/src/osx/webview_webkit.mm
@@ -151,6 +151,9 @@ bool wxWebViewWebKit::Create(wxWindow *parent,
 
     MacPostControlCreate(pos, size);
 
+    if (!m_customUserAgent.empty())
+        SetUserAgent(m_customUserAgent);
+
     [m_webView setHidden:false];
 
 
@@ -326,6 +329,21 @@ void wxWebViewWebKit::EnableAccessToDevTools(bool enable)
     SEL devToolsSelector = @selector(_setDeveloperExtrasEnabled:);
     if ([prefs respondsToSelector:devToolsSelector])
         [prefs performSelector:devToolsSelector withObject:(id)enable];
+}
+
+bool wxWebViewWebKit::SetUserAgent(const wxString& userAgent)
+{
+    if (WX_IS_MACOS_AVAILABLE(10, 11))
+    {
+        if (m_webView)
+            m_webView.customUserAgent = wxCFStringRef(userAgent).AsNSString();
+        else
+            m_customUserAgent = userAgent;
+
+        return true;
+    }
+    else
+        return false;
 }
 
 void wxWebViewWebKit::SetZoomType(wxWebViewZoomType zoomType)


### PR DESCRIPTION
Allow setting a custom user agent for a `wxWebView`.
Also allow access to the current user agent.

@MaartenBent 
If you have time maybe you could have a look at the MSW changes in regards to MinGW compatibility.
If it's not trivial to implement I would suggest to just disable it.