### PR TITLE
Remove unnecessary c_str() from wx var arg functions arguments

### DIFF
--- a/docs/doxygen/overviews/archive.h
+++ b/docs/doxygen/overviews/archive.h
@@ -297,11 +297,11 @@ if (in->IsOk())
 
         // list the contents of the archive
         while ((entry.reset(arc->GetNextEntry())), entry.get() != NULL)
-            std::wcout << entry->GetName().c_str() << "\n";
+            std::wcout << entry->GetName() << "\n";
     }
     else
     {
-        wxLogError(wxT("can't handle '%s'"), filename.c_str());
+        wxLogError(wxT("can't handle '%s'"), filename);
     }
 }
 @endcode

--- a/src/common/accelcmn.cpp
+++ b/src/common/accelcmn.cpp
@@ -149,7 +149,7 @@ static int IsNumberedAccelKey(const wxString& str,
     {
         // this must be a mistake, chances that this is a valid name of another
         // key are vanishingly small
-        wxLogDebug(wxT("Invalid key string \"%s\""), str.c_str());
+        wxLogDebug(wxT("Invalid key string \"%s\""), str);
         return 0;
     }
 
@@ -216,8 +216,7 @@ wxAcceleratorEntry::ParseAccel(const wxString& text, int *flagsOut, int *keyOut)
                 }
                 else
                 {
-                    wxLogDebug(wxT("Unknown accel modifier: '%s'"),
-                               current.c_str());
+                    wxLogDebug(wxT("Unknown accel modifier: '%s'"), current);
                 }
             }
 
@@ -284,8 +283,7 @@ wxAcceleratorEntry::ParseAccel(const wxString& text, int *flagsOut, int *keyOut)
 
             if ( !keyCode )
             {
-                wxLogDebug(wxT("Unrecognized accel key '%s', accel string ignored."),
-                           current.c_str());
+                wxLogDebug(wxT("Unrecognized accel key '%s', accel string ignored."), current);
                 return false;
             }
     }

--- a/src/common/appbase.cpp
+++ b/src/common/appbase.cpp
@@ -842,12 +842,9 @@ bool wxAppConsoleBase::CheckBuildOptions(const char *optionsSignature,
         wxString lib = wxString::FromAscii(WX_BUILD_OPTIONS_SIGNATURE);
         wxString prog = wxString::FromAscii(optionsSignature);
         wxString progName = wxString::FromAscii(componentName);
-        wxString msg;
 
-        msg.Printf(wxT("Mismatch between the program and library build versions detected.\nThe library used %s,\nand %s used %s."),
-                   lib.c_str(), progName.c_str(), prog.c_str());
-
-        wxLogFatalError(msg.c_str());
+        wxLogFatalError(wxT("Mismatch between the program and library build versions detected.\nThe library used %s,\nand %s used %s."),
+                        lib, progName, prog);
 
         // normally wxLogFatalError doesn't return
         return false;

--- a/src/common/appcmn.cpp
+++ b/src/common/appcmn.cpp
@@ -283,7 +283,7 @@ bool wxAppBase::OnCmdLineParsed(wxCmdLineParser& parser)
         wxTheme *theme = wxTheme::Create(themeName);
         if ( !theme )
         {
-            wxLogError(_("Unsupported theme '%s'."), themeName.c_str());
+            wxLogError(_("Unsupported theme '%s'."), themeName);
             return false;
         }
 
@@ -298,9 +298,9 @@ bool wxAppBase::OnCmdLineParsed(wxCmdLineParser& parser)
     if ( parser.Found(OPTION_MODE, &modeDesc) )
     {
         unsigned w, h, bpp;
-        if ( wxSscanf(modeDesc.c_str(), wxT("%ux%u-%u"), &w, &h, &bpp) != 3 )
+        if ( wxSscanf(modeDesc, wxT("%ux%u-%u"), &w, &h, &bpp) != 3 )
         {
-            wxLogError(_("Invalid display mode specification '%s'."), modeDesc.c_str());
+            wxLogError(_("Invalid display mode specification '%s'."), modeDesc);
             return false;
         }
 

--- a/src/common/debugrpt.cpp
+++ b/src/common/debugrpt.cpp
@@ -207,7 +207,7 @@ wxDebugReport::wxDebugReport()
     // permissions
     if ( !wxMkdir(m_dir, 0700) )
     {
-        wxLogSysError(_("Failed to create directory \"%s\""), m_dir.c_str());
+        wxLogSysError(_("Failed to create directory \"%s\""), m_dir);
         wxLogError(_("Debug report couldn't be created."));
 
         Reset();
@@ -226,7 +226,7 @@ wxDebugReport::~wxDebugReport()
             if ( wxRemove(wxFileName(m_dir, file).GetFullPath()) != 0 )
             {
                 wxLogSysError(_("Failed to remove debug report file \"%s\""),
-                              file.c_str());
+                              file);
                 m_dir.clear();
                 break;
             }
@@ -238,7 +238,7 @@ wxDebugReport::~wxDebugReport()
         if ( wxRmDir(m_dir) != 0 )
         {
             wxLogSysError(_("Failed to clean up debug report directory \"%s\""),
-                          m_dir.c_str());
+                          m_dir);
         }
     }
 }
@@ -559,7 +559,7 @@ bool wxDebugReport::Process()
     if ( !DoProcess() )
     {
         wxLogError(_("Processing debug report has failed, leaving the files in \"%s\" directory."),
-                   GetDirectory().c_str());
+                   GetDirectory());
 
         Reset();
 
@@ -586,7 +586,7 @@ bool wxDebugReport::DoProcess()
 
     msg += _("\nPlease send this report to the program maintainer, thank you!\n");
 
-    wxLogMessage(wxT("%s"), msg.c_str());
+    wxLogMessage(wxT("%s"), msg);
 
     // we have to do this or the report would be deleted, and we don't even
     // have any way to ask the user if he wants to keep it from here
@@ -718,10 +718,10 @@ bool wxDebugReportUpload::DoProcess()
     int rc = wxExecute(wxString::Format
                        (
                             wxT("%s -F \"%s=@%s\" %s"),
-                            m_curlCmd.c_str(),
-                            m_inputField.c_str(),
-                            GetCompressedFileName().c_str(),
-                            m_uploadURL.c_str()
+                            m_curlCmd,
+                            m_inputField,
+                            GetCompressedFileName(),
+                            m_uploadURL
                        ),
                        output,
                        errors);
@@ -736,7 +736,7 @@ bool wxDebugReportUpload::DoProcess()
         {
             for ( size_t n = 0; n < count; n++ )
             {
-                wxLogWarning(wxT("%s"), errors[n].c_str());
+                wxLogWarning(wxT("%s"), errors[n]);
             }
         }
 

--- a/src/common/dynload.cpp
+++ b/src/common/dynload.cpp
@@ -296,7 +296,7 @@ wxPluginManager::LoadLibrary(const wxString &libname, int flags)
     if ( entry )
     {
         wxLogTrace(wxT("dll"),
-                   wxT("LoadLibrary(%s): already loaded."), realname.c_str());
+                   wxT("LoadLibrary(%s): already loaded."), realname);
 
         entry->RefLib();
     }
@@ -309,13 +309,13 @@ wxPluginManager::LoadLibrary(const wxString &libname, int flags)
             (*ms_manifest)[realname] = entry;
 
             wxLogTrace(wxT("dll"),
-                       wxT("LoadLibrary(%s): loaded ok."), realname.c_str());
+                       wxT("LoadLibrary(%s): loaded ok."), realname);
 
         }
         else
         {
             wxLogTrace(wxT("dll"),
-                       wxT("LoadLibrary(%s): failed to load."), realname.c_str());
+                       wxT("LoadLibrary(%s): failed to load."), realname);
 
             // we have created entry just above
             if ( !entry->UnrefLib() )
@@ -347,12 +347,12 @@ bool wxPluginManager::UnloadLibrary(const wxString& libname)
     if ( !entry )
     {
         wxLogDebug(wxT("Attempt to unload library '%s' which is not loaded."),
-                   libname.c_str());
+                   libname);
 
         return false;
     }
 
-    wxLogTrace(wxT("dll"), wxT("UnloadLibrary(%s)"), realname.c_str());
+    wxLogTrace(wxT("dll"), wxT("UnloadLibrary(%s)"), realname);
 
     if ( !entry->UnrefLib() )
     {

--- a/src/common/ffile.cpp
+++ b/src/common/ffile.cpp
@@ -70,7 +70,7 @@ bool wxFFile::Close()
     {
         if ( fclose(m_fp) != 0 )
         {
-            wxLogSysError(_("can't close file '%s'"), m_name.c_str());
+            wxLogSysError(_("can't close file '%s'"), m_name);
 
             return false;
         }
@@ -104,7 +104,7 @@ bool wxFFile::ReadAll(wxString *str, const wxMBConv& conv)
 
     if ( Error() )
     {
-        wxLogSysError(_("Read error on file '%s'"), m_name.c_str());
+        wxLogSysError(_("Read error on file '%s'"), m_name);
 
         return false;
     }
@@ -129,7 +129,7 @@ size_t wxFFile::Read(void *pBuf, size_t nCount)
     size_t nRead = fread(pBuf, 1, nCount, m_fp);
     if ( (nRead < nCount) && Error() )
     {
-        wxLogSysError(_("Read error on file '%s'"), m_name.c_str());
+        wxLogSysError(_("Read error on file '%s'"), m_name);
     }
 
     return nRead;
@@ -146,7 +146,7 @@ size_t wxFFile::Write(const void *pBuf, size_t nCount)
     size_t nWritten = fwrite(pBuf, 1, nCount, m_fp);
     if ( nWritten < nCount )
     {
-        wxLogSysError(_("Write error on file '%s'"), m_name.c_str());
+        wxLogSysError(_("Write error on file '%s'"), m_name);
     }
 
     return nWritten;
@@ -184,7 +184,7 @@ bool wxFFile::Flush()
     {
         if ( fflush(m_fp) != 0 )
         {
-            wxLogSysError(_("failed to flush the file '%s'"), m_name.c_str());
+            wxLogSysError(_("failed to flush the file '%s'"), m_name);
 
             return false;
         }
@@ -224,7 +224,7 @@ bool wxFFile::Seek(wxFileOffset ofs, wxSeekMode mode)
 #ifndef wxHAS_LARGE_FFILES
     if ((long)ofs != ofs)
     {
-        wxLogError(_("Seek error on file '%s' (large files not supported by stdio)"), m_name.c_str());
+        wxLogError(_("Seek error on file '%s' (large files not supported by stdio)"), m_name);
 
         return false;
     }
@@ -234,7 +234,7 @@ bool wxFFile::Seek(wxFileOffset ofs, wxSeekMode mode)
     if ( wxFseek(m_fp, ofs, origin) != 0 )
 #endif
     {
-        wxLogSysError(_("Seek error on file '%s'"), m_name.c_str());
+        wxLogSysError(_("Seek error on file '%s'"), m_name);
 
         return false;
     }
@@ -250,8 +250,7 @@ wxFileOffset wxFFile::Tell() const
     wxFileOffset rc = wxFtell(m_fp);
     if ( rc == wxInvalidOffset )
     {
-        wxLogSysError(_("Can't find current position in file '%s'"),
-                      m_name.c_str());
+        wxLogSysError(_("Can't find current position in file '%s'"), m_name);
     }
 
     return rc;
@@ -374,12 +373,12 @@ bool wxTempFFile::Commit()
     m_file.Close();
 
     if ( wxFile::Exists(m_strName) && wxRemove(m_strName) != 0 ) {
-        wxLogSysError(_("can't remove file '%s'"), m_strName.c_str());
+        wxLogSysError(_("can't remove file '%s'"), m_strName);
         return false;
     }
 
     if ( !wxRenameFile(m_strTemp, m_strName)  ) {
-        wxLogSysError(_("can't commit changes to file '%s'"), m_strName.c_str());
+        wxLogSysError(_("can't commit changes to file '%s'"), m_strName);
         return false;
     }
 
@@ -391,7 +390,7 @@ void wxTempFFile::Discard()
     m_file.Close();
     if ( wxRemove(m_strTemp) != 0 )
     {
-        wxLogSysError(_("can't remove temporary file '%s'"), m_strTemp.c_str());
+        wxLogSysError(_("can't remove temporary file '%s'"), m_strTemp);
     }
 }
 

--- a/src/common/file.cpp
+++ b/src/common/file.cpp
@@ -605,12 +605,12 @@ bool wxTempFile::Commit()
     m_file.Close();
 
     if ( wxFile::Exists(m_strName) && wxRemove(m_strName) != 0 ) {
-        wxLogSysError(_("can't remove file '%s'"), m_strName.c_str());
+        wxLogSysError(_("can't remove file '%s'"), m_strName);
         return false;
     }
 
     if ( !wxRenameFile(m_strTemp, m_strName)  ) {
-        wxLogSysError(_("can't commit changes to file '%s'"), m_strName.c_str());
+        wxLogSysError(_("can't commit changes to file '%s'"), m_strName);
         return false;
     }
 
@@ -622,7 +622,7 @@ void wxTempFile::Discard()
     m_file.Close();
     if ( wxRemove(m_strTemp) != 0 )
     {
-        wxLogSysError(_("can't remove temporary file '%s'"), m_strTemp.c_str());
+        wxLogSysError(_("can't remove temporary file '%s'"), m_strTemp);
     }
 }
 

--- a/src/common/fileconf.cpp
+++ b/src/common/fileconf.cpp
@@ -311,7 +311,7 @@ void wxFileConfig::Init()
         }
         else
         {
-            wxLogWarning(_("can't open global configuration file '%s'."), m_fnGlobalFile.GetFullPath().c_str());
+            wxLogWarning(_("can't open global configuration file '%s'."), m_fnGlobalFile.GetFullPath());
         }
     }
 
@@ -328,12 +328,12 @@ void wxFileConfig::Init()
         {
             const wxString path = m_fnLocalFile.GetFullPath();
             wxLogWarning(_("can't open user configuration file '%s'."),
-                         path.c_str());
+                         path);
 
             if ( m_fnLocalFile.FileExists() )
             {
                 wxLogWarning(_("Changes won't be saved to avoid overwriting the existing file \"%s\""),
-                             path.c_str());
+                             path);
                 m_fnLocalFile.Clear();
             }
         }
@@ -619,7 +619,7 @@ void wxFileConfig::Parse(const wxTextBuffer& buffer, bool bLocal)
           if ( bLocal && pEntry->IsImmutable() ) {
             // immutable keys can't be changed by user
             wxLogWarning(_("file '%s', line %zu: value for immutable key '%s' ignored."),
-                         buffer.GetName(), n + 1, strKey.c_str());
+                         buffer.GetName(), n + 1, strKey);
             continue;
           }
           // the condition below catches the cases (a) and (b) but not (c):
@@ -629,7 +629,7 @@ void wxFileConfig::Parse(const wxTextBuffer& buffer, bool bLocal)
           // which is exactly what we want.
           else if ( !bLocal || pEntry->IsLocal() ) {
             wxLogWarning(_("file '%s', line %zu: key '%s' was first found at line %d."),
-                         buffer.GetName(), n + 1, strKey.c_str(), pEntry->Line());
+                         buffer.GetName(), n + 1, strKey, pEntry->Line());
 
           }
         }
@@ -904,9 +904,9 @@ bool wxFileConfig::DoWriteString(const wxString& key, const wxString& szValue)
 
     wxLogTrace( FILECONF_TRACE_MASK,
                 wxT("  Writing String '%s' = '%s' to Group '%s'"),
-                strName.c_str(),
-                szValue.c_str(),
-                GetPath().c_str() );
+                strName,
+                szValue,
+                GetPath() );
 
     if ( strName.empty() )
     {
@@ -918,7 +918,7 @@ bool wxFileConfig::DoWriteString(const wxString& key, const wxString& szValue)
 
         wxLogTrace( FILECONF_TRACE_MASK,
                     wxT("  Creating group %s"),
-                    m_pCurrentGroup->Name().c_str() );
+                    m_pCurrentGroup->Name() );
 
         SetDirty();
 
@@ -942,13 +942,13 @@ bool wxFileConfig::DoWriteString(const wxString& key, const wxString& szValue)
         {
             wxLogTrace( FILECONF_TRACE_MASK,
                         wxT("  Adding Entry %s"),
-                        strName.c_str() );
+                        strName );
             pEntry = m_pCurrentGroup->AddEntry(strName);
         }
 
         wxLogTrace( FILECONF_TRACE_MASK,
                     wxT("  Setting value %s"),
-                    szValue.c_str() );
+                    szValue );
         pEntry->SetValue(szValue);
 
         SetDirty();
@@ -1139,7 +1139,7 @@ bool wxFileConfig::DeleteAll()
            !wxRemoveFile(m_fnLocalFile.GetFullPath()) )
       {
           wxLogSysError(_("can't delete user configuration file '%s'"),
-                        m_fnLocalFile.GetFullPath().c_str());
+                        m_fnLocalFile.GetFullPath());
           return false;
       }
   }
@@ -1159,15 +1159,15 @@ wxFileConfigLineList *wxFileConfig::LineListAppend(const wxString& str)
 {
     wxLogTrace( FILECONF_TRACE_MASK,
                 wxT("    ** Adding Line '%s'"),
-                str.c_str() );
+                str );
     wxLogTrace( FILECONF_TRACE_MASK,
                 wxT("        head: %s"),
-                ((m_linesHead) ? (const wxChar*)m_linesHead->Text().c_str()
-                               : wxEmptyString) );
+                ((m_linesHead) ? m_linesHead->Text()
+                               : wxString()) );
     wxLogTrace( FILECONF_TRACE_MASK,
                 wxT("        tail: %s"),
-                ((m_linesTail) ? (const wxChar*)m_linesTail->Text().c_str()
-                               : wxEmptyString) );
+                ((m_linesTail) ? m_linesTail->Text()
+                               : wxString()) );
 
     wxFileConfigLineList *pLine = new wxFileConfigLineList(str);
 
@@ -1187,12 +1187,12 @@ wxFileConfigLineList *wxFileConfig::LineListAppend(const wxString& str)
 
     wxLogTrace( FILECONF_TRACE_MASK,
                 wxT("        head: %s"),
-                ((m_linesHead) ? (const wxChar*)m_linesHead->Text().c_str()
-                               : wxEmptyString) );
+                ((m_linesHead) ? m_linesHead->Text()
+                               : wxString()) );
     wxLogTrace( FILECONF_TRACE_MASK,
                 wxT("        tail: %s"),
-                ((m_linesTail) ? (const wxChar*)m_linesTail->Text().c_str()
-                               : wxEmptyString) );
+                ((m_linesTail) ? m_linesTail->Text()
+                               : wxString()) );
 
     return m_linesTail;
 }
@@ -1203,17 +1203,17 @@ wxFileConfigLineList *wxFileConfig::LineListInsert(const wxString& str,
 {
     wxLogTrace( FILECONF_TRACE_MASK,
                 wxT("    ** Inserting Line '%s' after '%s'"),
-                str.c_str(),
-                ((pLine) ? (const wxChar*)pLine->Text().c_str()
-                         : wxEmptyString) );
+                str,
+                ((pLine) ? pLine->Text()
+                         : wxString()) );
     wxLogTrace( FILECONF_TRACE_MASK,
                 wxT("        head: %s"),
-                ((m_linesHead) ? (const wxChar*)m_linesHead->Text().c_str()
-                               : wxEmptyString) );
+                ((m_linesHead) ? m_linesHead->Text()
+                               : wxString()) );
     wxLogTrace( FILECONF_TRACE_MASK,
                 wxT("        tail: %s"),
-                ((m_linesTail) ? (const wxChar*)m_linesTail->Text().c_str()
-                               : wxEmptyString) );
+                ((m_linesTail) ? m_linesTail->Text()
+                               : wxString()) );
 
     if ( pLine == m_linesTail )
         return LineListAppend(str);
@@ -1238,12 +1238,12 @@ wxFileConfigLineList *wxFileConfig::LineListInsert(const wxString& str,
 
     wxLogTrace( FILECONF_TRACE_MASK,
                 wxT("        head: %s"),
-                ((m_linesHead) ? (const wxChar*)m_linesHead->Text().c_str()
-                               : wxEmptyString) );
+                ((m_linesHead) ? m_linesHead->Text()
+                               : wxString()) );
     wxLogTrace( FILECONF_TRACE_MASK,
                 wxT("        tail: %s"),
-                ((m_linesTail) ? (const wxChar*)m_linesTail->Text().c_str()
-                               : wxEmptyString) );
+                ((m_linesTail) ? m_linesTail->Text()
+                               : wxString()) );
 
     return pNewLine;
 }
@@ -1252,15 +1252,15 @@ void wxFileConfig::LineListRemove(wxFileConfigLineList *pLine)
 {
     wxLogTrace( FILECONF_TRACE_MASK,
                 wxT("    ** Removing Line '%s'"),
-                pLine->Text().c_str() );
+                pLine->Text() );
     wxLogTrace( FILECONF_TRACE_MASK,
                 wxT("        head: %s"),
-                ((m_linesHead) ? (const wxChar*)m_linesHead->Text().c_str()
-                               : wxEmptyString) );
+                ((m_linesHead) ? m_linesHead->Text()
+                               : wxString()) );
     wxLogTrace( FILECONF_TRACE_MASK,
                 wxT("        tail: %s"),
-                ((m_linesTail) ? (const wxChar*)m_linesTail->Text().c_str()
-                               : wxEmptyString) );
+                ((m_linesTail) ? m_linesTail->Text()
+                               : wxString()) );
 
     wxFileConfigLineList    *pPrev = pLine->Prev(),
                             *pNext = pLine->Next();
@@ -1281,12 +1281,12 @@ void wxFileConfig::LineListRemove(wxFileConfigLineList *pLine)
 
     wxLogTrace( FILECONF_TRACE_MASK,
                 wxT("        head: %s"),
-                ((m_linesHead) ? (const wxChar*)m_linesHead->Text().c_str()
-                               : wxEmptyString) );
+                ((m_linesHead) ? m_linesHead->Text()
+                               : wxString()) );
     wxLogTrace( FILECONF_TRACE_MASK,
                 wxT("        tail: %s"),
-                ((m_linesTail) ? (const wxChar*)m_linesTail->Text().c_str()
-                               : wxEmptyString) );
+                ((m_linesTail) ? m_linesTail->Text()
+                               : wxString()) );
 
     delete pLine;
 }
@@ -1386,7 +1386,7 @@ wxFileConfigLineList *wxFileConfigGroup::GetGroupLine()
 {
     wxLogTrace( FILECONF_TRACE_MASK,
                 wxT("  GetGroupLine() for Group '%s'"),
-                Name().c_str() );
+                Name() );
 
     if ( !m_pLine )
     {
@@ -1400,7 +1400,7 @@ wxFileConfigLineList *wxFileConfigGroup::GetGroupLine()
         {
             wxLogTrace( FILECONF_TRACE_MASK,
                         wxT("    checking parent '%s'"),
-                        pParent->Name().c_str() );
+                        pParent->Name() );
 
             wxString    strFullName;
 
@@ -1446,7 +1446,7 @@ wxFileConfigLineList *wxFileConfigGroup::GetLastEntryLine()
 {
     wxLogTrace( FILECONF_TRACE_MASK,
                 wxT("  GetLastEntryLine() for Group '%s'"),
-                Name().c_str() );
+                Name() );
 
     if ( m_pLastEntry )
     {
@@ -1646,8 +1646,8 @@ bool wxFileConfigGroup::DeleteSubgroup(wxFileConfigGroup *pGroup)
 
     wxLogTrace( FILECONF_TRACE_MASK,
                 wxT("Deleting group '%s' from '%s'"),
-                pGroup->Name().c_str(),
-                Name().c_str() );
+                pGroup->Name(),
+                Name() );
 
     wxLogTrace( FILECONF_TRACE_MASK,
                 wxT("  (m_pLine) = prev: %p, this %p, next %p"),
@@ -1656,8 +1656,8 @@ bool wxFileConfigGroup::DeleteSubgroup(wxFileConfigGroup *pGroup)
                 m_pLine ? static_cast<void*>(m_pLine->Next()) : 0 );
     wxLogTrace( FILECONF_TRACE_MASK,
                 wxT("  text: '%s'"),
-                m_pLine ? (const wxChar*)m_pLine->Text().c_str()
-                        : wxEmptyString );
+                m_pLine ? m_pLine->Text()
+                        : wxString() );
 
     // delete all entries...
     size_t nCount = pGroup->m_aEntries.GetCount();
@@ -1673,7 +1673,7 @@ bool wxFileConfigGroup::DeleteSubgroup(wxFileConfigGroup *pGroup)
         {
             wxLogTrace( FILECONF_TRACE_MASK,
                         wxT("    '%s'"),
-                        pLine->Text().c_str() );
+                        pLine->Text() );
             m_pConfig->LineListRemove(pLine);
         }
     }
@@ -1695,13 +1695,13 @@ bool wxFileConfigGroup::DeleteSubgroup(wxFileConfigGroup *pGroup)
     {
         wxLogTrace( FILECONF_TRACE_MASK,
                     wxT("  Removing line for group '%s' : '%s'"),
-                    pGroup->Name().c_str(),
-                    pLine->Text().c_str() );
+                    pGroup->Name(),
+                    pLine->Text() );
         wxLogTrace( FILECONF_TRACE_MASK,
                     wxT("  Removing from group '%s' : '%s'"),
-                    Name().c_str(),
-                    ((m_pLine) ? (const wxChar*)m_pLine->Text().c_str()
-                               : wxEmptyString) );
+                    Name(),
+                    ((m_pLine) ? m_pLine->Text()
+                               : wxString()) );
 
         // notice that we may do this test inside the previous "if"
         // because the last entry's line is surely !NULL
@@ -1743,7 +1743,7 @@ bool wxFileConfigGroup::DeleteSubgroup(wxFileConfigGroup *pGroup)
     {
         wxLogTrace( FILECONF_TRACE_MASK,
                     wxT("  No line entry for Group '%s'?"),
-                    pGroup->Name().c_str() );
+                    pGroup->Name() );
     }
 
     m_aSubgroups.Remove(pGroup);
@@ -1833,7 +1833,7 @@ void wxFileConfigEntry::SetLine(wxFileConfigLineList *pLine)
 {
   if ( m_pLine != NULL ) {
     wxLogWarning(_("entry '%s' appears more than once in group '%s'"),
-                 Name().c_str(), m_pParent->GetFullName().c_str());
+                 Name(), m_pParent->GetFullName());
   }
 
   m_pLine = pLine;
@@ -1847,7 +1847,7 @@ void wxFileConfigEntry::SetValue(const wxString& strValue, bool bUser)
     if ( bUser && IsImmutable() )
     {
         wxLogWarning( _("attempt to change immutable key '%s' ignored."),
-                      Name().c_str());
+                      Name());
         return;
     }
 
@@ -1943,7 +1943,7 @@ static wxString FilterInValue(const wxString& str)
         {
             if ( ++i == end )
             {
-                wxLogWarning(_("trailing backslash ignored in '%s'"), str.c_str());
+                wxLogWarning(_("trailing backslash ignored in '%s'"), str);
                 break;
             }
 
@@ -1979,7 +1979,7 @@ static wxString FilterInValue(const wxString& str)
             else if ( i != end - 1 )
             {
                 wxLogWarning(_("unexpected \" at position %d in '%s'."),
-                             i - str.begin(), str.c_str());
+                             i - str.begin(), str);
             }
             //else: it's the last quote of a quoted string, ok
         }

--- a/src/common/filename.cpp
+++ b/src/common/filename.cpp
@@ -174,12 +174,12 @@ public:
             if ( mode == ReadAttr )
             {
                 wxLogSysError(_("Failed to open '%s' for reading"),
-                              filename.c_str());
+                              filename);
             }
             else
             {
                 wxLogSysError(_("Failed to open '%s' for writing"),
-                              filename.c_str());
+                              filename);
             }
         }
     }
@@ -2711,7 +2711,7 @@ bool wxFileName::SetTimes(const wxDateTime *dtAccess,
 #endif // platforms
 
     wxLogSysError(_("Failed to modify file times for '%s'"),
-                  GetFullPath().c_str());
+                  GetFullPath());
 
     return false;
 }
@@ -2725,7 +2725,7 @@ bool wxFileName::Touch() const
         return true;
     }
 
-    wxLogSysError(_("Failed to touch the file '%s'"), GetFullPath().c_str());
+    wxLogSysError(_("Failed to touch the file '%s'"), GetFullPath());
 
     return false;
 #else // other platform
@@ -2807,7 +2807,7 @@ bool wxFileName::GetTimes(wxDateTime *dtAccess,
 #endif // platforms
 
     wxLogSysError(_("Failed to retrieve file times for '%s'"),
-                  GetFullPath().c_str());
+                  GetFullPath());
 
     return false;
 }

--- a/src/common/fontcmn.cpp
+++ b/src/common/fontcmn.cpp
@@ -713,7 +713,7 @@ void wxNativeFontInfo::SetFaceName(const wxArrayString& facenames)
 
     // set the first valid facename we can find on this system
     wxString validfacename = wxFontEnumerator::GetFacenames().Item(0);
-    wxLogTrace(wxT("font"), wxT("Falling back to '%s'"), validfacename.c_str());
+    wxLogTrace(wxT("font"), wxT("Falling back to '%s'"), validfacename);
     SetFaceName(validfacename);
 #else // !wxUSE_FONTENUM
     SetFaceName(facenames[0]);

--- a/src/common/ftp.cpp
+++ b/src/common/ftp.cpp
@@ -119,7 +119,7 @@ bool wxFTP::Connect(const wxSockAddress& addr, bool WXUNUSED(wait))
     }
 
     wxString command;
-    command.Printf(wxT("USER %s"), m_username.c_str());
+    command.Printf(wxT("USER %s"), m_username);
     char rc = SendCommand(command);
     if ( rc == '2' )
     {
@@ -135,7 +135,7 @@ bool wxFTP::Connect(const wxSockAddress& addr, bool WXUNUSED(wait))
         return false;
     }
 
-    command.Printf(wxT("PASS %s"), m_password.c_str());
+    command.Printf(wxT("PASS %s"), m_password);
     if ( !CheckCommand(command, '2') )
     {
         m_lastError = wxPROTO_CONNERR;
@@ -353,7 +353,7 @@ char wxFTP::GetResult()
     if ( badReply )
     {
         wxLogDebug(wxT("Broken FTP server: '%s' is not a valid reply."),
-                   m_lastResult.c_str());
+                   m_lastResult);
 
         m_lastError = wxPROTO_PROTERR;
 
@@ -419,7 +419,7 @@ bool wxFTP::DoSimpleCommand(const wxChar *command, const wxString& arg)
 
     if ( !CheckCommand(fullcmd, '2') )
     {
-        wxLogDebug(wxT("FTP command '%s' failed."), fullcmd.c_str());
+        wxLogDebug(wxT("FTP command '%s' failed."), fullcmd);
         m_lastError = wxPROTO_NETERR;
 
         return false;
@@ -933,7 +933,7 @@ int wxFTP::GetFileSize(const wxString& fileName)
             // 213 is File Status (STD9)
             // "SIZE" is not described anywhere..? It works on most servers
             int statuscode;
-            if ( wxSscanf(GetLastResult().c_str(), wxT("%i %i"),
+            if ( wxSscanf(GetLastResult(), wxT("%i %i"),
                           &statuscode, &filesize) == 2 )
             {
                 // We've gotten a good reply.
@@ -999,7 +999,7 @@ int wxFTP::GetFileSize(const wxString& fileName)
                         if ( fileList[i].Mid(0, 1) == wxT("-") )
                         {
 
-                            if ( wxSscanf(fileList[i].c_str(),
+                            if ( wxSscanf(fileList[i],
                                           wxT("%*s %*s %*s %*s %i %*s %*s %*s %*s"),
                                           &filesize) != 9 )
                             {
@@ -1009,7 +1009,7 @@ int wxFTP::GetFileSize(const wxString& fileName)
                         }
                         else // Windows-style response (?)
                         {
-                            if ( wxSscanf(fileList[i].c_str(),
+                            if ( wxSscanf(fileList[i],
                                           wxT("%*s %*s %i %*s"),
                                           &filesize) != 4 )
                             {

--- a/src/common/msgout.cpp
+++ b/src/common/msgout.cpp
@@ -203,7 +203,7 @@ void wxMessageOutputLog::Output(const wxString& str)
 
     out.Replace(wxT("\t"), wxT("        "));
 
-    wxLogMessage(wxT("%s"), out.c_str());
+    wxLogMessage(wxT("%s"), out);
 }
 
 #endif // wxUSE_BASE

--- a/src/common/sckipc.cpp
+++ b/src/common/sckipc.cpp
@@ -524,7 +524,7 @@ wxTCPServer::~wxTCPServer()
     {
         if ( remove(m_filename.fn_str()) != 0 )
         {
-            wxLogDebug(wxT("Stale AF_UNIX file '%s' left."), m_filename.c_str());
+            wxLogDebug(wxT("Stale AF_UNIX file '%s' left."), m_filename);
         }
     }
 #endif // __UNIX_LIKE__

--- a/src/common/textbuf.cpp
+++ b/src/common/textbuf.cpp
@@ -230,7 +230,7 @@ wxTextFileType wxTextBuffer::GuessType() const
     // interpret the results (FIXME far from being even 50% fool proof)
     if ( nScan > 0 && nDos + nUnix + nMac == 0 ) {
         // no newlines at all
-        wxLogWarning(_("'%s' is probably a binary buffer."), m_strBufferName.c_str());
+        wxLogWarning(_("'%s' is probably a binary buffer."), m_strBufferName);
     }
     else {
         #define   GREATER_OF(t1, t2) n##t1 == n##t2 ? typeDefault               \

--- a/src/common/translation.cpp
+++ b/src/common/translation.cpp
@@ -1140,7 +1140,7 @@ bool wxMsgCatalogFile::LoadFile(const wxString& filename,
               );
     if ( !ok )
     {
-        wxLogWarning(_("'%s' is not a valid message catalog."), filename.c_str());
+        wxLogWarning(_("'%s' is not a valid message catalog."), filename);
         return false;
     }
 
@@ -1939,8 +1939,8 @@ wxMsgCatalog *wxFileTranslationsLoader::LoadCatalog(const wxString& domain,
         return NULL;
 
     // open file and read its data
-    wxLogVerbose(_("using catalog '%s' from '%s'."), domain, strFullName.c_str());
-    wxLogTrace(TRACE_I18N, wxS("Using catalog \"%s\"."), strFullName.c_str());
+    wxLogVerbose(_("using catalog '%s' from '%s'."), domain, strFullName);
+    wxLogTrace(TRACE_I18N, wxS("Using catalog \"%s\"."), strFullName);
 
     return wxMsgCatalog::CreateFromFile(strFullName, domain);
 }

--- a/src/common/utilscmn.cpp
+++ b/src/common/utilscmn.cpp
@@ -1202,7 +1202,7 @@ wxString wxStripMenuCodes(const wxString& in, int flags)
             // can't be the last character of the string
             if ( ++it == in.end() )
             {
-                wxLogDebug(wxT("Invalid menu string '%s'"), in.c_str());
+                wxLogDebug(wxT("Invalid menu string '%s'"), in);
                 break;
             }
             else

--- a/src/common/xtistrm.cpp
+++ b/src/common/xtistrm.cpp
@@ -160,7 +160,7 @@ void wxObjectWriter::WriteAllProperties( const wxObject * obj, const wxClassInfo
         }
         else
         {
-            wxLogError( _("Create Parameter %s not found in declared RTTI Parameters"), name.c_str() );
+            wxLogError( _("Create Parameter %s not found in declared RTTI Parameters"), name );
         }
         map.erase( name );
     }

--- a/src/common/zstream.cpp
+++ b/src/common/zstream.cpp
@@ -246,7 +246,7 @@ size_t wxZlibInputStream::OnSysRead(void *buffer, size_t size)
       wxString msg(m_inflate->msg, *wxConvCurrent);
       if (!msg)
         msg = wxString::Format(_("zlib error %d"), err);
-      wxLogError(_("Can't read from inflate stream: %s"), msg.c_str());
+      wxLogError(_("Can't read from inflate stream: %s"), msg);
       m_lasterror = wxSTREAM_READ_ERROR;
   }
 
@@ -421,7 +421,7 @@ size_t wxZlibOutputStream::OnSysWrite(const void *buffer, size_t size)
     wxString msg(m_deflate->msg, *wxConvCurrent);
     if (!msg)
       msg = wxString::Format(_("zlib error %d"), err);
-    wxLogError(_("Can't write to deflate stream: %s"), msg.c_str());
+    wxLogError(_("Can't write to deflate stream: %s"), msg);
   }
 
   size -= m_deflate->avail_in;

--- a/src/dfb/fontmgr.cpp
+++ b/src/dfb/fontmgr.cpp
@@ -193,11 +193,11 @@ void wxFontsManager::AddFontsFromDir(const wxString& indexFile)
     if ( !fn.FileExists() )
     {
         wxLogWarning(_("Fonts index file %s disappeared while loading fonts."),
-                     indexFile.c_str());
+                     indexFile);
         return;
     }
 
-    wxLogTrace("font", "adding fonts from %s", dir.c_str());
+    wxLogTrace("font", "adding fonts from %s", dir);
 
     wxFileConfig cfg(wxEmptyString, wxEmptyString,
                      indexFile, wxEmptyString,
@@ -231,9 +231,9 @@ void wxFontsManager::AddFont(const wxString& dir,
                              const wxString& name,
                              wxFileConfig& cfg)
 {
-    wxLogTrace("font", "adding font '%s'", name.c_str());
+    wxLogTrace("font", "adding font '%s'", name);
 
-    wxConfigPathChanger ch(&cfg, wxString::Format("/%s/", name.c_str()));
+    wxConfigPathChanger ch(&cfg, wxString::Format("/%s/", name));
 
     AddBundle
     (

--- a/src/generic/dcpsg.cpp
+++ b/src/generic/dcpsg.cpp
@@ -1161,14 +1161,14 @@ void wxPostScriptDCImpl::SetPSFont()
     // Generate PS code to register the font only once.
     if ( m_definedPSFonts.Index(name) == wxNOT_FOUND )
     {
-        buffer.Printf( "%s reencodeISO def\n", name.c_str() );
+        buffer.Printf( "%s reencodeISO def\n", name );
         PsPrint( buffer );
         m_definedPSFonts.Add(name);
     }
 
     // Select font
     double size = m_font.GetPointSize() * double(GetFontPointSizeAdjustment(DPI));
-    buffer.Printf( "%s findfont %f scalefont setfont\n", name.c_str(), size * m_scaleX );
+    buffer.Printf( "%s findfont %f scalefont setfont\n", name, size * m_scaleX );
     buffer.Replace( ",", "." );
     PsPrint( buffer );
 
@@ -2150,7 +2150,7 @@ void wxPostScriptDCImpl::DoGetTextExtent(const wxString& string,
            /  character widths in an array, which is processed below (see point 3.). */
         if (afmFile==NULL)
         {
-            wxLogDebug( wxT("GetTextExtent: can't open AFM file '%s'"), afmName.c_str() );
+            wxLogDebug( wxT("GetTextExtent: can't open AFM file '%s'"), afmName );
             wxLogDebug( wxT("               using approximate values"));
             for (int i=0; i<256; i++) lastWidths[i] = 500; /* an approximate value */
             lastDescender = -150; /* dito. */
@@ -2175,7 +2175,7 @@ void wxPostScriptDCImpl::DoGetTextExtent(const wxString& string,
                     if ((sscanf(line,"%s%d",descString,&lastDescender)!=2) ||
                             (strcmp(descString,"Descender")!=0))
                     {
-                        wxLogDebug( wxT("AFM-file '%s': line '%s' has error (bad descender)"), afmName.c_str(),line );
+                        wxLogDebug( wxT("AFM-file '%s': line '%s' has error (bad descender)"), afmName,line );
                     }
                 }
                 /* JC 1.) check for UnderlinePosition */
@@ -2184,7 +2184,7 @@ void wxPostScriptDCImpl::DoGetTextExtent(const wxString& string,
                     if ((sscanf(line,"%s%lf",upString,&UnderlinePosition)!=2) ||
                             (strcmp(upString,"UnderlinePosition")!=0))
                     {
-                        wxLogDebug( wxT("AFM-file '%s': line '%s' has error (bad UnderlinePosition)"), afmName.c_str(), line );
+                        wxLogDebug( wxT("AFM-file '%s': line '%s' has error (bad UnderlinePosition)"), afmName, line );
                     }
                 }
                 /* JC 2.) check for UnderlineThickness */
@@ -2193,7 +2193,7 @@ void wxPostScriptDCImpl::DoGetTextExtent(const wxString& string,
                     if ((sscanf(line,"%s%lf",utString,&UnderlineThickness)!=2) ||
                             (strcmp(utString,"UnderlineThickness")!=0))
                     {
-                        wxLogDebug( wxT("AFM-file '%s': line '%s' has error (bad UnderlineThickness)"), afmName.c_str(), line );
+                        wxLogDebug( wxT("AFM-file '%s': line '%s' has error (bad UnderlineThickness)"), afmName, line );
                     }
                 }
                 /* JC 3.) check for EncodingScheme */
@@ -2202,12 +2202,12 @@ void wxPostScriptDCImpl::DoGetTextExtent(const wxString& string,
                     if ((sscanf(line,"%s%s",utString,encString)!=2) ||
                             (strcmp(utString,"EncodingScheme")!=0))
                     {
-                        wxLogDebug( wxT("AFM-file '%s': line '%s' has error (bad EncodingScheme)"), afmName.c_str(), line );
+                        wxLogDebug( wxT("AFM-file '%s': line '%s' has error (bad EncodingScheme)"), afmName, line );
                     }
                     else if (strncmp(encString, "AdobeStandardEncoding", 21))
                     {
                         wxLogDebug( wxT("AFM-file '%s': line '%s' has error (unsupported EncodingScheme %s)"),
-                                afmName.c_str(),line, encString);
+                                afmName,line, encString);
                     }
                 }
                 /* B.) check for char-width */
@@ -2215,11 +2215,11 @@ void wxPostScriptDCImpl::DoGetTextExtent(const wxString& string,
                 {
                     if (sscanf(line,"%s%d%s%s%d",cString,&ascii,semiString,WXString,&cWidth)!=5)
                     {
-                        wxLogDebug(wxT("AFM-file '%s': line '%s' has an error (bad character width)"),afmName.c_str(),line);
+                        wxLogDebug(wxT("AFM-file '%s': line '%s' has an error (bad character width)"),afmName,line);
                     }
                     if(strcmp(cString,"C")!=0 || strcmp(semiString,";")!=0 || strcmp(WXString,"WX")!=0)
                     {
-                        wxLogDebug(wxT("AFM-file '%s': line '%s' has a format error"),afmName.c_str(),line);
+                        wxLogDebug(wxT("AFM-file '%s': line '%s' has a format error"),afmName,line);
                     }
                     /* printf("            char '%c'=%d has width '%d'\n",ascii,ascii,cWidth); */
                     if (ascii>=0 && ascii<256)
@@ -2229,7 +2229,7 @@ void wxPostScriptDCImpl::DoGetTextExtent(const wxString& string,
                     else
                     {
                         /* MATTHEW: this happens a lot; don't print an error */
-                        /* wxLogDebug("AFM-file '%s': ASCII value %d out of range",afmName.c_str(),ascii); */
+                        /* wxLogDebug("AFM-file '%s': ASCII value %d out of range",afmName,ascii); */
                     }
                 }
                 /* C.) ignore other entries. */

--- a/src/generic/gridctrl.cpp
+++ b/src/generic/gridctrl.cpp
@@ -326,7 +326,7 @@ wxString wxGridCellEnumRenderer::GetString(const wxGrid& grid, int row, int col)
     if ( table->CanGetValueAs(row, col, wxGRID_VALUE_NUMBER) )
     {
         int choiceno = table->GetValueAsLong(row, col);
-        text.Printf(wxT("%s"), m_choices[ choiceno ].c_str() );
+        text.Printf(wxT("%s"), m_choices[ choiceno ] );
     }
     else
     {
@@ -934,7 +934,7 @@ void wxGridCellFloatRenderer::SetParameters(const wxString& params)
             }
             else
             {
-                wxLogDebug(wxT("Invalid wxGridCellFloatRenderer width parameter string '%s ignored"), params.c_str());
+                wxLogDebug(wxT("Invalid wxGridCellFloatRenderer width parameter string '%s ignored"), params);
             }
         }
 
@@ -948,7 +948,7 @@ void wxGridCellFloatRenderer::SetParameters(const wxString& params)
             }
             else
             {
-                wxLogDebug(wxT("Invalid wxGridCellFloatRenderer precision parameter string '%s ignored"), params.c_str());
+                wxLogDebug(wxT("Invalid wxGridCellFloatRenderer precision parameter string '%s ignored"), params);
             }
         }
 

--- a/src/generic/grideditors.cpp
+++ b/src/generic/grideditors.cpp
@@ -653,7 +653,7 @@ void wxGridCellTextEditor::SetParameters(const wxString& params)
         }
         else
         {
-            wxLogDebug( wxT("Invalid wxGridCellTextEditor parameter string '%s' ignored"), params.c_str() );
+            wxLogDebug( wxT("Invalid wxGridCellTextEditor parameter string '%s' ignored"), params );
         }
     }
 }
@@ -934,7 +934,7 @@ void wxGridCellNumberEditor::SetParameters(const wxString& params)
             }
         }
 
-        wxLogDebug(wxT("Invalid wxGridCellNumberEditor parameter string '%s' ignored"), params.c_str());
+        wxLogDebug(wxT("Invalid wxGridCellNumberEditor parameter string '%s' ignored"), params);
     }
 }
 
@@ -1107,7 +1107,7 @@ void wxGridCellFloatEditor::SetParameters(const wxString& params)
             }
             else
             {
-                wxLogDebug(wxT("Invalid wxGridCellFloatRenderer width parameter string '%s ignored"), params.c_str());
+                wxLogDebug(wxT("Invalid wxGridCellFloatRenderer width parameter string '%s ignored"), params);
             }
         }
 
@@ -1121,7 +1121,7 @@ void wxGridCellFloatEditor::SetParameters(const wxString& params)
             }
             else
             {
-                wxLogDebug(wxT("Invalid wxGridCellFloatRenderer precision parameter string '%s ignored"), params.c_str());
+                wxLogDebug(wxT("Invalid wxGridCellFloatRenderer precision parameter string '%s ignored"), params);
             }
         }
 

--- a/src/generic/logg.cpp
+++ b/src/generic/logg.cpp
@@ -570,7 +570,7 @@ void wxLogFrame::OnSave(wxCommandEvent& WXUNUSED(event))
         wxLogError(_("Can't save log contents to file."));
     }
     else {
-        wxLogStatus((wxFrame*)this, _("Log saved to the file '%s'."), filename.c_str());
+        wxLogStatus((wxFrame*)this, _("Log saved to the file '%s'."), filename);
     }
 }
 #endif // CAN_SAVE_FILES
@@ -1009,7 +1009,7 @@ static int OpenLogFile(wxFile& file, wxString *pFilename, wxWindow *parent)
         bool bAppend = false;
         wxString strMsg;
         strMsg.Printf(_("Append log to file '%s' (choosing [No] will overwrite it)?"),
-                      filename.c_str());
+                      filename);
         switch ( wxMessageBox(strMsg, _("Question"),
                               wxICON_QUESTION | wxYES_NO | wxCANCEL) ) {
             case wxYES:

--- a/src/gtk/clipbrd.cpp
+++ b/src/gtk/clipbrd.cpp
@@ -156,7 +156,7 @@ targets_selection_received( GtkWidget *WXUNUSED(widget),
     wxDataFormat clip(gtk_selection_data_get_selection(selection_data));
     wxLogTrace( TRACE_CLIPBOARD,
                 wxT("Received available formats for clipboard %s"),
-                clip.GetId().c_str() );
+                clip.GetId() );
 
     // the atoms we received, holding a list of targets (= formats)
     const GdkAtom* const atoms = reinterpret_cast<const GdkAtom*>(gtk_selection_data_get_data(selection_data));
@@ -164,7 +164,7 @@ targets_selection_received( GtkWidget *WXUNUSED(widget),
     {
         const wxDataFormat format(atoms[i]);
 
-        wxLogTrace(TRACE_CLIPBOARD, wxT("\t%s"), format.GetId().c_str());
+        wxLogTrace(TRACE_CLIPBOARD, wxT("\t%s"), format.GetId());
 
         if ( clipboard->GTKOnTargetReceived(format) )
             return;
@@ -292,10 +292,10 @@ selection_handler( GtkWidget *WXUNUSED(widget),
 
     wxLogTrace(TRACE_CLIPBOARD,
                wxT("clipboard data in format %s, GtkSelectionData is target=%s type=%s selection=%s timestamp=%u"),
-               format.GetId().c_str(),
-               wxString::FromAscii(wxGtkString(gdk_atom_name(gtk_selection_data_get_target(selection_data)))).c_str(),
-               wxString::FromAscii(wxGtkString(gdk_atom_name(gtk_selection_data_get_data_type(selection_data)))).c_str(),
-               wxString::FromAscii(wxGtkString(gdk_atom_name(gtk_selection_data_get_selection(selection_data)))).c_str(),
+               format.GetId(),
+               wxString::FromAscii(wxGtkString(gdk_atom_name(gtk_selection_data_get_target(selection_data)))),
+               wxString::FromAscii(wxGtkString(gdk_atom_name(gtk_selection_data_get_data_type(selection_data)))),
+               wxString::FromAscii(wxGtkString(gdk_atom_name(gtk_selection_data_get_selection(selection_data)))),
                timestamp
                );
 
@@ -343,7 +343,7 @@ void wxClipboard::GTKOnSelectionReceived(const GtkSelectionData& sel)
 
     const wxDataFormat format(gtk_selection_data_get_target(const_cast<GtkSelectionData*>(&sel)));
     wxLogTrace(TRACE_CLIPBOARD, wxT("Received selection %s"),
-               format.GetId().c_str());
+               format.GetId());
 
     if ( !m_receivedData->IsSupportedFormat(format, wxDataObject::Set) )
         return;
@@ -405,7 +405,7 @@ async_targets_selection_received( GtkWidget *WXUNUSED(widget),
     wxDataFormat clip(gtk_selection_data_get_selection(selection_data));
     wxLogTrace( TRACE_CLIPBOARD,
                 wxT("Received available formats for clipboard %s"),
-                clip.GetId().c_str() );
+                clip.GetId() );
 
     // the atoms we received, holding a list of targets (= formats)
     const GdkAtom* const atoms = reinterpret_cast<const GdkAtom*>(gtk_selection_data_get_data(selection_data));
@@ -413,7 +413,7 @@ async_targets_selection_received( GtkWidget *WXUNUSED(widget),
     {
         const wxDataFormat format(atoms[i]);
 
-        wxLogTrace(TRACE_CLIPBOARD, wxT("\t%s"), format.GetId().c_str());
+        wxLogTrace(TRACE_CLIPBOARD, wxT("\t%s"), format.GetId());
 
         event->AddFormat( format );
     }
@@ -551,7 +551,7 @@ bool wxClipboard::DoIsSupported(const wxDataFormat& format)
     wxCHECK_MSG( format, false, wxT("invalid clipboard format") );
 
     wxLogTrace(TRACE_CLIPBOARD, wxT("Checking if format %s is available"),
-               format.GetId().c_str());
+               format.GetId());
 
     // these variables will be used by our GTKOnTargetReceived()
     m_targetRequested = format;
@@ -655,7 +655,7 @@ bool wxClipboard::AddData( wxDataObject *data )
         const wxDataFormat format(formats[i]);
 
         wxLogTrace(TRACE_CLIPBOARD, wxT("Adding support for %s"),
-                   format.GetId().c_str());
+                   format.GetId());
 
         AddSupportedTarget(format);
     }
@@ -719,7 +719,7 @@ bool wxClipboard::GetData( wxDataObject& data )
             continue;
 
         wxLogTrace(TRACE_CLIPBOARD, wxT("Requesting format %s"),
-                   format.GetId().c_str());
+                   format.GetId());
 
         // these variables will be used by our GTKOnSelectionReceived()
         m_receivedData = &data;

--- a/src/gtk1/control.cpp
+++ b/src/gtk1/control.cpp
@@ -136,7 +136,7 @@ wxString wxControl::GTKRemoveMnemonics(const wxString& label)
             if ( i == len - 1 )
             {
                 // "&" at the end of string is an error
-                wxLogDebug(wxT("Invalid label \"%s\"."), label.c_str());
+                wxLogDebug(wxT("Invalid label \"%s\"."), label);
                 break;
             }
 

--- a/src/html/chm.cpp
+++ b/src/html/chm.cpp
@@ -136,7 +136,7 @@ wxChmTools::wxChmTools(const wxFileName &archive)
     else
     {
         wxLogError(_("Failed to open CHM archive '%s'."),
-                   archive.GetFullPath().c_str());
+                   archive.GetFullPath());
         m_lasterror = (chmd->last_error(chmd));
         return;
     }
@@ -268,9 +268,9 @@ size_t wxChmTools::Extract(const wxString& pattern, const wxString& filename)
                 // Error
                 m_lasterror = d->last_error(d);
                 wxLogError(_("Could not extract %s into %s: %s"),
-                           wxString::FromAscii(f->filename).c_str(),
-                           filename.c_str(),
-                           ChmErrorMsg(m_lasterror).c_str());
+                           wxString::FromAscii(f->filename),
+                           filename,
+                           ChmErrorMsg(m_lasterror));
                 return 0;
             }
             else
@@ -434,7 +434,7 @@ wxChmInputStream::wxChmInputStream(const wxString& archive,
         }
         else
         {
-            wxLogError(_("Could not locate file '%s'."), filename.c_str());
+            wxLogError(_("Could not locate file '%s'."), filename);
             m_lasterror = wxSTREAM_READ_ERROR;
             return;
         }
@@ -708,7 +708,7 @@ bool wxChmInputStream::CreateFileStream(const wxString& pattern)
 
     if ( tmpfile.empty() )
     {
-        wxLogError(_("Could not create temporary file '%s'"), tmpfile.c_str());
+        wxLogError(_("Could not create temporary file '%s'"), tmpfile);
         return false;
     }
 
@@ -716,7 +716,7 @@ bool wxChmInputStream::CreateFileStream(const wxString& pattern)
     if ( m_chm->Extract(pattern, tmpfile) <= 0 )
     {
         wxLogError(_("Extraction of '%s' into '%s' failed."),
-                   pattern.c_str(), tmpfile.c_str());
+                   pattern, tmpfile);
         if ( wxFileExists(tmpfile) )
             wxRemoveFile(tmpfile);
         return false;
@@ -877,7 +877,7 @@ wxString wxChmFSHandler::FindFirst(const wxString& spec, int WXUNUSED(flags))
         !m_pattern.Contains(wxT(".hhp.cached")))
     {
         m_found.Printf(wxT("%s#chm:%s.hhp"),
-                       left.c_str(), m_pattern.BeforeLast(wxT('.')).c_str());
+                       left, m_pattern.BeforeLast(wxT('.')));
     }
 
     return m_found;

--- a/src/html/helpdata.cpp
+++ b/src/html/helpdata.cpp
@@ -293,7 +293,7 @@ bool wxHtmlHelpData::LoadMSProject(wxHtmlBookRecord *book, wxFileSystem& fsys,
     }
     else
     {
-        wxLogError(_("Cannot open contents file: %s"), contentsfile.c_str());
+        wxLogError(_("Cannot open contents file: %s"), contentsfile);
     }
 
     f = ( indexfile.empty() ? NULL : fsys.OpenFile(indexfile) );
@@ -307,7 +307,7 @@ bool wxHtmlHelpData::LoadMSProject(wxHtmlBookRecord *book, wxFileSystem& fsys,
     }
     else if (!indexfile.empty())
     {
-        wxLogError(_("Cannot open index file: %s"), indexfile.c_str());
+        wxLogError(_("Cannot open index file: %s"), indexfile);
     }
     return true;
 }
@@ -657,7 +657,7 @@ bool wxHtmlHelpData::AddBook(const wxString& book)
     fi = fsys.OpenFile(book);
     if (fi == NULL)
     {
-        wxLogError(_("Cannot open HTML help book: %s"), book.c_str());
+        wxLogError(_("Cannot open HTML help book: %s"), book);
         return false;
     }
     fsys.ChangePathTo(book);

--- a/src/html/htmlfilt.cpp
+++ b/src/html/htmlfilt.cpp
@@ -131,7 +131,7 @@ wxString wxHtmlFilterHTML::ReadFile(const wxFSFile& file) const
 
     if (s == NULL)
     {
-        wxLogError(_("Cannot open HTML document: %s"), file.GetLocation().c_str());
+        wxLogError(_("Cannot open HTML document: %s"), file.GetLocation());
         return wxEmptyString;
     }
 
@@ -170,7 +170,7 @@ wxString wxHtmlFilterHTML::ReadFile(const wxFSFile& file) const
     {
         wxString hdr;
         wxString mime = file.GetMimeType();
-        hdr.Printf(wxT("<meta http-equiv=\"Content-Type\" content=\"%s\">"), mime.c_str());
+        hdr.Printf(wxT("<meta http-equiv=\"Content-Type\" content=\"%s\">"), mime);
         return hdr+doc;
     }
 #endif

--- a/src/html/htmlwin.cpp
+++ b/src/html/htmlwin.cpp
@@ -583,7 +583,7 @@ bool wxHtmlWindow::LoadPage(const wxString& location)
 
         if (f == NULL)
         {
-            wxLogError(_("Unable to open requested HTML document: %s"), location.c_str());
+            wxLogError(_("Unable to open requested HTML document: %s"), location);
             m_tmpCanDrawLocks--;
             SetHTMLStatusText(wxEmptyString);
             return false;
@@ -688,7 +688,7 @@ bool wxHtmlWindow::ScrollToAnchor(const wxString& anchor)
     const wxHtmlCell *c = m_Cell->Find(wxHTML_COND_ISANCHOR, &anchor);
     if (!c)
     {
-        wxLogWarning(_("HTML anchor %s does not exist."), anchor.c_str());
+        wxLogWarning(_("HTML anchor %s does not exist."), anchor);
         return false;
     }
     else
@@ -718,7 +718,7 @@ void wxHtmlWindow::OnSetTitle(const wxString& title)
     if (m_RelatedFrame)
     {
         wxString tit;
-        tit.Printf(m_TitleFormat, title.c_str());
+        tit.Printf(m_TitleFormat, title);
         m_RelatedFrame->SetTitle(tit);
     }
     m_OpenedPageTitle = title;
@@ -1017,7 +1017,7 @@ bool wxHtmlWindow::CopySelection(ClipboardType t)
             wxTheClipboard->SetData(new wxTextDataObject(txt));
             wxTheClipboard->Close();
             wxLogTrace(wxT("wxhtmlselection"),
-                       _("Copied to clipboard:\"%s\""), txt.c_str());
+                       _("Copied to clipboard:\"%s\""), txt);
 
             return true;
         }

--- a/src/msw/iniconf.cpp
+++ b/src/msw/iniconf.cpp
@@ -452,7 +452,7 @@ bool wxIniConfig::DeleteAll()
   strFile << '\\' << m_strLocalFilename;
 
   if ( wxFile::Exists(strFile) && !wxRemoveFile(strFile) ) {
-    wxLogSysError(_("Can't delete the INI file '%s'"), strFile.c_str());
+    wxLogSysError(_("Can't delete the INI file '%s'"), strFile);
     return false;
   }
 

--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -674,7 +674,7 @@ bool wxNotebook::InsertPage(size_t nPage,
     // finally do insert it
     if ( TabCtrl_InsertItem(GetHwnd(), nPage, &tcItem) == -1 )
     {
-        wxLogError(wxT("Can't create the notebook page '%s'."), strText.c_str());
+        wxLogError(wxT("Can't create the notebook page '%s'."), strText);
 
         return false;
     }

--- a/src/msw/regconf.cpp
+++ b/src/msw/regconf.cpp
@@ -271,7 +271,7 @@ void wxRegConfig::SetPath(const wxString& strPath)
                     if ( !totalSlashes )
                     {
                         wxLogWarning(_("'%s' has extra '..', ignored."),
-                                     strFullPath.c_str());
+                                     strFullPath);
                     }
                     else // return to the previous path component
                     {
@@ -583,7 +583,7 @@ bool wxRegConfig::DoReadValue(const wxString& key, T* pValue) const
     if ( TryGetValue(m_keyGlobal, path.Name(), pValue) ) {
       if ( m_keyLocal.Exists() && LocalKey().HasValue(path.Name()) ) {
         wxLogWarning(wxT("User value for immutable key '%s' ignored."),
-                   path.Name().c_str());
+                   path.Name());
       }
 
       return true;
@@ -631,7 +631,7 @@ bool wxRegConfig::DoWriteValue(const wxString& key, const T& value)
   wxConfigPathChanger path(this, key);
 
   if ( IsImmutable(path.Name()) ) {
-    wxLogError(wxT("Can't change immutable entry '%s'."), path.Name().c_str());
+    wxLogError(wxT("Can't change immutable entry '%s'."), path.Name());
     return false;
   }
 

--- a/src/msw/stdpaths.cpp
+++ b/src/msw/stdpaths.cpp
@@ -96,7 +96,7 @@ void ResolveShellFunctions()
     wxDynamicLibrary dllShellFunctions( shellDllName );
     if ( !dllShellFunctions.IsLoaded() )
     {
-        wxLogTrace(TRACE_MASK, wxT("Failed to load %s.dll"), shellDllName.c_str() );
+        wxLogTrace(TRACE_MASK, wxT("Failed to load %s.dll"), shellDllName );
     }
 
     // don't give errors if the functions are unavailable, we're ready to deal

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -742,7 +742,7 @@ void wxTextCtrl::AdoptAttributesFromHWND()
         wxChar c;
         if ( wxSscanf(classname, wxT("RichEdit%d0%c"), &m_verRichEdit, &c) != 2 )
         {
-            wxLogDebug(wxT("Unknown edit control '%s'."), classname.c_str());
+            wxLogDebug(wxT("Unknown edit control '%s'."), classname);
 
             m_verRichEdit = 0;
         }

--- a/src/msw/tooltip.cpp
+++ b/src/msw/tooltip.cpp
@@ -463,7 +463,7 @@ void wxToolTip::DoAddHWND(WXHWND hWnd)
 
     if ( !SendTooltipMessage(GetToolTipCtrl(), TTM_ADDTOOL, &ti) )
     {
-        wxLogDebug(wxT("Failed to create the tooltip '%s'"), m_text.c_str());
+        wxLogDebug(wxT("Failed to create the tooltip '%s'"), m_text);
 
         return;
     }
@@ -479,7 +479,7 @@ void wxToolTip::DoAddHWND(WXHWND hWnd)
 
         if ( !SendTooltipMessage(GetToolTipCtrl(), TTM_ADDTOOL, &ti) )
         {
-            wxLogDebug(wxT("Failed to create the tooltip '%s'"), m_text.c_str());
+            wxLogDebug(wxT("Failed to create the tooltip '%s'"), m_text);
         }
     }
 }

--- a/src/msw/utilsexc.cpp
+++ b/src/msw/utilsexc.cpp
@@ -870,7 +870,7 @@ long wxExecute(const wxString& cmd, int flags, wxProcess *handler,
         }
 #endif // wxUSE_STREAMS
 
-        wxLogSysError(_("Execution of command '%s' failed"), command.c_str());
+        wxLogSysError(_("Execution of command '%s' failed"), command);
 
         return flags & wxEXEC_SYNC ? -1 : 0;
     }
@@ -1005,7 +1005,7 @@ long wxExecute(const wxString& cmd, int flags, wxProcess *handler,
         if ( !ddeOK )
         {
             wxLogDebug(wxT("Failed to send DDE request to the process \"%s\"."),
-                       cmd.c_str());
+                       cmd);
         }
     }
 #endif // wxUSE_IPC

--- a/src/msw/volume.cpp
+++ b/src/msw/volume.cpp
@@ -512,7 +512,7 @@ bool wxFSVolumeBase::Create(const wxString& name)
     long rc = SHGetFileInfo(m_volName.t_str(), 0, &fi, sizeof(fi), SHGFI_DISPLAYNAME);
     if (!rc)
     {
-        wxLogError(_("Cannot read typename from '%s'!"), m_volName.c_str());
+        wxLogError(_("Cannot read typename from '%s'!"), m_volName);
         return false;
     }
     m_dispName = fi.szDisplayName;
@@ -624,7 +624,7 @@ wxIcon wxFSVolume::GetIcon(wxFSIconType type) const
         long rc = SHGetFileInfo(m_volName.t_str(), 0, &fi, sizeof(fi), flags);
         if (!rc || !fi.hIcon)
         {
-            wxLogError(_("Cannot load icon from '%s'."), m_volName.c_str());
+            wxLogError(_("Cannot load icon from '%s'."), m_volName);
         }
         else
         {

--- a/src/osx/carbon/font.cpp
+++ b/src/osx/carbon/font.cpp
@@ -885,27 +885,27 @@ void wxNativeFontInfo::CreateCTFontDescriptor()
     wxString familyname;
     wxCFTypeRef(CTFontDescriptorCopyAttribute(m_descriptor, kCTFontFamilyNameAttribute)).GetValue(familyname);
     wxLogTrace(TRACE_CTFONT,"****** CreateCTFontDescriptor ******");
-    wxLogTrace(TRACE_CTFONT,"Descriptor FontFamilyName: %s",familyname.c_str());
+    wxLogTrace(TRACE_CTFONT,"Descriptor FontFamilyName: %s",familyname);
     
     wxString name;
     wxCFTypeRef(CTFontDescriptorCopyAttribute(m_descriptor, kCTFontNameAttribute)).GetValue(name);
-    wxLogTrace(TRACE_CTFONT,"Descriptor FontName: %s",name.c_str());
+    wxLogTrace(TRACE_CTFONT,"Descriptor FontName: %s",name);
     
     wxString display;
     wxCFTypeRef(CTFontDescriptorCopyAttribute(m_descriptor, kCTFontDisplayNameAttribute)).GetValue(display);
-    wxLogTrace(TRACE_CTFONT,"Descriptor DisplayName: %s",display.c_str());
+    wxLogTrace(TRACE_CTFONT,"Descriptor DisplayName: %s",display);
     
     wxString style;
     wxCFTypeRef(CTFontDescriptorCopyAttribute(m_descriptor, kCTFontStyleNameAttribute)).GetValue(style);
-    wxLogTrace(TRACE_CTFONT,"Descriptor StyleName: %s",style.c_str());
+    wxLogTrace(TRACE_CTFONT,"Descriptor StyleName: %s",style);
 
     wxString psname;
     wxCFTypeRef(CTFontCopyPostScriptName(font)).GetValue(psname);
-    wxLogTrace(TRACE_CTFONT,"Created Font PostScriptName: %s",psname.c_str());
+    wxLogTrace(TRACE_CTFONT,"Created Font PostScriptName: %s",psname);
     
     wxString fullname;
     wxCFTypeRef(CTFontCopyFullName(font)).GetValue(fullname);
-    wxLogTrace(TRACE_CTFONT,"Created Font FullName: %s",fullname.c_str());
+    wxLogTrace(TRACE_CTFONT,"Created Font FullName: %s",fullname);
     
     wxLogTrace(TRACE_CTFONT,"************************************");
 #endif

--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -167,7 +167,7 @@ bool wxCocoaLaunch(const char* const* argv, pid_t &pid)
     // Check the URL validity
     if( url == nil )
     {
-        wxLogDebug(wxT("wxCocoaLaunch Can't open path: %s"), path.c_str());
+        wxLogDebug(wxT("wxCocoaLaunch Can't open path: %s"), path);
         return false ;
     }
 

--- a/src/univ/toolbar.cpp
+++ b/src/univ/toolbar.cpp
@@ -713,7 +713,7 @@ bool wxToolBar::PerformAction(const wxControlAction& action,
     }
     else if ( action == wxACTION_TOOLBAR_PRESS )
     {
-        wxLogTrace(wxT("toolbar"), wxT("Button '%s' pressed."), tool->GetShortHelp().c_str());
+        wxLogTrace(wxT("toolbar"), wxT("Button '%s' pressed."), tool->GetShortHelp());
 
         tool->Invert();
 
@@ -721,7 +721,7 @@ bool wxToolBar::PerformAction(const wxControlAction& action,
     }
     else if ( action == wxACTION_TOOLBAR_RELEASE )
     {
-        wxLogTrace(wxT("toolbar"), wxT("Button '%s' released."), tool->GetShortHelp().c_str());
+        wxLogTrace(wxT("toolbar"), wxT("Button '%s' released."), tool->GetShortHelp());
 
         wxASSERT_MSG( tool->IsInverted(), wxT("release unpressed button?") );
 

--- a/src/unix/mimetype.cpp
+++ b/src/unix/mimetype.cpp
@@ -129,7 +129,7 @@ private:
 // Read a XDG *.desktop file of type 'Application'
 void wxMimeTypesManagerImpl::LoadXDGApp(const wxString& filename)
 {
-    wxLogTrace(TRACE_MIME, wxT("loading XDG file %s"), filename.c_str());
+    wxLogTrace(TRACE_MIME, wxT("loading XDG file %s"), filename);
 
     wxMimeTextFile file(filename);
     if ( !file.Open() )
@@ -243,7 +243,7 @@ void wxMimeTypesManagerImpl::LoadXDGGlobs(const wxString& filename)
     if ( !wxFileName::FileExists(filename) )
         return;
 
-    wxLogTrace(TRACE_MIME, wxT("loading XDG globs file from %s"), filename.c_str());
+    wxLogTrace(TRACE_MIME, wxT("loading XDG globs file from %s"), filename);
 
     wxMimeTextFile file(filename);
     if ( !file.Open() )

--- a/src/unix/snglinst.cpp
+++ b/src/unix/snglinst.cpp
@@ -163,7 +163,7 @@ LockResult wxSingleInstanceCheckerImpl::CreateLockFile()
             if ( write(m_fdLock, buf, len) != len )
             {
                 wxLogSysError(_("Failed to write to lock file '%s'"),
-                              m_nameLock.c_str());
+                              m_nameLock);
 
                 Unlock();
 
@@ -176,7 +176,7 @@ LockResult wxSingleInstanceCheckerImpl::CreateLockFile()
             if ( chmod(m_nameLock.fn_str(), S_IRUSR | S_IWUSR) != 0 )
             {
                 wxLogSysError(_("Failed to set permissions on lock file '%s'"),
-                              m_nameLock.c_str());
+                              m_nameLock);
 
                 Unlock();
 
@@ -193,7 +193,7 @@ LockResult wxSingleInstanceCheckerImpl::CreateLockFile()
             if ( errno != EACCES && errno != EAGAIN )
             {
                 wxLogSysError(_("Failed to lock the lock file '%s'"),
-                              m_nameLock.c_str());
+                              m_nameLock);
 
                 unlink(m_nameLock.fn_str());
 
@@ -235,17 +235,17 @@ bool wxSingleInstanceCheckerImpl::Create(const wxString& name)
     wxStructStat stats;
     if ( wxStat(name, &stats) != 0 )
     {
-        wxLogSysError(_("Failed to inspect the lock file '%s'"), name.c_str());
+        wxLogSysError(_("Failed to inspect the lock file '%s'"), name);
         return false;
     }
     if ( stats.st_uid != getuid() )
     {
-        wxLogError(_("Lock file '%s' has incorrect owner."), name.c_str());
+        wxLogError(_("Lock file '%s' has incorrect owner."), name);
         return false;
     }
     if ( stats.st_mode != (S_IFREG | S_IRUSR | S_IWUSR) )
     {
-        wxLogError(_("Lock file '%s' has incorrect permissions."), name.c_str());
+        wxLogError(_("Lock file '%s' has incorrect permissions."), name);
         return false;
     }
 
@@ -283,7 +283,7 @@ bool wxSingleInstanceCheckerImpl::Create(const wxString& name)
                 if ( unlink(name.fn_str()) != 0 )
                 {
                     wxLogError(_("Failed to remove stale lock file '%s'."),
-                               name.c_str());
+                               name);
 
                     // return true in this case for now...
                 }
@@ -296,7 +296,7 @@ bool wxSingleInstanceCheckerImpl::Create(const wxString& name)
                     // crashed), don't show it by default, i.e. unless the
                     // program is running with --verbose command line option.
                     wxLogVerbose(_("Deleted stale lock file '%s'."),
-                                 name.c_str());
+                                 name);
 
                     // retry now
                     (void)CreateLockFile();
@@ -306,7 +306,7 @@ bool wxSingleInstanceCheckerImpl::Create(const wxString& name)
         }
         else
         {
-            wxLogWarning(_("Invalid lock file '%s'."), name.c_str());
+            wxLogWarning(_("Invalid lock file '%s'."), name);
         }
     }
 
@@ -323,19 +323,19 @@ void wxSingleInstanceCheckerImpl::Unlock()
         if ( unlink(m_nameLock.fn_str()) != 0 )
         {
             wxLogSysError(_("Failed to remove lock file '%s'"),
-                          m_nameLock.c_str());
+                          m_nameLock);
         }
 
         if ( wxLockFile(m_fdLock, UNLOCK) != 0 )
         {
             wxLogSysError(_("Failed to unlock lock file '%s'"),
-                          m_nameLock.c_str());
+                          m_nameLock);
         }
 
         if ( close(m_fdLock) != 0 )
         {
             wxLogSysError(_("Failed to close lock file '%s'"),
-                          m_nameLock.c_str());
+                          m_nameLock);
         }
     }
 

--- a/src/unix/sound.cpp
+++ b/src/unix/sound.cpp
@@ -456,7 +456,7 @@ bool wxSound::Create(const wxString& fileName,
     if ( fileWave.Read(data, len) != lenOrig )
     {
         delete [] data;
-        wxLogError(_("Couldn't load sound data from '%s'."), fileName.c_str());
+        wxLogError(_("Couldn't load sound data from '%s'."), fileName);
         return false;
     }
 
@@ -464,7 +464,7 @@ bool wxSound::Create(const wxString& fileName,
     {
         delete [] data;
         wxLogError(_("Sound file '%s' is in unsupported format."),
-                   fileName.c_str());
+                   fileName);
         return false;
     }
 
@@ -498,12 +498,12 @@ bool wxSound::Create(size_t size, const void* data)
 #else
             wxString dllname;
             dllname.Printf(wxT("%s/%s"),
-                wxDynamicLibrary::GetPluginsDirectory().c_str(),
+                wxDynamicLibrary::GetPluginsDirectory(),
                 wxDynamicLibrary::CanonicalizePluginName(
-                    wxT("sound_sdl"), wxDL_PLUGIN_BASE).c_str());
+                    wxT("sound_sdl"), wxDL_PLUGIN_BASE));
             wxLogTrace(wxT("sound"),
                        wxT("trying to load SDL plugin from '%s'..."),
-                       dllname.c_str());
+                       dllname);
             wxLogNull null;
             ms_backendSDL = new wxDynamicLibrary(dllname, wxDL_NOW);
             if (!ms_backendSDL->IsLoaded())
@@ -546,7 +546,7 @@ bool wxSound::Create(size_t size, const void* data)
             ms_backend = new wxSoundSyncOnlyAdaptor(ms_backend);
 
         wxLogTrace(wxT("sound"),
-                   wxT("using backend '%s'"), ms_backend->GetName().c_str());
+                   wxT("using backend '%s'"), ms_backend->GetName());
     }
 }
 

--- a/src/unix/sound_sdl.cpp
+++ b/src/unix/sound_sdl.cpp
@@ -215,7 +215,7 @@ bool wxSoundBackendSDL::OpenAudio()
             wxStrlcpy(driver, SDL_GetCurrentAudioDriver(), 256);
 #endif
             wxLogTrace(wxT("sound"), wxT("opened audio, driver '%s'"),
-                       wxString(driver, wxConvLocal).c_str());
+                       wxString(driver, wxConvLocal));
 #endif
             m_audioOpen = true;
             return true;
@@ -223,7 +223,7 @@ bool wxSoundBackendSDL::OpenAudio()
         else
         {
             wxString err(SDL_GetError(), wxConvLocal);
-            wxLogError(_("Couldn't open audio: %s"), err.c_str());
+            wxLogError(_("Couldn't open audio: %s"), err);
             return false;
         }
     }

--- a/src/x11/app.cpp
+++ b/src/x11/app.cpp
@@ -125,7 +125,7 @@ bool wxApp::Initialize(int& argC, wxChar **argV)
                 if (wxSscanf(argV[i], wxT("%dx%d"), &w, &h) != 2)
                 {
                     wxLogError( _("Invalid geometry specification '%s'"),
-                                wxString(argV[i]).c_str() );
+                                wxString(argV[i]) );
                 }
                 else
                 {
@@ -360,7 +360,7 @@ bool wxApp::ProcessXEvent(WXEvent* _event)
 #if !wxUSE_NANOX
         case GraphicsExpose:
         {
-            wxLogTrace( wxT("expose"), wxT("GraphicsExpose from %s"), win->GetName().c_str());
+            wxLogTrace( wxT("expose"), wxT("GraphicsExpose from %s"), win->GetName());
 
             win->GetUpdateRegion().Union( event->xgraphicsexpose.x, event->xgraphicsexpose.y,
                                           event->xgraphicsexpose.width, event->xgraphicsexpose.height);
@@ -387,7 +387,7 @@ bool wxApp::ProcessXEvent(WXEvent* _event)
             wxKeyEvent keyEvent(wxEVT_KEY_DOWN);
             wxTranslateKeyEvent(keyEvent, win, window, event);
 
-            // wxLogDebug( "OnKey from %s", win->GetName().c_str() );
+            // wxLogDebug( "OnKey from %s", win->GetName() );
 
             // We didn't process wxEVT_KEY_DOWN, so send wxEVT_CHAR
             if (win->HandleWindowEvent( keyEvent ))
@@ -590,7 +590,7 @@ bool wxApp::ProcessXEvent(WXEvent* _event)
                     g_prevFocus = wxWindow::FindFocus();
                     g_nextFocus = win;
 
-                    wxLogTrace( wxT("focus"), wxT("About to call SetFocus on %s of type %s due to button press"), win->GetName().c_str(), win->GetClassInfo()->GetClassName() );
+                    wxLogTrace( wxT("focus"), wxT("About to call SetFocus on %s of type %s due to button press"), win->GetName(), win->GetClassInfo()->GetClassName() );
 
                     // Record the fact that this window is
                     // getting the focus, because we'll need to
@@ -621,7 +621,7 @@ bool wxApp::ProcessXEvent(WXEvent* _event)
                 (event->xfocus.mode == NotifyNormal))
 #endif
             {
-                wxLogTrace( wxT("focus"), wxT("FocusIn from %s of type %s"), win->GetName().c_str(), win->GetClassInfo()->GetClassName() );
+                wxLogTrace( wxT("focus"), wxT("FocusIn from %s of type %s"), win->GetName(), win->GetClassInfo()->GetClassName() );
 
                 extern wxWindow* g_GettingFocus;
                 if (g_GettingFocus && g_GettingFocus->GetParent() == win)
@@ -629,7 +629,7 @@ bool wxApp::ProcessXEvent(WXEvent* _event)
                     // Ignore this, this can be a spurious FocusIn
                     // caused by a child having its focus set.
                     g_GettingFocus = NULL;
-                    wxLogTrace( wxT("focus"), wxT("FocusIn from %s of type %s being deliberately ignored"), win->GetName().c_str(), win->GetClassInfo()->GetClassName() );
+                    wxLogTrace( wxT("focus"), wxT("FocusIn from %s of type %s being deliberately ignored"), win->GetName(), win->GetClassInfo()->GetClassName() );
                     return true;
                 }
                 else
@@ -650,7 +650,7 @@ bool wxApp::ProcessXEvent(WXEvent* _event)
                 (event->xfocus.mode == NotifyNormal))
 #endif
             {
-                wxLogTrace( wxT("focus"), wxT("FocusOut from %s of type %s"), win->GetName().c_str(), win->GetClassInfo()->GetClassName() );
+                wxLogTrace( wxT("focus"), wxT("FocusOut from %s of type %s"), win->GetName(), win->GetClassInfo()->GetClassName() );
 
                 wxFocusEvent focusEvent(wxEVT_KILL_FOCUS, win->GetId());
                 focusEvent.SetEventObject(win);

--- a/src/x11/utils.cpp
+++ b/src/x11/utils.cpp
@@ -168,7 +168,7 @@ void wxCloseDisplay()
         if ( XCloseDisplay(gs_currentDisplay) != 0 )
         {
             wxLogWarning(_("Failed to close the display \"%s\""),
-                         gs_displayName.c_str());
+                         gs_displayName);
         }
 
         gs_currentDisplay = NULL;
@@ -186,7 +186,7 @@ bool wxSetDisplay(const wxString& displayName)
 
     if ( !dpy )
     {
-        wxLogError(_("Failed to open display \"%s\"."), displayName.c_str());
+        wxLogError(_("Failed to open display \"%s\"."), displayName);
         return false;
     }
 

--- a/src/x11/window.cpp
+++ b/src/x11/window.cpp
@@ -168,7 +168,7 @@ bool wxWindowX11::Create(wxWindow *parent, wxWindowID id,
     // Add window's own scrollbars to main window, not to client window
     if (parent->GetInsertIntoMain())
     {
-        // wxLogDebug( "Inserted into main: %s", GetName().c_str() );
+        // wxLogDebug( "Inserted into main: %s", GetName() );
         xparent = (Window) parent->X11GetMainWindow();
     }
 
@@ -298,7 +298,7 @@ bool wxWindowX11::Create(wxWindow *parent, wxWindowID id,
     }
     else
     {
-        // wxLogDebug( "No two windows needed %s", GetName().c_str() );
+        // wxLogDebug( "No two windows needed %s", GetName() );
 #if wxUSE_NANOX
         long backColor, foreColor;
         backColor = GR_RGB(m_backgroundColour.Red(), m_backgroundColour.Green(), m_backgroundColour.Blue());
@@ -502,12 +502,12 @@ bool wxWindowX11::Show(bool show)
     Display *xdisp = wxGlobalDisplay();
     if (show)
     {
-        // wxLogDebug( "Mapping window of type %s", GetName().c_str() );
+        // wxLogDebug( "Mapping window of type %s", GetName() );
         XMapWindow(xdisp, xwindow);
     }
     else
     {
-        // wxLogDebug( "Unmapping window of type %s", GetName().c_str() );
+        // wxLogDebug( "Unmapping window of type %s", GetName() );
         XUnmapWindow(xdisp, xwindow);
     }
 
@@ -592,7 +592,7 @@ void wxWindowX11::DoReleaseMouse()
         XUngrabPointer( wxGlobalDisplay(), CurrentTime );
     }
 
-    // wxLogDebug( "Ungrabbed pointer in %s", GetName().c_str() );
+    // wxLogDebug( "Ungrabbed pointer in %s", GetName() );
 
     m_winCaptured = false;
 }

--- a/tests/archive/archivetest.cpp
+++ b/tests/archive/archivetest.cpp
@@ -367,7 +367,7 @@ void TempDir::RemoveDir(wxString& path)
 
     if (!wxRmdir(m_tmp))
     {
-        wxLogSysError(wxT("can't remove temporary dir '%s'"), m_tmp.c_str());
+        wxLogSysError(wxT("can't remove temporary dir '%s'"), m_tmp);
     }
 }
 
@@ -666,7 +666,7 @@ void ArchiveTestCase<ClassFactoryT>::CreateArchive(wxOutputStream& out,
         wxString tmparc = fn.GetPath(wxPATH_GET_SEPARATOR) + fn.GetFullName();
 
         // call the archiver to create an archive file
-        if ( system(wxString::Format(archiver, tmparc.c_str()).mb_str()) == -1 )
+        if ( system(wxString::Format(archiver, tmparc).mb_str()) == -1 )
         {
             wxLogError("Failed to run acrhiver command \"%s\"", archiver);
         }
@@ -894,7 +894,7 @@ void ArchiveTestCase<ClassFactoryT>::ExtractArchive(wxInputStream& in,
         }
 
         // call unarchiver
-        if ( system(wxString::Format(unarchiver, tmparc.c_str()).mb_str()) == -1 )
+        if ( system(wxString::Format(unarchiver, tmparc).mb_str()) == -1 )
         {
             wxLogError("Failed to run unarchiver command \"%s\"", unarchiver);
         }

--- a/utils/helpview/src/helpview.cpp
+++ b/utils/helpview/src/helpview.cpp
@@ -438,7 +438,7 @@ bool hvConnection::OnPoke(const wxString& WXUNUSED(topic),
 {
     const wxString data = GetTextFromData(buf, size, format);
 
-    //    wxLogStatus("Poke command: %s = %s", item.c_str(), data);
+    //    wxLogStatus("Poke command: %s = %s", item, data);
     //topic is not tested
 
     if ( wxGetApp().GetHelpController() )


### PR DESCRIPTION
Using c_str() for arguments to wxString::Printf(), Format() and
wxLogXXX() is useless since wx 2.9 days, so simply remove them.

No real changes, this is just a (long due) cleanup.