### PR TITLE
Require semicolon after wxDECLARE/IMPLEMENT_*_CLASS*

### DIFF
--- a/include/wx/html/m_templ.h
+++ b/include/wx/html/m_templ.h
@@ -75,7 +75,7 @@ I STRONGLY recommend reading and understanding these macros!!
 #define TAGS_MODULE_END(name)                                             \
                 }                                                         \
     };                                                                    \
-    wxIMPLEMENT_DYNAMIC_CLASS(wxHTML_Module##name , wxHtmlTagsModule)
+    wxIMPLEMENT_DYNAMIC_CLASS(wxHTML_Module##name , wxHtmlTagsModule);
 
 
 

--- a/include/wx/object.h
+++ b/include/wx/object.h
@@ -112,13 +112,13 @@ name##PluginSentinel  m_pluginsentinel
  wxDECLARE_ABSTRACT_CLASS(name); _DECLARE_DL_SENTINEL(name, usergoo)
 
 #define wxIMPLEMENT_PLUGGABLE_CLASS(name, basename) \
- wxIMPLEMENT_DYNAMIC_CLASS(name, basename) _IMPLEMENT_DL_SENTINEL(name)
+ wxIMPLEMENT_DYNAMIC_CLASS(name, basename); _IMPLEMENT_DL_SENTINEL(name)
 #define wxIMPLEMENT_PLUGGABLE_CLASS2(name, basename1, basename2)  \
- wxIMPLEMENT_DYNAMIC_CLASS2(name, basename1, basename2) _IMPLEMENT_DL_SENTINEL(name)
+ wxIMPLEMENT_DYNAMIC_CLASS2(name, basename1, basename2); _IMPLEMENT_DL_SENTINEL(name)
 #define wxIMPLEMENT_ABSTRACT_PLUGGABLE_CLASS(name, basename) \
- wxIMPLEMENT_ABSTRACT_CLASS(name, basename) _IMPLEMENT_DL_SENTINEL(name)
+ wxIMPLEMENT_ABSTRACT_CLASS(name, basename); _IMPLEMENT_DL_SENTINEL(name)
 #define wxIMPLEMENT_ABSTRACT_PLUGGABLE_CLASS2(name, basename1, basename2)  \
- wxIMPLEMENT_ABSTRACT_CLASS2(name, basename1, basename2) _IMPLEMENT_DL_SENTINEL(name)
+ wxIMPLEMENT_ABSTRACT_CLASS2(name, basename1, basename2); _IMPLEMENT_DL_SENTINEL(name)
 
 #define wxIMPLEMENT_USER_EXPORTED_PLUGGABLE_CLASS(name, basename) \
  wxIMPLEMENT_PLUGGABLE_CLASS(name, basename)
@@ -494,21 +494,21 @@ inline wxObject *wxCheckDynamicCast(wxObject *obj, wxClassInfo *classInfo)
 // (note that also some wx-prefixed macro do _not_ require a semicolon because
 // it's not always possible to force the compiler to require it)
 
-#define IMPLEMENT_DYNAMIC_CLASS(n,b)                                wxIMPLEMENT_DYNAMIC_CLASS(n,b)
-#define IMPLEMENT_DYNAMIC_CLASS2(n,b1,b2)                           wxIMPLEMENT_DYNAMIC_CLASS2(n,b1,b2)
-#define IMPLEMENT_ABSTRACT_CLASS(n,b)                               wxIMPLEMENT_ABSTRACT_CLASS(n,b)
-#define IMPLEMENT_ABSTRACT_CLASS2(n,b1,b2)                          wxIMPLEMENT_ABSTRACT_CLASS2(n,b1,b2)
-#define IMPLEMENT_CLASS(n,b)                                        wxIMPLEMENT_CLASS(n,b)
-#define IMPLEMENT_CLASS2(n,b1,b2)                                   wxIMPLEMENT_CLASS2(n,b1,b2)
+#define IMPLEMENT_DYNAMIC_CLASS(n,b)                                wxIMPLEMENT_DYNAMIC_CLASS(n,b);
+#define IMPLEMENT_DYNAMIC_CLASS2(n,b1,b2)                           wxIMPLEMENT_DYNAMIC_CLASS2(n,b1,b2);
+#define IMPLEMENT_ABSTRACT_CLASS(n,b)                               wxIMPLEMENT_ABSTRACT_CLASS(n,b);
+#define IMPLEMENT_ABSTRACT_CLASS2(n,b1,b2)                          wxIMPLEMENT_ABSTRACT_CLASS2(n,b1,b2);
+#define IMPLEMENT_CLASS(n,b)                                        wxIMPLEMENT_CLASS(n,b);
+#define IMPLEMENT_CLASS2(n,b1,b2)                                   wxIMPLEMENT_CLASS2(n,b1,b2);
 
-#define IMPLEMENT_PLUGGABLE_CLASS(n,b)                              wxIMPLEMENT_PLUGGABLE_CLASS(n,b)
-#define IMPLEMENT_PLUGGABLE_CLASS2(n,b,b2)                          wxIMPLEMENT_PLUGGABLE_CLASS2(n,b,b2)
-#define IMPLEMENT_ABSTRACT_PLUGGABLE_CLASS(n,b)                     wxIMPLEMENT_ABSTRACT_PLUGGABLE_CLASS(n,b)
-#define IMPLEMENT_ABSTRACT_PLUGGABLE_CLASS2(n,b,b2)                 wxIMPLEMENT_ABSTRACT_PLUGGABLE_CLASS2(n,b,b2)
-#define IMPLEMENT_USER_EXPORTED_PLUGGABLE_CLASS(n,b)                wxIMPLEMENT_USER_EXPORTED_PLUGGABLE_CLASS(n,b)
-#define IMPLEMENT_USER_EXPORTED_PLUGGABLE_CLASS2(n,b,b2)            wxIMPLEMENT_USER_EXPORTED_PLUGGABLE_CLASS2(n,b,b2)
-#define IMPLEMENT_USER_EXPORTED_ABSTRACT_PLUGGABLE_CLASS(n,b)       wxIMPLEMENT_USER_EXPORTED_ABSTRACT_PLUGGABLE_CLASS(n,b)
-#define IMPLEMENT_USER_EXPORTED_ABSTRACT_PLUGGABLE_CLASS2(n,b,b2)   wxIMPLEMENT_USER_EXPORTED_ABSTRACT_PLUGGABLE_CLASS2(n,b,b2)
+#define IMPLEMENT_PLUGGABLE_CLASS(n,b)                              wxIMPLEMENT_PLUGGABLE_CLASS(n,b);
+#define IMPLEMENT_PLUGGABLE_CLASS2(n,b,b2)                          wxIMPLEMENT_PLUGGABLE_CLASS2(n,b,b2);
+#define IMPLEMENT_ABSTRACT_PLUGGABLE_CLASS(n,b)                     wxIMPLEMENT_ABSTRACT_PLUGGABLE_CLASS(n,b);
+#define IMPLEMENT_ABSTRACT_PLUGGABLE_CLASS2(n,b,b2)                 wxIMPLEMENT_ABSTRACT_PLUGGABLE_CLASS2(n,b,b2);
+#define IMPLEMENT_USER_EXPORTED_PLUGGABLE_CLASS(n,b)                wxIMPLEMENT_USER_EXPORTED_PLUGGABLE_CLASS(n,b);
+#define IMPLEMENT_USER_EXPORTED_PLUGGABLE_CLASS2(n,b,b2)            wxIMPLEMENT_USER_EXPORTED_PLUGGABLE_CLASS2(n,b,b2);
+#define IMPLEMENT_USER_EXPORTED_ABSTRACT_PLUGGABLE_CLASS(n,b)       wxIMPLEMENT_USER_EXPORTED_ABSTRACT_PLUGGABLE_CLASS(n,b);
+#define IMPLEMENT_USER_EXPORTED_ABSTRACT_PLUGGABLE_CLASS2(n,b,b2)   wxIMPLEMENT_USER_EXPORTED_ABSTRACT_PLUGGABLE_CLASS2(n,b,b2);
 
 #define CLASSINFO(n)                                wxCLASSINFO(n)
 

--- a/include/wx/rtti.h
+++ b/include/wx/rtti.h
@@ -169,7 +169,8 @@ WXDLLIMPEXP_BASE wxObject *wxCreateDynamicObject(const wxString& name);
             func);                                                            \
                                                                               \
     wxClassInfo *name::GetClassInfo() const                                   \
-        { return &name::ms_classInfo; }
+        { return &name::ms_classInfo; }                                       \
+    typedef int wx_impl_class_common ## name
 
 #define wxIMPLEMENT_CLASS_COMMON1(name, basename, func)                       \
     wxIMPLEMENT_CLASS_COMMON(name, basename, NULL, func)
@@ -183,16 +184,18 @@ WXDLLIMPEXP_BASE wxObject *wxCreateDynamicObject(const wxString& name);
 
     // Single inheritance with one base class
 #define wxIMPLEMENT_DYNAMIC_CLASS(name, basename)                             \
-    wxIMPLEMENT_CLASS_COMMON1(name, basename, name::wxCreateObject)           \
+    wxIMPLEMENT_CLASS_COMMON1(name, basename, name::wxCreateObject);          \
     wxObject* name::wxCreateObject()                                          \
-        { return new name; }
+        { return new name; }                                                  \
+    typedef int wx_impl_dyn_class ## name
 
     // Multiple inheritance with two base classes
 #define wxIMPLEMENT_DYNAMIC_CLASS2(name, basename1, basename2)                \
     wxIMPLEMENT_CLASS_COMMON2(name, basename1, basename2,                     \
-                              name::wxCreateObject)                           \
+                              name::wxCreateObject);                          \
     wxObject* name::wxCreateObject()                                          \
-        { return new name; }
+        { return new name; }                                                  \
+    typedef int wx_impl_dyn_class2 ## name
 
 // -----------------------------------
 // for abstract classes

--- a/interface/wx/object.h
+++ b/interface/wx/object.h
@@ -686,6 +686,8 @@ public:
     made known to the class hierarchy, but objects of this class cannot be created
     dynamically.
 
+    Note that this macro requires a final semicolon.
+
     @header{wx/object.h}
 
     Example:
@@ -711,6 +713,8 @@ public:
     implies that the class should have a default constructor, if this is not
     the case consider using wxDECLARE_ABSTRACT_CLASS().
 
+    Note that this macro requires a final semicolon.
+
     @header{wx/object.h}
 
     Example:
@@ -734,6 +738,8 @@ public:
     known to the class hierarchy, but objects of this class cannot be created
     dynamically.
 
+    Note that this macro requires a final semicolon.
+
     The same as wxDECLARE_ABSTRACT_CLASS().
 
     @header{wx/object.h}
@@ -743,6 +749,8 @@ public:
 /**
     Used in a C++ implementation file to complete the declaration of a class
     that has run-time type information.
+
+    Note that this macro requires a final semicolon.
 
     @header{wx/object.h}
 
@@ -763,6 +771,8 @@ public:
     Used in a C++ implementation file to complete the declaration of a class
     that has run-time type information and two base classes.
 
+    Note that this macro requires a final semicolon.
+
     @header{wx/object.h}
 */
 #define wxIMPLEMENT_ABSTRACT_CLASS2( className, baseClassName1, baseClassName2 )
@@ -771,6 +781,8 @@ public:
     Used in a C++ implementation file to complete the declaration of a class
     that has run-time type information, and whose instances can be created
     dynamically.
+
+    Note that this macro requires a final semicolon.
 
     @header{wx/object.h}
 
@@ -792,6 +804,8 @@ public:
     that has run-time type information, and whose instances can be created
     dynamically. Use this for classes derived from two base classes.
 
+    Note that this macro requires a final semicolon.
+
     @header{wx/object.h}
 */
 #define wxIMPLEMENT_DYNAMIC_CLASS2( className, baseClassName1, baseClassName2 )
@@ -802,6 +816,8 @@ public:
     Please prefer to use the more clear, if longer,
     ::wxIMPLEMENT_ABSTRACT_CLASS in the new code.
 
+    Note that this macro requires a final semicolon.
+
     @header{wx/object.h}
 */
 #define wxIMPLEMENT_CLASS( className, baseClassName )
@@ -811,6 +827,8 @@ public:
 
     Please prefer to use the more clear, if longer,
     ::wxIMPLEMENT_ABSTRACT_CLASS2 in the new code.
+
+    Note that this macro requires a final semicolon.
 
     @header{wx/object.h}
 */

--- a/src/common/ipcbase.cpp
+++ b/src/common/ipcbase.cpp
@@ -17,9 +17,9 @@
 
 #include "wx/ipcbase.h"
 
-wxIMPLEMENT_ABSTRACT_CLASS(wxServerBase, wxObject)
-wxIMPLEMENT_ABSTRACT_CLASS(wxClientBase, wxObject)
-wxIMPLEMENT_ABSTRACT_CLASS(wxConnectionBase, wxObject)
+wxIMPLEMENT_ABSTRACT_CLASS(wxServerBase, wxObject);
+wxIMPLEMENT_ABSTRACT_CLASS(wxClientBase, wxObject);
+wxIMPLEMENT_ABSTRACT_CLASS(wxConnectionBase, wxObject);
 
 wxConnectionBase::wxConnectionBase(void *buffer, size_t bytes)
     : m_buffer((char *)buffer),

--- a/src/common/menucmn.cpp
+++ b/src/common/menucmn.cpp
@@ -100,7 +100,7 @@ bool wxMenuBarStreamingCallback( const wxObject *WXUNUSED(object), wxObjectWrite
 
 #if wxUSE_MENUBAR
 wxIMPLEMENT_DYNAMIC_CLASS_XTI_CALLBACK(wxMenuBar, wxWindow, "wx/menu.h", \
-                                       wxMenuBarStreamingCallback)
+                                       wxMenuBarStreamingCallback);
 #endif
 
 #if wxUSE_EXTENDED_RTTI
@@ -187,7 +187,7 @@ wxENUM_MEMBER( wxITEM_RADIO )
 wxEND_ENUM( wxItemKind )
 
 wxIMPLEMENT_DYNAMIC_CLASS_XTI_CALLBACK(wxMenuItem, wxObject, "wx/menuitem.h", \
-                                       wxMenuItemStreamingCallback)
+                                       wxMenuItemStreamingCallback);
 
 wxBEGIN_PROPERTIES_TABLE(wxMenuItem)
 wxPROPERTY( Parent, wxMenu*, SetMenu, GetMenu, wxEMPTY_PARAMETER_VALUE, \

--- a/src/common/module.cpp
+++ b/src/common/module.cpp
@@ -22,7 +22,7 @@
 
 #define TRACE_MODULE wxT("module")
 
-wxIMPLEMENT_ABSTRACT_CLASS(wxModule, wxObject)
+wxIMPLEMENT_ABSTRACT_CLASS(wxModule, wxObject);
 
 wxModuleList wxModule::ms_modules;
 bool wxModule::ms_areInitialized = false;

--- a/src/common/odcombocmn.cpp
+++ b/src/common/odcombocmn.cpp
@@ -38,7 +38,7 @@
 // ----------------------------------------------------------------------------
 
 wxIMPLEMENT_DYNAMIC_CLASS2_XTI(wxOwnerDrawnComboBox, wxComboCtrl, \
-                               wxControlWithItems, "wx/odcombo.h")
+                               wxControlWithItems, "wx/odcombo.h");
 
 wxBEGIN_PROPERTIES_TABLE(wxOwnerDrawnComboBox)
 wxEND_PROPERTIES_TABLE()

--- a/src/generic/progdlgg.cpp
+++ b/src/generic/progdlgg.cpp
@@ -63,7 +63,7 @@ wxEND_EVENT_TABLE()
 // wxGenericProgressDialog implementation
 // ============================================================================
 
-wxIMPLEMENT_CLASS(wxProgressDialog, wxDialog)
+wxIMPLEMENT_CLASS(wxProgressDialog, wxDialog);
 
 // ----------------------------------------------------------------------------
 // wxGenericProgressDialog creation

--- a/src/generic/richmsgdlgg.cpp
+++ b/src/generic/richmsgdlgg.cpp
@@ -24,7 +24,7 @@
 #include "wx/statline.h"
 #include "wx/artprov.h"
 
-wxIMPLEMENT_CLASS(wxRichMessageDialog, wxDialog)
+wxIMPLEMENT_CLASS(wxRichMessageDialog, wxDialog);
 
 // ----------------------------------------------------------------------------
 // Events and handlers

--- a/src/propgrid/props.cpp
+++ b/src/propgrid/props.cpp
@@ -191,7 +191,7 @@ bool wxNumericPropertyValidator::Validate(wxWindow* parent)
 // wxNumericProperty
 // -----------------------------------------------------------------------
 
-wxIMPLEMENT_ABSTRACT_CLASS(wxNumericProperty, wxPGProperty)
+wxIMPLEMENT_ABSTRACT_CLASS(wxNumericProperty, wxPGProperty);
 
 wxNumericProperty::wxNumericProperty(const wxString& label, const wxString& name)
     : wxPGProperty(label, name)
@@ -1958,7 +1958,7 @@ public:
 // wxDialogProperty
 // -----------------------------------------------------------------------
 
-wxIMPLEMENT_ABSTRACT_CLASS(wxEditorDialogProperty, wxPGProperty)
+wxIMPLEMENT_ABSTRACT_CLASS(wxEditorDialogProperty, wxPGProperty);
 
 wxEditorDialogProperty::wxEditorDialogProperty(const wxString& label, const wxString& name)
     : wxPGProperty(label, name)

--- a/src/xrc/xh_aui.cpp
+++ b/src/xrc/xh_aui.cpp
@@ -17,7 +17,7 @@
 #include "wx/aui/framemanager.h"
 #include "wx/aui/auibook.h"
 
-wxIMPLEMENT_DYNAMIC_CLASS(wxAuiXmlHandler, wxXmlResourceHandler)
+wxIMPLEMENT_DYNAMIC_CLASS(wxAuiXmlHandler, wxXmlResourceHandler);
 
 wxAuiXmlHandler::wxAuiXmlHandler()
                 : wxXmlResourceHandler(),


### PR DESCRIPTION
As far as I understand from the documentation and comments in code, the it is desirable to require semicolon after `wxDECLARE/IMPLEMENT_*` macros, but it hasn't been forced for all of them so far. Here is an attempt to force it for more macros than before.