### PR TITLE
Fix comparisons of const char* and wxString

### DIFF
--- a/samples/internat/internat.cpp
+++ b/samples/internat/internat.cpp
@@ -210,7 +210,7 @@ bool MyApp::OnInit()
         langInfo = wxLocale::GetLanguageInfo(wxLANGUAGE_DEFAULT);
     const wxString
         langDesc = langInfo ? langInfo->Description
-                            : "the default system locale";
+                            : wxString("the default system locale");
 
     if ( m_setLocale == Locale_Ask )
     {

--- a/samples/widgets/dirctrl.cpp
+++ b/samples/widgets/dirctrl.cpp
@@ -275,7 +275,7 @@ void DirCtrlWidgetsPage::CreateDirCtrl(bool defaultPath)
     wxGenericDirCtrl *dirCtrl = new wxGenericDirCtrl(
         this,
         DirCtrlPage_Ctrl,
-        defaultPath ? wxDirDialogDefaultFolderStr : m_dirCtrl->GetPath(),
+        defaultPath ? wxString(wxDirDialogDefaultFolderStr) : m_dirCtrl->GetPath(),
         wxDefaultPosition,
         wxDefaultSize,
         style

--- a/src/propgrid/props.cpp
+++ b/src/propgrid/props.cpp
@@ -2199,7 +2199,7 @@ bool wxFileProperty::DisplayEditorDialog(wxPropertyGrid* pg, wxVariant& value)
         m_dlgTitle.empty() ? _("Choose a file") : m_dlgTitle,
         m_initialPath.empty() ? path : m_initialPath,
         file,
-        m_wildcard.empty() ? wxALL_FILES : m_wildcard,
+        m_wildcard.empty() ? _(wxALL_FILES) : m_wildcard,
         m_dlgStyle,
         wxDefaultPosition);
 

--- a/tests/testimage.h
+++ b/tests/testimage.h
@@ -63,6 +63,7 @@ public:
             }
         }
 
+        const wxString dispAlphaValNull("--");
         const unsigned char* d1 = m_image.GetData();
         const unsigned char* d2 = other.GetData();
         const unsigned char* a1 = m_image.GetAlpha();
@@ -72,8 +73,8 @@ public:
         {
             for ( int x = 0; x < m_image.GetWidth(); ++x )
             {
-                wxString a1txt = dispAlphaVal ? (a1 != NULL ? wxString::Format("%02x", *a1) : "--") : "";
-                wxString a2txt = dispAlphaVal ? (a2 != NULL ? wxString::Format("%02x", *a2) : "--") : "";
+                wxString a1txt = dispAlphaVal ? (a1 != NULL ? wxString::Format("%02x", *a1) : dispAlphaValNull) : wxString();
+                wxString a2txt = dispAlphaVal ? (a2 != NULL ? wxString::Format("%02x", *a2) : dispAlphaValNull) : wxString();
 
                 for ( int i = 0; i < 3; i++ )
                 {


### PR DESCRIPTION
Comparing a const char* and a wxString with ternary operator resulted
into compile-time errors since the result type of the conditional
expression was ambiguous.