### PR TITLE
Allow paths to be hidden/shown in wxFileHistory menus

### DIFF
--- a/include/wx/filehistory.h
+++ b/include/wx/filehistory.h
@@ -67,10 +67,8 @@ public:
     void SetBaseId(wxWindowID baseId) { m_idBase = baseId; }
     wxWindowID GetBaseId() const { return m_idBase; }
 
-    void SetMenuPathStyle(wxFileHistoryMenuPathStyle style) { m_menuPathStyle = style; }
+    void SetMenuPathStyle(wxFileHistoryMenuPathStyle style);
     wxFileHistoryMenuPathStyle GetMenuPathStyle() const { return m_menuPathStyle; }
-
-    void RefreshLabels();
 
 protected:
     // Last n files
@@ -86,6 +84,9 @@ protected:
     wxFileHistoryMenuPathStyle m_menuPathStyle;
 
 private:
+    void DoRefreshLabels();
+
+
     // The ID of the first history menu item (Doesn't have to be wxID_FILE1)
     wxWindowID m_idBase;
 

--- a/include/wx/filehistory.h
+++ b/include/wx/filehistory.h
@@ -26,9 +26,9 @@ class WXDLLIMPEXP_FWD_BASE wxFileName;
 
 enum wxFileHistoryMenuPathStyle
 {
-    wxFH_HIDE_CURRENT_PATH = 0,
-    wxFH_HIDE_ALL_PATHS = 1,
-    wxFH_SHOW_FULL_PATH = 2
+    wxFH_PATH_SHOW_IF_DIFFERENT,
+    wxFH_PATH_SHOW_NEVER,
+    wxFH_PATH_SHOW_ALWAYS
 };
 
 // ----------------------------------------------------------------------------

--- a/include/wx/filehistory.h
+++ b/include/wx/filehistory.h
@@ -24,7 +24,7 @@ class WXDLLIMPEXP_FWD_CORE wxMenu;
 class WXDLLIMPEXP_FWD_BASE wxConfigBase;
 class WXDLLIMPEXP_FWD_BASE wxFileName;
 
-enum wxFileHistoryMenuLabelStyle
+enum wxFileHistoryMenuPathStyle
 {
     wxFH_HIDE_CURRENT_PATH = 0,
     wxFH_HIDE_ALL_PATHS = 1,
@@ -67,8 +67,8 @@ public:
     void SetBaseId(wxWindowID baseId) { m_idBase = baseId; }
     wxWindowID GetBaseId() const { return m_idBase; }
 
-    void SetMenuLabelStyle(wxFileHistoryMenuLabelStyle style) { m_menuLabelStyle = style; }
-    wxFileHistoryMenuLabelStyle GetMenuLabelStyle() const { return m_menuLabelStyle; }
+    void SetMenuPathStyle(wxFileHistoryMenuPathStyle style) { m_menuPathStyle = style; }
+    wxFileHistoryMenuPathStyle GetMenuPathStyle() const { return m_menuPathStyle; }
 
     void RefreshLabels();
 
@@ -82,8 +82,8 @@ protected:
     // Max files to maintain
     size_t                      m_fileMaxFiles;
 
-    // Style of the labels in the menu
-    wxFileHistoryMenuLabelStyle m_menuLabelStyle;
+    // Style of the paths in the menu labels
+    wxFileHistoryMenuPathStyle m_menuPathStyle;
 
 private:
     // The ID of the first history menu item (Doesn't have to be wxID_FILE1)

--- a/include/wx/filehistory.h
+++ b/include/wx/filehistory.h
@@ -24,6 +24,13 @@ class WXDLLIMPEXP_FWD_CORE wxMenu;
 class WXDLLIMPEXP_FWD_BASE wxConfigBase;
 class WXDLLIMPEXP_FWD_BASE wxFileName;
 
+enum wxFileHistoryMenuLabelStyle
+{
+    wxFH_HIDE_CURRENT_PATH = 0,
+    wxFH_HIDE_ALL_PATHS = 1,
+    wxFH_SHOW_FULL_PATH = 2
+};
+
 // ----------------------------------------------------------------------------
 // File history management
 // ----------------------------------------------------------------------------
@@ -60,15 +67,23 @@ public:
     void SetBaseId(wxWindowID baseId) { m_idBase = baseId; }
     wxWindowID GetBaseId() const { return m_idBase; }
 
+    void SetMenuLabelStyle(wxFileHistoryMenuLabelStyle style) { m_menuLabelStyle = style; }
+    wxFileHistoryMenuLabelStyle GetMenuLabelStyle() const { return m_menuLabelStyle; }
+
+    void RefreshLabels();
+
 protected:
     // Last n files
-    wxArrayString     m_fileHistory;
+    wxArrayString              m_fileHistory;
 
     // Menus to maintain (may need several for an MDI app)
-    wxList            m_fileMenus;
+    wxList                      m_fileMenus;
 
     // Max files to maintain
-    size_t            m_fileMaxFiles;
+    size_t                      m_fileMaxFiles;
+
+    // Style of the labels in the menu
+    wxFileHistoryMenuLabelStyle m_menuLabelStyle;
 
 private:
     // The ID of the first history menu item (Doesn't have to be wxID_FILE1)

--- a/interface/wx/filehistory.h
+++ b/interface/wx/filehistory.h
@@ -126,14 +126,6 @@ public:
     virtual void Load(const wxConfigBase& config);
 
     /**
-        Refresh the labels on all the menu items in the menus used by this
-        file history.
-
-        @since 3.1.5
-    */
-    void RefreshLabels();
-
-    /**
         Removes the specified file from the history.
     */
     virtual void RemoveFileFromHistory(size_t i);
@@ -169,7 +161,6 @@ public:
 
         By default, the menu item label style is ::wxFH_PATH_SHOW_IF_DIFFERENT.
 
-        @remarks Use RefreshLabels() to update any existing menu items to the new style.
         @since 3.1.5
     */
     void SetMenuPathStyle(wxFileHistoryMenuPathStyle style);

--- a/interface/wx/filehistory.h
+++ b/interface/wx/filehistory.h
@@ -6,6 +6,23 @@
 /////////////////////////////////////////////////////////////////////////////
 
 /**
+ Styles for the labels on menu items for wxFileHistory menus
+
+ @since 3.1.5
+*/
+enum wxFileHistoryMenuLabelStyle
+{
+    /** Hide the file path if it matches the path of the first item */
+    wxFH_HIDE_CURRENT_PATH,
+
+    /** Hide all paths and show only filenames */
+    wxFH_HIDE_ALL_PATHS,
+
+    /** Show the full path for all files */
+    wxFH_SHOW_FULL_PATH
+};
+
+/**
     @class wxFileHistory
 
     The wxFileHistory encapsulates a user interface convenience, the list of
@@ -14,6 +31,8 @@
     wxFileHistory can manage one or more file menus. More than one menu may be
     required in an MDI application, where the file history should appear on
     each MDI child menu as well as the MDI parent frame.
+
+    By default, the menu item label style will be @c wxFH_HIDE_CURRENT_PATH.
 
     @library{wxcore}
     @category{docview}
@@ -91,6 +110,14 @@ public:
     virtual void Load(const wxConfigBase& config);
 
     /**
+        Refresh the labels on all the menu items in the menus used by this
+        file history.
+
+        @since 3.1.5
+    */
+    void RefreshLabels();
+
+    /**
         Removes the specified file from the history.
     */
     virtual void RemoveFileFromHistory(size_t i);
@@ -120,4 +147,20 @@ public:
         called, as this is not done automatically.
     */
     virtual void UseMenu(wxMenu* menu);
+
+    /**
+        Set the style of the menu item labels.
+
+        @remarks Use RefreshLabels() to update any existing menu items to the new style.
+        @since 3.1.5
+    */
+    void SetMenuLabelStyle(wxFileHistoryMenuLabelStyle style);
+
+    /**
+        Get the current style of the menu item labels.
+        @since 3.1.5
+    */
+    wxFileHistoryMenuLabelStyle GetMenuLabelStyle() const;
+
+
 };

--- a/interface/wx/filehistory.h
+++ b/interface/wx/filehistory.h
@@ -8,21 +8,36 @@
 /**
     Styles for the paths shown in wxFileHistory menus.
 
-    The default style is wxFH_HIDE_CURRENT_PATH, i.e. the path of the file is
-    only shown in the menu if it's different from the path of the first file.
+    The values of this enum determine whether the labels in the menu managed by
+    wxFileHistory show the full path for the corresponding file or just the
+    base name.
+
+    The default style is wxFH_PATH_SHOW_IF_DIFFERENT, i.e. the full path of the
+    file is only shown in the menu if it's different from the path of the first
+    file.
 
     @since 3.1.5
 */
 enum wxFileHistoryMenuPathStyle
 {
-    /** Hide the file path if it matches the path of the first item */
-    wxFH_HIDE_CURRENT_PATH,
+    /**
+        Show the full path if it's different from the path of the first file.
 
-    /** Hide all paths and show only filenames */
-    wxFH_HIDE_ALL_PATHS,
+        Otherwise show just the file name.
 
-    /** Show the full path for all files */
-    wxFH_SHOW_FULL_PATH
+        This value corresponds to the default behaviour.
+     */
+    wxFH_PATH_SHOW_IF_DIFFERENT,
+
+    /**
+        Never show full path, always show just the base file name.
+     */
+    wxFH_PATH_SHOW_NEVER,
+
+    /**
+        Always show the full path for all files.
+     */
+    wxFH_PATH_SHOW_ALWAYS
 };
 
 /**
@@ -152,7 +167,7 @@ public:
     /**
         Set the style of the menu item labels.
 
-        By default, the menu item label style is ::wxFH_HIDE_CURRENT_PATH.
+        By default, the menu item label style is ::wxFH_PATH_SHOW_IF_DIFFERENT.
 
         @remarks Use RefreshLabels() to update any existing menu items to the new style.
         @since 3.1.5
@@ -162,7 +177,7 @@ public:
     /**
         Get the current style of the menu item labels.
 
-        Initially returns ::wxFH_HIDE_CURRENT_PATH.
+        Initially returns ::wxFH_PATH_SHOW_IF_DIFFERENT.
 
         @see SetMenuPathStyle()
 

--- a/interface/wx/filehistory.h
+++ b/interface/wx/filehistory.h
@@ -6,11 +6,14 @@
 /////////////////////////////////////////////////////////////////////////////
 
 /**
- Styles for the labels on menu items for wxFileHistory menus
+    Styles for the paths shown in wxFileHistory menus.
 
- @since 3.1.5
+    The default style is wxFH_HIDE_CURRENT_PATH, i.e. the path of the file is
+    only shown in the menu if it's different from the path of the first file.
+
+    @since 3.1.5
 */
-enum wxFileHistoryMenuLabelStyle
+enum wxFileHistoryMenuPathStyle
 {
     /** Hide the file path if it matches the path of the first item */
     wxFH_HIDE_CURRENT_PATH,
@@ -31,8 +34,6 @@ enum wxFileHistoryMenuLabelStyle
     wxFileHistory can manage one or more file menus. More than one menu may be
     required in an MDI application, where the file history should appear on
     each MDI child menu as well as the MDI parent frame.
-
-    By default, the menu item label style will be @c wxFH_HIDE_CURRENT_PATH.
 
     @library{wxcore}
     @category{docview}
@@ -151,16 +152,23 @@ public:
     /**
         Set the style of the menu item labels.
 
+        By default, the menu item label style is ::wxFH_HIDE_CURRENT_PATH.
+
         @remarks Use RefreshLabels() to update any existing menu items to the new style.
         @since 3.1.5
     */
-    void SetMenuLabelStyle(wxFileHistoryMenuLabelStyle style);
+    void SetMenuPathStyle(wxFileHistoryMenuPathStyle style);
 
     /**
         Get the current style of the menu item labels.
+
+        Initially returns ::wxFH_HIDE_CURRENT_PATH.
+
+        @see SetMenuPathStyle()
+
         @since 3.1.5
     */
-    wxFileHistoryMenuLabelStyle GetMenuLabelStyle() const;
+    wxFileHistoryMenuPathStyle GetMenuPathStyle() const;
 
 
 };

--- a/samples/menu/menu.cpp
+++ b/samples/menu/menu.cpp
@@ -748,6 +748,7 @@ MyFrame::MyFrame()
 
 MyFrame::~MyFrame()
 {
+    delete m_fileHistory;
     delete m_menu;
 
     // delete the event handler installed in ctor

--- a/samples/menu/menu.cpp
+++ b/samples/menu/menu.cpp
@@ -161,6 +161,8 @@ protected:
 
 #if wxUSE_FILE_HISTORY
     void OnFileHistoryMenuItem(wxCommandEvent& event);
+
+    void OnFileHistoryStyleItem(wxCommandEvent& event);
 #endif
 
 private:
@@ -297,6 +299,11 @@ enum
 #if wxUSE_TEXTDLG
     Menu_Menu_FindItem,
 #endif
+#if wxUSE_FILE_HISTORY
+    Menu_Menu_FileHistory1,
+    Menu_Menu_FileHistory2,
+    Menu_Menu_FileHistory3,
+#endif
 
     Menu_Test_Normal = 400,
     Menu_Test_Check,
@@ -380,6 +387,10 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(wxID_FILE1,          MyFrame::OnFileHistoryMenuItem)
     EVT_MENU(wxID_FILE2,          MyFrame::OnFileHistoryMenuItem)
     EVT_MENU(wxID_FILE3,          MyFrame::OnFileHistoryMenuItem)
+
+    EVT_MENU(Menu_Menu_FileHistory1,     MyFrame::OnFileHistoryStyleItem)
+    EVT_MENU(Menu_Menu_FileHistory2,     MyFrame::OnFileHistoryStyleItem)
+    EVT_MENU(Menu_Menu_FileHistory3,     MyFrame::OnFileHistoryStyleItem)
 #endif
 
     EVT_UPDATE_UI(Menu_SubMenu_Normal,    MyFrame::OnUpdateSubMenuNormal)
@@ -646,6 +657,16 @@ MyFrame::MyFrame()
     menuMenu->AppendSeparator();
     menuMenu->Append(Menu_Menu_FindItem, "Find menu item from label",
                      "Find a menu item by searching for its label");
+#endif
+#if wxUSE_FILE_HISTORY
+    wxMenu* menuFileHistoryStyle = new wxMenu();
+
+    menuFileHistoryStyle->AppendRadioItem(Menu_Menu_FileHistory1, "Hide current path");
+    menuFileHistoryStyle->AppendRadioItem(Menu_Menu_FileHistory2, "Hide all paths");
+    menuFileHistoryStyle->AppendRadioItem(Menu_Menu_FileHistory3, "Show all paths");
+
+    menuMenu->AppendSeparator();
+    menuMenu->AppendSubMenu(menuFileHistoryStyle, "Select file history menu style");
 #endif
 
     wxMenu *testMenu = new wxMenu;
@@ -1366,6 +1387,24 @@ void MyFrame::OnFileHistoryMenuItem(wxCommandEvent& event)
                  wxOK | wxICON_INFORMATION);
 
     m_fileHistory->AddFileToHistory(fname);
+}
+
+void MyFrame::OnFileHistoryStyleItem(wxCommandEvent& event)
+{
+    switch( event.GetId() )
+    {
+    case Menu_Menu_FileHistory1:
+        m_fileHistory->SetMenuLabelStyle(wxFH_HIDE_CURRENT_PATH);
+        break;
+    case Menu_Menu_FileHistory2:
+        m_fileHistory->SetMenuLabelStyle(wxFH_HIDE_ALL_PATHS);
+        break;
+    case Menu_Menu_FileHistory3:
+        m_fileHistory->SetMenuLabelStyle(wxFH_SHOW_FULL_PATH);
+        break;
+    }
+
+    m_fileHistory->RefreshLabels();
 }
 #endif
 

--- a/samples/menu/menu.cpp
+++ b/samples/menu/menu.cpp
@@ -1403,8 +1403,6 @@ void MyFrame::OnFileHistoryStyleItem(wxCommandEvent& event)
         m_fileHistory->SetMenuPathStyle(wxFH_PATH_SHOW_ALWAYS);
         break;
     }
-
-    m_fileHistory->RefreshLabels();
 }
 #endif
 

--- a/samples/menu/menu.cpp
+++ b/samples/menu/menu.cpp
@@ -1394,13 +1394,13 @@ void MyFrame::OnFileHistoryStyleItem(wxCommandEvent& event)
     switch( event.GetId() )
     {
     case Menu_Menu_FileHistory1:
-        m_fileHistory->SetMenuPathStyle(wxFH_HIDE_CURRENT_PATH);
+        m_fileHistory->SetMenuPathStyle(wxFH_PATH_SHOW_IF_DIFFERENT);
         break;
     case Menu_Menu_FileHistory2:
-        m_fileHistory->SetMenuPathStyle(wxFH_HIDE_ALL_PATHS);
+        m_fileHistory->SetMenuPathStyle(wxFH_PATH_SHOW_NEVER);
         break;
     case Menu_Menu_FileHistory3:
-        m_fileHistory->SetMenuPathStyle(wxFH_SHOW_FULL_PATH);
+        m_fileHistory->SetMenuPathStyle(wxFH_PATH_SHOW_ALWAYS);
         break;
     }
 

--- a/samples/menu/menu.cpp
+++ b/samples/menu/menu.cpp
@@ -1394,13 +1394,13 @@ void MyFrame::OnFileHistoryStyleItem(wxCommandEvent& event)
     switch( event.GetId() )
     {
     case Menu_Menu_FileHistory1:
-        m_fileHistory->SetMenuLabelStyle(wxFH_HIDE_CURRENT_PATH);
+        m_fileHistory->SetMenuPathStyle(wxFH_HIDE_CURRENT_PATH);
         break;
     case Menu_Menu_FileHistory2:
-        m_fileHistory->SetMenuLabelStyle(wxFH_HIDE_ALL_PATHS);
+        m_fileHistory->SetMenuPathStyle(wxFH_HIDE_ALL_PATHS);
         break;
     case Menu_Menu_FileHistory3:
-        m_fileHistory->SetMenuLabelStyle(wxFH_SHOW_FULL_PATH);
+        m_fileHistory->SetMenuPathStyle(wxFH_SHOW_FULL_PATH);
         break;
     }
 

--- a/samples/menu/menu.cpp
+++ b/samples/menu/menu.cpp
@@ -23,6 +23,8 @@
 #ifndef WX_PRECOMP
     #include "wx/app.h"
     #include "wx/bitmap.h"
+    #include "wx/filehistory.h"
+    #include "wx/filename.h"
     #include "wx/frame.h"
     #include "wx/image.h"
     #include "wx/menu.h"
@@ -157,6 +159,10 @@ protected:
 
     void OnSize(wxSizeEvent& event);
 
+#if wxUSE_FILE_HISTORY
+    void OnFileHistoryMenuItem(wxCommandEvent& event);
+#endif
+
 private:
 #if USE_LOG_WINDOW
     void LogMenuOpenCloseOrHighlight(const wxMenuEvent& event, const wxString& what);
@@ -176,6 +182,11 @@ private:
 #if USE_LOG_WINDOW
     // the control used for logging
     wxTextCtrl *m_textctrl;
+#endif
+
+#if wxUSE_FILE_HISTORY
+    wxMenu*        m_fileHistoryMenu;
+    wxFileHistory* m_fileHistory;
 #endif
 
     // the previous log target
@@ -365,6 +376,12 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(Menu_Test_Radio2,    MyFrame::OnTestRadio)
     EVT_MENU(Menu_Test_Radio3,    MyFrame::OnTestRadio)
 
+#if wxUSE_FILE_HISTORY
+    EVT_MENU(wxID_FILE1,          MyFrame::OnFileHistoryMenuItem)
+    EVT_MENU(wxID_FILE2,          MyFrame::OnFileHistoryMenuItem)
+    EVT_MENU(wxID_FILE3,          MyFrame::OnFileHistoryMenuItem)
+#endif
+
     EVT_UPDATE_UI(Menu_SubMenu_Normal,    MyFrame::OnUpdateSubMenuNormal)
     EVT_UPDATE_UI(Menu_SubMenu_Check,     MyFrame::OnUpdateSubMenuCheck)
     EVT_UPDATE_UI(Menu_SubMenu_Radio1,    MyFrame::OnUpdateSubMenuRadio)
@@ -538,6 +555,27 @@ MyFrame::MyFrame()
     fileMenu->Append(Menu_File_ShowDialog, "Show &Dialog\tCtrl-D",
                         "Show a dialog");
     fileMenu->AppendSeparator();
+
+#if wxUSE_FILE_HISTORY
+    m_fileHistoryMenu = new wxMenu();
+
+    m_fileHistory = new wxFileHistory();
+    m_fileHistory->UseMenu(m_fileHistoryMenu);
+
+    wxFileName fn( "menu.cpp" );
+    fn.Normalize();
+    m_fileHistory->AddFileToHistory( fn.GetFullPath() );
+
+    fn = "Makefile.in";
+    fn.Normalize();
+    m_fileHistory->AddFileToHistory( fn.GetFullPath() );
+
+    fn.Assign("minimal", "minimal", "cpp");
+    fn.Normalize();
+    m_fileHistory->AddFileToHistory( fn.GetFullPath() );
+
+    fileMenu->AppendSubMenu(m_fileHistoryMenu, "Sample file history");
+#endif
 
     fileMenu->Append(Menu_File_Quit, "E&xit\tAlt-X", "Quit menu sample");
 
@@ -1316,6 +1354,20 @@ void MyFrame::OnSize(wxSizeEvent& WXUNUSED(event))
     PositionMenuBar();
 #endif // __WXUNIVERSAL__
 }
+
+#if wxUSE_FILE_HISTORY
+void MyFrame::OnFileHistoryMenuItem(wxCommandEvent& event)
+{
+    int eventID = event.GetId();
+
+    wxString fname = m_fileHistory->GetHistoryFile(eventID - wxID_FILE1);
+
+    wxMessageBox(wxString::Format("Selected file %s", fname), "File history activated",
+                 wxOK | wxICON_INFORMATION);
+
+    m_fileHistory->AddFileToHistory(fname);
+}
+#endif
 
 // ----------------------------------------------------------------------------
 // MyDialog

--- a/src/common/filehistorycmn.cpp
+++ b/src/common/filehistorycmn.cpp
@@ -141,8 +141,7 @@ void wxFileHistoryBase::AddFileToHistory(const wxString& file)
 
 void wxFileHistoryBase::DoRefreshLabels()
 {
-    size_t i;
-    size_t numFiles = m_fileHistory.size();
+    const size_t numFiles = m_fileHistory.size();
 
     // If no files, then no need to refresh the menu
     if ( numFiles == 0 )
@@ -152,7 +151,7 @@ void wxFileHistoryBase::DoRefreshLabels()
     wxFileName firstFn(m_fileHistory[0]);
 
     // Update the labels in all menus
-    for ( i = 0; i < numFiles; i++ )
+    for ( size_t i = 0; i < numFiles; i++ )
     {
         const wxFileName currFn(m_fileHistory[i]);
 

--- a/src/common/filehistorycmn.cpp
+++ b/src/common/filehistorycmn.cpp
@@ -70,6 +70,7 @@ wxFileHistoryBase::wxFileHistoryBase(size_t maxFiles, wxWindowID idBase)
 {
     m_fileMaxFiles = maxFiles;
     m_idBase = idBase;
+    m_menuLabelStyle = wxFH_HIDE_CURRENT_PATH;
 }
 
 /* static */
@@ -135,20 +136,43 @@ void wxFileHistoryBase::AddFileToHistory(const wxString& file)
     m_fileHistory.insert(m_fileHistory.begin(), file);
     numFiles++;
 
-    // update the labels in all menus
+    RefreshLabels();
+}
+
+void wxFileHistoryBase::RefreshLabels()
+{
+    size_t i;
+    size_t numFiles = m_fileHistory.size();
+
+    // If no files, then no need to refresh the menu
+    if ( numFiles == 0 )
+        return;
+
+    // Use the first file as the current path
+    wxFileName firstFn(m_fileHistory[0]);
+
+    // Update the labels in all menus
     for ( i = 0; i < numFiles; i++ )
     {
-        // if in same directory just show the filename; otherwise the full path
-        const wxFileName fnOld(m_fileHistory[i]);
+        const wxFileName currFn(m_fileHistory[i]);
 
         wxString pathInMenu;
-        if ( (fnOld.GetPath() == fnNew.GetPath()) && fnOld.HasName() )
+
+        if ( m_menuLabelStyle == wxFH_HIDE_ALL_PATHS )
         {
-            pathInMenu = fnOld.GetFullName();
+            // Only show the filename + extension and not the path
+            pathInMenu = currFn.GetFullName();
         }
-        else // file in different directory or it's not a file but a directory
+        else if ( ( m_menuLabelStyle == wxFH_HIDE_CURRENT_PATH ) &&
+                  ( currFn.GetPath() == firstFn.GetPath() ) && currFn.HasName() )
         {
-            // absolute path; could also set relative path
+            // Hide the path if it is in the same folder as the first file
+            pathInMenu = currFn.GetFullName();
+        }
+        else
+        {
+            // Either has wxFH_SHOW_FULL_PATH menu style, or the file is in a different directory
+            // from the first file
             pathInMenu = m_fileHistory[i];
         }
 

--- a/src/common/filehistorycmn.cpp
+++ b/src/common/filehistorycmn.cpp
@@ -70,7 +70,7 @@ wxFileHistoryBase::wxFileHistoryBase(size_t maxFiles, wxWindowID idBase)
 {
     m_fileMaxFiles = maxFiles;
     m_idBase = idBase;
-    m_menuPathStyle = wxFH_HIDE_CURRENT_PATH;
+    m_menuPathStyle = wxFH_PATH_SHOW_IF_DIFFERENT;
 }
 
 /* static */
@@ -158,12 +158,12 @@ void wxFileHistoryBase::RefreshLabels()
 
         wxString pathInMenu;
 
-        if ( m_menuPathStyle == wxFH_HIDE_ALL_PATHS )
+        if ( m_menuPathStyle == wxFH_PATH_SHOW_NEVER )
         {
             // Only show the filename + extension and not the path
             pathInMenu = currFn.GetFullName();
         }
-        else if ( ( m_menuPathStyle == wxFH_HIDE_CURRENT_PATH ) &&
+        else if ( ( m_menuPathStyle == wxFH_PATH_SHOW_IF_DIFFERENT ) &&
                   ( currFn.GetPath() == firstFn.GetPath() ) && currFn.HasName() )
         {
             // Hide the path if it is in the same folder as the first file
@@ -171,7 +171,7 @@ void wxFileHistoryBase::RefreshLabels()
         }
         else
         {
-            // Either has wxFH_SHOW_FULL_PATH menu style, or the file is in a different directory
+            // Either has wxFH_PATH_SHOW_ALWAYS menu style, or the file is in a different directory
             // from the first file
             pathInMenu = m_fileHistory[i];
         }

--- a/src/common/filehistorycmn.cpp
+++ b/src/common/filehistorycmn.cpp
@@ -70,7 +70,7 @@ wxFileHistoryBase::wxFileHistoryBase(size_t maxFiles, wxWindowID idBase)
 {
     m_fileMaxFiles = maxFiles;
     m_idBase = idBase;
-    m_menuLabelStyle = wxFH_HIDE_CURRENT_PATH;
+    m_menuPathStyle = wxFH_HIDE_CURRENT_PATH;
 }
 
 /* static */
@@ -158,12 +158,12 @@ void wxFileHistoryBase::RefreshLabels()
 
         wxString pathInMenu;
 
-        if ( m_menuLabelStyle == wxFH_HIDE_ALL_PATHS )
+        if ( m_menuPathStyle == wxFH_HIDE_ALL_PATHS )
         {
             // Only show the filename + extension and not the path
             pathInMenu = currFn.GetFullName();
         }
-        else if ( ( m_menuLabelStyle == wxFH_HIDE_CURRENT_PATH ) &&
+        else if ( ( m_menuPathStyle == wxFH_HIDE_CURRENT_PATH ) &&
                   ( currFn.GetPath() == firstFn.GetPath() ) && currFn.HasName() )
         {
             // Hide the path if it is in the same folder as the first file

--- a/src/common/filehistorycmn.cpp
+++ b/src/common/filehistorycmn.cpp
@@ -147,8 +147,8 @@ void wxFileHistoryBase::DoRefreshLabels()
     if ( numFiles == 0 )
         return;
 
-    // Use the first file as the current path
-    wxFileName firstFn(m_fileHistory[0]);
+    // Remember the path in case we need to compare with it below.
+    const wxString firstPath(wxFileName(m_fileHistory[0]).GetPath());
 
     // Update the labels in all menus
     for ( size_t i = 0; i < numFiles; i++ )
@@ -156,23 +156,24 @@ void wxFileHistoryBase::DoRefreshLabels()
         const wxFileName currFn(m_fileHistory[i]);
 
         wxString pathInMenu;
+        switch ( m_menuPathStyle )
+        {
+            case wxFH_PATH_SHOW_IF_DIFFERENT:
+                if ( currFn.HasName() && currFn.GetPath() == firstPath )
+                    pathInMenu = currFn.GetFullName();
+                else
+                    pathInMenu = currFn.GetFullPath();
+                break;
 
-        if ( m_menuPathStyle == wxFH_PATH_SHOW_NEVER )
-        {
-            // Only show the filename + extension and not the path
-            pathInMenu = currFn.GetFullName();
-        }
-        else if ( ( m_menuPathStyle == wxFH_PATH_SHOW_IF_DIFFERENT ) &&
-                  ( currFn.GetPath() == firstFn.GetPath() ) && currFn.HasName() )
-        {
-            // Hide the path if it is in the same folder as the first file
-            pathInMenu = currFn.GetFullName();
-        }
-        else
-        {
-            // Either has wxFH_PATH_SHOW_ALWAYS menu style, or the file is in a different directory
-            // from the first file
-            pathInMenu = m_fileHistory[i];
+            case wxFH_PATH_SHOW_NEVER:
+                // Only show the filename + extension and not the path.
+                pathInMenu = currFn.GetFullName();
+                break;
+
+            case wxFH_PATH_SHOW_ALWAYS:
+                // Always show full path.
+                pathInMenu = currFn.GetFullPath();
+                break;
         }
 
         for ( wxList::compatibility_iterator node = m_fileMenus.GetFirst();

--- a/src/common/filehistorycmn.cpp
+++ b/src/common/filehistorycmn.cpp
@@ -136,10 +136,10 @@ void wxFileHistoryBase::AddFileToHistory(const wxString& file)
     m_fileHistory.insert(m_fileHistory.begin(), file);
     numFiles++;
 
-    RefreshLabels();
+    DoRefreshLabels();
 }
 
-void wxFileHistoryBase::RefreshLabels()
+void wxFileHistoryBase::DoRefreshLabels()
 {
     size_t i;
     size_t numFiles = m_fileHistory.size();
@@ -184,6 +184,15 @@ void wxFileHistoryBase::RefreshLabels()
 
             menu->SetLabel(m_idBase + i, GetMRUEntryLabel(i, pathInMenu));
         }
+    }
+}
+
+void wxFileHistoryBase::SetMenuPathStyle(wxFileHistoryMenuPathStyle style)
+{
+    if ( style != m_menuPathStyle )
+    {
+        m_menuPathStyle = style;
+        DoRefreshLabels();
     }
 }
 


### PR DESCRIPTION
This PR adds the ability to customize the menu item labels in menus associated with a file history, so that one of three behaviors is done:
* The path is hidden if it matches the first file in the list (this is the current behavior, and remains the default if it is not set explicitly)
* All paths can be hidden and only the filename + extension is shown
* All paths are shown

Example with no paths shown:
![NoPaths](https://user-images.githubusercontent.com/2262453/111563489-fa0a8a80-878f-11eb-92a5-97c7f452fc07.png)

Customizing this is useful for an application because there doesn't appear to be a standard way of displaying a file history menu, for instance a survey of programs shows the following:
* LibreOffice - Just file name
* Pluma - Just file name
* Atril - Just file name
* FreeCAD - Just file name
* FoxitReader - Just file name
* Sublime Text - Full path
* VLC - Full path
* TexStudio - Full path
* wxFormBuilder - Full path
* Audacity - Full path