### PR TITLE
Fix wxGenericColourButton after recent bitmap changes

### DIFF
--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -2384,9 +2384,11 @@ void wxAuiToolBar::OnIdle(wxIdleEvent& evt)
     evt.Skip();
 }
 
-void wxAuiToolBar::OnDPIChanged(wxDPIChangedEvent& WXUNUSED(event))
+void wxAuiToolBar::OnDPIChanged(wxDPIChangedEvent& event)
 {
     Realize();
+
+    event.Skip();
 }
 
 void wxAuiToolBar::UpdateWindowUI(long flags)

--- a/src/generic/clrpickerg.cpp
+++ b/src/generic/clrpickerg.cpp
@@ -120,10 +120,12 @@ void wxGenericColourButton::OnColourChanged(wxColourDialogEvent& ev)
     parent->ProcessWindowEvent(event);
 }
 
-void wxGenericColourButton::OnDPIChanged(wxDPIChangedEvent&WXUNUSED(event))
+void wxGenericColourButton::OnDPIChanged(wxDPIChangedEvent& event)
 {
     m_bitmap = wxBitmap(FromDIP(defaultBitmapSize));
     UpdateColour();
+
+    event.Skip();
 }
 
 void wxGenericColourButton::UpdateColour()

--- a/src/generic/clrpickerg.cpp
+++ b/src/generic/clrpickerg.cpp
@@ -149,6 +149,8 @@ void wxGenericColourButton::UpdateColour()
     }
 
     dc.SelectObject( wxNullBitmap );
+
+    SetBitmapLabel( wxNullBitmap );
     SetBitmapLabel( m_bitmap );
 }
 

--- a/src/generic/colrdlgg.cpp
+++ b/src/generic/colrdlgg.cpp
@@ -278,13 +278,15 @@ void wxGenericColourDialog::OnPaint(wxPaintEvent& WXUNUSED(event))
     PaintHighlight(dc, true);
 }
 
-void wxGenericColourDialog::OnDPIChanged(wxDPIChangedEvent& WXUNUSED(event))
+void wxGenericColourDialog::OnDPIChanged(wxDPIChangedEvent& event)
 {
     CalculateMeasurements();
 
 #if wxCLRDLGG_USE_PREVIEW_WITH_ALPHA
     CreateCustomBitmaps();
 #endif
+
+    event.Skip();
 }
 
 void wxGenericColourDialog::CalculateMeasurements()

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -5682,6 +5682,8 @@ void wxDataViewCtrl::OnDPIChanged(wxDPIChangedEvent& event)
             width = event.ScaleX(width);
         m_cols[i]->SetWidth(width);
     }
+
+    event.Skip();
 }
 
 void wxDataViewCtrl::SetFocus()

--- a/src/generic/odcombo.cpp
+++ b/src/generic/odcombo.cpp
@@ -108,9 +108,11 @@ void wxVListBoxComboPopup::SetFocus()
 #endif
 }
 
-void wxVListBoxComboPopup::OnDPIChanged(wxDPIChangedEvent& WXUNUSED(event))
+void wxVListBoxComboPopup::OnDPIChanged(wxDPIChangedEvent& event)
 {
     m_itemHeight = m_combo->GetCharHeight();
+
+    event.Skip();
 }
 
 bool wxVListBoxComboPopup::LazyCreate()

--- a/src/generic/srchctlg.cpp
+++ b/src/generic/srchctlg.cpp
@@ -1200,9 +1200,11 @@ void wxSearchCtrl::OnSize( wxSizeEvent& WXUNUSED(event) )
     LayoutControls();
 }
 
-void wxSearchCtrl::OnDPIChanged(wxDPIChangedEvent &WXUNUSED(event))
+void wxSearchCtrl::OnDPIChanged(wxDPIChangedEvent &event)
 {
     RecalcBitmaps();
+
+    event.Skip();
 }
 
 #if wxUSE_MENUS

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -467,6 +467,8 @@ void wxListCtrl::OnDPIChanged(wxDPIChangedEvent &event)
 
         SetColumnWidth(i, event.ScaleX(width));
     }
+
+    event.Skip();
 }
 
 bool wxListCtrl::IsDoubleBuffered() const

--- a/src/msw/slider.cpp
+++ b/src/msw/slider.cpp
@@ -654,6 +654,8 @@ void wxSlider::OnDPIChanged(wxDPIChangedEvent& event)
     int thumbLen = GetThumbLength();
 
     SetThumbLength(event.ScaleX(thumbLen));
+
+    event.Skip();
 }
 
 // ----------------------------------------------------------------------------

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1992,6 +1992,8 @@ void wxToolBar::OnDPIChanged(wxDPIChangedEvent& event)
     // there are still minor but visible cosmetic problems when moving the
     // toolbar from 125% to 175% display.
     CallAfter(&wxToolBar::RealizeHelper);
+
+    event.Skip();
 }
 
 bool wxToolBar::HandleSize(WXWPARAM WXUNUSED(wParam), WXLPARAM WXUNUSED(lParam))

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -1360,11 +1360,13 @@ void wxPropertyGrid::OnSysColourChanged( wxSysColourChangedEvent &WXUNUSED(event
     }
 }
 
-void wxPropertyGrid::OnDPIChanged(wxDPIChangedEvent &WXUNUSED(event))
+void wxPropertyGrid::OnDPIChanged(wxDPIChangedEvent &event)
 {
     m_vspacing = FromDIP(wxPG_DEFAULT_VSPACING);
     CalculateFontAndBitmapStuff(m_vspacing);
     Refresh();
+
+    event.Skip();
 }
 
 // -----------------------------------------------------------------------

--- a/src/stc/PlatWX.cpp
+++ b/src/stc/PlatWX.cpp
@@ -2940,7 +2940,7 @@ void wxSTCListBox::OnSysColourChanged(wxSysColourChangedEvent& WXUNUSED(event))
     GetParent()->Refresh();
 }
 
-void wxSTCListBox::OnDPIChanged(wxDPIChangedEvent& WXUNUSED(event))
+void wxSTCListBox::OnDPIChanged(wxDPIChangedEvent& event)
 {
     m_imagePadding = FromDIP(1);
     m_textBoxToTextGap = FromDIP(3);
@@ -2950,6 +2950,8 @@ void wxSTCListBox::OnDPIChanged(wxDPIChangedEvent& WXUNUSED(event))
     GetTextExtent(EXTENT_TEST, &w, &m_textHeight);
 
     RecalculateItemHeight();
+
+    event.Skip();
 }
 
 void wxSTCListBox::OnMouseLeaveWindow(wxMouseEvent& event)

--- a/src/stc/stc.cpp
+++ b/src/stc/stc.cpp
@@ -5450,6 +5450,8 @@ void wxStyledTextCtrl::OnDPIChanged(wxDPIChangedEvent& evt) {
     {
         AutoCompCancel();
     }
+
+    evt.Skip();
 }
 
 

--- a/src/stc/stc.cpp.in
+++ b/src/stc/stc.cpp.in
@@ -977,6 +977,8 @@ void wxStyledTextCtrl::OnDPIChanged(wxDPIChangedEvent& evt) {
     {
         AutoCompCancel();
     }
+
+    evt.Skip();
 }
 
 


### PR DESCRIPTION
I noticed the `wxGenericColourButton` was broken after recent changes. On a DPI change, its size didn't update. And after changing the colour only the `normal` state was updated, none of the other button states (`hover`, `focus`, `disabled`, etc).
This is visible in the widgets sample on the `ColourPicker` page.

This became more obvious after https://github.com/wxWidgets/wxWidgets/commit/ee93f4cae82cc56b22b3d15026eaea64281665b2 because it initializes the `focused` state, but it already happened before this change for the `disabled` state (see by reverting the commit, go to `ColourPicker` page in widgets sample, change colour, and disable (ctrl+e) the control).

First of all, skip the `wxDPIChangedEvents` so the base class handlers will be called as well.
Second, invalidate the bitmap so when setting the valid bitmap, all state bitmaps will be updated.


