### PR TITLE
WebView add asynchronous RunScript variant: RunScriptAsync

### DIFF
--- a/include/wx/gtk/webview_webkit.h
+++ b/include/wx/gtk/webview_webkit.h
@@ -27,6 +27,8 @@ typedef struct _WebKitWebView WebKitWebView;
 // wxWebViewWebKit
 //-----------------------------------------------------------------------------
 
+class wxWebKitRunScriptParams;
+
 class WXDLLIMPEXP_WEBVIEW wxWebViewWebKit : public wxWebView
 {
 public:
@@ -119,13 +121,15 @@ public:
     virtual wxString GetSelectedSource() const wxOVERRIDE;
     virtual void ClearSelection() wxOVERRIDE;
 
-    virtual bool RunScript(const wxString& javascript, wxString* output = NULL) const wxOVERRIDE;
 #if wxUSE_WEBVIEW_WEBKIT2
+    virtual void RunScriptAsync(const wxString& javascript, void* clientData = NULL) const wxOVERRIDE;
     virtual bool AddScriptMessageHandler(const wxString& name) wxOVERRIDE;
     virtual bool RemoveScriptMessageHandler(const wxString& name) wxOVERRIDE;
     virtual bool AddUserScript(const wxString& javascript,
         wxWebViewUserScriptInjectionTime injectionTime = wxWEBVIEW_INJECT_AT_DOCUMENT_START) wxOVERRIDE;
     virtual void RemoveAllUserScripts() wxOVERRIDE;
+#else
+    virtual bool RunScript(const wxString& javascript, wxString* output = NULL) const wxOVERRIDE;
 #endif
 
     //Virtual Filesystem Support
@@ -151,6 +155,11 @@ public:
     //create-web-view signal and so we need to send a new window event
     bool m_creating;
 
+#if wxUSE_WEBVIEW_WEBKIT2
+    // This methods needs to be public to make it callable from a callback
+    void ProcessJavaScriptResult(GAsyncResult *res, wxWebKitRunScriptParams* params) const;
+#endif
+
 protected:
     virtual void DoSetPage(const wxString& html, const wxString& baseUrl) wxOVERRIDE;
 
@@ -173,7 +182,6 @@ private:
     bool CanExecuteEditingCommand(const gchar* command) const;
     void SetupWebExtensionServer();
     GDBusProxy *GetExtensionProxy() const;
-    bool RunScriptSync(const wxString& javascript, wxString* output = NULL) const;
 #endif
 
     WebKitWebView *m_web_view;

--- a/include/wx/gtk/webview_webkit.h
+++ b/include/wx/gtk/webview_webkit.h
@@ -156,7 +156,7 @@ public:
     bool m_creating;
 
 #if wxUSE_WEBVIEW_WEBKIT2
-    // This methods needs to be public to make it callable from a callback
+    // This method needs to be public to make it callable from a callback
     void ProcessJavaScriptResult(GAsyncResult *res, wxWebKitRunScriptParams* params) const;
 #endif
 

--- a/include/wx/msw/webview_edge.h
+++ b/include/wx/msw/webview_edge.h
@@ -88,7 +88,7 @@ public:
 
     virtual bool SetUserAgent(const wxString& userAgent) wxOVERRIDE;
 
-    virtual bool RunScript(const wxString& javascript, wxString* output = NULL) const wxOVERRIDE;
+    virtual void RunScriptAsync(const wxString& javascript, void* clientData = NULL) const wxOVERRIDE;
     virtual bool AddScriptMessageHandler(const wxString& name) wxOVERRIDE;
     virtual bool RemoveScriptMessageHandler(const wxString& name) wxOVERRIDE;
     virtual bool AddUserScript(const wxString& javascript,

--- a/include/wx/msw/webview_edge.h
+++ b/include/wx/msw/webview_edge.h
@@ -113,8 +113,6 @@ private:
 
     void OnTopLevelParentIconized(wxIconizeEvent& event);
 
-    bool RunScriptSync(const wxString& javascript, wxString* output = NULL) const;
-
     wxDECLARE_DYNAMIC_CLASS(wxWebViewEdge);
 };
 

--- a/include/wx/osx/webview_webkit.h
+++ b/include/wx/osx/webview_webkit.h
@@ -118,8 +118,6 @@ private:
 
     WX_NSObject m_navigationDelegate;
     WX_NSObject m_UIDelegate;
-
-    bool RunScriptSync(const wxString& javascript, wxString* output = NULL) const;
 };
 
 class WXDLLIMPEXP_WEBVIEW wxWebViewFactoryWebKit : public wxWebViewFactory

--- a/include/wx/osx/webview_webkit.h
+++ b/include/wx/osx/webview_webkit.h
@@ -94,7 +94,7 @@ public:
     virtual void SetEditable(bool enable = true) wxOVERRIDE;
     virtual bool IsEditable() const wxOVERRIDE;
 
-    bool RunScript(const wxString& javascript, wxString* output = NULL) const wxOVERRIDE;
+    virtual void RunScriptAsync(const wxString& javascript, void* clientData = NULL) const wxOVERRIDE;
     virtual bool AddScriptMessageHandler(const wxString& name) wxOVERRIDE;
     virtual bool RemoveScriptMessageHandler(const wxString& name) wxOVERRIDE;
     virtual bool AddUserScript(const wxString& javascript,

--- a/include/wx/private/jsscriptwrapper.h
+++ b/include/wx/private/jsscriptwrapper.h
@@ -24,18 +24,16 @@
 class wxJSScriptWrapper
 {
 public:
-    wxJSScriptWrapper(const wxString& js, int* runScriptCount)
-        : m_escapedCode(js)
-    {
-        // We assign the return value of JavaScript snippet we execute to the
-        // variable with this name in order to be able to access it later if
-        // needed.
-        //
-        // Note that we use a different name for it for each call to
-        // RunScript() (which creates a new wxJSScriptWrapper every time) to
-        // avoid any possible conflict between different calls.
-        m_outputVarName = wxString::Format(wxASCII_STR("__wxOut%i"), (*runScriptCount)++);
+    enum OutputType {
+        JS_OUTPUT_STRING, // All return types are converted to a string
+        JS_OUTPUT_WEBKIT, // Some return types will be processed
+        JS_OUTPUT_IE, // Most return types will be processed
+        JS_OUTPUT_RAW // The return types is returned as is
+    };
 
+    wxJSScriptWrapper(const wxString& js, OutputType outputType)
+        : m_escapedCode(js), m_outputType(outputType)
+    {
         // Adds one escape level.
         const char *charsNeededToBeEscaped = "\\\"\n\r\v\t\b\f";
         for (
@@ -69,126 +67,139 @@ public:
         }
     }
 
-    // Get the code to execute, its returned value will be either boolean true,
-    // if it executed successfully, or the exception message if an error
-    // occurred.
+    // Get the code to execute, its returned value will be either the value,
+    // if it executed successfully, or the exception message prefixed with
+    // "__wxexc:" if an error occurred.
     //
-    // Execute GetOutputCode() later to get the real output after successful
-    // execution of this code.
+    // Either use SetOutput() to specify the script result or access it directly
+    // Using GetOutputRef()
+    //
+    // Execute ExtractOutput() later to get the real output after successful
+    // execution of this code or the proper error message.
     wxString GetWrappedCode() const
     {
-        return wxString::Format
-               (
-                wxASCII_STR("try { var %s = eval(\"%s\"); true; } "
-                "catch (e) { e.name + \": \" + e.message; }"),
-                m_outputVarName,
-                m_escapedCode
-               );
-    }
+        wxString code = wxString::Format(
+            wxASCII_STR("(function () { try { var res = eval(\"%s\"); "),
+            m_escapedCode);
 
-    // Get code returning the result of the last successful execution of the
-    // code returned by GetWrappedCode().
-    wxString GetOutputCode() const
-    {
-#if wxUSE_WEBVIEW && wxUSE_WEBVIEW_WEBKIT && defined(__WXOSX__)
-        return wxString::Format
-               (
-                wxASCII_STR("if (typeof %s == 'object') JSON.stringify(%s);"
-                "else if (typeof %s == 'undefined') 'undefined';"
-                "else %s;"),
-                m_outputVarName,
-                m_outputVarName,
-                m_outputVarName,
-                m_outputVarName
-               );
-#elif wxUSE_WEBVIEW && wxUSE_WEBVIEW_IE
-        return wxString::Format
-               (
-                wxASCII_STR("try {"
-                    "(%s == null || typeof %s != 'object') ? String(%s)"
-                                                          ": JSON.stringify(%s);"
-                "}"
-                "catch (e) {"
+        switch (m_outputType)
+        {
+            case JS_OUTPUT_STRING:
+                code += wxASCII_STR(
+                            "if (typeof res == 'object') return JSON.stringify(res);"
+                            "else if (typeof res == 'undefined') return 'undefined';"
+                            "else return String(res);"
+                        );
+                break;
+            case JS_OUTPUT_WEBKIT:
+                code += wxASCII_STR(
+                            "if (typeof res == 'object') return JSON.stringify(res);"
+                            "else if (typeof res == 'undefined') return 'undefined';"
+                            "else return res;"
+                        );
+                break;
+            case JS_OUTPUT_IE:
+                code += wxASCII_STR(
                     "try {"
-                        "function __wx$stringifyJSON(obj) {"
-                            "if (!(obj instanceof Object))"
-                                "return typeof obj === \"string\""
-                                    "? \'\"\' + obj + \'\"\'"
-                                    ": \'\' + obj;"
-                            "else if (obj instanceof Array) {"
-                                "if (obj[0] === undefined)"
-                                    "return \'[]\';"
-                                "else {"
-                                    "var arr = [];"
-                                    "for (var i = 0; i < obj.length; i++)"
-                                        "arr.push(__wx$stringifyJSON(obj[i]));"
-                                    "return \'[\' + arr + \']\';"
-                                "}"
-                            "}"
-                            "else if (typeof obj === \"object\") {"
-                                "if (obj instanceof Date) {"
-                                    "if (!Date.prototype.toISOString) {"
-                                        "(function() {"
-                                            "function pad(number) {"
-                                                "return number < 10"
-                                                    "? '0' + number"
-                                                    ": number;"
-                                            "}"
-                                            "Date.prototype.toISOString = function() {"
-                                                "return this.getUTCFullYear() +"
-                                                    "'-' + pad(this.getUTCMonth() + 1) +"
-                                                    "'-' + pad(this.getUTCDate()) +"
-                                                    "'T' + pad(this.getUTCHours()) +"
-                                                    "':' + pad(this.getUTCMinutes()) +"
-                                                    "':' + pad(this.getUTCSeconds()) +"
-                                                    "'.' + (this.getUTCMilliseconds() / 1000)"
-                                                            ".toFixed(3).slice(2, 5) + 'Z\"';"
-                                            "};"
-                                        "}());"
-                                    "}"
-                                    "return '\"' + obj.toISOString(); + '\"'"
-                                "}"
-                                "var objElements = [];"
-                                "for (var key in obj)"
-                                "{"
-                                    "if (typeof obj[key] === \"function\")"
-                                        "return \'{}\';"
-                                    "else {"
-                                        "objElements.push(\'\"\'"
-                                            "+ key + \'\":\' +"
-                                            "__wx$stringifyJSON(obj[key]));"
-                                    "}"
-                                "}"
-                                "return \'{\' + objElements + \'}\';"
-                            "}"
-                        "}"
-                        "__wx$stringifyJSON(%s);"
+                    "return (res == null || typeof res != 'object') ? String(res)"
+                               ": JSON.stringify(res);"
                     "}"
-                    "catch (e) { e.name + \": \" + e.message; }"
-                "}"),
-                m_outputVarName,
-                m_outputVarName,
-                m_outputVarName,
-                m_outputVarName,
-                m_outputVarName
-               );
-#else
-        return m_outputVarName;
-#endif
+                    "catch (e) {"
+                     "try {"
+                         "function __wx$stringifyJSON(obj) {"
+                             "if (!(obj instanceof Object))"
+                                 "return typeof obj === \"string\""
+                                     "? \'\"\' + obj + \'\"\'"
+                                     ": \'\' + obj;"
+                             "else if (obj instanceof Array) {"
+                                 "if (obj[0] === undefined)"
+                                     "return \'[]\';"
+                                 "else {"
+                                     "var arr = [];"
+                                     "for (var i = 0; i < obj.length; i++)"
+                                         "arr.push(__wx$stringifyJSON(obj[i]));"
+                                     "return \'[\' + arr + \']\';"
+                                 "}"
+                             "}"
+                             "else if (typeof obj === \"object\") {"
+                                 "if (obj instanceof Date) {"
+                                     "if (!Date.prototype.toISOString) {"
+                                         "(function() {"
+                                             "function pad(number) {"
+                                                 "return number < 10"
+                                                     "? '0' + number"
+                                                     ": number;"
+                                             "}"
+                                             "Date.prototype.toISOString = function() {"
+                                                 "return this.getUTCFullYear() +"
+                                                     "'-' + pad(this.getUTCMonth() + 1) +"
+                                                     "'-' + pad(this.getUTCDate()) +"
+                                                     "'T' + pad(this.getUTCHours()) +"
+                                                     "':' + pad(this.getUTCMinutes()) +"
+                                                     "':' + pad(this.getUTCSeconds()) +"
+                                                     "'.' + (this.getUTCMilliseconds() / 1000)"
+                                                             ".toFixed(3).slice(2, 5) + 'Z\"';"
+                                             "};"
+                                         "}());"
+                                     "}"
+                                     "return '\"' + obj.toISOString(); + '\"'"
+                                 "}"
+                                 "var objElements = [];"
+                                 "for (var key in obj)"
+                                 "{"
+                                     "if (typeof obj[key] === \"function\")"
+                                         "return \'{}\';"
+                                     "else {"
+                                         "objElements.push(\'\"\'"
+                                             "+ key + \'\":\' +"
+                                             "__wx$stringifyJSON(obj[key]));"
+                                     "}"
+                                 "}"
+                                 "return \'{\' + objElements + \'}\';"
+                             "}"
+                         "}"
+                         "return __wx$stringifyJSON(res);"
+                     "}"
+                     "catch (e) { return \"__wxexc:\" + e.name + \": \" + e.message; }"
+                    "}");
+                break;
+            case JS_OUTPUT_RAW:
+                code += wxASCII_STR("return res;");
+                break;
+        }
+
+        code +=
+            wxASCII_STR("} catch (e) { return \"__wxexc:\" + e.name + \": \" + e.message; }"
+                        "})()");
+        return code;
     }
 
-    const wxString& GetUnwrappedOutputCode() { return m_outputVarName; }
-
-    // Execute the code returned by this function to let the output of the code
-    // we executed be garbage-collected.
-    wxString GetCleanUpCode() const
+    // Extract the output value
+    //
+    // Returns true if executed successfully
+    //    string of the result will be put into output
+    // Returns false when an exception occurred
+    //    string will be the exception message
+    static bool ExtractOutput(const wxString& result, wxString* output)
     {
-        return wxString::Format(wxASCII_STR("%s = undefined;"), m_outputVarName);
+        if (output)
+            *output = result;
+
+        if (result.starts_with(wxASCII_STR("__wxexc:")))
+        {
+            if (output)
+                output->Remove(0, 8);
+            return false;
+        }
+        else
+        {
+            return true;
+        }
     }
 
 private:
     wxString m_escapedCode;
-    wxString m_outputVarName;
+    OutputType m_outputType;
 
     wxDECLARE_NO_COPY_CLASS(wxJSScriptWrapper);
 };

--- a/include/wx/private/jsscriptwrapper.h
+++ b/include/wx/private/jsscriptwrapper.h
@@ -24,7 +24,8 @@
 class wxJSScriptWrapper
 {
 public:
-    enum OutputType {
+    enum OutputType
+    {
         JS_OUTPUT_STRING, // All return types are converted to a string
         JS_OUTPUT_WEBKIT, // Some return types will be processed
         JS_OUTPUT_IE, // Most return types will be processed

--- a/include/wx/webview.h
+++ b/include/wx/webview.h
@@ -139,6 +139,7 @@ public:
     {
         m_showMenu = true;
         m_runScriptCount = 0;
+        m_syncScriptResult = 0;
     }
 
     virtual ~wxWebView() {}

--- a/include/wx/webview.h
+++ b/include/wx/webview.h
@@ -191,7 +191,8 @@ public:
     virtual wxString GetUserAgent() const;
 
     // Script
-    virtual bool RunScript(const wxString& javascript, wxString* output = NULL) const = 0;
+    virtual bool RunScript(const wxString& javascript, wxString* output = NULL) const;
+    virtual void RunScriptAsync(const wxString& javascript, void* clientData = NULL) const;
     virtual bool AddScriptMessageHandler(const wxString& name)
     { wxUnusedVar(name); return false; }
     virtual bool RemoveScriptMessageHandler(const wxString& name)
@@ -267,6 +268,9 @@ protected:
     bool QueryCommandEnabled(const wxString& command) const;
     void ExecCommand(const wxString& command);
 
+    void SendScriptResult(void* clientData, bool success,
+        const wxString& output) const;
+
     // Count the number of calls to RunScript() in order to prevent
     // the_same variable from being used twice in more than one call.
     mutable int m_runScriptCount;
@@ -276,6 +280,8 @@ private:
     static wxStringWebViewFactoryMap::iterator FindFactory(const wxString &backend);
 
     bool m_showMenu;
+    mutable int m_syncScriptResult;
+    mutable wxString m_syncScriptOutput;
     wxString m_findText;
     static wxStringWebViewFactoryMap m_factoryMap;
 
@@ -319,6 +325,7 @@ wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_WEBVIEW, wxEVT_WEBVIEW_NEWWINDOW, wxWebVie
 wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_WEBVIEW, wxEVT_WEBVIEW_TITLE_CHANGED, wxWebViewEvent );
 wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_WEBVIEW, wxEVT_WEBVIEW_FULLSCREEN_CHANGED, wxWebViewEvent);
 wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_WEBVIEW, wxEVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED, wxWebViewEvent);
+wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_WEBVIEW, wxEVT_WEBVIEW_SCRIPT_RESULT, wxWebViewEvent);
 
 typedef void (wxEvtHandler::*wxWebViewEventFunction)
              (wxWebViewEvent&);

--- a/include/wx/webview.h
+++ b/include/wx/webview.h
@@ -138,7 +138,6 @@ public:
     wxWebView()
     {
         m_showMenu = true;
-        m_runScriptCount = 0;
         m_syncScriptResult = 0;
     }
 
@@ -271,10 +270,6 @@ protected:
 
     void SendScriptResult(void* clientData, bool success,
         const wxString& output) const;
-
-    // Count the number of calls to RunScript() in order to prevent
-    // the_same variable from being used twice in more than one call.
-    mutable int m_runScriptCount;
 
 private:
     static void InitFactoryMap();

--- a/include/wx/webview.h
+++ b/include/wx/webview.h
@@ -300,6 +300,7 @@ public:
           m_actionFlags(flags), m_messageHandler(messageHandler)
     {}
 
+    bool IsError() const { return GetInt() == 0; }
 
     const wxString& GetURL() const { return m_url; }
     const wxString& GetTarget() const { return m_target; }

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -714,6 +714,11 @@ public:
     /**
         Runs the given JavaScript code.
 
+        @note Because of various potential issues it's recommended to use
+            RunScriptAsync() instead of this method. This is especially true
+            if you plan to run code from a webview event and will also prevent
+            unintended side effects on the UI outside of the webview.
+
         JavaScript code is executed inside the browser control and has full
         access to DOM and other browser-provided functionality. For example,
         this code

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -1345,6 +1345,14 @@ public:
         @since 3.1.5
     */
     const wxString& GetMessageHandler() const;
+
+    /**
+        Returns true the script execution failed. Only valid for events of type
+        @c wxEVT_WEBVIEW_SCRIPT_RESULT
+
+        @since 3.1.6
+    */
+    bool IsError() const;
 };
 
 

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -777,6 +777,11 @@ public:
         Runs the given JavaScript code asynchronously and returns the result
         via a @c wxEVT_WEBVIEW_SCRIPT_RESULT.
 
+        The script result value can be retrieved via wxWebViewEvent::GetString().
+        If the execution fails wxWebViewEvent::IsError() will return @true. In this
+        case additional script execution error information maybe available
+        via wxWebViewEvent::GetString().
+
         @param javascript JavaScript code to execute.
         @param clientData Arbirary pointer to data that can be retrieved from
             the result event.
@@ -1301,6 +1306,10 @@ public:
         Process a @c wxEVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED event
         only available in wxWidgets 3.1.5 or later. For usage details see
         wxWebView::AddScriptMessageHandler().
+    @event{wxEVT_WEBVIEW_SCRIPT_RESULT(id, func)}
+        Process a @c wxEVT_WEBVIEW_SCRIPT_RESULT event
+        only available in wxWidgets 3.1.6 or later. For usage details see
+        wxWebView::RunScriptAsync().
     @endEventTable
 
     @since 2.9.3

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -485,6 +485,10 @@ public:
         Process a @c wxEVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED event
         only available in wxWidgets 3.1.5 or later. For usage details see
         AddScriptMessageHandler().
+    @event{wxEVT_WEBVIEW_SCRIPT_RESULT(id, func)}
+        Process a @c wxEVT_WEBVIEW_SCRIPT_RESULT event
+        only available in wxWidgets 3.1.6 or later. For usage details see
+        RunScriptAsync().
     @endEventTable
 
     @since 2.9.3
@@ -764,8 +768,26 @@ public:
             @NULL if it is not needed. This parameter is new since wxWidgets
             version 3.1.1.
         @return @true if there is a result, @false if there is an error.
+
+        @see RunScriptAsync()
     */
     virtual bool RunScript(const wxString& javascript, wxString* output = NULL) const = 0;
+
+    /**
+        Runs the given JavaScript code asynchronously and returns the result
+        via a @c wxEVT_WEBVIEW_SCRIPT_RESULT.
+
+        @param javascript JavaScript code to execute.
+        @param clientData Arbirary pointer to data that can be retrieved from
+            the result event.
+
+        @note The IE backend does not support async script execution.
+
+        @since 3.1.6
+        @see RunScript()
+    */
+    virtual void RunScriptAsync(const wxString& javascript, void* clientData = NULL) const;
+
 
     /**
         Add a script message handler with the given name.

--- a/samples/webview/webview.cpp
+++ b/samples/webview/webview.cpp
@@ -932,7 +932,10 @@ void WebFrame::OnScriptMessage(wxWebViewEvent& evt)
 
 void WebFrame::OnScriptResult(wxWebViewEvent& evt)
 {
-    wxLogMessage("Async script result received; value = %s", evt.GetString());
+    if (evt.IsError())
+        wxLogError("Async script execution failed: %s", evt.GetString());
+    else
+        wxLogMessage("Async script result received; value = %s", evt.GetString());
 }
 
 void WebFrame::OnSetPage(wxCommandEvent& WXUNUSED(evt))

--- a/samples/webview/webview.cpp
+++ b/samples/webview/webview.cpp
@@ -122,6 +122,7 @@ public:
     void OnTitleChanged(wxWebViewEvent& evt);
     void OnFullScreenChanged(wxWebViewEvent& evt);
     void OnScriptMessage(wxWebViewEvent& evt);
+    void OnScriptResult(wxWebViewEvent& evt);
     void OnSetPage(wxCommandEvent& evt);
     void OnViewSourceRequest(wxCommandEvent& evt);
     void OnViewTextRequest(wxCommandEvent& evt);
@@ -159,6 +160,7 @@ public:
     void OnRunScriptArrayWithEmulationLevel(wxCommandEvent& evt);
 #endif
     void OnRunScriptMessage(wxCommandEvent& evt);
+    void OnRunScriptAsync(wxCommandEvent& evt);
     void OnRunScriptCustom(wxCommandEvent& evt);
     void OnAddUserScript(wxCommandEvent& evt);
     void OnSetCustomUserAgent(wxCommandEvent& evt);
@@ -233,6 +235,7 @@ private:
 #endif
     wxMenuItem* m_script_message;
     wxMenuItem* m_script_custom;
+    wxMenuItem* m_script_async;
     wxMenuItem* m_selection_clear;
     wxMenuItem* m_selection_delete;
     wxMenuItem* m_find;
@@ -492,6 +495,7 @@ WebFrame::WebFrame(const wxString& url) :
         m_script_array_el = script_menu->Append(wxID_ANY, "Return array changing emulation level");
     }
 #endif
+    m_script_async = script_menu->Append(wxID_ANY, "Return String async");
     m_script_message = script_menu->Append(wxID_ANY, "Send script message");
     m_script_custom = script_menu->Append(wxID_ANY, "Custom script");
     m_tools_menu->AppendSubMenu(script_menu, _("Run Script"));
@@ -551,6 +555,7 @@ WebFrame::WebFrame(const wxString& url) :
     Bind(wxEVT_WEBVIEW_TITLE_CHANGED, &WebFrame::OnTitleChanged, this, m_browser->GetId());
     Bind(wxEVT_WEBVIEW_FULLSCREEN_CHANGED, &WebFrame::OnFullScreenChanged, this, m_browser->GetId());
     Bind(wxEVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED, &WebFrame::OnScriptMessage, this, m_browser->GetId());
+    Bind(wxEVT_WEBVIEW_SCRIPT_RESULT, &WebFrame::OnScriptResult, this, m_browser->GetId());
 
     // Connect the menu events
     Bind(wxEVT_MENU, &WebFrame::OnSetPage, this, setPage->GetId());
@@ -596,6 +601,7 @@ WebFrame::WebFrame(const wxString& url) :
 #endif
     Bind(wxEVT_MENU, &WebFrame::OnRunScriptMessage, this, m_script_message->GetId());
     Bind(wxEVT_MENU, &WebFrame::OnRunScriptCustom, this, m_script_custom->GetId());
+    Bind(wxEVT_MENU, &WebFrame::OnRunScriptAsync, this, m_script_async->GetId());
     Bind(wxEVT_MENU, &WebFrame::OnAddUserScript, this, addUserScript->GetId());
     Bind(wxEVT_MENU, &WebFrame::OnSetCustomUserAgent, this, setCustomUserAgent->GetId());
     Bind(wxEVT_MENU, &WebFrame::OnClearSelection, this, m_selection_clear->GetId());
@@ -924,6 +930,11 @@ void WebFrame::OnScriptMessage(wxWebViewEvent& evt)
     wxLogMessage("Script message received; value = %s, handler = %s", evt.GetString(), evt.GetMessageHandler());
 }
 
+void WebFrame::OnScriptResult(wxWebViewEvent& evt)
+{
+    wxLogMessage("Async script result received; value = %s", evt.GetString());
+}
+
 void WebFrame::OnSetPage(wxCommandEvent& WXUNUSED(evt))
 {
     m_browser->SetPage
@@ -1197,6 +1208,11 @@ void WebFrame::OnRunScriptArrayWithEmulationLevel(wxCommandEvent& WXUNUSED(evt))
 void WebFrame::OnRunScriptMessage(wxCommandEvent& WXUNUSED(evt))
 {
     RunScript("window.wx.postMessage('This is a web message');");
+}
+
+void WebFrame::OnRunScriptAsync(wxCommandEvent& WXUNUSED(evt))
+{
+    m_browser->RunScriptAsync("function f(a){return a;}f('Hello World!');");
 }
 
 void WebFrame::OnRunScriptCustom(wxCommandEvent& WXUNUSED(evt))

--- a/src/common/webview.cpp
+++ b/src/common/webview.cpp
@@ -229,7 +229,7 @@ bool wxWebView::RunScript(const wxString& javascript, wxString* output) const
 {
     m_syncScriptResult = -1;
     m_syncScriptOutput.clear();
-    RunScriptAsync(javascript, (void*)this);
+    RunScriptAsync(javascript);
 
     // Wait for script exection
     while (m_syncScriptResult == -1)

--- a/src/common/webview.cpp
+++ b/src/common/webview.cpp
@@ -228,7 +228,7 @@ wxString wxWebView::GetUserAgent() const
 bool wxWebView::RunScript(const wxString& javascript, wxString* output) const
 {
     m_syncScriptResult = -1;
-    m_syncScriptOutput.Clear();
+    m_syncScriptOutput.clear();
     RunScriptAsync(javascript, (void*)this);
 
     // Wait for script exection
@@ -249,7 +249,7 @@ void wxWebView::RunScriptAsync(const wxString& WXUNUSED(javascript),
 void wxWebView::SendScriptResult(void* clientData, bool success,
     const wxString& output) const
 {
-    // If currently running sync RunScript() don't send an event, but use
+    // If currently running sync RunScript(), don't send an event, but use
     // the scripts result directly
     if (m_syncScriptResult == -1)
     {

--- a/src/common/webview.cpp
+++ b/src/common/webview.cpp
@@ -50,6 +50,7 @@ wxDEFINE_EVENT( wxEVT_WEBVIEW_NEWWINDOW, wxWebViewEvent );
 wxDEFINE_EVENT( wxEVT_WEBVIEW_TITLE_CHANGED, wxWebViewEvent );
 wxDEFINE_EVENT( wxEVT_WEBVIEW_FULLSCREEN_CHANGED, wxWebViewEvent);
 wxDEFINE_EVENT( wxEVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED, wxWebViewEvent);
+wxDEFINE_EVENT( wxEVT_WEBVIEW_SCRIPT_RESULT, wxWebViewEvent);
 
 wxStringWebViewFactoryMap wxWebView::m_factoryMap;
 
@@ -222,6 +223,51 @@ wxString wxWebView::GetUserAgent() const
     wxString userAgent;
     RunScript("navigator.userAgent", &userAgent);
     return userAgent;
+}
+
+bool wxWebView::RunScript(const wxString& javascript, wxString* output) const
+{
+    m_syncScriptResult = -1;
+    m_syncScriptOutput.Clear();
+    RunScriptAsync(javascript, (void*)this);
+
+    // Wait for script exection
+    while (m_syncScriptResult == -1)
+        wxYield();
+
+    if (m_syncScriptResult && output)
+        *output = m_syncScriptOutput;
+    return m_syncScriptResult == 1;
+}
+
+void wxWebView::RunScriptAsync(const wxString& WXUNUSED(javascript),
+    void* WXUNUSED(clientData)) const
+{
+    wxLogError(_("RunScriptAsync not supported"));
+}
+
+void wxWebView::SendScriptResult(void* clientData, bool success,
+    const wxString& output) const
+{
+    // If currently running sync RunScript() don't send an event, but use
+    // the scripts result directly
+    if (m_syncScriptResult == -1)
+    {
+        if (!success)
+            wxLogWarning(_("Error running JavaScript: %s"), output);
+        m_syncScriptOutput = output;
+        m_syncScriptResult = success;
+    }
+    else
+    {
+        wxWebViewEvent evt(wxEVT_WEBVIEW_SCRIPT_RESULT, GetId(), "", "",
+            wxWEBVIEW_NAV_ACTION_NONE);
+        evt.SetEventObject(const_cast<wxWebView*>(this));
+        evt.SetClientData(clientData);
+        evt.SetInt(success);
+        evt.SetString(output);
+        HandleWindowEvent(evt);
+    }
 }
 
 // static

--- a/src/gtk/webview_webkit2.cpp
+++ b/src/gtk/webview_webkit2.cpp
@@ -1287,31 +1287,26 @@ bool wxWebViewWebKit::RunScriptSync(const wxString& javascript, wxString* output
 
 bool wxWebViewWebKit::RunScript(const wxString& javascript, wxString* output) const
 {
-    wxJSScriptWrapper wrapJS(javascript, &m_runScriptCount);
+    wxJSScriptWrapper wrapJS(javascript, wxJSScriptWrapper::JS_OUTPUT_STRING);
 
-    // This string is also used as an error indicator: it's cleared if there is
-    // no error or used in the warning message below if there is one.
+    bool success = false;
     wxString result;
-    if ( RunScriptSync(wrapJS.GetWrappedCode(), &result)
-            && result == wxS("true") )
+    wxString scriptOutput;
+    if (RunScriptSync(wrapJS.GetWrappedCode(), &result))
     {
-        if ( RunScriptSync(wrapJS.GetOutputCode(), &result) )
-        {
-            if ( output )
-                *output = result;
-            result.clear();
-        }
-
-        RunScriptSync(wrapJS.GetCleanUpCode());
+        success = wxJSScriptWrapper::ExtractOutput(result, &scriptOutput);
     }
 
-    if ( !result.empty() )
+    if (output)
+        output->assign(scriptOutput);
+
+    if (!success)
     {
-        wxLogWarning(_("Error running JavaScript: %s"), result);
+        wxLogWarning(_("Error running JavaScript: %s"), scriptOutput);
         return false;
     }
-
-    return true;
+    else
+        return true;
 }
 
 bool wxWebViewWebKit::AddScriptMessageHandler(const wxString& name)

--- a/src/gtk/webview_webkit2.cpp
+++ b/src/gtk/webview_webkit2.cpp
@@ -1231,6 +1231,13 @@ wxString wxWebViewWebKit::GetPageText() const
     return wxString();
 }
 
+class wxWebKitRunScriptParams
+{
+public:
+    const wxWebViewWebKit* webKitCtrl;
+    void* clientData;
+};
+
 extern "C"
 {
 
@@ -1238,75 +1245,55 @@ static void wxgtk_run_javascript_cb(GObject *,
                                     GAsyncResult *res,
                                     void *user_data)
 {
-    g_object_ref(res);
-
-    GAsyncResult** res_out = static_cast<GAsyncResult**>(user_data);
-    *res_out = res;
+    wxWebKitRunScriptParams* params = static_cast<wxWebKitRunScriptParams*>(user_data);
+    params->webKitCtrl->ProcessJavaScriptResult(res, params);
 }
 
 } // extern "C"
 
-// Run the given script synchronously and return its result in output.
-bool wxWebViewWebKit::RunScriptSync(const wxString& javascript, wxString* output) const
+void wxWebViewWebKit::ProcessJavaScriptResult(GAsyncResult *res, wxWebKitRunScriptParams* params) const
 {
-    GAsyncResult *result = NULL;
-    webkit_web_view_run_javascript(m_web_view,
-                                   javascript.utf8_str(),
-                                   NULL,
-                                   wxgtk_run_javascript_cb,
-                                   &result);
-
-    GMainContext *main_context = g_main_context_get_thread_default();
-
-    while ( !result )
-        g_main_context_iteration(main_context, TRUE);
-
     wxGtkError error;
     wxWebKitJavascriptResult js_result
                              (
                                 webkit_web_view_run_javascript_finish
                                 (
                                     m_web_view,
-                                    result,
+                                    res,
                                     error.Out()
                                 )
                              );
 
-    // Match g_object_ref() in wxgtk_run_javascript_cb()
-    g_object_unref(result);
-
-    if ( !js_result )
+    if ( js_result )
     {
-        if ( output )
-            *output = error.GetMessage();
-        return false;
+        wxString scriptResult;
+        if ( wxGetStringFromJSResult(js_result, &scriptResult) )
+        {
+            wxString scriptOutput;
+            bool success = wxJSScriptWrapper::ExtractOutput(scriptResult, &scriptOutput);
+            SendScriptResult(params->clientData, success, scriptOutput);
+        }
     }
+    else
+        SendScriptResult(params->clientData, false, error.GetMessage());
 
-    return wxGetStringFromJSResult(js_result, output);
+    delete params;
 }
 
-bool wxWebViewWebKit::RunScript(const wxString& javascript, wxString* output) const
+void wxWebViewWebKit::RunScriptAsync(const wxString& javascript, void* clientData) const
 {
     wxJSScriptWrapper wrapJS(javascript, wxJSScriptWrapper::JS_OUTPUT_STRING);
 
-    bool success = false;
-    wxString result;
-    wxString scriptOutput;
-    if (RunScriptSync(wrapJS.GetWrappedCode(), &result))
-    {
-        success = wxJSScriptWrapper::ExtractOutput(result, &scriptOutput);
-    }
+    // Collect parameters for access from the callback
+    wxWebKitRunScriptParams* params = new wxWebKitRunScriptParams;
+    params->webKitCtrl = this;
+    params->clientData = clientData;
 
-    if (output)
-        output->assign(scriptOutput);
-
-    if (!success)
-    {
-        wxLogWarning(_("Error running JavaScript: %s"), scriptOutput);
-        return false;
-    }
-    else
-        return true;
+    webkit_web_view_run_javascript(m_web_view,
+                                   wrapJS.GetWrappedCode().utf8_str(),
+                                   NULL,
+                                   wxgtk_run_javascript_cb,
+                                   params);
 }
 
 bool wxWebViewWebKit::AddScriptMessageHandler(const wxString& name)

--- a/src/msw/webview_ie.cpp
+++ b/src/msw/webview_ie.cpp
@@ -1045,40 +1045,25 @@ bool wxWebViewIE::RunScript(const wxString& javascript, wxString* output) const
         return false;
     }
 
-    wxJSScriptWrapper wrapJS(javascript, &m_runScriptCount);
+    wxJSScriptWrapper wrapJS(javascript, wxJSScriptWrapper::JS_OUTPUT_IE);
 
     wxAutomationObject scriptAO(scriptDispatch);
     wxVariant varResult;
 
-    wxString err;
-    if ( !CallEval(wrapJS.GetWrappedCode(), scriptAO, &varResult) )
-    {
-        err = _("failed to evaluate");
-    }
-    else if ( varResult.IsType("bool") && varResult.GetBool() )
-    {
-        if ( output != NULL )
-        {
-            if ( CallEval(wrapJS.GetOutputCode(), scriptAO, &varResult) )
-                *output = varResult.MakeString();
-            else
-                err = _("failed to retrieve execution result");
-        }
+    bool success = false;
+    wxString scriptOutput;
+    if ( CallEval(wrapJS.GetWrappedCode(), scriptAO, &varResult) )
+        success = wxJSScriptWrapper::ExtractOutput(varResult.MakeString(), &scriptOutput);
+    else
+        scriptOutput = _("failed to evaluate");
 
-        CallEval(wrapJS.GetCleanUpCode(), scriptAO, &varResult);
-    }
-    else // result available but not the expected "true"
-    {
-        err = varResult.MakeString();
-    }
+    if (!success)
+        wxLogWarning(_("Error running JavaScript: %s"), scriptOutput);
 
-    if ( !err.empty() )
-    {
-        wxLogWarning(_("Error running JavaScript: %s"), varResult.MakeString());
-        return false;
-    }
+    if (success && output)
+        *output = scriptOutput;
 
-    return true;
+    return success;
 }
 
 void wxWebViewIE::RegisterHandler(wxSharedPtr<wxWebViewHandler> handler)


### PR DESCRIPTION
Add `RunScriptAsync()` to `wxWebView`

My current implementation and proposal is this:
````C++
    virtual void RunScriptAsync(const wxString& javascript, void* clientData = NULL) const;
````
When running `RunScriptAsync()` a new event `wxEVT_WEBVIEW_SCRIPT_RESULT` is triggered on success or failure. It will contain the specified `clientData` via `GetClientData()`. `IsError()` will be `false` if the execution was successful and `GetString()` will contain the scripts output/return value. On error `IsError()` will be `true` and an error message is available via `GetString()`.

I've simplified the current javascript wrapper code to a single javascript call. Which is especially useful for async operation but also reduces calls to the native API from 3 times per `RunScript()` call to once.

I've included a new generic `wxWebView::RunScript()` implementation which will use the backends `wxWebView::RunScriptAsync()` to enable synchronous calls. This should unifiy the different backends implementation as the native API is asynchronous anyway (except for IE, where I think async execution will not be implemented).


ToDo List:
- [x] Complete documentation
- [x] Integrate into sample
- [x] Add unit tests?
- [x] Add `IsError()` to `wxWebViewEvent`
- [x] Simplify JavaScript Wrapper
  - [x] Edge
  - [x] IE
  - [x] WKWebView
  - [x] webkit2
- [x] Implement `RunScriptAsync()`
  - [x] Edge
  - [x] WKWebView
  - [x] webkit2

As always any ideas feedback is welcome.

I would also like to know how to test easily test the webkit1 backend.