### PR TITLE
Improve high DPI support docs

### DIFF
--- a/docs/doxygen/overviews/high_dpi.md
+++ b/docs/doxygen/overviews/high_dpi.md
@@ -107,7 +107,9 @@ bitmap sizes. They are also used for drawing operations on wxGLCanvas, which
 is _different_ from wxDC and wxGraphicsContext that use logical pixels.
 
 Under MSW physical pixels are same as logical ones, but when writing portable
-code you need to convert between logical and physical pixels using
+code you need to convert between logical and physical pixels. This can be done
+using convenience wxWindow::FromPhys() and wxWindow::ToPhys() functions
+similar to the DIP functions above or by directly multiplying or dividing by
 wxWindow::GetContentScaleFactor(): this function returns a value greater than
 or equal to 1 (and always just 1 under MSW), so a value in logical pixels
 needs to be multiplied by it in order to obtain the value in physical pixels.
@@ -133,7 +135,7 @@ However under all platforms the following functions can be used to convert
 between different kinds of pixels:
 
 * From DIP to logical pixels: use wxWindow::FromDIP() or wxWindow::ToDIP().
-* Logical pixels and physical pixels: multiply or divide by wxWindow::GetContentScaleFactor().
+* From physical to logical pixels: use wxWindow::FromPhys() or wxWindow::ToPhys().
 * From DIP to physical pixels: multiply or divide by wxWindow::GetDPIScaleFactor().
 
 Or, in the diagram form:
@@ -147,7 +149,7 @@ digraph Pixels
     DIP [fillcolor = yellow, label = "DI\nPixels"];
     PP  [fillcolor = green, label = "Physical\nPixels"];
 
-    LP  -> PP [fontname = Helvetica, labeldistance = 5, labelangle = 30, dir = both, weight = 2, minlen = 3, label = "GetContentScaleFactor()", headlabel = "multiply by", taillabel = "divide by"];
+    LP  -> PP [fontname = Helvetica, labeldistance = 5, labelangle = 30, dir = both, weight = 2, minlen = 3, headlabel = "ToPhys()", taillabel = "FromPhys()"];
     LP -> DIP [fontname = Helvetica, labeldistance = 6, dir = both, weight = 2, minlen = 3, headlabel = "ToDIP()", taillabel = "FromDIP()"];
     DIP -> PP [fontname = Helvetica, dir = both, minlen = 10, label = "GetDPIScaleFactor()" headlabel = "multiply by", taillabel = "divide by", constraint = false] ;
 }

--- a/docs/doxygen/overviews/high_dpi.md
+++ b/docs/doxygen/overviews/high_dpi.md
@@ -2,7 +2,7 @@ High DPI Support in wxWidgets       {#overview_high_dpi}
 =============================
 [TOC]
 
-Introduction
+Introduction                        {#high_dpi_intro}
 ============
 
 Many modern displays have way more pixels on the same surface than used to be
@@ -50,10 +50,10 @@ on high DPI displays is needed: one which allows to scale some pixel values
 drawing, which should remain unscaled to use the full available resolution).
 
 
-Pixel Values in wxWidgets
+Pixel Values in wxWidgets           {#high_dpi_pixel_types}
 =========================
 
-Logical and Device-Independent Pixels
+Logical and Device-Independent Pixels {#high_dpi_lp_and_dip}
 -------------------------------------
 
 Some systems like eg Apple's OSes automatically scale all the coordinates by
@@ -97,7 +97,7 @@ must be in logical pixels that can depend on the current DPI scaling, and so
 should never be fixed at compilation time.
 
 
-Physical Pixels
+Physical Pixels                     {#high_dpi_pp}
 ---------------
 
 In addition to (logical) pixels and DIPs discussed above, you may also need to
@@ -121,7 +121,7 @@ pixels first, but you can also do it directly, by using
 wxWindow::GetDPIScaleFactor(). This function can return a value different from
 1 even under MSW, i.e. it returns DPI scaling for physical display pixels.
 
-Summary of Different Pixel Kinds
+Summary of Different Pixel Kinds    {#high_dpi_pixel_conversions}
 --------------------------------
 
 Under MSW, logical pixels are always the same as physical pixels, but are
@@ -154,7 +154,7 @@ digraph Pixels
 @enddot
 
 
-High-Resolution Images and Artwork
+High-Resolution Images and Artwork  {#high_dpi_artwork}
 ==================================
 
 In order to benefit from the increased detail on High DPI devices you might want
@@ -168,7 +168,7 @@ sizes / resolutions.
 
 [comment]: # (TODO: API and Use Cases)
 
-Platform-Specific Build Issues
+Platform-Specific Build Issues      {#high_dpi_platform_specific}
 ==============================
 
 Generally speaking, all systems handle applications not specifically marked as
@@ -177,7 +177,7 @@ up, resulting in blurry graphics and fonts, but globally preserving the
 application appearance. For the best results, the application needs to be
 explicitly marked as DPI-aware in a platform-dependent way.
 
-MSW
+MSW                                 {#high_dpi_platform_msw}
 ---
 
 The behaviour of the application when running on a high-DPI display depends on
@@ -192,7 +192,7 @@ full, per-monitor DPI awareness supported by Windows 10 version 1703 or later.
 [1]: https://docs.microsoft.com/en-us/windows/win32/sbscs/application-manifests
 [2]: https://docs.microsoft.com/en-us/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows
 
-macOS
+macOS                               {#high_dpi_platform_mac}
 -----
 
 DPI-aware applications must set their `NSPrincipalClass` to `wxNSApplication`

--- a/docs/doxygen/overviews/high_dpi.md
+++ b/docs/doxygen/overviews/high_dpi.md
@@ -123,6 +123,16 @@ pixels first, but you can also do it directly, by using
 wxWindow::GetDPIScaleFactor(). This function can return a value different from
 1 even under MSW, i.e. it returns DPI scaling for physical display pixels.
 
+**Warning:** It is possible that conversion between different pixel
+coordinates is not lossless due to rounding. E.g. to create a window big
+enough to show a bitmap 15 pixels wide, you need to use `FromPhys(15)`,
+however the exact result of this function is not representable as an `int`
+when using 200% DPI scaling. In this case, the value is always rounded
+upwards, i.e. the function returns `8`, to ensure that a window of this size
+in logical pixels is always big enough to show the bitmap, but this can only
+be done at the price of having one "extra" pixel in the window.
+
+
 Summary of Different Pixel Kinds    {#high_dpi_pixel_conversions}
 --------------------------------
 

--- a/docs/doxygen/overviews/high_dpi.md
+++ b/docs/doxygen/overviews/high_dpi.md
@@ -77,13 +77,13 @@ change is to just replace the pixel values with the values in DIP: for this,
 just use wxWindow::FromDIP() to convert from one to the other.
 
 For example, if you have the existing code:
-```cpp
+~~~{cpp}
 myFrame->SetClientSize(wxSize(400, 300));
-```
+~~~
 you can just replace it with
-```cpp
+~~~{cpp}
 myFrame->SetClientSize(myFrame->FromDIP(wxSize(400, 300)));
-```
+~~~
 
 Physical Pixels
 ---------------

--- a/docs/doxygen/overviews/install.md
+++ b/docs/doxygen/overviews/install.md
@@ -199,7 +199,8 @@ project, there are several things you must do.
   `defaults write com.apple.dt.Xcode UseSanitizedBuildSystemEnvironment -bool NO`
 - Set the variables for use with the launch agent (application to OSX 10.10
 and up)
-```
+
+~~~{xml}
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -218,7 +219,7 @@ launchctl setenv WXWIN /Users/dconnet/devtools/wx/wxWidgets-3.1.5
   <true/>
 </dict>
 </plist>
-```
+~~~
 
 ### Other IDEs
 


### PR DESCRIPTION
The dot diagram is still ugly:
![pixels_convert](https://user-images.githubusercontent.com/146917/149260698-0cce1ea8-6522-41c4-8c8c-ab60a5686599.png)
but I just don't know how to position the labels correctly with it.

See #18889.