### PR TITLE
Fix uses of wxDEPRECATED in WXWIN_COMPATIBILITY_2_8-only code

### DIFF
--- a/include/wx/artprov.h
+++ b/include/wx/artprov.h
@@ -139,7 +139,7 @@ public:
 
 #if WXWIN_COMPATIBILITY_2_8
     // use PushBack(), it's the same thing
-    static wxDEPRECATED( void Insert(wxArtProvider *provider) );
+    wxDEPRECATED( static void Insert(wxArtProvider *provider) );
 #endif
 
     // Remove latest added provider and delete it.

--- a/include/wx/effects.h
+++ b/include/wx/effects.h
@@ -83,7 +83,7 @@ protected:
 // directly deprecating the classes...)
 //
 // note that this g++ bug (16370) is supposed to be fixed in g++ 4.3.0
-typedef wxEffectsImpl wxDEPRECATED(wxEffects);
+wxDEPRECATED(typedef wxEffectsImpl wxEffects);
 
 #endif // WXWIN_COMPATIBILITY_2_8
 

--- a/include/wx/image.h
+++ b/include/wx/image.h
@@ -645,14 +645,14 @@ public:
         }
     )
 
-    static wxDEPRECATED(
+    wxDEPRECATED(static
         wxImageHandler *FindHandler(const wxString& ext, long type)
         {
             return FindHandler(ext, (wxBitmapType)type);
         }
     )
 
-    static wxDEPRECATED(
+    wxDEPRECATED(static
         wxImageHandler *FindHandler(long imageType)
         {
             return FindHandler((wxBitmapType)imageType);

--- a/include/wx/log.h
+++ b/include/wx/log.h
@@ -578,7 +578,7 @@ public:
 
     // don't use integer masks any more, use string trace masks instead
 #if WXWIN_COMPATIBILITY_2_8
-    static wxDEPRECATED_INLINE( void SetTraceMask(wxTraceMask ulMask),
+    wxDEPRECATED_INLINE( static void SetTraceMask(wxTraceMask ulMask),
         ms_ulTraceMask = ulMask; )
 
     // this one can't be marked deprecated as it's used in our own wxLogger

--- a/include/wx/menuitem.h
+++ b/include/wx/menuitem.h
@@ -146,7 +146,7 @@ public:
     wxDEPRECATED( const wxString& GetText() const );
 
     // Now use GetLabelText to strip the accelerators
-    static wxDEPRECATED( wxString GetLabelFromText(const wxString& text) );
+    wxDEPRECATED( static wxString GetLabelFromText(const wxString& text) );
 
     // Now use SetItemLabel
     wxDEPRECATED( virtual void SetText(const wxString& str) );

--- a/include/wx/validate.h
+++ b/include/wx/validate.h
@@ -81,7 +81,7 @@ public:
     // unnaturally: it disabled the bell when it was true, not false as could
     // be expected; use SuppressBellOnError() instead
 #if WXWIN_COMPATIBILITY_2_8
-    static wxDEPRECATED_INLINE(
+    wxDEPRECATED_INLINE(static
         void SetBellOnError(bool doIt = true),
         ms_isSilent = doIt;
     )


### PR DESCRIPTION
wxDEPRECATED must be used for the entire declaration to really work,
but this wasn't the case for a few functions (and one typedef) guarded
by WXWIN_COMPATIBILITY_2_8, resulting in gcc -Wattributes warning about
the attribute being ignored and the declaration not being really marked
as deprecated.

Fix this by applying the deprecation macro to the entire declaration,
which works well for gcc and should hopefully work for MSVC too.