### PR TITLE
Don't make wxConfig::Do{Read,Write}LongLong() pure virtual

### DIFF
--- a/include/wx/confbase.h
+++ b/include/wx/confbase.h
@@ -395,7 +395,7 @@ protected:
   virtual bool DoReadString(const wxString& key, wxString *pStr) const = 0;
   virtual bool DoReadLong(const wxString& key, long *pl) const = 0;
 #ifdef wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
-  virtual bool DoReadLongLong(const wxString& key, wxLongLong_t *pll) const = 0;
+  virtual bool DoReadLongLong(const wxString& key, wxLongLong_t *pll) const;
 #endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
   virtual bool DoReadDouble(const wxString& key, double* val) const;
   virtual bool DoReadBool(const wxString& key, bool* val) const;
@@ -406,7 +406,7 @@ protected:
   virtual bool DoWriteString(const wxString& key, const wxString& value) = 0;
   virtual bool DoWriteLong(const wxString& key, long value) = 0;
 #ifdef wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
-  virtual bool DoWriteLongLong(const wxString& key, wxLongLong_t value) = 0;
+  virtual bool DoWriteLongLong(const wxString& key, wxLongLong_t value);
 #endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
   virtual bool DoWriteDouble(const wxString& key, double value);
   virtual bool DoWriteBool(const wxString& key, bool value);

--- a/include/wx/fileconf.h
+++ b/include/wx/fileconf.h
@@ -196,18 +196,12 @@ public:
 protected:
   virtual bool DoReadString(const wxString& key, wxString *pStr) const wxOVERRIDE;
   virtual bool DoReadLong(const wxString& key, long *pl) const wxOVERRIDE;
-#ifdef wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
-  virtual bool DoReadLongLong(const wxString& key, wxLongLong_t *pll) const wxOVERRIDE;
-#endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
 #if wxUSE_BASE64
   virtual bool DoReadBinary(const wxString& key, wxMemoryBuffer* buf) const wxOVERRIDE;
 #endif // wxUSE_BASE64
 
   virtual bool DoWriteString(const wxString& key, const wxString& szValue) wxOVERRIDE;
   virtual bool DoWriteLong(const wxString& key, long lValue) wxOVERRIDE;
-#ifdef wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
-  virtual bool DoWriteLongLong(const wxString& key, wxLongLong_t value) wxOVERRIDE;
-#endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
 #if wxUSE_BASE64
   virtual bool DoWriteBinary(const wxString& key, const wxMemoryBuffer& buf) wxOVERRIDE;
 #endif // wxUSE_BASE64

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -266,6 +266,21 @@ bool wxConfigBase::DoReadBool(const wxString& key, bool* val) const
     return true;
 }
 
+#ifdef wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
+
+bool wxConfigBase::DoReadLongLong(const wxString& key, wxLongLong_t *pll) const
+{
+    wxString str;
+    if ( !Read(key, &str) )
+        return false;
+
+    str.Trim();
+
+    return str.ToLongLong(pll);
+}
+
+#endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
+
 bool wxConfigBase::DoReadDouble(const wxString& key, double* val) const
 {
     wxString str;
@@ -298,6 +313,15 @@ wxString wxConfigBase::ExpandEnvVars(const wxString& str) const
 // ----------------------------------------------------------------------------
 // wxConfigBase writing
 // ----------------------------------------------------------------------------
+
+#ifdef wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
+
+bool wxConfigBase::DoWriteLongLong(const wxString& key, wxLongLong_t llValue)
+{
+  return Write(key, wxString::Format("%" wxLongLongFmtSpec "d", llValue));
+}
+
+#endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
 
 bool wxConfigBase::DoWriteDouble(const wxString& key, double val)
 {

--- a/src/common/fileconf.cpp
+++ b/src/common/fileconf.cpp
@@ -881,21 +881,6 @@ bool wxFileConfig::DoReadLong(const wxString& key, long *pl) const
     return str.ToLong(pl);
 }
 
-#ifdef wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
-
-bool wxFileConfig::DoReadLongLong(const wxString& key, wxLongLong_t *pll) const
-{
-    wxString str;
-    if ( !Read(key, &str) )
-        return false;
-
-    str.Trim();
-
-    return str.ToLongLong(pll);
-}
-
-#endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
-
 #if wxUSE_BASE64
 
 bool wxFileConfig::DoReadBinary(const wxString& key, wxMemoryBuffer* buf) const
@@ -976,15 +961,6 @@ bool wxFileConfig::DoWriteLong(const wxString& key, long lValue)
 {
   return Write(key, wxString::Format(wxT("%ld"), lValue));
 }
-
-#ifdef wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
-
-bool wxFileConfig::DoWriteLongLong(const wxString& key, wxLongLong_t llValue)
-{
-  return Write(key, wxString::Format("%" wxLongLongFmtSpec "d", llValue));
-}
-
-#endif // wxHAS_LONG_LONG_T_DIFFERENT_FROM_LONG
 
 #if wxUSE_BASE64
 


### PR DESCRIPTION
These functions, added in the recent fce8780297 (Add 64-bit integers
support to wxConfig, 2021-03-09) break compilation of existing code
defining classes inheriting from wxConfig, and we can avoid it by using
strings for storing long long values by default -- as this is what
wxFileConfig is doing, and wxRegConfig provides its own overridden
version anyhow.