### PR TITLE
Fix compilation of wxFormBuilder-generated code using wxTE_XXX

### DIFF
--- a/include/wx/combobox.h
+++ b/include/wx/combobox.h
@@ -15,10 +15,6 @@
 
 #if wxUSE_COMBOBOX
 
-// For compatibility with 2.8 include this header to allow using wxTE_XXX
-// styles with wxComboBox without explicitly including it in the user code.
-#include "wx/textctrl.h"
-
 extern WXDLLIMPEXP_DATA_CORE(const char) wxComboBoxNameStr[];
 
 // ----------------------------------------------------------------------------

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -1736,6 +1736,19 @@ wxALLOW_COMBINING_ENUMS(wxDirection, wxGeometryCentre)
 #define wxLI_HORIZONTAL         wxHORIZONTAL
 #define wxLI_VERTICAL           wxVERTICAL
 
+/*
+    wxTextCtrl flags also used by other controls.
+
+    wxComboBox, wxSpinCtrl and may be others can also use some of these flags,
+    so define them in common header. More wxTE_XXX are in wx/textctrl.h.
+ */
+#define wxTE_READONLY       0x0010
+#define wxTE_MULTILINE      0x0020
+#define wxTE_PROCESS_TAB    0x0040
+
+#define wxTE_PROCESS_ENTER  0x0400
+#define wxTE_PASSWORD       0x0800
+
 
 /*
  * extended dialog specifiers. these values are stored in a different

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -57,11 +57,9 @@ const wxTextCoord wxInvalidTextCoord    = -2;
 // wxTextCtrl style flags
 // ----------------------------------------------------------------------------
 
-#define wxTE_NO_VSCROLL     0x0002
+// Some of wxTE_XXX are defined in wx/defs.h, they take 0x0C70 bits.
 
-#define wxTE_READONLY       0x0010
-#define wxTE_MULTILINE      0x0020
-#define wxTE_PROCESS_TAB    0x0040
+#define wxTE_NO_VSCROLL     0x0002
 
 // alignment flags
 #define wxTE_LEFT           0x0000                    // 0x0000
@@ -72,9 +70,6 @@ const wxTextCoord wxInvalidTextCoord    = -2;
 // this style means to use RICHEDIT control and does something only under wxMSW
 // and Win32 and is silently ignored under all other platforms
 #define wxTE_RICH           0x0080
-
-#define wxTE_PROCESS_ENTER  0x0400
-#define wxTE_PASSWORD       0x0800
 
 // automatically detect the URLs and generate the events when mouse is
 // moved/clicked over an URL


### PR DESCRIPTION
Move definitions of wxTE_XXX flags that can be used with the controls
other than wxTextCtrl to wx/defs.h, as wxFormBuilder generates code
using them without including wx/textctrl.h, so that this code doesn't
compile.

This was already addressed in 2970f22a89 (Include <wx/textctrl.h> from
<wx/combobox.h> for compatibility., 2012-03-25) for wxComboBox, but it
also happened for wxSpinCtrl, so fix it once and for all by always
defining these styles.

This partially reverts the changes done in c57e33394c ([...] moved
wxTextCtrl-specific stuff from defs.h/event.h to textctrl.h, 2001-07-29)
as it turns out, 20 years later, that this wasn't such a great idea.

See #14132.

Closes #19225.