### PR TITLE
Add missing references to wxSize parameters in wxBitmapBundle

### DIFF
--- a/include/wx/bmpbndl.h
+++ b/include/wx/bmpbndl.h
@@ -73,10 +73,10 @@ public:
     // Create from the SVG data (data is supposed to be in UTF-8 encoding).
     // Notice that the data here is non-const because it can be temporarily
     // modified while parsing it.
-    static wxBitmapBundle FromSVG(char* data, const wxSize sizeDef);
+    static wxBitmapBundle FromSVG(char* data, const wxSize& sizeDef);
 
     // This overload currently makes a copy of the data.
-    static wxBitmapBundle FromSVG(const char* data, const wxSize sizeDef);
+    static wxBitmapBundle FromSVG(const char* data, const wxSize& sizeDef);
 #endif // wxHAS_SVG
 
     // Create from the resources: all existing versions of the bitmap of the
@@ -97,7 +97,7 @@ public:
     // available size by rescaling it if necessary.
     //
     // If size == wxDefaultSize, GetDefaultSize() is used for it instead.
-    wxBitmap GetBitmap(const wxSize size) const;
+    wxBitmap GetBitmap(const wxSize& size) const;
 
     // Access implementation
     wxBitmapBundleImpl* GetImpl() const { return m_impl.get(); }
@@ -178,7 +178,7 @@ public:
     //
     // Note that this function is non-const because it may generate the bitmap
     // on demand and cache it.
-    virtual wxBitmap GetBitmap(const wxSize size) = 0;
+    virtual wxBitmap GetBitmap(const wxSize& size) = 0;
 
 #ifdef __WXOSX__
     // returns the native representation of the bitmap bundle

--- a/interface/wx/bmpbndl.h
+++ b/interface/wx/bmpbndl.h
@@ -219,10 +219,10 @@ public:
             this bundle. As SVG images usually don't have any natural
             default size, it should be provided when creating the bundle.
      */
-    static wxBitmapBundle FromSVG(char* data, const wxSize sizeDef);
+    static wxBitmapBundle FromSVG(char* data, const wxSize& sizeDef);
 
     /// @overload
-    static wxBitmapBundle FromSVG(const char* data, const wxSize sizeDef);
+    static wxBitmapBundle FromSVG(const char* data, const wxSize& sizeDef);
 
     /**
         Check if bitmap bundle is non-empty.
@@ -254,7 +254,7 @@ public:
         this will create many bitmaps that will never be deleted and will
         consume resources until the application termination.
      */
-    wxBitmap GetBitmap(const wxSize size) const;
+    wxBitmap GetBitmap(const wxSize& size) const;
 };
 
 /**
@@ -277,7 +277,7 @@ public:
                 ... determine the minimum/default size for bitmap to use ...
             }
 
-            wxBitmap GetBitmap(const wxSize size) wxOVERRIDE
+            wxBitmap GetBitmap(const wxSize& size) wxOVERRIDE
             {
                 ... get the bitmap of the requested size from somewhere and
                     cache it if necessary, i.e. if getting it is expensive ...
@@ -312,7 +312,7 @@ public:
         Note that this function is non-const because it may generate the bitmap
         on demand and cache it.
      */
-    virtual wxBitmap GetBitmap(const wxSize size) = 0;
+    virtual wxBitmap GetBitmap(const wxSize& size) = 0;
 };
 
 /**

--- a/samples/toolbar/toolbar.cpp
+++ b/samples/toolbar/toolbar.cpp
@@ -520,7 +520,7 @@ void MyFrame::PopulateToolbar(wxToolBarBase* toolBar)
                     return m_sizeDef;
                 }
 
-                wxBitmap GetBitmap(const wxSize size) wxOVERRIDE
+                wxBitmap GetBitmap(const wxSize& size) wxOVERRIDE
                 {
                     // In this simple implementation we don't bother caching
                     // anything.

--- a/src/common/bmpbndl.cpp
+++ b/src/common/bmpbndl.cpp
@@ -63,7 +63,7 @@ public:
     }
 
     virtual wxSize GetDefaultSize() const wxOVERRIDE;
-    virtual wxBitmap GetBitmap(const wxSize size) wxOVERRIDE;
+    virtual wxBitmap GetBitmap(const wxSize& size) wxOVERRIDE;
 
 #ifdef __WXOSX__
     virtual WXImage OSXGetImage() const wxOVERRIDE;
@@ -156,7 +156,7 @@ wxSize wxBitmapBundleImplSet::GetDefaultSize() const
     return m_entries[0].bitmap.GetSize();
 }
 
-wxBitmap wxBitmapBundleImplSet::GetBitmap(const wxSize size)
+wxBitmap wxBitmapBundleImplSet::GetBitmap(const wxSize& size)
 {
     // We use linear search instead if binary one because it's simpler and the
     // vector size is small enough (< 10) for it not to matter in practice.
@@ -320,7 +320,7 @@ wxSize wxBitmapBundle::GetDefaultSize() const
     return m_impl->GetDefaultSize();
 }
 
-wxBitmap wxBitmapBundle::GetBitmap(const wxSize size) const
+wxBitmap wxBitmapBundle::GetBitmap(const wxSize& size) const
 {
     if ( !m_impl )
         return wxBitmap();

--- a/src/generic/bmpsvg.cpp
+++ b/src/generic/bmpsvg.cpp
@@ -78,10 +78,10 @@ public:
     }
 
     virtual wxSize GetDefaultSize() const wxOVERRIDE;
-    virtual wxBitmap GetBitmap(const wxSize size) wxOVERRIDE;
+    virtual wxBitmap GetBitmap(const wxSize& size) wxOVERRIDE;
 
 private:
-    wxBitmap DoRasterize(const wxSize size);
+    wxBitmap DoRasterize(const wxSize& size);
 
     NSVGimage* const m_svgImage;
     NSVGrasterizer* const m_svgRasterizer;
@@ -111,7 +111,7 @@ wxSize wxBitmapBundleImplSVG::GetDefaultSize() const
     return m_sizeDef;
 }
 
-wxBitmap wxBitmapBundleImplSVG::GetBitmap(const wxSize size)
+wxBitmap wxBitmapBundleImplSVG::GetBitmap(const wxSize& size)
 {
     if ( !m_cachedBitmap.IsOk() || m_cachedBitmap.GetSize() != size )
     {
@@ -121,7 +121,7 @@ wxBitmap wxBitmapBundleImplSVG::GetBitmap(const wxSize size)
     return m_cachedBitmap;
 }
 
-wxBitmap wxBitmapBundleImplSVG::DoRasterize(const wxSize size)
+wxBitmap wxBitmapBundleImplSVG::DoRasterize(const wxSize& size)
 {
     wxVector<unsigned char> buffer(size.x*size.y*4);
     nsvgRasterize
@@ -164,7 +164,7 @@ wxBitmap wxBitmapBundleImplSVG::DoRasterize(const wxSize size)
 }
 
 /* static */
-wxBitmapBundle wxBitmapBundle::FromSVG(char* data, const wxSize sizeDef)
+wxBitmapBundle wxBitmapBundle::FromSVG(char* data, const wxSize& sizeDef)
 {
     NSVGimage* const svgImage = nsvgParse(data, "px", 96);
     if ( !svgImage )
@@ -174,7 +174,7 @@ wxBitmapBundle wxBitmapBundle::FromSVG(char* data, const wxSize sizeDef)
 }
 
 /* static */
-wxBitmapBundle wxBitmapBundle::FromSVG(const char* data, const wxSize sizeDef)
+wxBitmapBundle wxBitmapBundle::FromSVG(const char* data, const wxSize& sizeDef)
 {
     wxCharBuffer copy(data);
 

--- a/src/msw/bmpbndl.cpp
+++ b/src/msw/bmpbndl.cpp
@@ -138,7 +138,7 @@ public:
                          const wxBitmap& bitmap);
 
     virtual wxSize GetDefaultSize() const wxOVERRIDE;
-    virtual wxBitmap GetBitmap(const wxSize size) wxOVERRIDE;
+    virtual wxBitmap GetBitmap(const wxSize& size) wxOVERRIDE;
 
 private:
     // Load the bitmap from the given resource and add it m_bitmaps, after
@@ -230,7 +230,7 @@ wxBitmapBundleImplRC::AddBitmap(const ResourceInfo& info,
     return bitmap;
 }
 
-wxBitmap wxBitmapBundleImplRC::GetBitmap(const wxSize size)
+wxBitmap wxBitmapBundleImplRC::GetBitmap(const wxSize& size)
 {
     // First check if we already have the bitmap of this size: we're only
     // interested in the exact match here.

--- a/src/osx/core/bmpbndl.mm
+++ b/src/osx/core/bmpbndl.mm
@@ -46,7 +46,7 @@ public:
     ~wxOSXImageBundleImpl();
 
     virtual wxSize GetDefaultSize() const wxOVERRIDE;
-    virtual wxBitmap GetBitmap(const wxSize size) wxOVERRIDE;
+    virtual wxBitmap GetBitmap(const wxSize& size) wxOVERRIDE;
 
     virtual WXImage OSXGetImage() const wxOVERRIDE;
 
@@ -76,7 +76,7 @@ wxSize wxOSXImageBundleImpl::GetDefaultSize() const
     return wxSize(sz.width, sz.height);
 }
 
-wxBitmap wxOSXImageBundleImpl::GetBitmap(const wxSize size)
+wxBitmap wxOSXImageBundleImpl::GetBitmap(const wxSize& size)
 {
     return wxBitmap();
 }


### PR DESCRIPTION
Pass wxSize by const reference instead of "const" value.

Note that passing wxSize by value might be not such a bad thing,
actually, but we use const reference for it everywhere else, so do it
here as well for consistency (and the original intention was to do it
like this, missing "&" was just a typo subsequently propagated through
copy-pasting).

No real changes.