### PR TITLE
DVC on macos: make the same visual representation of DVC for different macOS versions

### DIFF
--- a/include/wx/osx/cocoa/dataview.h
+++ b/include/wx/osx/cocoa/dataview.h
@@ -434,7 +434,6 @@ private:
 // ============================================================================
 // wxCocoaOutlineView
 // ============================================================================
-
 @interface wxCocoaOutlineView : NSOutlineView <NSOutlineViewDelegate>
 {
 @private
@@ -447,6 +446,10 @@ private:
 
     -(wxCocoaDataViewControl*) implementation;
     -(void) setImplementation:(wxCocoaDataViewControl*) newImplementation;
+
+#if __MAC_OS_X_VERSION_MAX_ALLOWED < 110000
+    -(void)setStyle:(NSInteger)style;
+#endif
 @end
 
 // ============================================================================

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2108,6 +2108,16 @@ wxCocoaDataViewControl::wxCocoaDataViewControl(wxWindow* peer,
     InitOutlineView(style);
 }
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED < 110000
+        typedef NS_ENUM(NSInteger, NSTableViewStyle) {
+            NSTableViewStyleAutomatic,
+            NSTableViewStyleFullWidth,
+            NSTableViewStyleInset,
+            NSTableViewStyleSourceList,
+            NSTableViewStylePlain
+        };
+#endif
+
 void wxCocoaDataViewControl::InitOutlineView(long style)
 {
     // we cannot call InstallHandler(m_OutlineView) here, because we are handling

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2129,6 +2129,16 @@ void wxCocoaDataViewControl::InitOutlineView(long style)
 
     if ( style & wxDV_NO_HEADER )
         [m_OutlineView setHeaderView:nil];
+
+    if (@available(macOS 11.0, *))
+    {
+        // TODO:
+        // The default value for this property is NSTableViewStyleAutomatic in macOS 11 and later.
+        // Apps that link to previous macOS versions default to NSTableViewStylePlain.
+
+        // Prior to Big Sur, the default intercellSpacing was (width = 3, height = 2), but on Big Sur it's (width = 17, height = 0). Big Sur really loves its whitespace!
+        [m_OutlineView setIntercellSpacing:NSMakeSize(3, 2)];
+    }
 }
 
 wxCocoaDataViewControl::~wxCocoaDataViewControl()

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2130,11 +2130,11 @@ void wxCocoaDataViewControl::InitOutlineView(long style)
     if ( style & wxDV_NO_HEADER )
         [m_OutlineView setHeaderView:nil];
 
-    if (@available(macOS 11.0, *))
+    if (WX_IS_MACOS_AVAILABLE(11, 0))
     {
-        // TODO:
         // The default value for this property is NSTableViewStyleAutomatic in macOS 11 and later.
         // Apps that link to previous macOS versions default to NSTableViewStylePlain.
+        [m_OutlineView setStyle:NSTableViewStylePlain];
 
         // Prior to Big Sur, the default intercellSpacing was (width = 3, height = 2), but on Big Sur it's (width = 17, height = 0). Big Sur really loves its whitespace!
         [m_OutlineView setIntercellSpacing:NSMakeSize(3, 2)];


### PR DESCRIPTION
1) Prior to Big Sur, the default intercellSpacing was (width = 3, height = 2), but on Big Sur it's (width = 17, height = 0)
2) Plain style for Big Sur and newer
