### PR TITLE
Fix build on linux with mingw

### DIFF
--- a/build/cmake/lib/net/CMakeLists.txt
+++ b/build/cmake/lib/net/CMakeLists.txt
@@ -27,7 +27,7 @@ if(WIN32)
     wx_lib_link_libraries(wxnet PRIVATE ws2_32)
 
     if(wxUSE_WEBREQUEST_WINHTTP)
-        wx_lib_link_libraries(wxnet PRIVATE Winhttp)
+        wx_lib_link_libraries(wxnet PRIVATE winhttp)
     endif()
 endif()
 


### PR DESCRIPTION
When I try to build wxWidgets-3.1.5 on Linux with mingw I get an error
```
[ 28%] Linking CXX shared library ../../lib/wxbase315u_net_gcc_custom.dll
/usr/lib/gcc/x86_64-w64-mingw32/11.1.0/../../../../x86_64-w64-mingw32/bin/ld: cannot find -lWinhttp
```
because on Linux filesystems are case sensitive by default
