### PR TITLE
Add wxBitmapBundle support to wxStaticBitmap

### DIFF
--- a/docs/doxygen/mainpages/const_cpp.h
+++ b/docs/doxygen/mainpages/const_cpp.h
@@ -401,6 +401,9 @@ more details.
         defined when compiling code which uses wxWidgets as a DLL/shared library}
 @itemdef{WXBUILDING,
         defined when building wxWidgets itself, whether as a static or shared library}
+@itemdef{wxICON_IS_BITMAP,
+         defined in the ports where wxIcon inherits from wxBitmap (all but
+         wxMSW currently)}
 @endDefList
 
 */

--- a/include/wx/bmpbndl.h
+++ b/include/wx/bmpbndl.h
@@ -100,7 +100,7 @@ public:
     // Get preferred size, i.e. usually the closest size in which a bitmap is
     // available to the ideal size determined from the default size and the DPI
     // scaling, for the given window.
-    wxSize GetPreferredSizeFor(wxWindow* window) const;
+    wxSize GetPreferredSizeFor(const wxWindow* window) const;
     wxSize GetPreferredSizeAtScale(double scale) const;
 
     // Get bitmap of the specified size, creating a new bitmap from the closest

--- a/include/wx/bmpbndl.h
+++ b/include/wx/bmpbndl.h
@@ -109,6 +109,11 @@ public:
     // If size == wxDefaultSize, GetDefaultSize() is used for it instead.
     wxBitmap GetBitmap(const wxSize& size) const;
 
+    // Helper combining GetBitmap() and GetPreferredSizeFor(): returns the
+    // bitmap of the size appropriate for the current DPI scaling of the given
+    // window.
+    wxBitmap GetBitmapFor(const wxWindow* window) const;
+
     // Access implementation
     wxBitmapBundleImpl* GetImpl() const { return m_impl.get(); }
 

--- a/include/wx/generic/statbmpg.h
+++ b/include/wx/generic/statbmpg.h
@@ -18,7 +18,7 @@ public:
     wxGenericStaticBitmap() {}
     wxGenericStaticBitmap(wxWindow *parent,
                           wxWindowID id,
-                          const wxBitmap& bitmap,
+                          const wxBitmapBundle& bitmap,
                           const wxPoint& pos = wxDefaultPosition,
                           const wxSize& size = wxDefaultSize,
                           long style = 0,
@@ -29,21 +29,19 @@ public:
 
     bool Create(wxWindow *parent,
                 wxWindowID id,
-                const wxBitmap& bitmap,
+                const wxBitmapBundle& bitmap,
                 const wxPoint& pos = wxDefaultPosition,
                 const wxSize& size = wxDefaultSize,
                 long style = 0,
                 const wxString& name = wxASCII_STR(wxStaticBitmapNameStr));
 
-    virtual void SetBitmap(const wxBitmap& bitmap) wxOVERRIDE
+    virtual void SetBitmap(const wxBitmapBundle& bitmap) wxOVERRIDE
     {
-        m_bitmap = bitmap;
+        m_bitmapBundle = bitmap;
         InvalidateBestSize();
         SetSize(GetBestSize());
         Refresh();
     }
-
-    virtual wxBitmap GetBitmap() const wxOVERRIDE { return m_bitmap; }
 
     virtual void SetScaleMode(ScaleMode scaleMode) wxOVERRIDE
     {
@@ -56,7 +54,6 @@ public:
 private:
     void OnPaint(wxPaintEvent& event);
 
-    wxBitmap m_bitmap;
     ScaleMode m_scaleMode;
 
     wxDECLARE_DYNAMIC_CLASS(wxGenericStaticBitmap);

--- a/include/wx/generic/statbmpg.h
+++ b/include/wx/generic/statbmpg.h
@@ -44,18 +44,6 @@ public:
 
     virtual wxBitmap GetBitmap() const wxOVERRIDE { return m_bitmap; }
 
-    virtual void SetIcon(const wxIcon& icon) wxOVERRIDE
-    {
-        m_bitmap.CopyFromIcon(icon);
-        SetInitialSize(GetBitmapSize());
-        Refresh();
-    }
-
-#if defined(__WXGTK20__) || defined(__WXMAC__)
-    // icons and bitmaps are really the same thing in wxGTK and wxMac
-    wxIcon GetIcon() const wxOVERRIDE  { return (const wxIcon &)m_bitmap; }
-#endif
-
     virtual void SetScaleMode(ScaleMode scaleMode) wxOVERRIDE
     {
         m_scaleMode = scaleMode;

--- a/include/wx/generic/statbmpg.h
+++ b/include/wx/generic/statbmpg.h
@@ -38,7 +38,8 @@ public:
     virtual void SetBitmap(const wxBitmap& bitmap) wxOVERRIDE
     {
         m_bitmap = bitmap;
-        SetInitialSize(GetBitmapSize());
+        InvalidateBestSize();
+        SetSize(GetBestSize());
         Refresh();
     }
 
@@ -53,12 +54,6 @@ public:
     virtual ScaleMode GetScaleMode() const wxOVERRIDE { return m_scaleMode; }
 
 private:
-    wxSize GetBitmapSize()
-    {
-        return m_bitmap.IsOk() ? m_bitmap.GetScaledSize()
-                               : wxSize(16, 16); // this is completely arbitrary
-    }
-
     void OnPaint(wxPaintEvent& event);
 
     wxBitmap m_bitmap;

--- a/include/wx/gtk/statbmp.h
+++ b/include/wx/gtk/statbmp.h
@@ -21,28 +21,25 @@ public:
     wxStaticBitmap();
     wxStaticBitmap( wxWindow *parent,
                     wxWindowID id,
-                    const wxBitmap& label,
+                    const wxBitmapBundle& label,
                     const wxPoint& pos = wxDefaultPosition,
                     const wxSize& size = wxDefaultSize,
                     long style = 0,
                     const wxString& name = wxASCII_STR(wxStaticBitmapNameStr));
     bool Create( wxWindow *parent,
                  wxWindowID id,
-                 const wxBitmap& label,
+                 const wxBitmapBundle& label,
                  const wxPoint& pos = wxDefaultPosition,
                  const wxSize& size = wxDefaultSize,
                  long style = 0,
                  const wxString& name = wxASCII_STR(wxStaticBitmapNameStr));
 
-    virtual void SetBitmap( const wxBitmap& bitmap ) wxOVERRIDE;
-    virtual wxBitmap GetBitmap() const wxOVERRIDE { return m_bitmap; }
+    virtual void SetBitmap( const wxBitmapBundle& bitmap ) wxOVERRIDE;
 
     static wxVisualAttributes
     GetClassDefaultAttributes(wxWindowVariant variant = wxWINDOW_VARIANT_NORMAL);
 
 private:
-    wxBitmap   m_bitmap;
-
     wxDECLARE_DYNAMIC_CLASS(wxStaticBitmap);
 };
 

--- a/include/wx/gtk/statbmp.h
+++ b/include/wx/gtk/statbmp.h
@@ -34,17 +34,8 @@ public:
                  long style = 0,
                  const wxString& name = wxASCII_STR(wxStaticBitmapNameStr));
 
-    virtual void SetIcon(const wxIcon& icon) wxOVERRIDE { SetBitmap( icon ); }
     virtual void SetBitmap( const wxBitmap& bitmap ) wxOVERRIDE;
     virtual wxBitmap GetBitmap() const wxOVERRIDE { return m_bitmap; }
-
-    // for compatibility with wxMSW
-    wxIcon GetIcon() const wxOVERRIDE
-    {
-        // don't use wxDynamicCast, icons and bitmaps are really the same thing
-        // in wxGTK
-        return (const wxIcon &)m_bitmap;
-    }
 
     static wxVisualAttributes
     GetClassDefaultAttributes(wxWindowVariant variant = wxWINDOW_VARIANT_NORMAL);

--- a/include/wx/gtk1/statbmp.h
+++ b/include/wx/gtk1/statbmp.h
@@ -21,21 +21,20 @@ public:
     wxStaticBitmap();
     wxStaticBitmap( wxWindow *parent,
                     wxWindowID id,
-                    const wxBitmap& label,
+                    const wxBitmapBundle& label,
                     const wxPoint& pos = wxDefaultPosition,
                     const wxSize& size = wxDefaultSize,
                     long style = 0,
                     const wxString& name = wxASCII_STR(wxStaticBitmapNameStr) );
     bool Create( wxWindow *parent,
                  wxWindowID id,
-                 const wxBitmap& label,
+                 const wxBitmapBundle& label,
                  const wxPoint& pos = wxDefaultPosition,
                  const wxSize& size = wxDefaultSize,
                  long style = 0,
                  const wxString& name = wxASCII_STR(wxStaticBitmapNameStr));
 
-    virtual void SetBitmap( const wxBitmap& bitmap );
-    virtual wxBitmap GetBitmap() const { return m_bitmap; }
+    virtual void SetBitmapBundle( const wxBitmapBundle& bitmap );
 
     static wxVisualAttributes
     GetClassDefaultAttributes(wxWindowVariant variant = wxWINDOW_VARIANT_NORMAL);

--- a/include/wx/gtk1/statbmp.h
+++ b/include/wx/gtk1/statbmp.h
@@ -34,17 +34,8 @@ public:
                  long style = 0,
                  const wxString& name = wxASCII_STR(wxStaticBitmapNameStr));
 
-    virtual void SetIcon(const wxIcon& icon) { SetBitmap( icon ); }
     virtual void SetBitmap( const wxBitmap& bitmap );
     virtual wxBitmap GetBitmap() const { return m_bitmap; }
-
-    // for compatibility with wxMSW
-    wxIcon GetIcon() const
-    {
-        // don't use wxDynamicCast, icons and bitmaps are really the same thing
-        // in wxGTK
-        return (const wxIcon &)m_bitmap;
-    }
 
     static wxVisualAttributes
     GetClassDefaultAttributes(wxWindowVariant variant = wxWINDOW_VARIANT_NORMAL);

--- a/include/wx/icon.h
+++ b/include/wx/icon.h
@@ -25,6 +25,8 @@
 #if defined(__WXMSW__)
   #define wxICON_DEFAULT_TYPE   wxBITMAP_TYPE_ICO_RESOURCE
   #include "wx/msw/icon.h"
+
+  #define wxICON_DIFFERENT_FROM_BITMAP
 #elif defined(__WXMOTIF__)
   #define wxICON_DEFAULT_TYPE   wxBITMAP_TYPE_XPM
   #include "wx/motif/icon.h"
@@ -56,6 +58,10 @@
 #elif defined(__WXQT__)
   #define wxICON_DEFAULT_TYPE   wxBITMAP_TYPE_XPM
   #include "wx/generic/icon.h"
+#endif
+
+#ifndef wxICON_DIFFERENT_FROM_BITMAP
+    #define wxICON_IS_BITMAP
 #endif
 
 //-----------------------------------------------------------------------------

--- a/include/wx/motif/statbmp.h
+++ b/include/wx/motif/statbmp.h
@@ -48,19 +48,6 @@ public:
 
     wxBitmap GetBitmap() const { return m_messageBitmap; }
 
-    // for compatibility with wxMSW
-    wxIcon GetIcon() const
-    {
-        // don't use wxDynamicCast, icons and bitmaps are really the same thing
-        return *(const wxIcon*)&m_messageBitmap;
-    }
-
-    // for compatibility with wxMSW
-    void  SetIcon(const wxIcon& icon)
-    {
-        SetBitmap( icon );
-    }
-
     // Implementation
     virtual void ChangeBackgroundColour();
     virtual void ChangeForegroundColour();

--- a/include/wx/motif/statbmp.h
+++ b/include/wx/motif/statbmp.h
@@ -23,7 +23,7 @@ public:
     virtual ~wxStaticBitmap();
 
     wxStaticBitmap(wxWindow *parent, wxWindowID id,
-        const wxBitmap& label,
+        const wxBitmapBundle& label,
         const wxPoint& pos = wxDefaultPosition,
         const wxSize& size = wxDefaultSize,
         long style = 0,
@@ -33,20 +33,18 @@ public:
     }
 
     bool Create(wxWindow *parent, wxWindowID id,
-        const wxBitmap& label,
+        const wxBitmapBundle& label,
         const wxPoint& pos = wxDefaultPosition,
         const wxSize& size = wxDefaultSize,
         long style = 0,
         const wxString& name = wxASCII_STR(wxStaticBitmapNameStr));
 
-    virtual void SetBitmap(const wxBitmap& bitmap);
+    virtual void SetBitmap(const wxBitmapBundle& bitmap);
 
     virtual bool ProcessCommand(wxCommandEvent& WXUNUSED(event))
     {
         return false;
     }
-
-    wxBitmap GetBitmap() const { return m_messageBitmap; }
 
     // Implementation
     virtual void ChangeBackgroundColour();
@@ -57,7 +55,7 @@ protected:
 
 protected:
     wxBitmap m_messageBitmap;
-    wxBitmap m_messageBitmapOriginal;
+    wxBitmapBundle m_messageBitmapOriginal;
     wxBitmapCache m_bitmapCache;
 };
 

--- a/include/wx/msw/statbmp.h
+++ b/include/wx/msw/statbmp.h
@@ -112,7 +112,9 @@ private:
     // can we leave it to it)
     void DoPaintManually(wxPaintEvent& event);
 
+    // event handlers
     void WXHandleSize(wxSizeEvent& event);
+    void WXHandleDPIChanged(wxDPIChangedEvent& event);
 
     // return the size of m_icon or the appropriate size of m_bitmapBundle at
     // the current DPI scaling (may still be invalid of both of them are)

--- a/include/wx/msw/statbmp.h
+++ b/include/wx/msw/statbmp.h
@@ -25,7 +25,7 @@ public:
 
     wxStaticBitmap(wxWindow *parent,
                    wxWindowID id,
-                   const wxBitmap& label,
+                   const wxBitmapBundle& label,
                    const wxPoint& pos = wxDefaultPosition,
                    const wxSize& size = wxDefaultSize,
                    long style = 0,
@@ -51,13 +51,13 @@ public:
 
     bool Create(wxWindow *parent,
                 wxWindowID id,
-                const wxBitmap& label,
+                const wxBitmapBundle& label,
                 const wxPoint& pos = wxDefaultPosition,
                 const wxSize& size = wxDefaultSize,
                 long style = 0,
                 const wxString& name = wxASCII_STR(wxStaticBitmapNameStr))
     {
-        m_bitmap = label;
+        m_bitmapBundle = label;
 
         return DoCreate(parent, id, pos, size, style, name);
     }
@@ -78,7 +78,7 @@ public:
     virtual ~wxStaticBitmap() { Free(); }
 
     virtual void SetIcon(const wxIcon& icon) wxOVERRIDE;
-    virtual void SetBitmap(const wxBitmap& bitmap) wxOVERRIDE;
+    virtual void SetBitmap(const wxBitmapBundle& bitmap) wxOVERRIDE;
     virtual wxBitmap GetBitmap() const wxOVERRIDE;
     virtual wxIcon GetIcon() const wxOVERRIDE;
 
@@ -103,9 +103,9 @@ private:
                   long style,
                   const wxString& name);
 
-    // update the image to correspond to the current m_icon or m_bitmap value,
-    // resize the control if the new size is different from the old one and
-    // update its style if the new "is icon" value differs from the old one
+    // update the image to correspond to the current m_icon or m_bitmapBundle
+    // value, resize the control if the new size is different from the old one
+    // and update its style if the new "is icon" value differs from the old one
     void DoUpdateImage(const wxSize& sizeOld, bool wasIcon);
 
     // draw the bitmap ourselves here if the OS can't do it correctly (if it
@@ -114,15 +114,14 @@ private:
 
     void WXHandleSize(wxSizeEvent& event);
 
-    // return the either m_icon or m_bitmap (may still be invalid of both of
-    // them are)
-    const wxGDIImage& GetImage() const;
+    // return the size of m_icon or the appropriate size of m_bitmapBundle at
+    // the current DPI scaling (may still be invalid of both of them are)
+    wxSize GetImageSize() const;
 
 
     // we can have either an icon or a bitmap: if m_icon is valid, it is used,
-    // otherwise m_bitmap is used if it is valid
+    // otherwise m_bitmapBundle defined in the base class is used if it is valid
     wxIcon m_icon;
-    wxBitmap m_bitmap;
 
     // handle used in last call to STM_SETIMAGE
     WXHANDLE m_currentHandle;

--- a/include/wx/msw/statbmp.h
+++ b/include/wx/msw/statbmp.h
@@ -90,9 +90,6 @@ private:
     // HICON (which can be 0) and destroy the previous image if necessary.
     void MSWReplaceImageHandle(WXLPARAM handle);
 
-    // Delete the current handle only if we own it.
-    void DeleteCurrentHandleIfNeeded();
-
 
     wxDECLARE_DYNAMIC_CLASS(wxStaticBitmap);
     wxDECLARE_EVENT_TABLE();

--- a/include/wx/msw/statbmp.h
+++ b/include/wx/msw/statbmp.h
@@ -25,7 +25,20 @@ public:
 
     wxStaticBitmap(wxWindow *parent,
                    wxWindowID id,
-                   const wxGDIImage& label,
+                   const wxBitmap& label,
+                   const wxPoint& pos = wxDefaultPosition,
+                   const wxSize& size = wxDefaultSize,
+                   long style = 0,
+                   const wxString& name = wxASCII_STR(wxStaticBitmapNameStr))
+    {
+        Init();
+
+        Create(parent, id, label, pos, size, style, name);
+    }
+
+    wxStaticBitmap(wxWindow *parent,
+                   wxWindowID id,
+                   const wxIcon& label,
                    const wxPoint& pos = wxDefaultPosition,
                    const wxSize& size = wxDefaultSize,
                    long style = 0,
@@ -38,16 +51,34 @@ public:
 
     bool Create(wxWindow *parent,
                 wxWindowID id,
-                const wxGDIImage& label,
+                const wxBitmap& label,
                 const wxPoint& pos = wxDefaultPosition,
                 const wxSize& size = wxDefaultSize,
                 long style = 0,
-                const wxString& name = wxASCII_STR(wxStaticBitmapNameStr));
+                const wxString& name = wxASCII_STR(wxStaticBitmapNameStr))
+    {
+        m_bitmap = label;
+
+        return DoCreate(parent, id, pos, size, style, name);
+    }
+
+    bool Create(wxWindow *parent,
+                wxWindowID id,
+                const wxIcon& label,
+                const wxPoint& pos = wxDefaultPosition,
+                const wxSize& size = wxDefaultSize,
+                long style = 0,
+                const wxString& name = wxASCII_STR(wxStaticBitmapNameStr))
+    {
+        m_icon = label;
+
+        return DoCreate(parent, id, pos, size, style, name);
+    }
 
     virtual ~wxStaticBitmap() { Free(); }
 
-    virtual void SetIcon(const wxIcon& icon) wxOVERRIDE { SetImage(&icon); }
-    virtual void SetBitmap(const wxBitmap& bitmap) wxOVERRIDE { SetImage(&bitmap); }
+    virtual void SetIcon(const wxIcon& icon) wxOVERRIDE;
+    virtual void SetBitmap(const wxBitmap& bitmap) wxOVERRIDE;
     virtual wxBitmap GetBitmap() const wxOVERRIDE;
     virtual wxIcon GetIcon() const wxOVERRIDE;
 
@@ -59,15 +90,23 @@ public:
 protected:
     virtual wxSize DoGetBestClientSize() const wxOVERRIDE;
 
+private:
     // ctor/dtor helpers
     void Init();
     void Free();
 
-    // true if icon/bitmap is valid
-    bool ImageIsOk() const;
+    // common part of both Create() overloads
+    bool DoCreate(wxWindow *parent,
+                  wxWindowID id,
+                  const wxPoint& pos,
+                  const wxSize& size,
+                  long style,
+                  const wxString& name);
 
-    void SetImage(const wxGDIImage* image);
-    void SetImageNoCopy( wxGDIImage* image );
+    // update the image to correspond to the current m_icon or m_bitmap value,
+    // resize the control if the new size is different from the old one and
+    // update its style if the new "is icon" value differs from the old one
+    void DoUpdateImage(const wxSize& sizeOld, bool wasIcon);
 
     // draw the bitmap ourselves here if the OS can't do it correctly (if it
     // can we leave it to it)
@@ -75,14 +114,19 @@ protected:
 
     void WXHandleSize(wxSizeEvent& event);
 
-    // we can have either an icon or a bitmap
-    bool m_isIcon;
-    wxGDIImage *m_image;
+    // return the either m_icon or m_bitmap (may still be invalid of both of
+    // them are)
+    const wxGDIImage& GetImage() const;
+
+
+    // we can have either an icon or a bitmap: if m_icon is valid, it is used,
+    // otherwise m_bitmap is used if it is valid
+    wxIcon m_icon;
+    wxBitmap m_bitmap;
 
     // handle used in last call to STM_SETIMAGE
     WXHANDLE m_currentHandle;
 
-private:
     // Flag indicating whether we own m_currentHandle, i.e. should delete it.
     bool m_ownsCurrentHandle;
 

--- a/include/wx/msw/statbmp.h
+++ b/include/wx/msw/statbmp.h
@@ -132,7 +132,7 @@ private:
 
     // Replace the image at the native control level with the given HBITMAP or
     // HICON (which can be 0) and destroy the previous image if necessary.
-    void MSWReplaceImageHandle(WXLPARAM handle);
+    void MSWReplaceImageHandle(WXHANDLE handle);
 
 
     wxDECLARE_DYNAMIC_CLASS(wxStaticBitmap);

--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -586,7 +586,7 @@ public :
     static wxWidgetImplType*    CreateStaticBitmap( wxWindowMac* wxpeer,
                                                    wxWindowMac* parent,
                                                    wxWindowID id,
-                                                   const wxBitmap& bitmap,
+                                                   const wxBitmapBundle& bitmap,
                                                    const wxPoint& pos,
                                                    const wxSize& size,
                                                    long style,

--- a/include/wx/osx/statbmp.h
+++ b/include/wx/osx/statbmp.h
@@ -35,12 +35,6 @@ public:
     virtual ScaleMode GetScaleMode() const wxOVERRIDE { return m_scaleMode; }
 
 private:
-    wxSize GetBitmapSize()
-    {
-        return m_bitmap.IsOk() ? m_bitmap.GetScaledSize()
-        : wxSize(16, 16); // this is completely arbitrary
-    }
-
     void OnPaint(wxPaintEvent& event);
 
     wxBitmap m_bitmap;

--- a/include/wx/osx/statbmp.h
+++ b/include/wx/osx/statbmp.h
@@ -30,18 +30,6 @@ public:
 
     virtual wxBitmap GetBitmap() const wxOVERRIDE { return m_bitmap; }
 
-    virtual void SetIcon(const wxIcon& icon) wxOVERRIDE
-    {
-        wxBitmap bmp;
-        bmp.CopyFromIcon(icon);
-        SetBitmap(bmp);
-    }
-
-#if defined(__WXGTK20__) || defined(__WXMAC__)
-    // icons and bitmaps are really the same thing in wxGTK and wxMac
-    wxIcon GetIcon() const wxOVERRIDE  { return (const wxIcon &)m_bitmap; }
-#endif
-
     virtual void SetScaleMode(ScaleMode scaleMode) wxOVERRIDE;
 
     virtual ScaleMode GetScaleMode() const wxOVERRIDE { return m_scaleMode; }

--- a/include/wx/osx/statbmp.h
+++ b/include/wx/osx/statbmp.h
@@ -9,7 +9,7 @@ public:
     wxStaticBitmap() {}
     wxStaticBitmap(wxWindow *parent,
                           wxWindowID id,
-                          const wxBitmap& bitmap,
+                          const wxBitmapBundle& bitmap,
                           const wxPoint& pos = wxDefaultPosition,
                           const wxSize& size = wxDefaultSize,
                           long style = 0,
@@ -20,15 +20,13 @@ public:
 
     bool Create(wxWindow *parent,
                 wxWindowID id,
-                const wxBitmap& bitmap,
+                const wxBitmapBundle& bitmap,
                 const wxPoint& pos = wxDefaultPosition,
                 const wxSize& size = wxDefaultSize,
                 long style = 0,
                 const wxString& name = wxASCII_STR(wxStaticBitmapNameStr));
 
-    virtual void SetBitmap(const wxBitmap& bitmap) wxOVERRIDE;
-
-    virtual wxBitmap GetBitmap() const wxOVERRIDE { return m_bitmap; }
+    virtual void SetBitmap(const wxBitmapBundle& bitmap) wxOVERRIDE;
 
     virtual void SetScaleMode(ScaleMode scaleMode) wxOVERRIDE;
 
@@ -37,7 +35,6 @@ public:
 private:
     void OnPaint(wxPaintEvent& event);
 
-    wxBitmap m_bitmap;
     ScaleMode m_scaleMode;
 
     wxDECLARE_DYNAMIC_CLASS(wxStaticBitmap);

--- a/include/wx/qt/statbmp.h
+++ b/include/wx/qt/statbmp.h
@@ -16,7 +16,7 @@ public:
     wxStaticBitmap();
     wxStaticBitmap( wxWindow *parent,
                     wxWindowID id,
-                    const wxBitmap& label,
+                    const wxBitmapBundle& label,
                     const wxPoint& pos = wxDefaultPosition,
                     const wxSize& size = wxDefaultSize,
                     long style = 0,
@@ -24,13 +24,13 @@ public:
 
     bool Create( wxWindow *parent,
                  wxWindowID id,
-                 const wxBitmap& label,
+                 const wxBitmapBundle& label,
                  const wxPoint& pos = wxDefaultPosition,
                  const wxSize& size = wxDefaultSize,
                  long style = 0,
                  const wxString& name = wxASCII_STR(wxStaticBitmapNameStr));
 
-    virtual void SetBitmap(const wxBitmap& bitmap) wxOVERRIDE;
+    virtual void SetBitmap(const wxBitmapBundle& bitmap) wxOVERRIDE;
     virtual wxBitmap GetBitmap() const wxOVERRIDE;
 
     virtual QWidget *GetHandle() const wxOVERRIDE;

--- a/include/wx/qt/statbmp.h
+++ b/include/wx/qt/statbmp.h
@@ -30,10 +30,8 @@ public:
                  long style = 0,
                  const wxString& name = wxASCII_STR(wxStaticBitmapNameStr));
 
-    virtual void SetIcon(const wxIcon& icon) wxOVERRIDE;
     virtual void SetBitmap(const wxBitmap& bitmap) wxOVERRIDE;
     virtual wxBitmap GetBitmap() const wxOVERRIDE;
-    virtual wxIcon GetIcon() const wxOVERRIDE;
 
     virtual QWidget *GetHandle() const wxOVERRIDE;
 protected:

--- a/include/wx/statbmp.h
+++ b/include/wx/statbmp.h
@@ -16,7 +16,7 @@
 #if wxUSE_STATBMP
 
 #include "wx/control.h"
-#include "wx/bitmap.h"
+#include "wx/bmpbndl.h"
 #include "wx/icon.h"
 
 extern WXDLLIMPEXP_DATA_CORE(const char) wxStaticBitmapNameStr[];
@@ -37,8 +37,8 @@ public:
     virtual ~wxStaticBitmapBase();
 
     // our interface
-    virtual void SetBitmap(const wxBitmap& bitmap) = 0;
-    virtual wxBitmap GetBitmap() const = 0;
+    virtual void SetBitmap(const wxBitmapBundle& bitmap) = 0;
+    virtual wxBitmap GetBitmap() const;
 
     virtual void SetIcon(const wxIcon& icon);
     virtual wxIcon GetIcon() const;
@@ -55,6 +55,9 @@ protected:
     virtual wxBorder GetDefaultBorder() const wxOVERRIDE { return wxBORDER_NONE; }
 
     virtual wxSize DoGetBestSize() const wxOVERRIDE;
+
+    // Bitmap bundle passed to ctor or SetBitmap().
+    wxBitmapBundle m_bitmapBundle;
 
     wxDECLARE_NO_COPY_CLASS(wxStaticBitmapBase);
 };

--- a/include/wx/statbmp.h
+++ b/include/wx/statbmp.h
@@ -37,15 +37,12 @@ public:
     virtual ~wxStaticBitmapBase();
 
     // our interface
-    virtual void SetIcon(const wxIcon& icon) = 0;
     virtual void SetBitmap(const wxBitmap& bitmap) = 0;
     virtual wxBitmap GetBitmap() const = 0;
-    virtual wxIcon GetIcon() const /* = 0 -- should be pure virtual */
-    {
-        // stub it out here for now as not all ports implement it (but they
-        // should)
-        return wxIcon();
-    }
+
+    virtual void SetIcon(const wxIcon& icon);
+    virtual wxIcon GetIcon() const;
+
     virtual void SetScaleMode(ScaleMode WXUNUSED(scaleMode)) { }
     virtual ScaleMode GetScaleMode() const { return Scale_None; }
 

--- a/include/wx/univ/statbmp.h
+++ b/include/wx/univ/statbmp.h
@@ -25,7 +25,7 @@ public:
     }
 
     wxStaticBitmap(wxWindow *parent,
-                   const wxBitmap& label,
+                   const wxBitmapBundle& label,
                    const wxPoint& pos = wxDefaultPosition,
                    const wxSize& size = wxDefaultSize,
                    long style = 0)
@@ -35,7 +35,7 @@ public:
 
     wxStaticBitmap(wxWindow *parent,
                    wxWindowID id,
-                   const wxBitmap& label,
+                   const wxBitmapBundle& label,
                    const wxPoint& pos = wxDefaultPosition,
                    const wxSize& size = wxDefaultSize,
                    long style = 0,
@@ -46,14 +46,13 @@ public:
 
     bool Create(wxWindow *parent,
                 wxWindowID id,
-                const wxBitmap& label,
+                const wxBitmapBundle& label,
                 const wxPoint& pos = wxDefaultPosition,
                 const wxSize& size = wxDefaultSize,
                 long style = 0,
                 const wxString& name = wxASCII_STR(wxStaticBitmapNameStr));
 
-    virtual void SetBitmap(const wxBitmap& bitmap) wxOVERRIDE;
-    virtual wxBitmap GetBitmap() const wxOVERRIDE { return m_bitmap; }
+    virtual void SetBitmap(const wxBitmapBundle& bitmap) wxOVERRIDE;
 
     virtual bool HasTransparentBackground() wxOVERRIDE { return true; }
 
@@ -61,9 +60,6 @@ protected:
     virtual void DoDraw(wxControlRenderer *renderer) wxOVERRIDE;
 
 private:
-    // the bitmap which we show
-    wxBitmap m_bitmap;
-
     wxDECLARE_DYNAMIC_CLASS(wxStaticBitmap);
 };
 

--- a/include/wx/univ/statbmp.h
+++ b/include/wx/univ/statbmp.h
@@ -53,10 +53,7 @@ public:
                 const wxString& name = wxASCII_STR(wxStaticBitmapNameStr));
 
     virtual void SetBitmap(const wxBitmap& bitmap) wxOVERRIDE;
-    virtual void SetIcon(const wxIcon& icon) wxOVERRIDE;
     virtual wxBitmap GetBitmap() const wxOVERRIDE { return m_bitmap; }
-
-    wxIcon GetIcon() const wxOVERRIDE;
 
     virtual bool HasTransparentBackground() wxOVERRIDE { return true; }
 

--- a/interface/wx/bmpbndl.h
+++ b/interface/wx/bmpbndl.h
@@ -288,6 +288,19 @@ public:
         consume resources until the application termination.
      */
     wxBitmap GetBitmap(const wxSize& size) const;
+
+    /**
+        Get bitmap of the size appropriate for the DPI scaling used by the
+        given window.
+
+        This helper function simply combines GetBitmap() and
+        GetPreferredSizeFor(), i.e. it returns a (normally unscaled) bitmap
+        from the bundle of the closest size to the size that should be used at
+        the DPI scaling of the provided window.
+
+        @param window Non-null and fully created window.
+     */
+    wxBitmap GetBitmapFor(const wxWindow* window) const;
 };
 
 /**

--- a/interface/wx/bmpbndl.h
+++ b/interface/wx/bmpbndl.h
@@ -275,7 +275,7 @@ public:
 
         @param window Non-null and fully created window.
      */
-    wxSize GetPreferredSizeFor(wxWindow* window) const;
+    wxSize GetPreferredSizeFor(const wxWindow* window) const;
 
     /**
         Get bitmap of the specified size, creating a new bitmap from the closest

--- a/src/common/bmpbndl.cpp
+++ b/src/common/bmpbndl.cpp
@@ -407,6 +407,11 @@ wxBitmap wxBitmapBundle::GetBitmap(const wxSize& size) const
     return bmp;
 }
 
+wxBitmap wxBitmapBundle::GetBitmapFor(const wxWindow* window) const
+{
+    return GetBitmap(GetPreferredSizeFor(window));
+}
+
 // ============================================================================
 // wxBitmapBundleImpl implementation
 // ============================================================================

--- a/src/common/bmpbndl.cpp
+++ b/src/common/bmpbndl.cpp
@@ -375,7 +375,7 @@ wxSize wxBitmapBundle::GetDefaultSize() const
     return m_impl->GetDefaultSize();
 }
 
-wxSize wxBitmapBundle::GetPreferredSizeFor(wxWindow* window) const
+wxSize wxBitmapBundle::GetPreferredSizeFor(const wxWindow* window) const
 {
     wxCHECK_MSG( window, wxDefaultSize, "window must be valid" );
 

--- a/src/common/ctrlcmn.cpp
+++ b/src/common/ctrlcmn.cpp
@@ -620,24 +620,4 @@ wxString wxControlBase::Ellipsize(const wxString& label, const wxDC& dc,
     return ret;
 }
 
-// ----------------------------------------------------------------------------
-// wxStaticBitmap
-// ----------------------------------------------------------------------------
-
-#if wxUSE_STATBMP
-
-wxStaticBitmapBase::~wxStaticBitmapBase()
-{
-    // this destructor is required for Darwin
-}
-
-wxSize wxStaticBitmapBase::DoGetBestSize() const
-{
-    // the fall back size is completely arbitrary
-    const wxBitmap bmp = GetBitmap();
-    return bmp.IsOk() ? bmp.GetScaledSize() : wxSize(16, 16);
-}
-
-#endif // wxUSE_STATBMP
-
 #endif // wxUSE_CONTROLS

--- a/src/common/statbmpcmn.cpp
+++ b/src/common/statbmpcmn.cpp
@@ -96,4 +96,38 @@ wxSize wxStaticBitmapBase::DoGetBestSize() const
     return bmp.IsOk() ? bmp.GetScaledSize() : wxSize(16, 16);
 }
 
+// Only wxMSW handles icons and bitmaps differently, in all the other ports
+// they are exactly the same thing.
+#ifdef wxICON_IS_BITMAP
+
+void wxStaticBitmapBase::SetIcon(const wxIcon& icon)
+{
+    SetBitmap(icon);
+}
+
+wxIcon wxStaticBitmapBase::GetIcon() const
+{
+    wxIcon icon;
+    icon.CopyFromBitmap(GetBitmap());
+    return icon;
+}
+
+#else // !wxICON_IS_BITMAP
+
+// Just provide the stabs for them, they're never used anyhow as they're
+// overridden in wxMSW implementation of this class.
+void wxStaticBitmapBase::SetIcon(const wxIcon& WXUNUSED(icon))
+{
+    wxFAIL_MSG(wxS("unreachable"));
+}
+
+wxIcon wxStaticBitmapBase::GetIcon() const
+{
+    wxFAIL_MSG(wxS("unreachable"));
+
+    return wxIcon();
+}
+
+#endif // wxICON_IS_BITMAP/!wxICON_IS_BITMAP
+
 #endif // wxUSE_STATBMP

--- a/src/common/statbmpcmn.cpp
+++ b/src/common/statbmpcmn.cpp
@@ -80,4 +80,20 @@ wxCONSTRUCTOR_5( wxStaticBitmap, wxWindow*, Parent, wxWindowID, Id, \
         bitmap
 */
 
+// ----------------------------------------------------------------------------
+// wxStaticBitmap
+// ----------------------------------------------------------------------------
+
+wxStaticBitmapBase::~wxStaticBitmapBase()
+{
+    // this destructor is required for Darwin
+}
+
+wxSize wxStaticBitmapBase::DoGetBestSize() const
+{
+    // the fall back size is completely arbitrary
+    const wxBitmap bmp = GetBitmap();
+    return bmp.IsOk() ? bmp.GetScaledSize() : wxSize(16, 16);
+}
+
 #endif // wxUSE_STATBMP

--- a/src/generic/statbmpg.cpp
+++ b/src/generic/statbmpg.cpp
@@ -55,7 +55,7 @@ void wxGenericStaticBitmap::OnPaint(wxPaintEvent& WXUNUSED(event))
     if ( !drawSize.x || !drawSize.y )
         return;
 
-    const wxBitmap bitmap = GetBitmap();
+    wxBitmap bitmap = GetBitmap();
     const wxSize bmpSize = bitmap.GetSize();
     wxDouble w = 0;
     wxDouble h = 0;
@@ -96,9 +96,8 @@ void wxGenericStaticBitmap::OnPaint(wxPaintEvent& WXUNUSED(event))
         gc(wxGraphicsRenderer::GetDefaultRenderer()->CreateContext(dc));
     gc->DrawBitmap(bitmap, x, y, w, h);
 #else
-    wxImage img = bitmap.ConvertToImage();
-    img.Rescale(wxRound(w), wxRound(h), wxIMAGE_QUALITY_HIGH);
-    dc.DrawBitmap(wxBitmap(img), wxRound(x), wxRound(y), true);
+    wxBitmap::Rescale(bitmap, wxSize(wxRound(w), wxRound(h)));
+    dc.DrawBitmap(bitmap, wxRound(x), wxRound(y), true);
 #endif
 }
 

--- a/src/generic/statbmpg.cpp
+++ b/src/generic/statbmpg.cpp
@@ -34,7 +34,13 @@ bool wxGenericStaticBitmap::Create(wxWindow *parent, wxWindowID id,
                             wxDefaultValidator, name))
         return false;
     m_scaleMode = Scale_None;
-    SetBitmap(bitmap);
+
+    // Don't call SetBitmap() here, as it changes the size and refreshes the
+    // window unnecessarily, when we don't need either of these side effects
+    // here.
+    m_bitmap = bitmap;
+    SetInitialSize(size);
+
     Bind(wxEVT_PAINT, &wxGenericStaticBitmap::OnPaint, this);
     return true;
 }

--- a/src/generic/statbmpg.cpp
+++ b/src/generic/statbmpg.cpp
@@ -26,7 +26,7 @@
 #endif
 
 bool wxGenericStaticBitmap::Create(wxWindow *parent, wxWindowID id,
-                                   const wxBitmap& bitmap,
+                                   const wxBitmapBundle& bitmap,
                                    const wxPoint& pos, const wxSize& size,
                                    long style, const wxString& name)
 {
@@ -38,7 +38,7 @@ bool wxGenericStaticBitmap::Create(wxWindow *parent, wxWindowID id,
     // Don't call SetBitmap() here, as it changes the size and refreshes the
     // window unnecessarily, when we don't need either of these side effects
     // here.
-    m_bitmap = bitmap;
+    m_bitmapBundle = bitmap;
     SetInitialSize(size);
 
     Bind(wxEVT_PAINT, &wxGenericStaticBitmap::OnPaint, this);
@@ -47,7 +47,7 @@ bool wxGenericStaticBitmap::Create(wxWindow *parent, wxWindowID id,
 
 void wxGenericStaticBitmap::OnPaint(wxPaintEvent& WXUNUSED(event))
 {
-    if ( !m_bitmap.IsOk() )
+    if ( !m_bitmapBundle.IsOk() )
         return;
 
     wxPaintDC dc(this);
@@ -55,13 +55,14 @@ void wxGenericStaticBitmap::OnPaint(wxPaintEvent& WXUNUSED(event))
     if ( !drawSize.x || !drawSize.y )
         return;
 
-    const wxSize bmpSize = m_bitmap.GetSize();
+    const wxBitmap bitmap = GetBitmap();
+    const wxSize bmpSize = bitmap.GetSize();
     wxDouble w = 0;
     wxDouble h = 0;
     switch ( m_scaleMode )
     {
         case Scale_None:
-            dc.DrawBitmap(m_bitmap, 0, 0, true);
+            dc.DrawBitmap(bitmap, 0, 0, true);
             return;
         case Scale_Fill:
             w = drawSize.x;
@@ -93,9 +94,9 @@ void wxGenericStaticBitmap::OnPaint(wxPaintEvent& WXUNUSED(event))
 #if wxUSE_GRAPHICS_CONTEXT
     wxScopedPtr<wxGraphicsContext> const
         gc(wxGraphicsRenderer::GetDefaultRenderer()->CreateContext(dc));
-    gc->DrawBitmap(m_bitmap, x, y, w, h);
+    gc->DrawBitmap(bitmap, x, y, w, h);
 #else
-    wxImage img = m_bitmap.ConvertToImage();
+    wxImage img = bitmap.ConvertToImage();
     img.Rescale(wxRound(w), wxRound(h), wxIMAGE_QUALITY_HIGH);
     dc.DrawBitmap(wxBitmap(img), wxRound(x), wxRound(y), true);
 #endif

--- a/src/gtk/statbmp.cpp
+++ b/src/gtk/statbmp.cpp
@@ -24,14 +24,14 @@ wxStaticBitmap::wxStaticBitmap(void)
 {
 }
 
-wxStaticBitmap::wxStaticBitmap( wxWindow *parent, wxWindowID id, const wxBitmap &bitmap,
+wxStaticBitmap::wxStaticBitmap( wxWindow *parent, wxWindowID id, const wxBitmapBundle &bitmap,
       const wxPoint &pos, const wxSize &size,
       long style, const wxString &name )
 {
     Create( parent, id, bitmap, pos, size, style, name );
 }
 
-bool wxStaticBitmap::Create( wxWindow *parent, wxWindowID id, const wxBitmap &bitmap,
+bool wxStaticBitmap::Create( wxWindow *parent, wxWindowID id, const wxBitmapBundle &bitmap,
                              const wxPoint &pos, const wxSize &size,
                              long style, const wxString &name )
 {
@@ -54,12 +54,14 @@ bool wxStaticBitmap::Create( wxWindow *parent, wxWindowID id, const wxBitmap &bi
     return true;
 }
 
-void wxStaticBitmap::SetBitmap( const wxBitmap &bitmap )
+void wxStaticBitmap::SetBitmap( const wxBitmapBundle &bitmap )
 {
-    const wxSize sizeOld(m_bitmap.IsOk() ? m_bitmap.GetSize() : wxSize());
-    const wxSize sizeNew(bitmap.IsOk() ? bitmap.GetSize() : wxSize());
+    const wxSize sizeOld(DoGetBestSize());
 
-    m_bitmap = bitmap;
+    m_bitmapBundle = bitmap;
+
+    const wxSize sizeNew(DoGetBestSize());
+
     WX_GTK_IMAGE(m_widget)->Set(bitmap);
 
     if (sizeNew != sizeOld)

--- a/src/gtk1/statbmp.cpp
+++ b/src/gtk1/statbmp.cpp
@@ -24,7 +24,7 @@ wxStaticBitmap::wxStaticBitmap(void)
 {
 }
 
-wxStaticBitmap::wxStaticBitmap( wxWindow *parent, wxWindowID id, const wxBitmap &bitmap,
+wxStaticBitmap::wxStaticBitmap( wxWindow *parent, wxWindowID id, const wxBitmapBundle &bitmap,
       const wxPoint &pos, const wxSize &size,
       long style, const wxString &name )
 {
@@ -38,7 +38,7 @@ static char * bogus_xpm[] = {
 "  ",
 "  "};
 
-bool wxStaticBitmap::Create( wxWindow *parent, wxWindowID id, const wxBitmap &bitmap,
+bool wxStaticBitmap::Create( wxWindow *parent, wxWindowID id, const wxBitmapBundle &bitmap,
                              const wxPoint &pos, const wxSize &size,
                              long style, const wxString &name )
 {
@@ -52,6 +52,7 @@ bool wxStaticBitmap::Create( wxWindow *parent, wxWindowID id, const wxBitmap &bi
     }
 
     m_bitmap = bitmap;
+    m_bitmapBundle = bitmap;
 
     wxBitmap bmp(bitmap.IsOk() ? bitmap : wxBitmap(bogus_xpm));
     m_widget = gtk_pixmap_new(bmp.GetPixmap(), NULL);
@@ -65,9 +66,10 @@ bool wxStaticBitmap::Create( wxWindow *parent, wxWindowID id, const wxBitmap &bi
     return true;
 }
 
-void wxStaticBitmap::SetBitmap( const wxBitmap &bitmap )
+void wxStaticBitmap::SetBitmap( const wxBitmapBundle &bitmap )
 {
-    m_bitmap = bitmap;
+    m_bitmapBundle = bitmap;
+    m_bitmap = bitmap.GetBitmapFor(this);
 
     if (m_bitmap.IsOk())
     {

--- a/src/motif/statbmp.cpp
+++ b/src/motif/statbmp.cpp
@@ -58,9 +58,9 @@ bool wxStaticBitmap::Create(wxWindow *parent, wxWindowID id,
     wxSize actualSize(size);
     // work around the cases where the bitmap is a wxNull(Icon/Bitmap)
     if (actualSize.x == -1)
-        actualSize.x = bitmap.IsOk() ? bitmap.GetWidth() : 1;
+        actualSize.x = bitmap.IsOk() ? bitmap.GetWidth() : 16;
     if (actualSize.y == -1)
-        actualSize.y = bitmap.IsOk() ? bitmap.GetHeight() : 1;
+        actualSize.y = bitmap.IsOk() ? bitmap.GetHeight() : 16;
 
     PostCreation();
     DoSetBitmap();

--- a/src/motif/statbmp.cpp
+++ b/src/motif/statbmp.cpp
@@ -30,7 +30,7 @@
  */
 
 bool wxStaticBitmap::Create(wxWindow *parent, wxWindowID id,
-           const wxBitmap& bitmap,
+           const wxBitmapBundle& bitmap,
            const wxPoint& pos,
            const wxSize& size,
            long style,
@@ -41,7 +41,6 @@ bool wxStaticBitmap::Create(wxWindow *parent, wxWindowID id,
         return false;
     PreCreation();
 
-    m_messageBitmap = bitmap;
     m_messageBitmapOriginal = bitmap;
 
     Widget parentWidget = (Widget) parent->GetClientWidget();
@@ -58,9 +57,9 @@ bool wxStaticBitmap::Create(wxWindow *parent, wxWindowID id,
     wxSize actualSize(size);
     // work around the cases where the bitmap is a wxNull(Icon/Bitmap)
     if (actualSize.x == -1)
-        actualSize.x = bitmap.IsOk() ? bitmap.GetWidth() : 16;
+        actualSize.x = bitmap.IsOk() ? bitmap.GetDefaultSize().x : 16;
     if (actualSize.y == -1)
-        actualSize.y = bitmap.IsOk() ? bitmap.GetHeight() : 16;
+        actualSize.y = bitmap.IsOk() ? bitmap.GetDefaultSize().y : 16;
 
     PostCreation();
     DoSetBitmap();
@@ -80,16 +79,17 @@ void wxStaticBitmap::DoSetBitmap()
     Widget widget = (Widget) m_mainWidget;
     int w2, h2;
 
-    if (m_messageBitmapOriginal.IsOk())
+    wxBitmap bitmapOriginal = m_messageBitmapOriginal.GetBitmap(wxDefaultSize);
+    if (bitmapOriginal.IsOk())
     {
-        w2 = m_messageBitmapOriginal.GetWidth();
-        h2 = m_messageBitmapOriginal.GetHeight();
+        w2 = bitmapOriginal.GetWidth();
+        h2 = bitmapOriginal.GetHeight();
 
         Pixmap pixmap;
 
         // Must re-make the bitmap to have its transparent areas drawn
         // in the current widget background colour.
-        if (m_messageBitmapOriginal.GetMask())
+        if (bitmapOriginal.GetMask())
         {
             WXPixel backgroundPixel;
             XtVaGetValues( widget, XmNbackground, &backgroundPixel,
@@ -98,13 +98,14 @@ void wxStaticBitmap::DoSetBitmap()
             wxColour col;
             col.SetPixel(backgroundPixel);
 
-            wxBitmap newBitmap = wxCreateMaskedBitmap(m_messageBitmapOriginal, col);
+            wxBitmap newBitmap = wxCreateMaskedBitmap(bitmapOriginal, col);
             m_messageBitmap = newBitmap;
 
             pixmap = (Pixmap) m_messageBitmap.GetDrawable();
         }
         else
         {
+            m_messageBitmap = bitmapOriginal;
             m_bitmapCache.SetBitmap( m_messageBitmap );
             pixmap = (Pixmap)m_bitmapCache.GetLabelPixmap(widget);
         }
@@ -127,9 +128,8 @@ void wxStaticBitmap::DoSetBitmap()
     }
 }
 
-void wxStaticBitmap::SetBitmap(const wxBitmap& bitmap)
+void wxStaticBitmap::SetBitmap(const wxBitmapBundle& bitmap)
 {
-    m_messageBitmap = bitmap;
     m_messageBitmapOriginal = bitmap;
 
     DoSetBitmap();

--- a/src/msw/statbmp.cpp
+++ b/src/msw/statbmp.cpp
@@ -221,7 +221,7 @@ void wxStaticBitmap::DoPaintManually(wxPaintEvent& WXUNUSED(event))
                   true /* use mask */);
 }
 
-void wxStaticBitmap::MSWReplaceImageHandle(WXLPARAM handle)
+void wxStaticBitmap::MSWReplaceImageHandle(WXHANDLE handle)
 {
     HGDIOBJ oldHandle = (HGDIOBJ)::SendMessage(GetHwnd(), STM_SETIMAGE,
                   m_icon.IsOk() ? IMAGE_ICON : IMAGE_BITMAP, (LPARAM)handle);
@@ -271,7 +271,7 @@ void wxStaticBitmap::DoUpdateImage(const wxSize& sizeOld, bool wasIcon)
             .TurnOn(isIcon ? SS_ICON : SS_BITMAP);
     }
 
-    MSWReplaceImageHandle((WXLPARAM)handle);
+    MSWReplaceImageHandle(handle);
 
     m_currentHandle = (WXHANDLE)handle;
     m_ownsCurrentHandle = handle != handleOrig;

--- a/src/msw/statbmp.cpp
+++ b/src/msw/statbmp.cpp
@@ -45,6 +45,7 @@
 
 wxBEGIN_EVENT_TABLE(wxStaticBitmap, wxStaticBitmapBase)
     EVT_SIZE(wxStaticBitmap::WXHandleSize)
+    EVT_DPI_CHANGED(wxStaticBitmap::WXHandleDPIChanged)
 wxEND_EVENT_TABLE()
 
 // ===========================================================================
@@ -186,6 +187,16 @@ void wxStaticBitmap::WXHandleSize(wxSizeEvent& event)
     // Invalidate everything when our size changes as the image position (it's
     // drawn centred in the window client area) changes.
     Refresh();
+
+    event.Skip();
+}
+
+void wxStaticBitmap::WXHandleDPIChanged(wxDPIChangedEvent& event)
+{
+    // Icons only exist in a single resolution, so don't bother updating in
+    // this case.
+    if ( !m_icon.IsOk() && m_bitmapBundle.IsOk() )
+        DoUpdateImage(wxSize(), false /* not using an icon */);
 
     event.Skip();
 }

--- a/src/msw/statbmp.cpp
+++ b/src/msw/statbmp.cpp
@@ -191,20 +191,15 @@ void wxStaticBitmap::Init()
     m_ownsCurrentHandle = false;
 }
 
-void wxStaticBitmap::DeleteCurrentHandleIfNeeded()
+void wxStaticBitmap::Free()
 {
+    MSWReplaceImageHandle(0);
+
     if ( m_ownsCurrentHandle )
     {
         ::DeleteObject(m_currentHandle);
         m_ownsCurrentHandle = false;
     }
-}
-
-void wxStaticBitmap::Free()
-{
-    MSWReplaceImageHandle(0);
-
-    DeleteCurrentHandleIfNeeded();
 
     wxDELETE(m_image);
 }

--- a/src/osx/cocoa/statbmp.mm
+++ b/src/osx/cocoa/statbmp.mm
@@ -106,7 +106,7 @@ void wxStaticBitmap::SetScaleMode(ScaleMode scaleMode)
 wxWidgetImplType* wxWidgetImpl::CreateStaticBitmap( wxWindowMac* wxpeer,
                                                    wxWindowMac* WXUNUSED(parent),
                                                    wxWindowID WXUNUSED(id),
-                                                   const wxBitmap& WXUNUSED(bitmap),
+                                                   const wxBitmapBundle& WXUNUSED(bitmap),
                                                    const wxPoint& pos,
                                                    const wxSize& size,
                                                    long WXUNUSED(style),

--- a/src/osx/iphone/statbmp.mm
+++ b/src/osx/iphone/statbmp.mm
@@ -82,7 +82,7 @@ void wxStaticBitmap::SetScaleMode(ScaleMode scaleMode)
 wxWidgetImplType* wxWidgetImpl::CreateStaticBitmap( wxWindowMac* wxpeer,
                                                    wxWindowMac* WXUNUSED(parent),
                                                    wxWindowID WXUNUSED(id),
-                                                   const wxBitmap& bitmap,
+                                                   const wxBitmapBundle& WXUNUSED(bitmap),
                                                    const wxPoint& pos,
                                                    const wxSize& size,
                                                    long WXUNUSED(style),

--- a/src/osx/statbmp_osx.cpp
+++ b/src/osx/statbmp_osx.cpp
@@ -29,7 +29,7 @@
 
 bool wxStaticBitmap::Create(wxWindow *parent,
                             wxWindowID id,
-                            const wxBitmap& bitmap,
+                            const wxBitmapBundle& bitmap,
                             const wxPoint& pos,
                             const wxSize& size,
                             long style,
@@ -49,7 +49,7 @@ bool wxStaticBitmap::Create(wxWindow *parent,
 
     // Don't call SetBitmap() here, as we don't need to change the size nor
     // refresh the window here.
-    m_bitmap = bitmap;
+    m_bitmapBundle = bitmap;
     GetPeer()->SetBitmap(bitmap);
 
     SetInitialSize(size);
@@ -58,9 +58,9 @@ bool wxStaticBitmap::Create(wxWindow *parent,
 }
 
 
-void wxStaticBitmap::SetBitmap(const wxBitmap& bitmap)
+void wxStaticBitmap::SetBitmap(const wxBitmapBundle& bitmap)
 {
-    m_bitmap = bitmap;
+    m_bitmapBundle = bitmap;
     GetPeer()->SetBitmap(bitmap);
 
     InvalidateBestSize();

--- a/src/osx/statbmp_osx.cpp
+++ b/src/osx/statbmp_osx.cpp
@@ -47,7 +47,12 @@ bool wxStaticBitmap::Create(wxWindow *parent,
 
     MacPostControlCreate( pos, size );
 
-    SetBitmap(bitmap);
+    // Don't call SetBitmap() here, as we don't need to change the size nor
+    // refresh the window here.
+    m_bitmap = bitmap;
+    GetPeer()->SetBitmap(bitmap);
+
+    SetInitialSize(size);
 
     return true;
 }
@@ -56,10 +61,10 @@ bool wxStaticBitmap::Create(wxWindow *parent,
 void wxStaticBitmap::SetBitmap(const wxBitmap& bitmap)
 {
     m_bitmap = bitmap;
-    SetInitialSize(GetBitmapSize());
-
     GetPeer()->SetBitmap(bitmap);
 
+    InvalidateBestSize();
+    SetSize(GetBestSize());
     Refresh();
 }
 

--- a/src/qt/statbmp.cpp
+++ b/src/qt/statbmp.cpp
@@ -28,7 +28,7 @@ wxStaticBitmap::wxStaticBitmap() :
 
 wxStaticBitmap::wxStaticBitmap( wxWindow *parent,
                 wxWindowID id,
-                const wxBitmap& label,
+                const wxBitmapBundle& label,
                 const wxPoint& pos,
                 const wxSize& size,
                 long style,
@@ -39,7 +39,7 @@ wxStaticBitmap::wxStaticBitmap( wxWindow *parent,
 
 bool wxStaticBitmap::Create( wxWindow *parent,
              wxWindowID id,
-             const wxBitmap& label,
+             const wxBitmapBundle& label,
              const wxPoint& pos,
              const wxSize& size,
              long style,
@@ -57,9 +57,9 @@ static void SetPixmap( QLabel *label, const QPixmap *pixMap )
         label->setPixmap( *pixMap );
 }
 
-void wxStaticBitmap::SetBitmap(const wxBitmap& bitmap)
+void wxStaticBitmap::SetBitmap(const wxBitmapBundle& bitmap)
 {
-    SetPixmap( m_qtLabel, bitmap.GetHandle() );
+    SetPixmap( m_qtLabel, bitmap.GetBitmapFor(this).GetHandle() );
 }
 
 wxBitmap wxStaticBitmap::GetBitmap() const

--- a/src/qt/statbmp.cpp
+++ b/src/qt/statbmp.cpp
@@ -57,11 +57,6 @@ static void SetPixmap( QLabel *label, const QPixmap *pixMap )
         label->setPixmap( *pixMap );
 }
 
-void wxStaticBitmap::SetIcon(const wxIcon& icon)
-{
-    SetPixmap( m_qtLabel, icon.GetHandle() );
-}
-
 void wxStaticBitmap::SetBitmap(const wxBitmap& bitmap)
 {
     SetPixmap( m_qtLabel, bitmap.GetHandle() );
@@ -74,13 +69,6 @@ wxBitmap wxStaticBitmap::GetBitmap() const
         return wxBitmap( *pix );
     else
         return wxBitmap();
-}
-
-wxIcon wxStaticBitmap::GetIcon() const
-{
-    wxIcon icon;
-    icon.CopyFromBitmap( GetBitmap() );
-    return icon;
 }
 
 QWidget *wxStaticBitmap::GetHandle() const

--- a/src/univ/statbmp.cpp
+++ b/src/univ/statbmp.cpp
@@ -67,6 +67,10 @@ bool wxStaticBitmap::Create(wxWindow *parent,
 void wxStaticBitmap::SetBitmap(const wxBitmap& bitmap)
 {
     m_bitmap = bitmap;
+
+    InvalidateBestSize();
+    SetSize(GetBestSize());
+    Refresh();
 }
 
 // ----------------------------------------------------------------------------

--- a/src/univ/statbmp.cpp
+++ b/src/univ/statbmp.cpp
@@ -69,26 +69,6 @@ void wxStaticBitmap::SetBitmap(const wxBitmap& bitmap)
     m_bitmap = bitmap;
 }
 
-void wxStaticBitmap::SetIcon(const wxIcon& icon)
-{
-#ifdef __WXMSW__
-    m_bitmap.CopyFromIcon(icon);
-#else
-    m_bitmap = (const wxBitmap&)icon;
-#endif
-}
-
-wxIcon wxStaticBitmap::GetIcon() const
-{
-    wxIcon icon;
-#ifdef __WXMSW__
-    icon.CopyFromBitmap(m_bitmap);
-#else
-    icon = (const wxIcon&)m_bitmap;
-#endif
-    return icon;
-}
-
 // ----------------------------------------------------------------------------
 // drawing
 // ----------------------------------------------------------------------------

--- a/src/univ/statbmp.cpp
+++ b/src/univ/statbmp.cpp
@@ -42,7 +42,7 @@
 
 bool wxStaticBitmap::Create(wxWindow *parent,
                             wxWindowID id,
-                            const wxBitmap &label,
+                            const wxBitmapBundle &label,
                             const wxPoint &pos,
                             const wxSize &size,
                             long style,
@@ -64,9 +64,9 @@ bool wxStaticBitmap::Create(wxWindow *parent,
 // bitmap/icon setting/getting and converting between
 // ----------------------------------------------------------------------------
 
-void wxStaticBitmap::SetBitmap(const wxBitmap& bitmap)
+void wxStaticBitmap::SetBitmap(const wxBitmapBundle& bitmap)
 {
-    m_bitmap = bitmap;
+    m_bitmapBundle = bitmap;
 
     InvalidateBestSize();
     SetSize(GetBestSize());


### PR DESCRIPTION
Unfortunately this was less simple than I thought because it required clearing the mess with icons/bitmaps in different ports first.

It also uncovered another problem: not only converting scaled bitmaps to `wxBitmapBundle` doesn't work correctly, but going in the other direction doesn't work as expected neither and `wxGenericStaticBitmap` draws upscaled bitmaps twice bigger than necessary in high DPI since I've updated it to get the bitmap from bundle in non-MSW ports (i.e. GTK 3 and Mac). This probably means that we should either return scaled bitmaps from `wxBitmapBundle` or pass the scale to `DrawBitmap()` as another argument. I don't like neither approach very much, but how else can generic code doing what `wxGenericStaticBitmap` does be written?