### PR TITLE
Add wxKeyEvent.IsAutoRepeat()

### DIFF
--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -2218,6 +2218,9 @@ public:
     // get the raw key flags (platform-dependent)
     wxUint32 GetRawKeyFlags() const { return m_rawFlags; }
 
+    // returns true if this is a key auto repeat event
+    bool IsAutoRepeat() const { return m_isRepeat; }
+
     // Find the position of the event
     void GetPosition(wxCoord *xpos, wxCoord *ypos) const
     {
@@ -2279,6 +2282,9 @@ public:
     wxUint32      m_rawCode;
     wxUint32      m_rawFlags;
 
+    // Indicates whether the key event is a repeat
+    bool          m_isRepeat;
+
 private:
     // Set the event to propagate if necessary, i.e. if it's of wxEVT_CHAR_HOOK
     // type. This is used by all ctors.
@@ -2305,6 +2311,7 @@ private:
 #if wxUSE_UNICODE
         m_uniChar = evt.m_uniChar;
 #endif
+        m_isRepeat = evt.m_isRepeat;
     }
 
     // Initialize m_x and m_y using the current mouse cursor position if

--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -1547,6 +1547,15 @@ public:
     */
     bool IsKeyInCategory(int category) const;
 
+    /**
+        Returns true if this event is an auto-repeat of the key, false if this
+        is the initial key press.
+
+        @since 3.1.6
+        @onlyfor{wxosx,wxmsw,wxQt}
+    */
+    bool IsAutoRepeat() const;
+
     //@{
     /**
         Obtains the position (in client coordinates) at which the key was pressed.

--- a/samples/keyboard/keyboard.cpp
+++ b/samples/keyboard/keyboard.cpp
@@ -235,7 +235,7 @@ MyFrame::MyFrame(const wxString& title)
                                             wxTE_READONLY);
     headerText->SetValue(
                " event          key     KeyCode mod   UnicodeKey  "
-               "  RawKeyCode RawKeyFlags  Position");
+               "  RawKeyCode RawKeyFlags  Position      Repeat");
 
 
     m_logText = new wxTextCtrl(this, wxID_ANY, "",
@@ -538,6 +538,7 @@ void MyFrame::LogEvent(const wxString& name, wxKeyEvent& event)
                    "  not-set    not-set"
 #endif
                    "  (%5d,%5d)"
+                   "  %s"
                    "\n",
                name,
                GetKeyName(event),
@@ -556,6 +557,7 @@ void MyFrame::LogEvent(const wxString& name, wxKeyEvent& event)
 #endif
                , event.GetX()
                , event.GetY()
+               , event.IsAutoRepeat() ? "Yes" : "No"
                );
 
     m_logText->AppendText(msg);

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -6303,6 +6303,8 @@ MSWInitAnyKeyEvent(wxKeyEvent& event,
     event.m_rawCode = (wxUint32) wParam;
     event.m_rawFlags = (wxUint32) lParam;
     event.SetTimestamp(::GetMessageTime());
+
+    event.m_isRepeat = ((HIWORD(lParam) & KF_REPEAT) == KF_REPEAT;
 }
 
 } // anonymous namespace

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -452,6 +452,7 @@ void wxWidgetCocoaImpl::SetupKeyEvent(wxKeyEvent &wxevent , NSEvent * nsEvent, N
     wxevent.m_rawFlags = modifiers;
 
     wxevent.SetTimestamp( (int)([nsEvent timestamp] * 1000) ) ;
+    wxevent.m_isRepeat = (eventType == NSKeyDown) && [nsEvent isARepeat];
 
     wxString chars;
     if ( eventType != NSFlagsChanged )

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -1390,6 +1390,7 @@ bool wxWindowQt::QtHandleKeyEvent ( QWidget *WXUNUSED( handler ), QKeyEvent *eve
 
     e.m_rawCode = event->nativeVirtualKey();
     e.m_rawFlags = event->nativeModifiers();
+    e.m_isRepeat = event->isAutoRepeat();
 
     // Modifiers
     wxQtFillKeyboardModifiers( event->modifiers(), &e );


### PR DESCRIPTION
This adds the ability to detect whether a KEY_DOWN event is due to OS-level auto repeat, or is a user-initiated KEY_DOWN event.

This patch is coming from desire for this functionality on a project I am working on rather than manually tracking UP/DOWN events, and it has also been asked a number of times on the developer forums.

The flag is readily available on OSX/Cocoa, Qt and MSW, though in the research I've done, I can't seem to find any way to do this with GTK.

I have added a "Repeat" column to samples/keyboard to demonstrate its use.

Thanks!