### PR TITLE
Fix an issue that MSVC 2019 cannot compile with CMake

### DIFF
--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -383,7 +383,7 @@ endmacro()
 # Enable cotire for target, use optional second argument for prec. header
 macro(wx_target_enable_precomp target_name)
     target_compile_definitions(${target_name} PRIVATE WX_PRECOMP)
-    if(NOT ${ARGV1} STREQUAL "")
+    if(${ARGC} GREATER 1 AND NOT ${ARGV1} STREQUAL "")
         set_target_properties(${target_name} PROPERTIES
             COTIRE_CXX_PREFIX_HEADER_INIT ${ARGV1})
     endif()

--- a/build/cmake/lib/stc/CMakeLists.txt
+++ b/build/cmake/lib/stc/CMakeLists.txt
@@ -176,7 +176,7 @@ if(wxBUILD_PRECOMP)
     # standard c++ headers when using clang.
     # Do not disable precompiled headers entirely but use the main Scintilla
     # header as prefix header so there is at least a small speedup.
-    if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
         set(wxSCINTILLA_PREC_HEADER "${wxSOURCE_DIR}/src/stc/scintilla/include/Scintilla.h")
     endif()
     wx_target_enable_precomp(wxscintilla ${wxSCINTILLA_PREC_HEADER})

--- a/build/cmake/lib/stc/CMakeLists.txt
+++ b/build/cmake/lib/stc/CMakeLists.txt
@@ -176,7 +176,7 @@ if(wxBUILD_PRECOMP)
     # standard c++ headers when using clang.
     # Do not disable precompiled headers entirely but use the main Scintilla
     # header as prefix header so there is at least a small speedup.
-    if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
+    if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
         set(wxSCINTILLA_PREC_HEADER "${wxSOURCE_DIR}/src/stc/scintilla/include/Scintilla.h")
     endif()
     wx_target_enable_precomp(wxscintilla ${wxSCINTILLA_PREC_HEADER})


### PR DESCRIPTION
MSVC + CMake cannot compile wxWidgets without this change.

An known issue mentioned in the ‘Issue’ page of vcpkg: microsoft/vcpkg#17980

If the codes compile with MSVC in Visual Studio 2019 GUI, the error is showing like this:

> Severity	Code	Description	Project	File	Line	Suppression State
Error	C1083	Cannot open include file: 'D:\wxWidgets-3.1.5\build\cmake\lib\stc\REQUIRED': No such file or directory	D:\wxWidgets-3.1.5\out\build\x64-Debug\wxWidgets-3.1.5	D:\wxWidgets-3.1.5\out\build\x64-Debug\libs\stc\cotire\wxscintilla_CXX_prefix.hxx	4

Contents of wxscintilla_CXX_prefix.hxx :

```
/* cotire.cmake 1.8.0 generated file */
/* D:/wxWidgets-3.1.5/out/build/x64-Debug/libs/stc/cotire/wxscintilla_CXX_prefix.hxx */
#ifdef __cplusplus
#include "D:\wxWidgets-3.1.5\build\cmake\lib\stc\REQUIRED"
#endif
```