### PR TITLE
wxSearchCtrl on macos: Give a possibility to reset the same wxMenu te…

### DIFF
--- a/src/osx/srchctrl_osx.cpp
+++ b/src/osx/srchctrl_osx.cpp
@@ -94,7 +94,9 @@ void wxSearchCtrl::SetMenu( wxMenu* menu )
 {
     if ( menu == m_menu )
     {
-        // no change
+        if ( m_menu )
+            GetSearchPeer()->SetSearchMenu( m_menu ); // menu template can be reset by user
+
         return;
     }
 


### PR DESCRIPTION
…mplate

> The trick is that setSearchMenuTemplate sets just a template.

from
[https://cocoadev.github.io/NSSearchFieldWithSearchMenu/](https://cocoadev.github.io/NSSearchFieldWithSearchMenu/)