### PR TITLE
Don't attempt to run tests on Ubuntu 16 becasue it's no longer available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,18 +49,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Ubuntu 16.04 wxGTK 2
-            runner: ubuntu-16.04
+          - name: Ubuntu 18.04 wxGTK 2
+            runner: ubuntu-18.04
             gtk_version: 2
-            use_xvfb: true
-          - name: Ubuntu 16.04 wxGTK 3 static
-            runner: ubuntu-16.04
-            configure_flags: --disable-shared
             use_xvfb: true
           - name: Ubuntu 18.04 wxGTK 2 UTF-8
             runner: ubuntu-18.04
             gtk_version: 2
             configure_flags: --enable-utf8 --enable-utf8only --enable-monolithic
+            use_xvfb: true
+          - name: Ubuntu 18.04 wxGTK3 static
+            runner: ubuntu-18.04
+            configure_flags: --disable-shared
             use_xvfb: true
           - name: Ubuntu 18.04 wxGTK 3 STL
             runner: ubuntu-18.04

--- a/samples/toolbar/toolbar.rc
+++ b/samples/toolbar/toolbar.rc
@@ -8,4 +8,3 @@ cut BITMAP "bitmaps/cut.bmp"
 paste BITMAP "bitmaps/paste.bmp"
 print BITMAP "bitmaps/print.bmp"
 help BITMAP "bitmaps/help.bmp"
-


### PR DESCRIPTION
Support for Ubuntu 16.04 ended on September 20, 2021.
[https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/](https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/)