### PR TITLE
macOS: Improve/Fix web view clipboard handling

### DIFF
--- a/include/wx/osx/webview_webkit.h
+++ b/include/wx/osx/webview_webkit.h
@@ -82,6 +82,8 @@ public:
     virtual wxVector<wxSharedPtr<wxWebViewHistoryItem> > GetForwardHistory() wxOVERRIDE;
     virtual void LoadHistoryItem(wxSharedPtr<wxWebViewHistoryItem> item) wxOVERRIDE;
 
+    virtual void Paste() wxOVERRIDE;
+
     //Undo / redo functionality
     virtual bool CanUndo() const wxOVERRIDE;
     virtual bool CanRedo() const wxOVERRIDE;

--- a/src/osx/webview_webkit.mm
+++ b/src/osx/webview_webkit.mm
@@ -568,6 +568,18 @@ void wxWebViewWebKit::LoadHistoryItem(wxSharedPtr<wxWebViewHistoryItem> item)
     [m_webView goToBackForwardListItem:item->m_histItem];
 }
 
+void wxWebViewWebKit::Paste()
+{
+#if defined(__WXOSX_IPHONE__)
+    wxWebView::Paste();
+#else
+    // The default (javascript) implementation presents the user with a popup
+    // menu containing a single 'Paste' menu item.
+    // Send this action to directly paste as expected.
+    [[NSApplication sharedApplication] sendAction:@selector(paste:) to:nil from:m_webView];
+#endif
+}
+
 bool wxWebViewWebKit::CanUndo() const
 {
     return [[m_webView undoManager] canUndo];

--- a/src/osx/webview_webkit.mm
+++ b/src/osx/webview_webkit.mm
@@ -624,7 +624,30 @@ void wxWebViewWebKit::RegisterHandler(wxSharedPtr<wxWebViewHandler> handler)
         return [super validRequestorForSendType:sendType returnType:returnType];
 }
 
-#endif
+- (BOOL)performKeyEquivalent:(NSEvent *)event
+{
+    if ([event modifierFlags] & NSCommandKeyMask)
+    {
+        switch ([event.characters characterAtIndex:0])
+        {
+            case 'a':
+                [self selectAll:nil];
+                return YES;
+            case 'c':
+                m_webView->Copy();
+                return YES;
+            case 'v':
+                m_webView->Paste();
+                return YES;
+            case 'x':
+                m_webView->Cut();
+                return YES;
+        }
+    }
+
+    return [super performKeyEquivalent:event];
+}
+#endif // !defined(__WXOSX_IPHONE__)
 
 @end
 


### PR DESCRIPTION
* Enable usage of standard editing keys Cmd+A/C/V/X
* Improve wxWebView::Paste()
  The default (javascript) implementation presents the user with a popup menu containing a single 'Paste' menu item.
  Send an action to directly paste as expected.