### PR TITLE
Windows Printing extended

### DIFF
--- a/include/wx/msw/printdlg.h
+++ b/include/wx/msw/printdlg.h
@@ -42,6 +42,7 @@ public:
     void SetDevMode(void* data) { m_devMode = data; }
     void* GetDevNames() const { return m_devNames; }
     void SetDevNames(void* data) { m_devNames = data; }
+    bool CopyAndSetDevMode(LPDEVMODE pDevMode);
 
 private:
     void* m_devMode;

--- a/include/wx/msw/printdlg.h
+++ b/include/wx/msw/printdlg.h
@@ -73,6 +73,8 @@ public:
 
     virtual wxDC *GetPrintDC() wxOVERRIDE;
 
+    static wxPrintData GetDefaultPrintData(const wxString& printerName = wxEmptyString);
+
 private:
     wxPrintDialogData m_printDialogData;
     wxPrinterDC*      m_printerDC;

--- a/src/msw/printdlg.cpp
+++ b/src/msw/printdlg.cpp
@@ -208,9 +208,7 @@ bool wxWindowsPrintNativeData::IsOk() const
 
 bool wxWindowsPrintNativeData::CopyAndSetDevMode(LPDEVMODE pDevMode)
 {
-    if (!pDevMode) {
-        return false;
-    }
+    wxCHECK_MSG(pDevMode, false, "null DEVMODE pointer");
 
     DWORD devModeSize = pDevMode->dmSize + pDevMode->dmDriverExtra;
     LPDEVMODE newDevMode = static_cast<LPDEVMODE>(GlobalAlloc(GMEM_FIXED | GMEM_ZEROINIT, devModeSize));
@@ -534,15 +532,14 @@ void wxWindowsPrintNativeData::InitializeDevMode(const wxString& printerName, Wi
         LPDEVMODE tempDevMode = static_cast<LPDEVMODE>(lockDevMode.Get());
         if (tempDevMode)
         {
-            wxString _printerName = tempDevMode->dmDeviceName;
-            WinPrinter _printer;
-            if (_printer.Open(_printerName))
+            WinPrinter winPrinter;
+            if (winPrinter.Open(tempDevMode->dmDeviceName))
             {
                 bool devModeSwitched = false;
 
                 // try to switch to level 9 user data
                 if (!devModeSwitched) {
-                    wxMemoryBuffer buffer9 = _printer.GetData(9);
+                    wxMemoryBuffer buffer9 = winPrinter.GetData(9);
                     if (!buffer9.IsEmpty())
                     {
                         PRINTER_INFO_9* printerInfo9 = static_cast<PRINTER_INFO_9*>(buffer9.GetData());
@@ -553,10 +550,10 @@ void wxWindowsPrintNativeData::InitializeDevMode(const wxString& printerName, Wi
                     }
                 }
 
-                // try to switch to level 8 data
+                // try to switch to level 8 system data if level 9 user data are not available
                 if (!devModeSwitched)
                 {
-                    wxMemoryBuffer buffer8 = _printer.GetData(8);
+                    wxMemoryBuffer buffer8 = winPrinter.GetData(8);
                     if (!buffer8.IsEmpty())
                     {
                         PRINTER_INFO_8* printerInfo8 = static_cast<PRINTER_INFO_8*>(buffer8.GetData());

--- a/src/msw/printdlg.cpp
+++ b/src/msw/printdlg.cpp
@@ -770,6 +770,7 @@ bool wxWindowsPrintNativeData::TransferFrom( const wxPrintData &data )
 
 wxPrintData GetDefaultPrintData(const wxString& printerName = wxEmptyString) {
     wxPrintData defaultData;
+    defaultData.SetPrinterName(printerName);
     WinPrinter printer;
     wxWindowsPrintNativeData nativeData;
     nativeData.InitializeDevMode(printerName, &printer);

--- a/src/msw/printdlg.cpp
+++ b/src/msw/printdlg.cpp
@@ -766,16 +766,6 @@ bool wxWindowsPrintNativeData::TransferFrom( const wxPrintData &data )
     return true;
 }
 
-wxPrintData GetDefaultPrintData(const wxString& printerName = wxEmptyString) {
-    wxPrintData defaultData;
-    defaultData.SetPrinterName(printerName);
-    WinPrinter printer;
-    wxWindowsPrintNativeData nativeData;
-    nativeData.InitializeDevMode(printerName, &printer);
-    nativeData.TransferTo(defaultData);
-    return defaultData;
-}
-
 // ---------------------------------------------------------------------------
 // wxPrintDialog
 // ---------------------------------------------------------------------------
@@ -983,6 +973,17 @@ bool wxWindowsPrintDialog::ConvertFromNative( wxPrintDialogData &data )
     data.EnableHelp( ((pd->Flags & PD_SHOWHELP) == PD_SHOWHELP) );
 
     return true;
+}
+
+wxPrintData wxWindowsPrintDialog::GetDefaultPrintData(const wxString& printerName)
+{
+    wxPrintData defaultData;
+    defaultData.SetPrinterName(printerName);
+    WinPrinter printer;
+    wxWindowsPrintNativeData nativeData;
+    nativeData.InitializeDevMode(printerName, &printer);
+    nativeData.TransferTo(defaultData);
+    return defaultData;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/msw/printdlg.cpp
+++ b/src/msw/printdlg.cpp
@@ -522,7 +522,8 @@ void wxWindowsPrintNativeData::InitializeDevMode(const wxString& printerName, Wi
                 // try to switch to level 9 user data
                 if (!devModeSwitched) {
                     wxMemoryBuffer buffer9 = _printer.GetData(9);
-                    if (!buffer9.IsEmpty()) {
+                    if (!buffer9.IsEmpty())
+                    {
                         PRINTER_INFO_9* printerInfo9 = static_cast<PRINTER_INFO_9*>(buffer9.GetData());
                         if (printerInfo9->pDevMode)
                         {
@@ -540,9 +541,11 @@ void wxWindowsPrintNativeData::InitializeDevMode(const wxString& printerName, Wi
                 }
 
                 // try to switch to level 8 data
-                if (!devModeSwitched) {
+                if (!devModeSwitched)
+                {
                     wxMemoryBuffer buffer8 = _printer.GetData(8);
-                    if (!buffer8.IsEmpty()) {
+                    if (!buffer8.IsEmpty())
+                    {
                         PRINTER_INFO_8* printerInfo8 = static_cast<PRINTER_INFO_8*>(buffer8.GetData());
                         if (printerInfo8->pDevMode)
                         {

--- a/src/msw/printdlg.cpp
+++ b/src/msw/printdlg.cpp
@@ -76,17 +76,18 @@ public:
         return result;
     }
 
-    wxMemoryBuffer GetData(int level) {
+    wxMemoryBuffer GetData(int level)
+    {
         if (m_hPrinter)
         {
-            DWORD buf_size = 0;
-            GetPrinter(m_hPrinter, level, NULL, 0, &buf_size);
-            if (buf_size)
+            DWORD bufSize = 0;
+            GetPrinter(m_hPrinter, level, NULL, 0, &bufSize);
+            if (bufSize)
             {
-                wxMemoryBuffer buffer(buf_size);
-                if (GetPrinter(m_hPrinter, level, (LPBYTE) buffer.GetWriteBuf(buf_size), buf_size, &buf_size))
+                wxMemoryBuffer buffer(bufSize);
+                if (GetPrinter(m_hPrinter, level, (LPBYTE) buffer.GetWriteBuf(bufSize), bufSize, &bufSize))
                 {
-                    buffer.SetDataLen(buf_size);
+                    buffer.SetDataLen(bufSize);
                     return buffer;
                 }
             }


### PR DESCRIPTION
Default printing preferences are currently not used in the windows port. Per user printing preferences are provided by the `PRINTER_INFO_9` info and per system preferences by the `PRINTER_INFO_8` structures in windows. I have extended the `InitializeDevMode` function to query these information and to use these info instead of the driver defaults.

Furthermore I have added the helper method `wxPrintData GetDefaultPrintData(const wxString& printerName = wxEmptyString)` to receive default wxPrintData for a printer. This is currently not possible in wxWidgets. In Windows, every user can set printing preferences for a printer and in our application, we have to use this information so that the user don't have to set that information again and again. GetDefaultPrintData queries that information and returns the wxPrintData object. Implemented currently only in printdlg.cpp of the windows port. The method is currently not visible because I have only implemented this for the Windows port so that I can use it in my own project, but it would be nice to provide such a method or that functionality in wxWidgets to all ports.

