### PR TITLE
MSW: Fix decimal point assert with unknown win32 locales

### DIFF
--- a/include/wx/intl.h
+++ b/include/wx/intl.h
@@ -363,6 +363,9 @@ private:
 
     const char  *m_pszOldLocale;      // previous locale from setlocale()
     wxLocale      *m_pOldLocale;      // previous wxLocale
+#ifdef __WIN32__
+    wxUint32       m_oldLCID;
+#endif
 
     bool           m_initialized;
 

--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -1688,10 +1688,7 @@ GetInfoFromLCID(LCID lcid,
 /* static */
 wxString wxLocale::GetInfo(wxLocaleInfo index, wxLocaleCategory cat)
 {
-    const wxLanguageInfo * const
-        info = wxGetLocale() ? GetLanguageInfo(wxGetLocale()->GetLanguage())
-                             : NULL;
-    if ( !info )
+    if ( !wxGetLocale() )
     {
         // wxSetLocale() hadn't been called yet of failed, hence CRT must be
         // using "C" locale -- but check it to detect bugs that would happen if
@@ -1734,7 +1731,8 @@ wxString wxLocale::GetInfo(wxLocaleInfo index, wxLocaleCategory cat)
         }
     }
 
-    return GetInfoFromLCID(info->GetLCID(), index, cat);
+    // wxSetLocale() succeeded and so thread locale was set together with CRT one.
+    return GetInfoFromLCID(::GetThreadLocale(), index, cat);
 }
 
 /* static */

--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -253,6 +253,9 @@ void wxLocale::DoCommonInit()
     if ( m_pszOldLocale )
         m_pszOldLocale = wxStrdup(m_pszOldLocale);
 
+#ifdef __WIN32__
+    m_oldLCID = ::GetThreadLocale();
+#endif
 
     m_pOldLocale = wxSetLocale(this);
 
@@ -1098,6 +1101,11 @@ wxLocale::~wxLocale()
         wxSetlocale(LC_ALL, m_pszOldLocale);
         free(const_cast<char *>(m_pszOldLocale));
     }
+
+#ifdef __WIN32__
+    ::SetThreadLocale(m_oldLCID);
+    wxMSWSetThreadUILanguage(LANGIDFROMLCID(m_oldLCID));
+#endif
 }
 
 


### PR DESCRIPTION
This is a deceptively simple patch that requires careful review — I am *far* from sure it is the right thing to do. In fact it contains two commits, showing my first fix, and then its replacement by what I think is a correct one (i.e. commit one shouldn't be merged), which I realized in the process of writing this description.

I am sure *something* needs to be done, though.

I started getting unexpected assert from `GetInfoFromLCID()` on Windows 10 (20H2) here:
```cpp
// As we get our decimal point separator from Win32 and not the
// CRT there is a possibility of mismatch between them and this
// can easily happen if the user code called setlocale()
// instead of using wxLocale to change the locale. And this can
// result in very strange bugs elsewhere in the code as the
// assumptions that formatted strings do use the decimal
// separator actually fail, so check for it here.
wxASSERT_MSG
(
    wxString::Format("%.3f", 1.23).find(str) != wxString::npos,
    "Decimal separator mismatch -- did you use setlocale()?"
    "If so, use wxLocale to change the locale instead."
);
```

The app sets locale at launch to user's default one. Which in my case was English, so this was confusing. Turns out, it was a special kind of English, namely en-AT ("English as spoken in Austria"), which, uh, a weird choice of thing to explicitly support in latest Windows 10 builds. At some point, I must have configured this locale during setup - as a way to get European time and date formatting with US English texts… and also "," for decimal point. Presumably that's common enough need that MS added en-AT.

Crucially, wx doesn't know about en-AT. [It doesn't  even have LCID assigned.](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/926e694f-1797-4418-a922-343d1c5e91a6) So what happens is that `GetInfo()` searches the languages database and finds en-US as the best match and runs with it…

…until it hits the above assert.

I think it is wrong on rely on the languages database in this direction. It was meant to be used in the other direction, as API input only, to allow wx users to easily specify the language. It shouldn't be used internally for anything else.

This is something similar to a situation that led to introduction of `GetOSInfo()` in 9fc78c81679274d08ae4c956e652df7a4bfec3e5. But this situation is a third exception where GetOSInfo() and GetInfo() differ: wx doesn't know native locale, which was set using `wxLANGUAGE_DEFAULT`.

I *think* the second commit, ce2aabb, fixes it correctly: it handles the "nobody called wxSetLocale" exception as before, but otherwise behaves as `GetOSInfo`. I think this is correct because if `wSetLocale` didn't fail, then it had set both CRT and win32 thread locales to the same thing, no? And the other exception where GetOSInfo and GetInfo could differ, i.e. locale unsupported by the OS, would result in neither CRT locale nor win32 locale being changed, no? 

Also: isn't this assert in fact fundamentally wrong, because it assumes the `lcid` always corresponds to CRT locale — but the whole point of having `GetInfo()` and `GetOSInfo()` is that there may be subtle differences, and if they are, it is bound to assert when called from one of the two?
