### PR TITLE
wxGLCanvas EGL: don't assert if eglChooseConfig fails

### DIFF
--- a/src/unix/glegl.cpp
+++ b/src/unix/glegl.cpp
@@ -578,7 +578,6 @@ EGLConfig *wxGLCanvasEGL::InitConfig(const wxGLAttributes& dispAttrs)
     }
     else
     {
-        wxFAIL_MSG("eglChooseConfig failed");
         delete config;
         return NULL;
     }


### PR DESCRIPTION
This assert prevents `wxGLCanvas::IsDisplaySupported()` from working properly in the case where unsupported attributes are passed.