### PR TITLE
Performance tweak for `samples/display`, resulting in a much faster application start by cutting down number of UI messages sent.

### DIFF
--- a/samples/display/display.cpp
+++ b/samples/display/display.cpp
@@ -28,6 +28,7 @@
 #include "wx/artprov.h"
 #include "wx/bookctrl.h"
 #include "wx/sysopt.h"
+#include "wx/wupdlock.h"
 
 #include "wx/display.h"
 
@@ -314,31 +315,18 @@ void MyFrame::PopuplateWithDisplayInfo()
 		// which happens deep inside the Append() call chain and executes another inner loop calling SendMessage() to get the control contents.
 		// 
 		// With the 'display' sample, that's about 500+ rounds and about 500*500/2 SendMessage() calls less now.
-		choiceModes->Freeze();
-
-		const wxArrayVideoModes modes = display.GetModes();
-        const size_t countModes = modes.GetCount();
-        for ( size_t nMode = 0; nMode < countModes; nMode++ )
-        {
-            const wxVideoMode& mode = modes[nMode];
-
-			// unfreeze the choice control for the last item: so the control can get properly resized for when we're done adding these items here.
-			if (nMode == countModes - 1)
-			{
-				if (choiceModes->IsFrozen())
-				{
-					choiceModes->Thaw();
-				}
-			}
-
-            choiceModes->Append(VideoModeToText(mode),
-                                new MyVideoModeClientData(mode));
-        }
-
-		// Always make sure to unfreeze the choice dropdown, even when there were ZERO items to add above.
-		if (choiceModes->IsFrozen())
 		{
-			choiceModes->Thaw();
+			wxWindowUpdateLocker lockUpdates(choiceModes);
+
+			const wxArrayVideoModes modes = display.GetModes();
+			const size_t countModes = modes.GetCount();
+			for ( size_t nMode = 0; nMode < countModes; nMode++ )
+			{
+				const wxVideoMode& mode = modes[nMode];
+
+				choiceModes->Append(VideoModeToText(mode),
+									new MyVideoModeClientData(mode));
+			}
 		}
 
         const wxString currentMode = VideoModeToText(display.GetCurrentMode());


### PR DESCRIPTION
Performance tweak for `samples/display`, resulting in a much faster application start, particularly when built in debug mode, when Windows messages are dumped to the system debug channel for inspection/diagnosis.

Speed up the `Append()` loop below by foregoing the repeated resizing of the choice drop-down via repeated calls to `GetBestSize()` which happens deep inside the `Append()` call chain and executes another inner loop calling `SendMessage()` to get the control contents. (This exhibits <img src="https://render.githubusercontent.com/render/math?mode=inline&math=\frac 1 2 O(N^2)"> behaviour thanks to the linear growth of the length of the inner loop to the length of the outer loop (= number of items to add), while it is re-executed for every new added item.)

With the `display` sample, that's about 500+ rounds and about <img src="https://render.githubusercontent.com/render/math?mode=inline&math=\frac {500 \times 500} 2"> `SendMessage()` calls less now on my dev/test rig, taking noticable time to start the display application.

---

Issue was found due to the barrage of '(winmsg)' Windows Message debug log lines zipping by in the monitor app when the sample was built in Debug Mode. Only significant difference with the Release Build is those debug lines being output, hence the performance gain is less, but still measurable, in a Release build. When the machine is otherwise severely loaded (UI render core maxing out), "measurable" becomes "obnoxiously noticable" again on Win10/64.

This tweak fixes that.
