### PR TITLE
Replace DoGetBorderSize() with GetWindowBorderSize()

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -196,6 +196,9 @@ Changes in behaviour which may result in build errors
 - wxImage constructor from XPM data is now explicit, write "wxImage(xpmData)"
   instead of just "xpmData" if you really need to use it.
 
+- wxWindow::DoGetBorderSize() was removed, if you used this non-public function
+  in your code, you can replace it with public GetWindowBorderSize().
+
 - Microsoft Visual Studio 2003 (a.k.a. MSVC 7) is not supported any longer, the
   minimum required version is now 2005.
 

--- a/include/wx/gtk/window.h
+++ b/include/wx/gtk/window.h
@@ -76,6 +76,8 @@ public:
 
     virtual bool Reparent( wxWindowBase *newParent ) wxOVERRIDE;
 
+    virtual wxSize GetWindowBorderSize() const wxOVERRIDE;
+
     virtual void WarpPointer(int x, int y) wxOVERRIDE;
 #ifdef __WXGTK3__
     virtual bool EnableTouchEvents(int eventsMask) wxOVERRIDE;
@@ -384,7 +386,6 @@ protected:
                            int width, int height,
                            int sizeFlags = wxSIZE_AUTO) wxOVERRIDE;
     virtual void DoSetClientSize(int width, int height) wxOVERRIDE;
-    virtual wxSize DoGetBorderSize() const wxOVERRIDE;
     virtual void DoMoveWindow(int x, int y, int width, int height) wxOVERRIDE;
     virtual void DoEnable(bool enable) wxOVERRIDE;
 

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -102,6 +102,7 @@ public:
     virtual wxSize GetDPI() const wxOVERRIDE;
     virtual double GetDPIScaleFactor() const wxOVERRIDE;
 
+    virtual wxSize GetWindowBorderSize() const wxOVERRIDE;
 
     virtual void WarpPointer(int x, int y) wxOVERRIDE;
     virtual bool EnableTouchEvents(int eventsMask) wxOVERRIDE;
@@ -653,8 +654,6 @@ protected:
                            int width, int height,
                            int sizeFlags = wxSIZE_AUTO) wxOVERRIDE;
     virtual void DoSetClientSize(int width, int height) wxOVERRIDE;
-
-    virtual wxSize DoGetBorderSize() const wxOVERRIDE;
 
     virtual void DoCaptureMouse() wxOVERRIDE;
     virtual void DoReleaseMouse() wxOVERRIDE;

--- a/include/wx/univ/window.h
+++ b/include/wx/univ/window.h
@@ -197,6 +197,8 @@ public:
         return wxWindowNative::IsClientAreaChild(child);
     }
 
+    virtual wxSize GetWindowBorderSize() const wxOVERRIDE;
+
 protected:
     // common part of all ctors
     void Init();
@@ -233,9 +235,6 @@ protected:
 
     // draw the controls contents
     virtual void DoDraw(wxControlRenderer *renderer);
-
-    // override the base class method to return the size of the window borders
-    virtual wxSize DoGetBorderSize() const wxOVERRIDE;
 
     // adjust the size of the window to take into account its borders
     wxSize AdjustSize(const wxSize& size) const;

--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -1909,15 +1909,6 @@ protected:
                                  int maxW, int maxH,
                                  int incW, int incH );
 
-    // return the total size of the window borders, i.e. the sum of the widths
-    // of the left and the right border in the x component of the returned size
-    // and the sum of the heights of the top and bottom borders in the y one
-    //
-    // NB: this is currently only implemented properly for wxMSW, wxGTK and
-    //     wxUniv and doesn't behave correctly in the presence of scrollbars in
-    //     the other ports
-    virtual wxSize DoGetBorderSize() const;
-
     // move the window to the specified location and resize it: this is called
     // from both DoSetSize() and DoSetClientSize() and would usually just
     // reposition this window except for composite controls which will want to

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -892,18 +892,6 @@ wxSize wxWindowBase::GetEffectiveMinSize() const
     return min;
 }
 
-wxSize wxWindowBase::DoGetBorderSize() const
-{
-    // there is one case in which we can implement it for all ports easily
-    if ( GetBorder() == wxBORDER_NONE )
-        return wxSize(0, 0);
-
-    // otherwise use the difference between the real size and the client size
-    // as a fallback: notice that this is incorrect in general as client size
-    // also doesn't take the scrollbars into account
-    return GetSize() - GetClientSize();
-}
-
 wxSize wxWindowBase::GetBestSize() const
 {
     if ( !m_windowSizer && m_bestSizeCache.IsFullySpecified() )
@@ -913,7 +901,7 @@ wxSize wxWindowBase::GetBestSize() const
     // it to be used
     wxSize size = DoGetBestClientSize();
     if ( size != wxDefaultSize )
-        size += DoGetBorderSize();
+        size += GetWindowBorderSize();
     else
         size = DoGetBestSize();
 
@@ -934,7 +922,7 @@ int wxWindowBase::GetBestHeight(int width) const
 
     return height == wxDefaultCoord
             ? GetBestSize().y
-            : height + DoGetBorderSize().y;
+            : height + GetWindowBorderSize().y;
 }
 
 int wxWindowBase::GetBestWidth(int height) const
@@ -943,7 +931,7 @@ int wxWindowBase::GetBestWidth(int height) const
 
     return width == wxDefaultCoord
             ? GetBestSize().x
-            : width + DoGetBorderSize().x;
+            : width + GetWindowBorderSize().x;
 }
 
 void wxWindowBase::SetMinSize(const wxSize& minSize)

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -4021,7 +4021,7 @@ void wxWindowGTK::DoGetClientSize( int *width, int *height ) const
             }
         }
 
-        const wxSize sizeBorders = DoGetBorderSize();
+        const wxSize sizeBorders = GetWindowBorderSize();
         w -= sizeBorders.x;
         h -= sizeBorders.y;
 
@@ -4035,10 +4035,10 @@ void wxWindowGTK::DoGetClientSize( int *width, int *height ) const
     if (height) *height = h;
 }
 
-wxSize wxWindowGTK::DoGetBorderSize() const
+wxSize wxWindowGTK::GetWindowBorderSize() const
 {
     if ( !m_wxwindow )
-        return wxWindowBase::DoGetBorderSize();
+        return wxWindowBase::GetWindowBorderSize();
 
     GtkBorder border;
     WX_PIZZA(m_wxwindow)->get_border(border);

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -1604,7 +1604,7 @@ wxSize wxListCtrl::MSWGetBestViewRect(int x, int y) const
     // OTOH we have to subtract the size of our borders because the base class
     // public method already adds them, but ListView_ApproximateViewRect()
     // already takes the borders into account, so this would be superfluous.
-    return size - DoGetBorderSize();
+    return size - GetWindowBorderSize();
 }
 
 // ----------------------------------------------------------------------------

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -2249,7 +2249,7 @@ void wxWindowMSW::DoSetClientSize(int width, int height)
     }
 }
 
-wxSize wxWindowMSW::DoGetBorderSize() const
+wxSize wxWindowMSW::GetWindowBorderSize() const
 {
     wxCoord border;
     switch ( GetBorder() )

--- a/src/propgrid/manager.cpp
+++ b/src/propgrid/manager.cpp
@@ -291,7 +291,7 @@ private:
         wxPropertyGrid* pg = m_manager->GetGrid();
 
         // Internal border width
-        int borderWidth = pg->DoGetBorderSize().x / 2;
+        int borderWidth = pg->GetWindowBorderSize().x / 2;
 
         const unsigned int colCount = m_page->GetColumnCount();
         for ( unsigned int i = 0; i < colCount; i++ )
@@ -327,7 +327,7 @@ private:
         wxPropertyGrid* pg = m_manager->GetGrid();
 
         // Internal border width
-        int borderWidth = pg->DoGetBorderSize().x / 2;
+        int borderWidth = pg->GetWindowBorderSize().x / 2;
 
         // Compensate for the internal border
         int x = -borderWidth;

--- a/src/univ/winuniv.cpp
+++ b/src/univ/winuniv.cpp
@@ -712,7 +712,7 @@ void wxWindow::OnSize(wxSizeEvent& event)
 #endif
 }
 
-wxSize wxWindow::DoGetBorderSize() const
+wxSize wxWindow::GetWindowBorderSize() const
 {
     return AdjustSize(wxSize(0, 0));
 }


### PR DESCRIPTION
We accidentally ended up with two functions doing the same thing, since
DoGetBorderSize() was added in 743b426605 (Added DoGetClientBestSize()
and use it for a couple of controls in wxMSW., 2009-06-22), as we
already had GetWindowBorderSize() added even earlier in 333d70525c
(added wxWindow::GetWindowBorderSize(), 2006-11-25), so remove the
redundant non-public function and use GetWindowBorderSize() everywhere.

This does change the behaviour of GetWindowBorderSize() in wxMSW, wxGTK
and wxUniv, as it now does what DoGetBorderSize() used to do, but this
should be an improvement, as DoGetBorderSize() implementation was more
precise.

---

See [this post](https://groups.google.com/g/wx-dev/c/qjwtnkHzcJM/m/AdBjGfuAAgAJ) for more details.