### PR TITLE
Fixes for rendering text with bottom/right alignment

### DIFF
--- a/samples/dataview/mymodels.cpp
+++ b/samples/dataview/mymodels.cpp
@@ -339,9 +339,12 @@ static int my_sort( int *v1, int *v2 )
 
 #define INITIAL_NUMBER_OF_ITEMS 10000
 
-MyListModel::MyListModel() :
+MyListModel::MyListModel(int modelFlags) :
         wxDataViewVirtualListModel( INITIAL_NUMBER_OF_ITEMS )
 {
+    const wxString multiLineText = L"top (\u1ED6)\ncentre\nbottom (g)";
+    const bool useMultiLine = (modelFlags & MODEL_USE_MULTI_LINE_TEXT) != 0;
+
     // the first 100 items are really stored in this model;
     // all the others are synthesized on request
     static const unsigned NUMBER_REAL_ITEMS = 100;
@@ -349,17 +352,32 @@ MyListModel::MyListModel() :
     m_toggleColValues.reserve(NUMBER_REAL_ITEMS);
     m_textColValues.reserve(NUMBER_REAL_ITEMS);
     m_toggleColValues.push_back(false);
-    m_textColValues.push_back("first row with long label to test ellipsization");
+    m_textColValues.push_back(useMultiLine
+        ? multiLineText
+        : wxString("first row with long label to test ellipsization"));
     for (unsigned int i = 1; i < NUMBER_REAL_ITEMS; i++)
     {
         m_toggleColValues.push_back(false);
         m_textColValues.push_back(wxString::Format("real row %d", i));
     }
 
-    m_iconColValues.assign(NUMBER_REAL_ITEMS, "test");
+    m_iconColValues.assign(NUMBER_REAL_ITEMS,
+        useMultiLine ? multiLineText : wxString("test"));
 
     m_icon[0] = wxIcon( null_xpm );
-    m_icon[1] = wxIcon( wx_small_xpm );
+
+    const int newSize = m_icon[0].GetWidth() * 2;
+    const bool useTallRows = (modelFlags & MODEL_USE_TALL_ROWS) != 0;
+
+    if ( useTallRows )
+        m_icon[0].CopyFromBitmap(
+            wxImage(null_xpm).Rescale(newSize, newSize));
+
+    if ( !useTallRows || (modelFlags & MODEL_KEEP_LOGO_SMALL) )
+        m_icon[1] = wxIcon( wx_small_xpm );
+    else
+        m_icon[1].CopyFromBitmap(
+            wxImage(wx_small_xpm).Rescale(newSize, newSize));
 }
 
 void MyListModel::Prepend( const wxString &text )

--- a/samples/dataview/mymodels.h
+++ b/samples/dataview/mymodels.h
@@ -216,7 +216,7 @@ public:
         Col_Max
     };
 
-    MyListModel();
+    MyListModel(int modelFlags);
 
     // helper methods to change the model
 
@@ -309,4 +309,11 @@ private:
     wxArrayString m_strings;
 
     wxDECLARE_NO_COPY_CLASS(MyIndexListModel);
+};
+
+enum ModelFlags
+{
+    MODEL_USE_TALL_ROWS = 1 << 0,
+    MODEL_KEEP_LOGO_SMALL = 1 << 1,
+    MODEL_USE_MULTI_LINE_TEXT = 1 << 2
 };

--- a/samples/render/render.cpp
+++ b/samples/render/render.cpp
@@ -246,6 +246,26 @@ private:
         dc.DrawText("Using flags: " + flagsString, x1, y);
         y += lineHeight*3;
 
+        const wxCoord heightListItem = FromDIP(48);
+        const wxCoord widthListItem = 30*GetCharWidth();
+
+        {
+
+        dc.DrawText("DrawItemText() alignment", x1, y);
+
+        wxRect textRect(x2, y, widthListItem, heightListItem);
+        wxDCBrushChanger setBrush(dc, *wxTRANSPARENT_BRUSH);
+        wxDCPenChanger setPen(dc, *wxGREEN_PEN);
+        dc.DrawRectangle(textRect);
+
+        renderer.DrawItemText(this, dc, L"Top Left (\u1ED6)", textRect);
+        renderer.DrawItemText(this, dc, "Bottom right", textRect,
+            wxALIGN_BOTTOM | wxALIGN_RIGHT);
+
+        y += lineHeight + heightListItem;
+
+        }
+
         const wxCoord heightHdr = renderer.GetHeaderButtonHeight(this);
         const wxCoord width = 15*GetCharWidth();
 
@@ -345,9 +365,6 @@ private:
             25, 100, m_flags | wxCONTROL_SPECIAL);
 
         y += lineHeight + heightGauge;
-
-        const wxCoord heightListItem = FromDIP(48);
-        const wxCoord widthListItem = 30*GetCharWidth();
 
         dc.DrawText("DrawItemSelectionRect()", x1, y);
         renderer.DrawItemSelectionRect(this, dc,

--- a/samples/render/render.cpp
+++ b/samples/render/render.cpp
@@ -288,9 +288,15 @@ private:
                                wxRect(wxPoint(x2, y), sizeMark), m_flags);
         y += lineHeight + sizeMark.y;
 
+        const wxString notImplementedText = "(generic version unimplemented)";
+
         dc.DrawText("DrawRadioBitmap()", x1, y);
-        renderer.DrawRadioBitmap(this, dc,
-                                 wxRect(wxPoint(x2, y), sizeCheck), m_flags);
+        if ( m_useGeneric )
+            dc.DrawText(notImplementedText, x2, y);
+        else
+            renderer.DrawRadioBitmap(this, dc,
+                                     wxRect(wxPoint(x2, y), sizeCheck), m_flags);
+
         y += lineHeight + sizeCheck.y;
 
         dc.DrawText("DrawCollapseButton()", x1, y);
@@ -354,8 +360,11 @@ private:
 
         y += lineHeight;
         dc.DrawText("DrawChoice()", x1, y);
-        renderer.DrawChoice(this, dc,
-                            wxRect(x2, y, width, 1.5*GetCharHeight()), m_flags);
+        if ( m_useGeneric )
+            dc.DrawText(notImplementedText, x2, y);
+        else
+            renderer.DrawChoice(this, dc,
+                                wxRect(x2, y, width, 1.5*GetCharHeight()), m_flags);
     }
 
     int m_flags;

--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -1090,17 +1090,12 @@ wxDataViewCustomRendererBase::RenderText(const wxString& text,
     if ( !(GetOwner()->GetOwner()->IsEnabled() && GetEnabled()) )
         flags |= wxCONTROL_DISABLED;
 
-    // Notice that we intentionally don't use any alignment here: it is not
-    // necessary because the cell rectangle had been already adjusted to
-    // account for the alignment in WXCallRender() and using the alignment here
-    // results in problems with ellipsization when using native MSW renderer,
-    // see https://trac.wxwidgets.org/ticket/17363, so just don't do it.
     wxRendererNative::Get().DrawItemText(
         GetOwner()->GetOwner(),
         *dc,
         text,
         rectText,
-        wxALIGN_NOT,
+        GetEffectiveAlignment(),
         flags,
         GetEllipsizeMode());
 }

--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -32,6 +32,10 @@
     #include "wx/access.h"
 #endif // wxUSE_ACCESSIBILITY
 
+// Uncomment this line to, for custom renderers, visually show the extent
+// of both a cell and its item.
+//#define DEBUG_RENDER_EXTENTS
+
 const char wxDataViewCtrlNameStr[] = "dataviewCtrl";
 
 namespace
@@ -1034,6 +1038,20 @@ wxDataViewCustomRendererBase::WXCallRender(wxRect rectCell, wxDC *dc, int state)
     wxDCFontChanger changeFont(*dc);
     if ( m_attr.HasFont() )
         changeFont.Set(m_attr.GetEffectiveFont(dc->GetFont()));
+
+#ifdef DEBUG_RENDER_EXTENTS
+    {
+
+    wxDCBrushChanger changeBrush(*dc, *wxTRANSPARENT_BRUSH);
+    wxDCPenChanger changePen(*dc, *wxRED);
+
+    dc->DrawRectangle(rectCell);
+
+    dc->SetPen(*wxGREEN);
+    dc->DrawRectangle(rectItem);
+
+    }
+#endif
 
     Render(rectItem, dc, state);
 }

--- a/src/common/dcbase.cpp
+++ b/src/common/dcbase.cpp
@@ -1196,7 +1196,7 @@ void wxDC::DrawLabel(const wxString& text,
     wxCoord x, y;
     if ( alignment & wxALIGN_RIGHT )
     {
-        x = rect.GetRight() - width;
+        x = rect.GetRight() - width + 1;
     }
     else if ( alignment & wxALIGN_CENTRE_HORIZONTAL )
     {
@@ -1209,7 +1209,7 @@ void wxDC::DrawLabel(const wxString& text,
 
     if ( alignment & wxALIGN_BOTTOM )
     {
-        y = rect.GetBottom() - height;
+        y = rect.GetBottom() - height + 1;
     }
     else if ( alignment & wxALIGN_CENTRE_VERTICAL )
     {

--- a/src/common/dcgraph.cpp
+++ b/src/common/dcgraph.cpp
@@ -1279,13 +1279,13 @@ void wxGCDCImpl::DoGetTextExtent( const wxString &str, wxCoord *width, wxCoord *
                       );
 
     if ( height )
-        *height = (wxCoord)wxRound(h);
+        *height = (wxCoord)ceil(h);
     if ( descent )
-        *descent = (wxCoord)wxRound(d);
+        *descent = (wxCoord)ceil(d);
     if ( externalLeading )
-        *externalLeading = (wxCoord)wxRound(e);
+        *externalLeading = (wxCoord)ceil(e);
     if ( width )
-        *width = (wxCoord)wxRound(w);
+        *width = (wxCoord)ceil(w);
 
     if ( theFont )
     {

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -1057,7 +1057,7 @@ void wxRendererXP::DrawItemText(wxWindow* win,
         s_initDone = true;
     }
 
-    if ( s_DrawThemeTextEx && // Might be not available if we're under XP
+    if ( s_DrawThemeTextEx && // Not available under XP
             ::IsThemePartDefined(hTheme, LVP_LISTITEM, 0) )
     {
         RECT rc = ConvertToRECT(dc, rect);

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -1093,10 +1093,7 @@ void wxRendererXP::DrawItemText(wxWindow* win,
         if ( align & wxALIGN_CENTER_HORIZONTAL )
             textFlags |= DT_CENTER;
         else if ( align & wxALIGN_RIGHT )
-        {
             textFlags |= DT_RIGHT;
-            rc.right--; // Alignment is inconsistent with DrawLabel otherwise
-        }
         else
             textFlags |= DT_LEFT;
 

--- a/src/univ/ctrlrend.cpp
+++ b/src/univ/ctrlrend.cpp
@@ -185,7 +185,7 @@ void wxControlRenderer::DrawBitmap(wxDC &dc,
     {
         if ( alignment & wxALIGN_RIGHT )
         {
-            x = rect.GetRight() - width;
+            x = rect.GetRight() - width + 1;
         }
         else if ( alignment & wxALIGN_CENTRE )
         {
@@ -198,7 +198,7 @@ void wxControlRenderer::DrawBitmap(wxDC &dc,
 
         if ( alignment & wxALIGN_BOTTOM )
         {
-            y = rect.GetBottom() - height;
+            y = rect.GetBottom() - height + 1;
         }
         else if ( alignment & wxALIGN_CENTRE_VERTICAL )
         {


### PR DESCRIPTION
Fixes several generic and Windows specific drawing issues, almost all with text, that can be seen by using `DrawItemText()` with bottom and right alignment in the render sample starting with 8388a70.

Some notes:

Both commits that get reverted were originally a result of `wxDC::DrawLabel()`'s off-by-one with right aligned text (see also 129cf3a). The off-by-ones seem to have always been there and it's likely that it affects other user/wx code as well in silent ways. So far I have only noticed small offset differences that got more noticeable and required changing `wxGCDCImpl::DoGetTextExtent()` (see d9d0ff9).

The changes to the dataview sample included in this PR also help with demonstrating some of the problems described in commit messages. I tried to make the changes a bit generic and not too debug specific. For the render sample they are more crude and could perhaps use similar alignment options (it already has them for horizontal alignment), so that a single `DrawItemSelectionRect()` can be used to also show e.g. bottom alignment.

Finally regarding the new usage of `::GetThemeTextExtent()`: Here it's only used for positioning multi-line text but in general it results in better calculated extents for themed text. It should eventually probably be refactored to be used somehow by wx' text measurement code elsewhere.