### PR TITLE
Allow zero scroll pixels per line for wxGrid

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -8170,23 +8170,14 @@ void wxGrid::MakeCellVisible( int row, int col )
         }
     }
 
+    if ( xpos != -1 && m_xScrollPixelsPerLine )
+        xpos /= m_xScrollPixelsPerLine;
+    if ( ypos != -1 && m_yScrollPixelsPerLine )
+        ypos /= m_yScrollPixelsPerLine;
+
     if ( xpos == -1 && ypos == -1 )
         return;
 
-    if ( xpos != -1 )
-    {
-        if (m_xScrollPixelsPerLine == 0)
-            xpos = -1;
-        else
-            xpos /= m_xScrollPixelsPerLine;
-    }
-    if ( ypos != -1 )
-    {
-        if (m_yScrollPixelsPerLine == 0)
-            ypos = -1;
-        else
-            ypos /= m_yScrollPixelsPerLine;
-    }
     Scroll(xpos, ypos);
     AdjustScrollbars();
 }

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -8174,9 +8174,19 @@ void wxGrid::MakeCellVisible( int row, int col )
         return;
 
     if ( xpos != -1 )
-        xpos /= m_xScrollPixelsPerLine;
+    {
+        if (xpos == 0)
+            xpos = -1;
+        else
+            xpos /= m_xScrollPixelsPerLine;
+    }
     if ( ypos != -1 )
-        ypos /= m_yScrollPixelsPerLine;
+    {
+        if (ypos == 0)
+            ypos = -1;
+        else
+            ypos /= m_yScrollPixelsPerLine;
+    }
     Scroll(xpos, ypos);
     AdjustScrollbars();
 }

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -8175,14 +8175,14 @@ void wxGrid::MakeCellVisible( int row, int col )
 
     if ( xpos != -1 )
     {
-        if (xpos == 0)
+        if (m_xScrollPixelsPerLine == 0)
             xpos = -1;
         else
             xpos /= m_xScrollPixelsPerLine;
     }
     if ( ypos != -1 )
     {
-        if (ypos == 0)
+        if (m_yScrollPixelsPerLine == 0)
             ypos = -1;
         else
             ypos /= m_yScrollPixelsPerLine;


### PR DESCRIPTION
This commit allows for m_xScrollPixelsPerLine and m_yScrollPixelsPerLine to be set to zero by adding an explicit check for division by zero.

By setting the pixel scroll size to 0, the effect is that the scrollbar is not displayed when otherwise needed. This is desirable and allows for the user to toggle off the scrollbar when necessary using the functions wxGrid::SetScrollLineX and wxGrid::SetScrollLineY.