### PR TITLE
Fix key events for wxDataViewCtrl in wxGTK

### DIFF
--- a/src/gtk/toolbar.cpp
+++ b/src/gtk/toolbar.cpp
@@ -463,7 +463,6 @@ bool wxToolBar::Create( wxWindow *parent,
     else
     {
         m_widget = gtk_event_box_new();
-        ConnectWidget( m_widget );
     }
     gtk_container_add(GTK_CONTAINER(m_widget), GTK_WIDGET(m_toolbar));
     wxGCC_WARNING_RESTORE()

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -3692,10 +3692,18 @@ void wxWindowGTK::ConnectWidget( GtkWidget *widget )
         g_source_unref(source);
     }
 
-    g_signal_connect (widget, "key_press_event",
+    // When we're called for the main widget itself (but not when connecting
+    // events for some other widget, such as individual radio buttons in
+    // wxRadioBox::Create()), connect to m_focusWidget for the keyboard events
+    // instead, as it should be used for everything keyboard input-related.
+    GtkWidget* const focusWidget = widget == m_widget && m_focusWidget
+                                    ? m_focusWidget
+                                    : widget;
+    g_signal_connect (focusWidget, "key_press_event",
                       G_CALLBACK (gtk_window_key_press_callback), this);
-    g_signal_connect (widget, "key_release_event",
+    g_signal_connect (focusWidget, "key_release_event",
                       G_CALLBACK (gtk_window_key_release_callback), this);
+
     g_signal_connect (widget, "button_press_event",
                       G_CALLBACK (gtk_window_button_press_callback), this);
     g_signal_connect (widget, "button_release_event",

--- a/tests/controls/dataviewctrltest.cpp
+++ b/tests/controls/dataviewctrltest.cpp
@@ -17,6 +17,8 @@
 
 #include "wx/app.h"
 #include "wx/dataview.h"
+#include "wx/uiaction.h"
+
 #ifdef __WXGTK__
     #include "wx/stopwatch.h"
 #endif // __WXGTK__
@@ -411,5 +413,27 @@ TEST_CASE_METHOD(MultiColumnsDataViewCtrlTestCase,
     CHECK( m_lastColumn->GetWidth() <= lastColumnMaxWidth );
     CHECK( m_lastColumn->GetWidth() >= lastColumnMinWidth );
 }
+
+#if wxUSE_UIACTIONSIMULATOR
+
+TEST_CASE_METHOD(SingleSelectDataViewCtrlTestCase,
+                 "wxDVC::KeyEvents",
+                 "[wxDataViewCtrl][event]")
+{
+    if ( !EnableUITests() )
+        return;
+
+    EventCounter keyEvents(m_dvc->GetMainWindow(), wxEVT_KEY_DOWN);
+
+    m_dvc->SetFocus();
+
+    wxUIActionSimulator sim;
+    sim.Char(WXK_DOWN);
+    wxYield();
+
+    CHECK( keyEvents.GetCount() == 1 );
+}
+
+#endif // wxUSE_UIACTIONSIMULATOR
 
 #endif //wxUSE_DATAVIEWCTRL


### PR DESCRIPTION
This change does fix the problem for wxDVC, the question is whether it can break anything for any other controls. I've removed an apparently unnecessary `ConnectWidget()` call from `wxToolBar` and I think the only other remaining direct call to it from `wxRadioBox` should be fine, but I'm not totally sure if it can't break something for one of the other controls setting `m_focusWidget`, which are `wxComboBox`, `wxListBox`, `wxTextCtrl`, `wxSearchCtrl` and `wxFileCtrl`. But I think using the "focus widget" for the key event makes sense, doesn't it?