### PR TITLE
Set standard to C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@
 
 cmake_minimum_required(VERSION 2.8.12)
 
+set(CMAKE_CXX_STANDARD 11)
+
 if(NOT CMAKE_CONFIGURATION_TYPES)
     get_property(HAVE_MULTI_CONFIG_GENERATOR GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
     # Set default configuration types for multi-config generators

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,6 @@
 
 cmake_minimum_required(VERSION 2.8.12)
 
-set(CMAKE_CXX_STANDARD 11)
-
 if(NOT CMAKE_CONFIGURATION_TYPES)
     get_property(HAVE_MULTI_CONFIG_GENERATOR GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
     # Set default configuration types for multi-config generators

--- a/build/cmake/options.cmake
+++ b/build/cmake/options.cmake
@@ -47,6 +47,8 @@ if(NOT MSVC OR MSVC_VERSION GREATER 1800)
     # support setting the C++ standard, present it an option to the user
     if(DEFINED CMAKE_CXX_STANDARD)
         set(wxCXX_STANDARD_DEFAULT ${CMAKE_CXX_STANDARD})
+    elseif(APPLE)
+        set(wxCXX_STANDARD_DEFAULT 11)
     else()
         set(wxCXX_STANDARD_DEFAULT COMPILER_DEFAULT)
     endif()


### PR DESCRIPTION
Setting the standard to C++ 11, avoids multiple compiler warnings saying that the standard is C++11