### PR TITLE
wxListCtrl sort indicator fixes

### DIFF
--- a/include/wx/generic/listctrl.h
+++ b/include/wx/generic/listctrl.h
@@ -115,10 +115,7 @@ public:
     bool IsItemChecked(long item) const wxOVERRIDE;
     void CheckItem(long item, bool check) wxOVERRIDE;
 
-    void EnableSortIndicator(bool enable = true) wxOVERRIDE;
-    bool IsSortIndicatorEnabled() const wxOVERRIDE;
     void ShowSortIndicator(int idx, bool ascending = true) wxOVERRIDE;
-    void RemoveSortIndicator() wxOVERRIDE;
     int GetSortIndicator() const wxOVERRIDE;
     bool IsAscendingSortIndicator() const wxOVERRIDE;
 

--- a/include/wx/generic/listctrl.h
+++ b/include/wx/generic/listctrl.h
@@ -115,9 +115,9 @@ public:
     bool IsItemChecked(long item) const wxOVERRIDE;
     void CheckItem(long item, bool check) wxOVERRIDE;
 
-    void EnableSortIndicator(const bool enable = true) wxOVERRIDE;
+    void EnableSortIndicator(bool enable = true) wxOVERRIDE;
     bool IsSortIndicatorEnabled() const wxOVERRIDE;
-    void ShowSortIndicator(const int idx, const bool ascending = true) wxOVERRIDE;
+    void ShowSortIndicator(int idx, bool ascending = true) wxOVERRIDE;
     void RemoveSortIndicator() wxOVERRIDE;
     int GetSortIndicator() const wxOVERRIDE;
     bool IsAscendingSortIndicator() const wxOVERRIDE;

--- a/include/wx/generic/private/listctrl.h
+++ b/include/wx/generic/private/listctrl.h
@@ -381,7 +381,6 @@ public:
     int m_colToSend;
     int m_widthToSend;
 
-    bool m_enableSortCol;
     bool m_sortAsc;
     int m_sortCol;
 

--- a/include/wx/listbase.h
+++ b/include/wx/listbase.h
@@ -447,9 +447,9 @@ public:
     virtual void CheckItem(long WXUNUSED(item), bool WXUNUSED(check)) { }
 
     // Sort indicator in header.
-    virtual void EnableSortIndicator(const bool WXUNUSED(enable) = true) { }
+    virtual void EnableSortIndicator(bool WXUNUSED(enable) = true) { }
     virtual bool IsSortIndicatorEnabled() const { return false; }
-    virtual void ShowSortIndicator(const int WXUNUSED(idx), const bool WXUNUSED(ascending) = true) { }
+    virtual void ShowSortIndicator(int WXUNUSED(idx), bool WXUNUSED(ascending) = true) { }
     virtual void RemoveSortIndicator() { }
     virtual int GetSortIndicator() const { return -1; }
     virtual bool IsAscendingSortIndicator() const { return true; }

--- a/include/wx/listbase.h
+++ b/include/wx/listbase.h
@@ -447,7 +447,7 @@ public:
     virtual void CheckItem(long WXUNUSED(item), bool WXUNUSED(check)) { }
 
     // Sort indicator in header.
-    virtual void ShowSortIndicator(int WXUNUSED(idx), bool WXUNUSED(ascending) = true) { }
+    virtual void ShowSortIndicator(int WXUNUSED(col), bool WXUNUSED(ascending) = true) { }
     void RemoveSortIndicator() { ShowSortIndicator(-1); }
     virtual int GetSortIndicator() const { return -1; }
     virtual bool IsAscendingSortIndicator() const { return true; }

--- a/include/wx/listbase.h
+++ b/include/wx/listbase.h
@@ -447,10 +447,8 @@ public:
     virtual void CheckItem(long WXUNUSED(item), bool WXUNUSED(check)) { }
 
     // Sort indicator in header.
-    virtual void EnableSortIndicator(bool WXUNUSED(enable) = true) { }
-    virtual bool IsSortIndicatorEnabled() const { return false; }
     virtual void ShowSortIndicator(int WXUNUSED(idx), bool WXUNUSED(ascending) = true) { }
-    virtual void RemoveSortIndicator() { }
+    void RemoveSortIndicator() { ShowSortIndicator(-1); }
     virtual int GetSortIndicator() const { return -1; }
     virtual bool IsAscendingSortIndicator() const { return true; }
 

--- a/include/wx/listbase.h
+++ b/include/wx/listbase.h
@@ -451,6 +451,12 @@ public:
     void RemoveSortIndicator() { ShowSortIndicator(-1); }
     virtual int GetSortIndicator() const { return -1; }
     virtual bool IsAscendingSortIndicator() const { return true; }
+    bool GetUpdatedAscendingSortIndicator(int col) const
+    {
+        // If clicking on the same column by which we already sort, toggle the sort
+        // direction, otherwise use ascending sort by default.
+        return col == GetSortIndicator() ? !IsAscendingSortIndicator() : true;
+    }
 
 protected:
     // Return pointer to the corresponding m_imagesXXX.

--- a/include/wx/msw/listctrl.h
+++ b/include/wx/msw/listctrl.h
@@ -426,6 +426,11 @@ protected:
     int               m_colCount;   // Windows doesn't have GetColumnCount so must
                                     // keep track of inserted/deleted columns
 
+    // m_sortCol and m_sortAsc are used only if m_enableSortCol is true.
+    //
+    // Note that m_sortCol may be set to -1, but this is not the same as
+    // setting m_enableSortCol to false, as the control updates the sort
+    // indicator on column click in the former case, but not in the latter.
     bool m_enableSortCol;
     bool m_sortAsc;
     int m_sortCol;
@@ -457,7 +462,8 @@ private:
     // in-place editor control.
     void OnCharHook(wxKeyEvent& event);
 
-    // Draw the sort arrow arror in the header.
+    // Draw the sort arrow in the header. Should only be called when sort
+    // indicators are enabled.
     void DrawSortArrow();
 
     // Object using for header custom drawing if necessary, may be NULL.

--- a/include/wx/msw/listctrl.h
+++ b/include/wx/msw/listctrl.h
@@ -226,9 +226,9 @@ public:
     void CheckItem(long item, bool check) wxOVERRIDE;
 
     // Sort indicator in header
-    void EnableSortIndicator(const bool enable = true) wxOVERRIDE;
+    void EnableSortIndicator(bool enable = true) wxOVERRIDE;
     bool IsSortIndicatorEnabled() const wxOVERRIDE;
-    void ShowSortIndicator(const int idx, const bool ascending = true) wxOVERRIDE;
+    void ShowSortIndicator(int idx, bool ascending = true) wxOVERRIDE;
     void RemoveSortIndicator() wxOVERRIDE;
     int GetSortIndicator() const wxOVERRIDE;
     bool IsAscendingSortIndicator() const wxOVERRIDE;

--- a/include/wx/msw/listctrl.h
+++ b/include/wx/msw/listctrl.h
@@ -226,10 +226,7 @@ public:
     void CheckItem(long item, bool check) wxOVERRIDE;
 
     // Sort indicator in header
-    void EnableSortIndicator(bool enable = true) wxOVERRIDE;
-    bool IsSortIndicatorEnabled() const wxOVERRIDE;
     void ShowSortIndicator(int idx, bool ascending = true) wxOVERRIDE;
-    void RemoveSortIndicator() wxOVERRIDE;
     int GetSortIndicator() const wxOVERRIDE;
     bool IsAscendingSortIndicator() const wxOVERRIDE;
 
@@ -426,20 +423,15 @@ protected:
     int               m_colCount;   // Windows doesn't have GetColumnCount so must
                                     // keep track of inserted/deleted columns
 
-    // m_sortCol and m_sortAsc are used only if m_enableSortCol is true.
-    //
-    // Note that m_sortCol may be set to -1, but this is not the same as
-    // setting m_enableSortCol to false, as the control updates the sort
-    // indicator on column click in the former case, but not in the latter.
-    bool m_enableSortCol;
-    bool m_sortAsc;
-    int m_sortCol;
-
     // all wxMSWListItemData objects we use
     wxVector<wxMSWListItemData *> m_internalData;
 
     // true if we have any items with custom attributes
     bool m_hasAnyAttr;
+
+    // m_sortAsc is only used if m_sortCol != -1
+    bool m_sortAsc;
+    int m_sortCol;
 
 private:
     // process NM_CUSTOMDRAW notification message
@@ -462,8 +454,7 @@ private:
     // in-place editor control.
     void OnCharHook(wxKeyEvent& event);
 
-    // Draw the sort arrow in the header. Should only be called when sort
-    // indicators are enabled.
+    // Draw the sort arrow in the header.
     void DrawSortArrow();
 
     // Object using for header custom drawing if necessary, may be NULL.

--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -1428,6 +1428,9 @@ public:
         indicator in ascending order, or toggle it in the opposite order. To
         sort the list, call SortItems() in EVT_LIST_COL_CLICK.
 
+        Note that calling ShowSortIndicator() implicitly enables sort
+        indicators.
+
         @note In wxMSW, this will disable the header icon of the column.
 
         @param enable
@@ -1448,7 +1451,9 @@ public:
 
     /**
         Show the sort indicator of a specific column in a specific direction.
-        Sort indicators have to be enabled using EnableSortIndicator().
+
+        This function also enables showing sort indicators if
+        EnableSortIndicator() hadn't been called.
 
         @note This does not actually sort the list, use SortItems() for this.
 

--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -1461,6 +1461,31 @@ public:
     int GetSortIndicator() const;
 
     /**
+        Returns the new value to use for sort indicator after clicking a
+        column.
+
+        This helper function can be useful in the EVT_LIST_COL_CLICK handler
+        when it updates the sort indicator after the user clicked on a column.
+
+        For example:
+        @code
+            void MyListCtrl::OnColClick(wxListEvent& event)
+            {
+                int col = event.GetColumn();
+                if ( col == -1 )
+                    return; // clicked outside any column.
+
+                const bool ascending = GetUpdatedAscendingSortIndicator(col);
+                SortItems(MyCompareFunction, ascending);
+                ShowSortIndicator(col, ascending);
+            }
+        @endcode
+
+        @since 3.1.6
+    */
+    bool GetUpdatedAscendingSortIndicator(int col) const;
+
+    /**
         Returns @true if the sort indicator direction is ascending,
         @false when the direction is descending.
 

--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -1432,7 +1432,7 @@ public:
 
         @note This does not actually sort the list, use SortItems() for this.
 
-        @param idx
+        @param col
             The column to set the sort indicator for.
             If @c -1 is given, then the currently shown sort indicator
             will be removed.
@@ -1442,7 +1442,7 @@ public:
 
         @since 3.1.6
     */
-    void ShowSortIndicator(int idx, bool ascending = true);
+    void ShowSortIndicator(int col, bool ascending = true);
 
     /**
         Remove the sort indicator from the column being used as sort key.

--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -1435,7 +1435,7 @@ public:
 
         @since 3.1.6
     */
-    void EnableSortIndicator(const bool enable);
+    void EnableSortIndicator(bool enable);
 
     /**
         Returns true if a sort indicator is enabled.
@@ -1462,7 +1462,7 @@ public:
 
         @since 3.1.6
     */
-    void ShowSortIndicator(const int idx, const bool ascending = true);
+    void ShowSortIndicator(int idx, bool ascending = true);
 
     /**
         Remove the sort indicator from the column being used as sort key.

--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -1421,39 +1421,14 @@ public:
     void ExtendRulesAndAlternateColour(bool extend = true);
 
     /**
-        Enable or disable showing a sort indicator in the header bar.
-        Sort indicators are only shown in report view.
-
-        When clicking on the header of a column, this column will get the sort-
-        indicator in ascending order, or toggle it in the opposite order. To
-        sort the list, call SortItems() in EVT_LIST_COL_CLICK.
-
-        Note that calling ShowSortIndicator() implicitly enables sort
-        indicators.
-
-        @note In wxMSW, this will disable the header icon of the column.
-
-        @param enable
-            If @true, enable showing a sort indicator, otherwise disable.
-
-        @since 3.1.6
-    */
-    void EnableSortIndicator(bool enable);
-
-    /**
-        Returns true if a sort indicator is enabled.
-
-        @see EnableSortIndicator()
-
-        @since 3.1.6
-    */
-    bool IsSortIndicatorEnabled() const;
-
-    /**
         Show the sort indicator of a specific column in a specific direction.
 
-        This function also enables showing sort indicators if
-        EnableSortIndicator() hadn't been called.
+        Sort indicators are only shown in report view and in the native wxMSW
+        version override any column icon, i.e. if the sort indicator is shown
+        for a column, no (other) icon is shown.
+
+        This function should typically be called from EVT_LIST_COL_CLICK
+        handler.
 
         @note This does not actually sort the list, use SortItems() for this.
 
@@ -1478,6 +1453,8 @@ public:
 
     /**
         Returns the column that shows the sort indicator.
+
+        Can return @c -1 if there is no sort indicator currently shown.
 
         @since 3.1.6
     */

--- a/samples/listctrl/listtest.cpp
+++ b/samples/listctrl/listtest.cpp
@@ -461,8 +461,6 @@ void MyFrame::RecreateList(long flags, bool withText)
                                     flags |
                                     wxBORDER_THEME | wxLC_EDIT_LABELS);
 
-        m_listCtrl->EnableSortIndicator();
-
         if ( old )
         {
             wxSizer* const sizer = m_panel->GetSizer();
@@ -1091,10 +1089,18 @@ void MyListCtrl::OnColClick(wxListEvent& event)
         return; // clicked outside any column.
     }
 
-    if ( IsSortIndicatorEnabled() )
+    // If clicking on the same column by which we already sort, toggle the sort
+    // direction, otherwise use ascending sort by default.
+    bool ascending;
+    if ( col == GetSortIndicator() )
+        ascending = !IsAscendingSortIndicator();
+    else
+        ascending = true;
+
+    // sort on item data (SetItemData)
+    if ( SortItems(MyCompareFunction, ascending) )
     {
-        // sort on  item data (SetItemData), disable when sorting fails
-        EnableSortIndicator( SortItems(MyCompareFunction, IsAscendingSortIndicator()) );
+        ShowSortIndicator(col, ascending);
     }
 
     // set or unset image

--- a/samples/listctrl/listtest.cpp
+++ b/samples/listctrl/listtest.cpp
@@ -1089,15 +1089,8 @@ void MyListCtrl::OnColClick(wxListEvent& event)
         return; // clicked outside any column.
     }
 
-    // If clicking on the same column by which we already sort, toggle the sort
-    // direction, otherwise use ascending sort by default.
-    bool ascending;
-    if ( col == GetSortIndicator() )
-        ascending = !IsAscendingSortIndicator();
-    else
-        ascending = true;
-
     // sort on item data (SetItemData)
+    const bool ascending = GetUpdatedAscendingSortIndicator(col);
     if ( SortItems(MyCompareFunction, ascending) )
     {
         ShowSortIndicator(col, ascending);

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -5108,6 +5108,7 @@ void wxGenericListCtrl::ShowSortIndicator(int idx, bool ascending)
                 (idx != m_headerWin->m_sortCol ||
                  ascending != m_headerWin->m_sortAsc) )
     {
+        m_headerWin->m_enableSortCol = true;
         m_headerWin->m_sortCol = idx;
         m_headerWin->m_sortAsc = ascending;
         m_headerWin->Refresh();

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -1104,7 +1104,7 @@ void wxListHeaderWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
 #endif
 
         wxHeaderSortIconType sortArrow = wxHDR_SORT_ICON_NONE;
-        if ( !m_owner->IsVirtual() && m_enableSortCol && i == m_sortCol )
+        if ( m_enableSortCol && i == m_sortCol )
         {
             if ( m_sortAsc )
                 sortArrow = wxHDR_SORT_ICON_UP;

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -5086,10 +5086,10 @@ bool wxGenericListCtrl::IsItemChecked(long item) const
 
 void wxGenericListCtrl::EnableSortIndicator(bool enable)
 {
-    if ( m_headerWin )
+    if ( m_headerWin && enable != m_headerWin->m_enableSortCol )
     {
         m_headerWin->m_enableSortCol = enable;
-        Refresh();
+        m_headerWin->Refresh();
     }
 }
 
@@ -5104,21 +5104,23 @@ void wxGenericListCtrl::ShowSortIndicator(int idx, bool ascending)
     {
         RemoveSortIndicator();
     }
-    else if ( m_headerWin )
+    else if ( m_headerWin &&
+                (idx != m_headerWin->m_sortCol ||
+                 ascending != m_headerWin->m_sortAsc) )
     {
         m_headerWin->m_sortCol = idx;
         m_headerWin->m_sortAsc = ascending;
-        Refresh();
+        m_headerWin->Refresh();
     }
 }
 
 void wxGenericListCtrl::RemoveSortIndicator()
 {
-    if ( m_headerWin )
+    if ( m_headerWin && m_headerWin->m_sortCol != -1 )
     {
         m_headerWin->m_sortCol = -1;
         m_headerWin->m_sortAsc = true;
-        Refresh();
+        m_headerWin->Refresh();
     }
 }
 

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -982,7 +982,6 @@ wxListHeaderWindow::wxListHeaderWindow()
     m_owner = NULL;
     m_resizeCursor = NULL;
 
-    m_enableSortCol = false;
     m_sortAsc = true;
     m_sortCol = -1;
 }
@@ -1104,7 +1103,7 @@ void wxListHeaderWindow::OnPaint( wxPaintEvent &WXUNUSED(event) )
 #endif
 
         wxHeaderSortIconType sortArrow = wxHDR_SORT_ICON_NONE;
-        if ( m_enableSortCol && i == m_sortCol )
+        if ( i == m_sortCol )
         {
             if ( m_sortAsc )
                 sortArrow = wxHDR_SORT_ICON_UP;
@@ -1334,12 +1333,6 @@ void wxListHeaderWindow::OnMouse( wxMouseEvent &event )
                             colItem.SetState(state & ~wxLIST_STATE_SELECTED);
                         m_owner->SetColumn(i, colItem);
                     }
-
-                    if ( m_sortCol != m_column )
-                        m_sortAsc = true;
-                    else
-                        m_sortAsc = !m_sortAsc;
-                    m_sortCol = m_column;
                 }
 
                 SendListEvent( event.LeftDown()
@@ -5084,43 +5077,14 @@ bool wxGenericListCtrl::IsItemChecked(long item) const
     return m_mainWin->IsItemChecked(item);
 }
 
-void wxGenericListCtrl::EnableSortIndicator(bool enable)
-{
-    if ( m_headerWin && enable != m_headerWin->m_enableSortCol )
-    {
-        m_headerWin->m_enableSortCol = enable;
-        m_headerWin->Refresh();
-    }
-}
-
-bool wxGenericListCtrl::IsSortIndicatorEnabled() const
-{
-    return m_headerWin && m_headerWin->m_enableSortCol;
-}
-
 void wxGenericListCtrl::ShowSortIndicator(int idx, bool ascending)
 {
-    if ( idx == -1 )
-    {
-        RemoveSortIndicator();
-    }
-    else if ( m_headerWin &&
+    if ( m_headerWin &&
                 (idx != m_headerWin->m_sortCol ||
-                 ascending != m_headerWin->m_sortAsc) )
+                 (idx != -1 && ascending != m_headerWin->m_sortAsc)) )
     {
-        m_headerWin->m_enableSortCol = true;
         m_headerWin->m_sortCol = idx;
         m_headerWin->m_sortAsc = ascending;
-        m_headerWin->Refresh();
-    }
-}
-
-void wxGenericListCtrl::RemoveSortIndicator()
-{
-    if ( m_headerWin && m_headerWin->m_sortCol != -1 )
-    {
-        m_headerWin->m_sortCol = -1;
-        m_headerWin->m_sortAsc = true;
         m_headerWin->Refresh();
     }
 }

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -5084,7 +5084,7 @@ bool wxGenericListCtrl::IsItemChecked(long item) const
     return m_mainWin->IsItemChecked(item);
 }
 
-void wxGenericListCtrl::EnableSortIndicator(const bool enable)
+void wxGenericListCtrl::EnableSortIndicator(bool enable)
 {
     if ( m_headerWin )
     {
@@ -5098,7 +5098,7 @@ bool wxGenericListCtrl::IsSortIndicatorEnabled() const
     return m_headerWin && m_headerWin->m_enableSortCol;
 }
 
-void wxGenericListCtrl::ShowSortIndicator(const int idx, const bool ascending)
+void wxGenericListCtrl::ShowSortIndicator(int idx, bool ascending)
 {
     if ( idx == -1 )
     {

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -1456,7 +1456,7 @@ bool wxListCtrl::IsItemChecked(long item) const
     return ListView_GetCheckState(GetHwnd(), (UINT)item) != 0;
 }
 
-void wxListCtrl::EnableSortIndicator(const bool enable)
+void wxListCtrl::EnableSortIndicator(bool enable)
 {
     m_enableSortCol = enable;
     DrawSortArrow();
@@ -1467,7 +1467,7 @@ bool wxListCtrl::IsSortIndicatorEnabled() const
     return m_enableSortCol;
 }
 
-void wxListCtrl::ShowSortIndicator(const int idx, const bool ascending)
+void wxListCtrl::ShowSortIndicator(int idx, bool ascending)
 {
     if ( idx == -1 )
     {

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -3432,7 +3432,7 @@ void wxListCtrl::DrawSortArrow()
     {
         if ( ListView_GetColumn(GetHwnd(), col, &lvCol) )
         {
-            if ( !IsVirtual() && m_enableSortCol && col == m_sortCol )
+            if ( m_enableSortCol && col == m_sortCol )
             {
                 if ( m_sortAsc )
                     lvCol.fmt = (lvCol.fmt & ~HDF_SORTDOWN) | HDF_SORTUP;


### PR DESCRIPTION
@MaartenBent The most important change here is the one enabling the use of sort indicators for virtual list controls, as this looks like an important use case and I don't understand at all why were they disabled in it -- could you please let me know if I'm missing something?

I've also made `ShowSortIndicator()` enable the indicators as otherwise it just silently does nothing, which can't be the right thing to do.

But there are still more problems here: the generic version doesn't handle clicking on the columns automatically, even with sort indicators enabled, while the MSW one does. We need to harmonize this, but I'd actually prefer to remove the automatic update, as it seems simpler to call `ShowSortIndicator()` from the `wxEVT_LIST_COL_CLICK` handler you're going to have to define anyhow than to rely on this happening from inside wx. I.e. I'd rather remove `EnableSortIndicator()` completely and just show the sort indicator if `ShowSortIndicator()` is called and never update it automatically. This seems much simpler to understand than the current situation. What do you think?