### PR TITLE
Explicitly cancel editing on Esc in wxOSX wxDataViewCtrl

### DIFF
--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -375,6 +375,7 @@ public:
     typedef void (*wxOSX_EventHandlerPtr)(NSView* self, SEL _cmd, NSEvent *event);
     typedef BOOL (*wxOSX_PerformKeyEventHandlerPtr)(NSView* self, SEL _cmd, NSEvent *event);
     typedef BOOL (*wxOSX_FocusHandlerPtr)(NSView* self, SEL _cmd);
+    typedef void (*wxOSX_DoCommandBySelectorPtr)(NSView* self, SEL _cmd, SEL _sel);
     typedef NSDragOperation (*wxOSX_DraggingEnteredOrUpdatedHandlerPtr)(NSView *self, SEL _cmd, void *sender);
     typedef void (*wxOSX_DraggingExitedHandlerPtr)(NSView *self, SEL _cmd, void *sender);
     typedef BOOL (*wxOSX_PerformDragOperationHandlerPtr)(NSView *self, SEL _cmd, void *sender);

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2158,12 +2158,23 @@ bool wxCocoaDataViewControl::doCommandBySelector(void* sel, WXWidget slf, void* 
 {
     bool handled = wxWidgetCocoaImpl::doCommandBySelector(sel, slf, _cmd);
     // if this special key has not been handled
-    if ( !handled && IsInNativeKeyDown() )
+    if ( !handled )
     {
-        // send the original key event back to the native implementation to get proper default handling like eg for arrow keys
-        wxOSX_EventHandlerPtr superimpl = (wxOSX_EventHandlerPtr) [[slf superclass] instanceMethodForSelector:@selector(keyDown:)];
-        superimpl(slf, @selector(keyDown:), GetLastNativeKeyDownEvent());
+        if ( IsInNativeKeyDown() )
+        {
+            // send the original key event back to the native implementation to get proper default handling like eg for arrow keys
+            wxOSX_EventHandlerPtr superimpl = (wxOSX_EventHandlerPtr) [[slf superclass] instanceMethodForSelector:@selector(keyDown:)];
+            superimpl(slf, @selector(keyDown:), GetLastNativeKeyDownEvent());
+        }
+        else
+        {
+            const auto superimpl = (wxOSX_DoCommandBySelectorPtr)
+                [[slf superclass] instanceMethodForSelector:@selector(doCommandBySelector:)];
+            if ( superimpl )
+                superimpl(slf, @selector(doCommandBySelector:), (SEL)sel);
+        }
     }
+
     return handled;
 }
 


### PR DESCRIPTION
Handle @selector(cancelOperation:) ourselves because we never get the
keyDown events that are supposed to take care of generating it from the
native code somehow.

This fixes cancelling editing with Escape which stopped working since
26d6f82a81 (Implement EVT_CHAR generation for wxDataViewCtrl under Mac,
2021-04-13).

Closes #17835.

---

Stefan, this fixes the visible problem, but I'm almost sure that this is _not_ the right thing to do. Unfortunately I have no idea what is... All I know is that without the original commit which broke this (26d6f82a81), we get `KeyDown` event for Escape which we then pass to AppKit and which ends in `-[wxCocoaOutlineView cancelOperation:]` being called from `AppKit`-[NSResponder doCommandBySelector:]`. But with this commit this method is never called and the event is clearly consumed somewhere because we never get `NSKeyDown` in our `wxCocoaDataViewControl::keyEvent()` at all, so the code added to `wxCocoaDataViewControl::keyEvent()` in this commit is never executed. In fact, if I run the sample with `WXTRACE=keyevent`, I see that we never get any key down events anywhere in our key handling code, only `keyUp` ones -- but I have no idea at all who could be eating them.

Hence the hack with waiting until we get `cancelOperation:` itself, which we still do get, and cancelling editing explicitly. As I said, this shouldn't be needed because normally we should be getting the `keyDown` for Escape and pass it on to the native control which should cancel editing on its own. But we just don't get it and hence this is the only way I can see to solve the problem other than just reverting the commit.

As this fixes an important user-visible functionality regression, I'm going to merge it if no better solution is found, even though I really, really don't like this hack.