### PR TITLE
Fix compilation on CentOS 6: 'friend' keyword needs 'class'

### DIFF
--- a/include/wx/private/rescale.h
+++ b/include/wx/private/rescale.h
@@ -70,7 +70,7 @@ private:
     const wxSize m_oldScale;
 
     // Only it can create objects of this class.
-    friend wxRescaleCoordWithValue<T>;
+    friend class wxRescaleCoordWithValue<T>;
 };
 
 // Specialization for just a single value.
@@ -95,7 +95,7 @@ private:
     const wxSize m_oldScale;
 
     // Only it can create objects of this class.
-    friend wxRescaleCoordWithValue<int>;
+    friend class wxRescaleCoordWithValue<int>;
 };
 
 template <typename T>


### PR DESCRIPTION
CentOS 6 uses GCC 4.4.7.