### PR TITLE
Call Update before giving away focus on dismiss menu

### DIFF
--- a/src/univ/menu.cpp
+++ b/src/univ/menu.cpp
@@ -2563,6 +2563,7 @@ void wxMenuBar::OnDismiss()
         m_current = -1;
 
         RefreshItem(current);
+        Update();
     }
 
     GiveAwayFocus();


### PR DESCRIPTION
Without immediate refreshing menu is appearing as inactive.