### PR TITLE
Various list control fixes

### DIFF
--- a/include/wx/generic/listctrl.h
+++ b/include/wx/generic/listctrl.h
@@ -68,6 +68,14 @@ public:
     bool SetColumn( int col, const wxListItem& item ) wxOVERRIDE;
     int GetColumnWidth( int col ) const wxOVERRIDE;
     bool SetColumnWidth( int col, int width) wxOVERRIDE;
+
+    // Column ordering functions
+    int GetColumnOrder(int col) const wxOVERRIDE;
+    int GetColumnIndexFromOrder(int order) const wxOVERRIDE;
+
+    wxArrayInt GetColumnsOrder() const wxOVERRIDE;
+    bool SetColumnsOrder(const wxArrayInt& orders) wxOVERRIDE;
+
     int GetCountPerPage() const; // not the same in wxGLC as in Windows, I think
     wxRect GetViewRect() const;
 

--- a/include/wx/generic/private/listctrl.h
+++ b/include/wx/generic/private/listctrl.h
@@ -190,9 +190,9 @@ public:
                             wxT("width can only be increased") );
 
             m_rectAll.width = w;
-            m_rectLabel.x = m_rectAll.x + (w - m_rectLabel.width) / 2;
-            m_rectIcon.x = m_rectAll.x + (w - m_rectIcon.width) / 2;
-            m_rectHighlight.x = m_rectAll.x + (w - m_rectHighlight.width) / 2;
+            m_rectLabel.x = m_rectLabel.x + (w - m_rectLabel.width) / 2;
+            m_rectIcon.x = m_rectIcon.x + (w - m_rectIcon.width) / 2;
+            m_rectHighlight.x = m_rectHighlight.x + (w - m_rectHighlight.width) / 2;
         }
     }
     *m_gi;

--- a/include/wx/listbase.h
+++ b/include/wx/listbase.h
@@ -399,6 +399,14 @@ public:
     virtual int GetColumnWidth(int col) const = 0;
     virtual bool SetColumnWidth(int col, int width) = 0;
 
+    // Column ordering functions
+    virtual int GetColumnOrder(int col) const = 0;
+    virtual int GetColumnIndexFromOrder(int order) const = 0;
+
+    virtual wxArrayInt GetColumnsOrder() const = 0;
+    virtual bool SetColumnsOrder(const wxArrayInt& orders) = 0;
+
+
     // Other miscellaneous accessors.
     // ------------------------------
 

--- a/include/wx/msw/listctrl.h
+++ b/include/wx/msw/listctrl.h
@@ -129,14 +129,14 @@ public:
 
 
     // Gets the column order from its index or index from its order
-    int GetColumnOrder(int col) const;
-    int GetColumnIndexFromOrder(int order) const;
+    int GetColumnOrder(int col) const wxOVERRIDE;
+    int GetColumnIndexFromOrder(int order) const wxOVERRIDE;
 
     // Gets the column order for all columns
-    wxArrayInt GetColumnsOrder() const;
+    wxArrayInt GetColumnsOrder() const wxOVERRIDE;
 
     // Sets the column order for all columns
-    bool SetColumnsOrder(const wxArrayInt& orders);
+    bool SetColumnsOrder(const wxArrayInt& orders) wxOVERRIDE;
 
 
     // Gets the number of items that can fit vertically in the

--- a/include/wx/qt/listctrl.h
+++ b/include/wx/qt/listctrl.h
@@ -60,14 +60,14 @@ public:
 
 
     // Gets the column order from its index or index from its order
-    int GetColumnOrder(int col) const;
-    int GetColumnIndexFromOrder(int order) const;
+    int GetColumnOrder(int col) const wxOVERRIDE;
+    int GetColumnIndexFromOrder(int order) const wxOVERRIDE;
 
     // Gets the column order for all columns
-    wxArrayInt GetColumnsOrder() const;
+    wxArrayInt GetColumnsOrder() const wxOVERRIDE;
 
     // Sets the column order for all columns
-    bool SetColumnsOrder(const wxArrayInt& orders);
+    bool SetColumnsOrder(const wxArrayInt& orders) wxOVERRIDE;
 
 
     // Gets the number of items that can fit vertically in the

--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -147,10 +147,9 @@ enum
     To intercept events from a list control, use the event table macros described
     in wxListEvent.
 
-    <b>wxMac Note</b>: Starting with wxWidgets 2.8, wxListCtrl uses a native
-    implementation for report mode, and uses a generic implementation for other
-    modes. You can use the generic implementation for report mode as well by setting
-    the @c mac.listctrl.always_use_generic system option (see wxSystemOptions) to 1.
+    @note The native wxOSX implementation for report mode that was added in wxWidgets
+    2.8 was removed in wxWidgets 3.1, meaning for wxWidgets 3.1+ wxOSX uses the generic
+    implementation for all modes.
 
     @subsection column_order Column Ordering
 

--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -152,6 +152,40 @@ enum
     modes. You can use the generic implementation for report mode as well by setting
     the @c mac.listctrl.always_use_generic system option (see wxSystemOptions) to 1.
 
+    @subsection column_order Column Ordering
+
+    By default, the columns of a list control appear on the screen in order
+    of their indices, i.e. column 0 appears first, then column 1 next,
+    and so on. However this can be changed by using the SetColumnsOrder() function
+    to arbitrarily reorder the columns visual order.
+
+    The user can also rearrange the columns interactively by dragging them.
+    In this case, the index of the column is not the same as its order and
+    the functions GetColumnOrder() and GetColumnIndexFromOrder() should be
+    used to translate between them.
+
+    @note All the other functions still work with the column indices,
+    i.e. the visual positioning of the columns on screen doesn't affect the
+    code setting or getting their values for example.
+
+    Example of reordering columns:
+    @code
+        wxListCtrl *list = new wxListCtrl(...);
+        for ( int i = 0; i < 3; i++ )
+            list->InsertColumn(i, wxString::Format("Column %d", i));
+
+        wxArrayInt order(3);
+        order[0] = 2;
+        order[1] = 0;
+        order[2] = 1;
+        list->SetColumnsOrder(order);
+
+        // now list->GetColumnsOrder() will return order and
+        // list->GetColumnIndexFromOrder(n) will return order[n] and
+        // list->GetColumnOrder() will return 1, 2 and 0 for the column 0,
+        // 1 and 2 respectively
+    @endcode
+
 
     @beginStyleTable
     @style{wxLC_LIST}
@@ -538,8 +572,10 @@ public:
         corresponds to the value of the element number @a pos in the array
         returned by GetColumnsOrder().
 
-        Please see SetColumnsOrder() documentation for an example and
-        additional remarks about the columns ordering.
+        @note This function makes sense for report view only and currently is only
+        implemented in the wxMSW port. Use @c wxHAS_LISTCTRL_COLUMN_ORDER to guard uses
+        of this function so that they will start working under the other platforms when
+        support for the column reordering is added there.
 
         @see GetColumnOrder()
     */
@@ -552,8 +588,10 @@ public:
         given visual position, e.g. calling it with @a col equal to 0 returns
         the index of the first shown column.
 
-        Please see SetColumnsOrder() documentation for an example and
-        additional remarks about the columns ordering.
+        @note This function makes sense for report view only and currently is only
+        implemented in the wxMSW port. Use @c wxHAS_LISTCTRL_COLUMN_ORDER to guard uses
+        of this function so that they will start working under the other platforms when
+        support for the column reordering is added there.
 
         @see GetColumnsOrder(), GetColumnIndexFromOrder()
     */
@@ -569,8 +607,10 @@ public:
 
         On error, an empty array is returned.
 
-        Please see SetColumnsOrder() documentation for an example and
-        additional remarks about the columns ordering.
+        @note This function makes sense for report view only and currently is only
+        implemented in the wxMSW port. Use @c wxHAS_LISTCTRL_COLUMN_ORDER to guard uses
+        of this function so that they will start working under the other platforms when
+        support for the column reordering is added there.
 
         @see GetColumnOrder(), GetColumnIndexFromOrder()
     */
@@ -1027,17 +1067,6 @@ public:
     /**
         Changes the order in which the columns are shown.
 
-        By default, the columns of a list control appear on the screen in order
-        of their indices, i.e. the column 0 appears first, the column 1 next
-        and so on. However by using this function it is possible to arbitrarily
-        reorder the columns visual order and the user can also rearrange the
-        columns interactively by dragging them. In this case, the index of the
-        column is not the same as its order and the functions GetColumnOrder()
-        and GetColumnIndexFromOrder() should be used to translate between them.
-        Notice that all the other functions still work with the column indices,
-        i.e. the visual positioning of the columns on screen doesn't affect the
-        code setting or getting their values for example.
-
         The @a orders array must have the same number elements as the number of
         columns and contain each position exactly once. Its n-th element
         contains the index of the column to be shown in n-th position, so for a
@@ -1045,28 +1074,9 @@ public:
         results in the third column being displayed first, the first one next
         and the second one last.
 
-        Example of using it:
-        @code
-            wxListCtrl *list = new wxListCtrl(...);
-            for ( int i = 0; i < 3; i++ )
-                list->InsertColumn(i, wxString::Format("Column %d", i));
-
-            wxArrayInt order(3);
-            order[0] = 2;
-            order[1] = 0;
-            order[2] = 1;
-            list->SetColumnsOrder(order);
-
-            // now list->GetColumnsOrder() will return order and
-            // list->GetColumnIndexFromOrder(n) will return order[n] and
-            // list->GetColumnOrder() will return 1, 2 and 0 for the column 0,
-            // 1 and 2 respectively
-        @endcode
-
-        Please notice that this function makes sense for report view only and
-        currently is only implemented in wxMSW port. To avoid explicit tests
-        for @c __WXMSW__ in your code, please use @c wxHAS_LISTCTRL_COLUMN_ORDER
-        as this will allow it to start working under the other platforms when
+        @note This function makes sense for report view only and currently is only
+        implemented in the wxMSW port. Use @c wxHAS_LISTCTRL_COLUMN_ORDER to guard uses
+        of this function so that they will start working under the other platforms when
         support for the column reordering is added there.
 
         @see GetColumnsOrder()

--- a/interface/wx/sysopt.h
+++ b/interface/wx/sysopt.h
@@ -105,9 +105,6 @@
     @flag{window-default-variant}
         The default variant used by windows (cast to integer from the wxWindowVariant enum).
         Also known as wxWINDOW_DEFAULT_VARIANT.
-    @flag{mac.listctrl.always_use_generic}
-        Tells wxListCtrl to use the generic control even when it is capable of
-        using the native control instead. Also known as wxMAC_ALWAYS_USE_GENERIC_LISTCTRL.
     @flag{mac.textcontrol-use-spell-checker}
         If 1 activates the spell checking in wxTextCtrl.
     @flag{osx.openfiledialog.always-show-types}

--- a/samples/listctrl/listtest.cpp
+++ b/samples/listctrl/listtest.cpp
@@ -150,9 +150,6 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(LIST_TOGGLE_HEADER, MyFrame::OnToggleHeader)
     EVT_MENU(LIST_TOGGLE_BELL, MyFrame::OnToggleBell)
     EVT_MENU(LIST_CHECKVISIBILITY, MyFrame::OnCheckVisibility)
-#ifdef __WXOSX__
-    EVT_MENU(LIST_MAC_USE_GENERIC, MyFrame::OnToggleMacUseGeneric)
-#endif // __WXOSX__
     EVT_MENU(LIST_FIND, MyFrame::OnFind)
     EVT_MENU(LIST_TOGGLE_CHECKBOX, MyFrame::OnToggleItemCheckBox)
     EVT_MENU(LIST_GET_CHECKBOX, MyFrame::OnGetItemCheckBox)
@@ -229,10 +226,6 @@ MyFrame::MyFrame(const wxString& title)
     menuView->Append(LIST_SMALL_VIRTUAL_VIEW, "Small virtual vie&w\tF8");
     menuView->AppendSeparator();
     menuView->Append(LIST_SET_ITEMS_COUNT, "Set &number of items");
-#ifdef __WXOSX__
-    menuView->AppendSeparator();
-    menuView->AppendCheckItem(LIST_MAC_USE_GENERIC, "Mac: Use Generic Control");
-#endif
 
     wxMenu *menuList = new wxMenu;
     menuList->Append(LIST_GOTO, "&Go to item #3\tCtrl-3");
@@ -391,15 +384,6 @@ void MyFrame::OnCheckVisibility(wxCommandEvent& WXUNUSED(event))
         wxLogMessage( "Line 9 is not visible" );
 }
 
-#ifdef __WXOSX__
-
-void MyFrame::OnToggleMacUseGeneric(wxCommandEvent& event)
-{
-    wxSystemOptions::SetOption("mac.listctrl.always_use_generic", event.IsChecked());
-}
-
-#endif // __WXOSX__
-
 void MyFrame::OnGoTo(wxCommandEvent& WXUNUSED(event))
 {
     if ( m_listCtrl->IsEmpty() )
@@ -433,7 +417,7 @@ void MyFrame::OnFocusLast(wxCommandEvent& WXUNUSED(event))
 void MyFrame::OnToggleFirstSel(wxCommandEvent& WXUNUSED(event))
 {
     if ( !m_listCtrl->IsEmpty() )
-    { 
+    {
         m_listCtrl->SetItemState(0, (~m_listCtrl->GetItemState(0, wxLIST_STATE_SELECTED) ) & wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
     }
     else

--- a/samples/listctrl/listtest.h
+++ b/samples/listctrl/listtest.h
@@ -148,9 +148,6 @@ protected:
     void OnToggleLines(wxCommandEvent& event);
     void OnToggleHeader(wxCommandEvent& event);
     void OnToggleBell(wxCommandEvent& event);
-#ifdef __WXOSX__
-    void OnToggleMacUseGeneric(wxCommandEvent& event);
-#endif // __WXOSX__
     void OnFind(wxCommandEvent& event);
     void OnToggleItemCheckBox(wxCommandEvent& event);
     void OnGetItemCheckBox(wxCommandEvent& event);
@@ -245,9 +242,6 @@ enum
     LIST_FREEZE,
     LIST_THAW,
     LIST_TOGGLE_LINES,
-#ifdef __WXOSX__
-    LIST_MAC_USE_GENERIC,
-#endif
     LIST_CHECKVISIBILITY,
     LIST_CTRL                   = 1000
 };

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -552,8 +552,7 @@ void wxListLineData::SetPosition( int x, int y, int spacing )
 
             if ( item->HasImage() )
             {
-                m_gi->m_rectIcon.x = m_gi->m_rectAll.x + 4 +
-                    (m_gi->m_rectAll.width - m_gi->m_rectIcon.width) / 2;
+                m_gi->m_rectIcon.x = m_gi->m_rectAll.x + 4;
                 m_gi->m_rectIcon.y = m_gi->m_rectAll.y + 4;
             }
 

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -5162,6 +5162,31 @@ bool wxGenericListCtrl::SetColumnWidth( int col, int width )
     return true;
 }
 
+// Column ordering functions
+int wxGenericListCtrl::GetColumnOrder(int col) const
+{
+    // TODO: Implement this on generic port
+    return col;
+}
+
+int wxGenericListCtrl::GetColumnIndexFromOrder(int order) const
+{
+    // TODO: Implement this on generic port
+    return order;
+}
+
+wxArrayInt wxGenericListCtrl::GetColumnsOrder() const
+{
+    // TODO: Implement this on generic port
+    return wxArrayInt();
+}
+
+bool wxGenericListCtrl::SetColumnsOrder(const wxArrayInt& WXUNUSED(orders))
+{
+    // TODO: Implement this on generic port
+    return false;
+}
+
 int wxGenericListCtrl::GetCountPerPage() const
 {
   return m_mainWin->GetCountPerPage();  // different from Windows ?


### PR DESCRIPTION
This PR contains a few different fixes for the `wxListCtrl` widget including:

* Fix centering of images in wxListCtrl items when selected in icon view (Trac ticket: https://trac.wxwidgets.org/ticket/11331)

Before:
![image](https://user-images.githubusercontent.com/2262453/115641758-a56ba980-a311-11eb-91fd-21e22b5b2918.png)



After:
![image](https://user-images.githubusercontent.com/2262453/115641434-0050d100-a311-11eb-8cc2-76ea558f9a31.png)
![image](https://user-images.githubusercontent.com/2262453/115641516-2bd3bb80-a311-11eb-9cfd-f32e1d4bff6c.png)



* Introduce ABI shims for the column ordering functions on all ports.

This commit adds pure virtual methods to the base class for these functions and then adds stub methods to the generic port that serve as placeholders. The wxQT port already had stub methods for these, so those are just marked override now.

* Remove the documentation on the old native wxMAC `wxListCtrl` control for report mode.

The native control was using the old Carbon library and was removed in https://github.com/wxWidgets/wxWidgets/commit/5ba67c67e47d069f65d648ab16dfc505c5400bfc, and the only remaining references to it was in the documentation and the sample program. This removes the remaining documentation references and the sample program parts.