### PR TITLE
Make scale factor-related functions available in wxIcon in wxMSW too

### DIFF
--- a/include/wx/msw/bitmap.h
+++ b/include/wx/msw/bitmap.h
@@ -191,19 +191,6 @@ public:
     void UseAlpha(bool use = true);
     void ResetAlpha() { UseAlpha(false); }
 
-    // allow setting and storing the scale factor
-    virtual void SetScaleFactor(double scale);
-    virtual double GetScaleFactor() const;
-
-    // return the size divided by scale factor
-    wxSize GetDIPSize() const;
-
-    // logical metrics accessors return the same thing as physical ones, just
-    // as in all the other ports without wxHAS_DPI_INDEPENDENT_PIXELS.
-    double GetLogicalWidth() const;
-    double GetLogicalHeight() const;
-    wxSize GetLogicalSize() const;
-
     // old synonyms for CreateWithLogicalSize() and GetLogicalXXX() functions
     bool CreateScaled(int w, int h, int d, double logicalScale)
         { return CreateWithLogicalSize(wxSize(w, h), logicalScale, d); }

--- a/include/wx/msw/gdiimage.h
+++ b/include/wx/msw/gdiimage.h
@@ -118,10 +118,19 @@ public:
     int GetWidth() const { return IsNull() ? 0 : GetGDIImageData()->m_width; }
     int GetHeight() const { return IsNull() ? 0 : GetGDIImageData()->m_height; }
     int GetDepth() const { return IsNull() ? 0 : GetGDIImageData()->m_depth; }
-    double GetScaleFactor() const
-    {
-        return IsNull() ? 1.0 : GetGDIImageData()->m_scaleFactor;
-    }
+
+    // allow setting and storing the scale factor
+    void SetScaleFactor(double scale);
+    double GetScaleFactor() const;
+
+    // return the size divided by scale factor
+    wxSize GetDIPSize() const;
+
+    // logical metrics accessors return the same thing as physical ones, just
+    // as in all the other ports without wxHAS_DPI_INDEPENDENT_PIXELS.
+    double GetLogicalWidth() const;
+    double GetLogicalHeight() const;
+    wxSize GetLogicalSize() const;
 
     wxSize GetSize() const
     {

--- a/interface/wx/icon.h
+++ b/interface/wx/icon.h
@@ -222,16 +222,59 @@ public:
     int GetDepth() const;
 
     /**
-        Gets the height of the icon in pixels.
+        Gets the height of the icon in physical pixels.
 
-        @see GetWidth()
+        @see GetWidth(), GetLogicalHeight()
     */
     int GetHeight() const;
 
     /**
-        Gets the width of the icon in pixels.
+        Gets the height of the icon in logical pixels.
 
-        @see GetHeight()
+        See wxBitmap::GetLogicalHeight().
+
+        @since 3.1.6
+     */
+    double GetLogicalHeight() const;
+
+    /**
+        Gets the size of the icon in logical pixels.
+
+        See wxBitmap::GetLogicalSize().
+
+        @since 3.1.6
+     */
+    double GetLogicalSize() const;
+
+    /**
+        Gets the width of the icon in logical pixels.
+
+        See wxBitmap::GetLogicalWidth().
+
+        @since 3.1.6
+     */
+    double GetLogicalWidth() const;
+
+    /**
+        Gets the scale factor of this icon.
+
+        See wxBitmap::GetScaleFactor().
+
+        @since 3.1.6
+     */
+    double GetScaleFactor() const;
+
+    /**
+        Gets the size of the icon in physical pixels.
+
+        @see GetLogicalSize()
+     */
+    wxSize GetSize() const;
+
+    /**
+        Gets the width of the icon in physical pixels.
+
+        @see GetHeight(), GetLogicalWidth()
     */
     int GetWidth() const;
 

--- a/src/msw/bitmap.cpp
+++ b/src/msw/bitmap.cpp
@@ -1365,47 +1365,6 @@ bool wxBitmap::InitFromHBITMAP(WXHBITMAP bmp, int width, int height, int depth)
 }
 
 // ----------------------------------------------------------------------------
-// scale factor-related functions
-// ----------------------------------------------------------------------------
-
-// wxMSW doesn't really use scale factor, but we must still store it to use the
-// correct sizes in the code which uses it to decide on the bitmap size to use.
-
-void  wxBitmap::SetScaleFactor(double scale)
-{
-    wxCHECK_RET( IsOk(), wxT("invalid bitmap") );
-
-    GetBitmapData()->m_scaleFactor = scale;
-}
-
-double wxBitmap::GetScaleFactor() const
-{
-    wxCHECK_MSG( IsOk(), -1, wxT("invalid bitmap") );
-
-    return GetBitmapData()->m_scaleFactor;
-}
-
-wxSize wxBitmap::GetDIPSize() const
-{
-    return GetSize() / GetScaleFactor();
-}
-
-double wxBitmap::GetLogicalWidth() const
-{
-    return GetWidth();
-}
-
-double wxBitmap::GetLogicalHeight() const
-{
-    return GetHeight();
-}
-
-wxSize wxBitmap::GetLogicalSize() const
-{
-    return GetSize();
-}
-
-// ----------------------------------------------------------------------------
 // raw bitmap access support
 // ----------------------------------------------------------------------------
 

--- a/src/msw/gdiimage.cpp
+++ b/src/msw/gdiimage.cpp
@@ -346,6 +346,8 @@ void wxGDIImage::SetScaleFactor(double scale)
 {
     wxCHECK_RET( IsOk(), wxT("invalid bitmap") );
 
+    AllocExclusive();
+
     GetGDIImageData()->m_scaleFactor = scale;
 }
 

--- a/src/msw/gdiimage.cpp
+++ b/src/msw/gdiimage.cpp
@@ -336,6 +336,47 @@ void wxGDIImage::InitStandardHandlers()
 }
 
 // ----------------------------------------------------------------------------
+// scale factor-related functions
+// ----------------------------------------------------------------------------
+
+// wxMSW doesn't really use scale factor, but we must still store it to use the
+// correct sizes in the code which uses it to decide on the bitmap size to use.
+
+void wxGDIImage::SetScaleFactor(double scale)
+{
+    wxCHECK_RET( IsOk(), wxT("invalid bitmap") );
+
+    GetGDIImageData()->m_scaleFactor = scale;
+}
+
+double wxGDIImage::GetScaleFactor() const
+{
+    wxCHECK_MSG( IsOk(), -1, wxT("invalid bitmap") );
+
+    return GetGDIImageData()->m_scaleFactor;
+}
+
+wxSize wxGDIImage::GetDIPSize() const
+{
+    return GetSize() / GetScaleFactor();
+}
+
+double wxGDIImage::GetLogicalWidth() const
+{
+    return GetWidth();
+}
+
+double wxGDIImage::GetLogicalHeight() const
+{
+    return GetHeight();
+}
+
+wxSize wxGDIImage::GetLogicalSize() const
+{
+    return GetSize();
+}
+
+// ----------------------------------------------------------------------------
 // wxBitmap handlers
 // ----------------------------------------------------------------------------
 

--- a/src/msw/icon.cpp
+++ b/src/msw/icon.cpp
@@ -115,7 +115,8 @@ void wxIcon::CopyFromBitmap(const wxBitmap& bmp)
     }
     else
     {
-        InitFromHICON((WXHICON)hicon, bmp.GetWidth(), bmp.GetHeight());
+        InitFromHICON((WXHICON)hicon, bmp.GetWidth(), bmp.GetHeight(),
+                      bmp.GetScaleFactor());
     }
 }
 


### PR DESCRIPTION
Refactor the code by moving the functions from `wxBitmap` to `wxGDIImage`, which makes them available in `wxIcon` too.