### PR TITLE
Fix wxGrid selection compatibility

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -2301,17 +2301,12 @@ void wxGrid::Render( wxDC& dc,
 
     // remove grid selection, don't paint selection colour
     // unless we have wxGRID_DRAW_SELECTION
-    // block selections are the only ones catered for here
-    wxGridCellCoordsArray selectedCells;
-    bool hasSelection = IsSelection();
-    if ( hasSelection && !( style & wxGRID_DRAW_SELECTION ) )
+    wxGridSelection* selectionOrig = NULL;
+    if ( m_selection && !( style & wxGRID_DRAW_SELECTION ) )
     {
-        selectedCells = GetSelectionBlockTopLeft();
-        // non block selections may not have a bottom right
-        if ( GetSelectionBlockBottomRight().size() )
-            selectedCells.Add( GetSelectionBlockBottomRight()[ 0 ] );
-
-        ClearSelection();
+        // remove the selection temporarily, it will be restored below
+        selectionOrig = m_selection;
+        m_selection = NULL;
     }
 
     // store user device origin
@@ -2437,12 +2432,9 @@ void wxGrid::Render( wxDC& dc,
     dc.SetDeviceOrigin( userOriginX, userOriginY );
     dc.SetUserScale( scaleUserX, scaleUserY );
 
-    if ( selectedCells.size() && !( style & wxGRID_DRAW_SELECTION ) )
+    if ( selectionOrig )
     {
-        SelectBlock( selectedCells[ 0 ].GetRow(),
-                     selectedCells[ 0 ].GetCol(),
-                     selectedCells[ selectedCells.size() -1 ].GetRow(),
-                     selectedCells[ selectedCells.size() -1 ].GetCol() );
+        m_selection = selectionOrig;
     }
 }
 

--- a/src/generic/gridsel.cpp
+++ b/src/generic/gridsel.cpp
@@ -746,10 +746,6 @@ wxGridCellCoordsArray wxGridSelection::GetCellSelection() const
 
 wxGridCellCoordsArray wxGridSelection::GetBlockSelectionTopLeft() const
 {
-    // return blocks only in wxGridSelectCells selection mode
-    if ( m_selectionMode != wxGrid::wxGridSelectCells )
-        return wxGridCellCoordsArray();
-
     wxGridCellCoordsArray coords;
     const size_t count = m_selection.size();
     coords.reserve(count);
@@ -762,9 +758,6 @@ wxGridCellCoordsArray wxGridSelection::GetBlockSelectionTopLeft() const
 
 wxGridCellCoordsArray wxGridSelection::GetBlockSelectionBottomRight() const
 {
-    if ( m_selectionMode != wxGrid::wxGridSelectCells )
-        return wxGridCellCoordsArray();
-
     wxGridCellCoordsArray coords;
     const size_t count = m_selection.size();
     coords.reserve(count);

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -1163,6 +1163,16 @@ TEST_CASE_METHOD(GridTestCase, "Grid::SelectionMode", "[grid]")
     CHECK( m_grid->IsInSelection(5, 1) );
     CHECK( !m_grid->IsInSelection(3, 1) );
 
+    // Check that top left/bottom right selection functions still work in row
+    // selection mode.
+    wxGridCellCoordsArray arr = m_grid->GetSelectionBlockTopLeft();
+    REQUIRE( arr.size() == 1 );
+    CHECK( arr[0] == wxGridCellCoords(5, 0) );
+
+    arr = m_grid->GetSelectionBlockBottomRight();
+    REQUIRE( arr.size() == 1 );
+    CHECK( arr[0] == wxGridCellCoords(5, 1) );
+
     //Test row selection be selecting a single cell and checking the whole
     //row is selected
     m_grid->ClearSelection();


### PR DESCRIPTION
Make `wxGrid::GetSelectionBlock{TopLeft,BottomRight}()` work as before.

Also improve selection handling in `Render()`, which shouldn't have been using these functions in the first place.