### PR TITLE
Avoid creating wxGenericNotificationMessageImpl twice

### DIFF
--- a/src/common/notifmsgcmn.cpp
+++ b/src/common/notifmsgcmn.cpp
@@ -91,7 +91,6 @@ bool wxNotificationMessageBase::AddAction(wxWindowID actionid, const wxString &l
 
 void wxNotificationMessage::Init()
 {
-    m_impl = new wxGenericNotificationMessageImpl(this);
 }
 
 #endif


### PR DESCRIPTION
In the case where native `wxNotificationMessage` is not available and `wxGenericNotificationMessage` is used as `wxNotificationMessage`, m_impl was being initialized twice.  This happens already in the constructor for `wxGenericNotificationMessage`.  This was causing a leak of a `wxGenericNotificationMessageImpl` and even more problematic, a leak of a `wxFrame`, which caused some oddities.  So, just remove the initialization from `wxNotificationMessage`.

CC: @TcT2k 