### PR TITLE
Performance updates and fixes for OSX DataView

### DIFF
--- a/include/wx/osx/cocoa/dataview.h
+++ b/include/wx/osx/cocoa/dataview.h
@@ -501,7 +501,7 @@ public:
     virtual wxDataViewColumn* GetColumn(unsigned int pos) const wxOVERRIDE;
     virtual int GetColumnPosition(wxDataViewColumn const* columnPtr) const wxOVERRIDE;
     virtual bool InsertColumn(unsigned int pos, wxDataViewColumn* columnPtr) wxOVERRIDE;
-    virtual void FitColumnWidthToContent(unsigned int pos) wxOVERRIDE;
+    virtual void FitColumnWidthToContent(unsigned int pos, bool fitRowHeight = false) wxOVERRIDE;
 
     // item related methods (inherited from wxDataViewWidgetImpl)
     virtual bool Add(const wxDataViewItem& parent, const wxDataViewItem& item) wxOVERRIDE;
@@ -570,6 +570,7 @@ public:
 
     // Cocoa-specific helpers
     id GetItemAtRow(int row) const;
+    virtual int GetRowHeight() wxOVERRIDE;
 
     virtual void SetFont(const wxFont& font) wxOVERRIDE;
 

--- a/include/wx/osx/core/dataview.h
+++ b/include/wx/osx/core/dataview.h
@@ -53,7 +53,7 @@ public:
   virtual int               GetColumnPosition  (wxDataViewColumn const* columnPtr) const       = 0; // returns the position of the passed column in the native control
   virtual bool              InsertColumn       (unsigned int pos, wxDataViewColumn* columnPtr) = 0; // inserts a column at pos in the native control;
                                                                                                     // the method can assume that the column's owner is already set
-  virtual void              FitColumnWidthToContent(unsigned int pos)                          = 0; // resizes column to fit its content
+  virtual void              FitColumnWidthToContent(unsigned int pos, bool fitRowHeight = false) = 0; // resizes column to fit its content, optionally adjust the row height
 
  //
  // item related methods
@@ -112,6 +112,8 @@ public:
   virtual void SetRowHeight(wxDataViewItem const& item, unsigned int height)                                = 0; // sets the height of the row containing the passed item in the native control
   virtual void OnSize()                                                                                     = 0; // updates the layout of the native control after a size event
   virtual void StartEditor( const wxDataViewItem & item, unsigned int column )                              = 0; // starts editing the passed in item and column
+
+  virtual int GetRowHeight()                                                                                = 0; // return the height of all rows
 };
 
 #endif // _WX_DATAVIEWCTRL_CORE_H_

--- a/include/wx/osx/dataview.h
+++ b/include/wx/osx/dataview.h
@@ -285,6 +285,7 @@ protected:
  // event handling
   void OnSize(wxSizeEvent &event);
 
+  virtual void DoThaw() wxOVERRIDE;
 private:
  // initializing of local variables:
   void Init();

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2092,7 +2092,7 @@ wxCocoaDataViewControl::wxCocoaDataViewControl(wxWindow* peer,
       ),
       m_DataSource(NULL),
       m_OutlineView([[wxCocoaOutlineView alloc] init]),
-      m_expanderWidth(0)
+      m_expanderWidth(-1)
 {
     // initialize scrollview (the outline view is part of a scrollview):
     NSScrollView* scrollview = (NSScrollView*) GetWXWidget();
@@ -2257,7 +2257,7 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos, bool fitR
               m_view(view),
               m_column(columnIndex),
               m_indent(0),
-              m_expander(0),
+              m_expander(-1),
               m_tableColumn(column)
         {
             // account for indentation in the column with expander
@@ -2279,7 +2279,7 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos, bool fitR
             if ( m_indent )
                 cellWidth += m_indent * [m_view levelForRow:row];
 
-            if ( m_expander == 0 && m_tableColumn == [m_view outlineTableColumn] )
+            if ( m_expander == -1 && m_tableColumn == [m_view outlineTableColumn] )
             {
                 NSRect rc = [m_view frameOfOutlineCellAtRow:row];
                 m_expander = ceil(rc.origin.x + rc.size.width);
@@ -2306,7 +2306,7 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos, bool fitR
     MaxWidthCalculator calculator(m_OutlineView, column, pos);
 
     bool calculateAllRows = fitRowHeight || ((GetColumn(pos)->GetWidthVariable() == wxCOL_WIDTH_AUTOSIZE)
-        || (m_expanderWidth == 0 && column == [m_OutlineView outlineTableColumn]));
+        || (m_expanderWidth == -1 && column == [m_OutlineView outlineTableColumn]));
 
 
     if ( [column headerCell] )
@@ -2378,13 +2378,13 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos, bool fitR
     }
     // there might not necessarily be an expander in the rows we've examined above so let's
     // globally store the expander width for re-use because it should always be the same
-    if ( m_expanderWidth == 0 )
+    if ( m_expanderWidth == -1 )
         m_expanderWidth = calculator.GetExpanderWidth();
 
     const bool isLast = pos == noOfColumns - 1;
 
     int autoWidth = calculator.GetMaxWidth();
-    if (column == [m_OutlineView outlineTableColumn])
+    if (m_expanderWidth != -1 && column == [m_OutlineView outlineTableColumn])
     {
         autoWidth += m_expanderWidth;
     }

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2406,13 +2406,19 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos, bool fitR
         }
         else
         {
-            [column setMinWidth:10];
+            int minW = GetColumn(pos)->GetMinWidth();
+            if (minW == 0) {
+                minW = 10;
+            }
+            [column setMinWidth:minW];
             [m_OutlineView sizeLastColumnToFit];
         }
     }
     else if ( GetColumn(pos)->GetWidthVariable() == wxCOL_WIDTH_AUTOSIZE )
     {
         [column setWidth:autoWidth];
+        int minW = GetColumn(pos)->GetMinWidth();
+        [column setMinWidth:minW];
     }
     else if ( nativeData->GetIsLast() )
     {

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2305,6 +2305,10 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos)
 
     MaxWidthCalculator calculator(m_OutlineView, column, pos);
 
+    bool calculateAllRows = ((GetColumn(pos)->GetWidthVariable() == wxCOL_WIDTH_AUTOSIZE)
+        || (m_expanderWidth == 0 && column == [m_OutlineView outlineTableColumn]));
+
+
     if ( [column headerCell] )
     {
         calculator.UpdateWithWidth(ceil([[column headerCell] cellSize].width));
@@ -2320,63 +2324,70 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos)
     // visible miscalculations, we also include all currently visible items
     // no matter what.  Finally, the value of N is determined dynamically by
     // measuring how much time we spent on the determining item widths so far.
-
+    if (calculateAllRows)
+    {
 #if wxUSE_STOPWATCH
-    int top_part_end = count;
-    static const long CALC_TIMEOUT = 20/*ms*/;
-    // don't call wxStopWatch::Time() too often
-    static const unsigned CALC_CHECK_FREQ = 100;
-    wxStopWatch timer;
+        int top_part_end = count;
+        static const long CALC_TIMEOUT = 20/*ms*/;
+        // don't call wxStopWatch::Time() too often
+        static const unsigned CALC_CHECK_FREQ = 100;
+        wxStopWatch timer;
 #else
-    // use some hard-coded limit, that's the best we can do without timer
-    int top_part_end = wxMin(500, count);
+        // use some hard-coded limit, that's the best we can do without timer
+        int top_part_end = wxMin(500, count);
 #endif // wxUSE_STOPWATCH/!wxUSE_STOPWATCH
 
-    int row = 0;
+        int row = 0;
 
-    for ( row = 0; row < top_part_end; row++ )
-    {
+        for ( row = 0; row < top_part_end; row++ )
+        {
 #if wxUSE_STOPWATCH
-        if ( row % CALC_CHECK_FREQ == CALC_CHECK_FREQ-1 &&
-             timer.Time() > CALC_TIMEOUT )
-            break;
+            if ( row % CALC_CHECK_FREQ == CALC_CHECK_FREQ-1 &&
+                timer.Time() > CALC_TIMEOUT )
+                break;
 #endif // wxUSE_STOPWATCH
-        calculator.UpdateWithRow(row);
-    }
-
-    // row is the first unmeasured item now; that's our value of N/2
-
-    if ( row < count )
-    {
-        top_part_end = row;
-
-        // add bottom N/2 items now:
-        const int bottom_part_start = wxMax(row, count - row);
-        for ( row = bottom_part_start; row < count; row++ )
             calculator.UpdateWithRow(row);
+        }
 
-        // finally, include currently visible items in the calculation:
-        const NSRange visible = [m_OutlineView rowsInRect:[m_OutlineView visibleRect]];
-        const int first_visible = wxMax(visible.location, top_part_end);
-        const int last_visible = wxMin(first_visible + visible.length, bottom_part_start);
+        // row is the first unmeasured item now; that's our value of N/2
 
-        for ( row = first_visible; row < last_visible; row++ )
-            calculator.UpdateWithRow(row);
+        if ( row < count )
+        {
+            top_part_end = row;
 
-        wxLogTrace("dataview",
-                   "determined best size from %d top, %d bottom plus %d more visible items out of %d total",
-                   top_part_end,
-                   count - bottom_part_start,
-                   wxMax(0, last_visible - first_visible),
-                   count);
+            // add bottom N/2 items now:
+            const int bottom_part_start = wxMax(row, count - row);
+            for ( row = bottom_part_start; row < count; row++ )
+                calculator.UpdateWithRow(row);
+
+            // finally, include currently visible items in the calculation:
+            const NSRange visible = [m_OutlineView rowsInRect:[m_OutlineView visibleRect]];
+            const int first_visible = wxMax(visible.location, top_part_end);
+            const int last_visible = wxMin(first_visible + visible.length, bottom_part_start);
+
+            for ( row = first_visible; row < last_visible; row++ )
+                calculator.UpdateWithRow(row);
+
+            wxLogTrace("dataview",
+                       "determined best size from %d top, %d bottom plus %d more visible items out of %d total",
+                       top_part_end,
+                       count - bottom_part_start,
+                       wxMax(0, last_visible - first_visible),
+                       count);
+        }
     }
-
     // there might not necessarily be an expander in the rows we've examined above so let's
     // globally store the expander width for re-use because it should always be the same
     if ( m_expanderWidth == 0 )
         m_expanderWidth = calculator.GetExpanderWidth();
 
     const bool isLast = pos == noOfColumns - 1;
+
+    int autoWidth = calculator.GetMaxWidth();
+    if (column == [m_OutlineView outlineTableColumn])
+    {
+        autoWidth += m_expanderWidth;
+    }
 
     if ( isLast )
     {
@@ -2389,11 +2400,19 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos)
         // previous width in that case because it must not get lost.
         nativeData->SetPrevWidth(GetColumn(pos)->GetWidth());
 
-        [m_OutlineView sizeLastColumnToFit];
+        if ( GetColumn(pos)->GetWidthVariable() == wxCOL_WIDTH_AUTOSIZE )
+        {
+            [column setWidth:autoWidth];
+        }
+        else
+        {
+            [column setMinWidth:10];
+            [m_OutlineView sizeLastColumnToFit];
+        }
     }
     else if ( GetColumn(pos)->GetWidthVariable() == wxCOL_WIDTH_AUTOSIZE )
     {
-        [column setWidth:calculator.GetMaxWidth() + m_expanderWidth];
+        [column setWidth:autoWidth];
     }
     else if ( nativeData->GetIsLast() )
     {

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2402,16 +2402,24 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos, bool fitR
 
         if ( GetColumn(pos)->GetWidthVariable() == wxCOL_WIDTH_AUTOSIZE )
         {
-            [column setWidth:autoWidth];
+            [column setMinWidth:autoWidth];
+            [m_OutlineView sizeLastColumnToFit];
+            int minW = GetColumn(pos)->GetMinWidth();
+            [column setMinWidth:minW];
         }
         else
         {
             int minW = GetColumn(pos)->GetMinWidth();
             if (minW == 0) {
-                minW = 10;
+                [column setMinWidth:10];
+            } else {
+                [column setMinWidth:minW];
             }
             [column setMinWidth:minW];
             [m_OutlineView sizeLastColumnToFit];
+            if (minW == 0) {
+                [column setMinWidth:0];
+            }
         }
     }
     else if ( GetColumn(pos)->GetWidthVariable() == wxCOL_WIDTH_AUTOSIZE )
@@ -2781,7 +2789,10 @@ void wxCocoaDataViewControl::SetRowHeight(const wxDataViewItem& WXUNUSED(item), 
 
 void wxCocoaDataViewControl::OnSize()
 {
-    [m_OutlineView sizeLastColumnToFit];
+    UInt32 const noOfColumns = [[m_OutlineView tableColumns] count];
+    if (noOfColumns) {
+        FitColumnWidthToContent(noOfColumns - 1);
+    }
 }
 
 //

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2240,7 +2240,7 @@ bool wxCocoaDataViewControl::InsertColumn(unsigned int pos, wxDataViewColumn* co
     return true;
 }
 
-void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos)
+void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos, bool fitRowHeight)
 {
     const int count = GetCount();
     wxDataViewColumnNativeData *nativeData = GetColumn(pos)->GetNativeData();
@@ -2305,7 +2305,7 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos)
 
     MaxWidthCalculator calculator(m_OutlineView, column, pos);
 
-    bool calculateAllRows = ((GetColumn(pos)->GetWidthVariable() == wxCOL_WIDTH_AUTOSIZE)
+    bool calculateAllRows = fitRowHeight || ((GetColumn(pos)->GetWidthVariable() == wxCOL_WIDTH_AUTOSIZE)
         || (m_expanderWidth == 0 && column == [m_OutlineView outlineTableColumn]));
 
 
@@ -2751,6 +2751,9 @@ void wxCocoaDataViewControl::HitTest(const wxPoint& point, wxDataViewItem& item,
 void wxCocoaDataViewControl::SetRowHeight(int height)
 {
     [m_OutlineView setRowHeight:wxMax(height, GetDefaultRowHeight())];
+}
+int wxCocoaDataViewControl::GetRowHeight() {
+    return ceil([m_OutlineView rowHeight]);
 }
 
 int wxCocoaDataViewControl::GetDefaultRowHeight() const

--- a/src/osx/dataview_osx.cpp
+++ b/src/osx/dataview_osx.cpp
@@ -299,10 +299,13 @@ void wxOSXDataViewModelNotifier::AdjustRowHeights(wxDataViewItemArray const& ite
 
 void wxOSXDataViewModelNotifier::AdjustAutosizedColumns()
 {
-  unsigned count = m_DataViewCtrlPtr->GetColumnCount();
-  for ( unsigned col = 0; col < count; col++ )
+  if (!m_DataViewCtrlPtr->IsFrozen())
   {
-    m_DataViewCtrlPtr->GetDataViewPeer()->FitColumnWidthToContent(col);
+    unsigned count = m_DataViewCtrlPtr->GetColumnCount();
+    for ( unsigned col = 0; col < count; col++ )
+    {
+      m_DataViewCtrlPtr->GetDataViewPeer()->FitColumnWidthToContent(col);
+    }
   }
 }
 
@@ -703,6 +706,12 @@ void wxDataViewCtrl::AdjustAutosizedColumns() const
 {
   if ( m_ModelNotifier )
     m_ModelNotifier->AdjustAutosizedColumns();
+}
+
+void wxDataViewCtrl::DoThaw()
+{
+  AdjustAutosizedColumns();
+  wxDataViewCtrlBase::DoThaw();
 }
 
 /*static*/

--- a/src/osx/dataview_osx.cpp
+++ b/src/osx/dataview_osx.cpp
@@ -74,7 +74,7 @@ public:
   virtual void Resort() wxOVERRIDE;
 
  // adjust wxCOL_WIDTH_AUTOSIZE columns to fit the data
-  void AdjustAutosizedColumns();
+  void AdjustAutosizedColumns(bool fitRowHeight = false);
 
 protected:
  // if the dataview control can have a variable row height this method sets the dataview's control row height of
@@ -233,78 +233,64 @@ void wxOSXDataViewModelNotifier::Resort()
 
 void wxOSXDataViewModelNotifier::AdjustRowHeight(wxDataViewItem const& item)
 {
-  if ((m_DataViewCtrlPtr->GetWindowStyle() & wxDV_VARIABLE_LINE_HEIGHT) != 0)
+  if (!m_DataViewCtrlPtr->IsFrozen() ||  ((m_DataViewCtrlPtr->GetWindowStyle() & wxDV_VARIABLE_LINE_HEIGHT) != 0))
   {
-      wxDataViewModel *model = GetOwner();
+    wxDataViewModel *model = GetOwner();
 
-      int height = 20; // TODO find out standard height
-      unsigned int num = m_DataViewCtrlPtr->GetColumnCount();
-      unsigned int col;
-      for (col = 0; col < num; col++)
+    int height = ((m_DataViewCtrlPtr->GetWindowStyle() & wxDV_VARIABLE_LINE_HEIGHT) != 0)
+        ? 20
+        : m_DataViewCtrlPtr->GetDataViewPeer()->GetRowHeight();
+    int origHeight = height;
+    unsigned int num = m_DataViewCtrlPtr->GetColumnCount();
+    unsigned int col;
+    for (col = 0; col < num; col++)
+    {
+      wxDataViewColumn* column(m_DataViewCtrlPtr->GetColumnPtr(col));
+
+      if (!(column->IsHidden()))
       {
-          wxDataViewColumn* column(m_DataViewCtrlPtr->GetColumnPtr(col));
-
-          if (!(column->IsHidden()))
-          {
-            wxDataViewCustomRenderer *renderer = dynamic_cast<wxDataViewCustomRenderer*>(column->GetRenderer());
-            if (renderer)
-            {
-                wxVariant value;
-                model->GetValue( value, item, column->GetModelColumn() );
-                renderer->SetValue( value );
-                height = wxMax( height, renderer->GetSize().y );
-            }
-          }
+        wxDataViewCustomRenderer *renderer = dynamic_cast<wxDataViewCustomRenderer*>(column->GetRenderer());
+        if (renderer)
+        {
+          wxVariant value;
+          model->GetValue( value, item, column->GetModelColumn() );
+          renderer->SetValue( value );
+          height = wxMax( height, renderer->GetSize().y );
+        }
       }
+    }
+    if ((m_DataViewCtrlPtr->GetWindowStyle() & wxDV_VARIABLE_LINE_HEIGHT) != 0)
+    {
       if (height > 20)
         m_DataViewCtrlPtr->GetDataViewPeer()->SetRowHeight(item,height);
+    }
+    else if (origHeight != height)
+    {
+      m_DataViewCtrlPtr->GetDataViewPeer()->SetRowHeight(height);
+    }
   }
 }
 
 void wxOSXDataViewModelNotifier::AdjustRowHeights(wxDataViewItemArray const& items)
 {
-  if ((m_DataViewCtrlPtr->GetWindowStyle() & wxDV_VARIABLE_LINE_HEIGHT) != 0)
+  if (!m_DataViewCtrlPtr->IsFrozen() || ((m_DataViewCtrlPtr->GetWindowStyle() & wxDV_VARIABLE_LINE_HEIGHT) != 0))
   {
-      size_t const noOfItems = items.GetCount();
-
-      wxDataViewModel *model = GetOwner();
-
-      for (size_t itemIndex=0; itemIndex<noOfItems; ++itemIndex)
-      {
-        int height = 20; // TODO find out standard height
-        unsigned int num = m_DataViewCtrlPtr->GetColumnCount();
-        unsigned int col;
-
-        for (col = 0; col < num; col++)
-        {
-            wxDataViewColumn* column(m_DataViewCtrlPtr->GetColumnPtr(col));
-
-            if (!(column->IsHidden()))
-            {
-              wxDataViewCustomRenderer *renderer = dynamic_cast<wxDataViewCustomRenderer*>(column->GetRenderer());
-              if (renderer)
-              {
-                  wxVariant value;
-                  model->GetValue( value, items[itemIndex], column->GetModelColumn() );
-                  renderer->SetValue( value );
-                  height = wxMax( height, renderer->GetSize().y );
-              }
-            }
-        }
-        if (height > 20)
-          m_DataViewCtrlPtr->GetDataViewPeer()->SetRowHeight(items[itemIndex],height);
-      }
+    size_t const noOfItems = items.GetCount();
+    for (size_t itemIndex=0; itemIndex<noOfItems; ++itemIndex)
+    {
+      AdjustRowHeight(items[itemIndex]);
+    }
   }
 }
 
-void wxOSXDataViewModelNotifier::AdjustAutosizedColumns()
+void wxOSXDataViewModelNotifier::AdjustAutosizedColumns(bool fitRowHeight)
 {
   if (!m_DataViewCtrlPtr->IsFrozen())
   {
     unsigned count = m_DataViewCtrlPtr->GetColumnCount();
     for ( unsigned col = 0; col < count; col++ )
     {
-      m_DataViewCtrlPtr->GetDataViewPeer()->FitColumnWidthToContent(col);
+      m_DataViewCtrlPtr->GetDataViewPeer()->FitColumnWidthToContent(col, fitRowHeight);
     }
   }
 }
@@ -710,7 +696,11 @@ void wxDataViewCtrl::AdjustAutosizedColumns() const
 
 void wxDataViewCtrl::DoThaw()
 {
-  AdjustAutosizedColumns();
+  if ( m_ModelNotifier )
+  {
+    // also adjust the standard row heights since we have to calculate the widths anyway
+    m_ModelNotifier->AdjustAutosizedColumns(true);
+  }
   wxDataViewCtrlBase::DoThaw();
 }
 


### PR DESCRIPTION
This is an updated version of #2352. It contains the following changes:

1. We don't use `sizeLastColumnToFit` any longer because it always causes the view to refresh which will make our code very slow.
2. For autosizing columns, the text in the last column is no longer ellipsized in case it is wider than the available space. Instead, scrollbars will be added.