### PR TITLE
Fix handling wxSHOW_SB_ALWAYS in SetScrollbar

### DIFF
--- a/src/univ/winuniv.cpp
+++ b/src/univ/winuniv.cpp
@@ -958,7 +958,7 @@ void wxWindow::SetScrollbar(int orient,
         if ( scrollbar )
         {
             // wxALWAYS_SHOW_SB only applies to the vertical scrollbar
-            if ( range == -1 || (orient & wxVERTICAL) && (GetWindowStyle() & wxALWAYS_SHOW_SB) )
+            if ( range == -1 || ((orient & wxVERTICAL) && (GetWindowStyle() & wxALWAYS_SHOW_SB)) )
             {
                 // just disable the scrollbar
                 scrollbar->SetScrollbar(pos, pageSize, range == -1 ? 0 : range, pageSize, refresh);

--- a/src/univ/winuniv.cpp
+++ b/src/univ/winuniv.cpp
@@ -915,7 +915,7 @@ void wxWindow::SetScrollbar(int orient,
                             bool refresh)
 {
 #if wxUSE_SCROLLBAR
-    wxASSERT_MSG( pageSize <= range,
+    wxASSERT_MSG( (range == -1 || pageSize <= range),
                     wxT("page size can't be greater than range") );
 
     bool hasClientSizeChanged = false;
@@ -958,10 +958,10 @@ void wxWindow::SetScrollbar(int orient,
         if ( scrollbar )
         {
             // wxALWAYS_SHOW_SB only applies to the vertical scrollbar
-            if ( (orient & wxVERTICAL) && (GetWindowStyle() & wxALWAYS_SHOW_SB) )
+            if ( range == -1 || (orient & wxVERTICAL) && (GetWindowStyle() & wxALWAYS_SHOW_SB) )
             {
                 // just disable the scrollbar
-                scrollbar->SetScrollbar(pos, pageSize, range, pageSize, refresh);
+                scrollbar->SetScrollbar(pos, pageSize, range == -1 ? 0 : range, pageSize, refresh);
                 scrollbar->Disable();
             }
             else // really remove the scrollbar


### PR DESCRIPTION
Range can be equal to -1 [when wxSHOW_SB_ALWAYS is set](https://github.com/wxWidgets/wxWidgets/blob/master/src/generic/scrlwing.cpp#L1301) so here is fix to prevent unexpected assert failure.