### PR TITLE
Add wxSpinCtrl::GetTextValue()

### DIFF
--- a/include/wx/generic/spinctlg.h
+++ b/include/wx/generic/spinctlg.h
@@ -60,6 +60,7 @@ public:
     virtual ~wxSpinCtrlGenericBase();
 
     // accessors
+    virtual wxString GetTextValue() const wxOVERRIDE;
     // T GetValue() const
     // T GetMin() const
     // T GetMax() const

--- a/include/wx/gtk/spinctrl.h
+++ b/include/wx/gtk/spinctrl.h
@@ -72,6 +72,7 @@ public:
     virtual bool GTKOutput(wxString* text) const = 0;
 
     virtual void GTKValueChanged() = 0;
+    void GTKTextChanged();
 
 protected:
     wxSpinCtrlGTKBase();

--- a/include/wx/gtk/spinctrl.h
+++ b/include/wx/gtk/spinctrl.h
@@ -71,6 +71,8 @@ public:
     virtual GTKInputResult GTKInput(double* value) const = 0;
     virtual bool GTKOutput(wxString* text) const = 0;
 
+    virtual void GTKValueChanged() = 0;
+
 protected:
     double DoGetValue() const;
     double DoGetMin() const;
@@ -153,6 +155,7 @@ public:
 
     virtual GTKInputResult GTKInput(double* value) const wxOVERRIDE;
     virtual bool GTKOutput(wxString* text) const wxOVERRIDE;
+    virtual void GTKValueChanged() wxOVERRIDE;
 
 protected:
     virtual void GtkSetEntryWidth() wxOVERRIDE;
@@ -224,6 +227,7 @@ public:
 
     virtual GTKInputResult GTKInput(double* value) const wxOVERRIDE;
     virtual bool GTKOutput(wxString* text) const wxOVERRIDE;
+    virtual void GTKValueChanged() wxOVERRIDE;
 
 protected:
     virtual void GtkSetEntryWidth() wxOVERRIDE;

--- a/include/wx/gtk/spinctrl.h
+++ b/include/wx/gtk/spinctrl.h
@@ -58,6 +58,19 @@ public:
     // implementation
     void OnChar( wxKeyEvent &event );
 
+
+    // These values map to the possible return values of "input" GTK signal but
+    // are more readable and type-safe.
+    enum GTKInputResult
+    {
+        GTKInput_Error = -1,
+        GTKInput_Default,
+        GTKInput_Converted
+    };
+
+    virtual GTKInputResult GTKInput(double* value) const = 0;
+    virtual bool GTKOutput(wxString* text) const = 0;
+
 protected:
     double DoGetValue() const;
     double DoGetMin() const;
@@ -138,6 +151,9 @@ public:
     virtual int GetBase() const wxOVERRIDE { return m_base; }
     virtual bool SetBase(int base) wxOVERRIDE;
 
+    virtual GTKInputResult GTKInput(double* value) const wxOVERRIDE;
+    virtual bool GTKOutput(wxString* text) const wxOVERRIDE;
+
 protected:
     virtual void GtkSetEntryWidth() wxOVERRIDE;
 
@@ -205,6 +221,9 @@ public:
 
     virtual int GetBase() const wxOVERRIDE { return 10; }
     virtual bool SetBase(int WXUNUSED(base)) wxOVERRIDE { return false; }
+
+    virtual GTKInputResult GTKInput(double* value) const wxOVERRIDE;
+    virtual bool GTKOutput(wxString* text) const wxOVERRIDE;
 
 protected:
     virtual void GtkSetEntryWidth() wxOVERRIDE;

--- a/include/wx/gtk/spinctrl.h
+++ b/include/wx/gtk/spinctrl.h
@@ -102,9 +102,16 @@ protected:
     // override this and return true.
     virtual bool UseGTKStyleBase() const wxOVERRIDE { return true; }
 
-    // Set or reset m_textOverride.
+    // Set m_textOverride to use the given text instead of the numeric value.
     void GTKSetTextOverride(const wxString& text);
+
+    // Reset the override and changing the value to correspond to the
+    // previously overridden numeric value.
     void GTKResetTextOverride();
+
+    // Just reset the override, without touching the value, returning true if
+    // we did it. In most cases, the function above should be used instead.
+    bool GTKResetTextOverrideOnly();
 
 private:
     // This function does _not_ take into account m_textOverride, so it is

--- a/include/wx/gtk/spinctrl.h
+++ b/include/wx/gtk/spinctrl.h
@@ -74,6 +74,9 @@ public:
     virtual void GTKValueChanged() = 0;
 
 protected:
+    wxSpinCtrlGTKBase();
+    ~wxSpinCtrlGTKBase();
+
     double DoGetValue() const;
     double DoGetMin() const;
     double DoGetMax() const;
@@ -97,6 +100,19 @@ protected:
     // Widgets that use the style->base colour for the BG colour should
     // override this and return true.
     virtual bool UseGTKStyleBase() const wxOVERRIDE { return true; }
+
+    // Set or reset m_textOverride.
+    void GTKSetTextOverride(const wxString& text);
+    void GTKResetTextOverride();
+
+private:
+    // This function does _not_ take into account m_textOverride, so it is
+    // private and normally shouldn't be used -- use DoGetValue() instead.
+    double GTKGetValue() const;
+
+    // Non-null when the text value is different from the numeric value.
+    class wxSpinCtrlGTKTextOverride* m_textOverride;
+
 
     friend class wxSpinCtrlEventDisabler;
 

--- a/include/wx/gtk/spinctrl.h
+++ b/include/wx/gtk/spinctrl.h
@@ -35,6 +35,7 @@ public:
     // wxSpinCtrl(Double) methods call DoXXX functions of the same name
 
     // accessors
+    virtual wxString GetTextValue() const wxOVERRIDE;
     // T GetValue() const
     // T GetMin() const
     // T GetMax() const

--- a/include/wx/gtk1/spinctrl.h
+++ b/include/wx/gtk1/spinctrl.h
@@ -48,6 +48,7 @@ public:
     void SetValue(const wxString& text);
     void SetSelection(long from, long to);
 
+    virtual wxString GetTextValue() const;
     virtual int GetValue() const;
     virtual void SetValue( int value );
     virtual void SetRange( int minVal, int maxVal );

--- a/include/wx/msw/spinctrl.h
+++ b/include/wx/msw/spinctrl.h
@@ -62,6 +62,7 @@ public:
     void SetSelection(long from, long to);
 
     // wxSpinCtrlBase methods
+    virtual wxString GetTextValue() const;
     virtual int GetBase() const;
     virtual bool SetBase(int base);
 

--- a/include/wx/qt/spinctrl.h
+++ b/include/wx/qt/spinctrl.h
@@ -29,6 +29,7 @@ public:
         T min, T max, T initial, T inc,
         const wxString& name );
 
+    virtual wxString GetTextValue() const wxOVERRIDE;
     virtual void SetValue(const wxString&) wxOVERRIDE {}
 
     virtual void SetSnapToTicks(bool snap_to_ticks) wxOVERRIDE;

--- a/include/wx/spinctrl.h
+++ b/include/wx/spinctrl.h
@@ -35,7 +35,7 @@ public:
     wxSpinCtrlBase() {}
 
     // accessor functions that derived classes are expected to have
-    virtual wxString GetTextValue() const { return wxString(); }
+    virtual wxString GetTextValue() const = 0;
     // T GetValue() const
     // T GetMin() const
     // T GetMax() const

--- a/include/wx/spinctrl.h
+++ b/include/wx/spinctrl.h
@@ -35,6 +35,7 @@ public:
     wxSpinCtrlBase() {}
 
     // accessor functions that derived classes are expected to have
+    virtual wxString GetTextValue() const { return wxString(); }
     // T GetValue() const
     // T GetMin() const
     // T GetMax() const

--- a/interface/wx/spinctrl.h
+++ b/interface/wx/spinctrl.h
@@ -197,6 +197,10 @@ public:
         Sets the value of the spin control.
 
         It is recommended to use the overload taking an integer value instead.
+        The behaviour of this function when @a text doesn't represent a valid
+        number currently differs between the platforms, however passing an
+        empty string does clear the text part contents, without affecting the
+        value returned by GetValue(), under all of them.
 
         Notice that, unlike wxTextCtrl::SetValue(), but like most of the other
         setter methods in wxWidgets, calling this method does not generate any
@@ -249,6 +253,14 @@ public:
 
     /**
         Constructor, creating and showing a spin control.
+
+        If @a value is non-empty, it will be shown in the text entry part of
+        the control and if it has numeric value, the initial numeric value of
+        the control, as returned by GetValue() will also be determined by it
+        instead of by @a initial. Hence, it only makes sense to specify @a
+        initial if @a value is an empty string or is not convertible to a
+        number, otherwise @a initial is simply ignored and the number specified
+        by @a value is used.
 
         @param parent
             Parent window. Must not be @NULL.
@@ -356,6 +368,10 @@ public:
         Sets the value of the spin control.
 
         It is recommended to use the overload taking a double value instead.
+        The behaviour of this function when @a text doesn't represent a valid
+        number currently differs between the platforms, however
+        passing an empty string does clear the text part contents, without
+        affecting the value returned by GetValue(), under all of them.
 
         Notice that, unlike wxTextCtrl::SetValue(), but like most of the other
         setter methods in wxWidgets, calling this method does not generate any

--- a/interface/wx/spinctrl.h
+++ b/interface/wx/spinctrl.h
@@ -134,6 +134,13 @@ public:
     int GetMin() const;
 
     /**
+        Returns the text in the text entry part of the control.
+
+        @since 3.1.6
+    */
+    wxString GetTextValue() const;
+
+    /**
         Gets the value of the spin control.
     */
     int GetValue() const;
@@ -314,6 +321,13 @@ public:
         Gets minimal allowable value.
     */
     double GetMin() const;
+
+    /**
+        Returns the text in the text entry part of the control.
+
+        @since 3.1.6
+    */
+    wxString GetTextValue() const;
 
     /**
         Gets the value of the spin control.

--- a/samples/widgets/spinbtn.cpp
+++ b/samples/widgets/spinbtn.cpp
@@ -483,6 +483,14 @@ void SpinBtnWidgetsPage::OnButtonSetBase(wxCommandEvent& WXUNUSED(event))
 
 void SpinBtnWidgetsPage::OnButtonSetValue(wxCommandEvent& WXUNUSED(event))
 {
+    if ( m_textValue->IsEmpty() )
+    {
+        m_spinctrl->SetValue( wxEmptyString );
+        m_spinctrldbl->SetValue( wxEmptyString );
+
+        return;
+    }
+
     long val;
     if ( !m_textValue->GetValue().ToLong(&val) || !IsValidValue(val) )
     {
@@ -499,7 +507,8 @@ void SpinBtnWidgetsPage::OnButtonSetValue(wxCommandEvent& WXUNUSED(event))
 void SpinBtnWidgetsPage::OnUpdateUIValueButton(wxUpdateUIEvent& event)
 {
     long val;
-    event.Enable( m_textValue->GetValue().ToLong(&val) && IsValidValue(val) );
+    event.Enable( m_textValue->IsEmpty() ||
+                  ( m_textValue->GetValue().ToLong(&val) && IsValidValue(val) ) );
 }
 
 void SpinBtnWidgetsPage::OnUpdateUIMinMaxButton(wxUpdateUIEvent& event)

--- a/src/generic/spinctlg.cpp
+++ b/src/generic/spinctlg.cpp
@@ -506,6 +506,11 @@ bool wxSpinCtrlGenericBase::SyncSpinToText(SendEvent sendEvent)
 // changing value and range
 // ----------------------------------------------------------------------------
 
+wxString wxSpinCtrlGenericBase::GetTextValue() const
+{
+    return m_textCtrl ? m_textCtrl->GetValue() : wxString();
+}
+
 void wxSpinCtrlGenericBase::SetValue(const wxString& text)
 {
     wxCHECK_RET( m_textCtrl, wxT("invalid call to wxSpinCtrl::SetValue") );

--- a/src/gtk/spinctrl.cpp
+++ b/src/gtk/spinctrl.cpp
@@ -524,6 +524,8 @@ bool wxSpinCtrlGTKBase::GTKOutput(wxString* text) const
 
 void wxSpinCtrlGTKBase::GTKTextChanged()
 {
+    GTKResetTextOverride();
+
     wxCommandEvent event( wxEVT_TEXT, GetId() );
     event.SetEventObject( this );
     event.SetString(GetTextValue());

--- a/src/gtk/spinctrl.cpp
+++ b/src/gtk/spinctrl.cpp
@@ -218,7 +218,7 @@ wxString wxSpinCtrlGTKBase::GetTextValue() const
 {
     wxCHECK_MSG(m_widget, wxEmptyString, "invalid spin button");
 
-    return gtk_entry_get_text( GTK_ENTRY(m_widget) );
+    return wxGTK_CONV_BACK(gtk_entry_get_text( GTK_ENTRY(m_widget) ));
 }
 
 bool wxSpinCtrlGTKBase::GetSnapToTicks() const

--- a/src/gtk/spinctrl.cpp
+++ b/src/gtk/spinctrl.cpp
@@ -176,13 +176,21 @@ void wxSpinCtrlGTKBase::GTKSetTextOverride(const wxString& text)
     m_textOverride->m_text = text;
 }
 
-void wxSpinCtrlGTKBase::GTKResetTextOverride()
+bool wxSpinCtrlGTKBase::GTKResetTextOverrideOnly()
 {
     if ( !m_textOverride )
-        return;
+        return false;
 
     delete m_textOverride;
     m_textOverride = NULL;
+
+    return true;
+}
+
+void wxSpinCtrlGTKBase::GTKResetTextOverride()
+{
+    if ( !GTKResetTextOverrideOnly() )
+        return;
 
     // Update the text part to reflect the numeric value now that we don't
     // override it any longer, otherwise we'd keep showing the old one because
@@ -524,7 +532,10 @@ bool wxSpinCtrlGTKBase::GTKOutput(wxString* text) const
 
 void wxSpinCtrlGTKBase::GTKTextChanged()
 {
-    GTKResetTextOverride();
+    // We can't use GTKResetTextOverride() itself here because it would also
+    // reset the value and we do not want this to happen -- the value is being
+    // changed to correspond to the new text.
+    GTKResetTextOverrideOnly();
 
     wxCommandEvent event( wxEVT_TEXT, GetId() );
     event.SetEventObject( this );

--- a/src/gtk/spinctrl.cpp
+++ b/src/gtk/spinctrl.cpp
@@ -88,7 +88,7 @@ wx_gtk_spin_input(GtkSpinButton*, gdouble* val, wxSpinCtrlGTKBase* win)
     return FALSE;
 }
 
-static gint
+static gboolean
 wx_gtk_spin_output(GtkSpinButton* spin, wxSpinCtrlGTKBase* win)
 {
     wxString text;

--- a/src/gtk/spinctrl.cpp
+++ b/src/gtk/spinctrl.cpp
@@ -214,6 +214,13 @@ double wxSpinCtrlGTKBase::DoGetIncrement() const
     return inc;
 }
 
+wxString wxSpinCtrlGTKBase::GetTextValue() const
+{
+    wxCHECK_MSG(m_widget, wxEmptyString, "invalid spin button");
+
+    return gtk_entry_get_text( GTK_ENTRY(m_widget) );
+}
+
 bool wxSpinCtrlGTKBase::GetSnapToTicks() const
 {
     wxCHECK_MSG(m_widget, false, "invalid spin button");

--- a/src/gtk/spinctrl.cpp
+++ b/src/gtk/spinctrl.cpp
@@ -54,11 +54,7 @@ extern "C" {
 static void
 gtk_changed(GtkSpinButton*, wxSpinCtrl* win)
 {
-    wxCommandEvent event( wxEVT_TEXT, win->GetId() );
-    event.SetEventObject( win );
-    event.SetString(win->GetTextValue());
-    event.SetInt(win->GetValue());
-    win->HandleWindowEvent( event );
+    win->GTKTextChanged();
 }
 }
 
@@ -524,6 +520,15 @@ bool wxSpinCtrlGTKBase::GTKOutput(wxString* text) const
     }
 
     return false;
+}
+
+void wxSpinCtrlGTKBase::GTKTextChanged()
+{
+    wxCommandEvent event( wxEVT_TEXT, GetId() );
+    event.SetEventObject( this );
+    event.SetString(GetTextValue());
+    event.SetInt(static_cast<int>(DoGetValue()));
+    HandleWindowEvent( event );
 }
 
 //-----------------------------------------------------------------------------

--- a/src/gtk/spinctrl.cpp
+++ b/src/gtk/spinctrl.cpp
@@ -37,27 +37,12 @@ extern bool   g_blockEventsOnDrag;
 
 extern "C" {
 static void
-gtk_value_changed(GtkSpinButton* spinbutton, wxSpinCtrlGTKBase* win)
+gtk_value_changed(GtkSpinButton*, wxSpinCtrlGTKBase* win)
 {
     if (g_blockEventsOnDrag)
         return;
 
-    if (wxIsKindOf(win, wxSpinCtrl))
-    {
-        wxSpinEvent event(wxEVT_SPINCTRL, win->GetId());
-        event.SetEventObject( win );
-        event.SetPosition(static_cast<wxSpinCtrl*>(win)->GetValue());
-        event.SetString(gtk_entry_get_text(GTK_ENTRY(spinbutton)));
-        win->HandleWindowEvent( event );
-    }
-    else // wxIsKindOf(win, wxSpinCtrlDouble)
-    {
-        wxSpinDoubleEvent event( wxEVT_SPINCTRLDOUBLE, win->GetId());
-        event.SetEventObject( win );
-        event.SetValue(static_cast<wxSpinCtrlDouble*>(win)->GetValue());
-        event.SetString(gtk_entry_get_text(GTK_ENTRY(spinbutton)));
-        win->HandleWindowEvent( event );
-    }
+    win->GTKValueChanged();
 }
 }
 
@@ -523,6 +508,15 @@ bool wxSpinCtrl::GTKOutput(wxString* text) const
     return true;
 }
 
+void wxSpinCtrl::GTKValueChanged()
+{
+    wxSpinEvent event(wxEVT_SPINCTRL, GetId());
+    event.SetEventObject( this );
+    event.SetPosition(GetValue());
+    event.SetString(GetTextValue());
+    HandleWindowEvent( event );
+}
+
 //-----------------------------------------------------------------------------
 // wxSpinCtrlDouble
 //-----------------------------------------------------------------------------
@@ -566,6 +560,15 @@ wxSpinCtrlDouble::GTKInput(double* WXUNUSED(value)) const
 bool wxSpinCtrlDouble::GTKOutput(wxString* WXUNUSED(text)) const
 {
     return false;
+}
+
+void wxSpinCtrlDouble::GTKValueChanged()
+{
+    wxSpinDoubleEvent event( wxEVT_SPINCTRLDOUBLE, GetId());
+    event.SetEventObject( this );
+    event.SetValue(GetValue());
+    event.SetString(GetTextValue());
+    HandleWindowEvent( event );
 }
 
 #endif // wxUSE_SPINCTRL

--- a/src/gtk/spinctrl.cpp
+++ b/src/gtk/spinctrl.cpp
@@ -67,11 +67,11 @@ gtk_value_changed(GtkSpinButton* spinbutton, wxSpinCtrlGTKBase* win)
 
 extern "C" {
 static void
-gtk_changed(GtkSpinButton* spinbutton, wxSpinCtrl* win)
+gtk_changed(GtkSpinButton*, wxSpinCtrl* win)
 {
     wxCommandEvent event( wxEVT_TEXT, win->GetId() );
     event.SetEventObject( win );
-    event.SetString(gtk_entry_get_text(GTK_ENTRY(spinbutton)));
+    event.SetString(win->GetTextValue());
     event.SetInt(win->GetValue());
     win->HandleWindowEvent( event );
 }
@@ -343,9 +343,7 @@ void wxSpinCtrlGTKBase::OnChar( wxKeyEvent &event )
     {
         wxCommandEvent evt( wxEVT_TEXT_ENTER, m_windowId );
         evt.SetEventObject(this);
-        GtkSpinButton *gsb = GTK_SPIN_BUTTON(m_widget);
-        wxString val = wxGTK_CONV_BACK( gtk_entry_get_text( &gsb->entry ) );
-        evt.SetString( val );
+        evt.SetString(GetTextValue());
         if (HandleWindowEvent(evt)) return;
     }
 

--- a/src/gtk1/spinctrl.cpp
+++ b/src/gtk1/spinctrl.cpp
@@ -203,6 +203,13 @@ int wxSpinCtrl::GetMax() const
     return (int)ceil(m_adjust->upper);
 }
 
+wxString wxSpinCtrl::GetTextValue() const
+{
+    wxCHECK_MSG(m_widget, wxEmptyString, "invalid spin button");
+
+    return gtk_entry_get_text( GTK_ENTRY(m_widget) );
+}
+
 int wxSpinCtrl::GetValue() const
 {
     wxCHECK_MSG( (m_widget != NULL), 0, wxT("invalid spin button") );

--- a/src/msw/spinctrl.cpp
+++ b/src/msw/spinctrl.cpp
@@ -442,6 +442,11 @@ bool wxSpinCtrl::SetBase(int base)
 // wxTextCtrl-like methods
 // ----------------------------------------------------------------------------
 
+wxString wxSpinCtrl::GetTextValue() const
+{
+    return wxGetWindowText(m_hwndBuddy);
+}
+
 void wxSpinCtrl::SetValue(const wxString& text)
 {
     if ( !::SetWindowText(GetBuddyHwnd(), text.c_str()) )

--- a/src/qt/spinctrl.cpp
+++ b/src/qt/spinctrl.cpp
@@ -59,6 +59,12 @@ bool wxSpinCtrlQt< T, Widget >::Create( wxWindow *parent, wxWindowID id,
 }
 
 template< typename T, typename Widget >
+wxString wxSpinCtrlQt< T, Widget >::GetTextValue() const
+{
+    return wxQtConvertString(m_qtSpinBox->text());
+}
+
+template< typename T, typename Widget >
 void wxSpinCtrlQt< T, Widget >::SetValue( T val )
 {
     m_qtSpinBox->blockSignals(true);

--- a/tests/controls/spinctrldbltest.cpp
+++ b/tests/controls/spinctrldbltest.cpp
@@ -168,6 +168,17 @@ TEST_CASE_METHOD(SpinCtrlDoubleTestCase,
     // Calling SetValue() shouldn't have generated any events.
     CHECK( updatedSpin.GetCount() == 0 );
     CHECK( updatedText.GetCount() == 0 );
+
+    // Also test that setting the text value works.
+    CHECK( m_spin->GetTextValue() == "49.10" );
+
+    m_spin->SetValue("57.30");
+    CHECK( m_spin->GetTextValue() == "57.30" );
+    CHECK( m_spin->GetValue() == 57.3 );
+
+    m_spin->SetValue("");
+    CHECK( m_spin->GetTextValue() == "" );
+    CHECK( m_spin->GetValue() == 57.3 );
 }
 
 #if wxUSE_UIACTIONSIMULATOR

--- a/tests/controls/spinctrldbltest.cpp
+++ b/tests/controls/spinctrldbltest.cpp
@@ -19,76 +19,59 @@
 #include "wx/uiaction.h"
 #include "wx/spinctrl.h"
 
-class SpinCtrlDoubleTestCase : public CppUnit::TestCase
+class SpinCtrlDoubleTestCase
 {
 public:
-    SpinCtrlDoubleTestCase() { }
+    SpinCtrlDoubleTestCase(int style = wxSP_ARROW_KEYS)
+        : m_spin(new wxSpinCtrlDouble(wxTheApp->GetTopWindow(), wxID_ANY, "",
+                                      wxDefaultPosition, wxDefaultSize,
+                                      style))
+    {
+    }
 
-    void setUp() wxOVERRIDE;
-    void tearDown() wxOVERRIDE;
+    ~SpinCtrlDoubleTestCase()
+    {
+        delete m_spin;
+    }
 
-private:
-    CPPUNIT_TEST_SUITE( SpinCtrlDoubleTestCase );
-        CPPUNIT_TEST( NoEventsInCtor );
-        WXUISIM_TEST( Arrows );
-        WXUISIM_TEST( Wrap );
-        CPPUNIT_TEST( Range );
-        CPPUNIT_TEST( Value );
-        WXUISIM_TEST( Increment );
-        CPPUNIT_TEST( Digits );
-    CPPUNIT_TEST_SUITE_END();
-
-    void NoEventsInCtor();
-    void Arrows();
-    void Wrap();
-    void Range();
-    void Value();
-    void Increment();
-    void Digits();
-
-    wxSpinCtrlDouble* m_spin;
+protected:
+    wxSpinCtrlDouble* const m_spin;
 
     wxDECLARE_NO_COPY_CLASS(SpinCtrlDoubleTestCase);
 };
 
-// register in the unnamed registry so that these tests are run by default
-CPPUNIT_TEST_SUITE_REGISTRATION( SpinCtrlDoubleTestCase );
-
-// also include in its own registry so that these tests can be run alone
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( SpinCtrlDoubleTestCase, "SpinCtrlDoubleTestCase" );
-
-void SpinCtrlDoubleTestCase::setUp()
+class SpinCtrlDoubleTestCaseWrap : public SpinCtrlDoubleTestCase
 {
-    m_spin = new wxSpinCtrlDouble(wxTheApp->GetTopWindow());
-}
+public:
+    SpinCtrlDoubleTestCaseWrap()
+        : SpinCtrlDoubleTestCase(wxSP_ARROW_KEYS | wxSP_WRAP)
+    {
+    }
+};
 
-void SpinCtrlDoubleTestCase::tearDown()
-{
-    wxDELETE(m_spin);
-}
 
-void SpinCtrlDoubleTestCase::NoEventsInCtor()
+TEST_CASE("SpinCtrlDouble::NoEventsInCtor", "[spinctrl][spinctrldouble]")
 {
     // Verify that creating the control does not generate any events. This is
     // unexpected and shouldn't happen.
-    wxWindow* const parent = m_spin->GetParent();
-    delete m_spin;
-    m_spin = new wxSpinCtrlDouble;
+    wxSpinCtrlDouble *m_spin = new wxSpinCtrlDouble;
 
     EventCounter updatedSpin(m_spin, wxEVT_SPINCTRLDOUBLE);
     EventCounter updatedText(m_spin, wxEVT_TEXT);
 
-    m_spin->Create(parent, wxID_ANY, "",
+    m_spin->Create(wxTheApp->GetTopWindow(), wxID_ANY, "",
                    wxDefaultPosition, wxDefaultSize, 0,
                    0., 100., 17.);
 
-    CPPUNIT_ASSERT_EQUAL(0, updatedSpin.GetCount());
-    CPPUNIT_ASSERT_EQUAL(0, updatedText.GetCount());
+    CHECK( updatedSpin.GetCount() == 0 );
+    CHECK( updatedText.GetCount() == 0 );
 }
 
-void SpinCtrlDoubleTestCase::Arrows()
-{
 #if wxUSE_UIACTIONSIMULATOR
+
+TEST_CASE_METHOD(SpinCtrlDoubleTestCase,
+                 "SpinCtrlDouble::Arrows", "[spinctrl][spinctrldouble]")
+{
     EventCounter updated(m_spin, wxEVT_SPINCTRLDOUBLE);
 
     wxUIActionSimulator sim;
@@ -99,26 +82,20 @@ void SpinCtrlDoubleTestCase::Arrows()
     sim.Char(WXK_UP);
     wxYield();
 
-    CPPUNIT_ASSERT_EQUAL(1, updated.GetCount());
-    CPPUNIT_ASSERT_EQUAL(1.0, m_spin->GetValue());
+    CHECK( updated.GetCount() == 1 );
+    CHECK( m_spin->GetValue() == 1.0 );
     updated.Clear();
 
     sim.Char(WXK_DOWN);
     wxYield();
 
-    CPPUNIT_ASSERT_EQUAL(1, updated.GetCount());
-    CPPUNIT_ASSERT_EQUAL(0.0, m_spin->GetValue());
-#endif
+    CHECK( updated.GetCount() == 1 );
+    CHECK( m_spin->GetValue() == 0.0 );
 }
 
-void SpinCtrlDoubleTestCase::Wrap()
+TEST_CASE_METHOD(SpinCtrlDoubleTestCaseWrap,
+                 "SpinCtrlDouble::Wrap", "[spinctrl][spinctrldouble]")
 {
-#if wxUSE_UIACTIONSIMULATOR
-    wxDELETE(m_spin);
-    m_spin = new wxSpinCtrlDouble(wxTheApp->GetTopWindow(), wxID_ANY, "",
-                                  wxDefaultPosition, wxDefaultSize,
-                                  wxSP_ARROW_KEYS | wxSP_WRAP);
-
     wxUIActionSimulator sim;
 
     m_spin->SetFocus();
@@ -128,20 +105,21 @@ void SpinCtrlDoubleTestCase::Wrap()
 
     wxYield();
 
-    CPPUNIT_ASSERT_EQUAL(100.0, m_spin->GetValue());
+    CHECK( m_spin->GetValue() == 100.0 );
 
     sim.Char(WXK_UP);
 
     wxYield();
 
-    CPPUNIT_ASSERT_EQUAL(0.0, m_spin->GetValue());
-#endif
+    CHECK( m_spin->GetValue() == 0.0 );
 }
+#endif // wxUSE_UIACTIONSIMULATOR
 
-void SpinCtrlDoubleTestCase::Range()
+TEST_CASE_METHOD(SpinCtrlDoubleTestCase,
+                 "SpinCtrlDouble::Range", "[spinctrl][spinctrldouble]")
 {
-    CPPUNIT_ASSERT_EQUAL(0.0, m_spin->GetMin());
-    CPPUNIT_ASSERT_EQUAL(100.0, m_spin->GetMax());
+    CHECK( m_spin->GetMin() == 0.0 );
+    CHECK( m_spin->GetMax() == 100.0 );
 
     // Test that the value is adjusted to be inside the new valid range but
     // that this doesn't result in any events (as this is not something done by
@@ -151,26 +129,27 @@ void SpinCtrlDoubleTestCase::Range()
         EventCounter updatedText(m_spin, wxEVT_TEXT);
 
         m_spin->SetRange(1., 10.);
-        CPPUNIT_ASSERT_EQUAL(1., m_spin->GetValue());
+        CHECK( m_spin->GetValue() == 1. );
 
-        CPPUNIT_ASSERT_EQUAL(0, updatedSpin.GetCount());
-        CPPUNIT_ASSERT_EQUAL(0, updatedText.GetCount());
+        CHECK( updatedSpin.GetCount() == 0 );
+        CHECK( updatedText.GetCount() == 0 );
     }
 
     //Test negative ranges
     m_spin->SetRange(-10.0, 10.0);
 
-    CPPUNIT_ASSERT_EQUAL(-10.0, m_spin->GetMin());
-    CPPUNIT_ASSERT_EQUAL(10.0, m_spin->GetMax());
+    CHECK( m_spin->GetMin() == -10.0 );
+    CHECK( m_spin->GetMax() == 10.0 );
 
     //Test backwards ranges
     m_spin->SetRange(75.0, 50.0);
 
-    CPPUNIT_ASSERT_EQUAL(75.0, m_spin->GetMin());
-    CPPUNIT_ASSERT_EQUAL(50.0, m_spin->GetMax());
+    CHECK( m_spin->GetMin() == 75.0 );
+    CHECK( m_spin->GetMax() == 50.0 );
 }
 
-void SpinCtrlDoubleTestCase::Value()
+TEST_CASE_METHOD(SpinCtrlDoubleTestCase,
+                 "SpinCtrlDouble::Value", "[spinctrl][spinctrldouble]")
 {
     EventCounter updatedSpin(m_spin, wxEVT_SPINCTRLDOUBLE);
     EventCounter updatedText(m_spin, wxEVT_TEXT);
@@ -178,28 +157,30 @@ void SpinCtrlDoubleTestCase::Value()
     m_spin->SetDigits(2);
     m_spin->SetIncrement(0.1);
 
-    CPPUNIT_ASSERT_EQUAL(0.0, m_spin->GetValue());
+    CHECK( m_spin->GetValue() == 0.0 );
 
     m_spin->SetValue(50.0);
-    CPPUNIT_ASSERT_EQUAL(50.0, m_spin->GetValue());
+    CHECK( m_spin->GetValue() == 50.0 );
 
     m_spin->SetValue(49.1);
-    CPPUNIT_ASSERT_EQUAL(49.1, m_spin->GetValue());
+    CHECK( m_spin->GetValue() == 49.1 );
 
     // Calling SetValue() shouldn't have generated any events.
-    CPPUNIT_ASSERT_EQUAL(0, updatedSpin.GetCount());
-    CPPUNIT_ASSERT_EQUAL(0, updatedText.GetCount());
+    CHECK( updatedSpin.GetCount() == 0 );
+    CHECK( updatedText.GetCount() == 0 );
 }
 
-void SpinCtrlDoubleTestCase::Increment()
-{
 #if wxUSE_UIACTIONSIMULATOR
-    CPPUNIT_ASSERT_EQUAL(1.0, m_spin->GetIncrement());
+
+TEST_CASE_METHOD(SpinCtrlDoubleTestCase,
+                 "SpinCtrlDouble::Increment", "[spinctrl][spinctrldouble]")
+{
+    CHECK( m_spin->GetIncrement() == 1.0 );
 
     m_spin->SetDigits(1);
     m_spin->SetIncrement(0.1);
 
-    CPPUNIT_ASSERT_EQUAL(0.1, m_spin->GetIncrement());
+    CHECK( m_spin->GetIncrement() == 0.1 );
 
     wxUIActionSimulator sim;
 
@@ -210,15 +191,17 @@ void SpinCtrlDoubleTestCase::Increment()
 
     wxYield();
 
-    CPPUNIT_ASSERT_EQUAL(0.1, m_spin->GetValue());
-#endif
+    CHECK( m_spin->GetValue() == 0.1 );
 }
 
-void SpinCtrlDoubleTestCase::Digits()
+#endif // wxUSE_UIACTIONSIMULATOR
+
+TEST_CASE_METHOD(SpinCtrlDoubleTestCase,
+                 "SpinCtrlDouble::Digits", "[spinctrl][spinctrldouble]")
 {
     m_spin->SetDigits(5);
 
-    CPPUNIT_ASSERT_EQUAL(5, m_spin->GetDigits());
+    CHECK( m_spin->GetDigits() == 5 );
 }
 
 static inline unsigned int GetInitialDigits(double inc)
@@ -230,7 +213,7 @@ static inline unsigned int GetInitialDigits(double inc)
     return digits;
 }
 
-TEST_CASE("SpinCtrlDoubleTestCase::InitialDigits", "[spinctrldouble][initialdigits]")
+TEST_CASE("SpinCtrlDouble::InitialDigits", "[spinctrldouble][initialdigits]")
 {
     REQUIRE(GetInitialDigits(15) == 0);
     REQUIRE(GetInitialDigits(10) == 0);

--- a/tests/controls/spinctrltest.cpp
+++ b/tests/controls/spinctrltest.cpp
@@ -268,6 +268,17 @@ TEST_CASE_METHOD(SpinCtrlTestCase2, "SpinCtrl::Value", "[spinctrl]")
     // Calling SetValue() shouldn't have generated any events.
     CHECK(updatedSpin.GetCount() == 0);
     CHECK(updatedText.GetCount() == 0);
+
+    // Also test that setting the text value works.
+    CHECK( m_spin->GetTextValue() == "100" );
+
+    m_spin->SetValue("57");
+    CHECK( m_spin->GetTextValue() == "57" );
+    CHECK( m_spin->GetValue() == 57 );
+
+    m_spin->SetValue("");
+    CHECK( m_spin->GetTextValue() == "" );
+    CHECK( m_spin->GetValue() == 57 );
 }
 
 TEST_CASE_METHOD(SpinCtrlTestCase2, "SpinCtrl::Base", "[spinctrl]")


### PR DESCRIPTION
This allows to retrieve the current contents of the text entry part of
wxSpinCtrl.

See [#19140](https://trac.wxwidgets.org/ticket/19140)