### PR TITLE
Include Windows 11 and macOS 12 name in wxGetOsDescription()

### DIFF
--- a/interface/wx/utils.h
+++ b/interface/wx/utils.h
@@ -917,7 +917,7 @@ wxString wxGetOsDescription();
     numbers will have a value of -1.
 
     On systems where only the micro version can't be detected or doesn't make
-    sense such as Windows, it will have a value of 0.
+    sense, it will have a value of 0.
 
     For Unix-like systems (@c wxOS_UNIX) the major, minor, and micro version
     integers will contain the kernel's major, minor, and micro version
@@ -928,24 +928,106 @@ wxString wxGetOsDescription();
     natural version numbers associated with the OS; e.g. "10", "11" and "2" if
     the machine is using macOS El Capitan 10.11.2.
 
-    For Windows-like systems (@c wxOS_WINDOWS) the major and minor version integers will
-    contain the following values:
-    @beginTable
-    @row3col{<b>Windows OS name</b>, <b>Major version</b>, <b>Minor version</b>}
-    @row3col{Windows 10,               10, 0}
-    @row3col{Windows Server 2016,      10, 0}
-    @row3col{Windows 8.1,               6, 3}
-    @row3col{Windows Server 2012 R2,    6, 3}
-    @row3col{Windows 8,                 6, 2}
-    @row3col{Windows Server 2012,       6, 2}
-    @row3col{Windows 7,                 6, 1}
-    @row3col{Windows Server 2008 R2,    6, 1}
-    @row3col{Windows Server 2008,       6, 0}
-    @row3col{Windows Vista,             6, 0}
-    @row3col{Windows Server 2003 R2,    5, 2}
-    @row3col{Windows Server 2003,       5, 2}
-    @row3col{Windows XP,                5, 1}
-    @endDefList
+    For Windows-like systems (@c wxOS_WINDOWS) the major, minor and micro
+    (equal to the build number) version integers will contain the following values:
+    <table>
+        <tr>
+            <th>Windows OS name</th>
+            <th>Major version</th>
+            <th>Minor version</th>
+            <th>Build number</th>
+        </tr>
+        <tr>
+            <td>Windows 11</td>
+            <td>10</td>
+            <td>0</td>
+            <td>&gt;= 22000</td>
+        </tr>
+        <tr>
+            <td>Windows Server 2022</td>
+            <td>10</td>
+            <td>0</td>
+            <td>&gt;= 22000</td>
+        </tr>
+        <tr>
+            <td>Windows 10</td>
+            <td>10</td>
+            <td>0</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Windows Server 2016</td>
+            <td>10</td>
+            <td>0</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Windows 8.1</td>
+            <td>6</td>
+            <td>3</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Windows Server 2012 R2</td>
+            <td>6</td>
+            <td>3</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Windows 8</td>
+            <td>6</td>
+            <td>2</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Windows Server 2012</td>
+            <td>6</td>
+            <td>2</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Windows 7</td>
+            <td>6</td>
+            <td>1</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Windows 2008 R2</td>
+            <td>6</td>
+            <td>1</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Windows Vista</td>
+            <td>6</td>
+            <td>0</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Windows Server 2008</td>
+            <td>6</td>
+            <td>0</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Windows Server 2003 R2</td>
+            <td>5</td>
+            <td>2</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Windows Server 2003</td>
+            <td>5</td>
+            <td>2</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Windows XP</td>
+            <td>5</td>
+            <td>1</td>
+            <td></td>
+        </tr>
+    </table>
     See the <a href="http://msdn.microsoft.com/en-us/library/ms724832(VS.85).aspx">MSDN</a>
     for more info about the values above.
 

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -1134,9 +1134,14 @@ wxString wxGetOsDescription()
                     break;
 
                 case 10:
-                    str = wxIsWindowsServer() == 1
-                            ? "Windows Server 2016"
-                            : "Windows 10";
+                    if (info.dwBuildNumber >= 22000)
+                        str = wxIsWindowsServer() == 1
+                            ? "Windows Server 2022"
+                            : "Windows 11";
+                    else
+                        str = wxIsWindowsServer() == 1
+                                ? "Windows Server 2016"
+                                : "Windows 10";
                     break;
             }
 

--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -115,6 +115,9 @@ wxString wxGetOsDescription()
             case 11:
                 osName = "Big Sur";
                 break;
+            case 12:
+                osName = "Monterey";
+                break;
         }
     }
 #else


### PR DESCRIPTION
To me it's still perplexing that macOS users refer to these cryptic code names instead of a version number, but they do so this can still be helpful. There still doesn't seem to be an API available to get it.

Windows 11 still reports as 10.0 but build number 22000 and up is Windows 11.