### PR TITLE
Fix timing issue with wxWebViewEdge::SetPage()

### DIFF
--- a/include/wx/msw/private/webview_edge.h
+++ b/include/wx/msw/private/webview_edge.h
@@ -55,6 +55,7 @@ public:
     bool m_initialized;
     bool m_isBusy;
     wxString m_pendingURL;
+    wxString m_pendingPage;
     int m_pendingContextMenuEnabled;
     int m_pendingAccessToDevToolsEnabled;
     wxVector<wxString> m_pendingUserScripts;


### PR DESCRIPTION
When `SetPage()` was called during the webview was still initializing
it would silently fail. This will now load the contents when the
webview is ready. Additionally error handling for the underlying
`NavigateToString()` has been added so it wont fail silently.

Potential fix to #22048, but definitely a useful change regardless.