### PR TITLE
CMake: enable spellcheck

### DIFF
--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -630,14 +630,6 @@ function(wx_add_thirdparty_library var_name lib_name help_str)
         endif()
     endif()
 
-    if(${var_name} STREQUAL "builtin" AND NOT wxBUILD_SHARED)
-        # Only install if we build as static libraries
-        wx_install(TARGETS ${target_name}
-            LIBRARY DESTINATION lib
-            ARCHIVE DESTINATION lib
-            )
-    endif()
-
     set(wxTHIRD_PARTY_LIBRARIES ${wxTHIRD_PARTY_LIBRARIES} ${var_name} "${help_str}" PARENT_SCOPE)
 endfunction()
 

--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -26,6 +26,11 @@ else()
     set(WIN32_MSVC_NAMING 0)
 endif()
 
+if(MSVC)
+    # Generator expression to not create different Debug and Release directories
+    set(MSVC_DIR_FIX "$<1:/>")
+endif()
+
 # This function adds a list of headers to a variable while prepending
 # include/ to the path
 macro(wx_add_headers src_var)
@@ -97,9 +102,9 @@ function(wx_set_common_target_properties target_name)
     cmake_parse_arguments(wxCOMMON_TARGET_PROPS "DEFAULT_WARNINGS" "" "" ${ARGN})
 
     set_target_properties(${target_name} PROPERTIES
-        LIBRARY_OUTPUT_DIRECTORY "${wxOUTPUT_DIR}${wxPLATFORM_LIB_DIR}"
-        ARCHIVE_OUTPUT_DIRECTORY "${wxOUTPUT_DIR}${wxPLATFORM_LIB_DIR}"
-        RUNTIME_OUTPUT_DIRECTORY "${wxOUTPUT_DIR}${wxPLATFORM_LIB_DIR}"
+        LIBRARY_OUTPUT_DIRECTORY "${wxOUTPUT_DIR}${MSVC_DIR_FIX}${wxPLATFORM_LIB_DIR}"
+        ARCHIVE_OUTPUT_DIRECTORY "${wxOUTPUT_DIR}${MSVC_DIR_FIX}${wxPLATFORM_LIB_DIR}"
+        RUNTIME_OUTPUT_DIRECTORY "${wxOUTPUT_DIR}${MSVC_DIR_FIX}${wxPLATFORM_LIB_DIR}"
         )
 
     if(wxBUILD_PIC)
@@ -417,9 +422,9 @@ macro(wx_add_library name)
             set(runtime_dir "bin")
         endif()
         wx_install(TARGETS ${name}
-            LIBRARY DESTINATION "lib${wxPLATFORM_LIB_DIR}"
-            ARCHIVE DESTINATION "lib${wxPLATFORM_LIB_DIR}"
-            RUNTIME DESTINATION "${runtime_dir}${wxPLATFORM_LIB_DIR}"
+            LIBRARY DESTINATION "lib${MSVC_DIR_FIX}${wxPLATFORM_LIB_DIR}"
+            ARCHIVE DESTINATION "lib${MSVC_DIR_FIX}${wxPLATFORM_LIB_DIR}"
+            RUNTIME DESTINATION "${runtime_dir}${MSVC_DIR_FIX}${wxPLATFORM_LIB_DIR}"
             BUNDLE DESTINATION Applications/wxWidgets
             )
     endif()
@@ -574,7 +579,7 @@ function(wx_set_builtin_target_properties target_name)
 
     wx_set_common_target_properties(${target_name} DEFAULT_WARNINGS)
     if(NOT wxBUILD_SHARED)
-        wx_install(TARGETS ${name} ARCHIVE DESTINATION "lib${wxPLATFORM_LIB_DIR}")
+        wx_install(TARGETS ${name} ARCHIVE DESTINATION "lib${MSVC_DIR_FIX}${wxPLATFORM_LIB_DIR}")
     endif()
 endfunction()
 

--- a/build/cmake/init.cmake
+++ b/build/cmake/init.cmake
@@ -563,6 +563,17 @@ if(wxUSE_GUI)
     else()
         set(wxUSE_LIBGNOMEVFS OFF)
     endif()
+
+    if(WXGTK3 AND wxUSE_SPELLCHECK)
+        find_package(GSPELL)
+        if(GSPELL_FOUND)
+            list(APPEND wxTOOLKIT_INCLUDE_DIRS ${GSPELL_INCLUDE_DIRS})
+            list(APPEND wxTOOLKIT_LIBRARIES ${GSPELL_LIBRARIES})
+        else()
+            message(STATUS "gspell-1 not found, spell checking in wxTextCtrl won't be available")
+            wx_option_force_value(wxUSE_SPELLCHECK OFF)
+        endif()
+    endif()
 endif()
 
 # test if precompiled headers are supported using the cotire test project

--- a/build/cmake/init.cmake
+++ b/build/cmake/init.cmake
@@ -153,8 +153,7 @@ if(WIN32_MSVC_NAMING)
         set(lib_suffix "_lib")
     endif()
 
-    # Include generator expression to suppress default Debug/Release pair
-    set(wxPLATFORM_LIB_DIR "$<1:/>${wxCOMPILER_PREFIX}${wxARCH_SUFFIX}${lib_suffix}")
+    set(wxPLATFORM_LIB_DIR "${wxCOMPILER_PREFIX}${wxARCH_SUFFIX}${lib_suffix}")
 endif()
 
 if(wxBUILD_CUSTOM_SETUP_HEADER_PATH)
@@ -171,7 +170,7 @@ else()
             set(lib_unicode)
         endif()
         set(wxSETUP_HEADER_PATH
-            ${wxOUTPUT_DIR}/${wxCOMPILER_PREFIX}${wxARCH_SUFFIX}${lib_suffix}/${wxBUILD_TOOLKIT}${lib_unicode})
+            ${wxOUTPUT_DIR}/${wxPLATFORM_LIB_DIR}/${wxBUILD_TOOLKIT}${lib_unicode})
         file(MAKE_DIRECTORY ${wxSETUP_HEADER_PATH}/wx)
         file(MAKE_DIRECTORY ${wxSETUP_HEADER_PATH}d/wx)
         set(wxSETUP_HEADER_FILE_DEBUG ${wxSETUP_HEADER_PATH}d/wx/setup.h)

--- a/build/cmake/install.cmake
+++ b/build/cmake/install.cmake
@@ -32,7 +32,7 @@ endif()
 if(WIN32_MSVC_NAMING)
     wx_install(
         DIRECTORY "${wxSETUP_HEADER_PATH}"
-        DESTINATION "lib${wxPLATFORM_LIB_DIR}")
+        DESTINATION "lib/${wxPLATFORM_LIB_DIR}")
 else()
     wx_install(
         DIRECTORY "${wxSETUP_HEADER_PATH}"

--- a/build/cmake/modules/FindGSPELL.cmake
+++ b/build/cmake/modules/FindGSPELL.cmake
@@ -1,0 +1,42 @@
+# - Try to find gspell
+# Once done this will define
+#
+#  GSPELL_FOUND - system has gspell
+#  GSPELL_INCLUDE_DIRS - The include directory to use for the gspell headers
+#  GSPELL_LIBRARIES - Link these to use gspell
+
+find_package(PkgConfig)
+pkg_check_modules(PC_GSPELL QUIET gspell-1)
+
+find_path(GSPELL_INCLUDE_DIRS
+    NAMES gspell/gspell.h
+    HINTS ${PC_GSPELL_INCLUDEDIR}
+          ${PC_GSPELL_INCLUDE_DIRS}
+)
+
+find_library(GSPELL_LIBRARIES
+    NAMES gspell-1
+    HINTS ${PC_GSPELL_LIBDIR}
+          ${PC_GSPELL_LIBRARY_DIRS}
+)
+
+pkg_check_modules(PC_ENCHANT QUIET enchant-2 enchant)
+find_path(ENCHANT_INCLUDE_DIRS
+    NAMES enchant.h
+    HINTS ${PC_ENCHANT_INCLUDEDIR}
+          ${PC_ENCHANT_INCLUDE_DIRS}
+    PATH_SUFFIXES enchant-2 enchant
+)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(GSPELL DEFAULT_MSG GSPELL_INCLUDE_DIRS ENCHANT_INCLUDE_DIRS GSPELL_LIBRARIES)
+
+if(GSPELL_FOUND)
+    set(GSPELL_INCLUDE_DIRS ${GSPELL_INCLUDE_DIRS} ${ENCHANT_INCLUDE_DIRS})
+endif()
+
+mark_as_advanced(
+    GSPELL_INCLUDE_DIRS
+    GSPELL_LIBRARIES
+    ENCHANT_INCLUDE_DIRS
+)

--- a/build/cmake/options.cmake
+++ b/build/cmake/options.cmake
@@ -190,6 +190,7 @@ wx_option(wxUSE_PRINTF_POS_PARAMS "use wxVsnprintf() which supports positional p
 wx_option(wxUSE_SECRETSTORE "use wxSecretStore class")
 wx_option(wxUSE_SNGLINST_CHECKER "use wxSingleInstanceChecker class")
 wx_option(wxUSE_SOUND "use wxSound class")
+wx_option(wxUSE_SPELLCHECK "enable spellchecking in wxTextCtrl class (MSW and GTK3 only)")
 wx_option(wxUSE_STDPATHS "use wxStandardPaths class")
 wx_option(wxUSE_STOPWATCH "use wxStopWatch class")
 wx_option(wxUSE_STREAMS "use wxStream etc classes")


### PR DESCRIPTION
Enable `wxUSE_SPELLCHECK`.

Remove duplicate install and remove generator expression from `wxPLATFORM_LIB_DIR`.