### PR TITLE
Adding min and max arguments to the wxIntegerValidator constructor

### DIFF
--- a/include/wx/valnum.h
+++ b/include/wx/valnum.h
@@ -347,6 +347,19 @@ public:
         this->SetMax(std::numeric_limits<ValueType>::max());
     }
 
+  // Ctor for an integer validator.
+  //
+  // Sets the range to the specified interval [min, max].
+  wxIntegerValidator(ValueType *value,
+                     ValueType min,
+                     ValueType max,
+                     int style = wxNUM_VAL_DEFAULT)
+      : Base(value, style)
+  {
+    this->SetMin(min);
+    this->SetMax(max);
+  }
+
     virtual wxObject *Clone() const wxOVERRIDE { return new wxIntegerValidator(*this); }
 
     virtual bool IsInRange(LongestValueType value) const wxOVERRIDE

--- a/include/wx/valnum.h
+++ b/include/wx/valnum.h
@@ -338,13 +338,15 @@ public:
 
     // Ctor for an integer validator.
     //
-    // Sets the range appropriately for the type, including setting 0 as the
+    // Sets the range as specified or to the maximum range appropriately for the type, including setting 0 as the
     // minimal value for the unsigned types.
-    wxIntegerValidator(ValueType *value = NULL, int style = wxNUM_VAL_DEFAULT)
-        : Base(value, style)
+    wxIntegerValidator(ValueType *value = NULL, int style = wxNUM_VAL_DEFAULT,
+                       ValueType min=std::numeric_limits<ValueType>::min(),
+                       ValueType max=std::numeric_limits<ValueType>::max())
+                       : Base(value, style)
     {
-        this->SetMin(std::numeric_limits<ValueType>::min());
-        this->SetMax(std::numeric_limits<ValueType>::max());
+        this->SetMin(min);
+        this->SetMax(max);
     }
 
     virtual wxObject *Clone() const wxOVERRIDE { return new wxIntegerValidator(*this); }

--- a/include/wx/valnum.h
+++ b/include/wx/valnum.h
@@ -338,13 +338,14 @@ public:
 
     // Ctor for an integer validator.
     //
-    // Sets the range appropriately for the type, including setting 0 as the
+    // Sets the range as specified or to the maximum range appropriately for the type, including setting 0 as the
     // minimal value for the unsigned types.
-    wxIntegerValidator(ValueType *value = NULL, int style = wxNUM_VAL_DEFAULT)
-        : Base(value, style)
+    wxIntegerValidator(ValueType *value = NULL, int style = wxNUM_VAL_DEFAULT,
+                       ValueType min=std::numeric_limits<ValueType>::min(),
+                       ValueType max=std::numeric_limits<ValueType>::max())
     {
-        this->SetMin(std::numeric_limits<ValueType>::min());
-        this->SetMax(std::numeric_limits<ValueType>::max());
+        this->SetMin(min);
+        this->SetMax(max);
     }
 
     virtual wxObject *Clone() const wxOVERRIDE { return new wxIntegerValidator(*this); }

--- a/include/wx/valnum.h
+++ b/include/wx/valnum.h
@@ -338,15 +338,13 @@ public:
 
     // Ctor for an integer validator.
     //
-    // Sets the range as specified or to the maximum range appropriately for the type, including setting 0 as the
+    // Sets the range as appropriate for the type, including setting 0 as the
     // minimal value for the unsigned types.
-    wxIntegerValidator(ValueType *value = NULL, int style = wxNUM_VAL_DEFAULT,
-                       ValueType min=std::numeric_limits<ValueType>::min(),
-                       ValueType max=std::numeric_limits<ValueType>::max())
+    wxIntegerValidator(ValueType *value = NULL, int style = wxNUM_VAL_DEFAULT)
                        : Base(value, style)
     {
-        this->SetMin(min);
-        this->SetMax(max);
+        this->SetMin(std::numeric_limits<ValueType>::min());
+        this->SetMax(std::numeric_limits<ValueType>::max());
     }
 
   // Ctor for an integer validator.

--- a/interface/wx/valnum.h
+++ b/interface/wx/valnum.h
@@ -288,6 +288,25 @@ public:
             of wxNUM_VAL_NO_TRAILING_ZEROES which can't be used here.
     */
     wxIntegerValidator(ValueType *value = NULL, int style = wxNUM_VAL_DEFAULT);
+
+    /**
+        Validator constructor with specified range.
+
+        @param value
+            A pointer to the variable associated with the validator. This variable
+            should have a lifetime equal to or longer than the validator lifetime
+            (which is usually determined by the lifetime of the window).
+        @param min
+            The minimum value accepted by the validator.
+        @param max
+            The maximum value accepted by the validator.
+        @param style
+            A combination of wxNumValidatorStyle enum values with the exception
+            of wxNUM_VAL_NO_TRAILING_ZEROES which can't be used here.
+
+        @since 3.1.6
+    */
+    wxIntegerValidator(ValueType *value, ValueType min, ValueType max, int style = wxNUM_VAL_DEFAULT);
 };
 
 /**

--- a/tests/validators/valnum.cpp
+++ b/tests/validators/valnum.cpp
@@ -114,6 +114,40 @@ TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::TransferUnsigned", "[valnum]")
     CHECK( !valUnsigned.TransferFromWindow() );
 }
 
+TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::TransferUnsignedRange", "[valnum]")
+{
+    unsigned value = 1;
+    wxIntegerValidator<unsigned> valUnsigned(&value, 1, 20);
+    valUnsigned.SetWindow(m_text);
+
+    CHECK( valUnsigned.TransferToWindow() );
+    CHECK( m_text->GetValue() == "1" );
+
+    value = 17;
+    CHECK( valUnsigned.TransferToWindow() );
+    CHECK( m_text->GetValue() == "17" );
+
+    m_text->ChangeValue("foobar");
+    CHECK( !valUnsigned.TransferFromWindow() );
+
+    m_text->ChangeValue("0");
+    CHECK( !valUnsigned.TransferFromWindow() );
+
+    m_text->ChangeValue("1")
+    CHECK( valUnsigned.TransferFromWindow() );
+    CHECK( value == 1);
+
+    m_text->ChangeValue("20")
+    CHECK( valUnsigned.TransferFromWindow() );
+    CHECK( value == 20);
+
+    m_text->ChangeValue("21");
+    CHECK( !valUnsigned.TransferFromWindow() );
+
+    m_text->Clear();
+    CHECK( !valUnsigned.TransferFromWindow() );
+}
+
 TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::TransferULL", "[valnum]")
 {
     unsigned long long value = 0;

--- a/tests/validators/valnum.cpp
+++ b/tests/validators/valnum.cpp
@@ -133,11 +133,11 @@ TEST_CASE_METHOD(NumValidatorTestCase, "ValNum::TransferUnsignedRange", "[valnum
     m_text->ChangeValue("0");
     CHECK( !valUnsigned.TransferFromWindow() );
 
-    m_text->ChangeValue("1")
+    m_text->ChangeValue("1");
     CHECK( valUnsigned.TransferFromWindow() );
     CHECK( value == 1);
 
-    m_text->ChangeValue("20")
+    m_text->ChangeValue("20");
     CHECK( valUnsigned.TransferFromWindow() );
     CHECK( value == 20);
 


### PR DESCRIPTION
A  ``wxIntegerValidator`` object currently cannot be created and set to a specific range in one step, although it seems trivially simple to add a `min` and `max` argument to the constructor, which I did. 

