### PR TITLE
Readd accidentally deleted argument in wxConfig interface

### DIFF
--- a/interface/wx/config.h
+++ b/interface/wx/config.h
@@ -571,6 +571,7 @@ public:
         @endWxPerlOnly
     */
     bool Read(const wxString& key, wxLongLong_t* ll,
+              wxLongLong_t defaultVal) const;
     /**
         Reads a size_t value, returning @true if the value was found.
         If the value was not found, @a value is not changed.


### PR DESCRIPTION
This missing argument was removed in 0c837e5310998e4d57bc1f37cdfc170eb3dad49e and causes the doxygen docs for wxConfigBase to be incorrect and miss a lot of functions. This then also causes wxPython Phoenix not to build properly.