### PR TITLE
Fix handling mouse capture

### DIFF
--- a/include/wx/univ/menu.h
+++ b/include/wx/univ/menu.h
@@ -190,6 +190,7 @@ protected:
     void OnMouseMove(wxMouseEvent& event);
     void OnKeyDown(wxKeyEvent& event);
     void OnKillFocus(wxFocusEvent& event);
+    void OnCaptureLost(wxMouseCaptureLostEvent& event);
 
     // process the mouse move event, return true if we did, false to continue
     // processing as usual

--- a/include/wx/univ/menu.h
+++ b/include/wx/univ/menu.h
@@ -187,6 +187,7 @@ protected:
 
     // event handlers
     void OnLeftDown(wxMouseEvent& event);
+    void OnLeftUp(wxMouseEvent& event);
     void OnMouseMove(wxMouseEvent& event);
     void OnKeyDown(wxKeyEvent& event);
     void OnKillFocus(wxFocusEvent& event);

--- a/src/univ/menu.cpp
+++ b/src/univ/menu.cpp
@@ -369,7 +369,13 @@ void wxPopupMenuWindow::ChangeCurrent(wxMenuItemIter node)
         }
 
         if ( m_nodeCurrent )
-            RefreshItem(m_nodeCurrent->GetData());
+        {
+            wxMenuItem *item = m_nodeCurrent->GetData();
+            if ( item && item->GetMenu()->IsShown() )
+            {
+                RefreshItem(m_nodeCurrent->GetData());
+            }
+        }
     }
 }
 

--- a/src/univ/menu.cpp
+++ b/src/univ/menu.cpp
@@ -2139,10 +2139,7 @@ void wxMenuBar::OnLeftDown(wxMouseEvent& event)
 {
     if ( HasCapture() )
     {
-        if ( IsShowingMenu() )
-        {
-            DismissMenu();
-        }
+        OnDismiss();
         event.Skip();
     }
     else // we didn't have mouse capture, capture it now
@@ -2154,6 +2151,8 @@ void wxMenuBar::OnLeftDown(wxMouseEvent& event)
             {
                 DismissMenu(); // event outside menubar - dismiss
                 ReleaseMouseCapture(); // we could get capture back from popup window so release it
+                RefreshItem((size_t)m_current);
+                m_current = -1;
             }
         }
         else if ( item == m_current && IsShowingMenu() )
@@ -2161,6 +2160,8 @@ void wxMenuBar::OnLeftDown(wxMouseEvent& event)
             // double-click
             DismissMenu();
             ReleaseMouseCapture();
+            RefreshItem((size_t)m_current);
+            m_current = -1;
         }
         else // on item
         {
@@ -2184,6 +2185,8 @@ void wxMenuBar::OnLeftUp(wxMouseEvent& event)
     {
         DismissMenu();
         ReleaseMouseCapture();
+        RefreshItem((size_t)m_current);
+        m_current = -1;
     }
 }
 


### PR DESCRIPTION
Fix for [[wxUniv(MSW)] Re-selecting menu is generate assert error "Recapturing the mouse in the same window?" ](https://trac.wxwidgets.org/ticket/19208).

In draft state, also need to add handling LEFT_UP somehow. 