### PR TITLE
Undocument SetClippingRegion overload in wxSVGFileDC

### DIFF
--- a/interface/wx/dcsvg.h
+++ b/interface/wx/dcsvg.h
@@ -103,17 +103,6 @@ public:
     void SetShapeRenderingMode(wxSVGShapeRenderingMode renderingMode);
 
     /**
-        Sets the clipping region for this device context to the intersection of
-        the given region described by the parameters of this method and the previously
-        set clipping region.
-        Clipping is implemented in the SVG output using SVG group elements (\<g\>), with
-        nested group elements being used to represent clipping region intersections when
-        two or more calls are made to SetClippingRegion().
-    */
-    void SetClippingRegion(wxCoord x, wxCoord y, wxCoord width,
-                           wxCoord height);
-
-    /**
         Destroys the current clipping region so that none of the DC is clipped.
         Since intersections arising from sequential calls to SetClippingRegion are represented
         with nested SVG group elements (\<g\>), all such groups are closed when


### PR DESCRIPTION
Documentation of the other overloads was removed in 6a442d2 and there is
nothing special about the wxCoord variant in wxSVGFileDC, so remove it so
all the overloads are consistently documented in just wxDC.