### PR TITLE
GH Actions: add CMake build with MSVC

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -72,6 +72,7 @@ jobs:
           submodules: 'recursive'
 
       - name: Set environment variables
+        shell: bash
         run: |
           wxPROC_COUNT=`./build/tools/proc_count.sh`
           if [ "${{ matrix.cmake_generator }}" == "Xcode" ]; then

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -61,6 +61,8 @@ jobs:
           - name: Windows MSVC
             runner: windows-latest
             cmake_generator: Ninja
+            cmake_samples: SOME
+            cmake_tests: CONSOLE_ONLY
 
     env:
       wxGTK_VERSION: ${{ matrix.gtk_version && matrix.gtk_version || 3 }}

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -58,6 +58,9 @@ jobs:
             cmake_defines: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_FIND_ROOT_PATH=/usr/local -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO
             cmake_samples: OFF
             cmake_tests: OFF
+          - name: Windows MSVC
+            runner: windows-latest
+            cmake_generator: Ninja
 
     env:
       wxGTK_VERSION: ${{ matrix.gtk_version && matrix.gtk_version || 3 }}
@@ -94,6 +97,11 @@ jobs:
       - name: Before install
         run: |
           ./build/tools/before_install.sh
+
+      # required for CMake to find Ninja
+      - name: "[Windows] Set up MSVC Developer Command Prompt"
+        if: runner.os == 'Windows'
+        uses: seanmiddleditch/gha-setup-vsdevenv@v3
 
       - name: Configuring
         run: |


### PR DESCRIPTION
I stumbled over #2372 in the 3.1.5 and was surprised that a release was made that did not build. This should prevent that from happening again.