### PR TITLE
Add wxApp::GTKSuppressDiagnostics()

### DIFF
--- a/include/wx/gtk/app.h
+++ b/include/wx/gtk/app.h
@@ -58,6 +58,12 @@ public:
     // various bugs arising due to this.
     static bool GTKIsUsingGlobalMenu();
 
+    // Provide the ability to suppress GTK output. By default, all output
+    // will be suppressed, but the user can pass in a mask specifiyng the
+    // types of messages to suppress. Flags are defined by glib with the
+    // GLogLevelFlags enum.
+    static void GTKSuppressDiagnostics(int flags = -1);
+
     // implementation only from now on
     // -------------------------------
 

--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -1002,6 +1002,37 @@ public:
     */
     void SetUseBestVisual(bool flag, bool forceTrueColour = false);
 
+    /**
+        @name GTK-specific functions
+    */
+    //@{
+
+    /**
+        Disables the printing of various GTK messages.
+
+        This function can be called to suppress GTK diagnostic messages that
+        are output on the standard error stream by default.
+
+        The default value of the argument disables all messages, but you
+        can pass in a mask flag to specifically disable only particular
+        categories of messages.
+
+        Note that this function only works when using glib 2.50 (released in
+        September 2016) or later and does nothing with the older versions of
+        the library.
+
+        @param flags
+           The mask for the types of messages to suppress. Refer to the
+           glib documentation for the @c GLogLevelFlags enum, which defines
+           the various message types.
+
+        @onlyfor{wxgtk}
+
+        @since 3.1.6
+    */
+    static void GTKSuppressDiagnostics(int flags = -1);
+
+    //@}
 
     /**
         @name Mac-specific functions


### PR DESCRIPTION
This allows to avoid GTK messages that are often more annoying and
confusing than useful.

Closes [#19347](http://trac.wxwidgets.org/ticket/19347).