### PR TITLE
Refresh scrolling area under wxUniv when handle OnMouseWheel

### DIFF
--- a/src/generic/scrlwing.cpp
+++ b/src/generic/scrlwing.cpp
@@ -1049,6 +1049,9 @@ void wxScrollHelperBase::HandleOnMouseWheel(wxMouseEvent& event)
             int times = abs(lines);
             for (; times > 0; times--)
                 m_win->GetEventHandler()->ProcessEvent(newEvent);
+#ifdef __WXUNIVERSAL__
+            m_win->Refresh(true, GetScrollRect());
+#endif
         }
     }
 }


### PR DESCRIPTION
Without refreshing, scrolling wxGrid is corrupting row labels.
Before:
![before](https://user-images.githubusercontent.com/17313967/133894549-7a73ae6f-c089-44cf-9dfb-df59336c610e.jpg)
After:
![after](https://user-images.githubusercontent.com/17313967/133894568-37fee5a7-501e-4e1c-8b79-cb833bde800f.jpg)
