### PR TITLE
Fix converting wxIcon to wxBitmap in wxOSX and simplify it for all ports

### DIFF
--- a/include/wx/bitmap.h
+++ b/include/wx/bitmap.h
@@ -223,7 +223,7 @@ public:
 #endif // wxUSE_PALETTE
 
     // copies the contents and mask of the given (colour) icon to the bitmap
-    virtual bool CopyFromIcon(const wxIcon& icon) = 0;
+    bool CopyFromIcon(const wxIcon& icon);
 
     // implementation:
 #if WXWIN_COMPATIBILITY_3_0

--- a/include/wx/dfb/bitmap.h
+++ b/include/wx/dfb/bitmap.h
@@ -63,9 +63,6 @@ public:
     virtual void SetPalette(const wxPalette& palette);
 #endif
 
-    // copies the contents and mask of the given (colour) icon to the bitmap
-    virtual bool CopyFromIcon(const wxIcon& icon);
-
     static void InitStandardHandlers();
 
     // raw bitmap access support functions

--- a/include/wx/gtk/bitmap.h
+++ b/include/wx/gtk/bitmap.h
@@ -103,9 +103,6 @@ public:
     wxImage ConvertToImage() const wxOVERRIDE;
 #endif // wxUSE_IMAGE
 
-    // copies the contents and mask of the given (colour) icon to the bitmap
-    virtual bool CopyFromIcon(const wxIcon& icon) wxOVERRIDE;
-
     wxMask *GetMask() const wxOVERRIDE;
     void SetMask( wxMask *mask ) wxOVERRIDE;
 

--- a/include/wx/gtk1/bitmap.h
+++ b/include/wx/gtk1/bitmap.h
@@ -88,9 +88,6 @@ public:
 
     wxImage ConvertToImage() const;
 
-    // copies the contents and mask of the given (colour) icon to the bitmap
-    virtual bool CopyFromIcon(const wxIcon& icon);
-
     wxMask *GetMask() const;
     void SetMask( wxMask *mask );
 

--- a/include/wx/osx/bitmap.h
+++ b/include/wx/osx/bitmap.h
@@ -165,9 +165,6 @@ public:
     wxBitmapRefData *GetBitmapData()
         { return (wxBitmapRefData *)m_refData; }
 
-    // copies the contents and mask of the given (colour) icon to the bitmap
-    virtual bool CopyFromIcon(const wxIcon& icon) wxOVERRIDE;
-
     int GetWidth() const wxOVERRIDE;
     int GetHeight() const wxOVERRIDE;
     int GetDepth() const wxOVERRIDE;

--- a/include/wx/qt/bitmap.h
+++ b/include/wx/qt/bitmap.h
@@ -61,9 +61,6 @@ public:
     virtual void SetPalette(const wxPalette& palette) wxOVERRIDE;
 #endif // wxUSE_PALETTE
 
-    // copies the contents and mask of the given (colour) icon to the bitmap
-    virtual bool CopyFromIcon(const wxIcon& icon) wxOVERRIDE;
-
     // implementation:
 #if WXWIN_COMPATIBILITY_3_0
     wxDEPRECATED(virtual void SetHeight(int height) wxOVERRIDE);

--- a/include/wx/x11/bitmap.h
+++ b/include/wx/x11/bitmap.h
@@ -98,9 +98,6 @@ public:
     bool CreateFromImage(const wxImage& image, int depth = -1);
 #endif // wxUSE_IMAGE
 
-    // copies the contents and mask of the given (colour) icon to the bitmap
-    virtual bool CopyFromIcon(const wxIcon& icon);
-
     wxMask *GetMask() const;
     void SetMask( wxMask *mask );
 

--- a/src/common/bmpbase.cpp
+++ b/src/common/bmpbase.cpp
@@ -196,6 +196,12 @@ public:
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxBitmapBaseModule, wxModule);
 
+bool wxBitmapBase::CopyFromIcon(const wxIcon& icon)
+{
+    *this = icon;
+    return IsOk();
+}
+
 // ----------------------------------------------------------------------------
 // Trivial implementations of scale-factor related functions
 // ----------------------------------------------------------------------------

--- a/src/dfb/bitmap.cpp
+++ b/src/dfb/bitmap.cpp
@@ -603,12 +603,6 @@ void wxBitmap::SetMask(wxMask *mask)
     M_BITMAP->m_mask = mask;
 }
 
-bool wxBitmap::CopyFromIcon(const wxIcon& icon)
-{
-    *this = *((wxBitmap*)(&icon));
-    return true;
-}
-
 wxBitmap wxBitmap::GetSubBitmap(const wxRect& rect) const
 {
     wxCHECK_MSG( IsOk() &&

--- a/src/gtk/bitmap.cpp
+++ b/src/gtk/bitmap.cpp
@@ -988,12 +988,6 @@ void wxBitmap::SetMask( wxMask *mask )
     }
 }
 
-bool wxBitmap::CopyFromIcon(const wxIcon& icon)
-{
-    *this = icon;
-    return IsOk();
-}
-
 #ifdef __WXGTK3__
 bool wxBitmap::CreateScaled(int w, int h, int depth, double scale)
 {

--- a/src/gtk1/bitmap.cpp
+++ b/src/gtk1/bitmap.cpp
@@ -1192,12 +1192,6 @@ void wxBitmap::SetMask( wxMask *mask )
     M_BMPDATA->m_mask = mask;
 }
 
-bool wxBitmap::CopyFromIcon(const wxIcon& icon)
-{
-    *this = icon;
-    return true;
-}
-
 wxBitmap wxBitmap::GetSubBitmap( const wxRect& rect) const
 {
     wxCHECK_MSG( IsOk() &&

--- a/src/osx/core/bitmap.cpp
+++ b/src/osx/core/bitmap.cpp
@@ -784,7 +784,8 @@ wxBitmapRefData::~wxBitmapRefData()
 
 bool wxBitmap::CopyFromIcon(const wxIcon& icon)
 {
-    return Create( icon.OSXGetImage() );
+    *this = icon;
+    return IsOk();
 }
 
 wxBitmap::wxBitmap(const char bits[], int the_width, int the_height, int no_bits)

--- a/src/osx/core/bitmap.cpp
+++ b/src/osx/core/bitmap.cpp
@@ -782,12 +782,6 @@ wxBitmapRefData::~wxBitmapRefData()
 // wxBitmap
 // ----------------------------------------------------------------------------
 
-bool wxBitmap::CopyFromIcon(const wxIcon& icon)
-{
-    *this = icon;
-    return IsOk();
-}
-
 wxBitmap::wxBitmap(const char bits[], int the_width, int the_height, int no_bits)
 {
     m_refData = new wxBitmapRefData( the_width , the_height , no_bits ) ;

--- a/src/qt/bitmap.cpp
+++ b/src/qt/bitmap.cpp
@@ -372,13 +372,6 @@ void wxBitmap::SetPalette(const wxPalette& WXUNUSED(palette))
 
 #endif // wxUSE_PALETTE
 
-// copies the contents and mask of the given (colour) icon to the bitmap
-bool wxBitmap::CopyFromIcon(const wxIcon& icon)
-{
-    *this = icon;
-    return IsOk();
-}
-
 #if WXWIN_COMPATIBILITY_3_0
 void wxBitmap::SetHeight(int height)
 {

--- a/src/x11/bitmap.cpp
+++ b/src/x11/bitmap.cpp
@@ -993,12 +993,6 @@ void wxBitmap::SetMask( wxMask *mask )
     M_BMPDATA->m_mask = mask;
 }
 
-bool wxBitmap::CopyFromIcon(const wxIcon& icon)
-{
-    *this = icon;
-    return true;
-}
-
 wxBitmap wxBitmap::GetSubBitmap( const wxRect& rect) const
 {
     wxCHECK_MSG( IsOk() &&


### PR DESCRIPTION
The important change here is in the first commit which fixes the surreptitious change in the scale factor when converting `wxIcon` to `wxBitmap` in wxOSX (which resulted in completely wrong sizes when using `wxStaticBitmap` with icons on high DPI screens), the rest is just cleanup.