### PR TITLE
Avoid crash in wxBitmap::GetImage() for invalid bitmaps

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -129,6 +129,10 @@ Changes in behaviour not resulting in compilation errors
 - wxSpinCtrl::SetValue(wxString) overload doesn't generate any events with
   wxMSW, which was already the documented behaviour.
 
+- wxButton::GetBitmap{Current,Disabled,Focus,Pressed}() only return valid
+  bitmaps in wxMSW if the corresponding Set had been called before, as in the
+  other ports, instead of returning the normal bitmap as fallback in this case.
+
 
 Changes in behaviour which may result in build errors
 -----------------------------------------------------

--- a/include/wx/osx/bitmap.h
+++ b/include/wx/osx/bitmap.h
@@ -205,16 +205,16 @@ public:
     CGImageRef CreateCGImage() const ;
 
     // returns nil for invalid bitmap
-    WXImage GetImage() const;
+    WXImage OSXGetImage() const;
 #if wxOSX_USE_COCOA
     // returns an autoreleased version of the image
     WX_NSImage GetNSImage() const
-        { return GetImage(); }
+        { return OSXGetImage(); }
 #endif
 #if wxOSX_USE_IPHONE
     // returns an autoreleased version of the image
     WX_UIImage GetUIImage() const
-        { return GetImage(); }
+        { return OSXGetImage(); }
 #endif
 
 #if WXWIN_COMPATIBILITY_3_0

--- a/include/wx/osx/bitmap.h
+++ b/include/wx/osx/bitmap.h
@@ -204,6 +204,7 @@ public:
     // returns a CGImageRef which must released after usage with CGImageRelease
     CGImageRef CreateCGImage() const ;
 
+    // returns nil for invalid bitmap
     WXImage GetImage() const;
 #if wxOSX_USE_COCOA
     // returns an autoreleased version of the image

--- a/interface/wx/anybutton.h
+++ b/interface/wx/anybutton.h
@@ -41,10 +41,10 @@ public:
     wxBitmap GetBitmap() const;
 
     /**
-        Returns the bitmap used when the mouse is over the button, which may be
-        invalid.
+        Returns the bitmap used when the mouse is over the button.
 
-        @see SetBitmapCurrent()
+        The returned bitmap is only valid if SetBitmapCurrent() had been
+        previously called.
 
         @since 2.9.1 (available as wxBitmapButton::GetBitmapHover() in previous
             versions)
@@ -52,18 +52,20 @@ public:
     wxBitmap GetBitmapCurrent() const;
 
     /**
-        Returns the bitmap for the disabled state, which may be invalid.
+        Returns the bitmap used for the disabled state.
 
-        @see SetBitmapDisabled()
+        The returned bitmap is only valid if SetBitmapDisabled() had been
+        previously called.
 
         @since 2.9.1 (available in wxBitmapButton only in previous versions)
     */
     wxBitmap GetBitmapDisabled() const;
 
     /**
-        Returns the bitmap for the focused state, which may be invalid.
+        Returns the bitmap used for the focused state.
 
-        @see SetBitmapFocus()
+        The returned bitmap is only valid if SetBitmapFocus() had been
+        previously called.
 
         @since 2.9.1 (available in wxBitmapButton only in previous versions)
     */
@@ -82,9 +84,10 @@ public:
     wxBitmap GetBitmapLabel() const;
 
     /**
-        Returns the bitmap for the pressed state, which may be invalid.
+        Returns the bitmap used when the button is pressed.
 
-        @see SetBitmapPressed()
+        The returned bitmap is only valid if SetBitmapPressed() had been
+        previously called.
 
         @since 2.9.1 (available as wxBitmapButton::GetBitmapSelected() in
             previous versions)

--- a/src/msw/anybutton.cpp
+++ b/src/msw/anybutton.cpp
@@ -716,7 +716,7 @@ void wxAnyButton::DoSetBitmap(const wxBitmap& bitmap, State which)
     if ( m_imageData &&
           bitmap.GetSize() != m_imageData->GetBitmap(State_Normal).GetSize() )
     {
-        wxASSERT_MSG( (which == State_Normal) || bitmap.IsNull(),
+        wxASSERT_MSG( which == State_Normal,
                       "Must set normal bitmap with the new size first" );
 
 #if wxUSE_UXTHEME

--- a/src/osx/carbon/graphics.cpp
+++ b/src/osx/carbon/graphics.cpp
@@ -2419,7 +2419,7 @@ void wxMacCoreGraphicsContext::DrawBitmap( const wxBitmap &bmp, wxDouble x, wxDo
     if (EnsureIsValid())
     {
         CGRect r = CGRectMake( (CGFloat) x , (CGFloat) y , (CGFloat) w , (CGFloat) h );
-        wxOSXDrawNSImage( m_cgContext, &r, bmp.GetImage());
+        wxOSXDrawNSImage( m_cgContext, &r, bmp.GetNSImage());
     }
 #else
     wxGraphicsBitmap bitmap = GetRenderer()->CreateBitmap(bmp);
@@ -2482,7 +2482,7 @@ void wxMacCoreGraphicsContext::DrawIcon( const wxIcon &icon, wxDouble x, wxDoubl
 #if wxOSX_USE_COCOA
     {
         CGRect r = CGRectMake( (CGFloat) x , (CGFloat) y , (CGFloat) w , (CGFloat) h );
-        wxOSXDrawNSImage( m_cgContext, &r, icon.GetImage());
+        wxOSXDrawNSImage( m_cgContext, &r, icon.GetNSImage());
     }
 #endif
 

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -3438,10 +3438,7 @@ bool wxDataViewIconTextRenderer::MacRender()
 
     cell = (wxImageTextCell*) GetNativeData()->GetItemCell();
     iconText << GetValue();
-    if (iconText.GetIcon().IsOk())
-        [cell setImage:wxBitmap(iconText.GetIcon()).GetNSImage()];
-    else
-        [cell setImage:nil];
+    [cell setImage:iconText.GetIcon().GetNSImage()];
     [cell setStringValue:wxCFStringRef(iconText.GetText()).AsNSString()];
     return true;
 }

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -3444,11 +3444,7 @@ void wxWidgetCocoaImpl::SetBitmap( const wxBitmap& bitmap )
 {
     if (  [m_osxView respondsToSelector:@selector(setImage:)] )
     {
-        if (bitmap.IsOk())
-            [m_osxView setImage:bitmap.GetNSImage()];
-        else
-            [m_osxView setImage:nil];
-
+        [m_osxView setImage:bitmap.GetNSImage()];
         [m_osxView setNeedsDisplay:YES];
     }
 }

--- a/src/osx/core/bitmap.cpp
+++ b/src/osx/core/bitmap.cpp
@@ -782,7 +782,7 @@ wxBitmapRefData::~wxBitmapRefData()
 
 bool wxBitmap::CopyFromIcon(const wxIcon& icon)
 {
-    return Create( icon.GetImage() );
+    return Create( icon.OSXGetImage() );
 }
 
 wxBitmap::wxBitmap(const char bits[], int the_width, int the_height, int no_bits)
@@ -949,7 +949,7 @@ bool wxBitmap::Create(CGContextRef bitmapcontext)
     return GetBitmapData()->IsOk() ;
 }
 
-WXImage wxBitmap::GetImage() const
+WXImage wxBitmap::OSXGetImage() const
 {
     return IsOk() ? GetBitmapData()->GetImage() : NULL;
 }

--- a/src/osx/core/bitmap.cpp
+++ b/src/osx/core/bitmap.cpp
@@ -951,7 +951,7 @@ bool wxBitmap::Create(CGContextRef bitmapcontext)
 
 WXImage wxBitmap::GetImage() const
 {
-    return GetBitmapData()->GetImage();
+    return IsOk() ? GetBitmapData()->GetImage() : NULL;
 }
 
 wxBitmap wxBitmap::GetSubBitmap(const wxRect &rect) const

--- a/src/osx/iphone/button.mm
+++ b/src/osx/iphone/button.mm
@@ -111,7 +111,7 @@ wxWidgetImplType* wxWidgetImpl::CreateBitmapButton( wxWindowMac* wxpeer,
     v.frame = r;
 
     if (bitmap.IsOk())
-        [v setImage:bitmap.GetImage() forState:UIControlStateNormal];
+        [v setImage:bitmap.GetUIImage() forState:UIControlStateNormal];
 
     wxWidgetIPhoneImpl* c = new wxWidgetIPhoneImpl( wxpeer, v );
     return c;

--- a/tests/controls/buttontest.cpp
+++ b/tests/controls/buttontest.cpp
@@ -156,6 +156,17 @@ TEST_CASE_METHOD(ButtonTestCase, "Button::Bitmap", "[button]")
 
     CHECK(m_button->GetBitmap().IsOk());
 
+    // The call above shouldn't affect any other bitmaps as returned by the API
+    // even though the same (normal) bitmap does appear for all the states.
+    CHECK( !m_button->GetBitmapCurrent().IsOk() );
+    CHECK( !m_button->GetBitmapDisabled().IsOk() );
+    CHECK( !m_button->GetBitmapFocus().IsOk() );
+    CHECK( !m_button->GetBitmapPressed().IsOk() );
+
+    // Do set one of the bitmaps now.
+    m_button->SetBitmapPressed(wxArtProvider::GetBitmap(wxART_ERROR));
+    CHECK( m_button->GetBitmapPressed().IsOk() );
+
     // Check that resetting the button label doesn't result in problems when
     // updating the bitmap later, as it used to be the case in wxGTK (#18898).
     m_button->SetLabel(wxString());

--- a/tests/controls/buttontest.cpp
+++ b/tests/controls/buttontest.cpp
@@ -160,6 +160,11 @@ TEST_CASE_METHOD(ButtonTestCase, "Button::Bitmap", "[button]")
     // updating the bitmap later, as it used to be the case in wxGTK (#18898).
     m_button->SetLabel(wxString());
     CHECK_NOTHROW( m_button->Disable() );
+
+    // Also check that setting an invalid bitmap doesn't do anything untoward,
+    // such as crashing, as it used to do in wxOSX (#19257).
+    CHECK_NOTHROW( m_button->SetBitmapPressed(wxNullBitmap) );
+    CHECK( !m_button->GetBitmapPressed().IsOk() );
 }
 
 #endif //wxUSE_BUTTON


### PR DESCRIPTION
Just return NULL from this (wxOSX private, in spite of not using a
port-specific prefix) method.

This fixes crash in wxButton::SetBitmapXXX(wxNullBitmap), as shown by
the new test case which used to crash but doesn't do it any longer.

Closes [#19257](https://trac.wxwidgets.org/ticket/19257).

---

Stefan, I think it's more natural and safer to fix it like this rather than avoiding calls to `GetNSImage()` for empty bitmaps, as there are quite a few calls to it in the code and it seems that at least a couple of others could result in a crash as well. If you don't mind this change, I'm also going to go through the other ones and maybe remove the redundant checks for `bitmap.IsOk()`.

Alternatively, if you do mind, I can replace the check here with an assert (`wxCHECK`) and add check to `wxButton` code too.