### PR TITLE
Stop expanding env vars by default in wxFileName::Normalize()

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -13,6 +13,10 @@ Changes in behaviour not resulting in compilation errors
 --------------------------------------------------------
 
 - wxRibbonButtonBar::DeleteButton() now deletes and not just removes the button.
+
+- wxFileName::Normalize() doesn't expand environment variables by default any
+  longer, specify wxPATH_NORM_ENV_VARS explicitly if this is what you need.
+
 - Default interpolation mode in wxGDIPlusContext under MSW is now
   wxINTERPOLATION_DEFAULT and not wxINTERPOLATION_GOOD as in 3.0 for
   consistency with OS X, call SetInterpolationQuality() explicitly if needed.

--- a/include/wx/filename.h
+++ b/include/wx/filename.h
@@ -72,7 +72,7 @@ enum wxPathNormalize
     wxPATH_NORM_ABSOLUTE = 0x0010,  // make the path absolute
     wxPATH_NORM_LONG =     0x0020,  // make the path the long form
     wxPATH_NORM_SHORTCUT = 0x0040,  // resolve the shortcut, if it is a shortcut
-    wxPATH_NORM_ALL      = 0x00ff & ~wxPATH_NORM_CASE
+    wxPATH_NORM_ALL      = 0x00ff & ~(wxPATH_NORM_CASE | wxPATH_NORM_ENV_VARS)
 };
 
 // what exactly should GetPath() return?

--- a/interface/wx/filename.h
+++ b/interface/wx/filename.h
@@ -54,10 +54,16 @@ enum wxSizeConvention
 */
 enum wxPathNormalize
 {
-    //! Replace environment variables with their values.
-    //! wxFileName understands both Unix and Windows (but only under Windows) environment
-    //! variables expansion: i.e. @c "$var", @c "$(var)" and @c "${var}" are always understood
-    //! and in addition under Windows @c "%var%" is also.
+    /**
+        Replace environment variables with their values.
+
+        wxFileName understands both Unix and Windows (but only under Windows) environment
+        variables expansion: i.e. @c "$var", @c "$(var)" and @c "${var}" are always understood
+        and in addition under Windows @c "%var%" is also.
+
+        Note that since wxWidgets 3.1.6 this flag is not used by
+        wxFileName::Normalize() by default any longer.
+     */
     wxPATH_NORM_ENV_VARS = 0x0001,
 
     wxPATH_NORM_DOTS     = 0x0002,  //!< Squeeze all @c ".." and @c ".".
@@ -67,8 +73,16 @@ enum wxPathNormalize
     wxPATH_NORM_LONG =     0x0020,  //!< Expand the path to the "long" form (Windows only).
     wxPATH_NORM_SHORTCUT = 0x0040,  //!< Resolve the shortcut, if it is a shortcut (Windows only).
 
-    //! A value indicating all normalization flags except for @c wxPATH_NORM_CASE.
-    wxPATH_NORM_ALL      = 0x00ff & ~wxPATH_NORM_CASE
+    /**
+        Flags used by wxFileName::Normalize() by default.
+
+        This includes all normalization flags except for @c wxPATH_NORM_CASE
+        and, since wxWidgets 3.1.6, @c wxPATH_NORM_ENV_VARS, i.e. by default,
+        the case won't be changed and environment variables are not expanded.
+        If these normalizations are needed, they must be specified explicitly
+        when calling wxFileName::Normalize().
+     */
+    wxPATH_NORM_ALL      = 0x00ff & ~(wxPATH_NORM_CASE | wxPATH_NORM_ENV_VARS)
 };
 
 /**
@@ -1067,7 +1081,9 @@ public:
         Normalize the path.
 
         With the default flags value, the path will be made absolute, without
-        any ".." and "." and all environment variables will be expanded in it.
+        any ".." and ".", and, for the Unix format paths, any occurrences of
+        tilde (@c ~) character will be replaced with the home directory of the
+        user following it.
 
         Notice that in some rare cases normalizing a valid path may result in
         an invalid wxFileName object. E.g. normalizing "./" path using
@@ -1078,6 +1094,9 @@ public:
         @param flags
             The kind of normalization to do with the file name. It can be
             any or-combination of the ::wxPathNormalize enumeration values.
+            By default, most, but not all, in spite of the name of the
+            constant, normalizations are applied, see wxPathNormalize enum for
+            more details.
         @param cwd
             If not empty, this directory will be used instead of current
             working directory in normalization (see @c wxPATH_NORM_ABSOLUTE).

--- a/tests/filename/filenametest.cpp
+++ b/tests/filename/filenametest.cpp
@@ -317,6 +317,13 @@ TEST_CASE("wxFileName::Normalize", "[filename]")
         { ".\\foo", wxPATH_NORM_LONG, ".\\foo", wxPATH_DOS },
         { "..\\Makefile.in", wxPATH_NORM_LONG, "..\\Makefile.in", wxPATH_DOS },
         { "..\\foo", wxPATH_NORM_LONG, "..\\foo", wxPATH_DOS },
+
+        // test default behaviour with wxPATH_NORM_ALL
+#ifdef __WINDOWS__
+        { "%ABCDEF%/g/h/i", wxPATH_NORM_ALL, "CWD/%ABCDEF%/g/h/i", wxPATH_UNIX },
+#else
+        { "$(ABCDEF)/g/h/i", wxPATH_NORM_ALL, "CWD/$(ABCDEF)/g/h/i", wxPATH_UNIX },
+#endif
     };
 
     // set the env var ABCDEF


### PR DESCRIPTION
This was often unexpected as it could break program operation with paths
containing components starting with the dollar sign, which was a serious
problem precisely because such paths are quite rare and it could remain
unnoticed for a long time, as was the case for the use of Normalize() in
our own code in wxStandardPathsBase::GetExecutablePath(), for example.

Fix this by not performing variable expansion by default: this will
still be done if wxPATH_NORM_ENV_VARS is explicitly specified, but not
if Normalize() is called without any arguments.

This is a silent change in behaviour, but hopefully not that many
programs rely on Normalize() expanding the environment variables even
without explicit wxPATH_NORM_ENV_VARS.

Closes #19214.