### PR TITLE
Fix example code in wxArtProvider docs

### DIFF
--- a/interface/wx/artprov.h
+++ b/interface/wx/artprov.h
@@ -112,11 +112,11 @@ const char* wxART_EDIT;
       protected:
         wxBitmap CreateBitmap(const wxArtID& id,
                               const wxArtClient& client,
-                              const wxSize size)
+                              const wxSize& size);
 
         // optionally override this one as well
         wxIconBundle CreateIconBundle(const wxArtID& id,
-                                      const wxArtClient& client)
+                                      const wxArtClient& client);
         { ... }
       };
       ...


### PR DESCRIPTION
I have also noticed that the GTK stock items URL is invalid. It could probably be replaced with a link to GTK3 stock items:
https://developer.gnome.org/gtk3/stable/gtk3-Stock-Items.html

However, I know nothing about GTK so I did not dare to change it.

I also forgot to add the "closes ticket" part to the commit. 

If this is merged (and perhaps the URL change confirmed), I can make the change for the 3.0 branch as well (using GTK2 URL https://developer.gnome.org/gtk2/stable/gtk2-Stock-Items.html), assuming there is still a release planned there.

