### PR TITLE
Make wxImage ctor from XPM data explicit

### DIFF
--- a/include/wx/dfb/cursor.h
+++ b/include/wx/dfb/cursor.h
@@ -11,6 +11,7 @@
 #define _WX_DFB_CURSOR_H_
 
 class WXDLLIMPEXP_FWD_CORE wxBitmap;
+class WXDLLIMPEXP_FWD_CORE wxImage;
 
 //-----------------------------------------------------------------------------
 // wxCursor
@@ -24,6 +25,10 @@ public:
 #if WXWIN_COMPATIBILITY_2_8
     wxCursor(int id) { InitFromStock((wxStockCursor)id); }
 #endif
+#if wxUSE_IMAGE
+    wxCursor(const wxImage& image);
+    wxCursor(const char* const* xpmData);
+#endif // wxUSE_IMAGE
     wxCursor(const wxString& name,
              wxBitmapType type = wxCURSOR_DEFAULT_TYPE,
              int hotSpotX = 0, int hotSpotY = 0);

--- a/include/wx/gtk/cursor.h
+++ b/include/wx/gtk/cursor.h
@@ -25,6 +25,7 @@ public:
 #endif
 #if wxUSE_IMAGE
     wxCursor( const wxImage & image );
+    wxCursor(const char* const* xpmData);
 #endif // wxUSE_IMAGE
     wxCursor(const wxString& name,
              wxBitmapType type = wxCURSOR_DEFAULT_TYPE,

--- a/include/wx/gtk/cursor.h
+++ b/include/wx/gtk/cursor.h
@@ -25,10 +25,10 @@ public:
 #endif
 #if wxUSE_IMAGE
     wxCursor( const wxImage & image );
+#endif // wxUSE_IMAGE
     wxCursor(const wxString& name,
              wxBitmapType type = wxCURSOR_DEFAULT_TYPE,
              int hotSpotX = 0, int hotSpotY = 0);
-#endif
     wxCursor( const char bits[], int width, int height,
               int hotSpotX = -1, int hotSpotY = -1,
               const char maskBits[] = NULL,

--- a/include/wx/image.h
+++ b/include/wx/image.h
@@ -310,7 +310,7 @@ public:
         { LoadFile( name, type, index ); }
     wxImage( const wxString& name, const wxString& mimetype, int index = -1 )
         { LoadFile( name, mimetype, index ); }
-    wxImage( const char* const* xpmData )
+    explicit wxImage( const char* const* xpmData )
         { Create(xpmData); }
 
 #if wxUSE_STREAMS

--- a/include/wx/motif/cursor.h
+++ b/include/wx/motif/cursor.h
@@ -32,6 +32,7 @@ public:
 
 #if wxUSE_IMAGE
     wxCursor(const wxImage& image);
+    wxCursor(const char* const* xpmData);
 #endif
 
     wxCursor(wxStockCursor id) { InitFromStock(id); }
@@ -51,6 +52,10 @@ protected:
 
 private:
     void InitFromStock(wxStockCursor);
+
+#if wxUSE_IMAGE
+    void InitFromImage(const wxImage& image);
+#endif
 
     void Create(const char bits[], int width, int height,
                 int hotSpotX = -1, int hotSpotY = -1,

--- a/include/wx/msw/cursor.h
+++ b/include/wx/msw/cursor.h
@@ -19,7 +19,9 @@ class WXDLLIMPEXP_CORE wxCursor : public wxCursorBase
 public:
     // constructors
     wxCursor();
+#if wxUSE_IMAGE
     wxCursor(const wxImage& image);
+#endif // wxUSE_IMAGE
     wxCursor(const wxString& name,
              wxBitmapType type = wxCURSOR_DEFAULT_TYPE,
              int hotSpotX = 0, int hotSpotY = 0);

--- a/include/wx/msw/cursor.h
+++ b/include/wx/msw/cursor.h
@@ -21,6 +21,7 @@ public:
     wxCursor();
 #if wxUSE_IMAGE
     wxCursor(const wxImage& image);
+    wxCursor(const char* const* xpmData);
 #endif // wxUSE_IMAGE
     wxCursor(const wxString& name,
              wxBitmapType type = wxCURSOR_DEFAULT_TYPE,
@@ -44,6 +45,10 @@ protected:
     virtual wxGDIImageRefData *CreateData() const wxOVERRIDE;
 
 private:
+#if wxUSE_IMAGE
+    void InitFromImage(const wxImage& image);
+#endif // wxUSE_IMAGE
+
     wxDECLARE_DYNAMIC_CLASS(wxCursor);
 };
 

--- a/include/wx/osx/cursor.h
+++ b/include/wx/osx/cursor.h
@@ -19,7 +19,9 @@ class WXDLLIMPEXP_CORE wxCursor : public wxCursorBase
 public:
     wxCursor();
 
+#if wxUSE_IMAGE
     wxCursor(const wxImage & image) ;
+#endif // wxUSE_IMAGE
     wxCursor(const wxString& name,
              wxBitmapType type = wxCURSOR_DEFAULT_TYPE,
              int hotSpotX = 0, int hotSpotY = 0);

--- a/include/wx/osx/cursor.h
+++ b/include/wx/osx/cursor.h
@@ -21,6 +21,7 @@ public:
 
 #if wxUSE_IMAGE
     wxCursor(const wxImage & image) ;
+    wxCursor(const char* const* xpmData);
 #endif // wxUSE_IMAGE
     wxCursor(const wxString& name,
              wxBitmapType type = wxCURSOR_DEFAULT_TYPE,

--- a/include/wx/osx/cursor.h
+++ b/include/wx/osx/cursor.h
@@ -44,7 +44,9 @@ protected:
 private:
     void InitFromStock(wxStockCursor);
 
-    void CreateFromImage(const wxImage & image) ;
+#if wxUSE_IMAGE
+    void InitFromImage(const wxImage & image) ;
+#endif // wxUSE_IMAGE
 
     wxDECLARE_DYNAMIC_CLASS(wxCursor);
 };

--- a/include/wx/qt/cursor.h
+++ b/include/wx/qt/cursor.h
@@ -22,10 +22,10 @@ public:
 #endif
 #if wxUSE_IMAGE
     wxCursor( const wxImage & image );
+#endif // wxUSE_IMAGE
     wxCursor(const wxString& name,
              wxBitmapType type = wxCURSOR_DEFAULT_TYPE,
              int hotSpotX = 0, int hotSpotY = 0);
-#endif
 
     virtual wxPoint GetHotSpot() const wxOVERRIDE;
     QCursor &GetHandle() const;

--- a/include/wx/qt/cursor.h
+++ b/include/wx/qt/cursor.h
@@ -22,6 +22,7 @@ public:
 #endif
 #if wxUSE_IMAGE
     wxCursor( const wxImage & image );
+    wxCursor(const char* const* xpmData);
 #endif // wxUSE_IMAGE
     wxCursor(const wxString& name,
              wxBitmapType type = wxCURSOR_DEFAULT_TYPE,

--- a/include/wx/x11/cursor.h
+++ b/include/wx/x11/cursor.h
@@ -29,6 +29,7 @@ public:
 #endif
 #if wxUSE_IMAGE
     wxCursor( const wxImage & image );
+    wxCursor(const char* const* xpmData);
 #endif
 
     wxCursor(const wxString& name,

--- a/interface/wx/cursor.h
+++ b/interface/wx/cursor.h
@@ -191,6 +191,17 @@ public:
     wxCursor(const wxImage& image);
 
     /**
+        Constructs a cursor from XPM data.
+
+        In versions of wxWidgets until 3.1.6 constructing wxCursor from XPM
+        data implicitly used wxImage constructor from XPM data and wxCursor
+        constructor from wxImage. Since 3.1.6 this constructor overload is
+        available to allow constructing wxCursor from XPM to still work, even
+        though wxImage constructor from XPM is now @c explicit.
+     */
+    wxCursor(const char* const* xpmData);
+
+    /**
         Copy constructor, uses @ref overview_refcount "reference counting".
 
         @param cursor

--- a/interface/wx/image.h
+++ b/interface/wx/image.h
@@ -611,8 +611,10 @@ public:
         @beginWxPerlOnly
         Not supported by wxPerl.
         @endWxPerlOnly
+
+        This constructor has become @c explicit in wxWidgets 3.1.6.
     */
-    wxImage(const char* const* xpmData);
+    explicit wxImage(const char* const* xpmData);
 
     /**
         Creates an image from a file.

--- a/src/dfb/cursor.cpp
+++ b/src/dfb/cursor.cpp
@@ -53,6 +53,20 @@ void wxCursor::InitFromStock(wxStockCursor cursorId)
 #warning "FIXME -- implement the cursor as bitmaps (that's what DFB uses)"
 }
 
+#if wxUSE_IMAGE
+
+wxCursor::wxCursor(const wxImage& image)
+{
+#warning "FIXME"
+}
+
+wxCursor::wxCursor(const char* const* xpmData)
+{
+#warning "FIXME"
+}
+
+#endif // wxUSE_IMAGE
+
 wxCursor::wxCursor(const wxString& cursor_file,
                    wxBitmapType type,
                    int WXUNUSED(hotSpotX), int WXUNUSED(hotSpotY))

--- a/src/gtk/cursor.cpp
+++ b/src/gtk/cursor.cpp
@@ -76,6 +76,7 @@ wxCursor::wxCursor(const wxString& cursor_file,
                    wxBitmapType type,
                    int hotSpotX, int hotSpotY)
 {
+#if wxUSE_IMAGE
     wxImage img;
     if (!img.LoadFile(cursor_file, type))
         return;
@@ -94,6 +95,11 @@ wxCursor::wxCursor(const wxString& cursor_file,
 wxCursor::wxCursor(const wxImage& img)
 {
     InitFromImage(img);
+}
+
+wxCursor::wxCursor(const char* const* xpmData)
+{
+    InitFromImage(wxImage(xpmData));
 }
 #endif // wxUSE_IMAGE
 

--- a/src/gtk/cursor.cpp
+++ b/src/gtk/cursor.cpp
@@ -72,7 +72,6 @@ wxCursor::wxCursor()
 {
 }
 
-#if wxUSE_IMAGE
 wxCursor::wxCursor(const wxString& cursor_file,
                    wxBitmapType type,
                    int hotSpotX, int hotSpotY)
@@ -88,13 +87,15 @@ wxCursor::wxCursor(const wxString& cursor_file,
         img.SetOption(wxIMAGE_OPTION_CUR_HOTSPOT_Y, hotSpotY);
 
     InitFromImage(img);
+#endif // wxUSE_IMAGE
 }
 
+#if wxUSE_IMAGE
 wxCursor::wxCursor(const wxImage& img)
 {
     InitFromImage(img);
 }
-#endif
+#endif // wxUSE_IMAGE
 
 wxCursor::wxCursor(const char bits[], int width, int height,
                    int hotSpotX, int hotSpotY,

--- a/src/motif/cursor.cpp
+++ b/src/motif/cursor.cpp
@@ -93,7 +93,7 @@ wxCursor::wxCursor()
 }
 
 #if wxUSE_IMAGE
-wxCursor::wxCursor(const wxImage & image)
+void wxCursor::InitFromImage(const wxImage & image)
 {
     unsigned char * rgbBits = image.GetData();
     int w = image.GetWidth() ;
@@ -173,6 +173,16 @@ wxCursor::wxCursor(const wxImage & image)
 
     delete[] bits;
     delete[] maskBits;
+}
+
+wxCursor::wxCursor(const wxImage& image)
+{
+    InitFromImage(image);
+}
+
+wxCursor::wxCursor(const char* const* xpmData)
+{
+    InitFromImage(wxImage(xpmData));
 }
 #endif
 

--- a/src/msw/cursor.cpp
+++ b/src/msw/cursor.cpp
@@ -154,6 +154,16 @@ wxCursor::wxCursor()
 #if wxUSE_IMAGE
 wxCursor::wxCursor(const wxImage& image)
 {
+    InitFromImage(image);
+}
+
+wxCursor::wxCursor(const char* const* xpmData)
+{
+    InitFromImage(wxImage(xpmData));
+}
+
+void wxCursor::InitFromImage(const wxImage& image)
+{
     // image has to be of the standard cursor size, otherwise we won't be able
     // to create it
     const int w = wxCursorRefData::GetStandardWidth();

--- a/src/osx/carbon/cursor.cpp
+++ b/src/osx/carbon/cursor.cpp
@@ -230,6 +230,11 @@ wxCursor::wxCursor( const wxImage &image )
 {
     InitFromImage( image ) ;
 }
+
+wxCursor::wxCursor(const char* const* xpmData)
+{
+    InitFromImage( wxImage(xpmData) ) ;
+}
 #endif // wxUSE_IMAGE
 
 wxGDIRefData *wxCursor::CreateGDIRefData() const

--- a/src/osx/carbon/cursor.cpp
+++ b/src/osx/carbon/cursor.cpp
@@ -225,12 +225,12 @@ wxCursor::wxCursor()
 {
 }
 
+#if wxUSE_IMAGE
 wxCursor::wxCursor( const wxImage &image )
 {
-#if wxUSE_IMAGE
     CreateFromImage( image ) ;
-#endif
 }
+#endif // wxUSE_IMAGE
 
 wxGDIRefData *wxCursor::CreateGDIRefData() const
 {

--- a/src/osx/carbon/cursor.cpp
+++ b/src/osx/carbon/cursor.cpp
@@ -228,7 +228,7 @@ wxCursor::wxCursor()
 #if wxUSE_IMAGE
 wxCursor::wxCursor( const wxImage &image )
 {
-    CreateFromImage( image ) ;
+    InitFromImage( image ) ;
 }
 #endif // wxUSE_IMAGE
 
@@ -249,7 +249,7 @@ WXHCURSOR wxCursor::GetHCURSOR() const
 
 #if wxUSE_IMAGE
 
-void wxCursor::CreateFromImage(const wxImage & image)
+void wxCursor::InitFromImage(const wxImage & image)
 {
     m_refData = new wxCursorRefData;
     int hotSpotX = image.GetOptionInt(wxIMAGE_OPTION_CUR_HOTSPOT_X);
@@ -287,7 +287,7 @@ wxCursor::wxCursor(const wxString& cursor_file, wxBitmapType flags, int hotSpotX
             image.SetOption( wxIMAGE_OPTION_CUR_HOTSPOT_Y, hotSpotY ) ;
             m_refData->DecRef() ;
             m_refData = NULL ;
-            CreateFromImage( image ) ;
+            InitFromImage( image ) ;
         }
 #endif
     }

--- a/src/qt/cursor.cpp
+++ b/src/qt/cursor.cpp
@@ -83,6 +83,11 @@ wxCursor::wxCursor(const wxImage& img)
 {
     InitFromImage(img);
 }
+
+wxCursor::wxCursor(const char* const* xpmData)
+{
+    InitFromImage(wxImage(xpmData));
+}
 #endif // wxUSE_IMAGE
 
 wxPoint wxCursor::GetHotSpot() const

--- a/src/qt/cursor.cpp
+++ b/src/qt/cursor.cpp
@@ -59,11 +59,11 @@ public:
 wxIMPLEMENT_DYNAMIC_CLASS(wxCursor, wxGDIObject);
 
 
-#if wxUSE_IMAGE
 wxCursor::wxCursor(const wxString& cursor_file,
                    wxBitmapType type,
                    int hotSpotX, int hotSpotY)
 {
+#if wxUSE_IMAGE
     wxImage img;
     if (!img.LoadFile(cursor_file, type))
         return;
@@ -75,13 +75,15 @@ wxCursor::wxCursor(const wxString& cursor_file,
         img.SetOption(wxIMAGE_OPTION_CUR_HOTSPOT_Y, hotSpotY);
 
     InitFromImage(img);
+#endif // wxUSE_IMAGE
 }
 
+#if wxUSE_IMAGE
 wxCursor::wxCursor(const wxImage& img)
 {
     InitFromImage(img);
 }
-#endif
+#endif // wxUSE_IMAGE
 
 wxPoint wxCursor::GetHotSpot() const
 {

--- a/src/x11/cursor.cpp
+++ b/src/x11/cursor.cpp
@@ -140,6 +140,11 @@ wxCursor::wxCursor( const wxImage & WXUNUSED(image) )
 {
    wxFAIL_MSG( wxT("wxCursor creation from wxImage not yet implemented") );
 }
+
+wxCursor::wxCursor(const char* const* WXUNUSED(xpmData))
+{
+    wxFAIL_MSG( wxT("wxCursor creation from XPM not yet implemented") );
+}
 #endif
 
 wxCursor::~wxCursor()

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -21,6 +21,8 @@
 
 #include "wx/anidecod.h" // wxImageArray
 #include "wx/bitmap.h"
+#include "wx/cursor.h"
+#include "wx/icon.h"
 #include "wx/palette.h"
 #include "wx/url.h"
 #include "wx/log.h"
@@ -2162,6 +2164,40 @@ TEST_CASE("wxImage::InitAlpha", "[image][initalpha]")
                 CHECK_EQUAL_COLOUR_RGBA(cRes, cSrc);
             }
     }
+}
+
+TEST_CASE("wxImage::XPM", "[image][xpm]")
+{
+   static const char * dummy_xpm[] = {
+      "16 16 2 1",
+      "@ c Black",
+      "  c None",
+      "@               ",
+      " @              ",
+      "  @             ",
+      "   @            ",
+      "    @           ",
+      "     @          ",
+      "      @         ",
+      "       @        ",
+      "        @       ",
+      "         @      ",
+      "          @     ",
+      "           @    ",
+      "            @   ",
+      "             @  ",
+      "              @ ",
+      "               @"
+   };
+
+   wxImage image(dummy_xpm);
+   CHECK( image.IsOk() );
+
+   // The goal here is mostly just to check that this code compiles, i.e. that
+   // creating all these classes from XPM works.
+   CHECK( wxBitmap(dummy_xpm).IsOk() );
+   CHECK( wxCursor(dummy_xpm).IsOk() );
+   CHECK( wxIcon(dummy_xpm).IsOk() );
 }
 
 /*


### PR DESCRIPTION
This avoids accidental conversions from XPM to wxImage which can result
in the use of an expected wxBitmap ctor later.

See [#19149](https://trac.wxwidgets.org/ticket/19149).