### PR TITLE
Install 32 bit OpenGL libraries explicitly in the CI workflow

### DIFF
--- a/.github/workflows/ci_msw_cross.yml
+++ b/.github/workflows/ci_msw_cross.yml
@@ -83,7 +83,7 @@ jobs:
         shell: bash
         run: |
           apt-get -q -o=Dpkg::Use-Pty=0 update
-          apt-get -qq install sudo
+          apt-get -q -o=Dpkg::Use-Pty=0 -y install sudo
 
           # Create a user with the same UID/GID and name as the existing user
           # outside of the container and allow it using sudo without password.
@@ -114,7 +114,7 @@ jobs:
               ;;
           esac
 
-          sudo DEBIAN_FRONTEND=noninteractive apt-get -qq install $packages
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -q -o=Dpkg::Use-Pty=0 -y install $packages
 
           echo "wxTEST_RUNNER=${winerun}" >> $GITHUB_ENV
 

--- a/.github/workflows/ci_msw_cross.yml
+++ b/.github/workflows/ci_msw_cross.yml
@@ -106,7 +106,7 @@ jobs:
             i686-w64-mingw32)
               sudo dpkg --add-architecture i386
               sudo apt-get -q -o=Dpkg::Use-Pty=0 update
-              packages="$packages g++-mingw-w64-i686 wine32"
+              packages="$packages g++-mingw-w64-i686 wine32 libgl1:i386"
               winerun=wine
               ;;
 

--- a/.github/workflows/ci_msw_cross.yml
+++ b/.github/workflows/ci_msw_cross.yml
@@ -93,8 +93,6 @@ jobs:
 
       - name: Install prerequisites
         run: |
-          export DEBIAN_FRONTEND=noninteractive
-
           packages="git make wine x11-xserver-utils xvfb"
 
           case "${HOST_TRIPLET}" in
@@ -116,7 +114,7 @@ jobs:
               ;;
           esac
 
-          sudo apt-get -qq install $packages
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -qq install $packages
 
           echo "wxTEST_RUNNER=${winerun}" >> $GITHUB_ENV
 


### PR DESCRIPTION
For some reason 32 bit libgl1 is not pulled in as win32 dependency any
more, resulting in errors when running the test using Direct2D.

Fix this by installing the package explicitly.