### PR TITLE
wxBitmapBundle for wxButton fixes

### DIFF
--- a/src/msw/anybutton.cpp
+++ b/src/msw/anybutton.cpp
@@ -106,13 +106,24 @@ class wxButtonImageData: public wxObject
 {
 public:
     wxButtonImageData(wxWindow* btn, const wxBitmapBundle& normalBundle)
+        : m_btn(btn)
     {
         m_bitmapSize = normalBundle.GetPreferredSizeFor(btn);
 
         m_bitmapBundles[wxAnyButton::State_Normal] = normalBundle;
+
+        // React to DPI changes in the future.
+        m_btn->Bind(wxEVT_DPI_CHANGED, &wxButtonImageData::OnDPIChanged, this);
     }
 
     virtual ~wxButtonImageData() { }
+
+    virtual void OnDPIChanged(wxDPIChangedEvent& event)
+    {
+        event.Skip();
+
+        m_bitmapSize = m_bitmapBundles[wxAnyButton::State_Normal].GetPreferredSizeFor(m_btn);
+    }
 
     // Bitmap can be set either explicitly, when the bitmap for the given state
     // is specified by the application, or implicitly, when the bitmap for some
@@ -164,6 +175,9 @@ protected:
     wxSize m_bitmapSize;
 
     wxBitmapBundle m_bitmapBundles[wxAnyButton::State_Max];
+
+    // the button we're associated with
+    wxWindow* const m_btn;
 
     wxDECLARE_NO_COPY_CLASS(wxButtonImageData);
 };
@@ -246,6 +260,13 @@ private:
         }
     }
 
+    void OnDPIChanged(wxDPIChangedEvent& event) wxOVERRIDE
+    {
+        wxButtonImageData::OnDPIChanged(event);
+
+        InitImageList();
+    }
+
     // just store the values passed to us to be able to retrieve them later
     // from the drawing code
     wxBitmap m_bitmaps[wxAnyButton::State_Max];
@@ -270,8 +291,7 @@ public:
     // we must be constructed with the size of our images as we need to create
     // the image list
     wxXPButtonImageData(wxAnyButton *btn, const wxBitmapBundle& bitmapBundle)
-        : wxButtonImageData(btn, bitmapBundle),
-          m_btn(btn)
+        : wxButtonImageData(btn, bitmapBundle)
     {
         InitImageList();
 
@@ -282,9 +302,6 @@ public:
         m_data.uAlign = BUTTON_IMAGELIST_ALIGN_LEFT;
 
         UpdateImageInfo();
-
-        // React to DPI changes in the future.
-        btn->Bind(wxEVT_DPI_CHANGED, &wxXPButtonImageData::OnDPIChanged, this);
     }
 
     virtual wxBitmap GetBitmap(wxAnyButton::State which) const wxOVERRIDE
@@ -426,13 +443,9 @@ private:
         }
     }
 
-    void OnDPIChanged(wxDPIChangedEvent& event)
+    void OnDPIChanged(wxDPIChangedEvent& event) wxOVERRIDE
     {
-        event.Skip();
-
-        // We need to recreate the image list using the new size and re-add all
-        // bitmaps to it.
-        m_bitmapSize = m_bitmapBundles[wxAnyButton::State_Normal].GetPreferredSizeFor(m_btn);
+        wxButtonImageData::OnDPIChanged(event);
 
         m_iml.Destroy();
         InitImageList();
@@ -446,10 +459,6 @@ private:
 
     // store the rest of the data in BCM_SETIMAGELIST-friendly form
     BUTTON_IMAGELIST m_data;
-
-    // the button we're associated with
-    wxWindow* const m_btn;
-
 
     wxDECLARE_NO_COPY_CLASS(wxXPButtonImageData);
     wxDECLARE_ABSTRACT_CLASS(wxXPButtonImageData);

--- a/src/msw/anybutton.cpp
+++ b/src/msw/anybutton.cpp
@@ -420,7 +420,7 @@ private:
                     stateBitmap = bitmap;
             }
 
-            m_iml.Add(bitmap);
+            m_iml.Add(stateBitmap);
         }
 
         // In addition to the states supported by wxWidgets such as normal,

--- a/src/msw/anybutton.cpp
+++ b/src/msw/anybutton.cpp
@@ -846,7 +846,8 @@ void wxAnyButton::DoSetBitmap(const wxBitmapBundle& bitmapBundle, State which)
 
     // Check if we already had bitmaps of different size.
     if ( m_imageData &&
-          bitmapBundle.GetDefaultSize() != m_imageData->GetBitmapSize() )
+          bitmapBundle.GetDefaultSize() !=
+            m_imageData->GetBitmapBundle(State_Normal).GetDefaultSize() )
     {
         wxASSERT_MSG( which == State_Normal,
                       "Must set normal bitmap with the new size first" );

--- a/src/msw/anybutton.cpp
+++ b/src/msw/anybutton.cpp
@@ -181,12 +181,8 @@ public:
     wxODButtonImageData(wxAnyButton *btn, const wxBitmapBundle& bitmapBundle)
         : wxButtonImageData(btn, bitmapBundle)
     {
-        SetBitmap(GetBitmapFromBundle(bitmapBundle),
-                  wxAnyButton::State_Normal);
-#if wxUSE_IMAGE
-        SetBitmap(GetBitmapFromBundle(bitmapBundle).ConvertToDisabled(),
-                  wxAnyButton::State_Disabled);
-#endif
+        InitImageList();
+
         m_dir = wxLEFT;
 
         // we use margins when we have both bitmap and text, but when we have
@@ -229,6 +225,27 @@ public:
     }
 
 private:
+    void InitImageList()
+    {
+        const wxBitmap bitmap = m_bitmapBundles[wxAnyButton::State_Normal].GetBitmap(m_bitmapSize);
+
+        for ( int n = 0; n < wxAnyButton::State_Max; n++ )
+        {
+            wxBitmap stateBitmap = m_bitmapBundles[n].GetBitmap(m_bitmapSize);
+            if ( !stateBitmap.IsOk() )
+            {
+#if wxUSE_IMAGE
+                if ( n == wxAnyButton::State_Disabled )
+                    stateBitmap = bitmap.ConvertToDisabled();
+                else
+#endif // wxUSE_IMAGE
+                    stateBitmap = bitmap;
+            }
+
+            SetBitmap(stateBitmap, (wxAnyButton::State)n);
+        }
+    }
+
     // just store the values passed to us to be able to retrieve them later
     // from the drawing code
     wxBitmap m_bitmaps[wxAnyButton::State_Max];

--- a/src/msw/anybutton.cpp
+++ b/src/msw/anybutton.cpp
@@ -116,7 +116,10 @@ public:
         m_btn->Bind(wxEVT_DPI_CHANGED, &wxButtonImageData::OnDPIChanged, this);
     }
 
-    virtual ~wxButtonImageData() { }
+    virtual ~wxButtonImageData()
+    {
+        m_btn->Unbind(wxEVT_DPI_CHANGED, &wxButtonImageData::OnDPIChanged, this);
+    }
 
     virtual void OnDPIChanged(wxDPIChangedEvent& event)
     {


### PR DESCRIPTION
When the DPI changed, the button would still have an entry in the event table,
trying to access the removed wxXPButtonImageData.