### PR TITLE
Use UTF-8 for memory FS data if it's not in Latin-1

### DIFF
--- a/interface/wx/fs_mem.h
+++ b/interface/wx/fs_mem.h
@@ -83,6 +83,10 @@ public:
         Stored data (bitmap, text or raw data) will be copied into private memory
         stream and available under name @c "memory:" + @e filename.
 
+        When using the overload taking @c wxString data, the string must
+        contain only Latin-1 characters (which includes strings created using
+        wxString::From8BitData()).
+
         @note you must use a @a type value (aka image format) that wxWidgets
               can save (e.g. JPG, PNG, see wxImage documentation)!
 

--- a/interface/wx/fs_mem.h
+++ b/interface/wx/fs_mem.h
@@ -83,9 +83,11 @@ public:
         Stored data (bitmap, text or raw data) will be copied into private memory
         stream and available under name @c "memory:" + @e filename.
 
-        When using the overload taking @c wxString data, the string must
-        contain only Latin-1 characters (which includes strings created using
-        wxString::From8BitData()).
+        When using the overload taking @c wxString data, if the string contains
+        only Latin-1 characters (which includes strings created using
+        wxString::From8BitData()), its data is used as is. Otherwise, the UTF-8
+        representation of the string is stored as the data associated with the
+        given @a filename.
 
         @note you must use a @a type value (aka image format) that wxWidgets
               can save (e.g. JPG, PNG, see wxImage documentation)!

--- a/src/common/fs_mem.cpp
+++ b/src/common/fs_mem.cpp
@@ -180,7 +180,12 @@ void wxMemoryFSHandlerBase::AddFileWithMimeType(const wxString& filename,
                                                 const wxString& textdata,
                                                 const wxString& mimetype)
 {
-    const wxCharBuffer buf(textdata.To8BitData());
+    // We try to use the provided data "as is" if possible, but if not, we fall
+    // back to UTF-8 because it's better to do this than just lose the data
+    // completely.
+    wxCharBuffer buf(textdata.To8BitData());
+    if ( !buf.length() )
+        buf = textdata.utf8_str();
 
     AddFileWithMimeType(filename, buf.data(), buf.length(), mimetype);
 }


### PR DESCRIPTION
See [#19314](https://trac.wxwidgets.org/ticket/19314).