### PR TITLE
removed build-time condition SDK >= 10.14

### DIFF
--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -2622,11 +2622,9 @@ void wxWidgetCocoaImpl::SetVisibility( bool visible )
     [m_osxView setHidden:(visible ? NO:YES)];
     
     // trigger redraw upon shown for layer-backed views
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
     if ( WX_IS_MACOS_AVAILABLE(10, 14 ) )
         if( !m_osxView.isHiddenOrHasHiddenAncestor )
             SetNeedsDisplay(NULL);
-#endif
 }
 
 double wxWidgetCocoaImpl::GetContentScaleFactor() const
@@ -3080,7 +3078,6 @@ void wxWidgetCocoaImpl::GetContentArea( int&left, int &top, int &width, int &hei
     }
 }
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
 namespace
 {
     
@@ -3114,7 +3111,6 @@ void SetSubviewsNeedDisplay( NSView *view, NSRect rect )
 }
 
 }
-#endif
 
 
 void wxWidgetCocoaImpl::SetNeedsDisplay( const wxRect* where )
@@ -3129,7 +3125,6 @@ void wxWidgetCocoaImpl::SetNeedsDisplay( const wxRect* where )
     // Layer-backed views (which are all in Mojave's Dark Mode) may not have
     // their children implicitly redrawn with the parent. For compatibility,
     // do it manually here:
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_14
     if ( WX_IS_MACOS_AVAILABLE(10, 14 ) )
     {
         if ( where )
@@ -3137,7 +3132,6 @@ void wxWidgetCocoaImpl::SetNeedsDisplay( const wxRect* where )
         else
             SetSubviewsNeedDisplay(m_osxView);
     }
-#endif
 }
 
 bool wxWidgetCocoaImpl::GetNeedsDisplay() const


### PR DESCRIPTION
"trigger redraw upon shown for layer-backed views" is also needed when building with sdk 10.13

the build-time check that the used SDK must be 10.14 or higher is not needed
I checked building with SDK 10.12 and 10.13

the used NsView functions are available in far older SDK's
* https://developer.apple.com/documentation/appkit/nsview/1483475-setneedsdisplay
 Availability macOS 10.0+ 
* https://developer.apple.com/documentation/appkit/nsview/1483473-ishiddenorhashiddenancestor
 Availability macOS 10.3+

I did not add an ifdef checking for sdk 10.3 or higher - I assume the minimum requirement for building wxWidgets is higher than 10.3

see also https://github.com/wxWidgets/wxWidgets/commit/e484a2db1926374311ec4327605e8935d04ac873