### PR TITLE
Update wxComboPopupWindow::OnDismiss for wxUniv

### DIFF
--- a/src/common/combocmn.cpp
+++ b/src/common/combocmn.cpp
@@ -517,11 +517,13 @@ bool wxComboPopupWindow::ProcessLeftDown(wxMouseEvent& event)
 // First thing that happens when a transient popup closes is that this method gets called.
 void wxComboPopupWindow::OnDismiss()
 {
+#ifndef __WXUNIVERSAL__
     wxComboCtrlBase* combo = (wxComboCtrlBase*) GetParent();
     wxASSERT_MSG( wxDynamicCast(combo, wxComboCtrlBase),
                   wxT("parent might not be wxComboCtrl, but check wxIMPLEMENT_DYNAMIC_CLASS2() macro for correctness") );
 
     combo->OnPopupDismiss(true);
+#endif
 }
 #endif // USES_WXPOPUPTRANSIENTWINDOW
 


### PR DESCRIPTION
wxComboBox in wxUniv not inherited from wxComboBoxBase and attempt to use wxComboBox without this changes is generate debug assert:

> src\common\combocmn.cpp(523): assert "((wxComboCtrlBase *) wxCheckDynamicCast( const_cast<wxObject *>(static_cast<const wxObject *>( const_cast<wxComboCtrlBase *>(static_cast<const wxComboCtrlBase *>(combo)))), &wxComboCtrlBase::ms_classInfo))" failed in wxComboPopupWindow::OnDismiss(): parent might not be wxComboCtrl, but check wxIMPLEMENT_DYNAMIC_CLASS2() macro for correctness
