### PR TITLE
Fix too dark day number colors with dark themes in calendar control

### DIFF
--- a/src/generic/calctrlg.cpp
+++ b/src/generic/calctrlg.cpp
@@ -902,8 +902,6 @@ void wxGenericCalendarCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
         }
     }
 
-    // then the calendar itself
-    dc.SetTextForeground(*wxBLACK);
     //dc.SetFont(*wxNORMAL_FONT);
 
     y += m_heightRow;
@@ -911,6 +909,7 @@ void wxGenericCalendarCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
     // draw column with calendar week nr
     if ( HasFlag( wxCAL_SHOW_WEEK_NUMBERS ) && IsExposed( 0, y, m_calendarWeekWidth, m_heightRow * 6 ))
     {
+        dc.SetTextForeground(*wxBLACK);
         dc.SetBackgroundMode(wxBRUSHSTYLE_TRANSPARENT);
         dc.SetBrush(wxBrush(m_colHeaderBg, wxBRUSHSTYLE_SOLID));
         dc.SetPen(wxPen(m_colHeaderBg, 1, wxPENSTYLE_SOLID));
@@ -924,6 +923,9 @@ void wxGenericCalendarCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
             date += wxDateSpan::Week();
         }
     }
+
+    // then the calendar itself
+    dc.SetTextForeground(GetForegroundColour());
 
     wxDateTime date = GetStartDate();
 


### PR DESCRIPTION
`wxBLACK` was used for some day numbers, and with a dark theme the numbers
are drawn on a nearly black background, making them barely visible.

Instead, use `wxBLACK` explicitly for week numbers, but get the proper color
for day numbers always (and not just sometimes) with `GetForegroundColour()`.

How to reproduce without this PR applied:
* Start the `calendar` sample on macOS, in dark mode, and click on day numbers -> some days are colored black, some white, depending on where you click.
* By toggling holidays off, an even greater portion of the day numbers become black.