### PR TITLE
Improve sort performance with DataViewModel sorting

### DIFF
--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -3631,6 +3631,7 @@ wxDataViewCtrlInternal::wxDataViewCtrlInternal( wxDataViewCtrl *owner, wxDataVie
     m_root = NULL;
     m_sort_order = GTK_SORT_ASCENDING;
     m_sort_column = -1;
+    m_allow_sort = true;
     m_dataview_sort_column = NULL;
 
     m_dragDataObject = NULL;

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -3723,10 +3723,10 @@ void wxDataViewCtrlInternal::BuildBranch( wxGtkTreeModelNode *node )
         for (pos = 0; pos < count; pos++)
         {
             wxDataViewItem child = children[pos];
-        	bool allow_sort = false ;
+        	bool allow_sort = false;
 
-        	if ( pos == count - 1 )
-        		allow_sort = true ;
+        	if (pos == count - 1)
+        		allow_sort = true;
 
             if (m_wx_model->IsContainer( child ))
                 node->AddNode( new wxGtkTreeModelNode( node, child, this ), allow_sort );

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -3722,8 +3722,11 @@ void wxDataViewCtrlInternal::BuildBranch( wxGtkTreeModelNode *node )
         unsigned int pos;
         for (pos = 0; pos < count; pos++)
         {
-        	bool allow_sort = (pos==count-1) ;
             wxDataViewItem child = children[pos];
+        	bool allow_sort = false ;
+
+        	if ( pos == count-1 )
+        		allow_sort = true ;
 
             if (m_wx_model->IsContainer( child ))
                 node->AddNode( new wxGtkTreeModelNode( node, child, this ), allow_sort );

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -344,7 +344,7 @@ public:
         }
     }
 
-    void AddNode( wxGtkTreeModelNode* child )
+    void AddNode( wxGtkTreeModelNode* child, bool allow_sort=true )
         {
             m_nodes.Add( child );
 
@@ -352,7 +352,7 @@ public:
 
             m_children.Add( id );
 
-            if (m_internal->ShouldBeSorted())
+            if (allow_sort && m_internal->ShouldBeSorted())
             {
                 gs_internal = m_internal;
                 m_children.Sort( &wxGtkTreeModelChildCmp );
@@ -390,16 +390,16 @@ public:
             m_children.Insert( id, pos );
         }
 
-    void AddLeaf( void* id )
+    void AddLeaf( void* id, bool allow_sort=true )
         {
-            InsertLeaf(id, m_children.size());
+            InsertLeaf(id, m_children.size(), allow_sort);
         }
 
-    void InsertLeaf( void* id, unsigned pos )
+    void InsertLeaf( void* id, unsigned pos, bool allow_sort=true )
         {
             m_children.Insert( id, pos );
 
-            if (m_internal->ShouldBeSorted())
+            if (allow_sort && m_internal->ShouldBeSorted())
             {
                 gs_internal = m_internal;
                 m_children.Sort( &wxGtkTreeModelChildCmp );
@@ -3722,12 +3722,13 @@ void wxDataViewCtrlInternal::BuildBranch( wxGtkTreeModelNode *node )
         unsigned int pos;
         for (pos = 0; pos < count; pos++)
         {
+        	bool allow_sort=(pos==count-1) ;
             wxDataViewItem child = children[pos];
 
             if (m_wx_model->IsContainer( child ))
-                node->AddNode( new wxGtkTreeModelNode( node, child, this ) );
+                node->AddNode( new wxGtkTreeModelNode( node, child, this ), allow_sort );
             else
-                node->AddLeaf( child.GetID() );
+                node->AddLeaf( child.GetID(), allow_sort );
 
             // Don't send any events here
         }

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -3722,7 +3722,7 @@ void wxDataViewCtrlInternal::BuildBranch( wxGtkTreeModelNode *node )
         unsigned int pos;
         for (pos = 0; pos < count; pos++)
         {
-        	bool allow_sort=(pos==count-1) ;
+        	bool allow_sort = (pos==count-1) ;
             wxDataViewItem child = children[pos];
 
             if (m_wx_model->IsContainer( child ))

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -3734,8 +3734,8 @@ void wxDataViewCtrlInternal::BuildBranch( wxGtkTreeModelNode *node )
         {
             wxDataViewItem child = children[pos];
 
-        	if (pos==count-1)
-        		node->AllowSort();
+            if (pos==count-1)
+                node->AllowSort();
 
             if (m_wx_model->IsContainer( child ))
                 node->AddNode( new wxGtkTreeModelNode( node, child, this ) );
@@ -3744,8 +3744,7 @@ void wxDataViewCtrlInternal::BuildBranch( wxGtkTreeModelNode *node )
 
             // Don't send any events here
         }
-		node->AllowSort();	// in case ther is no child
-
+        node->AllowSort(); // in case there is no child
     }
 }
 

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -3725,7 +3725,7 @@ void wxDataViewCtrlInternal::BuildBranch( wxGtkTreeModelNode *node )
             wxDataViewItem child = children[pos];
         	bool allow_sort = false ;
 
-        	if ( pos == count-1 )
+        	if ( pos == count - 1 )
         		allow_sort = true ;
 
             if (m_wx_model->IsContainer( child ))


### PR DESCRIPTION
I was suffering terrible performance issue when trying to sort a list with only a few thousand of elements and eventually figured out what was going on.

In wxDataViewCtrlInternal::BuildBranch when building a sorted list of nodes we end up by sorting the child node list **everytime a new is added**, resulting in a tremendous and growing exponentially waste of time when increasing the number of items.

What I made here to fix this issue is to ensure that we wait to insert the last child before attempting to make a sort, leaving with only one sort per node.