### PR TITLE
Allow rescaling larger images in Win64 builds

### DIFF
--- a/interface/wx/image.h
+++ b/interface/wx/image.h
@@ -972,6 +972,11 @@ public:
         }
         @endcode
 
+        @note The algorithm used for the default (normal) quality value doesn't
+        work with the images larger than 65536 (2^16) pixels in any direction
+        in either size in 32 bits programs. For 64 bits programs the limit is
+        2^48 and so not relevant in practice.
+
         @see Rescale()
     */
     wxImage Scale(int width, int height,

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -2249,6 +2249,18 @@ TEST_CASE("wxImage::ChangeColours", "[image]")
     CHECK_THAT(test, RGBSameAs(expected));
 }
 
+TEST_CASE("wxImage::SizeLimits", "[image]")
+{
+#if SIZEOF_VOID_P == 8
+    // Check that we can resample an image of size greater than 2^16, which is
+    // the limit used in 32-bit code to avoid integer overflows.
+    wxImage image(100000, 2);
+    REQUIRE_NOTHROW( image = image.ResampleNearest(100000, 1) );
+    CHECK( image.GetWidth() == 100000 );
+    CHECK( image.GetHeight() == 1 );
+#endif // SIZEOF_VOID_P == 8
+}
+
 /*
     TODO: add lots of more tests to wxImage functions
 */


### PR DESCRIPTION
Use wxUIntPtr rather than (unsigned) long in wxImage::ResampleNearest()
as long is still 32 bits under Win64 and so doesn't allow the code there
to work with images larger than 2^16 in either direction, when it could
be allowed in this case.

Document the current limits on the size of the image and add a unit test
checking that resizing images of size greater than 2^16 works in 64 bits.

See [#18550](http://trac.wxwidgets.org/ticket/18550).

---

There actually are people using `wxImage` with images larger than 65536 pixels in size (in one direction only), so allow doing this in Win64 programs.

I ran the unit test under UBSAN which didn't find anything (in this test, anyhow, it did find plenty of things elsewhere).