### PR TITLE
Implement native wxTextCtrl spell checking V2.0

### DIFF
--- a/build/cmake/setup.h.in
+++ b/build/cmake/setup.h.in
@@ -216,6 +216,12 @@
 
 #cmakedefine01 wxUSE_SECRETSTORE
 
+#if (defined(__WXGTK3__) || defined(__WXMSW__))
+#cmakedefine01 wxUSE_SPELLCHECK
+#else
+#cmakedefine01 wxUSE_SPELLCHECK
+#endif
+
 #cmakedefine01 wxUSE_STDPATHS
 
 #cmakedefine01 wxUSE_TEXTBUFFER

--- a/build/cmake/setup.h.in
+++ b/build/cmake/setup.h.in
@@ -216,11 +216,7 @@
 
 #cmakedefine01 wxUSE_SECRETSTORE
 
-#if (defined(__WXGTK3__) || defined(__WXMSW__))
 #cmakedefine01 wxUSE_SPELLCHECK
-#else
-#cmakedefine01 wxUSE_SPELLCHECK
-#endif
 
 #cmakedefine01 wxUSE_STDPATHS
 

--- a/build/tools/before_install.sh
+++ b/build/tools/before_install.sh
@@ -50,7 +50,7 @@ case $(uname -s) in
                 *)
                     case "$wxGTK_VERSION" in
                         3)  libtoolkit_dev=libgtk-3-dev
-                            extra_deps='libwebkit2gtk-4.0-dev libwebkitgtk-3.0-dev'
+                            extra_deps='libwebkit2gtk-4.0-dev libwebkitgtk-3.0-dev libgtkspell3-3-dev'
                             ;;
                         2)  libtoolkit_dev=libgtk2.0-dev
                             extra_deps='libwebkitgtk-dev'

--- a/configure
+++ b/configure
@@ -33977,11 +33977,7 @@ fi
 
 if test "$wxUSE_SPELLCHECK" = "yes"; then
 
-    if test "$wxUSE_MSW" = 1 -o test "$wxUSE_OSX_COCOA" = 1; then
-                has_spellcheck_support=yes
-
-    elif test "$wxUSE_GTK" = 1; then
-        if test "$WXGTK3" = 1; then
+    if test "$WXGTK3" = 1; then
 
 pkg_failed=no
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for GTKSPELL" >&5
@@ -34042,16 +34038,16 @@ fi
 	echo "$GTKSPELL_PKG_ERRORS" >&5
 
 
-                    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: gtkspell3-3.0 not found, spellchecking won't be available" >&5
-$as_echo "$as_me: WARNING: gtkspell3-3.0 not found, spellchecking won't be available" >&2;}
-                    has_spellcheck_support=no
+                { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: gtkspell3-3.0 not found, spell checking in wxTextCtrl won't be available" >&5
+$as_echo "$as_me: WARNING: gtkspell3-3.0 not found, spell checking in wxTextCtrl won't be available" >&2;}
+                wxUSE_SPELLCHECK=no
 
 
 elif test $pkg_failed = untried; then
 
-                    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: gtkspell3-3.0 not found, spellchecking won't be available" >&5
-$as_echo "$as_me: WARNING: gtkspell3-3.0 not found, spellchecking won't be available" >&2;}
-                    has_spellcheck_support=no
+                { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: gtkspell3-3.0 not found, spell checking in wxTextCtrl won't be available" >&5
+$as_echo "$as_me: WARNING: gtkspell3-3.0 not found, spell checking in wxTextCtrl won't be available" >&2;}
+                wxUSE_SPELLCHECK=no
 
 
 else
@@ -34060,24 +34056,13 @@ else
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 
-                    CXXFLAGS="$GTKSPELL_CFLAGS $CXXFLAGS"
-                    LIBS="$GTKSPELL_LIBS $LIBS"
-                    has_spellcheck_support=yes
+                CXXFLAGS="$GTKSPELL_CFLAGS $CXXFLAGS"
+                LIBS="$GTKSPELL_LIBS $LIBS"
 
 fi
-        else
-            { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Spellchecking is not supported on GTK < 3" >&5
-$as_echo "$as_me: WARNING: Spellchecking is not supported on GTK < 3" >&2;}
-            has_spellcheck_support=no
-        fi
-
-    else
-                { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Spellchecking is not supported on this platform" >&5
-$as_echo "$as_me: WARNING: Spellchecking is not supported on this platform" >&2;}
-        has_spellcheck_support=no
     fi
 
-    if test "$has_spellcheck_support" = "yes"; then
+    if test "$wxUSE_SPELLCHECK" = "yes"; then
         $as_echo "#define wxUSE_SPELLCHECK 1" >>confdefs.h
 
     fi

--- a/configure
+++ b/configure
@@ -951,6 +951,8 @@ GTKPRINT_CFLAGS
 SDL_CONFIG
 SDL_LIBS
 SDL_CFLAGS
+GTKSPELL_LIBS
+GTKSPELL_CFLAGS
 LIBSECRET_LIBS
 LIBSECRET_CFLAGS
 GXX_VERSION
@@ -1203,6 +1205,7 @@ enable_printfposparam
 enable_secretstore
 enable_snglinst
 enable_sound
+enable_spellcheck
 enable_stdpaths
 enable_stopwatch
 enable_streams
@@ -1430,6 +1433,8 @@ MesaGL_CFLAGS
 MesaGL_LIBS
 LIBSECRET_CFLAGS
 LIBSECRET_LIBS
+GTKSPELL_CFLAGS
+GTKSPELL_LIBS
 SDL_CFLAGS
 SDL_LIBS
 GTKPRINT_CFLAGS
@@ -2170,6 +2175,7 @@ Optional Features:
   --enable-secretstore    use wxSecretStore class
   --enable-snglinst       use wxSingleInstanceChecker class
   --enable-sound          use wxSound class
+  --enable-spellcheck     enable spellchecking in wxTextCtrl class (MSW and GTK3 only)
   --enable-stdpaths       use wxStandardPaths class
   --enable-stopwatch      use wxStopWatch class
   --enable-streams        use wxStream etc classes
@@ -2467,6 +2473,10 @@ Some influential environment variables:
               C compiler flags for LIBSECRET, overriding pkg-config
   LIBSECRET_LIBS
               linker flags for LIBSECRET, overriding pkg-config
+  GTKSPELL_CFLAGS
+              C compiler flags for GTKSPELL, overriding pkg-config
+  GTKSPELL_LIBS
+              linker flags for GTKSPELL, overriding pkg-config
   SDL_CFLAGS  C compiler flags for SDL, overriding pkg-config
   SDL_LIBS    linker flags for SDL, overriding pkg-config
   GTKPRINT_CFLAGS
@@ -7861,6 +7871,35 @@ fi
 
 
           eval "$wx_cv_use_sound"
+
+
+          enablestring=
+          defaultval=$wxUSE_ALL_FEATURES
+          if test -z "$defaultval"; then
+              if test x"$enablestring" = xdisable; then
+                  defaultval=yes
+              else
+                  defaultval=no
+              fi
+          fi
+
+          # Check whether --enable-spellcheck was given.
+if test "${enable_spellcheck+set}" = set; then :
+  enableval=$enable_spellcheck;
+                          if test "$enableval" = yes; then
+                            wx_cv_use_spellcheck='wxUSE_SPELLCHECK=yes'
+                          else
+                            wx_cv_use_spellcheck='wxUSE_SPELLCHECK=no'
+                          fi
+
+else
+
+                          wx_cv_use_spellcheck='wxUSE_SPELLCHECK=${'DEFAULT_wxUSE_SPELLCHECK":-$defaultval}"
+
+fi
+
+
+          eval "$wx_cv_use_spellcheck"
 
 
           enablestring=
@@ -33931,6 +33970,116 @@ fi
         $as_echo "#define wxUSE_SECRETSTORE 1" >>confdefs.h
 
         SAMPLES_SUBDIRS="$SAMPLES_SUBDIRS secretstore"
+    fi
+fi
+
+
+
+if test "$wxUSE_SPELLCHECK" = "yes"; then
+
+    if test "$wxUSE_MSW" = 1 -o test "$wxUSE_OSX_COCOA" = 1; then
+                has_spellcheck_support=yes
+
+    elif test "$wxUSE_GTK" = 1; then
+        if test "$WXGTK3" = 1; then
+
+pkg_failed=no
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for GTKSPELL" >&5
+$as_echo_n "checking for GTKSPELL... " >&6; }
+
+if test -n "$PKG_CONFIG"; then
+    if test -n "$GTKSPELL_CFLAGS"; then
+        pkg_cv_GTKSPELL_CFLAGS="$GTKSPELL_CFLAGS"
+    else
+        if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"gtkspell3-3.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "gtkspell3-3.0") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_GTKSPELL_CFLAGS=`$PKG_CONFIG --cflags "gtkspell3-3.0" 2>/dev/null`
+else
+  pkg_failed=yes
+fi
+    fi
+else
+	pkg_failed=untried
+fi
+if test -n "$PKG_CONFIG"; then
+    if test -n "$GTKSPELL_LIBS"; then
+        pkg_cv_GTKSPELL_LIBS="$GTKSPELL_LIBS"
+    else
+        if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"gtkspell3-3.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "gtkspell3-3.0") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_GTKSPELL_LIBS=`$PKG_CONFIG --libs "gtkspell3-3.0" 2>/dev/null`
+else
+  pkg_failed=yes
+fi
+    fi
+else
+	pkg_failed=untried
+fi
+
+
+
+if test $pkg_failed = yes; then
+
+if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+        _pkg_short_errors_supported=yes
+else
+        _pkg_short_errors_supported=no
+fi
+        if test $_pkg_short_errors_supported = yes; then
+	        GTKSPELL_PKG_ERRORS=`$PKG_CONFIG --short-errors --errors-to-stdout --print-errors "gtkspell3-3.0"`
+        else
+	        GTKSPELL_PKG_ERRORS=`$PKG_CONFIG --errors-to-stdout --print-errors "gtkspell3-3.0"`
+        fi
+	# Put the nasty error message in config.log where it belongs
+	echo "$GTKSPELL_PKG_ERRORS" >&5
+
+
+                    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: gtkspell3-3.0 not found, spellchecking won't be available" >&5
+$as_echo "$as_me: WARNING: gtkspell3-3.0 not found, spellchecking won't be available" >&2;}
+                    has_spellcheck_support=no
+
+
+elif test $pkg_failed = untried; then
+
+                    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: gtkspell3-3.0 not found, spellchecking won't be available" >&5
+$as_echo "$as_me: WARNING: gtkspell3-3.0 not found, spellchecking won't be available" >&2;}
+                    has_spellcheck_support=no
+
+
+else
+	GTKSPELL_CFLAGS=$pkg_cv_GTKSPELL_CFLAGS
+	GTKSPELL_LIBS=$pkg_cv_GTKSPELL_LIBS
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+
+                    CXXFLAGS="$GTKSPELL_CFLAGS $CXXFLAGS"
+                    LIBS="$GTKSPELL_LIBS $LIBS"
+                    has_spellcheck_support=yes
+
+fi
+        else
+            { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Spellchecking is not supported on GTK < 3" >&5
+$as_echo "$as_me: WARNING: Spellchecking is not supported on GTK < 3" >&2;}
+            has_spellcheck_support=no
+        fi
+
+    else
+                { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Spellchecking is not supported on this platform" >&5
+$as_echo "$as_me: WARNING: Spellchecking is not supported on this platform" >&2;}
+        has_spellcheck_support=no
+    fi
+
+    if test "$has_spellcheck_support" = "yes"; then
+        $as_echo "#define wxUSE_SPELLCHECK 1" >>confdefs.h
+
     fi
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -5768,38 +5768,24 @@ dnl Spellchecking for wxTextCtrl
 dnl ---------------------------------------------------------------------------
 
 if test "$wxUSE_SPELLCHECK" = "yes"; then
-    dnl The required APIs are always available under MSW and OS X but we must
-    dnl have GTK3 and GNOME gtkspell under Unix to be able to compile this feature.
+    dnl The required APIs are always available under MSW and OS X and we don't
+    dnl implement support for spell checking in the other ports, but for GTK 3
+    dnl we need to check for gtkspell library.
 
-    if test "$wxUSE_MSW" = 1 -o test "$wxUSE_OSX_COCOA" = 1; then
-        dnl Always available under these systems
-        has_spellcheck_support=yes
-
-    elif test "$wxUSE_GTK" = 1; then
-        if test "$WXGTK3" = 1; then
-            PKG_CHECK_MODULES(GTKSPELL, [gtkspell3-3.0],
-                [
-                    CXXFLAGS="$GTKSPELL_CFLAGS $CXXFLAGS"
-                    LIBS="$GTKSPELL_LIBS $LIBS"
-                    has_spellcheck_support=yes
-                ],
-                [
-                    AC_MSG_WARN([gtkspell3-3.0 not found, spellchecking won't be available])
-                    has_spellcheck_support=no
-                ]
-            )
-        else
-            AC_MSG_WARN([Spellchecking is not supported on GTK < 3])
-            has_spellcheck_support=no
-        fi
-
-    else
-        dnl Not implemented in the other ports yet.
-        AC_MSG_WARN([Spellchecking is not supported on this platform])
-        has_spellcheck_support=no
+    if test "$WXGTK3" = 1; then
+        PKG_CHECK_MODULES(GTKSPELL, [gtkspell3-3.0],
+            [
+                CXXFLAGS="$GTKSPELL_CFLAGS $CXXFLAGS"
+                LIBS="$GTKSPELL_LIBS $LIBS"
+            ],
+            [
+                AC_MSG_WARN([gtkspell3-3.0 not found, spell checking in wxTextCtrl won't be available])
+                wxUSE_SPELLCHECK=no
+            ]
+        )
     fi
 
-    if test "$has_spellcheck_support" = "yes"; then
+    if test "$wxUSE_SPELLCHECK" = "yes"; then
         AC_DEFINE(wxUSE_SPELLCHECK)
     fi
 fi

--- a/configure.in
+++ b/configure.in
@@ -766,6 +766,7 @@ WX_ARG_FEATURE(printfposparam,[  --enable-printfposparam use wxVsnprintf() which
 WX_ARG_FEATURE(secretstore,   [  --enable-secretstore    use wxSecretStore class], wxUSE_SECRETSTORE)
 WX_ARG_FEATURE(snglinst,      [  --enable-snglinst       use wxSingleInstanceChecker class], wxUSE_SNGLINST_CHECKER)
 WX_ARG_FEATURE(sound,         [  --enable-sound          use wxSound class], wxUSE_SOUND)
+WX_ARG_FEATURE(spellcheck,    [  --enable-spellcheck     enable spellchecking in wxTextCtrl class (MSW and GTK3 only)], wxUSE_SPELLCHECK)
 WX_ARG_FEATURE(stdpaths,      [  --enable-stdpaths       use wxStandardPaths class], wxUSE_STDPATHS)
 WX_ARG_FEATURE(stopwatch,     [  --enable-stopwatch      use wxStopWatch class], wxUSE_STOPWATCH)
 WX_ARG_FEATURE(streams,       [  --enable-streams        use wxStream etc classes], wxUSE_STREAMS)
@@ -5758,6 +5759,48 @@ if test "$wxUSE_SECRETSTORE" = "yes"; then
 
         AC_DEFINE(wxUSE_SECRETSTORE)
         SAMPLES_SUBDIRS="$SAMPLES_SUBDIRS secretstore"
+    fi
+fi
+
+
+dnl ---------------------------------------------------------------------------
+dnl Spellchecking for wxTextCtrl
+dnl ---------------------------------------------------------------------------
+
+if test "$wxUSE_SPELLCHECK" = "yes"; then
+    dnl The required APIs are always available under MSW and OS X but we must
+    dnl have GTK3 and GNOME gtkspell under Unix to be able to compile this feature.
+
+    if test "$wxUSE_MSW" = 1 -o test "$wxUSE_OSX_COCOA" = 1; then
+        dnl Always available under these systems
+        has_spellcheck_support=yes
+
+    elif test "$wxUSE_GTK" = 1; then
+        if test "$WXGTK3" = 1; then
+            PKG_CHECK_MODULES(GTKSPELL, [gtkspell3-3.0],
+                [
+                    CXXFLAGS="$GTKSPELL_CFLAGS $CXXFLAGS"
+                    LIBS="$GTKSPELL_LIBS $LIBS"
+                    has_spellcheck_support=yes
+                ],
+                [
+                    AC_MSG_WARN([gtkspell3-3.0 not found, spellchecking won't be available])
+                    has_spellcheck_support=no
+                ]
+            )
+        else
+            AC_MSG_WARN([Spellchecking is not supported on GTK < 3])
+            has_spellcheck_support=no
+        fi
+
+    else
+        dnl Not implemented in the other ports yet.
+        AC_MSG_WARN([Spellchecking is not supported on this platform])
+        has_spellcheck_support=no
+    fi
+
+    if test "$has_spellcheck_support" = "yes"; then
+        AC_DEFINE(wxUSE_SPELLCHECK)
     fi
 fi
 

--- a/include/wx/android/setup.h
+++ b/include/wx/android/setup.h
@@ -447,6 +447,18 @@
 // Recommended setting: 1 (but may be safely disabled if you don't use it)
 #define wxUSE_SECRETSTORE   1
 
+// Allow the use of the OS built-in spellchecker on wxTextCtrl (multiline
+// only). Currently only wxGTK3 and wxMSW are implemented.
+//
+// Default is 1 on wxGTK3 and wxMSW platforms and 0 otherwise.
+//
+// Recommended setting: 1 on supported platforms.
+#if (defined(__WXGTK3__) || defined(__WXMSW__))
+#define wxUSE_SPELLCHECK 1
+#else
+#define wxUSE_SPELLCHECK 0
+#endif
+
 // Use wxStandardPaths class which allows to retrieve some standard locations
 // in the file system
 //

--- a/include/wx/android/setup.h
+++ b/include/wx/android/setup.h
@@ -447,17 +447,13 @@
 // Recommended setting: 1 (but may be safely disabled if you don't use it)
 #define wxUSE_SECRETSTORE   1
 
-// Allow the use of the OS built-in spellchecker on wxTextCtrl (multiline
-// only). Currently only wxGTK3 and wxMSW are implemented.
+// Allow the use of the OS built-in spell checker in wxTextCtrl.
 //
-// Default is 1 on wxGTK3 and wxMSW platforms and 0 otherwise.
+// Default is 1, the corresponding wxTextCtrl functions simply won't do
+// anything if the functionality is not supported by the current platform.
 //
-// Recommended setting: 1 on supported platforms.
-#if (defined(__WXGTK3__) || defined(__WXMSW__))
+// Recommended setting: 1 unless you want to save a tiny bit of code.
 #define wxUSE_SPELLCHECK 1
-#else
-#define wxUSE_SPELLCHECK 0
-#endif
 
 // Use wxStandardPaths class which allows to retrieve some standard locations
 // in the file system

--- a/include/wx/chkconf.h
+++ b/include/wx/chkconf.h
@@ -282,6 +282,14 @@
 #   endif
 #endif /* !defined(wxUSE_SECRETSTORE) */
 
+#ifndef wxUSE_SPELLCHECK
+#   ifdef wxABORT_ON_CONFIG_ERROR
+#       error "wxUSE_SPELLCHECK must be defined, please read comment near the top of this file."
+#   else
+#       define wxUSE_SPELLCHECK 1
+#   endif
+#endif /* !defined(wxUSE_SPELLCHECK) */
+
 #ifndef wxUSE_STDPATHS
 #   ifdef wxABORT_ON_CONFIG_ERROR
 #       error "wxUSE_STDPATHS must be defined, please read comment near the top of this file."

--- a/include/wx/gtk/setup.h
+++ b/include/wx/gtk/setup.h
@@ -448,17 +448,13 @@
 // Recommended setting: 1 (but may be safely disabled if you don't use it)
 #define wxUSE_SECRETSTORE   1
 
-// Allow the use of the OS built-in spellchecker on wxTextCtrl (multiline
-// only). Currently only wxGTK3 and wxMSW are implemented.
+// Allow the use of the OS built-in spell checker in wxTextCtrl.
 //
-// Default is 1 on wxGTK3 and wxMSW platforms and 0 otherwise.
+// Default is 1, the corresponding wxTextCtrl functions simply won't do
+// anything if the functionality is not supported by the current platform.
 //
-// Recommended setting: 1 on supported platforms.
-#if (defined(__WXGTK3__) || defined(__WXMSW__))
+// Recommended setting: 1 unless you want to save a tiny bit of code.
 #define wxUSE_SPELLCHECK 1
-#else
-#define wxUSE_SPELLCHECK 0
-#endif
 
 // Use wxStandardPaths class which allows to retrieve some standard locations
 // in the file system

--- a/include/wx/gtk/setup.h
+++ b/include/wx/gtk/setup.h
@@ -448,6 +448,18 @@
 // Recommended setting: 1 (but may be safely disabled if you don't use it)
 #define wxUSE_SECRETSTORE   1
 
+// Allow the use of the OS built-in spellchecker on wxTextCtrl (multiline
+// only). Currently only wxGTK3 and wxMSW are implemented.
+//
+// Default is 1 on wxGTK3 and wxMSW platforms and 0 otherwise.
+//
+// Recommended setting: 1 on supported platforms.
+#if (defined(__WXGTK3__) || defined(__WXMSW__))
+#define wxUSE_SPELLCHECK 1
+#else
+#define wxUSE_SPELLCHECK 0
+#endif
+
 // Use wxStandardPaths class which allows to retrieve some standard locations
 // in the file system
 //

--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -96,13 +96,13 @@ public:
     // Overridden wxWindow methods
     virtual void SetWindowStyleFlag( long style ) wxOVERRIDE;
 
-#if wxUSE_SPELLCHECK
+#if wxUSE_SPELLCHECK && defined(__WXGTK3__)
     // Use native spelling and grammar checking functions.
     virtual bool EnableProofCheck(bool WXUNUSED(enable) = true,
                                   const wxTextProofOptions& WXUNUSED(options) =
                                   wxTextProofOptions()) wxOVERRIDE;
     virtual bool IsProofCheckEnabled() const wxOVERRIDE;
-#endif // wxUSE_SPELLCHECK
+#endif // wxUSE_SPELLCHECK && __WXGTK3__
 
     // Implementation from now on
     void OnDropFiles( wxDropFilesEvent &event );

--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -96,6 +96,14 @@ public:
     // Overridden wxWindow methods
     virtual void SetWindowStyleFlag( long style ) wxOVERRIDE;
 
+#if wxUSE_SPELLCHECK
+    // Use native spelling and grammar checking functions.
+    virtual bool EnableProofCheck(bool WXUNUSED(enable) = true,
+                                  const wxTextProofOptions& WXUNUSED(options) =
+                                  wxTextProofOptions()) wxOVERRIDE;
+    virtual bool IsProofCheckEnabled() const wxOVERRIDE;
+#endif // wxUSE_SPELLCHECK
+
     // Implementation from now on
     void OnDropFiles( wxDropFilesEvent &event );
     void OnChar( wxKeyEvent &event );

--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -98,10 +98,8 @@ public:
 
 #if wxUSE_SPELLCHECK && defined(__WXGTK3__)
     // Use native spelling and grammar checking functions.
-    virtual bool EnableProofCheck(
-            bool enable = true,
-            const wxTextProofOptions& options = wxTextProofOptions()
-        ) wxOVERRIDE;
+    virtual bool EnableProofCheck(const wxTextProofOptions& options
+                                    = wxTextProofOptions::Default()) wxOVERRIDE;
     virtual bool IsProofCheckEnabled() const wxOVERRIDE;
 #endif // wxUSE_SPELLCHECK && __WXGTK3__
 

--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -100,7 +100,7 @@ public:
     // Use native spelling and grammar checking functions.
     virtual bool EnableProofCheck(const wxTextProofOptions& options
                                     = wxTextProofOptions::Default()) wxOVERRIDE;
-    virtual bool IsProofCheckEnabled() const wxOVERRIDE;
+    virtual wxTextProofOptions GetProofCheckOptions() const wxOVERRIDE;
 #endif // wxUSE_SPELLCHECK && __WXGTK3__
 
     // Implementation from now on

--- a/include/wx/gtk/textctrl.h
+++ b/include/wx/gtk/textctrl.h
@@ -98,9 +98,10 @@ public:
 
 #if wxUSE_SPELLCHECK && defined(__WXGTK3__)
     // Use native spelling and grammar checking functions.
-    virtual bool EnableProofCheck(bool WXUNUSED(enable) = true,
-                                  const wxTextProofOptions& WXUNUSED(options) =
-                                  wxTextProofOptions()) wxOVERRIDE;
+    virtual bool EnableProofCheck(
+            bool enable = true,
+            const wxTextProofOptions& options = wxTextProofOptions()
+        ) wxOVERRIDE;
     virtual bool IsProofCheckEnabled() const wxOVERRIDE;
 #endif // wxUSE_SPELLCHECK && __WXGTK3__
 

--- a/include/wx/motif/setup.h
+++ b/include/wx/motif/setup.h
@@ -448,17 +448,13 @@
 // Recommended setting: 1 (but may be safely disabled if you don't use it)
 #define wxUSE_SECRETSTORE   1
 
-// Allow the use of the OS built-in spellchecker on wxTextCtrl (multiline
-// only). Currently only wxGTK3 and wxMSW are implemented.
+// Allow the use of the OS built-in spell checker in wxTextCtrl.
 //
-// Default is 1 on wxGTK3 and wxMSW platforms and 0 otherwise.
+// Default is 1, the corresponding wxTextCtrl functions simply won't do
+// anything if the functionality is not supported by the current platform.
 //
-// Recommended setting: 1 on supported platforms.
-#if (defined(__WXGTK3__) || defined(__WXMSW__))
+// Recommended setting: 1 unless you want to save a tiny bit of code.
 #define wxUSE_SPELLCHECK 1
-#else
-#define wxUSE_SPELLCHECK 0
-#endif
 
 // Use wxStandardPaths class which allows to retrieve some standard locations
 // in the file system

--- a/include/wx/motif/setup.h
+++ b/include/wx/motif/setup.h
@@ -448,6 +448,18 @@
 // Recommended setting: 1 (but may be safely disabled if you don't use it)
 #define wxUSE_SECRETSTORE   1
 
+// Allow the use of the OS built-in spellchecker on wxTextCtrl (multiline
+// only). Currently only wxGTK3 and wxMSW are implemented.
+//
+// Default is 1 on wxGTK3 and wxMSW platforms and 0 otherwise.
+//
+// Recommended setting: 1 on supported platforms.
+#if (defined(__WXGTK3__) || defined(__WXMSW__))
+#define wxUSE_SPELLCHECK 1
+#else
+#define wxUSE_SPELLCHECK 0
+#endif
+
 // Use wxStandardPaths class which allows to retrieve some standard locations
 // in the file system
 //

--- a/include/wx/msw/setup.h
+++ b/include/wx/msw/setup.h
@@ -448,17 +448,13 @@
 // Recommended setting: 1 (but may be safely disabled if you don't use it)
 #define wxUSE_SECRETSTORE   1
 
-// Allow the use of the OS built-in spellchecker on wxTextCtrl (multiline
-// only). Currently only wxGTK3 and wxMSW are implemented.
+// Allow the use of the OS built-in spell checker in wxTextCtrl.
 //
-// Default is 1 on wxGTK3 and wxMSW platforms and 0 otherwise.
+// Default is 1, the corresponding wxTextCtrl functions simply won't do
+// anything if the functionality is not supported by the current platform.
 //
-// Recommended setting: 1 on supported platforms.
-#if (defined(__WXGTK3__) || defined(__WXMSW__))
+// Recommended setting: 1 unless you want to save a tiny bit of code.
 #define wxUSE_SPELLCHECK 1
-#else
-#define wxUSE_SPELLCHECK 0
-#endif
 
 // Use wxStandardPaths class which allows to retrieve some standard locations
 // in the file system

--- a/include/wx/msw/setup.h
+++ b/include/wx/msw/setup.h
@@ -448,6 +448,18 @@
 // Recommended setting: 1 (but may be safely disabled if you don't use it)
 #define wxUSE_SECRETSTORE   1
 
+// Allow the use of the OS built-in spellchecker on wxTextCtrl (multiline
+// only). Currently only wxGTK3 and wxMSW are implemented.
+//
+// Default is 1 on wxGTK3 and wxMSW platforms and 0 otherwise.
+//
+// Recommended setting: 1 on supported platforms.
+#if (defined(__WXGTK3__) || defined(__WXMSW__))
+#define wxUSE_SPELLCHECK 1
+#else
+#define wxUSE_SPELLCHECK 0
+#endif
+
 // Use wxStandardPaths class which allows to retrieve some standard locations
 // in the file system
 //

--- a/include/wx/msw/textctrl.h
+++ b/include/wx/msw/textctrl.h
@@ -111,6 +111,15 @@ public:
     bool ShowNativeCaret(bool show = true);
     bool HideNativeCaret() { return ShowNativeCaret(false); }
 
+#if wxUSE_RICHEDIT && wxUSE_SPELLCHECK
+    // Use native spelling and grammar checking functions.
+    // This is only available in wxTE_RICH2 controls.
+    virtual bool EnableProofCheck(bool WXUNUSED(enable) = true,
+                                  const wxTextProofOptions& WXUNUSED(options) =
+                                  wxTextProofOptions()) wxOVERRIDE;
+    virtual bool IsProofCheckEnabled() const wxOVERRIDE;
+#endif // wxUSE_RICHEDIT && wxUSE_SPELLCHECK
+
     // Implementation from now on
     // --------------------------
 

--- a/include/wx/msw/textctrl.h
+++ b/include/wx/msw/textctrl.h
@@ -114,9 +114,10 @@ public:
 #if wxUSE_RICHEDIT && wxUSE_SPELLCHECK
     // Use native spelling and grammar checking functions.
     // This is only available in wxTE_RICH2 controls.
-    virtual bool EnableProofCheck(bool WXUNUSED(enable) = true,
-                                  const wxTextProofOptions& WXUNUSED(options) =
-                                  wxTextProofOptions()) wxOVERRIDE;
+    virtual bool EnableProofCheck(
+            bool enable = true,
+            const wxTextProofOptions& options = wxTextProofOptions()
+        ) wxOVERRIDE;
     virtual bool IsProofCheckEnabled() const wxOVERRIDE;
 #endif // wxUSE_RICHEDIT && wxUSE_SPELLCHECK
 

--- a/include/wx/msw/textctrl.h
+++ b/include/wx/msw/textctrl.h
@@ -116,7 +116,7 @@ public:
     // This is only available in wxTE_RICH2 controls.
     virtual bool EnableProofCheck(const wxTextProofOptions& options
                                     = wxTextProofOptions::Default()) wxOVERRIDE;
-    virtual bool IsProofCheckEnabled() const wxOVERRIDE;
+    virtual wxTextProofOptions GetProofCheckOptions() const wxOVERRIDE;
 #endif // wxUSE_RICHEDIT && wxUSE_SPELLCHECK
 
     // Implementation from now on

--- a/include/wx/msw/textctrl.h
+++ b/include/wx/msw/textctrl.h
@@ -114,10 +114,8 @@ public:
 #if wxUSE_RICHEDIT && wxUSE_SPELLCHECK
     // Use native spelling and grammar checking functions.
     // This is only available in wxTE_RICH2 controls.
-    virtual bool EnableProofCheck(
-            bool enable = true,
-            const wxTextProofOptions& options = wxTextProofOptions()
-        ) wxOVERRIDE;
+    virtual bool EnableProofCheck(const wxTextProofOptions& options
+                                    = wxTextProofOptions::Default()) wxOVERRIDE;
     virtual bool IsProofCheckEnabled() const wxOVERRIDE;
 #endif // wxUSE_RICHEDIT && wxUSE_SPELLCHECK
 

--- a/include/wx/osx/cocoa/private/textimpl.h
+++ b/include/wx/osx/cocoa/private/textimpl.h
@@ -127,8 +127,10 @@ public:
 
     virtual bool HasOwnContextMenu() const wxOVERRIDE { return true; }
 
-    virtual void CheckSpelling(bool check) wxOVERRIDE;
+#if wxUSE_SPELLCHECK
+    virtual void CheckSpelling(const wxTextProofOptions& options) wxOVERRIDE;
     virtual bool IsSpellingCheckEnabled() const wxOVERRIDE;
+#endif // wxUSE_SPELLCHECK
     virtual void EnableAutomaticQuoteSubstitution(bool enable) wxOVERRIDE;
     virtual void EnableAutomaticDashSubstitution(bool enable) wxOVERRIDE;
 

--- a/include/wx/osx/cocoa/private/textimpl.h
+++ b/include/wx/osx/cocoa/private/textimpl.h
@@ -128,6 +128,7 @@ public:
     virtual bool HasOwnContextMenu() const wxOVERRIDE { return true; }
 
     virtual void CheckSpelling(bool check) wxOVERRIDE;
+    virtual bool IsSpellingCheckEnabled() const wxOVERRIDE;
     virtual void EnableAutomaticQuoteSubstitution(bool enable) wxOVERRIDE;
     virtual void EnableAutomaticDashSubstitution(bool enable) wxOVERRIDE;
 

--- a/include/wx/osx/cocoa/private/textimpl.h
+++ b/include/wx/osx/cocoa/private/textimpl.h
@@ -129,7 +129,7 @@ public:
 
 #if wxUSE_SPELLCHECK
     virtual void CheckSpelling(const wxTextProofOptions& options) wxOVERRIDE;
-    virtual bool IsSpellingCheckEnabled() const wxOVERRIDE;
+    virtual wxTextProofOptions GetCheckingOptions() const wxOVERRIDE;
 #endif // wxUSE_SPELLCHECK
     virtual void EnableAutomaticQuoteSubstitution(bool enable) wxOVERRIDE;
     virtual void EnableAutomaticDashSubstitution(bool enable) wxOVERRIDE;

--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -741,7 +741,7 @@ public :
     virtual wxString GetLineText(long lineNo) const ;
 #if wxUSE_SPELLCHECK
     virtual void CheckSpelling(const wxTextProofOptions& WXUNUSED(options)) { }
-    virtual bool IsSpellingCheckEnabled() const { return false; }
+    virtual wxTextProofOptions GetCheckingOptions() const;
 #endif // wxUSE_SPELLCHECK
     virtual void EnableAutomaticQuoteSubstitution(bool WXUNUSED(enable)) {}
     virtual void EnableAutomaticDashSubstitution(bool WXUNUSED(enable)) {}

--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -77,6 +77,8 @@ WXDLLIMPEXP_BASE CFURLRef wxOSXCreateURLFromFileSystemPath( const wxString& path
 #include "wx/bitmap.h"
 #include "wx/window.h"
 
+class wxTextProofOptions;
+
 class WXDLLIMPEXP_CORE wxMacCGContextStateSaver
 {
     wxDECLARE_NO_COPY_CLASS(wxMacCGContextStateSaver);
@@ -737,8 +739,10 @@ public :
     virtual void ShowPosition(long pos) ;
     virtual int GetLineLength(long lineNo) const ;
     virtual wxString GetLineText(long lineNo) const ;
-    virtual void CheckSpelling(bool WXUNUSED(check)) { }
+#if wxUSE_SPELLCHECK
+    virtual void CheckSpelling(const wxTextProofOptions& WXUNUSED(options)) { }
     virtual bool IsSpellingCheckEnabled() const { return false; }
+#endif // wxUSE_SPELLCHECK
     virtual void EnableAutomaticQuoteSubstitution(bool WXUNUSED(enable)) {}
     virtual void EnableAutomaticDashSubstitution(bool WXUNUSED(enable)) {}
 

--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -738,6 +738,7 @@ public :
     virtual int GetLineLength(long lineNo) const ;
     virtual wxString GetLineText(long lineNo) const ;
     virtual void CheckSpelling(bool WXUNUSED(check)) { }
+    virtual bool IsSpellingCheckEnabled() const { return false; }
     virtual void EnableAutomaticQuoteSubstitution(bool WXUNUSED(enable)) {}
     virtual void EnableAutomaticDashSubstitution(bool WXUNUSED(enable)) {}
 

--- a/include/wx/osx/iphone/private/textimpl.h
+++ b/include/wx/osx/iphone/private/textimpl.h
@@ -72,6 +72,8 @@ public:
     virtual bool HasOwnContextMenu() const { return true; }
 
     virtual void CheckSpelling(bool check);
+    virtual bool IsSpellingCheckEnabled() const;
+
     virtual wxSize GetBestSize() const;
 
 protected:

--- a/include/wx/osx/iphone/private/textimpl.h
+++ b/include/wx/osx/iphone/private/textimpl.h
@@ -71,8 +71,10 @@ public:
 
     virtual bool HasOwnContextMenu() const { return true; }
 
-    virtual void CheckSpelling(bool check);
+#if wxUSE_SPELLCHECK
+    virtual void CheckSpelling(const wxTextProofOptions& options);
     virtual bool IsSpellingCheckEnabled() const;
+#endif // wxUSE_SPELLCHECK
 
     virtual wxSize GetBestSize() const;
 

--- a/include/wx/osx/iphone/private/textimpl.h
+++ b/include/wx/osx/iphone/private/textimpl.h
@@ -71,11 +71,6 @@ public:
 
     virtual bool HasOwnContextMenu() const { return true; }
 
-#if wxUSE_SPELLCHECK
-    virtual void CheckSpelling(const wxTextProofOptions& options);
-    virtual bool IsSpellingCheckEnabled() const;
-#endif // wxUSE_SPELLCHECK
-
     virtual wxSize GetBestSize() const;
 
 protected:

--- a/include/wx/osx/setup.h
+++ b/include/wx/osx/setup.h
@@ -454,6 +454,18 @@
 // Recommended setting: 1 (but may be safely disabled if you don't use it)
 #define wxUSE_SECRETSTORE   1
 
+// Allow the use of the OS built-in spellchecker on wxTextCtrl (multiline
+// only). Currently only wxGTK3 and wxMSW are implemented.
+//
+// Default is 1 on wxGTK3 and wxMSW platforms and 0 otherwise.
+//
+// Recommended setting: 1 on supported platforms.
+#if (defined(__WXGTK3__) || defined(__WXMSW__))
+#define wxUSE_SPELLCHECK 1
+#else
+#define wxUSE_SPELLCHECK 0
+#endif
+
 // Use wxStandardPaths class which allows to retrieve some standard locations
 // in the file system
 //

--- a/include/wx/osx/setup.h
+++ b/include/wx/osx/setup.h
@@ -454,17 +454,13 @@
 // Recommended setting: 1 (but may be safely disabled if you don't use it)
 #define wxUSE_SECRETSTORE   1
 
-// Allow the use of the OS built-in spellchecker on wxTextCtrl (multiline
-// only). Currently only wxGTK3 and wxMSW are implemented.
+// Allow the use of the OS built-in spell checker in wxTextCtrl.
 //
-// Default is 1 on wxGTK3 and wxMSW platforms and 0 otherwise.
+// Default is 1, the corresponding wxTextCtrl functions simply won't do
+// anything if the functionality is not supported by the current platform.
 //
-// Recommended setting: 1 on supported platforms.
-#if (defined(__WXGTK3__) || defined(__WXMSW__))
+// Recommended setting: 1 unless you want to save a tiny bit of code.
 #define wxUSE_SPELLCHECK 1
-#else
-#define wxUSE_SPELLCHECK 0
-#endif
 
 // Use wxStandardPaths class which allows to retrieve some standard locations
 // in the file system

--- a/include/wx/osx/textctrl.h
+++ b/include/wx/osx/textctrl.h
@@ -99,10 +99,8 @@ public:
 
 #if wxUSE_SPELLCHECK
     // Use native spelling and grammar checking functions (multiline only).
-    virtual bool EnableProofCheck(
-            bool enable = true,
-            const wxTextProofOptions& options = wxTextProofOptions()
-        ) wxOVERRIDE;
+    virtual bool EnableProofCheck(const wxTextProofOptions& options
+                                    = wxTextProofOptions::Default()) wxOVERRIDE;
     virtual bool IsProofCheckEnabled() const wxOVERRIDE;
 #endif // wxUSE_SPELLCHECK
 

--- a/include/wx/osx/textctrl.h
+++ b/include/wx/osx/textctrl.h
@@ -97,6 +97,15 @@ public:
     virtual void Cut() wxOVERRIDE;
     virtual void Paste() wxOVERRIDE;
 
+#if wxUSE_SPELLCHECK
+    // Use native spelling and grammar checking functions (multiline only).
+    virtual bool EnableProofCheck(
+            bool enable = true,
+            const wxTextProofOptions& options = wxTextProofOptions()
+        ) wxOVERRIDE;
+    virtual bool IsProofCheckEnabled() const wxOVERRIDE;
+#endif // wxUSE_SPELLCHECK
+
     // Implementation
     // --------------
     virtual void Command(wxCommandEvent& event) wxOVERRIDE;
@@ -130,7 +139,11 @@ public:
 
     virtual void MacVisibilityChanged() wxOVERRIDE;
     virtual void MacSuperChangedPosition() wxOVERRIDE;
-    virtual void MacCheckSpelling(bool check);
+
+    // Use portable EnableProofCheck() instead now.
+#if WXWIN_COMPATIBILITY_3_0
+    wxDEPRECATED( virtual void MacCheckSpelling(bool check) );
+#endif // WXWIN_COMPATIBILITY_3_0
 
     void OSXEnableAutomaticQuoteSubstitution(bool enable);
     void OSXEnableAutomaticDashSubstitution(bool enable);

--- a/include/wx/osx/textctrl.h
+++ b/include/wx/osx/textctrl.h
@@ -101,7 +101,7 @@ public:
     // Use native spelling and grammar checking functions (multiline only).
     virtual bool EnableProofCheck(const wxTextProofOptions& options
                                     = wxTextProofOptions::Default()) wxOVERRIDE;
-    virtual bool IsProofCheckEnabled() const wxOVERRIDE;
+    virtual wxTextProofOptions GetProofCheckOptions() const wxOVERRIDE;
 #endif // wxUSE_SPELLCHECK
 
     // Implementation

--- a/include/wx/osx/textctrl.h
+++ b/include/wx/osx/textctrl.h
@@ -139,9 +139,9 @@ public:
     virtual void MacSuperChangedPosition() wxOVERRIDE;
 
     // Use portable EnableProofCheck() instead now.
-#if WXWIN_COMPATIBILITY_3_0
+#if WXWIN_COMPATIBILITY_3_0 && wxUSE_SPELLCHECK
     wxDEPRECATED( virtual void MacCheckSpelling(bool check) );
-#endif // WXWIN_COMPATIBILITY_3_0
+#endif // WXWIN_COMPATIBILITY_3_0 && wxUSE_SPELLCHECK
 
     void OSXEnableAutomaticQuoteSubstitution(bool enable);
     void OSXEnableAutomaticDashSubstitution(bool enable);

--- a/include/wx/setup_inc.h
+++ b/include/wx/setup_inc.h
@@ -444,6 +444,18 @@
 // Recommended setting: 1 (but may be safely disabled if you don't use it)
 #define wxUSE_SECRETSTORE   1
 
+// Allow the use of the OS built-in spellchecker on wxTextCtrl (multiline
+// only). Currently only wxGTK3 and wxMSW are implemented.
+//
+// Default is 1 on wxGTK3 and wxMSW platforms and 0 otherwise.
+//
+// Recommended setting: 1 on supported platforms.
+#if (defined(__WXGTK3__) || defined(__WXMSW__))
+#define wxUSE_SPELLCHECK 1
+#else
+#define wxUSE_SPELLCHECK 0
+#endif
+
 // Use wxStandardPaths class which allows to retrieve some standard locations
 // in the file system
 //

--- a/include/wx/setup_inc.h
+++ b/include/wx/setup_inc.h
@@ -444,17 +444,13 @@
 // Recommended setting: 1 (but may be safely disabled if you don't use it)
 #define wxUSE_SECRETSTORE   1
 
-// Allow the use of the OS built-in spellchecker on wxTextCtrl (multiline
-// only). Currently only wxGTK3 and wxMSW are implemented.
+// Allow the use of the OS built-in spell checker in wxTextCtrl.
 //
-// Default is 1 on wxGTK3 and wxMSW platforms and 0 otherwise.
+// Default is 1, the corresponding wxTextCtrl functions simply won't do
+// anything if the functionality is not supported by the current platform.
 //
-// Recommended setting: 1 on supported platforms.
-#if (defined(__WXGTK3__) || defined(__WXMSW__))
+// Recommended setting: 1 unless you want to save a tiny bit of code.
 #define wxUSE_SPELLCHECK 1
-#else
-#define wxUSE_SPELLCHECK 0
-#endif
 
 // Use wxStandardPaths class which allows to retrieve some standard locations
 // in the file system

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -133,7 +133,7 @@ enum wxTextCtrlHitTestResult
 // Passed to ::EnableProofCheck() to configure the proofing options for
 // this control
 // ----------------------------------------------------------------------------
-class WXDLLIMPEXP_CORE wxTextProofOptions
+class wxTextProofOptions
 {
 public:
     wxTextProofOptions(const wxString& lang = wxEmptyString)

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -171,9 +171,14 @@ public:
     }
 
     // And the corresponding accessors.
-    bool IsSpellCheckingEnabled() const { return m_EnableSpellCheck; }
-    bool IsGrammarCheckingEnabled() const { return m_EnableGrammarCheck; }
+    bool IsSpellCheckEnabled() const { return m_EnableSpellCheck; }
+    bool IsGrammarCheckEnabled() const { return m_EnableGrammarCheck; }
     const wxString& GetLang() const { return m_lang; }
+
+    bool AnyChecksEnabled() const
+    {
+        return IsSpellCheckEnabled() || IsGrammarCheckEnabled();
+    }
 
 private:
     // Ctor is private, use static factory methods to create objects of this
@@ -830,7 +835,10 @@ public:
     {
         return false;
     }
-    virtual bool IsProofCheckEnabled() const { return false; }
+    virtual wxTextProofOptions GetProofCheckOptions() const
+    {
+        return wxTextProofOptions::Disable();
+    }
 #endif // wxUSE_SPELLCHECK
 
 protected:

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -126,6 +126,45 @@ enum wxTextCtrlHitTestResult
 };
 // ... the character returned
 
+#if wxUSE_SPELLCHECK
+
+// ----------------------------------------------------------------------------
+// wxTextCtrl proof options object
+// Passed to ::EnableProofCheck() to configure the proofing options for
+// this control
+// ----------------------------------------------------------------------------
+class WXDLLIMPEXP_CORE wxTextProofOptions
+{
+public:
+    wxTextProofOptions(const wxString& lang = wxEmptyString)
+    : m_lang(lang)
+    {
+        m_EnableSpellCheck = true;
+        m_EnableGrammarCheck = false;
+    }
+
+    wxTextProofOptions& SpellCheck(bool enable = true)
+    {
+        m_EnableSpellCheck = enable;
+        return *this;
+    }
+
+    wxTextProofOptions& GrammarCheck(bool enable = true)
+    {
+        m_EnableGrammarCheck = enable;
+        return *this;
+    }
+
+    const wxString& GetLang() const { return m_lang; }
+
+private:
+    wxString m_lang;
+    bool m_EnableSpellCheck;
+    bool m_EnableGrammarCheck;
+};
+
+#endif // wxUSE_SPELLCHECK
+
 // ----------------------------------------------------------------------------
 // Types for wxTextAttr
 // ----------------------------------------------------------------------------
@@ -757,6 +796,15 @@ public:
     }
 
     virtual const wxTextEntry* WXGetTextEntry() const wxOVERRIDE { return this; }
+
+#if wxUSE_SPELLCHECK
+    // Use native spelling and grammar checking functions.
+    virtual bool EnableProofCheck(bool WXUNUSED(enable) = true,
+                                  const wxTextProofOptions& WXUNUSED(options) =
+                                  wxTextProofOptions())
+                                  { return false; }
+    virtual bool IsProofCheckEnabled() const { return false; }
+#endif // wxUSE_SPELLCHECK
 
 protected:
     // Override wxEvtHandler method to check for a common problem of binding

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -129,20 +129,29 @@ enum wxTextCtrlHitTestResult
 #if wxUSE_SPELLCHECK
 
 // ----------------------------------------------------------------------------
-// wxTextCtrl proof options object
-// Passed to ::EnableProofCheck() to configure the proofing options for
-// this control
+// This object can be passed to wxTextCtrl::EnableProofCheck() to configure the
+// proofing options for this control.
 // ----------------------------------------------------------------------------
 class wxTextProofOptions
 {
 public:
-    wxTextProofOptions(const wxString& lang = wxEmptyString)
-    : m_lang(lang)
+    // Return the object corresponding to the default options: current
+    // language, spell checking enabled, grammar checking disabled.
+    static wxTextProofOptions Default()
     {
-        m_EnableSpellCheck = true;
-        m_EnableGrammarCheck = false;
+        wxTextProofOptions opts;
+        return opts.SpellCheck(true);
     }
 
+    // Return the object with all checks disabled.
+    static wxTextProofOptions Disable()
+    {
+        return wxTextProofOptions();
+    }
+
+    // Default copy ctor, assignment operator and dtor are ok
+
+    // Methods that can be used to set the various options.
     wxTextProofOptions& SpellCheck(bool enable = true)
     {
         m_EnableSpellCheck = enable;
@@ -155,9 +164,26 @@ public:
         return *this;
     }
 
+    wxTextProofOptions& Language(const wxString& lang)
+    {
+        m_lang = lang;
+        return *this;
+    }
+
+    // And the corresponding accessors.
+    bool IsSpellCheckingEnabled() const { return m_EnableSpellCheck; }
+    bool IsGrammarCheckingEnabled() const { return m_EnableGrammarCheck; }
     const wxString& GetLang() const { return m_lang; }
 
 private:
+    // Ctor is private, use static factory methods to create objects of this
+    // class.
+    wxTextProofOptions()
+    {
+        m_EnableSpellCheck =
+        m_EnableGrammarCheck = false;
+    }
+
     wxString m_lang;
     bool m_EnableSpellCheck;
     bool m_EnableGrammarCheck;
@@ -799,10 +825,8 @@ public:
 
 #if wxUSE_SPELLCHECK
     // Use native spelling and grammar checking functions.
-    virtual bool EnableProofCheck(
-            bool WXUNUSED(enable) = true,
-            const wxTextProofOptions& WXUNUSED(options) = wxTextProofOptions()
-        )
+    virtual bool EnableProofCheck(const wxTextProofOptions& WXUNUSED(options)
+                                    = wxTextProofOptions::Default())
     {
         return false;
     }

--- a/include/wx/textctrl.h
+++ b/include/wx/textctrl.h
@@ -799,10 +799,13 @@ public:
 
 #if wxUSE_SPELLCHECK
     // Use native spelling and grammar checking functions.
-    virtual bool EnableProofCheck(bool WXUNUSED(enable) = true,
-                                  const wxTextProofOptions& WXUNUSED(options) =
-                                  wxTextProofOptions())
-                                  { return false; }
+    virtual bool EnableProofCheck(
+            bool WXUNUSED(enable) = true,
+            const wxTextProofOptions& WXUNUSED(options) = wxTextProofOptions()
+        )
+    {
+        return false;
+    }
     virtual bool IsProofCheckEnabled() const { return false; }
 #endif // wxUSE_SPELLCHECK
 

--- a/include/wx/univ/setup.h
+++ b/include/wx/univ/setup.h
@@ -447,6 +447,18 @@
 // Recommended setting: 1 (but may be safely disabled if you don't use it)
 #define wxUSE_SECRETSTORE   1
 
+// Allow the use of the OS built-in spellchecker on wxTextCtrl (multiline
+// only). Currently only wxGTK3 and wxMSW are implemented.
+//
+// Default is 1 on wxGTK3 and wxMSW platforms and 0 otherwise.
+//
+// Recommended setting: 1 on supported platforms.
+#if (defined(__WXGTK3__) || defined(__WXMSW__))
+#define wxUSE_SPELLCHECK 1
+#else
+#define wxUSE_SPELLCHECK 0
+#endif
+
 // Use wxStandardPaths class which allows to retrieve some standard locations
 // in the file system
 //

--- a/include/wx/univ/setup.h
+++ b/include/wx/univ/setup.h
@@ -447,17 +447,13 @@
 // Recommended setting: 1 (but may be safely disabled if you don't use it)
 #define wxUSE_SECRETSTORE   1
 
-// Allow the use of the OS built-in spellchecker on wxTextCtrl (multiline
-// only). Currently only wxGTK3 and wxMSW are implemented.
+// Allow the use of the OS built-in spell checker in wxTextCtrl.
 //
-// Default is 1 on wxGTK3 and wxMSW platforms and 0 otherwise.
+// Default is 1, the corresponding wxTextCtrl functions simply won't do
+// anything if the functionality is not supported by the current platform.
 //
-// Recommended setting: 1 on supported platforms.
-#if (defined(__WXGTK3__) || defined(__WXMSW__))
+// Recommended setting: 1 unless you want to save a tiny bit of code.
 #define wxUSE_SPELLCHECK 1
-#else
-#define wxUSE_SPELLCHECK 0
-#endif
 
 // Use wxStandardPaths class which allows to retrieve some standard locations
 // in the file system

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -1398,9 +1398,9 @@ public:
         available on the current platform.
 
         Currently this is supported in wxMSW (when running under Windows 8 or
-        later) and wxGTK when using GTK 3. In addition, wxMSW requires that the
-        text control has the wxTE_RICH2 style set. wxGTK3 requires that the
-        control has the wxTE_MULTILINE style.
+        later), wxGTK when using GTK 3 and wxOSX. In addition, wxMSW requires
+        that the text control has the wxTE_RICH2 style set. wxGTK3 and wxOSX
+        require that the control has the wxTE_MULTILINE style.
 
         @param enable
             Enables native proof checking if true, disables it otherwise.
@@ -1566,9 +1566,8 @@ public:
         Returns @true if proof (spell) checking is currently active on this
         control, @false otherwise.
 
-        @onlyfor{wxmsw,wxgtk}
-
-        @see EnableProofCheck()
+        This function is implemented for the same platforms as
+        EnableProofCheck() and returns @false for the other ones.
 
         @since 3.1.6
     */

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -1397,10 +1397,10 @@ public:
         Enable or disable native spell checking on this text control if it is
         available on the current platform.
 
-        @onlyfor{wxmsw,wxgtk}
-        Currently wxMSW (>= Windows 7) and wxGTK3 are supported. In addition,
-        wxMSW use requires that the text control has the wxTE_RICH2 style
-        set. wxGTK3 requires that the control has the wxTE_MULTILINE style.
+        Currently this is supported in wxMSW (when running under Windows 8 or
+        later) and wxGTK when using GTK 3. In addition, wxMSW requires that the
+        text control has the wxTE_RICH2 style set. wxGTK3 requires that the
+        control has the wxTE_MULTILINE style.
 
         @param enable
             Enables native proof checking if true, disables it otherwise.

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -982,24 +982,27 @@ public:
     @class wxTextProofOptions
 
     This class provides a convenient means of passing multiple parameters to
-    wxTextCtrl::EnableProofCheck(). Typical (and the default) usage is:
+    wxTextCtrl::EnableProofCheck().
+
+    By default, i.e. when calling EnableProofCheck() without any parameters,
+    Default() proof options are used, which enable spelling (but not grammar)
+    checks for the current language.
+
+    However it is also possible to customize the options:
 
     @code
-    m_pText->EnableProofCheck(true, wxTextProofOptions(wxEmptyString).SpellCheck(true));
+    textctrl->EnableProofCheck(wxTextProofOptions::Default().Language("fr").GrammarCheck());
     @endcode
 
-    If this is the exact behaviour desired, then the parameters can be omitted.
-    The following code will have the same result:
+    or disable the all checks entirely:
 
     @code
-    m_pText->EnableProofCheck();
+    textctrl->EnableProofCheck(wxTextProofOptions::Disable());
     @endcode
 
-    Options can also be cascaded if required as follows:
-
-    @code
-    m_pText->EnableProofCheck(true, wxTextProofOptions("fr_FR").SpellCheck(false).GrammarCheck(true));
-    @endcode
+    Note that this class has no public constructor, except for the copy
+    constructor, so its objects can only be created using the static factory
+    methods Default() or Disable().
 
     @see wxTextCtrl::EnableProofCheck(), wxTextCtrl::IsProofCheckEnabled().
 
@@ -1008,24 +1011,22 @@ public:
 class WXDLLIMPEXP_CORE wxTextProofOptions
 {
     /**
-       Default constructor. The proofing language is set to the current locale language,
-       spell checking is enabled and grammar checking is disabled.
+       Create an object corresponding to the default checks.
 
-       @param lang
-        The ISO 639 / ISO 3166 canonical language name of the dictionary
-        to be used. See wxLocale::GetCanonicalName() for examples. If an
-        empty string is passed (default), then the current locale will be
-        used. This parameter is ignored and only the current locale
-        language (default option) is supported at this time.
+       The returned object enables spelling checks and disables grammar checks.
      */
-    wxTextProofOptions(const wxString& lang = wxEmptyString)
+    static wxTextProofOptions Default()
+
+    /**
+       Create an object disabling all checks.
+
+       The returned object can be passed to wxTextCtrl::EnableProofCheck() to
+       disable all checks in the text control.
+     */
+    static wxTextProofOptions Disable()
 
     /**
        Enable / disable spell checking for this control.
-
-       This option is currently hard coded to @true and is ignored.
-       Use the global enable parameter passed to
-       wxTextCtrl::EnableProofCheck() to enable / disable spell checking.
      */
     wxTextProofOptions& SpellCheck(bool enable = true)
 
@@ -1035,6 +1036,12 @@ class WXDLLIMPEXP_CORE wxTextProofOptions
        This option is not currently supported and is ignored.
      */
     wxTextProofOptions& GrammarCheck(bool enable = true)
+
+    /// Return true if spell checking is enabled.
+    bool IsSpellCheckingEnabled() const;
+
+    /// Return true if grammar checking is enabled.
+    bool IsGrammarCheckingEnabled() const;
 };
 
 /**
@@ -1402,24 +1409,23 @@ public:
         that the text control has the wxTE_RICH2 style set. wxGTK3 and wxOSX
         require that the control has the wxTE_MULTILINE style.
 
-        @param enable
-            Enables native proof checking if true, disables it otherwise.
-
         @param options
             A wxTextProofOptions object specifying the desired behaviour
             of the proof checker (e.g. language to use, spell check, grammar
-            check, etc.). This parameter is currently unused and the control is
-            initialised with the default setting of current locale language /
-            spell check only.
+            check, etc.) and whether the proof checks should be enabled at all.
+            By default, spelling checks for the current language are enabled.
+            Passing wxTextProofOptions::Disable() disables all the checks.
 
         @return
-            @true if proof checking has been successfully enabled (and true was
-            passed as the enable parameter), @false otherwise.
+            @true if proof checking has been successfully enabled or disabled,
+            @false otherwise (usually because the corresponding functionality
+            is not available under the current platform or for this type of
+            text control).
 
         @since 3.1.6
     */
-    virtual bool EnableProofCheck(bool enable = true,
-                                  const wxTextProofOptions& options = wxTextProofOptions());
+    virtual bool EnableProofCheck(const wxTextProofOptions& options
+                                    = wxTextProofOptions::Default());
 
     /**
         Returns the style currently used for the new text.

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -1033,7 +1033,8 @@ class WXDLLIMPEXP_CORE wxTextProofOptions
     /**
        Enable / disable grammar checking for this control.
 
-       This option is not currently supported and is ignored.
+       This option is currently only supported under macOS and is ignored under
+       the other platforms.
      */
     wxTextProofOptions& GrammarCheck(bool enable = true)
 

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -258,7 +258,6 @@ enum wxTextCtrlHitTestResult
     wxTE_HT_BEYOND
 };
 
-
 /**
     @class wxTextAttr
 
@@ -979,6 +978,62 @@ public:
     void operator=(const wxTextAttr& attr);
 };
 
+/**
+    @class wxTextProofOptions
+
+    This class provides a convenient means of passing multiple parameters to
+    wxTextCtrl::EnableProofCheck(). Typical (and the default) usage is:
+
+    @code
+    m_pText->EnableProofCheck(true, wxTextProofOptions(wxEmptyString).SpellCheck(true));
+    @endcode
+
+    If this is the exact behaviour desired, then the parameters can be omitted.
+    The following code will have the same result:
+
+    @code
+    m_pText->EnableProofCheck();
+    @endcode
+
+    Options can also be cascaded if required as follows:
+
+    @code
+    m_pText->EnableProofCheck(true, wxTextProofOptions("fr_FR").SpellCheck(false).GrammarCheck(true));
+    @endcode
+
+    @see wxTextCtrl::EnableProofCheck(), wxTextCtrl::IsProofCheckEnabled().
+*/
+class WXDLLIMPEXP_CORE wxTextProofOptions
+{
+    /**
+       Default constructor. The proofing language is set to the current locale language,
+       spell checking is enabled and grammar checking is disabled.
+
+       @param lang
+        The ISO 639 / ISO 3166 canonical language name of the dictionary
+        to be used. See wxLocale::GetCanonicalName() for examples. If an
+        empty string is passed (default), then the current locale will be
+        used. This parameter is ignored and only the current locale
+        language (default option) is supported at this time.
+     */
+    wxTextProofOptions(const wxString& lang = wxEmptyString)
+
+    /**
+       Enable / disable spell checking for this control.
+
+       This option is currently hard coded to @true and is ignored.
+       Use the global enable parameter passed to
+       wxTextCtrl::EnableProofCheck() to enable / disable spell checking.
+     */
+    wxTextProofOptions& SpellCheck(bool enable = true)
+
+    /**
+       Enable / disable grammar checking for this control.
+
+       This option is not currently supported and is ignored.
+     */
+    wxTextProofOptions& GrammarCheck(bool enable = true)
+};
 
 /**
     @class wxTextCtrl
@@ -1337,6 +1392,34 @@ public:
     virtual bool EmulateKeyPress(const wxKeyEvent& event);
 
     /**
+        Enable or disable native spell checking on this text control if it is
+        available on the current platform.
+
+        @onlyfor{wxmsw,wxgtk}
+        Currently wxMSW (>= Windows 7) and wxGTK3 are supported. In addition,
+        wxMSW use requires that the text control has the wxTE_RICH2 style
+        set. wxGTK3 requires that the control has the wxTE_MULTILINE style.
+
+        @param enable
+            Enables native proof checking if true, disables it otherwise.
+
+        @param options
+            A wxTextProofOptions object specifying the desired behaviour
+            of the proof checker (e.g. language to use, spell check, grammar
+            check, etc.). This parameter is currently unused and the control is
+            initialised with the default setting of current locale language /
+            spell check only.
+
+        @return
+            @true if proof checking has been successfully enabled (and true was
+            passed as the enable parameter), @false otherwise.
+
+        @since 3.1.6
+    */
+    virtual bool EnableProofCheck(bool enable = true,
+                                  const wxTextProofOptions& options = wxTextProofOptions());
+
+    /**
         Returns the style currently used for the new text.
 
         @see SetDefaultStyle()
@@ -1476,6 +1559,18 @@ public:
         @see IsSingleLine(), IsMultiLine()
     */
     bool IsSingleLine() const;
+
+    /**
+        Returns @true if proof (spell) checking is currently active on this
+        control, @false otherwise.
+
+        @onlyfor{wxmsw,wxgtk}
+
+        @see EnableProofCheck()
+
+        @since 3.1.6
+    */
+    virtual bool IsProofCheckEnabled();
 
     /**
         Loads and displays the named file, if it exists.

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -1002,6 +1002,8 @@ public:
     @endcode
 
     @see wxTextCtrl::EnableProofCheck(), wxTextCtrl::IsProofCheckEnabled().
+
+    @since 3.1.6
 */
 class WXDLLIMPEXP_CORE wxTextProofOptions
 {

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -1004,7 +1004,7 @@ public:
     constructor, so its objects can only be created using the static factory
     methods Default() or Disable().
 
-    @see wxTextCtrl::EnableProofCheck(), wxTextCtrl::IsProofCheckEnabled().
+    @see wxTextCtrl::EnableProofCheck(), wxTextCtrl::GetProofCheckOptions().
 
     @since 3.1.6
 */
@@ -1039,10 +1039,13 @@ class WXDLLIMPEXP_CORE wxTextProofOptions
     wxTextProofOptions& GrammarCheck(bool enable = true)
 
     /// Return true if spell checking is enabled.
-    bool IsSpellCheckingEnabled() const;
+    bool IsSpellCheckEnabled() const;
 
     /// Return true if grammar checking is enabled.
-    bool IsGrammarCheckingEnabled() const;
+    bool IsGrammarCheckEnabled() const;
+
+    /// Returns true if any checks are enabled.
+    bool AnyChecksEnabled() const
 };
 
 /**
@@ -1570,15 +1573,16 @@ public:
     bool IsSingleLine() const;
 
     /**
-        Returns @true if proof (spell) checking is currently active on this
-        control, @false otherwise.
+        Returns the current text proofing options.
 
         This function is implemented for the same platforms as
-        EnableProofCheck() and returns @false for the other ones.
+        EnableProofCheck() and returns wxTextProofOptions with all checks
+        disabled, i.e. such that wxTextProofOptions::AnyChecksEnabled() returns
+        @false.
 
         @since 3.1.6
     */
-    virtual bool IsProofCheckEnabled();
+    virtual wxTextProofOptions GetProofCheckOptions();
 
     /**
         Loads and displays the named file, if it exists.

--- a/samples/text/text.cpp
+++ b/samples/text/text.cpp
@@ -1209,20 +1209,23 @@ MyPanel::MyPanel( wxFrame *frame, int x, int y, int w, int h )
     m_enter->SetClientData(const_cast<void*>(static_cast<const void*>(wxS("enter"))));
 
 #if wxUSE_SPELLCHECK
+    (*m_enter) << "\n";
+
     // Enable grammar check just for demonstration purposes (note that it's
     // only supported under Mac, but spell checking will be enabled under the
     // other platforms too, if supported). If we didn't want to enable it, we
     // could omit the EnableProofCheck() argument entirely.
     if ( !m_enter->EnableProofCheck(wxTextProofOptions::Default().GrammarCheck()) )
     {
-        wxMessageDialog error(this,
-                                wxT("Spell checking is not available on this platform or control style."),
-                                wxT("Spell checker error"),
-                                wxOK | wxCENTER | wxICON_ERROR);
-        error.ShowModal();
+        (*m_enter) << "Spell checking is not available on this platform, sorry.";
     }
     else
-        (*m_enter) << wxT("\nSpell checking is enabled, try typing a misspelled word...");
+    {
+        // Break the string in several parts to avoid misspellings in the sources.
+        (*m_enter) << "Spell checking is enabled, mis"
+                      "s"
+                      "spelled words should be highlighted.";
+    }
 #endif
 
     m_textrich = new MyTextCtrl(this, wxID_ANY, "Allows more than 30Kb of text\n"

--- a/samples/text/text.cpp
+++ b/samples/text/text.cpp
@@ -1205,8 +1205,21 @@ MyPanel::MyPanel( wxFrame *frame, int x, int y, int w, int h )
     m_tab->SetClientData(const_cast<void*>(static_cast<const void*>(wxS("tab"))));
 
     m_enter = new MyTextCtrl( this, 100, "Multiline, allow <ENTER> processing.",
-      wxPoint(180,170), wxSize(200,70), wxTE_MULTILINE | wxTE_PROCESS_ENTER );
+      wxPoint(180,170), wxSize(200,70), wxTE_MULTILINE | wxTE_PROCESS_ENTER | wxTE_RICH2 );
     m_enter->SetClientData(const_cast<void*>(static_cast<const void*>(wxS("enter"))));
+
+#if wxUSE_SPELLCHECK
+    if ( !m_enter->EnableProofCheck(true, wxTextProofOptions("en_US").SpellCheck()) )
+    {
+        wxMessageDialog error(this,
+                                wxT("Spell checking is not available on this platform or control style."),
+                                wxT("Spell checker error"),
+                                wxOK | wxCENTER | wxICON_ERROR);
+        error.ShowModal();
+    }
+    else
+        (*m_enter) << wxT("\nSpell checking is enabled, try typing a misspelled word...");
+#endif
 
     m_textrich = new MyTextCtrl(this, wxID_ANY, "Allows more than 30Kb of text\n"
                                 "(on all Windows versions)\n"

--- a/samples/text/text.cpp
+++ b/samples/text/text.cpp
@@ -1209,7 +1209,11 @@ MyPanel::MyPanel( wxFrame *frame, int x, int y, int w, int h )
     m_enter->SetClientData(const_cast<void*>(static_cast<const void*>(wxS("enter"))));
 
 #if wxUSE_SPELLCHECK
-    if ( !m_enter->EnableProofCheck(true, wxTextProofOptions("en_US").SpellCheck()) )
+    // Enable grammar check just for demonstration purposes (note that it's
+    // only supported under Mac, but spell checking will be enabled under the
+    // other platforms too, if supported). If we didn't want to enable it, we
+    // could omit the EnableProofCheck() argument entirely.
+    if ( !m_enter->EnableProofCheck(wxTextProofOptions::Default().GrammarCheck()) )
     {
         wxMessageDialog error(this,
                                 wxT("Spell checking is not available on this platform or control style."),

--- a/setup.h.in
+++ b/setup.h.in
@@ -216,11 +216,7 @@
 
 #define wxUSE_SECRETSTORE   0
 
-#if (defined(__WXGTK3__) || defined(__WXMSW__))
 #define wxUSE_SPELLCHECK 0
-#else
-#define wxUSE_SPELLCHECK 0
-#endif
 
 #define wxUSE_STDPATHS      0
 

--- a/setup.h.in
+++ b/setup.h.in
@@ -216,6 +216,12 @@
 
 #define wxUSE_SECRETSTORE   0
 
+#if (defined(__WXGTK3__) || defined(__WXMSW__))
+#define wxUSE_SPELLCHECK 0
+#else
+#define wxUSE_SPELLCHECK 0
+#endif
+
 #define wxUSE_STDPATHS      0
 
 #define wxUSE_TEXTBUFFER    0

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -1036,7 +1036,7 @@ bool wxTextCtrl::EnableProofCheck(const wxTextProofOptions& options)
 
     GtkSpellChecker *spell = gtk_spell_checker_get_from_text_view(textview);
 
-    if ( options.IsSpellCheckingEnabled() )
+    if ( options.IsSpellCheckEnabled() )
     {
         if ( !spell )
         {
@@ -1057,19 +1057,22 @@ bool wxTextCtrl::EnableProofCheck(const wxTextProofOptions& options)
             gtk_spell_checker_detach(spell);
     }
 
-   return IsProofCheckEnabled();
+   return GetProofCheckOptions().IsSpellCheckEnabled();
 }
 
-bool wxTextCtrl::IsProofCheckEnabled() const
+wxTextProofOptions wxTextCtrl::GetProofCheckOptions() const
 {
+    wxTextProofOptions opts = wxTextProofOptions::Disable();
+
     GtkTextView *textview = GTK_TEXT_VIEW(m_text);
 
-    if ( !IsMultiLine() || textview == NULL )
-        return false;
+    if ( IsMultiLine() && textview )
+    {
+        if ( gtk_spell_checker_get_from_text_view(textview) )
+            opts.SpellCheck();
+    }
 
-    GtkSpellChecker *spell = gtk_spell_checker_get_from_text_view(textview);
-
-    return (spell != NULL);
+    return opts;
 }
 
 #endif // wxUSE_SPELLCHECK && __WXGTK3__

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -1025,7 +1025,7 @@ void wxTextCtrl::GTKSetJustification()
 
 #if wxUSE_SPELLCHECK && defined(__WXGTK3__)
 
-bool wxTextCtrl::EnableProofCheck(bool enable, const wxTextProofOptions& options)
+bool wxTextCtrl::EnableProofCheck(const wxTextProofOptions& options)
 {
     wxCHECK_MSG( IsMultiLine(), false,
                 "Unable to enable spell check on control "
@@ -1036,7 +1036,7 @@ bool wxTextCtrl::EnableProofCheck(bool enable, const wxTextProofOptions& options
 
     GtkSpellChecker *spell = gtk_spell_checker_get_from_text_view(textview);
 
-    if ( enable )
+    if ( options.IsSpellCheckingEnabled() )
     {
         if ( !spell )
         {

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -32,11 +32,11 @@
 #include "wx/gtk/private.h"
 #include "wx/gtk/private/gtk3-compat.h"
 
-#if wxUSE_SPELLCHECK
+#if wxUSE_SPELLCHECK && defined(__WXGTK3__)
 extern "C" {
 #include <gtkspell-3.0/gtkspell/gtkspell.h>
 }
-#endif // wxUSE_SPELLCHECK
+#endif // wxUSE_SPELLCHECK && __WXGTK3__
 
 // ----------------------------------------------------------------------------
 // helpers
@@ -1023,7 +1023,7 @@ void wxTextCtrl::GTKSetJustification()
     }
 }
 
-#if wxUSE_SPELLCHECK
+#if wxUSE_SPELLCHECK && defined(__WXGTK3__)
 
 bool wxTextCtrl::EnableProofCheck(bool enable, const wxTextProofOptions& options)
 {
@@ -1072,7 +1072,7 @@ bool wxTextCtrl::IsProofCheckEnabled() const
     return (spell != NULL);
 }
 
-#endif // wxUSE_SPELLCHECK
+#endif // wxUSE_SPELLCHECK && __WXGTK3__
 
 void wxTextCtrl::SetWindowStyleFlag(long style)
 {

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -846,21 +846,26 @@ bool wxTextCtrl::EnableProofCheck(const wxTextProofOptions& options)
 
     LRESULT langOptions = ::SendMessage(GetHwnd(), EM_GETLANGOPTIONS, 0, 0);
 
-    if ( options.IsSpellCheckingEnabled() )
+    if ( options.IsSpellCheckEnabled() )
         langOptions |= IMF_SPELLCHECKING;
     else
         langOptions &= ~IMF_SPELLCHECKING;
 
     ::SendMessage(GetHwnd(), EM_SETLANGOPTIONS, 0, langOptions);
 
-   return IsProofCheckEnabled();
+   return GetProofCheckOptions().IsSpellCheckEnabled();
 }
 
-bool wxTextCtrl::IsProofCheckEnabled() const
+wxTextProofOptions wxTextCtrl::GetProofCheckOptions() const
 {
+    wxTextProofOptions opts = wxTextProofOptions::Disable();
+
     LRESULT langOptions = ::SendMessage(GetHwnd(), EM_GETLANGOPTIONS, 0, 0);
 
-    return (langOptions & IMF_SPELLCHECKING);
+    if (langOptions & IMF_SPELLCHECKING)
+        opts.SpellCheck();
+
+    return opts;
 }
 
 #endif // wxUSE_SPELLCHECK

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -834,7 +834,7 @@ WXDWORD wxTextCtrl::MSWGetStyle(long style, WXDWORD *exstyle) const
 
 #if wxUSE_RICHEDIT && wxUSE_SPELLCHECK
 
-bool wxTextCtrl::EnableProofCheck(bool enable, const wxTextProofOptions& WXUNUSED(options))
+bool wxTextCtrl::EnableProofCheck(const wxTextProofOptions& options)
 {
     wxCHECK_MSG((m_windowStyle & wxTE_RICH2), false,
             "Unable to enable proof checking on a control "
@@ -846,7 +846,7 @@ bool wxTextCtrl::EnableProofCheck(bool enable, const wxTextProofOptions& WXUNUSE
 
     LRESULT langOptions = ::SendMessage(GetHwnd(), EM_GETLANGOPTIONS, 0, 0);
 
-    if ( enable )
+    if ( options.IsSpellCheckingEnabled() )
         langOptions |= IMF_SPELLCHECKING;
     else
         langOptions &= ~IMF_SPELLCHECKING;

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -1283,6 +1283,11 @@ void wxNSTextViewControl::CheckSpelling(bool check)
         [m_textView setContinuousSpellCheckingEnabled: check];
 }
 
+bool wxNSTextViewControl::IsSpellingCheckEnabled() const
+{
+    return m_textView && m_textView.continuousSpellCheckingEnabled;
+}
+
 void wxNSTextViewControl::EnableAutomaticQuoteSubstitution(bool enable)
 {
     if (m_textView)

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -1283,13 +1283,20 @@ void wxNSTextViewControl::CheckSpelling(const wxTextProofOptions& options)
 {
     wxCHECK_RET( m_textView, "control must be created first" );
 
-    m_textView.continuousSpellCheckingEnabled = options.IsSpellCheckingEnabled();
-    m_textView.grammarCheckingEnabled = options.IsGrammarCheckingEnabled();
+    m_textView.continuousSpellCheckingEnabled = options.IsSpellCheckEnabled();
+    m_textView.grammarCheckingEnabled = options.IsGrammarCheckEnabled();
 }
 
-bool wxNSTextViewControl::IsSpellingCheckEnabled() const
+wxTextProofOptions wxNSTextViewControl::GetCheckingOptions() const
 {
-    return m_textView && m_textView.continuousSpellCheckingEnabled;
+    wxTextProofOptions opts = wxTextProofOptions::Disable();
+    if ( m_textView )
+    {
+        opts.SpellCheck(m_textView.continuousSpellCheckingEnabled);
+        opts.GrammarCheck(m_textView.grammarCheckingEnabled);
+    }
+
+    return opts;
 }
 
 #endif // wxUSE_SPELLCHECK

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -1277,16 +1277,22 @@ void wxNSTextViewControl::SetStyle(long start,
     }
 }
 
-void wxNSTextViewControl::CheckSpelling(bool check)
+#if wxUSE_SPELLCHECK
+
+void wxNSTextViewControl::CheckSpelling(const wxTextProofOptions& options)
 {
-    if (m_textView)
-        [m_textView setContinuousSpellCheckingEnabled: check];
+    wxCHECK_RET( m_textView, "control must be created first" );
+
+    m_textView.continuousSpellCheckingEnabled = options.IsSpellCheckingEnabled();
+    m_textView.grammarCheckingEnabled = options.IsGrammarCheckingEnabled();
 }
 
 bool wxNSTextViewControl::IsSpellingCheckEnabled() const
 {
     return m_textView && m_textView.continuousSpellCheckingEnabled;
 }
+
+#endif // wxUSE_SPELLCHECK
 
 void wxNSTextViewControl::EnableAutomaticQuoteSubstitution(bool enable)
 {

--- a/src/osx/iphone/textctrl.mm
+++ b/src/osx/iphone/textctrl.mm
@@ -500,19 +500,6 @@ void wxUITextViewControl::SetStyle(long start,
     }
 }
 
-#if wxUSE_SPELLCHECK
-
-void wxUITextViewControl::CheckSpelling(const wxTextProofOptions& WXUNUSED(options))
-{
-}
-
-bool wxUITextViewControl::IsSpellingCheckEnabled() const
-{
-    return false;
-}
-
-#endif // wxUSE_SPELLCHECK
-
 wxSize wxUITextViewControl::GetBestSize() const
 {
     wxRect r;

--- a/src/osx/iphone/textctrl.mm
+++ b/src/osx/iphone/textctrl.mm
@@ -500,7 +500,9 @@ void wxUITextViewControl::SetStyle(long start,
     }
 }
 
-void wxUITextViewControl::CheckSpelling(bool check)
+#if wxUSE_SPELLCHECK
+
+void wxUITextViewControl::CheckSpelling(const wxTextProofOptions& WXUNUSED(options))
 {
 }
 
@@ -508,6 +510,8 @@ bool wxUITextViewControl::IsSpellingCheckEnabled() const
 {
     return false;
 }
+
+#endif // wxUSE_SPELLCHECK
 
 wxSize wxUITextViewControl::GetBestSize() const
 {

--- a/src/osx/iphone/textctrl.mm
+++ b/src/osx/iphone/textctrl.mm
@@ -504,6 +504,11 @@ void wxUITextViewControl::CheckSpelling(bool check)
 {
 }
 
+bool wxUITextViewControl::IsSpellingCheckEnabled() const
+{
+    return false;
+}
+
 wxSize wxUITextViewControl::GetBestSize() const
 {
     wxRect r;

--- a/src/osx/textctrl_osx.cpp
+++ b/src/osx/textctrl_osx.cpp
@@ -124,10 +124,12 @@ void wxTextCtrl::MacVisibilityChanged()
 {
 }
 
+#if WXWIN_COMPATIBILITY_3_0
 void wxTextCtrl::MacCheckSpelling(bool check)
 {
     GetTextPeer()->CheckSpelling(check);
 }
+#endif // WXWIN_COMPATIBILITY_3_0
 
 void wxTextCtrl::OSXEnableAutomaticQuoteSubstitution(bool enable)
 {
@@ -339,6 +341,25 @@ void wxTextCtrl::Paste()
         }
     }
 }
+
+#if wxUSE_SPELLCHECK
+
+bool wxTextCtrl::EnableProofCheck(
+        bool enable,
+        const wxTextProofOptions& WXUNUSED(options)
+    )
+{
+    GetTextPeer()->CheckSpelling(enable);
+
+    return true;
+}
+
+bool wxTextCtrl::IsProofCheckEnabled() const
+{
+    return GetTextPeer()->IsSpellingCheckEnabled();
+}
+
+#endif // wxUSE_SPELLCHECK
 
 void wxTextCtrl::OnDropFiles(wxDropFilesEvent& event)
 {

--- a/src/osx/textctrl_osx.cpp
+++ b/src/osx/textctrl_osx.cpp
@@ -352,9 +352,9 @@ bool wxTextCtrl::EnableProofCheck(const wxTextProofOptions& options)
     return true;
 }
 
-bool wxTextCtrl::IsProofCheckEnabled() const
+wxTextProofOptions wxTextCtrl::GetProofCheckOptions() const
 {
-    return GetTextPeer()->IsSpellingCheckEnabled();
+    return GetTextPeer()->GetCheckingOptions();
 }
 
 #endif // wxUSE_SPELLCHECK
@@ -826,6 +826,15 @@ int wxTextWidgetImpl::GetLineLength(long lineNo) const
 
     return -1 ;
 }
+
+#if wxUSE_SPELLCHECK
+
+wxTextProofOptions wxTextWidgetImpl::GetCheckingOptions() const
+{
+    return wxTextProofOptions::Disable();
+}
+
+#endif // wxUSE_SPELLCHECK
 
 void wxTextWidgetImpl::SetJustification()
 {

--- a/src/osx/textctrl_osx.cpp
+++ b/src/osx/textctrl_osx.cpp
@@ -344,12 +344,9 @@ void wxTextCtrl::Paste()
 
 #if wxUSE_SPELLCHECK
 
-bool wxTextCtrl::EnableProofCheck(
-        bool enable,
-        const wxTextProofOptions& WXUNUSED(options)
-    )
+bool wxTextCtrl::EnableProofCheck(const wxTextProofOptions& options)
 {
-    GetTextPeer()->CheckSpelling(enable);
+    GetTextPeer()->CheckSpelling(options.IsSpellCheckingEnabled());
 
     return true;
 }

--- a/src/osx/textctrl_osx.cpp
+++ b/src/osx/textctrl_osx.cpp
@@ -124,12 +124,13 @@ void wxTextCtrl::MacVisibilityChanged()
 {
 }
 
-#if WXWIN_COMPATIBILITY_3_0
+#if WXWIN_COMPATIBILITY_3_0 && wxUSE_SPELLCHECK
 void wxTextCtrl::MacCheckSpelling(bool check)
 {
-    GetTextPeer()->CheckSpelling(check);
+    GetTextPeer()->CheckSpelling(check ? wxTextProofOptions::Default()
+                                       : wxTextProofOptions::Disable());
 }
-#endif // WXWIN_COMPATIBILITY_3_0
+#endif // WXWIN_COMPATIBILITY_3_0 && wxUSE_SPELLCHECK
 
 void wxTextCtrl::OSXEnableAutomaticQuoteSubstitution(bool enable)
 {
@@ -346,7 +347,7 @@ void wxTextCtrl::Paste()
 
 bool wxTextCtrl::EnableProofCheck(const wxTextProofOptions& options)
 {
-    GetTextPeer()->CheckSpelling(options.IsSpellCheckingEnabled());
+    GetTextPeer()->CheckSpelling(options);
 
     return true;
 }


### PR DESCRIPTION
This is an update to the original Pull Request at #742 which in turn was based on wxTrac ticket https://trac.wxwidgets.org/ticket/17544.

The comments made against the original commit have been addressed in this new PR, but were answered in the original conversation for traceability. Comments can now be continued in this PR and referenced to the original PR #742 if necessary.