### PR TITLE
Add support for symbolic links to wxOSX wxFileSystemWatcherEvent.

### DIFF
--- a/src/osx/fswatcher_fsevents.cpp
+++ b/src/osx/fswatcher_fsevents.cpp
@@ -186,6 +186,10 @@ static void FileNameFromEvent(wxFileName& eventFileName, char* path,
     {
         eventFileName.AssignDir(strPath);
     }
+    if ( flags & kFSEventStreamEventFlagItemIsSymlink )
+    {
+        eventFileName.Assign(strPath);
+    }
 }
 
 // This is the function that the FsEvents API


### PR DESCRIPTION
With reference to the discussion at https://groups.google.com/g/wx-dev/c/krsmT_n9njg, this is a simple fix to let the raised wxFileSystemWatcherEvent OSX include the path of the modified/created/deleted file/directory if it is a symbolic link.
The code was previously raising an event with no path inside it.