### PR TITLE
Optimize column adjustments when wxDVC is frozen under Mac

### DIFF
--- a/include/wx/osx/dataview.h
+++ b/include/wx/osx/dataview.h
@@ -285,6 +285,8 @@ protected:
  // event handling
   void OnSize(wxSizeEvent &event);
 
+  virtual void DoThaw() wxOVERRIDE;
+
 private:
  // initializing of local variables:
   void Init();

--- a/src/osx/dataview_osx.cpp
+++ b/src/osx/dataview_osx.cpp
@@ -702,7 +702,7 @@ void wxDataViewCtrl::FinishCustomItemEditing()
 
 void wxDataViewCtrl::AdjustAutosizedColumns() const
 {
-  if ( m_ModelNotifier && !IsFrozen() )
+  if ( m_ModelNotifier )
     m_ModelNotifier->AdjustAutosizedColumns();
 }
 

--- a/src/osx/dataview_osx.cpp
+++ b/src/osx/dataview_osx.cpp
@@ -74,17 +74,24 @@ public:
   virtual void Resort() wxOVERRIDE;
 
   // adjust wxCOL_WIDTH_AUTOSIZE columns to fit the data, does nothing if the
-  // control is frozen
+  // control is frozen but remember it for later
   void AdjustAutosizedColumns()
   {
     if (!m_DataViewCtrlPtr->IsFrozen())
       DoAdjustAutosizedColumns();
+    else
+      m_needsAdjustmentOnThaw = true;
   }
 
   // called by the control when it is thawed to adjust the columns if necessary
   void OnThaw()
   {
-    DoAdjustAutosizedColumns();
+    if (m_needsAdjustmentOnThaw)
+    {
+      DoAdjustAutosizedColumns();
+
+      m_needsAdjustmentOnThaw = false;
+    }
   }
 
 protected:
@@ -99,6 +106,11 @@ private:
   void DoAdjustAutosizedColumns();
 
   wxDataViewCtrl* m_DataViewCtrlPtr;
+
+  // This is set to true only if AdjustAutosizedColumns() is called while the
+  // control is frozen and in this case OnThaw() readjusts the columns when it
+  // is thawed.
+  bool m_needsAdjustmentOnThaw;
 };
 
 //
@@ -109,6 +121,8 @@ wxOSXDataViewModelNotifier::wxOSXDataViewModelNotifier(wxDataViewCtrl* initDataV
 {
   if (initDataViewCtrlPtr == NULL)
     wxFAIL_MSG("Pointer to dataview control must not be NULL");
+
+  m_needsAdjustmentOnThaw = false;
 }
 
 bool wxOSXDataViewModelNotifier::ItemAdded(wxDataViewItem const& parent, wxDataViewItem const& item)

--- a/src/osx/dataview_osx.cpp
+++ b/src/osx/dataview_osx.cpp
@@ -74,7 +74,7 @@ public:
   virtual void Resort() wxOVERRIDE;
 
  // adjust wxCOL_WIDTH_AUTOSIZE columns to fit the data
-  void AdjustAutosizedColumns();
+  void AdjustAutosizedColumns(bool force = false);
 
 protected:
  // if the dataview control can have a variable row height this method sets the dataview's control row height of
@@ -297,8 +297,11 @@ void wxOSXDataViewModelNotifier::AdjustRowHeights(wxDataViewItemArray const& ite
   }
 }
 
-void wxOSXDataViewModelNotifier::AdjustAutosizedColumns()
+void wxOSXDataViewModelNotifier::AdjustAutosizedColumns(bool forced)
 {
+  if (m_DataViewCtrlPtr->IsFrozen() && !forced)
+    return;
+
   unsigned count = m_DataViewCtrlPtr->GetColumnCount();
   for ( unsigned col = 0; col < count; col++ )
   {
@@ -699,8 +702,18 @@ void wxDataViewCtrl::FinishCustomItemEditing()
 
 void wxDataViewCtrl::AdjustAutosizedColumns() const
 {
-  if ( m_ModelNotifier )
+  if ( m_ModelNotifier && !IsFrozen() )
     m_ModelNotifier->AdjustAutosizedColumns();
+}
+
+void wxDataViewCtrl::DoThaw()
+{
+    if ( m_ModelNotifier )
+    {
+        // On thaw, we want to force the updating of the colum sizes
+        m_ModelNotifier->AdjustAutosizedColumns(true);
+    }
+    wxDataViewCtrlBase::DoThaw();
 }
 
 /*static*/


### PR DESCRIPTION
This is a slightly improved version of #2527.

@dkulp and @vslavik please review and, ideally, test it as I don't have any test code for this. TIA!