### PR TITLE
Correct dependencies for wxAUI library in documentation

### DIFF
--- a/docs/doxygen/mainpages/libs.h
+++ b/docs/doxygen/mainpages/libs.h
@@ -45,7 +45,7 @@ digraph Dependencies
     wxNet -> wxBase;
     wxXML -> wxBase;
 
-    wxAUI -> wxCore; wxAUI -> wxHTML;
+    wxAUI -> wxCore;
     wxGL -> wxCore;
     wxHTML -> wxCore;
     wxMedia -> wxCore;
@@ -74,8 +74,7 @@ libraries), and all green libraries depend on the @ref page_libs_wxcore library
 
 This contains the Advanced User Interface docking library.
 
-Requires @ref page_libs_wxhtml, @ref page_libs_wxxml,
-@ref page_libs_wxcore, @ref page_libs_wxbase.
+Requires @ref page_libs_wxcore, @ref page_libs_wxbase.
 
 
 @section page_libs_wxbase wxBase


### PR DESCRIPTION
Library wxAUI does not depend on libraries wxHTML or wxXRC,
remove these incorrect dependencies from documentation.