### PR TITLE
CMake: enable more warnings for GCC/Clang 

### DIFF
--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -87,6 +87,25 @@ function(wx_set_common_target_properties target_name)
         set_target_properties(${target_name} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
     endif()
 
+    set(common_gcc_clang_compile_options
+        -Wall
+        -Wno-ctor-dtor-privacy
+        -Woverloaded-virtual
+        -Wundef
+        -Wunused-parameter
+    )
+
+    if(WXOSX_COCOA OR WXGTK3)
+        # when building using GTK+ 3 or Cocoa we currently get tons of deprecation
+        # warnings from the standard headers -- disable them as we already know
+        # that they're deprecated but we still have to use them to support older
+        # toolkit versions and leaving this warning enabled prevents seeing any
+        # other ones
+        list(APPEND common_gcc_clang_compile_options
+            -Wno-deprecated-declarations
+        )
+    endif()
+
     if(MSVC)
         if(wxCOMMON_TARGET_PROPS_DEFAULT_WARNINGS)
             set(MSVC_WARNING_LEVEL "/W3")
@@ -96,11 +115,11 @@ function(wx_set_common_target_properties target_name)
         target_compile_options(${target_name} PRIVATE ${MSVC_WARNING_LEVEL})
     elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND NOT wxCOMMON_TARGET_PROPS_DEFAULT_WARNINGS)
         target_compile_options(${target_name} PRIVATE
-            -Wall
+            ${common_gcc_clang_compile_options}
             )
     elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" AND NOT wxCOMMON_TARGET_PROPS_DEFAULT_WARNINGS)
         target_compile_options(${target_name} PRIVATE
-            -Wall
+            ${common_gcc_clang_compile_options}
             -Wno-ignored-attributes
             )
     endif()

--- a/src/osx/webview_webkit.mm
+++ b/src/osx/webview_webkit.mm
@@ -496,7 +496,7 @@ void wxWebViewWebKit::DoSetPage(const wxString& src, const wxString& baseUrl)
                                     wxCFStringRef( baseUrl ).AsNSString()]];
 }
 
-void wxWebViewWebKit::EnableHistory(bool enable)
+void wxWebViewWebKit::EnableHistory(bool WXUNUSED(enable))
 {
     if ( !m_webView )
         return;


### PR DESCRIPTION
Enable the same warnings for GCC and Clang as are
enabled with a configure build