### PR TITLE
Simplify function pointer syntax in GetPreferredUILanguage

### DIFF
--- a/src/common/translation.cpp
+++ b/src/common/translation.cpp
@@ -141,16 +141,16 @@ wxString GetPreferredUILanguage(const wxArrayString& available)
     {
         ULONG numLangs;
         ULONG bufferSize = 0;
-        if ( (*s_pfnGetUserPreferredUILanguages)(MUI_LANGUAGE_NAME,
-                                                 &numLangs,
-                                                 NULL,
-                                                 &bufferSize) )
+        if ( s_pfnGetUserPreferredUILanguages(MUI_LANGUAGE_NAME,
+                                              &numLangs,
+                                              NULL,
+                                              &bufferSize) )
         {
             wxScopedArray<WCHAR> langs(bufferSize);
-            if ( (*s_pfnGetUserPreferredUILanguages)(MUI_LANGUAGE_NAME,
-                                                     &numLangs,
-                                                     langs.get(),
-                                                     &bufferSize) )
+            if ( s_pfnGetUserPreferredUILanguages(MUI_LANGUAGE_NAME,
+                                                  &numLangs,
+                                                  langs.get(),
+                                                  &bufferSize) )
             {
                 wxArrayString preferred;
 


### PR DESCRIPTION
No need for (*func)(args), just call func(args).

No real changes.