### PR TITLE
[cmake] Fix the generator expression with CUDA using file(GENERATE)

### DIFF
--- a/build/cmake/modules/cotire.cmake
+++ b/build/cmake/modules/cotire.cmake
@@ -2316,6 +2316,10 @@ function (cotire_generate_target_script _language _configurations _target _targe
 			"${_config}" "${_language}" "${_target}" COTIRE_TARGET_COMPILE_DEFINITIONS_${_upperConfig})
 		cotire_get_target_compiler_flags(
 			"${_config}" "${_language}" "${_target}" COTIRE_TARGET_COMPILE_FLAGS_${_upperConfig})
+        string(REPLACE
+            "<COMPILE_LANG_AND_ID:CUDA,NVIDIA>" "<COMPILE_LANGUAGE:CUDA>"
+            COTIRE_TARGET_COMPILE_FLAGS_${_upperConfig} "${COTIRE_TARGET_COMPILE_FLAGS_${_upperConfig}}"
+        )
 		cotire_get_source_files_compile_definitions(
 			"${_config}" "${_language}" COTIRE_TARGET_SOURCES_COMPILE_DEFINITIONS_${_upperConfig} ${_targetSources})
 	endforeach()

--- a/build/cmake/modules/cotire.cmake
+++ b/build/cmake/modules/cotire.cmake
@@ -2316,6 +2316,10 @@ function (cotire_generate_target_script _language _configurations _target _targe
 			"${_config}" "${_language}" "${_target}" COTIRE_TARGET_COMPILE_DEFINITIONS_${_upperConfig})
 		cotire_get_target_compiler_flags(
 			"${_config}" "${_language}" "${_target}" COTIRE_TARGET_COMPILE_FLAGS_${_upperConfig})
+		string(REPLACE
+			"<COMPILE_LANG_AND_ID:CUDA,NVIDIA>" "<COMPILE_LANGUAGE:CUDA>"
+			COTIRE_TARGET_COMPILE_FLAGS_${_upperConfig} "${COTIRE_TARGET_COMPILE_FLAGS_${_upperConfig}}"
+		)
 		cotire_get_source_files_compile_definitions(
 			"${_config}" "${_language}" COTIRE_TARGET_SOURCES_COMPILE_DEFINITIONS_${_upperConfig} ${_targetSources})
 	endforeach()
@@ -2371,7 +2375,7 @@ function (cotire_generate_target_script _language _configurations _target _targe
 		# use file(GENERATE ...) to expand generator expressions in the target script at CMake generate-time
 		set (_configNameOrNoneGeneratorExpression "$<$<CONFIG:>:None>$<$<NOT:$<CONFIG:>>:$<CONFIGURATION>>")
 		set (_targetCotireConfigScript "${CMAKE_CURRENT_BINARY_DIR}/${_target}_${_language}_${_configNameOrNoneGeneratorExpression}_${_moduleName}")
-		file (GENERATE OUTPUT "${_targetCotireConfigScript}" INPUT "${_targetCotireScript}" TARGET "${_target}")
+		file (GENERATE OUTPUT "${_targetCotireConfigScript}" INPUT "${_targetCotireScript}")
 	else()
 		set (_targetCotireConfigScript "${_targetCotireScript}")
 	endif()

--- a/build/cmake/modules/cotire.cmake
+++ b/build/cmake/modules/cotire.cmake
@@ -2316,10 +2316,6 @@ function (cotire_generate_target_script _language _configurations _target _targe
 			"${_config}" "${_language}" "${_target}" COTIRE_TARGET_COMPILE_DEFINITIONS_${_upperConfig})
 		cotire_get_target_compiler_flags(
 			"${_config}" "${_language}" "${_target}" COTIRE_TARGET_COMPILE_FLAGS_${_upperConfig})
-        string(REPLACE
-            "<COMPILE_LANG_AND_ID:CUDA,NVIDIA>" "<COMPILE_LANGUAGE:CUDA>"
-            COTIRE_TARGET_COMPILE_FLAGS_${_upperConfig} "${COTIRE_TARGET_COMPILE_FLAGS_${_upperConfig}}"
-        )
 		cotire_get_source_files_compile_definitions(
 			"${_config}" "${_language}" COTIRE_TARGET_SOURCES_COMPILE_DEFINITIONS_${_upperConfig} ${_targetSources})
 	endforeach()
@@ -2375,7 +2371,7 @@ function (cotire_generate_target_script _language _configurations _target _targe
 		# use file(GENERATE ...) to expand generator expressions in the target script at CMake generate-time
 		set (_configNameOrNoneGeneratorExpression "$<$<CONFIG:>:None>$<$<NOT:$<CONFIG:>>:$<CONFIGURATION>>")
 		set (_targetCotireConfigScript "${CMAKE_CURRENT_BINARY_DIR}/${_target}_${_language}_${_configNameOrNoneGeneratorExpression}_${_moduleName}")
-		file (GENERATE OUTPUT "${_targetCotireConfigScript}" INPUT "${_targetCotireScript}")
+		file (GENERATE OUTPUT "${_targetCotireConfigScript}" INPUT "${_targetCotireScript}" TARGET "${_target}")
 	else()
 		set (_targetCotireConfigScript "${_targetCotireScript}")
 	endif()


### PR DESCRIPTION
Fix bug:
```
CMake Error at build/cmake/modules/cotire.cmake:2375 (file):
  Error evaluating generator expression:

    $<COMPILE_LANG_AND_ID:CUDA,NVIDIA>

  $<COMPILE_LANG_AND_ID:lang,id> may only be used with binary targets to
  specify include directories, compile definitions, and compile options.  It
  may not be used with the add_custom_command, add_custom_target, or
  file(GENERATE) commands.
Call Stack (most recent call first):
  build/cmake/modules/cotire.cmake:2997 (cotire_generate_target_script)
  build/cmake/modules/cotire.cmake:3388 (cotire_process_target_language)
  build/cmake/modules/cotire.cmake:3572 (cotire_target)
  build/cmake/functions.cmake:400 (cotire)
  build/cmake/functions.cmake:416 (wx_target_enable_precomp)
  build/cmake/lib/net/CMakeLists.txt:39 (wx_finalize_lib)
```

Related:
- cmake issue: https://gitlab.kitware.com/cmake/cmake/-/issues/21074
- folly issue https://github.com/facebook/folly/commit/eedb340bd5fff6a4a44006ff641cb3ecc2b293fb
- https://github.com/microsoft/vcpkg/pull/17111#issuecomment-858874472