### PR TITLE
Add call of wxWindow::OnSize to proper positioning of scrollbar

### DIFF
--- a/src/generic/filectrlg.cpp
+++ b/src/generic/filectrlg.cpp
@@ -808,7 +808,7 @@ void wxFileListCtrl::OnListColClick( wxListEvent &event )
 
 void wxFileListCtrl::OnSize( wxSizeEvent &event )
 {
-    event.Skip();
+    wxWindow::OnSize(event);
 
     if ( InReportView() )
     {

--- a/src/generic/filectrlg.cpp
+++ b/src/generic/filectrlg.cpp
@@ -808,7 +808,11 @@ void wxFileListCtrl::OnListColClick( wxListEvent &event )
 
 void wxFileListCtrl::OnSize( wxSizeEvent &event )
 {
+#ifndef __WXUNIVERSAL__
+    event.Skip();
+#else
     wxWindow::OnSize(event);
+#endif
 
     if ( InReportView() )
     {


### PR DESCRIPTION
Fix for [[wxUniv(MSW)] Incorrect positioning of scrollbar in wxGenericFileCtrl after resizing](https://trac.wxwidgets.org/ticket/19254)

with just event.Skip() base class handler where position of scrollbar [is setting](https://github.com/wxWidgets/wxWidgets/blob/master/src/univ/winuniv.cpp#L608) wasn't called at all. 
Even after this changes position of scrollbar is not ideal - after resizing scrollbar is very slightly shifted down. But I think for now it's not important. 