### PR TITLE
Move wxHAVE_DPI_INDEPENDENT_PIXELS guards and inline code

### DIFF
--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -49,6 +49,10 @@
     #define wxUSE_MENUS_NATIVE wxUSE_MENUS
 #endif // __WXUNIVERSAL__/!__WXUNIVERSAL__
 
+#if defined(__WXGTK3__) || defined(__WXMAC__)
+    #define wxHAVE_DPI_INDEPENDENT_PIXELS
+#endif
+
 // ----------------------------------------------------------------------------
 // forward declarations
 // ----------------------------------------------------------------------------
@@ -993,7 +997,14 @@ public:
         // horizontal and vertical directions, but this could, in principle,
         // change too, so prefer using the overloads taking wxPoint or wxSize.
 
+#ifdef wxHAVE_DPI_INDEPENDENT_PIXELS
+    static wxSize FromDIP(const wxSize& sz, const wxWindowBase* WXUNUSED(w))
+    {
+        return sz;
+    }
+#else
     static wxSize FromDIP(const wxSize& sz, const wxWindowBase* w);
+#endif // wxHAVE_DPI_INDEPENDENT_PIXELS
     static wxPoint FromDIP(const wxPoint& pt, const wxWindowBase* w)
     {
         const wxSize sz = FromDIP(wxSize(pt.x, pt.y), w);
@@ -1008,7 +1019,14 @@ public:
     wxPoint FromDIP(const wxPoint& pt) const { return FromDIP(pt, this); }
     int FromDIP(int d) const { return FromDIP(d, this); }
 
+#ifdef wxHAVE_DPI_INDEPENDENT_PIXELS
+    static wxSize ToDIP(const wxSize& sz, const wxWindowBase* WXUNUSED(w))
+    {
+        return sz;
+    }
+#else
     static wxSize ToDIP(const wxSize& sz, const wxWindowBase* w);
+#endif // wxHAVE_DPI_INDEPENDENT_PIXELS
     static wxPoint ToDIP(const wxPoint& pt, const wxWindowBase* w)
     {
         const wxSize sz = ToDIP(wxSize(pt.x, pt.y), w);
@@ -2017,9 +2035,6 @@ inline void wxWindowBase::SetInitialBestSize(const wxSize& size)
         #define wxWindowGTK wxWindow
     #endif // wxUniv
     #include "wx/gtk/window.h"
-    #ifdef __WXGTK3__
-        #define wxHAVE_DPI_INDEPENDENT_PIXELS
-    #endif
 #elif defined(__WXGTK__)
     #ifdef __WXUNIVERSAL__
         #define wxWindowNative wxWindowGTK
@@ -2044,7 +2059,6 @@ inline void wxWindowBase::SetInitialBestSize(const wxSize& size)
         #define wxWindowMac wxWindow
     #endif // wxUniv
     #include "wx/osx/window.h"
-    #define wxHAVE_DPI_INDEPENDENT_PIXELS
 #elif defined(__WXQT__)
     #ifdef __WXUNIVERSAL__
         #define wxWindowNative wxWindowQt
@@ -2073,27 +2087,6 @@ inline wxWindow *wxWindowBase::GetGrandParent() const
 {
     return m_parent ? m_parent->GetParent() : NULL;
 }
-
-#ifdef wxHAVE_DPI_INDEPENDENT_PIXELS
-
-// FromDIP() and ToDIP() become trivial in this case, so make them inline to
-// avoid any overhead.
-
-/* static */
-inline wxSize
-wxWindowBase::FromDIP(const wxSize& sz, const wxWindowBase* WXUNUSED(w))
-{
-    return sz;
-}
-
-/* static */
-inline wxSize
-wxWindowBase::ToDIP(const wxSize& sz, const wxWindowBase* WXUNUSED(w))
-{
-    return sz;
-}
-
-#endif // wxHAVE_DPI_INDEPENDENT_PIXELS
 
 // ----------------------------------------------------------------------------
 // global functions


### PR DESCRIPTION
These changes are needed under GTK3/Win32 to prevent this warning:
include/wx/window.h:2047:1: warning: 'static wxSize wxWindowBase::FromDIP(const wxSize&, const wxWindowBase*)' redeclared without dllimport attribute after being referenced with dll linkage

I am primarily an C programmer; so, this change needs checked for simple C++ mistakes.
It fixes the build warnings; but, I have not tested the binaries built work correctly.