### PR TITLE
Add setting the increment to wxSpinCtrl

### DIFF
--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -2031,6 +2031,9 @@ exactly one non-toplevel window as its child.
     Minimum allowed value (default: 0).}
 @row3col{max, integer,
     Maximum allowed value (default: 100).}
+@row3col{inc, integer,
+    Increment (default: 1).}
+
 @endTable
 
 

--- a/include/wx/msw/spinbutt.h
+++ b/include/wx/msw/spinbutt.h
@@ -58,6 +58,8 @@ public:
 
     // returns true if the platform should explicitly apply a theme border
     virtual bool CanApplyThemeBorder() const wxOVERRIDE { return false; }
+    virtual void SetIncrement(int value) wxOVERRIDE;
+    virtual int  GetIncrement() const wxOVERRIDE;
 
 protected:
    virtual wxSize DoGetBestSize() const wxOVERRIDE;

--- a/include/wx/msw/spinctrl.h
+++ b/include/wx/msw/spinctrl.h
@@ -116,8 +116,6 @@ public:
     virtual void SetLayoutDirection(wxLayoutDirection dir) wxOVERRIDE;
 
     virtual WXHWND MSWGetFocusHWND() const wxOVERRIDE;
-    virtual void SetIncrement(int value) wxOVERRIDE;
-    virtual int  GetIncrement() const wxOVERRIDE;
 protected:
     virtual void DoGetPosition(int *x, int *y) const wxOVERRIDE;
     virtual void DoMoveWindow(int x, int y, int width, int height) wxOVERRIDE;

--- a/include/wx/msw/spinctrl.h
+++ b/include/wx/msw/spinctrl.h
@@ -116,7 +116,8 @@ public:
     virtual void SetLayoutDirection(wxLayoutDirection dir) wxOVERRIDE;
 
     virtual WXHWND MSWGetFocusHWND() const wxOVERRIDE;
-
+    virtual bool SetIncrement(int value) wxOVERRIDE;
+    virtual int  GetIncrement() const wxOVERRIDE;
 protected:
     virtual void DoGetPosition(int *x, int *y) const wxOVERRIDE;
     virtual void DoMoveWindow(int x, int y, int width, int height) wxOVERRIDE;

--- a/include/wx/msw/spinctrl.h
+++ b/include/wx/msw/spinctrl.h
@@ -116,7 +116,7 @@ public:
     virtual void SetLayoutDirection(wxLayoutDirection dir) wxOVERRIDE;
 
     virtual WXHWND MSWGetFocusHWND() const wxOVERRIDE;
-    virtual bool SetIncrement(int value) wxOVERRIDE;
+    virtual void SetIncrement(int value) wxOVERRIDE;
     virtual int  GetIncrement() const wxOVERRIDE;
 protected:
     virtual void DoGetPosition(int *x, int *y) const wxOVERRIDE;

--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -149,8 +149,10 @@ public :
     bool                ButtonClickDidStateChange() wxOVERRIDE { return true; }
     void                SetMinimum( wxInt32 v ) wxOVERRIDE;
     void                SetMaximum( wxInt32 v ) wxOVERRIDE;
+    void                SetIncrement(int value) wxOVERRIDE;
     wxInt32             GetMinimum() const wxOVERRIDE;
     wxInt32             GetMaximum() const wxOVERRIDE;
+    int                 GetIncrement() const wxOVERRIDE;
     void                PulseGauge() wxOVERRIDE;
     void                SetScrollThumb( wxInt32 value, wxInt32 thumbSize ) wxOVERRIDE;
 

--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -347,8 +347,10 @@ public :
     virtual void        Enable( bool enable ) = 0;
     virtual void        SetMinimum( wxInt32 v ) = 0;
     virtual void        SetMaximum( wxInt32 v ) = 0;
+    virtual void        SetIncrement(int value) = 0;
     virtual wxInt32     GetMinimum() const = 0;
     virtual wxInt32     GetMaximum() const = 0;
+    virtual int         GetIncrement() const = 0;
     virtual void        PulseGauge() = 0;
     virtual void        SetScrollThumb( wxInt32 value, wxInt32 thumbSize ) = 0;
 

--- a/include/wx/osx/iphone/private.h
+++ b/include/wx/osx/iphone/private.h
@@ -100,8 +100,10 @@ public :
     bool                ButtonClickDidStateChange() { return true ;}
     void                SetMinimum( wxInt32 v );
     void                SetMaximum( wxInt32 v );
+    void                SetIncrement(int WXUNUSED(value)) { }
     wxInt32             GetMinimum() const;
     wxInt32             GetMaximum() const;
+    int                 GetIncrement() const { return 1; }
     void                PulseGauge();
     void                SetScrollThumb( wxInt32 value, wxInt32 thumbSize );
 

--- a/include/wx/osx/spinbutt.h
+++ b/include/wx/osx/spinbutt.h
@@ -62,7 +62,8 @@ public:
     // osx specific event handling common for all osx-ports
 
     virtual bool OSXHandleClicked( double timestampsec ) wxOVERRIDE;
-
+    virtual void SetIncrement(int value) wxOVERRIDE;
+    virtual int GetIncrement() const wxOVERRIDE;
 protected:
     void         SendThumbTrackEvent() ;
 

--- a/include/wx/spinbutt.h
+++ b/include/wx/spinbutt.h
@@ -61,12 +61,14 @@ public:
 
     // is this spin button vertically oriented?
     bool IsVertical() const { return (m_windowStyle & wxSP_VERTICAL) != 0; }
+    virtual bool SetIncrement(int value) { m_increment = value; return true; }
+    virtual int GetIncrement() const { return m_increment; }
 
 protected:
     // the range value
     int   m_min;
     int   m_max;
-
+    int   m_increment;
     wxDECLARE_NO_COPY_CLASS(wxSpinButtonBase);
 };
 

--- a/include/wx/spinbutt.h
+++ b/include/wx/spinbutt.h
@@ -61,7 +61,7 @@ public:
 
     // is this spin button vertically oriented?
     bool IsVertical() const { return (m_windowStyle & wxSP_VERTICAL) != 0; }
-    virtual void SetIncrement(int WXUNUSED(value)) { };
+    virtual void SetIncrement(int WXUNUSED(value)) { }
     virtual int GetIncrement() const { return 1; }
 
 protected:

--- a/include/wx/spinbutt.h
+++ b/include/wx/spinbutt.h
@@ -61,7 +61,7 @@ public:
 
     // is this spin button vertically oriented?
     bool IsVertical() const { return (m_windowStyle & wxSP_VERTICAL) != 0; }
-    virtual void SetIncrement(int value) { m_increment = 1; }
+    virtual void SetIncrement(int WXUNUSED(value)) { m_increment = 1; }
     virtual int GetIncrement() const { return m_increment; }
 
 protected:

--- a/include/wx/spinbutt.h
+++ b/include/wx/spinbutt.h
@@ -61,7 +61,7 @@ public:
 
     // is this spin button vertically oriented?
     bool IsVertical() const { return (m_windowStyle & wxSP_VERTICAL) != 0; }
-    virtual bool SetIncrement(int value) { m_increment = value; return true; }
+    virtual void SetIncrement(int value) { m_increment = 1; }
     virtual int GetIncrement() const { return m_increment; }
 
 protected:

--- a/include/wx/spinbutt.h
+++ b/include/wx/spinbutt.h
@@ -61,14 +61,13 @@ public:
 
     // is this spin button vertically oriented?
     bool IsVertical() const { return (m_windowStyle & wxSP_VERTICAL) != 0; }
-    virtual void SetIncrement(int WXUNUSED(value)) { m_increment = 1; }
-    virtual int GetIncrement() const { return m_increment; }
+    virtual void SetIncrement(int WXUNUSED(value)) { };
+    virtual int GetIncrement() const { return 1; }
 
 protected:
     // the range value
     int   m_min;
     int   m_max;
-    int   m_increment;
     wxDECLARE_NO_COPY_CLASS(wxSpinButtonBase);
 };
 

--- a/interface/wx/spinbutt.h
+++ b/interface/wx/spinbutt.h
@@ -54,7 +54,7 @@ public:
 
     A wxSpinButton has two small up and down (or left and right) arrow buttons.
 
-    It is often used next to a text control for increment and decrementing a value.
+    It is often used next to a text control for incrementing and decrementing a value.
     Portable programs should try to use wxSpinCtrl instead as wxSpinButton is not
     implemented for all platforms but wxSpinCtrl is as it degenerates to a simple
     wxTextCtrl on such platforms.

--- a/interface/wx/spinctrl.h
+++ b/interface/wx/spinctrl.h
@@ -146,6 +146,13 @@ public:
     int GetValue() const;
 
     /**
+        Get the value f increment fr a spin control.
+
+        @since 3.1.6
+    */
+    int GetIncrement() const;
+
+    /**
         Sets the base to use for the numbers in this control.
 
         Currently the only supported values are 10 (which is the default) and
@@ -214,6 +221,13 @@ public:
         Calling this method doesn't generate any @c wxEVT_SPINCTRL events.
     */
     void SetValue(int value);
+
+    /**
+        Sets the increment for the control, just like with wxSpinCtrlDouble
+
+        @since 3.1.6
+    */
+    void SetIncrement(int value);
 };
 
 /**

--- a/interface/wx/spinctrl.h
+++ b/interface/wx/spinctrl.h
@@ -146,8 +146,10 @@ public:
     int GetValue() const;
 
     /**
-        Get the value f increment fr a spin control.
+        Get the value for increment for a spin control.
+        The default value is 1
 
+        @see SetIncrement()
         @since 3.1.6
     */
     int GetIncrement() const;
@@ -223,7 +225,7 @@ public:
     void SetValue(int value);
 
     /**
-        Sets the increment for the control, just like with wxSpinCtrlDouble
+        Sets the increment for the control.
 
         @since 3.1.6
     */

--- a/misc/schema/xrc_schema.rnc
+++ b/misc/schema/xrc_schema.rnc
@@ -1481,7 +1481,8 @@ wxSpinButton =
         stdWindowProperties &
         [xrc:p="o"] element value {_, t_integer }* &
         [xrc:p="o"] element min   {_, t_integer }* &
-        [xrc:p="o"] element max   {_, t_integer }*
+        [xrc:p="o"] element max   {_, t_integer }* &
+        [xrc:p="o"] element inc   {_, t_integer }*
     }
 
 
@@ -1493,7 +1494,8 @@ wxSpinCtrl =
         [xrc:p="o"] element value {_, t_integer }* &
         [xrc:p="o"] element min   {_, t_integer }* &
         [xrc:p="o"] element max   {_, t_integer }* &
-        [xrc:p="o"] element base  {_, ("10" | "16") }*
+        [xrc:p="o"] element base  {_, ("10" | "16") }* &
+        [xrc:p="o"] element inc   {_, t_integer }*
     }
 
 

--- a/samples/widgets/spinbtn.cpp
+++ b/samples/widgets/spinbtn.cpp
@@ -506,10 +506,7 @@ void SpinBtnWidgetsPage::OnButtonSetIncrement(wxCommandEvent& WXUNUSED (event))
     }
 
     m_increment = increment;
-    if( !m_spinctrl->SetIncrement (m_increment) )
-    {
-        wxLogWarning( "Setting increment to %d failed", m_increment );
-    }
+    m_spinctrl->SetIncrement (m_increment);
     wxLogWarning("Setting increment to %d.", m_increment);
 }
 

--- a/samples/widgets/spinbtn.cpp
+++ b/samples/widgets/spinbtn.cpp
@@ -55,11 +55,13 @@ enum
     SpinBtnPage_SetValue,
     SpinBtnPage_SetMinAndMax,
     SpinBtnPage_SetBase,
+    SpinBtnPage_SetIncrement,
     SpinBtnPage_CurValueText,
     SpinBtnPage_ValueText,
     SpinBtnPage_MinText,
     SpinBtnPage_MaxText,
     SpinBtnPage_BaseText,
+    SpinBtnPage_SetIncrementText,
     SpinBtnPage_SpinBtn,
     SpinBtnPage_SpinCtrl,
     SpinBtnPage_SpinCtrlDouble
@@ -103,7 +105,7 @@ protected:
     void OnButtonSetValue(wxCommandEvent& event);
     void OnButtonSetMinAndMax(wxCommandEvent& event);
     void OnButtonSetBase(wxCommandEvent& event);
-
+    void OnButtonSetIncrement(wxCommandEvent &event);
     void OnCheckOrRadioBox(wxCommandEvent& event);
 
     void OnSpinBtn(wxSpinEvent& event);
@@ -138,6 +140,9 @@ protected:
     // and numeric base
     int m_base;
 
+    // the increment
+    int m_increment;
+
     // the controls
     // ------------
 
@@ -159,7 +164,8 @@ protected:
     wxTextCtrl *m_textValue,
                *m_textMin,
                *m_textMax,
-               *m_textBase;
+               *m_textBase,
+               *m_textIncrement;
 
 private:
     wxDECLARE_EVENT_TABLE();
@@ -175,7 +181,7 @@ wxBEGIN_EVENT_TABLE(SpinBtnWidgetsPage, WidgetsPage)
     EVT_BUTTON(SpinBtnPage_SetValue, SpinBtnWidgetsPage::OnButtonSetValue)
     EVT_BUTTON(SpinBtnPage_SetMinAndMax, SpinBtnWidgetsPage::OnButtonSetMinAndMax)
     EVT_BUTTON(SpinBtnPage_SetBase, SpinBtnWidgetsPage::OnButtonSetBase)
-
+    EVT_BUTTON(SpinBtnPage_SetIncrement, SpinBtnWidgetsPage::OnButtonSetIncrement)
     EVT_UPDATE_UI(SpinBtnPage_SetValue, SpinBtnWidgetsPage::OnUpdateUIValueButton)
     EVT_UPDATE_UI(SpinBtnPage_SetMinAndMax, SpinBtnWidgetsPage::OnUpdateUIMinMaxButton)
     EVT_UPDATE_UI(SpinBtnPage_SetBase, SpinBtnWidgetsPage::OnUpdateUIBaseButton)
@@ -227,12 +233,14 @@ SpinBtnWidgetsPage::SpinBtnWidgetsPage(WidgetsBookCtrl *book,
     m_textValue =
     m_textMin =
     m_textMax =
-    m_textBase = NULL;
+    m_textBase =
+    m_textIncrement = NULL;
 
     m_min = 0;
     m_max = 10;
 
     m_base = 10;
+    m_increment = 1;
 
     m_sizerSpin = NULL;
 }
@@ -310,6 +318,13 @@ void SpinBtnWidgetsPage::CreateContent()
                                             &m_textBase);
     m_textBase->SetValue("10");
     sizerMiddle->Add(sizerRow, 0, wxALL | wxGROW, 5);
+
+    sizerRow = CreateSizerWithTextAndButton( SpinBtnPage_SetIncrement,
+                                             "Set Increment",
+                                             SpinBtnPage_SetIncrementText,
+                                             &m_textIncrement );
+    m_textIncrement->SetValue( "1" );
+    sizerMiddle->Add( sizerRow, 0, wxALL | wxGROW, 5 );
 
     // right pane
     wxSizer *sizerRight = new wxBoxSizer(wxVERTICAL);
@@ -479,6 +494,23 @@ void SpinBtnWidgetsPage::OnButtonSetBase(wxCommandEvent& WXUNUSED(event))
     }
 
     m_sizerSpin->Layout();
+}
+
+void SpinBtnWidgetsPage::OnButtonSetIncrement(wxCommandEvent& WXUNUSED (event))
+{
+    unsigned long increment;
+    if( !m_textIncrement->GetValue().ToULong(&increment) || !increment )
+    {
+        wxLogWarning("Invalid base value.");
+        return;
+    }
+
+    m_increment = increment;
+    if( !m_spinctrl->SetIncrement (m_increment) )
+    {
+        wxLogWarning( "Setting increment to %d failed", m_increment );
+    }
+    wxLogWarning("Setting increment to %d.", m_increment);
 }
 
 void SpinBtnWidgetsPage::OnButtonSetValue(wxCommandEvent& WXUNUSED(event))

--- a/samples/widgets/spinbtn.cpp
+++ b/samples/widgets/spinbtn.cpp
@@ -498,8 +498,8 @@ void SpinBtnWidgetsPage::OnButtonSetBase(wxCommandEvent& WXUNUSED(event))
 
 void SpinBtnWidgetsPage::OnButtonSetIncrement(wxCommandEvent& WXUNUSED (event))
 {
-    unsigned long increment;
-    if( !m_textIncrement->GetValue().ToULong(&increment) || !increment )
+    int increment = wxAtoi( m_textIncrement->GetValue() );
+    if( !increment )
     {
         wxLogWarning("Invalid base value.");
         return;

--- a/samples/xrc/rc/controls.xrc
+++ b/samples/xrc/rc/controls.xrc
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="iso-8859-1"?>
 
 
 <resource xmlns="http://www.wxwidgets.org/wxxrc" version="2.5.3.0">
@@ -962,6 +962,7 @@ lay them out using wxSizers, absolute positioning, everything you like!
                                     <style>wxSP_WRAP</style>
                                     <max>100</max>
                                     <value>0</value>
+                                    <inc>2</inc>
                                 </object>
                             </object>
                         </object>
@@ -985,6 +986,7 @@ lay them out using wxSizers, absolute positioning, everything you like!
                                     <max>100</max>
                                     <value>17</value>
                                     <base>16</base>
+                                    <inc>2</inc>
                                 </object>
                             </object>
                         </object>

--- a/src/msw/spinbutt.cpp
+++ b/src/msw/spinbutt.cpp
@@ -288,4 +288,21 @@ bool wxSpinButton::MSWCommand(WXUINT WXUNUSED(cmd), WXWORD WXUNUSED(id))
     return false;
 }
 
+void wxSpinButton::SetIncrement(int value)
+{
+    UDACCEL accel;
+    accel.nSec = 0;
+    accel.nInc = value;
+    ::SendMessage( GetHwnd (), UDM_SETACCEL, 1, (LPARAM) &accel);
+}
+
+int  wxSpinButton::GetIncrement() const
+{
+    UDACCEL accel;
+    int num = ::SendMessage( GetHwnd(), UDM_GETACCEL, 1, (LPARAM) &accel );
+    if( num == 1 )
+        return accel.nInc;
+    else
+        return 1;
+}
 #endif // wxUSE_SPINBTN

--- a/src/msw/spinctrl.cpp
+++ b/src/msw/spinctrl.cpp
@@ -889,7 +889,10 @@ void wxSpinCtrl::SetIncrement(int value)
 int  wxSpinCtrl::GetIncrement() const
 {
     UDACCEL accel;
-    ::SendMessage( GetHwnd(), UDM_GETACCEL, 1, (LPARAM) &accel );
-    return accel.nInc;
+    int num = ::SendMessage( GetHwnd(), UDM_GETACCEL, 1, (LPARAM) &accel );
+    if( num == 1 )
+        return accel.nInc;
+    else
+        return 1;
 }
 #endif // wxUSE_SPINCTRL

--- a/src/msw/spinctrl.cpp
+++ b/src/msw/spinctrl.cpp
@@ -877,22 +877,4 @@ void wxSpinCtrl::DoClientToScreen(int *x, int *y) const
 {
     wxWindow::MSWDoClientToScreen(GetBuddyHwnd(), x, y);
 }
-
-void wxSpinCtrl::SetIncrement(int value)
-{
-    UDACCEL accel;
-    accel.nSec = 0;
-    accel.nInc = value;
-    ::SendMessage( GetHwnd (), UDM_SETACCEL, 1, (LPARAM) &accel);
-}
-
-int  wxSpinCtrl::GetIncrement() const
-{
-    UDACCEL accel;
-    int num = ::SendMessage( GetHwnd(), UDM_GETACCEL, 1, (LPARAM) &accel );
-    if( num == 1 )
-        return accel.nInc;
-    else
-        return 1;
-}
 #endif // wxUSE_SPINCTRL

--- a/src/msw/spinctrl.cpp
+++ b/src/msw/spinctrl.cpp
@@ -878,4 +878,20 @@ void wxSpinCtrl::DoClientToScreen(int *x, int *y) const
     wxWindow::MSWDoClientToScreen(GetBuddyHwnd(), x, y);
 }
 
+bool wxSpinCtrl::SetIncrement(int value)
+{
+    UDACCEL accel;
+    accel.nSec = 0;
+    accel.nInc = value;
+    return ::SendMessage( GetHwnd (), UDM_SETACCEL, 1, (LPARAM) &accel);
+}
+
+int  wxSpinCtrl::GetIncrement() const
+{
+    int increment;
+    UDACCEL accel;
+    ::SendMessage( GetHwnd(), UDM_GETACCEL, 1, (LPARAM) &accel );
+    increment = accel.nInc;
+    return increment;
+}
 #endif // wxUSE_SPINCTRL

--- a/src/msw/spinctrl.cpp
+++ b/src/msw/spinctrl.cpp
@@ -878,12 +878,12 @@ void wxSpinCtrl::DoClientToScreen(int *x, int *y) const
     wxWindow::MSWDoClientToScreen(GetBuddyHwnd(), x, y);
 }
 
-bool wxSpinCtrl::SetIncrement(int value)
+void wxSpinCtrl::SetIncrement(int value)
 {
     UDACCEL accel;
     accel.nSec = 0;
     accel.nInc = value;
-    return ::SendMessage( GetHwnd (), UDM_SETACCEL, 1, (LPARAM) &accel);
+    ::SendMessage( GetHwnd (), UDM_SETACCEL, 1, (LPARAM) &accel);
 }
 
 int  wxSpinCtrl::GetIncrement() const

--- a/src/msw/spinctrl.cpp
+++ b/src/msw/spinctrl.cpp
@@ -888,10 +888,8 @@ void wxSpinCtrl::SetIncrement(int value)
 
 int  wxSpinCtrl::GetIncrement() const
 {
-    int increment;
     UDACCEL accel;
     ::SendMessage( GetHwnd(), UDM_GETACCEL, 1, (LPARAM) &accel );
-    increment = accel.nInc;
-    return increment;
+    return accel.nInc;
 }
 #endif // wxUSE_SPINCTRL

--- a/src/osx/cocoa/spinbutt.mm
+++ b/src/osx/cocoa/spinbutt.mm
@@ -51,6 +51,8 @@ public :
     virtual void SetValue(wxInt32 v) wxOVERRIDE;
     virtual void SetMinimum(wxInt32 v) wxOVERRIDE;
     virtual void SetMaximum(wxInt32 v) wxOVERRIDE;
+    virtual void SetIncrement(int value) wxOVERRIDE;
+    virtual int GetIncrement() const wxOVERRIDE;
     virtual void controlAction(WXWidget slf, void* _cmd, void *sender) wxOVERRIDE;
     virtual void mouseEvent(WX_NSEvent event, WXWidget slf, void* _cmd) wxOVERRIDE;
 private:
@@ -121,6 +123,16 @@ void wxSpinButtonCocoaImpl::controlAction( WXWidget WXUNUSED(slf), void *WXUNUSE
         m_formerValue = [(NSStepper*)m_osxView intValue];
         m_trackValue = false;
     }
+}
+
+void wxSpinButtonCocoaImpl::SetIncrement(int value)
+{
+    [(NSStepper*)m_osxView setIncrement:value];
+}
+
+int wxSpinButtonCocoaImpl::GetIncrement() const
+{
+    return [(NSStepper *) m_osxView increment];
 }
 
 wxWidgetImplType* wxWidgetImpl::CreateSpinButton( wxWindowMac* wxpeer,

--- a/src/osx/cocoa/window.mm
+++ b/src/osx/cocoa/window.mm
@@ -181,9 +181,10 @@ NSRect wxOSXGetFrameForControl( wxWindowMac* window , const wxPoint& pos , const
 
 - (double)minValue;
 - (double)maxValue;
+- (int)increment;
 - (void)setMinValue:(double)aDouble;
 - (void)setMaxValue:(double)aDouble;
-
+- (void)setIncrement:(int)value;
 - (void)sizeToFit;
 
 - (BOOL)isEnabled;
@@ -3413,6 +3414,23 @@ wxInt32 wxWidgetCocoaImpl::GetMinimum() const
     if (  [m_osxView respondsToSelector:@selector(minValue)] )
     {
         return (int)[m_osxView minValue];
+    }
+    return 0;
+}
+
+void wxWidgetCocoaImpl::SetIncrement(int value)
+{
+    if (  [m_osxView respondsToSelector:@selector(setIncrement:)] )
+    {
+        [m_osxView setIncrement:value];
+    }
+}
+
+int wxWidgetCocoaImpl::GetIncrement() const
+{
+    if(  [m_osxView respondsToSelector:@selector(increment)] )
+    {
+        return (int) [m_osxView increment];
     }
     return 0;
 }

--- a/src/osx/spinbutt_osx.cpp
+++ b/src/osx/spinbutt_osx.cpp
@@ -142,4 +142,14 @@ void wxSpinButton::TriggerScrollEvent(wxEventType scrollEvent)
         SendThumbTrackEvent() ;
 }
 
+void wxSpinButton::SetIncrement(int value)
+{
+    GetPeer()->SetIncrement( value );
+}
+
+int wxSpinButton::GetIncrement() const
+{
+    return GetPeer()->GetIncrement();
+}
+
 #endif // wxUSE_SPINBTN

--- a/src/xrc/xh_spin.cpp
+++ b/src/xrc/xh_spin.cpp
@@ -22,6 +22,7 @@
 static const long DEFAULT_VALUE = 0;
 static const long DEFAULT_MIN = 0;
 static const long DEFAULT_MAX = 100;
+static const int DEFAULT_INCREMENT = 1;
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxSpinButtonXmlHandler, wxXmlResourceHandler);
 
@@ -48,6 +49,7 @@ wxObject *wxSpinButtonXmlHandler::DoCreateResource()
     control->SetValue(GetLong( wxT("value"), DEFAULT_VALUE));
     control->SetRange(GetLong( wxT("min"), DEFAULT_MIN),
                       GetLong(wxT("max"), DEFAULT_MAX));
+    control->SetValue( GetLong( wxT( "inc" ), DEFAULT_INCREMENT ) );
     SetupWindow(control);
 
     return control;
@@ -98,7 +100,7 @@ wxObject *wxSpinCtrlXmlHandler::DoCreateResource()
                     GetLong(wxT("max"), DEFAULT_MAX),
                     GetLong(wxT("value"), DEFAULT_VALUE),
                     GetName());
-
+    control->SetIncrement( GetLong( wxT( "inc" ), DEFAULT_INCREMENT ) );
     const long base = GetLong(wxS("base"), 10);
     if ( base != 10 )
         control->SetBase(base);

--- a/tests/controls/spinctrltest.cpp
+++ b/tests/controls/spinctrltest.cpp
@@ -368,4 +368,28 @@ TEST_CASE_METHOD(SpinCtrlTestCase3, "SpinCtrl::SetValueInsideEventHandler", "[sp
 #endif // wxUSE_UIACTIONSIMULATOR
 }
 
+TEST_CASE_METHOD(SpinCtrlTestCase1, "SpinCtrl::Increment", "[spinctrl]")
+{
+#if wxUSE_UIACTIONSIMULATOR
+    m_spin->Create(wxTheApp->GetTopWindow(), wxID_ANY, "",
+        wxDefaultPosition, wxDefaultSize,
+        wxSP_ARROW_KEYS | wxSP_WRAP);
+
+    wxUIActionSimulator sim;
+
+    m_spin->SetFocus();
+    wxYield();
+    m_spin->SetIncrement( 5 );
+    sim.Char(WXK_UP);
+
+    wxYield();
+
+    CHECK(m_spin->GetValue() == 5);
+
+    int increment = m_spin->GetIncrement();
+
+    CHECK( increment == 5 );
+#endif
+}
+
 #endif

--- a/tests/controls/spinctrltest.cpp
+++ b/tests/controls/spinctrltest.cpp
@@ -377,6 +377,8 @@ TEST_CASE_METHOD(SpinCtrlTestCase1, "SpinCtrl::Increment", "[spinctrl]")
 
     wxUIActionSimulator sim;
 
+    CHECK( m_spin->GetIncrement() == 1 );
+
     m_spin->SetFocus();
     wxYield();
     m_spin->SetIncrement( 5 );


### PR DESCRIPTION
This PR will add the setting/getting the increment to wxSpinCtrl.

The code has been tested on Windows 8.1 with MSVC 2017 and OSX 10.13.

GTK already had the feature implemented.

Documentation is updated accordingly - 2 new functions are added. Widgets sample and test suite are also updated and the tests are passed on MSW.

I'm updating the Qt machine at the moment. When its done I will look into adding this to wxQt if its not already there.

Please review and apply.
