### PR TITLE
wxTiff: disable-libdeflate

### DIFF
--- a/configure
+++ b/configure
@@ -22528,6 +22528,7 @@ ac_abs_srcdir=$ac_abs_top_srcdir$ac_dir_suffix
       as_fn_append ax_args " '--disable-jbig'"
       as_fn_append ax_args " '--disable-webp'"
       as_fn_append ax_args " '--disable-zstd'"
+      as_fn_append ax_args " '--disable-libdeflate'"
       as_fn_append ax_args " '$tiff_lzma_option'"
       as_fn_append ax_args " '$tiff_jpeg_option'"
 

--- a/configure.in
+++ b/configure.in
@@ -2816,6 +2816,7 @@ if test "$wxUSE_LIBTIFF" != "no" ; then
             [[--disable-jbig],
              [--disable-webp],
              [--disable-zstd],
+             [--disable-libdeflate],
              [$tiff_lzma_option],
              [$tiff_jpeg_option]])
     fi


### PR DESCRIPTION
Prevents undefined reference to libdeflate_free_compressor during
sample and test building when using builtin wxtiff while building
static wxWidgets via msys2 package created using configure/make method.

To see the problem you need to have libdeflate installed during configure.
Tim S.