### PR TITLE
Correct documentation for XRC sizeritem property "ratio"

### DIFF
--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -2452,7 +2452,7 @@ properties:
 @row3col{minsize, @ref overview_xrcformat_type_size,
     Minimal size of this item (default: no min size).}
 @row3col{ratio, @ref overview_xrcformat_type_pair_ints,
-    Item ratio, see wxSizer::SetRatio() (default: no ratio).}
+    Item ratio, see wxSizerItem::SetRatio() (default: no ratio).}
 @row3col{cellpos, @ref overview_xrcformat_type_pair_ints,
     (wxGridBagSizer only) Position, see wxGBSizerItem::SetPos() (required). }
 @row3col{cellspan, @ref overview_xrcformat_type_pair_ints,


### PR DESCRIPTION
In the description of XRC sizeritem property "ratio" refer to
wxSizerItem::SetRatio() instead of non-existent wxSizer::SetRatio().