### PR TITLE
Draw all borders for unfocused textctrl

### DIFF
--- a/src/univ/themes/gtk.cpp
+++ b/src/univ/themes/gtk.cpp
@@ -825,14 +825,10 @@ void wxGTKRenderer::DrawTextBorder(wxDC& dc,
 
     if ( border != wxBORDER_NONE )
     {
+        DrawRect(dc, &rect, m_penBlack);
         if ( flags & wxCONTROL_FOCUSED )
         {
-            DrawRect(dc, &rect, m_penBlack);
             DrawAntiShadedRect(dc, &rect, m_penDarkGrey, m_penHighlight);
-        }
-        else // !focused
-        {
-            DrawInnerShadedRect(dc, &rect);
         }
     }
 


### PR DESCRIPTION
Fix for [19248 [wxUniv(MSW)] Incorrect drawing of unfocused wxTextCtrl](http://trac.wxwidgets.org/ticket/19248)