### PR TITLE
[wxDEBUG_COLLECT_TRACE_MASKS=1] dump the collected log mask IDs to the debug channel once the application terminates

### DIFF
--- a/include/wx/log.h
+++ b/include/wx/log.h
@@ -14,6 +14,14 @@
 #include "wx/defs.h"
 #include "wx/cpp.h"
 
+#if !defined(wxDEBUG_COLLECT_TRACE_MASKS)
+	#if wxDEBUG_LEVEL >= 11
+		#define wxDEBUG_COLLECT_TRACE_MASKS	1
+	#else
+		#define wxDEBUG_COLLECT_TRACE_MASKS	0
+	#endif
+#endif
+
 // ----------------------------------------------------------------------------
 // types
 // ----------------------------------------------------------------------------
@@ -495,6 +503,10 @@ public:
     // is this trace mask in the list?
     static bool IsAllowedTraceMask(const wxString& mask);
 
+#if wxDEBUG_COLLECT_TRACE_MASKS
+	// Dump the set of masks collect through observing calls to IsAllowedTraceMask()
+	static void DumpCollectedTraceMasks();
+#endif
 
     // log formatting
     // -----------------
@@ -1360,6 +1372,9 @@ WXDLLIMPEXP_BASE wxString wxSysErrorMsgStr(unsigned long nErrCode = 0);
 
 
 #else // !wxUSE_LOG
+
+//#if wxUSE_LOG_DEBUG || wxUSE_LOG_TRACE
+#pragma message("WARNING: you won't get any wxTrace nor any wxDebug messages as you have wxUSE_LOG turned OFF!")
 
 #undef wxUSE_LOG_DEBUG
 #define wxUSE_LOG_DEBUG 0

--- a/src/common/appbase.cpp
+++ b/src/common/appbase.cpp
@@ -189,7 +189,12 @@ wxAppConsoleBase::~wxAppConsoleBase()
 {
     wxEvtHandler::RemoveFilter(this);
 
-    // we're being destroyed and using this object from now on may not work or
+#if wxDEBUG_COLLECT_TRACE_MASKS
+	// Now dump the log/trace masks the wxWidgets library has been using during this run.
+	wxLog::DumpCollectedTraceMasks();
+#endif
+
+	// we're being destroyed and using this object from now on may not work or
     // even crash so don't leave dangling pointers to it
     ms_appInstance = NULL;
 

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -32,6 +32,7 @@
     #include "wx/utils.h"
 #endif //WX_PRECOMP
 
+#include "wx/arrstr.h"
 #include "wx/apptrait.h"
 #include "wx/datetime.h"
 #include "wx/file.h"
@@ -702,9 +703,48 @@ void wxLog::ClearTraceMasks()
     TraceMasks().Clear();
 }
 
+#if wxDEBUG_COLLECT_TRACE_MASKS
+static wxArrayString collected_masks;
+
+void wxLog::DumpCollectedTraceMasks()
+{
+	wxMessageOutputDebug().Output(wxT("[wxCollectedTraceMasks]\n"));
+	for (wxArrayString::const_iterator it = collected_masks.begin(),
+		en = collected_masks.end();
+		it != en;
+	++it)
+	{
+		wxString mask = *it;
+		wxMessageOutputDebug().Output(mask + wxS('\n'));
+	}
+	wxMessageOutputDebug().Output(wxT("[/wxCollectedTraceMasks]\n"));
+}
+#endif
+
 /*static*/ bool wxLog::IsAllowedTraceMask(const wxString& mask)
 {
     wxCRIT_SECT_LOCKER(lock, GetTraceMaskCS());
+
+#if wxDEBUG_COLLECT_TRACE_MASKS
+	{
+		bool foundIt = false;
+		for (wxArrayString::const_iterator it = collected_masks.begin(),
+			en = collected_masks.end();
+			it != en;
+			++it)
+		{
+			if (*it == mask)
+			{
+				foundIt = true;
+				break;
+			}
+		}
+		if (!foundIt)
+		{
+			collected_masks.Add(mask);
+		}
+	}
+#endif
 
     const wxArrayString& masks = GetTraceMasks();
     for ( wxArrayString::const_iterator it = masks.begin(),


### PR DESCRIPTION
tweak: dump the collected log mask IDs to the debug channel once the application terminates, when running in debug mode, when the `wxDEBUG_COLLECT_TRACE_MASKS` flag has been turned ON(1) in the wxWidgets library build settings. 

This is useful for detecting which log masks are employed in a larger application, where static analysis might be more costly (but would provide a more complete picture).

---

IMHO, this is a useful end to the `wxDEBUG_COLLECT_TRACE_MASKS` work that's already present in the wxWidgets core.