### PR TITLE
Fix check for whether we're using a wxLocale object

### DIFF
--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -1208,6 +1208,15 @@ wxString wxLocale::GetHeaderValue(const wxString& header,
 namespace
 {
 
+// Helper checking if the locale was not only set, but actually successfully
+// changed.
+bool HasSuccessfullyChangedLocale()
+{
+    const wxLocale* const locale = wxGetLocale();
+
+    return locale && locale->GetLanguage() != wxLANGUAGE_UNKNOWN;
+}
+
 bool IsAtTwoSingleQuotes(const wxString& fmt, wxString::const_iterator p)
 {
     if ( p != fmt.end() && *p == '\'')
@@ -1696,7 +1705,7 @@ GetInfoFromLCID(LCID lcid,
 /* static */
 wxString wxLocale::GetInfo(wxLocaleInfo index, wxLocaleCategory cat)
 {
-    if ( !wxGetLocale() )
+    if ( !HasSuccessfullyChangedLocale() )
     {
         // wxSetLocale() hadn't been called yet of failed, hence CRT must be
         // using "C" locale -- but check it to detect bugs that would happen if
@@ -1755,7 +1764,7 @@ wxString wxLocale::GetOSInfo(wxLocaleInfo index, wxLocaleCategory cat)
 wxString wxLocale::GetInfo(wxLocaleInfo index, wxLocaleCategory WXUNUSED(cat))
 {
     CFLocaleRef userLocaleRefRaw;
-    if ( wxGetLocale() )
+    if ( HasSuccessfullyChangedLocale() )
     {
         userLocaleRefRaw = CFLocaleCreate
                         (


### PR DESCRIPTION
wxGetLocale() returns non-null as soon as a wxLocale object is created,
but nothing is really done until it is initialized, so don't use this
function to check if the CRT locale has been changed.

Use the new wxHasSuccessfullyChangedLocale() instead, which fixes the
problem with the decimal separator mismatch check since the changes of
c6d6ec9295 (Merge branch 'msw-fix-decimal-point' of
https://github.com/vslavik/wxWidgets, 2021-04-18).

Closes [#19154](https://trac.wxwidgets.org/ticket/19154).