### PR TITLE
Fix compilation issues with GCC 12

### DIFF
--- a/include/wx/colour.h
+++ b/include/wx/colour.h
@@ -147,10 +147,10 @@ public:
     }
 
     wxUint32 GetRGB() const
-        { return Red() | (Green() << 8) | (Blue() << 16); }
+        { return wxUint32(Red()) | wxUint32(Green() << 8) | wxUint32(Blue() << 16); }
 
     wxUint32 GetRGBA() const
-        { return Red() | (Green() << 8) | (Blue() << 16) | (Alpha() << 24); }
+        { return wxUint32(Red()) | wxUint32(Green() << 8) | wxUint32(Blue() << 16) | wxUint32(Alpha() << 24); }
 
 #if !wxCOLOUR_IS_GDIOBJECT
     virtual bool IsOk() const= 0;

--- a/include/wx/image.h
+++ b/include/wx/image.h
@@ -210,7 +210,7 @@ public:
                                  unsigned char g,
                                  unsigned char b)
     {
-        return (r << 16) | (g << 8) | b;
+        return (unsigned long)(r << 16) | (unsigned long)(g << 8) | (unsigned long)(b);
     }
 
     // find first colour that is not used in the image and has higher


### PR DESCRIPTION
When building the all headers test with GCC 12 on Fedora Rawhide, the following errors were encountered:
```
In file included from ../../include/wx/bitmap.h:20,
                 from ../../include/wx/generic/icon.h:14,
                 from ../../include/wx/icon.h:37,
                 from ../../include/wx/aboutdlg.h:18,
                 from ../../tests/allheaders.h:20,
                 from ../../tests/allheaders.cpp:388:
../../include/wx/colour.h: In member function 'wxUint32 wxColourBase::GetRGB() const':
../../include/wx/colour.h:150:41: error: conversion to 'wxUint32' {aka 'unsigned int'} from 'int' may change the sign of the result [-Werror=arith-conversion]
  150 |         { return Red() | (Green() << 8) | (Blue() << 16); }
      |                  ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
../../include/wx/colour.h: In member function 'wxUint32 wxColourBase::GetRGBA() const':
../../include/wx/colour.h:153:58: error: conversion to 'wxUint32' {aka 'unsigned int'} from 'int' may change the sign of the result [-Werror=arith-conversion]
  153 |         { return Red() | (Green() << 8) | (Blue() << 16) | (Alpha() << 24); }
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
In file included from ../../include/wx/bitmap.h:21:
../../include/wx/image.h: In static member function 'static long unsigned int wxImageHistogram::MakeKey(unsigned char, unsigned char, unsigned char)':
../../include/wx/image.h:213:37: error: conversion to 'long unsigned int' from 'int' may change the sign of the result [-Werror=arith-conversion]
  213 |         return (r << 16) | (g << 8) | b;
      |                ~~~~~~~~~~~~~~~~~~~~~^~~
```

Evidently, GCC 12 treats a left bit-shifted unsigned char as a signed int and thus flags a possible sign change.  Resolve this by casting as unsigned values of the appropriate size.