### PR TITLE
Upscale the biggest bitmap in the bundle if it's too small

### DIFF
--- a/src/common/bmpbndl.cpp
+++ b/src/common/bmpbndl.cpp
@@ -205,7 +205,14 @@ wxSize wxBitmapBundleImplSet::GetPreferredSizeAtScale(double scale) const
 
     // We only get here if the target size is bigger than all the available
     // sizes, in which case we have no choice but to use the biggest bitmap.
-    return m_entries.back().bitmap.GetSize();
+    const wxSize sizeMax = m_entries.back().bitmap.GetSize();
+
+    // But check how far is it from the requested scale: if it's more than 1.5
+    // times smaller, we should still scale it, notably to ensure that bitmaps
+    // of standard size are scaled when 2x DPI scaling is used.
+    return static_cast<double>(sizeTarget.y) / sizeMax.y >= 1.5
+            ? sizeTarget
+            : sizeMax;
 }
 
 wxBitmap wxBitmapBundleImplSet::GetBitmap(const wxSize& size)

--- a/tests/graphics/bmpbundle.cpp
+++ b/tests/graphics/bmpbundle.cpp
@@ -57,6 +57,8 @@ TEST_CASE("BitmapBundle::GetPreferredSize", "[bmpbundle]")
     const wxBitmapBundle
         b = wxBitmapBundle::FromBitmaps(wxBitmap(normal), wxBitmap(bigger));
 
+    // Check that the existing bitmaps are used without scaling for most of the
+    // typical scaling values.
     CHECK( b.GetPreferredSizeAtScale(0   ) == normal );
     CHECK( b.GetPreferredSizeAtScale(1   ) == normal );
     CHECK( b.GetPreferredSizeAtScale(1.25) == normal );
@@ -65,7 +67,10 @@ TEST_CASE("BitmapBundle::GetPreferredSize", "[bmpbundle]")
     CHECK( b.GetPreferredSizeAtScale(1.75) == bigger );
     CHECK( b.GetPreferredSizeAtScale(2   ) == bigger );
     CHECK( b.GetPreferredSizeAtScale(2.5 ) == bigger );
-    CHECK( b.GetPreferredSizeAtScale(3   ) == bigger );
+
+    // This scale is too big to use any of the existing bitmaps, so they will
+    // be scaled.
+    CHECK( b.GetPreferredSizeAtScale(3   ) == 3*normal );
 }
 
 #ifdef wxHAS_BITMAP_SCALE_FACTOR


### PR DESCRIPTION
The changes of b20552116c (Allow wxBitmapBundle to specify its preferred
bitmap size, 2021-10-19) resulted in never rescaling the bitmaps in
standard size in high DPI at all, which isn't the right thing to do: by
default, i.e. if just a single bitmap is specified, we should scale it
up as necessary in order to show the UI elements in the correct sizes.

---

This fixes the first of <strike>two</strike> three problems I've found while testing.