### PR TITLE
Export wxITEM_* constants used in the AUI toolbar through defs.h

### DIFF
--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -1976,6 +1976,9 @@ enum wxItemKind
     wxITEM_CHECK,
     wxITEM_RADIO,
     wxITEM_DROPDOWN,
+    wxITEM_CONTROL,
+    wxITEM_LABEL,
+    wxITEM_SPACER,
     wxITEM_MAX
 };
 

--- a/interface/wx/defs.h
+++ b/interface/wx/defs.h
@@ -767,26 +767,31 @@ enum wxStandardID
 */
 enum wxItemKind
 {
+    /**
+        Separator tool / menu item.
+
+        @see wxToolBar::AddSeparator(), wxMenu::AppendSeparator(), wxAuiToolBar::AddSeparator().
+    */
     wxITEM_SEPARATOR = -1,
 
     /**
         Normal tool button / menu item.
 
-        @see wxToolBar::AddTool(), wxMenu::AppendItem().
+        @see wxToolBar::AddTool(), wxMenu::AppendItem(), wxAuiToolBar::AddTool().
     */
     wxITEM_NORMAL,
 
     /**
         Check (or toggle) tool button / menu item.
 
-        @see wxToolBar::AddCheckTool(), wxMenu::AppendCheckItem().
+        @see wxToolBar::AddCheckTool(), wxMenu::AppendCheckItem(), wxAuiToolBar::AddTool().
     */
     wxITEM_CHECK,
 
     /**
         Radio tool button / menu item.
 
-        @see wxToolBar::AddRadioTool(), wxMenu::AppendRadioItem().
+        @see wxToolBar::AddRadioTool(), wxMenu::AppendRadioItem(), wxAuiToolBar::AddTool().
     */
     wxITEM_RADIO,
 
@@ -798,6 +803,30 @@ enum wxItemKind
         under MSW and GTK.
     */
     wxITEM_DROPDOWN,
+
+    /**
+        A wxControl toolbar item in an AUI toolbar.
+
+        @see wxAuiToolBar::AddControl()
+        @since 3.1.5
+    */
+    wxITEM_CONTROL,
+
+    /**
+        A text label item in an AUI toolbar
+
+        @see wxAuiToolBar::AddLabel()
+        @since 3.1.5
+    */
+    wxITEM_LABEL,
+
+    /**
+        A spacer in an AUI toolbar.
+
+        @see wxAuiToolBar::AddSpacer()
+        @since 3.1.5
+    */
+    wxITEM_SPACER,
 
     wxITEM_MAX
 };

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -51,15 +51,6 @@ wxIMPLEMENT_CLASS(wxAuiToolBar, wxControl);
 wxIMPLEMENT_DYNAMIC_CLASS(wxAuiToolBarEvent, wxEvent);
 
 
-// missing wxITEM_* items
-enum
-{
-    wxITEM_CONTROL = wxITEM_MAX,
-    wxITEM_LABEL,
-    wxITEM_SPACER
-};
-
-
 wxBitmap wxAuiBitmapFromBits(const unsigned char bits[], int w, int h,
                              const wxColour& color);
 


### PR DESCRIPTION
These constants were added to the AUI toolbar a while ago to represent specific tool types but were never exported to the user. They are exposed through the `wxAuiToolBarItem::GetKind()` function, so they should be exposed to the user.