### PR TITLE
Add IconText column to dataview sample

### DIFF
--- a/samples/dataview/dataview.cpp
+++ b/samples/dataview/dataview.cpp
@@ -904,6 +904,16 @@ void MyFrame::BuildDataViewCtrl(wxPanel* parent, unsigned int nPanel,
             const int alignment = modelFlags & wxALIGN_MASK;
             colCheckIconText->GetRenderer()->SetAlignment(alignment);
 
+            wxDataViewColumn* const colIconText = new wxDataViewColumn
+                (
+                     L"icon + text",
+                     new wxDataViewIconTextRenderer(),
+                     MyListModel::Col_IconText,
+                     wxCOL_WIDTH_AUTOSIZE
+                );
+            m_ctrl[Page_List]->AppendColumn(colIconText);
+            colIconText->GetRenderer()->SetAlignment(alignment);
+
             wxDataViewColumn* const colEditable =
                 m_ctrl[Page_List]->AppendTextColumn("editable string",
                                         MyListModel::Col_EditableText,

--- a/samples/dataview/mymodels.cpp
+++ b/samples/dataview/mymodels.cpp
@@ -478,6 +478,22 @@ void MyListModel::GetValueByRow( wxVariant &variant,
             }
             break;
 
+        case Col_IconText:
+            {
+                wxString text;
+                if ( row >= m_iconColValues.GetCount() )
+                {
+                    text = "virtual icon";
+                }
+                else
+                {
+                    text = m_iconColValues[row];
+                }
+
+                variant << wxDataViewIconText(text, m_icon[row % 2]);
+            }
+            break;
+
         case Col_Date:
             variant = wxDateTime(1, wxDateTime::Jan, 2000).Add(wxTimeSpan(row));
             break;
@@ -534,6 +550,13 @@ bool MyListModel::GetAttrByRow( unsigned int row, unsigned int col,
             return false;
 
         case Col_ToggleIconText:
+            if ( !(row % 2) )
+                return false;
+            attr.SetColour(*wxYELLOW);
+            attr.SetBackgroundColour(*wxLIGHT_GREY);
+            break;
+
+        case Col_IconText:
             if ( !(row % 2) )
                 return false;
             attr.SetColour(*wxYELLOW);

--- a/samples/dataview/mymodels.h
+++ b/samples/dataview/mymodels.h
@@ -209,6 +209,7 @@ public:
     enum
     {
         Col_ToggleIconText,
+        Col_IconText,
         Col_EditableText,
         Col_Date,
         Col_TextWithAttr,
@@ -237,6 +238,8 @@ public:
     {
         if (col == Col_ToggleIconText)
             return wxDataViewCheckIconTextRenderer::GetDefaultType();
+        if (col == Col_IconText)
+            return wxDataViewIconTextRenderer::GetDefaultType();
 
         return "string";
     }


### PR DESCRIPTION
This PR adds an IconText column to the dataview sample. This column provides an example of the issue reported in https://trac.wxwidgets.org/ticket/19301