### PR TITLE
Fix option --libs output library path

### DIFF
--- a/build/cmake/config.cmake
+++ b/build/cmake/config.cmake
@@ -40,7 +40,7 @@ macro(wx_get_dependencies var lib)
                     get_target_property(dep_name ${dep} OUTPUT_NAME)
                 endif()
             else()
-                # For the vaule like $<$<CONFIG:DEBUG>:LIB_PATH>
+                # For the value like $<$<CONFIG:DEBUG>:LIB_PATH>
                 # Or $<$<NOT:$<CONFIG:DEBUG>>:LIB_PATH>
                 string(REGEX REPLACE "^.+>:(.+)>$" "\\1" dep_name ${dep})
                 if (NOT dep_name)


### PR DESCRIPTION
The `dep` does not consider the cmake generator expression and the absolute path.
We may meet some different situation:
1. `dep` was already handled like `-pthread`:
`dep_name` should be `${dep}`.
2. `dep` is system library like `dl` / `m`:
`dep_name` should be `-l${dep}`
3. `dep` is `$<$<CONFIG:DEBUG>:LIB_PATH>` or `$<$<NOT:$<CONFIG:DEBUG>>:LIB_PATH>` that from `LIB-config.cmake`:
`dep_name` should be `${LIB_PATH}`.
4. `dep` is an absolute path like `/usr/home/lib.a` or `/usr/home/lib.so` etc:
`dep_name` should be `${dep}`.


Related: https://github.com/microsoft/vcpkg/pull/18580