### PR TITLE
Fix handle mouse in wxStdScrollBarInputHandler

### DIFF
--- a/src/univ/scrolbar.cpp
+++ b/src/univ/scrolbar.cpp
@@ -1086,7 +1086,7 @@ bool wxStdScrollBarInputHandler::HandleMouse(wxInputConsumer *consumer,
         }
     }
 
-    return wxStdInputHandler::HandleMouse(consumer, event);
+    return true;
 }
 
 bool wxStdScrollBarInputHandler::HandleMouseMove(wxInputConsumer *consumer,


### PR DESCRIPTION
Fix for [19230 - [wxUniv(MSW)] Access violation exception when using re-created scrollbar in filedialog.](http://trac.wxwidgets.org/ticket/19230)