### PR TITLE
Fix recent regression with drawing themed multi-line text

### DIFF
--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -1184,18 +1184,15 @@ void wxRendererXP::DrawItemText(wxWindow* win,
                 consequences for particularly multi-line text: it will now
                 always try to fit vertically while a rect received from wxDVC
                 may have its extent based on calculations for a single line
-                only and therefore couldn't show more than one line.
-                As a result of the expanded height clipping may be needed
-                which at least already happens with wxDVC which (out of
-                necessity) confines rendering to a cell's bounds.
+                only and therefore couldn't show more than one line. This is
+                consistent with other major platforms where no clipping to
+                the rect takes places either, including non-themed MSW.
                 */
-                const int heightDiff = rect.GetHeight() - rcExtent.bottom;
-                if ( heightDiff
-                     && (align & (wxALIGN_BOTTOM | wxALIGN_CENTRE_VERTICAL))
-                     && text.Contains(wxS('\n')) )
+                if ( text.Contains(wxS('\n')) )
                 {
                     useTopDrawing = true;
 
+                    const int heightDiff = rect.GetHeight() - rcExtent.bottom;
                     if ( align & wxALIGN_CENTRE_VERTICAL )
                     {
                         const int heightOffset = heightDiff / 2;


### PR DESCRIPTION
Remove conditions from MSW themed text drawing that prevent multi-lines
from being rendered properly and instead always use DT_TOP alignment
for multi-lines.

This fixes a regression occurring since 90ba137f20 (Work around text
extent differences resulting in clipped text, 2021-07-26) with themed
Vista+ :

Non-top aligned multi-line text gets rendered as a single line because
of DT_SINGLELINE being used if the height of the drawing rect and
multi-line text happen to be equal. This occurs on the "Variable line
height" page of the dataview sample, which calculates its cell height
by multiplying the text extent by the number of lines in the text (a
requirement with wxMSW, not wxGTK).

Removing the conditions also exposes top aligned multi-line themed text
to drawing beyond the drawing rect, which actually makes it behave more
like wxGTK and wxOSX as well as wxMSW non-themed drawing as they try to
render text fully without regard for the bounds of the drawing rect.