### PR TITLE
Updated the fileutils catalog name used in the internat sample

### DIFF
--- a/samples/internat/internat.cpp
+++ b/samples/internat/internat.cpp
@@ -268,7 +268,7 @@ bool MyApp::OnInit()
 #ifdef __LINUX__
     {
         wxLogNull noLog;
-        m_locale.AddCatalog("fileutils");
+        m_locale.AddCatalog("coreutils");
     }
 #endif
 


### PR DESCRIPTION
As stated in the project [page](https://www.gnu.org/software/fileutils/) it is currently named `coreutils`.