### PR TITLE
Fatal exception fixed in DVC on macOS while wxDataViewModel::Cleared …

### DIFF
--- a/samples/dataview/dataview.cpp
+++ b/samples/dataview/dataview.cpp
@@ -84,6 +84,7 @@ private:
 #endif // wxHAS_GENERIC_DATAVIEWCTRL
     void OnGetPageInfo(wxCommandEvent& event);
     void OnDisable(wxCommandEvent& event);
+    void OnClearMyMusicTreeModel(wxCommandEvent& event);
     void OnSetForegroundColour(wxCommandEvent& event);
     void OnIncIndent(wxCommandEvent& event);
     void OnDecIndent(wxCommandEvent& event);
@@ -400,6 +401,7 @@ enum
     ID_CLEARLOG = wxID_HIGHEST+1,
     ID_GET_PAGE_INFO,
     ID_DISABLE,
+    ID_CLEAR_MODEL,
     ID_BACKGROUND_COLOUR,
     ID_FOREGROUND_COLOUR,
     ID_CUSTOM_HEADER_ATTR,
@@ -481,6 +483,7 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
 
     EVT_MENU( ID_GET_PAGE_INFO, MyFrame::OnGetPageInfo )
     EVT_MENU( ID_DISABLE, MyFrame::OnDisable )
+    EVT_MENU( ID_CLEAR_MODEL, MyFrame::OnClearMyMusicTreeModel )
     EVT_MENU( ID_FOREGROUND_COLOUR, MyFrame::OnSetForegroundColour )
     EVT_MENU( ID_BACKGROUND_COLOUR, MyFrame::OnSetBackgroundColour )
     EVT_MENU( ID_CUSTOM_HEADER_ATTR, MyFrame::OnCustomHeaderAttr )
@@ -599,6 +602,7 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, int x, int y, int w, int
     file_menu->Append(ID_CLEARLOG, "&Clear log\tCtrl-L");
     file_menu->Append(ID_GET_PAGE_INFO, "Show current &page info");
     file_menu->AppendCheckItem(ID_DISABLE, "&Disable\tCtrl-D");
+    file_menu->Append(ID_CLEAR_MODEL, "&Clear MyMusicTreeModel\tCtrl-W");
     file_menu->Append(ID_FOREGROUND_COLOUR, "Set &foreground colour...\tCtrl-S");
     file_menu->Append(ID_BACKGROUND_COLOUR, "Set &background colour...\tCtrl-B");
     file_menu->AppendCheckItem(ID_CUSTOM_HEADER_ATTR, "C&ustom header attributes");
@@ -1144,6 +1148,11 @@ void MyFrame::OnGetPageInfo(wxCommandEvent& WXUNUSED(event))
 void MyFrame::OnDisable(wxCommandEvent& event)
 {
     m_ctrl[m_notebook->GetSelection()]->Enable(!event.IsChecked());
+}
+
+void MyFrame::OnClearMyMusicTreeModel(wxCommandEvent& WXUNUSED(event))
+{
+    m_music_model->Clear();
 }
 
 void MyFrame::OnSetForegroundColour(wxCommandEvent& WXUNUSED(event))

--- a/samples/dataview/mymodels.cpp
+++ b/samples/dataview/mymodels.cpp
@@ -152,6 +152,21 @@ void MyMusicTreeModel::Delete( const wxDataViewItem &item )
     // notify control
     ItemDeleted( parent, item );
 }
+void MyMusicTreeModel::Clear()
+{
+    m_pop       = NULL;
+    m_classical = NULL;
+    m_ninth     = NULL;
+
+    while (!m_root->GetChildren().IsEmpty())
+    {
+        MyMusicTreeModelNode* node = m_root->GetNthChild(0);
+        m_root->GetChildren().Remove(node);
+        delete node;
+    }
+
+    Cleared();
+}
 
 int MyMusicTreeModel::Compare( const wxDataViewItem &item1, const wxDataViewItem &item2,
                                unsigned int column, bool ascending ) const

--- a/samples/dataview/mymodels.h
+++ b/samples/dataview/mymodels.h
@@ -136,6 +136,7 @@ public:
     void AddToClassical( const wxString &title, const wxString &artist,
                          unsigned int year );
     void Delete( const wxDataViewItem &item );
+    void Clear();
 
     wxDataViewItem GetNinthItem() const
     {

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -551,6 +551,11 @@ outlineView:(NSOutlineView*)outlineView
 {
     wxUnusedVar(outlineView);
 
+    // See the comment in outlineView:objectValueForTableColumn:byItem: below:
+    // this function can also be called in the same circumstances.
+    if ( implementation->GetDataViewCtrl()->IsDeleting() )
+        return nil;
+
     if ((item == currentParentItem) &&
             (index < ((NSInteger) [self getChildCount])))
         return [self getChild:index];

--- a/src/osx/dataview_osx.cpp
+++ b/src/osx/dataview_osx.cpp
@@ -251,7 +251,14 @@ bool wxOSXDataViewModelNotifier::ValueChanged(wxDataViewItem const& item, unsign
 
 bool wxOSXDataViewModelNotifier::Cleared()
 {
-  return m_DataViewCtrlPtr->GetDataViewPeer()->Reload();
+  bool noFailureFlag;
+
+  // NOTE: See comments in ItemDeleted method above
+  m_DataViewCtrlPtr->SetDeleting(true);
+  noFailureFlag = m_DataViewCtrlPtr->GetDataViewPeer()->Reload();
+  m_DataViewCtrlPtr->SetDeleting(false);
+
+  return noFailureFlag;
 }
 
 void wxOSXDataViewModelNotifier::Resort()


### PR DESCRIPTION
…call + editing item.

Here are some inverstigated backtraces:

```
  * frame #0: 0x00007ff8132eeca8 libc++abi.dylib`__cxa_throw
    frame #1: 0x00007ff8131d3c9b libobjc.A.dylib`objc_exception_throw + 302
    frame #2: 0x00007ff81352e434 CoreFoundation`_CFThrowFormattedException + 202
    frame #3: 0x00007ff813399347 CoreFoundation`-[__NSArrayM objectAtIndex:] + 169
    frame #4: 0x00000001005afa27 ev_studio`-[wxCocoaOutlineDataSource outlineView:child:ofItem:] + 327
    frame #5: 0x00007ff8161921fb AppKit`refreshRowEntryItemAndLevelInfo + 167
    frame #6: 0x00007ff8165a64c8 AppKit`-[NSTableView _setNewObjectValueFromCell:ifNotEqualTo:forTableColumn:row:] + 148
    frame #7: 0x00007ff8165b2afc AppKit`-[NSTableView textDidEndEditing:] + 713
    frame #8: 0x00000001005b2c6b ev_studio`-[wxCocoaOutlineView textDidEndEditing:] + 43
    frame #9: 0x00007ff8133ecf23 CoreFoundation`__CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 12
    frame #10: 0x00007ff81348a3f9 CoreFoundation`___CFXRegistrationPost_block_invoke + 49
    frame #11: 0x00007ff81348a376 CoreFoundation`_CFXRegistrationPost + 496
    frame #12: 0x00007ff8133be836 CoreFoundation`_CFXNotificationPost + 733
    frame #13: 0x00007ff8142061ae Foundation`-[NSNotificationCenter postNotificationName:object:userInfo:] + 82
    frame #14: 0x00007ff8160e7185 AppKit`-[NSTextView(NSSharing) resignFirstResponder] + 771
    frame #15: 0x00007ff815f4eb07 AppKit`-[NSWindow _realMakeFirstResponder:] + 179
    frame #16: 0x000000010058b1fd ev_studio`-[wxNSWindow makeFirstResponder:] + 125
    frame #17: 0x00007ff816007d82 AppKit`-[NSWindow endEditingFor:] + 270
    frame #18: 0x00007ff815eed8d8 AppKit`-[NSTableView _endMyEditing] + 106
    frame #19: 0x00007ff8165b4115 AppKit`-[NSTableView _endMyEditingAndRemainFirstResponder] + 278
    frame #20: 0x00007ff815f450de AppKit`-[NSOutlineView reloadItem:reloadChildren:] + 993
    frame #21: 0x00000001005b540e ev_studio`non-virtual thunk to wxCocoaDataViewControl::Remove(wxDataViewItem const&) + 62
    frame #22: 0x00000001005c050f ev_studio`wxOSXDataViewModelNotifier::ItemDeleted(wxDataViewItem const&, wxDataViewItem const&) + 79
    frame #23: 0x00000001004adf40 ev_studio`wxDataViewModel::ItemDeleted(wxDataViewItem const&, wxDataViewItem const&) + 64
```


```
	0   CoreFoundation                      0x00007ff813472f0b __exceptionPreprocess + 242
	1   libobjc.A.dylib                     0x00007ff8131d3b9d objc_exception_throw + 48
	2   CoreFoundation                      0x00007ff8134f7adb -[NSObject(NSObject) __retain_OA] + 0
	3   CoreFoundation                      0x00007ff8133d9db9 ___forwarding___ + 1406
	4   CoreFoundation                      0x00007ff8133d97a8 _CF_forwarding_prep_0 + 120
	5   ev_studio                           0x00000001005afdcc -[wxCocoaOutlineDataSource outlineView:objectValueForTableColumn:byItem:] + 108
	6   AppKit                              0x00007ff8160c860b -[NSTableView preparedCellAtColumn:row:] + 425
	7   AppKit                              0x00007ff8161711f0 -[NSOutlineView preparedCellAtColumn:row:] + 51
	8   AppKit                              0x00007ff8160c8358 -[NSTableView _drawContentsAtRow:column:withCellFrame:] + 42
	9   AppKit                              0x00007ff816171160 -[NSOutlineView _drawContentsAtRow:column:withCellFrame:] + 71
	10  AppKit                              0x00007ff8160c7fc4 -[NSTableView drawRow:clipRect:] + 1638
	11  AppKit                              0x00007ff8160c763d -[NSTableView drawRowIndexes:clipRect:] + 709
	12  AppKit                              0x00007ff81616f866 -[NSOutlineView drawRowIndexes:clipRect:] + 94
	13  AppKit                              0x00007ff8160523bf -[NSTableView drawRect:] + 1670
	14  ev_studio                           0x00000001005a468f _ZN17wxWidgetCocoaImpl8drawRectEPvP6NSViewS0_ + 863
	15  ev_studio                           0x00000001005a1496 _Z14wxOSX_drawRectP6NSViewP13objc_selector6CGRect + 86
	16  AppKit                              0x00007ff815f81073 _NSViewDrawRect + 121
	17  AppKit                              0x00007ff81669bdec -[NSView _recursive:displayRectIgnoringOpacity:inContext:stopAtLayerBackedViews:] + 1832
	18  AppKit                              0x00007ff815f80771 -[NSView(NSLayerKitGlue) _drawViewBackingLayer:inContext:drawingHandler:] + 747
	19  AppKit                              0x00007ff815f803b0 -[NSView(NSLayerKitGlue) drawLayer:inContext:] + 290
	20  QuartzCore                          0x00007ff81a48e31e CABackingStoreUpdate_ + 613
	21  QuartzCore                          0x00007ff81a4f3415 ___ZN2CA5Layer8display_Ev_block_invoke + 53
	22  QuartzCore                          0x00007ff81a48d6b8 -[CALayer _display] + 2268
	23  AppKit                              0x00007ff815f801e6 -[_NSBackingLayer display] + 462
	24  AppKit                              0x00007ff815ef573d -[_NSViewBackingLayer display] + 554
	25  QuartzCore                          0x00007ff81a48c631 _ZN2CA5Layer17display_if_neededEPNS_11TransactionE + 867
	26  QuartzCore                          0x00007ff81a5dc723 _ZN2CA7Context18commit_transactionEPNS_11TransactionEdPd + 717
	27  QuartzCore                          0x00007ff81a46e292 _ZN2CA11Transaction6commitEv + 704
	28  AppKit                              0x00007ff815f91592 __62+[CATransaction(NSCATransaction) NS_setFlushesWithDisplayLink]_block_invoke + 285
	29  AppKit                              0x00007ff8166d81d4 ___NSRunLoopObserverCreateWithHandler_block_invoke + 41
	30  CoreFoundation                      0x00007ff8133f6cb7 __CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__ + 23
	31  CoreFoundation                      0x00007ff8133f6b54 __CFRunLoopDoObservers + 543
	32  CoreFoundation                      0x00007ff8133f5fe7 __CFRunLoopRun + 841
	33  CoreFoundation                      0x00007ff8133f55dd CFRunLoopRunSpecific + 563
	34  HIToolbox                           0x00007ff81c0284f1 RunCurrentEventLoopInMode + 292
	35  HIToolbox                           0x00007ff81c028118 ReceiveNextEventCommon + 284
	36  HIToolbox                           0x00007ff81c027fe5 _BlockUntilNextEventMatchingListInModeWithFilter + 70
	37  AppKit                              0x00007ff815e24b4c _DPSNextEvent + 886
	38  AppKit                              0x00007ff815e231b8 -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 1411
	39  AppKit                              0x00007ff815e155a9 -[NSApplication run] + 586
```