### PR TITLE
Fix floating for resizable auitoolbars (#19189)

### DIFF
--- a/include/wx/aui/framemanager.h
+++ b/include/wx/aui/framemanager.h
@@ -603,7 +603,6 @@ protected:
     wxRect m_lastHint;          // last hint rectangle
     wxPoint m_lastMouseMove;   // last mouse move position (see OnMotion)
     int  m_currentDragItem;
-    bool m_skipping;
     bool m_hasMaximized;
 
     double m_dockConstraintX;  // 0.0 .. 1.0; max pct of window width a dock can consume

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -614,7 +614,6 @@ wxAuiManager::wxAuiManager(wxWindow* managed_wnd, unsigned int flags)
     m_art = new wxAuiDefaultDockArt;
     m_hintWnd = NULL;
     m_flags = flags;
-    m_skipping = false;
     m_hasMaximized = false;
     m_frame = NULL;
     m_dockConstraintX = 0.3;
@@ -3020,8 +3019,6 @@ bool wxAuiManager::DoDrop(wxAuiDockInfoArray& docks,
             }
             return ProcessDockResult(target, drop);
         }
-
-        m_skipping = false;
 
         m_lastRect = part->dock->rect;
         m_lastRect.Inflate( m_frame->FromDIP(wxSize(15, 15)) );

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -3010,24 +3010,14 @@ bool wxAuiManager::DoDrop(wxAuiDockInfoArray& docks,
         if (!part->dock->fixed || part->dock->dock_direction == wxAUI_DOCK_CENTER ||
             pt.x >= cli_size.x || pt.x <= 0 || pt.y >= cli_size.y || pt.y <= 0)
         {
-            if (m_lastRect.IsEmpty() || m_lastRect.Contains(pt.x, pt.y ))
+            if ((m_flags & wxAUI_MGR_ALLOW_FLOATING) && drop.IsFloatable())
             {
-                m_skipping = true;
+                drop.Float();
             }
             else
             {
-                if ((m_flags & wxAUI_MGR_ALLOW_FLOATING) && drop.IsFloatable())
-                {
-                    drop.Float();
-                }
-
-                m_skipping = false;
-
-                return ProcessDockResult(target, drop);
+                drop.Position(pt.x - GetDockPixelOffset(drop) - offset.x);
             }
-
-            drop.Position(pt.x - GetDockPixelOffset(drop) - offset.x);
-
             return ProcessDockResult(target, drop);
         }
 


### PR DESCRIPTION
Fix for ticket [wxAuiToolbars become not floatable if all of them are resizable](http://trac.wxwidgets.org/ticket/19189)