### PR TITLE
Add --enable-silent-rules and --with-libtool-sysroot parameters to configure script

### DIFF
--- a/configure
+++ b/configure
@@ -1068,6 +1068,8 @@ with_subdirs
 with_flavour
 enable_official_build
 enable_vendor
+enable_silent_rules
+with_libtool_sysroot
 enable_all_features
 enable_sys_libs
 enable_tests
@@ -2075,6 +2077,7 @@ Optional Features:
   --enable-plugins        build parts of wxWidgets as loadable components
   --enable-official_build official build of wxWidgets (win32 DLL only)
   --enable-vendor=VENDOR  vendor name (win32 DLL only)
+  --enable-silent-rules   no-op
   --disable-all-features  disable all optional features to build minimal library
   --disable-sys-libs      disable use of system libraries for which built-in versions are available
   --disable-tests         disable building tests
@@ -2348,6 +2351,7 @@ Optional Packages:
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --without-subdirs       don't generate makefiles for samples/demos/...
   --with-flavour=NAME     specify a name to identify this build
+  --with-libtool-sysroot=PATH   no-op
   --with-dpi=none|system|per-monitor   set dpi-awareness (Win32 only), default is per-monitor
   --with-themes=all|list  use only the specified comma-separated list of wxUniversal themes
   --with-gtk[=VERSION]    use GTK+, VERSION can be 3 (default), 2, 1 or "any"
@@ -4292,6 +4296,17 @@ fi
 if test "x$VENDOR" = "x"; then
     VENDOR="custom"
 fi
+# Check whether --enable-silent-rules was given.
+if test "${enable_silent_rules+set}" = set; then :
+  enableval=$enable_silent_rules; SILENT_RULES="$enableval"
+fi
+
+
+# Check whether --with-libtool-sysroot was given.
+if test "${with_libtool_sysroot+set}" = set; then :
+  withval=$with_libtool_sysroot; LIBTOOL_SYSROOT="$withval"
+fi
+
 
 
           enablestring=disable

--- a/configure.in
+++ b/configure.in
@@ -400,6 +400,8 @@ AC_ARG_ENABLE(vendor,  [  --enable-vendor=VENDOR  vendor name (win32 DLL only)],
 if test "x$VENDOR" = "x"; then
     VENDOR="custom"
 fi
+AC_ARG_ENABLE(silent-rules, [  --enable-silent-rules   no-op ], [SILENT_RULES="$enableval"])
+AC_ARG_WITH(libtool-sysroot,[  --with-libtool-sysroot=PATH   no-op], [LIBTOOL_SYSROOT="$withval"])
 
 WX_ARG_DISABLE(all-features,[  --disable-all-features  disable all optional features to build minimal library], wxUSE_ALL_FEATURES)
 WX_ARG_DISABLE(sys-libs,    [  --disable-sys-libs      disable use of system libraries for which built-in versions are available], wxUSE_SYS_LIBS)


### PR DESCRIPTION
The Yocto framework [expects autotools-based software](https://git.yoctoproject.org/cgit/cgit.cgi/poky/tree/meta/classes/autotools.bbclass#n53) to accept the following parameters to their configure script:

- `--enable-silent-rules` to choose whether the compiler invocation shall be displayed or not during the build, and
- `--with-libtool-sysroot` for libtool.

For what I have understood, the wxWidgets' build system does not support these settings. However, they have to be accepted by the configure script to allow integration of wxWidgets into the Yocto framework.

This PR is a proposal for adding the above options as no-op's.

In particular, `--enable-silent-rules` is for Automake and does not seem to be supported by Bakefile.
The `--with-libtool-sysroot` option seems not to be required in order to get a successful cross-plaform build. I am not sure if we are using libtool or not, though.

Edit: I misnamed Bakefile once more!