### PR TITLE
CMake: Never add static runtime flags on macOS

### DIFF
--- a/build/cmake/init.cmake
+++ b/build/cmake/init.cmake
@@ -83,7 +83,7 @@ elseif(("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") OR ("${CMAKE_CXX_COMPILER_ID}
         wx_string_append(CMAKE_C_FLAGS_RELEASE "${COMPILER_DBGSYM_FLAG}")
     endif()
 
-    if(wxBUILD_USE_STATIC_RUNTIME)
+    if(wxBUILD_USE_STATIC_RUNTIME AND NOT APPLE)
         if(MINGW)
             set(STATIC_LINKER_FLAGS " -static")
         else()


### PR DESCRIPTION
This option is disabled in the GUI, but users can still specify it on the command-line. Never add the linker flags to prevent errors (unsupported option '-static-libgcc') or warnings (argument unused during compilation: '-static-libstdc++').

Closes [#19330](https://trac.wxwidgets.org/ticket/19330)