### PR TITLE
Don't log AddFontResourceEx() errors with wxLogSysError()

### DIFF
--- a/src/msw/font.cpp
+++ b/src/msw/font.cpp
@@ -1123,7 +1123,7 @@ bool wxFontBase::AddPrivateFont(const wxString& filename)
 {
     if ( !AddFontResourceEx(filename.t_str(), FR_PRIVATE, 0) )
     {
-        wxLogSysError(_("Font file \"%s\" couldn't be loaded"), filename);
+        wxLogError(_("Font file \"%s\" couldn't be loaded"), filename);
         return false;
     }
 


### PR DESCRIPTION
According to AddFontResourceEx documentation[1], there is no extended error
information available on failure, so any error logged by wxLogSysError()
is unrelated to the call.

In my experience, the sys error that was logged on failure (e.g.
corrupted/unsupported but existing font file) was ERROR_FILE_NOT_FOUND,
but the same error would be logged after a successful call also.

[1] https://docs.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-addfontresourceexw