### PR TITLE
Avoid warnings in tif_print.c by excluding it from build

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -244,7 +244,6 @@ WXTIFF_OBJECTS =  \
 	wxtiff_tif_packbits.o \
 	wxtiff_tif_pixarlog.o \
 	wxtiff_tif_predict.o \
-	wxtiff_tif_print.o \
 	wxtiff_tif_read.o \
 	wxtiff_tif_strip.o \
 	wxtiff_tif_swab.o \
@@ -15317,9 +15316,6 @@ wxtiff_tif_pixarlog.o: $(srcdir)/src/tiff/libtiff/tif_pixarlog.c
 
 wxtiff_tif_predict.o: $(srcdir)/src/tiff/libtiff/tif_predict.c
 	$(CCC) -c -o $@ $(WXTIFF_CFLAGS) $(srcdir)/src/tiff/libtiff/tif_predict.c
-
-wxtiff_tif_print.o: $(srcdir)/src/tiff/libtiff/tif_print.c
-	$(CCC) -c -o $@ $(WXTIFF_CFLAGS) $(srcdir)/src/tiff/libtiff/tif_print.c
 
 wxtiff_tif_read.o: $(srcdir)/src/tiff/libtiff/tif_read.c
 	$(CCC) -c -o $@ $(WXTIFF_CFLAGS) $(srcdir)/src/tiff/libtiff/tif_read.c

--- a/build/bakefiles/tiff.bkl
+++ b/build/bakefiles/tiff.bkl
@@ -85,7 +85,14 @@
             src/tiff/libtiff/tif_packbits.c
             src/tiff/libtiff/tif_pixarlog.c
             src/tiff/libtiff/tif_predict.c
+            <!--
+                Exclude this file because it contains only TIFFPrintDirectory()
+                function that we never use, but compiling which generates tons
+                of warnings when using MinGW (e.g. when cross-compiling) and it
+                seems simpler to just not compile it at all than to fix them.
+
             src/tiff/libtiff/tif_print.c
+            -->
             src/tiff/libtiff/tif_read.c
             src/tiff/libtiff/tif_strip.c
             src/tiff/libtiff/tif_swab.c

--- a/build/msw/makefile.gcc
+++ b/build/msw/makefile.gcc
@@ -198,7 +198,6 @@ WXTIFF_OBJECTS =  \
 	$(OBJS)\wxtiff_tif_packbits.o \
 	$(OBJS)\wxtiff_tif_pixarlog.o \
 	$(OBJS)\wxtiff_tif_predict.o \
-	$(OBJS)\wxtiff_tif_print.o \
 	$(OBJS)\wxtiff_tif_read.o \
 	$(OBJS)\wxtiff_tif_strip.o \
 	$(OBJS)\wxtiff_tif_swab.o \
@@ -6440,9 +6439,6 @@ $(OBJS)\wxtiff_tif_pixarlog.o: ../../src/tiff/libtiff/tif_pixarlog.c
 	$(CC) -c -o $@ $(WXTIFF_CFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\wxtiff_tif_predict.o: ../../src/tiff/libtiff/tif_predict.c
-	$(CC) -c -o $@ $(WXTIFF_CFLAGS) $(CPPDEPS) $<
-
-$(OBJS)\wxtiff_tif_print.o: ../../src/tiff/libtiff/tif_print.c
 	$(CC) -c -o $@ $(WXTIFF_CFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\wxtiff_tif_read.o: ../../src/tiff/libtiff/tif_read.c

--- a/build/msw/makefile.vc
+++ b/build/msw/makefile.vc
@@ -215,7 +215,6 @@ WXTIFF_OBJECTS =  \
 	$(OBJS)\wxtiff_tif_packbits.obj \
 	$(OBJS)\wxtiff_tif_pixarlog.obj \
 	$(OBJS)\wxtiff_tif_predict.obj \
-	$(OBJS)\wxtiff_tif_print.obj \
 	$(OBJS)\wxtiff_tif_read.obj \
 	$(OBJS)\wxtiff_tif_strip.obj \
 	$(OBJS)\wxtiff_tif_swab.obj \
@@ -6872,9 +6871,6 @@ $(OBJS)\wxtiff_tif_pixarlog.obj: ..\..\src\tiff\libtiff\tif_pixarlog.c
 
 $(OBJS)\wxtiff_tif_predict.obj: ..\..\src\tiff\libtiff\tif_predict.c
 	$(CC) /c /nologo /TC /Fo$@ $(WXTIFF_CFLAGS) ..\..\src\tiff\libtiff\tif_predict.c
-
-$(OBJS)\wxtiff_tif_print.obj: ..\..\src\tiff\libtiff\tif_print.c
-	$(CC) /c /nologo /TC /Fo$@ $(WXTIFF_CFLAGS) ..\..\src\tiff\libtiff\tif_print.c
 
 $(OBJS)\wxtiff_tif_read.obj: ..\..\src\tiff\libtiff\tif_read.c
 	$(CC) /c /nologo /TC /Fo$@ $(WXTIFF_CFLAGS) ..\..\src\tiff\libtiff\tif_read.c

--- a/build/msw/wx_vc8_wxtiff.vcproj
+++ b/build/msw/wx_vc8_wxtiff.vcproj
@@ -783,10 +783,6 @@
 				>
 			</File>
 			<File
-				RelativePath="..\..\src\tiff\libtiff\tif_print.c"
-				>
-			</File>
-			<File
 				RelativePath="..\..\src\tiff\libtiff\tif_read.c"
 				>
 			</File>

--- a/build/msw/wx_vc9_wxtiff.vcproj
+++ b/build/msw/wx_vc9_wxtiff.vcproj
@@ -779,10 +779,6 @@
 				>
 			</File>
 			<File
-				RelativePath="..\..\src\tiff\libtiff\tif_print.c"
-				>
-			</File>
-			<File
 				RelativePath="..\..\src\tiff\libtiff\tif_read.c"
 				>
 			</File>


### PR DESCRIPTION
This is a rather drastic solution, but warnings given when
cross-compiling this file with MinGW are annoying, really fixing them is
not completely trivial and risks conflicting with the upstream changes
later, and we don't need the TIFFPrintDirectory() function defined in
this file anyhow, so just exclude it from the build.