### PR TITLE
Show assert stack if in the test if possible

### DIFF
--- a/include/wx/apptrait.h
+++ b/include/wx/apptrait.h
@@ -164,11 +164,13 @@ public:
     }
 
 
-protected:
 #if wxUSE_STACKWALKER
-    // utility function: returns the stack frame as a plain wxString
+    // Helper function mostly useful for derived classes ShowAssertDialog()
+    // implementation.
+    //
+    // Returns the stack frame as a plain (and possibly empty) wxString.
     virtual wxString GetAssertStackTrace();
-#endif
+#endif // wxUSE_STACKWALKER
 
 private:
     static wxSocketManager *ms_manager;

--- a/interface/wx/apptrait.h
+++ b/interface/wx/apptrait.h
@@ -156,5 +156,17 @@ public:
         @return @true if the message box was shown or @false otherwise.
      */
     virtual bool SafeMessageBox(const wxString& text, const wxString& title) = 0;
+
+    /**
+        Helper function mostly useful for derived classes ShowAssertDialog()
+        implementation.
+
+        Returns the stack frame as a plain (and possibly empty) wxString.
+
+        This function is only available when @c wxUSE_STACKWALKER is 1.
+
+        @since 3.1.5
+     */
+    virtual wxString GetAssertStackTrace();
 };
 

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -131,7 +131,7 @@ static void TestAssertHandler(const wxString& file,
     {
         // Exceptions thrown from worker threads are not caught currently and
         // so we'd just die without any useful information -- abort instead.
-        abortReason << assertMessage << wxASCII_STR("in a worker thread.");
+        abortReason << assertMessage << wxASCII_STR(" in a worker thread.");
     }
 #if __cplusplus >= 201703L || wxCHECK_VISUALC_VERSION(14)
     else if ( uncaught_exceptions() )
@@ -163,6 +163,12 @@ static void TestAssertHandler(const wxString& file,
 
         throw TestAssertFailure(file, line, func, cond, msg);
     }
+
+#if wxUSE_STACKWALKER
+    const wxString& stackTrace = wxApp::GetValidTraits().GetAssertStackTrace();
+    if ( !stackTrace.empty() )
+        abortReason << wxASCII_STR("\n\nAssert call stack:\n") << stackTrace;
+#endif // wxUSE_STACKWALKER
 
     wxFputs(abortReason, stderr);
     fflush(stderr);


### PR DESCRIPTION
Make wxAppTraitsBase::GetAssertStackTrace() and reuse it in the assert
handler defined in the test to show more information about the asserts,
especially those failing in worker threads, if possible.