### PR TITLE
Use SpinCtrl best size when computing wxGenericCalendarCtrl best size

### DIFF
--- a/samples/calendar/calendar.cpp
+++ b/samples/calendar/calendar.cpp
@@ -397,7 +397,7 @@ bool MyApp::OnInit()
 
     // Create the main application window
     MyFrame *frame = new MyFrame("Calendar wxWidgets sample"
-                                 ,wxPoint(50, 50), wxSize(450, 340)
+                                 ,wxPoint(50, 50), wxSize(460, 340)
                                  );
 
     frame->Show(true);

--- a/src/generic/calctrlg.cpp
+++ b/src/generic/calctrlg.cpp
@@ -690,11 +690,12 @@ wxSize wxGenericCalendarCtrl::DoGetBestSize() const
     if ( !HasFlag(wxCAL_SEQUENTIAL_MONTH_SELECTION) )
     {
         const wxSize bestSizeCombo = m_comboMonth->GetBestSize();
+        const wxSize bestSizeSpin = m_spinYear->GetBestSize();
 
-        height += wxMax(bestSizeCombo.y, m_spinYear->GetBestSize().y)
+        height += wxMax(bestSizeCombo.y, bestSizeSpin.y)
                     + VERT_MARGIN;
 
-        wxCoord w2 = bestSizeCombo.x + HORZ_MARGIN + GetCharWidth()*8;
+        wxCoord w2 = bestSizeCombo.x + HORZ_MARGIN + bestSizeSpin.x;
         if ( width < w2 )
             width = w2;
     }


### PR DESCRIPTION
This fixes the wxGenericCalendarCtrl on wxGTK3 where the SpinCtrl is much wider than on other platforms.

This seems to have been what VZ suggested 12 years ago (🙂) in https://trac.wxwidgets.org/ticket/11444.