### PR TITLE
Fix too dark day number colors with dark themes in wxCalendarCtrl

### DIFF
--- a/src/generic/calctrlg.cpp
+++ b/src/generic/calctrlg.cpp
@@ -907,8 +907,6 @@ void wxGenericCalendarCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
         }
     }
 
-    // then the calendar itself
-    dc.SetTextForeground(*wxBLACK);
     //dc.SetFont(*wxNORMAL_FONT);
 
     y += m_heightRow;
@@ -916,6 +914,7 @@ void wxGenericCalendarCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
     // draw column with calendar week nr
     if ( HasFlag( wxCAL_SHOW_WEEK_NUMBERS ) && IsExposed( 0, y, m_calendarWeekWidth, m_heightRow * 6 ))
     {
+        dc.SetTextForeground(*wxBLACK);
         dc.SetBackgroundMode(wxTRANSPARENT);
         dc.SetBrush(wxBrush(m_colHeaderBg, wxSOLID));
         dc.SetPen(wxPen(m_colHeaderBg, 1, wxSOLID));
@@ -929,6 +928,9 @@ void wxGenericCalendarCtrl::OnPaint(wxPaintEvent& WXUNUSED(event))
             date += wxDateSpan::Week();
         }
     }
+
+    // then the calendar itself
+    dc.SetTextForeground(GetForegroundColour());
 
     wxDateTime date = GetStartDate();
 


### PR DESCRIPTION
Cherry-picking this fix to 3.0 branch, too:

wxBLACK was used for some day numbers, and with a dark theme the numbers
are drawn on a nearly black background, making them barely visible.

Instead, use wxBLACK explicitly for week numbers, but get the proper
color for day numbers always (and not just sometimes) with
GetForegroundColour().

Closes https://github.com/wxWidgets/wxWidgets/pull/2643

(cherry picked from commit 783df59e668eba4d3fddb9603e86c2a312ec66e5)