### PR TITLE
Update xcode builds

### DIFF
--- a/build/osx/wx.xcconfig
+++ b/build/osx/wx.xcconfig
@@ -10,8 +10,8 @@ OTHER_CPLUSPLUSFLAGS = $(OTHER_CFLAGS) -fvisibility-inlines-hidden
 
 GCC_PREFIX_HEADER = $(WXROOT)/include/wx/wxprec.h
 GCC_PRECOMPILE_PREFIX_HEADER = YES
-HEADER_SEARCH_PATHS = "$(WXROOT)/src/tiff/libtiff" "$(WXROOT)/src/regex"
-USER_HEADER_SEARCH_PATHS = "$(WXROOT)/include" "$(WXROOT)/build/osx/setup/$(WXTOOLKIT)/include" "$(WXROOT)/src/zlib" "$(WXROOT)/src/jpeg" "$(WXROOT)/src/png" "$(WXROOT)/src/expat/expat/lib" "$(WXROOT)/src/tiff/libtiff" "$(WXROOT)/src/stc/scintilla/src" "$(WXROOT)/src/stc/scintilla/include" "$(WXROOT)/src/stc/scintilla/lexlib" "$(WXROOT)/3rdparty/pcre/src/wx"
+HEADER_SEARCH_PATHS = "$(WXROOT)/src/tiff/libtiff" "$(WXROOT)/src/regex" "$(WXROOT)/3rdparty/pcre/src/wx"
+USER_HEADER_SEARCH_PATHS = "$(WXROOT)/include" "$(WXROOT)/build/osx/setup/$(WXTOOLKIT)/include" "$(WXROOT)/src/zlib" "$(WXROOT)/src/jpeg" "$(WXROOT)/src/png" "$(WXROOT)/src/expat/expat/lib" "$(WXROOT)/src/tiff/libtiff" "$(WXROOT)/src/stc/scintilla/src" "$(WXROOT)/src/stc/scintilla/include" "$(WXROOT)/src/stc/scintilla/lexlib"
 ALWAYS_SEARCH_USER_PATHS = NO
 WX_PREPROCESSOR_DEFINITIONS = WXBUILDING $(WXPLATFORM) __WX__ _FILE_OFFSET_BITS=64 _LARGE_FILES MACOS_CLASSIC __WXMAC_XCODE__=1 SCI_LEXER NO_CXX11_REGEX WX_PRECOMP=1 wxUSE_UNICODE_UTF8=0 wxUSE_UNICODE_WCHAR=1 HAVE_CONFIG_H PNG_NO_CONFIG_H
 GCC_PREPROCESSOR_DEFINITIONS = $(WX_PREPROCESSOR_DEFINITIONS)

--- a/build/osx/wxcocoa.xcconfig
+++ b/build/osx/wxcocoa.xcconfig
@@ -4,9 +4,17 @@ WXTOOLKITUPPER = COCOA
 #include "wx.xcconfig"
 
 MACOSX_DEPLOYMENT_TARGET = 10.10
+MACOSX_DEPLOYMENT_TARGET[arch=arm64] = 11.0
 
 GCC_VERSION =
 
-ARCHS = i386 x86_64
+// Set ARCHS explicitly for when Xcode stops targeting x86_64 by default.
+// Unknown targets are ignored by Xcode (arm64 requires Xcode 12 or later).
+ARCHS = x86_64 arm64
+
+// Using i386 as a target results in a deprecation error since Xcode 10 (first
+// a warning in 9). If Xcode 9 or earlier is used and the i386 target is also
+// needed, one solution is to enable the following line locally.
+//ARCHS = i386 x86_64
 
 OTHER_LDFLAGS = -framework WebKit -framework IOKit -framework Carbon -framework Cocoa -framework AudioToolbox -framework OpenGL -framework AVFoundation -framework CoreMedia -framework Security -framework QuartzCore -weak_framework AVKit

--- a/build/osx/wxcocoa.xcodeproj/project.pbxproj
+++ b/build/osx/wxcocoa.xcodeproj/project.pbxproj
@@ -46,6 +46,9 @@
 		0095084719983B878378CA28 /* pngwrite.c in Sources */ = {isa = PBXBuildFile; fileRef = 69A6CAF721E53E83B4820DE6 /* pngwrite.c */; };
 		0095084719983B878378CA29 /* pngwrite.c in Sources */ = {isa = PBXBuildFile; fileRef = 69A6CAF721E53E83B4820DE6 /* pngwrite.c */; };
 		0095084719983B878378CA2A /* pngwrite.c in Sources */ = {isa = PBXBuildFile; fileRef = 69A6CAF721E53E83B4820DE6 /* pngwrite.c */; };
+		00E12455C98032E18378EE5E /* pcre2_newline.c in Sources */ = {isa = PBXBuildFile; fileRef = A208BFC0C8C43847A9620ADA /* pcre2_newline.c */; };
+		00E12455C98032E18378EE5F /* pcre2_newline.c in Sources */ = {isa = PBXBuildFile; fileRef = A208BFC0C8C43847A9620ADA /* pcre2_newline.c */; };
+		00E12455C98032E18378EE60 /* pcre2_newline.c in Sources */ = {isa = PBXBuildFile; fileRef = A208BFC0C8C43847A9620ADA /* pcre2_newline.c */; };
 		00E2F82590B33BDCA1F6D0C4 /* xh_htmllbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8E7ADC9F00803853B1004529 /* xh_htmllbox.cpp */; };
 		00E2F82590B33BDCA1F6D0C5 /* xh_htmllbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8E7ADC9F00803853B1004529 /* xh_htmllbox.cpp */; };
 		00E2F82590B33BDCA1F6D0C6 /* xh_htmllbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8E7ADC9F00803853B1004529 /* xh_htmllbox.cpp */; };
@@ -234,6 +237,12 @@
 		10743B74A58231639C6BF610 /* inffast.c in Sources */ = {isa = PBXBuildFile; fileRef = 400275BE019D3E5BA47988BE /* inffast.c */; };
 		10743B74A58231639C6BF611 /* inffast.c in Sources */ = {isa = PBXBuildFile; fileRef = 400275BE019D3E5BA47988BE /* inffast.c */; };
 		10743B74A58231639C6BF612 /* inffast.c in Sources */ = {isa = PBXBuildFile; fileRef = 400275BE019D3E5BA47988BE /* inffast.c */; };
+		10B5C2A72C713A678458CD9D /* pcre2_ord2utf.c in Sources */ = {isa = PBXBuildFile; fileRef = 4BFEBC5061693DA0B52BC4AC /* pcre2_ord2utf.c */; };
+		10B5C2A72C713A678458CD9E /* pcre2_ord2utf.c in Sources */ = {isa = PBXBuildFile; fileRef = 4BFEBC5061693DA0B52BC4AC /* pcre2_ord2utf.c */; };
+		10B5C2A72C713A678458CD9F /* pcre2_ord2utf.c in Sources */ = {isa = PBXBuildFile; fileRef = 4BFEBC5061693DA0B52BC4AC /* pcre2_ord2utf.c */; };
+		1142E2D85FD93E9AB5D8A55A /* pcre2_script_run.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4CDF9048EC36788619769D /* pcre2_script_run.c */; };
+		1142E2D85FD93E9AB5D8A55B /* pcre2_script_run.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4CDF9048EC36788619769D /* pcre2_script_run.c */; };
+		1142E2D85FD93E9AB5D8A55C /* pcre2_script_run.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4CDF9048EC36788619769D /* pcre2_script_run.c */; };
 		11818B68C5263EB68D708845 /* jdtrans.c in Sources */ = {isa = PBXBuildFile; fileRef = 4549845C0751356A907C23E0 /* jdtrans.c */; };
 		11818B68C5263EB68D708846 /* jdtrans.c in Sources */ = {isa = PBXBuildFile; fileRef = 4549845C0751356A907C23E0 /* jdtrans.c */; };
 		11818B68C5263EB68D708847 /* jdtrans.c in Sources */ = {isa = PBXBuildFile; fileRef = 4549845C0751356A907C23E0 /* jdtrans.c */; };
@@ -451,6 +460,9 @@
 		2020EE3C45743B53BE8C7F38 /* LexCoffeeScript.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 9794A709E3C036D79860CEC9 /* LexCoffeeScript.cxx */; };
 		2020EE3C45743B53BE8C7F39 /* LexCoffeeScript.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 9794A709E3C036D79860CEC9 /* LexCoffeeScript.cxx */; };
 		2020EE3C45743B53BE8C7F3A /* LexCoffeeScript.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 9794A709E3C036D79860CEC9 /* LexCoffeeScript.cxx */; };
+		2047544E505C3BA38F0144E6 /* pcre2_tables.c in Sources */ = {isa = PBXBuildFile; fileRef = B60497805D37375EBFCF3D98 /* pcre2_tables.c */; };
+		2047544E505C3BA38F0144E7 /* pcre2_tables.c in Sources */ = {isa = PBXBuildFile; fileRef = B60497805D37375EBFCF3D98 /* pcre2_tables.c */; };
+		2047544E505C3BA38F0144E8 /* pcre2_tables.c in Sources */ = {isa = PBXBuildFile; fileRef = B60497805D37375EBFCF3D98 /* pcre2_tables.c */; };
 		205520440CD13C0AB9E89159 /* anidecod.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EE959EC7BFDD3A628E856404 /* anidecod.cpp */; };
 		205520440CD13C0AB9E8915A /* anidecod.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EE959EC7BFDD3A628E856404 /* anidecod.cpp */; };
 		205520440CD13C0AB9E8915B /* anidecod.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EE959EC7BFDD3A628E856404 /* anidecod.cpp */; };
@@ -536,6 +548,9 @@
 		25656617A56D342AA3D1BFE2 /* ctrlcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0EB91E8407CB3300A19F387D /* ctrlcmn.cpp */; };
 		25656617A56D342AA3D1BFE3 /* ctrlcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0EB91E8407CB3300A19F387D /* ctrlcmn.cpp */; };
 		25656617A56D342AA3D1BFE4 /* ctrlcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0EB91E8407CB3300A19F387D /* ctrlcmn.cpp */; };
+		25B0940CABAB39CD90C6F3C5 /* intel_init.c in Sources */ = {isa = PBXBuildFile; fileRef = 994AF74DF2A13FF09A215853 /* intel_init.c */; };
+		25B0940CABAB39CD90C6F3C6 /* intel_init.c in Sources */ = {isa = PBXBuildFile; fileRef = 994AF74DF2A13FF09A215853 /* intel_init.c */; };
+		25B0940CABAB39CD90C6F3C7 /* intel_init.c in Sources */ = {isa = PBXBuildFile; fileRef = 994AF74DF2A13FF09A215853 /* intel_init.c */; };
 		25C5C1713C0B39AC8EB6A38E /* taskbar.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2A4D36DE66EC3EB09E883D6B /* taskbar.mm */; };
 		25C5C1713C0B39AC8EB6A38F /* taskbar.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2A4D36DE66EC3EB09E883D6B /* taskbar.mm */; };
 		25C5C1713C0B39AC8EB6A390 /* taskbar.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2A4D36DE66EC3EB09E883D6B /* taskbar.mm */; };
@@ -554,6 +569,9 @@
 		27759C2FBB0E35FDA847B2B5 /* LexForth.cxx in Sources */ = {isa = PBXBuildFile; fileRef = B181F564935730E89AB00D92 /* LexForth.cxx */; };
 		27759C2FBB0E35FDA847B2B6 /* LexForth.cxx in Sources */ = {isa = PBXBuildFile; fileRef = B181F564935730E89AB00D92 /* LexForth.cxx */; };
 		27759C2FBB0E35FDA847B2B7 /* LexForth.cxx in Sources */ = {isa = PBXBuildFile; fileRef = B181F564935730E89AB00D92 /* LexForth.cxx */; };
+		27B5431DC79733CD8D403E88 /* pcre2_context.c in Sources */ = {isa = PBXBuildFile; fileRef = 3026D20A03E53F1DB40FB35A /* pcre2_context.c */; };
+		27B5431DC79733CD8D403E89 /* pcre2_context.c in Sources */ = {isa = PBXBuildFile; fileRef = 3026D20A03E53F1DB40FB35A /* pcre2_context.c */; };
+		27B5431DC79733CD8D403E8A /* pcre2_context.c in Sources */ = {isa = PBXBuildFile; fileRef = 3026D20A03E53F1DB40FB35A /* pcre2_context.c */; };
 		27E2EABB117334CD89CFD2A4 /* mdi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B568A7364ECA30288820CCE7 /* mdi.cpp */; };
 		27E2EABB117334CD89CFD2A5 /* mdi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B568A7364ECA30288820CCE7 /* mdi.cpp */; };
 		27E2EABB117334CD89CFD2A6 /* mdi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B568A7364ECA30288820CCE7 /* mdi.cpp */; };
@@ -629,6 +647,9 @@
 		2F50DBC14FE538A49823925A /* calctrlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 496674699F173A5385EAFF07 /* calctrlg.cpp */; };
 		2F50DBC14FE538A49823925B /* calctrlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 496674699F173A5385EAFF07 /* calctrlg.cpp */; };
 		2F50DBC14FE538A49823925C /* calctrlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 496674699F173A5385EAFF07 /* calctrlg.cpp */; };
+		2F7328AC75393951B08F75F1 /* pcre2_error.c in Sources */ = {isa = PBXBuildFile; fileRef = 25E03E349FC13E4A9428B94E /* pcre2_error.c */; };
+		2F7328AC75393951B08F75F2 /* pcre2_error.c in Sources */ = {isa = PBXBuildFile; fileRef = 25E03E349FC13E4A9428B94E /* pcre2_error.c */; };
+		2F7328AC75393951B08F75F3 /* pcre2_error.c in Sources */ = {isa = PBXBuildFile; fileRef = 25E03E349FC13E4A9428B94E /* pcre2_error.c */; };
 		2F7F5B9BBCD83D90B237A1A0 /* markupparser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DA7F7633279936EFA0B9C5CF /* markupparser.cpp */; };
 		2F7F5B9BBCD83D90B237A1A1 /* markupparser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DA7F7633279936EFA0B9C5CF /* markupparser.cpp */; };
 		2F7F5B9BBCD83D90B237A1A2 /* markupparser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DA7F7633279936EFA0B9C5CF /* markupparser.cpp */; };
@@ -826,87 +847,6 @@
 		4040AE89BF9F34668091064A /* dragimgg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2A67053D16D63C588E555C84 /* dragimgg.cpp */; };
 		4040AE89BF9F34668091064B /* dragimgg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2A67053D16D63C588E555C84 /* dragimgg.cpp */; };
 		4040AE89BF9F34668091064C /* dragimgg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2A67053D16D63C588E555C84 /* dragimgg.cpp */; };
-		DFEB01E7B97A3515B785DCA9 /* pcre2_string_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = A6EE037AF43E343E8E1A7555 /* pcre2_string_utils.c */; };
-		DFEB01E7B97A3515B785DCAA /* pcre2_string_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = A6EE037AF43E343E8E1A7555 /* pcre2_string_utils.c */; };
-		D7F14BDFFB7F369B842AFC13 /* pcre2_config.c in Sources */ = {isa = PBXBuildFile; fileRef = FC6A8FAE9CA63EEB8883B6BD /* pcre2_config.c */; };
-		D7F14BDFFB7F369B842AFC14 /* pcre2_config.c in Sources */ = {isa = PBXBuildFile; fileRef = FC6A8FAE9CA63EEB8883B6BD /* pcre2_config.c */; };
-		B6728BCD1A0731299924C8C4 /* pcre2_substring.c in Sources */ = {isa = PBXBuildFile; fileRef = 5152B34D06E9343FBFAB3510 /* pcre2_substring.c */; };
-		B6728BCD1A0731299924C8C5 /* pcre2_substring.c in Sources */ = {isa = PBXBuildFile; fileRef = 5152B34D06E9343FBFAB3510 /* pcre2_substring.c */; };
-		60296753A32B39EB8BD0CB44 /* pcre2_study.c in Sources */ = {isa = PBXBuildFile; fileRef = 09CCDDC66F683C6B87BEDD2F /* pcre2_study.c */; };
-		60296753A32B39EB8BD0CB45 /* pcre2_study.c in Sources */ = {isa = PBXBuildFile; fileRef = 09CCDDC66F683C6B87BEDD2F /* pcre2_study.c */; };
-		10B5C2A72C713A678458CD9D /* pcre2_ord2utf.c in Sources */ = {isa = PBXBuildFile; fileRef = 4BFEBC5061693DA0B52BC4AC /* pcre2_ord2utf.c */; };
-		10B5C2A72C713A678458CD9E /* pcre2_ord2utf.c in Sources */ = {isa = PBXBuildFile; fileRef = 4BFEBC5061693DA0B52BC4AC /* pcre2_ord2utf.c */; };
-		27B5431DC79733CD8D403E88 /* pcre2_context.c in Sources */ = {isa = PBXBuildFile; fileRef = 3026D20A03E53F1DB40FB35A /* pcre2_context.c */; };
-		27B5431DC79733CD8D403E89 /* pcre2_context.c in Sources */ = {isa = PBXBuildFile; fileRef = 3026D20A03E53F1DB40FB35A /* pcre2_context.c */; };
-		6463C9BE78C0394CB7B451FA /* pcre2_compile.c in Sources */ = {isa = PBXBuildFile; fileRef = BDADEB1DA6433E52972C8934 /* pcre2_compile.c */; };
-		6463C9BE78C0394CB7B451FB /* pcre2_compile.c in Sources */ = {isa = PBXBuildFile; fileRef = BDADEB1DA6433E52972C8934 /* pcre2_compile.c */; };
-		C5C60B22CE6A3BCB868F69E8 /* pcre2_find_bracket.c in Sources */ = {isa = PBXBuildFile; fileRef = 943C7E9527C03FCDB5966273 /* pcre2_find_bracket.c */; };
-		C5C60B22CE6A3BCB868F69E9 /* pcre2_find_bracket.c in Sources */ = {isa = PBXBuildFile; fileRef = 943C7E9527C03FCDB5966273 /* pcre2_find_bracket.c */; };
-		00E12455C98032E18378EE5E /* pcre2_newline.c in Sources */ = {isa = PBXBuildFile; fileRef = A208BFC0C8C43847A9620ADA /* pcre2_newline.c */; };
-		00E12455C98032E18378EE5F /* pcre2_newline.c in Sources */ = {isa = PBXBuildFile; fileRef = A208BFC0C8C43847A9620ADA /* pcre2_newline.c */; };
-		57B41B6BACFB3906ACD1BFAF /* pcre2_jit_compile.c in Sources */ = {isa = PBXBuildFile; fileRef = 7C9F6184015A3BD1B8DA471E /* pcre2_jit_compile.c */; };
-		57B41B6BACFB3906ACD1BFB0 /* pcre2_jit_compile.c in Sources */ = {isa = PBXBuildFile; fileRef = 7C9F6184015A3BD1B8DA471E /* pcre2_jit_compile.c */; };
-		8C6E2BD9C31A3AE18AD17D44 /* pcre2_match.c in Sources */ = {isa = PBXBuildFile; fileRef = 3B93115BCC46333BBB31D6F7 /* pcre2_match.c */; };
-		8C6E2BD9C31A3AE18AD17D45 /* pcre2_match.c in Sources */ = {isa = PBXBuildFile; fileRef = 3B93115BCC46333BBB31D6F7 /* pcre2_match.c */; };
-		7BD3887F603E3704969A54E1 /* pcre2_chartables.c in Sources */ = {isa = PBXBuildFile; fileRef = 1895085EBEAE3A708FDD527A /* pcre2_chartables.c */; };
-		7BD3887F603E3704969A54E2 /* pcre2_chartables.c in Sources */ = {isa = PBXBuildFile; fileRef = 1895085EBEAE3A708FDD527A /* pcre2_chartables.c */; };
-		45E15DBB6B69382D8AF1BA21 /* pcre2_dfa_match.c in Sources */ = {isa = PBXBuildFile; fileRef = 96D620AEA83E3444BA0B04C4 /* pcre2_dfa_match.c */; };
-		45E15DBB6B69382D8AF1BA22 /* pcre2_dfa_match.c in Sources */ = {isa = PBXBuildFile; fileRef = 96D620AEA83E3444BA0B04C4 /* pcre2_dfa_match.c */; };
-		AF1875145B2537298E4A28D8 /* pcre2_xclass.c in Sources */ = {isa = PBXBuildFile; fileRef = 95CBA2C736623FFF8629E975 /* pcre2_xclass.c */; };
-		AF1875145B2537298E4A28D9 /* pcre2_xclass.c in Sources */ = {isa = PBXBuildFile; fileRef = 95CBA2C736623FFF8629E975 /* pcre2_xclass.c */; };
-		2F7328AC75393951B08F75F1 /* pcre2_error.c in Sources */ = {isa = PBXBuildFile; fileRef = 25E03E349FC13E4A9428B94E /* pcre2_error.c */; };
-		2F7328AC75393951B08F75F2 /* pcre2_error.c in Sources */ = {isa = PBXBuildFile; fileRef = 25E03E349FC13E4A9428B94E /* pcre2_error.c */; };
-		9FA6C4275F0D3E1A884ED561 /* pcre2_auto_possess.c in Sources */ = {isa = PBXBuildFile; fileRef = C3904351139F3F0DB4B72F94 /* pcre2_auto_possess.c */; };
-		9FA6C4275F0D3E1A884ED562 /* pcre2_auto_possess.c in Sources */ = {isa = PBXBuildFile; fileRef = C3904351139F3F0DB4B72F94 /* pcre2_auto_possess.c */; };
-		9FA6C4275F0D3E1A884ED563 /* pcre2_auto_possess.c in Sources */ = {isa = PBXBuildFile; fileRef = C3904351139F3F0DB4B72F94 /* pcre2_auto_possess.c */; };
-		E17048DEEF1138318314F1D0 /* pcre2_valid_utf.c in Sources */ = {isa = PBXBuildFile; fileRef = FAE49A61DFE9375AAB18E8DD /* pcre2_valid_utf.c */; };
-		E17048DEEF1138318314F1D1 /* pcre2_valid_utf.c in Sources */ = {isa = PBXBuildFile; fileRef = FAE49A61DFE9375AAB18E8DD /* pcre2_valid_utf.c */; };
-		9E37D29DCF7A3945A0EECB39 /* pcre2_serialize.c in Sources */ = {isa = PBXBuildFile; fileRef = BD2EBC2CCAE23AD6A1DF783E /* pcre2_serialize.c */; };
-		9E37D29DCF7A3945A0EECB3A /* pcre2_serialize.c in Sources */ = {isa = PBXBuildFile; fileRef = BD2EBC2CCAE23AD6A1DF783E /* pcre2_serialize.c */; };
-		2047544E505C3BA38F0144E6 /* pcre2_tables.c in Sources */ = {isa = PBXBuildFile; fileRef = B60497805D37375EBFCF3D98 /* pcre2_tables.c */; };
-		2047544E505C3BA38F0144E7 /* pcre2_tables.c in Sources */ = {isa = PBXBuildFile; fileRef = B60497805D37375EBFCF3D98 /* pcre2_tables.c */; };
-		A4DEBFA074C93388A1BBCB40 /* pcre2_substitute.c in Sources */ = {isa = PBXBuildFile; fileRef = FAC42945539F362D91D6F559 /* pcre2_substitute.c */; };
-		A4DEBFA074C93388A1BBCB41 /* pcre2_substitute.c in Sources */ = {isa = PBXBuildFile; fileRef = FAC42945539F362D91D6F559 /* pcre2_substitute.c */; };
-		5ED54DFAE28533108C08DF2A /* pcre2_extuni.c in Sources */ = {isa = PBXBuildFile; fileRef = F0E43FFDC808333AA01EE649 /* pcre2_extuni.c */; };
-		5ED54DFAE28533108C08DF2B /* pcre2_extuni.c in Sources */ = {isa = PBXBuildFile; fileRef = F0E43FFDC808333AA01EE649 /* pcre2_extuni.c */; };
-		8B87FEC23DB834EDBFB6EA32 /* pcre2_ucd.c in Sources */ = {isa = PBXBuildFile; fileRef = 70F4EB692873386AAA0A44B0 /* pcre2_ucd.c */; };
-		8B87FEC23DB834EDBFB6EA33 /* pcre2_ucd.c in Sources */ = {isa = PBXBuildFile; fileRef = 70F4EB692873386AAA0A44B0 /* pcre2_ucd.c */; };
-		88E56F89A0DA3AD386F05FD2 /* pcre2_pattern_info.c in Sources */ = {isa = PBXBuildFile; fileRef = 00DAA69F74D031B6BE9196A8 /* pcre2_pattern_info.c */; };
-		88E56F89A0DA3AD386F05FD3 /* pcre2_pattern_info.c in Sources */ = {isa = PBXBuildFile; fileRef = 00DAA69F74D031B6BE9196A8 /* pcre2_pattern_info.c */; };
-		1142E2D85FD93E9AB5D8A55A /* pcre2_script_run.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4CDF9048EC36788619769D /* pcre2_script_run.c */; };
-		1142E2D85FD93E9AB5D8A55B /* pcre2_script_run.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4CDF9048EC36788619769D /* pcre2_script_run.c */; };
-		EB206A0264AD3CAA9F68B8FC /* pcre2_convert.c in Sources */ = {isa = PBXBuildFile; fileRef = BCED9B1D0D7E3FBBAC78CE5B /* pcre2_convert.c */; };
-		EB206A0264AD3CAA9F68B8FD /* pcre2_convert.c in Sources */ = {isa = PBXBuildFile; fileRef = BCED9B1D0D7E3FBBAC78CE5B /* pcre2_convert.c */; };
-		D66F55C93D1130F488970C05 /* pcre2_match_data.c in Sources */ = {isa = PBXBuildFile; fileRef = 4E74E9E53454331F8E10ECC5 /* pcre2_match_data.c */; };
-		D66F55C93D1130F488970C06 /* pcre2_match_data.c in Sources */ = {isa = PBXBuildFile; fileRef = 4E74E9E53454331F8E10ECC5 /* pcre2_match_data.c */; };
-		7F62946D497A32CE857F65C9 /* pcre2_maketables.c in Sources */ = {isa = PBXBuildFile; fileRef = D016F584D14C31E192DB3179 /* pcre2_maketables.c */; };
-		7F62946D497A32CE857F65CA /* pcre2_maketables.c in Sources */ = {isa = PBXBuildFile; fileRef = D016F584D14C31E192DB3179 /* pcre2_maketables.c */; };
-		7BD3887F603E3704969A54E3 /* pcre2_chartables.c in Sources */ = {isa = PBXBuildFile; fileRef = 1895085EBEAE3A708FDD527A /* pcre2_chartables.c */; };
-		6463C9BE78C0394CB7B451FC /* pcre2_compile.c in Sources */ = {isa = PBXBuildFile; fileRef = BDADEB1DA6433E52972C8934 /* pcre2_compile.c */; };
-		D7F14BDFFB7F369B842AFC15 /* pcre2_config.c in Sources */ = {isa = PBXBuildFile; fileRef = FC6A8FAE9CA63EEB8883B6BD /* pcre2_config.c */; };
-		27B5431DC79733CD8D403E8A /* pcre2_context.c in Sources */ = {isa = PBXBuildFile; fileRef = 3026D20A03E53F1DB40FB35A /* pcre2_context.c */; };
-		EB206A0264AD3CAA9F68B8FE /* pcre2_convert.c in Sources */ = {isa = PBXBuildFile; fileRef = BCED9B1D0D7E3FBBAC78CE5B /* pcre2_convert.c */; };
-		45E15DBB6B69382D8AF1BA23 /* pcre2_dfa_match.c in Sources */ = {isa = PBXBuildFile; fileRef = 96D620AEA83E3444BA0B04C4 /* pcre2_dfa_match.c */; };
-		2F7328AC75393951B08F75F3 /* pcre2_error.c in Sources */ = {isa = PBXBuildFile; fileRef = 25E03E349FC13E4A9428B94E /* pcre2_error.c */; };
-		5ED54DFAE28533108C08DF2C /* pcre2_extuni.c in Sources */ = {isa = PBXBuildFile; fileRef = F0E43FFDC808333AA01EE649 /* pcre2_extuni.c */; };
-		C5C60B22CE6A3BCB868F69EA /* pcre2_find_bracket.c in Sources */ = {isa = PBXBuildFile; fileRef = 943C7E9527C03FCDB5966273 /* pcre2_find_bracket.c */; };
-		57B41B6BACFB3906ACD1BFB1 /* pcre2_jit_compile.c in Sources */ = {isa = PBXBuildFile; fileRef = 7C9F6184015A3BD1B8DA471E /* pcre2_jit_compile.c */; };
-		7F62946D497A32CE857F65CB /* pcre2_maketables.c in Sources */ = {isa = PBXBuildFile; fileRef = D016F584D14C31E192DB3179 /* pcre2_maketables.c */; };
-		D66F55C93D1130F488970C07 /* pcre2_match_data.c in Sources */ = {isa = PBXBuildFile; fileRef = 4E74E9E53454331F8E10ECC5 /* pcre2_match_data.c */; };
-		8C6E2BD9C31A3AE18AD17D46 /* pcre2_match.c in Sources */ = {isa = PBXBuildFile; fileRef = 3B93115BCC46333BBB31D6F7 /* pcre2_match.c */; };
-		00E12455C98032E18378EE60 /* pcre2_newline.c in Sources */ = {isa = PBXBuildFile; fileRef = A208BFC0C8C43847A9620ADA /* pcre2_newline.c */; };
-		10B5C2A72C713A678458CD9F /* pcre2_ord2utf.c in Sources */ = {isa = PBXBuildFile; fileRef = 4BFEBC5061693DA0B52BC4AC /* pcre2_ord2utf.c */; };
-		88E56F89A0DA3AD386F05FD4 /* pcre2_pattern_info.c in Sources */ = {isa = PBXBuildFile; fileRef = 00DAA69F74D031B6BE9196A8 /* pcre2_pattern_info.c */; };
-		1142E2D85FD93E9AB5D8A55C /* pcre2_script_run.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4CDF9048EC36788619769D /* pcre2_script_run.c */; };
-		9E37D29DCF7A3945A0EECB3B /* pcre2_serialize.c in Sources */ = {isa = PBXBuildFile; fileRef = BD2EBC2CCAE23AD6A1DF783E /* pcre2_serialize.c */; };
-		DFEB01E7B97A3515B785DCAB /* pcre2_string_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = A6EE037AF43E343E8E1A7555 /* pcre2_string_utils.c */; };
-		60296753A32B39EB8BD0CB46 /* pcre2_study.c in Sources */ = {isa = PBXBuildFile; fileRef = 09CCDDC66F683C6B87BEDD2F /* pcre2_study.c */; };
-		A4DEBFA074C93388A1BBCB42 /* pcre2_substitute.c in Sources */ = {isa = PBXBuildFile; fileRef = FAC42945539F362D91D6F559 /* pcre2_substitute.c */; };
-		B6728BCD1A0731299924C8C6 /* pcre2_substring.c in Sources */ = {isa = PBXBuildFile; fileRef = 5152B34D06E9343FBFAB3510 /* pcre2_substring.c */; };
-		2047544E505C3BA38F0144E8 /* pcre2_tables.c in Sources */ = {isa = PBXBuildFile; fileRef = B60497805D37375EBFCF3D98 /* pcre2_tables.c */; };
-		8B87FEC23DB834EDBFB6EA34 /* pcre2_ucd.c in Sources */ = {isa = PBXBuildFile; fileRef = 70F4EB692873386AAA0A44B0 /* pcre2_ucd.c */; };
-		E17048DEEF1138318314F1D2 /* pcre2_valid_utf.c in Sources */ = {isa = PBXBuildFile; fileRef = FAE49A61DFE9375AAB18E8DD /* pcre2_valid_utf.c */; };
-		AF1875145B2537298E4A28DA /* pcre2_xclass.c in Sources */ = {isa = PBXBuildFile; fileRef = 95CBA2C736623FFF8629E975 /* pcre2_xclass.c */; };
 		4156FDB73D0A397A870E4302 /* overlay.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0FBD8031E28A3C9CB7C45784 /* overlay.mm */; };
 		4156FDB73D0A397A870E4303 /* overlay.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0FBD8031E28A3C9CB7C45784 /* overlay.mm */; };
 		4156FDB73D0A397A870E4304 /* overlay.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0FBD8031E28A3C9CB7C45784 /* overlay.mm */; };
@@ -952,6 +892,9 @@
 		45D88A74B3EE3837B9F79595 /* LexFlagship.cxx in Sources */ = {isa = PBXBuildFile; fileRef = F32C0D20638232CE8F43BF33 /* LexFlagship.cxx */; };
 		45D88A74B3EE3837B9F79596 /* LexFlagship.cxx in Sources */ = {isa = PBXBuildFile; fileRef = F32C0D20638232CE8F43BF33 /* LexFlagship.cxx */; };
 		45D88A74B3EE3837B9F79597 /* LexFlagship.cxx in Sources */ = {isa = PBXBuildFile; fileRef = F32C0D20638232CE8F43BF33 /* LexFlagship.cxx */; };
+		45E15DBB6B69382D8AF1BA21 /* pcre2_dfa_match.c in Sources */ = {isa = PBXBuildFile; fileRef = 96D620AEA83E3444BA0B04C4 /* pcre2_dfa_match.c */; };
+		45E15DBB6B69382D8AF1BA22 /* pcre2_dfa_match.c in Sources */ = {isa = PBXBuildFile; fileRef = 96D620AEA83E3444BA0B04C4 /* pcre2_dfa_match.c */; };
+		45E15DBB6B69382D8AF1BA23 /* pcre2_dfa_match.c in Sources */ = {isa = PBXBuildFile; fileRef = 96D620AEA83E3444BA0B04C4 /* pcre2_dfa_match.c */; };
 		45FE206BBAD13DDCA1EA41CF /* treebase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BA6ADD758693BD180D3275B /* treebase.cpp */; };
 		45FE206BBAD13DDCA1EA41D0 /* treebase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BA6ADD758693BD180D3275B /* treebase.cpp */; };
 		45FE206BBAD13DDCA1EA41D1 /* treebase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BA6ADD758693BD180D3275B /* treebase.cpp */; };
@@ -1161,6 +1104,9 @@
 		57AE7FCF768F3965BD39B47A /* m_span.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 727F25F832AD32D4B12D8E39 /* m_span.cpp */; };
 		57AE7FCF768F3965BD39B47B /* m_span.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 727F25F832AD32D4B12D8E39 /* m_span.cpp */; };
 		57AE7FCF768F3965BD39B47C /* m_span.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 727F25F832AD32D4B12D8E39 /* m_span.cpp */; };
+		57B41B6BACFB3906ACD1BFAF /* pcre2_jit_compile.c in Sources */ = {isa = PBXBuildFile; fileRef = 7C9F6184015A3BD1B8DA471E /* pcre2_jit_compile.c */; };
+		57B41B6BACFB3906ACD1BFB0 /* pcre2_jit_compile.c in Sources */ = {isa = PBXBuildFile; fileRef = 7C9F6184015A3BD1B8DA471E /* pcre2_jit_compile.c */; };
+		57B41B6BACFB3906ACD1BFB1 /* pcre2_jit_compile.c in Sources */ = {isa = PBXBuildFile; fileRef = 7C9F6184015A3BD1B8DA471E /* pcre2_jit_compile.c */; };
 		57F8001809BC3864A5FA798B /* PlatWXcocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 18ABDAF9EF723072A7708009 /* PlatWXcocoa.mm */; };
 		57F8001809BC3864A5FA798C /* PlatWXcocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 18ABDAF9EF723072A7708009 /* PlatWXcocoa.mm */; };
 		57F8001809BC3864A5FA798D /* PlatWXcocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 18ABDAF9EF723072A7708009 /* PlatWXcocoa.mm */; };
@@ -1202,6 +1148,9 @@
 		5DA146A9F7653F53BF5299E8 /* spinbutt.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C4A7A93CAFC3E22A2A5F7F3 /* spinbutt.mm */; };
 		5DA146A9F7653F53BF5299E9 /* spinbutt.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C4A7A93CAFC3E22A2A5F7F3 /* spinbutt.mm */; };
 		5DA146A9F7653F53BF5299EA /* spinbutt.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C4A7A93CAFC3E22A2A5F7F3 /* spinbutt.mm */; };
+		5ED54DFAE28533108C08DF2A /* pcre2_extuni.c in Sources */ = {isa = PBXBuildFile; fileRef = F0E43FFDC808333AA01EE649 /* pcre2_extuni.c */; };
+		5ED54DFAE28533108C08DF2B /* pcre2_extuni.c in Sources */ = {isa = PBXBuildFile; fileRef = F0E43FFDC808333AA01EE649 /* pcre2_extuni.c */; };
+		5ED54DFAE28533108C08DF2C /* pcre2_extuni.c in Sources */ = {isa = PBXBuildFile; fileRef = F0E43FFDC808333AA01EE649 /* pcre2_extuni.c */; };
 		5EE94793DFCB3BA281A4864E /* infback.c in Sources */ = {isa = PBXBuildFile; fileRef = FDB0E2D0966C3E408C4A2D3D /* infback.c */; };
 		5EE94793DFCB3BA281A4864F /* infback.c in Sources */ = {isa = PBXBuildFile; fileRef = FDB0E2D0966C3E408C4A2D3D /* infback.c */; };
 		5EE94793DFCB3BA281A48650 /* infback.c in Sources */ = {isa = PBXBuildFile; fileRef = FDB0E2D0966C3E408C4A2D3D /* infback.c */; };
@@ -1220,6 +1169,9 @@
 		5FE969523BDB3353AEF96810 /* xh_filepicker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C8CEE782CD236A5A9999724 /* xh_filepicker.cpp */; };
 		5FE969523BDB3353AEF96811 /* xh_filepicker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C8CEE782CD236A5A9999724 /* xh_filepicker.cpp */; };
 		5FE969523BDB3353AEF96812 /* xh_filepicker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C8CEE782CD236A5A9999724 /* xh_filepicker.cpp */; };
+		60296753A32B39EB8BD0CB44 /* pcre2_study.c in Sources */ = {isa = PBXBuildFile; fileRef = 09CCDDC66F683C6B87BEDD2F /* pcre2_study.c */; };
+		60296753A32B39EB8BD0CB45 /* pcre2_study.c in Sources */ = {isa = PBXBuildFile; fileRef = 09CCDDC66F683C6B87BEDD2F /* pcre2_study.c */; };
+		60296753A32B39EB8BD0CB46 /* pcre2_study.c in Sources */ = {isa = PBXBuildFile; fileRef = 09CCDDC66F683C6B87BEDD2F /* pcre2_study.c */; };
 		603DF49D176737D383CE4F01 /* choice.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9F838F853CB03CF7932C08C3 /* choice.mm */; };
 		603DF49D176737D383CE4F02 /* choice.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9F838F853CB03CF7932C08C3 /* choice.mm */; };
 		603DF49D176737D383CE4F03 /* choice.mm in Sources */ = {isa = PBXBuildFile; fileRef = 9F838F853CB03CF7932C08C3 /* choice.mm */; };
@@ -1274,6 +1226,11 @@
 		63F2517EC6B2334CA825A6FA /* layout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BEB08798C70E33DDB360E563 /* layout.cpp */; };
 		63F2517EC6B2334CA825A6FB /* layout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BEB08798C70E33DDB360E563 /* layout.cpp */; };
 		63F895D6F5643E4B9E666B79 /* creddlgg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8DE97F5A2AD393CBD31AED3 /* creddlgg.cpp */; };
+		63F895D6F5643E4B9E666B7A /* creddlgg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8DE97F5A2AD393CBD31AED3 /* creddlgg.cpp */; };
+		63F895D6F5643E4B9E666B7B /* creddlgg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8DE97F5A2AD393CBD31AED3 /* creddlgg.cpp */; };
+		6463C9BE78C0394CB7B451FA /* pcre2_compile.c in Sources */ = {isa = PBXBuildFile; fileRef = BDADEB1DA6433E52972C8934 /* pcre2_compile.c */; };
+		6463C9BE78C0394CB7B451FB /* pcre2_compile.c in Sources */ = {isa = PBXBuildFile; fileRef = BDADEB1DA6433E52972C8934 /* pcre2_compile.c */; };
+		6463C9BE78C0394CB7B451FC /* pcre2_compile.c in Sources */ = {isa = PBXBuildFile; fileRef = BDADEB1DA6433E52972C8934 /* pcre2_compile.c */; };
 		64A716F87A5136F9A790EC5A /* webview.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0DA80913C0E33144A42BD30F /* webview.cpp */; };
 		64A716F87A5136F9A790EC5B /* webview.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0DA80913C0E33144A42BD30F /* webview.cpp */; };
 		64A716F87A5136F9A790EC5C /* webview.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0DA80913C0E33144A42BD30F /* webview.cpp */; };
@@ -1370,6 +1327,9 @@
 		6BF19C7CA9E93D989C210FE3 /* dseldlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1197B997B1D139C5AE4D198A /* dseldlg.cpp */; };
 		6BF19C7CA9E93D989C210FE4 /* dseldlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1197B997B1D139C5AE4D198A /* dseldlg.cpp */; };
 		6BF19C7CA9E93D989C210FE5 /* dseldlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1197B997B1D139C5AE4D198A /* dseldlg.cpp */; };
+		6C1171E3FB7137CCB9E3F536 /* tif_zstd.c in Sources */ = {isa = PBXBuildFile; fileRef = 3B98123FD57731139044B064 /* tif_zstd.c */; };
+		6C1171E3FB7137CCB9E3F537 /* tif_zstd.c in Sources */ = {isa = PBXBuildFile; fileRef = 3B98123FD57731139044B064 /* tif_zstd.c */; };
+		6C1171E3FB7137CCB9E3F538 /* tif_zstd.c in Sources */ = {isa = PBXBuildFile; fileRef = 3B98123FD57731139044B064 /* tif_zstd.c */; };
 		6C3A459236F736B8A14A13AC /* dialog.mm in Sources */ = {isa = PBXBuildFile; fileRef = 83B878A16ABC396E8C03A15E /* dialog.mm */; };
 		6C3A459236F736B8A14A13AD /* dialog.mm in Sources */ = {isa = PBXBuildFile; fileRef = 83B878A16ABC396E8C03A15E /* dialog.mm */; };
 		6C3A459236F736B8A14A13AE /* dialog.mm in Sources */ = {isa = PBXBuildFile; fileRef = 83B878A16ABC396E8C03A15E /* dialog.mm */; };
@@ -1529,6 +1489,9 @@
 		7B642B17F5D23F4F8ED38BB4 /* graphcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1BB59DD194923D6399087A75 /* graphcmn.cpp */; };
 		7B642B17F5D23F4F8ED38BB5 /* graphcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1BB59DD194923D6399087A75 /* graphcmn.cpp */; };
 		7B642B17F5D23F4F8ED38BB6 /* graphcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1BB59DD194923D6399087A75 /* graphcmn.cpp */; };
+		7BD3887F603E3704969A54E1 /* pcre2_chartables.c in Sources */ = {isa = PBXBuildFile; fileRef = 1895085EBEAE3A708FDD527A /* pcre2_chartables.c */; };
+		7BD3887F603E3704969A54E2 /* pcre2_chartables.c in Sources */ = {isa = PBXBuildFile; fileRef = 1895085EBEAE3A708FDD527A /* pcre2_chartables.c */; };
+		7BD3887F603E3704969A54E3 /* pcre2_chartables.c in Sources */ = {isa = PBXBuildFile; fileRef = 1895085EBEAE3A708FDD527A /* pcre2_chartables.c */; };
 		7C20B79175D33852A2E9DE83 /* LexRuby.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 8734C52C7559310784396455 /* LexRuby.cxx */; };
 		7C20B79175D33852A2E9DE84 /* LexRuby.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 8734C52C7559310784396455 /* LexRuby.cxx */; };
 		7C20B79175D33852A2E9DE85 /* LexRuby.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 8734C52C7559310784396455 /* LexRuby.cxx */; };
@@ -1571,6 +1534,9 @@
 		7EF89F935314301381802FAB /* filectrlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2334539088B036BEAB230D1C /* filectrlg.cpp */; };
 		7EF89F935314301381802FAC /* filectrlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2334539088B036BEAB230D1C /* filectrlg.cpp */; };
 		7EF89F935314301381802FAD /* filectrlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2334539088B036BEAB230D1C /* filectrlg.cpp */; };
+		7F62946D497A32CE857F65C9 /* pcre2_maketables.c in Sources */ = {isa = PBXBuildFile; fileRef = D016F584D14C31E192DB3179 /* pcre2_maketables.c */; };
+		7F62946D497A32CE857F65CA /* pcre2_maketables.c in Sources */ = {isa = PBXBuildFile; fileRef = D016F584D14C31E192DB3179 /* pcre2_maketables.c */; };
+		7F62946D497A32CE857F65CB /* pcre2_maketables.c in Sources */ = {isa = PBXBuildFile; fileRef = D016F584D14C31E192DB3179 /* pcre2_maketables.c */; };
 		7F77E347E1243D77A666FB43 /* clipbrd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 12453E271F2A3AC9969E62A4 /* clipbrd.cpp */; };
 		7F77E347E1243D77A666FB44 /* clipbrd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 12453E271F2A3AC9969E62A4 /* clipbrd.cpp */; };
 		7F77E347E1243D77A666FB45 /* clipbrd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 12453E271F2A3AC9969E62A4 /* clipbrd.cpp */; };
@@ -1632,6 +1598,9 @@
 		86003C8EB906304F9025F788 /* jcinit.c in Sources */ = {isa = PBXBuildFile; fileRef = AA6C6739C3BD3EFA9CF71102 /* jcinit.c */; };
 		86003C8EB906304F9025F789 /* jcinit.c in Sources */ = {isa = PBXBuildFile; fileRef = AA6C6739C3BD3EFA9CF71102 /* jcinit.c */; };
 		86003C8EB906304F9025F78A /* jcinit.c in Sources */ = {isa = PBXBuildFile; fileRef = AA6C6739C3BD3EFA9CF71102 /* jcinit.c */; };
+		8620088DDD233B139B250DD4 /* filter_sse2_intrinsics.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D602B5F09E8314CB9F65C11 /* filter_sse2_intrinsics.c */; };
+		8620088DDD233B139B250DD5 /* filter_sse2_intrinsics.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D602B5F09E8314CB9F65C11 /* filter_sse2_intrinsics.c */; };
+		8620088DDD233B139B250DD6 /* filter_sse2_intrinsics.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D602B5F09E8314CB9F65C11 /* filter_sse2_intrinsics.c */; };
 		86787E4138CC334BB74EC7B4 /* palette_neon_intrinsics.c in Sources */ = {isa = PBXBuildFile; fileRef = FB17368A86EC30E6B843E32F /* palette_neon_intrinsics.c */; };
 		86787E4138CC334BB74EC7B5 /* palette_neon_intrinsics.c in Sources */ = {isa = PBXBuildFile; fileRef = FB17368A86EC30E6B843E32F /* palette_neon_intrinsics.c */; };
 		86787E4138CC334BB74EC7B6 /* palette_neon_intrinsics.c in Sources */ = {isa = PBXBuildFile; fileRef = FB17368A86EC30E6B843E32F /* palette_neon_intrinsics.c */; };
@@ -1659,6 +1628,9 @@
 		88E1AE56FD393C8BA5CF8545 /* stringops.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F1E724EA70AB35DDB130F84F /* stringops.cpp */; };
 		88E1AE56FD393C8BA5CF8546 /* stringops.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F1E724EA70AB35DDB130F84F /* stringops.cpp */; };
 		88E1AE56FD393C8BA5CF8547 /* stringops.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F1E724EA70AB35DDB130F84F /* stringops.cpp */; };
+		88E56F89A0DA3AD386F05FD2 /* pcre2_pattern_info.c in Sources */ = {isa = PBXBuildFile; fileRef = 00DAA69F74D031B6BE9196A8 /* pcre2_pattern_info.c */; };
+		88E56F89A0DA3AD386F05FD3 /* pcre2_pattern_info.c in Sources */ = {isa = PBXBuildFile; fileRef = 00DAA69F74D031B6BE9196A8 /* pcre2_pattern_info.c */; };
+		88E56F89A0DA3AD386F05FD4 /* pcre2_pattern_info.c in Sources */ = {isa = PBXBuildFile; fileRef = 00DAA69F74D031B6BE9196A8 /* pcre2_pattern_info.c */; };
 		89046455F49D3D75A21C9DB8 /* imagfill.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 137E01C362E134449BF966ED /* imagfill.cpp */; };
 		89046455F49D3D75A21C9DB9 /* imagfill.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 137E01C362E134449BF966ED /* imagfill.cpp */; };
 		89046455F49D3D75A21C9DBA /* imagfill.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 137E01C362E134449BF966ED /* imagfill.cpp */; };
@@ -1695,6 +1667,9 @@
 		8B60964DA1DF3F3DB40BE123 /* datavgen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5F3D473DC5123EDAB767045C /* datavgen.cpp */; };
 		8B60964DA1DF3F3DB40BE124 /* datavgen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5F3D473DC5123EDAB767045C /* datavgen.cpp */; };
 		8B60964DA1DF3F3DB40BE125 /* datavgen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5F3D473DC5123EDAB767045C /* datavgen.cpp */; };
+		8B87FEC23DB834EDBFB6EA32 /* pcre2_ucd.c in Sources */ = {isa = PBXBuildFile; fileRef = 70F4EB692873386AAA0A44B0 /* pcre2_ucd.c */; };
+		8B87FEC23DB834EDBFB6EA33 /* pcre2_ucd.c in Sources */ = {isa = PBXBuildFile; fileRef = 70F4EB692873386AAA0A44B0 /* pcre2_ucd.c */; };
+		8B87FEC23DB834EDBFB6EA34 /* pcre2_ucd.c in Sources */ = {isa = PBXBuildFile; fileRef = 70F4EB692873386AAA0A44B0 /* pcre2_ucd.c */; };
 		8B9C9FCB954F3596A4CED9A5 /* jdapimin.c in Sources */ = {isa = PBXBuildFile; fileRef = 86884BC843F6337EABF744BB /* jdapimin.c */; };
 		8B9C9FCB954F3596A4CED9A6 /* jdapimin.c in Sources */ = {isa = PBXBuildFile; fileRef = 86884BC843F6337EABF744BB /* jdapimin.c */; };
 		8B9C9FCB954F3596A4CED9A7 /* jdapimin.c in Sources */ = {isa = PBXBuildFile; fileRef = 86884BC843F6337EABF744BB /* jdapimin.c */; };
@@ -1704,6 +1679,9 @@
 		8C52B1985BAA371FA22CCEBB /* combobox.mm in Sources */ = {isa = PBXBuildFile; fileRef = 57C06D5DB5F733A4A235B206 /* combobox.mm */; };
 		8C52B1985BAA371FA22CCEBC /* combobox.mm in Sources */ = {isa = PBXBuildFile; fileRef = 57C06D5DB5F733A4A235B206 /* combobox.mm */; };
 		8C52B1985BAA371FA22CCEBD /* combobox.mm in Sources */ = {isa = PBXBuildFile; fileRef = 57C06D5DB5F733A4A235B206 /* combobox.mm */; };
+		8C6E2BD9C31A3AE18AD17D44 /* pcre2_match.c in Sources */ = {isa = PBXBuildFile; fileRef = 3B93115BCC46333BBB31D6F7 /* pcre2_match.c */; };
+		8C6E2BD9C31A3AE18AD17D45 /* pcre2_match.c in Sources */ = {isa = PBXBuildFile; fileRef = 3B93115BCC46333BBB31D6F7 /* pcre2_match.c */; };
+		8C6E2BD9C31A3AE18AD17D46 /* pcre2_match.c in Sources */ = {isa = PBXBuildFile; fileRef = 3B93115BCC46333BBB31D6F7 /* pcre2_match.c */; };
 		8D6B0D48EA843E48AB0FE43D /* LexErrorList.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 2851EAAEE9B73FE8981912C9 /* LexErrorList.cxx */; };
 		8D6B0D48EA843E48AB0FE43E /* LexErrorList.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 2851EAAEE9B73FE8981912C9 /* LexErrorList.cxx */; };
 		8D6B0D48EA843E48AB0FE43F /* LexErrorList.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 2851EAAEE9B73FE8981912C9 /* LexErrorList.cxx */; };
@@ -1716,6 +1694,9 @@
 		8EE5A2467401365C8217AF2F /* preferences.mm in Sources */ = {isa = PBXBuildFile; fileRef = 835C22B71A0F3C469310E1E0 /* preferences.mm */; };
 		8EE5A2467401365C8217AF30 /* preferences.mm in Sources */ = {isa = PBXBuildFile; fileRef = 835C22B71A0F3C469310E1E0 /* preferences.mm */; };
 		8EE5A2467401365C8217AF31 /* preferences.mm in Sources */ = {isa = PBXBuildFile; fileRef = 835C22B71A0F3C469310E1E0 /* preferences.mm */; };
+		8F372080E11E382EA0B5ED0F /* rowheightcache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2B7B30FA60633339D8862C6 /* rowheightcache.cpp */; };
+		8F372080E11E382EA0B5ED10 /* rowheightcache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2B7B30FA60633339D8862C6 /* rowheightcache.cpp */; };
+		8F372080E11E382EA0B5ED11 /* rowheightcache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2B7B30FA60633339D8862C6 /* rowheightcache.cpp */; };
 		8F949B9010863F66A58FFEF1 /* xh_activityindicator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB60FA0E3524391D8581AD7C /* xh_activityindicator.cpp */; };
 		8F949B9010863F66A58FFEF2 /* xh_activityindicator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB60FA0E3524391D8581AD7C /* xh_activityindicator.cpp */; };
 		8F949B9010863F66A58FFEF3 /* xh_activityindicator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB60FA0E3524391D8581AD7C /* xh_activityindicator.cpp */; };
@@ -1812,6 +1793,9 @@
 		97F60B2A9CE93BC8949A8CCD /* LexCrontab.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 16A093604BDB3C22BA66EA89 /* LexCrontab.cxx */; };
 		97F60B2A9CE93BC8949A8CCE /* LexCrontab.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 16A093604BDB3C22BA66EA89 /* LexCrontab.cxx */; };
 		97F60B2A9CE93BC8949A8CCF /* LexCrontab.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 16A093604BDB3C22BA66EA89 /* LexCrontab.cxx */; };
+		980ED1DA2F96361985952254 /* webrequest_urlsession.mm in Sources */ = {isa = PBXBuildFile; fileRef = EA8CCF32688434EABEEEE04A /* webrequest_urlsession.mm */; };
+		980ED1DA2F96361985952255 /* webrequest_urlsession.mm in Sources */ = {isa = PBXBuildFile; fileRef = EA8CCF32688434EABEEEE04A /* webrequest_urlsession.mm */; };
+		980ED1DA2F96361985952256 /* webrequest_urlsession.mm in Sources */ = {isa = PBXBuildFile; fileRef = EA8CCF32688434EABEEEE04A /* webrequest_urlsession.mm */; };
 		9836B3D336963795928FE5A1 /* m_dflist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52FE1599218730CC99A3F801 /* m_dflist.cpp */; };
 		9836B3D336963795928FE5A2 /* m_dflist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52FE1599218730CC99A3F801 /* m_dflist.cpp */; };
 		9836B3D336963795928FE5A3 /* m_dflist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52FE1599218730CC99A3F801 /* m_dflist.cpp */; };
@@ -1836,6 +1820,12 @@
 		9A178ED42D96329D8CBF9B89 /* tif_predict.c in Sources */ = {isa = PBXBuildFile; fileRef = 2FA01C426EAF38D3B9ED35AC /* tif_predict.c */; };
 		9A178ED42D96329D8CBF9B8A /* tif_predict.c in Sources */ = {isa = PBXBuildFile; fileRef = 2FA01C426EAF38D3B9ED35AC /* tif_predict.c */; };
 		9A178ED42D96329D8CBF9B8B /* tif_predict.c in Sources */ = {isa = PBXBuildFile; fileRef = 2FA01C426EAF38D3B9ED35AC /* tif_predict.c */; };
+		9A63148F193E33B5964DD029 /* uilocale.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4E4466371B7E3265AE7B1E0C /* uilocale.cpp */; };
+		9A63148F193E33B5964DD02A /* uilocale.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4E4466371B7E3265AE7B1E0C /* uilocale.cpp */; };
+		9A63148F193E33B5964DD02B /* uilocale.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4E4466371B7E3265AE7B1E0C /* uilocale.cpp */; };
+		9A63148F193E33B5964DD02C /* uilocale.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4E4466371B7E3265AE7B1E0D /* uilocale.cpp */; };
+		9A63148F193E33B5964DD02D /* uilocale.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4E4466371B7E3265AE7B1E0D /* uilocale.cpp */; };
+		9A63148F193E33B5964DD02E /* uilocale.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4E4466371B7E3265AE7B1E0D /* uilocale.cpp */; };
 		9A83D365AD1F37FA9C7030C2 /* matrix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EF330EAACFA53877BE289896 /* matrix.cpp */; };
 		9A83D365AD1F37FA9C7030C3 /* matrix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EF330EAACFA53877BE289896 /* matrix.cpp */; };
 		9A83D365AD1F37FA9C7030C4 /* matrix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EF330EAACFA53877BE289896 /* matrix.cpp */; };
@@ -1869,6 +1859,9 @@
 		9E0B67E34B683412978BA82D /* filtall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4438C284ED5C31EF8CC28FF3 /* filtall.cpp */; };
 		9E0B67E34B683412978BA82E /* filtall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4438C284ED5C31EF8CC28FF3 /* filtall.cpp */; };
 		9E0B67E34B683412978BA82F /* filtall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4438C284ED5C31EF8CC28FF3 /* filtall.cpp */; };
+		9E37D29DCF7A3945A0EECB39 /* pcre2_serialize.c in Sources */ = {isa = PBXBuildFile; fileRef = BD2EBC2CCAE23AD6A1DF783E /* pcre2_serialize.c */; };
+		9E37D29DCF7A3945A0EECB3A /* pcre2_serialize.c in Sources */ = {isa = PBXBuildFile; fileRef = BD2EBC2CCAE23AD6A1DF783E /* pcre2_serialize.c */; };
+		9E37D29DCF7A3945A0EECB3B /* pcre2_serialize.c in Sources */ = {isa = PBXBuildFile; fileRef = BD2EBC2CCAE23AD6A1DF783E /* pcre2_serialize.c */; };
 		9EC837DA722736119D49868A /* pngpread.c in Sources */ = {isa = PBXBuildFile; fileRef = 9CAA325362C73AC8BE20FAA7 /* pngpread.c */; };
 		9EC837DA722736119D49868B /* pngpread.c in Sources */ = {isa = PBXBuildFile; fileRef = 9CAA325362C73AC8BE20FAA7 /* pngpread.c */; };
 		9EC837DA722736119D49868C /* pngpread.c in Sources */ = {isa = PBXBuildFile; fileRef = 9CAA325362C73AC8BE20FAA7 /* pngpread.c */; };
@@ -1878,6 +1871,9 @@
 		9F70A89D00B03D4894AF7638 /* validate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 01BA6D45FE4C381493EB4372 /* validate.cpp */; };
 		9F70A89D00B03D4894AF7639 /* validate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 01BA6D45FE4C381493EB4372 /* validate.cpp */; };
 		9F70A89D00B03D4894AF763A /* validate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 01BA6D45FE4C381493EB4372 /* validate.cpp */; };
+		9FA6C4275F0D3E1A884ED561 /* pcre2_auto_possess.c in Sources */ = {isa = PBXBuildFile; fileRef = C3904351139F3F0DB4B72F94 /* pcre2_auto_possess.c */; };
+		9FA6C4275F0D3E1A884ED562 /* pcre2_auto_possess.c in Sources */ = {isa = PBXBuildFile; fileRef = C3904351139F3F0DB4B72F94 /* pcre2_auto_possess.c */; };
+		9FA6C4275F0D3E1A884ED563 /* pcre2_auto_possess.c in Sources */ = {isa = PBXBuildFile; fileRef = C3904351139F3F0DB4B72F94 /* pcre2_auto_possess.c */; };
 		9FB1E1763EFA334CA0C07C49 /* tarstrm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C0F7BBD216853E718C9F23D9 /* tarstrm.cpp */; };
 		9FB1E1763EFA334CA0C07C4A /* tarstrm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C0F7BBD216853E718C9F23D9 /* tarstrm.cpp */; };
 		9FB1E1763EFA334CA0C07C4B /* tarstrm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C0F7BBD216853E718C9F23D9 /* tarstrm.cpp */; };
@@ -1942,6 +1938,12 @@
 		A465A43B756630F1944B5A56 /* vscroll.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1629FA905F903324AA5BE72C /* vscroll.cpp */; };
 		A465A43B756630F1944B5A57 /* vscroll.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1629FA905F903324AA5BE72C /* vscroll.cpp */; };
 		A465A43B756630F1944B5A58 /* vscroll.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1629FA905F903324AA5BE72C /* vscroll.cpp */; };
+		A486A28E216D320AB57452D3 /* lzmastream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 99A9D5F9254D35BE8F4176A4 /* lzmastream.cpp */; };
+		A486A28E216D320AB57452D4 /* lzmastream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 99A9D5F9254D35BE8F4176A4 /* lzmastream.cpp */; };
+		A486A28E216D320AB57452D5 /* lzmastream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 99A9D5F9254D35BE8F4176A4 /* lzmastream.cpp */; };
+		A4DEBFA074C93388A1BBCB40 /* pcre2_substitute.c in Sources */ = {isa = PBXBuildFile; fileRef = FAC42945539F362D91D6F559 /* pcre2_substitute.c */; };
+		A4DEBFA074C93388A1BBCB41 /* pcre2_substitute.c in Sources */ = {isa = PBXBuildFile; fileRef = FAC42945539F362D91D6F559 /* pcre2_substitute.c */; };
+		A4DEBFA074C93388A1BBCB42 /* pcre2_substitute.c in Sources */ = {isa = PBXBuildFile; fileRef = FAC42945539F362D91D6F559 /* pcre2_substitute.c */; };
 		A4F2426F36653C6D87EC18AE /* activityindicator.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5814208070CF3D899F132BA1 /* activityindicator.mm */; };
 		A4F2426F36653C6D87EC18AF /* activityindicator.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5814208070CF3D899F132BA1 /* activityindicator.mm */; };
 		A4F2426F36653C6D87EC18B0 /* activityindicator.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5814208070CF3D899F132BA1 /* activityindicator.mm */; };
@@ -2038,6 +2040,9 @@
 		AEEE6BC41B6531898A61CB16 /* LexHTML.cxx in Sources */ = {isa = PBXBuildFile; fileRef = D87406BCF3E833369E12D89A /* LexHTML.cxx */; };
 		AEEE6BC41B6531898A61CB17 /* LexHTML.cxx in Sources */ = {isa = PBXBuildFile; fileRef = D87406BCF3E833369E12D89A /* LexHTML.cxx */; };
 		AEEE6BC41B6531898A61CB18 /* LexHTML.cxx in Sources */ = {isa = PBXBuildFile; fileRef = D87406BCF3E833369E12D89A /* LexHTML.cxx */; };
+		AF1875145B2537298E4A28D8 /* pcre2_xclass.c in Sources */ = {isa = PBXBuildFile; fileRef = 95CBA2C736623FFF8629E975 /* pcre2_xclass.c */; };
+		AF1875145B2537298E4A28D9 /* pcre2_xclass.c in Sources */ = {isa = PBXBuildFile; fileRef = 95CBA2C736623FFF8629E975 /* pcre2_xclass.c */; };
+		AF1875145B2537298E4A28DA /* pcre2_xclass.c in Sources */ = {isa = PBXBuildFile; fileRef = 95CBA2C736623FFF8629E975 /* pcre2_xclass.c */; };
 		AF1E3338E892336E924AF631 /* pickerbase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1FBC22BAD63D3A1AB78F5F82 /* pickerbase.cpp */; };
 		AF1E3338E892336E924AF632 /* pickerbase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1FBC22BAD63D3A1AB78F5F82 /* pickerbase.cpp */; };
 		AF1E3338E892336E924AF633 /* pickerbase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1FBC22BAD63D3A1AB78F5F82 /* pickerbase.cpp */; };
@@ -2098,6 +2103,9 @@
 		B640A8A74D973A8FBEF63916 /* LexConf.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 04082EC1C91334379425802D /* LexConf.cxx */; };
 		B640A8A74D973A8FBEF63917 /* LexConf.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 04082EC1C91334379425802D /* LexConf.cxx */; };
 		B640A8A74D973A8FBEF63918 /* LexConf.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 04082EC1C91334379425802D /* LexConf.cxx */; };
+		B6728BCD1A0731299924C8C4 /* pcre2_substring.c in Sources */ = {isa = PBXBuildFile; fileRef = 5152B34D06E9343FBFAB3510 /* pcre2_substring.c */; };
+		B6728BCD1A0731299924C8C5 /* pcre2_substring.c in Sources */ = {isa = PBXBuildFile; fileRef = 5152B34D06E9343FBFAB3510 /* pcre2_substring.c */; };
+		B6728BCD1A0731299924C8C6 /* pcre2_substring.c in Sources */ = {isa = PBXBuildFile; fileRef = 5152B34D06E9343FBFAB3510 /* pcre2_substring.c */; };
 		B6891F848CA0325EAB6D1373 /* textentry_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 777385D10CCC350C90F02824 /* textentry_osx.cpp */; };
 		B6891F848CA0325EAB6D1374 /* textentry_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 777385D10CCC350C90F02824 /* textentry_osx.cpp */; };
 		B6891F848CA0325EAB6D1375 /* textentry_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 777385D10CCC350C90F02824 /* textentry_osx.cpp */; };
@@ -2281,6 +2289,9 @@
 		C5A8DF376BB13A2A8290C2E5 /* xh_unkwn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 15FCCD1B587637DDA3C1748A /* xh_unkwn.cpp */; };
 		C5A8DF376BB13A2A8290C2E6 /* xh_unkwn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 15FCCD1B587637DDA3C1748A /* xh_unkwn.cpp */; };
 		C5A8DF376BB13A2A8290C2E7 /* xh_unkwn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 15FCCD1B587637DDA3C1748A /* xh_unkwn.cpp */; };
+		C5C60B22CE6A3BCB868F69E8 /* pcre2_find_bracket.c in Sources */ = {isa = PBXBuildFile; fileRef = 943C7E9527C03FCDB5966273 /* pcre2_find_bracket.c */; };
+		C5C60B22CE6A3BCB868F69E9 /* pcre2_find_bracket.c in Sources */ = {isa = PBXBuildFile; fileRef = 943C7E9527C03FCDB5966273 /* pcre2_find_bracket.c */; };
+		C5C60B22CE6A3BCB868F69EA /* pcre2_find_bracket.c in Sources */ = {isa = PBXBuildFile; fileRef = 943C7E9527C03FCDB5966273 /* pcre2_find_bracket.c */; };
 		C5E5AB869065307F83E27DD1 /* htmlpars.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1800B1884CC73C78A09E7FF1 /* htmlpars.cpp */; };
 		C5E5AB869065307F83E27DD2 /* htmlpars.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1800B1884CC73C78A09E7FF1 /* htmlpars.cpp */; };
 		C5E5AB869065307F83E27DD3 /* htmlpars.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1800B1884CC73C78A09E7FF1 /* htmlpars.cpp */; };
@@ -2302,6 +2313,9 @@
 		C92005CB86C6361BBB9D7C67 /* LexBibTeX.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 0851C46057CE3C37991B9E34 /* LexBibTeX.cxx */; };
 		C92005CB86C6361BBB9D7C68 /* LexBibTeX.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 0851C46057CE3C37991B9E34 /* LexBibTeX.cxx */; };
 		C92005CB86C6361BBB9D7C69 /* LexBibTeX.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 0851C46057CE3C37991B9E34 /* LexBibTeX.cxx */; };
+		C987310872D1396BAF716E5A /* webrequest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5EA9E372A64B3B808A64B178 /* webrequest.cpp */; };
+		C987310872D1396BAF716E5B /* webrequest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5EA9E372A64B3B808A64B178 /* webrequest.cpp */; };
+		C987310872D1396BAF716E5C /* webrequest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5EA9E372A64B3B808A64B178 /* webrequest.cpp */; };
 		CA155860CE9A3A8189C3A4C2 /* zipstrm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 54FB8A5FCBD0309AAC2E4F70 /* zipstrm.cpp */; };
 		CA155860CE9A3A8189C3A4C3 /* zipstrm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 54FB8A5FCBD0309AAC2E4F70 /* zipstrm.cpp */; };
 		CA155860CE9A3A8189C3A4C4 /* zipstrm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 54FB8A5FCBD0309AAC2E4F70 /* zipstrm.cpp */; };
@@ -2437,6 +2451,9 @@
 		D5C5DD83882B3227A1CCFE0E /* LexSorcus.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 7D8BDFB06EE13E59ABB2A616 /* LexSorcus.cxx */; };
 		D5C5DD83882B3227A1CCFE0F /* LexSorcus.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 7D8BDFB06EE13E59ABB2A616 /* LexSorcus.cxx */; };
 		D5C5DD83882B3227A1CCFE10 /* LexSorcus.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 7D8BDFB06EE13E59ABB2A616 /* LexSorcus.cxx */; };
+		D66F55C93D1130F488970C05 /* pcre2_match_data.c in Sources */ = {isa = PBXBuildFile; fileRef = 4E74E9E53454331F8E10ECC5 /* pcre2_match_data.c */; };
+		D66F55C93D1130F488970C06 /* pcre2_match_data.c in Sources */ = {isa = PBXBuildFile; fileRef = 4E74E9E53454331F8E10ECC5 /* pcre2_match_data.c */; };
+		D66F55C93D1130F488970C07 /* pcre2_match_data.c in Sources */ = {isa = PBXBuildFile; fileRef = 4E74E9E53454331F8E10ECC5 /* pcre2_match_data.c */; };
 		D66F5D4D204B3B789C7F76B9 /* fontdlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18044326B5B13A98A49732DD /* fontdlg.cpp */; };
 		D66F5D4D204B3B789C7F76BA /* fontdlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18044326B5B13A98A49732DD /* fontdlg.cpp */; };
 		D66F5D4D204B3B789C7F76BB /* fontdlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18044326B5B13A98A49732DD /* fontdlg.cpp */; };
@@ -2455,6 +2472,12 @@
 		D72D99FC424337CF9EDC2042 /* props.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C20E46A504113C899B9DD9B7 /* props.cpp */; };
 		D72D99FC424337CF9EDC2043 /* props.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C20E46A504113C899B9DD9B7 /* props.cpp */; };
 		D72D99FC424337CF9EDC2044 /* props.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C20E46A504113C899B9DD9B7 /* props.cpp */; };
+		D772334837693C9D88069D98 /* tif_webp.c in Sources */ = {isa = PBXBuildFile; fileRef = 3716DA7B0C79360CBA26A71E /* tif_webp.c */; };
+		D772334837693C9D88069D99 /* tif_webp.c in Sources */ = {isa = PBXBuildFile; fileRef = 3716DA7B0C79360CBA26A71E /* tif_webp.c */; };
+		D772334837693C9D88069D9A /* tif_webp.c in Sources */ = {isa = PBXBuildFile; fileRef = 3716DA7B0C79360CBA26A71E /* tif_webp.c */; };
+		D7F14BDFFB7F369B842AFC13 /* pcre2_config.c in Sources */ = {isa = PBXBuildFile; fileRef = FC6A8FAE9CA63EEB8883B6BD /* pcre2_config.c */; };
+		D7F14BDFFB7F369B842AFC14 /* pcre2_config.c in Sources */ = {isa = PBXBuildFile; fileRef = FC6A8FAE9CA63EEB8883B6BD /* pcre2_config.c */; };
+		D7F14BDFFB7F369B842AFC15 /* pcre2_config.c in Sources */ = {isa = PBXBuildFile; fileRef = FC6A8FAE9CA63EEB8883B6BD /* pcre2_config.c */; };
 		D83B32B788EC310D919E0DF7 /* imagpcx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 10ED6D770A5A349AA4EE9747 /* imagpcx.cpp */; };
 		D83B32B788EC310D919E0DF8 /* imagpcx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 10ED6D770A5A349AA4EE9747 /* imagpcx.cpp */; };
 		D83B32B788EC310D919E0DF9 /* imagpcx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 10ED6D770A5A349AA4EE9747 /* imagpcx.cpp */; };
@@ -2542,6 +2565,9 @@
 		DF8CE011EAC23F73BDA1C44D /* scrolbar_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 600740717F7E320F8CA78384 /* scrolbar_osx.cpp */; };
 		DF8CE011EAC23F73BDA1C44E /* scrolbar_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 600740717F7E320F8CA78384 /* scrolbar_osx.cpp */; };
 		DF8CE011EAC23F73BDA1C44F /* scrolbar_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 600740717F7E320F8CA78384 /* scrolbar_osx.cpp */; };
+		DFEB01E7B97A3515B785DCA9 /* pcre2_string_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = A6EE037AF43E343E8E1A7555 /* pcre2_string_utils.c */; };
+		DFEB01E7B97A3515B785DCAA /* pcre2_string_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = A6EE037AF43E343E8E1A7555 /* pcre2_string_utils.c */; };
+		DFEB01E7B97A3515B785DCAB /* pcre2_string_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = A6EE037AF43E343E8E1A7555 /* pcre2_string_utils.c */; };
 		DFEB8DA3D42734949CB1E1AA /* clipcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 239D386E9D7D39C5A1E859C6 /* clipcmn.cpp */; };
 		DFEB8DA3D42734949CB1E1AB /* clipcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 239D386E9D7D39C5A1E859C6 /* clipcmn.cpp */; };
 		DFEB8DA3D42734949CB1E1AC /* clipcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 239D386E9D7D39C5A1E859C6 /* clipcmn.cpp */; };
@@ -2557,6 +2583,9 @@
 		E104017EE1A4357DAF84E1E6 /* auibook.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A298576700C33F018616E7BD /* auibook.cpp */; };
 		E104017EE1A4357DAF84E1E7 /* auibook.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A298576700C33F018616E7BD /* auibook.cpp */; };
 		E104017EE1A4357DAF84E1E8 /* auibook.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A298576700C33F018616E7BD /* auibook.cpp */; };
+		E17048DEEF1138318314F1D0 /* pcre2_valid_utf.c in Sources */ = {isa = PBXBuildFile; fileRef = FAE49A61DFE9375AAB18E8DD /* pcre2_valid_utf.c */; };
+		E17048DEEF1138318314F1D1 /* pcre2_valid_utf.c in Sources */ = {isa = PBXBuildFile; fileRef = FAE49A61DFE9375AAB18E8DD /* pcre2_valid_utf.c */; };
+		E17048DEEF1138318314F1D2 /* pcre2_valid_utf.c in Sources */ = {isa = PBXBuildFile; fileRef = FAE49A61DFE9375AAB18E8DD /* pcre2_valid_utf.c */; };
 		E1A20811148F31D289AF98AF /* xh_sizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6E855AB3AB08325980871AB4 /* xh_sizer.cpp */; };
 		E1A20811148F31D289AF98B0 /* xh_sizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6E855AB3AB08325980871AB4 /* xh_sizer.cpp */; };
 		E1A20811148F31D289AF98B1 /* xh_sizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6E855AB3AB08325980871AB4 /* xh_sizer.cpp */; };
@@ -2678,6 +2707,9 @@
 		EAE02BA934B43EEE92C496C7 /* dcpsg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EEA0945B20913754A54D0FD9 /* dcpsg.cpp */; };
 		EAE02BA934B43EEE92C496C8 /* dcpsg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EEA0945B20913754A54D0FD9 /* dcpsg.cpp */; };
 		EAE02BA934B43EEE92C496C9 /* dcpsg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EEA0945B20913754A54D0FD9 /* dcpsg.cpp */; };
+		EB206A0264AD3CAA9F68B8FC /* pcre2_convert.c in Sources */ = {isa = PBXBuildFile; fileRef = BCED9B1D0D7E3FBBAC78CE5B /* pcre2_convert.c */; };
+		EB206A0264AD3CAA9F68B8FD /* pcre2_convert.c in Sources */ = {isa = PBXBuildFile; fileRef = BCED9B1D0D7E3FBBAC78CE5B /* pcre2_convert.c */; };
+		EB206A0264AD3CAA9F68B8FE /* pcre2_convert.c in Sources */ = {isa = PBXBuildFile; fileRef = BCED9B1D0D7E3FBBAC78CE5B /* pcre2_convert.c */; };
 		EB52C6A915943813932944FE /* control.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 12363D1F50FE301DAEE7F04A /* control.cpp */; };
 		EB52C6A915943813932944FF /* control.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 12363D1F50FE301DAEE7F04A /* control.cpp */; };
 		EB52C6A91594381393294500 /* control.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 12363D1F50FE301DAEE7F04A /* control.cpp */; };
@@ -2717,6 +2749,9 @@
 		EE6474BBB4AF34D093E2451D /* MarginView.cxx in Sources */ = {isa = PBXBuildFile; fileRef = F951601E73683F27AD8CA99D /* MarginView.cxx */; };
 		EE6474BBB4AF34D093E2451E /* MarginView.cxx in Sources */ = {isa = PBXBuildFile; fileRef = F951601E73683F27AD8CA99D /* MarginView.cxx */; };
 		EE6474BBB4AF34D093E2451F /* MarginView.cxx in Sources */ = {isa = PBXBuildFile; fileRef = F951601E73683F27AD8CA99D /* MarginView.cxx */; };
+		EE972E8DC73F310B9B4C949C /* webrequest_curl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5279968877003A8BB8279765 /* webrequest_curl.cpp */; };
+		EE972E8DC73F310B9B4C949D /* webrequest_curl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5279968877003A8BB8279765 /* webrequest_curl.cpp */; };
+		EE972E8DC73F310B9B4C949E /* webrequest_curl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5279968877003A8BB8279765 /* webrequest_curl.cpp */; };
 		EEB0B28903693C7E9D07192F /* glcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E08A51FA8D8A361681B07295 /* glcmn.cpp */; };
 		EEB0B28903693C7E9D071930 /* glcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E08A51FA8D8A361681B07295 /* glcmn.cpp */; };
 		EEB0B28903693C7E9D071931 /* glcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E08A51FA8D8A361681B07295 /* glcmn.cpp */; };
@@ -3048,7 +3083,7 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = 19367367C9323490BB936F06 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 2FF0B5E0505D3AEA9A4ACF12;
+			remoteGlobalIDString = 2FF0B5E0505D3AEA9A4ACF11;
 			remoteInfo = adv;
 		};
 		1676DB01C7863A80A404586F /* PBXContainerItemProxy */ = {
@@ -3307,7 +3342,7 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = 19367367C9323490BB936F06 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 2FF0B5E0505D3AEA9A4ACF12;
+			remoteGlobalIDString = 2FF0B5E0505D3AEA9A4ACF11;
 			remoteInfo = adv;
 		};
 		1676DB01C7863A80A4045894 /* PBXContainerItemProxy */ = {
@@ -3370,7 +3405,7 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = 19367367C9323490BB936F06 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 2FF0B5E0505D3AEA9A4ACF12;
+			remoteGlobalIDString = 2FF0B5E0505D3AEA9A4ACF11;
 			remoteInfo = adv;
 		};
 		1676DB01C7863A80A404589D /* PBXContainerItemProxy */ = {
@@ -3433,7 +3468,7 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = 19367367C9323490BB936F06 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 2FF0B5E0505D3AEA9A4ACF12;
+			remoteGlobalIDString = 2FF0B5E0505D3AEA9A4ACF11;
 			remoteInfo = adv;
 		};
 		1676DB01C7863A80A40458A6 /* PBXContainerItemProxy */ = {
@@ -3657,7 +3692,7 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = 19367367C9323490BB936F06 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 2FF0B5E0505D3AEA9A4ACF12;
+			remoteGlobalIDString = 2FF0B5E0505D3AEA9A4ACF11;
 			remoteInfo = adv;
 		};
 		1676DB01C7863A80A40458C6 /* PBXContainerItemProxy */ = {
@@ -3797,7 +3832,7 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = 19367367C9323490BB936F06 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 2FF0B5E0505D3AEA9A4ACF12;
+			remoteGlobalIDString = 2FF0B5E0505D3AEA9A4ACF11;
 			remoteInfo = adv;
 		};
 		1676DB01C7863A80A40458DA /* PBXContainerItemProxy */ = {
@@ -3961,6 +3996,7 @@
 		00969CBE3B8F32C78C195619 /* panel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = panel.cpp; path = ../../src/ribbon/panel.cpp; sourceTree = "<group>"; };
 		00BC2298BC7A33B7A68584FE /* bookctrl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = bookctrl.cpp; path = ../../src/common/bookctrl.cpp; sourceTree = "<group>"; };
 		00DA3D3EEF5E305CA73A1871 /* region.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = region.cpp; path = ../../src/osx/carbon/region.cpp; sourceTree = "<group>"; };
+		00DAA69F74D031B6BE9196A8 /* pcre2_pattern_info.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_pattern_info.c; path = ../../3rdparty/pcre/src/pcre2_pattern_info.c; sourceTree = "<group>"; };
 		0116581B77DF3A5D889B8D17 /* dndcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = dndcmn.cpp; path = ../../src/common/dndcmn.cpp; sourceTree = "<group>"; };
 		018B15DE6F3A3D49B9CDE9DE /* hidjoystick.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = hidjoystick.cpp; path = ../../src/osx/core/hidjoystick.cpp; sourceTree = "<group>"; };
 		01BA6D45FE4C381493EB4372 /* validate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = validate.cpp; path = ../../src/common/validate.cpp; sourceTree = "<group>"; };
@@ -3988,6 +4024,7 @@
 		0903EE9B3793303285FF96E3 /* textfile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = textfile.cpp; path = ../../src/common/textfile.cpp; sourceTree = "<group>"; };
 		093B5233861B3F9B8C85762B /* xh_cald.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_cald.cpp; path = ../../src/xrc/xh_cald.cpp; sourceTree = "<group>"; };
 		0964797530CF3FE7B8DB6242 /* pngwtran.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pngwtran.c; path = ../../src/png/pngwtran.c; sourceTree = "<group>"; };
+		09CCDDC66F683C6B87BEDD2F /* pcre2_study.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_study.c; path = ../../3rdparty/pcre/src/pcre2_study.c; sourceTree = "<group>"; };
 		09F8B0818C3A3248A26EE05D /* choicbkg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = choicbkg.cpp; path = ../../src/generic/choicbkg.cpp; sourceTree = "<group>"; };
 		0A59A5C2305D3D1C8049BE71 /* LexCsound.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexCsound.cxx; path = ../../src/stc/scintilla/lexers/LexCsound.cxx; sourceTree = "<group>"; };
 		0B0DC125AFFC322E8E496262 /* dirdlg.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = dirdlg.mm; path = ../../src/osx/cocoa/dirdlg.mm; sourceTree = "<group>"; };
@@ -4003,7 +4040,7 @@
 		0EB91E8407CB3300A19F387D /* ctrlcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ctrlcmn.cpp; path = ../../src/common/ctrlcmn.cpp; sourceTree = "<group>"; };
 		0EEAD9C3E180305D8899441E /* strvararg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = strvararg.cpp; path = ../../src/common/strvararg.cpp; sourceTree = "<group>"; };
 		0FA0840034F1386F94D17639 /* timectrl_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = timectrl_osx.cpp; path = ../../src/osx/timectrl_osx.cpp; sourceTree = "<group>"; };
-		0FBD8031E28A3C9CB7C45784 /* overlay.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = overlay.mm; path = ../../src/osx/cocoa/overlay.mm; sourceTree = "<group>"; };
+		0FBD8031E28A3C9CB7C45784 /* overlay.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = overlay.mm; path = ../../src/osx/cocoa/overlay.mm; sourceTree = "<group>"; };
 		108517BCD39230E7A89BC943 /* jerror.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jerror.c; path = ../../src/jpeg/jerror.c; sourceTree = "<group>"; };
 		1094F7D0E7A93B0CAC949001 /* tif_dumpmode.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_dumpmode.c; path = ../../src/tiff/libtiff/tif_dumpmode.c; sourceTree = "<group>"; };
 		1098499A317A3DEEA4D16D0D /* LexVHDL.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexVHDL.cxx; path = ../../src/stc/scintilla/lexers/LexVHDL.cxx; sourceTree = "<group>"; };
@@ -4035,6 +4072,7 @@
 		1800B1884CC73C78A09E7FF1 /* htmlpars.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = htmlpars.cpp; path = ../../src/html/htmlpars.cpp; sourceTree = "<group>"; };
 		18044326B5B13A98A49732DD /* fontdlg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fontdlg.cpp; path = ../../src/osx/carbon/fontdlg.cpp; sourceTree = "<group>"; };
 		182C8AD4F822375495795B43 /* dbgrptg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = dbgrptg.cpp; path = ../../src/generic/dbgrptg.cpp; sourceTree = "<group>"; };
+		1895085EBEAE3A708FDD527A /* pcre2_chartables.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_chartables.c; path = ../../3rdparty/pcre/src/pcre2_chartables.c; sourceTree = "<group>"; };
 		18ABDAF9EF723072A7708009 /* PlatWXcocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = PlatWXcocoa.mm; path = ../../src/stc/PlatWXcocoa.mm; sourceTree = "<group>"; };
 		190409DF8A3C3D9580FBB8AA /* stdpaths.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = stdpaths.mm; path = ../../src/osx/cocoa/stdpaths.mm; sourceTree = "<group>"; };
 		194ADD28300E329E80F7892E /* htmprint.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = htmprint.cpp; path = ../../src/html/htmprint.cpp; sourceTree = "<group>"; };
@@ -4082,6 +4120,7 @@
 		24E82A05E9A9323287CDB15B /* artstd.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = artstd.cpp; path = ../../src/common/artstd.cpp; sourceTree = "<group>"; };
 		25A81E9028793C109D868068 /* xh_timectrl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_timectrl.cpp; path = ../../src/xrc/xh_timectrl.cpp; sourceTree = "<group>"; };
 		25C86D3D4839343BA1D8BDEE /* xti.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xti.cpp; path = ../../src/common/xti.cpp; sourceTree = "<group>"; };
+		25E03E349FC13E4A9428B94E /* pcre2_error.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_error.c; path = ../../3rdparty/pcre/src/pcre2_error.c; sourceTree = "<group>"; };
 		26381308E32A3A179E7A9B40 /* gridsel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = gridsel.cpp; path = ../../src/generic/gridsel.cpp; sourceTree = "<group>"; };
 		26632A254717372BAA4D514D /* framemanager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = framemanager.cpp; path = ../../src/aui/framemanager.cpp; sourceTree = "<group>"; };
 		267DB0E799183294B707A39D /* LexerNoExceptions.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexerNoExceptions.cxx; path = ../../src/stc/scintilla/lexlib/LexerNoExceptions.cxx; sourceTree = "<group>"; };
@@ -4098,8 +4137,8 @@
 		2A4D36DE66EC3EB09E883D6B /* taskbar.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = taskbar.mm; path = ../../src/osx/cocoa/taskbar.mm; sourceTree = "<group>"; };
 		2A5FC30FF3743DBAAF8910EC /* LexPowerPro.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexPowerPro.cxx; path = ../../src/stc/scintilla/lexers/LexPowerPro.cxx; sourceTree = "<group>"; };
 		2A67053D16D63C588E555C84 /* dragimgg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = dragimgg.cpp; path = ../../src/generic/dragimgg.cpp; sourceTree = "<group>"; };
-		2ACC8667173D3AB09F6214F4 /* sound.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = sound.cpp; path = ../../src/osx/carbon/sound.cpp; sourceTree = "<group>"; };
-		2ACC8667173D3AB09F6214F5 /* sound.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = sound.cpp; path = ../../src/osx/core/sound.cpp; sourceTree = "<group>"; };
+		2ACC8667173D3AB09F6214F4 /* sound.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = sound.cpp; path = ../../src/osx/core/sound.cpp; sourceTree = "<group>"; };
+		2ACC8667173D3AB09F6214F5 /* sound.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = sound.cpp; path = ../../src/osx/carbon/sound.cpp; sourceTree = "<group>"; };
 		2AF7739C389536F79DAA31E5 /* Selection.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Selection.cxx; path = ../../src/stc/scintilla/src/Selection.cxx; sourceTree = "<group>"; };
 		2AFC4A1CDA473688A590D19F /* utilscocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = utilscocoa.mm; path = ../../src/osx/carbon/utilscocoa.mm; sourceTree = "<group>"; };
 		2B1A318636A134DB93C0BA45 /* LexSQL.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexSQL.cxx; path = ../../src/stc/scintilla/lexers/LexSQL.cxx; sourceTree = "<group>"; };
@@ -4117,8 +4156,10 @@
 		2F316F7DD3CB3390A6E50179 /* mimecmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = mimecmn.cpp; path = ../../src/common/mimecmn.cpp; sourceTree = "<group>"; };
 		2F3EE2E9EE05311497826962 /* LexMySQL.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexMySQL.cxx; path = ../../src/stc/scintilla/lexers/LexMySQL.cxx; sourceTree = "<group>"; };
 		2F41EDEB298538CC86FF6DC1 /* jcparam.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jcparam.c; path = ../../src/jpeg/jcparam.c; sourceTree = "<group>"; };
+		2F4CDF9048EC36788619769D /* pcre2_script_run.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_script_run.c; path = ../../3rdparty/pcre/src/pcre2_script_run.c; sourceTree = "<group>"; };
 		2F94CF171F4532B89FECF475 /* busyinfo.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = busyinfo.cpp; path = ../../src/generic/busyinfo.cpp; sourceTree = "<group>"; };
 		2FA01C426EAF38D3B9ED35AC /* tif_predict.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_predict.c; path = ../../src/tiff/libtiff/tif_predict.c; sourceTree = "<group>"; };
+		3026D20A03E53F1DB40FB35A /* pcre2_context.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_context.c; path = ../../3rdparty/pcre/src/pcre2_context.c; sourceTree = "<group>"; };
 		302A13BC64C238A297F4399F /* brush.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = brush.cpp; path = ../../src/osx/brush.cpp; sourceTree = "<group>"; };
 		303ACF199BE431BD891C9301 /* overlaycmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = overlaycmn.cpp; path = ../../src/common/overlaycmn.cpp; sourceTree = "<group>"; };
 		305614D19CF23CB2B14A5B2E /* tif_flush.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_flush.c; path = ../../src/tiff/libtiff/tif_flush.c; sourceTree = "<group>"; };
@@ -4140,6 +4181,7 @@
 		36296C259D023EAAA240FC79 /* bannerwindow.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = bannerwindow.cpp; path = ../../src/generic/bannerwindow.cpp; sourceTree = "<group>"; };
 		36E1DBA275AD325DB759C180 /* fontenum.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fontenum.cpp; path = ../../src/osx/core/fontenum.cpp; sourceTree = "<group>"; };
 		36F7955F8075343C8A9953DB /* LexPowerShell.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexPowerShell.cxx; path = ../../src/stc/scintilla/lexers/LexPowerShell.cxx; sourceTree = "<group>"; };
+		3716DA7B0C79360CBA26A71E /* tif_webp.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_webp.c; path = ../../src/tiff/libtiff/tif_webp.c; sourceTree = "<group>"; };
 		3720038D64CF3C0B8F642A90 /* tokenzr.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = tokenzr.cpp; path = ../../src/common/tokenzr.cpp; sourceTree = "<group>"; };
 		373242CD08F330208A7CF438 /* fontenumcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fontenumcmn.cpp; path = ../../src/common/fontenumcmn.cpp; sourceTree = "<group>"; };
 		374E341C8703367686DEDE93 /* jmemnobs.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jmemnobs.c; path = ../../src/jpeg/jmemnobs.c; sourceTree = "<group>"; };
@@ -4150,9 +4192,11 @@
 		38CEA4A3579331EF808B8363 /* fontdlgosx.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = fontdlgosx.mm; path = ../../src/osx/carbon/fontdlgosx.mm; sourceTree = "<group>"; };
 		38E0F60AE1F83633A0CC18FC /* xh_slidr.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_slidr.cpp; path = ../../src/xrc/xh_slidr.cpp; sourceTree = "<group>"; };
 		38EF5FC5934C34D599FD6074 /* bmpbuttn_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = bmpbuttn_osx.cpp; path = ../../src/osx/bmpbuttn_osx.cpp; sourceTree = "<group>"; };
-		39507FA11D8838109A22B7DA /* filter_neon_intrinsics.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = filter_neon_intrinsics.c; path = ../../src/png/arm/filter_neon_intrinsics.c; sourceTree = "<group>"; };
+		39507FA11D8838109A22B7DA /* filter_neon_intrinsics.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = filter_neon_intrinsics.c; path = ../../src/png/arm/filter_neon_intrinsics.c; sourceTree = "<group>"; };
 		3ABD697F99673F16A0B2D4C1 /* styleparams.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = styleparams.cpp; path = ../../src/html/styleparams.cpp; sourceTree = "<group>"; };
 		3B548B1FF2A238809315C8A9 /* fdiounix.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fdiounix.cpp; path = ../../src/unix/fdiounix.cpp; sourceTree = "<group>"; };
+		3B93115BCC46333BBB31D6F7 /* pcre2_match.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_match.c; path = ../../3rdparty/pcre/src/pcre2_match.c; sourceTree = "<group>"; };
+		3B98123FD57731139044B064 /* tif_zstd.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_zstd.c; path = ../../src/tiff/libtiff/tif_zstd.c; sourceTree = "<group>"; };
 		3BFC1F090EFE30B784CE4C64 /* xh_toolb.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_toolb.cpp; path = ../../src/xrc/xh_toolb.cpp; sourceTree = "<group>"; };
 		3C131F7BF8A83960ACB26242 /* jidctflt.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jidctflt.c; path = ../../src/jpeg/jidctflt.c; sourceTree = "<group>"; };
 		3C4A7A93CAFC3E22A2A5F7F3 /* spinbutt.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = spinbutt.mm; path = ../../src/osx/cocoa/spinbutt.mm; sourceTree = "<group>"; };
@@ -4173,33 +4217,6 @@
 		4048A3523EC03409BD899BEF /* xtixml.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xtixml.cpp; path = ../../src/common/xtixml.cpp; sourceTree = "<group>"; };
 		40586C8986443431A64EB066 /* LexLisp.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexLisp.cxx; path = ../../src/stc/scintilla/lexers/LexLisp.cxx; sourceTree = "<group>"; };
 		4071FF90F1D4336C836B2AE4 /* tif_pixarlog.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_pixarlog.c; path = ../../src/tiff/libtiff/tif_pixarlog.c; sourceTree = "<group>"; };
-		A6EE037AF43E343E8E1A7555 /* pcre2_string_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_string_utils.c; path = ../../3rdparty/pcre/src/pcre2_string_utils.c; sourceTree = "<group>"; };
-		FC6A8FAE9CA63EEB8883B6BD /* pcre2_config.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_config.c; path = ../../3rdparty/pcre/src/pcre2_config.c; sourceTree = "<group>"; };
-		5152B34D06E9343FBFAB3510 /* pcre2_substring.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_substring.c; path = ../../3rdparty/pcre/src/pcre2_substring.c; sourceTree = "<group>"; };
-		09CCDDC66F683C6B87BEDD2F /* pcre2_study.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_study.c; path = ../../3rdparty/pcre/src/pcre2_study.c; sourceTree = "<group>"; };
-		4BFEBC5061693DA0B52BC4AC /* pcre2_ord2utf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_ord2utf.c; path = ../../3rdparty/pcre/src/pcre2_ord2utf.c; sourceTree = "<group>"; };
-		3026D20A03E53F1DB40FB35A /* pcre2_context.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_context.c; path = ../../3rdparty/pcre/src/pcre2_context.c; sourceTree = "<group>"; };
-		BDADEB1DA6433E52972C8934 /* pcre2_compile.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_compile.c; path = ../../3rdparty/pcre/src/pcre2_compile.c; sourceTree = "<group>"; };
-		943C7E9527C03FCDB5966273 /* pcre2_find_bracket.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_find_bracket.c; path = ../../3rdparty/pcre/src/pcre2_find_bracket.c; sourceTree = "<group>"; };
-		A208BFC0C8C43847A9620ADA /* pcre2_newline.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_newline.c; path = ../../3rdparty/pcre/src/pcre2_newline.c; sourceTree = "<group>"; };
-		7C9F6184015A3BD1B8DA471E /* pcre2_jit_compile.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_jit_compile.c; path = ../../3rdparty/pcre/src/pcre2_jit_compile.c; sourceTree = "<group>"; };
-		3B93115BCC46333BBB31D6F7 /* pcre2_match.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_match.c; path = ../../3rdparty/pcre/src/pcre2_match.c; sourceTree = "<group>"; };
-		1895085EBEAE3A708FDD527A /* pcre2_chartables.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_chartables.c; path = ../../3rdparty/pcre/src/pcre2_chartables.c; sourceTree = "<group>"; };
-		96D620AEA83E3444BA0B04C4 /* pcre2_dfa_match.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_dfa_match.c; path = ../../3rdparty/pcre/src/pcre2_dfa_match.c; sourceTree = "<group>"; };
-		95CBA2C736623FFF8629E975 /* pcre2_xclass.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_xclass.c; path = ../../3rdparty/pcre/src/pcre2_xclass.c; sourceTree = "<group>"; };
-		25E03E349FC13E4A9428B94E /* pcre2_error.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_error.c; path = ../../3rdparty/pcre/src/pcre2_error.c; sourceTree = "<group>"; };
-		C3904351139F3F0DB4B72F94 /* pcre2_auto_possess.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_auto_possess.c; path = ../../3rdparty/pcre/src/pcre2_auto_possess.c; sourceTree = "<group>"; };
-		FAE49A61DFE9375AAB18E8DD /* pcre2_valid_utf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_valid_utf.c; path = ../../3rdparty/pcre/src/pcre2_valid_utf.c; sourceTree = "<group>"; };
-		BD2EBC2CCAE23AD6A1DF783E /* pcre2_serialize.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_serialize.c; path = ../../3rdparty/pcre/src/pcre2_serialize.c; sourceTree = "<group>"; };
-		B60497805D37375EBFCF3D98 /* pcre2_tables.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_tables.c; path = ../../3rdparty/pcre/src/pcre2_tables.c; sourceTree = "<group>"; };
-		FAC42945539F362D91D6F559 /* pcre2_substitute.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_substitute.c; path = ../../3rdparty/pcre/src/pcre2_substitute.c; sourceTree = "<group>"; };
-		F0E43FFDC808333AA01EE649 /* pcre2_extuni.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_extuni.c; path = ../../3rdparty/pcre/src/pcre2_extuni.c; sourceTree = "<group>"; };
-		70F4EB692873386AAA0A44B0 /* pcre2_ucd.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_ucd.c; path = ../../3rdparty/pcre/src/pcre2_ucd.c; sourceTree = "<group>"; };
-		00DAA69F74D031B6BE9196A8 /* pcre2_pattern_info.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_pattern_info.c; path = ../../3rdparty/pcre/src/pcre2_pattern_info.c; sourceTree = "<group>"; };
-		2F4CDF9048EC36788619769D /* pcre2_script_run.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_script_run.c; path = ../../3rdparty/pcre/src/pcre2_script_run.c; sourceTree = "<group>"; };
-		BCED9B1D0D7E3FBBAC78CE5B /* pcre2_convert.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_convert.c; path = ../../3rdparty/pcre/src/pcre2_convert.c; sourceTree = "<group>"; };
-		4E74E9E53454331F8E10ECC5 /* pcre2_match_data.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_match_data.c; path = ../../3rdparty/pcre/src/pcre2_match_data.c; sourceTree = "<group>"; };
-		D016F584D14C31E192DB3179 /* pcre2_maketables.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_maketables.c; path = ../../3rdparty/pcre/src/pcre2_maketables.c; sourceTree = "<group>"; };
 		40CE02524DD4385AB2C3DF95 /* socket.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = socket.cpp; path = ../../src/common/socket.cpp; sourceTree = "<group>"; };
 		4188821BBA833CCAA678B234 /* utilscmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = utilscmn.cpp; path = ../../src/common/utilscmn.cpp; sourceTree = "<group>"; };
 		418AD9241B673308BE31DC06 /* xlocale.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xlocale.cpp; path = ../../src/common/xlocale.cpp; sourceTree = "<group>"; };
@@ -4213,7 +4230,7 @@
 		4549845C0751356A907C23E0 /* jdtrans.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jdtrans.c; path = ../../src/jpeg/jdtrans.c; sourceTree = "<group>"; };
 		45860601270D318D93BEE1F3 /* LexMagik.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexMagik.cxx; path = ../../src/stc/scintilla/lexers/LexMagik.cxx; sourceTree = "<group>"; };
 		4592464D4868329897F3864D /* LexSpice.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexSpice.cxx; path = ../../src/stc/scintilla/lexers/LexSpice.cxx; sourceTree = "<group>"; };
-		45C65E309F3A39598C043657 /* xh_infobar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = xh_infobar.cpp; path = ../../src/xrc/xh_infobar.cpp; sourceTree = "<group>"; };
+		45C65E309F3A39598C043657 /* xh_infobar.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_infobar.cpp; path = ../../src/xrc/xh_infobar.cpp; sourceTree = "<group>"; };
 		45D7558DF5E03A2EB41883F0 /* pngwutil.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pngwutil.c; path = ../../src/png/pngwutil.c; sourceTree = "<group>"; };
 		45E7EC6D0C0E3C878664C0A9 /* fldlgcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fldlgcmn.cpp; path = ../../src/common/fldlgcmn.cpp; sourceTree = "<group>"; };
 		4692909E4B823F71822B13F8 /* taskbarcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = taskbarcmn.cpp; path = ../../src/common/taskbarcmn.cpp; sourceTree = "<group>"; };
@@ -4236,8 +4253,12 @@
 		4B3B8AD0120F3EA6BF5B0AE0 /* LexCaml.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexCaml.cxx; path = ../../src/stc/scintilla/lexers/LexCaml.cxx; sourceTree = "<group>"; };
 		4BA14FFC0F4B3AE0B4D6B185 /* jquant1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jquant1.c; path = ../../src/jpeg/jquant1.c; sourceTree = "<group>"; };
 		4BA819575B5136B09FA8FEB1 /* pen.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = pen.cpp; path = ../../src/osx/pen.cpp; sourceTree = "<group>"; };
+		4BFEBC5061693DA0B52BC4AC /* pcre2_ord2utf.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_ord2utf.c; path = ../../3rdparty/pcre/src/pcre2_ord2utf.c; sourceTree = "<group>"; };
 		4C4649974D8B3A109D1BF145 /* art_internal.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = art_internal.cpp; path = ../../src/ribbon/art_internal.cpp; sourceTree = "<group>"; };
 		4CB467F9898C3952A68D988B /* zutil.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = zutil.c; path = ../../src/zlib/zutil.c; sourceTree = "<group>"; };
+		4E4466371B7E3265AE7B1E0C /* uilocale.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = uilocale.cpp; path = ../../src/common/uilocale.cpp; sourceTree = "<group>"; };
+		4E4466371B7E3265AE7B1E0D /* uilocale.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = uilocale.cpp; path = ../../src/osx/core/uilocale.cpp; sourceTree = "<group>"; };
+		4E74E9E53454331F8E10ECC5 /* pcre2_match_data.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_match_data.c; path = ../../3rdparty/pcre/src/pcre2_match_data.c; sourceTree = "<group>"; };
 		4EB3B255D20F3AE5A95230F6 /* LexCSS.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexCSS.cxx; path = ../../src/stc/scintilla/lexers/LexCSS.cxx; sourceTree = "<group>"; };
 		4F58B88D42A93BD0B74ADF75 /* CallTip.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = CallTip.cxx; path = ../../src/stc/scintilla/src/CallTip.cxx; sourceTree = "<group>"; };
 		4F768B23D8B535CE8D0BD343 /* tif_jpeg_12.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_jpeg_12.c; path = ../../src/tiff/libtiff/tif_jpeg_12.c; sourceTree = "<group>"; };
@@ -4251,10 +4272,12 @@
 		51054B41BFD83E97BAF76D07 /* tabart.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = tabart.cpp; path = ../../src/aui/tabart.cpp; sourceTree = "<group>"; };
 		513033E36E643593AC305B3D /* uncompr.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = uncompr.c; path = ../../src/zlib/uncompr.c; sourceTree = "<group>"; };
 		5145561C78303EEE9F827962 /* LexLua.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexLua.cxx; path = ../../src/stc/scintilla/lexers/LexLua.cxx; sourceTree = "<group>"; };
+		5152B34D06E9343FBFAB3510 /* pcre2_substring.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_substring.c; path = ../../3rdparty/pcre/src/pcre2_substring.c; sourceTree = "<group>"; };
 		5168ADF7BE39351F8F24E1E6 /* cfstring.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = cfstring.cpp; path = ../../src/osx/core/cfstring.cpp; sourceTree = "<group>"; };
 		5190E3E110443FD29F2474FC /* treelist.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = treelist.cpp; path = ../../src/generic/treelist.cpp; sourceTree = "<group>"; };
 		5219A792C6A736F193D4A82F /* ContractionState.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ContractionState.cxx; path = ../../src/stc/scintilla/src/ContractionState.cxx; sourceTree = "<group>"; };
 		5248A45AB113341EAC361910 /* notebook_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = notebook_osx.cpp; path = ../../src/osx/notebook_osx.cpp; sourceTree = "<group>"; };
+		5279968877003A8BB8279765 /* webrequest_curl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = webrequest_curl.cpp; path = ../../src/common/webrequest_curl.cpp; sourceTree = "<group>"; };
 		52FE1599218730CC99A3F801 /* m_dflist.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = m_dflist.cpp; path = ../../src/html/m_dflist.cpp; sourceTree = "<group>"; };
 		530DC2E26BF2313E8702AD43 /* popupwin.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = popupwin.cpp; path = ../../src/osx/carbon/popupwin.cpp; sourceTree = "<group>"; };
 		531B0E5DB9ED393996E3FBB8 /* radiocmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = radiocmn.cpp; path = ../../src/common/radiocmn.cpp; sourceTree = "<group>"; };
@@ -4311,6 +4334,7 @@
 		5E463A493FD930DE80E58608 /* pngset.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pngset.c; path = ../../src/png/pngset.c; sourceTree = "<group>"; };
 		5E53DC332DA23DF4B9BFCDE3 /* dataview_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = dataview_osx.cpp; path = ../../src/osx/dataview_osx.cpp; sourceTree = "<group>"; };
 		5E7A77AA776B3B5CAEE3CC90 /* listbkg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = listbkg.cpp; path = ../../src/generic/listbkg.cpp; sourceTree = "<group>"; };
+		5EA9E372A64B3B808A64B178 /* webrequest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = webrequest.cpp; path = ../../src/common/webrequest.cpp; sourceTree = "<group>"; };
 		5ED2105A5A033E3384EBC4ED /* selstore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = selstore.cpp; path = ../../src/generic/selstore.cpp; sourceTree = "<group>"; };
 		5F094B0B07DF33BCA6077BC0 /* fdrepdlg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fdrepdlg.cpp; path = ../../src/generic/fdrepdlg.cpp; sourceTree = "<group>"; };
 		5F3D473DC5123EDAB767045C /* datavgen.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = datavgen.cpp; path = ../../src/generic/datavgen.cpp; sourceTree = "<group>"; };
@@ -4330,7 +4354,7 @@
 		60DFD5962DE3379F801AF78F /* power.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = power.mm; path = ../../src/osx/cocoa/power.mm; sourceTree = "<group>"; };
 		60EE4448A28D38F5ADE17B5A /* xh_filectrl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_filectrl.cpp; path = ../../src/xrc/xh_filectrl.cpp; sourceTree = "<group>"; };
 		61548D0FE1353D7C846DD721 /* menuitem.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = menuitem.mm; path = ../../src/osx/cocoa/menuitem.mm; sourceTree = "<group>"; };
-		616466F521DB3ECAB304289F /* xh_dataview.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = xh_dataview.cpp; path = ../../src/xrc/xh_dataview.cpp; sourceTree = "<group>"; };
+		616466F521DB3ECAB304289F /* xh_dataview.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_dataview.cpp; path = ../../src/xrc/xh_dataview.cpp; sourceTree = "<group>"; };
 		61658C3EABB4341AA38C691E /* m_pre.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = m_pre.cpp; path = ../../src/html/m_pre.cpp; sourceTree = "<group>"; };
 		61DA2A4C0D143CBE804BB8A1 /* fileconf.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fileconf.cpp; path = ../../src/common/fileconf.cpp; sourceTree = "<group>"; };
 		62C46B0CE620348FBF3860A4 /* LexPLM.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexPLM.cxx; path = ../../src/stc/scintilla/lexers/LexPLM.cxx; sourceTree = "<group>"; };
@@ -4379,6 +4403,7 @@
 		701B84EE7C043B539FF5195A /* textbuf.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = textbuf.cpp; path = ../../src/common/textbuf.cpp; sourceTree = "<group>"; };
 		7020ADB5D3E0375E875B418B /* LexA68k.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexA68k.cxx; path = ../../src/stc/scintilla/lexers/LexA68k.cxx; sourceTree = "<group>"; };
 		70E9B2C076673C87B4218A01 /* panelcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = panelcmn.cpp; path = ../../src/common/panelcmn.cpp; sourceTree = "<group>"; };
+		70F4EB692873386AAA0A44B0 /* pcre2_ucd.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_ucd.c; path = ../../3rdparty/pcre/src/pcre2_ucd.c; sourceTree = "<group>"; };
 		7195E665E0F233839B967FC9 /* timercmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = timercmn.cpp; path = ../../src/common/timercmn.cpp; sourceTree = "<group>"; };
 		71DB140E670738839EC42C2B /* Document.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Document.cxx; path = ../../src/stc/scintilla/src/Document.cxx; sourceTree = "<group>"; };
 		724927B0045F3CC0884878BB /* radiobtncmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = radiobtncmn.cpp; path = ../../src/common/radiobtncmn.cpp; sourceTree = "<group>"; };
@@ -4416,6 +4441,7 @@
 		7C6CC76872BA32D2B61EB8AB /* libwx_baseu_xml.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libwx_baseu_xml.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		7C80A0223B993BCB80D1C0A0 /* srchctrl_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = srchctrl_osx.cpp; path = ../../src/osx/srchctrl_osx.cpp; sourceTree = "<group>"; };
 		7C97C1F26B5A38C49543060C /* mimetype.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = mimetype.cpp; path = ../../src/osx/core/mimetype.cpp; sourceTree = "<group>"; };
+		7C9F6184015A3BD1B8DA471E /* pcre2_jit_compile.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_jit_compile.c; path = ../../3rdparty/pcre/src/pcre2_jit_compile.c; sourceTree = "<group>"; };
 		7CC8B73BB8C0391E9EC1B2D1 /* colour.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = colour.mm; path = ../../src/osx/cocoa/colour.mm; sourceTree = "<group>"; };
 		7CF5C09D9A1230EEB42713E1 /* stattext_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = stattext_osx.cpp; path = ../../src/osx/stattext_osx.cpp; sourceTree = "<group>"; };
 		7D2BE094D90D3AFDAE49F589 /* fswatchercmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fswatchercmn.cpp; path = ../../src/common/fswatchercmn.cpp; sourceTree = "<group>"; };
@@ -4492,17 +4518,19 @@
 		924AA3A156F834BCA1A57976 /* notifmsgg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = notifmsgg.cpp; path = ../../src/generic/notifmsgg.cpp; sourceTree = "<group>"; };
 		926BDF9C386C3A9A8C24D453 /* statbox.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = statbox.mm; path = ../../src/osx/cocoa/statbox.mm; sourceTree = "<group>"; };
 		92F377099B8B37F18C26716B /* collheaderctrlg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = collheaderctrlg.cpp; path = ../../src/generic/collheaderctrlg.cpp; sourceTree = "<group>"; };
-		933D7637CAA43F6C99814BC5 /* arm_init.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = arm_init.c; path = ../../src/png/arm/arm_init.c; sourceTree = "<group>"; };
+		933D7637CAA43F6C99814BC5 /* arm_init.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = arm_init.c; path = ../../src/png/arm/arm_init.c; sourceTree = "<group>"; };
 		9389DAF8B91030B7AAB029FF /* PerLine.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PerLine.cxx; path = ../../src/stc/scintilla/src/PerLine.cxx; sourceTree = "<group>"; };
 		93B77251C0E0382D9A8E113D /* xh_grid.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_grid.cpp; path = ../../src/xrc/xh_grid.cpp; sourceTree = "<group>"; };
 		93BA27DFFB023F2EBD6295E3 /* dynload.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = dynload.cpp; path = ../../src/common/dynload.cpp; sourceTree = "<group>"; };
 		93D07403FCA530D7A9FD2917 /* jfdctflt.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jfdctflt.c; path = ../../src/jpeg/jfdctflt.c; sourceTree = "<group>"; };
 		93EDB3A2B85E3275A6D27C56 /* LexerBase.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexerBase.cxx; path = ../../src/stc/scintilla/lexlib/LexerBase.cxx; sourceTree = "<group>"; };
+		943C7E9527C03FCDB5966273 /* pcre2_find_bracket.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_find_bracket.c; path = ../../3rdparty/pcre/src/pcre2_find_bracket.c; sourceTree = "<group>"; };
 		950D51915EF83B57B5E8306F /* xh_spin.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_spin.cpp; path = ../../src/xrc/xh_spin.cpp; sourceTree = "<group>"; };
 		95186FEF3DEF39D8B1157BD5 /* stattext.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = stattext.mm; path = ../../src/osx/cocoa/stattext.mm; sourceTree = "<group>"; };
 		95A156A823B536DE8476E4F9 /* appbase.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = appbase.cpp; path = ../../src/common/appbase.cpp; sourceTree = "<group>"; };
 		95B4B2890C3A372DAB8DC7BA /* datectrl_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = datectrl_osx.cpp; path = ../../src/osx/datectrl_osx.cpp; sourceTree = "<group>"; };
 		95B4EDF38F8A3E5EBAFF560F /* trees.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = trees.c; path = ../../src/zlib/trees.c; sourceTree = "<group>"; };
+		95CBA2C736623FFF8629E975 /* pcre2_xclass.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_xclass.c; path = ../../3rdparty/pcre/src/pcre2_xclass.c; sourceTree = "<group>"; };
 		95DEEF60B1E9358A8CCCC67E /* datavcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = datavcmn.cpp; path = ../../src/common/datavcmn.cpp; sourceTree = "<group>"; };
 		95E2B80B2D7033808504DA8D /* utilsexc_cf.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = utilsexc_cf.cpp; path = ../../src/osx/core/utilsexc_cf.cpp; sourceTree = "<group>"; };
 		964578C24B9F390AAD08576E /* addremovectrl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = addremovectrl.cpp; path = ../../src/common/addremovectrl.cpp; sourceTree = "<group>"; };
@@ -4510,6 +4538,7 @@
 		966AA1B230CA3EFCB1260D80 /* libwx_baseu_net.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libwx_baseu_net.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		967EF76827CB3CDE87E1E733 /* propgridpagestate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = propgridpagestate.cpp; path = ../../src/propgrid/propgridpagestate.cpp; sourceTree = "<group>"; };
 		96CED508FA3C3B6B9265099E /* rendcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = rendcmn.cpp; path = ../../src/common/rendcmn.cpp; sourceTree = "<group>"; };
+		96D620AEA83E3444BA0B04C4 /* pcre2_dfa_match.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_dfa_match.c; path = ../../3rdparty/pcre/src/pcre2_dfa_match.c; sourceTree = "<group>"; };
 		9720FFA4490D3AC38E53BE03 /* StyleContext.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = StyleContext.cxx; path = ../../src/stc/scintilla/lexlib/StyleContext.cxx; sourceTree = "<group>"; };
 		972BC9B2B0D438EFB12BCE1E /* rearrangectrl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = rearrangectrl.cpp; path = ../../src/common/rearrangectrl.cpp; sourceTree = "<group>"; };
 		975E3B6A269434F0A069987D /* Catalogue.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Catalogue.cxx; path = ../../src/stc/scintilla/src/Catalogue.cxx; sourceTree = "<group>"; };
@@ -4519,9 +4548,11 @@
 		9860CD56245B3E7FBD0E7846 /* checklst_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = checklst_osx.cpp; path = ../../src/osx/checklst_osx.cpp; sourceTree = "<group>"; };
 		98A7F0605AAC3D28A8C9F253 /* gauge.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = gauge.mm; path = ../../src/osx/cocoa/gauge.mm; sourceTree = "<group>"; };
 		99479DE14D8D3F7E9EB3E9A2 /* LexNull.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexNull.cxx; path = ../../src/stc/scintilla/lexers/LexNull.cxx; sourceTree = "<group>"; };
+		994AF74DF2A13FF09A215853 /* intel_init.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = intel_init.c; path = ../../src/png/intel/intel_init.c; sourceTree = "<group>"; };
 		9988CBB0772A3539970162FA /* arttango.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = arttango.cpp; path = ../../src/common/arttango.cpp; sourceTree = "<group>"; };
 		998C092CB83639CFA3DC63B1 /* checkbox_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = checkbox_osx.cpp; path = ../../src/osx/checkbox_osx.cpp; sourceTree = "<group>"; };
 		998D611109EC33A9A6A11C5A /* gdicmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = gdicmn.cpp; path = ../../src/common/gdicmn.cpp; sourceTree = "<group>"; };
+		99A9D5F9254D35BE8F4176A4 /* lzmastream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = lzmastream.cpp; path = ../../src/common/lzmastream.cpp; sourceTree = "<group>"; };
 		99BC7A16DBCA36EDA9D6F1DB /* powercmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = powercmn.cpp; path = ../../src/common/powercmn.cpp; sourceTree = "<group>"; };
 		99E5B6DD00273D978C241BCA /* radiobut.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = radiobut.mm; path = ../../src/osx/cocoa/radiobut.mm; sourceTree = "<group>"; };
 		9A23D41D747D38BF8AD30067 /* xh_gauge.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_gauge.cpp; path = ../../src/xrc/xh_gauge.cpp; sourceTree = "<group>"; };
@@ -4536,6 +4567,7 @@
 		9CC7C6FFD67233788EEDFC5E /* LexYAML.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexYAML.cxx; path = ../../src/stc/scintilla/lexers/LexYAML.cxx; sourceTree = "<group>"; };
 		9CE73979D0933A43830307E4 /* tif_packbits.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_packbits.c; path = ../../src/tiff/libtiff/tif_packbits.c; sourceTree = "<group>"; };
 		9D1F14339D1C331087650931 /* colour.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = colour.cpp; path = ../../src/osx/core/colour.cpp; sourceTree = "<group>"; };
+		9D602B5F09E8314CB9F65C11 /* filter_sse2_intrinsics.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = filter_sse2_intrinsics.c; path = ../../src/png/intel/filter_sse2_intrinsics.c; sourceTree = "<group>"; };
 		9D6B0D32537D35069C7E053F /* inftrees.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = inftrees.c; path = ../../src/zlib/inftrees.c; sourceTree = "<group>"; };
 		9DB43FAB1E563B02ACEFF647 /* module.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = module.cpp; path = ../../src/common/module.cpp; sourceTree = "<group>"; };
 		9DD609EC0591359C9A576A43 /* printdlg_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = printdlg_osx.cpp; path = ../../src/osx/printdlg_osx.cpp; sourceTree = "<group>"; };
@@ -4557,8 +4589,10 @@
 		A1276C0E5D48337489DEE8DF /* LexErlang.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexErlang.cxx; path = ../../src/stc/scintilla/lexers/LexErlang.cxx; sourceTree = "<group>"; };
 		A1A53EC3A3463EFDB7614E93 /* bitmap.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = bitmap.cpp; path = ../../src/osx/core/bitmap.cpp; sourceTree = "<group>"; };
 		A1CB6A4171D4343BB0A9858A /* msgdlgg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = msgdlgg.cpp; path = ../../src/generic/msgdlgg.cpp; sourceTree = "<group>"; };
+		A208BFC0C8C43847A9620ADA /* pcre2_newline.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_newline.c; path = ../../3rdparty/pcre/src/pcre2_newline.c; sourceTree = "<group>"; };
 		A284E855892F3A9E9E19E854 /* LexTADS3.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexTADS3.cxx; path = ../../src/stc/scintilla/lexers/LexTADS3.cxx; sourceTree = "<group>"; };
 		A298576700C33F018616E7BD /* auibook.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = auibook.cpp; path = ../../src/aui/auibook.cpp; sourceTree = "<group>"; };
+		A2B7B30FA60633339D8862C6 /* rowheightcache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = rowheightcache.cpp; path = ../../src/generic/rowheightcache.cpp; sourceTree = "<group>"; };
 		A37E3D1FB4FB31AFAE88665A /* dpycmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = dpycmn.cpp; path = ../../src/common/dpycmn.cpp; sourceTree = "<group>"; };
 		A3BF8C9FF2D5314591329D0D /* toolbar.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = toolbar.mm; path = ../../src/osx/cocoa/toolbar.mm; sourceTree = "<group>"; };
 		A436B55DC44E3827A757A6D8 /* accelcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = accelcmn.cpp; path = ../../src/common/accelcmn.cpp; sourceTree = "<group>"; };
@@ -4573,6 +4607,7 @@
 		A5EE0B8985443BDCB36F781F /* m_layout.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = m_layout.cpp; path = ../../src/html/m_layout.cpp; sourceTree = "<group>"; };
 		A65399C8A6D636139E362119 /* LexAsm.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexAsm.cxx; path = ../../src/stc/scintilla/lexers/LexAsm.cxx; sourceTree = "<group>"; };
 		A6636144CDE83E8E85270FAF /* hashmap.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = hashmap.cpp; path = ../../src/common/hashmap.cpp; sourceTree = "<group>"; };
+		A6EE037AF43E343E8E1A7555 /* pcre2_string_utils.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_string_utils.c; path = ../../3rdparty/pcre/src/pcre2_string_utils.c; sourceTree = "<group>"; };
 		A737317EDE0F3921B1412966 /* LexRegistry.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexRegistry.cxx; path = ../../src/stc/scintilla/lexers/LexRegistry.cxx; sourceTree = "<group>"; };
 		A82C367B86F83981803D55DB /* LexASY.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexASY.cxx; path = ../../src/stc/scintilla/lexers/LexASY.cxx; sourceTree = "<group>"; };
 		A87662D69F0432FC96701280 /* xh_notbk.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_notbk.cpp; path = ../../src/xrc/xh_notbk.cpp; sourceTree = "<group>"; };
@@ -4635,6 +4670,7 @@
 		B56A9BF7AE1E3F11A5848297 /* tipdlg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = tipdlg.cpp; path = ../../src/generic/tipdlg.cpp; sourceTree = "<group>"; };
 		B580FD04D0D83601826FD5EE /* filepickerg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = filepickerg.cpp; path = ../../src/generic/filepickerg.cpp; sourceTree = "<group>"; };
 		B5E2D6917EB1352983C7FE85 /* wrapsizer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = wrapsizer.cpp; path = ../../src/common/wrapsizer.cpp; sourceTree = "<group>"; };
+		B60497805D37375EBFCF3D98 /* pcre2_tables.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_tables.c; path = ../../3rdparty/pcre/src/pcre2_tables.c; sourceTree = "<group>"; };
 		B63EBEE1A04537E7887E9FD0 /* ustring.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ustring.cpp; path = ../../src/common/ustring.cpp; sourceTree = "<group>"; };
 		B6A37A02D28E30CD9B83E134 /* xh_ribbon.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_ribbon.cpp; path = ../../src/xrc/xh_ribbon.cpp; sourceTree = "<group>"; };
 		B6AADC1056E03A3B80C20C5B /* LexBasic.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexBasic.cxx; path = ../../src/stc/scintilla/lexers/LexBasic.cxx; sourceTree = "<group>"; };
@@ -4661,11 +4697,14 @@
 		BC12B97F233B3B9494DA217F /* imagpnm.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = imagpnm.cpp; path = ../../src/common/imagpnm.cpp; sourceTree = "<group>"; };
 		BC5C5DB466CD3D6FA6985B56 /* LexNimrod.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexNimrod.cxx; path = ../../src/stc/scintilla/lexers/LexNimrod.cxx; sourceTree = "<group>"; };
 		BCD873D873A53BBF955D8A4E /* PositionCache.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PositionCache.cxx; path = ../../src/stc/scintilla/src/PositionCache.cxx; sourceTree = "<group>"; };
+		BCED9B1D0D7E3FBBAC78CE5B /* pcre2_convert.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_convert.c; path = ../../3rdparty/pcre/src/pcre2_convert.c; sourceTree = "<group>"; };
 		BD044F7074D0307985FCA361 /* wxcocoa_ml.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = wxcocoa_ml.xcconfig; sourceTree = "<group>"; };
 		BD169D8019A13A11BDB26214 /* xh_dirpicker.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_dirpicker.cpp; path = ../../src/xrc/xh_dirpicker.cpp; sourceTree = "<group>"; };
+		BD2EBC2CCAE23AD6A1DF783E /* pcre2_serialize.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_serialize.c; path = ../../3rdparty/pcre/src/pcre2_serialize.c; sourceTree = "<group>"; };
 		BD709DEB71623974B9836D69 /* dockart.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = dockart.cpp; path = ../../src/aui/dockart.cpp; sourceTree = "<group>"; };
 		BD88495AF72531A28D2201D0 /* tif_tile.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_tile.c; path = ../../src/tiff/libtiff/tif_tile.c; sourceTree = "<group>"; };
 		BD91A34971FB3D0299B894A5 /* appprogress.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = appprogress.mm; path = ../../src/osx/cocoa/appprogress.mm; sourceTree = "<group>"; };
+		BDADEB1DA6433E52972C8934 /* pcre2_compile.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_compile.c; path = ../../3rdparty/pcre/src/pcre2_compile.c; sourceTree = "<group>"; };
 		BDE76674C0F5391BAD2AFA2F /* dialog_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = dialog_osx.cpp; path = ../../src/osx/dialog_osx.cpp; sourceTree = "<group>"; };
 		BE22393DB53C3D259DFCEE64 /* libwxjpeg.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libwxjpeg.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE4B0CE56BA23002A5C8AEFF /* toolbar.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = toolbar.cpp; path = ../../src/ribbon/toolbar.cpp; sourceTree = "<group>"; };
@@ -4693,6 +4732,7 @@
 		C3019BA65DD73F30A865365F /* frame.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = frame.cpp; path = ../../src/osx/carbon/frame.cpp; sourceTree = "<group>"; };
 		C3784C240C2F330683494926 /* laywin.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = laywin.cpp; path = ../../src/generic/laywin.cpp; sourceTree = "<group>"; };
 		C37866F41B0C31E295AA7FA6 /* wfstream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = wfstream.cpp; path = ../../src/common/wfstream.cpp; sourceTree = "<group>"; };
+		C3904351139F3F0DB4B72F94 /* pcre2_auto_possess.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_auto_possess.c; path = ../../3rdparty/pcre/src/pcre2_auto_possess.c; sourceTree = "<group>"; };
 		C45AFE6CC20F3ED7A55FC8FA /* pngmem.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pngmem.c; path = ../../src/png/pngmem.c; sourceTree = "<group>"; };
 		C466F32CCBD13DBC87285B3D /* helpdata.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = helpdata.cpp; path = ../../src/html/helpdata.cpp; sourceTree = "<group>"; };
 		C4C45D3C63AA37CEBCE83321 /* richtextprint.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = richtextprint.cpp; path = ../../src/richtext/richtextprint.cpp; sourceTree = "<group>"; };
@@ -4732,6 +4772,7 @@
 		CF502E0E4D853CBBBEC885EF /* LexerSimple.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexerSimple.cxx; path = ../../src/stc/scintilla/lexlib/LexerSimple.cxx; sourceTree = "<group>"; };
 		CF6511DE2CB43534A5566403 /* menuitem_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = menuitem_osx.cpp; path = ../../src/osx/menuitem_osx.cpp; sourceTree = "<group>"; };
 		CFBDB327E4A236A3ABFA326F /* webviewfshandler.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = webviewfshandler.cpp; path = ../../src/common/webviewfshandler.cpp; sourceTree = "<group>"; };
+		D016F584D14C31E192DB3179 /* pcre2_maketables.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_maketables.c; path = ../../3rdparty/pcre/src/pcre2_maketables.c; sourceTree = "<group>"; };
 		D037EA567C253DEEA17E822B /* mousemanager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = mousemanager.cpp; path = ../../src/common/mousemanager.cpp; sourceTree = "<group>"; };
 		D049F49C75043592B7E318B3 /* datetimectrl_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = datetimectrl_osx.cpp; path = ../../src/osx/datetimectrl_osx.cpp; sourceTree = "<group>"; };
 		D0817D6A1AF83608B050EBC3 /* fontmap.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fontmap.cpp; path = ../../src/common/fontmap.cpp; sourceTree = "<group>"; };
@@ -4818,7 +4859,7 @@
 		E862A0A422483954B755053E /* wxcocoa_mlgui.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = wxcocoa_mlgui.xcconfig; sourceTree = "<group>"; };
 		E89AC104BF4F33A083F8B382 /* jccoefct.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jccoefct.c; path = ../../src/jpeg/jccoefct.c; sourceTree = "<group>"; };
 		E8BD1489D95E3FD78B200B1B /* commandlinkbuttong.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = commandlinkbuttong.cpp; path = ../../src/generic/commandlinkbuttong.cpp; sourceTree = "<group>"; };
-		E8DE97F5A2AD393CBD31AED3 /* creddlgg.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = creddlgg.cpp; path = ../../src/generic/creddlgg.cpp; sourceTree = "<group>"; };
+		E8DE97F5A2AD393CBD31AED3 /* creddlgg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = creddlgg.cpp; path = ../../src/generic/creddlgg.cpp; sourceTree = "<group>"; };
 		E8EE191DC59F362AAED2CDC1 /* bmpbase.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = bmpbase.cpp; path = ../../src/common/bmpbase.cpp; sourceTree = "<group>"; };
 		E968913A9A593B258BD8EACB /* msgout.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = msgout.cpp; path = ../../src/common/msgout.cpp; sourceTree = "<group>"; };
 		E97AE22E9F043AB6846B3BE7 /* xh_scwin.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_scwin.cpp; path = ../../src/xrc/xh_scwin.cpp; sourceTree = "<group>"; };
@@ -4830,6 +4871,7 @@
 		EA2520F427493A22A70A5C09 /* stackwalk.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = stackwalk.cpp; path = ../../src/unix/stackwalk.cpp; sourceTree = "<group>"; };
 		EA3F8832890138E9AB6E65D8 /* xh_chckl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_chckl.cpp; path = ../../src/xrc/xh_chckl.cpp; sourceTree = "<group>"; };
 		EA4AF89C36C53EB4B307DCAB /* filtfind.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = filtfind.cpp; path = ../../src/common/filtfind.cpp; sourceTree = "<group>"; };
+		EA8CCF32688434EABEEEE04A /* webrequest_urlsession.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = webrequest_urlsession.mm; path = ../../src/osx/webrequest_urlsession.mm; sourceTree = "<group>"; };
 		EA93D41B11683E758D456531 /* log.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = log.cpp; path = ../../src/common/log.cpp; sourceTree = "<group>"; };
 		EBAFC67A0C213E83BC2E072C /* libwx_osx_cocoau_adv.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libwx_osx_cocoau_adv.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		EBD381E57BAE3F2AA31A68CB /* xh_wizrd.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_wizrd.cpp; path = ../../src/xrc/xh_wizrd.cpp; sourceTree = "<group>"; };
@@ -4849,6 +4891,7 @@
 		EF330EAACFA53877BE289896 /* matrix.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = matrix.cpp; path = ../../src/common/matrix.cpp; sourceTree = "<group>"; };
 		F01DDE448E4C3983ACCE67FD /* appcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = appcmn.cpp; path = ../../src/common/appcmn.cpp; sourceTree = "<group>"; };
 		F0905A1EBD653F6D82395602 /* xh_combo.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_combo.cpp; path = ../../src/xrc/xh_combo.cpp; sourceTree = "<group>"; };
+		F0E43FFDC808333AA01EE649 /* pcre2_extuni.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_extuni.c; path = ../../3rdparty/pcre/src/pcre2_extuni.c; sourceTree = "<group>"; };
 		F175D6E8E5723FC797701275 /* menucmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = menucmn.cpp; path = ../../src/common/menucmn.cpp; sourceTree = "<group>"; };
 		F1A6F3936A0D31CBB58082BA /* jdcoefct.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jdcoefct.c; path = ../../src/jpeg/jdcoefct.c; sourceTree = "<group>"; };
 		F1E724EA70AB35DDB130F84F /* stringops.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = stringops.cpp; path = ../../src/common/stringops.cpp; sourceTree = "<group>"; };
@@ -4865,7 +4908,7 @@
 		F4B85051B7C835A8BF4E3EE1 /* xh_panel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_panel.cpp; path = ../../src/xrc/xh_panel.cpp; sourceTree = "<group>"; };
 		F4C72C5C61A6335C8B418BA1 /* LexMetapost.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexMetapost.cxx; path = ../../src/stc/scintilla/lexers/LexMetapost.cxx; sourceTree = "<group>"; };
 		F52DCBC0442233738B39138E /* CaseFolder.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = CaseFolder.cxx; path = ../../src/stc/scintilla/src/CaseFolder.cxx; sourceTree = "<group>"; };
-		F582C6B3A5AA3367BB4DBE97 /* statbmp_osx.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = statbmp_osx.cpp; path = ../../src/osx/statbmp_osx.cpp; sourceTree = "<group>"; };
+		F582C6B3A5AA3367BB4DBE97 /* statbmp_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = statbmp_osx.cpp; path = ../../src/osx/statbmp_osx.cpp; sourceTree = "<group>"; };
 		F5DAF1F49F0F3F41A427A21D /* icon.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = icon.cpp; path = ../../src/generic/icon.cpp; sourceTree = "<group>"; };
 		F6EA240B3DB93D398A990FAD /* tif_dirread.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_dirread.c; path = ../../src/tiff/libtiff/tif_dirread.c; sourceTree = "<group>"; };
 		F6F01A84F4DE3C9FB9849004 /* tif_jbig.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_jbig.c; path = ../../src/tiff/libtiff/tif_jbig.c; sourceTree = "<group>"; };
@@ -4880,19 +4923,22 @@
 		FA59091E3ED83FB781FB9659 /* glcanvas_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = glcanvas_osx.cpp; path = ../../src/osx/glcanvas_osx.cpp; sourceTree = "<group>"; };
 		FA7029BB5751398AA02D8C24 /* imagtga.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = imagtga.cpp; path = ../../src/common/imagtga.cpp; sourceTree = "<group>"; };
 		FA9DD56E399533A5BE7AAD16 /* jdarith.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jdarith.c; path = ../../src/jpeg/jdarith.c; sourceTree = "<group>"; };
+		FAC42945539F362D91D6F559 /* pcre2_substitute.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_substitute.c; path = ../../3rdparty/pcre/src/pcre2_substitute.c; sourceTree = "<group>"; };
 		FADE850169F7347F83FE1499 /* xh_statbar.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_statbar.cpp; path = ../../src/xrc/xh_statbar.cpp; sourceTree = "<group>"; };
-		FB17368A86EC30E6B843E32F /* palette_neon_intrinsics.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = palette_neon_intrinsics.c; path = ../../src/png/arm/palette_neon_intrinsics.c; sourceTree = "<group>"; };
+		FAE49A61DFE9375AAB18E8DD /* pcre2_valid_utf.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_valid_utf.c; path = ../../3rdparty/pcre/src/pcre2_valid_utf.c; sourceTree = "<group>"; };
+		FB17368A86EC30E6B843E32F /* palette_neon_intrinsics.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = palette_neon_intrinsics.c; path = ../../src/png/arm/palette_neon_intrinsics.c; sourceTree = "<group>"; };
 		FB355C2107A835E5B8F15C29 /* libwxzlib.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libwxzlib.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		FB46BC22F6B23909A938C561 /* regex.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = regex.cpp; path = ../../src/common/regex.cpp; sourceTree = "<group>"; };
 		FBC5A5797B0D369291A76D6E /* dcbufcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = dcbufcmn.cpp; path = ../../src/common/dcbufcmn.cpp; sourceTree = "<group>"; };
 		FBE1C531185131A89EFF7FAF /* cmdline.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = cmdline.cpp; path = ../../src/common/cmdline.cpp; sourceTree = "<group>"; };
 		FBE8E520BA0530C6AD857434 /* fontpickerg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fontpickerg.cpp; path = ../../src/generic/fontpickerg.cpp; sourceTree = "<group>"; };
+		FC6A8FAE9CA63EEB8883B6BD /* pcre2_config.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_config.c; path = ../../3rdparty/pcre/src/pcre2_config.c; sourceTree = "<group>"; };
 		FCCFF49F92B4323D9181CEDA /* htmltag.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = htmltag.cpp; path = ../../src/html/htmltag.cpp; sourceTree = "<group>"; };
 		FCE8B55EBD6B348B8351AB08 /* LexKVIrc.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexKVIrc.cxx; path = ../../src/stc/scintilla/lexers/LexKVIrc.cxx; sourceTree = "<group>"; };
 		FD0C7FCA25A3312E8F2FCF3C /* LexTeX.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexTeX.cxx; path = ../../src/stc/scintilla/lexers/LexTeX.cxx; sourceTree = "<group>"; };
 		FD55F391CD1032DFACA88CFD /* xh_srchctrl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_srchctrl.cpp; path = ../../src/xrc/xh_srchctrl.cpp; sourceTree = "<group>"; };
 		FD5F11A3646F397BA62EB037 /* htmllbox.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = htmllbox.cpp; path = ../../src/generic/htmllbox.cpp; sourceTree = "<group>"; };
-		FD6B26B5A6A733A89EF5AB9C /* statbmp.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = statbmp.mm; path = ../../src/osx/cocoa/statbmp.mm; sourceTree = "<group>"; };
+		FD6B26B5A6A733A89EF5AB9C /* statbmp.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = statbmp.mm; path = ../../src/osx/cocoa/statbmp.mm; sourceTree = "<group>"; };
 		FD6D2664C05131C3A06E98B4 /* ExternalLexer.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ExternalLexer.cxx; path = ../../src/stc/scintilla/src/ExternalLexer.cxx; sourceTree = "<group>"; };
 		FDAEFCE0ED9D30DA94340A3B /* xtistrm.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xtistrm.cpp; path = ../../src/common/xtistrm.cpp; sourceTree = "<group>"; };
 		FDB0E2D0966C3E408C4A2D3D /* infback.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = infback.c; path = ../../src/zlib/infback.c; sourceTree = "<group>"; };
@@ -5239,7 +5285,6 @@
 				83F62FA47C9636169F1E18E8 /* base */,
 				2E7B4F88F81E37B4A9FF6C0F /* core */,
 				374BD863E6AD33189B7E4040 /* net */,
-				2FF0B5E0505D3AEA9A4ACF11 /* adv */,
 				62E50658BDAD369D92294F68 /* webview */,
 				5C5CD199E7573C73AE6F392D /* media */,
 				60E51BFF5CD2327483201F14 /* html */,
@@ -5415,13 +5460,10 @@
 		2E7B4F88F81E37B4A9FF6C0F /* core */ = {
 			isa = PBXGroup;
 			children = (
-				F582C6B3A5AA3367BB4DBE97 /* statbmp_osx.cpp */,
-				FD6B26B5A6A733A89EF5AB9C /* statbmp.mm */,
 				B0665A40F3FC3F218074C63C /* artmac.cpp */,
 				302A13BC64C238A297F4399F /* brush.cpp */,
 				BDE76674C0F5391BAD2AFA2F /* dialog_osx.cpp */,
 				5FF661188B563D27A11F5716 /* fontutil.cpp */,
-				027D2F04BE933ED6B9BA1518 /* imaglist.cpp */,
 				693F731B7D1730A79485F9EC /* minifram.cpp */,
 				19559DDA007D364E838014B5 /* nonownedwnd_osx.cpp */,
 				BEF6B3FB66243812969E5BD1 /* palette.cpp */,
@@ -5433,7 +5475,6 @@
 				A1A53EC3A3463EFDB7614E93 /* bitmap.cpp */,
 				9D1F14339D1C331087650931 /* colour.cpp */,
 				343D4FDD5CC030618EF24729 /* dcmemory.cpp */,
-				A5617D10CB7136EC9A4194EF /* display.cpp */,
 				36E1DBA275AD325DB759C180 /* fontenum.cpp */,
 				160EB9744CB63A0B81DC651F /* hid.cpp */,
 				5CC5C13F8AA1387BADB7E60C /* printmac.cpp */,
@@ -5469,13 +5510,11 @@
 				6CD29E47B69D3F3482665E77 /* toolbar_osx.cpp */,
 				DAAED71A534135A9A61612A6 /* colordlgosx.mm */,
 				38CEA4A3579331EF808B8363 /* fontdlgosx.mm */,
-				0FBD8031E28A3C9CB7C45784 /* overlay.mm */,
 				8C78A1539462370CAA429508 /* accel.cpp */,
 				12453E271F2A3AC9969E62A4 /* clipbrd.cpp */,
 				0BF1F491B8A8376E8E2E8182 /* cursor.cpp */,
 				18044326B5B13A98A49732DD /* fontdlg.cpp */,
 				377056CEB1FC3EEB8526E7A6 /* gdiobj.cpp */,
-				F5DAF1F49F0F3F41A427A21D /* icon.cpp */,
 				757B31FCCA1F381C95B30DF8 /* app.cpp */,
 				12363D1F50FE301DAEE7F04A /* control.cpp */,
 				271B4B77622B3411A7BF6634 /* dataobj.cpp */,
@@ -5506,6 +5545,9 @@
 				64DA16CF41C834D7B7642024 /* prntdlgg.cpp */,
 				071FEABEA61E3B559A47A7DB /* statusbr.cpp */,
 				E9B31409EC6532FC83B0B957 /* textmeasure.cpp */,
+				F5DAF1F49F0F3F41A427A21D /* icon.cpp */,
+				F582C6B3A5AA3367BB4DBE97 /* statbmp_osx.cpp */,
+				027D2F04BE933ED6B9BA1518 /* imaglist.cpp */,
 				F4020D790AE7363CB29F1C2F /* anybutton.mm */,
 				BD91A34971FB3D0299B894A5 /* appprogress.mm */,
 				C06FED83BF933DF98C2466AE /* button.mm */,
@@ -5542,6 +5584,24 @@
 				31EFBD7D10003A5187348B35 /* tooltip.mm */,
 				C94DC3402FAE3C4FA776DEEA /* window.mm */,
 				6831AA74AB5B38D5AA6946D7 /* settings.mm */,
+				0FBD8031E28A3C9CB7C45784 /* overlay.mm */,
+				207F0F88390138B6B41183EB /* aboutdlg.mm */,
+				5E53DC332DA23DF4B9BFCDE3 /* dataview_osx.cpp */,
+				D9446ADCCDCD32E6BCF95599 /* notifmsg.mm */,
+				2A4D36DE66EC3EB09E883D6B /* taskbar.mm */,
+				95B4B2890C3A372DAB8DC7BA /* datectrl_osx.cpp */,
+				A0A63980677D371C85A60B75 /* datetimectrl.mm */,
+				2ACC8667173D3AB09F6214F4 /* sound.cpp */,
+				A9B2316B32653DA0939A372D /* sound_osx.cpp */,
+				D049F49C75043592B7E318B3 /* datetimectrl_osx.cpp */,
+				018B15DE6F3A3D49B9CDE9DE /* hidjoystick.cpp */,
+				2ACC8667173D3AB09F6214F5 /* sound.cpp */,
+				DB6963739198360DB3DBCC6C /* dataview.mm */,
+				0FA0840034F1386F94D17639 /* timectrl_osx.cpp */,
+				4692909E4B823F71822B13F8 /* taskbarcmn.cpp */,
+				5814208070CF3D899F132BA1 /* activityindicator.mm */,
+				FD6B26B5A6A733A89EF5AB9C /* statbmp.mm */,
+				A5617D10CB7136EC9A4194EF /* display.cpp */,
 				A436B55DC44E3827A757A6D8 /* accelcmn.cpp */,
 				8555204EBA8930809B732842 /* accesscmn.cpp */,
 				EE959EC7BFDD3A628E856404 /* anidecod.cpp */,
@@ -5670,6 +5730,7 @@
 				E9B9B85572D0312BBF2878DB /* windowid.cpp */,
 				B5E2D6917EB1352983C7FE85 /* wrapsizer.cpp */,
 				C562D5885AFF3E15837325CE /* xpmdecod.cpp */,
+				580AFC66F3003582B43043B1 /* animateg.cpp */,
 				2F94CF171F4532B89FECF475 /* busyinfo.cpp */,
 				5612DBC4125B379DA2B28824 /* buttonbar.cpp */,
 				CF23AF3EFC5731B2A5BCF4A3 /* choicdgg.cpp */,
@@ -5707,66 +5768,45 @@
 				AA90128E29A03CCCA30F4D35 /* vlbox.cpp */,
 				1629FA905F903324AA5BE72C /* vscroll.cpp */,
 				9AD367F1047838A9A7A34DBF /* xmlreshandler.cpp */,
-			);
-			name = core;
-			sourceTree = "<group>";
-		};
-		2FF0B5E0505D3AEA9A4ACF11 /* adv */ = {
-			isa = PBXGroup;
-			children = (
-				A8ABD099BCEA30DCBF7A04F4 /* animatecmn.cpp */,
-				8CF560E06F2A3B6088203D09 /* bmpcboxcmn.cpp */,
-				8D0EF4BDCB5F329ABE15EEED /* calctrlcmn.cpp */,
-				95DEEF60B1E9358A8CCCC67E /* datavcmn.cpp */,
-				FDD3CE34439B3D2BBD9DC8D3 /* gridcmn.cpp */,
-				8A7D521FE5B437D7AD5F4B54 /* hyperlnkcmn.cpp */,
-				6F23140777B733679D2FAAFC /* odcombocmn.cpp */,
-				7A1CE0B28CB73F90AE92B5AB /* richtooltipcmn.cpp */,
-				77D6E66F72443765A2FBE263 /* aboutdlgg.cpp */,
-				36296C259D023EAAA240FC79 /* bannerwindow.cpp */,
-				13FD4A890E9B3BAEBD568C3B /* bmpcboxg.cpp */,
-				496674699F173A5385EAFF07 /* calctrlg.cpp */,
-				E8BD1489D95E3FD78B200B1B /* commandlinkbuttong.cpp */,
-				5F3D473DC5123EDAB767045C /* datavgen.cpp */,
-				AE856D950B8C369EB0FE13BA /* datectlg.cpp */,
-				7D90D14874FD38079835AF0B /* editlbox.cpp */,
-				76337016F2CA3C85831702E6 /* grid.cpp */,
-				2A1BD6BCA15430CA8A4869EF /* gridctrl.cpp */,
-				66426B63AA3E3A279936C034 /* grideditors.cpp */,
-				26381308E32A3A179E7A9B40 /* gridsel.cpp */,
-				DF376BC55EA73F5FB7328142 /* helpext.cpp */,
-				CBCA90340E433DBBAE74EBE1 /* hyperlinkg.cpp */,
-				C3784C240C2F330683494926 /* laywin.cpp */,
+				3F8836E29C5A370E80CE070E /* splash.cpp */,
 				924AA3A156F834BCA1A57976 /* notifmsgg.cpp */,
 				7906BD74118A3B4DAC515BC2 /* odcombo.cpp */,
-				6BC93D1DE277395592610085 /* propdlg.cpp */,
-				54710DA2AC4F3262A8A1EA63 /* richtooltipg.cpp */,
+				8D0EF4BDCB5F329ABE15EEED /* calctrlcmn.cpp */,
+				66426B63AA3E3A279936C034 /* grideditors.cpp */,
+				8CF560E06F2A3B6088203D09 /* bmpcboxcmn.cpp */,
+				76337016F2CA3C85831702E6 /* grid.cpp */,
+				2A1BD6BCA15430CA8A4869EF /* gridctrl.cpp */,
+				CBCA90340E433DBBAE74EBE1 /* hyperlinkg.cpp */,
+				DF376BC55EA73F5FB7328142 /* helpext.cpp */,
 				917F2666B67E3D2EB84E74F8 /* sashwin.cpp */,
-				3F8836E29C5A370E80CE070E /* splash.cpp */,
-				741578B590AF3F2CABE615EB /* timectrlg.cpp */,
-				B56A9BF7AE1E3F11A5848297 /* tipdlg.cpp */,
-				5190E3E110443FD29F2474FC /* treelist.cpp */,
-				8F08F70E1EF239999A4D2AC4 /* wizard.cpp */,
+				26381308E32A3A179E7A9B40 /* gridsel.cpp */,
 				964578C24B9F390AAD08576E /* addremovectrl.cpp */,
+				B56A9BF7AE1E3F11A5848297 /* tipdlg.cpp */,
+				77D6E66F72443765A2FBE263 /* aboutdlgg.cpp */,
+				FDD3CE34439B3D2BBD9DC8D3 /* gridcmn.cpp */,
+				7A1CE0B28CB73F90AE92B5AB /* richtooltipcmn.cpp */,
+				AE856D950B8C369EB0FE13BA /* datectlg.cpp */,
+				36296C259D023EAAA240FC79 /* bannerwindow.cpp */,
+				5190E3E110443FD29F2474FC /* treelist.cpp */,
+				95DEEF60B1E9358A8CCCC67E /* datavcmn.cpp */,
+				A8ABD099BCEA30DCBF7A04F4 /* animatecmn.cpp */,
+				6F23140777B733679D2FAAFC /* odcombocmn.cpp */,
+				8A7D521FE5B437D7AD5F4B54 /* hyperlnkcmn.cpp */,
+				6BC93D1DE277395592610085 /* propdlg.cpp */,
+				13FD4A890E9B3BAEBD568C3B /* bmpcboxg.cpp */,
+				54710DA2AC4F3262A8A1EA63 /* richtooltipg.cpp */,
+				741578B590AF3F2CABE615EB /* timectrlg.cpp */,
+				E8BD1489D95E3FD78B200B1B /* commandlinkbuttong.cpp */,
 				B233180893DB3328AF4847DA /* notifmsgcmn.cpp */,
-				4692909E4B823F71822B13F8 /* taskbarcmn.cpp */,
-				580AFC66F3003582B43043B1 /* animateg.cpp */,
-				D049F49C75043592B7E318B3 /* datetimectrl_osx.cpp */,
-				95B4B2890C3A372DAB8DC7BA /* datectrl_osx.cpp */,
-				A9B2316B32653DA0939A372D /* sound_osx.cpp */,
-				0FA0840034F1386F94D17639 /* timectrl_osx.cpp */,
-				2ACC8667173D3AB09F6214F4 /* sound.cpp */,
-				2ACC8667173D3AB09F6214F5 /* sound.cpp */,
-				207F0F88390138B6B41183EB /* aboutdlg.mm */,
-				5E53DC332DA23DF4B9BFCDE3 /* dataview_osx.cpp */,
-				DB6963739198360DB3DBCC6C /* dataview.mm */,
-				A0A63980677D371C85A60B75 /* datetimectrl.mm */,
-				2A4D36DE66EC3EB09E883D6B /* taskbar.mm */,
-				018B15DE6F3A3D49B9CDE9DE /* hidjoystick.cpp */,
-				5814208070CF3D899F132BA1 /* activityindicator.mm */,
-				D9446ADCCDCD32E6BCF95599 /* notifmsg.mm */,
+				8F08F70E1EF239999A4D2AC4 /* wizard.cpp */,
+				5F3D473DC5123EDAB767045C /* datavgen.cpp */,
+				7D90D14874FD38079835AF0B /* editlbox.cpp */,
+				C3784C240C2F330683494926 /* laywin.cpp */,
+				496674699F173A5385EAFF07 /* calctrlg.cpp */,
+				E8DE97F5A2AD393CBD31AED3 /* creddlgg.cpp */,
+				A2B7B30FA60633339D8862C6 /* rowheightcache.cpp */,
 			);
-			name = adv;
+			name = core;
 			sourceTree = "<group>";
 		};
 		374BD863E6AD33189B7E4040 /* net */ = {
@@ -5782,9 +5822,12 @@
 				D784A32C094730FEAA391A9B /* sckstrm.cpp */,
 				40CE02524DD4385AB2C3DF95 /* socket.cpp */,
 				49612306912038DDBCABB4DE /* url.cpp */,
+				5EA9E372A64B3B808A64B178 /* webrequest.cpp */,
+				5279968877003A8BB8279765 /* webrequest_curl.cpp */,
 				DDE22D7DDAC93DCABAE5AED0 /* socketiohandler.cpp */,
 				BB7661E9E09A397790ED9545 /* sockunix.cpp */,
 				4969528429903F15882F5391 /* sockosx.cpp */,
+				EA8CCF32688434EABEEEE04A /* webrequest_urlsession.mm */,
 			);
 			name = net;
 			sourceTree = "<group>";
@@ -5837,16 +5880,6 @@
 				6A6A16F9C3B03A7B9077D013 /* mediactrl.mm */,
 			);
 			name = media;
-			sourceTree = "<group>";
-		};
-		5F780F001D3A393BAE9E9367 /* arm */ = {
-			isa = PBXGroup;
-			children = (
-				933D7637CAA43F6C99814BC5 /* arm_init.c */,
-				39507FA11D8838109A22B7DA /* filter_neon_intrinsics.c */,
-				FB17368A86EC30E6B843E32F /* palette_neon_intrinsics.c */,
-			);
-			name = arm;
 			sourceTree = "<group>";
 		};
 		60328E6EA3793DA990E18FC1 /* xrc */ = {
@@ -5960,7 +5993,6 @@
 		62E50658BDAD369D92294F68 /* webview */ = {
 			isa = PBXGroup;
 			children = (
-				E8DE97F5A2AD393CBD31AED3 /* creddlgg.cpp */,
 				5FEECFD764E037288CE94FEB /* webview_webkit.mm */,
 				0DA80913C0E33144A42BD30F /* webview.cpp */,
 				70112AB00E013A35BE974FF1 /* webviewarchivehandler.cpp */,
@@ -5990,7 +6022,6 @@
 		6E2C8858F68E3FB0BEFFFCE5 /* libpng */ = {
 			isa = PBXGroup;
 			children = (
-				5F780F001D3A393BAE9E9367 /* arm */,
 				AF26BAB1F4733114926F1724 /* png.c */,
 				1A0650754DC2358CA5933B28 /* pngerror.c */,
 				91300EB871CC39ECBC430D48 /* pngget.c */,
@@ -6006,6 +6037,11 @@
 				69A6CAF721E53E83B4820DE6 /* pngwrite.c */,
 				0964797530CF3FE7B8DB6242 /* pngwtran.c */,
 				45D7558DF5E03A2EB41883F0 /* pngwutil.c */,
+				933D7637CAA43F6C99814BC5 /* arm_init.c */,
+				39507FA11D8838109A22B7DA /* filter_neon_intrinsics.c */,
+				FB17368A86EC30E6B843E32F /* palette_neon_intrinsics.c */,
+				994AF74DF2A13FF09A215853 /* intel_init.c */,
+				9D602B5F09E8314CB9F65C11 /* filter_sse2_intrinsics.c */,
 			);
 			name = libpng;
 			sourceTree = "<group>";
@@ -6163,12 +6199,15 @@
 				7D2BE094D90D3AFDAE49F589 /* fswatchercmn.cpp */,
 				47783A330B2A3B4EBB1CD95D /* fswatcherg.cpp */,
 				5BE1FB352696346BB642C044 /* secretstore.cpp */,
+				99A9D5F9254D35BE8F4176A4 /* lzmastream.cpp */,
+				4E4466371B7E3265AE7B1E0C /* uilocale.cpp */,
 				7C97C1F26B5A38C49543060C /* mimetype.cpp */,
 				5168ADF7BE39351F8F24E1E6 /* cfstring.cpp */,
 				5BD6231188AB329CAA5E1171 /* evtloop_cf.cpp */,
 				D5F9383D1CE931499F339D85 /* strconv_cf.cpp */,
 				2ED0C0702D2734D9B08FC31D /* utils_base.mm */,
 				5BE1FB352696346BB642C045 /* secretstore.cpp */,
+				4E4466371B7E3265AE7B1E0D /* uilocale.cpp */,
 				47F784C2BB5A3B5DAD276583 /* fdiodispatcher.cpp */,
 				A5D569A4DE643DC8B0C28087 /* selectdispatcher.cpp */,
 				B40E0F6AA0273ACD9BDEAD72 /* appunix.cpp */,
@@ -6209,7 +6248,6 @@
 			isa = PBXGroup;
 			children = (
 				C3904351139F3F0DB4B72F94 /* pcre2_auto_possess.c */,
-				1895085EBEAE3A708FDD527A /* pcre2_chartables.c */,
 				BDADEB1DA6433E52972C8934 /* pcre2_compile.c */,
 				FC6A8FAE9CA63EEB8883B6BD /* pcre2_config.c */,
 				3026D20A03E53F1DB40FB35A /* pcre2_context.c */,
@@ -6220,8 +6258,8 @@
 				943C7E9527C03FCDB5966273 /* pcre2_find_bracket.c */,
 				7C9F6184015A3BD1B8DA471E /* pcre2_jit_compile.c */,
 				D016F584D14C31E192DB3179 /* pcre2_maketables.c */,
-				4E74E9E53454331F8E10ECC5 /* pcre2_match_data.c */,
 				3B93115BCC46333BBB31D6F7 /* pcre2_match.c */,
+				4E74E9E53454331F8E10ECC5 /* pcre2_match_data.c */,
 				A208BFC0C8C43847A9620ADA /* pcre2_newline.c */,
 				4BFEBC5061693DA0B52BC4AC /* pcre2_ord2utf.c */,
 				00DAA69F74D031B6BE9196A8 /* pcre2_pattern_info.c */,
@@ -6235,6 +6273,7 @@
 				70F4EB692873386AAA0A44B0 /* pcre2_ucd.c */,
 				FAE49A61DFE9375AAB18E8DD /* pcre2_valid_utf.c */,
 				95CBA2C736623FFF8629E975 /* pcre2_xclass.c */,
+				1895085EBEAE3A708FDD527A /* pcre2_chartables.c */,
 			);
 			name = libregex;
 			sourceTree = "<group>";
@@ -6337,8 +6376,10 @@
 				BD88495AF72531A28D2201D0 /* tif_tile.c */,
 				3E6F40F4740C3ED29D83E107 /* tif_version.c */,
 				C83C97A1FCC5345896C9D7DE /* tif_warning.c */,
+				3716DA7B0C79360CBA26A71E /* tif_webp.c */,
 				E9B992CB6C28339FB0CA5E27 /* tif_write.c */,
 				726C0457DF1232C793918DC1 /* tif_zip.c */,
+				3B98123FD57731139044B064 /* tif_zstd.c */,
 			);
 			name = libtiff;
 			sourceTree = "<group>";
@@ -6594,7 +6635,7 @@
 			productReference = D1AA14D7251A30ACB5E66678 /* libwx_osx_cocoau_core.dylib */;
 			productType = "com.apple.product-type.library.dynamic";
 		};
-		2FF0B5E0505D3AEA9A4ACF12 /* adv */ = {
+		2FF0B5E0505D3AEA9A4ACF11 /* adv */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A8113561D292346DAE12EFD5 /* Build configuration list for PBXNativeTarget "adv" */;
 			buildPhases = (
@@ -7124,8 +7165,6 @@
 /* Begin PBXProject section */
 		19367367C9323490BB936F06 /* Project object */ = {
 			isa = PBXProject;
-			attributes = {
-			};
 			buildConfigurationList = 6976B5F5F3A63A21A92029E3 /* Build configuration list for PBXProject "wxcocoa" */;
 			compatibilityVersion = "Xcode 3.1";
 			developmentRegion = English;
@@ -7143,7 +7182,7 @@
 			targets = (
 				363401F972C53D8EBD3D4BD9 /* dynamic */,
 				BAB02EC06578349A9171CCAC /* static */,
-				2FF0B5E0505D3AEA9A4ACF12 /* adv */,
+				2FF0B5E0505D3AEA9A4ACF11 /* adv */,
 				04311EAB76193D5593D43DBC /* aui */,
 				83F62FA47C9636169F1E18E9 /* base */,
 				2E7B4F88F81E37B4A9FF6C10 /* core */,
@@ -7591,12 +7630,15 @@
 				A93D0E6F0871368EA8FC9FFB /* fswatchercmn.cpp in Sources */,
 				E49F0D43B5A63EF1A57A7114 /* fswatcherg.cpp in Sources */,
 				B0FD1B96EAE635AFBFCF2C93 /* secretstore.cpp in Sources */,
+				A486A28E216D320AB57452D5 /* lzmastream.cpp in Sources */,
+				9A63148F193E33B5964DD02B /* uilocale.cpp in Sources */,
 				4657E7382E9E3EDC8DE24020 /* mimetype.cpp in Sources */,
 				1DBDF75500D73A3098015E81 /* cfstring.cpp in Sources */,
 				9FBC642677C63D01AA2511BE /* evtloop_cf.cpp in Sources */,
 				AAAB5DF8E60736D88273DD00 /* strconv_cf.cpp in Sources */,
 				68C300D096BF39239876D045 /* utils_base.mm in Sources */,
 				B0FD1B96EAE635AFBFCF2C96 /* secretstore.cpp in Sources */,
+				9A63148F193E33B5964DD02E /* uilocale.cpp in Sources */,
 				D36E76A4CAF5352D9397E201 /* fdiodispatcher.cpp in Sources */,
 				D3FB75C8E3A73AE38EE8A6F8 /* selectdispatcher.cpp in Sources */,
 				BAAB6B1D80A33843A8436B12 /* appunix.cpp in Sources */,
@@ -7637,9 +7679,12 @@
 				A3A898DA3114311EB7F02229 /* sckstrm.cpp in Sources */,
 				6978D7A20DA93A329DDD1385 /* socket.cpp in Sources */,
 				E7140F3AB94D3FDFA86D8C08 /* url.cpp in Sources */,
+				C987310872D1396BAF716E5C /* webrequest.cpp in Sources */,
+				EE972E8DC73F310B9B4C949E /* webrequest_curl.cpp in Sources */,
 				652CFDD9A1C1366E99B5D6BE /* socketiohandler.cpp in Sources */,
 				346D274E17673A01B0177D5D /* sockunix.cpp in Sources */,
 				AD07124BBA613B47829F0694 /* sockosx.cpp in Sources */,
+				980ED1DA2F96361985952256 /* webrequest_urlsession.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7657,7 +7702,6 @@
 				296692A7A3783E3A83D005C8 /* brush.cpp in Sources */,
 				86AED49CEAFC3637B1F10539 /* dialog_osx.cpp in Sources */,
 				DC6B669C9A78398F914AEE55 /* fontutil.cpp in Sources */,
-				1EDED99760B23A1999E75C14 /* imaglist.cpp in Sources */,
 				C1CDD035AA393ACC9E202C05 /* minifram.cpp in Sources */,
 				4269B85FDC5639BEB76A8AED /* nonownedwnd_osx.cpp in Sources */,
 				AC91349D7F0E37739B1F5167 /* palette.cpp in Sources */,
@@ -7669,7 +7713,6 @@
 				03BF1610E2FC3BD5ACB754F2 /* bitmap.cpp in Sources */,
 				FF50EC0EC5F23DF890C6E961 /* colour.cpp in Sources */,
 				BD2B17EB72E73A6EB6E0B271 /* dcmemory.cpp in Sources */,
-				F1F484DD591337399FCD0465 /* display.cpp in Sources */,
 				371809DA4AD1382F8B53287A /* fontenum.cpp in Sources */,
 				86BE5213D3F131D8A686267B /* hid.cpp in Sources */,
 				AB58406CEBA13BC4A2A83B68 /* printmac.cpp in Sources */,
@@ -7687,7 +7730,6 @@
 				0FFFFA2F762B3160955D1D8A /* gauge_osx.cpp in Sources */,
 				E4B826CE70283D999CB591F5 /* listbox_osx.cpp in Sources */,
 				B198DA8239E9358A9D56B98A /* menu_osx.cpp in Sources */,
-				750C716389AD3ADBABC9D68B /* statbmp_osx.cpp in Sources */,
 				1DF3A4F85FCB3BA79A552F3F /* menuitem_osx.cpp in Sources */,
 				A3321FE2A87D3BD69E0BB00B /* notebook_osx.cpp in Sources */,
 				0C9A379D97B133FA831175A9 /* printdlg_osx.cpp in Sources */,
@@ -7704,7 +7746,6 @@
 				EDCA35F1555F3509895CCA6B /* textctrl_osx.cpp in Sources */,
 				664A54F914443110B7BB692A /* tglbtn_osx.cpp in Sources */,
 				A569A33A2097316D8110C2C3 /* toolbar_osx.cpp in Sources */,
-				215958201947310B88BBEDB5 /* statbmp.mm in Sources */,
 				F5FF98C231B33E3EB7902C66 /* colordlgosx.mm in Sources */,
 				2386B575BC3931D2AF86CB35 /* fontdlgosx.mm in Sources */,
 				2EECB3C2F9523D0B95847A81 /* accel.cpp in Sources */,
@@ -7712,7 +7753,6 @@
 				5417332FE2DB3CD3A647B15F /* cursor.cpp in Sources */,
 				D66F5D4D204B3B789C7F76BB /* fontdlg.cpp in Sources */,
 				692FCCABFB963696AFC1E124 /* gdiobj.cpp in Sources */,
-				01D4C5F2147F3942A7CE91AC /* icon.cpp in Sources */,
 				B0E94A59C83637C09FAAE71E /* app.cpp in Sources */,
 				EB52C6A91594381393294500 /* control.cpp in Sources */,
 				45AB45C6B24A3983B22E56A7 /* dataobj.cpp in Sources */,
@@ -7743,6 +7783,9 @@
 				C005C2D547E735E9B0816590 /* prntdlgg.cpp in Sources */,
 				A1AF8FF873D6383996995ED1 /* statusbr.cpp in Sources */,
 				2E059BFE8E3B3D9299D5596B /* textmeasure.cpp in Sources */,
+				01D4C5F2147F3942A7CE91AC /* icon.cpp in Sources */,
+				750C716389AD3ADBABC9D68B /* statbmp_osx.cpp in Sources */,
+				1EDED99760B23A1999E75C14 /* imaglist.cpp in Sources */,
 				65AD3B31319C35F1AC9EC627 /* anybutton.mm in Sources */,
 				CE32C5250F2834D4B81BE89A /* appprogress.mm in Sources */,
 				14D6D5F8F5ED3C71936DD2B1 /* button.mm in Sources */,
@@ -7779,6 +7822,24 @@
 				2B4507BC09563DB5B0F16598 /* tooltip.mm in Sources */,
 				815AE3FED68330F4933AA171 /* window.mm in Sources */,
 				47C31B7492F33C3EBE53262C /* settings.mm in Sources */,
+				4156FDB73D0A397A870E4304 /* overlay.mm in Sources */,
+				14DEBD7C01FC358B917FDAF4 /* aboutdlg.mm in Sources */,
+				0723C4E8B52C39FDBC2158B8 /* dataview_osx.cpp in Sources */,
+				1B69C40CD7493FED9A272837 /* notifmsg.mm in Sources */,
+				25C5C1713C0B39AC8EB6A390 /* taskbar.mm in Sources */,
+				4F99EB97F65330C28EB4D079 /* datectrl_osx.cpp in Sources */,
+				3316A16628B03D5E88529EA9 /* datetimectrl.mm in Sources */,
+				61FEDBF2D47A3B4E861F8298 /* sound.cpp in Sources */,
+				CE2C937117FE3AB599DD30BB /* sound_osx.cpp in Sources */,
+				219304C9DDA33E9AADB515DE /* datetimectrl_osx.cpp in Sources */,
+				C1DCF69200593986A8C606A8 /* hidjoystick.cpp in Sources */,
+				61FEDBF2D47A3B4E861F829B /* sound.cpp in Sources */,
+				049052C49B0B3810BE0179CB /* dataview.mm in Sources */,
+				20D05D14BFAD3F969666D03D /* timectrl_osx.cpp in Sources */,
+				D00AF125FCB63A7A8F9B87E0 /* taskbarcmn.cpp in Sources */,
+				A4F2426F36653C6D87EC18B0 /* activityindicator.mm in Sources */,
+				215958201947310B88BBEDB5 /* statbmp.mm in Sources */,
+				F1F484DD591337399FCD0465 /* display.cpp in Sources */,
 				3CDE2B6BF88D326189F069BF /* accelcmn.cpp in Sources */,
 				BDB8EF0E0DA03693BFB77EF9 /* accesscmn.cpp in Sources */,
 				205520440CD13C0AB9E8915B /* anidecod.cpp in Sources */,
@@ -7808,7 +7869,6 @@
 				BF1760458996391E8EB4294B /* ctrlsub.cpp in Sources */,
 				2D60F289103837EA8925E3F3 /* dcbase.cpp in Sources */,
 				39D6435B10073B85A499AFDA /* dcbufcmn.cpp in Sources */,
-				4156FDB73D0A397A870E4304 /* overlay.mm in Sources */,
 				9564A6968D66325DAEADEBA5 /* dcgraph.cpp in Sources */,
 				B791BD05072B3B909A7093C4 /* dcsvg.cpp in Sources */,
 				B559E894684A38238CAAA117 /* dirctrlcmn.cpp in Sources */,
@@ -7908,6 +7968,7 @@
 				1BCC944F5E0936F5830F03EA /* windowid.cpp in Sources */,
 				3399AB7BB1333B5AAF5FAF57 /* wrapsizer.cpp in Sources */,
 				C1E5799141603A75A26BEEA9 /* xpmdecod.cpp in Sources */,
+				46F341B46F80376B962759F7 /* animateg.cpp in Sources */,
 				F5806029B1BA3924A8FDDBC3 /* busyinfo.cpp in Sources */,
 				CB078622E90F33BE9D131133 /* buttonbar.cpp in Sources */,
 				03035C5CE4BC3288A5A18426 /* choicdgg.cpp in Sources */,
@@ -7945,6 +8006,43 @@
 				87C67583D36C3465ACD64105 /* vlbox.cpp in Sources */,
 				A465A43B756630F1944B5A58 /* vscroll.cpp in Sources */,
 				1CBF34ACA39330028A5EA9AE /* xmlreshandler.cpp in Sources */,
+				8AA341CCFB8E3F6AB3523597 /* splash.cpp in Sources */,
+				CEE0D7A7D5D8323B9957A782 /* notifmsgg.cpp in Sources */,
+				1E17F95DD433379E8C18298E /* odcombo.cpp in Sources */,
+				901F659891613419B8643954 /* calctrlcmn.cpp in Sources */,
+				E5D698D2606A304DA743AF94 /* grideditors.cpp in Sources */,
+				5C44446AB150378696CD6B3E /* bmpcboxcmn.cpp in Sources */,
+				A139B846584436BCBEBAE3C1 /* grid.cpp in Sources */,
+				2E930206397C3EDCBD8206FE /* gridctrl.cpp in Sources */,
+				760C729E41D93CC1AA2B4E0F /* hyperlinkg.cpp in Sources */,
+				F016C51053373E658ED4C9AB /* helpext.cpp in Sources */,
+				3554C88010CE3D2A8970A137 /* sashwin.cpp in Sources */,
+				187F921A95DA3594B0AD980F /* gridsel.cpp in Sources */,
+				EC3D181D65F33E09A675FFF4 /* addremovectrl.cpp in Sources */,
+				77BC918AF05C30E8A0BD27FA /* tipdlg.cpp in Sources */,
+				FEA741A9B6663A4C929893C4 /* aboutdlgg.cpp in Sources */,
+				2FAE979E6FE23D088C768B7F /* gridcmn.cpp in Sources */,
+				2FE10EA678C73523836FCC1E /* richtooltipcmn.cpp in Sources */,
+				B4425B59CC27389CA9FF81D3 /* datectlg.cpp in Sources */,
+				E0FAB345D2933D42B62917A5 /* bannerwindow.cpp in Sources */,
+				060E095718B03EF98C75479B /* treelist.cpp in Sources */,
+				1CD4F67F48CF3A5FA477D870 /* datavcmn.cpp in Sources */,
+				CFDBB80A4C9A3BA092273938 /* animatecmn.cpp in Sources */,
+				E6D18B2EDE353F67883085A1 /* odcombocmn.cpp in Sources */,
+				7B4DA2F5F25B3E188CBAFE3A /* hyperlnkcmn.cpp in Sources */,
+				6A10511265493FA2BB79CE4F /* propdlg.cpp in Sources */,
+				B189DB62AE9F30A1B613756D /* bmpcboxg.cpp in Sources */,
+				C67EAE20657E36839BF86692 /* richtooltipg.cpp in Sources */,
+				98F52D5224B438DFA8887E08 /* timectrlg.cpp in Sources */,
+				8A662992FFCB32E99D11950E /* commandlinkbuttong.cpp in Sources */,
+				800CFCEDBB7938338C65EEAE /* notifmsgcmn.cpp in Sources */,
+				82FA4AA043213728AC266702 /* wizard.cpp in Sources */,
+				8B60964DA1DF3F3DB40BE125 /* datavgen.cpp in Sources */,
+				5557AA36FBCC3ED9A5F5751C /* editlbox.cpp in Sources */,
+				955D2199F1893D37BA2D747A /* laywin.cpp in Sources */,
+				2F50DBC14FE538A49823925C /* calctrlg.cpp in Sources */,
+				63F895D6F5643E4B9E666B7B /* creddlgg.cpp in Sources */,
+				8F372080E11E382EA0B5ED11 /* rowheightcache.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7952,57 +8050,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				CFDBB80A4C9A3BA092273938 /* animatecmn.cpp in Sources */,
-				5C44446AB150378696CD6B3E /* bmpcboxcmn.cpp in Sources */,
-				901F659891613419B8643954 /* calctrlcmn.cpp in Sources */,
-				1CD4F67F48CF3A5FA477D870 /* datavcmn.cpp in Sources */,
-				2FAE979E6FE23D088C768B7F /* gridcmn.cpp in Sources */,
-				7B4DA2F5F25B3E188CBAFE3A /* hyperlnkcmn.cpp in Sources */,
-				E6D18B2EDE353F67883085A1 /* odcombocmn.cpp in Sources */,
-				2FE10EA678C73523836FCC1E /* richtooltipcmn.cpp in Sources */,
-				FEA741A9B6663A4C929893C4 /* aboutdlgg.cpp in Sources */,
-				E0FAB345D2933D42B62917A5 /* bannerwindow.cpp in Sources */,
-				B189DB62AE9F30A1B613756D /* bmpcboxg.cpp in Sources */,
-				2F50DBC14FE538A49823925C /* calctrlg.cpp in Sources */,
-				8A662992FFCB32E99D11950E /* commandlinkbuttong.cpp in Sources */,
-				8B60964DA1DF3F3DB40BE125 /* datavgen.cpp in Sources */,
-				B4425B59CC27389CA9FF81D3 /* datectlg.cpp in Sources */,
-				5557AA36FBCC3ED9A5F5751C /* editlbox.cpp in Sources */,
-				A139B846584436BCBEBAE3C1 /* grid.cpp in Sources */,
-				2E930206397C3EDCBD8206FE /* gridctrl.cpp in Sources */,
-				E5D698D2606A304DA743AF94 /* grideditors.cpp in Sources */,
-				187F921A95DA3594B0AD980F /* gridsel.cpp in Sources */,
-				F016C51053373E658ED4C9AB /* helpext.cpp in Sources */,
-				760C729E41D93CC1AA2B4E0F /* hyperlinkg.cpp in Sources */,
-				955D2199F1893D37BA2D747A /* laywin.cpp in Sources */,
-				CEE0D7A7D5D8323B9957A782 /* notifmsgg.cpp in Sources */,
-				1E17F95DD433379E8C18298E /* odcombo.cpp in Sources */,
-				6A10511265493FA2BB79CE4F /* propdlg.cpp in Sources */,
-				C67EAE20657E36839BF86692 /* richtooltipg.cpp in Sources */,
-				3554C88010CE3D2A8970A137 /* sashwin.cpp in Sources */,
-				8AA341CCFB8E3F6AB3523597 /* splash.cpp in Sources */,
-				98F52D5224B438DFA8887E08 /* timectrlg.cpp in Sources */,
-				77BC918AF05C30E8A0BD27FA /* tipdlg.cpp in Sources */,
-				060E095718B03EF98C75479B /* treelist.cpp in Sources */,
-				82FA4AA043213728AC266702 /* wizard.cpp in Sources */,
-				EC3D181D65F33E09A675FFF4 /* addremovectrl.cpp in Sources */,
-				800CFCEDBB7938338C65EEAE /* notifmsgcmn.cpp in Sources */,
-				D00AF125FCB63A7A8F9B87E0 /* taskbarcmn.cpp in Sources */,
-				46F341B46F80376B962759F7 /* animateg.cpp in Sources */,
-				219304C9DDA33E9AADB515DE /* datetimectrl_osx.cpp in Sources */,
-				4F99EB97F65330C28EB4D079 /* datectrl_osx.cpp in Sources */,
-				CE2C937117FE3AB599DD30BB /* sound_osx.cpp in Sources */,
-				20D05D14BFAD3F969666D03D /* timectrl_osx.cpp in Sources */,
-				61FEDBF2D47A3B4E861F8298 /* sound.cpp in Sources */,
-				61FEDBF2D47A3B4E861F829B /* sound.cpp in Sources */,
-				14DEBD7C01FC358B917FDAF4 /* aboutdlg.mm in Sources */,
-				0723C4E8B52C39FDBC2158B8 /* dataview_osx.cpp in Sources */,
-				049052C49B0B3810BE0179CB /* dataview.mm in Sources */,
-				3316A16628B03D5E88529EA9 /* datetimectrl.mm in Sources */,
-				25C5C1713C0B39AC8EB6A390 /* taskbar.mm in Sources */,
-				C1DCF69200593986A8C606A8 /* hidjoystick.cpp in Sources */,
-				A4F2426F36653C6D87EC18B0 /* activityindicator.mm in Sources */,
-				1B69C40CD7493FED9A272837 /* notifmsg.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8072,7 +8119,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EA10DA3199813E90B39C70D5 /* xh_infobar.cpp in Sources */,
 				8F949B9010863F66A58FFEF3 /* xh_activityindicator.cpp in Sources */,
 				FBE4DB30865D3177B3A9993D /* xh_animatctrl.cpp in Sources */,
 				702616D38A5B345D9CC87116 /* xh_bannerwindow.cpp in Sources */,
@@ -8090,6 +8136,7 @@
 				E7921B0472B63E4091F4F519 /* xh_collpane.cpp in Sources */,
 				84382E5DB3203A73AC5EE392 /* xh_combo.cpp in Sources */,
 				F569D7A3F0E038E9B4CC2A78 /* xh_comboctrl.cpp in Sources */,
+				14F303FD6B5F383DADDFD78A /* xh_dataview.cpp in Sources */,
 				FB09720D13673A7B81BCB647 /* xh_datectrl.cpp in Sources */,
 				F7D10B6E0CBA32EFAF79C77E /* xh_dirpicker.cpp in Sources */,
 				3B7E035ECF3D3FFB9827AC1E /* xh_dlg.cpp in Sources */,
@@ -8101,9 +8148,9 @@
 				BE99A85EE76236CC8C719A66 /* xh_gauge.cpp in Sources */,
 				26649553E4763EE6BA268B7F /* xh_gdctl.cpp in Sources */,
 				72AD4417FF7C3094BB1FF62E /* xh_grid.cpp in Sources */,
-				14F303FD6B5F383DADDFD78A /* xh_dataview.cpp in Sources */,
 				83616D33080E3F0F9FA5FBB6 /* xh_html.cpp in Sources */,
 				2B13BFC894C63373B7ACFA3F /* xh_hyperlink.cpp in Sources */,
+				EA10DA3199813E90B39C70D5 /* xh_infobar.cpp in Sources */,
 				C34B8675439F39B4845FFC52 /* xh_listb.cpp in Sources */,
 				F5DF7AF0FA9E371BB71EF79A /* xh_listbk.cpp in Sources */,
 				96B507455762391688B5E502 /* xh_listc.cpp in Sources */,
@@ -8215,7 +8262,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				59BFB8C8310E37B39AF8B0D5 /* any.cpp in Sources */,
-				E17048DEEF1138318314F1D1 /* pcre2_valid_utf.c in Sources */,
 				D5A25AC579F436509805335B /* appbase.cpp in Sources */,
 				C2B07E2ECDDC3833BDC9B28D /* arcall.cpp in Sources */,
 				4CF9BA40653C3153805D88AC /* arcfind.cpp in Sources */,
@@ -8263,19 +8309,16 @@
 				31DD19A942283FA8810B6383 /* numformatter.cpp in Sources */,
 				23A7AF68A03E380785EE7C25 /* object.cpp in Sources */,
 				D6B73239BF0E32288161679D /* platinfo.cpp in Sources */,
-				45E15DBB6B69382D8AF1BA22 /* pcre2_dfa_match.c in Sources */,
 				0A406D2D1ADA343891E3664D /* powercmn.cpp in Sources */,
 				CA85901B9E2538CFB7E44217 /* process.cpp in Sources */,
 				7A7439BE66AA3771B4A89049 /* regex.cpp in Sources */,
 				CF3082BA1ED232F4B904BD15 /* stdpbase.cpp in Sources */,
 				539B586AEAD630A79FC12ED0 /* sstream.cpp in Sources */,
-				7F62946D497A32CE857F65CA /* pcre2_maketables.c in Sources */,
 				028257C52CAE3038AA862C36 /* stdstream.cpp in Sources */,
 				6AA0EE765330326380989FD2 /* stopwatch.cpp in Sources */,
 				E882402BEE0330A080A65170 /* strconv.cpp in Sources */,
 				30493B486DFF35AF80D12C4A /* stream.cpp in Sources */,
 				795613831EC8332A83FF26E8 /* string.cpp in Sources */,
-				750C716389AD3ADBABC9D68A /* statbmp_osx.cpp in Sources */,
 				55F0D287F60F3EDEA16CCB65 /* stringimpl.cpp in Sources */,
 				88E1AE56FD393C8BA5CF8546 /* stringops.cpp in Sources */,
 				056E30EA43753A7CB1AF8C9F /* strvararg.cpp in Sources */,
@@ -8283,7 +8326,6 @@
 				9FB1E1763EFA334CA0C07C4A /* tarstrm.cpp in Sources */,
 				2E4747E0736B30569ACD5423 /* textbuf.cpp in Sources */,
 				6167245C417A32179EC37D2E /* textfile.cpp in Sources */,
-				EA10DA3199813E90B39C70D4 /* xh_infobar.cpp in Sources */,
 				B20B7313102232A4B3E01ABB /* threadinfo.cpp in Sources */,
 				98AD7D0478BA36249B03C624 /* time.cpp in Sources */,
 				7FC3D17B3C853FE58841002E /* timercmn.cpp in Sources */,
@@ -8306,12 +8348,15 @@
 				A93D0E6F0871368EA8FC9FFA /* fswatchercmn.cpp in Sources */,
 				E49F0D43B5A63EF1A57A7113 /* fswatcherg.cpp in Sources */,
 				B0FD1B96EAE635AFBFCF2C92 /* secretstore.cpp in Sources */,
+				A486A28E216D320AB57452D4 /* lzmastream.cpp in Sources */,
+				9A63148F193E33B5964DD02A /* uilocale.cpp in Sources */,
 				4657E7382E9E3EDC8DE2401F /* mimetype.cpp in Sources */,
 				1DBDF75500D73A3098015E80 /* cfstring.cpp in Sources */,
 				9FBC642677C63D01AA2511BD /* evtloop_cf.cpp in Sources */,
 				AAAB5DF8E60736D88273DCFF /* strconv_cf.cpp in Sources */,
 				68C300D096BF39239876D044 /* utils_base.mm in Sources */,
 				B0FD1B96EAE635AFBFCF2C95 /* secretstore.cpp in Sources */,
+				9A63148F193E33B5964DD02D /* uilocale.cpp in Sources */,
 				D36E76A4CAF5352D9397E200 /* fdiodispatcher.cpp in Sources */,
 				D3FB75C8E3A73AE38EE8A6F7 /* selectdispatcher.cpp in Sources */,
 				BAAB6B1D80A33843A8436B11 /* appunix.cpp in Sources */,
@@ -8339,7 +8384,6 @@
 				296692A7A3783E3A83D005C7 /* brush.cpp in Sources */,
 				86AED49CEAFC3637B1F10538 /* dialog_osx.cpp in Sources */,
 				DC6B669C9A78398F914AEE54 /* fontutil.cpp in Sources */,
-				1EDED99760B23A1999E75C13 /* imaglist.cpp in Sources */,
 				C1CDD035AA393ACC9E202C04 /* minifram.cpp in Sources */,
 				4269B85FDC5639BEB76A8AEC /* nonownedwnd_osx.cpp in Sources */,
 				AC91349D7F0E37739B1F5166 /* palette.cpp in Sources */,
@@ -8351,7 +8395,6 @@
 				03BF1610E2FC3BD5ACB754F1 /* bitmap.cpp in Sources */,
 				FF50EC0EC5F23DF890C6E960 /* colour.cpp in Sources */,
 				BD2B17EB72E73A6EB6E0B270 /* dcmemory.cpp in Sources */,
-				F1F484DD591337399FCD0464 /* display.cpp in Sources */,
 				371809DA4AD1382F8B532879 /* fontenum.cpp in Sources */,
 				86BE5213D3F131D8A686267A /* hid.cpp in Sources */,
 				AB58406CEBA13BC4A2A83B67 /* printmac.cpp in Sources */,
@@ -8363,7 +8406,6 @@
 				6AC347D2DCC730149A0A83D9 /* button_osx.cpp in Sources */,
 				0E92CEF677AA32C9A8CDA0A8 /* checkbox_osx.cpp in Sources */,
 				07412469921A3E488A2F9BA7 /* checklst_osx.cpp in Sources */,
-				2F7328AC75393951B08F75F2 /* pcre2_error.c in Sources */,
 				4666CDC48BA9301EA283C000 /* choice_osx.cpp in Sources */,
 				0836590D35FE37988DE70443 /* combobox_osx.cpp in Sources */,
 				2DF74933A90E34129F1BEF73 /* dnd_osx.cpp in Sources */,
@@ -8384,7 +8426,6 @@
 				283C3ABE42433244983C27C2 /* stattext_osx.cpp in Sources */,
 				B6891F848CA0325EAB6D1374 /* textentry_osx.cpp in Sources */,
 				EDCA35F1555F3509895CCA6A /* textctrl_osx.cpp in Sources */,
-				B6728BCD1A0731299924C8C5 /* pcre2_substring.c in Sources */,
 				664A54F914443110B7BB6929 /* tglbtn_osx.cpp in Sources */,
 				A569A33A2097316D8110C2C2 /* toolbar_osx.cpp in Sources */,
 				F5FF98C231B33E3EB7902C65 /* colordlgosx.mm in Sources */,
@@ -8394,7 +8435,6 @@
 				5417332FE2DB3CD3A647B15E /* cursor.cpp in Sources */,
 				D66F5D4D204B3B789C7F76BA /* fontdlg.cpp in Sources */,
 				692FCCABFB963696AFC1E123 /* gdiobj.cpp in Sources */,
-				01D4C5F2147F3942A7CE91AB /* icon.cpp in Sources */,
 				B0E94A59C83637C09FAAE71D /* app.cpp in Sources */,
 				EB52C6A915943813932944FF /* control.cpp in Sources */,
 				45AB45C6B24A3983B22E56A6 /* dataobj.cpp in Sources */,
@@ -8425,6 +8465,9 @@
 				C005C2D547E735E9B081658F /* prntdlgg.cpp in Sources */,
 				A1AF8FF873D6383996995ED0 /* statusbr.cpp in Sources */,
 				2E059BFE8E3B3D9299D5596A /* textmeasure.cpp in Sources */,
+				01D4C5F2147F3942A7CE91AB /* icon.cpp in Sources */,
+				750C716389AD3ADBABC9D68A /* statbmp_osx.cpp in Sources */,
+				1EDED99760B23A1999E75C13 /* imaglist.cpp in Sources */,
 				65AD3B31319C35F1AC9EC626 /* anybutton.mm in Sources */,
 				CE32C5250F2834D4B81BE899 /* appprogress.mm in Sources */,
 				14D6D5F8F5ED3C71936DD2B0 /* button.mm in Sources */,
@@ -8450,7 +8493,6 @@
 				22E90F33B5C9308EBF37A701 /* printdlg.mm in Sources */,
 				5303FA25D0773FAEB963D8E4 /* scrolbar.mm in Sources */,
 				30AEDF41EC5C374DBF96EFFC /* slider.mm in Sources */,
-				4156FDB73D0A397A870E4303 /* overlay.mm in Sources */,
 				5DA146A9F7653F53BF5299E9 /* spinbutt.mm in Sources */,
 				55F01295F1D23805BCA12F16 /* srchctrl.mm in Sources */,
 				B30D10F6257631B0A1926F8A /* statbox.mm in Sources */,
@@ -8462,6 +8504,24 @@
 				2B4507BC09563DB5B0F16597 /* tooltip.mm in Sources */,
 				815AE3FED68330F4933AA170 /* window.mm in Sources */,
 				47C31B7492F33C3EBE53262B /* settings.mm in Sources */,
+				4156FDB73D0A397A870E4303 /* overlay.mm in Sources */,
+				14DEBD7C01FC358B917FDAF3 /* aboutdlg.mm in Sources */,
+				0723C4E8B52C39FDBC2158B7 /* dataview_osx.cpp in Sources */,
+				1B69C40CD7493FED9A272836 /* notifmsg.mm in Sources */,
+				25C5C1713C0B39AC8EB6A38F /* taskbar.mm in Sources */,
+				4F99EB97F65330C28EB4D078 /* datectrl_osx.cpp in Sources */,
+				3316A16628B03D5E88529EA8 /* datetimectrl.mm in Sources */,
+				61FEDBF2D47A3B4E861F8297 /* sound.cpp in Sources */,
+				CE2C937117FE3AB599DD30BA /* sound_osx.cpp in Sources */,
+				219304C9DDA33E9AADB515DD /* datetimectrl_osx.cpp in Sources */,
+				C1DCF69200593986A8C606A7 /* hidjoystick.cpp in Sources */,
+				61FEDBF2D47A3B4E861F829A /* sound.cpp in Sources */,
+				049052C49B0B3810BE0179CA /* dataview.mm in Sources */,
+				20D05D14BFAD3F969666D03C /* timectrl_osx.cpp in Sources */,
+				D00AF125FCB63A7A8F9B87DF /* taskbarcmn.cpp in Sources */,
+				A4F2426F36653C6D87EC18AF /* activityindicator.mm in Sources */,
+				215958201947310B88BBEDB4 /* statbmp.mm in Sources */,
+				F1F484DD591337399FCD0464 /* display.cpp in Sources */,
 				3CDE2B6BF88D326189F069BE /* accelcmn.cpp in Sources */,
 				BDB8EF0E0DA03693BFB77EF8 /* accesscmn.cpp in Sources */,
 				205520440CD13C0AB9E8915A /* anidecod.cpp in Sources */,
@@ -8484,7 +8544,6 @@
 				335DD610974A33D4B6581E2B /* colourdata.cpp in Sources */,
 				D542C7819D593112AE5F7C3E /* combocmn.cpp in Sources */,
 				6F0605F3A4E83BF0BF4C8B7F /* cmdproc.cpp in Sources */,
-				88E56F89A0DA3AD386F05FD3 /* pcre2_pattern_info.c in Sources */,
 				20F10669703137E68318C6FE /* cmndata.cpp in Sources */,
 				6FA47EAACE613B039B6EC262 /* containr.cpp in Sources */,
 				0C485288EA86379D9FD66537 /* cshelp.cpp in Sources */,
@@ -8497,7 +8556,6 @@
 				B559E894684A38238CAAA116 /* dirctrlcmn.cpp in Sources */,
 				63F0C8EEDF4B3641878A8B4E /* dlgcmn.cpp in Sources */,
 				B839235BED6F3609BDB732B9 /* dndcmn.cpp in Sources */,
-				27B5431DC79733CD8D403E89 /* pcre2_context.c in Sources */,
 				2CCC30C0162131DBBE9D8028 /* dobjcmn.cpp in Sources */,
 				F0B3F484C38C3BA0B9927CDA /* docmdi.cpp in Sources */,
 				B1E30CF6CFA932F5A3DBA950 /* docview.cpp in Sources */,
@@ -8521,7 +8579,6 @@
 				5A8638C234133824BDF93BC0 /* gbsizer.cpp in Sources */,
 				0E60E17BA4B23347A4F20161 /* gdicmn.cpp in Sources */,
 				95AD56D602CF3C5085602AF9 /* geometry.cpp in Sources */,
-				5ED54DFAE28533108C08DF2B /* pcre2_extuni.c in Sources */,
 				758629DA468A3EF7B1C15242 /* gifdecod.cpp in Sources */,
 				7B642B17F5D23F4F8ED38BB5 /* graphcmn.cpp in Sources */,
 				B8FEEC2C94183AB69C963178 /* headercolcmn.cpp in Sources */,
@@ -8529,7 +8586,6 @@
 				4657479AF35533AEB7876677 /* helpbase.cpp in Sources */,
 				BF2585CFA6853023975F1E79 /* iconbndl.cpp in Sources */,
 				5B5B8DF915D438AA9FCEB39F /* imagall.cpp in Sources */,
-				EB206A0264AD3CAA9F68B8FD /* pcre2_convert.c in Sources */,
 				0813551C951A3AD1A5EF01B3 /* imagbmp.cpp in Sources */,
 				6C822F7F313734DCB51F44BA /* image.cpp in Sources */,
 				89046455F49D3D75A21C9DB9 /* imagfill.cpp in Sources */,
@@ -8537,7 +8593,6 @@
 				9110ACFC3CFB3C7994E907B1 /* imagiff.cpp in Sources */,
 				D13596A4E3CD31DE810061A2 /* imagjpeg.cpp in Sources */,
 				D83B32B788EC310D919E0DF8 /* imagpcx.cpp in Sources */,
-				D66F55C93D1130F488970C06 /* pcre2_match_data.c in Sources */,
 				23965E313EDC3BBE9B2FA1C6 /* imagpng.cpp in Sources */,
 				46E331300D8F349DB36AB50B /* imagpnm.cpp in Sources */,
 				AAABEE399008310A8BC9BE44 /* imagtga.cpp in Sources */,
@@ -8595,6 +8650,7 @@
 				1BCC944F5E0936F5830F03E9 /* windowid.cpp in Sources */,
 				3399AB7BB1333B5AAF5FAF56 /* wrapsizer.cpp in Sources */,
 				C1E5799141603A75A26BEEA8 /* xpmdecod.cpp in Sources */,
+				46F341B46F80376B962759F6 /* animateg.cpp in Sources */,
 				F5806029B1BA3924A8FDDBC2 /* busyinfo.cpp in Sources */,
 				CB078622E90F33BE9D131132 /* buttonbar.cpp in Sources */,
 				03035C5CE4BC3288A5A18425 /* choicdgg.cpp in Sources */,
@@ -8612,7 +8668,6 @@
 				633DD2E870263F42A8DBF9C0 /* markuptext.cpp in Sources */,
 				745C39E90E8C3C08A887B51D /* msgdlgg.cpp in Sources */,
 				1AF2B2346C9639DAA4D15F31 /* numdlgg.cpp in Sources */,
-				60296753A32B39EB8BD0CB45 /* pcre2_study.c in Sources */,
 				4D0BA8B9F72C3C31BC170CE3 /* progdlgg.cpp in Sources */,
 				A1A7B833061C35B4AABD093D /* preferencesg.cpp in Sources */,
 				DEB35F871F8E3B90AD207AEF /* printps.cpp in Sources */,
@@ -8633,6 +8688,43 @@
 				87C67583D36C3465ACD64104 /* vlbox.cpp in Sources */,
 				A465A43B756630F1944B5A57 /* vscroll.cpp in Sources */,
 				1CBF34ACA39330028A5EA9AD /* xmlreshandler.cpp in Sources */,
+				8AA341CCFB8E3F6AB3523596 /* splash.cpp in Sources */,
+				CEE0D7A7D5D8323B9957A781 /* notifmsgg.cpp in Sources */,
+				1E17F95DD433379E8C18298D /* odcombo.cpp in Sources */,
+				901F659891613419B8643953 /* calctrlcmn.cpp in Sources */,
+				E5D698D2606A304DA743AF93 /* grideditors.cpp in Sources */,
+				5C44446AB150378696CD6B3D /* bmpcboxcmn.cpp in Sources */,
+				A139B846584436BCBEBAE3C0 /* grid.cpp in Sources */,
+				2E930206397C3EDCBD8206FD /* gridctrl.cpp in Sources */,
+				760C729E41D93CC1AA2B4E0E /* hyperlinkg.cpp in Sources */,
+				F016C51053373E658ED4C9AA /* helpext.cpp in Sources */,
+				3554C88010CE3D2A8970A136 /* sashwin.cpp in Sources */,
+				187F921A95DA3594B0AD980E /* gridsel.cpp in Sources */,
+				EC3D181D65F33E09A675FFF3 /* addremovectrl.cpp in Sources */,
+				77BC918AF05C30E8A0BD27F9 /* tipdlg.cpp in Sources */,
+				FEA741A9B6663A4C929893C3 /* aboutdlgg.cpp in Sources */,
+				2FAE979E6FE23D088C768B7E /* gridcmn.cpp in Sources */,
+				2FE10EA678C73523836FCC1D /* richtooltipcmn.cpp in Sources */,
+				B4425B59CC27389CA9FF81D2 /* datectlg.cpp in Sources */,
+				E0FAB345D2933D42B62917A4 /* bannerwindow.cpp in Sources */,
+				060E095718B03EF98C75479A /* treelist.cpp in Sources */,
+				1CD4F67F48CF3A5FA477D86F /* datavcmn.cpp in Sources */,
+				CFDBB80A4C9A3BA092273937 /* animatecmn.cpp in Sources */,
+				E6D18B2EDE353F67883085A0 /* odcombocmn.cpp in Sources */,
+				7B4DA2F5F25B3E188CBAFE39 /* hyperlnkcmn.cpp in Sources */,
+				6A10511265493FA2BB79CE4E /* propdlg.cpp in Sources */,
+				B189DB62AE9F30A1B613756C /* bmpcboxg.cpp in Sources */,
+				C67EAE20657E36839BF86691 /* richtooltipg.cpp in Sources */,
+				98F52D5224B438DFA8887E07 /* timectrlg.cpp in Sources */,
+				8A662992FFCB32E99D11950D /* commandlinkbuttong.cpp in Sources */,
+				800CFCEDBB7938338C65EEAD /* notifmsgcmn.cpp in Sources */,
+				82FA4AA043213728AC266701 /* wizard.cpp in Sources */,
+				8B60964DA1DF3F3DB40BE124 /* datavgen.cpp in Sources */,
+				5557AA36FBCC3ED9A5F5751B /* editlbox.cpp in Sources */,
+				955D2199F1893D37BA2D7479 /* laywin.cpp in Sources */,
+				2F50DBC14FE538A49823925B /* calctrlg.cpp in Sources */,
+				63F895D6F5643E4B9E666B7A /* creddlgg.cpp in Sources */,
+				8F372080E11E382EA0B5ED10 /* rowheightcache.cpp in Sources */,
 				567A32722BA33AEE9FF93D7D /* fs_inet.cpp in Sources */,
 				65514CD6A9F23ED98436AC03 /* ftp.cpp in Sources */,
 				B84642DA949638A189032CE7 /* http.cpp in Sources */,
@@ -8643,62 +8735,13 @@
 				A3A898DA3114311EB7F02228 /* sckstrm.cpp in Sources */,
 				6978D7A20DA93A329DDD1384 /* socket.cpp in Sources */,
 				E7140F3AB94D3FDFA86D8C07 /* url.cpp in Sources */,
+				C987310872D1396BAF716E5B /* webrequest.cpp in Sources */,
+				EE972E8DC73F310B9B4C949D /* webrequest_curl.cpp in Sources */,
 				652CFDD9A1C1366E99B5D6BD /* socketiohandler.cpp in Sources */,
 				346D274E17673A01B0177D5C /* sockunix.cpp in Sources */,
 				AD07124BBA613B47829F0693 /* sockosx.cpp in Sources */,
-				CFDBB80A4C9A3BA092273937 /* animatecmn.cpp in Sources */,
-				5C44446AB150378696CD6B3D /* bmpcboxcmn.cpp in Sources */,
-				901F659891613419B8643953 /* calctrlcmn.cpp in Sources */,
-				1CD4F67F48CF3A5FA477D86F /* datavcmn.cpp in Sources */,
-				2FAE979E6FE23D088C768B7E /* gridcmn.cpp in Sources */,
-				7B4DA2F5F25B3E188CBAFE39 /* hyperlnkcmn.cpp in Sources */,
-				E6D18B2EDE353F67883085A0 /* odcombocmn.cpp in Sources */,
-				2FE10EA678C73523836FCC1D /* richtooltipcmn.cpp in Sources */,
-				FEA741A9B6663A4C929893C3 /* aboutdlgg.cpp in Sources */,
-				E0FAB345D2933D42B62917A4 /* bannerwindow.cpp in Sources */,
-				B189DB62AE9F30A1B613756C /* bmpcboxg.cpp in Sources */,
-				2F50DBC14FE538A49823925B /* calctrlg.cpp in Sources */,
-				8A662992FFCB32E99D11950D /* commandlinkbuttong.cpp in Sources */,
-				8B60964DA1DF3F3DB40BE124 /* datavgen.cpp in Sources */,
-				B4425B59CC27389CA9FF81D2 /* datectlg.cpp in Sources */,
-				5557AA36FBCC3ED9A5F5751B /* editlbox.cpp in Sources */,
-				A139B846584436BCBEBAE3C0 /* grid.cpp in Sources */,
-				2E930206397C3EDCBD8206FD /* gridctrl.cpp in Sources */,
-				E5D698D2606A304DA743AF93 /* grideditors.cpp in Sources */,
-				187F921A95DA3594B0AD980E /* gridsel.cpp in Sources */,
-				F016C51053373E658ED4C9AA /* helpext.cpp in Sources */,
-				760C729E41D93CC1AA2B4E0E /* hyperlinkg.cpp in Sources */,
-				955D2199F1893D37BA2D7479 /* laywin.cpp in Sources */,
-				CEE0D7A7D5D8323B9957A781 /* notifmsgg.cpp in Sources */,
-				1E17F95DD433379E8C18298D /* odcombo.cpp in Sources */,
-				6A10511265493FA2BB79CE4E /* propdlg.cpp in Sources */,
-				C67EAE20657E36839BF86691 /* richtooltipg.cpp in Sources */,
-				3554C88010CE3D2A8970A136 /* sashwin.cpp in Sources */,
-				8AA341CCFB8E3F6AB3523596 /* splash.cpp in Sources */,
-				98F52D5224B438DFA8887E07 /* timectrlg.cpp in Sources */,
-				77BC918AF05C30E8A0BD27F9 /* tipdlg.cpp in Sources */,
-				060E095718B03EF98C75479A /* treelist.cpp in Sources */,
-				82FA4AA043213728AC266701 /* wizard.cpp in Sources */,
-				EC3D181D65F33E09A675FFF3 /* addremovectrl.cpp in Sources */,
-				800CFCEDBB7938338C65EEAD /* notifmsgcmn.cpp in Sources */,
-				D00AF125FCB63A7A8F9B87DF /* taskbarcmn.cpp in Sources */,
-				46F341B46F80376B962759F6 /* animateg.cpp in Sources */,
-				219304C9DDA33E9AADB515DD /* datetimectrl_osx.cpp in Sources */,
-				4F99EB97F65330C28EB4D078 /* datectrl_osx.cpp in Sources */,
-				CE2C937117FE3AB599DD30BA /* sound_osx.cpp in Sources */,
-				20D05D14BFAD3F969666D03C /* timectrl_osx.cpp in Sources */,
-				61FEDBF2D47A3B4E861F8297 /* sound.cpp in Sources */,
-				61FEDBF2D47A3B4E861F829A /* sound.cpp in Sources */,
-				14DEBD7C01FC358B917FDAF3 /* aboutdlg.mm in Sources */,
-				0723C4E8B52C39FDBC2158B7 /* dataview_osx.cpp in Sources */,
-				049052C49B0B3810BE0179CA /* dataview.mm in Sources */,
-				3316A16628B03D5E88529EA8 /* datetimectrl.mm in Sources */,
-				25C5C1713C0B39AC8EB6A38F /* taskbar.mm in Sources */,
-				C1DCF69200593986A8C606A7 /* hidjoystick.cpp in Sources */,
-				A4F2426F36653C6D87EC18AF /* activityindicator.mm in Sources */,
-				1B69C40CD7493FED9A272836 /* notifmsg.mm in Sources */,
+				980ED1DA2F96361985952255 /* webrequest_urlsession.mm in Sources */,
 				2DBF5F96CCC63F7481C26A44 /* webview_webkit.mm in Sources */,
-				10B5C2A72C713A678458CD9E /* pcre2_ord2utf.c in Sources */,
 				64A716F87A5136F9A790EC5B /* webview.cpp in Sources */,
 				5C5D0983160A36189A770743 /* webviewarchivehandler.cpp in Sources */,
 				048986FB629E313EA670CD0D /* webviewfshandler.cpp in Sources */,
@@ -8717,7 +8760,6 @@
 				93E04642049537EB8A37BA27 /* htmlwin.cpp in Sources */,
 				3E99016BDE043A08B4D6B3CF /* htmprint.cpp in Sources */,
 				9836B3D336963795928FE5A2 /* m_dflist.cpp in Sources */,
-				14F303FD6B5F383DADDFD789 /* xh_dataview.cpp in Sources */,
 				66584BC871303041BA622DE1 /* m_fonts.cpp in Sources */,
 				99F7D7BFBB543A04AB728376 /* m_hline.cpp in Sources */,
 				A3586433C4B1398FB1C361D7 /* m_image.cpp in Sources */,
@@ -8735,7 +8777,6 @@
 				FBE4DB30865D3177B3A9993C /* xh_animatctrl.cpp in Sources */,
 				702616D38A5B345D9CC87115 /* xh_bannerwindow.cpp in Sources */,
 				94E510619F433AE3AC884756 /* xh_bmp.cpp in Sources */,
-				7BD3887F603E3704969A54E2 /* pcre2_chartables.c in Sources */,
 				8966F77CC97B3ED780C8F138 /* xh_bmpcbox.cpp in Sources */,
 				84B3625464F732C3A79E1315 /* xh_bmpbt.cpp in Sources */,
 				D5C304182151365FA9FF8A3E /* xh_bttn.cpp in Sources */,
@@ -8744,12 +8785,12 @@
 				5F2C2A46781739D897CF293E /* xh_chckl.cpp in Sources */,
 				CE17002B5B7E37558274763A /* xh_choic.cpp in Sources */,
 				26E4813A97DE323E88119164 /* xh_choicbk.cpp in Sources */,
-				215958201947310B88BBEDB4 /* statbmp.mm in Sources */,
 				E7AF3BF2B3473AD9BE66D1A2 /* xh_clrpicker.cpp in Sources */,
 				1AB50C98FF473B33A3CA4D3A /* xh_cmdlinkbn.cpp in Sources */,
 				E7921B0472B63E4091F4F518 /* xh_collpane.cpp in Sources */,
 				84382E5DB3203A73AC5EE391 /* xh_combo.cpp in Sources */,
 				F569D7A3F0E038E9B4CC2A77 /* xh_comboctrl.cpp in Sources */,
+				14F303FD6B5F383DADDFD789 /* xh_dataview.cpp in Sources */,
 				FB09720D13673A7B81BCB646 /* xh_datectrl.cpp in Sources */,
 				F7D10B6E0CBA32EFAF79C77D /* xh_dirpicker.cpp in Sources */,
 				3B7E035ECF3D3FFB9827AC1D /* xh_dlg.cpp in Sources */,
@@ -8763,12 +8804,12 @@
 				72AD4417FF7C3094BB1FF62D /* xh_grid.cpp in Sources */,
 				83616D33080E3F0F9FA5FBB5 /* xh_html.cpp in Sources */,
 				2B13BFC894C63373B7ACFA3E /* xh_hyperlink.cpp in Sources */,
+				EA10DA3199813E90B39C70D4 /* xh_infobar.cpp in Sources */,
 				C34B8675439F39B4845FFC51 /* xh_listb.cpp in Sources */,
 				F5DF7AF0FA9E371BB71EF799 /* xh_listbk.cpp in Sources */,
 				96B507455762391688B5E501 /* xh_listc.cpp in Sources */,
 				F34D240EB4513FE996179183 /* xh_mdi.cpp in Sources */,
 				65FCDBFFF3F138A3ABBAA651 /* xh_menu.cpp in Sources */,
-				D7F14BDFFB7F369B842AFC14 /* pcre2_config.c in Sources */,
 				0FBF7C9EDFB53D8DA0991B56 /* xh_notbk.cpp in Sources */,
 				0FA6E1E47F123FF4A902E4D3 /* xh_odcombo.cpp in Sources */,
 				36B0B923B836358D9DB0AE11 /* xh_panel.cpp in Sources */,
@@ -8786,7 +8827,6 @@
 				7C9EAFF4A0223EE597E0E39F /* xh_srchctrl.cpp in Sources */,
 				8AB7191F7CB838FC8337C48E /* xh_statbar.cpp in Sources */,
 				3D3EA1BAAD1833B1B48E9C87 /* xh_stbmp.cpp in Sources */,
-				57B41B6BACFB3906ACD1BFB0 /* pcre2_jit_compile.c in Sources */,
 				F22C401903993639AE05A296 /* xh_stbox.cpp in Sources */,
 				BF3D600A93403C589B65C5C0 /* xh_stlin.cpp in Sources */,
 				8292D346BFC33D6E8D3CDDC0 /* xh_sttxt.cpp in Sources */,
@@ -8801,7 +8841,6 @@
 				37DD17F479A1371ABF3589BA /* xh_wizrd.cpp in Sources */,
 				1710A4BB0E6339558A187F8E /* xmlres.cpp in Sources */,
 				135DFCE48FC03D8294D01A8A /* xmlrsall.cpp in Sources */,
-				8B87FEC23DB834EDBFB6EA33 /* pcre2_ucd.c in Sources */,
 				50E89226E8D7390D9D21C80A /* debugrpt.cpp in Sources */,
 				7C5552FA058034238F485901 /* dbgrptg.cpp in Sources */,
 				61FD5E0E28F732E8AB1729F9 /* xml.cpp in Sources */,
@@ -8809,7 +8848,6 @@
 				EEB0B28903693C7E9D071930 /* glcmn.cpp in Sources */,
 				59F995B6E6EE3CA5A4487845 /* glcanvas.mm in Sources */,
 				F2813BF297C73A3ABD02EC99 /* glcanvas_osx.cpp in Sources */,
-				6463C9BE78C0394CB7B451FB /* pcre2_compile.c in Sources */,
 				36EB5D19429D3BD1A01001D6 /* framemanager.cpp in Sources */,
 				C7B6240E0E213836996A178C /* dockart.cpp in Sources */,
 				15048519756B33959B15B162 /* floatpane.cpp in Sources */,
@@ -8820,9 +8858,7 @@
 				C3C19BD343B235F9909D495A /* xh_aui.cpp in Sources */,
 				44C6F11C7D1C399F99CF6BD5 /* xh_auitoolb.cpp in Sources */,
 				DE43350F6C9D3148A64F0AFA /* art_internal.cpp in Sources */,
-				C5C60B22CE6A3BCB868F69E9 /* pcre2_find_bracket.c in Sources */,
 				7DC4A542372437ECA0790F88 /* art_msw.cpp in Sources */,
-				9E37D29DCF7A3945A0EECB3A /* pcre2_serialize.c in Sources */,
 				A0BA01A85C303C78A3130712 /* art_aui.cpp in Sources */,
 				056CA84179433AA48D55DA66 /* bar.cpp in Sources */,
 				CB078622E90F33BE9D131135 /* buttonbar.cpp in Sources */,
@@ -8830,7 +8866,6 @@
 				5F57C4908E5038D19D68ED7B /* gallery.cpp in Sources */,
 				4BAFAE70A6B1313B96D86631 /* page.cpp in Sources */,
 				F0D892C2618130FEAD46BB87 /* panel.cpp in Sources */,
-				DFEB01E7B97A3515B785DCAA /* pcre2_string_utils.c in Sources */,
 				EA02FA6D3B003F8F8A2963C7 /* toolbar.cpp in Sources */,
 				5A459FC1180130C5B705AEDB /* xh_ribbon.cpp in Sources */,
 				D54A162E557834A48F4646AA /* advprops.cpp in Sources */,
@@ -8847,7 +8882,6 @@
 				70F898F8B129380BBECAC55A /* richtexthtml.cpp in Sources */,
 				F43DAE2E829A3A7493531382 /* richtextimagedlg.cpp in Sources */,
 				0FDDE8E193743F3A8CBDC67D /* richtextprint.cpp in Sources */,
-				A4DEBFA074C93388A1BBCB41 /* pcre2_substitute.c in Sources */,
 				FADD46CB89B135D1AF1D5F8B /* richtextstyledlg.cpp in Sources */,
 				2563C775427E3D68BD384F30 /* richtextstyles.cpp in Sources */,
 				604ABF86317C3D4F899DBF38 /* richtextsymboldlg.cpp in Sources */,
@@ -8856,13 +8890,13 @@
 				E3B3E4F75D503DB89B5C622E /* stc.cpp in Sources */,
 				908957F65B7E36F8BF3858DE /* PlatWX.cpp in Sources */,
 				3E6AA08E72A030D39D867D4C /* ScintillaWX.cpp in Sources */,
+				57F8001809BC3864A5FA798C /* PlatWXcocoa.mm in Sources */,
 				F5B0B26BD0803719A3FCB4D8 /* adler32.c in Sources */,
 				BE3ED6EF34303867B8C8E924 /* compress.c in Sources */,
 				AC07BA4EA5403443914DFDB2 /* crc32.c in Sources */,
 				8DE45CEAF2DD3C22AA019F75 /* deflate.c in Sources */,
 				213CE0DD5B2335D0AD53B54B /* gzclose.c in Sources */,
 				0E8A0B8FA40E365690C20231 /* gzlib.c in Sources */,
-				00E12455C98032E18378EE5F /* pcre2_newline.c in Sources */,
 				4B996B4C54163D7091427DB6 /* gzread.c in Sources */,
 				4E2737AC738431EB9898B8B7 /* gzwrite.c in Sources */,
 				5EE94793DFCB3BA281A4864F /* infback.c in Sources */,
@@ -8878,11 +8912,9 @@
 				8E674574343A3C009B1BCD01 /* tif_codec.c in Sources */,
 				D95C5F467D37339AB8DF2355 /* tif_color.c in Sources */,
 				6D073876E1753549B5EEFDDB /* tif_compress.c in Sources */,
-				0F2FD12272023C869CE86009 /* filter_neon_intrinsics.c in Sources */,
 				E3136EF5DD843ACE886E2869 /* tif_dir.c in Sources */,
 				7ECC6EE6D5273F75BB6B7B75 /* tif_dirinfo.c in Sources */,
 				D51B3389209E370489078892 /* tif_dirread.c in Sources */,
-				2047544E505C3BA38F0144E7 /* pcre2_tables.c in Sources */,
 				E7F35B834A163C67B65176C7 /* tif_dirwrite.c in Sources */,
 				2D4D105CA9BE3FA6995A6000 /* tif_dumpmode.c in Sources */,
 				C2CF6B59914A3183ADE84029 /* tif_error.c in Sources */,
@@ -8911,9 +8943,10 @@
 				FEB073547F3F3AC19D31F699 /* tif_tile.c in Sources */,
 				096BA201623034AD97218369 /* tif_version.c in Sources */,
 				7A79D9AC608E3B8287229175 /* tif_warning.c in Sources */,
+				D772334837693C9D88069D99 /* tif_webp.c in Sources */,
 				F2F2963D8ECC32D39FDBF102 /* tif_write.c in Sources */,
 				6E2C2E8AA1713ADE9C33837A /* tif_zip.c in Sources */,
-				86787E4138CC334BB74EC7B5 /* palette_neon_intrinsics.c in Sources */,
+				6C1171E3FB7137CCB9E3F537 /* tif_zstd.c in Sources */,
 				5D3AD309AF39385EBF7D9DF9 /* jaricom.c in Sources */,
 				894D43C8F224394FB3171F27 /* jcapimin.c in Sources */,
 				743BB23211B336A6A0F26E58 /* jcapistd.c in Sources */,
@@ -8958,7 +8991,6 @@
 				18A318847EAC37F2B915F082 /* jmemmgr.c in Sources */,
 				A7692B4D8658347BA16EEB84 /* jmemnobs.c in Sources */,
 				15D65A523EB23EC385C05E0C /* jquant1.c in Sources */,
-				9FA6C4275F0D3E1A884ED562 /* pcre2_auto_possess.c in Sources */,
 				3C0EB1DDA5243E31B2D92CE3 /* jquant2.c in Sources */,
 				311840186794346AAAA42092 /* jutils.c in Sources */,
 				94B1C88076793400810FAC31 /* png.c in Sources */,
@@ -8966,18 +8998,48 @@
 				D9496139621533328AE727B7 /* pngget.c in Sources */,
 				CFA91122523B31B9A07A3827 /* pngmem.c in Sources */,
 				9EC837DA722736119D49868B /* pngpread.c in Sources */,
-				1142E2D85FD93E9AB5D8A55B /* pcre2_script_run.c in Sources */,
 				9B8E5690A6103FC1BDC6C47F /* pngread.c in Sources */,
 				31FEAB56919D372993CAD89D /* pngrio.c in Sources */,
 				8FDC800D873F30E282691833 /* pngrtran.c in Sources */,
 				61A2B54FD2E33C759CF5A5E9 /* pngrutil.c in Sources */,
-				8C6E2BD9C31A3AE18AD17D45 /* pcre2_match.c in Sources */,
 				309C0A78D45C3AB7B8778B5A /* pngset.c in Sources */,
 				E515EAE375AE390688CBF8D4 /* pngtrans.c in Sources */,
 				C8C68927DB243AEAB51E11F3 /* pngwio.c in Sources */,
 				0095084719983B878378CA29 /* pngwrite.c in Sources */,
 				242E1D1A9BF331BA918134ED /* pngwtran.c in Sources */,
 				2989056891153968B372EA15 /* pngwutil.c in Sources */,
+				BB12132A86E2350AA47414CD /* arm_init.c in Sources */,
+				0F2FD12272023C869CE86009 /* filter_neon_intrinsics.c in Sources */,
+				86787E4138CC334BB74EC7B5 /* palette_neon_intrinsics.c in Sources */,
+				25B0940CABAB39CD90C6F3C6 /* intel_init.c in Sources */,
+				8620088DDD233B139B250DD5 /* filter_sse2_intrinsics.c in Sources */,
+				9FA6C4275F0D3E1A884ED562 /* pcre2_auto_possess.c in Sources */,
+				6463C9BE78C0394CB7B451FB /* pcre2_compile.c in Sources */,
+				D7F14BDFFB7F369B842AFC14 /* pcre2_config.c in Sources */,
+				27B5431DC79733CD8D403E89 /* pcre2_context.c in Sources */,
+				EB206A0264AD3CAA9F68B8FD /* pcre2_convert.c in Sources */,
+				45E15DBB6B69382D8AF1BA22 /* pcre2_dfa_match.c in Sources */,
+				2F7328AC75393951B08F75F2 /* pcre2_error.c in Sources */,
+				5ED54DFAE28533108C08DF2B /* pcre2_extuni.c in Sources */,
+				C5C60B22CE6A3BCB868F69E9 /* pcre2_find_bracket.c in Sources */,
+				57B41B6BACFB3906ACD1BFB0 /* pcre2_jit_compile.c in Sources */,
+				7F62946D497A32CE857F65CA /* pcre2_maketables.c in Sources */,
+				8C6E2BD9C31A3AE18AD17D45 /* pcre2_match.c in Sources */,
+				D66F55C93D1130F488970C06 /* pcre2_match_data.c in Sources */,
+				00E12455C98032E18378EE5F /* pcre2_newline.c in Sources */,
+				10B5C2A72C713A678458CD9E /* pcre2_ord2utf.c in Sources */,
+				88E56F89A0DA3AD386F05FD3 /* pcre2_pattern_info.c in Sources */,
+				1142E2D85FD93E9AB5D8A55B /* pcre2_script_run.c in Sources */,
+				9E37D29DCF7A3945A0EECB3A /* pcre2_serialize.c in Sources */,
+				DFEB01E7B97A3515B785DCAA /* pcre2_string_utils.c in Sources */,
+				60296753A32B39EB8BD0CB45 /* pcre2_study.c in Sources */,
+				A4DEBFA074C93388A1BBCB41 /* pcre2_substitute.c in Sources */,
+				B6728BCD1A0731299924C8C5 /* pcre2_substring.c in Sources */,
+				2047544E505C3BA38F0144E7 /* pcre2_tables.c in Sources */,
+				8B87FEC23DB834EDBFB6EA33 /* pcre2_ucd.c in Sources */,
+				E17048DEEF1138318314F1D1 /* pcre2_valid_utf.c in Sources */,
+				AF1875145B2537298E4A28D9 /* pcre2_xclass.c in Sources */,
+				7BD3887F603E3704969A54E2 /* pcre2_chartables.c in Sources */,
 				23CECD8647C037E0B41DF0D5 /* LexA68k.cxx in Sources */,
 				66FD099CE5A338C18329FC37 /* LexAbaqus.cxx in Sources */,
 				CD35A576FD363FD49C3AC4B4 /* LexAda.cxx in Sources */,
@@ -9079,10 +9141,7 @@
 				BA57708D2D563967A0D1F004 /* LexTxt2tags.cxx in Sources */,
 				D4EC9DB5F8DF319EA0FD26A5 /* LexVB.cxx in Sources */,
 				3C5E1A45A57B3169A4C073DA /* LexVerilog.cxx in Sources */,
-				BB12132A86E2350AA47414CD /* arm_init.c in Sources */,
 				16021CFD78623B8CBD08FC20 /* LexVHDL.cxx in Sources */,
-				57F8001809BC3864A5FA798C /* PlatWXcocoa.mm in Sources */,
-				AF1875145B2537298E4A28D9 /* pcre2_xclass.c in Sources */,
 				9CC92BB4B0E233A0A7F8127A /* LexVisualProlog.cxx in Sources */,
 				159E4248CB1333AD841D9F04 /* LexYAML.cxx in Sources */,
 				91364FDD73053139BBAA313C /* Accessor.cxx in Sources */,
@@ -9252,8 +9311,10 @@
 				FEB073547F3F3AC19D31F69A /* tif_tile.c in Sources */,
 				096BA201623034AD9721836A /* tif_version.c in Sources */,
 				7A79D9AC608E3B8287229176 /* tif_warning.c in Sources */,
+				D772334837693C9D88069D9A /* tif_webp.c in Sources */,
 				F2F2963D8ECC32D39FDBF103 /* tif_write.c in Sources */,
 				6E2C2E8AA1713ADE9C33837B /* tif_zip.c in Sources */,
+				6C1171E3FB7137CCB9E3F538 /* tif_zstd.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9286,11 +9347,8 @@
 				94B1C88076793400810FAC32 /* png.c in Sources */,
 				1569BB4728693B6285623A25 /* pngerror.c in Sources */,
 				D9496139621533328AE727B8 /* pngget.c in Sources */,
-				0F2FD12272023C869CE8600A /* filter_neon_intrinsics.c in Sources */,
 				CFA91122523B31B9A07A3828 /* pngmem.c in Sources */,
-				86787E4138CC334BB74EC7B6 /* palette_neon_intrinsics.c in Sources */,
 				9EC837DA722736119D49868C /* pngpread.c in Sources */,
-				BB12132A86E2350AA47414CE /* arm_init.c in Sources */,
 				9B8E5690A6103FC1BDC6C480 /* pngread.c in Sources */,
 				31FEAB56919D372993CAD89E /* pngrio.c in Sources */,
 				8FDC800D873F30E282691834 /* pngrtran.c in Sources */,
@@ -9301,6 +9359,11 @@
 				0095084719983B878378CA2A /* pngwrite.c in Sources */,
 				242E1D1A9BF331BA918134EE /* pngwtran.c in Sources */,
 				2989056891153968B372EA16 /* pngwutil.c in Sources */,
+				BB12132A86E2350AA47414CE /* arm_init.c in Sources */,
+				0F2FD12272023C869CE8600A /* filter_neon_intrinsics.c in Sources */,
+				86787E4138CC334BB74EC7B6 /* palette_neon_intrinsics.c in Sources */,
+				25B0940CABAB39CD90C6F3C7 /* intel_init.c in Sources */,
+				8620088DDD233B139B250DD6 /* filter_sse2_intrinsics.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9308,33 +9371,33 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B6728BCD1A0731299924C8C6 /* pcre2_substring.c in Sources */,
-				8C6E2BD9C31A3AE18AD17D46 /* pcre2_match.c in Sources */,
-				10B5C2A72C713A678458CD9F /* pcre2_ord2utf.c in Sources */,
-				C5C60B22CE6A3BCB868F69EA /* pcre2_find_bracket.c in Sources */,
-				DFEB01E7B97A3515B785DCAB /* pcre2_string_utils.c in Sources */,
-				E17048DEEF1138318314F1D2 /* pcre2_valid_utf.c in Sources */,
-				00E12455C98032E18378EE60 /* pcre2_newline.c in Sources */,
-				27B5431DC79733CD8D403E8A /* pcre2_context.c in Sources */,
-				9E37D29DCF7A3945A0EECB3B /* pcre2_serialize.c in Sources */,
-				D7F14BDFFB7F369B842AFC15 /* pcre2_config.c in Sources */,
-				EB206A0264AD3CAA9F68B8FE /* pcre2_convert.c in Sources */,
-				2F7328AC75393951B08F75F3 /* pcre2_error.c in Sources */,
-				88E56F89A0DA3AD386F05FD4 /* pcre2_pattern_info.c in Sources */,
-				D66F55C93D1130F488970C07 /* pcre2_match_data.c in Sources */,
-				2047544E505C3BA38F0144E8 /* pcre2_tables.c in Sources */,
 				9FA6C4275F0D3E1A884ED563 /* pcre2_auto_possess.c in Sources */,
-				1142E2D85FD93E9AB5D8A55C /* pcre2_script_run.c in Sources */,
-				7BD3887F603E3704969A54E3 /* pcre2_chartables.c in Sources */,
-				7F62946D497A32CE857F65CB /* pcre2_maketables.c in Sources */,
-				45E15DBB6B69382D8AF1BA23 /* pcre2_dfa_match.c in Sources */,
 				6463C9BE78C0394CB7B451FC /* pcre2_compile.c in Sources */,
-				60296753A32B39EB8BD0CB46 /* pcre2_study.c in Sources */,
+				D7F14BDFFB7F369B842AFC15 /* pcre2_config.c in Sources */,
+				27B5431DC79733CD8D403E8A /* pcre2_context.c in Sources */,
+				EB206A0264AD3CAA9F68B8FE /* pcre2_convert.c in Sources */,
+				45E15DBB6B69382D8AF1BA23 /* pcre2_dfa_match.c in Sources */,
+				2F7328AC75393951B08F75F3 /* pcre2_error.c in Sources */,
 				5ED54DFAE28533108C08DF2C /* pcre2_extuni.c in Sources */,
-				A4DEBFA074C93388A1BBCB42 /* pcre2_substitute.c in Sources */,
+				C5C60B22CE6A3BCB868F69EA /* pcre2_find_bracket.c in Sources */,
 				57B41B6BACFB3906ACD1BFB1 /* pcre2_jit_compile.c in Sources */,
+				7F62946D497A32CE857F65CB /* pcre2_maketables.c in Sources */,
+				8C6E2BD9C31A3AE18AD17D46 /* pcre2_match.c in Sources */,
+				D66F55C93D1130F488970C07 /* pcre2_match_data.c in Sources */,
+				00E12455C98032E18378EE60 /* pcre2_newline.c in Sources */,
+				10B5C2A72C713A678458CD9F /* pcre2_ord2utf.c in Sources */,
+				88E56F89A0DA3AD386F05FD4 /* pcre2_pattern_info.c in Sources */,
+				1142E2D85FD93E9AB5D8A55C /* pcre2_script_run.c in Sources */,
+				9E37D29DCF7A3945A0EECB3B /* pcre2_serialize.c in Sources */,
+				DFEB01E7B97A3515B785DCAB /* pcre2_string_utils.c in Sources */,
+				60296753A32B39EB8BD0CB46 /* pcre2_study.c in Sources */,
+				A4DEBFA074C93388A1BBCB42 /* pcre2_substitute.c in Sources */,
+				B6728BCD1A0731299924C8C6 /* pcre2_substring.c in Sources */,
+				2047544E505C3BA38F0144E8 /* pcre2_tables.c in Sources */,
 				8B87FEC23DB834EDBFB6EA34 /* pcre2_ucd.c in Sources */,
+				E17048DEEF1138318314F1D2 /* pcre2_valid_utf.c in Sources */,
 				AF1875145B2537298E4A28DA /* pcre2_xclass.c in Sources */,
+				7BD3887F603E3704969A54E3 /* pcre2_chartables.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9508,7 +9571,6 @@
 				3ED6F4B64C283232A79423CF /* dircmn.cpp in Sources */,
 				AD7EEB418C7930CB828EAF87 /* dynlib.cpp in Sources */,
 				0164A65CDB7A334A8E9AA4BF /* dynload.cpp in Sources */,
-				2047544E505C3BA38F0144E6 /* pcre2_tables.c in Sources */,
 				246B4FF96BA135258FE45F4F /* encconv.cpp in Sources */,
 				97BAFEAD53E238B6881178DD /* evtloopcmn.cpp in Sources */,
 				F07D84D124F23E7FA11CF148 /* extended.c in Sources */,
@@ -9544,23 +9606,19 @@
 				CA85901B9E2538CFB7E44216 /* process.cpp in Sources */,
 				7A7439BE66AA3771B4A89048 /* regex.cpp in Sources */,
 				CF3082BA1ED232F4B904BD14 /* stdpbase.cpp in Sources */,
-				27B5431DC79733CD8D403E88 /* pcre2_context.c in Sources */,
 				539B586AEAD630A79FC12ECF /* sstream.cpp in Sources */,
 				028257C52CAE3038AA862C35 /* stdstream.cpp in Sources */,
 				6AA0EE765330326380989FD1 /* stopwatch.cpp in Sources */,
 				E882402BEE0330A080A6516F /* strconv.cpp in Sources */,
 				30493B486DFF35AF80D12C49 /* stream.cpp in Sources */,
 				795613831EC8332A83FF26E7 /* string.cpp in Sources */,
-				750C716389AD3ADBABC9D689 /* statbmp_osx.cpp in Sources */,
 				55F0D287F60F3EDEA16CCB64 /* stringimpl.cpp in Sources */,
 				88E1AE56FD393C8BA5CF8545 /* stringops.cpp in Sources */,
-				00E12455C98032E18378EE5E /* pcre2_newline.c in Sources */,
 				056E30EA43753A7CB1AF8C9E /* strvararg.cpp in Sources */,
 				4DD98A9436C83CF3B9425A78 /* sysopt.cpp in Sources */,
 				9FB1E1763EFA334CA0C07C49 /* tarstrm.cpp in Sources */,
 				2E4747E0736B30569ACD5422 /* textbuf.cpp in Sources */,
 				6167245C417A32179EC37D2D /* textfile.cpp in Sources */,
-				EA10DA3199813E90B39C70D3 /* xh_infobar.cpp in Sources */,
 				B20B7313102232A4B3E01ABA /* threadinfo.cpp in Sources */,
 				98AD7D0478BA36249B03C623 /* time.cpp in Sources */,
 				7FC3D17B3C853FE58841002D /* timercmn.cpp in Sources */,
@@ -9583,19 +9641,21 @@
 				A93D0E6F0871368EA8FC9FF9 /* fswatchercmn.cpp in Sources */,
 				E49F0D43B5A63EF1A57A7112 /* fswatcherg.cpp in Sources */,
 				B0FD1B96EAE635AFBFCF2C91 /* secretstore.cpp in Sources */,
+				A486A28E216D320AB57452D3 /* lzmastream.cpp in Sources */,
+				9A63148F193E33B5964DD029 /* uilocale.cpp in Sources */,
 				4657E7382E9E3EDC8DE2401E /* mimetype.cpp in Sources */,
 				1DBDF75500D73A3098015E7F /* cfstring.cpp in Sources */,
 				9FBC642677C63D01AA2511BC /* evtloop_cf.cpp in Sources */,
 				AAAB5DF8E60736D88273DCFE /* strconv_cf.cpp in Sources */,
 				68C300D096BF39239876D043 /* utils_base.mm in Sources */,
 				B0FD1B96EAE635AFBFCF2C94 /* secretstore.cpp in Sources */,
+				9A63148F193E33B5964DD02C /* uilocale.cpp in Sources */,
 				D36E76A4CAF5352D9397E1FF /* fdiodispatcher.cpp in Sources */,
 				D3FB75C8E3A73AE38EE8A6F6 /* selectdispatcher.cpp in Sources */,
 				BAAB6B1D80A33843A8436B10 /* appunix.cpp in Sources */,
 				403FBA20CEFE3EAFB4E6B905 /* dir.cpp in Sources */,
 				20BEEFFA08F3396791596870 /* dlunix.cpp in Sources */,
 				CBBD7B32DB7B3E24AE745D78 /* epolldispatcher.cpp in Sources */,
-				45E15DBB6B69382D8AF1BA21 /* pcre2_dfa_match.c in Sources */,
 				D18E2985C48733B2B7B3D442 /* evtloopunix.cpp in Sources */,
 				3D22FC202D903007AEE3D164 /* fdiounix.cpp in Sources */,
 				4B88254FF9963833A276A64C /* snglinst.cpp in Sources */,
@@ -9607,8 +9667,6 @@
 				FF7DB2884F6E3C5DB4BDF61D /* fswatcher_kqueue.cpp in Sources */,
 				830A61EA04FD367C9EB6A757 /* fswatcher_fsevents.cpp in Sources */,
 				DA71FBB9EFB2350ABB3CEC80 /* stdpaths.mm in Sources */,
-				D66F55C93D1130F488970C05 /* pcre2_match_data.c in Sources */,
-				DFEB01E7B97A3515B785DCA9 /* pcre2_string_utils.c in Sources */,
 				55D893FDD00633FEA82ABD81 /* event.cpp in Sources */,
 				131B879180AE3FB481F81CC7 /* fs_mem.cpp in Sources */,
 				05814571E7A83F5DBFB6E4C4 /* msgout.cpp in Sources */,
@@ -9619,7 +9677,6 @@
 				296692A7A3783E3A83D005C6 /* brush.cpp in Sources */,
 				86AED49CEAFC3637B1F10537 /* dialog_osx.cpp in Sources */,
 				DC6B669C9A78398F914AEE53 /* fontutil.cpp in Sources */,
-				1EDED99760B23A1999E75C12 /* imaglist.cpp in Sources */,
 				C1CDD035AA393ACC9E202C03 /* minifram.cpp in Sources */,
 				4269B85FDC5639BEB76A8AEB /* nonownedwnd_osx.cpp in Sources */,
 				AC91349D7F0E37739B1F5165 /* palette.cpp in Sources */,
@@ -9631,7 +9688,6 @@
 				03BF1610E2FC3BD5ACB754F0 /* bitmap.cpp in Sources */,
 				FF50EC0EC5F23DF890C6E95F /* colour.cpp in Sources */,
 				BD2B17EB72E73A6EB6E0B26F /* dcmemory.cpp in Sources */,
-				F1F484DD591337399FCD0463 /* display.cpp in Sources */,
 				371809DA4AD1382F8B532878 /* fontenum.cpp in Sources */,
 				86BE5213D3F131D8A6862679 /* hid.cpp in Sources */,
 				AB58406CEBA13BC4A2A83B66 /* printmac.cpp in Sources */,
@@ -9654,11 +9710,9 @@
 				0C9A379D97B133FA831175A7 /* printdlg_osx.cpp in Sources */,
 				B1775EF7C72233408044034B /* radiobox_osx.cpp in Sources */,
 				6A081BF19747385CB4C1877F /* radiobut_osx.cpp in Sources */,
-				63F895D6F5643E4B9E666B79 /* creddlgg.cpp in Sources */,
 				DF8CE011EAC23F73BDA1C44D /* scrolbar_osx.cpp in Sources */,
 				27E73CA5C35A30CE89946ECA /* slider_osx.cpp in Sources */,
 				00F1531404F832C6AE0748F2 /* spinbutt_osx.cpp in Sources */,
-				9E37D29DCF7A3945A0EECB39 /* pcre2_serialize.c in Sources */,
 				91EA325FCE3A3A6A8D1D21A5 /* srchctrl_osx.cpp in Sources */,
 				221DC4F6678A3EC5ACDDEA4F /* statbox_osx.cpp in Sources */,
 				91BC7802C15337CDA84C3742 /* statline_osx.cpp in Sources */,
@@ -9674,7 +9728,6 @@
 				5417332FE2DB3CD3A647B15D /* cursor.cpp in Sources */,
 				D66F5D4D204B3B789C7F76B9 /* fontdlg.cpp in Sources */,
 				692FCCABFB963696AFC1E122 /* gdiobj.cpp in Sources */,
-				01D4C5F2147F3942A7CE91AA /* icon.cpp in Sources */,
 				B0E94A59C83637C09FAAE71C /* app.cpp in Sources */,
 				EB52C6A915943813932944FE /* control.cpp in Sources */,
 				45AB45C6B24A3983B22E56A5 /* dataobj.cpp in Sources */,
@@ -9682,7 +9735,6 @@
 				182DFDBB58653FD9863D4176 /* dcprint.cpp in Sources */,
 				AAC2CB4D851230008AE4ABA1 /* dcscreen.cpp in Sources */,
 				774EB9F3F7E93A379E1F7551 /* graphics.cpp in Sources */,
-				AF1875145B2537298E4A28D8 /* pcre2_xclass.c in Sources */,
 				5792675690843C6AA4125A72 /* font.cpp in Sources */,
 				BDAB44F5D017395D9D3A1F23 /* frame.cpp in Sources */,
 				27E2EABB117334CD89CFD2A4 /* mdi.cpp in Sources */,
@@ -9692,7 +9744,6 @@
 				F6A1AC5CF84E32C19F91A614 /* statbrma.cpp in Sources */,
 				D070C3BE95483FE38BABA1BE /* region.cpp in Sources */,
 				07158EBC05A637ECA9DC7B4F /* utilscocoa.mm in Sources */,
-				6463C9BE78C0394CB7B451FA /* pcre2_compile.c in Sources */,
 				7E6C627A325F32FFB2EF9B9E /* caret.cpp in Sources */,
 				FB8B6E4789A3311A98C5B0A8 /* clrpickerg.cpp in Sources */,
 				7569F0BC3C603EB19168088F /* collpaneg.cpp in Sources */,
@@ -9707,6 +9758,9 @@
 				C005C2D547E735E9B081658E /* prntdlgg.cpp in Sources */,
 				A1AF8FF873D6383996995ECF /* statusbr.cpp in Sources */,
 				2E059BFE8E3B3D9299D55969 /* textmeasure.cpp in Sources */,
+				01D4C5F2147F3942A7CE91AA /* icon.cpp in Sources */,
+				750C716389AD3ADBABC9D689 /* statbmp_osx.cpp in Sources */,
+				1EDED99760B23A1999E75C12 /* imaglist.cpp in Sources */,
 				65AD3B31319C35F1AC9EC625 /* anybutton.mm in Sources */,
 				CE32C5250F2834D4B81BE898 /* appprogress.mm in Sources */,
 				14D6D5F8F5ED3C71936DD2AF /* button.mm in Sources */,
@@ -9719,7 +9773,6 @@
 				5700B7F9166A37FDAA72E9DB /* dnd.mm in Sources */,
 				58AABAD40AA236438347DDDE /* evtloop.mm in Sources */,
 				C40AA245D5773351979A2850 /* filedlg.mm in Sources */,
-				1142E2D85FD93E9AB5D8A55A /* pcre2_script_run.c in Sources */,
 				23E9AF567E873B948EFEA180 /* gauge.mm in Sources */,
 				6E1FD7D3DEF03748AEE3A29D /* listbox.mm in Sources */,
 				2A79B68D20FE3C9B98A15534 /* menu.mm in Sources */,
@@ -9735,7 +9788,6 @@
 				30AEDF41EC5C374DBF96EFFB /* slider.mm in Sources */,
 				5DA146A9F7653F53BF5299E8 /* spinbutt.mm in Sources */,
 				55F01295F1D23805BCA12F15 /* srchctrl.mm in Sources */,
-				57B41B6BACFB3906ACD1BFAF /* pcre2_jit_compile.c in Sources */,
 				B30D10F6257631B0A1926F89 /* statbox.mm in Sources */,
 				1DE75213D296323B815A02BE /* statline.mm in Sources */,
 				21F74D4D4D84375AB155FD5B /* stattext.mm in Sources */,
@@ -9745,6 +9797,24 @@
 				2B4507BC09563DB5B0F16596 /* tooltip.mm in Sources */,
 				815AE3FED68330F4933AA16F /* window.mm in Sources */,
 				47C31B7492F33C3EBE53262A /* settings.mm in Sources */,
+				4156FDB73D0A397A870E4302 /* overlay.mm in Sources */,
+				14DEBD7C01FC358B917FDAF2 /* aboutdlg.mm in Sources */,
+				0723C4E8B52C39FDBC2158B6 /* dataview_osx.cpp in Sources */,
+				1B69C40CD7493FED9A272835 /* notifmsg.mm in Sources */,
+				25C5C1713C0B39AC8EB6A38E /* taskbar.mm in Sources */,
+				4F99EB97F65330C28EB4D077 /* datectrl_osx.cpp in Sources */,
+				3316A16628B03D5E88529EA7 /* datetimectrl.mm in Sources */,
+				61FEDBF2D47A3B4E861F8296 /* sound.cpp in Sources */,
+				CE2C937117FE3AB599DD30B9 /* sound_osx.cpp in Sources */,
+				219304C9DDA33E9AADB515DC /* datetimectrl_osx.cpp in Sources */,
+				C1DCF69200593986A8C606A6 /* hidjoystick.cpp in Sources */,
+				61FEDBF2D47A3B4E861F8299 /* sound.cpp in Sources */,
+				049052C49B0B3810BE0179C9 /* dataview.mm in Sources */,
+				20D05D14BFAD3F969666D03B /* timectrl_osx.cpp in Sources */,
+				D00AF125FCB63A7A8F9B87DE /* taskbarcmn.cpp in Sources */,
+				A4F2426F36653C6D87EC18AE /* activityindicator.mm in Sources */,
+				215958201947310B88BBEDB3 /* statbmp.mm in Sources */,
+				F1F484DD591337399FCD0463 /* display.cpp in Sources */,
 				3CDE2B6BF88D326189F069BD /* accelcmn.cpp in Sources */,
 				BDB8EF0E0DA03693BFB77EF7 /* accesscmn.cpp in Sources */,
 				205520440CD13C0AB9E89159 /* anidecod.cpp in Sources */,
@@ -9815,7 +9885,6 @@
 				36DB80FD5B153E9099DB6912 /* imaggif.cpp in Sources */,
 				9110ACFC3CFB3C7994E907B0 /* imagiff.cpp in Sources */,
 				D13596A4E3CD31DE810061A1 /* imagjpeg.cpp in Sources */,
-				2F7328AC75393951B08F75F1 /* pcre2_error.c in Sources */,
 				D83B32B788EC310D919E0DF7 /* imagpcx.cpp in Sources */,
 				23965E313EDC3BBE9B2FA1C5 /* imagpng.cpp in Sources */,
 				46E331300D8F349DB36AB50A /* imagpnm.cpp in Sources */,
@@ -9856,8 +9925,6 @@
 				4AEC67BF65B039D99F421666 /* statbar.cpp in Sources */,
 				7C52E7CC12463941B0E4D402 /* statbmpcmn.cpp in Sources */,
 				D9DCBE799DB634C2A73FD6BD /* statboxcmn.cpp in Sources */,
-				5ED54DFAE28533108C08DF2A /* pcre2_extuni.c in Sources */,
-				7F62946D497A32CE857F65C9 /* pcre2_maketables.c in Sources */,
 				8B38C6C416BA3A51B37F60C4 /* statlinecmn.cpp in Sources */,
 				D9EE059D3C3C3C13AE4419F1 /* stattextcmn.cpp in Sources */,
 				BAFF04F1680F32DA988EB03D /* stockitem.cpp in Sources */,
@@ -9872,11 +9939,11 @@
 				9F70A89D00B03D4894AF7638 /* validate.cpp in Sources */,
 				1937FBA0A0DD32A8A743CFE1 /* valtext.cpp in Sources */,
 				6A032420671B375D81273714 /* valnum.cpp in Sources */,
-				4156FDB73D0A397A870E4302 /* overlay.mm in Sources */,
 				A2769D1659AE3CA3B58C2CAE /* wincmn.cpp in Sources */,
 				1BCC944F5E0936F5830F03E8 /* windowid.cpp in Sources */,
 				3399AB7BB1333B5AAF5FAF55 /* wrapsizer.cpp in Sources */,
 				C1E5799141603A75A26BEEA7 /* xpmdecod.cpp in Sources */,
+				46F341B46F80376B962759F5 /* animateg.cpp in Sources */,
 				F5806029B1BA3924A8FDDBC1 /* busyinfo.cpp in Sources */,
 				CB078622E90F33BE9D131131 /* buttonbar.cpp in Sources */,
 				03035C5CE4BC3288A5A18424 /* choicdgg.cpp in Sources */,
@@ -9899,14 +9966,11 @@
 				DEB35F871F8E3B90AD207AEE /* printps.cpp in Sources */,
 				96927C5A21FD3ACF936CDF6C /* renderg.cpp in Sources */,
 				F72020415D713C1BA41C17CF /* richmsgdlgg.cpp in Sources */,
-				EB206A0264AD3CAA9F68B8FC /* pcre2_convert.c in Sources */,
 				ED8D23D79FF33ED380FE09EB /* scrlwing.cpp in Sources */,
 				85F9828B80B03178A274BD17 /* selstore.cpp in Sources */,
 				84997126352137E798CD258A /* spinctlg.cpp in Sources */,
-				10B5C2A72C713A678458CD9D /* pcre2_ord2utf.c in Sources */,
 				62F1DC80D631335B892610A8 /* splitter.cpp in Sources */,
 				B6C364CB4AE33708A862B4B4 /* srchctlg.cpp in Sources */,
-				9FA6C4275F0D3E1A884ED561 /* pcre2_auto_possess.c in Sources */,
 				8FC1C07FEE793897A1E96D23 /* statbmpg.cpp in Sources */,
 				BF9B151DC0543E37878F8B9A /* stattextg.cpp in Sources */,
 				62757F24C4EE3B84B6AE3F14 /* textdlgg.cpp in Sources */,
@@ -9917,6 +9981,43 @@
 				87C67583D36C3465ACD64103 /* vlbox.cpp in Sources */,
 				A465A43B756630F1944B5A56 /* vscroll.cpp in Sources */,
 				1CBF34ACA39330028A5EA9AC /* xmlreshandler.cpp in Sources */,
+				8AA341CCFB8E3F6AB3523595 /* splash.cpp in Sources */,
+				CEE0D7A7D5D8323B9957A780 /* notifmsgg.cpp in Sources */,
+				1E17F95DD433379E8C18298C /* odcombo.cpp in Sources */,
+				901F659891613419B8643952 /* calctrlcmn.cpp in Sources */,
+				E5D698D2606A304DA743AF92 /* grideditors.cpp in Sources */,
+				5C44446AB150378696CD6B3C /* bmpcboxcmn.cpp in Sources */,
+				A139B846584436BCBEBAE3BF /* grid.cpp in Sources */,
+				2E930206397C3EDCBD8206FC /* gridctrl.cpp in Sources */,
+				760C729E41D93CC1AA2B4E0D /* hyperlinkg.cpp in Sources */,
+				F016C51053373E658ED4C9A9 /* helpext.cpp in Sources */,
+				3554C88010CE3D2A8970A135 /* sashwin.cpp in Sources */,
+				187F921A95DA3594B0AD980D /* gridsel.cpp in Sources */,
+				EC3D181D65F33E09A675FFF2 /* addremovectrl.cpp in Sources */,
+				77BC918AF05C30E8A0BD27F8 /* tipdlg.cpp in Sources */,
+				FEA741A9B6663A4C929893C2 /* aboutdlgg.cpp in Sources */,
+				2FAE979E6FE23D088C768B7D /* gridcmn.cpp in Sources */,
+				2FE10EA678C73523836FCC1C /* richtooltipcmn.cpp in Sources */,
+				B4425B59CC27389CA9FF81D1 /* datectlg.cpp in Sources */,
+				E0FAB345D2933D42B62917A3 /* bannerwindow.cpp in Sources */,
+				060E095718B03EF98C754799 /* treelist.cpp in Sources */,
+				1CD4F67F48CF3A5FA477D86E /* datavcmn.cpp in Sources */,
+				CFDBB80A4C9A3BA092273936 /* animatecmn.cpp in Sources */,
+				E6D18B2EDE353F678830859F /* odcombocmn.cpp in Sources */,
+				7B4DA2F5F25B3E188CBAFE38 /* hyperlnkcmn.cpp in Sources */,
+				6A10511265493FA2BB79CE4D /* propdlg.cpp in Sources */,
+				B189DB62AE9F30A1B613756B /* bmpcboxg.cpp in Sources */,
+				C67EAE20657E36839BF86690 /* richtooltipg.cpp in Sources */,
+				98F52D5224B438DFA8887E06 /* timectrlg.cpp in Sources */,
+				8A662992FFCB32E99D11950C /* commandlinkbuttong.cpp in Sources */,
+				800CFCEDBB7938338C65EEAC /* notifmsgcmn.cpp in Sources */,
+				82FA4AA043213728AC266700 /* wizard.cpp in Sources */,
+				8B60964DA1DF3F3DB40BE123 /* datavgen.cpp in Sources */,
+				5557AA36FBCC3ED9A5F5751A /* editlbox.cpp in Sources */,
+				955D2199F1893D37BA2D7478 /* laywin.cpp in Sources */,
+				2F50DBC14FE538A49823925A /* calctrlg.cpp in Sources */,
+				63F895D6F5643E4B9E666B79 /* creddlgg.cpp in Sources */,
+				8F372080E11E382EA0B5ED0F /* rowheightcache.cpp in Sources */,
 				567A32722BA33AEE9FF93D7C /* fs_inet.cpp in Sources */,
 				65514CD6A9F23ED98436AC02 /* ftp.cpp in Sources */,
 				B84642DA949638A189032CE6 /* http.cpp in Sources */,
@@ -9927,60 +10028,12 @@
 				A3A898DA3114311EB7F02227 /* sckstrm.cpp in Sources */,
 				6978D7A20DA93A329DDD1383 /* socket.cpp in Sources */,
 				E7140F3AB94D3FDFA86D8C06 /* url.cpp in Sources */,
+				C987310872D1396BAF716E5A /* webrequest.cpp in Sources */,
+				EE972E8DC73F310B9B4C949C /* webrequest_curl.cpp in Sources */,
 				652CFDD9A1C1366E99B5D6BC /* socketiohandler.cpp in Sources */,
 				346D274E17673A01B0177D5B /* sockunix.cpp in Sources */,
 				AD07124BBA613B47829F0692 /* sockosx.cpp in Sources */,
-				CFDBB80A4C9A3BA092273936 /* animatecmn.cpp in Sources */,
-				5C44446AB150378696CD6B3C /* bmpcboxcmn.cpp in Sources */,
-				901F659891613419B8643952 /* calctrlcmn.cpp in Sources */,
-				1CD4F67F48CF3A5FA477D86E /* datavcmn.cpp in Sources */,
-				2FAE979E6FE23D088C768B7D /* gridcmn.cpp in Sources */,
-				7B4DA2F5F25B3E188CBAFE38 /* hyperlnkcmn.cpp in Sources */,
-				E6D18B2EDE353F678830859F /* odcombocmn.cpp in Sources */,
-				2FE10EA678C73523836FCC1C /* richtooltipcmn.cpp in Sources */,
-				FEA741A9B6663A4C929893C2 /* aboutdlgg.cpp in Sources */,
-				E0FAB345D2933D42B62917A3 /* bannerwindow.cpp in Sources */,
-				B189DB62AE9F30A1B613756B /* bmpcboxg.cpp in Sources */,
-				2F50DBC14FE538A49823925A /* calctrlg.cpp in Sources */,
-				8A662992FFCB32E99D11950C /* commandlinkbuttong.cpp in Sources */,
-				8B60964DA1DF3F3DB40BE123 /* datavgen.cpp in Sources */,
-				B4425B59CC27389CA9FF81D1 /* datectlg.cpp in Sources */,
-				5557AA36FBCC3ED9A5F5751A /* editlbox.cpp in Sources */,
-				A139B846584436BCBEBAE3BF /* grid.cpp in Sources */,
-				2E930206397C3EDCBD8206FC /* gridctrl.cpp in Sources */,
-				E5D698D2606A304DA743AF92 /* grideditors.cpp in Sources */,
-				187F921A95DA3594B0AD980D /* gridsel.cpp in Sources */,
-				F016C51053373E658ED4C9A9 /* helpext.cpp in Sources */,
-				760C729E41D93CC1AA2B4E0D /* hyperlinkg.cpp in Sources */,
-				955D2199F1893D37BA2D7478 /* laywin.cpp in Sources */,
-				CEE0D7A7D5D8323B9957A780 /* notifmsgg.cpp in Sources */,
-				1E17F95DD433379E8C18298C /* odcombo.cpp in Sources */,
-				6A10511265493FA2BB79CE4D /* propdlg.cpp in Sources */,
-				C67EAE20657E36839BF86690 /* richtooltipg.cpp in Sources */,
-				3554C88010CE3D2A8970A135 /* sashwin.cpp in Sources */,
-				8AA341CCFB8E3F6AB3523595 /* splash.cpp in Sources */,
-				98F52D5224B438DFA8887E06 /* timectrlg.cpp in Sources */,
-				77BC918AF05C30E8A0BD27F8 /* tipdlg.cpp in Sources */,
-				060E095718B03EF98C754799 /* treelist.cpp in Sources */,
-				82FA4AA043213728AC266700 /* wizard.cpp in Sources */,
-				EC3D181D65F33E09A675FFF2 /* addremovectrl.cpp in Sources */,
-				800CFCEDBB7938338C65EEAC /* notifmsgcmn.cpp in Sources */,
-				D00AF125FCB63A7A8F9B87DE /* taskbarcmn.cpp in Sources */,
-				46F341B46F80376B962759F5 /* animateg.cpp in Sources */,
-				219304C9DDA33E9AADB515DC /* datetimectrl_osx.cpp in Sources */,
-				4F99EB97F65330C28EB4D077 /* datectrl_osx.cpp in Sources */,
-				CE2C937117FE3AB599DD30B9 /* sound_osx.cpp in Sources */,
-				20D05D14BFAD3F969666D03B /* timectrl_osx.cpp in Sources */,
-				61FEDBF2D47A3B4E861F8296 /* sound.cpp in Sources */,
-				61FEDBF2D47A3B4E861F8299 /* sound.cpp in Sources */,
-				14DEBD7C01FC358B917FDAF2 /* aboutdlg.mm in Sources */,
-				0723C4E8B52C39FDBC2158B6 /* dataview_osx.cpp in Sources */,
-				049052C49B0B3810BE0179C9 /* dataview.mm in Sources */,
-				3316A16628B03D5E88529EA7 /* datetimectrl.mm in Sources */,
-				25C5C1713C0B39AC8EB6A38E /* taskbar.mm in Sources */,
-				C1DCF69200593986A8C606A6 /* hidjoystick.cpp in Sources */,
-				A4F2426F36653C6D87EC18AE /* activityindicator.mm in Sources */,
-				1B69C40CD7493FED9A272835 /* notifmsg.mm in Sources */,
+				980ED1DA2F96361985952254 /* webrequest_urlsession.mm in Sources */,
 				2DBF5F96CCC63F7481C26A43 /* webview_webkit.mm in Sources */,
 				64A716F87A5136F9A790EC5A /* webview.cpp in Sources */,
 				5C5D0983160A36189A770742 /* webviewarchivehandler.cpp in Sources */,
@@ -9993,7 +10046,6 @@
 				D17E3053DA0D3F7EA4D0951B /* helpdlg.cpp in Sources */,
 				7C87CC7641033D91823ED688 /* helpfrm.cpp in Sources */,
 				3D762A0BBF1B39B88A769632 /* helpwnd.cpp in Sources */,
-				60296753A32B39EB8BD0CB44 /* pcre2_study.c in Sources */,
 				4DA209AEF4AD32AAB97F9718 /* htmlcell.cpp in Sources */,
 				FD3CC5F0AA41384B9388A1E0 /* htmlfilt.cpp in Sources */,
 				C5E5AB869065307F83E27DD1 /* htmlpars.cpp in Sources */,
@@ -10001,7 +10053,6 @@
 				93E04642049537EB8A37BA26 /* htmlwin.cpp in Sources */,
 				3E99016BDE043A08B4D6B3CE /* htmprint.cpp in Sources */,
 				9836B3D336963795928FE5A1 /* m_dflist.cpp in Sources */,
-				14F303FD6B5F383DADDFD788 /* xh_dataview.cpp in Sources */,
 				66584BC871303041BA622DE0 /* m_fonts.cpp in Sources */,
 				99F7D7BFBB543A04AB728375 /* m_hline.cpp in Sources */,
 				A3586433C4B1398FB1C361D6 /* m_image.cpp in Sources */,
@@ -10027,13 +10078,12 @@
 				5F2C2A46781739D897CF293D /* xh_chckl.cpp in Sources */,
 				CE17002B5B7E375582747639 /* xh_choic.cpp in Sources */,
 				26E4813A97DE323E88119163 /* xh_choicbk.cpp in Sources */,
-				215958201947310B88BBEDB3 /* statbmp.mm in Sources */,
 				E7AF3BF2B3473AD9BE66D1A1 /* xh_clrpicker.cpp in Sources */,
 				1AB50C98FF473B33A3CA4D39 /* xh_cmdlinkbn.cpp in Sources */,
-				8C6E2BD9C31A3AE18AD17D44 /* pcre2_match.c in Sources */,
 				E7921B0472B63E4091F4F517 /* xh_collpane.cpp in Sources */,
 				84382E5DB3203A73AC5EE390 /* xh_combo.cpp in Sources */,
 				F569D7A3F0E038E9B4CC2A76 /* xh_comboctrl.cpp in Sources */,
+				14F303FD6B5F383DADDFD788 /* xh_dataview.cpp in Sources */,
 				FB09720D13673A7B81BCB645 /* xh_datectrl.cpp in Sources */,
 				F7D10B6E0CBA32EFAF79C77C /* xh_dirpicker.cpp in Sources */,
 				3B7E035ECF3D3FFB9827AC1C /* xh_dlg.cpp in Sources */,
@@ -10047,6 +10097,7 @@
 				72AD4417FF7C3094BB1FF62C /* xh_grid.cpp in Sources */,
 				83616D33080E3F0F9FA5FBB4 /* xh_html.cpp in Sources */,
 				2B13BFC894C63373B7ACFA3D /* xh_hyperlink.cpp in Sources */,
+				EA10DA3199813E90B39C70D3 /* xh_infobar.cpp in Sources */,
 				C34B8675439F39B4845FFC50 /* xh_listb.cpp in Sources */,
 				F5DF7AF0FA9E371BB71EF798 /* xh_listbk.cpp in Sources */,
 				96B507455762391688B5E500 /* xh_listc.cpp in Sources */,
@@ -10059,7 +10110,6 @@
 				47F4FC8717AF3A848812DFCC /* xh_radbt.cpp in Sources */,
 				7181709A030D3749AB355B74 /* xh_radbx.cpp in Sources */,
 				FDE14459359334DE9FB03ED5 /* xh_scrol.cpp in Sources */,
-				88E56F89A0DA3AD386F05FD2 /* pcre2_pattern_info.c in Sources */,
 				87092C0C817D343DAB77E23E /* xh_scwin.cpp in Sources */,
 				00E2F82590B33BDCA1F6D0C4 /* xh_htmllbox.cpp in Sources */,
 				A39B0D7EB43137F7BA50A35C /* xh_simplebook.cpp in Sources */,
@@ -10116,7 +10166,6 @@
 				6B9EEA3CF2E536E3B1ADAC42 /* manager.cpp in Sources */,
 				46A4CCF128FC3EB092074DC5 /* property.cpp in Sources */,
 				26BB10834DA1388881BDD1EC /* propgrid.cpp in Sources */,
-				B6728BCD1A0731299924C8C4 /* pcre2_substring.c in Sources */,
 				BEA90F2C6BB93143958F899A /* propgridiface.cpp in Sources */,
 				A423177BBC0F3BE5A436B4B7 /* propgridpagestate.cpp in Sources */,
 				D72D99FC424337CF9EDC2042 /* props.cpp in Sources */,
@@ -10134,6 +10183,7 @@
 				E3B3E4F75D503DB89B5C622D /* stc.cpp in Sources */,
 				908957F65B7E36F8BF3858DD /* PlatWX.cpp in Sources */,
 				3E6AA08E72A030D39D867D4B /* ScintillaWX.cpp in Sources */,
+				57F8001809BC3864A5FA798B /* PlatWXcocoa.mm in Sources */,
 				F5B0B26BD0803719A3FCB4D7 /* adler32.c in Sources */,
 				BE3ED6EF34303867B8C8E923 /* compress.c in Sources */,
 				AC07BA4EA5403443914DFDB1 /* crc32.c in Sources */,
@@ -10150,18 +10200,15 @@
 				9C6E9E4BA54733EF9F87E4B7 /* uncompr.c in Sources */,
 				42260A6F1853361083803B0C /* zutil.c in Sources */,
 				99E7A46106C03484BA70D29E /* tif_unix.c in Sources */,
-				7BD3887F603E3704969A54E1 /* pcre2_chartables.c in Sources */,
 				4E396D8D2E9138D797F320C6 /* tif_aux.c in Sources */,
 				1EE845DDFDDE36CA8A218205 /* tif_close.c in Sources */,
 				8E674574343A3C009B1BCD00 /* tif_codec.c in Sources */,
 				D95C5F467D37339AB8DF2354 /* tif_color.c in Sources */,
 				6D073876E1753549B5EEFDDA /* tif_compress.c in Sources */,
-				0F2FD12272023C869CE86008 /* filter_neon_intrinsics.c in Sources */,
 				E3136EF5DD843ACE886E2868 /* tif_dir.c in Sources */,
 				7ECC6EE6D5273F75BB6B7B74 /* tif_dirinfo.c in Sources */,
 				D51B3389209E370489078891 /* tif_dirread.c in Sources */,
 				E7F35B834A163C67B65176C6 /* tif_dirwrite.c in Sources */,
-				C5C60B22CE6A3BCB868F69E8 /* pcre2_find_bracket.c in Sources */,
 				2D4D105CA9BE3FA6995A5FFF /* tif_dumpmode.c in Sources */,
 				C2CF6B59914A3183ADE84028 /* tif_error.c in Sources */,
 				2315C8692C443ED1AE431728 /* tif_extension.c in Sources */,
@@ -10189,13 +10236,13 @@
 				FEB073547F3F3AC19D31F698 /* tif_tile.c in Sources */,
 				096BA201623034AD97218368 /* tif_version.c in Sources */,
 				7A79D9AC608E3B8287229174 /* tif_warning.c in Sources */,
+				D772334837693C9D88069D98 /* tif_webp.c in Sources */,
 				F2F2963D8ECC32D39FDBF101 /* tif_write.c in Sources */,
 				6E2C2E8AA1713ADE9C338379 /* tif_zip.c in Sources */,
-				86787E4138CC334BB74EC7B4 /* palette_neon_intrinsics.c in Sources */,
+				6C1171E3FB7137CCB9E3F536 /* tif_zstd.c in Sources */,
 				5D3AD309AF39385EBF7D9DF8 /* jaricom.c in Sources */,
 				894D43C8F224394FB3171F26 /* jcapimin.c in Sources */,
 				743BB23211B336A6A0F26E57 /* jcapistd.c in Sources */,
-				E17048DEEF1138318314F1D0 /* pcre2_valid_utf.c in Sources */,
 				7EB83F6375BF3E73ABE56C40 /* jcarith.c in Sources */,
 				CA5BD8ABDBA13641BBE7CD66 /* jccoefct.c in Sources */,
 				11DD420E32FB3EFB9DA0AB5B /* jccolor.c in Sources */,
@@ -10254,8 +10301,39 @@
 				0095084719983B878378CA28 /* pngwrite.c in Sources */,
 				242E1D1A9BF331BA918134EC /* pngwtran.c in Sources */,
 				2989056891153968B372EA14 /* pngwutil.c in Sources */,
-				23CECD8647C037E0B41DF0D4 /* LexA68k.cxx in Sources */,
+				BB12132A86E2350AA47414CC /* arm_init.c in Sources */,
+				0F2FD12272023C869CE86008 /* filter_neon_intrinsics.c in Sources */,
+				86787E4138CC334BB74EC7B4 /* palette_neon_intrinsics.c in Sources */,
+				25B0940CABAB39CD90C6F3C5 /* intel_init.c in Sources */,
+				8620088DDD233B139B250DD4 /* filter_sse2_intrinsics.c in Sources */,
+				9FA6C4275F0D3E1A884ED561 /* pcre2_auto_possess.c in Sources */,
+				6463C9BE78C0394CB7B451FA /* pcre2_compile.c in Sources */,
+				D7F14BDFFB7F369B842AFC13 /* pcre2_config.c in Sources */,
+				27B5431DC79733CD8D403E88 /* pcre2_context.c in Sources */,
+				EB206A0264AD3CAA9F68B8FC /* pcre2_convert.c in Sources */,
+				45E15DBB6B69382D8AF1BA21 /* pcre2_dfa_match.c in Sources */,
+				2F7328AC75393951B08F75F1 /* pcre2_error.c in Sources */,
+				5ED54DFAE28533108C08DF2A /* pcre2_extuni.c in Sources */,
+				C5C60B22CE6A3BCB868F69E8 /* pcre2_find_bracket.c in Sources */,
+				57B41B6BACFB3906ACD1BFAF /* pcre2_jit_compile.c in Sources */,
+				7F62946D497A32CE857F65C9 /* pcre2_maketables.c in Sources */,
+				8C6E2BD9C31A3AE18AD17D44 /* pcre2_match.c in Sources */,
+				D66F55C93D1130F488970C05 /* pcre2_match_data.c in Sources */,
+				00E12455C98032E18378EE5E /* pcre2_newline.c in Sources */,
+				10B5C2A72C713A678458CD9D /* pcre2_ord2utf.c in Sources */,
+				88E56F89A0DA3AD386F05FD2 /* pcre2_pattern_info.c in Sources */,
+				1142E2D85FD93E9AB5D8A55A /* pcre2_script_run.c in Sources */,
+				9E37D29DCF7A3945A0EECB39 /* pcre2_serialize.c in Sources */,
+				DFEB01E7B97A3515B785DCA9 /* pcre2_string_utils.c in Sources */,
+				60296753A32B39EB8BD0CB44 /* pcre2_study.c in Sources */,
+				A4DEBFA074C93388A1BBCB40 /* pcre2_substitute.c in Sources */,
+				B6728BCD1A0731299924C8C4 /* pcre2_substring.c in Sources */,
+				2047544E505C3BA38F0144E6 /* pcre2_tables.c in Sources */,
 				8B87FEC23DB834EDBFB6EA32 /* pcre2_ucd.c in Sources */,
+				E17048DEEF1138318314F1D0 /* pcre2_valid_utf.c in Sources */,
+				AF1875145B2537298E4A28D8 /* pcre2_xclass.c in Sources */,
+				7BD3887F603E3704969A54E1 /* pcre2_chartables.c in Sources */,
+				23CECD8647C037E0B41DF0D4 /* LexA68k.cxx in Sources */,
 				66FD099CE5A338C18329FC36 /* LexAbaqus.cxx in Sources */,
 				CD35A576FD363FD49C3AC4B3 /* LexAda.cxx in Sources */,
 				0654BCC3F0763C50A7949504 /* LexAPDL.cxx in Sources */,
@@ -10275,7 +10353,6 @@
 				6F472413FFA03B53B395BB74 /* LexCLW.cxx in Sources */,
 				6F5A0D3C7763334396A3783D /* LexCmake.cxx in Sources */,
 				D8ADDD24BEAC3D94B3388D3E /* LexCOBOL.cxx in Sources */,
-				D7F14BDFFB7F369B842AFC13 /* pcre2_config.c in Sources */,
 				2020EE3C45743B53BE8C7F38 /* LexCoffeeScript.cxx in Sources */,
 				B640A8A74D973A8FBEF63916 /* LexConf.cxx in Sources */,
 				A0FCE3CF565C3F84B63712AC /* LexCPP.cxx in Sources */,
@@ -10330,7 +10407,6 @@
 				FD3B31CE1E7832218B5D9A15 /* LexPO.cxx in Sources */,
 				A3C4D47A84E8362295867525 /* LexPOV.cxx in Sources */,
 				22EC132AEF863BFBAA6EDEC3 /* LexPowerPro.cxx in Sources */,
-				A4DEBFA074C93388A1BBCB40 /* pcre2_substitute.c in Sources */,
 				1FB1622D59593932B25C55BA /* LexPowerShell.cxx in Sources */,
 				97C551F8AEF133D680D1FD36 /* LexProgress.cxx in Sources */,
 				56E1ED31F7CE38978F4A7CA0 /* LexProps.cxx in Sources */,
@@ -10358,9 +10434,7 @@
 				BA57708D2D563967A0D1F003 /* LexTxt2tags.cxx in Sources */,
 				D4EC9DB5F8DF319EA0FD26A4 /* LexVB.cxx in Sources */,
 				3C5E1A45A57B3169A4C073D9 /* LexVerilog.cxx in Sources */,
-				BB12132A86E2350AA47414CC /* arm_init.c in Sources */,
 				16021CFD78623B8CBD08FC1F /* LexVHDL.cxx in Sources */,
-				57F8001809BC3864A5FA798B /* PlatWXcocoa.mm in Sources */,
 				9CC92BB4B0E233A0A7F81279 /* LexVisualProlog.cxx in Sources */,
 				159E4248CB1333AD841D9F03 /* LexYAML.cxx in Sources */,
 				91364FDD73053139BBAA313B /* Accessor.cxx in Sources */,
@@ -10512,7 +10586,7 @@
 		};
 		3C176588698C3DC3BA9D6A4E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 2FF0B5E0505D3AEA9A4ACF12 /* adv */;
+			target = 2FF0B5E0505D3AEA9A4ACF11 /* adv */;
 			targetProxy = 1676DB01C7863A80A404586E /* PBXContainerItemProxy */;
 		};
 		3C176588698C3DC3BA9D6A4F /* PBXTargetDependency */ = {
@@ -10697,7 +10771,7 @@
 		};
 		3C176588698C3DC3BA9D6A73 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 2FF0B5E0505D3AEA9A4ACF12 /* adv */;
+			target = 2FF0B5E0505D3AEA9A4ACF11 /* adv */;
 			targetProxy = 1676DB01C7863A80A4045893 /* PBXContainerItemProxy */;
 		};
 		3C176588698C3DC3BA9D6A74 /* PBXTargetDependency */ = {
@@ -10742,7 +10816,7 @@
 		};
 		3C176588698C3DC3BA9D6A7C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 2FF0B5E0505D3AEA9A4ACF12 /* adv */;
+			target = 2FF0B5E0505D3AEA9A4ACF11 /* adv */;
 			targetProxy = 1676DB01C7863A80A404589C /* PBXContainerItemProxy */;
 		};
 		3C176588698C3DC3BA9D6A7D /* PBXTargetDependency */ = {
@@ -10787,7 +10861,7 @@
 		};
 		3C176588698C3DC3BA9D6A85 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 2FF0B5E0505D3AEA9A4ACF12 /* adv */;
+			target = 2FF0B5E0505D3AEA9A4ACF11 /* adv */;
 			targetProxy = 1676DB01C7863A80A40458A5 /* PBXContainerItemProxy */;
 		};
 		3C176588698C3DC3BA9D6A86 /* PBXTargetDependency */ = {
@@ -10947,7 +11021,7 @@
 		};
 		3C176588698C3DC3BA9D6AA5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 2FF0B5E0505D3AEA9A4ACF12 /* adv */;
+			target = 2FF0B5E0505D3AEA9A4ACF11 /* adv */;
 			targetProxy = 1676DB01C7863A80A40458C5 /* PBXContainerItemProxy */;
 		};
 		3C176588698C3DC3BA9D6AA6 /* PBXTargetDependency */ = {
@@ -11047,7 +11121,7 @@
 		};
 		3C176588698C3DC3BA9D6AB9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 2FF0B5E0505D3AEA9A4ACF12 /* adv */;
+			target = 2FF0B5E0505D3AEA9A4ACF11 /* adv */;
 			targetProxy = 1676DB01C7863A80A40458D9 /* PBXContainerItemProxy */;
 		};
 		3C176588698C3DC3BA9D6ABA /* PBXTargetDependency */ = {
@@ -11167,7 +11241,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7DEBE1EB2B94305E8E8D6EA5 /* wxcocoa.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
 				EXECUTABLE_PREFIX = lib;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(GCC_PREPROCESSOR_DEFINITIONS)",
@@ -11176,7 +11249,6 @@
 				);
 				INSTALL_PATH = "@executable_path/../Frameworks/";
 				OTHER_LDFLAGS = "$(OTHER_LDFLAGS)";
-				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -11450,7 +11522,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7DEBE1EB2B94305E8E8D6EA5 /* wxcocoa.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
 				EXECUTABLE_PREFIX = lib;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(GCC_PREPROCESSOR_DEFINITIONS)",
@@ -11459,7 +11530,6 @@
 				);
 				INSTALL_PATH = "@executable_path/../Frameworks/";
 				OTHER_LDFLAGS = "$(OTHER_LDFLAGS)";
-				SDKROOT = macosx;
 			};
 			name = Release;
 		};

--- a/build/osx/wxiphone.xcodeproj/project.pbxproj
+++ b/build/osx/wxiphone.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0095084719983B878378CA28 /* pngwrite.c in Sources */ = {isa = PBXBuildFile; fileRef = 69A6CAF721E53E83B4820DE6 /* pngwrite.c */; };
+		00E12455C98032E18378EE5E /* pcre2_newline.c in Sources */ = {isa = PBXBuildFile; fileRef = A208BFC0C8C43847A9620ADA /* pcre2_newline.c */; };
 		00E2F82590B33BDCA1F6D0C4 /* xh_htmllbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8E7ADC9F00803853B1004529 /* xh_htmllbox.cpp */; };
 		00F1531404F832C6AE0748F2 /* spinbutt_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5E2F1BF8904635049BAFD6E1 /* spinbutt_osx.cpp */; };
 		014AF0BAB1783A5D9D75A7ED /* zstream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B9B5BC858CCF3477895D2786 /* zstream.cpp */; };
@@ -62,12 +63,15 @@
 		0E8A0B8FA40E365690C20230 /* gzlib.c in Sources */ = {isa = PBXBuildFile; fileRef = 7395814D42CC38F6B8CD81B4 /* gzlib.c */; };
 		0E92CEF677AA32C9A8CDA0A7 /* checkbox_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 998C092CB83639CFA3DC63B1 /* checkbox_osx.cpp */; };
 		0EB6AB38A68D3845AC384A23 /* xh_text.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 53B95C9A1BCB30CC87495DA3 /* xh_text.cpp */; };
+		0F2FD12272023C869CE86008 /* filter_neon_intrinsics.c in Sources */ = {isa = PBXBuildFile; fileRef = 39507FA11D8838109A22B7DA /* filter_neon_intrinsics.c */; };
 		0F8C79010EF0316AA1B7392D /* LexTACL.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 9E5C91072D533919A78D8ED2 /* LexTACL.cxx */; };
 		0FA6E1E47F123FF4A902E4D2 /* xh_odcombo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0080254545B9383ABDF2045C /* xh_odcombo.cpp */; };
 		0FBF7C9EDFB53D8DA0991B55 /* xh_notbk.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A87662D69F0432FC96701280 /* xh_notbk.cpp */; };
 		0FDDE8E193743F3A8CBDC67C /* richtextprint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C4C45D3C63AA37CEBCE83321 /* richtextprint.cpp */; };
 		0FFFFA2F762B3160955D1D88 /* gauge_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC28591B403B32B7AFCC079D /* gauge_osx.cpp */; };
 		10743B74A58231639C6BF610 /* inffast.c in Sources */ = {isa = PBXBuildFile; fileRef = 400275BE019D3E5BA47988BE /* inffast.c */; };
+		10B5C2A72C713A678458CD9D /* pcre2_ord2utf.c in Sources */ = {isa = PBXBuildFile; fileRef = 4BFEBC5061693DA0B52BC4AC /* pcre2_ord2utf.c */; };
+		1142E2D85FD93E9AB5D8A55A /* pcre2_script_run.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4CDF9048EC36788619769D /* pcre2_script_run.c */; };
 		11818B68C5263EB68D708845 /* jdtrans.c in Sources */ = {isa = PBXBuildFile; fileRef = 4549845C0751356A907C23E0 /* jdtrans.c */; };
 		11DD420E32FB3EFB9DA0AB5B /* jccolor.c in Sources */ = {isa = PBXBuildFile; fileRef = 8EFF4707641D3F20AB602ED6 /* jccolor.c */; };
 		127E255EE601383A9E0EF7EA /* menuitem.mm in Sources */ = {isa = PBXBuildFile; fileRef = 61548D0FE1353D7C846DD721 /* menuitem.mm */; };
@@ -79,6 +83,7 @@
 		14C024EB327435A2A571DA2C /* LexKix.cxx in Sources */ = {isa = PBXBuildFile; fileRef = B303230368143F37B2409DE6 /* LexKix.cxx */; };
 		14D6D5F8F5ED3C71936DD2AF /* button.mm in Sources */ = {isa = PBXBuildFile; fileRef = C06FED83BF933DF98C2466AE /* button.mm */; };
 		14EF556997B0350F931EBE8E /* jdinput.c in Sources */ = {isa = PBXBuildFile; fileRef = CCF7564A2B733F759AA8496B /* jdinput.c */; };
+		14F303FD6B5F383DADDFD788 /* xh_dataview.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 616466F521DB3ECAB304289F /* xh_dataview.cpp */; };
 		15048519756B33959B15B161 /* floatpane.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A881F49ADCF33C299B041584 /* floatpane.cpp */; };
 		1569BB4728693B6285623A23 /* pngerror.c in Sources */ = {isa = PBXBuildFile; fileRef = 1A0650754DC2358CA5933B28 /* pngerror.c */; };
 		15735ED6556130F6A14F0BCD /* ScintillaBase.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 9BB9CE48AE853C47A1D157AE /* ScintillaBase.cxx */; };
@@ -119,11 +124,13 @@
 		1EE845DDFDDE36CA8A218205 /* tif_close.c in Sources */ = {isa = PBXBuildFile; fileRef = F82278F9AF0432529891E6D7 /* tif_close.c */; };
 		1FB1622D59593932B25C55BA /* LexPowerShell.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 36F7955F8075343C8A9953DB /* LexPowerShell.cxx */; };
 		2020EE3C45743B53BE8C7F38 /* LexCoffeeScript.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 9794A709E3C036D79860CEC9 /* LexCoffeeScript.cxx */; };
+		2047544E505C3BA38F0144E6 /* pcre2_tables.c in Sources */ = {isa = PBXBuildFile; fileRef = B60497805D37375EBFCF3D98 /* pcre2_tables.c */; };
 		205520440CD13C0AB9E89159 /* anidecod.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EE959EC7BFDD3A628E856404 /* anidecod.cpp */; };
 		20BEEFFA08F3396791596870 /* dlunix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CA2D9F325F833C408657E7B7 /* dlunix.cpp */; };
 		20F10669703137E68318C6FD /* cmndata.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0510EE0FB3FF36EF8670ABD1 /* cmndata.cpp */; };
 		2102C23970FB3F22AB46A59A /* LexTADS3.cxx in Sources */ = {isa = PBXBuildFile; fileRef = A284E855892F3A9E9E19E854 /* LexTADS3.cxx */; };
 		213CE0DD5B2335D0AD53B54A /* gzclose.c in Sources */ = {isa = PBXBuildFile; fileRef = 7A24E9101688368296C21EBE /* gzclose.c */; };
+		215958201947310B88BBEDB3 /* statbmp.mm in Sources */ = {isa = PBXBuildFile; fileRef = FD6B26B5A6A733A89EF5AB9C /* statbmp.mm */; };
 		21F74D4D4D84375AB155FD5B /* stattext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 95186FEF3DEF39D8B1157BD5 /* stattext.mm */; };
 		221DC4F6678A3EC5ACDDEA4F /* statbox_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9F16A18CD9C23410B18592FD /* statbox_osx.cpp */; };
 		22AE900003F73134BBEE8BB6 /* dirctrlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 91292D8E11203A6B8E9767DA /* dirctrlg.cpp */; };
@@ -143,11 +150,13 @@
 		24A5A71C79733E9CB913C5B7 /* LexPB.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 8744F2C80ECF375999195935 /* LexPB.cxx */; };
 		2563C775427E3D68BD384F2F /* richtextstyles.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D30617843F33310089C1F77A /* richtextstyles.cpp */; };
 		25656617A56D342AA3D1BFE2 /* ctrlcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0EB91E8407CB3300A19F387D /* ctrlcmn.cpp */; };
+		25B0940CABAB39CD90C6F3C5 /* intel_init.c in Sources */ = {isa = PBXBuildFile; fileRef = 994AF74DF2A13FF09A215853 /* intel_init.c */; };
 		26649553E4763EE6BA268B7D /* xh_gdctl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 84A2E6F103403BBFADD449FE /* xh_gdctl.cpp */; };
 		268DDC88C99A3A64AB8B2FFA /* LexCaml.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 4B3B8AD0120F3EA6BF5B0AE0 /* LexCaml.cxx */; };
 		26BB10834DA1388881BDD1EC /* propgrid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B98B72B3A0A73044B85AED60 /* propgrid.cpp */; };
 		26E4813A97DE323E88119163 /* xh_choicbk.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CCED0C7EF69A31A4A9240D60 /* xh_choicbk.cpp */; };
 		27759C2FBB0E35FDA847B2B5 /* LexForth.cxx in Sources */ = {isa = PBXBuildFile; fileRef = B181F564935730E89AB00D92 /* LexForth.cxx */; };
+		27B5431DC79733CD8D403E88 /* pcre2_context.c in Sources */ = {isa = PBXBuildFile; fileRef = 3026D20A03E53F1DB40FB35A /* pcre2_context.c */; };
 		27E2EABB117334CD89CFD2A4 /* mdi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B568A7364ECA30288820CCE7 /* mdi.cpp */; };
 		27E73CA5C35A30CE89946ECA /* slider_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D215A0D67563350CB4EECB06 /* slider_osx.cpp */; };
 		283C3ABE42433244983C27C1 /* stattext_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CF5C09D9A1230EEB42713E1 /* stattext_osx.cpp */; };
@@ -172,6 +181,7 @@
 		2EECB3C2F9523D0B95847A7F /* accel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8C78A1539462370CAA429508 /* accel.cpp */; };
 		2F35A207C3993DE08E4FE0B0 /* timerunx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0CB2CC8E60833A6993BEA321 /* timerunx.cpp */; };
 		2F50DBC14FE538A49823925A /* calctrlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 496674699F173A5385EAFF07 /* calctrlg.cpp */; };
+		2F7328AC75393951B08F75F1 /* pcre2_error.c in Sources */ = {isa = PBXBuildFile; fileRef = 25E03E349FC13E4A9428B94E /* pcre2_error.c */; };
 		2F7F5B9BBCD83D90B237A1A0 /* markupparser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DA7F7633279936EFA0B9C5CF /* markupparser.cpp */; };
 		2FA1A8FE3644325ABAD273A4 /* fmapbase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 832BBBFE664736D5978420C6 /* fmapbase.cpp */; };
 		2FAE979E6FE23D088C768B7D /* gridcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FDD3CE34439B3D2BBD9DC8D3 /* gridcmn.cpp */; };
@@ -229,33 +239,6 @@
 		3ED6F4B64C283232A79423CF /* dircmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EC9B6DFBF2F73917A99361C5 /* dircmn.cpp */; };
 		403FBA20CEFE3EAFB4E6B905 /* dir.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F7332A03D93D3DABB050615D /* dir.cpp */; };
 		4040AE89BF9F34668091064A /* dragimgg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2A67053D16D63C588E555C84 /* dragimgg.cpp */; };
-		D7F14BDFFB7F369B842AFC13 /* pcre2_config.c in Sources */ = {isa = PBXBuildFile; fileRef = FC6A8FAE9CA63EEB8883B6BD /* pcre2_config.c */; };
-		AF1875145B2537298E4A28D8 /* pcre2_xclass.c in Sources */ = {isa = PBXBuildFile; fileRef = 95CBA2C736623FFF8629E975 /* pcre2_xclass.c */; };
-		7BD3887F603E3704969A54E1 /* pcre2_chartables.c in Sources */ = {isa = PBXBuildFile; fileRef = 1895085EBEAE3A708FDD527A /* pcre2_chartables.c */; };
-		9E37D29DCF7A3945A0EECB39 /* pcre2_serialize.c in Sources */ = {isa = PBXBuildFile; fileRef = BD2EBC2CCAE23AD6A1DF783E /* pcre2_serialize.c */; };
-		88E56F89A0DA3AD386F05FD2 /* pcre2_pattern_info.c in Sources */ = {isa = PBXBuildFile; fileRef = 00DAA69F74D031B6BE9196A8 /* pcre2_pattern_info.c */; };
-		27B5431DC79733CD8D403E88 /* pcre2_context.c in Sources */ = {isa = PBXBuildFile; fileRef = 3026D20A03E53F1DB40FB35A /* pcre2_context.c */; };
-		2F7328AC75393951B08F75F1 /* pcre2_error.c in Sources */ = {isa = PBXBuildFile; fileRef = 25E03E349FC13E4A9428B94E /* pcre2_error.c */; };
-		60296753A32B39EB8BD0CB44 /* pcre2_study.c in Sources */ = {isa = PBXBuildFile; fileRef = 09CCDDC66F683C6B87BEDD2F /* pcre2_study.c */; };
-		1142E2D85FD93E9AB5D8A55A /* pcre2_script_run.c in Sources */ = {isa = PBXBuildFile; fileRef = 2F4CDF9048EC36788619769D /* pcre2_script_run.c */; };
-		EB206A0264AD3CAA9F68B8FC /* pcre2_convert.c in Sources */ = {isa = PBXBuildFile; fileRef = BCED9B1D0D7E3FBBAC78CE5B /* pcre2_convert.c */; };
-		DFEB01E7B97A3515B785DCA9 /* pcre2_string_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = A6EE037AF43E343E8E1A7555 /* pcre2_string_utils.c */; };
-		7F62946D497A32CE857F65C9 /* pcre2_maketables.c in Sources */ = {isa = PBXBuildFile; fileRef = D016F584D14C31E192DB3179 /* pcre2_maketables.c */; };
-		6463C9BE78C0394CB7B451FA /* pcre2_compile.c in Sources */ = {isa = PBXBuildFile; fileRef = BDADEB1DA6433E52972C8934 /* pcre2_compile.c */; };
-		8C6E2BD9C31A3AE18AD17D44 /* pcre2_match.c in Sources */ = {isa = PBXBuildFile; fileRef = 3B93115BCC46333BBB31D6F7 /* pcre2_match.c */; };
-		8B87FEC23DB834EDBFB6EA32 /* pcre2_ucd.c in Sources */ = {isa = PBXBuildFile; fileRef = 70F4EB692873386AAA0A44B0 /* pcre2_ucd.c */; };
-		45E15DBB6B69382D8AF1BA21 /* pcre2_dfa_match.c in Sources */ = {isa = PBXBuildFile; fileRef = 96D620AEA83E3444BA0B04C4 /* pcre2_dfa_match.c */; };
-		B6728BCD1A0731299924C8C4 /* pcre2_substring.c in Sources */ = {isa = PBXBuildFile; fileRef = 5152B34D06E9343FBFAB3510 /* pcre2_substring.c */; };
-		A4DEBFA074C93388A1BBCB40 /* pcre2_substitute.c in Sources */ = {isa = PBXBuildFile; fileRef = FAC42945539F362D91D6F559 /* pcre2_substitute.c */; };
-		9FA6C4275F0D3E1A884ED561 /* pcre2_auto_possess.c in Sources */ = {isa = PBXBuildFile; fileRef = C3904351139F3F0DB4B72F94 /* pcre2_auto_possess.c */; };
-		D66F55C93D1130F488970C05 /* pcre2_match_data.c in Sources */ = {isa = PBXBuildFile; fileRef = 4E74E9E53454331F8E10ECC5 /* pcre2_match_data.c */; };
-		00E12455C98032E18378EE5E /* pcre2_newline.c in Sources */ = {isa = PBXBuildFile; fileRef = A208BFC0C8C43847A9620ADA /* pcre2_newline.c */; };
-		10B5C2A72C713A678458CD9D /* pcre2_ord2utf.c in Sources */ = {isa = PBXBuildFile; fileRef = 4BFEBC5061693DA0B52BC4AC /* pcre2_ord2utf.c */; };
-		C5C60B22CE6A3BCB868F69E8 /* pcre2_find_bracket.c in Sources */ = {isa = PBXBuildFile; fileRef = 943C7E9527C03FCDB5966273 /* pcre2_find_bracket.c */; };
-		5ED54DFAE28533108C08DF2A /* pcre2_extuni.c in Sources */ = {isa = PBXBuildFile; fileRef = F0E43FFDC808333AA01EE649 /* pcre2_extuni.c */; };
-		57B41B6BACFB3906ACD1BFAF /* pcre2_jit_compile.c in Sources */ = {isa = PBXBuildFile; fileRef = 7C9F6184015A3BD1B8DA471E /* pcre2_jit_compile.c */; };
-		2047544E505C3BA38F0144E6 /* pcre2_tables.c in Sources */ = {isa = PBXBuildFile; fileRef = B60497805D37375EBFCF3D98 /* pcre2_tables.c */; };
-		E17048DEEF1138318314F1D0 /* pcre2_valid_utf.c in Sources */ = {isa = PBXBuildFile; fileRef = FAE49A61DFE9375AAB18E8DD /* pcre2_valid_utf.c */; };
 		41943A8F82723027A151A468 /* fileconf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 61DA2A4C0D143CBE804BB8A1 /* fileconf.cpp */; };
 		42260A6F1853361083803B0C /* zutil.c in Sources */ = {isa = PBXBuildFile; fileRef = 4CB467F9898C3952A68D988B /* zutil.c */; };
 		4269B85FDC5639BEB76A8AEB /* nonownedwnd_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 19559DDA007D364E838014B5 /* nonownedwnd_osx.cpp */; };
@@ -270,6 +253,7 @@
 		44C6F11C7D1C399F99CF6BD4 /* xh_auitoolb.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0CC4C44F4DB833839AD96DBD /* xh_auitoolb.cpp */; };
 		45AB45C6B24A3983B22E56A5 /* dataobj.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 271B4B77622B3411A7BF6634 /* dataobj.cpp */; };
 		45D88A74B3EE3837B9F79595 /* LexFlagship.cxx in Sources */ = {isa = PBXBuildFile; fileRef = F32C0D20638232CE8F43BF33 /* LexFlagship.cxx */; };
+		45E15DBB6B69382D8AF1BA21 /* pcre2_dfa_match.c in Sources */ = {isa = PBXBuildFile; fileRef = 96D620AEA83E3444BA0B04C4 /* pcre2_dfa_match.c */; };
 		45FE206BBAD13DDCA1EA41CF /* treebase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7BA6ADD758693BD180D3275B /* treebase.cpp */; };
 		46395873DB1C3B7FA81DE5F8 /* LexerBase.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 93EDB3A2B85E3275A6D27C56 /* LexerBase.cxx */; };
 		4657479AF35533AEB7876676 /* helpbase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BBB30516233A39BE809405AA /* helpbase.cpp */; };
@@ -328,6 +312,7 @@
 		570FA90F526E3F25A8E8FCF2 /* tif_read.c in Sources */ = {isa = PBXBuildFile; fileRef = 64B25B87203E3464BCDD277D /* tif_read.c */; };
 		5792675690843C6AA4125A72 /* font.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 77F5E7BCD9B2307D8DBCC052 /* font.cpp */; };
 		57AE7FCF768F3965BD39B47A /* m_span.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 727F25F832AD32D4B12D8E39 /* m_span.cpp */; };
+		57B41B6BACFB3906ACD1BFAF /* pcre2_jit_compile.c in Sources */ = {isa = PBXBuildFile; fileRef = 7C9F6184015A3BD1B8DA471E /* pcre2_jit_compile.c */; };
 		58AABAD40AA236438347DDDE /* evtloop.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8D2549709E0133C9A267E3A5 /* evtloop.mm */; };
 		595DCB164D55342EB86604EC /* hashmap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A6636144CDE83E8E85270FAF /* hashmap.cpp */; };
 		59BFB8C8310E37B39AF8B0D4 /* any.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4867546E8B8D3C8683A23ED5 /* any.cpp */; };
@@ -340,12 +325,14 @@
 		5C44446AB150378696CD6B3C /* bmpcboxcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8CF560E06F2A3B6088203D09 /* bmpcboxcmn.cpp */; };
 		5C5D0983160A36189A770742 /* webviewarchivehandler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70112AB00E013A35BE974FF1 /* webviewarchivehandler.cpp */; };
 		5D3AD309AF39385EBF7D9DF8 /* jaricom.c in Sources */ = {isa = PBXBuildFile; fileRef = 573D0D15EE9E3E629D61EA65 /* jaricom.c */; };
+		5ED54DFAE28533108C08DF2A /* pcre2_extuni.c in Sources */ = {isa = PBXBuildFile; fileRef = F0E43FFDC808333AA01EE649 /* pcre2_extuni.c */; };
 		5EE94793DFCB3BA281A4864E /* infback.c in Sources */ = {isa = PBXBuildFile; fileRef = FDB0E2D0966C3E408C4A2D3D /* infback.c */; };
 		5F2C2A46781739D897CF293D /* xh_chckl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EA3F8832890138E9AB6E65D8 /* xh_chckl.cpp */; };
 		5F57C4908E5038D19D68ED7A /* gallery.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3F1C1EB5C0B3302C86D91315 /* gallery.cpp */; };
 		5F6B4F226B473AACB7AC8DF5 /* xh_slidr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 38E0F60AE1F83633A0CC18FC /* xh_slidr.cpp */; };
 		5F78DB0417BF3CE1B4E35C7F /* stackwalk.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EA2520F427493A22A70A5C09 /* stackwalk.cpp */; };
 		5FE969523BDB3353AEF96810 /* xh_filepicker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5C8CEE782CD236A5A9999724 /* xh_filepicker.cpp */; };
+		60296753A32B39EB8BD0CB44 /* pcre2_study.c in Sources */ = {isa = PBXBuildFile; fileRef = 09CCDDC66F683C6B87BEDD2F /* pcre2_study.c */; };
 		604ABF86317C3D4F899DBF37 /* richtextsymboldlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB3FF9FECCB5300A9561CE36 /* richtextsymboldlg.cpp */; };
 		60706F8836A130A2AF282FE1 /* fontutilcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2E00E14795F23A8392713A26 /* fontutilcmn.cpp */; };
 		6138BCBC8E4438FA91E0EF9F /* xh_chckb.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB7DBBD53BA837D2B01CE2B6 /* xh_chckb.cpp */; };
@@ -361,6 +348,8 @@
 		633DD2E870263F42A8DBF9BF /* markuptext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D4FC6F0AB2AC34D2B26F8ED8 /* markuptext.cpp */; };
 		63F0C8EEDF4B3641878A8B4D /* dlgcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9051902662BE38B3912B34EA /* dlgcmn.cpp */; };
 		63F2517EC6B2334CA825A6F9 /* layout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BEB08798C70E33DDB360E563 /* layout.cpp */; };
+		63F895D6F5643E4B9E666B79 /* creddlgg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8DE97F5A2AD393CBD31AED3 /* creddlgg.cpp */; };
+		6463C9BE78C0394CB7B451FA /* pcre2_compile.c in Sources */ = {isa = PBXBuildFile; fileRef = BDADEB1DA6433E52972C8934 /* pcre2_compile.c */; };
 		64A716F87A5136F9A790EC5A /* webview.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0DA80913C0E33144A42BD30F /* webview.cpp */; };
 		64DD406C453D39FEBBE66ED1 /* tif_pixarlog.c in Sources */ = {isa = PBXBuildFile; fileRef = 4071FF90F1D4336C836B2AE4 /* tif_pixarlog.c */; };
 		64F11C549E3035DF85691060 /* tif_ojpeg.c in Sources */ = {isa = PBXBuildFile; fileRef = 1FBC6F8B4CA63A0081D6F34A /* tif_ojpeg.c */; };
@@ -393,6 +382,7 @@
 		6B9EEA3CF2E536E3B1ADAC42 /* manager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EBED392D081335FA80523244 /* manager.cpp */; };
 		6BC8B3EDB3AE3EF4BACFC08A /* ContractionState.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 5219A792C6A736F193D4A82F /* ContractionState.cxx */; };
 		6BF19C7CA9E93D989C210FE3 /* dseldlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1197B997B1D139C5AE4D198A /* dseldlg.cpp */; };
+		6C1171E3FB7137CCB9E3F536 /* tif_zstd.c in Sources */ = {isa = PBXBuildFile; fileRef = 3B98123FD57731139044B064 /* tif_zstd.c */; };
 		6C3A459236F736B8A14A13AC /* dialog.mm in Sources */ = {isa = PBXBuildFile; fileRef = 83B878A16ABC396E8C03A15E /* dialog.mm */; };
 		6C46AF0370793AA0B74A5A4A /* tabmdi.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C0155E0C2F6131358D2DA5ED /* tabmdi.cpp */; };
 		6C7C1CC506CB329FB2D086A9 /* LexBasic.cxx in Sources */ = {isa = PBXBuildFile; fileRef = B6AADC1056E03A3B80C20C5B /* LexBasic.cxx */; };
@@ -418,6 +408,7 @@
 		73AA68AB9F1236ED9F1FBB2E /* metafile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2BB2949CC0B387AB6879539 /* metafile.cpp */; };
 		743BB23211B336A6A0F26E57 /* jcapistd.c in Sources */ = {isa = PBXBuildFile; fileRef = F83172EE2DAE352FB969D4F2 /* jcapistd.c */; };
 		745C39E90E8C3C08A887B51C /* msgdlgg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1CB6A4171D4343BB0A9858A /* msgdlgg.cpp */; };
+		750C716389AD3ADBABC9D689 /* statbmp_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F582C6B3A5AA3367BB4DBE97 /* statbmp_osx.cpp */; };
 		7569F0BC3C603EB19168088F /* collpaneg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 84758329F2163F00A9C005DF /* collpaneg.cpp */; };
 		758629DA468A3EF7B1C15241 /* gifdecod.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 16FE98EC26223BF0A78AB2EE /* gifdecod.cpp */; };
 		75DCE6FF00E93C5D93970842 /* arttango.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9988CBB0772A3539970162FA /* arttango.cpp */; };
@@ -440,6 +431,7 @@
 		7B372FEA276438C186F7E340 /* RunStyles.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 7E0DD59CA6F8337C9964F954 /* RunStyles.cxx */; };
 		7B4DA2F5F25B3E188CBAFE38 /* hyperlnkcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8A7D521FE5B437D7AD5F4B54 /* hyperlnkcmn.cpp */; };
 		7B642B17F5D23F4F8ED38BB4 /* graphcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1BB59DD194923D6399087A75 /* graphcmn.cpp */; };
+		7BD3887F603E3704969A54E1 /* pcre2_chartables.c in Sources */ = {isa = PBXBuildFile; fileRef = 1895085EBEAE3A708FDD527A /* pcre2_chartables.c */; };
 		7C20B79175D33852A2E9DE83 /* LexRuby.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 8734C52C7559310784396455 /* LexRuby.cxx */; };
 		7C52E7CC12463941B0E4D402 /* statbmpcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 12EFC31E6FB631998E44B49C /* statbmpcmn.cpp */; };
 		7C5552FA058034238F485900 /* dbgrptg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 182C8AD4F822375495795B43 /* dbgrptg.cpp */; };
@@ -454,6 +446,7 @@
 		7EB83F6375BF3E73ABE56C40 /* jcarith.c in Sources */ = {isa = PBXBuildFile; fileRef = AA234ACC79743DA797601AA6 /* jcarith.c */; };
 		7ECC6EE6D5273F75BB6B7B74 /* tif_dirinfo.c in Sources */ = {isa = PBXBuildFile; fileRef = 032A38738B58394E8617617B /* tif_dirinfo.c */; };
 		7EF89F935314301381802FAB /* filectrlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2334539088B036BEAB230D1C /* filectrlg.cpp */; };
+		7F62946D497A32CE857F65C9 /* pcre2_maketables.c in Sources */ = {isa = PBXBuildFile; fileRef = D016F584D14C31E192DB3179 /* pcre2_maketables.c */; };
 		7F77E347E1243D77A666FB43 /* clipbrd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 12453E271F2A3AC9969E62A4 /* clipbrd.cpp */; };
 		7FC3D17B3C853FE58841002D /* timercmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7195E665E0F233839B967FC9 /* timercmn.cpp */; };
 		800CFCEDBB7938338C65EEAC /* notifmsgcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B233180893DB3328AF4847DA /* notifmsgcmn.cpp */; };
@@ -474,6 +467,8 @@
 		84B3625464F732C3A79E1314 /* xh_bmpbt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 11AE4D94B791344AB6BF6397 /* xh_bmpbt.cpp */; };
 		85F9828B80B03178A274BD17 /* selstore.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5ED2105A5A033E3384EBC4ED /* selstore.cpp */; };
 		86003C8EB906304F9025F788 /* jcinit.c in Sources */ = {isa = PBXBuildFile; fileRef = AA6C6739C3BD3EFA9CF71102 /* jcinit.c */; };
+		8620088DDD233B139B250DD4 /* filter_sse2_intrinsics.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D602B5F09E8314CB9F65C11 /* filter_sse2_intrinsics.c */; };
+		86787E4138CC334BB74EC7B4 /* palette_neon_intrinsics.c in Sources */ = {isa = PBXBuildFile; fileRef = FB17368A86EC30E6B843E32F /* palette_neon_intrinsics.c */; };
 		86AED49CEAFC3637B1F10537 /* dialog_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BDE76674C0F5391BAD2AFA2F /* dialog_osx.cpp */; };
 		86B0D280A43C308CAC14BE24 /* CaseFolder.cxx in Sources */ = {isa = PBXBuildFile; fileRef = F52DCBC0442233738B39138E /* CaseFolder.cxx */; };
 		86BE5213D3F131D8A6862679 /* hid.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 160EB9744CB63A0B81DC651F /* hid.cpp */; };
@@ -482,6 +477,7 @@
 		87C67583D36C3465ACD64103 /* vlbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA90128E29A03CCCA30F4D35 /* vlbox.cpp */; };
 		88A43B1C5A7438838DE97B94 /* tif_luv.c in Sources */ = {isa = PBXBuildFile; fileRef = 66FDA882451239EA8DF2E0B5 /* tif_luv.c */; };
 		88E1AE56FD393C8BA5CF8545 /* stringops.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F1E724EA70AB35DDB130F84F /* stringops.cpp */; };
+		88E56F89A0DA3AD386F05FD2 /* pcre2_pattern_info.c in Sources */ = {isa = PBXBuildFile; fileRef = 00DAA69F74D031B6BE9196A8 /* pcre2_pattern_info.c */; };
 		89046455F49D3D75A21C9DB8 /* imagfill.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 137E01C362E134449BF966ED /* imagfill.cpp */; };
 		89200B144075388BA69A07E2 /* xh_timectrl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 25A81E9028793C109D868068 /* xh_timectrl.cpp */; };
 		893BDA491EDE3A0E91FADE40 /* nonownedwnd.mm in Sources */ = {isa = PBXBuildFile; fileRef = AECB45CEAC093CE4AB4B7E45 /* nonownedwnd.mm */; };
@@ -493,10 +489,13 @@
 		8AB7191F7CB838FC8337C48D /* xh_statbar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FADE850169F7347F83FE1499 /* xh_statbar.cpp */; };
 		8B38C6C416BA3A51B37F60C4 /* statlinecmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 292C08C0A1203654ABAA2CB1 /* statlinecmn.cpp */; };
 		8B60964DA1DF3F3DB40BE123 /* datavgen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5F3D473DC5123EDAB767045C /* datavgen.cpp */; };
+		8B87FEC23DB834EDBFB6EA32 /* pcre2_ucd.c in Sources */ = {isa = PBXBuildFile; fileRef = 70F4EB692873386AAA0A44B0 /* pcre2_ucd.c */; };
 		8B9C9FCB954F3596A4CED9A5 /* jdapimin.c in Sources */ = {isa = PBXBuildFile; fileRef = 86884BC843F6337EABF744BB /* jdapimin.c */; };
+		8C6E2BD9C31A3AE18AD17D44 /* pcre2_match.c in Sources */ = {isa = PBXBuildFile; fileRef = 3B93115BCC46333BBB31D6F7 /* pcre2_match.c */; };
 		8D6B0D48EA843E48AB0FE43D /* LexErrorList.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 2851EAAEE9B73FE8981912C9 /* LexErrorList.cxx */; };
 		8DE45CEAF2DD3C22AA019F74 /* deflate.c in Sources */ = {isa = PBXBuildFile; fileRef = 3CF73F49AEC238C99CE89845 /* deflate.c */; };
 		8E674574343A3C009B1BCD00 /* tif_codec.c in Sources */ = {isa = PBXBuildFile; fileRef = 88FF67EB6E7D302A9CDEF660 /* tif_codec.c */; };
+		8F372080E11E382EA0B5ED0F /* rowheightcache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A2B7B30FA60633339D8862C6 /* rowheightcache.cpp */; };
 		8F949B9010863F66A58FFEF1 /* xh_activityindicator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BB60FA0E3524391D8581AD7C /* xh_activityindicator.cpp */; };
 		8F98C20E7B223FF4B352C130 /* Catalogue.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 975E3B6A269434F0A069987D /* Catalogue.cxx */; };
 		8FB5FBC5730C33F1A3D85D9F /* LexD.cxx in Sources */ = {isa = PBXBuildFile; fileRef = B9DFC4083C6A38CABE4BB4E3 /* LexD.cxx */; };
@@ -530,6 +529,7 @@
 		97BAFEAD53E238B6881178DD /* evtloopcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 640783FBACA43206B782C77B /* evtloopcmn.cpp */; };
 		97C551F8AEF133D680D1FD36 /* LexProgress.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 4F8E4A9905843A4683A6B460 /* LexProgress.cxx */; };
 		97F60B2A9CE93BC8949A8CCD /* LexCrontab.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 16A093604BDB3C22BA66EA89 /* LexCrontab.cxx */; };
+		980ED1DA2F96361985952254 /* webrequest_urlsession.mm in Sources */ = {isa = PBXBuildFile; fileRef = EA8CCF32688434EABEEEE04A /* webrequest_urlsession.mm */; };
 		9836B3D336963795928FE5A1 /* m_dflist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52FE1599218730CC99A3F801 /* m_dflist.cpp */; };
 		9881E3FB23ED3283B6CC71A2 /* filepickercmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BFA50405234C30EEA3F77F17 /* filepickercmn.cpp */; };
 		98AD7D0478BA36249B03C623 /* time.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5B9586328A1F3C4BA0390AA5 /* time.cpp */; };
@@ -538,6 +538,8 @@
 		99E7A46106C03484BA70D29E /* tif_unix.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D2F8259CC99380CB8217DEF /* tif_unix.c */; };
 		99F7D7BFBB543A04AB728375 /* m_hline.cpp in Sources */ = {isa = PBXBuildFile; fileRef = ECA4A44BEC2F3AED8CF0C911 /* m_hline.cpp */; };
 		9A178ED42D96329D8CBF9B89 /* tif_predict.c in Sources */ = {isa = PBXBuildFile; fileRef = 2FA01C426EAF38D3B9ED35AC /* tif_predict.c */; };
+		9A63148F193E33B5964DD029 /* uilocale.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4E4466371B7E3265AE7B1E0C /* uilocale.cpp */; };
+		9A63148F193E33B5964DD02A /* uilocale.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4E4466371B7E3265AE7B1E0D /* uilocale.cpp */; };
 		9A83D365AD1F37FA9C7030C2 /* matrix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EF330EAACFA53877BE289896 /* matrix.cpp */; };
 		9B3F9D04FB533D99B58BD519 /* jfdctfst.c in Sources */ = {isa = PBXBuildFile; fileRef = 029486D6A2EC3DE0902A6A24 /* jfdctfst.c */; };
 		9B6A35E706543CDAA6A5014A /* LexGui4Cli.cxx in Sources */ = {isa = PBXBuildFile; fileRef = FFB767BD2C7235F293F45796 /* LexGui4Cli.cxx */; };
@@ -549,9 +551,11 @@
 		9D003890CB7035A298DB7056 /* LexLua.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 5145561C78303EEE9F827962 /* LexLua.cxx */; };
 		9D4B67A357D23B5283CA8D98 /* clrpickercmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AB8A747FB60239B9AB710264 /* clrpickercmn.cpp */; };
 		9E0B67E34B683412978BA82D /* filtall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4438C284ED5C31EF8CC28FF3 /* filtall.cpp */; };
+		9E37D29DCF7A3945A0EECB39 /* pcre2_serialize.c in Sources */ = {isa = PBXBuildFile; fileRef = BD2EBC2CCAE23AD6A1DF783E /* pcre2_serialize.c */; };
 		9EC837DA722736119D49868A /* pngpread.c in Sources */ = {isa = PBXBuildFile; fileRef = 9CAA325362C73AC8BE20FAA7 /* pngpread.c */; };
 		9F608A33D52D327FAA295624 /* sckfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 56653FACC7D13804A70556AD /* sckfile.cpp */; };
 		9F70A89D00B03D4894AF7638 /* validate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 01BA6D45FE4C381493EB4372 /* validate.cpp */; };
+		9FA6C4275F0D3E1A884ED561 /* pcre2_auto_possess.c in Sources */ = {isa = PBXBuildFile; fileRef = C3904351139F3F0DB4B72F94 /* pcre2_auto_possess.c */; };
 		9FB1E1763EFA334CA0C07C49 /* tarstrm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C0F7BBD216853E718C9F23D9 /* tarstrm.cpp */; };
 		9FBC642677C63D01AA2511BC /* evtloop_cf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5BD6231188AB329CAA5E1171 /* evtloop_cf.cpp */; };
 		9FD99E06F6613A1A958FAF6B /* jdmainct.c in Sources */ = {isa = PBXBuildFile; fileRef = B2D390E5D5BF32D4AAA1E15A /* jdmainct.c */; };
@@ -573,6 +577,8 @@
 		A3C4D47A84E8362295867525 /* LexPOV.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 8EECA8EB93BF3C7A9CC827AD /* LexPOV.cxx */; };
 		A423177BBC0F3BE5A436B4B7 /* propgridpagestate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 967EF76827CB3CDE87E1E733 /* propgridpagestate.cpp */; };
 		A465A43B756630F1944B5A56 /* vscroll.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1629FA905F903324AA5BE72C /* vscroll.cpp */; };
+		A486A28E216D320AB57452D3 /* lzmastream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 99A9D5F9254D35BE8F4176A4 /* lzmastream.cpp */; };
+		A4DEBFA074C93388A1BBCB40 /* pcre2_substitute.c in Sources */ = {isa = PBXBuildFile; fileRef = FAC42945539F362D91D6F559 /* pcre2_substitute.c */; };
 		A52A7D2FEB1434E29C64582C /* RESearch.cxx in Sources */ = {isa = PBXBuildFile; fileRef = E145FC31ED523B4AA5080A61 /* RESearch.cxx */; };
 		A53B8C3ED0D33A1D9AA8219A /* toolbar.mm in Sources */ = {isa = PBXBuildFile; fileRef = A3BF8C9FF2D5314591329D0D /* toolbar.mm */; };
 		A569A33A2097316D8110C2C1 /* toolbar_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6CD29E47B69D3F3482665E77 /* toolbar_osx.cpp */; };
@@ -604,6 +610,7 @@
 		AE84BC9A1CCA3ADA9C483950 /* xmlrole.c in Sources */ = {isa = PBXBuildFile; fileRef = 59C6B9849FF6325E890942EF /* xmlrole.c */; };
 		AEB9099819B33F4A8AAB9F54 /* radiocmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 531B0E5DB9ED393996E3FBB8 /* radiocmn.cpp */; };
 		AEEE6BC41B6531898A61CB16 /* LexHTML.cxx in Sources */ = {isa = PBXBuildFile; fileRef = D87406BCF3E833369E12D89A /* LexHTML.cxx */; };
+		AF1875145B2537298E4A28D8 /* pcre2_xclass.c in Sources */ = {isa = PBXBuildFile; fileRef = 95CBA2C736623FFF8629E975 /* pcre2_xclass.c */; };
 		AF1E3338E892336E924AF631 /* pickerbase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1FBC22BAD63D3A1AB78F5F82 /* pickerbase.cpp */; };
 		B01C4EF49CF9390DA93A3502 /* jidctflt.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C131F7BF8A83960ACB26242 /* jidctflt.c */; };
 		B0C44C3054CB3E0590DDCBDA /* LexJSON.cxx in Sources */ = {isa = PBXBuildFile; fileRef = F48BFBB2D4E43930BE005A42 /* LexJSON.cxx */; };
@@ -623,6 +630,7 @@
 		B59FC7345C383D9099391AC3 /* mimecmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2F316F7DD3CB3390A6E50179 /* mimecmn.cpp */; };
 		B5C7FD8C27F43F3289A77FC9 /* utilsunx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DC75C7251C1732B0B07C7BD3 /* utilsunx.cpp */; };
 		B640A8A74D973A8FBEF63916 /* LexConf.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 04082EC1C91334379425802D /* LexConf.cxx */; };
+		B6728BCD1A0731299924C8C4 /* pcre2_substring.c in Sources */ = {isa = PBXBuildFile; fileRef = 5152B34D06E9343FBFAB3510 /* pcre2_substring.c */; };
 		B6891F848CA0325EAB6D1373 /* textentry_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 777385D10CCC350C90F02824 /* textentry_osx.cpp */; };
 		B6BC23F4F3E43315BD4C7CF8 /* mediactrl.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6A6A16F9C3B03A7B9077D013 /* mediactrl.mm */; };
 		B6C364CB4AE33708A862B4B4 /* srchctlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D46A36564C78312CAC538E93 /* srchctlg.cpp */; };
@@ -637,6 +645,7 @@
 		BAA75384DA82370298672333 /* helpctrl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 42E433D1700631A8907B8227 /* helpctrl.cpp */; };
 		BAAB6B1D80A33843A8436B10 /* appunix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B40E0F6AA0273ACD9BDEAD72 /* appunix.cpp */; };
 		BAFF04F1680F32DA988EB03D /* stockitem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B180290089B139F18B0C7BBA /* stockitem.cpp */; };
+		BB12132A86E2350AA47414CC /* arm_init.c in Sources */ = {isa = PBXBuildFile; fileRef = 933D7637CAA43F6C99814BC5 /* arm_init.c */; };
 		BB6FE851028C3DE7A070C213 /* convauto.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 20B922D61CDB3CCEB59A5194 /* convauto.cpp */; };
 		BBAABF3C693E37D3B0FF2502 /* colrdlgg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 66AC0EA493AB3B6A86DAE174 /* colrdlgg.cpp */; };
 		BCD81FD3D1EC305F801E1C1B /* sckipc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1F6E23CCDC1932BC985EFBD2 /* sckipc.cpp */; };
@@ -681,6 +690,7 @@
 		C43A9650A9DC3372AB8F5F78 /* jidctint.c in Sources */ = {isa = PBXBuildFile; fileRef = 1DAF0931E4AD3E6581D7FDBC /* jidctint.c */; };
 		C5419BC04D6234B5A8307B81 /* xti.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 25C86D3D4839343BA1D8BDEE /* xti.cpp */; };
 		C5A8DF376BB13A2A8290C2E5 /* xh_unkwn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 15FCCD1B587637DDA3C1748A /* xh_unkwn.cpp */; };
+		C5C60B22CE6A3BCB868F69E8 /* pcre2_find_bracket.c in Sources */ = {isa = PBXBuildFile; fileRef = 943C7E9527C03FCDB5966273 /* pcre2_find_bracket.c */; };
 		C5E5AB869065307F83E27DD1 /* htmlpars.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1800B1884CC73C78A09E7FF1 /* htmlpars.cpp */; };
 		C67EAE20657E36839BF86690 /* richtooltipg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 54710DA2AC4F3262A8A1EA63 /* richtooltipg.cpp */; };
 		C6DF6F29407B34F29ED1B66D /* jcmaster.c in Sources */ = {isa = PBXBuildFile; fileRef = 3E3043D7BE9C33B59E900CCE /* jcmaster.c */; };
@@ -688,6 +698,7 @@
 		C8C68927DB243AEAB51E11F2 /* pngwio.c in Sources */ = {isa = PBXBuildFile; fileRef = AF9EE701DD653E2299293E5F /* pngwio.c */; };
 		C8F1FB8C029031A5909DBC56 /* KeyMap.cxx in Sources */ = {isa = PBXBuildFile; fileRef = E72CF5F9C1E53BCFAA2BC253 /* KeyMap.cxx */; };
 		C92005CB86C6361BBB9D7C67 /* LexBibTeX.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 0851C46057CE3C37991B9E34 /* LexBibTeX.cxx */; };
+		C987310872D1396BAF716E5A /* webrequest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5EA9E372A64B3B808A64B178 /* webrequest.cpp */; };
 		CA155860CE9A3A8189C3A4C2 /* zipstrm.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 54FB8A5FCBD0309AAC2E4F70 /* zipstrm.cpp */; };
 		CA4DCD57060B38CC8B2283D7 /* filtfind.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EA4AF89C36C53EB4B307DCAB /* filtfind.cpp */; };
 		CA5BD8ABDBA13641BBE7CD66 /* jccoefct.c in Sources */ = {isa = PBXBuildFile; fileRef = E89AC104BF4F33A083F8B382 /* jccoefct.c */; };
@@ -731,11 +742,14 @@
 		D5AABE973F3A351EB1C1A5A6 /* fontmap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D0817D6A1AF83608B050EBC3 /* fontmap.cpp */; };
 		D5C304182151365FA9FF8A3D /* xh_bttn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0785AD527D033586A7DCE8B8 /* xh_bttn.cpp */; };
 		D5C5DD83882B3227A1CCFE0E /* LexSorcus.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 7D8BDFB06EE13E59ABB2A616 /* LexSorcus.cxx */; };
+		D66F55C93D1130F488970C05 /* pcre2_match_data.c in Sources */ = {isa = PBXBuildFile; fileRef = 4E74E9E53454331F8E10ECC5 /* pcre2_match_data.c */; };
 		D66F5D4D204B3B789C7F76B9 /* fontdlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18044326B5B13A98A49732DD /* fontdlg.cpp */; };
 		D6B2A64A78AF3F2983B441A8 /* ownerdrwcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 155ECF01CC4C318281AAA870 /* ownerdrwcmn.cpp */; };
 		D6B73239BF0E32288161679C /* platinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97FFB03FF6793506B246BAC6 /* platinfo.cpp */; };
 		D6C3421AD2A537AAA2F0AB80 /* file.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 168DB301ACC736FF96D7F581 /* file.cpp */; };
 		D72D99FC424337CF9EDC2042 /* props.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C20E46A504113C899B9DD9B7 /* props.cpp */; };
+		D772334837693C9D88069D98 /* tif_webp.c in Sources */ = {isa = PBXBuildFile; fileRef = 3716DA7B0C79360CBA26A71E /* tif_webp.c */; };
+		D7F14BDFFB7F369B842AFC13 /* pcre2_config.c in Sources */ = {isa = PBXBuildFile; fileRef = FC6A8FAE9CA63EEB8883B6BD /* pcre2_config.c */; };
 		D83B32B788EC310D919E0DF7 /* imagpcx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 10ED6D770A5A349AA4EE9747 /* imagpcx.cpp */; };
 		D8ADDD24BEAC3D94B3388D3E /* LexCOBOL.cxx in Sources */ = {isa = PBXBuildFile; fileRef = B3D9C4122372343DBEAF6492 /* LexCOBOL.cxx */; };
 		D9496139621533328AE727B6 /* pngget.c in Sources */ = {isa = PBXBuildFile; fileRef = 91300EB871CC39ECBC430D48 /* pngget.c */; };
@@ -747,7 +761,6 @@
 		D9F02AFDA07D3857A905527C /* jdcolor.c in Sources */ = {isa = PBXBuildFile; fileRef = 68B81FBDA49D3C1991B6356A /* jdcolor.c */; };
 		DA0FA502405A37B2A5698D20 /* config.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4FE0B33481283D3493613B0F /* config.cpp */; };
 		DA71FBB9EFB2350ABB3CEC80 /* stdpaths.mm in Sources */ = {isa = PBXBuildFile; fileRef = 190409DF8A3C3D9580FBB8AA /* stdpaths.mm */; };
-		DA71FBB9EFB2350ABB3CEC81 /* stdpaths.mm in Sources */ = {isa = PBXBuildFile; fileRef = 190409DF8A3C3D9580FBB8AB /* stdpaths.mm */; };
 		DAAFBED07FF8365B96D20B99 /* unichar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DB90ADAC10693B6F91E7D4E9 /* unichar.cpp */; };
 		DB3C3AA956A03FB492480266 /* treectlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7F039CCBBE6C32A09930EBDB /* treectlg.cpp */; };
 		DB73248401573A5996D8E68D /* jcmarker.c in Sources */ = {isa = PBXBuildFile; fileRef = 664736BDE465350C9C4750E9 /* jcmarker.c */; };
@@ -766,11 +779,13 @@
 		DF8124E5E17D386A84CEEA27 /* LexLisp.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 40586C8986443431A64EB066 /* LexLisp.cxx */; };
 		DF861EBD9C483E79ADF98602 /* CharacterCategory.cxx in Sources */ = {isa = PBXBuildFile; fileRef = 308B9C05F5A839B5BE8ACBE9 /* CharacterCategory.cxx */; };
 		DF8CE011EAC23F73BDA1C44D /* scrolbar_osx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 600740717F7E320F8CA78384 /* scrolbar_osx.cpp */; };
+		DFEB01E7B97A3515B785DCA9 /* pcre2_string_utils.c in Sources */ = {isa = PBXBuildFile; fileRef = A6EE037AF43E343E8E1A7555 /* pcre2_string_utils.c */; };
 		DFEB8DA3D42734949CB1E1AA /* clipcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 239D386E9D7D39C5A1E859C6 /* clipcmn.cpp */; };
 		E05B06A7FEEE32D5AD87EA4F /* xh_editlbox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 05310A868F0B35999C568681 /* xh_editlbox.cpp */; };
 		E0E40333B61C33B58787078E /* LexMarkdown.cxx in Sources */ = {isa = PBXBuildFile; fileRef = E78CBF86AAE637CB982B2EC0 /* LexMarkdown.cxx */; };
 		E0FAB345D2933D42B62917A3 /* bannerwindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 36296C259D023EAAA240FC79 /* bannerwindow.cpp */; };
 		E104017EE1A4357DAF84E1E6 /* auibook.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A298576700C33F018616E7BD /* auibook.cpp */; };
+		E17048DEEF1138318314F1D0 /* pcre2_valid_utf.c in Sources */ = {isa = PBXBuildFile; fileRef = FAE49A61DFE9375AAB18E8DD /* pcre2_valid_utf.c */; };
 		E1A20811148F31D289AF98AF /* xh_sizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6E855AB3AB08325980871AB4 /* xh_sizer.cpp */; };
 		E1F7C51F411B3AF39476E488 /* fdrepdlg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5F094B0B07DF33BCA6077BC0 /* fdrepdlg.cpp */; };
 		E2A73751CECF32A68FFAEE82 /* panelcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70E9B2C076673C87B4218A01 /* panelcmn.cpp */; };
@@ -805,6 +820,7 @@
 		EA10DA3199813E90B39C70D3 /* xh_infobar.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 45C65E309F3A39598C043657 /* xh_infobar.cpp */; };
 		EAA469E1A0CC33E4A21A3F7A /* gaugecmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 570D603125ED3A14848FA2E2 /* gaugecmn.cpp */; };
 		EAE02BA934B43EEE92C496C7 /* dcpsg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EEA0945B20913754A54D0FD9 /* dcpsg.cpp */; };
+		EB206A0264AD3CAA9F68B8FC /* pcre2_convert.c in Sources */ = {isa = PBXBuildFile; fileRef = BCED9B1D0D7E3FBBAC78CE5B /* pcre2_convert.c */; };
 		EB52C6A915943813932944FE /* control.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 12363D1F50FE301DAEE7F04A /* control.cpp */; };
 		EB52C6A915943813932944FF /* control.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 12363D1F50FE301DAEE7F04B /* control.cpp */; };
 		EBA0986930DA3B59B2FB4F1E /* htmltag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FCCFF49F92B4323D9181CEDA /* htmltag.cpp */; };
@@ -818,6 +834,7 @@
 		EDD92822EBD93E86AE5A2ED0 /* slidercmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E8072CA67D19346ABF4D465F /* slidercmn.cpp */; };
 		EE0EA850822E35F596B5EBBA /* artprov.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 29387393C07C39DB8FF1663B /* artprov.cpp */; };
 		EE6474BBB4AF34D093E2451D /* MarginView.cxx in Sources */ = {isa = PBXBuildFile; fileRef = F951601E73683F27AD8CA99D /* MarginView.cxx */; };
+		EE972E8DC73F310B9B4C949C /* webrequest_curl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5279968877003A8BB8279765 /* webrequest_curl.cpp */; };
 		EEB0B28903693C7E9D07192F /* glcmn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E08A51FA8D8A361681B07295 /* glcmn.cpp */; };
 		F016C51053373E658ED4C9A9 /* helpext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF376BC55EA73F5FB7328142 /* helpext.cpp */; };
 		F07D84D124F23E7FA11CF148 /* extended.c in Sources */ = {isa = PBXBuildFile; fileRef = 033B94A9AC8A3370A794503F /* extended.c */; };
@@ -887,6 +904,7 @@
 		00969CBE3B8F32C78C195619 /* panel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = panel.cpp; path = ../../src/ribbon/panel.cpp; sourceTree = "<group>"; };
 		00BC2298BC7A33B7A68584FE /* bookctrl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = bookctrl.cpp; path = ../../src/common/bookctrl.cpp; sourceTree = "<group>"; };
 		00DA3D3EEF5E305CA73A1871 /* region.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = region.cpp; path = ../../src/osx/carbon/region.cpp; sourceTree = "<group>"; };
+		00DAA69F74D031B6BE9196A8 /* pcre2_pattern_info.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_pattern_info.c; path = ../../3rdparty/pcre/src/pcre2_pattern_info.c; sourceTree = "<group>"; };
 		0116581B77DF3A5D889B8D17 /* dndcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = dndcmn.cpp; path = ../../src/common/dndcmn.cpp; sourceTree = "<group>"; };
 		01BA6D45FE4C381493EB4372 /* validate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = validate.cpp; path = ../../src/common/validate.cpp; sourceTree = "<group>"; };
 		027D2F04BE933ED6B9BA1518 /* imaglist.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = imaglist.cpp; path = ../../src/generic/imaglist.cpp; sourceTree = "<group>"; };
@@ -913,6 +931,7 @@
 		0903EE9B3793303285FF96E3 /* textfile.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = textfile.cpp; path = ../../src/common/textfile.cpp; sourceTree = "<group>"; };
 		093B5233861B3F9B8C85762B /* xh_cald.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_cald.cpp; path = ../../src/xrc/xh_cald.cpp; sourceTree = "<group>"; };
 		0964797530CF3FE7B8DB6242 /* pngwtran.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pngwtran.c; path = ../../src/png/pngwtran.c; sourceTree = "<group>"; };
+		09CCDDC66F683C6B87BEDD2F /* pcre2_study.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_study.c; path = ../../3rdparty/pcre/src/pcre2_study.c; sourceTree = "<group>"; };
 		09F8B0818C3A3248A26EE05D /* choicbkg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = choicbkg.cpp; path = ../../src/generic/choicbkg.cpp; sourceTree = "<group>"; };
 		0A59A5C2305D3D1C8049BE71 /* LexCsound.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexCsound.cxx; path = ../../src/stc/scintilla/lexers/LexCsound.cxx; sourceTree = "<group>"; };
 		0BF1F491B8A8376E8E2E8182 /* cursor.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = cursor.cpp; path = ../../src/osx/carbon/cursor.cpp; sourceTree = "<group>"; };
@@ -955,8 +974,8 @@
 		1800B1884CC73C78A09E7FF1 /* htmlpars.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = htmlpars.cpp; path = ../../src/html/htmlpars.cpp; sourceTree = "<group>"; };
 		18044326B5B13A98A49732DD /* fontdlg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fontdlg.cpp; path = ../../src/osx/carbon/fontdlg.cpp; sourceTree = "<group>"; };
 		182C8AD4F822375495795B43 /* dbgrptg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = dbgrptg.cpp; path = ../../src/generic/dbgrptg.cpp; sourceTree = "<group>"; };
+		1895085EBEAE3A708FDD527A /* pcre2_chartables.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_chartables.c; path = ../../3rdparty/pcre/src/pcre2_chartables.c; sourceTree = "<group>"; };
 		190409DF8A3C3D9580FBB8AA /* stdpaths.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = stdpaths.mm; path = ../../src/osx/cocoa/stdpaths.mm; sourceTree = "<group>"; };
-		190409DF8A3C3D9580FBB8AB /* stdpaths.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = stdpaths.mm; path = ../../src/osx/cocoa/stdpaths.mm; sourceTree = "<group>"; };
 		194ADD28300E329E80F7892E /* htmprint.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = htmprint.cpp; path = ../../src/html/htmprint.cpp; sourceTree = "<group>"; };
 		19559DDA007D364E838014B5 /* nonownedwnd_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = nonownedwnd_osx.cpp; path = ../../src/osx/nonownedwnd_osx.cpp; sourceTree = "<group>"; };
 		1A0650754DC2358CA5933B28 /* pngerror.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pngerror.c; path = ../../src/png/pngerror.c; sourceTree = "<group>"; };
@@ -971,7 +990,7 @@
 		1C86EC3AA4193E639EB08AA7 /* LexHex.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexHex.cxx; path = ../../src/stc/scintilla/lexers/LexHex.cxx; sourceTree = "<group>"; };
 		1CABAEA3B48333CB88B40F08 /* LexTCMD.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexTCMD.cxx; path = ../../src/stc/scintilla/lexers/LexTCMD.cxx; sourceTree = "<group>"; };
 		1CE9B3DD54AD318FAA821732 /* richtextimagedlg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = richtextimagedlg.cpp; path = ../../src/richtext/richtextimagedlg.cpp; sourceTree = "<group>"; };
-		1D799486AD7F336BB1F33DDC /* menu.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = menu.mm; path = ../../src/osx/iphone/menu.mm; sourceTree = "<group>"; };
+		1D799486AD7F336BB1F33DDC /* menu.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = menu.mm; path = ../../src/osx/iphone/menu.mm; sourceTree = "<group>"; };
 		1DAF0931E4AD3E6581D7FDBC /* jidctint.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jidctint.c; path = ../../src/jpeg/jidctint.c; sourceTree = "<group>"; };
 		1E2FEBCEED2D33CFAAF75206 /* gbsizer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = gbsizer.cpp; path = ../../src/common/gbsizer.cpp; sourceTree = "<group>"; };
 		1E4E3EB1CCA53E0EA322A1AF /* gzwrite.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = gzwrite.c; path = ../../src/zlib/gzwrite.c; sourceTree = "<group>"; };
@@ -998,6 +1017,7 @@
 		24E82A05E9A9323287CDB15B /* artstd.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = artstd.cpp; path = ../../src/common/artstd.cpp; sourceTree = "<group>"; };
 		25A81E9028793C109D868068 /* xh_timectrl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_timectrl.cpp; path = ../../src/xrc/xh_timectrl.cpp; sourceTree = "<group>"; };
 		25C86D3D4839343BA1D8BDEE /* xti.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xti.cpp; path = ../../src/common/xti.cpp; sourceTree = "<group>"; };
+		25E03E349FC13E4A9428B94E /* pcre2_error.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_error.c; path = ../../3rdparty/pcre/src/pcre2_error.c; sourceTree = "<group>"; };
 		26381308E32A3A179E7A9B40 /* gridsel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = gridsel.cpp; path = ../../src/generic/gridsel.cpp; sourceTree = "<group>"; };
 		26632A254717372BAA4D514D /* framemanager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = framemanager.cpp; path = ../../src/aui/framemanager.cpp; sourceTree = "<group>"; };
 		267DB0E799183294B707A39D /* LexerNoExceptions.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexerNoExceptions.cxx; path = ../../src/stc/scintilla/lexlib/LexerNoExceptions.cxx; sourceTree = "<group>"; };
@@ -1031,8 +1051,10 @@
 		2F316F7DD3CB3390A6E50179 /* mimecmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = mimecmn.cpp; path = ../../src/common/mimecmn.cpp; sourceTree = "<group>"; };
 		2F3EE2E9EE05311497826962 /* LexMySQL.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexMySQL.cxx; path = ../../src/stc/scintilla/lexers/LexMySQL.cxx; sourceTree = "<group>"; };
 		2F41EDEB298538CC86FF6DC1 /* jcparam.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jcparam.c; path = ../../src/jpeg/jcparam.c; sourceTree = "<group>"; };
+		2F4CDF9048EC36788619769D /* pcre2_script_run.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_script_run.c; path = ../../3rdparty/pcre/src/pcre2_script_run.c; sourceTree = "<group>"; };
 		2F94CF171F4532B89FECF475 /* busyinfo.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = busyinfo.cpp; path = ../../src/generic/busyinfo.cpp; sourceTree = "<group>"; };
 		2FA01C426EAF38D3B9ED35AC /* tif_predict.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_predict.c; path = ../../src/tiff/libtiff/tif_predict.c; sourceTree = "<group>"; };
+		3026D20A03E53F1DB40FB35A /* pcre2_context.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_context.c; path = ../../3rdparty/pcre/src/pcre2_context.c; sourceTree = "<group>"; };
 		302A13BC64C238A297F4399F /* brush.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = brush.cpp; path = ../../src/osx/brush.cpp; sourceTree = "<group>"; };
 		303ACF199BE431BD891C9301 /* overlaycmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = overlaycmn.cpp; path = ../../src/common/overlaycmn.cpp; sourceTree = "<group>"; };
 		305614D19CF23CB2B14A5B2E /* tif_flush.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_flush.c; path = ../../src/tiff/libtiff/tif_flush.c; sourceTree = "<group>"; };
@@ -1053,6 +1075,7 @@
 		36296C259D023EAAA240FC79 /* bannerwindow.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = bannerwindow.cpp; path = ../../src/generic/bannerwindow.cpp; sourceTree = "<group>"; };
 		36E1DBA275AD325DB759C180 /* fontenum.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fontenum.cpp; path = ../../src/osx/core/fontenum.cpp; sourceTree = "<group>"; };
 		36F7955F8075343C8A9953DB /* LexPowerShell.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexPowerShell.cxx; path = ../../src/stc/scintilla/lexers/LexPowerShell.cxx; sourceTree = "<group>"; };
+		3716DA7B0C79360CBA26A71E /* tif_webp.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_webp.c; path = ../../src/tiff/libtiff/tif_webp.c; sourceTree = "<group>"; };
 		3720038D64CF3C0B8F642A90 /* tokenzr.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = tokenzr.cpp; path = ../../src/common/tokenzr.cpp; sourceTree = "<group>"; };
 		373242CD08F330208A7CF438 /* fontenumcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fontenumcmn.cpp; path = ../../src/common/fontenumcmn.cpp; sourceTree = "<group>"; };
 		374E341C8703367686DEDE93 /* jmemnobs.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jmemnobs.c; path = ../../src/jpeg/jmemnobs.c; sourceTree = "<group>"; };
@@ -1063,8 +1086,11 @@
 		38CEA4A3579331EF808B8363 /* fontdlgosx.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = fontdlgosx.mm; path = ../../src/osx/carbon/fontdlgosx.mm; sourceTree = "<group>"; };
 		38E0F60AE1F83633A0CC18FC /* xh_slidr.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_slidr.cpp; path = ../../src/xrc/xh_slidr.cpp; sourceTree = "<group>"; };
 		38EF5FC5934C34D599FD6074 /* bmpbuttn_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = bmpbuttn_osx.cpp; path = ../../src/osx/bmpbuttn_osx.cpp; sourceTree = "<group>"; };
+		39507FA11D8838109A22B7DA /* filter_neon_intrinsics.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = filter_neon_intrinsics.c; path = ../../src/png/arm/filter_neon_intrinsics.c; sourceTree = "<group>"; };
 		3ABD697F99673F16A0B2D4C1 /* styleparams.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = styleparams.cpp; path = ../../src/html/styleparams.cpp; sourceTree = "<group>"; };
 		3B548B1FF2A238809315C8A9 /* fdiounix.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fdiounix.cpp; path = ../../src/unix/fdiounix.cpp; sourceTree = "<group>"; };
+		3B93115BCC46333BBB31D6F7 /* pcre2_match.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_match.c; path = ../../3rdparty/pcre/src/pcre2_match.c; sourceTree = "<group>"; };
+		3B98123FD57731139044B064 /* tif_zstd.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_zstd.c; path = ../../src/tiff/libtiff/tif_zstd.c; sourceTree = "<group>"; };
 		3BFC1F090EFE30B784CE4C64 /* xh_toolb.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_toolb.cpp; path = ../../src/xrc/xh_toolb.cpp; sourceTree = "<group>"; };
 		3C131F7BF8A83960ACB26242 /* jidctflt.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jidctflt.c; path = ../../src/jpeg/jidctflt.c; sourceTree = "<group>"; };
 		3C654A08F74B3DBCA96CC2A9 /* sizer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = sizer.cpp; path = ../../src/common/sizer.cpp; sourceTree = "<group>"; };
@@ -1084,33 +1110,6 @@
 		4048A3523EC03409BD899BEF /* xtixml.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xtixml.cpp; path = ../../src/common/xtixml.cpp; sourceTree = "<group>"; };
 		40586C8986443431A64EB066 /* LexLisp.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexLisp.cxx; path = ../../src/stc/scintilla/lexers/LexLisp.cxx; sourceTree = "<group>"; };
 		4071FF90F1D4336C836B2AE4 /* tif_pixarlog.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_pixarlog.c; path = ../../src/tiff/libtiff/tif_pixarlog.c; sourceTree = "<group>"; };
-		FC6A8FAE9CA63EEB8883B6BD /* pcre2_config.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_config.c; path = ../../3rdparty/pcre/src/pcre2_config.c; sourceTree = "<group>"; };
-		95CBA2C736623FFF8629E975 /* pcre2_xclass.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_xclass.c; path = ../../3rdparty/pcre/src/pcre2_xclass.c; sourceTree = "<group>"; };
-		1895085EBEAE3A708FDD527A /* pcre2_chartables.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_chartables.c; path = ../../3rdparty/pcre/src/pcre2_chartables.c; sourceTree = "<group>"; };
-		BD2EBC2CCAE23AD6A1DF783E /* pcre2_serialize.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_serialize.c; path = ../../3rdparty/pcre/src/pcre2_serialize.c; sourceTree = "<group>"; };
-		00DAA69F74D031B6BE9196A8 /* pcre2_pattern_info.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_pattern_info.c; path = ../../3rdparty/pcre/src/pcre2_pattern_info.c; sourceTree = "<group>"; };
-		3026D20A03E53F1DB40FB35A /* pcre2_context.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_context.c; path = ../../3rdparty/pcre/src/pcre2_context.c; sourceTree = "<group>"; };
-		25E03E349FC13E4A9428B94E /* pcre2_error.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_error.c; path = ../../3rdparty/pcre/src/pcre2_error.c; sourceTree = "<group>"; };
-		09CCDDC66F683C6B87BEDD2F /* pcre2_study.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_study.c; path = ../../3rdparty/pcre/src/pcre2_study.c; sourceTree = "<group>"; };
-		2F4CDF9048EC36788619769D /* pcre2_script_run.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_script_run.c; path = ../../3rdparty/pcre/src/pcre2_script_run.c; sourceTree = "<group>"; };
-		BCED9B1D0D7E3FBBAC78CE5B /* pcre2_convert.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_convert.c; path = ../../3rdparty/pcre/src/pcre2_convert.c; sourceTree = "<group>"; };
-		A6EE037AF43E343E8E1A7555 /* pcre2_string_utils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_string_utils.c; path = ../../3rdparty/pcre/src/pcre2_string_utils.c; sourceTree = "<group>"; };
-		D016F584D14C31E192DB3179 /* pcre2_maketables.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_maketables.c; path = ../../3rdparty/pcre/src/pcre2_maketables.c; sourceTree = "<group>"; };
-		BDADEB1DA6433E52972C8934 /* pcre2_compile.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_compile.c; path = ../../3rdparty/pcre/src/pcre2_compile.c; sourceTree = "<group>"; };
-		3B93115BCC46333BBB31D6F7 /* pcre2_match.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_match.c; path = ../../3rdparty/pcre/src/pcre2_match.c; sourceTree = "<group>"; };
-		70F4EB692873386AAA0A44B0 /* pcre2_ucd.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_ucd.c; path = ../../3rdparty/pcre/src/pcre2_ucd.c; sourceTree = "<group>"; };
-		96D620AEA83E3444BA0B04C4 /* pcre2_dfa_match.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_dfa_match.c; path = ../../3rdparty/pcre/src/pcre2_dfa_match.c; sourceTree = "<group>"; };
-		5152B34D06E9343FBFAB3510 /* pcre2_substring.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_substring.c; path = ../../3rdparty/pcre/src/pcre2_substring.c; sourceTree = "<group>"; };
-		FAC42945539F362D91D6F559 /* pcre2_substitute.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_substitute.c; path = ../../3rdparty/pcre/src/pcre2_substitute.c; sourceTree = "<group>"; };
-		C3904351139F3F0DB4B72F94 /* pcre2_auto_possess.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_auto_possess.c; path = ../../3rdparty/pcre/src/pcre2_auto_possess.c; sourceTree = "<group>"; };
-		4E74E9E53454331F8E10ECC5 /* pcre2_match_data.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_match_data.c; path = ../../3rdparty/pcre/src/pcre2_match_data.c; sourceTree = "<group>"; };
-		A208BFC0C8C43847A9620ADA /* pcre2_newline.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_newline.c; path = ../../3rdparty/pcre/src/pcre2_newline.c; sourceTree = "<group>"; };
-		4BFEBC5061693DA0B52BC4AC /* pcre2_ord2utf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_ord2utf.c; path = ../../3rdparty/pcre/src/pcre2_ord2utf.c; sourceTree = "<group>"; };
-		943C7E9527C03FCDB5966273 /* pcre2_find_bracket.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_find_bracket.c; path = ../../3rdparty/pcre/src/pcre2_find_bracket.c; sourceTree = "<group>"; };
-		F0E43FFDC808333AA01EE649 /* pcre2_extuni.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_extuni.c; path = ../../3rdparty/pcre/src/pcre2_extuni.c; sourceTree = "<group>"; };
-		7C9F6184015A3BD1B8DA471E /* pcre2_jit_compile.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_jit_compile.c; path = ../../3rdparty/pcre/src/pcre2_jit_compile.c; sourceTree = "<group>"; };
-		B60497805D37375EBFCF3D98 /* pcre2_tables.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_tables.c; path = ../../3rdparty/pcre/src/pcre2_tables.c; sourceTree = "<group>"; };
-		FAE49A61DFE9375AAB18E8DD /* pcre2_valid_utf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = pcre2_valid_utf.c; path = ../../3rdparty/pcre/src/pcre2_valid_utf.c; sourceTree = "<group>"; };
 		40CE02524DD4385AB2C3DF95 /* socket.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = socket.cpp; path = ../../src/common/socket.cpp; sourceTree = "<group>"; };
 		4188821BBA833CCAA678B234 /* utilscmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = utilscmn.cpp; path = ../../src/common/utilscmn.cpp; sourceTree = "<group>"; };
 		418AD9241B673308BE31DC06 /* xlocale.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xlocale.cpp; path = ../../src/common/xlocale.cpp; sourceTree = "<group>"; };
@@ -1124,7 +1123,7 @@
 		4549845C0751356A907C23E0 /* jdtrans.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jdtrans.c; path = ../../src/jpeg/jdtrans.c; sourceTree = "<group>"; };
 		45860601270D318D93BEE1F3 /* LexMagik.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexMagik.cxx; path = ../../src/stc/scintilla/lexers/LexMagik.cxx; sourceTree = "<group>"; };
 		4592464D4868329897F3864D /* LexSpice.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexSpice.cxx; path = ../../src/stc/scintilla/lexers/LexSpice.cxx; sourceTree = "<group>"; };
-		45C65E309F3A39598C043657 /* xh_infobar.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = xh_infobar.cpp; path = ../../src/xrc/xh_infobar.cpp; sourceTree = "<group>"; };
+		45C65E309F3A39598C043657 /* xh_infobar.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_infobar.cpp; path = ../../src/xrc/xh_infobar.cpp; sourceTree = "<group>"; };
 		45D7558DF5E03A2EB41883F0 /* pngwutil.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pngwutil.c; path = ../../src/png/pngwutil.c; sourceTree = "<group>"; };
 		45E7EC6D0C0E3C878664C0A9 /* fldlgcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fldlgcmn.cpp; path = ../../src/common/fldlgcmn.cpp; sourceTree = "<group>"; };
 		47783A330B2A3B4EBB1CD95D /* fswatcherg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fswatcherg.cpp; path = ../../src/generic/fswatcherg.cpp; sourceTree = "<group>"; };
@@ -1146,8 +1145,12 @@
 		4B3B8AD0120F3EA6BF5B0AE0 /* LexCaml.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexCaml.cxx; path = ../../src/stc/scintilla/lexers/LexCaml.cxx; sourceTree = "<group>"; };
 		4BA14FFC0F4B3AE0B4D6B185 /* jquant1.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jquant1.c; path = ../../src/jpeg/jquant1.c; sourceTree = "<group>"; };
 		4BA819575B5136B09FA8FEB1 /* pen.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = pen.cpp; path = ../../src/osx/pen.cpp; sourceTree = "<group>"; };
+		4BFEBC5061693DA0B52BC4AC /* pcre2_ord2utf.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_ord2utf.c; path = ../../3rdparty/pcre/src/pcre2_ord2utf.c; sourceTree = "<group>"; };
 		4C4649974D8B3A109D1BF145 /* art_internal.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = art_internal.cpp; path = ../../src/ribbon/art_internal.cpp; sourceTree = "<group>"; };
 		4CB467F9898C3952A68D988B /* zutil.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = zutil.c; path = ../../src/zlib/zutil.c; sourceTree = "<group>"; };
+		4E4466371B7E3265AE7B1E0C /* uilocale.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = uilocale.cpp; path = ../../src/common/uilocale.cpp; sourceTree = "<group>"; };
+		4E4466371B7E3265AE7B1E0D /* uilocale.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = uilocale.cpp; path = ../../src/osx/core/uilocale.cpp; sourceTree = "<group>"; };
+		4E74E9E53454331F8E10ECC5 /* pcre2_match_data.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_match_data.c; path = ../../3rdparty/pcre/src/pcre2_match_data.c; sourceTree = "<group>"; };
 		4EB3B255D20F3AE5A95230F6 /* LexCSS.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexCSS.cxx; path = ../../src/stc/scintilla/lexers/LexCSS.cxx; sourceTree = "<group>"; };
 		4F58B88D42A93BD0B74ADF75 /* CallTip.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = CallTip.cxx; path = ../../src/stc/scintilla/src/CallTip.cxx; sourceTree = "<group>"; };
 		4F768B23D8B535CE8D0BD343 /* tif_jpeg_12.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_jpeg_12.c; path = ../../src/tiff/libtiff/tif_jpeg_12.c; sourceTree = "<group>"; };
@@ -1160,10 +1163,12 @@
 		51054B41BFD83E97BAF76D07 /* tabart.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = tabart.cpp; path = ../../src/aui/tabart.cpp; sourceTree = "<group>"; };
 		513033E36E643593AC305B3D /* uncompr.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = uncompr.c; path = ../../src/zlib/uncompr.c; sourceTree = "<group>"; };
 		5145561C78303EEE9F827962 /* LexLua.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexLua.cxx; path = ../../src/stc/scintilla/lexers/LexLua.cxx; sourceTree = "<group>"; };
+		5152B34D06E9343FBFAB3510 /* pcre2_substring.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_substring.c; path = ../../3rdparty/pcre/src/pcre2_substring.c; sourceTree = "<group>"; };
 		5168ADF7BE39351F8F24E1E6 /* cfstring.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = cfstring.cpp; path = ../../src/osx/core/cfstring.cpp; sourceTree = "<group>"; };
 		5190E3E110443FD29F2474FC /* treelist.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = treelist.cpp; path = ../../src/generic/treelist.cpp; sourceTree = "<group>"; };
 		5219A792C6A736F193D4A82F /* ContractionState.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ContractionState.cxx; path = ../../src/stc/scintilla/src/ContractionState.cxx; sourceTree = "<group>"; };
 		5248A45AB113341EAC361910 /* notebook_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = notebook_osx.cpp; path = ../../src/osx/notebook_osx.cpp; sourceTree = "<group>"; };
+		5279968877003A8BB8279765 /* webrequest_curl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = webrequest_curl.cpp; path = ../../src/common/webrequest_curl.cpp; sourceTree = "<group>"; };
 		52FE1599218730CC99A3F801 /* m_dflist.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = m_dflist.cpp; path = ../../src/html/m_dflist.cpp; sourceTree = "<group>"; };
 		530DC2E26BF2313E8702AD43 /* popupwin.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = popupwin.cpp; path = ../../src/osx/carbon/popupwin.cpp; sourceTree = "<group>"; };
 		531B0E5DB9ED393996E3FBB8 /* radiocmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = radiocmn.cpp; path = ../../src/common/radiocmn.cpp; sourceTree = "<group>"; };
@@ -1216,6 +1221,7 @@
 		5E2F1BF8904635049BAFD6E1 /* spinbutt_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = spinbutt_osx.cpp; path = ../../src/osx/spinbutt_osx.cpp; sourceTree = "<group>"; };
 		5E463A493FD930DE80E58608 /* pngset.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pngset.c; path = ../../src/png/pngset.c; sourceTree = "<group>"; };
 		5E7A77AA776B3B5CAEE3CC90 /* listbkg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = listbkg.cpp; path = ../../src/generic/listbkg.cpp; sourceTree = "<group>"; };
+		5EA9E372A64B3B808A64B178 /* webrequest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = webrequest.cpp; path = ../../src/common/webrequest.cpp; sourceTree = "<group>"; };
 		5ED2105A5A033E3384EBC4ED /* selstore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = selstore.cpp; path = ../../src/generic/selstore.cpp; sourceTree = "<group>"; };
 		5F094B0B07DF33BCA6077BC0 /* fdrepdlg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fdrepdlg.cpp; path = ../../src/generic/fdrepdlg.cpp; sourceTree = "<group>"; };
 		5F3D473DC5123EDAB767045C /* datavgen.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = datavgen.cpp; path = ../../src/generic/datavgen.cpp; sourceTree = "<group>"; };
@@ -1232,7 +1238,8 @@
 		600740717F7E320F8CA78384 /* scrolbar_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = scrolbar_osx.cpp; path = ../../src/osx/scrolbar_osx.cpp; sourceTree = "<group>"; };
 		607EF0043E723B7B9BE101EA /* wxprintf.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = wxprintf.cpp; path = ../../src/common/wxprintf.cpp; sourceTree = "<group>"; };
 		60EE4448A28D38F5ADE17B5A /* xh_filectrl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_filectrl.cpp; path = ../../src/xrc/xh_filectrl.cpp; sourceTree = "<group>"; };
-		61548D0FE1353D7C846DD721 /* menuitem.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = menuitem.mm; path = ../../src/osx/iphone/menuitem.mm; sourceTree = "<group>"; };
+		61548D0FE1353D7C846DD721 /* menuitem.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = menuitem.mm; path = ../../src/osx/iphone/menuitem.mm; sourceTree = "<group>"; };
+		616466F521DB3ECAB304289F /* xh_dataview.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_dataview.cpp; path = ../../src/xrc/xh_dataview.cpp; sourceTree = "<group>"; };
 		61658C3EABB4341AA38C691E /* m_pre.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = m_pre.cpp; path = ../../src/html/m_pre.cpp; sourceTree = "<group>"; };
 		61DA2A4C0D143CBE804BB8A1 /* fileconf.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fileconf.cpp; path = ../../src/common/fileconf.cpp; sourceTree = "<group>"; };
 		62C46B0CE620348FBF3860A4 /* LexPLM.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexPLM.cxx; path = ../../src/stc/scintilla/lexers/LexPLM.cxx; sourceTree = "<group>"; };
@@ -1278,6 +1285,7 @@
 		701B84EE7C043B539FF5195A /* textbuf.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = textbuf.cpp; path = ../../src/common/textbuf.cpp; sourceTree = "<group>"; };
 		7020ADB5D3E0375E875B418B /* LexA68k.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexA68k.cxx; path = ../../src/stc/scintilla/lexers/LexA68k.cxx; sourceTree = "<group>"; };
 		70E9B2C076673C87B4218A01 /* panelcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = panelcmn.cpp; path = ../../src/common/panelcmn.cpp; sourceTree = "<group>"; };
+		70F4EB692873386AAA0A44B0 /* pcre2_ucd.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_ucd.c; path = ../../3rdparty/pcre/src/pcre2_ucd.c; sourceTree = "<group>"; };
 		7195E665E0F233839B967FC9 /* timercmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = timercmn.cpp; path = ../../src/common/timercmn.cpp; sourceTree = "<group>"; };
 		71DB140E670738839EC42C2B /* Document.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Document.cxx; path = ../../src/stc/scintilla/src/Document.cxx; sourceTree = "<group>"; };
 		724927B0045F3CC0884878BB /* radiobtncmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = radiobtncmn.cpp; path = ../../src/common/radiobtncmn.cpp; sourceTree = "<group>"; };
@@ -1313,6 +1321,7 @@
 		7BA6ADD758693BD180D3275B /* treebase.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = treebase.cpp; path = ../../src/common/treebase.cpp; sourceTree = "<group>"; };
 		7C80A0223B993BCB80D1C0A0 /* srchctrl_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = srchctrl_osx.cpp; path = ../../src/osx/srchctrl_osx.cpp; sourceTree = "<group>"; };
 		7C97C1F26B5A38C49543060C /* mimetype.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = mimetype.cpp; path = ../../src/osx/core/mimetype.cpp; sourceTree = "<group>"; };
+		7C9F6184015A3BD1B8DA471E /* pcre2_jit_compile.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_jit_compile.c; path = ../../3rdparty/pcre/src/pcre2_jit_compile.c; sourceTree = "<group>"; };
 		7CF5C09D9A1230EEB42713E1 /* stattext_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = stattext_osx.cpp; path = ../../src/osx/stattext_osx.cpp; sourceTree = "<group>"; };
 		7D2BE094D90D3AFDAE49F589 /* fswatchercmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fswatchercmn.cpp; path = ../../src/common/fswatchercmn.cpp; sourceTree = "<group>"; };
 		7D8BDFB06EE13E59ABB2A616 /* LexSorcus.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexSorcus.cxx; path = ../../src/stc/scintilla/lexers/LexSorcus.cxx; sourceTree = "<group>"; };
@@ -1383,21 +1392,25 @@
 		917F2666B67E3D2EB84E74F8 /* sashwin.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = sashwin.cpp; path = ../../src/generic/sashwin.cpp; sourceTree = "<group>"; };
 		924AA3A156F834BCA1A57976 /* notifmsgg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = notifmsgg.cpp; path = ../../src/generic/notifmsgg.cpp; sourceTree = "<group>"; };
 		92F377099B8B37F18C26716B /* collheaderctrlg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = collheaderctrlg.cpp; path = ../../src/generic/collheaderctrlg.cpp; sourceTree = "<group>"; };
+		933D7637CAA43F6C99814BC5 /* arm_init.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = arm_init.c; path = ../../src/png/arm/arm_init.c; sourceTree = "<group>"; };
 		9389DAF8B91030B7AAB029FF /* PerLine.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PerLine.cxx; path = ../../src/stc/scintilla/src/PerLine.cxx; sourceTree = "<group>"; };
 		93B77251C0E0382D9A8E113D /* xh_grid.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_grid.cpp; path = ../../src/xrc/xh_grid.cpp; sourceTree = "<group>"; };
 		93BA27DFFB023F2EBD6295E3 /* dynload.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = dynload.cpp; path = ../../src/common/dynload.cpp; sourceTree = "<group>"; };
 		93D07403FCA530D7A9FD2917 /* jfdctflt.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jfdctflt.c; path = ../../src/jpeg/jfdctflt.c; sourceTree = "<group>"; };
 		93EDB3A2B85E3275A6D27C56 /* LexerBase.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexerBase.cxx; path = ../../src/stc/scintilla/lexlib/LexerBase.cxx; sourceTree = "<group>"; };
+		943C7E9527C03FCDB5966273 /* pcre2_find_bracket.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_find_bracket.c; path = ../../3rdparty/pcre/src/pcre2_find_bracket.c; sourceTree = "<group>"; };
 		950D51915EF83B57B5E8306F /* xh_spin.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_spin.cpp; path = ../../src/xrc/xh_spin.cpp; sourceTree = "<group>"; };
 		95186FEF3DEF39D8B1157BD5 /* stattext.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = stattext.mm; path = ../../src/osx/iphone/stattext.mm; sourceTree = "<group>"; };
 		95A156A823B536DE8476E4F9 /* appbase.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = appbase.cpp; path = ../../src/common/appbase.cpp; sourceTree = "<group>"; };
 		95B4EDF38F8A3E5EBAFF560F /* trees.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = trees.c; path = ../../src/zlib/trees.c; sourceTree = "<group>"; };
+		95CBA2C736623FFF8629E975 /* pcre2_xclass.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_xclass.c; path = ../../3rdparty/pcre/src/pcre2_xclass.c; sourceTree = "<group>"; };
 		95DEEF60B1E9358A8CCCC67E /* datavcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = datavcmn.cpp; path = ../../src/common/datavcmn.cpp; sourceTree = "<group>"; };
 		95E2B80B2D7033808504DA8D /* utilsexc_cf.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = utilsexc_cf.cpp; path = ../../src/osx/core/utilsexc_cf.cpp; sourceTree = "<group>"; };
 		964578C24B9F390AAD08576E /* addremovectrl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = addremovectrl.cpp; path = ../../src/common/addremovectrl.cpp; sourceTree = "<group>"; };
 		9660AE8FEB7B3EDB857B9238 /* lboxcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = lboxcmn.cpp; path = ../../src/common/lboxcmn.cpp; sourceTree = "<group>"; };
 		967EF76827CB3CDE87E1E733 /* propgridpagestate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = propgridpagestate.cpp; path = ../../src/propgrid/propgridpagestate.cpp; sourceTree = "<group>"; };
 		96CED508FA3C3B6B9265099E /* rendcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = rendcmn.cpp; path = ../../src/common/rendcmn.cpp; sourceTree = "<group>"; };
+		96D620AEA83E3444BA0B04C4 /* pcre2_dfa_match.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_dfa_match.c; path = ../../3rdparty/pcre/src/pcre2_dfa_match.c; sourceTree = "<group>"; };
 		9720FFA4490D3AC38E53BE03 /* StyleContext.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = StyleContext.cxx; path = ../../src/stc/scintilla/lexlib/StyleContext.cxx; sourceTree = "<group>"; };
 		972BC9B2B0D438EFB12BCE1E /* rearrangectrl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = rearrangectrl.cpp; path = ../../src/common/rearrangectrl.cpp; sourceTree = "<group>"; };
 		975E3B6A269434F0A069987D /* Catalogue.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Catalogue.cxx; path = ../../src/stc/scintilla/src/Catalogue.cxx; sourceTree = "<group>"; };
@@ -1407,9 +1420,11 @@
 		9860CD56245B3E7FBD0E7846 /* checklst_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = checklst_osx.cpp; path = ../../src/osx/checklst_osx.cpp; sourceTree = "<group>"; };
 		98A7F0605AAC3D28A8C9F253 /* gauge.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = gauge.mm; path = ../../src/osx/iphone/gauge.mm; sourceTree = "<group>"; };
 		99479DE14D8D3F7E9EB3E9A2 /* LexNull.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexNull.cxx; path = ../../src/stc/scintilla/lexers/LexNull.cxx; sourceTree = "<group>"; };
+		994AF74DF2A13FF09A215853 /* intel_init.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = intel_init.c; path = ../../src/png/intel/intel_init.c; sourceTree = "<group>"; };
 		9988CBB0772A3539970162FA /* arttango.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = arttango.cpp; path = ../../src/common/arttango.cpp; sourceTree = "<group>"; };
 		998C092CB83639CFA3DC63B1 /* checkbox_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = checkbox_osx.cpp; path = ../../src/osx/checkbox_osx.cpp; sourceTree = "<group>"; };
 		998D611109EC33A9A6A11C5A /* gdicmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = gdicmn.cpp; path = ../../src/common/gdicmn.cpp; sourceTree = "<group>"; };
+		99A9D5F9254D35BE8F4176A4 /* lzmastream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = lzmastream.cpp; path = ../../src/common/lzmastream.cpp; sourceTree = "<group>"; };
 		99BC7A16DBCA36EDA9D6F1DB /* powercmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = powercmn.cpp; path = ../../src/common/powercmn.cpp; sourceTree = "<group>"; };
 		9A23D41D747D38BF8AD30067 /* xh_gauge.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_gauge.cpp; path = ../../src/xrc/xh_gauge.cpp; sourceTree = "<group>"; };
 		9AD367F1047838A9A7A34DBF /* xmlreshandler.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xmlreshandler.cpp; path = ../../src/xrc/xmlreshandler.cpp; sourceTree = "<group>"; };
@@ -1421,6 +1436,7 @@
 		9CC7C6FFD67233788EEDFC5E /* LexYAML.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexYAML.cxx; path = ../../src/stc/scintilla/lexers/LexYAML.cxx; sourceTree = "<group>"; };
 		9CE73979D0933A43830307E4 /* tif_packbits.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_packbits.c; path = ../../src/tiff/libtiff/tif_packbits.c; sourceTree = "<group>"; };
 		9D1F14339D1C331087650931 /* colour.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = colour.cpp; path = ../../src/osx/core/colour.cpp; sourceTree = "<group>"; };
+		9D602B5F09E8314CB9F65C11 /* filter_sse2_intrinsics.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = filter_sse2_intrinsics.c; path = ../../src/png/intel/filter_sse2_intrinsics.c; sourceTree = "<group>"; };
 		9D6B0D32537D35069C7E053F /* inftrees.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = inftrees.c; path = ../../src/zlib/inftrees.c; sourceTree = "<group>"; };
 		9DB43FAB1E563B02ACEFF647 /* module.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = module.cpp; path = ../../src/common/module.cpp; sourceTree = "<group>"; };
 		9DD609EC0591359C9A576A43 /* printdlg_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = printdlg_osx.cpp; path = ../../src/osx/printdlg_osx.cpp; sourceTree = "<group>"; };
@@ -1439,8 +1455,10 @@
 		A1276C0E5D48337489DEE8DF /* LexErlang.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexErlang.cxx; path = ../../src/stc/scintilla/lexers/LexErlang.cxx; sourceTree = "<group>"; };
 		A1A53EC3A3463EFDB7614E93 /* bitmap.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = bitmap.cpp; path = ../../src/osx/core/bitmap.cpp; sourceTree = "<group>"; };
 		A1CB6A4171D4343BB0A9858A /* msgdlgg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = msgdlgg.cpp; path = ../../src/generic/msgdlgg.cpp; sourceTree = "<group>"; };
+		A208BFC0C8C43847A9620ADA /* pcre2_newline.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_newline.c; path = ../../3rdparty/pcre/src/pcre2_newline.c; sourceTree = "<group>"; };
 		A284E855892F3A9E9E19E854 /* LexTADS3.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexTADS3.cxx; path = ../../src/stc/scintilla/lexers/LexTADS3.cxx; sourceTree = "<group>"; };
 		A298576700C33F018616E7BD /* auibook.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = auibook.cpp; path = ../../src/aui/auibook.cpp; sourceTree = "<group>"; };
+		A2B7B30FA60633339D8862C6 /* rowheightcache.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = rowheightcache.cpp; path = ../../src/generic/rowheightcache.cpp; sourceTree = "<group>"; };
 		A37E3D1FB4FB31AFAE88665A /* dpycmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = dpycmn.cpp; path = ../../src/common/dpycmn.cpp; sourceTree = "<group>"; };
 		A3BF8C9FF2D5314591329D0D /* toolbar.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = toolbar.mm; path = ../../src/osx/iphone/toolbar.mm; sourceTree = "<group>"; };
 		A436B55DC44E3827A757A6D8 /* accelcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = accelcmn.cpp; path = ../../src/common/accelcmn.cpp; sourceTree = "<group>"; };
@@ -1454,6 +1472,7 @@
 		A5EE0B8985443BDCB36F781F /* m_layout.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = m_layout.cpp; path = ../../src/html/m_layout.cpp; sourceTree = "<group>"; };
 		A65399C8A6D636139E362119 /* LexAsm.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexAsm.cxx; path = ../../src/stc/scintilla/lexers/LexAsm.cxx; sourceTree = "<group>"; };
 		A6636144CDE83E8E85270FAF /* hashmap.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = hashmap.cpp; path = ../../src/common/hashmap.cpp; sourceTree = "<group>"; };
+		A6EE037AF43E343E8E1A7555 /* pcre2_string_utils.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_string_utils.c; path = ../../3rdparty/pcre/src/pcre2_string_utils.c; sourceTree = "<group>"; };
 		A737317EDE0F3921B1412966 /* LexRegistry.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexRegistry.cxx; path = ../../src/stc/scintilla/lexers/LexRegistry.cxx; sourceTree = "<group>"; };
 		A82C367B86F83981803D55DB /* LexASY.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexASY.cxx; path = ../../src/stc/scintilla/lexers/LexASY.cxx; sourceTree = "<group>"; };
 		A87662D69F0432FC96701280 /* xh_notbk.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_notbk.cpp; path = ../../src/xrc/xh_notbk.cpp; sourceTree = "<group>"; };
@@ -1516,6 +1535,7 @@
 		B56A9BF7AE1E3F11A5848297 /* tipdlg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = tipdlg.cpp; path = ../../src/generic/tipdlg.cpp; sourceTree = "<group>"; };
 		B580FD04D0D83601826FD5EE /* filepickerg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = filepickerg.cpp; path = ../../src/generic/filepickerg.cpp; sourceTree = "<group>"; };
 		B5E2D6917EB1352983C7FE85 /* wrapsizer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = wrapsizer.cpp; path = ../../src/common/wrapsizer.cpp; sourceTree = "<group>"; };
+		B60497805D37375EBFCF3D98 /* pcre2_tables.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_tables.c; path = ../../3rdparty/pcre/src/pcre2_tables.c; sourceTree = "<group>"; };
 		B63EBEE1A04537E7887E9FD0 /* ustring.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ustring.cpp; path = ../../src/common/ustring.cpp; sourceTree = "<group>"; };
 		B6A37A02D28E30CD9B83E134 /* xh_ribbon.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_ribbon.cpp; path = ../../src/xrc/xh_ribbon.cpp; sourceTree = "<group>"; };
 		B6AADC1056E03A3B80C20C5B /* LexBasic.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexBasic.cxx; path = ../../src/stc/scintilla/lexers/LexBasic.cxx; sourceTree = "<group>"; };
@@ -1541,9 +1561,12 @@
 		BC12B97F233B3B9494DA217F /* imagpnm.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = imagpnm.cpp; path = ../../src/common/imagpnm.cpp; sourceTree = "<group>"; };
 		BC5C5DB466CD3D6FA6985B56 /* LexNimrod.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexNimrod.cxx; path = ../../src/stc/scintilla/lexers/LexNimrod.cxx; sourceTree = "<group>"; };
 		BCD873D873A53BBF955D8A4E /* PositionCache.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = PositionCache.cxx; path = ../../src/stc/scintilla/src/PositionCache.cxx; sourceTree = "<group>"; };
+		BCED9B1D0D7E3FBBAC78CE5B /* pcre2_convert.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_convert.c; path = ../../3rdparty/pcre/src/pcre2_convert.c; sourceTree = "<group>"; };
 		BD169D8019A13A11BDB26214 /* xh_dirpicker.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_dirpicker.cpp; path = ../../src/xrc/xh_dirpicker.cpp; sourceTree = "<group>"; };
+		BD2EBC2CCAE23AD6A1DF783E /* pcre2_serialize.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_serialize.c; path = ../../3rdparty/pcre/src/pcre2_serialize.c; sourceTree = "<group>"; };
 		BD709DEB71623974B9836D69 /* dockart.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = dockart.cpp; path = ../../src/aui/dockart.cpp; sourceTree = "<group>"; };
 		BD88495AF72531A28D2201D0 /* tif_tile.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_tile.c; path = ../../src/tiff/libtiff/tif_tile.c; sourceTree = "<group>"; };
+		BDADEB1DA6433E52972C8934 /* pcre2_compile.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_compile.c; path = ../../3rdparty/pcre/src/pcre2_compile.c; sourceTree = "<group>"; };
 		BDE76674C0F5391BAD2AFA2F /* dialog_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = dialog_osx.cpp; path = ../../src/osx/dialog_osx.cpp; sourceTree = "<group>"; };
 		BE4B0CE56BA23002A5C8AEFF /* toolbar.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = toolbar.cpp; path = ../../src/ribbon/toolbar.cpp; sourceTree = "<group>"; };
 		BEA102FF0FFC33DEAEF2FE14 /* progdlgg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = progdlgg.cpp; path = ../../src/generic/progdlgg.cpp; sourceTree = "<group>"; };
@@ -1570,6 +1593,7 @@
 		C3019BA65DD73F30A865365F /* frame.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = frame.cpp; path = ../../src/osx/carbon/frame.cpp; sourceTree = "<group>"; };
 		C3784C240C2F330683494926 /* laywin.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = laywin.cpp; path = ../../src/generic/laywin.cpp; sourceTree = "<group>"; };
 		C37866F41B0C31E295AA7FA6 /* wfstream.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = wfstream.cpp; path = ../../src/common/wfstream.cpp; sourceTree = "<group>"; };
+		C3904351139F3F0DB4B72F94 /* pcre2_auto_possess.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_auto_possess.c; path = ../../3rdparty/pcre/src/pcre2_auto_possess.c; sourceTree = "<group>"; };
 		C45AFE6CC20F3ED7A55FC8FA /* pngmem.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pngmem.c; path = ../../src/png/pngmem.c; sourceTree = "<group>"; };
 		C466F32CCBD13DBC87285B3D /* helpdata.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = helpdata.cpp; path = ../../src/html/helpdata.cpp; sourceTree = "<group>"; };
 		C4C45D3C63AA37CEBCE83321 /* richtextprint.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = richtextprint.cpp; path = ../../src/richtext/richtextprint.cpp; sourceTree = "<group>"; };
@@ -1606,6 +1630,7 @@
 		CF502E0E4D853CBBBEC885EF /* LexerSimple.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexerSimple.cxx; path = ../../src/stc/scintilla/lexlib/LexerSimple.cxx; sourceTree = "<group>"; };
 		CF6511DE2CB43534A5566403 /* menuitem_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = menuitem_osx.cpp; path = ../../src/osx/menuitem_osx.cpp; sourceTree = "<group>"; };
 		CFBDB327E4A236A3ABFA326F /* webviewfshandler.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = webviewfshandler.cpp; path = ../../src/common/webviewfshandler.cpp; sourceTree = "<group>"; };
+		D016F584D14C31E192DB3179 /* pcre2_maketables.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_maketables.c; path = ../../3rdparty/pcre/src/pcre2_maketables.c; sourceTree = "<group>"; };
 		D037EA567C253DEEA17E822B /* mousemanager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = mousemanager.cpp; path = ../../src/common/mousemanager.cpp; sourceTree = "<group>"; };
 		D0817D6A1AF83608B050EBC3 /* fontmap.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fontmap.cpp; path = ../../src/common/fontmap.cpp; sourceTree = "<group>"; };
 		D0B70966E9423F198C8CBE65 /* xh_cmdlinkbn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_cmdlinkbn.cpp; path = ../../src/xrc/xh_cmdlinkbn.cpp; sourceTree = "<group>"; };
@@ -1682,6 +1707,7 @@
 		E860DD54EEBF3119961B7BB1 /* CellBuffer.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = CellBuffer.cxx; path = ../../src/stc/scintilla/src/CellBuffer.cxx; sourceTree = "<group>"; };
 		E89AC104BF4F33A083F8B382 /* jccoefct.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jccoefct.c; path = ../../src/jpeg/jccoefct.c; sourceTree = "<group>"; };
 		E8BD1489D95E3FD78B200B1B /* commandlinkbuttong.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = commandlinkbuttong.cpp; path = ../../src/generic/commandlinkbuttong.cpp; sourceTree = "<group>"; };
+		E8DE97F5A2AD393CBD31AED3 /* creddlgg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = creddlgg.cpp; path = ../../src/generic/creddlgg.cpp; sourceTree = "<group>"; };
 		E8EE191DC59F362AAED2CDC1 /* bmpbase.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = bmpbase.cpp; path = ../../src/common/bmpbase.cpp; sourceTree = "<group>"; };
 		E968913A9A593B258BD8EACB /* msgout.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = msgout.cpp; path = ../../src/common/msgout.cpp; sourceTree = "<group>"; };
 		E97AE22E9F043AB6846B3BE7 /* xh_scwin.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_scwin.cpp; path = ../../src/xrc/xh_scwin.cpp; sourceTree = "<group>"; };
@@ -1693,6 +1719,7 @@
 		EA2520F427493A22A70A5C09 /* stackwalk.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = stackwalk.cpp; path = ../../src/unix/stackwalk.cpp; sourceTree = "<group>"; };
 		EA3F8832890138E9AB6E65D8 /* xh_chckl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_chckl.cpp; path = ../../src/xrc/xh_chckl.cpp; sourceTree = "<group>"; };
 		EA4AF89C36C53EB4B307DCAB /* filtfind.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = filtfind.cpp; path = ../../src/common/filtfind.cpp; sourceTree = "<group>"; };
+		EA8CCF32688434EABEEEE04A /* webrequest_urlsession.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = webrequest_urlsession.mm; path = ../../src/osx/webrequest_urlsession.mm; sourceTree = "<group>"; };
 		EA93D41B11683E758D456531 /* log.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = log.cpp; path = ../../src/common/log.cpp; sourceTree = "<group>"; };
 		EBD381E57BAE3F2AA31A68CB /* xh_wizrd.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_wizrd.cpp; path = ../../src/xrc/xh_wizrd.cpp; sourceTree = "<group>"; };
 		EBED392D081335FA80523244 /* manager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = manager.cpp; path = ../../src/propgrid/manager.cpp; sourceTree = "<group>"; };
@@ -1711,6 +1738,7 @@
 		EF330EAACFA53877BE289896 /* matrix.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = matrix.cpp; path = ../../src/common/matrix.cpp; sourceTree = "<group>"; };
 		F01DDE448E4C3983ACCE67FD /* appcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = appcmn.cpp; path = ../../src/common/appcmn.cpp; sourceTree = "<group>"; };
 		F0905A1EBD653F6D82395602 /* xh_combo.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_combo.cpp; path = ../../src/xrc/xh_combo.cpp; sourceTree = "<group>"; };
+		F0E43FFDC808333AA01EE649 /* pcre2_extuni.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_extuni.c; path = ../../3rdparty/pcre/src/pcre2_extuni.c; sourceTree = "<group>"; };
 		F175D6E8E5723FC797701275 /* menucmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = menucmn.cpp; path = ../../src/common/menucmn.cpp; sourceTree = "<group>"; };
 		F190B80DD28031A98E5BCA67 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		F1A6F3936A0D31CBB58082BA /* jdcoefct.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jdcoefct.c; path = ../../src/jpeg/jdcoefct.c; sourceTree = "<group>"; };
@@ -1726,6 +1754,7 @@
 		F4B85051B7C835A8BF4E3EE1 /* xh_panel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_panel.cpp; path = ../../src/xrc/xh_panel.cpp; sourceTree = "<group>"; };
 		F4C72C5C61A6335C8B418BA1 /* LexMetapost.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexMetapost.cxx; path = ../../src/stc/scintilla/lexers/LexMetapost.cxx; sourceTree = "<group>"; };
 		F52DCBC0442233738B39138E /* CaseFolder.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = CaseFolder.cxx; path = ../../src/stc/scintilla/src/CaseFolder.cxx; sourceTree = "<group>"; };
+		F582C6B3A5AA3367BB4DBE97 /* statbmp_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = statbmp_osx.cpp; path = ../../src/osx/statbmp_osx.cpp; sourceTree = "<group>"; };
 		F5DAF1F49F0F3F41A427A21D /* icon.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = icon.cpp; path = ../../src/generic/icon.cpp; sourceTree = "<group>"; };
 		F6EA240B3DB93D398A990FAD /* tif_dirread.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_dirread.c; path = ../../src/tiff/libtiff/tif_dirread.c; sourceTree = "<group>"; };
 		F6F01A84F4DE3C9FB9849004 /* tif_jbig.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = tif_jbig.c; path = ../../src/tiff/libtiff/tif_jbig.c; sourceTree = "<group>"; };
@@ -1740,16 +1769,21 @@
 		FA59091E3ED83FB781FB9659 /* glcanvas_osx.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = glcanvas_osx.cpp; path = ../../src/osx/glcanvas_osx.cpp; sourceTree = "<group>"; };
 		FA7029BB5751398AA02D8C24 /* imagtga.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = imagtga.cpp; path = ../../src/common/imagtga.cpp; sourceTree = "<group>"; };
 		FA9DD56E399533A5BE7AAD16 /* jdarith.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = jdarith.c; path = ../../src/jpeg/jdarith.c; sourceTree = "<group>"; };
+		FAC42945539F362D91D6F559 /* pcre2_substitute.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_substitute.c; path = ../../3rdparty/pcre/src/pcre2_substitute.c; sourceTree = "<group>"; };
 		FADE850169F7347F83FE1499 /* xh_statbar.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_statbar.cpp; path = ../../src/xrc/xh_statbar.cpp; sourceTree = "<group>"; };
+		FAE49A61DFE9375AAB18E8DD /* pcre2_valid_utf.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_valid_utf.c; path = ../../3rdparty/pcre/src/pcre2_valid_utf.c; sourceTree = "<group>"; };
+		FB17368A86EC30E6B843E32F /* palette_neon_intrinsics.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = palette_neon_intrinsics.c; path = ../../src/png/arm/palette_neon_intrinsics.c; sourceTree = "<group>"; };
 		FB46BC22F6B23909A938C561 /* regex.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = regex.cpp; path = ../../src/common/regex.cpp; sourceTree = "<group>"; };
 		FBC5A5797B0D369291A76D6E /* dcbufcmn.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = dcbufcmn.cpp; path = ../../src/common/dcbufcmn.cpp; sourceTree = "<group>"; };
 		FBE1C531185131A89EFF7FAF /* cmdline.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = cmdline.cpp; path = ../../src/common/cmdline.cpp; sourceTree = "<group>"; };
 		FBE8E520BA0530C6AD857434 /* fontpickerg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = fontpickerg.cpp; path = ../../src/generic/fontpickerg.cpp; sourceTree = "<group>"; };
+		FC6A8FAE9CA63EEB8883B6BD /* pcre2_config.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = pcre2_config.c; path = ../../3rdparty/pcre/src/pcre2_config.c; sourceTree = "<group>"; };
 		FCCFF49F92B4323D9181CEDA /* htmltag.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = htmltag.cpp; path = ../../src/html/htmltag.cpp; sourceTree = "<group>"; };
 		FCE8B55EBD6B348B8351AB08 /* LexKVIrc.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexKVIrc.cxx; path = ../../src/stc/scintilla/lexers/LexKVIrc.cxx; sourceTree = "<group>"; };
 		FD0C7FCA25A3312E8F2FCF3C /* LexTeX.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LexTeX.cxx; path = ../../src/stc/scintilla/lexers/LexTeX.cxx; sourceTree = "<group>"; };
 		FD55F391CD1032DFACA88CFD /* xh_srchctrl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xh_srchctrl.cpp; path = ../../src/xrc/xh_srchctrl.cpp; sourceTree = "<group>"; };
 		FD5F11A3646F397BA62EB037 /* htmllbox.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = htmllbox.cpp; path = ../../src/generic/htmllbox.cpp; sourceTree = "<group>"; };
+		FD6B26B5A6A733A89EF5AB9C /* statbmp.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = statbmp.mm; path = ../../src/osx/iphone/statbmp.mm; sourceTree = "<group>"; };
 		FD6D2664C05131C3A06E98B4 /* ExternalLexer.cxx */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = ExternalLexer.cxx; path = ../../src/stc/scintilla/src/ExternalLexer.cxx; sourceTree = "<group>"; };
 		FDAEFCE0ED9D30DA94340A3B /* xtistrm.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = xtistrm.cpp; path = ../../src/common/xtistrm.cpp; sourceTree = "<group>"; };
 		FDB0E2D0966C3E408C4A2D3D /* infback.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = infback.c; path = ../../src/zlib/infback.c; sourceTree = "<group>"; };
@@ -1785,7 +1819,6 @@
 				83F62FA47C9636169F1E18E8 /* base */,
 				2E7B4F88F81E37B4A9FF6C0F /* core */,
 				374BD863E6AD33189B7E4040 /* net */,
-				2FF0B5E0505D3AEA9A4ACF11 /* adv */,
 				62E50658BDAD369D92294F68 /* webview */,
 				5C5CD199E7573C73AE6F392D /* media */,
 				60E51BFF5CD2327483201F14 /* html */,
@@ -1981,7 +2014,6 @@
 				302A13BC64C238A297F4399F /* brush.cpp */,
 				BDE76674C0F5391BAD2AFA2F /* dialog_osx.cpp */,
 				5FF661188B563D27A11F5716 /* fontutil.cpp */,
-				027D2F04BE933ED6B9BA1518 /* imaglist.cpp */,
 				693F731B7D1730A79485F9EC /* minifram.cpp */,
 				19559DDA007D364E838014B5 /* nonownedwnd_osx.cpp */,
 				BEF6B3FB66243812969E5BD1 /* palette.cpp */,
@@ -2063,16 +2095,16 @@
 				64DA16CF41C834D7B7642024 /* prntdlgg.cpp */,
 				071FEABEA61E3B559A47A7DB /* statusbr.cpp */,
 				E9B31409EC6532FC83B0B957 /* textmeasure.cpp */,
-				FE538F33A1423FC2AC9E45F3 /* regiong.cpp */,
 				F5DAF1F49F0F3F41A427A21D /* icon.cpp */,
+				F582C6B3A5AA3367BB4DBE97 /* statbmp_osx.cpp */,
+				027D2F04BE933ED6B9BA1518 /* imaglist.cpp */,
+				FE538F33A1423FC2AC9E45F3 /* regiong.cpp */,
 				F4020D790AE7363CB29F1C2F /* anybutton.mm */,
 				C06FED83BF933DF98C2466AE /* button.mm */,
 				81708CFA21A03013ACB8DDD7 /* checkbox.mm */,
 				83B878A16ABC396E8C03A15E /* dialog.mm */,
 				8D2549709E0133C9A267E3A5 /* evtloop.mm */,
 				98A7F0605AAC3D28A8C9F253 /* gauge.mm */,
-				1D799486AD7F336BB1F33DDC /* menu.mm */,
-				61548D0FE1353D7C846DD721 /* menuitem.mm */,
 				33CFE51FD6F0362092DF1A85 /* msgdlg.mm */,
 				AECB45CEAC093CE4AB4B7E45 /* nonownedwnd.mm */,
 				CC2E24773D853A77B9FEFA4C /* scrolbar.mm */,
@@ -2082,8 +2114,12 @@
 				A3BF8C9FF2D5314591329D0D /* toolbar.mm */,
 				789F45D14FF23E248FCFB5FA /* utils.mm */,
 				C94DC3402FAE3C4FA776DEEA /* window.mm */,
-				190409DF8A3C3D9580FBB8AB /* stdpaths.mm */,
 				6831AA74AB5B38D5AA6946D7 /* settings.mm */,
+				A9B2316B32653DA0939A372D /* sound_osx.cpp */,
+				2ACC8667173D3AB09F6214F4 /* sound.cpp */,
+				FD6B26B5A6A733A89EF5AB9C /* statbmp.mm */,
+				61548D0FE1353D7C846DD721 /* menuitem.mm */,
+				1D799486AD7F336BB1F33DDC /* menu.mm */,
 				A436B55DC44E3827A757A6D8 /* accelcmn.cpp */,
 				8555204EBA8930809B732842 /* accesscmn.cpp */,
 				EE959EC7BFDD3A628E856404 /* anidecod.cpp */,
@@ -2212,6 +2248,7 @@
 				E9B9B85572D0312BBF2878DB /* windowid.cpp */,
 				B5E2D6917EB1352983C7FE85 /* wrapsizer.cpp */,
 				C562D5885AFF3E15837325CE /* xpmdecod.cpp */,
+				580AFC66F3003582B43043B1 /* animateg.cpp */,
 				2F94CF171F4532B89FECF475 /* busyinfo.cpp */,
 				5612DBC4125B379DA2B28824 /* buttonbar.cpp */,
 				CF23AF3EFC5731B2A5BCF4A3 /* choicdgg.cpp */,
@@ -2249,53 +2286,45 @@
 				AA90128E29A03CCCA30F4D35 /* vlbox.cpp */,
 				1629FA905F903324AA5BE72C /* vscroll.cpp */,
 				9AD367F1047838A9A7A34DBF /* xmlreshandler.cpp */,
-			);
-			name = core;
-			sourceTree = "<group>";
-		};
-		2FF0B5E0505D3AEA9A4ACF11 /* adv */ = {
-			isa = PBXGroup;
-			children = (
-				A8ABD099BCEA30DCBF7A04F4 /* animatecmn.cpp */,
-				8CF560E06F2A3B6088203D09 /* bmpcboxcmn.cpp */,
-				8D0EF4BDCB5F329ABE15EEED /* calctrlcmn.cpp */,
-				95DEEF60B1E9358A8CCCC67E /* datavcmn.cpp */,
-				FDD3CE34439B3D2BBD9DC8D3 /* gridcmn.cpp */,
-				8A7D521FE5B437D7AD5F4B54 /* hyperlnkcmn.cpp */,
-				6F23140777B733679D2FAAFC /* odcombocmn.cpp */,
-				7A1CE0B28CB73F90AE92B5AB /* richtooltipcmn.cpp */,
-				77D6E66F72443765A2FBE263 /* aboutdlgg.cpp */,
-				36296C259D023EAAA240FC79 /* bannerwindow.cpp */,
-				13FD4A890E9B3BAEBD568C3B /* bmpcboxg.cpp */,
-				496674699F173A5385EAFF07 /* calctrlg.cpp */,
-				E8BD1489D95E3FD78B200B1B /* commandlinkbuttong.cpp */,
-				5F3D473DC5123EDAB767045C /* datavgen.cpp */,
-				AE856D950B8C369EB0FE13BA /* datectlg.cpp */,
-				7D90D14874FD38079835AF0B /* editlbox.cpp */,
-				76337016F2CA3C85831702E6 /* grid.cpp */,
-				2A1BD6BCA15430CA8A4869EF /* gridctrl.cpp */,
-				66426B63AA3E3A279936C034 /* grideditors.cpp */,
-				26381308E32A3A179E7A9B40 /* gridsel.cpp */,
-				DF376BC55EA73F5FB7328142 /* helpext.cpp */,
-				CBCA90340E433DBBAE74EBE1 /* hyperlinkg.cpp */,
-				C3784C240C2F330683494926 /* laywin.cpp */,
+				3F8836E29C5A370E80CE070E /* splash.cpp */,
 				924AA3A156F834BCA1A57976 /* notifmsgg.cpp */,
 				7906BD74118A3B4DAC515BC2 /* odcombo.cpp */,
-				6BC93D1DE277395592610085 /* propdlg.cpp */,
-				54710DA2AC4F3262A8A1EA63 /* richtooltipg.cpp */,
+				8D0EF4BDCB5F329ABE15EEED /* calctrlcmn.cpp */,
+				66426B63AA3E3A279936C034 /* grideditors.cpp */,
+				8CF560E06F2A3B6088203D09 /* bmpcboxcmn.cpp */,
+				76337016F2CA3C85831702E6 /* grid.cpp */,
+				2A1BD6BCA15430CA8A4869EF /* gridctrl.cpp */,
+				CBCA90340E433DBBAE74EBE1 /* hyperlinkg.cpp */,
+				DF376BC55EA73F5FB7328142 /* helpext.cpp */,
 				917F2666B67E3D2EB84E74F8 /* sashwin.cpp */,
-				3F8836E29C5A370E80CE070E /* splash.cpp */,
-				741578B590AF3F2CABE615EB /* timectrlg.cpp */,
-				B56A9BF7AE1E3F11A5848297 /* tipdlg.cpp */,
-				5190E3E110443FD29F2474FC /* treelist.cpp */,
-				8F08F70E1EF239999A4D2AC4 /* wizard.cpp */,
+				26381308E32A3A179E7A9B40 /* gridsel.cpp */,
 				964578C24B9F390AAD08576E /* addremovectrl.cpp */,
+				B56A9BF7AE1E3F11A5848297 /* tipdlg.cpp */,
+				77D6E66F72443765A2FBE263 /* aboutdlgg.cpp */,
+				FDD3CE34439B3D2BBD9DC8D3 /* gridcmn.cpp */,
+				7A1CE0B28CB73F90AE92B5AB /* richtooltipcmn.cpp */,
+				AE856D950B8C369EB0FE13BA /* datectlg.cpp */,
+				36296C259D023EAAA240FC79 /* bannerwindow.cpp */,
+				5190E3E110443FD29F2474FC /* treelist.cpp */,
+				95DEEF60B1E9358A8CCCC67E /* datavcmn.cpp */,
+				A8ABD099BCEA30DCBF7A04F4 /* animatecmn.cpp */,
+				6F23140777B733679D2FAAFC /* odcombocmn.cpp */,
+				8A7D521FE5B437D7AD5F4B54 /* hyperlnkcmn.cpp */,
+				6BC93D1DE277395592610085 /* propdlg.cpp */,
+				13FD4A890E9B3BAEBD568C3B /* bmpcboxg.cpp */,
+				54710DA2AC4F3262A8A1EA63 /* richtooltipg.cpp */,
+				741578B590AF3F2CABE615EB /* timectrlg.cpp */,
+				E8BD1489D95E3FD78B200B1B /* commandlinkbuttong.cpp */,
 				B233180893DB3328AF4847DA /* notifmsgcmn.cpp */,
-				580AFC66F3003582B43043B1 /* animateg.cpp */,
-				A9B2316B32653DA0939A372D /* sound_osx.cpp */,
-				2ACC8667173D3AB09F6214F4 /* sound.cpp */,
+				8F08F70E1EF239999A4D2AC4 /* wizard.cpp */,
+				5F3D473DC5123EDAB767045C /* datavgen.cpp */,
+				7D90D14874FD38079835AF0B /* editlbox.cpp */,
+				C3784C240C2F330683494926 /* laywin.cpp */,
+				496674699F173A5385EAFF07 /* calctrlg.cpp */,
+				E8DE97F5A2AD393CBD31AED3 /* creddlgg.cpp */,
+				A2B7B30FA60633339D8862C6 /* rowheightcache.cpp */,
 			);
-			name = adv;
+			name = core;
 			sourceTree = "<group>";
 		};
 		374BD863E6AD33189B7E4040 /* net */ = {
@@ -2311,9 +2340,12 @@
 				D784A32C094730FEAA391A9B /* sckstrm.cpp */,
 				40CE02524DD4385AB2C3DF95 /* socket.cpp */,
 				49612306912038DDBCABB4DE /* url.cpp */,
+				5EA9E372A64B3B808A64B178 /* webrequest.cpp */,
+				5279968877003A8BB8279765 /* webrequest_curl.cpp */,
 				DDE22D7DDAC93DCABAE5AED0 /* socketiohandler.cpp */,
 				BB7661E9E09A397790ED9545 /* sockunix.cpp */,
 				4969528429903F15882F5391 /* sockosx.cpp */,
+				EA8CCF32688434EABEEEE04A /* webrequest_urlsession.mm */,
 			);
 			name = net;
 			sourceTree = "<group>";
@@ -2371,7 +2403,6 @@
 		60328E6EA3793DA990E18FC1 /* xrc */ = {
 			isa = PBXGroup;
 			children = (
-				45C65E309F3A39598C043657 /* xh_infobar.cpp */,
 				BB60FA0E3524391D8581AD7C /* xh_activityindicator.cpp */,
 				8C1E755F2408363288B2CE69 /* xh_animatctrl.cpp */,
 				3116006345D833509865FF7F /* xh_bannerwindow.cpp */,
@@ -2389,6 +2420,7 @@
 				F8638A6CCF773CCFB70DFC29 /* xh_collpane.cpp */,
 				F0905A1EBD653F6D82395602 /* xh_combo.cpp */,
 				5FC445EFDC503C74A5CC6D7D /* xh_comboctrl.cpp */,
+				616466F521DB3ECAB304289F /* xh_dataview.cpp */,
 				C63C964DAFAD311694367C94 /* xh_datectrl.cpp */,
 				BD169D8019A13A11BDB26214 /* xh_dirpicker.cpp */,
 				06B4A895955B32258DCD62BF /* xh_dlg.cpp */,
@@ -2402,6 +2434,7 @@
 				93B77251C0E0382D9A8E113D /* xh_grid.cpp */,
 				889FFA9573A835F280A21CB4 /* xh_html.cpp */,
 				B4E4032CA9883CA4B25BE082 /* xh_hyperlink.cpp */,
+				45C65E309F3A39598C043657 /* xh_infobar.cpp */,
 				B4DCCF66D880330A9EE9B6B2 /* xh_listb.cpp */,
 				57EB0085AFB93BFC88AC6FFC /* xh_listbk.cpp */,
 				5F5D02D60DCA35358B2780C7 /* xh_listc.cpp */,
@@ -2522,6 +2555,11 @@
 				69A6CAF721E53E83B4820DE6 /* pngwrite.c */,
 				0964797530CF3FE7B8DB6242 /* pngwtran.c */,
 				45D7558DF5E03A2EB41883F0 /* pngwutil.c */,
+				933D7637CAA43F6C99814BC5 /* arm_init.c */,
+				39507FA11D8838109A22B7DA /* filter_neon_intrinsics.c */,
+				FB17368A86EC30E6B843E32F /* palette_neon_intrinsics.c */,
+				994AF74DF2A13FF09A215853 /* intel_init.c */,
+				9D602B5F09E8314CB9F65C11 /* filter_sse2_intrinsics.c */,
 			);
 			name = libpng;
 			sourceTree = "<group>";
@@ -2687,12 +2725,15 @@
 				7D2BE094D90D3AFDAE49F589 /* fswatchercmn.cpp */,
 				47783A330B2A3B4EBB1CD95D /* fswatcherg.cpp */,
 				5BE1FB352696346BB642C044 /* secretstore.cpp */,
+				99A9D5F9254D35BE8F4176A4 /* lzmastream.cpp */,
+				4E4466371B7E3265AE7B1E0C /* uilocale.cpp */,
 				7C97C1F26B5A38C49543060C /* mimetype.cpp */,
 				5168ADF7BE39351F8F24E1E6 /* cfstring.cpp */,
 				5BD6231188AB329CAA5E1171 /* evtloop_cf.cpp */,
 				D5F9383D1CE931499F339D85 /* strconv_cf.cpp */,
 				2ED0C0702D2734D9B08FC31D /* utils_base.mm */,
 				5BE1FB352696346BB642C045 /* secretstore.cpp */,
+				4E4466371B7E3265AE7B1E0D /* uilocale.cpp */,
 				47F784C2BB5A3B5DAD276583 /* fdiodispatcher.cpp */,
 				A5D569A4DE643DC8B0C28087 /* selectdispatcher.cpp */,
 				B40E0F6AA0273ACD9BDEAD72 /* appunix.cpp */,
@@ -2731,7 +2772,6 @@
 			isa = PBXGroup;
 			children = (
 				C3904351139F3F0DB4B72F94 /* pcre2_auto_possess.c */,
-				1895085EBEAE3A708FDD527A /* pcre2_chartables.c */,
 				BDADEB1DA6433E52972C8934 /* pcre2_compile.c */,
 				FC6A8FAE9CA63EEB8883B6BD /* pcre2_config.c */,
 				3026D20A03E53F1DB40FB35A /* pcre2_context.c */,
@@ -2742,8 +2782,8 @@
 				943C7E9527C03FCDB5966273 /* pcre2_find_bracket.c */,
 				7C9F6184015A3BD1B8DA471E /* pcre2_jit_compile.c */,
 				D016F584D14C31E192DB3179 /* pcre2_maketables.c */,
-				4E74E9E53454331F8E10ECC5 /* pcre2_match_data.c */,
 				3B93115BCC46333BBB31D6F7 /* pcre2_match.c */,
+				4E74E9E53454331F8E10ECC5 /* pcre2_match_data.c */,
 				A208BFC0C8C43847A9620ADA /* pcre2_newline.c */,
 				4BFEBC5061693DA0B52BC4AC /* pcre2_ord2utf.c */,
 				00DAA69F74D031B6BE9196A8 /* pcre2_pattern_info.c */,
@@ -2757,6 +2797,7 @@
 				70F4EB692873386AAA0A44B0 /* pcre2_ucd.c */,
 				FAE49A61DFE9375AAB18E8DD /* pcre2_valid_utf.c */,
 				95CBA2C736623FFF8629E975 /* pcre2_xclass.c */,
+				1895085EBEAE3A708FDD527A /* pcre2_chartables.c */,
 			);
 			name = libregex;
 			sourceTree = "<group>";
@@ -2834,8 +2875,10 @@
 				BD88495AF72531A28D2201D0 /* tif_tile.c */,
 				3E6F40F4740C3ED29D83E107 /* tif_version.c */,
 				C83C97A1FCC5345896C9D7DE /* tif_warning.c */,
+				3716DA7B0C79360CBA26A71E /* tif_webp.c */,
 				E9B992CB6C28339FB0CA5E27 /* tif_write.c */,
 				726C0457DF1232C793918DC1 /* tif_zip.c */,
+				3B98123FD57731139044B064 /* tif_zstd.c */,
 			);
 			name = libtiff;
 			sourceTree = "<group>";
@@ -2894,8 +2937,6 @@
 /* Begin PBXProject section */
 		19367367C9323490BB936F06 /* Project object */ = {
 			isa = PBXProject;
-			attributes = {
-			};
 			buildConfigurationList = A66311F47C8832F6A58105B6 /* Build configuration list for PBXProject "wxiphone" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
@@ -2947,7 +2988,6 @@
 				319FB8E64CE731D6A58AD301 /* clntdata.cpp in Sources */,
 				51437DC2AD7B3BEB9A53CE1A /* cmdline.cpp in Sources */,
 				DA0FA502405A37B2A5698D20 /* config.cpp in Sources */,
-				27B5431DC79733CD8D403E88 /* pcre2_context.c in Sources */,
 				BB6FE851028C3DE7A070C213 /* convauto.cpp in Sources */,
 				F89405757B063F80B111F469 /* datetime.cpp in Sources */,
 				1D726139C977341A97D0C931 /* datetimefmt.cpp in Sources */,
@@ -2968,7 +3008,6 @@
 				9E0B67E34B683412978BA82D /* filtall.cpp in Sources */,
 				CA4DCD57060B38CC8B2283D7 /* filtfind.cpp in Sources */,
 				2FA1A8FE3644325ABAD273A4 /* fmapbase.cpp in Sources */,
-				DFEB01E7B97A3515B785DCA9 /* pcre2_string_utils.c in Sources */,
 				FE2DBCCC1D0B36A3BE4493C0 /* fs_arc.cpp in Sources */,
 				F6B85CD918E93923BE631B95 /* fs_filter.cpp in Sources */,
 				FE5285579C7F39C48FC66B10 /* hash.cpp in Sources */,
@@ -2992,7 +3031,6 @@
 				7A7439BE66AA3771B4A89048 /* regex.cpp in Sources */,
 				CF3082BA1ED232F4B904BD14 /* stdpbase.cpp in Sources */,
 				539B586AEAD630A79FC12ECF /* sstream.cpp in Sources */,
-				00E12455C98032E18378EE5E /* pcre2_newline.c in Sources */,
 				028257C52CAE3038AA862C35 /* stdstream.cpp in Sources */,
 				6AA0EE765330326380989FD1 /* stopwatch.cpp in Sources */,
 				E882402BEE0330A080A6516F /* strconv.cpp in Sources */,
@@ -3027,12 +3065,15 @@
 				A93D0E6F0871368EA8FC9FF9 /* fswatchercmn.cpp in Sources */,
 				E49F0D43B5A63EF1A57A7112 /* fswatcherg.cpp in Sources */,
 				B0FD1B96EAE635AFBFCF2C91 /* secretstore.cpp in Sources */,
+				A486A28E216D320AB57452D3 /* lzmastream.cpp in Sources */,
+				9A63148F193E33B5964DD029 /* uilocale.cpp in Sources */,
 				4657E7382E9E3EDC8DE2401E /* mimetype.cpp in Sources */,
 				1DBDF75500D73A3098015E7F /* cfstring.cpp in Sources */,
 				9FBC642677C63D01AA2511BC /* evtloop_cf.cpp in Sources */,
 				AAAB5DF8E60736D88273DCFE /* strconv_cf.cpp in Sources */,
 				68C300D096BF39239876D043 /* utils_base.mm in Sources */,
 				B0FD1B96EAE635AFBFCF2C92 /* secretstore.cpp in Sources */,
+				9A63148F193E33B5964DD02A /* uilocale.cpp in Sources */,
 				D36E76A4CAF5352D9397E1FF /* fdiodispatcher.cpp in Sources */,
 				D3FB75C8E3A73AE38EE8A6F6 /* selectdispatcher.cpp in Sources */,
 				BAAB6B1D80A33843A8436B10 /* appunix.cpp in Sources */,
@@ -3055,12 +3096,9 @@
 				05814571E7A83F5DBFB6E4C4 /* msgout.cpp in Sources */,
 				80665EEAE8613DF8A93A7984 /* utilscmn.cpp in Sources */,
 				F4C0CEADEDC23610BF6983D6 /* artmac.cpp in Sources */,
-				45E15DBB6B69382D8AF1BA21 /* pcre2_dfa_match.c in Sources */,
 				296692A7A3783E3A83D005C6 /* brush.cpp in Sources */,
 				86AED49CEAFC3637B1F10537 /* dialog_osx.cpp in Sources */,
 				DC6B669C9A78398F914AEE53 /* fontutil.cpp in Sources */,
-				1EDED99760B23A1999E75C12 /* imaglist.cpp in Sources */,
-				7BD3887F603E3704969A54E1 /* pcre2_chartables.c in Sources */,
 				C1CDD035AA393ACC9E202C03 /* minifram.cpp in Sources */,
 				4269B85FDC5639BEB76A8AEB /* nonownedwnd_osx.cpp in Sources */,
 				AC91349D7F0E37739B1F5165 /* palette.cpp in Sources */,
@@ -3121,7 +3159,6 @@
 				774EB9F3F7E93A379E1F7551 /* graphics.cpp in Sources */,
 				5792675690843C6AA4125A72 /* font.cpp in Sources */,
 				BDAB44F5D017395D9D3A1F23 /* frame.cpp in Sources */,
-				127E255EE601383A9E0EF7EA /* menuitem.mm in Sources */,
 				27E2EABB117334CD89CFD2A4 /* mdi.cpp in Sources */,
 				73AA68AB9F1236ED9F1FBB2E /* metafile.cpp in Sources */,
 				805CCAE64D023561AD334B53 /* popupwin.cpp in Sources */,
@@ -3143,8 +3180,10 @@
 				C005C2D547E735E9B081658E /* prntdlgg.cpp in Sources */,
 				A1AF8FF873D6383996995ECF /* statusbr.cpp in Sources */,
 				2E059BFE8E3B3D9299D55969 /* textmeasure.cpp in Sources */,
-				9519D59421513FF28FF717B6 /* regiong.cpp in Sources */,
 				01D4C5F2147F3942A7CE91AA /* icon.cpp in Sources */,
+				750C716389AD3ADBABC9D689 /* statbmp_osx.cpp in Sources */,
+				1EDED99760B23A1999E75C12 /* imaglist.cpp in Sources */,
+				9519D59421513FF28FF717B6 /* regiong.cpp in Sources */,
 				65AD3B31319C35F1AC9EC625 /* anybutton.mm in Sources */,
 				14D6D5F8F5ED3C71936DD2AF /* button.mm in Sources */,
 				67A0583ADD8C35B8B9BA3D12 /* checkbox.mm in Sources */,
@@ -3160,8 +3199,12 @@
 				A53B8C3ED0D33A1D9AA8219A /* toolbar.mm in Sources */,
 				A1A7D793B034398B8696EF33 /* utils.mm in Sources */,
 				815AE3FED68330F4933AA16F /* window.mm in Sources */,
-				DA71FBB9EFB2350ABB3CEC81 /* stdpaths.mm in Sources */,
 				47C31B7492F33C3EBE53262A /* settings.mm in Sources */,
+				CE2C937117FE3AB599DD30B9 /* sound_osx.cpp in Sources */,
+				61FEDBF2D47A3B4E861F8296 /* sound.cpp in Sources */,
+				215958201947310B88BBEDB3 /* statbmp.mm in Sources */,
+				127E255EE601383A9E0EF7EA /* menuitem.mm in Sources */,
+				2A79B68D20FE3C9B98A15534 /* menu.mm in Sources */,
 				3CDE2B6BF88D326189F069BD /* accelcmn.cpp in Sources */,
 				BDB8EF0E0DA03693BFB77EF7 /* accesscmn.cpp in Sources */,
 				205520440CD13C0AB9E89159 /* anidecod.cpp in Sources */,
@@ -3183,7 +3226,6 @@
 				EBF2D44758003221A22202BC /* colourcmn.cpp in Sources */,
 				335DD610974A33D4B6581E2A /* colourdata.cpp in Sources */,
 				D542C7819D593112AE5F7C3D /* combocmn.cpp in Sources */,
-				2047544E505C3BA38F0144E6 /* pcre2_tables.c in Sources */,
 				6F0605F3A4E83BF0BF4C8B7E /* cmdproc.cpp in Sources */,
 				20F10669703137E68318C6FD /* cmndata.cpp in Sources */,
 				6FA47EAACE613B039B6EC261 /* containr.cpp in Sources */,
@@ -3256,7 +3298,6 @@
 				AF1E3338E892336E924AF631 /* pickerbase.cpp in Sources */,
 				6E68759BC2E63CA59C12FDC0 /* popupcmn.cpp in Sources */,
 				6292B023DBF4337A91404AD0 /* preferencescmn.cpp in Sources */,
-				7F62946D497A32CE857F65C9 /* pcre2_maketables.c in Sources */,
 				1C52CB9487DF3AB9AF243B47 /* prntbase.cpp in Sources */,
 				0B98B6721DEE37A1ADEA382B /* quantize.cpp in Sources */,
 				AE5286C71D1130EAA368A1C4 /* radiobtncmn.cpp in Sources */,
@@ -3292,6 +3333,7 @@
 				1BCC944F5E0936F5830F03E8 /* windowid.cpp in Sources */,
 				3399AB7BB1333B5AAF5FAF55 /* wrapsizer.cpp in Sources */,
 				C1E5799141603A75A26BEEA7 /* xpmdecod.cpp in Sources */,
+				46F341B46F80376B962759F5 /* animateg.cpp in Sources */,
 				F5806029B1BA3924A8FDDBC1 /* busyinfo.cpp in Sources */,
 				CB078622E90F33BE9D131131 /* buttonbar.cpp in Sources */,
 				03035C5CE4BC3288A5A18424 /* choicdgg.cpp in Sources */,
@@ -3299,8 +3341,6 @@
 				4442EA28B0B3373B9A2D0862 /* collheaderctrlg.cpp in Sources */,
 				9C1F073349FD393E9220C0D3 /* combog.cpp in Sources */,
 				EAE02BA934B43EEE92C496C7 /* dcpsg.cpp in Sources */,
-				9FA6C4275F0D3E1A884ED561 /* pcre2_auto_possess.c in Sources */,
-				9E37D29DCF7A3945A0EECB39 /* pcre2_serialize.c in Sources */,
 				22AE900003F73134BBEE8BB6 /* dirctrlg.cpp in Sources */,
 				4040AE89BF9F34668091064A /* dragimgg.cpp in Sources */,
 				7EF89F935314301381802FAB /* filectrlg.cpp in Sources */,
@@ -3331,6 +3371,43 @@
 				87C67583D36C3465ACD64103 /* vlbox.cpp in Sources */,
 				A465A43B756630F1944B5A56 /* vscroll.cpp in Sources */,
 				1CBF34ACA39330028A5EA9AC /* xmlreshandler.cpp in Sources */,
+				8AA341CCFB8E3F6AB3523595 /* splash.cpp in Sources */,
+				CEE0D7A7D5D8323B9957A780 /* notifmsgg.cpp in Sources */,
+				1E17F95DD433379E8C18298C /* odcombo.cpp in Sources */,
+				901F659891613419B8643952 /* calctrlcmn.cpp in Sources */,
+				E5D698D2606A304DA743AF92 /* grideditors.cpp in Sources */,
+				5C44446AB150378696CD6B3C /* bmpcboxcmn.cpp in Sources */,
+				A139B846584436BCBEBAE3BF /* grid.cpp in Sources */,
+				2E930206397C3EDCBD8206FC /* gridctrl.cpp in Sources */,
+				760C729E41D93CC1AA2B4E0D /* hyperlinkg.cpp in Sources */,
+				F016C51053373E658ED4C9A9 /* helpext.cpp in Sources */,
+				3554C88010CE3D2A8970A135 /* sashwin.cpp in Sources */,
+				187F921A95DA3594B0AD980D /* gridsel.cpp in Sources */,
+				EC3D181D65F33E09A675FFF2 /* addremovectrl.cpp in Sources */,
+				77BC918AF05C30E8A0BD27F8 /* tipdlg.cpp in Sources */,
+				FEA741A9B6663A4C929893C2 /* aboutdlgg.cpp in Sources */,
+				2FAE979E6FE23D088C768B7D /* gridcmn.cpp in Sources */,
+				2FE10EA678C73523836FCC1C /* richtooltipcmn.cpp in Sources */,
+				B4425B59CC27389CA9FF81D1 /* datectlg.cpp in Sources */,
+				E0FAB345D2933D42B62917A3 /* bannerwindow.cpp in Sources */,
+				060E095718B03EF98C754799 /* treelist.cpp in Sources */,
+				1CD4F67F48CF3A5FA477D86E /* datavcmn.cpp in Sources */,
+				CFDBB80A4C9A3BA092273936 /* animatecmn.cpp in Sources */,
+				E6D18B2EDE353F678830859F /* odcombocmn.cpp in Sources */,
+				7B4DA2F5F25B3E188CBAFE38 /* hyperlnkcmn.cpp in Sources */,
+				6A10511265493FA2BB79CE4D /* propdlg.cpp in Sources */,
+				B189DB62AE9F30A1B613756B /* bmpcboxg.cpp in Sources */,
+				C67EAE20657E36839BF86690 /* richtooltipg.cpp in Sources */,
+				98F52D5224B438DFA8887E06 /* timectrlg.cpp in Sources */,
+				8A662992FFCB32E99D11950C /* commandlinkbuttong.cpp in Sources */,
+				800CFCEDBB7938338C65EEAC /* notifmsgcmn.cpp in Sources */,
+				82FA4AA043213728AC266700 /* wizard.cpp in Sources */,
+				8B60964DA1DF3F3DB40BE123 /* datavgen.cpp in Sources */,
+				5557AA36FBCC3ED9A5F5751A /* editlbox.cpp in Sources */,
+				955D2199F1893D37BA2D7478 /* laywin.cpp in Sources */,
+				2F50DBC14FE538A49823925A /* calctrlg.cpp in Sources */,
+				63F895D6F5643E4B9E666B79 /* creddlgg.cpp in Sources */,
+				8F372080E11E382EA0B5ED0F /* rowheightcache.cpp in Sources */,
 				567A32722BA33AEE9FF93D7C /* fs_inet.cpp in Sources */,
 				65514CD6A9F23ED98436AC02 /* ftp.cpp in Sources */,
 				B84642DA949638A189032CE6 /* http.cpp in Sources */,
@@ -3341,51 +3418,12 @@
 				A3A898DA3114311EB7F02227 /* sckstrm.cpp in Sources */,
 				6978D7A20DA93A329DDD1383 /* socket.cpp in Sources */,
 				E7140F3AB94D3FDFA86D8C06 /* url.cpp in Sources */,
+				C987310872D1396BAF716E5A /* webrequest.cpp in Sources */,
+				EE972E8DC73F310B9B4C949C /* webrequest_curl.cpp in Sources */,
 				652CFDD9A1C1366E99B5D6BC /* socketiohandler.cpp in Sources */,
 				346D274E17673A01B0177D5B /* sockunix.cpp in Sources */,
 				AD07124BBA613B47829F0692 /* sockosx.cpp in Sources */,
-				CFDBB80A4C9A3BA092273936 /* animatecmn.cpp in Sources */,
-				5C44446AB150378696CD6B3C /* bmpcboxcmn.cpp in Sources */,
-				901F659891613419B8643952 /* calctrlcmn.cpp in Sources */,
-				EB206A0264AD3CAA9F68B8FC /* pcre2_convert.c in Sources */,
-				1CD4F67F48CF3A5FA477D86E /* datavcmn.cpp in Sources */,
-				2FAE979E6FE23D088C768B7D /* gridcmn.cpp in Sources */,
-				7B4DA2F5F25B3E188CBAFE38 /* hyperlnkcmn.cpp in Sources */,
-				E6D18B2EDE353F678830859F /* odcombocmn.cpp in Sources */,
-				2FE10EA678C73523836FCC1C /* richtooltipcmn.cpp in Sources */,
-				FEA741A9B6663A4C929893C2 /* aboutdlgg.cpp in Sources */,
-				E0FAB345D2933D42B62917A3 /* bannerwindow.cpp in Sources */,
-				B189DB62AE9F30A1B613756B /* bmpcboxg.cpp in Sources */,
-				E17048DEEF1138318314F1D0 /* pcre2_valid_utf.c in Sources */,
-				2F50DBC14FE538A49823925A /* calctrlg.cpp in Sources */,
-				8A662992FFCB32E99D11950C /* commandlinkbuttong.cpp in Sources */,
-				8B60964DA1DF3F3DB40BE123 /* datavgen.cpp in Sources */,
-				B4425B59CC27389CA9FF81D1 /* datectlg.cpp in Sources */,
-				5557AA36FBCC3ED9A5F5751A /* editlbox.cpp in Sources */,
-				A139B846584436BCBEBAE3BF /* grid.cpp in Sources */,
-				2E930206397C3EDCBD8206FC /* gridctrl.cpp in Sources */,
-				E5D698D2606A304DA743AF92 /* grideditors.cpp in Sources */,
-				187F921A95DA3594B0AD980D /* gridsel.cpp in Sources */,
-				F016C51053373E658ED4C9A9 /* helpext.cpp in Sources */,
-				10B5C2A72C713A678458CD9D /* pcre2_ord2utf.c in Sources */,
-				760C729E41D93CC1AA2B4E0D /* hyperlinkg.cpp in Sources */,
-				955D2199F1893D37BA2D7478 /* laywin.cpp in Sources */,
-				CEE0D7A7D5D8323B9957A780 /* notifmsgg.cpp in Sources */,
-				1E17F95DD433379E8C18298C /* odcombo.cpp in Sources */,
-				6A10511265493FA2BB79CE4D /* propdlg.cpp in Sources */,
-				C67EAE20657E36839BF86690 /* richtooltipg.cpp in Sources */,
-				3554C88010CE3D2A8970A135 /* sashwin.cpp in Sources */,
-				8AA341CCFB8E3F6AB3523595 /* splash.cpp in Sources */,
-				98F52D5224B438DFA8887E06 /* timectrlg.cpp in Sources */,
-				77BC918AF05C30E8A0BD27F8 /* tipdlg.cpp in Sources */,
-				2A79B68D20FE3C9B98A15534 /* menu.mm in Sources */,
-				060E095718B03EF98C754799 /* treelist.cpp in Sources */,
-				82FA4AA043213728AC266700 /* wizard.cpp in Sources */,
-				EC3D181D65F33E09A675FFF2 /* addremovectrl.cpp in Sources */,
-				800CFCEDBB7938338C65EEAC /* notifmsgcmn.cpp in Sources */,
-				46F341B46F80376B962759F5 /* animateg.cpp in Sources */,
-				CE2C937117FE3AB599DD30B9 /* sound_osx.cpp in Sources */,
-				61FEDBF2D47A3B4E861F8296 /* sound.cpp in Sources */,
+				980ED1DA2F96361985952254 /* webrequest_urlsession.mm in Sources */,
 				2DBF5F96CCC63F7481C26A43 /* webview_webkit.mm in Sources */,
 				64A716F87A5136F9A790EC5A /* webview.cpp in Sources */,
 				5C5D0983160A36189A770742 /* webviewarchivehandler.cpp in Sources */,
@@ -3397,7 +3435,6 @@
 				2CAD4DF9505F36E4A2EAD53D /* helpdata.cpp in Sources */,
 				D17E3053DA0D3F7EA4D0951B /* helpdlg.cpp in Sources */,
 				7C87CC7641033D91823ED688 /* helpfrm.cpp in Sources */,
-				A4DEBFA074C93388A1BBCB40 /* pcre2_substitute.c in Sources */,
 				3D762A0BBF1B39B88A769632 /* helpwnd.cpp in Sources */,
 				4DA209AEF4AD32AAB97F9718 /* htmlcell.cpp in Sources */,
 				FD3CC5F0AA41384B9388A1E0 /* htmlfilt.cpp in Sources */,
@@ -3419,7 +3456,6 @@
 				F3AC352D6DAE3A12A5664768 /* styleparams.cpp in Sources */,
 				2A7640E4210334AC93366900 /* winpars.cpp in Sources */,
 				87AA9C5D887B3C31A2AFB49D /* htmllbox.cpp in Sources */,
-				EA10DA3199813E90B39C70D3 /* xh_infobar.cpp in Sources */,
 				8F949B9010863F66A58FFEF1 /* xh_activityindicator.cpp in Sources */,
 				FBE4DB30865D3177B3A9993B /* xh_animatctrl.cpp in Sources */,
 				702616D38A5B345D9CC87114 /* xh_bannerwindow.cpp in Sources */,
@@ -3437,6 +3473,7 @@
 				E7921B0472B63E4091F4F517 /* xh_collpane.cpp in Sources */,
 				84382E5DB3203A73AC5EE390 /* xh_combo.cpp in Sources */,
 				F569D7A3F0E038E9B4CC2A76 /* xh_comboctrl.cpp in Sources */,
+				14F303FD6B5F383DADDFD788 /* xh_dataview.cpp in Sources */,
 				FB09720D13673A7B81BCB645 /* xh_datectrl.cpp in Sources */,
 				F7D10B6E0CBA32EFAF79C77C /* xh_dirpicker.cpp in Sources */,
 				3B7E035ECF3D3FFB9827AC1C /* xh_dlg.cpp in Sources */,
@@ -3449,8 +3486,8 @@
 				26649553E4763EE6BA268B7D /* xh_gdctl.cpp in Sources */,
 				72AD4417FF7C3094BB1FF62C /* xh_grid.cpp in Sources */,
 				83616D33080E3F0F9FA5FBB4 /* xh_html.cpp in Sources */,
-				B6728BCD1A0731299924C8C4 /* pcre2_substring.c in Sources */,
 				2B13BFC894C63373B7ACFA3D /* xh_hyperlink.cpp in Sources */,
+				EA10DA3199813E90B39C70D3 /* xh_infobar.cpp in Sources */,
 				C34B8675439F39B4845FFC50 /* xh_listb.cpp in Sources */,
 				F5DF7AF0FA9E371BB71EF798 /* xh_listbk.cpp in Sources */,
 				96B507455762391688B5E500 /* xh_listc.cpp in Sources */,
@@ -3468,11 +3505,9 @@
 				A39B0D7EB43137F7BA50A35C /* xh_simplebook.cpp in Sources */,
 				E1A20811148F31D289AF98AF /* xh_sizer.cpp in Sources */,
 				5F6B4F226B473AACB7AC8DF5 /* xh_slidr.cpp in Sources */,
-				8C6E2BD9C31A3AE18AD17D44 /* pcre2_match.c in Sources */,
 				C32EF2EC1A103BC3A6254321 /* xh_spin.cpp in Sources */,
 				33ED014A7FF7398794E6E4CF /* xh_split.cpp in Sources */,
 				7C9EAFF4A0223EE597E0E39E /* xh_srchctrl.cpp in Sources */,
-				AF1875145B2537298E4A28D8 /* pcre2_xclass.c in Sources */,
 				8AB7191F7CB838FC8337C48D /* xh_statbar.cpp in Sources */,
 				3D3EA1BAAD1833B1B48E9C86 /* xh_stbmp.cpp in Sources */,
 				F22C401903993639AE05A295 /* xh_stbox.cpp in Sources */,
@@ -3502,7 +3537,6 @@
 				E104017EE1A4357DAF84E1E6 /* auibook.cpp in Sources */,
 				39CC380F801F3EE984523275 /* auibar.cpp in Sources */,
 				6C46AF0370793AA0B74A5A4A /* tabmdi.cpp in Sources */,
-				5ED54DFAE28533108C08DF2A /* pcre2_extuni.c in Sources */,
 				AC0B0C52922B30188AE95E94 /* tabart.cpp in Sources */,
 				C3C19BD343B235F9909D4959 /* xh_aui.cpp in Sources */,
 				44C6F11C7D1C399F99CF6BD4 /* xh_auitoolb.cpp in Sources */,
@@ -3516,7 +3550,6 @@
 				4BAFAE70A6B1313B96D86630 /* page.cpp in Sources */,
 				F0D892C2618130FEAD46BB86 /* panel.cpp in Sources */,
 				EA02FA6D3B003F8F8A2963C6 /* toolbar.cpp in Sources */,
-				D7F14BDFFB7F369B842AFC13 /* pcre2_config.c in Sources */,
 				5A459FC1180130C5B705AEDA /* xh_ribbon.cpp in Sources */,
 				D54A162E557834A48F4646A9 /* advprops.cpp in Sources */,
 				F501AB044AAC39DCB8C0B3E1 /* editors.cpp in Sources */,
@@ -3564,7 +3597,6 @@
 				E3136EF5DD843ACE886E2868 /* tif_dir.c in Sources */,
 				7ECC6EE6D5273F75BB6B7B74 /* tif_dirinfo.c in Sources */,
 				D51B3389209E370489078891 /* tif_dirread.c in Sources */,
-				C5C60B22CE6A3BCB868F69E8 /* pcre2_find_bracket.c in Sources */,
 				E7F35B834A163C67B65176C6 /* tif_dirwrite.c in Sources */,
 				2D4D105CA9BE3FA6995A5FFF /* tif_dumpmode.c in Sources */,
 				C2CF6B59914A3183ADE84028 /* tif_error.c in Sources */,
@@ -3586,18 +3618,17 @@
 				64DD406C453D39FEBBE66ED1 /* tif_pixarlog.c in Sources */,
 				9A178ED42D96329D8CBF9B89 /* tif_predict.c in Sources */,
 				C170B941F01334F982315E4A /* tif_print.c in Sources */,
-				8B87FEC23DB834EDBFB6EA32 /* pcre2_ucd.c in Sources */,
 				570FA90F526E3F25A8E8FCF2 /* tif_read.c in Sources */,
-				D66F55C93D1130F488970C05 /* pcre2_match_data.c in Sources */,
 				912C69ADB1673ACEB0E6CF08 /* tif_strip.c in Sources */,
 				552708E6296D33EBB5F6A493 /* tif_swab.c in Sources */,
 				527054445A0D3A00A5C2EC44 /* tif_thunder.c in Sources */,
 				FEB073547F3F3AC19D31F698 /* tif_tile.c in Sources */,
 				096BA201623034AD97218368 /* tif_version.c in Sources */,
-				60296753A32B39EB8BD0CB44 /* pcre2_study.c in Sources */,
 				7A79D9AC608E3B8287229174 /* tif_warning.c in Sources */,
+				D772334837693C9D88069D98 /* tif_webp.c in Sources */,
 				F2F2963D8ECC32D39FDBF101 /* tif_write.c in Sources */,
 				6E2C2E8AA1713ADE9C338379 /* tif_zip.c in Sources */,
+				6C1171E3FB7137CCB9E3F536 /* tif_zstd.c in Sources */,
 				5D3AD309AF39385EBF7D9DF8 /* jaricom.c in Sources */,
 				894D43C8F224394FB3171F26 /* jcapimin.c in Sources */,
 				743BB23211B336A6A0F26E57 /* jcapistd.c in Sources */,
@@ -3617,7 +3648,6 @@
 				CCE4ECA9CE883B008065C6FB /* jctrans.c in Sources */,
 				8B9C9FCB954F3596A4CED9A5 /* jdapimin.c in Sources */,
 				67EBCE5FA5FF36349ADF0916 /* jdapistd.c in Sources */,
-				57B41B6BACFB3906ACD1BFAF /* pcre2_jit_compile.c in Sources */,
 				8093A858CA9E3E9EA2D2185F /* jdarith.c in Sources */,
 				76A83A293C9F33BCB7DFDE26 /* jdatadst.c in Sources */,
 				4CB3626391CE34D4B1F71AA0 /* jdatasrc.c in Sources */,
@@ -3625,7 +3655,6 @@
 				D9F02AFDA07D3857A905527C /* jdcolor.c in Sources */,
 				13854E7822783719A2530792 /* jddctmgr.c in Sources */,
 				28ADE8D385A53445A5451F23 /* jdhuff.c in Sources */,
-				6463C9BE78C0394CB7B451FA /* pcre2_compile.c in Sources */,
 				14EF556997B0350F931EBE8E /* jdinput.c in Sources */,
 				9FD99E06F6613A1A958FAF6B /* jdmainct.c in Sources */,
 				61C3F7D495FB3E8BA402E4F8 /* jdmarker.c in Sources */,
@@ -3661,6 +3690,38 @@
 				0095084719983B878378CA28 /* pngwrite.c in Sources */,
 				242E1D1A9BF331BA918134EC /* pngwtran.c in Sources */,
 				2989056891153968B372EA14 /* pngwutil.c in Sources */,
+				BB12132A86E2350AA47414CC /* arm_init.c in Sources */,
+				0F2FD12272023C869CE86008 /* filter_neon_intrinsics.c in Sources */,
+				86787E4138CC334BB74EC7B4 /* palette_neon_intrinsics.c in Sources */,
+				25B0940CABAB39CD90C6F3C5 /* intel_init.c in Sources */,
+				8620088DDD233B139B250DD4 /* filter_sse2_intrinsics.c in Sources */,
+				9FA6C4275F0D3E1A884ED561 /* pcre2_auto_possess.c in Sources */,
+				6463C9BE78C0394CB7B451FA /* pcre2_compile.c in Sources */,
+				D7F14BDFFB7F369B842AFC13 /* pcre2_config.c in Sources */,
+				27B5431DC79733CD8D403E88 /* pcre2_context.c in Sources */,
+				EB206A0264AD3CAA9F68B8FC /* pcre2_convert.c in Sources */,
+				45E15DBB6B69382D8AF1BA21 /* pcre2_dfa_match.c in Sources */,
+				2F7328AC75393951B08F75F1 /* pcre2_error.c in Sources */,
+				5ED54DFAE28533108C08DF2A /* pcre2_extuni.c in Sources */,
+				C5C60B22CE6A3BCB868F69E8 /* pcre2_find_bracket.c in Sources */,
+				57B41B6BACFB3906ACD1BFAF /* pcre2_jit_compile.c in Sources */,
+				7F62946D497A32CE857F65C9 /* pcre2_maketables.c in Sources */,
+				8C6E2BD9C31A3AE18AD17D44 /* pcre2_match.c in Sources */,
+				D66F55C93D1130F488970C05 /* pcre2_match_data.c in Sources */,
+				00E12455C98032E18378EE5E /* pcre2_newline.c in Sources */,
+				10B5C2A72C713A678458CD9D /* pcre2_ord2utf.c in Sources */,
+				88E56F89A0DA3AD386F05FD2 /* pcre2_pattern_info.c in Sources */,
+				1142E2D85FD93E9AB5D8A55A /* pcre2_script_run.c in Sources */,
+				9E37D29DCF7A3945A0EECB39 /* pcre2_serialize.c in Sources */,
+				DFEB01E7B97A3515B785DCA9 /* pcre2_string_utils.c in Sources */,
+				60296753A32B39EB8BD0CB44 /* pcre2_study.c in Sources */,
+				A4DEBFA074C93388A1BBCB40 /* pcre2_substitute.c in Sources */,
+				B6728BCD1A0731299924C8C4 /* pcre2_substring.c in Sources */,
+				2047544E505C3BA38F0144E6 /* pcre2_tables.c in Sources */,
+				8B87FEC23DB834EDBFB6EA32 /* pcre2_ucd.c in Sources */,
+				E17048DEEF1138318314F1D0 /* pcre2_valid_utf.c in Sources */,
+				AF1875145B2537298E4A28D8 /* pcre2_xclass.c in Sources */,
+				7BD3887F603E3704969A54E1 /* pcre2_chartables.c in Sources */,
 				23CECD8647C037E0B41DF0D4 /* LexA68k.cxx in Sources */,
 				66FD099CE5A338C18329FC36 /* LexAbaqus.cxx in Sources */,
 				CD35A576FD363FD49C3AC4B3 /* LexAda.cxx in Sources */,
@@ -3696,7 +3757,6 @@
 				E8BBC08597EF383597DA0308 /* LexEiffel.cxx in Sources */,
 				BFD3BFBDC8DA3B1EAD141F96 /* LexErlang.cxx in Sources */,
 				8D6B0D48EA843E48AB0FE43D /* LexErrorList.cxx in Sources */,
-				88E56F89A0DA3AD386F05FD2 /* pcre2_pattern_info.c in Sources */,
 				4788F736CD9C324E8A3DFA74 /* LexEScript.cxx in Sources */,
 				45D88A74B3EE3837B9F79595 /* LexFlagship.cxx in Sources */,
 				27759C2FBB0E35FDA847B2B5 /* LexForth.cxx in Sources */,
@@ -3728,7 +3788,6 @@
 				22C76BF2C3E331CD87657E6E /* LexNsis.cxx in Sources */,
 				A8476B3CE46B3FD4A2832F00 /* LexNull.cxx in Sources */,
 				76D1A1A49CC831FFB9EBB1F5 /* LexOpal.cxx in Sources */,
-				1142E2D85FD93E9AB5D8A55A /* pcre2_script_run.c in Sources */,
 				324B2BAC54553D45B3C56BFD /* LexOScript.cxx in Sources */,
 				0718E7524134312090541D6E /* LexPascal.cxx in Sources */,
 				24A5A71C79733E9CB913C5B7 /* LexPB.cxx in Sources */,
@@ -3752,7 +3811,6 @@
 				FE5B7C7A84B83C17A38E8403 /* LexSML.cxx in Sources */,
 				D5C5DD83882B3227A1CCFE0E /* LexSorcus.cxx in Sources */,
 				6F8129E317EE3486A89D8548 /* LexSpecman.cxx in Sources */,
-				2F7328AC75393951B08F75F1 /* pcre2_error.c in Sources */,
 				9678C2B19D293818AA8E9E0D /* LexSpice.cxx in Sources */,
 				71CCB06E790C3C54BFF1199D /* LexSQL.cxx in Sources */,
 				E46BEC5C8D643BD099AF1D56 /* LexSTTXT.cxx in Sources */,
@@ -3856,20 +3914,20 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		A66311F47C8832F6A58105B6 /* Build configuration list for PBXProject "wxiphone" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				55C93151F6053EBCBDD70DF9 /* Debug */,
-				99B665C6D0D137B38CEA938F /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		336FCCBABBEF3C4AA92AD394 /* Build configuration list for PBXNativeTarget "static" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				55C93151F6053EBCBDD70DF8 /* Debug */,
 				99B665C6D0D137B38CEA938E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A66311F47C8832F6A58105B6 /* Build configuration list for PBXProject "wxiphone" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				55C93151F6053EBCBDD70DF9 /* Debug */,
+				99B665C6D0D137B38CEA938F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -182,6 +182,10 @@ Changes in behaviour which may result in build errors
 - Under macOS, 10.11 SDK is the minimum SDK, building and deploying under 10.10.5 and
   higher is supported, you must use at least Xcode 7.2.1.
 
+- wxOSX Xcode projects no longer include the i386 target by default and,
+  with Xcode 12 or later, build for the arm64 architecture in addition to
+  existing x86_64. See build/osx/wxcocoa.xcconfig for more information.
+
 - wxPGProperty ctors are not longer public since this class is intended to be
   a base class and should not be instantiated directly.
 

--- a/samples/minimal/minimal_cocoa.xcodeproj/project.pbxproj
+++ b/samples/minimal/minimal_cocoa.xcodeproj/project.pbxproj
@@ -283,7 +283,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 407A752213B0E1EB006BC2D5 /* wxcocoa.xcconfig */;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = YES;
 				PRODUCT_NAME = minimal_cocoa;
 				USER_HEADER_SEARCH_PATHS = "$(WXROOT)/include $(WXROOT)/build/osx/setup/$(WXTOOLKIT)/include";
 			};

--- a/samples/minimal/minimal_iphone.xcodeproj/project.pbxproj
+++ b/samples/minimal/minimal_iphone.xcodeproj/project.pbxproj
@@ -205,8 +205,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 404BEE0510EC7BF20080E2B8 /* wxiphone.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
-				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = minimal_iphone;
 			};
 			name = Debug;
@@ -215,7 +213,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 404BEE0510EC7BF20080E2B8 /* wxiphone.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
 				PRODUCT_NAME = minimal_iphone;
 			};
 			name = Release;


### PR DESCRIPTION
This PR is currently a draft only because for its Xcode project files changes depends on PR #2464.

Note 0b91768 which removes targeting i386 by default because its usage gives a deprecation error since Xcode 10. I think it's more important to build with newer Xcode versions OOTB with 3.2, and i386 can still be set explicitly/elsewhere if needed.