### PR TITLE
Change wxwin.m4 to use non-deprecated macros

### DIFF
--- a/wxwin.m4
+++ b/wxwin.m4
@@ -64,7 +64,7 @@ dnl If you want to support standard --enable-debug/unicode/shared options, you
 dnl may do the following:
 dnl
 dnl     ...
-dnl     AC_CANONICAL_SYSTEM
+dnl     AC_CANONICAL_TARGET
 dnl
 dnl     # define configure options
 dnl     WX_CONFIG_OPTIONS
@@ -516,7 +516,7 @@ dnl $5 = additional action to do in case option is given with "yes" value
 dnl ---------------------------------------------------------------------------
 AC_DEFUN([WX_ARG_ENABLE_YESNOAUTO],
          [AC_ARG_ENABLE($1,
-            AC_HELP_STRING([--enable-$1], [$3 (default is $4)]),
+            AS_HELP_STRING([--enable-$1],[$3 (default is $4)]),
             [], [enableval="$4"])
 
             dnl Show a message to the user about this option
@@ -540,7 +540,7 @@ AC_DEFUN([WX_ARG_ENABLE_YESNOAUTO],
 
 AC_DEFUN([WX_ARG_WITH_YESNOAUTO],
          [AC_ARG_WITH($1,
-            AC_HELP_STRING([--with-$1], [$3 (default is $4)]),
+            AS_HELP_STRING([--with-$1],[$3 (default is $4)]),
             [], [withval="$4"])
 
             dnl Show a message to the user about this option
@@ -600,8 +600,7 @@ AC_DEFUN([WX_STANDARD_OPTIONS],
         ifelse(index([$1], [toolkit]), [-1],,
                [
                 AC_ARG_WITH([toolkit],
-                            AC_HELP_STRING([--with-toolkit],
-                                           [Build against a specific wxWidgets toolkit (default is auto)]),
+                            AS_HELP_STRING([--with-toolkit],[Build against a specific wxWidgets toolkit (default is auto)]),
                             [], [withval="auto"])
 
                 dnl Show a message to the user about this option
@@ -674,8 +673,7 @@ AC_DEFUN([WX_STANDARD_OPTIONS],
         ifelse(index([$1], [wxversion]), [-1],,
                [
                 AC_ARG_WITH([wxversion],
-                            AC_HELP_STRING([--with-wxversion],
-                                           [Build against a specific version of wxWidgets (default is auto)]),
+                            AS_HELP_STRING([--with-wxversion],[Build against a specific version of wxWidgets (default is auto)]),
                             [], [withval="auto"])
 
                 dnl Show a message to the user about this option


### PR DESCRIPTION
`AC_HELP_STRING` and `AC_CANONICAL_SYSTEM` are deprecated past autoconf2.70. A quick runthrough with `autoupdate` brings `wxwin.m4` in line with this.