### PR TITLE
CMake: Never use lib prefix for msvc

### DIFF
--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -213,7 +213,7 @@ function(wx_set_target_properties target_name is_base)
     endif()
 
     set(lib_prefix "lib")
-    if(WIN32 AND wxBUILD_SHARED)
+    if(MSVC OR (WIN32 AND wxBUILD_SHARED))
         set(lib_prefix)
     endif()
 


### PR DESCRIPTION
Fixes regression introduced in f830bde25b.