### PR TITLE
wxDC changer improvements

### DIFF
--- a/include/wx/dc.h
+++ b/include/wx/dc.h
@@ -1512,15 +1512,24 @@ private:
 class WXDLLIMPEXP_CORE wxDCPenChanger
 {
 public:
-    wxDCPenChanger(wxDC& dc, const wxPen& pen) : m_dc(dc), m_penOld(dc.GetPen())
+    wxDCPenChanger(wxDC& dc) : m_dc(dc) { }
+
+    wxDCPenChanger(wxDC& dc, const wxPen& pen) : m_dc(dc)
     {
-        m_dc.SetPen(pen);
+        Set(pen);
     }
 
     ~wxDCPenChanger()
     {
         if ( m_penOld.IsOk() )
             m_dc.SetPen(m_penOld);
+    }
+
+    void Set(const wxPen& pen)
+    {
+        if ( !m_penOld.IsOk() )
+            m_penOld = m_dc.GetPen();
+        m_dc.SetPen(pen);
     }
 
 private:
@@ -1539,15 +1548,24 @@ private:
 class WXDLLIMPEXP_CORE wxDCBrushChanger
 {
 public:
-    wxDCBrushChanger(wxDC& dc, const wxBrush& brush) : m_dc(dc), m_brushOld(dc.GetBrush())
+    wxDCBrushChanger(wxDC& dc) : m_dc(dc) { }
+
+    wxDCBrushChanger(wxDC& dc, const wxBrush& brush) : m_dc(dc)
     {
-        m_dc.SetBrush(brush);
+        Set(brush);
     }
 
     ~wxDCBrushChanger()
     {
         if ( m_brushOld.IsOk() )
             m_dc.SetBrush(m_brushOld);
+    }
+
+    void Set(const wxBrush& brush)
+    {
+        if ( !m_brushOld.IsOk() )
+            m_brushOld = m_dc.GetBrush();
+        m_dc.SetBrush(brush);
     }
 
 private:

--- a/interface/wx/dc.h
+++ b/interface/wx/dc.h
@@ -1983,16 +1983,18 @@ public:
     /**
         Set the colour to use.
 
-        This method is meant to be called once only and only on the objects
-        created with the constructor overload not taking wxColour argument and
-        has the same effect as the other constructor, i.e. sets the colour to
-        the given @a col and ensures that the old value is restored when this
-        object is destroyed.
+        This method is meant to be called only on objects created with the
+        constructor overload not taking wxColour argument and has the same
+        effect as the other constructor, i.e. sets the colour to the given
+        @a col and ensures that the old value is restored when this object
+        is destroyed.
+        It's also safe to call on objects created with a wxColour argument
+        and to call it multiple times.
      */
     void Set(const wxColour& col);
 
     /**
-        Restores the colour originally selected in the DC passed to the ctor.
+        If stored, restores the colour originally selected in the DC.
     */
     ~wxDCTextColourChanger();
 };

--- a/src/osx/carbon/renderer.cpp
+++ b/src/osx/carbon/renderer.cpp
@@ -756,9 +756,11 @@ void wxRendererMac::DrawTitleBarBitmap(wxWindow *win,
         glyphColor = wxColour(145, 147, 149);
     }
 
+    wxDCPenChanger penChanger(dc);
+
     if ( drawCircle )
     {
-        wxDCPenChanger setPen(dc, circleBorderCol);
+        penChanger.Set(circleBorderCol);
         wxDCBrushChanger setBrush(dc, circleInteriorCol);
 
         wxRect circleRect(rect);
@@ -767,7 +769,7 @@ void wxRendererMac::DrawTitleBarBitmap(wxWindow *win,
         dc.DrawEllipse(circleRect);
     }
 
-    wxDCPenChanger setPen(dc, glyphColor);
+    penChanger.Set(glyphColor);
 
     wxRect centerRect(rect);
     centerRect.Deflate(5);


### PR DESCRIPTION
This PR synchronizes the `wxDC` changer classes somewhat after seeing the `wxDC` attribute preservation changes of #2412, and does so with its first commit. The remaining commits could be more questionable.

The second commit ignores the (four times repeated) [doc note](https://github.com/wxWidgets/wxWidgets/blob/9028ae74fcdd020224ddcb3a3e98519608ca57b7/interface/wx/dc.h#L1986-L1987) regarding `Set()` only meant to be called once for `wxDC` changers. I couldn't think of a reason for such a restriction other than allowing to change `Set()` behaviour more freely later, but it already stores the attribute at most one time and by now ever changing that behaviour seems like a bad idea. Also wx itself already uses `Set()` twice in some minor instance (wxUniv code).

I slightly changed the docs but not for all `wxDC` changer classes yet as I was also hoping there's another solution besides maintaining docs for six classes that only differ by attribute.

The last commit is tentative: it collapses the six classes into a single macro-based one, which at least helps with synchronizing them. For me the culprit with making it template-based is `wxDCTextBgModeChanger` which is the only one not preserving a GDI object but an int instead.

Finally I also considered not adding `Set()` to `wxDCPenChanger` and `wxDCBrushChanger` and always preserving the attribute with each of the six changer classes but decided not to:

* While it would allow for code to keep on using `wxDC::SetXXX()` calls, by using a changer's `Set()` it is clearer from a single line that a DC changer is involved which I think is worth something readability-wise.

* There's enough instances (of `wxDCTextColourChanger`) where an attribute eventually doesn't get changed that I think it's wasteful to then always preserve an attribute. It would also undo the behaviour first documented in 489cc69b396e927bdd62da9970cfe64951071f92.
