### PR TITLE
Try setting use_tls=0 in LSAN_OPTIONS to work around a crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,20 +215,18 @@ jobs:
           httpbin_launch
 
           export ASAN_OPTIONS=fast_unwind_on_malloc=0
+          # Work around sporadic crashes, see https://github.com/google/sanitizers/issues/1353
+          export LSAN_OPTIONS=use_tls=0
+
+          ulimit -c unlimited
 
           # Explicitly use bash because /bin/sh doesn't have pipefail option
           /bin/bash -o pipefail -c './test 2>&1 | tee test.out' || rc=$?
-          if [ ${{ matrix.use_asan }} ]; then
-            # Work around spurious crashes by running the test again.
-            # See https://github.com/google/sanitizers/issues/1353
-            if fgrep -q 'LeakSanitizer has encountered a fatal error' test.out; then
-                echo '+++ Rerunning the tests once again after LeakSanitizer crash +++'
-                unset rc
-                ./test || rc=$?
-            fi
-          fi
-
           if [ -n "$rc" ]; then
+            if fgrep -q '(core dumped)' test.out; then
+                echo '*** Test crashed, trying to get more information ***'
+                gdb --quiet --core=core -ex 'where' -ex 'thread apply all bt' -ex 'q' ./test
+            fi
             httpbin_show_log
             exit $rc
           fi


### PR DESCRIPTION
Rerunning the test again after a crash doesn't help, as it just crashes
again, see https://github.com/wxWidgets/wxWidgets/runs/3444920378

Try a different workaround suggested in ASAN issue tracker and set
use_tls=0 option.