### PR TITLE
Define NANOSVG_ALL_COLOR_KEYWORDS before including NanoSVG

### DIFF
--- a/src/generic/bmpsvg.cpp
+++ b/src/generic/bmpsvg.cpp
@@ -59,6 +59,7 @@
 
 #define NANOSVG_IMPLEMENTATION
 #define NANOSVGRAST_IMPLEMENTATION
+#define NANOSVG_ALL_COLOR_KEYWORDS
 #include "../../3rdparty/nanosvg/src/nanosvg.h"
 #include "../../3rdparty/nanosvg/src/nanosvgrast.h"
 


### PR DESCRIPTION
When NANOSVG_ALL_COLOR_KEYWORDS is not defined, only 10
of the 147 SVG named colors are recognized and all the
others are displayed as black.