### PR TITLE
Provide information in wxListEvent for generic virtual wxListCtrl

### DIFF
--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -2320,19 +2320,12 @@ void wxListMainWindow::SendNotify( size_t line,
         le.m_pointDrag = GetPosition() + point;
     }
 
-    // don't try to get the line info for virtual list controls: the main
-    // program has it anyhow and if we did it would result in accessing all
-    // the lines, even those which are not visible now and this is precisely
-    // what we're trying to avoid
-    if ( !IsVirtual() )
+    // provide information about the (first column of the) item in the event if
+    // we have a valid item and any columns at all
+    if ( line != (size_t)-1 && GetColumnCount() )
     {
-        if ( line != (size_t)-1 )
-        {
-            GetLine(line)->GetItem( 0, le.m_item );
-        }
-        //else: this happens for wxEVT_LIST_ITEM_FOCUSED event
+        GetLine(line)->GetItem( 0, le.m_item );
     }
-    //else: there may be no more such item
 
     GetParent()->GetEventHandler()->ProcessEvent( le );
 }


### PR DESCRIPTION
This wasn't done since the changes of c1c4c5516c (fixed unwanted owner
data accesses in virtual list ctrl, 2001-08-07), but there doesn't seem
to be any reason to avoid accessing the item in SendNotify() (any more?)
and if we ever did generate events for all the items in a virtual list
control, this would be already a problem, even if we didn't access the
line info from here.

So just revert the check for !IsVirtual() and always fill the item in
the generated event to make the behaviour of the generic version
consistent with the MSW one and slightly more useful.

Closes [#19235](https://trac.wxwidgets.org/ticket/19235).