### PR TITLE
Fix scrolling when m_win != m_targetWindow in wxUniv/MSW

### DIFF
--- a/src/generic/scrlwing.cpp
+++ b/src/generic/scrlwing.cpp
@@ -561,6 +561,12 @@ void wxScrollHelperBase::HandleOnScroll(wxScrollWinEvent& event)
     {
         m_targetWindow->ScrollWindow(dx, dy, GetScrollRect());
     }
+#ifdef __WXUNIVERSAL__
+    if (m_win != m_targetWindow)
+    {
+        m_win->Refresh(true, GetScrollRect());
+    }
+#endif // __WXUNIVERSAL__
 }
 
 int wxScrollHelperBase::CalcScrollInc(wxScrollWinEvent& event)

--- a/src/univ/winuniv.cpp
+++ b/src/univ/winuniv.cpp
@@ -1061,7 +1061,7 @@ void wxWindow::ScrollWindow(int dx, int dy, const wxRect *rect)
 {
     // use native scrolling when available and do it in generic way
     // otherwise:
-#if defined(__WXX11__) || defined(__WINDOWS__)
+#ifdef __WXX11__
 
     wxWindowNative::ScrollWindow(dx, dy, rect);
 


### PR DESCRIPTION
Fix for [[wxUniv(MSW)] Incorrect displaying of scrollbar in wxScrolledWindow after scrolling.](https://trac.wxwidgets.org/ticket/19357)

After debugging I found out that the bug was introduced in commit https://github.com/wxWidgets/wxWidgets/commit/3b3169fa156215251164f408d9e6797d4c350725 (it fixed problem for wxGrid, but created for other controls). 

Real reason of corrupting grid labels were in that that m_win and m_targetWindow isn't equal for wxGrid as it true for usual wxScrolled case. m_win (window that receiving events) it's a wxGrid and m_targetWindow (window that actual scrolling) it's a wxGridWindow. So to correctly refresh the whole grid (that call refresh for all parts of it) we need to call refresh for m_win.

