### PR TITLE
Additional wxRenderer fixes

### DIFF
--- a/include/wx/dc.h
+++ b/include/wx/dc.h
@@ -1478,7 +1478,7 @@ class WXDLLIMPEXP_CORE wxDCTextBgModeChanger
 public:
     wxDCTextBgModeChanger(wxDC& dc) : m_dc(dc), m_modeOld(wxBRUSHSTYLE_INVALID) { }
 
-    wxDCTextBgModeChanger(wxDC& dc, int mode) : m_dc(dc)
+    wxDCTextBgModeChanger(wxDC& dc, int mode) : m_dc(dc), m_modeOld(wxBRUSHSTYLE_INVALID)
     {
         Set(mode);
     }

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -1011,7 +1011,7 @@ wxRendererXP::DrawItemSelectionRect(wxWindow *win,
                                     const wxRect& rect,
                                     int flags)
 {
-    wxUxThemeHandle hTheme(win, L"EXPLORER::LISTVIEW");
+    wxUxThemeHandle hTheme(win, L"EXPLORER::LISTVIEW;LISTVIEW");
 
     const int itemState = GetListItemState(flags);
 
@@ -1038,7 +1038,7 @@ void wxRendererXP::DrawItemText(wxWindow* win,
                                 int flags,
                                 wxEllipsizeMode ellipsizeMode)
 {
-    wxUxThemeHandle hTheme(win, L"EXPLORER::LISTVIEW");
+    wxUxThemeHandle hTheme(win, L"EXPLORER::LISTVIEW;LISTVIEW");
 
     const int itemState = GetListItemState(flags);
 


### PR DESCRIPTION
The changes from #2412 caused two issues.

`wxDCTextBgModeChanger` did not work correctly when a `wxGraphicsContext` was set. After `wxDCTextBgModeChanger` was destructed, the background is not transparent anymore.

Also `EXPLORER::LISTVIEW` does not seem to work always. It works in the `render` sample, but not in the `dataview` sample.