### PR TITLE
Fix wxIcon wxDVC columns under wxGTK

### DIFF
--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -2562,8 +2562,16 @@ wxDataViewBitmapRenderer::wxDataViewBitmapRenderer( const wxString &varianttype,
 bool wxDataViewBitmapRenderer::SetValue( const wxVariant &value )
 {
     wxBitmap bitmap;
-    if (value.GetType() == wxS("wxBitmap") || value.GetType() == wxS("wxIcon"))
+    if (value.GetType() == wxS("wxBitmap"))
+    {
         bitmap << value;
+    }
+    else if (value.GetType() == wxS("wxIcon"))
+    {
+        wxIcon icon;
+        icon << value;
+        bitmap.CopyFromIcon(icon);
+    }
 
 #ifdef __WXGTK3__
     WX_CELL_RENDERER_PIXBUF(m_renderer)->Set(bitmap);


### PR DESCRIPTION
b376d1402bdc48614888704cf191f82a630d93c0 accidentally broke columns with `wxIcon` type. Contrary to that commit's assumption, `operator<<` cannot convert wxIcon to wxBitmap and asserts:
```
src/common/bmpbase.cpp(33): assert "variant.GetType() == "wxBitmap"" failed in operator<<().
```
Fixed by restoring explicit conversion.