### PR TITLE
Remove wrong or unneeded mentions of wxEvtHandler::Connect() from the docs

### DIFF
--- a/interface/wx/fswatcher.h
+++ b/interface/wx/fswatcher.h
@@ -36,7 +36,7 @@
     and use the event table @c EVT_FSWATCHER macro to handle these events in a
     derived class method. Alternatively, you can use
     wxFileSystemWatcher::SetOwner() to send the events to another object. Or
-    you could use wxEvtHandler::Connect() with @c wxEVT_FSWATCHER to handle
+    you could use wxEvtHandler::Bind() with @c wxEVT_FSWATCHER to handle
     these events in any other object. See the fswatcher sample for an example
     of the latter approach.
 

--- a/interface/wx/infobar.h
+++ b/interface/wx/infobar.h
@@ -131,7 +131,7 @@ public:
         Notice that the generic wxInfoBar implementation handles the button
         events itself and so they are not propagated to the info bar parent and
         you need to either inherit from wxInfoBar and handle them in your
-        derived class or use wxEvtHandler::Connect(), as is done in the dialogs
+        derived class or use wxEvtHandler::Bind(), as is done in the dialogs
         sample, to handle the button events in the parent frame.
 
         @param btnid

--- a/interface/wx/persist/window.h
+++ b/interface/wx/persist/window.h
@@ -28,7 +28,7 @@ public:
     /**
         Constructor for a persistent window object.
 
-        The constructor uses wxEvtHandler::Connect() to catch
+        The constructor uses wxEvtHandler::Bind() to catch
         wxWindowDestroyEvent generated when the window is destroyed and call
         wxPersistenceManager::SaveAndUnregister() when this happens. This
         ensures that the window properties are saved and that this object

--- a/interface/wx/propgrid/editors.h
+++ b/interface/wx/propgrid/editors.h
@@ -91,9 +91,8 @@ public:
             Initial size for control(s).
 
         @remarks
-        - Unlike in previous version of wxPropertyGrid, it is no longer
-          necessary to call wxEvtHandler::Connect() for interesting editor
-          events. Instead, all events from control are now automatically
+        - It is not necessary to call wxEvtHandler::Bind() for interesting
+          editor events. All events from controls are automatically
           forwarded to wxPGEditor::OnEvent() and wxPGProperty::OnEvent().
     */
     virtual wxPGWindowList CreateControls( wxPropertyGrid* propgrid,


### PR DESCRIPTION
FWIW, in the wxFileSystemWatcher docs, I would rather not recommend using the event table either
> By default these events  are sent to the wxFileSystemWatcher object itself so you can derive from it and use the event table @c EVT_FSWATCHER macro to handle these events in a  derived class method.

but I let it be.