### PR TITLE
Correct handling on modal dialog first hidden by Show(false) and restored by Show(true)

### DIFF
--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -229,6 +229,7 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(DIALOGS_MINIFRAME,                     MyFrame::MiniFrame)
 #endif // wxUSE_MINIFRAME
     EVT_MENU(DIALOGS_ONTOP,                         MyFrame::DlgOnTop)
+    EVT_MENU(DIALOGS_HIDEMODAL,                     MyFrame::DlgHideModal)
 
 #if wxUSE_STARTUP_TIPS
     EVT_MENU(DIALOGS_TIP,                           MyFrame::ShowTip)
@@ -304,6 +305,11 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
 
     EVT_MENU(wxID_EXIT,                             MyFrame::OnExit)
 wxEND_EVENT_TABLE()
+
+    wxBEGIN_EVENT_TABLE(TestHideModalDialog, wxDialog)
+        EVT_BUTTON(wxID_ANY, TestHideModalDialog::OnButton)
+        EVT_BUTTON(wxID_OK, TestHideModalDialog::OnOk)
+   wxEND_EVENT_TABLE()
 
 #if USE_MODAL_PRESENTATION
 
@@ -598,6 +604,7 @@ bool MyApp::OnInit()
     dialogs_menu->Append(DIALOGS_MINIFRAME, "&Mini frame");
 #endif // wxUSE_MINIFRAME
     dialogs_menu->Append(DIALOGS_ONTOP, "Dialog staying on &top");
+    dialogs_menu->Append(DIALOGS_HIDEMODAL, "Test &Hide Modal Dialog");
     menuDlg->Append(wxID_ANY, "&Generic dialogs", dialogs_menu);
 
 #if USE_SETTINGS_DIALOG
@@ -2128,6 +2135,12 @@ void MyFrame::DlgOnTop(wxCommandEvent& WXUNUSED(event))
     dlg.ShowModal();
 }
 
+void MyFrame::DlgHideModal(wxCommandEvent& WXUNUSED(event))
+{
+    TestHideModalDialog dlg(this);
+    dlg.ShowModal();
+}
+
 #if wxUSE_STARTUP_TIPS
 void MyFrame::ShowTip(wxCommandEvent& WXUNUSED(event))
 {
@@ -3420,6 +3433,56 @@ void MyCanvas::OnPaint(wxPaintEvent& WXUNUSED(event) )
                 " test application"
                 , 10, 10);
 }
+
+// ----------------------------------------------------------------------------
+// TestHideModalDialog
+// ----------------------------------------------------------------------------
+
+wxIMPLEMENT_CLASS(TestHideModalDialog, wxPropertySheetDialog);
+
+TestHideModalDialog::TestHideModalDialog(wxWindow *parent)
+    : wxPropertySheetDialog(parent, wxID_ANY, wxString("Test Hide Modal dialog"))
+{
+    wxBoxSizer *sizerTop = new wxBoxSizer(wxHORIZONTAL);
+
+    m_btnTest = new wxButton(this, wxID_ANY, "&Hide Modal dialog...");
+
+    sizerTop->Add(m_btnTest, 0, wxALIGN_CENTER | wxALL, 5);
+    sizerTop->Add(new wxButton(this, wxID_CANCEL), 0, wxALIGN_CENTER | wxALL, 5);
+    sizerTop->Add(new wxButton(this, wxID_OK), 0, wxALIGN_CENTER | wxALL, 5);
+
+    SetSizerAndFit(sizerTop);
+
+    SetEscapeId(wxID_CANCEL);
+
+    m_btnTest->SetFocus();
+    m_btnTest->SetDefault();
+}
+
+void TestHideModalDialog::OnButton(wxCommandEvent& event)
+{
+    if ( event.GetEventObject() == m_btnTest )
+    {
+      Show(false);
+      wxMessageBox("Pressed OK to continue", "Info",
+                   wxOK | wxICON_INFORMATION, this);
+      Show(true);
+      Raise();
+      Update();
+      // Raise();
+      wxSafeYield();
+    }
+    else
+    {
+        event.Skip();
+    }
+}
+
+void TestHideModalDialog::OnOk(wxCommandEvent& /*event*/)
+{
+    EndModal(wxID_OK);
+}
+
 
 #if USE_MODAL_PRESENTATION
 

--- a/samples/dialogs/dialogs.h
+++ b/samples/dialogs/dialogs.h
@@ -123,6 +123,22 @@ private:
     long m_startupProgressStyle;
 };
 
+// Property sheet dialog
+class TestHideModalDialog: public wxPropertySheetDialog
+{
+    wxDECLARE_CLASS(TestHideModalDialog);
+public:
+    TestHideModalDialog(wxWindow *parent);
+
+    void OnButton(wxCommandEvent& event);
+    void OnOk(wxCommandEvent& event);
+
+private:
+    wxButton *m_btnTest;
+
+    DECLARE_EVENT_TABLE();
+};
+
 #if USE_MODAL_PRESENTATION
 
 // A custom modeless dialog
@@ -466,6 +482,7 @@ public:
     void DlgCenteredParent(wxCommandEvent& event);
     void MiniFrame(wxCommandEvent& event);
     void DlgOnTop(wxCommandEvent& event);
+    void DlgHideModal(wxCommandEvent& event);
 
 #if wxUSE_PROGRESSDLG
     void ShowProgress(wxCommandEvent& event);
@@ -635,6 +652,7 @@ enum
     DIALOGS_CENTRE_PARENT,
     DIALOGS_MINIFRAME,
     DIALOGS_ONTOP,
+    DIALOGS_HIDEMODAL,
     DIALOGS_MODELESS_BTN,
     DIALOGS_PROGRESS,
     DIALOGS_PROGRESS_GENERIC,

--- a/src/osx/dialog_osx.cpp
+++ b/src/osx/dialog_osx.cpp
@@ -145,8 +145,19 @@ bool wxDialog::Show(bool show)
                 SendWindowModalDialogEvent ( wxEVT_WINDOW_MODAL_DIALOG_CLOSED  );
                 break;
             default:
+                // wxDIALOG_MODALITY_APP_MODAL is not handled and modal dialog
+                // will not be closed. But m_modality is set back to default
+                // when the modal dialog is hidden. Must be restored in case
+                // of modal dialog is shown again. See below.
                 break;
         }
+    }
+    else if(m_eventLoop) {
+      // In case of Modal Dialog had been hidden, the dialog is not closed, but
+      // m_modality had been changed. When Show(true) is called again, the value
+      // must be restored, so wxDialogBase::EndDialog() is calling EndModal()
+      // instead of Hide() to avoid event loop is never finished.
+      m_modality = wxDIALOG_MODALITY_APP_MODAL;
     }
 
     return true;


### PR DESCRIPTION
In the application pwsafe we do timely disabling of the dialogs shown by the application, independent if the main window or a modal dialog is shown. Recursively all Windows are hidden by calling Show(false). For modal dialog, running with own event loop in ShowModul(), the dialog is not closed in call of wxDialog::Show(false) [dialog_osx.cpp], but mark in m_modality is set back. When calling Show(true) for all Windows of the application, later time when having entered the password, the value of m_modality must be restored. When Show(true) is called again, the value must be restored, so wxDialogBase::EndDialog() is calling EndModal() instead of Hide() to avoid event loop is never finished.