### PR TITLE
Undo Ubuntu bug workaround in the CI script

### DIFF
--- a/build/tools/before_install.sh
+++ b/build/tools/before_install.sh
@@ -37,11 +37,6 @@ case $(uname -s) in
                 # Note that this command works only on Ubuntu 18.04 LTS and newer.
                 run_apt install -y ubuntu-dbgsym-keyring
 
-                # The key in the package above is currently (2021-03-22) out of
-                # date, so get the latest key manually (this is completely
-                # insecure, of course, but we don't care).
-                wget -O - http://ddebs.ubuntu.com/dbgsym-release-key.asc | $SUDO apt-key add -
-
                 # Install the symbols to allow LSAN suppression list to work.
                 dbgsym_pkgs='libfontconfig1-dbgsym libglib2.0-0-dbgsym libgtk-3-0-dbgsym libatk-bridge2.0-0-dbgsym'
             fi

--- a/build/tools/before_install.sh
+++ b/build/tools/before_install.sh
@@ -14,8 +14,6 @@ case $(uname -s) in
             # Show information about the repositories and priorities used.
             echo 'APT sources used:'
             $SUDO grep --no-messages '^[^#]' /etc/apt/sources.list /etc/apt/sources.list.d/* || true
-            echo 'APT preferences:'
-            $SUDO grep --no-messages '^[^#]' /etc/apt/preferences /etc/apt/preferences.d/* || true
             echo '--- End of APT files dump ---'
 
             run_apt() {

--- a/build/tools/before_install.sh
+++ b/build/tools/before_install.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 #
-# This script is used by Travis CI to install the dependencies before building
-# wxWidgets but can also be run by hand if necessary but currently it only
-# works for Ubuntu versions used by Travis builds.
+# This script is used by both GitHub and Travis CI to install the dependencies
+# before building wxWidgets but can also be run by hand if necessary (but
+# currently it only works for Ubuntu versions used by the CI builds).
 
 set -e
 


### PR DESCRIPTION
This shouldn't be necessary any longer, as the bug is supposed to be fixed.

Installing debug symbols still doesn't work, however, as there is no version of `libgtk-3-0-dbgsym` matching `libgtk-3-0` version in focal-updates anywhere.