### PR TITLE
Fixes for the initial state of generic wx{List,Spin}Ctrl

### DIFF
--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -1379,7 +1379,7 @@ following properties (all of them optional):
 @row3col{text, @ref overview_xrcformat_type_text,
     The title of the column. }
 @row3col{width, integer,
-    The column width. }
+    The column width. @c wxLIST_DEFAULT_COL_WIDTH is used by default. }
 @row3col{image, integer,
     The zero-based index of the image associated with the item in the 'small' image list. }
 @endTable

--- a/include/wx/generic/spinctlg.h
+++ b/include/wx/generic/spinctlg.h
@@ -145,6 +145,9 @@ protected:
     // check if the value is in range
     bool InRange(double n) const { return (n >= m_min) && (n <= m_max); }
 
+    // adjust the value to fit the range and snap it to ticks if necessary
+    double AdjustAndSnap(double value) const;
+
     // ensure that the value is in range wrapping it round if necessary
     double AdjustToFitInRange(double value) const;
 

--- a/include/wx/listbase.h
+++ b/include/wx/listbase.h
@@ -135,11 +135,12 @@ enum wxListColumnFormat
     wxLIST_FORMAT_CENTER = wxLIST_FORMAT_CENTRE
 };
 
-// Autosize values for SetColumnWidth
+// Values for SetColumnWidth()
 enum
 {
     wxLIST_AUTOSIZE = -1,
-    wxLIST_AUTOSIZE_USEHEADER = -2      // partly supported by generic version
+    wxLIST_AUTOSIZE_USEHEADER = -2,     // partly supported by generic version
+    wxLIST_DEFAULT_COL_WIDTH = 80
 };
 
 // Flag values for GetItemRect

--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -89,7 +89,7 @@ enum wxListColumnFormat
     wxLIST_FORMAT_CENTER = wxLIST_FORMAT_CENTRE
 };
 
-/// Autosize values for SetColumnWidth
+/// Values for SetColumnWidth()
 enum
 {
     wxLIST_AUTOSIZE = -1,

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -313,8 +313,9 @@ void wxListHeaderData::SetItem( const wxListItem &item )
     if ( m_mask & wxLIST_MASK_FORMAT )
         m_format = item.m_format;
 
-    if ( m_mask & wxLIST_MASK_WIDTH )
-        SetWidth(item.m_width);
+    // Always give some initial width to the new columns (it's still possible
+    // to set the width to 0 explicitly, however).
+    SetWidth(m_mask & wxLIST_MASK_WIDTH ? item.m_width : wxLIST_DEFAULT_COL_WIDTH);
 
     if ( m_mask & wxLIST_MASK_STATE )
         SetState(item.m_state);

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -96,9 +96,6 @@ static const int MARGIN_BETWEEN_ROWS = 6;
 // when autosizing the columns, add some slack
 static const int AUTOSIZE_COL_MARGIN = 10;
 
-// default width for the header columns
-static const int WIDTH_COL_DEFAULT = 80;
-
 // the space between the image and the text in the report mode
 static const int IMAGE_MARGIN_IN_REPORT_MODE = 5;
 
@@ -336,7 +333,7 @@ void wxListHeaderData::SetHeight( int h )
 
 void wxListHeaderData::SetWidth( int w )
 {
-    m_width = w < 0 ? WIDTH_COL_DEFAULT : w;
+    m_width = w < 0 ? wxLIST_DEFAULT_COL_WIDTH : w;
 }
 
 void wxListHeaderData::SetState( int flag )

--- a/src/generic/spinctlg.cpp
+++ b/src/generic/spinctlg.cpp
@@ -222,10 +222,13 @@ bool wxSpinCtrlGenericBase::Create(wxWindow *parent,
         return false;
     }
 
-    m_value = initial;
-    m_min   = min;
-    m_max   = max;
+    m_min = min;
+    m_max = max;
     m_increment = increment;
+
+    // Note that AdjustAndSnap() uses the variables set above, so only call it
+    // after assigning the values to them.
+    m_value = AdjustAndSnap(initial);
 
     // the string value overrides the numeric one (for backwards compatibility
     // reasons and also because it is simpler to specify the string value which
@@ -235,7 +238,7 @@ bool wxSpinCtrlGenericBase::Create(wxWindow *parent,
     {
         double d;
         if ( DoTextToValue(value, &d) )
-            m_value = d;
+            m_value = AdjustAndSnap(d);
     }
 
     m_textCtrl   = new wxSpinCtrlTextGeneric(this, DoValueToText(m_value), style);
@@ -529,10 +532,8 @@ void wxSpinCtrlGenericBase::SetValue(const wxString& text)
     }
 }
 
-bool wxSpinCtrlGenericBase::DoSetValue(double val, SendEvent sendEvent)
+double wxSpinCtrlGenericBase::AdjustAndSnap(double val) const
 {
-    wxCHECK_MSG( m_textCtrl, false, wxT("invalid call to wxSpinCtrl::SetValue") );
-
     if ( val < m_min )
         val = m_min;
     if ( val > m_max )
@@ -550,6 +551,15 @@ bool wxSpinCtrlGenericBase::DoSetValue(double val, SendEvent sendEvent)
                 val = ceil(snap_value) * m_increment;
         }
     }
+
+    return val;
+}
+
+bool wxSpinCtrlGenericBase::DoSetValue(double val, SendEvent sendEvent)
+{
+    wxCHECK_MSG( m_textCtrl, false, wxT("invalid call to wxSpinCtrl::SetValue") );
+
+    val = AdjustAndSnap(val);
 
     wxString str(DoValueToText(val));
 

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -2057,7 +2057,7 @@ long wxListCtrl::DoInsertColumn(long col, const wxListItem& item)
         // always give some width to the new column: this one is compatible
         // with the generic version
         lvCol.mask |= LVCF_WIDTH;
-        lvCol.cx = 80;
+        lvCol.cx = wxLIST_DEFAULT_COL_WIDTH;
     }
 
     long n = ListView_InsertColumn(GetHwnd(), col, &lvCol);

--- a/tests/controls/spinctrltest.cpp
+++ b/tests/controls/spinctrltest.cpp
@@ -124,6 +124,17 @@ TEST_CASE_METHOD(SpinCtrlTestCase1, "SpinCtrl::Init4", "[spinctrl]")
     CHECK(m_spin->GetValue() == 99);
 }
 
+TEST_CASE_METHOD(SpinCtrlTestCase1, "SpinCtrl::InitOutOfRange", "[spinctrl]")
+{
+    m_spin->Create(wxTheApp->GetTopWindow(), wxID_ANY, "",
+                   wxDefaultPosition, wxDefaultSize, 0,
+                   10, 20, 0);
+
+    // Recreate the control with another "initial" outside of the valid range:
+    // it shouldn't be taken into account.
+    CHECK(m_spin->GetValue() == 10);
+}
+
 TEST_CASE_METHOD(SpinCtrlTestCase1, "SpinCtrl::NoEventsInCtor", "[spinctrl]")
 {
     // Verify that creating the control does not generate any events. This is


### PR DESCRIPTION
I ran into some problems while testing an application developed mostly under MSW to Mac due to inconsistent behaviour or `wxSpinCtrl` and `wxListCtrl` (created from XRC, but it's not really due to using XRC), here are the fixes for them. Strictly speaking, they're not 100% backwards-compatible but AFAICS shouldn't break any code, i.e. they can only fix previously broken code. But please let me know if I'm missing anything.