### PR TITLE
Reduce M1 CI builds number and add a universal build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - master
     paths-ignore:
-      - '.github/workflows/MacS-M1-make.yml'
+      - '.github/workflows/ci_mac_selfhosted.yml'
       - '.github/workflows/ci_cmake.yml'
       - '.github/workflows/ci_msw_cross.yml'
       - 'build/tools/appveyor*.bat'
@@ -24,7 +24,7 @@ on:
     branches:
       - master
     paths-ignore:
-      - '.github/workflows/MacS-M1-make.yml'
+      - '.github/workflows/ci_mac_selfhosted.yml'
       - '.github/workflows/ci_cmake.yml'
       - '.github/workflows/ci_msw_cross.yml'
       - 'build/tools/appveyor*.bat'

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -7,6 +7,7 @@ on:
       - master
     paths-ignore:
       - '.github/workflows/ci.yml'
+      - '.github/workflows/ci_mac_selfhosted.yml'
       - '.github/workflows/ci_msw_cross.yml'
       - 'build/tools/appveyor*.bat'
       - 'distrib/**'
@@ -24,6 +25,7 @@ on:
       - master
     paths-ignore:
       - '.github/workflows/ci.yml'
+      - '.github/workflows/ci_mac_selfhosted.yml'
       - '.github/workflows/ci_msw_cross.yml'
       - 'build/tools/appveyor*.bat'
       - 'distrib/**'

--- a/.github/workflows/ci_mac_selfhosted.yml
+++ b/.github/workflows/ci_mac_selfhosted.yml
@@ -65,26 +65,24 @@ jobs:
 
     runs-on: self-hosted
 
-    name: ${{ matrix.build }}, arch ${{ matrix.arch }}, cxx${{ matrix.cxx }}
+    name: ${{ matrix.name }}
 
     strategy:
       fail-fast: false
       matrix:
-        arch: [arm64e, x86_64]
-        build: [debug, release]
-        cxx: [11, 17]
         include:
-        - build: debug
-          configure_flags: --without-liblzma --enable-debug --disable-sys-libs --with-osx_cocoa
-        - build: release
-          configure_flags: --without-liblzma --disable-sys-libs --with-osx_cocoa
-        - cxx: 17
-          cxxconfig: --with-macosx-version-min=10.12
-        - cxx: 11
-          cxxconfig:
+        - name: ARM C++11
+          arch: arm64
+          configure_flags: --with-cxx=11 --disable-debug
+        - name: Intel C++17
+          arch: x86_64
+          configure_flags: --with-cxx=17 --with-macosx-version-min=10.12 --enable-debug
+        - name: Universal C++14
+          arch: arm64
+          configure_flags: --with-cxx=14 --enable-universal_binary=arm64,x86_64 --disable-shared --disable-debug
 
     env:
-      wxCONFIGURE_FLAGS: ${{ matrix.configure_flags }} ${{ matrix.cxxconfig }} --with-cxx=${{ matrix.cxx }} --prefix=${{ github.workspace }}/localbin_${{ matrix.arch }}
+      wxCONFIGURE_FLAGS: --disable-sys-libs --without-liblzma ${{ matrix.configure_flags }} --prefix=${{ github.workspace }}/localbin_${{ matrix.arch }}
       DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
       NSUnbufferedIO: YES
 

--- a/.github/workflows/ci_mac_selfhosted.yml
+++ b/.github/workflows/ci_mac_selfhosted.yml
@@ -73,16 +73,18 @@ jobs:
         include:
         - name: ARM C++11
           arch: arm64
-          configure_flags: --with-cxx=11 --disable-debug
+          configure_flags: --with-cxx=11
+          use_asan: true
         - name: Intel C++17
           arch: x86_64
           configure_flags: --with-cxx=17 --with-macosx-version-min=10.12 --enable-debug
         - name: Universal C++14
           arch: arm64
-          configure_flags: --with-cxx=14 --enable-universal_binary=arm64,x86_64 --disable-shared --disable-debug
+          configure_flags: --with-cxx=14 --enable-universal_binary=arm64,x86_64 --disable-shared --disable-debug --enable-optimise
 
     env:
       wxCONFIGURE_FLAGS: --disable-sys-libs --without-liblzma ${{ matrix.configure_flags }} --prefix=${{ github.workspace }}/localbin_${{ matrix.arch }}
+      wxUSE_ASAN: ${{ matrix.use_asan && 1 || 0 }}
       DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
       NSUnbufferedIO: YES
 
@@ -134,6 +136,15 @@ jobs:
       run: |
         wxCONFIGURE_OPTIONS="--disable-optimise $wxCONFIGURE_FLAGS"
         ./configure $wxCONFIGURE_OPTIONS --disable-debug_info || rc=$?
+        if [ ${{ matrix.use_asan }} ]; then
+          wxASAN_CFLAGS="-fsanitize=address -fno-omit-frame-pointer"
+          wxASAN_CXXFLAGS=$wxASAN_CFLAGS
+          wxASAN_LDFLAGS="-fsanitize=address"
+
+          ./configure $wxCONFIGURE_OPTIONS --enable-debug "CFLAGS=$wxASAN_CFLAGS" "CXXFLAGS=$wxASAN_CXXFLAGS" "LDFLAGS=$wxASAN_LDFLAGS" || rc=$?
+        else
+          ./configure $wxCONFIGURE_OPTIONS --disable-debug_info || rc=$?
+        fi
         if [ -n "$rc" ]; then
           echo '*** Configuring failed, contents of config.log follows: ***'
           echo '-----------------------------------------------------------'

--- a/.github/workflows/ci_mac_selfhosted.yml
+++ b/.github/workflows/ci_mac_selfhosted.yml
@@ -1,12 +1,14 @@
-name: Mac make CI
+name: Mac builds
 
 on:
   workflow_dispatch:
   push:
     branches: [ master ]
     paths-ignore:
+    - '.github/workflows/ci.yml'
+    - '.github/workflows/ci_cmake.yml'
+    - '.github/workflows/ci_msw_cross.yml'
     - 'build/tools/appveyor*.bat'
-    - 'build/tools/travis-ci.sh'
     - 'distrib/**'
     - 'docs/**'
     - 'interface/**'
@@ -30,8 +32,10 @@ on:
   pull_request:
     branches: [ master ]
     paths-ignore:
+    - '.github/workflows/ci.yml'
+    - '.github/workflows/ci_cmake.yml'
+    - '.github/workflows/ci_msw_cross.yml'
     - 'build/tools/appveyor*.bat'
-    - 'build/tools/travis-ci.sh'
     - 'distrib/**'
     - 'docs/**'
     - 'interface/**'

--- a/.github/workflows/ci_msw_cross.yml
+++ b/.github/workflows/ci_msw_cross.yml
@@ -1,5 +1,5 @@
 # CI workflow cross-building wxMSW under Linux.
-name: wxMSW cross-build
+name: MSW cross-builds
 
 on:
   push:

--- a/.github/workflows/ci_msw_cross.yml
+++ b/.github/workflows/ci_msw_cross.yml
@@ -7,6 +7,8 @@ on:
       - master
     paths-ignore:
       - '.github/workflows/ci.yml'
+      - '.github/workflows/ci_cmake.yml'
+      - '.github/workflows/ci_mac_selfhosted.yml'
       - 'build/tools/appveyor*.bat'
       - 'distrib/**'
       - 'docs/**'
@@ -25,6 +27,8 @@ on:
       - master
     paths-ignore:
       - '.github/workflows/ci.yml'
+      - '.github/workflows/ci_cmake.yml'
+      - '.github/workflows/ci_mac_selfhosted.yml'
       - 'build/tools/appveyor*.bat'
       - 'distrib/**'
       - 'docs/**'

--- a/include/wx/debug.h
+++ b/include/wx/debug.h
@@ -331,6 +331,8 @@ extern WXDLLIMPEXP_BASE void wxOnAssert(const char *file,
     #define wxFAIL
     #define wxFAIL_MSG(msg)
     #define wxFAIL_COND_MSG(cond, msg)
+    #define wxFAIL_MSG_AT(msg, file, line, func)
+    #define wxFAIL_COND_MSG_AT(cond, msg, file, line, func)
 #endif  // wxDEBUG_LEVEL
 
 #if wxDEBUG_LEVEL >= 2

--- a/include/wx/testing.h
+++ b/include/wx/testing.h
@@ -34,6 +34,10 @@ class WXDLLIMPEXP_FWD_CORE wxFileDialogBase;
 #include "wx/msgdlg.h"
 #include "wx/filedlg.h"
 
+#ifndef __WXDEBUG__
+    #include "wx/crt.h"
+#endif // !__WXDEBUG__
+
 #include <typeinfo>
 
 class wxTestingModalHook;
@@ -421,10 +425,20 @@ protected:
     // course, can itself be customized.
     virtual void ReportFailure(const wxString& msg)
     {
+#ifdef __WXDEBUG__
         wxFAIL_MSG_AT( msg,
                        m_file ? m_file : __FILE__,
                        m_line ? m_line : __LINE__,
                        m_func ? m_func : __WXFUNCTION__ );
+#else // !__WXDEBUG__
+        // We still need to report the failure somehow when wx asserts are
+        // disabled.
+        wxFprintf(stderr, wxASCII_STR("%s at %s:%d in %s()\n"),
+                  msg,
+                  wxASCII_STR(m_file ? m_file : __FILE__),
+                  m_line ? m_line : __LINE__,
+                  wxASCII_STR(m_func ? m_func : __WXFUNCTION__));
+#endif // __WXDEBUG__/!__WXDEBUG__
     }
 
 private:

--- a/tests/misc/misctests.cpp
+++ b/tests/misc/misctests.cpp
@@ -125,12 +125,16 @@ void MiscTestCase::Delete()
 namespace
 {
 
+#ifdef __WXDEBUG__
+
 // helper function used just to avoid warnings about value computed not being
 // used in WX_ASSERT_FAILS_WITH_ASSERT() in StaticCast() below
 bool IsNull(void *p)
 {
     return p == NULL;
 }
+
+#endif // __WXDEBUG__
 
 } // anonymous namespace
 

--- a/tests/testprec.h
+++ b/tests/testprec.h
@@ -128,6 +128,7 @@ public:
     // normal build with wxDEBUG_LEVEL != 0 we can pass something not
     // evaluating to a bool at all but it then would fail to compile in
     // wxDEBUG_LEVEL == 0 case, so just don't do anything at all now).
+    #define WX_ASSERT_FAILS_WITH_ASSERT_MESSAGE(msg, code)
     #define WX_ASSERT_FAILS_WITH_ASSERT(cond)
 #endif
 


### PR DESCRIPTION
As discussed in #2336, here is an attempt to run fewer CI builds on our Mac.