### PR TITLE
Remove wxGTK1 mentions from the documentation

### DIFF
--- a/interface/wx/checkbox.h
+++ b/interface/wx/checkbox.h
@@ -50,7 +50,7 @@ enum wxCheckBoxState
     @style{wxCHK_2STATE}
            Create a 2-state checkbox. This is the default.
     @style{wxCHK_3STATE}
-           Create a 3-state checkbox. Not implemented in wxGTK1.
+           Create a 3-state checkbox.
     @style{wxCHK_ALLOW_3RD_STATE_FOR_USER}
            By default a user can't set a 3-state checkbox to the third state.
            It can only be done from code. Using this flags allows the user to

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -1029,7 +1029,7 @@ public:
            show it. It doesn't do anything under other platforms.
     @style{wxHSCROLL}
            A horizontal scrollbar will be created and used, so that text won't
-           be wrapped. No effect under wxGTK1.
+           be wrapped.
     @style{wxTE_NO_VSCROLL}
            For multiline controls only: vertical scrollbar will never be
            created. This limits the amount of text which can be entered into

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -2196,10 +2196,10 @@ public:
     virtual bool HasTransparentBackground();
 
     /**
-        Causes this window, and all of its children recursively (except under wxGTK1
-        where this is not implemented), to be repainted. Note that repainting doesn't
-        happen immediately but only during the next event loop iteration, if you need
-        to update the window immediately you should use Update() instead.
+        Causes this window, and all of its children recursively, to be repainted.
+        Note that repainting doesn't happen immediately but only during the next
+        event loop iteration, if you need to update the window immediately you
+        should use Update() instead.
 
         @param eraseBackground
             If @true, the background will be erased.


### PR DESCRIPTION
GTK1 is no longer supported, so do not document control limitations when using it.

**Off-topic:** @vadz, since past few weeks, whenever I push into my wxWidgets fork, I immediately get notification about failed Mac make CI, like this: https://github.com/PBfordev/wxWidgets/actions/runs/836191897
Am I doing something wrong / can I get rid of this?

