### PR TITLE
Determine availability of each required locale function by compiling

### DIFF
--- a/configure
+++ b/configure
@@ -35180,6 +35180,8 @@ main ()
 
         locale_t t;
         strtod_l(NULL, NULL, t);
+        strtol_l(NULL, NULL, 0, t);
+        strtoul_l(NULL, NULL, 0, t);
 
   ;
   return 0;

--- a/configure.in
+++ b/configure.in
@@ -6096,6 +6096,8 @@ if test "$wxUSE_XLOCALE" = "yes" ; then
         [
         locale_t t;
         strtod_l(NULL, NULL, t);
+        strtol_l(NULL, NULL, 0, t);
+        strtoul_l(NULL, NULL, 0, t);
         ],
         wx_cv_type_locale_t=yes,
         wx_cv_type_locale_t=no


### PR DESCRIPTION
The case of missing strtod_l() is already handled by
9507bc430e (Determine availability of the required xlocale API by compiling, 2017-04-14)

Similarly test for all the strto*_l() functions used by wx.

It appears that the 'musl' C standard library, used on e.g. Alpine Linux,
does have strtod_l(), but not the others. Because of which this check did
not properly disable the feature, and compilation would fail.

The compilation failure despite successful `configure` on Alpine Linux was
reported by someone on IRC on `#wxwidgets`.