### PR TITLE
Use gspell for proof checking on wxGTK instead of gtkspell

### DIFF
--- a/build/tools/before_install.sh
+++ b/build/tools/before_install.sh
@@ -50,7 +50,7 @@ case $(uname -s) in
                 *)
                     case "$wxGTK_VERSION" in
                         3)  libtoolkit_dev=libgtk-3-dev
-                            extra_deps='libwebkit2gtk-4.0-dev libwebkitgtk-3.0-dev libgtkspell3-3-dev'
+                            extra_deps='libwebkit2gtk-4.0-dev libwebkitgtk-3.0-dev libgspell-1-dev'
                             ;;
                         2)  libtoolkit_dev=libgtk2.0-dev
                             extra_deps='libwebkitgtk-dev'

--- a/configure
+++ b/configure
@@ -951,8 +951,8 @@ GTKPRINT_CFLAGS
 SDL_CONFIG
 SDL_LIBS
 SDL_CFLAGS
-GTKSPELL_LIBS
-GTKSPELL_CFLAGS
+GSPELL_LIBS
+GSPELL_CFLAGS
 LIBSECRET_LIBS
 LIBSECRET_CFLAGS
 GXX_VERSION
@@ -1434,8 +1434,8 @@ MesaGL_CFLAGS
 MesaGL_LIBS
 LIBSECRET_CFLAGS
 LIBSECRET_LIBS
-GTKSPELL_CFLAGS
-GTKSPELL_LIBS
+GSPELL_CFLAGS
+GSPELL_LIBS
 SDL_CFLAGS
 SDL_LIBS
 GTKPRINT_CFLAGS
@@ -2475,10 +2475,9 @@ Some influential environment variables:
               C compiler flags for LIBSECRET, overriding pkg-config
   LIBSECRET_LIBS
               linker flags for LIBSECRET, overriding pkg-config
-  GTKSPELL_CFLAGS
-              C compiler flags for GTKSPELL, overriding pkg-config
-  GTKSPELL_LIBS
-              linker flags for GTKSPELL, overriding pkg-config
+  GSPELL_CFLAGS
+              C compiler flags for GSPELL, overriding pkg-config
+  GSPELL_LIBS linker flags for GSPELL, overriding pkg-config
   SDL_CFLAGS  C compiler flags for SDL, overriding pkg-config
   SDL_LIBS    linker flags for SDL, overriding pkg-config
   GTKPRINT_CFLAGS
@@ -34014,20 +34013,20 @@ if test "$wxUSE_SPELLCHECK" = "yes"; then
     if test "$WXGTK3" = 1; then
 
 pkg_failed=no
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for GTKSPELL" >&5
-$as_echo_n "checking for GTKSPELL... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for GSPELL" >&5
+$as_echo_n "checking for GSPELL... " >&6; }
 
 if test -n "$PKG_CONFIG"; then
-    if test -n "$GTKSPELL_CFLAGS"; then
-        pkg_cv_GTKSPELL_CFLAGS="$GTKSPELL_CFLAGS"
+    if test -n "$GSPELL_CFLAGS"; then
+        pkg_cv_GSPELL_CFLAGS="$GSPELL_CFLAGS"
     else
         if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"gtkspell3-3.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "gtkspell3-3.0") 2>&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"gspell-1\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "gspell-1") 2>&5
   ac_status=$?
   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_GTKSPELL_CFLAGS=`$PKG_CONFIG --cflags "gtkspell3-3.0" 2>/dev/null`
+  pkg_cv_GSPELL_CFLAGS=`$PKG_CONFIG --cflags "gspell-1" 2>/dev/null`
 else
   pkg_failed=yes
 fi
@@ -34036,16 +34035,16 @@ else
 	pkg_failed=untried
 fi
 if test -n "$PKG_CONFIG"; then
-    if test -n "$GTKSPELL_LIBS"; then
-        pkg_cv_GTKSPELL_LIBS="$GTKSPELL_LIBS"
+    if test -n "$GSPELL_LIBS"; then
+        pkg_cv_GSPELL_LIBS="$GSPELL_LIBS"
     else
         if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"gtkspell3-3.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "gtkspell3-3.0") 2>&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"gspell-1\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "gspell-1") 2>&5
   ac_status=$?
   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_GTKSPELL_LIBS=`$PKG_CONFIG --libs "gtkspell3-3.0" 2>/dev/null`
+  pkg_cv_GSPELL_LIBS=`$PKG_CONFIG --libs "gspell-1" 2>/dev/null`
 else
   pkg_failed=yes
 fi
@@ -34064,34 +34063,34 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-	        GTKSPELL_PKG_ERRORS=`$PKG_CONFIG --short-errors --errors-to-stdout --print-errors "gtkspell3-3.0"`
+	        GSPELL_PKG_ERRORS=`$PKG_CONFIG --short-errors --errors-to-stdout --print-errors "gspell-1"`
         else
-	        GTKSPELL_PKG_ERRORS=`$PKG_CONFIG --errors-to-stdout --print-errors "gtkspell3-3.0"`
+	        GSPELL_PKG_ERRORS=`$PKG_CONFIG --errors-to-stdout --print-errors "gspell-1"`
         fi
 	# Put the nasty error message in config.log where it belongs
-	echo "$GTKSPELL_PKG_ERRORS" >&5
+	echo "$GSPELL_PKG_ERRORS" >&5
 
 
-                { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: gtkspell3-3.0 not found, spell checking in wxTextCtrl won't be available" >&5
-$as_echo "$as_me: WARNING: gtkspell3-3.0 not found, spell checking in wxTextCtrl won't be available" >&2;}
+                { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: gspell-1 not found, spell checking in wxTextCtrl won't be available" >&5
+$as_echo "$as_me: WARNING: gspell-1 not found, spell checking in wxTextCtrl won't be available" >&2;}
                 wxUSE_SPELLCHECK=no
 
 
 elif test $pkg_failed = untried; then
 
-                { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: gtkspell3-3.0 not found, spell checking in wxTextCtrl won't be available" >&5
-$as_echo "$as_me: WARNING: gtkspell3-3.0 not found, spell checking in wxTextCtrl won't be available" >&2;}
+                { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: gspell-1 not found, spell checking in wxTextCtrl won't be available" >&5
+$as_echo "$as_me: WARNING: gspell-1 not found, spell checking in wxTextCtrl won't be available" >&2;}
                 wxUSE_SPELLCHECK=no
 
 
 else
-	GTKSPELL_CFLAGS=$pkg_cv_GTKSPELL_CFLAGS
-	GTKSPELL_LIBS=$pkg_cv_GTKSPELL_LIBS
+	GSPELL_CFLAGS=$pkg_cv_GSPELL_CFLAGS
+	GSPELL_LIBS=$pkg_cv_GSPELL_LIBS
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 
-                CXXFLAGS="$GTKSPELL_CFLAGS $CXXFLAGS"
-                LIBS="$GTKSPELL_LIBS $LIBS"
+                CXXFLAGS="$GSPELL_CFLAGS $CXXFLAGS"
+                LIBS="$GSPELL_LIBS $LIBS"
 
 fi
     fi

--- a/configure.in
+++ b/configure.in
@@ -5774,16 +5774,16 @@ dnl ---------------------------------------------------------------------------
 if test "$wxUSE_SPELLCHECK" = "yes"; then
     dnl The required APIs are always available under MSW and OS X and we don't
     dnl implement support for spell checking in the other ports, but for GTK 3
-    dnl we need to check for gtkspell library.
+    dnl we need to check for the gspell library.
 
     if test "$WXGTK3" = 1; then
-        PKG_CHECK_MODULES(GTKSPELL, [gtkspell3-3.0],
+        PKG_CHECK_MODULES(GSPELL, [gspell-1],
             [
-                CXXFLAGS="$GTKSPELL_CFLAGS $CXXFLAGS"
-                LIBS="$GTKSPELL_LIBS $LIBS"
+                CXXFLAGS="$GSPELL_CFLAGS $CXXFLAGS"
+                LIBS="$GSPELL_LIBS $LIBS"
             ],
             [
-                AC_MSG_WARN([gtkspell3-3.0 not found, spell checking in wxTextCtrl won't be available])
+                AC_MSG_WARN([gspell-1 not found, spell checking in wxTextCtrl won't be available])
                 wxUSE_SPELLCHECK=no
             ]
         )

--- a/samples/text/text.cpp
+++ b/samples/text/text.cpp
@@ -1124,13 +1124,12 @@ MyPanel::MyPanel( wxFrame *frame, int x, int y, int w, int h )
     m_text->WriteText( "Prepended. " );
 
 #if wxUSE_SPELLCHECK
-    (*m_text) << "\n";
-
     if ( m_text->EnableProofCheck(wxTextProofOptions::Default()) )
     {
-        (*m_text) << "Spell checking is enabled, mis"
+        // Break the string in several parts to avoid misspellings in the sources.
+        (*m_text) << " Mis"
                       "s"
-                      "spelled words should be highlighted.";
+                      "spelled.";
     }
 #endif
 
@@ -1232,7 +1231,6 @@ MyPanel::MyPanel( wxFrame *frame, int x, int y, int w, int h )
     }
     else
     {
-        // Break the string in several parts to avoid misspellings in the sources.
         (*m_enter) << "Spell checking is enabled, mis"
                       "s"
                       "spelled words should be highlighted.";

--- a/samples/text/text.cpp
+++ b/samples/text/text.cpp
@@ -1123,6 +1123,26 @@ MyPanel::MyPanel( wxFrame *frame, int x, int y, int w, int h )
     m_text->SetInsertionPoint(0);
     m_text->WriteText( "Prepended. " );
 
+#if wxUSE_SPELLCHECK
+    (*m_text) << "\n";
+
+    // Enable grammar check just for demonstration purposes (note that it's
+    // only supported under Mac, but spell checking will be enabled under the
+    // other platforms too, if supported). If we didn't want to enable it, we
+    // could omit the EnableProofCheck() argument entirely.
+    if ( !m_text->EnableProofCheck(wxTextProofOptions::Default().GrammarCheck()) )
+    {
+        (*m_text) << "Spell checking is not available on this platform, sorry.";
+    }
+    else
+    {
+        // Break the string in several parts to avoid misspellings in the sources.
+        (*m_text) << "Spell checking is enabled, mis"
+                      "s"
+                      "spelled words should be highlighted.";
+    }
+#endif
+
     m_password = new MyTextCtrl( this, wxID_ANY, "",
       wxPoint(10,50), wxSize(140,wxDefaultCoord), wxTE_PASSWORD );
     m_password->SetHint("Don't use 12345 here");

--- a/samples/text/text.cpp
+++ b/samples/text/text.cpp
@@ -1126,17 +1126,8 @@ MyPanel::MyPanel( wxFrame *frame, int x, int y, int w, int h )
 #if wxUSE_SPELLCHECK
     (*m_text) << "\n";
 
-    // Enable grammar check just for demonstration purposes (note that it's
-    // only supported under Mac, but spell checking will be enabled under the
-    // other platforms too, if supported). If we didn't want to enable it, we
-    // could omit the EnableProofCheck() argument entirely.
-    if ( !m_text->EnableProofCheck(wxTextProofOptions::Default().GrammarCheck()) )
+    if ( m_text->EnableProofCheck(wxTextProofOptions::Default()) )
     {
-        (*m_text) << "Spell checking is not available on this platform, sorry.";
-    }
-    else
-    {
-        // Break the string in several parts to avoid misspellings in the sources.
         (*m_text) << "Spell checking is enabled, mis"
                       "s"
                       "spelled words should be highlighted.";

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -35,6 +35,7 @@
 #if wxUSE_SPELLCHECK && defined(__WXGTK3__)
 extern "C" {
 #include <gtkspell-3.0/gtkspell/gtkspell.h>
+#include <gspell-1/gspell/gspell.h>
 }
 #endif // wxUSE_SPELLCHECK && __WXGTK3__
 
@@ -1027,53 +1028,60 @@ void wxTextCtrl::GTKSetJustification()
 
 bool wxTextCtrl::EnableProofCheck(const wxTextProofOptions& options)
 {
-    wxCHECK_MSG( IsMultiLine(), false,
-                "Unable to enable spell check on control "
-                "which does not have wxTE_MULTILINE style" );
-
-    GtkTextView *textview = GTK_TEXT_VIEW(m_text);
-    wxCHECK_MSG( textview, false, wxS("wxTextCtrl is not a GtkTextView"));
-
-    GtkSpellChecker *spell = gtk_spell_checker_get_from_text_view(textview);
-
-    if ( options.IsSpellCheckEnabled() )
+    if ( IsMultiLine() )
     {
-        if ( !spell )
-        {
-            spell = gtk_spell_checker_new();
-            gtk_spell_checker_attach(spell, textview);
-        }
+        GtkTextView *textview = GTK_TEXT_VIEW(m_text);
+        wxCHECK_MSG( textview, false, wxS("wxTextCtrl is not a GtkTextView") );
 
-        wxString lang = options.GetLang();
-
-        if ( !gtk_spell_checker_set_language(spell,
-                                    lang.empty() ? NULL : (const gchar *)lang.utf8_str(),
-                                    NULL) )
+        GspellTextView *spell = gspell_text_view_get_from_gtk_text_view (textview);
+        if (!spell)
             return false;
+
+        gspell_text_view_basic_setup(spell);
+        gspell_text_view_set_inline_spell_checking(spell, options.IsSpellCheckEnabled());
+        gspell_text_view_set_enable_language_menu(spell, options.IsSpellCheckEnabled());
     }
+
     else
     {
-        if ( spell )
-            gtk_spell_checker_detach(spell);
+        GtkEntry *entry = GTK_ENTRY(m_text);
+        wxCHECK_MSG( entry, false, wxS("wxTextCtrl is not a GtkEntry") );
+        
+        GspellEntry *spell = gspell_entry_get_from_gtk_entry(entry);
+        if (!spell)
+            return false;
+
+        gspell_entry_basic_setup(spell);
+        gspell_entry_set_inline_spell_checking(spell, options.IsSpellCheckEnabled());
+        // gspell_entry_set_enable_language_menu(spell, options.IsSpellCheckEnabled());
     }
 
-   return GetProofCheckOptions().IsSpellCheckEnabled();
+    return GetProofCheckOptions().IsSpellCheckEnabled();
 }
 
 wxTextProofOptions wxTextCtrl::GetProofCheckOptions() const
 {
     wxTextProofOptions opts = wxTextProofOptions::Disable();
 
-    GtkTextView *textview = GTK_TEXT_VIEW(m_text);
-
-    if ( IsMultiLine() && textview )
+    if ( IsMultiLine() )
     {
-        if ( gtk_spell_checker_get_from_text_view(textview) )
+        GtkTextView *textview = GTK_TEXT_VIEW(m_text);
+
+        if ( textview && gspell_text_view_get_from_gtk_text_view(textview) )
+            opts.SpellCheck();
+    }
+
+    else
+    {
+        GtkEntry *entry = GTK_ENTRY(m_text);
+        
+        if ( entry && gspell_entry_get_from_gtk_entry(entry) )
             opts.SpellCheck();
     }
 
     return opts;
 }
+
 
 #endif // wxUSE_SPELLCHECK && __WXGTK3__
 

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -1045,7 +1045,7 @@ bool wxTextCtrl::EnableProofCheck(const wxTextProofOptions& options)
     {
         GtkEntry *entry = GTK_ENTRY(m_text);
         wxCHECK_MSG( entry, false, wxS("wxTextCtrl is not a GtkEntry") );
-        
+
         GspellEntry *spell = gspell_entry_get_from_gtk_entry(entry);
         if (!spell)
             return false;
@@ -1073,7 +1073,7 @@ wxTextProofOptions wxTextCtrl::GetProofCheckOptions() const
     else
     {
         GtkEntry *entry = GTK_ENTRY(m_text);
-        
+
         if ( entry && gspell_entry_get_from_gtk_entry(entry) )
             opts.SpellCheck();
     }

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -34,7 +34,6 @@
 
 #if wxUSE_SPELLCHECK && defined(__WXGTK3__)
 extern "C" {
-#include <gtkspell-3.0/gtkspell/gtkspell.h>
 #include <gspell-1/gspell/gspell.h>
 }
 #endif // wxUSE_SPELLCHECK && __WXGTK3__


### PR DESCRIPTION
This is an update to the original [proof check pull request](https://github.com/wxWidgets/wxWidgets/pull/2473). 

The purpose of this PR is to switch from `gtkspell` to `gspell` in order to have spell check available for single line `wxTextCtrl`.