### PR TITLE
wxUniv: Fix universal build under windows

### DIFF
--- a/include/wx/msw/chkconf.h
+++ b/include/wx/msw/chkconf.h
@@ -472,20 +472,6 @@
 #   define wxUSE_POSTSCRIPT 1
 #endif
 
-#if wxUSE_GRAPHICS_CONTEXT && defined(__WXUNIVERSAL__) && !defined(wxUSE_GRAPHICS_GDIPLUS)
-#   define wxUSE_GRAPHICS_GDIPLUS 1
-#endif
-#if !wxUSE_GRAPHICS_GDIPLUS
-#   if wxUSE_GRAPHICS_CONTEXT
-#       ifdef wxABORT_ON_CONFIG_ERROR
-#           error "wxUSE_GRAPHICS_CONTEXT requires wxUSE_GRAPHICS_GDIPLUS"
-#       else
-#           undef wxUSE_GRAPHICS_GDIPLUS
-#           define wxUSE_GRAPHICS_GDIPLUS 1
-#       endif
-#   endif
-#endif
-
 /*
     IPv6 support requires winsock2.h, but the default of wxUSE_WINSOCK2 is 0.
     Don't require changing it explicitly and just turn it on automatically if

--- a/include/wx/msw/chkconf.h
+++ b/include/wx/msw/chkconf.h
@@ -472,6 +472,20 @@
 #   define wxUSE_POSTSCRIPT 1
 #endif
 
+#if wxUSE_GRAPHICS_CONTEXT && defined(__WXUNIVERSAL__) && !defined(wxUSE_GRAPHICS_GDIPLUS)
+#   define wxUSE_GRAPHICS_GDIPLUS 1
+#endif
+#if !wxUSE_GRAPHICS_GDIPLUS
+#   if wxUSE_GRAPHICS_CONTEXT
+#       ifdef wxABORT_ON_CONFIG_ERROR
+#           error "wxUSE_GRAPHICS_CONTEXT requires wxUSE_GRAPHICS_GDIPLUS"
+#       else
+#           undef wxUSE_GRAPHICS_GDIPLUS
+#           define wxUSE_GRAPHICS_GDIPLUS 1
+#       endif
+#   endif
+#endif
+
 /*
     IPv6 support requires winsock2.h, but the default of wxUSE_WINSOCK2 is 0.
     Don't require changing it explicitly and just turn it on automatically if

--- a/include/wx/univ/setup.h
+++ b/include/wx/univ/setup.h
@@ -1637,6 +1637,8 @@
 // Recommended setting: 1, required by wxMediaCtrl
 #define wxUSE_ACTIVEX 1
 
+#define wxUSE_WINRT 0
+
 // wxDC caching implementation
 #define wxUSE_DC_CACHEING 1
 
@@ -1693,6 +1695,8 @@
 // Recommended setting: 1, set to 0 for a tiny library size reduction
 #define wxUSE_TASKBARICON_BALLOONS 1
 
+#define wxUSE_TASKBARBUTTON 0
+
 // Set to 1 to compile MS Windows XP theme engine support
 #define wxUSE_UXTHEME           1
 
@@ -1728,6 +1732,18 @@
 // ----------------------------------------------------------------------------
 // Crash debugging helpers
 // ----------------------------------------------------------------------------
+
+// Set this to 1 to use dbghelp.dll for providing stack traces in crash
+// reports.
+//
+// Default is 1 if the compiler supports it, 0 for old MinGW.
+//
+// Recommended setting: 1, there is not much gain in disabling this
+#if defined(__VISUALC__) || defined(__MINGW64_TOOLCHAIN__)
+    #define wxUSE_DBGHELP 1
+#else
+    #define wxUSE_DBGHELP 0
+#endif
 
 // Set this to 1 to be able to use wxCrashReport::Generate() to create mini
 // dumps of your program when it crashes (or at any other moment)

--- a/include/wx/univ/setup.h
+++ b/include/wx/univ/setup.h
@@ -1609,6 +1609,35 @@
 
 /* --- start MSW options --- */
 // ----------------------------------------------------------------------------
+// Windows-specific backends choices
+// ----------------------------------------------------------------------------
+
+// The options here are only taken into account if wxUSE_GRAPHICS_CONTEXT is 1.
+
+// Enable support for GDI+-based implementation of wxGraphicsContext.
+//
+// Default is 1.
+//
+// Recommended setting: 1 if you need to support XP, as Direct2D is not
+// available there.
+#define wxUSE_GRAPHICS_GDIPLUS wxUSE_GRAPHICS_CONTEXT
+
+// Enable support for Direct2D-based implementation of wxGraphicsContext.
+//
+// Default is 1 for compilers which support it, i.e. VC10+ currently. If you
+// use an earlier MSVC version or another compiler and installed the necessary
+// SDK components manually, you need to change this setting.
+//
+// Recommended setting: 1 for faster and better quality graphics under Windows
+// 7 and later systems (if wxUSE_GRAPHICS_GDIPLUS is also enabled, earlier
+// systems will fall back on using GDI+).
+#if defined(_MSC_VER) && _MSC_VER >= 1600
+    #define wxUSE_GRAPHICS_DIRECT2D wxUSE_GRAPHICS_CONTEXT
+#else
+    #define wxUSE_GRAPHICS_DIRECT2D 0
+#endif
+
+// ----------------------------------------------------------------------------
 // Windows-only settings
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
Add standard defines of wxUSE_WINRT and wxUSE_DBGHELP to wx/univ/setup.h
And, set wxUSE_TASKBARBUTTON to zero in wx/univ/setup.h
Also, disable wxUSE_GRAPHICS_CONTEXT in wx/msw/chkconf.h

This problem was discussed on [forums.wxwidgets.org](https://forums.wxwidgets.org/viewtopic.php?f=19&t=48256&p=205889)

Tim S.