### PR TITLE
Implement wxCmpNatural() for Mac too

### DIFF
--- a/src/common/arrstr.cpp
+++ b/src/common/arrstr.cpp
@@ -897,11 +897,11 @@ int wxCMPFUNC_CONV wxCmpNaturalGeneric(const wxString& s1, const wxString& s2)
 // ----------------------------------------------------------------------------
 
 // If native natural sort function isn't available, use the generic version.
-#if !defined(__WINDOWS__)
+#if !(defined(__WINDOWS__) || defined(__DARWIN__) || defined(__WXOSX_IPHONE__))
 
 int wxCMPFUNC_CONV wxCmpNatural(const wxString& s1, const wxString& s2)
 {
     return wxCmpNaturalGeneric(s1, s2);
 }
 
-#endif // #if !defined( __WINDOWS__ )
+#endif // not a platform with native implementation

--- a/src/common/arrstr.cpp
+++ b/src/common/arrstr.cpp
@@ -25,23 +25,6 @@
 #include <functional>
 #include "wx/afterstd.h"
 
-#if defined( __WINDOWS__ )
-    #include <shlwapi.h>
-
-    // In some distributions of MinGW32, this function is exported in the library,
-    // but not declared in shlwapi.h. Therefore we declare it here.
-    #if defined( __MINGW32_TOOLCHAIN__ )
-        extern "C" __declspec(dllimport) int WINAPI StrCmpLogicalW(LPCWSTR psz1, LPCWSTR psz2);
-    #endif
-
-    // For MSVC we can also link the library containing StrCmpLogicalW()
-    // directly from here, for the other compilers this needs to be done at
-    // makefiles level.
-    #ifdef __VISUALC__
-        #pragma comment(lib, "shlwapi")
-    #endif
-#endif
-
 // ============================================================================
 // ArrayString
 // ============================================================================
@@ -912,15 +895,13 @@ int wxCMPFUNC_CONV wxCmpNaturalGeneric(const wxString& s1, const wxString& s2)
 // ----------------------------------------------------------------------------
 // wxCmpNatural
 // ----------------------------------------------------------------------------
-//
-// If a native version of Natural sort is available, then use that, otherwise
-// use the generic version.
+
+// If native natural sort function isn't available, use the generic version.
+#if !defined(__WINDOWS__)
+
 int wxCMPFUNC_CONV wxCmpNatural(const wxString& s1, const wxString& s2)
 {
-#if defined( __WINDOWS__ )
-    return StrCmpLogicalW(s1.wc_str(), s2.wc_str());
-#else
     return wxCmpNaturalGeneric(s1, s2);
-#endif // #if defined( __WINDOWS__ )
 }
 
+#endif // #if !defined( __WINDOWS__ )

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -95,6 +95,22 @@
 // For wxKillAllChildren
 #include <tlhelp32.h>
 
+// For wxCmpNatural()
+#include <shlwapi.h>
+
+// In some distributions of MinGW32, this function is exported in the library,
+// but not declared in shlwapi.h. Therefore we declare it here.
+#if defined( __MINGW32_TOOLCHAIN__ )
+    extern "C" __declspec(dllimport) int WINAPI StrCmpLogicalW(LPCWSTR psz1, LPCWSTR psz2);
+#endif
+
+// For MSVC we can also link the library containing StrCmpLogicalW()
+// directly from here, for the other compilers this needs to be done at
+// makefiles level.
+#ifdef __VISUALC__
+    #pragma comment(lib, "shlwapi")
+#endif
+
 // ----------------------------------------------------------------------------
 // constants
 // ----------------------------------------------------------------------------
@@ -1582,4 +1598,9 @@ wxCreateHiddenWindow(LPCTSTR *pclassname, LPCTSTR classname, WNDPROC wndproc)
     }
 
     return hwnd;
+}
+
+int wxCMPFUNC_CONV wxCmpNatural(const wxString& s1, const wxString& s2)
+{
+    return StrCmpLogicalW(s1.wc_str(), s2.wc_str());
 }

--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -266,3 +266,10 @@ bool wxCocoaLaunch(const char* const* argv, pid_t &pid)
 }
 
 #endif
+
+int wxCMPFUNC_CONV wxCmpNatural(const wxString& s1, const wxString& s2)
+{
+    // The values of NSOrdered{Ascending,Same,Descending} are the same as
+    // expected return values of wxCmpNatural(), so we don't need to convert.
+    return [wxCFStringRef(s1).AsNSString() localizedStandardCompare: wxCFStringRef(s2).AsNSString()];
+}

--- a/tests/arrays/arrays.cpp
+++ b/tests/arrays/arrays.cpp
@@ -769,7 +769,7 @@ TEST_CASE("wxDynArray::IndexFromEnd", "[dynarray]")
 }
 
 
-TEST_CASE("wxNaturalStringComparisonGeneric()", "[wxString][compare]")
+TEST_CASE("wxCmpNaturalGeneric", "[wxString][compare]")
 {
     // simple string comparison
     CHECK(wxCmpNaturalGeneric("a", "a") == 0);

--- a/tests/arrays/arrays.cpp
+++ b/tests/arrays/arrays.cpp
@@ -844,3 +844,9 @@ TEST_CASE("wxCmpNaturalGeneric", "[wxString][compare]")
     CHECK(wxCmpNaturalGeneric("a5th 5", "a 10th 10") > 0);
 }
 
+TEST_CASE("wxCmpNatural", "[wxString][compare]")
+{
+    // We can't expect much from the native natural comparison function as it's
+    // locale-dependent, so just run a simple sanity test
+    CHECK(wxCmpNatural("same", "same") == 0);
+}


### PR DESCRIPTION
It seems like `[NSString localizedStandardCompare:]` is exactly what we need to implement this function.