### PR TITLE
Fix performance regression in macOS wxDataViewCtrl

### DIFF
--- a/src/osx/dataview_osx.cpp
+++ b/src/osx/dataview_osx.cpp
@@ -302,7 +302,9 @@ void wxOSXDataViewModelNotifier::AdjustAutosizedColumns()
   unsigned count = m_DataViewCtrlPtr->GetColumnCount();
   for ( unsigned col = 0; col < count; col++ )
   {
-    m_DataViewCtrlPtr->GetDataViewPeer()->FitColumnWidthToContent(col);
+    wxDataViewColumn *column = m_DataViewCtrlPtr->GetColumnPtr(col);
+    if ( column->GetWidthVariable() == wxCOL_WIDTH_AUTOSIZE || m_DataViewCtrlPtr->HasFlag(wxDV_VARIABLE_LINE_HEIGHT) )
+        m_DataViewCtrlPtr->GetDataViewPeer()->FitColumnWidthToContent(col);
   }
 }
 


### PR DESCRIPTION
Fixes *severe* degradation of performance caused by 36ea7ff4d61e174a2d116819f98e66f22a7f5b8a, which forces calculation of fitting size even for non-autosized columns.

The purpose of the change, as per @softwarefailure's explanation under the above commit, was to update row heights as well, but doing that doesn't make sense when the row height is fixed. This PR simply avoids calling `FitColumnWidthToContent()` unless it actually is needed, i.e. the column is autosized or variable row heights are used.

It possibly (probably?) conflicts with PR #2352 by @dkulp but if it is a correct thing to do, it is both simpler *and* more functional fix for the performance regression — i.e. I think they should be both applied.

In [Poedit](https://github.com/vslavik/poedit), a cell in a DVC control is updated every time the user types; it's a single cell, with fixed-sized columns, with ~1000 rows in my tests (files an order of magnitude larger are common; I didn't dare try them). The performance impact was approximately as follows:

1. before 36ea7ff4d61e174a2d116819f98e66f22a7f5b8a: typing in realtime, CPU use under 10% (unrelated processing)
2. 36ea7ff4d61e174a2d116819f98e66f22a7f5b8a: typing with extreme latency, one second between keystrokes, 100% CPU usage
3. with PR #2352: much better, but still  high latency and 50-70% CPU usage
4. with this PR: back to 1., no noticeable latency