### PR TITLE
Fix crash in wxOSX when calling Disable() before Create()

### DIFF
--- a/src/osx/window_osx.cpp
+++ b/src/osx/window_osx.cpp
@@ -1269,6 +1269,11 @@ bool wxWindowMac::OSXShowWithEffect(bool show,
 
 void wxWindowMac::DoEnable(bool enable)
 {
+    // We can be called before the window is created in order to create it in
+    // the initially disabled state.
+    if ( !GetPeer() )
+        return;
+
     GetPeer()->Enable( enable ) ;
     MacInvalidateBorders();
 }


### PR DESCRIPTION
This is explicitly allowed and we even have a unit test checking for
this, but the test crashed under macOS.

Fix this by simply doing nothing in wxWindow::DoEnable() if the window
is not created yet.

---

While testing #2508, I've run into this crash in the button unit tests, so I've fixed it too. The test still doesn't pass (because it never gets the expected event when using `wxUIActionSimulator` which is unfortunately something I could never be able to fix), but at least it doesn't crash any longer.