### PR TITLE
Add CMake builds to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
     paths-ignore:
+      - '.github/workflows/ci_cmake.yml'
       - '.github/workflows/ci_msw_cross.yml'
       - 'build/tools/appveyor*.bat'
       - 'distrib/**'
@@ -22,6 +23,7 @@ on:
     branches:
       - master
     paths-ignore:
+      - '.github/workflows/ci_cmake.yml'
       - '.github/workflows/ci_msw_cross.yml'
       - 'build/tools/appveyor*.bat'
       - 'distrib/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,23 +119,7 @@ jobs:
         run: |
           echo LD_LIBRARY_PATH=`pwd`/lib >> $GITHUB_ENV
 
-          case `uname` in
-            Linux)
-                wxPROC_COUNT=`nproc`
-                ;;
-
-            Darwin)
-                wxPROC_COUNT=`sysctl -n hw.ncpu`
-                ;;
-
-            *)
-                echo "*** Unknown platform: `uname` ***"
-                wxPROC_COUNT=0
-                ;;
-          esac
-
-          ((wxPROC_COUNT++))
-          echo wxPROC_COUNT=$wxPROC_COUNT >> $GITHUB_ENV
+          wxPROC_COUNT=`./build/tools/proc_count.sh`
           echo wxBUILD_ARGS=-j$wxPROC_COUNT >> $GITHUB_ENV
 
           # Setting this variable suppresses "Error retrieving accessibility bus address"

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -1,0 +1,134 @@
+# CI workflow for wxWidgets builds using CMake.
+name: CMake builds
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '.github/workflows/ci.yml'
+      - '.github/workflows/ci_msw_cross.yml'
+      - 'build/tools/appveyor*.bat'
+      - 'distrib/**'
+      - 'docs/**'
+      - 'interface/**'
+      - 'include/msvc/**'
+      - 'include/wx/msw/**'
+      - 'locale/**'
+      - 'src/msw/**'
+      - '*.md'
+      - '*.yml'
+      - 'wxwidgets.props'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '.github/workflows/ci.yml'
+      - '.github/workflows/ci_msw_cross.yml'
+      - 'build/tools/appveyor*.bat'
+      - 'distrib/**'
+      - 'docs/**'
+      - 'interface/**'
+      - 'include/msvc/**'
+      - 'include/wx/msw/**'
+      - 'locale/**'
+      - 'src/msw/**'
+      - '*.md'
+      - '*.yml'
+      - 'wxwidgets.props'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.runner }}
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Ubuntu 18.04 wxGTK 3
+            runner: ubuntu-18.04
+            cmake_generator: Unix Makefiles
+          - name: macOS 10.15 wxOSX
+            runner: macos-10.15
+            cmake_generator: Xcode
+            cmake_defines: -DCMAKE_CXX_STANDARD=11
+          - name: macOS 10.15 wxIOS
+            runner: macos-10.15
+            cmake_generator: Xcode
+            cmake_defines: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_FIND_ROOT_PATH=/usr/local -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO
+            cmake_samples: OFF
+            cmake_tests: OFF
+
+    env:
+      wxGTK_VERSION: ${{ matrix.gtk_version && matrix.gtk_version || 3 }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Set environment variables
+        run: |
+          wxPROC_COUNT=`./build/tools/proc_count.sh`
+          if [ "${{ matrix.cmake_generator }}" == "Xcode" ]; then
+              # Xcode generates a lot of output, suppress it so only warnings and errors are visible
+              wxBUILD_ARGS="-jobs $wxPROC_COUNT -quiet"
+          else
+              wxBUILD_ARGS=-j$wxPROC_COUNT
+          fi
+          echo wxBUILD_ARGS=$wxBUILD_ARGS >> $GITHUB_ENV
+
+          cmake_tests=${{ matrix.cmake_tests }}
+          if [ -z $cmake_tests ]; then cmake_tests=CONSOLE_ONLY; fi
+          echo wxCMAKE_TESTS=$cmake_tests >> $GITHUB_ENV
+
+          cmake_samples=${{ matrix.cmake_samples }}
+          if [ -z $cmake_samples ]; then cmake_samples=SOME; fi
+          echo wxCMAKE_SAMPLES=$cmake_samples >> $GITHUB_ENV
+
+          # Setting this variable suppresses "Error retrieving accessibility bus address"
+          # messages from WebKit tests that we're not interested in.
+          echo NO_AT_BRIDGE=1 >> $GITHUB_ENV
+
+      - name: Before install
+        run: |
+          ./build/tools/before_install.sh
+
+      - name: Configuring
+        run: |
+          cmake --version
+          mkdir build_cmake
+          pushd build_cmake
+          cmake -G "${{ matrix.cmake_generator }}" ${{ matrix.cmake_defines }} -DwxBUILD_SAMPLES=$wxCMAKE_SAMPLES -DwxBUILD_TESTS=$wxCMAKE_TESTS ..
+
+      - name: Building
+        working-directory: build_cmake
+        run: |
+          cmake --build . -- $wxBUILD_ARGS
+
+      - name: Installing
+        working-directory: build_cmake
+        run: |
+          sudo cmake --build . --target install
+
+      - name: Testing
+        if: matrix.cmake_tests != 'OFF'
+        working-directory: build_cmake
+        run: |
+          . ../build/tools/httpbin.sh
+
+          httpbin_launch
+
+          ctest -V -C Debug --output-on-failure --interactive-debug-mode 0 . || rc=$?
+          if [ -n "$rc" ]; then
+              httpbin_show_log
+              exit $rc
+          fi
+
+      - name: Testing installation
+        run: |
+          mkdir build_cmake_install_test
+          pushd build_cmake_install_test
+          cmake -G "${{ matrix.cmake_generator }}" ${{ matrix.cmake_defines }} ../samples/minimal
+          cmake --build .

--- a/build/tools/proc_count.sh
+++ b/build/tools/proc_count.sh
@@ -1,0 +1,18 @@
+# This script outputs the number of available processors/cores plus one.
+
+case `uname` in
+    Linux)
+        wxPROC_COUNT=`nproc`
+        ;;
+
+    Darwin)
+        wxPROC_COUNT=`sysctl -n hw.ncpu`
+        ;;
+
+    *)
+        wxPROC_COUNT=0
+        ;;
+esac
+
+((wxPROC_COUNT++))
+echo $wxPROC_COUNT

--- a/include/wx/platform.h
+++ b/include/wx/platform.h
@@ -415,6 +415,7 @@
 #ifdef __WXOSX__
 /* setup precise defines according to sdk used */
 #   include <TargetConditionals.h>
+#   include <Availability.h>
 #   if defined(__WXOSX_IPHONE__)
 #       if !( defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE )
 #           error "incorrect SDK for an iPhone build"


### PR DESCRIPTION
These are not run by Travis anymore, so move them to GitHub Actions.

Based on `travis-ci.sh`, running tests and testing installation still need to be added.