### PR TITLE
Fix passing of default language to wxTranslations

### DIFF
--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -615,7 +615,9 @@ bool wxLocale::Init(int lang, int flags)
            (
                 retloc != NULL,
                 name,
-                shortName,
+                // wxLANGUAGE_DEFAULT needs to be passed to wxTranslations as ""
+                // for correct detection of user's preferred language(s)
+                lang == wxLANGUAGE_DEFAULT ? wxString() : shortName,
                 flags & wxLOCALE_LOAD_DEFAULT
            );
 #else // !(__UNIX__ || __WIN32__)


### PR DESCRIPTION
`wxTranslations` needs the information that user's default language is used; in particular, it may choose to use a cascade of user-preferred languages to choose the best UI language.

This was accidentally broken by 18bf718f607ad0f11a5e4c5e48916d73c50a16a0 which changed the logic to fill shortName from the builtin database. This consequently changed `wxTranslations` to use only the single detected language and ignore user's preference cascade.

(Bug found via https://github.com/vslavik/poedit/issues/701)