### PR TITLE
Fix size of button with bitmap

### DIFF
--- a/src/msw/anybutton.cpp
+++ b/src/msw/anybutton.cpp
@@ -621,7 +621,7 @@ wxSize wxAnyButton::DoGetBestSize() const
     }
 
     if ( m_imageData )
-        AdjustForBitmapMargins(size);
+        AdjustForBitmapSize(size);
 
     return wxMSWButton::IncreaseToStdSizeAndCache(self, size);
 }


### PR DESCRIPTION
After changes in 53eff92e only the margin was accounted for, not the image size.

Visible in the widgets sample, button page, toggle `Bitmap only`.