### PR TITLE
Add note about calling EnableAlternateRowColours() (again) when you change a list control's background color

### DIFF
--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -1038,7 +1038,7 @@ public:
 
         Note that the wxWindow::GetBackgroundColour() function of wxWindow base
         class can be used to retrieve the current background colour.
-        
+
         @note If alternate row colouring is enabled, then call
         EnableAlternateRowColours() again after changing the background colour. This
         will update the alternate row color to match the new background colour.

--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -1038,6 +1038,10 @@ public:
 
         Note that the wxWindow::GetBackgroundColour() function of wxWindow base
         class can be used to retrieve the current background colour.
+        
+        @note If alternate row colouring is enabled, then call
+        EnableAlternateRowColours() again after changing the background colour. This
+        will update the alternate row color to match the new background colour.
     */
     virtual bool SetBackgroundColour(const wxColour& col);
 


### PR DESCRIPTION
I use alternate row coloring and was dynamically changing my control's background color.  After digging into the code, finding this trick saved me a lot of coding. Hopefully this note will help others.