### PR TITLE
Implement SVG rasterization using Direct2D

### DIFF
--- a/src/generic/bmpsvg.cpp
+++ b/src/generic/bmpsvg.cpp
@@ -311,14 +311,14 @@ private:
 
 // This is a maximum size wxBitmapBundleImplSVGD2D can rasterize to.
 // The larger the size, the larger memory needed and the memory is
-// allocated (ms_bitmap and ms_context)  upon the first use of
+// allocated (ms_bitmap and ms_context) upon the first use of
 // wxBitmapBundleImplSVGD2D and freed only when wxWidgets shuts down.
 // The size should be large enough for wxBitmapBundle purpose.
 const wxSize wxBitmapBundleImplSVGD2D::ms_maxBitmapSize(512, 512);
 
 bool wxBitmapBundleImplSVGD2D::ms_initialized = false;
-wxCOMPtr<IWICBitmap>wxBitmapBundleImplSVGD2D::ms_bitmap;
-wxCOMPtr<ID2D1DeviceContext5>wxBitmapBundleImplSVGD2D::ms_context;
+wxCOMPtr<IWICBitmap> wxBitmapBundleImplSVGD2D::ms_bitmap;
+wxCOMPtr<ID2D1DeviceContext5> wxBitmapBundleImplSVGD2D::ms_context;
 
 wxBitmapBundleImplSVGD2D::wxBitmapBundleImplSVGD2D(const char* data, const wxSize& sizeDef)
     : wxBitmapBundleImplSVG(sizeDef)
@@ -339,11 +339,12 @@ bool wxBitmapBundleImplSVGD2D::IsOk() const
 
 bool wxBitmapBundleImplSVGD2D::CreateSVGDocument(const wxCOMPtr<IStream>& SVGStream)
 {
-    HRESULT     hr;
-    D2D1_SIZE_F viewportSize = D2D1::SizeF(32, 32); // viewportSize is ignored when creating SVGDocument
+    const D2D1_SIZE_F viewportSize = D2D1::SizeF(32, 32); // viewportSize is ignored when creating SVGDocument
 
+    HRESULT hr;
+    
     hr = ms_context->CreateSvgDocument(SVGStream, viewportSize, &m_SVGDocument);
-    if ( FAILED (hr) )
+    if ( FAILED(hr) )
     {
         wxLogApiError("ID2D1DeviceContext5::CreateSvgDocument", hr);
         return false;
@@ -685,10 +686,13 @@ wxBitmapBundle wxBitmapBundle::FromSVG(char* data, const wxSize& sizeDef)
 
     if ( wxBitmapBundleImplSVGD2D::IsAvailable() )
     {
-        wxBitmapBundle bundle(new wxBitmapBundleImplSVGD2D(data, sizeDef));
+        const wxBitmapBundleImplSVGD2D* D2DImpl = new wxBitmapBundleImplSVGD2D(data, sizeDef));
 
-        if ( bundle.IsOk() )
-            return bundle;
+        if ( D2DImpl->IsOk() ) // SVG loaded successfully
+            return wxBitmapBundle(D2DImpl);
+        else
+            delete D2DImpl;
+        // fall back to NanoSVG
     }
 
 #endif // #ifdef wxHAS_BMPBUNDLE_IMPL_SVG_D2D

--- a/src/generic/bmpsvg.cpp
+++ b/src/generic/bmpsvg.cpp
@@ -83,6 +83,30 @@
 
 #include "wx/private/bmpbndl.h"
 
+#if defined(__WXMSW__) && wxUSE_GRAPHICS_DIRECT2D
+    #ifdef __has_include
+        #if __has_include(<d2d1_3.h>)
+            // Ensure no previous defines interfere with the Direct2D API headers
+            #undef GetHwnd
+            #include <d2d1_3.h>
+
+            #ifdef _D2D1_SVG_ // defined by a Direct2D header with SVG APIs
+                #define wxHAS_BMPBUNDLE_IMPL_SVG_D2D
+            #endif // #ifdef _D2D1_SVG_
+
+        #endif // #if __has_include(<d2d1_3.h>)
+    #endif // #ifdef __has_include
+#endif // #if defined(__WXMSW__) && wxUSE_GRAPHICS_DIRECT2D
+
+#ifdef wxHAS_BMPBUNDLE_IMPL_SVG_D2D
+    #include "wx/platinfo.h"
+    //#include "wx/msw/private.h"
+    #include "wx/msw/private/comptr.h"
+    #include "wx/msw/private/graphicsd2d.h"
+
+    #include <combaseapi.h> // for CreateStreamOnHGlobal()
+#endif // #ifdef wxHAS_BMPBUNDLE_IMPL_SVG_D2D
+
 // ----------------------------------------------------------------------------
 // private helpers
 // ----------------------------------------------------------------------------
@@ -90,32 +114,40 @@
 namespace
 {
 
+// ============================================================================
+// wxBitmapBundleImplSVG
+// ============================================================================
+
 class wxBitmapBundleImplSVG : public wxBitmapBundleImpl
 {
 public:
-    // Ctor must be passed a valid NSVGimage and takes ownership of it.
-    wxBitmapBundleImplSVG(NSVGimage* svgImage, const wxSize& sizeDef)
-        : m_svgImage(svgImage),
-          m_svgRasterizer(nsvgCreateRasterizer()),
-          m_sizeDef(sizeDef)
+    wxBitmapBundleImplSVG(const wxSize& sizeDef)
+        : m_sizeDef(sizeDef)
     {
     }
 
-    ~wxBitmapBundleImplSVG()
+    virtual wxSize GetDefaultSize() const wxOVERRIDE
     {
-        nsvgDeleteRasterizer(m_svgRasterizer);
-        nsvgDelete(m_svgImage);
+        return m_sizeDef;
+    };
+
+    virtual wxSize GetPreferredSizeAtScale(double scale) const wxOVERRIDE
+    {
+        return m_sizeDef*scale;
     }
 
-    virtual wxSize GetDefaultSize() const wxOVERRIDE;
-    virtual wxSize GetPreferredSizeAtScale(double scale) const wxOVERRIDE;
-    virtual wxBitmap GetBitmap(const wxSize& size) wxOVERRIDE;
+    virtual wxBitmap GetBitmap(const wxSize& size) wxOVERRIDE
+    {
+        if ( !m_cachedBitmap.IsOk() || m_cachedBitmap.GetSize() != size )
+        {
+            m_cachedBitmap = DoRasterize(size);
+        }
 
-private:
-    wxBitmap DoRasterize(const wxSize& size);
+        return m_cachedBitmap;
+    }
 
-    NSVGimage* const m_svgImage;
-    NSVGrasterizer* const m_svgRasterizer;
+protected:
+    virtual wxBitmap DoRasterize(const wxSize& size) = 0;
 
     const wxSize m_sizeDef;
 
@@ -134,31 +166,38 @@ private:
 } // anonymous namespace
 
 // ============================================================================
-// wxBitmapBundleImplSVG implementation
+// wxBitmapBundleImplSVGNano
 // ============================================================================
 
-wxSize wxBitmapBundleImplSVG::GetDefaultSize() const
+class wxBitmapBundleImplSVGNano : public wxBitmapBundleImplSVG
 {
-    return m_sizeDef;
-}
-
-wxSize wxBitmapBundleImplSVG::GetPreferredSizeAtScale(double scale) const
-{
-    // We consider that we can render at any scale.
-    return m_sizeDef*scale;
-}
-
-wxBitmap wxBitmapBundleImplSVG::GetBitmap(const wxSize& size)
-{
-    if ( !m_cachedBitmap.IsOk() || m_cachedBitmap.GetSize() != size )
+public:
+    // Ctor must be passed a valid NSVGimage and takes ownership of it.
+    wxBitmapBundleImplSVGNano(NSVGimage* svgImage, const wxSize& sizeDef)
+        : wxBitmapBundleImplSVG(sizeDef),
+          m_svgImage(svgImage),
+          m_svgRasterizer(nsvgCreateRasterizer())
     {
-        m_cachedBitmap = DoRasterize(size);
     }
 
-    return m_cachedBitmap;
-}
+    ~wxBitmapBundleImplSVGNano()
+    {
+        nsvgDeleteRasterizer(m_svgRasterizer);
+        nsvgDelete(m_svgImage);
+    }
 
-wxBitmap wxBitmapBundleImplSVG::DoRasterize(const wxSize& size)
+protected:
+    virtual wxBitmap DoRasterize(const wxSize& size) wxOVERRIDE;
+
+private:
+    NSVGimage* const m_svgImage;
+    NSVGrasterizer* const m_svgRasterizer;
+
+    wxDECLARE_NO_COPY_CLASS(wxBitmapBundleImplSVGNano);
+};
+
+
+wxBitmap wxBitmapBundleImplSVGNano::DoRasterize(const wxSize& size)
 {
     wxVector<unsigned char> buffer(size.x*size.y*4);
     nsvgRasterize
@@ -200,14 +239,464 @@ wxBitmap wxBitmapBundleImplSVG::DoRasterize(const wxSize& size)
     return bitmap;
 }
 
+#ifdef wxHAS_BMPBUNDLE_IMPL_SVG_D2D
+
+// ============================================================================
+// wxBitmapBundleImplSVGD2D declaration
+// ============================================================================
+
+/*
+    wxBitmapBundleImpl using SVG support in Direct2D to
+    rasterize an SVG to wxBitmap at given size.
+
+    Run-time limitations: requires Windows 10 Fall Creators Update
+    and newer, for limitations of the Direct2D SVG renderer see
+    https://docs.microsoft.com/en-us/windows/win32/direct2d/svg-support
+    For example, text elements are not supported at all.
+
+    wxBitmapBundleImplSVGD2D implementation limitations: maximum size of
+    bitmap for rasterization cannot be larger then wxBitmapBundleImplSVGD2D::ms_maxBitmapSize.
+    The SVG must have its width and height specified, if it does not, its viewBox is used
+    for the dimensions. If it does noth have width/height nor viewBox, the SVG cannot be rendered.
+ */
+
+class wxBitmapBundleImplSVGD2D : public wxBitmapBundleImplSVG
+{
+public:
+    // data must be 0 terminated
+    wxBitmapBundleImplSVGD2D(const char* data, const wxSize& sizeDef);
+
+    bool IsOk() const;
+
+    // only available on Windows 10 Fall Creators Update and newer
+    static bool IsAvailable();
+
+private:
+    // maximum dimension of the bitmap an SVG can be rasterized to
+    static const wxSize ms_maxBitmapSize;
+
+    // whether there was an attempt to initialize, regardless of its success
+    static bool ms_initialized;
+    // large bitmap shared by all instances of wxBitmapBundleImplSVGD2D
+    // on which the SVGs are rendered onto
+    static wxCOMPtr<IWICBitmap>          ms_bitmap;
+    static wxCOMPtr<ID2D1DeviceContext5> ms_context;
+
+    static void Initialize();
+    static void Uninitialize();
+    static bool IsInitialized();
+
+    // can rasterize bitmaps only up to ms_maxBitmapSize
+    static bool CanRasterizeAtSize(const wxSize& size);
+
+    static bool CreateIStreamFromPtr(const char* data, wxCOMPtr<IStream>& SVGStream);
+
+    wxCOMPtr<ID2D1SvgDocument> m_SVGDocument;
+    wxSize                     m_SVGDocumentDimensions;
+
+    virtual wxBitmap DoRasterize(const wxSize& size) wxOVERRIDE;
+
+    bool CreateSVGDocument(const wxCOMPtr<IStream>& SVGStream);
+
+    bool GetSVGBitmapFromSharedBitmap(const wxSize& size, wxBitmap& bmp);
+
+    friend class wxBitmapBundleImplSVGD2DModule;
+
+    wxDECLARE_NO_COPY_CLASS(wxBitmapBundleImplSVGD2D);
+};
+
+// ============================================================================
+// wxBitmapBundleImplSVGD2D implementation
+// ============================================================================
+
+// This is a maximum size wxBitmapBundleImplSVGD2D can rasterize to.
+// The larger the size, the larger memory needed and the memory is
+// allocated (ms_bitmap and ms_context)  upon the first use of
+// wxBitmapBundleImplSVGD2D and freed only when wxWidgets shuts down.
+// The size should be large enough for wxBitmapBundle purpose.
+const wxSize wxBitmapBundleImplSVGD2D::ms_maxBitmapSize(512, 512);
+
+bool wxBitmapBundleImplSVGD2D::ms_initialized = false;
+wxCOMPtr<IWICBitmap>wxBitmapBundleImplSVGD2D::ms_bitmap;
+wxCOMPtr<ID2D1DeviceContext5>wxBitmapBundleImplSVGD2D::ms_context;
+
+wxBitmapBundleImplSVGD2D::wxBitmapBundleImplSVGD2D(const char* data, const wxSize& sizeDef)
+    : wxBitmapBundleImplSVG(sizeDef)
+{
+    wxCHECK_RET(data, "null data");
+    wxCHECK_RET(IsAvailable(), "Don't create instances of wxBitmapBundleImplSVGD2D when wxBitmapBundleImplSVGD2D::IsAvailable() returns false");
+
+    wxCOMPtr<IStream> SVGStream;
+
+    if ( CreateIStreamFromPtr(data, SVGStream) )
+        CreateSVGDocument(SVGStream);
+}
+
+bool wxBitmapBundleImplSVGD2D::IsOk() const
+{
+    return m_SVGDocument.get() != NULL;
+}
+
+bool wxBitmapBundleImplSVGD2D::CreateSVGDocument(const wxCOMPtr<IStream>& SVGStream)
+{
+    HRESULT     hr;
+    D2D1_SIZE_F viewportSize = D2D1::SizeF(32, 32); // viewportSize is ignored when creating SVGDocument
+
+    hr = ms_context->CreateSvgDocument(SVGStream, viewportSize, &m_SVGDocument);
+    if ( FAILED (hr) )
+    {
+        wxLogApiError("ID2D1DeviceContext5::CreateSvgDocument", hr);
+        return false;
+    }
+
+    // @TODO: Deal with units?
+
+    wxCOMPtr<ID2D1SvgElement> root;
+    D2D1_SVG_LENGTH           width, height;
+
+    m_SVGDocument->GetRoot(&root);
+
+    width.value = height.value = 0;
+    if ( root->IsAttributeSpecified(L"width") )
+        root->GetAttributeValue(L"width", &width);
+    if ( root->IsAttributeSpecified(L"height") )
+        root->GetAttributeValue(L"height", &height);
+
+    // If the SVG is missing width/height attributes,
+    // try to get the viewbox
+    if ( (width.value == 0. || height.value == 0.)
+         && root->IsAttributeSpecified(L"viewBox") )
+    {
+        D2D1_SVG_VIEWBOX viewBox;
+
+        hr = root->GetAttributeValue(L"viewBox", D2D1_SVG_ATTRIBUTE_POD_TYPE_VIEWBOX, &viewBox, sizeof(viewBox));
+        if ( SUCCEEDED(hr) )
+        {
+            width.value = viewBox.width;
+            height.value = viewBox.height;
+
+            wxLogDebug("SVG doesn't have width/height specified, using viewBox instead");
+            m_SVGDocument->SetViewportSize(D2D1::SizeF(viewBox.width, viewBox.height));
+        }
+    }
+
+    if ( width.value == 0. || height.value == 0. )
+    {
+        wxLogDebug("Couldn't obtain SVG dimensions");
+        m_SVGDocument.reset();
+        return false;
+    }
+
+    m_SVGDocumentDimensions = wxSize(width.value, height.value);
+    return true;
+}
+
+// Obtains the bitmap drawn on ms_bitmap at (0, 0, size.x, size.y)
+bool wxBitmapBundleImplSVGD2D::GetSVGBitmapFromSharedBitmap(const wxSize& size, wxBitmap& bmp)
+{
+    const WICRect lockRect = { 0, 0, size.x, size.y };
+
+    HRESULT                  hr;
+    wxCOMPtr<IWICBitmapLock> lock;
+
+    hr = ms_bitmap->Lock(&lockRect, WICBitmapLockRead, &lock);
+    if ( FAILED(hr) )
+    {
+        wxLogApiError("IWICBitmap::Lock", hr);
+        return false;
+    }
+
+    wxBitmap bmpOut = wxBitmap(size, 32);
+
+    if ( !bmpOut.IsOk() )
+    {
+        wxLogDebug("Failed to created wxBitmap bmpOut");
+        return false;
+    }
+
+    UINT  stride     = 0;
+    UINT  bufferSize = 0;
+    BYTE* buffer     = NULL;
+
+    hr = lock->GetStride(&stride);
+    if ( FAILED(hr) )
+    {
+        wxLogApiError("IWICBitmapLock::GetStride", hr);
+        return false;
+    }
+
+    if ( stride != static_cast<UINT>(ms_maxBitmapSize.x) * 4 )
+    {
+        wxLogDebug("Unexpected bitmap stride");
+        return false;
+    }
+
+    hr = lock->GetDataPointer(&bufferSize, &buffer);
+    if ( FAILED(hr) )
+    {
+        wxLogApiError("IWICBitmapLock::GetDataPointer", hr);
+        return false;
+    }
+
+    const unsigned char* src = &buffer[0];
+    // we may not want the whole row
+    const size_t         rowBytesToSkip = (ms_maxBitmapSize.x - size.x) * 4;
+
+    wxAlphaPixelData           bmpdata(bmpOut);
+    wxAlphaPixelData::Iterator dst(bmpdata);
+
+    for ( int y = 0; y < size.y; ++y )
+    {
+        dst.MoveTo(bmpdata, 0, y);
+
+        // @TODO: Make sure the alpha are OK
+
+        for ( int x = 0; x < size.x; ++x )
+        {
+            const unsigned char a = src[3];
+
+            dst.Red()   = src[0] * a / 255;
+            dst.Green() = src[1] * a / 255;
+            dst.Blue()  = src[2] * a / 255;
+            dst.Alpha() = a;
+
+            ++dst;
+            src += 4;
+        }
+        src += rowBytesToSkip;
+    }
+
+    bmp = bmpOut;
+    return true;
+}
+
+wxBitmap wxBitmapBundleImplSVGD2D::DoRasterize(const wxSize& size)
+{
+    if ( !IsOk() )
+    {
+        wxLogDebug("m_SVGDocument is invalid");
+    }
+    else
+    if ( !CanRasterizeAtSize(size) )
+    {
+        wxLogDebug("Couldn't rasterize to bitmap with dimensions %dx%d", size.x, size.y);
+    }
+    else
+    {
+        const float         scaleValue = wxMin((float)size.x / m_SVGDocumentDimensions.x, (float)size.y / m_SVGDocumentDimensions.y);
+        const D2D1_POINT_2F scaleCenter = D2D1::Point2F(size.x / 2.0f, size.y / 2.0f);
+        const D2D1_SIZE_F   transl = D2D1::SizeF((size.x - m_SVGDocumentDimensions.x) / 2.0f, (size.y - m_SVGDocumentDimensions.y) / 2.0f);
+
+        D2D1_MATRIX_3X2_F transform = D2D1::Matrix3x2F::Identity();
+        wxBitmap          bmp;
+
+        // center
+        transform = transform * D2D1::Matrix3x2F::Translation(transl);
+        // scale
+        transform = transform * D2D1::Matrix3x2F::Scale(scaleValue, scaleValue, scaleCenter);
+
+        ms_context->BeginDraw();
+        ms_context->Clear();
+        ms_context->SetTransform(transform);
+        ms_context->DrawSvgDocument(m_SVGDocument);
+        ms_context->EndDraw();
+
+        if ( GetSVGBitmapFromSharedBitmap(size, bmp) )
+            return bmp;
+    }
+
+    return wxBitmap();
+}
+
+
+// static
+void wxBitmapBundleImplSVGD2D::Initialize()
+{
+    if ( IsInitialized() )
+        return;
+    ms_initialized = true;
+
+    const wxPlatformInfo& platformInfo = wxPlatformInfo::Get();
+
+    // we need at least Windows 10 Fall Creators Update
+    if ( !platformInfo.CheckOSVersion(10, 0, 16299) )
+        return;
+
+    HRESULT hr;
+    UINT    width, height;
+
+    width  = static_cast<UINT>(ms_maxBitmapSize.x);
+    height = static_cast<UINT>(ms_maxBitmapSize.y);
+
+    if ( wxWICImagingFactory() == NULL || wxD2D1Factory() == NULL )
+    {
+        wxLogDebug("wxDirect2D is not available even when it should be.");
+        return;
+    }
+
+    hr = wxWICImagingFactory()->CreateBitmap(width, height, GUID_WICPixelFormat32bppPRGBA, WICBitmapCacheOnDemand, &ms_bitmap);
+    if ( FAILED(hr) )
+    {
+        wxLogApiError("IWICImagingFactory::CreateBitmap", hr);
+        return;
+    }
+
+    D2D1_RENDER_TARGET_PROPERTIES props;
+    wxCOMPtr<ID2D1RenderTarget>   target;
+
+    props.type                  = D2D1_RENDER_TARGET_TYPE_DEFAULT;
+    props.pixelFormat.format    = DXGI_FORMAT_UNKNOWN;
+    props.pixelFormat.alphaMode = D2D1_ALPHA_MODE_UNKNOWN;
+    props.dpiX = props.dpiY     = 96;
+    props.usage                 = D2D1_RENDER_TARGET_USAGE_NONE;
+    props.minLevel              = D2D1_FEATURE_LEVEL_DEFAULT;
+
+    hr = wxD2D1Factory()->CreateWicBitmapRenderTarget(ms_bitmap, props, &target);
+    if ( FAILED(hr) )
+    {
+        wxLogApiError("ID2D1Factory::CreateWicBitmapRenderTarget", hr);
+        ms_bitmap.reset();
+        return;
+    }
+
+    hr = target->QueryInterface(wxIID_PPV_ARGS(ID2D1DeviceContext5, &ms_context));
+    if ( FAILED(hr) )
+    {
+        wxLogApiError("ID2D1RenderTarget::QueryInterface(ID2D1DeviceContext5)", hr);
+        target.reset();
+        ms_bitmap.reset();
+        return;
+    }
+}
+
+// static
+void wxBitmapBundleImplSVGD2D::Uninitialize()
+{
+    ms_context.reset();
+    ms_bitmap.reset();
+    ms_initialized = false;
+}
+
+// static
+bool wxBitmapBundleImplSVGD2D::IsInitialized()
+{
+    return ms_initialized;
+}
+
+// static
+bool wxBitmapBundleImplSVGD2D::IsAvailable()
+{
+    if ( !IsInitialized() )
+        Initialize();
+
+    return ms_context.get() != NULL;
+}
+
+// static
+bool wxBitmapBundleImplSVGD2D::wxBitmapBundleImplSVGD2D::CanRasterizeAtSize(const wxSize& size)
+{
+    const int width  = size.x;
+    const int height = size.y;
+
+    return width > 0 && height > 0
+           && width <= ms_maxBitmapSize.x
+           && height <= ms_maxBitmapSize.y;
+}
+
+// static
+ bool wxBitmapBundleImplSVGD2D::CreateIStreamFromPtr(const char* data, wxCOMPtr<IStream>& SVGStream)
+ {
+     const size_t dataLen = strlen(data);
+
+    HGLOBAL hMem = ::GlobalAlloc(GMEM_MOVEABLE, dataLen);
+
+    if ( !hMem )
+    {
+        wxLogDebug("Failed to allocate memory for SVG stream");
+        return false;
+    }
+
+    // It could be better to use SHCreateMemStream, but more complicated
+    // to implement: https://docs.microsoft.com/en-us/windows/win32/api/shlwapi/nf-shlwapi-shcreatememstream#remarks
+
+    LPVOID buff = ::GlobalLock(hMem);
+
+    if ( !buff )
+    {
+        wxLogDebug("Failed to lock memory for SVG stream");
+        ::GlobalFree(hMem);
+        return false;
+    }
+
+    memcpy(buff, data, dataLen);
+    ::GlobalUnlock(hMem);
+
+    const HRESULT hr = ::CreateStreamOnHGlobal(hMem, TRUE, &SVGStream);
+
+    if ( FAILED(hr) )
+    {
+        ::GlobalFree(hMem);
+        wxLogApiError("::CreateStreamOnHGlobal", hr);
+        return false;
+    }
+
+    ULARGE_INTEGER largeSize;
+
+    largeSize.QuadPart = dataLen;
+    SVGStream->SetSize(largeSize);
+    return true;
+ }
+
+// wxBitmapBundleImplSVGD2DModule ensures that wxBitmapBundleImplSVGD2D::Uninitialize()
+// is called before wxDirect2D shuts down.
+class wxBitmapBundleImplSVGD2DModule : public wxModule
+{
+public:
+    wxBitmapBundleImplSVGD2DModule()
+    {
+        AddDependency("wxDirect2DModule");
+    }
+
+    virtual bool OnInit() wxOVERRIDE
+    {
+        // we will initialize static members of wxBitmapBundleImplSVGD2D
+        // only on demand, in wxBitmapBundleImplSVGD2D::Initialize()
+        return true;
+    }
+
+    virtual void OnExit() wxOVERRIDE
+    {
+        wxBitmapBundleImplSVGD2D::Uninitialize();
+    }
+
+private:
+    wxDECLARE_DYNAMIC_CLASS(wxBitmapBundleImplSVGD2DModule);
+};
+
+wxIMPLEMENT_DYNAMIC_CLASS(wxBitmapBundleImplSVGD2DModule, wxModule);
+
+#endif // #ifdef wxHAS_BMPBUNDLE_IMPL_SVG_D2D
+
 /* static */
 wxBitmapBundle wxBitmapBundle::FromSVG(char* data, const wxSize& sizeDef)
 {
+#ifdef wxHAS_BMPBUNDLE_IMPL_SVG_D2D
+
+    if ( wxBitmapBundleImplSVGD2D::IsAvailable() )
+    {
+        wxBitmapBundle bundle(new wxBitmapBundleImplSVGD2D(data, sizeDef));
+
+        if ( bundle.IsOk() )
+            return bundle;
+    }
+
+#endif // #ifdef wxHAS_BMPBUNDLE_IMPL_SVG_D2D
+
     NSVGimage* const svgImage = nsvgParse(data, "px", 96);
     if ( !svgImage )
         return wxBitmapBundle();
 
-    return wxBitmapBundle(new wxBitmapBundleImplSVG(svgImage, sizeDef));
+    return wxBitmapBundle(new wxBitmapBundleImplSVGNano(svgImage, sizeDef));
 }
 
 /* static */


### PR DESCRIPTION
Vadim recently mentioned that it could be good to use Direct2D to rasterize SVGs in `wxBitmapBundle`.

This is an attempt to implement this in a class `wxBitmapBundleImplSVGD2D`. Disclaimer: I have no experience with Direct2D or any other high-performance graphic API nor am I very knowledgeable about SVG format.

I was surprised how limited SVG support in Direct2D is. For example, even the latest version does not support text element, for more information about SVG support in Direct2D see [here](https://docs.microsoft.com/en-us/windows/win32/direct2d/svg-support).

This makes me wonder if using Direct2D renderer is really any better than existing NanoSVG one. I will benchmark the two and see if Direct2D is at least (much) faster but considering its purpose here, the speed may not matter much. I will also finish the program displaying SVGs with both renderers to help check how they cope with different SVGs.

**My implementation limitations:**
1. I chose the approach to render SVGs to `IWICBitmap`, the device context and bitmap are shared among all instances of `wxBitmapBundleImplSVGD2D`, created upon first use of any `wxBitmapBundleImplSVGD2D` method and kept alive during the program lifetime. This may be an utterly wrong approach, please feel free to point it out.
2. The maximum bitmap size to be render is limited, currently to 512x512, see the code comments.
3. The code requires Windows 10 Fall Creators Update (v1709, released in October 2017) or newer. I chose it because this offers most complete (less incomplete) SVG support and vast majority of Windows 10 users should have it.
4. The SVGs must have their width and height specified. If they do not, I try to use the viewBox as viewPort. If an SVG does not have width and height or viewBox, I refuse to render it. I don't think using some default size would be any better and I do not know what else to do.
5. Direct2D SVG support needs quite recent Windows headers. AFAIK, this rules out any current mingw distribution and leaves only MSVC with recent enough Platform SDK.

**Known issues**
I call Direct2D APIs like this
```
HRESULT hr = wxD2D1Factory()->CreateWicBitmapRenderTarget(ms_bitmap, props, &target);
if ( FAILED(hr) ) ...
```
However, anytime such a call fails, a `D2D DEBUG ERROR` exception is thrown before `if ( FAILED(...)` is executed. I find this very surprising, similar code I saw actually had to ask for an exception with `DX::ThrowIfFailed()`. Yet, I do not want exceptions but I still get them. I could wrap the code with `try catch`, but I think this should not be needed. Any ideas?