### PR TITLE
Make menu sample build when using precompiled headers

### DIFF
--- a/samples/menu/menu.cpp
+++ b/samples/menu/menu.cpp
@@ -23,8 +23,6 @@
 #ifndef WX_PRECOMP
     #include "wx/app.h"
     #include "wx/bitmap.h"
-    #include "wx/filehistory.h"
-    #include "wx/filename.h"
     #include "wx/frame.h"
     #include "wx/image.h"
     #include "wx/menu.h"
@@ -33,6 +31,9 @@
     #include "wx/textctrl.h"
     #include "wx/textdlg.h"
 #endif
+
+#include "wx/filehistory.h"
+#include "wx/filename.h"
 
 #if !wxUSE_MENUS
     // nice try...


### PR DESCRIPTION
Headers wx/filehistory.h and wx/filename.h were included only
when WX_PRECOMP was not defined.

However, these two files are not included in wx/wxprec.h,
so they must be always included directly.