### PR TITLE
Remove usage of __w64 for recent MSVC versions

### DIFF
--- a/include/wx/types.h
+++ b/include/wx/types.h
@@ -347,7 +347,7 @@ typedef wxUint32 wxDword;
     each time we cast it to a pointer or a handle (which results in hundreds
     of warnings as Win32 API often passes pointers in them)
  */
-#ifdef __VISUALC__
+#if defined(__VISUALC__) && (_MSC_VER < 1800)
     #define wxW64 __w64
 #else
     #define wxW64


### PR DESCRIPTION
Do not impact old versions.
`__w64` just increases warnings and errors since VS 2013 (according to [this documentation](https://docs.microsoft.com/en-us/cpp/cpp/w64?view=msvc-160)).