### PR TITLE
Optimize wrapping lines in wxRichTextCtrl

### DIFF
--- a/include/wx/richtext/richtextbuffer.h
+++ b/include/wx/richtext/richtextbuffer.h
@@ -4654,6 +4654,7 @@ protected:
 
     // The lines that make up the wrapped paragraph
     wxRichTextLineList  m_cachedLines;
+    wxVector<wxRichTextLine*> m_cachedLinesVect;
 
     // Whether the paragraph is impacted by floating objects from above
     int                 m_impactedByFloatingObjects;


### PR DESCRIPTION
When one inserts one big line to a wxRichTextCtrl that contains 300k words of average size 9, then wxRichTextCtrl could freeze for a few seconds. It could also freeze again when the control is resized (such that word wrapping is triggered again).

Problem: `wxRichTextParagraph::AllocateLine(int pos)` can be called many times. Each call triggers `m_cachedLines.Item(pos)`, which traverses the linked list. As a result we get quadratic time complexity.
In this commit, we improve the function by also caching the lines in a vector, which supports random access in O(1) time.