### PR TITLE
Use the colour directly in SetForegroundColour() in Cocoa

### DIFF
--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -3619,8 +3619,7 @@ void wxWidgetCocoaImpl::SetForegroundColour(const wxColour& col)
 
     if ([targetView respondsToSelector:@selector(setTextColor:)])
     {
-        wxColor col = GetWXPeer()->GetForegroundColour();
-        [targetView setTextColor: col.OSXGetNSColor()];
+        [targetView setTextColor: col.IsOk() ? col.OSXGetNSColor() : nil];
     }
 }
 

--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -527,7 +527,12 @@ bool wxWindowMac::SetForegroundColour(const wxColour& col )
         return false;
 
     if ( GetPeer() )
-        GetPeer()->SetForegroundColour(col);
+    {
+        // Note that we use GetForegroundColour() and not "col" itself here in
+        // case we're now inheriting our parent foreground rather than passing
+        // the (null) colour argument.
+        GetPeer()->SetForegroundColour(GetForegroundColour());
+    }
 
     return true;
 }


### PR DESCRIPTION
This was changed to use the colour of the associated window, ignoring
the collour parameter of this function itself, in 4aafab47e7 (Simplify
SetFont() in wxOSX implementations, 2020-10-25), but this doesn't seem
to really be a simplification, so undo this change and instead just use
the provided colour directly.

See https://github.com/wxWidgets/wxWidgets/pull/2103