### PR TITLE
wxMBConv_iconv: Fix wrong buffer size

### DIFF
--- a/src/common/strconv.cpp
+++ b/src/common/strconv.cpp
@@ -2343,13 +2343,13 @@ wxMBConv_iconv::ToWChar(wchar_t *dst, size_t dstLen,
         do
         {
             char* bufPtr = (char*)tbuf;
-            dstLen = 8 * SIZEOF_WCHAR_T;
+            dstLen = sizeof(tbuf);
 
             cres = iconv(m2w,
                          ICONV_CHAR_CAST(&pszPtr), &srcLen,
                          &bufPtr, &dstLen );
 
-            res += 8 - (dstLen / SIZEOF_WCHAR_T);
+            res += (sizeof(tbuf) - dstLen) / SIZEOF_WCHAR_T;
         }
         while ((cres == (size_t)-1) && (errno == E2BIG));
     }


### PR DESCRIPTION
The tbuf[] size has been raised up to 256 in commit 878c265, but those extra buffers weren't used at all.