### PR TITLE
Fix sending wxEVT_GRID_RANGE_SELECTED from Select{All,Col,Row}()

### DIFF
--- a/src/generic/gridsel.cpp
+++ b/src/generic/gridsel.cpp
@@ -173,7 +173,7 @@ void wxGridSelection::SelectRow(int row, const wxKeyboardState& kbd)
         return;
 
     Select(wxGridBlockCoords(row, 0, row, m_grid->GetNumberCols() - 1),
-           kbd, true);
+           kbd, wxEVT_GRID_RANGE_SELECTED);
 }
 
 void wxGridSelection::SelectCol(int col, const wxKeyboardState& kbd)
@@ -183,7 +183,7 @@ void wxGridSelection::SelectCol(int col, const wxKeyboardState& kbd)
         return;
 
     Select(wxGridBlockCoords(0, col, m_grid->GetNumberRows() - 1, col),
-           kbd, true);
+           kbd, wxEVT_GRID_RANGE_SELECTED);
 }
 
 void wxGridSelection::SelectBlock( int topRow, int leftCol,
@@ -251,7 +251,7 @@ wxGridSelection::SelectAll()
     if ( numRows && numCols )
     {
         Select(wxGridBlockCoords(0, 0, numRows - 1, numCols - 1),
-               wxKeyboardState(), true /* send event */);
+               wxKeyboardState(), wxEVT_GRID_RANGE_SELECTED);
     }
 }
 

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -760,7 +760,11 @@ TEST_CASE_METHOD(GridTestCase, "Grid::KeyboardSelection", "[grid][selection]")
 
 TEST_CASE_METHOD(GridTestCase, "Grid::Selection", "[grid]")
 {
+    EventCounter select(m_grid, wxEVT_GRID_RANGE_SELECTED);
+
     m_grid->SelectAll();
+
+    CHECK(select.GetCount() == 1);
 
     CHECK(m_grid->IsSelection());
     CHECK(m_grid->IsInSelection(0, 0));
@@ -779,13 +783,21 @@ TEST_CASE_METHOD(GridTestCase, "Grid::Selection", "[grid]")
     CHECK(bottomright.Item(0).GetCol() == 1);
     CHECK(bottomright.Item(0).GetRow() == 3);
 
+    // Note that calling SelectCol() results in 2 events because there is a
+    // deselection event first.
+    select.Clear();
     m_grid->SelectCol(1);
+    CHECK(select.GetCount() == 2);
 
     CHECK(m_grid->IsInSelection(0, 1));
     CHECK(m_grid->IsInSelection(9, 1));
     CHECK(!m_grid->IsInSelection(3, 0));
 
+    // But if we explicitly avoid deselecting the existing selection, we should
+    // get exactly one event.
+    select.Clear();
     m_grid->SelectRow(4, true /* add to selection */);
+    CHECK(select.GetCount() == 1);
 
     CHECK(m_grid->IsInSelection(4, 0));
     CHECK(m_grid->IsInSelection(4, 1));


### PR DESCRIPTION
This was broken in to 682cb8355c (Replace "sendEvent" parameter in
wxGridSelection with "eventType", 2020-08-21) which changed Select() to
take wxEventType argument but still passed it "true" in a few places.

Fix this and add a unit test verifying that this works as expected.

Ideal would, of course, be to avoid implicit conversions from bool to
wxEventType but making wxEventType anything other than int, for which
such conversions are unavoidable, is too backwards-incompatible to
seriously consider.