### PR TITLE
Fix wxSplitterWindow painting regression on macOS 11

### DIFF
--- a/src/generic/splitter.cpp
+++ b/src/generic/splitter.cpp
@@ -97,13 +97,24 @@ bool wxSplitterWindow::Create(wxWindow *parent, wxWindowID id,
 
     m_permitUnsplitAlways = (style & wxSP_PERMIT_UNSPLIT) != 0;
 
-    // FIXME: with this line the background is not erased at all under GTK1,
-    //        so temporary avoid it there
-#if !defined(__WXGTK__) || defined(__WXGTK20__)
-    // don't erase the splitter background, it's pointless as we overwrite it
-    // anyhow
-    SetBackgroundStyle(wxBG_STYLE_PAINT);
+#ifdef __WXOSX__
+  #if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_16
+    if ( WX_IS_MACOS_AVAILABLE(10, 16) )
+    {
+        // Nothing to do: see OnPaint()
+    }
+    else
+  #endif
 #endif
+    {
+        // FIXME: with this line the background is not erased at all under GTK1,
+        //        so temporary avoid it there
+#if !defined(__WXGTK__) || defined(__WXGTK20__)
+        // don't erase the splitter background, it's pointless as we overwrite it
+        // anyhow
+        SetBackgroundStyle(wxBG_STYLE_PAINT);
+#endif
+    }
 
     return true;
 }


### PR DESCRIPTION
Fixes regression in wxSplitterWindow rendering introduced in 287ee5e4c7d15273d2f18a6aa77409bb35b1f9aa (PR #2158) - the splitter wouldn't correctly render its background under some (but not all) circumstances on macOS 11. See also https://trac.wxwidgets.org/ticket/19106 and comments under the 287ee5e4c7d15273d2f18a6aa77409bb35b1f9aa commit.

Sorry it took so long. In retrospect, the bug in 287ee5e4c7d15273d2f18a6aa77409bb35b1f9aa is obvious and I should have spotted it right away. But I was convinced this was a deeper problem with wxOSX's drawing internals and/or my understanding of macOS rendering (the latter is apparently true at least...).

Complicated matters was the difficulty of reproducing. This is the minimal-ish reproduction, where the part within `#if 1` is required — there's no rendering problem without a toolbar, there is one with a toolbar present:
```cpp
void CreateTestWindow()
{
    auto w = new wxFrame(nullptr, wxID_ANY, "Bg test", wxDefaultPosition, wxSize(600,400));
    
    // The sizer for the whole top-level window.
    wxSizer *topWindowSizer = new wxBoxSizer(wxVERTICAL);
    w->SetSizer(topWindowSizer);

#if 1 // this is important, won't render incorrectly without a toolbar!
    wxToolBar *toolBar = w->CreateToolBar();
    toolBar->AddTool(wxNewId(), wxEmptyString, wxArtProvider::GetBitmap(wxART_FILE_OPEN, wxART_TOOLBAR), _("Show/hide navigation panel"));
    toolBar->Realize();
#endif
    
    wxSizer *navigSizer = NULL;

    auto m_Splitter = new wxSplitterWindow(w, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSP_LIVE_UPDATE);
    topWindowSizer->Add(m_Splitter, 1, wxEXPAND);

    auto m_HtmlWin = new wxWindow(m_Splitter, wxID_ANY);
    m_HtmlWin->SetBackgroundColour(*wxWHITE);
    auto m_NavigPan = new wxPanel(m_Splitter, wxID_ANY);
    m_NavigPan->SetName("NavigPan");
    
    auto m_NavigNotebook = new wxNotebook(m_NavigPan, wxID_ANY);
    m_NavigNotebook->SetWindowVariant(wxWINDOW_VARIANT_SMALL);

    navigSizer = new wxBoxSizer(wxVERTICAL);
    navigSizer->Add(m_NavigNotebook, wxSizerFlags(1).Expand().Border(wxALL, 20));

    m_NavigPan->SetSizer(navigSizer);

    m_Splitter->SetMinimumPaneSize(20);
    m_NavigPan->Show();
    m_Splitter->SplitVertically(m_NavigPan, m_HtmlWin, 100);
    
    w->Show();
}
```
I still don't understand what changes within AppKit rendering (I can't find anything in wx itself) with the presence of a toolbar. But *something* does, and affects this part of rendering. My best bet is that the view has transparent background (rgba(0,0,0,0)) and the transparency is lost with a toolbar somehow, somewhere, resulting in (0,0,0) background.

Anyway: regardless of that, the bug I introduced was that `wxBG_STYLE_PAINT` was still used, but no painting was done. It's not surprising that this broke, it's surprising that in the situations I tested it *didn't* break visibly. So in the end, the fix is as simple as not calling `SetBackgroundStyle(wxBG_STYLE_PAINT);`. And because I'm scared of breaking something again, I did it on macOS 11 aka 10.16 only.