### PR TITLE
Fix potential wxTextMeasureBase::DoGetPartialTextExtents() crashes

### DIFF
--- a/src/common/textmeasurecmn.cpp
+++ b/src/common/textmeasurecmn.cpp
@@ -263,12 +263,13 @@ bool wxTextMeasureBase::DoGetPartialTextExtents(const wxString& text,
     int totalWidth = 0;
 
     // reset the cache if font or horizontal scale have changed
+    const wxFont font = GetFont();
     if ( !s_fontWidthCache.m_widths ||
          !wxIsSameDouble(s_fontWidthCache.m_scaleX, scaleX) ||
-         (s_fontWidthCache.m_font != *m_font) )
+         (s_fontWidthCache.m_font != font) )
     {
         s_fontWidthCache.Reset();
-        s_fontWidthCache.m_font = *m_font;
+        s_fontWidthCache.m_font = font;
         s_fontWidthCache.m_scaleX = scaleX;
     }
 
@@ -289,7 +290,8 @@ bool wxTextMeasureBase::DoGetPartialTextExtents(const wxString& text,
         }
         else
         {
-            DoGetTextExtent(c, &w, NULL);
+            int dummyHeight;
+            DoGetTextExtent(c, &w, &dummyHeight);
             if (c_int < FWC_SIZE)
                 s_fontWidthCache.m_widths[c_int] = w;
         }


### PR DESCRIPTION
If wxTextMeasure is constructed without a font and the base version of
DoGetPartialTextExtents() gets used then there's a crash due to
dereferencing a null pointer. To fix, simply use GetFont() like
elsewhere to get the effective font used.

To fix another null pointer dereference crash don't call
wxTextMeasure::DoGetTextExtent() with null height pointer, as it
requires that both width and height pointers are non-null since
8cd79b7af0 (Factor out text measurement from wxDC and wxWindow into
wxTextMeasure., 2012-10-18), but not for all back-ends any longer since
d76774b444 (Don't dereference NULL output pointer in wxTextMeasure.,
2012-11-25).

There currently appears to be no code in wx that would result in either
crash. For Windows both crashes can be artificially reproduced with
the render sample (requiring static linking with wx due to using private
wxTextMeasure) when using the GDI+ renderer along with the patch:

```diff
diff --git a/samples/render/render.cpp b/samples/render/render.cpp
index 6bae34781b..bc4f8d405b 100644
--- a/samples/render/render.cpp
+++ b/samples/render/render.cpp
@@ -34,6 +34,7 @@
     #include "wx/image.h"
 #endif

+#include "wx/private/textmeasure.h"
 #include "wx/apptrait.h"
 #include "wx/artprov.h"
 #include "wx/renderer.h"
@@ -209,6 +210,10 @@ private:
             wxGraphicsContext* ctx = m_renderer->CreateContext(pdc);
             gdc.SetBackground(GetBackgroundColour());
             gdc.SetGraphicsContext(ctx);
+
+            wxTextMeasure txm(&gdc);
+            wxArrayInt widths;
+            txm.GetPartialTextExtents("a", widths, 1.0);
         }

         wxDC& dc = m_renderer ? static_cast<wxDC&>(gdc) : pdc;
```