### PR TITLE
Fix library file names when cross compiling on Linux

### DIFF
--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -211,7 +211,7 @@ function(wx_set_target_properties target_name is_base)
         endif()
     else()
         set(cross_target "")
-        if (CMAKE_CROSSCOMPILING)
+        if (CMAKE_CROSSCOMPILING AND NOT IPHONE)
             set(cross_target "-${CMAKE_SYSTEM_NAME}")
         endif ()
 

--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -214,7 +214,7 @@ function(wx_set_target_properties target_name is_base)
         if (CMAKE_CROSSCOMPILING)
             set(cross_target "-${CMAKE_SYSTEM_NAME}")
         endif ()
-        
+
         set_target_properties(${target_name}
             PROPERTIES
                 OUTPUT_NAME wx_${lib_toolkit}${lib_unicode}${lib_flavour}${lib_suffix}-${lib_version}${cross_target}

--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -210,12 +210,17 @@ function(wx_set_target_properties target_name is_base)
                 "-DWXDLLNAME=wx${lib_toolkit}${dll_version}${lib_unicode}$<$<CONFIG:Debug>:d>${dll_suffix}")
         endif()
     else()
+        set(cross_target "")
+        if (CMAKE_CROSSCOMPILING)
+            set(cross_target "-${CMAKE_SYSTEM_NAME}")
+        endif ()
+        
         set_target_properties(${target_name}
             PROPERTIES
-                OUTPUT_NAME wx_${lib_toolkit}${lib_unicode}${lib_flavour}${lib_suffix}-${lib_version}
+                OUTPUT_NAME wx_${lib_toolkit}${lib_unicode}${lib_flavour}${lib_suffix}-${lib_version}${cross_target}
                 # NOTE: wx-config can not be used to connect the libraries with the debug suffix.
                 #OUTPUT_NAME_DEBUG wx_${lib_toolkit}${lib_unicode}d${lib_flavour}${lib_suffix}-${lib_version}
-                OUTPUT_NAME_DEBUG wx_${lib_toolkit}${lib_unicode}${lib_flavour}${lib_suffix}-${lib_version}
+                OUTPUT_NAME_DEBUG wx_${lib_toolkit}${lib_unicode}${lib_flavour}${lib_suffix}-${lib_version}${cross_target}
             )
     endif()
     if(CYGWIN)


### PR DESCRIPTION
Library file names are not what wx-config expects after cross compiling wxWidgets on Linux.

The issue may require more changes to be fixed on all platforms. This commit gets CMake downstream projects recognize and link wxWidgets succesfully on Linux.