### PR TITLE
setup.h: Replace "__MINGW64_TOOLCHAIN__" with "__MINGW64_VERSION_MAJOR"

### DIFF
--- a/build/cmake/setup.h.in
+++ b/build/cmake/setup.h.in
@@ -738,7 +738,7 @@
 #cmakedefine01 wxUSE_TIMEPICKCTRL_GENERIC
 
 
-#if defined(__VISUALC__) || defined(__MINGW64_TOOLCHAIN__)
+#if defined(__VISUALC__) || defined(__MINGW64_VERSION_MAJOR)
     #cmakedefine01 wxUSE_DBGHELP
 #else
     #cmakedefine01 wxUSE_DBGHELP

--- a/include/wx/gtk/setup.h
+++ b/include/wx/gtk/setup.h
@@ -1805,7 +1805,7 @@
 // Default is 1 if the compiler supports it, 0 for old MinGW.
 //
 // Recommended setting: 1, there is not much gain in disabling this
-#if defined(__VISUALC__) || defined(__MINGW64_TOOLCHAIN__)
+#if defined(__VISUALC__) || defined(__MINGW64_VERSION_MAJOR)
     #define wxUSE_DBGHELP 1
 #else
     #define wxUSE_DBGHELP 0

--- a/include/wx/msw/setup.h
+++ b/include/wx/msw/setup.h
@@ -1805,7 +1805,7 @@
 // Default is 1 if the compiler supports it, 0 for old MinGW.
 //
 // Recommended setting: 1, there is not much gain in disabling this
-#if defined(__VISUALC__) || defined(__MINGW64_TOOLCHAIN__)
+#if defined(__VISUALC__) || defined(__MINGW64_VERSION_MAJOR)
     #define wxUSE_DBGHELP 1
 #else
     #define wxUSE_DBGHELP 0

--- a/include/wx/msw/setup_inc.h
+++ b/include/wx/msw/setup_inc.h
@@ -203,7 +203,7 @@
 // Default is 1 if the compiler supports it, 0 for old MinGW.
 //
 // Recommended setting: 1, there is not much gain in disabling this
-#if defined(__VISUALC__) || defined(__MINGW64_TOOLCHAIN__)
+#if defined(__VISUALC__) || defined(__MINGW64_VERSION_MAJOR)
     #define wxUSE_DBGHELP 1
 #else
     #define wxUSE_DBGHELP 0

--- a/include/wx/univ/setup.h
+++ b/include/wx/univ/setup.h
@@ -1768,7 +1768,7 @@
 // Default is 1 if the compiler supports it, 0 for old MinGW.
 //
 // Recommended setting: 1, there is not much gain in disabling this
-#if defined(__VISUALC__) || defined(__MINGW64_TOOLCHAIN__)
+#if defined(__VISUALC__) || defined(__MINGW64_VERSION_MAJOR)
     #define wxUSE_DBGHELP 1
 #else
     #define wxUSE_DBGHELP 0

--- a/setup.h.in
+++ b/setup.h.in
@@ -738,7 +738,7 @@
 #define wxUSE_TIMEPICKCTRL_GENERIC 0
 
 
-#if defined(__VISUALC__) || defined(__MINGW64_TOOLCHAIN__)
+#if defined(__VISUALC__) || defined(__MINGW64_VERSION_MAJOR)
     #define wxUSE_DBGHELP 0
 #else
     #define wxUSE_DBGHELP 0


### PR DESCRIPTION
The setup.h file is included inside platform.h before "__MINGW64_TOOLCHAIN__" is
defined by wx/msw/gccpriv.h.