### PR TITLE
Implement thaw/freeze for dataviewctrl on OSX

### DIFF
--- a/include/wx/osx/dataview.h
+++ b/include/wx/osx/dataview.h
@@ -285,6 +285,7 @@ protected:
  // event handling
   void OnSize(wxSizeEvent &event);
 
+  virtual void DoThaw() wxOVERRIDE;
 private:
  // initializing of local variables:
   void Init();


### PR DESCRIPTION
Simple freeze/thaw for autosize columns for DataViewCtrl on OSX.   It doesn't freeze the row size updates, but those require a specific non-default style flag anyway and in general are less of an issue as it just walks the values in the one row which is usually significantly fewer than the possible hundreds of rows.