### PR TITLE
Remove incorrect Release() calls from wxWebViewIEImpl::IsElementVisible

### DIFF
--- a/src/msw/webview_ie.cpp
+++ b/src/msw/webview_ie.cpp
@@ -1173,22 +1173,15 @@ bool wxWebViewIEImpl::IsElementVisible(wxCOMPtr<IHTMLElement> elm)
                 {
                     is_visible = false;
                 }
-                style->Release();
             }
-            elm2->Release();
         }
 
         //Lets check the object's parent element.
         IHTMLElement* parent;
         if(is_visible && SUCCEEDED(elm1->get_parentElement(&parent)))
-        {
             elm1 = parent;
-        }
         else
-        {
-            elm1->Release();
             break;
-        }
     }
     return is_visible;
 }


### PR DESCRIPTION
When a COM interface is held by wxCOMPtr, one should not call
Interface->Release(), as it decreases the interface's reference
count without wxCOMPtr owning the interface being aware of that.
When then wxCOMPtr calls Interface->Release() in its destructor
the reference count is erroneously decreased again, which is bound
to result in bad things happening.

If one needs to release an interface held by wxCOMPtr immediately,
wxCOMPtr::reset() should be used instead.

Closes #15207.

@sjlamerton, could you please take a look to make sure I am not missing something obvious (you implemented wxCOMPtr in wxWebViewIE in 938506b)