### PR TITLE
Fixes for tests for wxTextCtrl in wxUniv

### DIFF
--- a/include/wx/univ/textctrl.h
+++ b/include/wx/univ/textctrl.h
@@ -36,6 +36,7 @@ class WXDLLIMPEXP_FWD_CORE wxTextCtrlCommandProcessor;
 #define wxACTION_TEXT_WORD_RIGHT    wxT("wordright")
 #define wxACTION_TEXT_PAGE_UP       wxT("pageup")
 #define wxACTION_TEXT_PAGE_DOWN     wxT("pagedown")
+#define wxACTION_TEXT_RETURN        wxT("return")
 
 // clipboard operations
 #define wxACTION_TEXT_COPY          wxT("copy")
@@ -450,6 +451,8 @@ protected:
     // return code)
     bool DoCut();
     bool DoPaste();
+
+    bool ClickDefaultButtonIfPossible();
 
 private:
     // all these methods are for multiline text controls only

--- a/include/wx/univ/textctrl.h
+++ b/include/wx/univ/textctrl.h
@@ -451,12 +451,6 @@ protected:
     bool DoCut();
     bool DoPaste();
 
-#ifdef __WXMSW__
-public:
-    // override MSWHandleMessage to process WM_GETDLGCODE
-    bool MSWHandleMessage(WXLRESULT *result, WXUINT message, WXWPARAM wParam, WXLPARAM lParam);
-#endif // __WXMSW__
-
 private:
     // all these methods are for multiline text controls only
 

--- a/include/wx/univ/textctrl.h
+++ b/include/wx/univ/textctrl.h
@@ -451,6 +451,12 @@ protected:
     bool DoCut();
     bool DoPaste();
 
+#ifdef __WXMSW__
+public:
+    // override MSWHandleMessage to process WM_GETDLGCODE
+    bool MSWHandleMessage(WXLRESULT *result, WXUINT message, WXWPARAM wParam, WXLPARAM lParam);
+#endif // __WXMSW__
+
 private:
     // all these methods are for multiline text controls only
 

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -2676,104 +2676,7 @@ bool wxWindowMSW::MSWProcessMessage(WXMSG* pMsg)
         }
     }
 #else // __WXUNIVERSAL__
-    // But it also handles clicks on default button
-    if ( m_hWnd &&
-            HasFlag(wxTAB_TRAVERSAL) &&
-                wxHasWindowExStyle(this, WS_EX_CONTROLPARENT) )
-    {
-        MSG *msg = (MSG *)pMsg;
-
-        if ( msg->message == WM_KEYDOWN )
-        {
-            bool bCtrlDown = wxIsCtrlDown();
-
-            // WM_GETDLGCODE: ask the control if it wants the key for itself,
-            // don't process it if it's the case (except for Ctrl-Tab/Enter
-            // combinations which are always processed)
-            LONG lDlgCode = ::SendMessage(msg->hwnd, WM_GETDLGCODE, 0, 0);
-
-            // surprisingly, DLGC_WANTALLKEYS bit mask doesn't contain the
-            // DLGC_WANTTAB nor DLGC_WANTARROWS bits although, logically,
-            // it, of course, implies them
-            if ( lDlgCode & DLGC_WANTALLKEYS )
-            {
-                lDlgCode |= DLGC_WANTTAB | DLGC_WANTARROWS;
-            }
-
-            switch ( msg->wParam )
-            {
-                case VK_RETURN:
-                    {
-#if wxUSE_BUTTON
-                        // currently active button should get enter press even
-                        // if there is a default button elsewhere so check if
-                        // this window is a button first
-                        wxButton *btn = NULL;
-                        if ( lDlgCode & DLGC_DEFPUSHBUTTON )
-                        {
-                            // let IsDialogMessage() handle this for all
-                            // buttons except the owner-drawn ones which it
-                            // just seems to ignore
-                            long style = ::GetWindowLong(msg->hwnd, GWL_STYLE);
-                            if ( (style & BS_OWNERDRAW) == BS_OWNERDRAW )
-                            {
-                                btn = wxDynamicCast
-                                      (
-                                        wxFindWinFromHandle(msg->hwnd),
-                                        wxButton
-                                      );
-                            }
-                        }
-                        else // not a button itself, do we have default button?
-                        {
-                            // check if this window or any of its ancestors
-                            // wants the message for itself (we always reserve
-                            // Ctrl-Enter for dialog navigation though)
-                            wxWindow *win = wxDynamicCast(this, wxWindow);
-                            if ( !bCtrlDown )
-                            {
-                                // this will contain the dialog code of this
-                                // window and all of its parent windows in turn
-                                LONG lDlgCode2 = lDlgCode;
-
-                                while ( win )
-                                {
-                                    if ( lDlgCode2 & DLGC_WANTMESSAGE )
-                                    {
-                                        // as it wants to process Enter itself,
-                                        // don't call IsDialogMessage() which
-                                        // would consume it
-                                        return false;
-                                    }
-
-                                    // don't propagate keyboard messages beyond
-                                    // the first top level window parent
-                                    if ( win->IsTopLevel() )
-                                        break;
-
-                                    win = win->GetParent();
-
-                                    lDlgCode2 = ::SendMessage
-                                                  (
-                                                    GetHwndOf(win),
-                                                    WM_GETDLGCODE,
-                                                    0,
-                                                    0
-                                                  );
-                                }
-                            }
-
-                            btn = MSWGetDefaultButtonFor(win);
-                        }
-
-                        if ( MSWClickButtonIfPossible(btn) )
-                            return true;
-#endif // wxUSE_BUTTON
-                    }
-                    break;
-            }
-        }
-    }
+    wxUnusedVar(pMsg);
 #endif // !__WXUNIVERSAL__/__WXUNIVERSAL__
 
 #if wxUSE_TOOLTIPS
@@ -2909,14 +2812,8 @@ bool wxWindowMSW::MSWClickButtonIfPossible(wxButton* btn)
 #if wxUSE_BUTTON
     if ( btn && btn->IsEnabled() && btn->IsShownOnScreen() )
     {
-#ifndef __WXUNIVERSAL__
         btn->MSWCommand(BN_CLICKED, 0 /* unused */);
         return true;
-#endif // !__WXUNIVERSAL
-
-        wxCommandEvent event(wxEVT_BUTTON, btn->GetId());
-        event.SetEventObject(btn);
-        return btn->HandleWindowEvent(event);
     }
 #endif // wxUSE_BUTTON
 

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -2676,7 +2676,104 @@ bool wxWindowMSW::MSWProcessMessage(WXMSG* pMsg)
         }
     }
 #else // __WXUNIVERSAL__
-    wxUnusedVar(pMsg);
+    // But it also handles clicks on default button
+    if ( m_hWnd &&
+            HasFlag(wxTAB_TRAVERSAL) &&
+                wxHasWindowExStyle(this, WS_EX_CONTROLPARENT) )
+    {
+        MSG *msg = (MSG *)pMsg;
+
+        if ( msg->message == WM_KEYDOWN )
+        {
+            bool bCtrlDown = wxIsCtrlDown();
+
+            // WM_GETDLGCODE: ask the control if it wants the key for itself,
+            // don't process it if it's the case (except for Ctrl-Tab/Enter
+            // combinations which are always processed)
+            LONG lDlgCode = ::SendMessage(msg->hwnd, WM_GETDLGCODE, 0, 0);
+
+            // surprisingly, DLGC_WANTALLKEYS bit mask doesn't contain the
+            // DLGC_WANTTAB nor DLGC_WANTARROWS bits although, logically,
+            // it, of course, implies them
+            if ( lDlgCode & DLGC_WANTALLKEYS )
+            {
+                lDlgCode |= DLGC_WANTTAB | DLGC_WANTARROWS;
+            }
+
+            switch ( msg->wParam )
+            {
+                case VK_RETURN:
+                    {
+#if wxUSE_BUTTON
+                        // currently active button should get enter press even
+                        // if there is a default button elsewhere so check if
+                        // this window is a button first
+                        wxButton *btn = NULL;
+                        if ( lDlgCode & DLGC_DEFPUSHBUTTON )
+                        {
+                            // let IsDialogMessage() handle this for all
+                            // buttons except the owner-drawn ones which it
+                            // just seems to ignore
+                            long style = ::GetWindowLong(msg->hwnd, GWL_STYLE);
+                            if ( (style & BS_OWNERDRAW) == BS_OWNERDRAW )
+                            {
+                                btn = wxDynamicCast
+                                      (
+                                        wxFindWinFromHandle(msg->hwnd),
+                                        wxButton
+                                      );
+                            }
+                        }
+                        else // not a button itself, do we have default button?
+                        {
+                            // check if this window or any of its ancestors
+                            // wants the message for itself (we always reserve
+                            // Ctrl-Enter for dialog navigation though)
+                            wxWindow *win = wxDynamicCast(this, wxWindow);
+                            if ( !bCtrlDown )
+                            {
+                                // this will contain the dialog code of this
+                                // window and all of its parent windows in turn
+                                LONG lDlgCode2 = lDlgCode;
+
+                                while ( win )
+                                {
+                                    if ( lDlgCode2 & DLGC_WANTMESSAGE )
+                                    {
+                                        // as it wants to process Enter itself,
+                                        // don't call IsDialogMessage() which
+                                        // would consume it
+                                        return false;
+                                    }
+
+                                    // don't propagate keyboard messages beyond
+                                    // the first top level window parent
+                                    if ( win->IsTopLevel() )
+                                        break;
+
+                                    win = win->GetParent();
+
+                                    lDlgCode2 = ::SendMessage
+                                                  (
+                                                    GetHwndOf(win),
+                                                    WM_GETDLGCODE,
+                                                    0,
+                                                    0
+                                                  );
+                                }
+                            }
+
+                            btn = MSWGetDefaultButtonFor(win);
+                        }
+
+                        if ( MSWClickButtonIfPossible(btn) )
+                            return true;
+#endif // wxUSE_BUTTON
+                    }
+                    break;
+            }
+        }
+    }
 #endif // !__WXUNIVERSAL__/__WXUNIVERSAL__
 
 #if wxUSE_TOOLTIPS
@@ -2812,8 +2909,14 @@ bool wxWindowMSW::MSWClickButtonIfPossible(wxButton* btn)
 #if wxUSE_BUTTON
     if ( btn && btn->IsEnabled() && btn->IsShownOnScreen() )
     {
+#ifndef __WXUNIVERSAL__
         btn->MSWCommand(BN_CLICKED, 0 /* unused */);
         return true;
+#endif // !__WXUNIVERSAL
+
+        wxCommandEvent event(wxEVT_BUTTON, btn->GetId());
+        event.SetEventObject(btn);
+        return btn->HandleWindowEvent(event);
     }
 #endif // wxUSE_BUTTON
 

--- a/src/univ/dialog.cpp
+++ b/src/univ/dialog.cpp
@@ -96,8 +96,12 @@ void wxDialog::OnOK(wxCommandEvent &WXUNUSED(event))
         }
         else
         {
-            SetReturnCode(wxID_OK);
-            Show(false);
+            // don't change return code from event char if it was set earlier
+            if (GetReturnCode() == 0)
+            {
+                SetReturnCode(wxID_OK);
+                Show(false);
+            }
         }
     }
 }

--- a/src/univ/dialog.cpp
+++ b/src/univ/dialog.cpp
@@ -96,12 +96,8 @@ void wxDialog::OnOK(wxCommandEvent &WXUNUSED(event))
         }
         else
         {
-            // don't change return code from event char if it was set earlier
-            if (GetReturnCode() == 0)
-            {
-                SetReturnCode(wxID_OK);
-                Show(false);
-            }
+            SetReturnCode(wxID_OK);
+            Show(false);
         }
     }
 }

--- a/src/univ/textctrl.cpp
+++ b/src/univ/textctrl.cpp
@@ -2884,16 +2884,7 @@ wxTextCtrlHitTestResult wxTextCtrl::HitTestLine(const wxString& line,
     dc.GetTextExtent(line, &width, NULL);
     if ( x >= width )
     {
-        // clicking beyond the end of line is equivalent to clicking at
-        // the end of it, so return the last line column
         col = line.length();
-        if ( col )
-        {
-            // unless the line is empty and so doesn't have any column at all -
-            // in this case return 0, what else can we do?
-            col--;
-        }
-
         res = wxTE_HT_BEYOND;
     }
     else if ( x < 0 )

--- a/src/univ/textctrl.cpp
+++ b/src/univ/textctrl.cpp
@@ -790,10 +790,7 @@ void wxTextCtrl::DoSetValue(const wxString& value, int flags)
 
         Replace(0, GetLastPosition(), value);
 
-        if ( IsSingleLine() )
-        {
-            SetInsertionPoint(0);
-        }
+        SetInsertionPoint(0);
     }
     else // nothing changed
     {

--- a/src/univ/textctrl.cpp
+++ b/src/univ/textctrl.cpp
@@ -4805,28 +4805,6 @@ void wxTextCtrl::OnChar(wxKeyEvent& event)
     event.Skip();
 }
 
-#ifdef __WXMSW__
-bool wxTextCtrl::MSWHandleMessage(WXLRESULT* result, WXUINT message, WXWPARAM wParam, WXLPARAM lParam)
-{
-    bool processed = wxTextCtrlBase::MSWHandleMessage(result, message, wParam, lParam);
-    switch ( message )
-    {
-        case WM_GETDLGCODE:
-            {
-                long lDlgCode = 0;
-
-                // multiline controls should always get ENTER for themselves
-                if ( HasFlag(wxTE_PROCESS_ENTER) || HasFlag(wxTE_MULTILINE) )
-                    lDlgCode |= DLGC_WANTMESSAGE;
-
-                *result |= lDlgCode;
-                return true;
-            }
-    }
-    return processed;
-}
-#endif // __WXMSW__
-
 /* static */
 wxInputHandler *wxTextCtrl::GetStdInputHandler(wxInputHandler *handlerDef)
 {

--- a/src/univ/textctrl.cpp
+++ b/src/univ/textctrl.cpp
@@ -4763,7 +4763,8 @@ void wxTextCtrl::OnChar(wxKeyEvent& event)
                 wxCommandEvent event(wxEVT_TEXT_ENTER, GetId());
                 InitCommandEvent(event);
                 event.SetString(GetValue());
-                GetEventHandler()->ProcessEvent(event);
+                if( GetEventHandler()->ProcessEvent(event) )
+                    return;
             }
 
             if ( IsSingleLine() )

--- a/src/univ/textctrl.cpp
+++ b/src/univ/textctrl.cpp
@@ -4805,6 +4805,28 @@ void wxTextCtrl::OnChar(wxKeyEvent& event)
     event.Skip();
 }
 
+#ifdef __WXMSW__
+bool wxTextCtrl::MSWHandleMessage(WXLRESULT* result, WXUINT message, WXWPARAM wParam, WXLPARAM lParam)
+{
+    bool processed = wxTextCtrlBase::MSWHandleMessage(result, message, wParam, lParam);
+    switch ( message )
+    {
+        case WM_GETDLGCODE:
+            {
+                long lDlgCode = 0;
+
+                // multiline controls should always get ENTER for themselves
+                if ( HasFlag(wxTE_PROCESS_ENTER) || HasFlag(wxTE_MULTILINE) )
+                    lDlgCode |= DLGC_WANTMESSAGE;
+
+                *result |= lDlgCode;
+                return true;
+            }
+    }
+    return processed;
+}
+#endif // __WXMSW__
+
 /* static */
 wxInputHandler *wxTextCtrl::GetStdInputHandler(wxInputHandler *handlerDef)
 {

--- a/src/univ/textctrl.cpp
+++ b/src/univ/textctrl.cpp
@@ -2454,7 +2454,7 @@ void wxTextCtrl::UpdateLastVisible()
         return;
 
     // use (efficient) HitTestLine to find the last visible character
-    wxString text = m_value;//m_value.Mid((size_t)SData().m_colStart /* to the end */);
+    wxString text = m_value;
     wxTextCoord col;
     switch ( HitTestLine(text, m_rectText.width, &col) )
     {

--- a/src/univ/textctrl.cpp
+++ b/src/univ/textctrl.cpp
@@ -2459,7 +2459,7 @@ void wxTextCtrl::UpdateLastVisible()
         return;
 
     // use (efficient) HitTestLine to find the last visible character
-    wxString text = m_value.Mid((size_t)SData().m_colStart /* to the end */);
+    wxString text = m_value;//m_value.Mid((size_t)SData().m_colStart /* to the end */);
     wxTextCoord col;
     switch ( HitTestLine(text, m_rectText.width, &col) )
     {
@@ -3379,7 +3379,7 @@ void wxTextCtrl::ScrollText(wxTextCoord col)
         SData().m_colStart = col;
 
         // after changing m_colStart, recalc the last visible position: we need
-        // to recalc the last visible position beore scrolling in order to make
+        // to recalc the last visible position before scrolling in order to make
         // it appear exactly at the right edge of the text area after scrolling
         UpdateLastVisible();
 

--- a/src/univ/textctrl.cpp
+++ b/src/univ/textctrl.cpp
@@ -1192,13 +1192,6 @@ void wxTextCtrl::Replace(wxTextPos from, wxTextPos to, const wxString& text)
         // update the (cached) last position first as refresh functions use it
         m_posLast += text.length() - to + from;
 
-#if defined(__WXMSW__)
-        // Take into account that every new line mark occupies
-        // two characters, not one.
-        if ( !HasFlag(wxTE_RICH | wxTE_RICH2) )
-            m_posLast += nReplaceCount - 1;
-#endif // WXMSW
-
         // we may optimize refresh if the number of rows didn't change - but if
         // it did we have to refresh everything below the part we chanegd as
         // well as it might have moved
@@ -1740,10 +1733,6 @@ wxTextPos wxTextCtrl::XYToPosition(wxTextCoord x, wxTextCoord y) const
             // start of the next one are different
             pos += GetLines()[nLine].length() + 1;
 
-#if defined(__WXMSW__)
-            if( !HasFlag(wxTE_RICH | wxTE_RICH2) && nLine + 1 != nLineCount)
-                pos += 1;
-#endif // WXMSW
         }
 
         // out of the line
@@ -1778,20 +1767,12 @@ bool wxTextCtrl::PositionToXY(wxTextPos pos,
             // +1 is because the start of the next line is one
             // position after the end of this one
             wxTextPos posNew = posCur + GetLines()[nLine].length() + 1;
-#if defined(__WXMSW__)
-            if( !HasFlag(wxTE_RICH | wxTE_RICH2) && nLine + 1 != nLineCount)
-                posNew += 1;
-#endif // WXMSW
+
             if ( posNew > pos )
             {
                 // we've found the line, now just calc the column
                 if ( x )
                     *x = pos - posCur;
-
-#if defined(__WXMSW__)
-                if ( !HasFlag(wxTE_RICH | wxTE_RICH2) && x && nLine + 1 != nLineCount && posNew - 1 == pos)
-                    *x = pos - posCur - 1;
-#endif // WXMSW
 
                 if ( y )
                     *y = nLine;

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -437,7 +437,7 @@ void TextCtrlTestCase::ProcessEnter()
 
 void TextCtrlTestCase::Url()
 {
-#if wxUSE_UIACTIONSIMULATOR && defined(__WXMSW__)
+#if wxUSE_UIACTIONSIMULATOR && defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
     // For some unfathomable reason, this test consistently fails when run in
     // AppVeyor CI environment, even though it passes locally, so skip it
     // there.
@@ -543,7 +543,11 @@ void TextCtrlTestCase::FontStyle()
     m_text->AppendText("Default font size 14");
 
     wxTextAttr attrOut;
-    m_text->GetStyle(5, attrOut);
+    if ( !m_text->GetStyle(5, attrOut) )
+    {
+        WARN("Retrieving text style not supported, skipping test.");
+        return;
+    }
 
     CPPUNIT_ASSERT( attrOut.HasFont() );
 
@@ -686,7 +690,7 @@ void TextCtrlTestCase::DoPositionToCoordsTestWithStyle(long style)
     const wxPoint pos0 = m_text->PositionToCoords(0);
     if ( pos0 == wxDefaultPosition )
     {
-#if defined(__WXMSW__) || defined(__WXGTK20__)
+#if ( defined(__WXMSW__) && !defined(__WXUNIVERSAL__) ) || defined(__WXGTK20__)
         CPPUNIT_FAIL( "PositionToCoords() unexpectedly failed." );
 #endif
         return;

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -38,7 +38,11 @@
 
 static const int TEXT_HEIGHT = 200;
 
-#define wxHAS_2CHAR_NEWLINES defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#define wxHAS_2CHAR_NEWLINES 1
+#else
+#define wxHAS_2CHAR_NEWLINES 0
+#endif
 
 // ----------------------------------------------------------------------------
 // test class

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -38,6 +38,8 @@
 
 static const int TEXT_HEIGHT = 200;
 
+#define wxHAS_2CHAR_NEWLINES defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+
 // ----------------------------------------------------------------------------
 // test class
 // ----------------------------------------------------------------------------
@@ -437,7 +439,7 @@ void TextCtrlTestCase::ProcessEnter()
 
 void TextCtrlTestCase::Url()
 {
-#if wxUSE_UIACTIONSIMULATOR && defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#if wxUSE_UIACTIONSIMULATOR && wxHAS_2CHAR_NEWLINES
     // For some unfathomable reason, this test consistently fails when run in
     // AppVeyor CI environment, even though it passes locally, so skip it
     // there.
@@ -690,7 +692,7 @@ void TextCtrlTestCase::DoPositionToCoordsTestWithStyle(long style)
     const wxPoint pos0 = m_text->PositionToCoords(0);
     if ( pos0 == wxDefaultPosition )
     {
-#if ( defined(__WXMSW__) && !defined(__WXUNIVERSAL__) ) || defined(__WXGTK20__)
+#if ( wxHAS_2CHAR_NEWLINES ) || defined(__WXGTK20__)
         CPPUNIT_FAIL( "PositionToCoords() unexpectedly failed." );
 #endif
         return;
@@ -793,7 +795,7 @@ void TextCtrlTestCase::DoPositionToXYMultiLine(long style)
     delete m_text;
     CreateText(style|wxTE_MULTILINE|wxTE_DONTWRAP);
 
-#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#if wxHAS_2CHAR_NEWLINES
     const bool isRichEdit = (style & (wxTE_RICH | wxTE_RICH2)) != 0;
 #endif
 
@@ -844,7 +846,7 @@ void TextCtrlTestCase::DoPositionToXYMultiLine(long style)
     text = wxS("123\nab\nX");
     m_text->SetValue(text);
 
-#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#if wxHAS_2CHAR_NEWLINES
     // Take into account that every new line mark occupies
     // two characters, not one.
     const long numChars_msw_2 = 8 + 2;
@@ -863,14 +865,14 @@ void TextCtrlTestCase::DoPositionToXYMultiLine(long style)
           { 0, 2 }, { 1, 2 } };
 
     const long &ref_numChars_2 =
-#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#if wxHAS_2CHAR_NEWLINES
         isRichEdit ? numChars_2 : numChars_msw_2;
 #else
         numChars_2;
 #endif
 
     XYPos *ref_coords_2 =
-#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#if wxHAS_2CHAR_NEWLINES
         isRichEdit ? coords_2 : coords_2_msw;
 #else
         coords_2;
@@ -892,7 +894,7 @@ void TextCtrlTestCase::DoPositionToXYMultiLine(long style)
     text = wxS("\n\n\n");
     m_text->SetValue(text);
 
-#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#if wxHAS_2CHAR_NEWLINES
     // Take into account that every new line mark occupies
     // two characters, not one.
     const long numChars_msw_3 = 3 + 3;
@@ -913,14 +915,14 @@ void TextCtrlTestCase::DoPositionToXYMultiLine(long style)
           { 0, 3 } };
 
     const long &ref_numChars_3 =
-#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#if wxHAS_2CHAR_NEWLINES
         isRichEdit ? numChars_3 : numChars_msw_3;
 #else
         numChars_3;
 #endif
 
     XYPos *ref_coords_3 =
-#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#if wxHAS_2CHAR_NEWLINES
         isRichEdit ? coords_3 : coords_3_msw;
 #else
         coords_3;
@@ -942,7 +944,7 @@ void TextCtrlTestCase::DoPositionToXYMultiLine(long style)
     text = wxS("123\na\n\nX\n\n");
     m_text->SetValue(text);
 
-#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#if wxHAS_2CHAR_NEWLINES
     // Take into account that every new line mark occupies
     // two characters, not one.
     const long numChars_msw_4 = 10 + 5;
@@ -967,14 +969,14 @@ void TextCtrlTestCase::DoPositionToXYMultiLine(long style)
           { 0, 5 } };
 
     const long &ref_numChars_4 =
-#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#if wxHAS_2CHAR_NEWLINES
         isRichEdit ? numChars_4 : numChars_msw_4;
 #else
         numChars_4;
 #endif
 
     XYPos *ref_coords_4 =
-#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#if wxHAS_2CHAR_NEWLINES
         isRichEdit ? coords_4 : coords_4_msw;
 #else
         coords_4;
@@ -1015,7 +1017,7 @@ void TextCtrlTestCase::DoXYToPositionMultiLine(long style)
     delete m_text;
     CreateText(style|wxTE_MULTILINE|wxTE_DONTWRAP);
 
-#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#if wxHAS_2CHAR_NEWLINES
     const bool isRichEdit = (style & (wxTE_RICH | wxTE_RICH2)) != 0;
 #endif
 
@@ -1059,7 +1061,7 @@ void TextCtrlTestCase::DoXYToPositionMultiLine(long style)
     const long maxLineLength_2 = 4;
     const long numLines_2 = 3;
     CPPUNIT_ASSERT_EQUAL( numLines_2, m_text->GetNumberOfLines() );
-#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#if wxHAS_2CHAR_NEWLINES
     // Note: New lines are occupied by two characters.
     long pos_2_msw[numLines_2 + 1][maxLineLength_2 + 1] =
         { {  0,  1,  2,  3, -1 },   // New line occupies positions 3, 4
@@ -1074,7 +1076,7 @@ void TextCtrlTestCase::DoXYToPositionMultiLine(long style)
           { -1, -1, -1, -1, -1 } };
 
     long (&ref_pos_2)[numLines_2 + 1][maxLineLength_2 + 1] =
-#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#if wxHAS_2CHAR_NEWLINES
         isRichEdit ? pos_2 : pos_2_msw;
 #else
         pos_2;
@@ -1094,7 +1096,7 @@ void TextCtrlTestCase::DoXYToPositionMultiLine(long style)
     const long maxLineLength_3 = 1;
     const long numLines_3 = 4;
     CPPUNIT_ASSERT_EQUAL( numLines_3, m_text->GetNumberOfLines() );
-#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#if wxHAS_2CHAR_NEWLINES
     // Note: New lines are occupied by two characters.
     long pos_3_msw[numLines_3 + 1][maxLineLength_3 + 1] =
         { {  0, -1 },    // New line occupies positions 0, 1
@@ -1111,7 +1113,7 @@ void TextCtrlTestCase::DoXYToPositionMultiLine(long style)
           { -1, -1 } };
 
     long (&ref_pos_3)[numLines_3 + 1][maxLineLength_3 + 1] =
-#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#if wxHAS_2CHAR_NEWLINES
         isRichEdit ? pos_3 : pos_3_msw;
 #else
         pos_3;
@@ -1131,7 +1133,7 @@ void TextCtrlTestCase::DoXYToPositionMultiLine(long style)
     const long maxLineLength_4 = 4;
     const long numLines_4 = 6;
     CPPUNIT_ASSERT_EQUAL( numLines_4, m_text->GetNumberOfLines() );
-#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#if wxHAS_2CHAR_NEWLINES
     // Note: New lines are occupied by two characters.
     long pos_4_msw[numLines_4 + 1][maxLineLength_4 + 1] =
         { {  0,  1,  2,  3, -1 },    // New line occupies positions 3, 4
@@ -1152,7 +1154,7 @@ void TextCtrlTestCase::DoXYToPositionMultiLine(long style)
           { -1, -1, -1, -1, -1 } };
 
     long (&ref_pos_4)[numLines_4 + 1][maxLineLength_4 + 1] =
-#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
+#if wxHAS_2CHAR_NEWLINES
         isRichEdit ? pos_4 : pos_4_msw;
 #else
         pos_4;

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -793,7 +793,7 @@ void TextCtrlTestCase::DoPositionToXYMultiLine(long style)
     delete m_text;
     CreateText(style|wxTE_MULTILINE|wxTE_DONTWRAP);
 
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
     const bool isRichEdit = (style & (wxTE_RICH | wxTE_RICH2)) != 0;
 #endif
 
@@ -844,7 +844,7 @@ void TextCtrlTestCase::DoPositionToXYMultiLine(long style)
     text = wxS("123\nab\nX");
     m_text->SetValue(text);
 
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
     // Take into account that every new line mark occupies
     // two characters, not one.
     const long numChars_msw_2 = 8 + 2;
@@ -863,14 +863,14 @@ void TextCtrlTestCase::DoPositionToXYMultiLine(long style)
           { 0, 2 }, { 1, 2 } };
 
     const long &ref_numChars_2 =
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
         isRichEdit ? numChars_2 : numChars_msw_2;
 #else
         numChars_2;
 #endif
 
     XYPos *ref_coords_2 =
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
         isRichEdit ? coords_2 : coords_2_msw;
 #else
         coords_2;
@@ -892,7 +892,7 @@ void TextCtrlTestCase::DoPositionToXYMultiLine(long style)
     text = wxS("\n\n\n");
     m_text->SetValue(text);
 
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
     // Take into account that every new line mark occupies
     // two characters, not one.
     const long numChars_msw_3 = 3 + 3;
@@ -913,14 +913,14 @@ void TextCtrlTestCase::DoPositionToXYMultiLine(long style)
           { 0, 3 } };
 
     const long &ref_numChars_3 =
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
         isRichEdit ? numChars_3 : numChars_msw_3;
 #else
         numChars_3;
 #endif
 
     XYPos *ref_coords_3 =
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
         isRichEdit ? coords_3 : coords_3_msw;
 #else
         coords_3;
@@ -942,7 +942,7 @@ void TextCtrlTestCase::DoPositionToXYMultiLine(long style)
     text = wxS("123\na\n\nX\n\n");
     m_text->SetValue(text);
 
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
     // Take into account that every new line mark occupies
     // two characters, not one.
     const long numChars_msw_4 = 10 + 5;
@@ -967,14 +967,14 @@ void TextCtrlTestCase::DoPositionToXYMultiLine(long style)
           { 0, 5 } };
 
     const long &ref_numChars_4 =
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
         isRichEdit ? numChars_4 : numChars_msw_4;
 #else
         numChars_4;
 #endif
 
     XYPos *ref_coords_4 =
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
         isRichEdit ? coords_4 : coords_4_msw;
 #else
         coords_4;
@@ -1015,7 +1015,7 @@ void TextCtrlTestCase::DoXYToPositionMultiLine(long style)
     delete m_text;
     CreateText(style|wxTE_MULTILINE|wxTE_DONTWRAP);
 
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
     const bool isRichEdit = (style & (wxTE_RICH | wxTE_RICH2)) != 0;
 #endif
 
@@ -1059,7 +1059,7 @@ void TextCtrlTestCase::DoXYToPositionMultiLine(long style)
     const long maxLineLength_2 = 4;
     const long numLines_2 = 3;
     CPPUNIT_ASSERT_EQUAL( numLines_2, m_text->GetNumberOfLines() );
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
     // Note: New lines are occupied by two characters.
     long pos_2_msw[numLines_2 + 1][maxLineLength_2 + 1] =
         { {  0,  1,  2,  3, -1 },   // New line occupies positions 3, 4
@@ -1074,7 +1074,7 @@ void TextCtrlTestCase::DoXYToPositionMultiLine(long style)
           { -1, -1, -1, -1, -1 } };
 
     long (&ref_pos_2)[numLines_2 + 1][maxLineLength_2 + 1] =
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
         isRichEdit ? pos_2 : pos_2_msw;
 #else
         pos_2;
@@ -1094,7 +1094,7 @@ void TextCtrlTestCase::DoXYToPositionMultiLine(long style)
     const long maxLineLength_3 = 1;
     const long numLines_3 = 4;
     CPPUNIT_ASSERT_EQUAL( numLines_3, m_text->GetNumberOfLines() );
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
     // Note: New lines are occupied by two characters.
     long pos_3_msw[numLines_3 + 1][maxLineLength_3 + 1] =
         { {  0, -1 },    // New line occupies positions 0, 1
@@ -1111,7 +1111,7 @@ void TextCtrlTestCase::DoXYToPositionMultiLine(long style)
           { -1, -1 } };
 
     long (&ref_pos_3)[numLines_3 + 1][maxLineLength_3 + 1] =
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
         isRichEdit ? pos_3 : pos_3_msw;
 #else
         pos_3;
@@ -1131,7 +1131,7 @@ void TextCtrlTestCase::DoXYToPositionMultiLine(long style)
     const long maxLineLength_4 = 4;
     const long numLines_4 = 6;
     CPPUNIT_ASSERT_EQUAL( numLines_4, m_text->GetNumberOfLines() );
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
     // Note: New lines are occupied by two characters.
     long pos_4_msw[numLines_4 + 1][maxLineLength_4 + 1] =
         { {  0,  1,  2,  3, -1 },    // New line occupies positions 3, 4
@@ -1152,7 +1152,7 @@ void TextCtrlTestCase::DoXYToPositionMultiLine(long style)
           { -1, -1, -1, -1, -1 } };
 
     long (&ref_pos_4)[numLines_4 + 1][maxLineLength_4 + 1] =
-#if defined(__WXMSW__)
+#if defined(__WXMSW__) && !defined(__WXUNIVERSAL__)
         isRichEdit ? pos_4 : pos_4_msw;
 #else
         pos_4;


### PR DESCRIPTION
- [X]   HitTestSingleLine(Beyond)
- [X]   HitTestSingleLine(Scrolled)
- [x]   InsertionPoint
- [x]   Url
- [x]   FontStyle
- [x]   PositionToCoords
- [x]   PositionToCoordsRich
- [x]   PositionToCoordsRich2
- [x]   PositionToXYMultiLine
- [x]   XYToPositionMultiLine
- [x]   XYToPositionMultiLineRich
- [x]   XYToPositionMultiLineRich2
- [x]   wxTextCtrl::ProcessEnter(Without wxTE_PROCESS_ENTER) crash wxWidgets assert: "IsValidPosition(pos)" failed
- [x]  With wxTE_PROCESS_ENTER but skipping
- [x]  With wxTE_PROCESS_ENTER without skipping
- [x]  Without wxTE_PROCESS_ENTER but with wxTE_MULTILINE
- [x]  With wxTE_PROCESS_ENTER and wxTE_MULTILINE without skipping