### PR TITLE
Check STL build in wxMSW cross-compile CI workflow

### DIFF
--- a/.github/workflows/ci_mac.yml
+++ b/.github/workflows/ci_mac.yml
@@ -73,10 +73,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - name: wxMac ARM C++11
+        - name: wxMac ARM C++11 STL
           runner: self-hosted
           arch: arm64
-          configure_flags: --with-cxx=11
+          configure_flags: --with-cxx=11 --enable-stl
           use_asan: true
         - name: wxMac Intel C++17
           runner: self-hosted

--- a/.github/workflows/ci_mac.yml
+++ b/.github/workflows/ci_mac.yml
@@ -203,7 +203,11 @@ jobs:
       if: matrix.skip_testing != true
       working-directory: tests
       run: |
-        export ASAN_OPTIONS=fast_unwind_on_malloc=0
+        # We currently need to disable container overflow detection as we get
+        # what seems to be a false positive in BitmapComboBoxTestCase triggered
+        # by creating a new string from std::allocator<wxString>::construct()
+        # used by std::vector<>::insert().
+        export ASAN_OPTIONS='fast_unwind_on_malloc=0 detect_container_overflow=0'
         # Exclude tests that are currently known to fail
         wx_tests_selection='~[valnum] ~wxPersistTLW ~wxPersistDVC ~wxTopLevel::Show ~wxFont::Weight ~wxFont::NativeFontInfo ~WebView ~RadioButton::Single ~RadioButton::Focus ~wxHtmlPrintout::Pagination ~ChoiceTestCase ~ComboBoxTestCase ~CheckListBoxTestCase ~ListBoxTestCase ~RearrangeListTestCase ~wxTextCtrl::GetBestSize ~TextCtrlTestCase ~ClippingBoxTestCase::wxClientDC ~wxExecute::RedirectUTF8 ~Ellipsization::NormalCase ~SpinCtrl::* ~SpinCtrlDouble::* ~NotebookTestCase ~SettingsTestCase ~XRC::LoadURL ~Window::Show ~ModalDialogsTestCase ~Button::Click ~Button::Disabled ~wxDVC::GetItemRect ~wxDVC::AppendTextColumn ~Grid::KeyboardSelection ~Grid::CellClick ~Grid::ReorderedColumnsCellClick ~Grid::CellSelect ~wxStyledTextCtrl::AutoComp ~EvtLoopTestCase ~EventPropagationTestCase'
         ./test_gui $wx_tests_selection

--- a/.github/workflows/ci_msw.yml
+++ b/.github/workflows/ci_msw.yml
@@ -58,12 +58,22 @@ jobs:
           - configuration: 'DLL Release'
             platform: 'x64'
             vsversion: 2019
+            use_stl: true
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+
+      - name: Configure to use STL
+        if: matrix.use_stl
+        working-directory: include/wx/msw
+        run: |
+            $txt = Get-Content setup.h
+            Write-Output $txt |
+            %{$_ -replace "define wxUSE_STL 0", "define wxUSE_STL 1"} |
+            Set-Content setup.h
 
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v1.0.3

--- a/.github/workflows/ci_msw_cross.yml
+++ b/.github/workflows/ci_msw_cross.yml
@@ -58,9 +58,12 @@ jobs:
       matrix:
         include:
           - name: wxMSW 64 bits
+            configure_flags: --enable-stl --disable-compat30
           - name: wxMSW 32 bits
             triplet: i686-w64-mingw32
     env:
+      wxCONFIGURE_FLAGS: ${{ matrix.configure_flags }}
+
       # Default to 64-bit build.
       HOST_TRIPLET: ${{ matrix.triplet || 'x86_64-w64-mingw32' }}
 
@@ -144,7 +147,7 @@ jobs:
 
       - name: Configure
         run: |
-          ./configure --host=${HOST_TRIPLET} --disable-sys-libs --disable-optimise --disable-debug_info || rc=$?
+          ./configure --host=${HOST_TRIPLET} --disable-sys-libs --disable-optimise --disable-debug_info $wxCONFIGURE_FLAGS || rc=$?
 
           if [ -n "$rc" ]; then
             echo '*** Configuring failed, contents of config.log follows: ***'


### PR DESCRIPTION
Use --enable-stl for one of the builds (and also --disable-compat30 just
to test it too) to check that wxMSW compiles correctly in STL mode too.