### PR TITLE
Rename wxBitmapBundle::GetPreferredSizeFor()

### DIFF
--- a/include/wx/bmpbndl.h
+++ b/include/wx/bmpbndl.h
@@ -102,7 +102,9 @@ public:
     // Get preferred size, i.e. usually the closest size in which a bitmap is
     // available to the ideal size determined from the default size and the DPI
     // scaling, for the given window.
-    wxSize GetPreferredSizeFor(const wxWindow* window) const;
+    wxSize GetPreferredBitmapSizeFor(const wxWindow* window) const;
+    // Same as above, but returning value is in logical size.
+    wxSize GetPreferredLogicalSizeFor(const wxWindow* window) const;
     wxSize GetPreferredSizeAtScale(double scale) const;
 
     // Get bitmap of the specified size, creating a new bitmap from the closest

--- a/include/wx/bmpbndl.h
+++ b/include/wx/bmpbndl.h
@@ -105,7 +105,7 @@ public:
     wxSize GetPreferredBitmapSizeFor(const wxWindow* window) const;
     // Same as above, but returning value is in logical size.
     wxSize GetPreferredLogicalSizeFor(const wxWindow* window) const;
-    wxSize GetPreferredSizeAtScale(double scale) const;
+    wxSize GetPreferredBitmapSizeAtScale(double scale) const;
 
     // Get bitmap of the specified size, creating a new bitmap from the closest
     // available size by rescaling it if necessary.
@@ -219,7 +219,7 @@ public:
     // Return the preferred size that should be used at the given scale.
     //
     // Must always return a valid size.
-    virtual wxSize GetPreferredSizeAtScale(double scale) const = 0;
+    virtual wxSize GetPreferredBitmapSizeAtScale(double scale) const = 0;
 
     // Retrieve the bitmap of exactly the given size.
     //

--- a/interface/wx/bmpbndl.h
+++ b/interface/wx/bmpbndl.h
@@ -293,18 +293,30 @@ public:
         bitmap doesn't need to be rescaled, which typically significantly
         lowers its quality.
      */
-    wxSize GetPreferredSizeAtScale(double scale) const;
+    wxSize GetPreferredBitmapSizeAtScale(double scale) const;
 
     /**
         Get the size that would be best to use for this bundle at the DPI
         scaling factor used by the given window.
 
-        This is just a convenient wrapper for GetPreferredSizeAtScale() calling
+        This is just a convenient wrapper for GetPreferredBitmapSizeAtScale() calling
         that function with the result of wxWindow::GetDPIScaleFactor().
 
         @param window Non-null and fully created window.
      */
-    wxSize GetPreferredSizeFor(const wxWindow* window) const;
+    wxSize GetPreferredBitmapSizeFor(const wxWindow* window) const;
+
+    /**
+        Get the size that would be best to use for this bundle at the DPI
+        scaling factor used by the given window in logical size.
+
+        This is just call GetPreferredBitmapSizeAtScale() with the result of
+        wxWindow::GetDPIScaleFactor() and convert returned value with
+        wxWindow::FromPhys().
+
+        @param window Non-null and fully created window.
+     */
+    wxSize GetPreferredLogicalSizeFor(const wxWindow* window) const;
 
     /**
         Get bitmap of the specified size, creating a new bitmap from the closest
@@ -384,7 +396,7 @@ public:
                 ... determine the minimum/default size for bitmap to use ...
             }
 
-            wxSize GetPreferredSizeAtScale(double scale) const wxOVERRIDE
+            wxSize GetPreferredBitmapSizeAtScale(double scale) const wxOVERRIDE
             {
                 // If it's ok to scale the bitmap, just use the standard size
                 // at the given scale:
@@ -428,7 +440,7 @@ public:
 
         Must always return a valid size.
      */
-    virtual wxSize GetPreferredSizeAtScale(double scale) const = 0;
+    virtual wxSize GetPreferredBitmapSizeAtScale(double scale) const = 0;
 
     /**
         Retrieve the bitmap of exactly the given size.

--- a/samples/toolbar/toolbar.cpp
+++ b/samples/toolbar/toolbar.cpp
@@ -520,7 +520,7 @@ void MyFrame::PopulateToolbar(wxToolBarBase* toolBar)
                     return m_sizeDef;
                 }
 
-                wxSize GetPreferredSizeAtScale(double scale) const wxOVERRIDE
+                wxSize GetPreferredBitmapSizeAtScale(double scale) const wxOVERRIDE
                 {
                     // We just scale the bitmap to fit the requested size, so
                     // we don't really have any preferences.

--- a/samples/treectrl/treetest.cpp
+++ b/samples/treectrl/treetest.cpp
@@ -1015,7 +1015,7 @@ void MyTreeCtrl::CreateImages(int size)
             return m_sizeDef;
         }
 
-        wxSize GetPreferredSizeAtScale(double scale) const wxOVERRIDE
+        wxSize GetPreferredBitmapSizeAtScale(double scale) const wxOVERRIDE
         {
             return m_sizeDef*scale;
         }

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -410,7 +410,7 @@ void wxAuiGenericToolBarArt::DrawDropDownButton(
 
 
 
-    const wxSize sizeDropDown = m_buttonDropDownBmp.GetPreferredSizeFor(wnd);
+    const wxSize sizeDropDown = m_buttonDropDownBmp.GetPreferredLogicalSizeFor(wnd);
     dropBmpX = dropDownRect.x +
                 (dropDownRect.width/2) -
                 (sizeDropDown.x/2);

--- a/src/aui/dockart.cpp
+++ b/src/aui/dockart.cpp
@@ -685,7 +685,7 @@ wxAuiDefaultDockArt::DrawIcon(wxDC& dc, wxWindow *window, const wxRect& rect, wx
     }
 
     // Ensure the icon fits into the title bar.
-    wxSize iconSize = pane.icon.GetPreferredBitmapSizeFor(window);
+    wxSize iconSize = pane.icon.GetPreferredLogicalSizeFor(window);
     if (iconSize.y > rect.height)
     {
         iconSize *= static_cast<double>(rect.height) / iconSize.y;
@@ -693,7 +693,7 @@ wxAuiDefaultDockArt::DrawIcon(wxDC& dc, wxWindow *window, const wxRect& rect, wx
 
     // Draw the icon centered vertically
     int xOffset = window->FromDIP(2);
-    const wxBitmap& icon = pane.icon.GetBitmap(iconSize);
+    const wxBitmap& icon = pane.icon.GetBitmap(window->ToPhys(iconSize));
     dc.DrawBitmap(icon,
                   rect.x+xOffset, rect.y+(rect.height-icon.GetLogicalHeight())/2,
                   true);

--- a/src/aui/dockart.cpp
+++ b/src/aui/dockart.cpp
@@ -685,7 +685,7 @@ wxAuiDefaultDockArt::DrawIcon(wxDC& dc, wxWindow *window, const wxRect& rect, wx
     }
 
     // Ensure the icon fits into the title bar.
-    wxSize iconSize = pane.icon.GetPreferredSizeFor(window);
+    wxSize iconSize = pane.icon.GetPreferredBitmapSizeFor(window);
     if (iconSize.y > rect.height)
     {
         iconSize *= static_cast<double>(rect.height) / iconSize.y;

--- a/src/aui/tabart.cpp
+++ b/src/aui/tabart.cpp
@@ -248,9 +248,9 @@ void wxAuiGenericTabArt::SetSizingInfo(const wxSize& tab_ctrl_size,
     int tot_width = (int)tab_ctrl_size.x - GetIndentSize() - wnd->FromDIP(4);
 
     if (m_flags & wxAUI_NB_CLOSE_BUTTON)
-        tot_width -= wnd->FromPhys(m_activeCloseBmp.GetPreferredSizeFor(wnd).x);
+        tot_width -= m_activeCloseBmp.GetPreferredLogicalSizeFor(wnd).x;
     if (m_flags & wxAUI_NB_WINDOWLIST_BUTTON)
-        tot_width -= wnd->FromPhys(m_activeWindowListBmp.GetPreferredSizeFor(wnd).x);
+        tot_width -= m_activeWindowListBmp.GetPreferredLogicalSizeFor(wnd).x;
 
     if (tab_count > 0)
     {
@@ -705,7 +705,7 @@ wxSize wxAuiGenericTabArt::GetTabSize(wxDC& dc,
     {
         // we need the correct size of the bitmap to be used on this window in
         // logical dimensions for drawing
-        const wxSize bitmapSize = wnd->FromPhys(bitmap.GetPreferredSizeFor(wnd));
+        const wxSize bitmapSize = bitmap.GetPreferredLogicalSizeFor(wnd);
 
         // increase by bitmap plus right side bitmap padding
         tab_width += bitmapSize.x + wnd->FromDIP(3);

--- a/src/aui/tabartmsw.cpp
+++ b/src/aui/tabartmsw.cpp
@@ -306,7 +306,7 @@ wxSize wxAuiMSWTabArt::GetTabSize(wxDC& dc,
     // if there's a bitmap, add space for it
     if ( bitmap.IsOk() )
     {
-        const wxSize bitmapSize = wnd->FromPhys(bitmap.GetPreferredSizeFor(wnd));
+        const wxSize bitmapSize = bitmap.GetPreferredLogicalSizeFor(wnd);
 
         tabWidth += bitmapSize.x + wnd->FromDIP(3); // bitmap padding
         tabHeight = wxMax(tabHeight, bitmapSize.y + wnd->FromDIP(2));

--- a/src/common/artprov.cpp
+++ b/src/common/artprov.cpp
@@ -162,7 +162,7 @@ public:
         return m_sizeDefault;
     }
 
-    virtual wxSize GetPreferredSizeAtScale(double scale) const wxOVERRIDE
+    virtual wxSize GetPreferredBitmapSizeAtScale(double scale) const wxOVERRIDE
     {
         // We have no preferred sizes.
         return m_sizeDefault*scale;

--- a/src/common/bmpbndl.cpp
+++ b/src/common/bmpbndl.cpp
@@ -429,11 +429,18 @@ wxSize wxBitmapBundle::GetDefaultSize() const
     return m_impl->GetDefaultSize();
 }
 
-wxSize wxBitmapBundle::GetPreferredSizeFor(const wxWindow* window) const
+wxSize wxBitmapBundle::GetPreferredBitmapSizeFor(const wxWindow* window) const
 {
     wxCHECK_MSG( window, wxDefaultSize, "window must be valid" );
 
     return GetPreferredSizeAtScale(window->GetDPIScaleFactor());
+}
+
+wxSize wxBitmapBundle::GetPreferredLogicalSizeFor(const wxWindow* window) const
+{
+    wxCHECK_MSG( window, wxDefaultSize, "window must be valid" );
+
+    return window->FromPhys(GetPreferredSizeAtScale(window->GetDPIScaleFactor()));
 }
 
 wxSize wxBitmapBundle::GetPreferredSizeAtScale(double scale) const
@@ -474,12 +481,12 @@ wxIcon wxBitmapBundle::GetIcon(const wxSize& size) const
 
 wxBitmap wxBitmapBundle::GetBitmapFor(const wxWindow* window) const
 {
-    return GetBitmap(GetPreferredSizeFor(window));
+    return GetBitmap(GetPreferredBitmapSizeFor(window));
 }
 
 wxIcon wxBitmapBundle::GetIconFor(const wxWindow* window) const
 {
-    return GetIcon(GetPreferredSizeFor(window));
+    return GetIcon(GetPreferredBitmapSizeFor(window));
 }
 
 namespace

--- a/src/common/bmpbndl.cpp
+++ b/src/common/bmpbndl.cpp
@@ -63,7 +63,7 @@ public:
     }
 
     virtual wxSize GetDefaultSize() const wxOVERRIDE;
-    virtual wxSize GetPreferredSizeAtScale(double scale) const wxOVERRIDE;
+    virtual wxSize GetPreferredBitmapSizeAtScale(double scale) const wxOVERRIDE;
     virtual wxBitmap GetBitmap(const wxSize& size) wxOVERRIDE;
 
 private:
@@ -169,7 +169,7 @@ wxSize wxBitmapBundleImplSet::GetDefaultSize() const
     return m_sizeDefault;
 }
 
-wxSize wxBitmapBundleImplSet::GetPreferredSizeAtScale(double scale) const
+wxSize wxBitmapBundleImplSet::GetPreferredBitmapSizeAtScale(double scale) const
 {
     // Target size is the ideal size we'd like the bitmap to have at this scale.
     const wxSize sizeTarget = GetDefaultSize()*scale;
@@ -433,22 +433,22 @@ wxSize wxBitmapBundle::GetPreferredBitmapSizeFor(const wxWindow* window) const
 {
     wxCHECK_MSG( window, wxDefaultSize, "window must be valid" );
 
-    return GetPreferredSizeAtScale(window->GetDPIScaleFactor());
+    return GetPreferredBitmapSizeAtScale(window->GetDPIScaleFactor());
 }
 
 wxSize wxBitmapBundle::GetPreferredLogicalSizeFor(const wxWindow* window) const
 {
     wxCHECK_MSG( window, wxDefaultSize, "window must be valid" );
 
-    return window->FromPhys(GetPreferredSizeAtScale(window->GetDPIScaleFactor()));
+    return window->FromPhys(GetPreferredBitmapSizeAtScale(window->GetDPIScaleFactor()));
 }
 
-wxSize wxBitmapBundle::GetPreferredSizeAtScale(double scale) const
+wxSize wxBitmapBundle::GetPreferredBitmapSizeAtScale(double scale) const
 {
     if ( !m_impl )
         return wxDefaultSize;
 
-    return m_impl->GetPreferredSizeAtScale(scale);
+    return m_impl->GetPreferredBitmapSizeAtScale(scale);
 }
 
 wxBitmap wxBitmapBundle::GetBitmap(const wxSize& size) const
@@ -537,7 +537,7 @@ wxBitmapBundle::GetConsensusSizeFor(wxWindow* win,
     SizePrefs prefs;
     for ( size_t n = 0; n < bundles.size(); ++n )
     {
-        RecordSizePref(prefs, bundles[n].GetPreferredSizeAtScale(scale));
+        RecordSizePref(prefs, bundles[n].GetPreferredBitmapSizeAtScale(scale));
     }
 
     // Now find the size preferred by most tools.

--- a/src/common/statbmpcmn.cpp
+++ b/src/common/statbmpcmn.cpp
@@ -92,7 +92,7 @@ wxStaticBitmapBase::~wxStaticBitmapBase()
 wxSize wxStaticBitmapBase::DoGetBestSize() const
 {
     if ( m_bitmapBundle.IsOk() )
-        return FromPhys(m_bitmapBundle.GetPreferredSizeFor(this));
+        return m_bitmapBundle.GetPreferredLogicalSizeFor(this);
 
     // the fall back size is completely arbitrary
     return wxSize(16, 16);

--- a/src/generic/bmpsvg.cpp
+++ b/src/generic/bmpsvg.cpp
@@ -108,7 +108,7 @@ public:
     }
 
     virtual wxSize GetDefaultSize() const wxOVERRIDE;
-    virtual wxSize GetPreferredSizeAtScale(double scale) const wxOVERRIDE;
+    virtual wxSize GetPreferredBitmapSizeAtScale(double scale) const wxOVERRIDE;
     virtual wxBitmap GetBitmap(const wxSize& size) wxOVERRIDE;
 
 private:
@@ -142,7 +142,7 @@ wxSize wxBitmapBundleImplSVG::GetDefaultSize() const
     return m_sizeDef;
 }
 
-wxSize wxBitmapBundleImplSVG::GetPreferredSizeAtScale(double scale) const
+wxSize wxBitmapBundleImplSVG::GetPreferredBitmapSizeAtScale(double scale) const
 {
     // We consider that we can render at any scale.
     return m_sizeDef*scale;

--- a/src/msw/anybutton.cpp
+++ b/src/msw/anybutton.cpp
@@ -108,7 +108,7 @@ public:
     wxButtonImageData(wxWindow* btn, const wxBitmapBundle& normalBundle)
         : m_btn(btn)
     {
-        m_bitmapSize = normalBundle.GetPreferredSizeFor(btn);
+        m_bitmapSize = normalBundle.GetPreferredBitmapSizeFor(btn);
 
         m_bitmapBundles[wxAnyButton::State_Normal] = normalBundle;
 
@@ -125,7 +125,7 @@ public:
     {
         event.Skip();
 
-        m_bitmapSize = m_bitmapBundles[wxAnyButton::State_Normal].GetPreferredSizeFor(m_btn);
+        m_bitmapSize = m_bitmapBundles[wxAnyButton::State_Normal].GetPreferredBitmapSizeFor(m_btn);
     }
 
     // Bitmap can be set either explicitly, when the bitmap for the given state

--- a/src/msw/bmpbndl.cpp
+++ b/src/msw/bmpbndl.cpp
@@ -138,7 +138,7 @@ public:
                          const wxBitmap& bitmap);
 
     virtual wxSize GetDefaultSize() const wxOVERRIDE;
-    virtual wxSize GetPreferredSizeAtScale(double scale) const wxOVERRIDE;
+    virtual wxSize GetPreferredBitmapSizeAtScale(double scale) const wxOVERRIDE;
     virtual wxBitmap GetBitmap(const wxSize& size) wxOVERRIDE;
 
 private:
@@ -186,7 +186,7 @@ wxSize wxBitmapBundleImplRC::GetDefaultSize() const
     return m_bitmaps[0].GetSize();
 }
 
-wxSize wxBitmapBundleImplRC::GetPreferredSizeAtScale(double scale) const
+wxSize wxBitmapBundleImplRC::GetPreferredBitmapSizeAtScale(double scale) const
 {
     // Optimistically assume we're going to use this exact scale by default.
     double scalePreferred = scale;

--- a/src/msw/statbmp.cpp
+++ b/src/msw/statbmp.cpp
@@ -109,7 +109,7 @@ WXDWORD wxStaticBitmap::MSWGetStyle(long style, WXDWORD *exstyle) const
 wxSize wxStaticBitmap::GetImageSize() const
 {
     return m_icon.IsOk() ? m_icon.GetSize()
-                         : m_bitmapBundle.GetPreferredSizeFor(this);
+                         : m_bitmapBundle.GetPreferredBitmapSizeFor(this);
 }
 
 void wxStaticBitmap::SetIcon(const wxIcon& icon)

--- a/src/osx/core/bmpbndl.mm
+++ b/src/osx/core/bmpbndl.mm
@@ -113,7 +113,7 @@ public:
     ~wxOSXImageBundleImpl();
 
     virtual wxSize GetDefaultSize() const wxOVERRIDE;
-    virtual wxSize GetPreferredSizeAtScale(double scale) const wxOVERRIDE;
+    virtual wxSize GetPreferredBitmapSizeAtScale(double scale) const wxOVERRIDE;
     virtual wxBitmap GetBitmap(const wxSize& size) wxOVERRIDE;
 };
 
@@ -138,7 +138,7 @@ wxSize wxOSXImageBundleImpl::GetDefaultSize() const
     return wxSize(sz.width, sz.height);
 }
 
-wxSize wxOSXImageBundleImpl::GetPreferredSizeAtScale(double scale) const
+wxSize wxOSXImageBundleImpl::GetPreferredBitmapSizeAtScale(double scale) const
 {
     // The system always performs scaling, as the scaling factor is integer and
     // so it doesn't make sense to round it up or down, hence we should use the
@@ -253,7 +253,7 @@ WXImage wxOSXGetImageFromBundle(const wxBitmapBundle& bundle)
         image = wxOSXImageFromBitmap(bmp);
 
         // unconditionally try to add a 2x version, if there really is a different one
-        wxSize doublesz = impl->GetPreferredSizeAtScale(2.0);
+        wxSize doublesz = impl->GetPreferredBitmapSizeAtScale(2.0);
         if ( doublesz != sz )
         {
             bmp = const_cast<wxBitmapBundleImpl*>(impl)->GetBitmap(doublesz);

--- a/tests/graphics/bmpbundle.cpp
+++ b/tests/graphics/bmpbundle.cpp
@@ -49,7 +49,7 @@ TEST_CASE("BitmapBundle::FromBitmaps", "[bmpbundle]")
 
 TEST_CASE("BitmapBundle::GetPreferredSize", "[bmpbundle]")
 {
-    CHECK( wxBitmapBundle().GetPreferredSizeAtScale(1) == wxDefaultSize );
+    CHECK( wxBitmapBundle().GetPreferredBitmapSizeAtScale(1) == wxDefaultSize );
 
     const wxSize normal(32, 32);
     const wxSize bigger(64, 64);
@@ -59,18 +59,18 @@ TEST_CASE("BitmapBundle::GetPreferredSize", "[bmpbundle]")
 
     // Check that the existing bitmaps are used without scaling for most of the
     // typical scaling values.
-    CHECK( b.GetPreferredSizeAtScale(0   ) == normal );
-    CHECK( b.GetPreferredSizeAtScale(1   ) == normal );
-    CHECK( b.GetPreferredSizeAtScale(1.25) == normal );
-    CHECK( b.GetPreferredSizeAtScale(1.4 ) == normal );
-    CHECK( b.GetPreferredSizeAtScale(1.5 ) == bigger );
-    CHECK( b.GetPreferredSizeAtScale(1.75) == bigger );
-    CHECK( b.GetPreferredSizeAtScale(2   ) == bigger );
-    CHECK( b.GetPreferredSizeAtScale(2.5 ) == bigger );
+    CHECK( b.GetPreferredBitmapSizeAtScale(0   ) == normal );
+    CHECK( b.GetPreferredBitmapSizeAtScale(1   ) == normal );
+    CHECK( b.GetPreferredBitmapSizeAtScale(1.25) == normal );
+    CHECK( b.GetPreferredBitmapSizeAtScale(1.4 ) == normal );
+    CHECK( b.GetPreferredBitmapSizeAtScale(1.5 ) == bigger );
+    CHECK( b.GetPreferredBitmapSizeAtScale(1.75) == bigger );
+    CHECK( b.GetPreferredBitmapSizeAtScale(2   ) == bigger );
+    CHECK( b.GetPreferredBitmapSizeAtScale(2.5 ) == bigger );
 
     // This scale is too big to use any of the existing bitmaps, so they will
     // be scaled.
-    CHECK( b.GetPreferredSizeAtScale(3   ) == 3*normal );
+    CHECK( b.GetPreferredBitmapSizeAtScale(3   ) == 3*normal );
 }
 
 #ifdef wxHAS_DPI_INDEPENDENT_PIXELS


### PR DESCRIPTION
Rename wxBitmapBundle::GetPreferredSizeFor() to GetPreferredBitmapSizeFor to be more explicit
Add wxBitmapBundle::GetPreferredLogicalSizeFor() which return GetPreferredBitmapSizeFor() in logical size