### PR TITLE
Fix check items state in wxSearchCtrl menu

### DIFF
--- a/include/wx/osx/menu.h
+++ b/include/wx/osx/menu.h
@@ -44,8 +44,8 @@ public:
     // implementation only from now on
     // -------------------------------
 
-    bool HandleCommandUpdateStatus( wxMenuItem* menuItem, wxWindow* senderWindow = NULL);
-    bool HandleCommandProcess( wxMenuItem* menuItem, wxWindow* senderWindow = NULL);
+    bool HandleCommandUpdateStatus( wxMenuItem* menuItem );
+    bool HandleCommandProcess( wxMenuItem* menuItem );
     void HandleMenuItemHighlighted( wxMenuItem* menuItem );
     void HandleMenuOpened();
     void HandleMenuClosed();

--- a/include/wx/osx/srchctrl.h
+++ b/include/wx/osx/srchctrl.h
@@ -62,6 +62,10 @@ public:
 
     wxSearchWidgetImpl * GetSearchPeer() const;
 
+#if wxUSE_MENUS
+    virtual void OSXAfterMenuEvent() wxOVERRIDE;
+#endif  // wxUSE_MENUS
+
 protected:
 
     wxSize DoGetBestSize() const wxOVERRIDE;

--- a/include/wx/osx/window.h
+++ b/include/wx/osx/window.h
@@ -299,6 +299,11 @@ public:
     // Return the DPI corresponding to the given scale factor.
     static wxSize       OSXMakeDPIFromScaleFactor(double scaleFactor);
 
+#if wxUSE_MENUS
+    // Called on the invoking window after handling the menu event.
+    virtual void        OSXAfterMenuEvent() { }
+#endif // wxUSE_MENUS
+
 protected:
     // For controls like radio buttons which are genuinely composite
     wxList              m_subControls;

--- a/samples/widgets/searchctrl.cpp
+++ b/samples/widgets/searchctrl.cpp
@@ -53,7 +53,8 @@ enum
      ID_CANCEL_CB,
      ID_MENU_CB,
 
-     ID_SEARCHMENU
+     ID_SEARCHMENU,
+     ID_SEARCHMENU_LAST = ID_SEARCHMENU + 5
 };
 
 
@@ -81,6 +82,8 @@ protected:
 
     void OnText(wxCommandEvent& event);
     void OnTextEnter(wxCommandEvent& event);
+
+    void OnSearchMenu(wxCommandEvent& event);
 
     void OnSearch(wxCommandEvent& event);
     void OnSearchCancel(wxCommandEvent& event);
@@ -112,6 +115,9 @@ wxBEGIN_EVENT_TABLE(SearchCtrlWidgetsPage, WidgetsPage)
 
     EVT_TEXT(wxID_ANY, SearchCtrlWidgetsPage::OnText)
     EVT_TEXT_ENTER(wxID_ANY, SearchCtrlWidgetsPage::OnTextEnter)
+
+    EVT_MENU_RANGE(ID_SEARCHMENU, ID_SEARCHMENU_LAST,
+                   SearchCtrlWidgetsPage::OnSearchMenu)
 
     EVT_SEARCH(wxID_ANY, SearchCtrlWidgetsPage::OnSearch)
     EVT_SEARCH_CANCEL(wxID_ANY, SearchCtrlWidgetsPage::OnSearchCancel)
@@ -187,10 +193,9 @@ void SearchCtrlWidgetsPage::RecreateWidget()
 wxMenu* SearchCtrlWidgetsPage::CreateTestMenu()
 {
     wxMenu* menu = new wxMenu;
-    const int SEARCH_MENU_SIZE = 5;
     wxMenuItem* menuItem = menu->Append(wxID_ANY, "Recent Searches", "", wxITEM_NORMAL);
     menuItem->Enable(false);
-    for ( int i = 0; i < SEARCH_MENU_SIZE; i++ )
+    for ( int i = 0; i < ID_SEARCHMENU_LAST - ID_SEARCHMENU; i++ )
     {
         wxString itemText = wxString::Format("item %i",i);
         wxString tipText = wxString::Format("tip %i",i);
@@ -233,6 +238,12 @@ void SearchCtrlWidgetsPage::OnTextEnter(wxCommandEvent& event)
 {
     wxLogMessage("Search control: enter pressed, contents is \"%s\".",
                  event.GetString());
+}
+
+void SearchCtrlWidgetsPage::OnSearchMenu(wxCommandEvent& event)
+{
+    int id = event.GetId() - ID_SEARCHMENU;
+    wxLogMessage("Search menu: \"item %i\" selected (%s).", id);
 }
 
 void SearchCtrlWidgetsPage::OnSearch(wxCommandEvent& event)

--- a/samples/widgets/searchctrl.cpp
+++ b/samples/widgets/searchctrl.cpp
@@ -199,7 +199,7 @@ wxMenu* SearchCtrlWidgetsPage::CreateTestMenu()
     {
         wxString itemText = wxString::Format("item %i",i);
         wxString tipText = wxString::Format("tip %i",i);
-        menu->Append(ID_SEARCHMENU+i, itemText, tipText, wxITEM_NORMAL);
+        menu->Append(ID_SEARCHMENU+i, itemText, tipText, wxITEM_CHECK);
     }
     return menu;
 }
@@ -243,7 +243,8 @@ void SearchCtrlWidgetsPage::OnTextEnter(wxCommandEvent& event)
 void SearchCtrlWidgetsPage::OnSearchMenu(wxCommandEvent& event)
 {
     int id = event.GetId() - ID_SEARCHMENU;
-    wxLogMessage("Search menu: \"item %i\" selected (%s).", id);
+    wxLogMessage("Search menu: \"item %i\" selected (%s).",
+                 id, event.IsChecked() ? "checked" : "unchecked");
 }
 
 void SearchCtrlWidgetsPage::OnSearch(wxCommandEvent& event)

--- a/src/osx/menu_osx.cpp
+++ b/src/osx/menu_osx.cpp
@@ -318,7 +318,7 @@ void wxMenu::DoRearrange()
 }
 
 
-bool wxMenu::HandleCommandUpdateStatus( wxMenuItem* item, wxWindow* senderWindow )
+bool wxMenu::HandleCommandUpdateStatus( wxMenuItem* item )
 {
     int menuid = item ? item->GetId() : 0;
     wxUpdateUIEvent event(menuid);
@@ -328,11 +328,6 @@ bool wxMenu::HandleCommandUpdateStatus( wxMenuItem* item, wxWindow* senderWindow
         event.DisallowCheck();
 
     bool processed = DoProcessEvent(this, event, GetWindow());
-
-    if ( !processed && senderWindow != NULL)
-    {
-        processed = senderWindow->HandleWindowEvent(event);
-    }
 
     if ( processed )
     {
@@ -348,7 +343,7 @@ bool wxMenu::HandleCommandUpdateStatus( wxMenuItem* item, wxWindow* senderWindow
     return processed;
 }
 
-bool wxMenu::HandleCommandProcess( wxMenuItem* item, wxWindow* senderWindow )
+bool wxMenu::HandleCommandProcess( wxMenuItem* item )
 {
     int menuid = item ? item->GetId() : 0;
     bool processed = false;
@@ -357,18 +352,6 @@ bool wxMenu::HandleCommandProcess( wxMenuItem* item, wxWindow* senderWindow )
 
     if ( SendEvent( menuid , item->IsCheckable() ? item->IsChecked() : -1 ) )
         processed = true ;
-    else
-    {
-        if ( senderWindow != NULL )
-        {
-            wxCommandEvent event(wxEVT_MENU , menuid);
-            event.SetEventObject(this);
-            event.SetInt(item->IsCheckable() ? item->IsChecked() : -1);
-
-            if ( senderWindow->HandleWindowEvent(event) )
-                processed = true ;
-        }
-    }
 
     if(!processed && item)
     {

--- a/src/osx/menu_osx.cpp
+++ b/src/osx/menu_osx.cpp
@@ -375,6 +375,12 @@ bool wxMenu::HandleCommandProcess( wxMenuItem* item, wxWindow* senderWindow )
         processed = item->GetPeer()->DoDefault();  
     }
     
+    if (wxWindow* const w = GetInvokingWindow())
+    {
+        // Let the invoking window update itself if necessary.
+        w->OSXAfterMenuEvent();
+    }
+
     return processed;
 }
 

--- a/src/osx/srchctrl_osx.cpp
+++ b/src/osx/srchctrl_osx.cpp
@@ -119,6 +119,14 @@ wxMenu* wxSearchCtrl::GetMenu()
     return m_menu;
 }
 
+void wxSearchCtrl::OSXAfterMenuEvent()
+{
+    // The menu is used as a template for creating the actual menu shown by the
+    // control, so update this template with the latest menu state after a menu
+    // command as the state of check/radio items could have changed after it.
+    GetSearchPeer()->SetSearchMenu( m_menu );
+}
+
 #endif  // wxUSE_MENUS
 
 void wxSearchCtrl::ShowSearchButton( bool show )


### PR DESCRIPTION
This implements a less-than-ideal-but-better-than-none fix for the problem discussed in https://github.com/wxWidgets/wxWidgets/pull/2286

I've also added a cleanup commit in the same code area, which could be omitted if you (@csomor) have any plans to use this parameter in the future.