### PR TITLE
Always define old names for grid event constants and macros

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -3513,21 +3513,17 @@ typedef void (wxEvtHandler::*wxGridEditorCreatedEventFunction)(wxGridEditorCreat
 // wxEVT_GRID_CELL_CHANGING and CHANGED ones in wx 2.9.0, however the CHANGED
 // is basically the same as the old CHANGE event so we keep the name for
 // compatibility
-#if WXWIN_COMPATIBILITY_2_8
-    #define wxEVT_GRID_CELL_CHANGE wxEVT_GRID_CELL_CHANGED
+#define wxEVT_GRID_CELL_CHANGE wxEVT_GRID_CELL_CHANGED
 
-    #define EVT_GRID_CMD_CELL_CHANGE EVT_GRID_CMD_CELL_CHANGED
-    #define EVT_GRID_CELL_CHANGE EVT_GRID_CELL_CHANGED
-#endif // WXWIN_COMPATIBILITY_2_8
+#define EVT_GRID_CMD_CELL_CHANGE EVT_GRID_CMD_CELL_CHANGED
+#define EVT_GRID_CELL_CHANGE EVT_GRID_CELL_CHANGED
 
 // same as above: RANGE_SELECT was split in RANGE_SELECTING and SELECTED in 3.2,
 // but we keep the old name for compatibility
-#if WXWIN_COMPATIBILITY_3_0
-    #define wxEVT_GRID_RANGE_SELECT wxEVT_GRID_RANGE_SELECTED
+#define wxEVT_GRID_RANGE_SELECT wxEVT_GRID_RANGE_SELECTED
 
-    #define EVT_GRID_CMD_RANGE_SELECT EVT_GRID_CMD_RANGE_SELECTED
-    #define EVT_GRID_RANGE_SELECT EVT_GRID_RANGE_SELECTED
-#endif // WXWIN_COMPATIBILITY_3_0
+#define EVT_GRID_CMD_RANGE_SELECT EVT_GRID_CMD_RANGE_SELECTED
+#define EVT_GRID_RANGE_SELECT EVT_GRID_RANGE_SELECTED
 
 
 #if 0  // TODO: implement these ?  others ?


### PR DESCRIPTION
It doesn't cost us anything to define the compatible names, and there is
no real advantage for the existing application code in using the new
names, so define them without WXWIN_COMPATIBILITY_X_Y checks around
them, to avoid forcing unnecessary changes in the application code when
upgrading to wx 3.2.0.

This commit is best viewed ignoring whitespace-only changes.

---

Please let me know if anybody have any objections to doing this.