### PR TITLE
macOS: Add wxFullScreenEvent

### DIFF
--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -681,6 +681,7 @@ class WXDLLIMPEXP_FWD_CORE wxWindowDestroyEvent;
 class WXDLLIMPEXP_FWD_CORE wxShowEvent;
 class WXDLLIMPEXP_FWD_CORE wxIconizeEvent;
 class WXDLLIMPEXP_FWD_CORE wxMaximizeEvent;
+class WXDLLIMPEXP_FWD_CORE wxFullScreenEvent;
 class WXDLLIMPEXP_FWD_CORE wxMouseCaptureChangedEvent;
 class WXDLLIMPEXP_FWD_CORE wxMouseCaptureLostEvent;
 class WXDLLIMPEXP_FWD_CORE wxPaintEvent;
@@ -832,6 +833,7 @@ wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_DESTROY, wxWindowDestroyEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_SHOW, wxShowEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_ICONIZE, wxIconizeEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_MAXIMIZE, wxMaximizeEvent);
+wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_FULLSCREEN, wxFullScreenEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_MOUSE_CAPTURE_CHANGED, wxMouseCaptureChangedEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_MOUSE_CAPTURE_LOST, wxMouseCaptureLostEvent);
 wxDECLARE_EXPORTED_EVENT(WXDLLIMPEXP_CORE, wxEVT_PAINT, wxPaintEvent);
@@ -2723,6 +2725,30 @@ public:
 
 private:
     wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(wxMaximizeEvent);
+};
+
+/*
+ wxEVT_FULLSCREEN
+ */
+class WXDLLIMPEXP_CORE wxFullScreenEvent : public wxEvent
+{
+public:
+    wxFullScreenEvent(int winid = 0, bool fullscreen = true)
+        : wxEvent(winid, wxEVT_FULLSCREEN)
+        { m_fullscreen = fullscreen; }
+    wxFullScreenEvent(const wxFullScreenEvent& event)
+        : wxEvent(event)
+    { m_fullscreen = event.m_fullscreen; }
+
+    bool IsFullScreen() const { return m_fullscreen; }
+
+    virtual wxEvent *Clone() const wxOVERRIDE { return new wxFullScreenEvent(*this); }
+
+protected:
+    bool m_fullscreen;
+
+private:
+    wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(wxFullScreenEvent);
 };
 
 // Joystick event class

--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -2738,7 +2738,7 @@ public:
         { m_fullscreen = fullscreen; }
     wxFullScreenEvent(const wxFullScreenEvent& event)
         : wxEvent(event)
-    { m_fullscreen = event.m_fullscreen; }
+        { m_fullscreen = event.m_fullscreen; }
 
     bool IsFullScreen() const { return m_fullscreen; }
 

--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -341,7 +341,7 @@ public :
     CGWindowLevel   GetWindowLevel() const wxOVERRIDE { return m_macWindowLevel; }
     void            RestoreWindowLevel() wxOVERRIDE;
 
-    bool m_macIgnoreNextFullscreenChange;
+    bool m_macIgnoreNextFullscreenChange = false;
 
     static WX_NSResponder GetNextFirstResponder() ;
     static WX_NSResponder GetFormerFirstResponder() ;

--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -341,6 +341,8 @@ public :
     CGWindowLevel   GetWindowLevel() const wxOVERRIDE { return m_macWindowLevel; }
     void            RestoreWindowLevel() wxOVERRIDE;
 
+    bool m_macIgnoreNextFullscreenChange;
+
     static WX_NSResponder GetNextFirstResponder() ;
     static WX_NSResponder GetFormerFirstResponder() ;
 protected :

--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -2263,6 +2263,46 @@ public:
 };
 
 /**
+    @class wxFullScreenEvent
+
+    An event being sent when the frame enters or exits fullscreen.
+
+    Currently this event is only generated in the wxOSX/Cocoa port when
+    wxTopLevelWindow::EnableFullScreenView is enabled. It is not only
+    generated when wxTopLevelWindow::ShowFullScreen is called, but also
+    when the user enters or exits full screen.
+
+    @beginEventTable{wxFullScreenEvent}
+    @event{EVT_FULLSCREEN(func)}
+        Process a @c wxEVT_FULLSCREEN event.
+    @endEventTable
+
+    @library{wxcore}
+    @category{events}
+
+    @since 3.1.5
+
+    @see @ref overview_events, wxTopLevelWindow::EnableFullScreenView,
+         wxTopLevelWindow::IsFullScreen
+*/
+class wxFullScreenEvent : public wxEvent
+{
+public:
+    /**
+        Constructor.
+    */
+    wxFullScreenEvent(int id = 0, bool fullscreen = true);
+
+    /**
+        Returns @true if the frame entered full screen, @false if exited
+        full screen.
+    */
+    bool IsFullScreen() const;
+};
+
+
+
+/**
     The possibles modes to pass to wxUpdateUIEvent::SetMode().
 */
 enum wxUpdateUIMode

--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -2268,7 +2268,7 @@ public:
     An event being sent when the frame enters or exits fullscreen.
 
     Currently this event is only generated in the wxOSX/Cocoa port when
-    wxTopLevelWindow::EnableFullScreenView is enabled. It is not only
+    wxTopLevelWindow::EnableFullScreenView() is enabled. It is not only
     generated when wxTopLevelWindow::ShowFullScreen is called, but also
     when the user enters or exits full screen.
 
@@ -5191,4 +5191,3 @@ wxEventType wxEVT_WINDOW_MODAL_DIALOG_CLOSED;
 #endif // wxUSE_GUI
 
 //@}
-

--- a/interface/wx/toplevel.h
+++ b/interface/wx/toplevel.h
@@ -643,7 +643,7 @@ public:
             If @true (default) make the zoom button toggle full screen;
             if @false the button does only toggle zoom.
 
-        @return @true if the button activated, @false if running
+        @return @true if the button behaviour has been changed, @false if running
         under another OS.
 
         @note Having the button is also required to let ShowFullScreen()
@@ -719,4 +719,3 @@ public:
     */
     void UseNativeDecorationsByDefault(bool native = true);
 };
-

--- a/interface/wx/toplevel.h
+++ b/interface/wx/toplevel.h
@@ -68,6 +68,8 @@ enum
         See wxMoveEvent.
     @event{EVT_SHOW(func)}
         Process a @c wxEVT_SHOW event. See wxShowEvent.
+    @event{EVT_FULLSCREEN(id, func)}
+        Process a @c wxEVT_FULLSCREEN event. See wxFullScreenEvent.
     @endEventTable
 
     @library{wxcore}
@@ -632,17 +634,16 @@ public:
     virtual void ShowWithoutActivating();
 
     /**
-        Enables the maximize button to toggle full screen mode. Prior to
-        macOS 10.10 a full screen button is added to the right upper corner
-        of a window's title bar.
+        Enables the zoom button to toggle full screen mode.
 
-        Currently only available for wxOSX/Cocoa.
+        A wxFullScreenEvent is generated when the users enters or exits
+        full screen via the enter/exit full screen button.
 
         @param enable
-            If @true (default) adds the full screen button in the title bar;
-            if @false the button is removed.
+            If @true (default) make the zoom button toggle full screen;
+            if @false the button does only toggle zoom.
 
-        @return @true if the button was added or removed, @false if running
+        @return @true if the button activated, @false if running
         under another OS.
 
         @note Having the button is also required to let ShowFullScreen()
@@ -653,7 +654,7 @@ public:
 
         @onlyfor{wxosx}
 
-        @see ShowFullScreen()
+        @see ShowFullScreen(), wxFullScreenEvent
 
         @since 3.1.0
     */

--- a/src/common/event.cpp
+++ b/src/common/event.cpp
@@ -80,6 +80,7 @@
     wxIMPLEMENT_DYNAMIC_CLASS(wxShowEvent, wxEvent);
     wxIMPLEMENT_DYNAMIC_CLASS(wxMaximizeEvent, wxEvent);
     wxIMPLEMENT_DYNAMIC_CLASS(wxIconizeEvent, wxEvent);
+    wxIMPLEMENT_DYNAMIC_CLASS(wxFullScreenEvent, wxEvent);
     wxIMPLEMENT_DYNAMIC_CLASS(wxMenuEvent, wxEvent);
     wxIMPLEMENT_DYNAMIC_CLASS(wxJoystickEvent, wxEvent);
     wxIMPLEMENT_DYNAMIC_CLASS(wxDropFilesEvent, wxEvent);
@@ -288,6 +289,7 @@ wxDEFINE_EVENT( wxEVT_DESTROY, wxWindowDestroyEvent );
 wxDEFINE_EVENT( wxEVT_SHOW, wxShowEvent );
 wxDEFINE_EVENT( wxEVT_ICONIZE, wxIconizeEvent );
 wxDEFINE_EVENT( wxEVT_MAXIMIZE, wxMaximizeEvent );
+wxDEFINE_EVENT( wxEVT_FULLSCREEN, wxFullScreenEvent );
 wxDEFINE_EVENT( wxEVT_MOUSE_CAPTURE_CHANGED, wxMouseCaptureChangedEvent );
 wxDEFINE_EVENT( wxEVT_MOUSE_CAPTURE_LOST, wxMouseCaptureLostEvent );
 wxDEFINE_EVENT( wxEVT_PAINT, wxPaintEvent );

--- a/src/osx/cocoa/nonownedwnd.mm
+++ b/src/osx/cocoa/nonownedwnd.mm
@@ -612,6 +612,12 @@ static void SendFullScreenWindowEvent(NSNotification* notification, bool fullscr
     wxNonOwnedWindowCocoaImpl* windowimpl = [window WX_implementation];
     if ( windowimpl )
     {
+        if (windowimpl->m_macIgnoreNextFullscreenChange)
+        {
+            windowimpl->m_macIgnoreNextFullscreenChange = false;
+            return;
+        }
+
         wxNonOwnedWindow* wxpeer = windowimpl->GetWXPeer();
         wxFullScreenEvent event(wxpeer->GetId(), fullscreen);
         event.SetEventObject(wxpeer);
@@ -1198,6 +1204,7 @@ bool wxNonOwnedWindowCocoaImpl::ShowFullScreen(bool show, long WXUNUSED(style))
     {
         if ( show != IsFullScreen() )
         {
+            m_macIgnoreNextFullscreenChange = true;
             [m_macWindow toggleFullScreen: nil];
         }
 

--- a/src/osx/cocoa/nonownedwnd.mm
+++ b/src/osx/cocoa/nonownedwnd.mm
@@ -606,6 +606,19 @@ extern int wxOSXGetIdFromSelector(SEL action );
     return true;
 }
 
+static void SendFullScreenWindowEvent(NSNotification* notification, bool fullscreen)
+{
+    NSWindow* window = (NSWindow*) [notification object];
+    wxNonOwnedWindowCocoaImpl* windowimpl = [window WX_implementation];
+    if ( windowimpl )
+    {
+        wxNonOwnedWindow* wxpeer = windowimpl->GetWXPeer();
+        wxFullScreenEvent event(wxpeer->GetId(), fullscreen);
+        event.SetEventObject(wxpeer);
+        wxpeer->HandleWindowEvent(event);
+    }
+}
+
 // work around OS X bug, on a secondary monitor an already fully sized window
 // (eg maximized) will not be correctly put to full screen size and keeps a 22px
 // title band at the top free, therefore we force the correct content size
@@ -624,6 +637,13 @@ extern int wxOSXGetIdFromSelector(SEL action );
     {
         [view setFrameSize: expectedframerect.size];
     }
+
+    SendFullScreenWindowEvent(notification, true);
+}
+
+- (void)windowWillExitFullScreen:(NSNotification *)notification
+{
+    SendFullScreenWindowEvent(notification, false);
 }
 
 // from https://developer.apple.com/library/archive/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/CapturingScreenContents/CapturingScreenContents.html


### PR DESCRIPTION
Send a `wxFullScreenEvent` when the user enters or exits full screen on
macOS. `EnableFullScreenView()` has to be used to enable the native
full screen API.

While this is currently only useful on macOS it's not unreasonable that something similar might be available with other toolkits in the future (or even currently?).