### PR TITLE
Fix wxListCtrl checkbox style when reapplying extended styles

### DIFF
--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -351,6 +351,10 @@ void wxListCtrl::MSWSetExListStyles()
     if ( !GetToolTip() )
         exStyle |= LVS_EX_LABELTIP;
 
+    // include the checkbox style
+    if ( HasCheckBoxes() )
+        exStyle |= LVS_EX_CHECKBOXES;
+
     if ( wxApp::GetComCtl32Version() >= 600 )
     {
         // We must enable double buffering when using the system theme to avoid


### PR DESCRIPTION
Fixes [#19263](https://trac.wxwidgets.org/ticket/19263)