### PR TITLE
Add functions for wxIcon interoperability to wxBitmapBundle too

### DIFF
--- a/include/wx/bmpbndl.h
+++ b/include/wx/bmpbndl.h
@@ -111,6 +111,10 @@ public:
     // If size == wxDefaultSize, GetDefaultSize() is used for it instead.
     wxBitmap GetBitmap(const wxSize& size) const;
 
+    // Get icon of the specified size, this is just a convenient wrapper for
+    // GetBitmap() converting the returned bitmap to the icon.
+    wxIcon GetIcon(const wxSize& size) const;
+
     // Helper combining GetBitmap() and GetPreferredSizeFor(): returns the
     // bitmap of the size appropriate for the current DPI scaling of the given
     // window.

--- a/include/wx/bmpbndl.h
+++ b/include/wx/bmpbndl.h
@@ -115,10 +115,11 @@ public:
     // GetBitmap() converting the returned bitmap to the icon.
     wxIcon GetIcon(const wxSize& size) const;
 
-    // Helper combining GetBitmap() and GetPreferredSizeFor(): returns the
-    // bitmap of the size appropriate for the current DPI scaling of the given
-    // window.
+    // Helpers combining GetBitmap() or GetIcon() and GetPreferredSizeFor():
+    // return the bitmap or icon of the size appropriate for the current DPI
+    // scaling of the given window.
     wxBitmap GetBitmapFor(const wxWindow* window) const;
+    wxIcon GetIconFor(const wxWindow* window) const;
 
     // Access implementation
     wxBitmapBundleImpl* GetImpl() const { return m_impl.get(); }

--- a/include/wx/bmpbndl.h
+++ b/include/wx/bmpbndl.h
@@ -123,6 +123,11 @@ public:
     // Access implementation
     wxBitmapBundleImpl* GetImpl() const { return m_impl.get(); }
 
+    // Check if two objects refer to the same bundle.
+    bool IsSameAs(const wxBitmapBundle& other) const
+    {
+        return GetImpl() == other.GetImpl();
+    }
 
     // Implementation only from now on.
 

--- a/interface/wx/bmpbndl.h
+++ b/interface/wx/bmpbndl.h
@@ -341,6 +341,16 @@ public:
         the returned bitmap to wxIcon.
      */
     wxIcon GetIcon(const wxSize& size) const;
+
+    /**
+        Check if the two bundles refer to the same object.
+
+        Bundles are considered to be same only if they actually use the same
+        underlying object, i.e. are copies of each other. If the two bundles
+        were independently constructed, they're @e not considered to be the
+        same, even if they were created from the same bitmap.
+     */
+    bool IsSameAs(const wxBitmapBundle& other) const;
 };
 
 /**

--- a/interface/wx/bmpbndl.h
+++ b/interface/wx/bmpbndl.h
@@ -343,6 +343,17 @@ public:
     wxIcon GetIcon(const wxSize& size) const;
 
     /**
+        Get icon of the size appropriate for the DPI scaling used by the
+        given window.
+
+        This is similar to GetBitmapFor(), but returns a wxIcon, as GetIcon()
+        does.
+
+        @param window Non-null and fully created window.
+     */
+    wxIcon GetIconFor(const wxWindow* window) const;
+
+    /**
         Check if the two bundles refer to the same object.
 
         Bundles are considered to be same only if they actually use the same

--- a/interface/wx/bmpbndl.h
+++ b/interface/wx/bmpbndl.h
@@ -315,6 +315,9 @@ public:
         cached, avoid calling it for many different sizes if you do use it, as
         this will create many bitmaps that will never be deleted and will
         consume resources until the application termination.
+
+        @param size The size of the bitmap to return, in physical pixels. If
+            this parameter is wxDefaultSize, default bundle size is used.
      */
     wxBitmap GetBitmap(const wxSize& size) const;
 

--- a/interface/wx/bmpbndl.h
+++ b/interface/wx/bmpbndl.h
@@ -333,6 +333,14 @@ public:
         @param window Non-null and fully created window.
      */
     wxBitmap GetBitmapFor(const wxWindow* window) const;
+
+    /**
+        Get icon of the specified size.
+
+        This is just a convenient wrapper for GetBitmap() and simply converts
+        the returned bitmap to wxIcon.
+     */
+    wxIcon GetIcon(const wxSize& size) const;
 };
 
 /**

--- a/src/common/bmpbndl.cpp
+++ b/src/common/bmpbndl.cpp
@@ -477,6 +477,11 @@ wxBitmap wxBitmapBundle::GetBitmapFor(const wxWindow* window) const
     return GetBitmap(GetPreferredSizeFor(window));
 }
 
+wxIcon wxBitmapBundle::GetIconFor(const wxWindow* window) const
+{
+    return GetIcon(GetPreferredSizeFor(window));
+}
+
 namespace
 {
 

--- a/src/common/bmpbndl.cpp
+++ b/src/common/bmpbndl.cpp
@@ -461,6 +461,17 @@ wxBitmap wxBitmapBundle::GetBitmap(const wxSize& size) const
     return bmp;
 }
 
+wxIcon wxBitmapBundle::GetIcon(const wxSize& size) const
+{
+    wxIcon icon;
+
+    const wxBitmap bmp = GetBitmap(size);
+    if ( bmp.IsOk() )
+        icon.CopyFromBitmap(bmp);
+
+    return icon;
+}
+
 wxBitmap wxBitmapBundle::GetBitmapFor(const wxWindow* window) const
 {
     return GetBitmap(GetPreferredSizeFor(window));


### PR DESCRIPTION
This simply treats `wxIcon` the same as `wxBitmap`, which is especially important for the ports where it's not the same as `wxBitmap`.