### PR TITLE
Run tests on GitHub-hosted macOS 11 runner

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -62,6 +62,16 @@ jobs:
             cmake_defines: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_FIND_ROOT_PATH=/usr/local -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO
             cmake_samples: OFF
             cmake_tests: OFF
+          - name: macOS 11 wxOSX
+            runner: macos-11
+            cmake_generator: Xcode
+            cmake_defines: -DCMAKE_CXX_STANDARD=11
+          - name: macOS 11 wxIOS
+            runner: macos-11
+            cmake_generator: Xcode
+            cmake_defines: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_FIND_ROOT_PATH=/usr/local -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO
+            cmake_samples: OFF
+            cmake_tests: OFF
 
     env:
       wxGTK_VERSION: ${{ matrix.gtk_version && matrix.gtk_version || 3 }}

--- a/.github/workflows/ci_mac.yml
+++ b/.github/workflows/ci_mac.yml
@@ -78,10 +78,6 @@ jobs:
           arch: arm64
           configure_flags: --with-cxx=11
           use_asan: true
-        - name: wxMac Intel C++17
-          runner: self-hosted
-          arch: x86_64
-          configure_flags: --with-cxx=17 --with-macosx-version-min=10.12 --enable-debug
         - name: wxMac Universal C++14
           runner: self-hosted
           arch: arm64
@@ -92,6 +88,31 @@ jobs:
           configure_flags: --disable-sys-libs
         - name: wxiOS
           runner: macos-10.15
+          arch: x86_64
+          configure_flags: --with-osx_iphone --enable-monolithic  --disable-sys-libs --host=i686-apple-darwin_sim --build=x86_64-apple-darwin17.7.0
+          xcode_sdk: iphonesimulator
+          skip_samples: true
+          skip_testing: true
+          allow_warnings: true
+        - name: wxMac macOS 11 C++11
+          runner: macos-11
+          arch: x86_64
+          configure_flags: --with-cxx=11
+          use_asan: true
+        - name: wxMac macOS 11 C++14
+          runner: macos-11
+          arch: x86_64
+          configure_flags: --with-cxx=14 --disable-shared --disable-debug --enable-optimise
+        - name: wxMac macOS 11 C++17
+          runner: macos-11
+          arch: x86_64
+          configure_flags: --with-cxx=17 --with-macosx-version-min=10.12 --enable-debug
+        - name: wxMac macOS 11
+          runner: macos-11
+          arch: x86_64
+          configure_flags: --disable-sys-libs
+        - name: wxiOS macOS 11
+          runner: macos-11
           arch: x86_64
           configure_flags: --with-osx_iphone --enable-monolithic  --disable-sys-libs --host=i686-apple-darwin_sim --build=x86_64-apple-darwin17.7.0
           xcode_sdk: iphonesimulator


### PR DESCRIPTION
macOS 11 runner is already available on GitHub. Unfortunately, arm64 architecture is not available.