### PR TITLE
Make wxOverlay less dependent on external wxDCs

### DIFF
--- a/include/wx/dfb/dcclient.h
+++ b/include/wx/dfb/dcclient.h
@@ -35,7 +35,7 @@ private:
 
     bool m_shouldFlip; // flip the surface when done?
 
-    friend class wxOverlayImpl; // for m_shouldFlip;
+    friend class wxOverlayDFBImpl; // for m_shouldFlip;
 
     wxDECLARE_DYNAMIC_CLASS(wxWindowDCImpl);
     wxDECLARE_NO_COPY_CLASS(wxWindowDCImpl);

--- a/include/wx/dfb/private/overlay.h
+++ b/include/wx/dfb/private/overlay.h
@@ -11,29 +11,31 @@
 #define _WX_DFB_PRIVATE_OVERLAY_H_
 
 #include "wx/dfb/dfbptr.h"
-#include "wx/gdicmn.h"
+#include "wx/private/overlay.h"
 
 wxDFB_DECLARE_INTERFACE(IDirectFBSurface);
 
 class WXDLLIMPEXP_FWD_CORE wxWindow;
 class WXDLLIMPEXP_FWD_CORE wxDC;
 
-class wxOverlayImpl
+class wxOverlayDFBImpl : public wxOverlayImpl
 {
 public:
-    wxOverlayImpl();
-    ~wxOverlayImpl();
+    wxOverlayDFBImpl();
+    ~wxOverlayDFBImpl();
 
-    void Reset();
-    bool IsOk();
-    void Init(wxDC* dc, int x , int y , int width , int height);
-    void BeginDrawing(wxDC* dc);
-    void EndDrawing(wxDC* dc);
-    void Clear(wxDC* dc);
+    virtual void Reset() wxOVERRIDE;
+    virtual bool IsOk() wxOVERRIDE;
+    virtual void InitFromDC(wxDC* dc, int x , int y , int width , int height) wxOVERRIDE;
+    virtual void InitFromWindow(wxWindow* win, bool fullscreen) wxOVERRIDE;
+    virtual void BeginDrawing(wxDC* dc) wxOVERRIDE;
+    virtual void EndDrawing(wxDC* dc) wxOVERRIDE;
+    virtual void Clear(wxDC* dc) wxOVERRIDE;
+
+    virtual wxRect GetRect() const wxOVERRIDE { return m_rect; }
 
     // wxDFB specific methods:
     bool IsEmpty() const { return m_isEmpty; }
-    wxRect GetRect() const { return m_rect; }
     wxIDirectFBSurfacePtr GetDirectFBSurface() const { return m_surface; }
 
 public:

--- a/include/wx/dfb/window.h
+++ b/include/wx/dfb/window.h
@@ -182,7 +182,7 @@ private:
     wxDfbOverlaysList *m_overlays;
 
     friend class wxNonOwnedWindow; // for HandleXXXEvent
-    friend class wxOverlayImpl; // for Add/RemoveOverlay
+    friend class wxOverlayDFBImpl; // for Add/RemoveOverlay
     friend class wxWindowDCImpl; // for PaintOverlays
 
     wxDECLARE_DYNAMIC_CLASS(wxWindowDFB);

--- a/include/wx/generic/caret.h
+++ b/include/wx/generic/caret.h
@@ -64,6 +64,10 @@ protected:
     // refresh the caret
     void Refresh();
 
+    // helper function called by Refresh()
+    // returns true if the overlay needs to be reset
+    bool DoRefresh();
+
     // draw the caret on the given DC
     void DoDraw(wxDC *dc, wxWindow* win);
 

--- a/include/wx/generic/caret.h
+++ b/include/wx/generic/caret.h
@@ -15,10 +15,6 @@
 #include "wx/dc.h"
 #include "wx/overlay.h"
 
-#ifdef wxHAS_NATIVE_OVERLAY
-    #define wxHAS_CARET_USING_OVERLAYS
-#endif
-
 class WXDLLIMPEXP_FWD_CORE wxCaret;
 
 class WXDLLIMPEXP_CORE wxCaretTimer : public wxTimer
@@ -75,16 +71,8 @@ private:
     // GTK specific initialization
     void InitGeneric();
 
-#ifdef wxHAS_CARET_USING_OVERLAYS
     // the overlay for displaying the caret
     wxOverlay   m_overlay;
-#else
-    // the bitmap holding the part of window hidden by the caret when it was
-    // at (m_xOld, m_yOld)
-    wxBitmap      m_bmpUnderCaret;
-    int           m_xOld,
-                  m_yOld;
-#endif
 
     wxCaretTimer  m_timer;
     bool          m_blinkedOut,     // true => caret hidden right now

--- a/include/wx/osx/cocoa/private/overlay.h
+++ b/include/wx/osx/cocoa/private/overlay.h
@@ -14,28 +14,32 @@
 #include "wx/osx/private.h"
 #include "wx/toplevel.h"
 #include "wx/graphics.h"
+#include "wx/private/overlay.h"
 
-class wxOverlayImpl
+
+class wxOverlayCocoaImpl : public wxOverlayImpl
 {
 public:
-    wxOverlayImpl() ;
-    ~wxOverlayImpl() ;
+    wxOverlayCocoaImpl() ;
+    ~wxOverlayCocoaImpl() ;
 
 
     // clears the overlay without restoring the former state
     // to be done eg when the window content has been changed and repainted
-    void Reset();
+    virtual void Reset() wxOVERRIDE;
 
     // returns true if it has been setup
-    bool IsOk();
+    virtual bool IsOk() wxOVERRIDE;
 
-    void Init( wxDC* dc, int x , int y , int width , int height );
+    virtual void InitFromDC( wxDC* dc, int x , int y , int width , int height ) wxOVERRIDE;
 
-    void BeginDrawing( wxDC* dc);
+    virtual void InitFromWindow(wxWindow* win, bool fullscreen) wxOVERRIDE;
 
-    void EndDrawing( wxDC* dc);
+    virtual void BeginDrawing( wxDC* dc) wxOVERRIDE;
 
-    void Clear( wxDC* dc);
+    virtual void EndDrawing( wxDC* dc) wxOVERRIDE;
+
+    virtual void Clear( wxDC* dc) wxOVERRIDE;
 
 private:
     void CreateOverlayWindow( wxDC* dc );

--- a/include/wx/overlay.h
+++ b/include/wx/overlay.h
@@ -42,6 +42,9 @@ public:
     wxOverlay();
     ~wxOverlay();
 
+    // use generic implementation even if the native one is available
+    void UseGeneric();
+
     // clears the overlay without restoring the former state
     // to be done eg when the window content has been changed and repainted
     void Reset();

--- a/include/wx/overlay.h
+++ b/include/wx/overlay.h
@@ -45,6 +45,9 @@ public:
     // use generic implementation even if the native one is available
     void UseGeneric();
 
+    // returns true if we are using a native implementation
+    bool IsNative() const;
+
     // clears the overlay without restoring the former state
     // to be done eg when the window content has been changed and repainted
     void Reset();

--- a/include/wx/overlay.h
+++ b/include/wx/overlay.h
@@ -21,6 +21,10 @@
     // don't define wxHAS_NATIVE_OVERLAY
 #endif
 
+#ifdef wxOVERLAY_NO_EXTERNAL_DC
+    #include "wx/dcmemory.h"
+#endif
+
 // ----------------------------------------------------------------------------
 // creates an overlay over an existing window, allowing for manipulations like
 // rubberbanding etc. This API is not stable yet, not to be used outside wx
@@ -29,6 +33,8 @@
 
 class WXDLLIMPEXP_FWD_CORE wxOverlayImpl;
 class WXDLLIMPEXP_FWD_CORE wxDC;
+class WXDLLIMPEXP_FWD_CORE wxWindow;
+class WXDLLIMPEXP_FWD_CORE wxRect;
 
 class WXDLLIMPEXP_CORE wxOverlay
 {
@@ -50,6 +56,8 @@ private:
     bool IsOk();
 
     void Init(wxDC* dc, int x , int y , int width , int height);
+
+    void Init(wxWindow* win, bool fullscreen);
 
     void BeginDrawing(wxDC* dc);
 
@@ -76,19 +84,40 @@ public:
     // convenience wrapper that behaves the same using the entire area of the dc
     wxDCOverlay(wxOverlay &overlay, wxDC *dc);
 
+    // alternatively, if these ctors are used instead, the drawing should be done
+    // via this class directly (just cast the object to wxDC:  wxDC& dc = overlaydc)
+    wxDCOverlay(wxOverlay &overlay, wxWindow *win, int x, int y, int width, int height);
+    wxDCOverlay(wxOverlay &overlay, wxWindow *win, bool fullscreen = false);
+
     // removes the connection between the overlay and the dc
     virtual ~wxDCOverlay();
+
+    // implicit conversion to wxDC
+    operator wxDC& () const
+    {
+        wxASSERT_MSG( m_dc, "Invalid device context" );
+        return *m_dc;
+    }
 
     // clears the layer, restoring the state at the last init
     void Clear();
 
+    // sets the rectangle to be refreshed/updated within the overlay.
+    void SetUpdateRectangle(const wxRect& rect);
+
 private:
+    void Init(wxDC *dc);
     void Init(wxDC *dc, int x , int y , int width , int height);
+    void Init(wxWindow *win, bool fullscreen, const wxRect& rect);
 
     wxOverlay& m_overlay;
 
-    wxDC* m_dc;
+    wxDC*      m_dc;
+    bool       m_ownsDC;
 
+#ifdef wxOVERLAY_NO_EXTERNAL_DC
+    wxMemoryDC m_memDC;
+#endif // wxOVERLAY_NO_EXTERNAL_DC
 
     wxDECLARE_NO_COPY_CLASS(wxDCOverlay);
 };

--- a/include/wx/private/overlay.h
+++ b/include/wx/private/overlay.h
@@ -25,6 +25,12 @@ public:
     // derived from this class.
     virtual bool IsNative() const { return true; }
 
+    // Although wxOverlayGenericImpl is always available on all platforms,
+    // it is known that it doesn't work well under some of them (Wayland specifically)
+    // and therefore cannot be used if this function returns false even if a call to
+    // wxOverlay::UseGeneric() has been made, in which case the call should not be honored.
+    virtual bool IsGenericSupported() const { return true; }
+
     void Init(wxDC* dc, int x, int y, int width, int height)
     {
         InitFromDC(dc, x, y, width, height);

--- a/include/wx/private/overlay.h
+++ b/include/wx/private/overlay.h
@@ -11,56 +11,57 @@
 #ifndef _WX_PRIVATE_OVERLAY_H_
 #define _WX_PRIVATE_OVERLAY_H_
 
-#include "wx/overlay.h"
-
-#ifdef wxHAS_NATIVE_OVERLAY
-
-#if defined(__WXOSX__) && wxOSX_USE_COCOA
-    #include "wx/osx/cocoa/private/overlay.h"
-#elif defined(__WXDFB__)
-    #include "wx/dfb/private/overlay.h"
-#else
-    #error "unknown native wxOverlay implementation"
-#endif
-
-#else // !wxHAS_NATIVE_OVERLAY
-
 #include "wx/bitmap.h"
 
-class WXDLLIMPEXP_FWD_CORE wxWindow;
-
-// generic implementation of wxOverlay
 class wxOverlayImpl
 {
 public:
-    wxOverlayImpl();
-    ~wxOverlayImpl();
+    wxOverlayImpl() { }
+    virtual ~wxOverlayImpl() { }
 
+    static wxOverlayImpl* Create();
+
+    // wxOverlayGenericImpl is the only not native implementation
+    // derived from this class.
+    virtual bool IsNative() const { return true; }
+
+    void Init(wxDC* dc, int x, int y, int width, int height)
+    {
+        InitFromDC(dc, x, y, width, height);
+    }
+
+    void Init(wxWindow* win, bool fullscreen)
+    {
+        InitFromWindow(win, fullscreen);
+    }
+
+    // returns true if it has been setup
+    virtual bool IsOk() = 0;
 
     // clears the overlay without restoring the former state
     // to be done eg when the window content has been changed and repainted
-    void Reset();
+    virtual void Reset() = 0;
 
-    // returns true if it has been setup
-    bool IsOk();
+    virtual void Clear(wxDC* dc) = 0;
 
-    void Init(wxDC* dc, int x , int y , int width , int height);
+    virtual void BeginDrawing(wxDC* WXUNUSED(dc)) { }
 
-    void BeginDrawing(wxDC* dc);
+    virtual void EndDrawing(wxDC* WXUNUSED(dc)) { }
 
-    void EndDrawing(wxDC* dc);
+    virtual wxRect GetRect() const { return wxRect(); }
 
-    void Clear(wxDC* dc);
+    virtual void SetUpdateRectangle(const wxRect& WXUNUSED(rect)) { }
+
+    wxBitmap& GetBitmap() { return m_bitmap; }
+
+protected:
+    virtual void InitFromDC(wxDC* dc, int x, int y, int width, int height) = 0;
+    virtual void InitFromWindow(wxWindow* win, bool fullscreen) = 0;
 
 private:
-    wxBitmap m_bmpSaved ;
-    int m_x ;
-    int m_y ;
-    int m_width ;
-    int m_height ;
-    wxWindow* m_window ;
-};
+    wxBitmap m_bitmap;
 
-#endif // wxHAS_NATIVE_OVERLAY/!wxHAS_NATIVE_OVERLAY
+    wxDECLARE_NO_COPY_CLASS(wxOverlayImpl);
+};
 
 #endif // _WX_PRIVATE_OVERLAY_H_

--- a/samples/caret/caret.cpp
+++ b/samples/caret/caret.cpp
@@ -325,10 +325,11 @@ MyCanvas::~MyCanvas()
 
 void MyCanvas::CreateCaret()
 {
+    SetCaret(NULL);
     wxCaret *caret = new wxCaret(this, m_widthChar, m_heightChar);
     SetCaret(caret);
 
-    caret->Move(m_xMargin, m_yMargin);
+    DoMoveCaret();
     caret->Show();
 }
 

--- a/samples/drawing/drawing.cpp
+++ b/samples/drawing/drawing.cpp
@@ -107,6 +107,8 @@ public:
     void OnMouseMove(wxMouseEvent &event);
     void OnMouseDown(wxMouseEvent &event);
     void OnMouseUp(wxMouseEvent &event);
+    void OnMouseWheel(wxMouseEvent &event);
+    void OnCaptureLost(wxMouseCaptureLostEvent& event);
 
     void ToShow(int show) { m_show = show; Refresh(); }
     int GetPage() { return m_show; }
@@ -157,6 +159,8 @@ protected:
     void DrawSystemColours(wxDC& dc);
 
     void DrawRegionsHelper(wxDC& dc, wxCoord x, bool firstTime);
+
+    void DrawRubberBand(const wxPoint& pos);
 
 private:
     MyFrame *m_owner;
@@ -502,6 +506,8 @@ wxBEGIN_EVENT_TABLE(MyCanvas, wxScrolledWindow)
     EVT_MOTION (MyCanvas::OnMouseMove)
     EVT_LEFT_DOWN (MyCanvas::OnMouseDown)
     EVT_LEFT_UP (MyCanvas::OnMouseUp)
+    EVT_MOUSEWHEEL (MyCanvas::OnMouseWheel)
+    EVT_MOUSE_CAPTURE_LOST (MyCanvas::OnCaptureLost)
 wxEND_EVENT_TABLE()
 
 #include "smile.xpm"
@@ -2002,6 +2008,28 @@ void MyCanvas::Draw(wxDC& pdc)
     }
 }
 
+void MyCanvas::DrawRubberBand(const wxPoint& pos)
+{
+    int xx, yy;
+    CalcUnscrolledPosition( pos.x, pos.y, &xx, &yy );
+    m_currentpoint = wxPoint( xx , yy ) ;
+    wxRect newrect ( m_anchorpoint , m_currentpoint );
+
+    wxDCOverlay overlaydc( m_overlay, this );
+    overlaydc.Clear();
+
+    wxDC& dc = overlaydc;
+
+#ifdef wxHAS_NATIVE_OVERLAY
+    dc.SetPen( *wxGREY_PEN );
+    dc.SetBrush( wxColour( 192,192,192,64 ) );
+#else
+    dc.SetPen( wxPen( *wxLIGHT_GREY, 2 ) );
+    dc.SetBrush( *wxTRANSPARENT_BRUSH );
+#endif // wxHAS_NATIVE_OVERLAY
+    dc.DrawRectangle( newrect );
+}
+
 void MyCanvas::OnMouseMove(wxMouseEvent &event)
 {
 #if wxUSE_STATUSBAR
@@ -2018,25 +2046,7 @@ void MyCanvas::OnMouseMove(wxMouseEvent &event)
 
     if ( m_rubberBand )
     {
-        int x,y, xx, yy ;
-        event.GetPosition(&x,&y);
-        CalcUnscrolledPosition( x, y, &xx, &yy );
-        m_currentpoint = wxPoint( xx , yy ) ;
-        wxRect newrect ( m_anchorpoint , m_currentpoint ) ;
-
-        wxClientDC dc( this ) ;
-        PrepareDC( dc ) ;
-
-        wxDCOverlay overlaydc( m_overlay, &dc );
-        overlaydc.Clear();
-#ifdef __WXMAC__
-        dc.SetPen( *wxGREY_PEN );
-        dc.SetBrush( wxColour( 192,192,192,64 ) );
-#else
-        dc.SetPen( wxPen( *wxLIGHT_GREY, 2 ) );
-        dc.SetBrush( *wxTRANSPARENT_BRUSH );
-#endif
-        dc.DrawRectangle( newrect );
+        DrawRubberBand(event.GetPosition());
     }
 #else
     wxUnusedVar(event);
@@ -2060,9 +2070,7 @@ void MyCanvas::OnMouseUp(wxMouseEvent &event)
     {
         ReleaseMouse();
         {
-            wxClientDC dc( this );
-            PrepareDC( dc );
-            wxDCOverlay overlaydc( m_overlay, &dc );
+            wxDCOverlay overlaydc( m_overlay, this );
             overlaydc.Clear();
         }
         m_overlay.Reset();
@@ -2078,6 +2086,23 @@ void MyCanvas::OnMouseUp(wxMouseEvent &event)
                          endpoint.x, endpoint.y);
         }
     }
+}
+
+void MyCanvas::OnMouseWheel(wxMouseEvent& event)
+{
+    if ( m_rubberBand )
+    {
+        // we should call DrawRubberBand after the window has finished
+        // scrolling.
+        CallAfter(&MyCanvas::DrawRubberBand, event.GetPosition());
+    }
+
+    event.Skip();
+}
+
+void MyCanvas::OnCaptureLost(wxMouseCaptureLostEvent& WXUNUSED(event))
+{
+    ReleaseMouse();
 }
 
 #if wxUSE_GRAPHICS_CONTEXT

--- a/src/common/overlaycmn.cpp
+++ b/src/common/overlaycmn.cpp
@@ -27,9 +27,9 @@
 #include "wx/dcgraph.h"
 #else // !wxOVERLAY_NO_EXTERNAL_DC
 #include "wx/dcmemory.h"
+#endif // wxOVERLAY_NO_EXTERNAL_DC
 #include "wx/dcscreen.h"
 #include "wx/scrolwin.h"
-#endif // wxOVERLAY_NO_EXTERNAL_DC
 
 // ============================================================================
 // implementation
@@ -41,7 +41,7 @@
 
 wxOverlay::wxOverlay()
 {
-    m_impl = new wxOverlayImpl();
+    m_impl = wxOverlayImpl::Create();
     m_inDrawing = false;
 }
 
@@ -151,7 +151,9 @@ void wxDCOverlay::Init(wxWindow* win, bool fullscreen, const wxRect& rect)
         m_overlay.Init(win, fullscreen);
     }
 
-    if ( m_overlay.IsOk() )
+    const bool isNative = m_overlay.GetImpl()->IsNative();
+
+    if ( m_overlay.IsOk() && isNative )
     {
         wxBitmap& bitmap = m_overlay.GetImpl()->GetBitmap();
         m_memDC.SelectObject(bitmap);
@@ -169,7 +171,7 @@ void wxDCOverlay::Init(wxWindow* win, bool fullscreen, const wxRect& rect)
             SetUpdateRectangle(rect);
     }
     else
- #endif // !wxOVERLAY_NO_EXTERNAL_DC
+#endif // !wxOVERLAY_NO_EXTERNAL_DC
     {
         wxDC* dc;
 
@@ -212,70 +214,74 @@ void wxDCOverlay::Clear()
 
 void wxDCOverlay::SetUpdateRectangle(const wxRect& rect)
 {
-#ifdef wxOVERLAY_NO_EXTERNAL_DC
     m_overlay.GetImpl()->SetUpdateRectangle(rect);
-#else // !wxOVERLAY_NO_EXTERNAL_DC
-    wxUnusedVar(rect);
-#endif // wxOVERLAY_NO_EXTERNAL_DC
 }
 
 // ----------------------------------------------------------------------------
 // generic implementation of wxOverlayImpl
 // ----------------------------------------------------------------------------
 
+class wxOverlayGenericImpl : public wxOverlayImpl
+{
+public:
+    wxOverlayGenericImpl() : wxOverlayImpl()
+    {
+        m_window = NULL;
+    }
+
+    virtual bool IsNative() const wxOVERRIDE { return false; }
+
+    virtual bool IsOk() wxOVERRIDE
+    {
+        return GetBitmap().IsOk();
+    }
+
+    virtual void InitFromDC(wxDC* dc, int x, int y, int width, int height) wxOVERRIDE
+    {
+        m_window = dc->GetWindow();
+        m_rect   = wxRect(x, y, width, height);
+
+        wxMemoryDC dcMem ;
+        wxBitmap& bmpSaved = GetBitmap();
+        bmpSaved.Create( width, height );
+        dcMem.SelectObject( bmpSaved );
+        dcMem.Blit(0, 0, width, height, dc, x, y);
+        dcMem.SelectObject( wxNullBitmap );
+    }
+
+    virtual void InitFromWindow(wxWindow* WXUNUSED(win), bool WXUNUSED(fullscreen)) wxOVERRIDE
+    {
+        // Not constructible from wxWindow.
+    }
+
+    virtual void Clear(wxDC* dc) wxOVERRIDE
+    {
+        wxMemoryDC dcMem ;
+        wxBitmap& bmpSaved = GetBitmap();
+        dcMem.SelectObject( bmpSaved );
+        dc->Blit( m_rect.x, m_rect.y, m_rect.width, m_rect.height, &dcMem, 0, 0 );
+        dcMem.SelectObject( wxNullBitmap );
+    }
+
+    virtual void Reset() wxOVERRIDE
+    {
+        GetBitmap() = wxBitmap();
+    }
+
+private:
+    wxRect    m_rect;
+    wxWindow* m_window;
+};
+
+void wxOverlay::UseGeneric()
+{
+#ifdef wxHAS_NATIVE_OVERLAY
+    wxASSERT_MSG( !IsOk(), "should only be called for uninitialized overlay" );
+    delete m_impl;
+    m_impl = new wxOverlayGenericImpl();
+#endif // wxHAS_NATIVE_OVERLAY
+}
+
 #ifndef wxHAS_NATIVE_OVERLAY
-
-wxOverlayImpl::wxOverlayImpl()
-{
-     m_window = NULL ;
-     m_x = m_y = m_width = m_height = 0 ;
-}
-
-wxOverlayImpl::~wxOverlayImpl()
-{
-}
-
-bool wxOverlayImpl::IsOk()
-{
-    return m_bmpSaved.IsOk() ;
-}
-
-void wxOverlayImpl::Init( wxDC* dc, int x , int y , int width , int height )
-{
-    m_window = dc->GetWindow();
-    wxMemoryDC dcMem ;
-    m_bmpSaved.Create( width, height );
-    dcMem.SelectObject( m_bmpSaved );
-    m_x = x ;
-    m_y = y ;
-    m_width = width ;
-    m_height = height ;
-    dcMem.Blit(0, 0, m_width, m_height,
-        dc, x, y);
-    dcMem.SelectObject( wxNullBitmap );
-}
-
-void wxOverlayImpl::Clear(wxDC* dc)
-{
-    wxMemoryDC dcMem ;
-    dcMem.SelectObject( m_bmpSaved );
-    dc->Blit( m_x, m_y, m_width, m_height , &dcMem , 0 , 0 );
-    dcMem.SelectObject( wxNullBitmap );
-}
-
-void wxOverlayImpl::Reset()
-{
-    m_bmpSaved = wxBitmap();
-}
-
-void wxOverlayImpl::BeginDrawing(wxDC*  WXUNUSED(dc))
-{
-}
-
-void wxOverlayImpl::EndDrawing(wxDC* WXUNUSED(dc))
-{
-}
-
-#endif // !wxHAS_NATIVE_OVERLAY
-
-
+wxOverlayImpl* wxOverlayImpl::Create() { return new wxOverlayGenericImpl(); }
+#endif

--- a/src/common/overlaycmn.cpp
+++ b/src/common/overlaycmn.cpp
@@ -50,6 +50,11 @@ wxOverlay::~wxOverlay()
     delete m_impl;
 }
 
+bool wxOverlay::IsNative() const
+{
+    return m_impl->IsNative();
+}
+
 bool wxOverlay::IsOk()
 {
     return m_impl->IsOk();
@@ -277,6 +282,13 @@ void wxOverlay::UseGeneric()
 {
 #ifdef wxHAS_NATIVE_OVERLAY
     wxASSERT_MSG( !IsOk(), "should only be called for uninitialized overlay" );
+
+    if ( !m_impl->IsGenericSupported() )
+    {
+        // Only native overlay can be used (Wayland for ex.)
+        return;
+    }
+
     delete m_impl;
     m_impl = new wxOverlayGenericImpl();
 #endif // wxHAS_NATIVE_OVERLAY

--- a/src/common/overlaycmn.cpp
+++ b/src/common/overlaycmn.cpp
@@ -23,7 +23,13 @@
 #include "wx/overlay.h"
 #include "wx/private/overlay.h"
 #include "wx/dcclient.h"
+#ifdef wxOVERLAY_NO_EXTERNAL_DC
+#include "wx/dcgraph.h"
+#else // !wxOVERLAY_NO_EXTERNAL_DC
 #include "wx/dcmemory.h"
+#include "wx/dcscreen.h"
+#include "wx/scrolwin.h"
+#endif // wxOVERLAY_NO_EXTERNAL_DC
 
 // ============================================================================
 // implementation
@@ -52,6 +58,16 @@ bool wxOverlay::IsOk()
 void wxOverlay::Init( wxDC* dc, int x , int y , int width , int height )
 {
     m_impl->Init(dc, x, y, width, height);
+}
+
+void wxOverlay::Init( wxWindow* win, bool fullscreen )
+{
+#ifdef wxOVERLAY_NO_EXTERNAL_DC
+    m_impl->Init(win, fullscreen);
+#else // !wxOVERLAY_NO_EXTERNAL_DC
+    wxUnusedVar(win);
+    wxUnusedVar(fullscreen);
+#endif // wxOVERLAY_NO_EXTERNAL_DC
 }
 
 void wxOverlay::BeginDrawing( wxDC* dc)
@@ -83,13 +99,97 @@ void wxOverlay::Reset()
 // ----------------------------------------------------------------------------
 
 wxDCOverlay::wxDCOverlay(wxOverlay &overlay, wxDC *dc, int x , int y , int width , int height) :
-    m_overlay(overlay)
+    m_overlay(overlay), m_ownsDC(false)
 {
     Init(dc, x, y, width, height);
 }
 
 wxDCOverlay::wxDCOverlay(wxOverlay &overlay, wxDC *dc) :
-    m_overlay(overlay)
+    m_overlay(overlay), m_ownsDC(false)
+{
+    Init(dc);
+}
+
+wxDCOverlay::wxDCOverlay(wxOverlay& overlay, wxWindow* win,
+                         int x, int y, int width, int height) :
+    m_overlay(overlay), m_ownsDC(true)
+{
+    Init(win, false /*fullscreen*/, wxRect(x, y, width, height));
+}
+
+wxDCOverlay::wxDCOverlay(wxOverlay& overlay, wxWindow* win, bool fullscreen) :
+    m_overlay(overlay), m_ownsDC(true)
+{
+    Init(win, fullscreen, wxRect());
+}
+
+wxDCOverlay::~wxDCOverlay()
+{
+    m_overlay.EndDrawing(m_dc);
+
+    if ( m_ownsDC && m_dc )
+        delete m_dc;
+}
+
+void wxDCOverlay::Init(wxDC *dc, int x , int y , int width , int height )
+{
+    m_dc = dc ;
+    if ( !m_overlay.IsOk() )
+    {
+        m_overlay.Init(dc,x,y,width,height);
+    }
+    m_overlay.BeginDrawing(dc);
+}
+
+void wxDCOverlay::Init(wxWindow* win, bool fullscreen, const wxRect& rect)
+{
+    wxCHECK_RET( win, wxS("Invalid window pointer") );
+
+#ifdef wxOVERLAY_NO_EXTERNAL_DC
+    if ( !m_overlay.IsOk() )
+    {
+        m_overlay.Init(win, fullscreen);
+    }
+
+    if ( m_overlay.IsOk() )
+    {
+        wxBitmap& bitmap = m_overlay.GetImpl()->GetBitmap();
+        m_memDC.SelectObject(bitmap);
+
+#if wxUSE_GRAPHICS_CONTEXT
+        m_dc = new wxGCDC;
+        m_dc->SetGraphicsContext(wxGraphicsContext::Create(m_memDC));
+#else // !wxUSE_GRAPHICS_CONTEXT
+        m_dc = &m_memDC;
+        m_ownsDC = false;
+#endif // wxUSE_GRAPHICS_CONTEXT
+        m_overlay.BeginDrawing(m_dc);
+
+        if ( !rect.IsEmpty() )
+            SetUpdateRectangle(rect);
+    }
+    else
+ #endif // !wxOVERLAY_NO_EXTERNAL_DC
+    {
+        wxDC* dc;
+
+        if ( fullscreen )
+            dc = new wxScreenDC;
+        else
+            dc = new wxClientDC(win);
+
+        wxScrolledWindow* const sw = wxDynamicCast(win, wxScrolledWindow);
+        if ( sw )
+            sw->PrepareDC(*dc);
+
+        if ( rect.IsEmpty() )
+            Init(dc);
+        else
+            Init(dc, rect.x, rect.y, rect.width, rect.height);
+    }
+}
+
+void wxDCOverlay::Init(wxDC* dc)
 {
     const wxSize size(dc->GetSize());
 
@@ -105,24 +205,18 @@ wxDCOverlay::wxDCOverlay(wxOverlay &overlay, wxDC *dc) :
          logicalBottom - logicalTop);
 }
 
-wxDCOverlay::~wxDCOverlay()
-{
-    m_overlay.EndDrawing(m_dc);
-}
-
-void wxDCOverlay::Init(wxDC *dc, int x , int y , int width , int height )
-{
-    m_dc = dc ;
-    if ( !m_overlay.IsOk() )
-    {
-        m_overlay.Init(dc,x,y,width,height);
-    }
-    m_overlay.BeginDrawing(dc);
-}
-
 void wxDCOverlay::Clear()
 {
     m_overlay.Clear(m_dc);
+}
+
+void wxDCOverlay::SetUpdateRectangle(const wxRect& rect)
+{
+#ifdef wxOVERLAY_NO_EXTERNAL_DC
+    m_overlay.GetImpl()->SetUpdateRectangle(rect);
+#else // !wxOVERLAY_NO_EXTERNAL_DC
+    wxUnusedVar(rect);
+#endif // wxOVERLAY_NO_EXTERNAL_DC
 }
 
 // ----------------------------------------------------------------------------

--- a/src/dfb/overlay.cpp
+++ b/src/dfb/overlay.cpp
@@ -24,9 +24,9 @@
     #include "wx/dcclient.h"
 #endif
 
-#include "wx/private/overlay.h"
 #include "wx/dfb/dcclient.h"
 #include "wx/dfb/private.h"
+#include "wx/dfb/private/overlay.h"
 
 // ============================================================================
 // implementation
@@ -36,23 +36,23 @@
 // wxOverlay
 // ----------------------------------------------------------------------------
 
-wxOverlayImpl::wxOverlayImpl()
+wxOverlayDFBImpl::wxOverlayDFBImpl()
 {
     m_window = NULL;
     m_isEmpty = true;
 }
 
-wxOverlayImpl::~wxOverlayImpl()
+wxOverlayDFBImpl::~wxOverlayDFBImpl()
 {
     Reset();
 }
 
-bool wxOverlayImpl::IsOk()
+bool wxOverlayDFBImpl::IsOk()
 {
     return m_window != NULL;
 }
 
-void wxOverlayImpl::Init(wxDC *dc, int x, int y, int width, int height)
+void wxOverlayDFBImpl::InitFromDC(wxDC *dc, int x, int y, int width, int height)
 {
     wxCHECK_RET( dc, "NULL dc pointer" );
     wxASSERT_MSG( !IsOk() , "You cannot Init an overlay twice" );
@@ -76,7 +76,12 @@ void wxOverlayImpl::Init(wxDC *dc, int x, int y, int width, int height)
     m_window->AddOverlay(this);
 }
 
-void wxOverlayImpl::BeginDrawing(wxDC *dc)
+void wxOverlayDFBImpl::InitFromWindow(wxWindow* WXUNUSED(win), bool WXUNUSED(fullscreen))
+{
+    // don't forget to define wxOVERLAY_NO_EXTERNAL_DC in wx/overlay.h when implement this
+}
+
+void wxOverlayDFBImpl::BeginDrawing(wxDC *dc)
 {
     wxCHECK_RET( dc, "NULL dc pointer" );
 
@@ -98,12 +103,12 @@ void wxOverlayImpl::BeginDrawing(wxDC *dc)
     m_isEmpty = false;
 }
 
-void wxOverlayImpl::EndDrawing(wxDC *WXUNUSED(dc))
+void wxOverlayDFBImpl::EndDrawing(wxDC *WXUNUSED(dc))
 {
     m_window->RefreshWindowRect(m_rect);
 }
 
-void wxOverlayImpl::Clear(wxDC *WXUNUSED(dc))
+void wxOverlayDFBImpl::Clear(wxDC *WXUNUSED(dc))
 {
     wxASSERT_MSG( IsOk(),
                   "You cannot Clear an overlay that is not initialized" );
@@ -111,7 +116,7 @@ void wxOverlayImpl::Clear(wxDC *WXUNUSED(dc))
     m_isEmpty = true;
 }
 
-void wxOverlayImpl::Reset()
+void wxOverlayDFBImpl::Reset()
 {
     if ( m_window )
     {
@@ -120,3 +125,5 @@ void wxOverlayImpl::Reset()
         m_surface.Reset();
     }
 }
+
+wxOverlayImpl* wxOverlayImpl::Create() { return new wxOverlayDFBImpl(); }

--- a/src/dfb/window.cpp
+++ b/src/dfb/window.cpp
@@ -31,7 +31,7 @@
 #include "wx/dynarray.h"
 
 #include "wx/dfb/private.h"
-#include "wx/private/overlay.h"
+#include "wx/dfb/private/overlay.h"
 
 #define TRACE_EVENTS "events"
 #define TRACE_PAINT  "paint"
@@ -749,7 +749,8 @@ void wxWindowDFB::PaintOverlays(const wxRect& rect)
     for ( wxDfbOverlaysList::const_iterator i = m_overlays->begin();
           i != m_overlays->end(); ++i )
     {
-        const wxOverlayImpl * const overlay = *i;
+        const wxOverlayDFBImpl * const overlay =
+            static_cast<wxOverlayDFBImpl * const>(*i);
 
         wxRect orectOrig(overlay->GetRect());
         wxRect orect(orectOrig);

--- a/src/generic/caret.cpp
+++ b/src/generic/caret.cpp
@@ -97,12 +97,8 @@ void wxCaret::InitGeneric()
 {
     m_hasFocus = true;
     m_blinkedOut = true;
-#ifndef wxHAS_CARET_USING_OVERLAYS
-    m_xOld =
-    m_yOld = -1;
-    if (m_width && m_height)
-        m_bmpUnderCaret.Create(m_width, m_height);
-#endif
+
+    m_overlay.UseGeneric();
 }
 
 wxCaret::~wxCaret()
@@ -141,9 +137,6 @@ void wxCaret::DoHide()
 
 void wxCaret::DoMove()
 {
-#ifdef wxHAS_CARET_USING_OVERLAYS
-    m_overlay.Reset();
-#endif
     if ( IsVisible() )
     {
         if ( !m_blinkedOut )
@@ -168,15 +161,9 @@ void wxCaret::DoSize()
         m_countVisible = 0;
         DoHide();
     }
-#ifdef wxHAS_CARET_USING_OVERLAYS
+
     m_overlay.Reset();
-#else
-    // Change bitmap size
-    if (m_width && m_height)
-        m_bmpUnderCaret = wxBitmap(m_width, m_height);
-    else
-        m_bmpUnderCaret = wxBitmap();
-#endif
+
     if (countVisible > 0)
     {
         m_countVisible = countVisible;
@@ -228,47 +215,32 @@ void wxCaret::Blink()
 
 void wxCaret::Refresh()
 {
-    wxClientDC dcWin(GetWindow());
-// this is the new code, switch to 0 if this gives problems
-#ifdef wxHAS_CARET_USING_OVERLAYS
-    wxDCOverlay dcOverlay( m_overlay, &dcWin, m_x, m_y, m_width , m_height );
-    if ( m_blinkedOut )
+    wxWindow* const win = GetWindow();
+
+    if ( !win->IsShownOnScreen() )
     {
-        dcOverlay.Clear();
+        return;
     }
-    else
+
+    // Extra-block: we can't reset the overlay while dcOverlay is still alive!
     {
-        DoDraw( &dcWin, GetWindow() );
-    }
-#else
-    wxMemoryDC dcMem;
-    dcMem.SelectObject(m_bmpUnderCaret);
-    if ( m_blinkedOut )
-    {
-        // restore the old image
-        dcWin.Blit(m_xOld, m_yOld, m_width, m_height,
-                   &dcMem, 0, 0);
-        m_xOld =
-        m_yOld = -1;
-    }
-    else
-    {
-        if ( m_xOld == -1 && m_yOld == -1 )
+        wxDCOverlay dcOverlay( m_overlay, win, m_x, m_y, m_width , m_height );
+
+        if ( m_blinkedOut )
         {
-            // save the part we're going to overdraw
-            dcMem.Blit(0, 0, m_width, m_height,
-                       &dcWin, m_x, m_y);
-
-            m_xOld = m_x;
-            m_yOld = m_y;
+            dcOverlay.Clear();
         }
-        //else: we already saved the image below the caret, don't do it any
-        //      more
-
-        // and draw the caret there
-        DoDraw(&dcWin, GetWindow());
+        else
+        {
+            wxDC& dc = dcOverlay;
+            DoDraw( &dc, win );
+        }
     }
-#endif
+
+    if ( m_blinkedOut )
+    {
+        m_overlay.Reset();
+    }
 }
 
 void wxCaret::DoDraw(wxDC *dc, wxWindow* win)


### PR DESCRIPTION
Working with `wxOverlay` requires three entities:
- a `wxOverlay` object (which hides port-specific code to create the actual overlay window)
- a `wxDC` to draw on
- a `wxDCOverlay` to connect the overlay with the drawing dc

With this PR the user is no longer required to specify the drawing dc explicitly.
i.e. if dc is omitted (see the new added ctors), a `wxClientDC` or `wxScreenDC` will be created internally for use. this will cover all the overlays used internally by the library itself.

The aim is to remove the dependency on the external dc and just use a `wxMemoryDC` instead.
AFAICT **wxOverlay** under `wxMSW` and `wxGTK` (and `wxMAC` ?) can simply use `wxMemoryDC` and blit the result.

If you agree to this, i'll close the other PRs ([this](https://github.com/wxWidgets/wxWidgets/pull/2448) and [this](https://github.com/wxWidgets/wxWidgets/pull/2386)) and continue with this one.

TIA.