### PR TITLE
Handle invalid paths better in MSW wxDirDialog

### DIFF
--- a/src/msw/dirdlg.cpp
+++ b/src/msw/dirdlg.cpp
@@ -360,25 +360,14 @@ bool InitIFileOpenDialog(const wxString& message, const wxString& defaultPath,
                                             wxIID_PPV_ARGS(IShellItem,
                                                            &folder));
 
-        // Failing to parse the folder name is not really an error, we'll just
-        // ignore the initial directory in this case, but we should still show
-        // the dialog.
-        if ( FAILED(hr) )
-        {
-            if ( hr != HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND) )
-            {
-                wxLogApiError(wxS("SHCreateItemFromParsingName"), hr);
-                return false;
-            }
-        }
-        else // The folder was parsed correctly.
+        // Failing to parse the folder name or set it is not really an error,
+        // we'll just ignore the initial directory in this case, but we should
+        // still show the dialog.
+        if ( SUCCEEDED(hr) )
         {
             hr = dlg->SetFolder(folder);
             if ( FAILED(hr) )
-            {
                 wxLogApiError(wxS("IFileOpenDialog::SetFolder"), hr);
-                return false;
-            }
         }
     }
 


### PR DESCRIPTION
When setting a path including an invalid drive in IFileDialog-based
wxDirDialog, Windows returned ERROR_INVALID_DRIVE error. wxWidgets
treated this as an error and reverted to showing the old
ShowSHBrowseForFolder()-based dialog.

However, it is better to just ignore any errors produced when attempting
to set the default folder (as the code already did for ERROR_FILE_NOT_FOUND)
and show IFileDialog-based dialog anyway.