### PR TITLE
wxDVC on Mac: revert performance breaking commits

### DIFF
--- a/include/wx/osx/cocoa/dataview.h
+++ b/include/wx/osx/cocoa/dataview.h
@@ -86,7 +86,7 @@ class wxCocoaDataViewControl;
 class wxDataViewColumnNativeData
 {
 public:
-    wxDataViewColumnNativeData() : m_NativeColumnPtr(NULL), m_isLast(false), m_prevWidth(0)
+    wxDataViewColumnNativeData() : m_NativeColumnPtr(NULL)
     {
     }
 
@@ -105,32 +105,9 @@ public:
         m_NativeColumnPtr = newNativeColumnPtr;
     }
 
-    bool GetIsLast() const
-    {
-        return m_isLast;
-    }
-
-    void SetIsLast(bool isLast)
-    {
-        m_isLast = isLast;
-    }
-
-    int GetPrevWidth() const
-    {
-        return m_prevWidth;
-    }
-
-    void SetPrevWidth(int prevWidth)
-    {
-        m_prevWidth = prevWidth;
-    }
-
 private:
     // not owned by us
     NSTableColumn* m_NativeColumnPtr;
-
-    bool m_isLast;
-    int m_prevWidth;
 };
 
 // ============================================================================

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2092,7 +2092,7 @@ wxCocoaDataViewControl::wxCocoaDataViewControl(wxWindow* peer,
       ),
       m_DataSource(NULL),
       m_OutlineView([[wxCocoaOutlineView alloc] init]),
-      m_expanderWidth(0)
+      m_expanderWidth(-1)
 {
     // initialize scrollview (the outline view is part of a scrollview):
     NSScrollView* scrollview = (NSScrollView*) GetWXWidget();
@@ -2254,7 +2254,7 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos)
               m_view(view),
               m_column(columnIndex),
               m_indent(0),
-              m_expander(0),
+              m_expander(-1),
               m_tableColumn(column)
         {
             // account for indentation in the column with expander
@@ -2275,7 +2275,7 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos)
             if ( m_indent )
                 cellWidth += m_indent * [m_view levelForRow:row];
 
-            if ( m_expander == 0 && m_tableColumn == [m_view outlineTableColumn] )
+            if ( m_expander == -1 && m_tableColumn == [m_view outlineTableColumn] )
             {
                 NSRect rc = [m_view frameOfOutlineCellAtRow:row];
                 m_expander = ceil(rc.origin.x + rc.size.width);
@@ -2366,10 +2366,10 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos)
 
     // there might not necessarily be an expander in the rows we've examined above so let's
     // globally store the expander width for re-use because it should always be the same
-    if ( m_expanderWidth == 0 )
+    if ( m_expanderWidth == -1 )
         m_expanderWidth = calculator.GetExpanderWidth();
 
-    [column setWidth:calculator.GetMaxWidth() + m_expanderWidth];
+    [column setWidth:calculator.GetMaxWidth() + wxMax(0, m_expanderWidth)];
 }
 
 //

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2251,7 +2251,6 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos)
         MaxWidthCalculator(wxCocoaOutlineView *view,
                            NSTableColumn *column, unsigned columnIndex)
             : m_width(0),
-              m_height(0),
               m_view(view),
               m_column(columnIndex),
               m_indent(0),
@@ -2272,7 +2271,6 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos)
         {
             NSCell *cell = [m_view preparedCellAtColumn:m_column row:row];
             unsigned cellWidth = ceil([cell cellSize].width);
-            unsigned cellHeight = ceil([cell cellSize].height);
 
             if ( m_indent )
                 cellWidth += m_indent * [m_view levelForRow:row];
@@ -2284,16 +2282,13 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos)
             }
 
             m_width = wxMax(m_width, cellWidth);
-            m_height = wxMax(m_height, cellHeight);
         }
 
         int GetMaxWidth() const { return m_width; }
-        int GetMaxHeight() const { return m_height; }
         int GetExpanderWidth() const { return m_expander; }
 
     private:
         int m_width;
-        int m_height;
         wxCocoaOutlineView *m_view;
         unsigned m_column;
         int m_indent;
@@ -2375,14 +2370,6 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos)
         m_expanderWidth = calculator.GetExpanderWidth();
 
     [column setWidth:calculator.GetMaxWidth() + m_expanderWidth];
-
-    if ( !(GetDataViewCtrl()->GetWindowStyle() & wxDV_VARIABLE_LINE_HEIGHT) )
-    {
-        int curHeight = ceil([m_OutlineView rowHeight]);
-        int rowHeight = calculator.GetMaxHeight();
-        if ( rowHeight > curHeight )
-            SetRowHeight(rowHeight);
-    }
 }
 
 //

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2244,7 +2244,6 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos)
 {
     const int count = GetCount();
     NSTableColumn *column = GetColumn(pos)->GetNativeData()->GetNativeColumnPtr();
-    UInt32 const noOfColumns = [[m_OutlineView tableColumns] count];
 
     class MaxWidthCalculator
     {
@@ -2375,10 +2374,7 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos)
     if ( m_expanderWidth == 0 )
         m_expanderWidth = calculator.GetExpanderWidth();
 
-    if ( pos == noOfColumns - 1 )
-        [m_OutlineView sizeLastColumnToFit];
-    else
-        [column setWidth:calculator.GetMaxWidth() + m_expanderWidth];
+    [column setWidth:calculator.GetMaxWidth() + m_expanderWidth];
 
     if ( !(GetDataViewCtrl()->GetWindowStyle() & wxDV_VARIABLE_LINE_HEIGHT) )
     {

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2377,7 +2377,7 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos)
 
     if ( pos == noOfColumns - 1 )
         [m_OutlineView sizeLastColumnToFit];
-    else if ( GetColumn(pos)->GetWidthVariable() == wxCOL_WIDTH_AUTOSIZE )
+    else
         [column setWidth:calculator.GetMaxWidth() + m_expanderWidth];
 
     if ( !(GetDataViewCtrl()->GetWindowStyle() & wxDV_VARIABLE_LINE_HEIGHT) )

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2243,8 +2243,7 @@ bool wxCocoaDataViewControl::InsertColumn(unsigned int pos, wxDataViewColumn* co
 void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos)
 {
     const int count = GetCount();
-    wxDataViewColumnNativeData *nativeData = GetColumn(pos)->GetNativeData();
-    NSTableColumn *column = nativeData->GetNativeColumnPtr();
+    NSTableColumn *column = GetColumn(pos)->GetNativeData()->GetNativeColumnPtr();
     UInt32 const noOfColumns = [[m_OutlineView tableColumns] count];
 
     class MaxWidthCalculator
@@ -2376,31 +2375,10 @@ void wxCocoaDataViewControl::FitColumnWidthToContent(unsigned int pos)
     if ( m_expanderWidth == 0 )
         m_expanderWidth = calculator.GetExpanderWidth();
 
-    const bool isLast = pos == noOfColumns - 1;
-
-    if ( isLast )
-    {
-        // Note that FitColumnWidthToContent() is called whenever a column is
-        // added, so we might also just temporarily become the last column;
-        // since we cannot know at this time whether we will just temporarily
-        // be the last column, we store our current column width in order to
-        // restore it later in case we suddenly are no longer the last column
-        // because new columns have been added --> we need to restore our
-        // previous width in that case because it must not get lost.
-        nativeData->SetPrevWidth(GetColumn(pos)->GetWidth());
-
+    if ( pos == noOfColumns - 1 )
         [m_OutlineView sizeLastColumnToFit];
-    }
     else if ( GetColumn(pos)->GetWidthVariable() == wxCOL_WIDTH_AUTOSIZE )
-    {
         [column setWidth:calculator.GetMaxWidth() + m_expanderWidth];
-    }
-    else if ( nativeData->GetIsLast() )
-    {
-        [column setWidth:nativeData->GetPrevWidth()];
-    }
-
-    nativeData->SetIsLast(isLast);
 
     if ( !(GetDataViewCtrl()->GetWindowStyle() & wxDV_VARIABLE_LINE_HEIGHT) )
     {

--- a/src/osx/dataview_osx.cpp
+++ b/src/osx/dataview_osx.cpp
@@ -438,9 +438,6 @@ bool wxDataViewCtrl::InsertColumn(unsigned int pos, wxDataViewColumn* columnPtr)
      // otherwise ask the control to 'update' the data in the newly appended column:
       if (GetColumnCount() == 1)
         SetExpanderColumn(columnPtr);
-
-      AdjustAutosizedColumns();
-
      // done:
       return true;
     }
@@ -482,8 +479,6 @@ bool wxDataViewCtrl::DeleteColumn(wxDataViewColumn* columnPtr)
   {
     m_ColumnPtrs.Remove(columnPtr);
     delete columnPtr;
-
-    AdjustAutosizedColumns();
     return true;
   }
   else

--- a/src/osx/dataview_osx.cpp
+++ b/src/osx/dataview_osx.cpp
@@ -302,7 +302,10 @@ void wxOSXDataViewModelNotifier::AdjustAutosizedColumns()
   unsigned count = m_DataViewCtrlPtr->GetColumnCount();
   for ( unsigned col = 0; col < count; col++ )
   {
-    m_DataViewCtrlPtr->GetDataViewPeer()->FitColumnWidthToContent(col);
+      wxDataViewColumn *column = m_DataViewCtrlPtr->GetColumnPtr(col);
+
+      if ( column->GetWidthVariable() == wxCOL_WIDTH_AUTOSIZE )
+        m_DataViewCtrlPtr->GetDataViewPeer()->FitColumnWidthToContent(col);
   }
 }
 


### PR DESCRIPTION
I give up on untangling the performance-affecting changes and fixing remaining issues with #2381.

I think it is the best course of action now. Revert the issues, revert the introduced inconsistency (row height adjustment). Release 3.2, and then re-introduces fixes for whatever else these patches were addressing, in a more considered manner. For example, it surely does make sense to keep the freeze/thaw optimization 4a0f6c4a6c34c261085c67698eefd0f6d7085b8e from #2381, but it is too entangled with d2fc88c03dcba3f2d533030d3fa83438dac016af to apply (and its version for after-this-PR tree would be considerably simpler, as most of it was dealing with the heights). 

Thus, this PR mostly reverts the problematic commits.

---

Reverts performance regressions:
- c9221fd538540bd6d105853d0f41620ed25102a5 Fix sizing of temporarily last columns in macOS wxDataViewCtrl
- 36ea7ff4d61e174a2d116819f98e66f22a7f5b8a Autosize the right columns in macOS wxDataViewCtrl
- 7555d1b2459949c128d6ee3a473669a1a134f124 Fix expansion of the last column in macOS wxDataViewCtrl

Reverts incorrect change that triggered lot of this and that shouldn't have been made in the first place, because it is inconsistent with other platforms (autosizing heights):
- d2fc88c03dcba3f2d533030d3fa83438dac016af Mac: Fix truncation of images in wxDataViewCtrl

Does **NOT** revert changes that seem good:
- b2675d6a60a398d8681d0bc47655a2d9c2411239 Fix sending event when cancelling editing in wxDVC under Mac 
- e89e76bb82f6d4bd96d1e6943099cd8bfd4e8292 Make wxCOL_WIDTH_AUTOSIZE work correctly in Mac wxDataViewCtrl (aka "account for expander width in width calculations")
- 9ee866551f98a994a241aa61d87bc8acf94cd2f5 Mac: Update column width when expanding/collapsing
- ...plus some other minor refactorings etc. from the same branches

And finally adds:
- 8d4ab94 Use -1 as uninitialized value for m_expanderWidth  — optimizes e89e76b, which is kept, in an edge case



