### PR TITLE
Remove quotes from value returned from wxStandardPaths::GetDocumentsDir

### DIFF
--- a/src/unix/stdpaths.cpp
+++ b/src/unix/stdpaths.cpp
@@ -260,6 +260,8 @@ wxString wxStandardPaths::GetDocumentsDir() const
                         value.Replace(wxT("$HOME"), homeDir);
                         value.Trim(true);
                         value.Trim(false);
+                        // Remove quotes
+                        value.Replace("\"", "", true /* replace all */);
                         if (!value.IsEmpty() && wxDirExists(value))
                             return value;
                         else


### PR DESCRIPTION
Backport of part of https://github.com/wxWidgets/wxWidgets/pull/89 from commit a0fb80808771dfb27fcb452284a2cfdc9a9bf783.

Currently GetDocumentsDir will return a quoted and shell-escaped path (because `xdg-user-dirs-update` writes a quoted and shell-escaped path to `~/.config/user-dirs.dirs`), with this change at least the value is not quoted. Ideally it should also be unescaped, but this is what the code at HEAD does, so that's what I'm suggesting for the backport.