### PR TITLE
Avoid arithmetic conversion warnings from gcc 12

### DIFF
--- a/include/wx/colour.h
+++ b/include/wx/colour.h
@@ -125,6 +125,13 @@ public:
     virtual ChannelType Alpha() const
         { return wxALPHA_OPAQUE ; }
 
+    // These getters return the values as unsigned int, which avoids promoting
+    // them to (signed) int in arithmetic expressions, unlike the ones above.
+    unsigned int GetRed() const { return Red(); }
+    unsigned int GetGreen() const { return Green(); }
+    unsigned int GetBlue() const { return Blue(); }
+    unsigned int GetAlpha() const { return Alpha(); }
+
     virtual bool IsSolid() const
         { return true; }
 
@@ -147,10 +154,10 @@ public:
     }
 
     wxUint32 GetRGB() const
-        { return Red() | (Green() << 8) | (Blue() << 16); }
+        { return GetRed() | (GetGreen() << 8) | (GetBlue() << 16); }
 
     wxUint32 GetRGBA() const
-        { return Red() | (Green() << 8) | (Blue() << 16) | (Alpha() << 24); }
+        { return GetRed() | (GetGreen() << 8) | (GetBlue() << 16) | (GetAlpha() << 24); }
 
 #if !wxCOLOUR_IS_GDIOBJECT
     virtual bool IsOk() const= 0;

--- a/include/wx/image.h
+++ b/include/wx/image.h
@@ -210,7 +210,7 @@ public:
                                  unsigned char g,
                                  unsigned char b)
     {
-        return (r << 16) | (g << 8) | b;
+        return ((unsigned)r << 16) | ((unsigned)g << 8) | (unsigned)b;
     }
 
     // find first colour that is not used in the image and has higher

--- a/interface/wx/colour.h
+++ b/interface/wx/colour.h
@@ -34,6 +34,20 @@ const unsigned char wxALPHA_OPAQUE = 0xff;
 
     You can retrieve the current system colour settings with wxSystemSettings.
 
+
+    @section colour_accessors Channel Accessor Functions
+
+    Note that this class provides pairs of functions for each of the colour
+    channels, i.e. red, green, blue and alpha values. The one word functions
+    Red(), Green(), Blue() and Alpha() return the values of type @c unsigned @c
+    char, while GetRed(), GetGreen(), GetBlue() and GetAlpha() returns the same
+    value as @c unsigned @c int. According to the C++ integer promotion rules,
+    the result of any arithmetic expression involving the former will be
+    (signed) @c int, while that of the latter will be @c unsigned, which is
+    what would be commonly expected, so the latter family of functions should
+    be typically preferred (but they are only available since wxWidgets 3.1.6).
+
+
     @library{wxcore}
     @category{gdi}
 
@@ -94,13 +108,46 @@ public:
     /**
         Returns the alpha value, on platforms where alpha is not yet supported, this
         always returns wxALPHA_OPAQUE.
+
+        @see GetAlpha()
     */
     virtual unsigned char Alpha() const;
 
     /**
         Returns the blue intensity.
+
+        @see GetBlue()
     */
     virtual unsigned char Blue() const;
+
+    /**
+        Returns the alpha value, on platforms where alpha is not yet supported, this
+        always returns wxALPHA_OPAQUE.
+
+        @since 3.1.6
+     */
+    unsigned int GetAlpha() const;
+
+    /**
+        Returns the blue intensity as unsigned int.
+
+        @since 3.1.6
+     */
+    unsigned int GetBlue() const;
+
+    /**
+        Returns the green intensity as unsigned int.
+
+        @since 3.1.6
+     */
+    unsigned int GetGreen() const;
+
+    /**
+        Returns the red intensity as unsigned int.
+
+        @since 3.1.6
+     */
+    unsigned int GetRed() const;
 
     /**
         Converts this colour to a wxString using the given flags.
@@ -184,6 +231,8 @@ public:
 
     /**
         Returns the green intensity.
+
+        @see GetGreen()
     */
     virtual unsigned char Green() const;
 
@@ -195,6 +244,8 @@ public:
 
     /**
         Returns the red intensity.
+
+        @see GetRed()
     */
     virtual unsigned char Red() const;
 


### PR DESCRIPTION
This is an alternative version of #22057 and fixes warnings in `allheaders` test when compiling with gcc 12.