### PR TITLE
Include the queue header before renabling warnings in header test

### DIFF
--- a/tests/allheaders.cpp
+++ b/tests/allheaders.cpp
@@ -68,6 +68,7 @@
 #include <set>
 #include <sstream>
 #include <string>
+#include <queue>
 #include <vector>
 
 #if defined(HAVE_STD_UNORDERED_MAP)


### PR DESCRIPTION
Recent changes to the stdlib queue implementation showed warnings creeping in from it, so include it with the other headers to ensure it is read in before any other warnings are enabled. This would seem to point to a GCC bug with the warnings enabling/disabling stack, but it is such a complex piece of test code that making a MWE of the error seems very difficult.

This partially fixes https://trac.wxwidgets.org/ticket/19153