### PR TITLE
Fix handling of ampersands in wxCheckListBox under MSW

### DIFF
--- a/include/wx/msw/ownerdrw.h
+++ b/include/wx/msw/ownerdrw.h
@@ -21,6 +21,12 @@ public:
 
     virtual bool OnDrawItem(wxDC& dc, const wxRect& rc,
                             wxODAction act, wxODStatus stat) wxOVERRIDE;
+
+protected:
+    // get the type of the text to draw in OnDrawItem(), by default is
+    // DST_PREFIXTEXT but can be overridden to return DST_TEXT when not using
+    // mnemonics
+    virtual int MSWGetTextType() const;
 };
 
 #endif // wxUSE_OWNER_DRAWN

--- a/src/msw/checklst.cpp
+++ b/src/msw/checklst.cpp
@@ -100,6 +100,15 @@ public:
     void Toggle()
         { Check(!IsChecked()); }
 
+protected:
+    virtual int MSWGetTextType() const wxOVERRIDE
+    {
+        // Don't handle mnemonics in the label specially, they don't make sense
+        // for the listbox items that can't be activated from keyboard using
+        // them.
+        return DST_TEXT;
+    }
+
 private:
     wxCheckListBox *m_parent;
     bool m_checked;

--- a/src/msw/ownerdrw.cpp
+++ b/src/msw/ownerdrw.cpp
@@ -24,6 +24,12 @@
 // implementation of wxOwnerDrawn class
 // ============================================================================
 
+int wxOwnerDrawn::MSWGetTextType() const
+{
+    // By default, handle the mnemonics.
+    return DST_PREFIXTEXT;
+}
+
 // draw the item
 bool wxOwnerDrawn::OnDrawItem(wxDC& dc, const wxRect& rc,
                               wxODAction, wxODStatus stat)
@@ -64,7 +70,7 @@ bool wxOwnerDrawn::OnDrawItem(wxDC& dc, const wxRect& rc,
         SIZE sizeRect;
         ::GetTextExtentPoint32(hdc, text.c_str(), text.length(), &sizeRect);
 
-        int flags = DST_PREFIXTEXT;
+        int flags = MSWGetTextType();
         if ( (stat & wxODDisabled) && !(stat & wxODSelected) )
             flags |= DSS_DISABLED;
 


### PR DESCRIPTION
They were incorrectly interpreted as mnemonics when drawing
wxCheckListBox items, which didn't make sense and was inconsistent with
the other ports and even wxListBox in wxMSW itself.

It also affected wxRearrangeCtrl under MSW, which uses wxCheckListBox
for its implementation.

Closes #19201.