### PR TITLE
Improve sizer flags asserts

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -27,7 +27,9 @@ Changes in behaviour not resulting in compilation errors
 - Using invalid flags with wxBoxSizer or wxGridSizer items now triggers asserts
   when done from the code or error messages when done in XRC. These asserts are
   best avoided by fixing the flags, but wxSizerFlags::DisableConsistencyChecks()
-  can be used to globally suppress them until this can be done.
+  can be used to globally suppress them until this can be done. Even less
+  intrusively, environment variable WXSUPPRESS_SIZER_FLAGS_CHECK can be set (to
+  any value) to achieve the same effect.
 
 - wxWS_EX_VALIDATE_RECURSIVELY is now the default behaviour, i.e. calling
   Validate() or TransferData{From,To}Window() will now also call the same

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -25,7 +25,9 @@ Changes in behaviour not resulting in compilation errors
   (it used to succeed in wxMSW).
 
 - Using invalid flags with wxBoxSizer or wxGridSizer items now triggers asserts
-  when done from the code or error messages when done in XRC.
+  when done from the code or error messages when done in XRC. These asserts are
+  best avoided by fixing the flags, but wxSizerFlags::DisableConsistencyChecks()
+  can be used to globally suppress them until this can be done.
 
 - wxWS_EX_VALIDATE_RECURSIVELY is now the default behaviour, i.e. calling
   Validate() or TransferData{From,To}Window() will now also call the same

--- a/docs/doxygen/overviews/envvars.h
+++ b/docs/doxygen/overviews/envvars.h
@@ -32,5 +32,10 @@ wxWidgets programs.
          set it to @c "CURL" to force using libcurl-based implementation under
          MSW or macOS platforms where the native implementation would be chosen
          by default.}
+@itemdef{WXSUPPRESS_SIZER_FLAGS_CHECK,
+         If set, disables asserts about using invalid sizer flags in the code.
+         This can be helpful when running older programs recompiled with
+         wxWidgets 3.1 or later, as these asserts are mostly harmless and can
+         be safely ignored if the code works as expected.}
 */
 

--- a/include/wx/sizer.h
+++ b/include/wx/sizer.h
@@ -238,6 +238,9 @@ public:
     int GetFlags() const { return m_flags; }
     int GetBorderInPixels() const { return m_borderInPixels; }
 
+    // Disablee sizer flags (in)consistency asserts.
+    static void DisableConsistencyChecks();
+
 private:
 #ifdef wxNEEDS_BORDER_IN_PX
     static float DoGetDefaultBorderInPx();

--- a/interface/wx/sizer.h
+++ b/interface/wx/sizer.h
@@ -1481,6 +1481,29 @@ public:
     wxSizerFlags& CentreVertical();
 
     /**
+        Globally disable checks for sizer flag consistency in debug builds.
+
+        By default, sizer classes such as wxBoxSizer and wxFlexGridSizer assert
+        when passed invalid flags, even though doing this usually doesn't
+        result in any catastrophic consequences and the invalid flags are
+        simply ignored later. Due to this, and the fact that these checks were
+        only added in wxWidgets 3.1, existing code may run into multiple
+        asserts warning about incorrect sizer flags use. Using this function
+        provides a temporary solution for avoiding such asserts when upgrading
+        to wxWidgets 3.1 from a previous version and will prevent such checks
+        from being done.
+
+        Please do note that correcting the code by removing the invalid flags
+        remains a much better solution as these asserts may be very helpful to
+        understand why some code using sizer flags doesn't work as expected, so
+        using this function, especially permanently, rather than a temporary
+        workaround, is @e not recommended.
+
+        @since 3.1.6
+     */
+    static void DisableConsistencyChecks();
+
+    /**
         Sets the border in the given @a direction having twice the default
         border size.
     */

--- a/interface/wx/sizer.h
+++ b/interface/wx/sizer.h
@@ -1499,6 +1499,10 @@ public:
         using this function, especially permanently, rather than a temporary
         workaround, is @e not recommended.
 
+        Notice that the same effect as calling this function can be achieved by
+        setting the environment variable @c WXSUPPRESS_SIZER_FLAGS_CHECK to any
+        value.
+
         @since 3.1.6
      */
     static void DisableConsistencyChecks();

--- a/src/common/sizer.cpp
+++ b/src/common/sizer.cpp
@@ -144,18 +144,55 @@ static const int SIZER_FLAGS_MASK =
     wxADD_FLAG(wxSHAPED,
     0))))))))))))))))));
 
+namespace
+{
+
+wxString MakeFlagsCheckMessage(const char* start, const char* whatToRemove)
+{
+    return wxString::Format
+           (
+             "%s"
+             "\n\nDO NOT PANIC !!\n\n"
+             "If you're an end user running a program not developed by you, "
+             "please ignore this message, it is harmless, and please try "
+             "reporting the problem to the program developers.\n"
+             "\n"
+             "If you're the developer, simply remove %s from your code to "
+             "avoid getting this message.\n",
+             start,
+             whatToRemove
+           );
+}
+
+} // anonymous namespace
+
 #endif // wxDEBUG_LEVEL
 
 #define ASSERT_NO_IGNORED_FLAGS_IMPL(f, value, name, explanation) \
-    wxASSERT_MSG( !((f) & (value)), \
-                  name " will be ignored in this sizer: " explanation )
+    wxASSERT_MSG                                                  \
+    (                                                             \
+      !((f) & (value)),                                           \
+      MakeFlagsCheckMessage                                       \
+      (                                                           \
+        name " will be ignored in this sizer: " explanation,      \
+        "this flag"                                               \
+      )                                                           \
+    )
 
 #define ASSERT_NO_IGNORED_FLAGS(f, flags, explanation) \
     ASSERT_NO_IGNORED_FLAGS_IMPL(f, flags, #flags, explanation)
 
-#define ASSERT_INCOMPATIBLE_NOT_USED_IMPL(f, f1, n1, f2, n2) \
-    wxASSERT_MSG(((f) & (f1 | f2)) != (f1 | f2), \
-                 n1 " and " n2 " can't be used together")
+#define ASSERT_INCOMPATIBLE_NOT_USED_IMPL(f, f1, n1, f2, n2)       \
+    wxASSERT_MSG                                                   \
+    (                                                              \
+      ((f) & (f1 | f2)) != (f1 | f2),                              \
+      MakeFlagsCheckMessage                                        \
+      (                                                            \
+        "One of " n1 " and " n2 " will be ignored in this sizer: " \
+        "they are incompatible and cannot be used together",       \
+        "one of these flags"                                       \
+      )                                                            \
+    )
 
 #define ASSERT_INCOMPATIBLE_NOT_USED(f, f1, f2) \
     ASSERT_INCOMPATIBLE_NOT_USED_IMPL(f, f1, #f1, f2, #f2)
@@ -1480,7 +1517,11 @@ wxSizerItem *wxGridSizer::DoInsert(size_t index, wxSizerItem *item)
         (
             !(flags & (wxALIGN_BOTTOM | wxALIGN_CENTRE_VERTICAL)) ||
                 !(flags & (wxALIGN_RIGHT | wxALIGN_CENTRE_HORIZONTAL)),
-            "wxEXPAND flag will be overridden by alignment flags"
+            MakeFlagsCheckMessage
+            (
+                "wxEXPAND flag will be overridden by alignment flags",
+                "either wxEXPAND or the alignment in at least one direction"
+            )
         );
     }
 


### PR DESCRIPTION
Improve the error messages by indicating what should be done to avoid the asserts and provide a way to disable them if really needed.