### PR TITLE
Preserve size set after calling wxSizer::Fit() with GTK3

### DIFF
--- a/include/wx/gtk/toplevel.h
+++ b/include/wx/gtk/toplevel.h
@@ -136,6 +136,8 @@ public:
 
     void GTKUpdateDecorSize(const DecorSize& decorSize);
 
+    virtual void UpdateClientSizeFrom(const wxSize& size, SizeFrom from) wxOVERRIDE;
+
 protected:
     // give hints to the Window Manager for how the size
     // of the TLW can be changed by dragging
@@ -161,6 +163,7 @@ protected:
 private:
     void Init();
     DecorSize& GetCachedDecorSize();
+    void OnShow(wxShowEvent& event);
 
     // size hint increments
     int m_incWidth, m_incHeight;
@@ -174,6 +177,7 @@ private:
     // is the frame currently grabbed explicitly by the application?
     wxGUIEventLoop* m_grabbedEventLoop;
 
+    SizeFrom m_sizeFrom;
     bool m_updateDecorSize;
     bool m_deferShowAllowed;
 };

--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -610,6 +610,8 @@ public:
         wxDECLARE_NO_COPY_CLASS(ChildrenRepositioningGuard);
     };
 
+    enum SizeFrom { SizeFrom_None, SizeFrom_Fit, SizeFrom_SetSizeHints };
+    virtual void UpdateClientSizeFrom(const wxSize& size, SizeFrom from);
 
     // window state
     // ------------

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -1140,6 +1140,11 @@ bool wxWindowBase::HasScrollbar(int orient) const
                                   : sizeVirt.y > sizeClient.y;
 }
 
+void wxWindowBase::UpdateClientSizeFrom(const wxSize& size, SizeFrom /*from*/)
+{
+    DoSetClientSize(size.x, size.y);
+}
+
 // ----------------------------------------------------------------------------
 // show/hide/enable/disable the window
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Record whether size was set by a wxSizer function which needs to be
called again when style cache has been updated, and avoid calling them
again if size is set by some other means.
See #19134

This is not pretty, but I can't think of a better way to solve the problem.