### PR TITLE
Allow using non-text control as main window of wxComboCtrl

### DIFF
--- a/include/wx/combo.h
+++ b/include/wx/combo.h
@@ -197,6 +197,10 @@ public:
     // get the popup window containing the popup control
     wxWindow *GetPopupWindow() const { return m_winPopup; }
 
+    // Set the control to use instead of the default text control for the main
+    // (always visible) part of the combobox.
+    void SetMainControl(wxWindow* win);
+
     // Get the text control which is part of the combobox.
     wxTextCtrl *GetTextCtrl() const { return m_text; }
 
@@ -623,8 +627,12 @@ protected:
     // This is used when control is unfocused and m_valueString is empty
     wxString                m_hintText;
 
-    // the text control and button we show all the time
+    // This pointer is non-null if we use a text control, and not some other
+    // window, as the main control.
     wxTextCtrl*             m_text;
+
+    // the window and button we show all the time
+    wxWindow*               m_mainWindow;
     wxWindow*               m_btn;
 
     // wxPopupWindow or similar containing the window managed by the interface.

--- a/interface/wx/combo.h
+++ b/interface/wx/combo.h
@@ -751,6 +751,47 @@ public:
     */
     virtual void SetInsertionPointEnd();
 
+    /**
+        Uses the given window instead of the default text control as the main
+        window of the combo control.
+
+        By default, combo controls without @c wxCB_READONLY style create a
+        wxTextCtrl which shows the current value and allows to edit it. This
+        method allows to use some other window instead of this wxTextCtrl.
+
+        This method can be called after creating the combo fully, however in
+        this case a wxTextCtrl is unnecessarily created just to be immediately
+        destroyed when it's replaced by a custom window. If you wish to avoid
+        this, you can use the following approach, also shown in the combo
+        sample:
+
+        @code
+            // Create the combo control using its default ctor.
+            wxComboCtrl* combo = new wxComboCtrl();
+
+            // Create the custom main control using its default ctor too.
+            SomeWindow* main = new SomeWindow();
+
+            // Set the custom main control before creating the combo.
+            combo->SetMainControl(main);
+
+            // And only create it now: wxTextCtrl won't be unnecessarily
+            // created because the combo already has a main window.
+            combo->Create(panel, wxID_ANY, wxEmptyString);
+
+            // Finally create the main window itself, now that its parent was
+            // created.
+            main->Create(combo, ...);
+        @endcode
+
+        Note that when a custom main window is used, none of the methods of
+        this class inherited from wxTextEntry, such as SetValue(), Replace(),
+        SetInsertionPoint() etc do anything and simply return.
+
+        @since 3.1.6
+    */
+    void SetMainControl(wxWindow* win);
+
     //@{
     /**
         Attempts to set the control margins. When margins are given as wxPoint,

--- a/samples/combo/combo.cpp
+++ b/samples/combo/combo.cpp
@@ -884,7 +884,7 @@ MyFrame::MyFrame(const wxString& title)
     //
     rowSizer = new wxBoxSizer( wxHORIZONTAL );
     rowSizer->Add( new wxStaticText(panel,wxID_ANY,
-                        "wxComboCtrl with custom button action:"), 1,
+                        "wxComboCtrl with custom button and custom main control:"), 1,
                    wxALIGN_CENTER_VERTICAL|wxRIGHT, 4 );
 
 
@@ -898,7 +898,31 @@ MyFrame::MyFrame(const wxString& title)
                                   (long)0
                                  );
 
+    // This is a perfectly useless control, as the popup and main control
+    // don't interact with each other, but it shows that we can use something
+    // other than wxTextCtrl for the main part of wxComboCtrl too.
+    //
+    // In a real program, custom popup and main control would work together,
+    // i.e. changing selection in one of them would update the other one.
+    //
+    // Also note the complicated dance we need to go through to create the
+    // controls in the right order: we want to create the custom main control
+    // before actually creating the wxComboCtrl window, as otherwise it would
+    // unnecessarily create a wxTextCtrl by default, forcing us to use its
+    // default ctor and Create() later, but this, in turn, also requires using
+    // default ctor for the main control and creating it later too, as it can't
+    // be created before its parent window is.
+    wxComboCtrl* comboCustom = new wxComboCtrl();
+    wxCheckBox* cbox = new wxCheckBox();
+    comboCustom->SetMainControl(cbox);
+    comboCustom->Create(panel, wxID_ANY, wxEmptyString);
+    cbox->Create(comboCustom, wxID_ANY, "Checkbox as main control");
+    cbox->SetBackgroundColour(*wxWHITE);
+
+    comboCustom->SetPopupControl(new ListViewComboPopup());
+
     rowSizer->Add( fsc, 1, wxALIGN_CENTER_VERTICAL|wxALL, 4 );
+    rowSizer->Add( comboCustom, 1, wxALIGN_CENTER_VERTICAL|wxALL, 4 );
     colSizer->Add( rowSizer, 0, wxEXPAND|wxALL, 5 );
 
 

--- a/src/common/combocmn.cpp
+++ b/src/common/combocmn.cpp
@@ -918,7 +918,6 @@ wxComboCtrlBase::~wxComboCtrlBase()
 void wxComboCtrlBase::CalculateAreas( int btnWidth )
 {
     wxSize sz = GetClientSize();
-    int customBorder = m_widthCustomBorder;
     int btnBorder; // border for button only
 
     // check if button should really be outside the border: we'll do it it if
@@ -941,7 +940,7 @@ void wxComboCtrlBase::CalculateAreas( int btnWidth )
     else
     {
         m_iFlags &= ~(wxCC_IFLAG_BUTTON_OUTSIDE);
-        btnBorder = customBorder;
+        btnBorder = m_widthCustomBorder;
     }
 
     // Defaul indentation
@@ -1008,9 +1007,9 @@ void wxComboCtrlBase::CalculateAreas( int btnWidth )
             butHeight = bmpReqHeight;
 
         // Need to fix height?
-        if ( (sz.y-(customBorder*2)) < butHeight && btnWidth == 0 )
+        if ( (sz.y-(m_widthCustomBorder*2)) < butHeight && btnWidth == 0 )
         {
-            int newY = butHeight+(customBorder*2);
+            int newY = butHeight+(m_widthCustomBorder*2);
             SetClientSize(wxDefaultCoord,newY);
             if ( m_bmpNormal.IsOk() || m_btnArea.width != butWidth || m_btnArea.height != butHeight )
                 m_iFlags |= wxCC_IFLAG_HAS_NONSTANDARD_BUTTON;
@@ -1031,10 +1030,10 @@ void wxComboCtrlBase::CalculateAreas( int btnWidth )
     m_btnArea.width = butAreaWid;
     m_btnArea.height = sz.y - ((btnBorder+FOCUS_RING)*2);
 
-    m_tcArea.x = ( m_btnSide==wxRIGHT ? 0 : butAreaWid ) + customBorder;
-    m_tcArea.y = customBorder + FOCUS_RING;
-    m_tcArea.width = sz.x - butAreaWid - (customBorder*2) - FOCUS_RING;
-    m_tcArea.height = sz.y - ((customBorder+FOCUS_RING)*2);
+    m_tcArea.x = ( m_btnSide==wxRIGHT ? 0 : butAreaWid ) + m_widthCustomBorder;
+    m_tcArea.y = m_widthCustomBorder + FOCUS_RING;
+    m_tcArea.width = sz.x - butAreaWid - (m_widthCustomBorder*2) - FOCUS_RING;
+    m_tcArea.height = sz.y - ((m_widthCustomBorder+FOCUS_RING)*2);
 
 /*
     if ( m_text )
@@ -1052,7 +1051,6 @@ void wxComboCtrlBase::PositionTextCtrl( int textCtrlXAdjust, int textCtrlYAdjust
 
     wxSize sz = GetClientSize();
 
-    int customBorder = m_widthCustomBorder;
     if ( (m_text->GetWindowStyleFlag() & wxBORDER_MASK) == wxNO_BORDER )
     {
         int x;
@@ -1079,8 +1077,8 @@ void wxComboCtrlBase::PositionTextCtrl( int textCtrlXAdjust, int textCtrlYAdjust
         int diff0 = sz.y - tcSizeY;
         int y = textCtrlYAdjust + (diff0/2);
 
-        if ( y < customBorder )
-            y = customBorder;
+        if ( y < m_widthCustomBorder )
+            y = m_widthCustomBorder;
 
         m_text->SetSize(x,
                         y,
@@ -1089,7 +1087,7 @@ void wxComboCtrlBase::PositionTextCtrl( int textCtrlXAdjust, int textCtrlYAdjust
 
         // Make sure textctrl doesn't exceed the bottom custom border
         wxSize tsz = m_text->GetSize();
-        int diff1 = (y + tsz.y) - (sz.y - customBorder);
+        int diff1 = (y + tsz.y) - (sz.y - m_widthCustomBorder);
         if ( diff1 >= 0 )
         {
             tsz.y = tsz.y - diff1 - 1;


### PR DESCRIPTION
This can be useful to use something other than a normal `wxTextCtrl`, e.g. my program uses `wxHtmlWindow` for displaying rich text content.

Creating custom main control without creating an unnecessary text control is quite ugly, but I don't see any simple way to avoid this and it's not too bad for something that ought to be done only relatively rarely -- and hopefully showing how to do it in the docs and the sample should make it clear enough.

Please let me know if there are any objections to merging this.