### PR TITLE
These code of wxGenericCollapsiblePane always set top level window si…

### DIFF
--- a/src/generic/collpaneg.cpp
+++ b/src/generic/collpaneg.cpp
@@ -147,10 +147,6 @@ void wxGenericCollapsiblePane::OnStateChange(const wxSize& sz)
 
     const wxSize newBestSize = sizer->ComputeFittingClientSize(top);
     top->SetMinClientSize(newBestSize);
-
-    // we shouldn't attempt to resize a maximized window, whatever happens
-    if ( !top->IsMaximized() )
-        top->SetClientSize(newBestSize);
 }
 
 void wxGenericCollapsiblePane::Collapse(bool collapse)


### PR DESCRIPTION
wxGenericCollapsiblePane always set top level window size to itself's best size

This make the top level window can't keep its current size, and always be set to minimized size after click collapsiblePane's button.
Remove them.