### PR TITLE
Pass focus from wxWebViewEdge to the actual webview

### DIFF
--- a/include/wx/msw/webview_edge.h
+++ b/include/wx/msw/webview_edge.h
@@ -109,6 +109,8 @@ private:
 
     void OnSize(wxSizeEvent& event);
 
+    void OnSetFocus(wxFocusEvent& event);
+
     void OnTopLevelParentIconized(wxIconizeEvent& event);
 
     bool RunScriptSync(const wxString& javascript, wxString* output = NULL) const;

--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -535,6 +535,7 @@ bool wxWebViewEdge::Create(wxWindow* parent,
     if (!m_impl->Create())
         return false;
     Bind(wxEVT_SIZE, &wxWebViewEdge::OnSize, this);
+    Bind(wxEVT_SET_FOCUS, &wxWebViewEdge::OnSetFocus, this);
     wxWindow* topLevelParent = wxGetTopLevelParent(this);
     if (topLevelParent)
         topLevelParent->Bind(wxEVT_ICONIZE, &wxWebViewEdge::OnTopLevelParentIconized, this);
@@ -546,6 +547,13 @@ bool wxWebViewEdge::Create(wxWindow* parent,
 void wxWebViewEdge::OnSize(wxSizeEvent& event)
 {
     m_impl->UpdateBounds();
+    event.Skip();
+}
+
+void wxWebViewEdge::OnSetFocus(wxFocusEvent& event)
+{
+    if (m_impl && m_impl->m_webViewController)
+        m_impl->m_webViewController->MoveFocus(COREWEBVIEW2_MOVE_FOCUS_REASON_PROGRAMMATIC);
     event.Skip();
 }
 


### PR DESCRIPTION
It was impossible to give focus to the actual web view in wxWebViewEdge
by keyboard navigation or programmatically with wxWebViewEdge::SetFocus().

Fix it by calling CoreWebView2Controller::MoveFocus() in the wxWebViewEdge's
wxEVT_SET_FOCUS handler.

**EDIT**
The CI failure is unrelated (httpbin again).

Patched webview sample demonstrating issue with webview not obtaining focus by keyboard navigation is here: https://github.com/PBfordev/wxWidgets/commit/5248dd53610d30287af4f065d70ed0b5852afbe4

Code showing both keyboard and programmatic issues (the `User name` field in the webview should be focused after pressing the wxButton but is not) is here: https://gist.github.com/PBfordev/f1e71970aedca86b609ccc954f9a20b9
