### PR TITLE
Drop checks for pid_t from autoconf and CMake

### DIFF
--- a/build/cmake/setup.cmake
+++ b/build/cmake/setup.cmake
@@ -650,7 +650,6 @@ endif()
 set(SYSTYPES
     size_t
     wchar_t int long short
-    gid_t uid_t
     )
 if(NOT MSVC)
     list(APPEND SYSTYPES mode_t off_t)

--- a/build/cmake/setup.cmake
+++ b/build/cmake/setup.cmake
@@ -648,7 +648,7 @@ endif()
 
 # Check size and availability of various types
 set(SYSTYPES
-    pid_t size_t
+    size_t
     wchar_t int long short
     gid_t uid_t
     )

--- a/build/cmake/setup.cmake
+++ b/build/cmake/setup.cmake
@@ -646,14 +646,8 @@ if(wxUSE_XLOCALE)
     set(CMAKE_EXTRA_INCLUDE_FILES)
 endif()
 
-# Check size and availability of various types
-set(SYSTYPES
-    size_t
-    wchar_t int long short
-    )
-if(NOT MSVC)
-    list(APPEND SYSTYPES mode_t off_t)
-endif()
+# Check sizes of various types
+set(SYSTYPES size_t wchar_t int long short)
 
 foreach(SYSTYPE ${SYSTYPES})
     string(TOUPPER ${SYSTYPE} SYSTYPE_UPPER)

--- a/build/cmake/setup.h.in
+++ b/build/cmake/setup.h.in
@@ -18,9 +18,6 @@
 #cmakedefine wxINSTALL_PREFIX "@wxINSTALL_PREFIX@"
 
 /* Define to `int' if <sys/types.h> doesn't define.  */
-#cmakedefine gid_t int
-
-/* Define to `int' if <sys/types.h> doesn't define.  */
 #cmakedefine mode_t int
 
 /* Define to `long' if <sys/types.h> doesn't define.  */
@@ -39,9 +36,6 @@
 #ifndef _GNU_SOURCE
 #cmakedefine _GNU_SOURCE 1
 #endif
-
-/* Define to `int' if <sys/types.h> doesn't define.  */
-#cmakedefine uid_t int
 
 /* Define if your processor stores words with the most significant
    byte first (like Motorola and SPARC, unlike Intel and VAX).  */

--- a/build/cmake/setup.h.in
+++ b/build/cmake/setup.h.in
@@ -17,15 +17,6 @@
 /* the installation location prefix from configure */
 #cmakedefine wxINSTALL_PREFIX "@wxINSTALL_PREFIX@"
 
-/* Define to `int' if <sys/types.h> doesn't define.  */
-#cmakedefine mode_t int
-
-/* Define to `long' if <sys/types.h> doesn't define.  */
-#cmakedefine off_t long
-
-/* Define to `unsigned' if <sys/types.h> doesn't define.  */
-#cmakedefine size_t unsigned
-
 /* Define if ssize_t type is available.  */
 #cmakedefine HAVE_SSIZE_T
 

--- a/build/cmake/setup.h.in
+++ b/build/cmake/setup.h.in
@@ -26,9 +26,6 @@
 /* Define to `long' if <sys/types.h> doesn't define.  */
 #cmakedefine off_t long
 
-/* Define to `int' if <sys/types.h> doesn't define.  */
-#cmakedefine pid_t int
-
 /* Define to `unsigned' if <sys/types.h> doesn't define.  */
 #cmakedefine size_t unsigned
 

--- a/configure
+++ b/configure
@@ -29757,17 +29757,6 @@ _ACEOF
 
 fi
 
-ac_fn_c_check_type "$LINENO" "pid_t" "ac_cv_type_pid_t" "$ac_includes_default"
-if test "x$ac_cv_type_pid_t" = xyes; then :
-
-else
-
-cat >>confdefs.h <<_ACEOF
-#define pid_t int
-_ACEOF
-
-fi
-
 ac_fn_c_check_type "$LINENO" "size_t" "ac_cv_type_size_t" "$ac_includes_default"
 if test "x$ac_cv_type_size_t" = xyes; then :
 

--- a/configure
+++ b/configure
@@ -29735,40 +29735,6 @@ WX_LIBRARY_BASENAME_GUI="wx_${TOOLKIT_DIR}${TOOLKIT_VERSION}${WIDGET_SET}${lib_u
 
 
 
-ac_fn_c_check_type "$LINENO" "mode_t" "ac_cv_type_mode_t" "$ac_includes_default"
-if test "x$ac_cv_type_mode_t" = xyes; then :
-
-else
-
-cat >>confdefs.h <<_ACEOF
-#define mode_t int
-_ACEOF
-
-fi
-
-ac_fn_c_check_type "$LINENO" "off_t" "ac_cv_type_off_t" "$ac_includes_default"
-if test "x$ac_cv_type_off_t" = xyes; then :
-
-else
-
-cat >>confdefs.h <<_ACEOF
-#define off_t long int
-_ACEOF
-
-fi
-
-ac_fn_c_check_type "$LINENO" "size_t" "ac_cv_type_size_t" "$ac_includes_default"
-if test "x$ac_cv_type_size_t" = xyes; then :
-
-else
-
-cat >>confdefs.h <<_ACEOF
-#define size_t unsigned int
-_ACEOF
-
-fi
-
-
 ac_fn_c_check_type "$LINENO" "ssize_t" "ac_cv_type_ssize_t" "$ac_includes_default"
 if test "x$ac_cv_type_ssize_t" = xyes; then :
 

--- a/configure.in
+++ b/configure.in
@@ -4088,8 +4088,6 @@ dnl   defines mode_t if not already defined
 AC_TYPE_MODE_T
 dnl   defines off_t if not already defined
 AC_TYPE_OFF_T
-dnl   defines pid_t if not already defined
-AC_TYPE_PID_T
 dnl   defines size_t if not already defined
 AC_TYPE_SIZE_T
 

--- a/configure.in
+++ b/configure.in
@@ -4084,13 +4084,6 @@ dnl ---------------------------------------------------------------------------
 dnl Checks for typedefs
 dnl ---------------------------------------------------------------------------
 
-dnl   defines mode_t if not already defined
-AC_TYPE_MODE_T
-dnl   defines off_t if not already defined
-AC_TYPE_OFF_T
-dnl   defines size_t if not already defined
-AC_TYPE_SIZE_T
-
 dnl sets HAVE_SSIZE_T if ssize_t is defined
 AC_CHECK_TYPES(ssize_t)
 

--- a/setup.h.in
+++ b/setup.h.in
@@ -17,15 +17,6 @@
 /* the installation location prefix from configure */
 #undef wxINSTALL_PREFIX
 
-/* Define to `int' if <sys/types.h> doesn't define.  */
-#undef mode_t
-
-/* Define to `long' if <sys/types.h> doesn't define.  */
-#undef off_t
-
-/* Define to `unsigned' if <sys/types.h> doesn't define.  */
-#undef size_t
-
 /* Define if ssize_t type is available.  */
 #undef HAVE_SSIZE_T
 

--- a/setup.h.in
+++ b/setup.h.in
@@ -26,9 +26,6 @@
 /* Define to `long' if <sys/types.h> doesn't define.  */
 #undef off_t
 
-/* Define to `int' if <sys/types.h> doesn't define.  */
-#undef pid_t
-
 /* Define to `unsigned' if <sys/types.h> doesn't define.  */
 #undef size_t
 

--- a/setup.h.in
+++ b/setup.h.in
@@ -18,9 +18,6 @@
 #undef wxINSTALL_PREFIX
 
 /* Define to `int' if <sys/types.h> doesn't define.  */
-#undef gid_t
-
-/* Define to `int' if <sys/types.h> doesn't define.  */
 #undef mode_t
 
 /* Define to `long' if <sys/types.h> doesn't define.  */
@@ -39,9 +36,6 @@
 #ifndef _GNU_SOURCE
 #undef _GNU_SOURCE
 #endif
-
-/* Define to `int' if <sys/types.h> doesn't define.  */
-#undef uid_t
 
 /* Define if your processor stores words with the most significant
    byte first (like Motorola and SPARC, unlike Intel and VAX).  */

--- a/setup.h_vms
+++ b/setup.h_vms
@@ -45,9 +45,6 @@
 /* Define to `long' if <sys/types.h> doesn't define.  */
 #undef off_t
 
-/* Define to `int' if <sys/types.h> doesn't define.  */
-#undef pid_t
-
 /* Define to `unsigned' if <sys/types.h> doesn't define.  */
 #undef size_t
 

--- a/setup.h_vms
+++ b/setup.h_vms
@@ -37,9 +37,6 @@
 #undef _GNU_SOURCE
 
 /* Define to `int' if <sys/types.h> doesn't define.  */
-#undef gid_t
-
-/* Define to `int' if <sys/types.h> doesn't define.  */
 #undef mode_t
 
 /* Define to `long' if <sys/types.h> doesn't define.  */
@@ -53,9 +50,6 @@
 
 /* Define if you have the ANSI C header files.  */
 #define STDC_HEADERS 1
-
-/* Define to `int' if <sys/types.h> doesn't define.  */
-#undef uid_t
 
 /* Define if your processor stores words with the most significant
    byte first (like Motorola and SPARC, unlike Intel and VAX).  */

--- a/setup.h_vms
+++ b/setup.h_vms
@@ -36,15 +36,6 @@
 /* Define this to get extra features from GNU libc. */
 #undef _GNU_SOURCE
 
-/* Define to `int' if <sys/types.h> doesn't define.  */
-#undef mode_t
-
-/* Define to `long' if <sys/types.h> doesn't define.  */
-#undef off_t
-
-/* Define to `unsigned' if <sys/types.h> doesn't define.  */
-#undef size_t
-
 /* Define if ssize_t type is available.  */
 #define HAVE_SSIZE_T 1
 


### PR DESCRIPTION
This type should always be defined in sys/types.h on any non-ancient
Unix system, so don't bother checking for it, which is not only wasteful
but can even be harmful because it can conflict with pid_t definitions
in the other libraries under Windows, where we (wrongly) define it as
int (which is actually a bug in autoconf, which was recently fixed, see
https://savannah.gnu.org/support/index.php?110296) when using CMake.

So just don't define it at all: it should be already defined under Unix
and we don't use it under MSW anyhow.

See https://github.com/microsoft/vcpkg/issues/19110

See [#18150](https://trac.wxwidgets.org/ticket/18150).