### PR TITLE
CMake: Fix library directory when using MinGW

### DIFF
--- a/build/cmake/config.cmake
+++ b/build/cmake/config.cmake
@@ -12,11 +12,8 @@ file(MAKE_DIRECTORY ${wxCONFIG_DIR})
 set(TOOLCHAIN_FULLNAME ${wxBUILD_FILE_ID})
 
 macro(wx_configure_script input output)
-    set(abs_top_srcdir ${CMAKE_CURRENT_SOURCE_DIR})
-    set(abs_top_builddir ${CMAKE_CURRENT_BINARY_DIR})
-
     configure_file(
-        ${input}
+        ${CMAKE_CURRENT_SOURCE_DIR}/${input}
         ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${output}
         ESCAPE_QUOTES @ONLY NEWLINE_STYLE UNIX)
     file(COPY
@@ -68,7 +65,7 @@ endmacro()
 
 function(wx_write_config_inplace)
     wx_configure_script(
-        "${CMAKE_CURRENT_SOURCE_DIR}/wx-config-inplace.in"
+        "wx-config-inplace.in"
         "inplace-${TOOLCHAIN_FULLNAME}"
         )
     if(WIN32_MSVC_NAMING)
@@ -191,7 +188,7 @@ function(wx_write_config)
     set(RESCOMP)
 
     wx_configure_script(
-        "${CMAKE_CURRENT_SOURCE_DIR}/wx-config.in"
+        "wx-config.in"
         "${TOOLCHAIN_FULLNAME}"
         )
 endfunction()

--- a/build/cmake/config.cmake
+++ b/build/cmake/config.cmake
@@ -71,9 +71,14 @@ function(wx_write_config_inplace)
         "${CMAKE_CURRENT_SOURCE_DIR}/wx-config-inplace.in"
         "inplace-${TOOLCHAIN_FULLNAME}"
         )
+    if(WIN32_MSVC_NAMING)
+        set(COPY_CMD copy)
+    else()
+        set(COPY_CMD create_symlink)
+    endif()
     execute_process(
         COMMAND
-        ${CMAKE_COMMAND} -E create_symlink
+        ${CMAKE_COMMAND} -E ${COPY_CMD}
         "lib/wx/config/inplace-${TOOLCHAIN_FULLNAME}"
         "${CMAKE_CURRENT_BINARY_DIR}/wx-config"
         )

--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -26,9 +26,9 @@ else()
     set(WIN32_MSVC_NAMING 0)
 endif()
 
-if(MSVC)
+if(WIN32_MSVC_NAMING)
     # Generator expression to not create different Debug and Release directories
-    set(MSVC_DIR_FIX "$<1:/>")
+    set(GEN_EXPR_DIR_FIX "$<1:/>")
 endif()
 
 # This function adds a list of headers to a variable while prepending
@@ -102,9 +102,9 @@ function(wx_set_common_target_properties target_name)
     cmake_parse_arguments(wxCOMMON_TARGET_PROPS "DEFAULT_WARNINGS" "" "" ${ARGN})
 
     set_target_properties(${target_name} PROPERTIES
-        LIBRARY_OUTPUT_DIRECTORY "${wxOUTPUT_DIR}${MSVC_DIR_FIX}${wxPLATFORM_LIB_DIR}"
-        ARCHIVE_OUTPUT_DIRECTORY "${wxOUTPUT_DIR}${MSVC_DIR_FIX}${wxPLATFORM_LIB_DIR}"
-        RUNTIME_OUTPUT_DIRECTORY "${wxOUTPUT_DIR}${MSVC_DIR_FIX}${wxPLATFORM_LIB_DIR}"
+        LIBRARY_OUTPUT_DIRECTORY "${wxOUTPUT_DIR}/${GEN_EXPR_DIR_FIX}${wxPLATFORM_LIB_DIR}"
+        ARCHIVE_OUTPUT_DIRECTORY "${wxOUTPUT_DIR}/${GEN_EXPR_DIR_FIX}${wxPLATFORM_LIB_DIR}"
+        RUNTIME_OUTPUT_DIRECTORY "${wxOUTPUT_DIR}/${GEN_EXPR_DIR_FIX}${wxPLATFORM_LIB_DIR}"
         )
 
     if(wxBUILD_PIC)
@@ -422,9 +422,9 @@ macro(wx_add_library name)
             set(runtime_dir "bin")
         endif()
         wx_install(TARGETS ${name}
-            LIBRARY DESTINATION "lib${MSVC_DIR_FIX}${wxPLATFORM_LIB_DIR}"
-            ARCHIVE DESTINATION "lib${MSVC_DIR_FIX}${wxPLATFORM_LIB_DIR}"
-            RUNTIME DESTINATION "${runtime_dir}${MSVC_DIR_FIX}${wxPLATFORM_LIB_DIR}"
+            LIBRARY DESTINATION "lib/${GEN_EXPR_DIR_FIX}${wxPLATFORM_LIB_DIR}"
+            ARCHIVE DESTINATION "lib/${GEN_EXPR_DIR_FIX}${wxPLATFORM_LIB_DIR}"
+            RUNTIME DESTINATION "${runtime_dir}/${GEN_EXPR_DIR_FIX}${wxPLATFORM_LIB_DIR}"
             BUNDLE DESTINATION Applications/wxWidgets
             )
     endif()
@@ -579,7 +579,7 @@ function(wx_set_builtin_target_properties target_name)
 
     wx_set_common_target_properties(${target_name} DEFAULT_WARNINGS)
     if(NOT wxBUILD_SHARED)
-        wx_install(TARGETS ${name} ARCHIVE DESTINATION "lib${MSVC_DIR_FIX}${wxPLATFORM_LIB_DIR}")
+        wx_install(TARGETS ${name} ARCHIVE DESTINATION "lib/${GEN_EXPR_DIR_FIX}${wxPLATFORM_LIB_DIR}")
     endif()
 endfunction()
 


### PR DESCRIPTION
This was broken in b102afc316 (CMake: Don't include generator expression in wxPLATFORM_LIB_DIR, 2021-10-17).
And for clarity, always add a '/' after directories.

Closes [#19305](https://trac.wxwidgets.org/ticket/19305)