### PR TITLE
Assorted wxFileName fixes

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -133,6 +133,12 @@ Changes in behaviour not resulting in compilation errors
   bitmaps in wxMSW if the corresponding Set had been called before, as in the
   other ports, instead of returning the normal bitmap as fallback in this case.
 
+- wxFileName::GetVolume() now returns "\\share" and not just "share" for the
+  UNC paths (i.e. \\share\path\on\remote\server) and "\\?\Volume{GUID}" for the
+  volume GUID paths rather than just "Volume{GUID}" as before. This allows
+  distinguishing them from the drive letters, even for single letter network
+  share name.
+
 
 Changes in behaviour which may result in build errors
 -----------------------------------------------------

--- a/include/wx/filename.h
+++ b/include/wx/filename.h
@@ -638,6 +638,9 @@ private:
                    int flags = SetPath_MayHaveVolume);
 
     // the drive/volume/device specification (always empty for Unix)
+    //
+    // for the drive letters, contains just the letter itself, but for MSW UNC
+    // and volume GUID paths, it starts with double backslash, e.g. "\\share"
     wxString        m_volume;
 
     // the path components of the file

--- a/include/wx/filename.h
+++ b/include/wx/filename.h
@@ -626,6 +626,17 @@ private:
     // check whether this dir is valid for Append/Prepend/InsertDir()
     static bool IsValidDirComponent(const wxString& dir);
 
+    // flags used with DoSetPath()
+    enum
+    {
+        SetPath_PathOnly = 0,
+        SetPath_MayHaveVolume = 1
+    };
+
+    // helper of public SetPath() also used internally
+    void DoSetPath(const wxString& path, wxPathFormat format,
+                   int flags = SetPath_MayHaveVolume);
+
     // the drive/volume/device specification (always empty for Unix)
     wxString        m_volume;
 

--- a/interface/wx/filename.h
+++ b/interface/wx/filename.h
@@ -877,6 +877,14 @@ public:
 
     /**
         Returns the string separating the volume from the path for this format.
+
+        Note that for @c wxPATH_DOS paths this string can only be used for
+        single-character volumes representing the drive letters, but not with
+        the UNC or GUID volumes (see their description in GetVolume()
+        documentation). For this reason, its use should be avoided, prefer
+        using wxFileName constructor and Assign() overload taking the volume
+        and the path as separate arguments to combining the volume and the path
+        into a single string using the volume separator between them.
     */
     static wxString GetVolumeSeparator(wxPathFormat format = wxPATH_NATIVE);
 

--- a/interface/wx/filename.h
+++ b/interface/wx/filename.h
@@ -859,9 +859,19 @@ public:
                   wxDateTime* dtCreate) const;
 
     /**
-        Returns the string containing the volume for this file name, empty if it
-        doesn't have one or if the file system doesn't support volumes at all
-        (for example, Unix).
+        Returns the string containing the volume for this file name.
+
+        The returned string is empty if this object doesn't have a volume name,
+        as is always the case for the paths in Unix format which don't support
+        volumes at all.
+
+        Note that for @c wxPATH_DOS format paths, the returned string may have
+        one of the following forms:
+
+        - Just a single letter, for the usual drive letter volumes, e.g. @c C.
+        - A share name preceded by a double backslash, e.g. @c \\\\share.
+        - A GUID volume preceded by a double backslash and a question mark,
+          e.g. @c \\\\?\\Volume{12345678-9abc-def0-1234-56789abcdef0}.
     */
     wxString GetVolume() const;
 

--- a/interface/wx/filename.h
+++ b/interface/wx/filename.h
@@ -1225,9 +1225,12 @@ public:
         Deletes the specified directory from the file system.
 
         @param flags
-            Can contain one of wxPATH_RMDIR_FULL or wxPATH_RMDIR_RECURSIVE. By
-            default contains neither so the directory will not be removed
-            unless it is empty.
+            With default value, the directory is removed only if it is empty.
+            If wxPATH_RMDIR_FULL is specified, it is removed even if it
+            contains subdirectories, provided that there are no files in
+            neither this directory nor its subdirectories. If flags contains
+            wxPATH_RMDIR_RECURSIVE, then the directory is removed with all the
+            files and directories under it.
 
         @return Returns @true if the directory was successfully deleted, @false
                 otherwise.
@@ -1240,9 +1243,12 @@ public:
         @param dir
             The directory to delete
         @param flags
-            Can contain one of wxPATH_RMDIR_FULL or wxPATH_RMDIR_RECURSIVE. By
-            default contains neither so the directory will not be removed
-            unless it is empty.
+            With default value, the directory is removed only if it is empty.
+            If wxPATH_RMDIR_FULL is specified, it is removed even if it
+            contains subdirectories, provided that there are no files in
+            neither this directory nor its subdirectories. If flags contains
+            wxPATH_RMDIR_RECURSIVE, then the directory is removed with all the
+            files and directories under it.
 
         @return Returns @true if the directory was successfully deleted, @false
                 otherwise.

--- a/src/common/filename.cpp
+++ b/src/common/filename.cpp
@@ -290,7 +290,7 @@ inline bool IsDOSPathSep(wxUniChar ch)
 // like a UNC path
 static bool IsUNCPath(const wxString& path, wxPathFormat format)
 {
-    return format == wxPATH_DOS &&
+    return wxFileName::GetFormat(format) == wxPATH_DOS &&
                 path.length() >= 4 && // "\\a" can't be a UNC path
                     IsDOSPathSep(path[0u]) &&
                         IsDOSPathSep(path[1u]) &&

--- a/src/common/filename.cpp
+++ b/src/common/filename.cpp
@@ -1283,7 +1283,10 @@ bool wxFileName::Mkdir( const wxString& dir, int perm, int flags )
         size_t count = dirs.GetCount();
         for ( size_t i = 0; i < count; i++ )
         {
-            if ( i > 0 || filename.IsAbsolute() )
+            // Do not use IsAbsolute() here because we want the path to start
+            // with the separator even if it doesn't have any volume, but
+            // IsAbsolute() would return false in this case.
+            if ( i > 0 || !filename.m_relative )
                 currPath += wxFILE_SEP_PATH;
             currPath += dirs[i];
 

--- a/tests/filename/filenametest.cpp
+++ b/tests/filename/filenametest.cpp
@@ -550,6 +550,14 @@ TEST_CASE("wxFileName::UNC", "[filename]")
     fn.Assign("\\\\share2\\path2\\name.ext", wxPATH_DOS);
     CHECK( fn.GetVolume() == "share2" );
     CHECK( fn.GetPath(wxPATH_NO_SEPARATOR, wxPATH_DOS) == "\\path2" );
+
+#ifdef __WINDOWS__
+    // Check that doubled backslashes in the beginning of the path are not
+    // misinterpreted as UNC volume when we have a drive letter in the
+    // beginning.
+    fn.Assign("d:\\\\root\\directory\\file");
+    CHECK( fn.GetFullPath() == "d:\\root\\directory\\file" );
+#endif // __WINDOWS__
 }
 
 TEST_CASE("wxFileName::VolumeUniqueName", "[filename]")

--- a/tests/filename/filenametest.cpp
+++ b/tests/filename/filenametest.cpp
@@ -169,7 +169,9 @@ TEST_CASE("wxFileName::Construction", "[filename]")
         // if the test is run from root directory or its direct subdirectory
         CHECK( fn.Normalize(wxPATH_NORM_ALL, "/foo/bar/baz", fni.format) );
 
-        if ( *fni.volume && *fni.path )
+        // restrict this check to drive letter volumes as UNC and GUID volumes
+        // can't be combined with the path using the volume separator
+        if ( strlen(fni.volume) == 1 && *fni.path )
         {
             // check that specifying the volume separately or as part of the
             // path doesn't make any difference

--- a/tests/filename/filenametest.cpp
+++ b/tests/filename/filenametest.cpp
@@ -287,6 +287,7 @@ TEST_CASE("wxFileName::Normalize", "[filename]")
         { "a/.././b/c/../../", wxPATH_NORM_DOTS, "", wxPATH_UNIX },
         { "", wxPATH_NORM_DOTS, "", wxPATH_UNIX },
         { "./foo", wxPATH_NORM_DOTS, "foo", wxPATH_UNIX },
+        { "foo/./bar", wxPATH_NORM_DOTS, "foo/bar", wxPATH_UNIX },
         { "b/../bar", wxPATH_NORM_DOTS, "bar", wxPATH_UNIX },
         { "c/../../quux", wxPATH_NORM_DOTS, "../quux", wxPATH_UNIX },
         { "/c/../../quux", wxPATH_NORM_DOTS, "/quux", wxPATH_UNIX },

--- a/tests/filename/filenametest.cpp
+++ b/tests/filename/filenametest.cpp
@@ -716,6 +716,18 @@ TEST_CASE("wxFileName::Exists", "[filename]")
 #endif // __UNIX__
 }
 
+TEST_CASE("wxFileName::Mkdir", "[filename]")
+{
+    wxFileName fn;
+    fn.AssignDir("/foo/bar");
+    if ( fn.Mkdir(wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL) )
+    {
+        CHECK( fn.DirExists() );
+        CHECK( fn.Rmdir() );
+    }
+    //else: creating the directory may fail because of permissions
+}
+
 TEST_CASE("wxFileName::SameAs", "[filename]")
 {
     wxFileName fn1( wxFileName::CreateTempFileName( "filenametest1" ) );

--- a/tests/filename/filenametest.cpp
+++ b/tests/filename/filenametest.cpp
@@ -82,9 +82,9 @@ static struct TestFileNameInfo
     { "c:\\foo.bar", "c", "\\", "foo", "bar", true, wxPATH_DOS },
     { "c:\\Windows\\command.com", "c", "\\Windows", "command", "com", true, wxPATH_DOS },
     { "\\\\?\\Volume{8089d7d7-d0ac-11db-9dd0-806d6172696f}\\",
-      "Volume{8089d7d7-d0ac-11db-9dd0-806d6172696f}", "\\", "", "", true, wxPATH_DOS },
+      "\\\\?\\Volume{8089d7d7-d0ac-11db-9dd0-806d6172696f}", "\\", "", "", true, wxPATH_DOS },
     { "\\\\?\\Volume{8089d7d7-d0ac-11db-9dd0-806d6172696f}\\Program Files\\setup.exe",
-      "Volume{8089d7d7-d0ac-11db-9dd0-806d6172696f}", "\\Program Files", "setup", "exe", true, wxPATH_DOS },
+      "\\\\?\\Volume{8089d7d7-d0ac-11db-9dd0-806d6172696f}", "\\Program Files", "setup", "exe", true, wxPATH_DOS },
 
 #if 0
     // NB: when using the wxFileName::GetLongPath() function on these two
@@ -544,11 +544,11 @@ TEST_CASE("wxFileName::ShortLongPath", "[filename]")
 TEST_CASE("wxFileName::UNC", "[filename]")
 {
     wxFileName fn("//share/path/name.ext", wxPATH_DOS);
-    CHECK( fn.GetVolume() == "share" );
+    CHECK( fn.GetVolume() == "\\\\share" );
     CHECK( fn.GetPath(wxPATH_NO_SEPARATOR, wxPATH_DOS) == "\\path" );
 
     fn.Assign("\\\\share2\\path2\\name.ext", wxPATH_DOS);
-    CHECK( fn.GetVolume() == "share2" );
+    CHECK( fn.GetVolume() == "\\\\share2" );
     CHECK( fn.GetPath(wxPATH_NO_SEPARATOR, wxPATH_DOS) == "\\path2" );
 
 #ifdef __WINDOWS__
@@ -557,6 +557,11 @@ TEST_CASE("wxFileName::UNC", "[filename]")
     // beginning.
     fn.Assign("d:\\\\root\\directory\\file");
     CHECK( fn.GetFullPath() == "d:\\root\\directory\\file" );
+
+    // Check that single letter UNC paths don't turn into drive letters, as
+    // they used to do.
+    fn.Assign("\\\\x\\dir\\file");
+    CHECK( fn.GetFullPath() == "\\\\x\\dir\\file" );
 #endif // __WINDOWS__
 }
 
@@ -564,13 +569,13 @@ TEST_CASE("wxFileName::VolumeUniqueName", "[filename]")
 {
     wxFileName fn("\\\\?\\Volume{8089d7d7-d0ac-11db-9dd0-806d6172696f}\\",
                   wxPATH_DOS);
-    CHECK( fn.GetVolume() == "Volume{8089d7d7-d0ac-11db-9dd0-806d6172696f}" );
+    CHECK( fn.GetVolume() == "\\\\?\\Volume{8089d7d7-d0ac-11db-9dd0-806d6172696f}" );
     CHECK( fn.GetPath(wxPATH_NO_SEPARATOR, wxPATH_DOS) == "\\" );
     CHECK( fn.GetFullPath(wxPATH_DOS) == "\\\\?\\Volume{8089d7d7-d0ac-11db-9dd0-806d6172696f}\\" );
 
     fn.Assign("\\\\?\\Volume{8089d7d7-d0ac-11db-9dd0-806d6172696f}\\"
               "Program Files\\setup.exe", wxPATH_DOS);
-    CHECK( fn.GetVolume() == "Volume{8089d7d7-d0ac-11db-9dd0-806d6172696f}" );
+    CHECK( fn.GetVolume() == "\\\\?\\Volume{8089d7d7-d0ac-11db-9dd0-806d6172696f}" );
     CHECK( fn.GetPath(wxPATH_NO_SEPARATOR, wxPATH_DOS) == "\\Program Files" );
     CHECK( fn.GetFullPath(wxPATH_DOS) == "\\\\?\\Volume{8089d7d7-d0ac-11db-9dd0-806d6172696f}\\Program Files\\setup.exe" );
 }


### PR DESCRIPTION
Various fixes, including a backwards incompatible, but IMO worth doing, change to the format of the volume for the UNC (and volume GUID) paths, see 549e0a5.