### PR TITLE
Added an example how to use the new splitter resize event

### DIFF
--- a/include/wx/generic/splitter.h
+++ b/include/wx/generic/splitter.h
@@ -409,8 +409,8 @@ private:
         struct
         {
             int pos;            // position for SASH_POS_* events
-            int oldSize;        // window size for SASH_POS_UPDATE event
-            int newSize;        // window size for SASH_POS_UPDATE event
+            int oldSize;        // window size for SASH_POS_RESIZE event
+            int newSize;        // window size for SASH_POS_RESIZE event
         } resize;
         wxWindow *win;      // window being removed for UNSPLIT event
         struct
@@ -437,7 +437,7 @@ typedef void (wxEvtHandler::*wxSplitterEventFunction)(wxSplitterEvent&);
     wx__DECLARE_SPLITTEREVT(SASH_POS_CHANGING, id, fn)
 
 #define EVT_SPLITTER_SASH_POS_RESIZE(id, fn) \
-    wx__DECLARE_SPLITTEREVT(SASH_POS_UPDATE, id, fn)
+    wx__DECLARE_SPLITTEREVT(SASH_POS_RESIZE, id, fn)
 
 #define EVT_SPLITTER_DCLICK(id, fn) \
     wx__DECLARE_SPLITTEREVT(DOUBLECLICKED, id, fn)

--- a/include/wx/generic/splitter.h
+++ b/include/wx/generic/splitter.h
@@ -230,10 +230,6 @@ protected:
     void OnSetCursor(wxSetCursorEvent& event);
 #endif // wxMSW
 
-    // send the given event, return false if the event was processed and vetoed
-    // by the user code
-    bool DoSendEvent(wxSplitterEvent& event);
-
     // common part of all ctors
     void Init();
 

--- a/samples/splitter/splitter.cpp
+++ b/samples/splitter/splitter.cpp
@@ -571,6 +571,9 @@ void MySplitterWindow::OnPositionChanging(wxSplitterEvent& event)
 {
     wxLogStatus(m_frame, "Position is changing, now = %d (or %d)",
                 event.GetSashPosition(), GetSashPosition());
+
+    // Let the splitter window handle the event as well.
+    event.Skip();
 }
 
 void MySplitterWindow::OnDClick(wxSplitterEvent& event)

--- a/samples/splitter/splitter.cpp
+++ b/samples/splitter/splitter.cpp
@@ -129,7 +129,7 @@ private:
     wxSplitterWindow* m_splitter;
     wxWindow *m_replacewindow;
     int m_sashPos;
-    bool m_lockSash:1;
+    bool m_lockSash;
 
     wxDECLARE_EVENT_TABLE();
     wxDECLARE_NO_COPY_CLASS(MyFrame);
@@ -277,7 +277,7 @@ MyFrame::MyFrame()
     splitMenu->Append(SPLIT_SETGRAVITY,
                       "Set &gravity\tCtrl-G",
                       "Set gravity of sash");
-    splitMenu->Append(SPLIT_LOCKSASH,
+    splitMenu->AppendCheckItem(SPLIT_LOCKSASH,
                       "Toggle sash &lock on resize\tCtrl-R",
                       "Keep the sash in a fixed position while resizing");
     splitMenu->AppendSeparator();
@@ -550,8 +550,6 @@ void MySplitterWindow::OnPositionChanged(wxSplitterEvent& event)
     // new position. If the sash is not locked, this has no effect but
     // doesn't hurt either.
     m_frame->SetSashPos(event.GetSashPosition());
-
-    event.Skip();
 }
 
 void MySplitterWindow::OnPositionResize(wxSplitterEvent &event)
@@ -560,17 +558,19 @@ void MySplitterWindow::OnPositionResize(wxSplitterEvent &event)
     // if it is not locked. Otherwise we hold it at the position
     // the user specified by manually dragging.
     if (m_frame->IsSashLocked())
+    {
+        // We set the last known position to keep the sash in place.
+        // For this particular example we could also simply use
+        // event.Veto()
+        // as well and it would have the same effect.
         event.SetSashPosition(m_frame->GetSashPos());
-
-    event.Skip();
+    }
 }
 
 void MySplitterWindow::OnPositionChanging(wxSplitterEvent& event)
 {
     wxLogStatus(m_frame, "Position is changing, now = %d (or %d)",
                 event.GetSashPosition(), GetSashPosition());
-
-    event.Skip();
 }
 
 void MySplitterWindow::OnDClick(wxSplitterEvent& event)
@@ -579,6 +579,7 @@ void MySplitterWindow::OnDClick(wxSplitterEvent& event)
     m_frame->SetStatusText("Splitter double clicked", 1);
 #endif // wxUSE_STATUSBAR
 
+    // Let the splitter window handle the event as well.
     event.Skip();
 }
 
@@ -588,6 +589,7 @@ void MySplitterWindow::OnUnsplitEvent(wxSplitterEvent& event)
     m_frame->SetStatusText("Splitter unsplit", 1);
 #endif // wxUSE_STATUSBAR
 
+    // Let the splitter window handle the event as well.
     event.Skip();
 }
 

--- a/src/generic/splitter.cpp
+++ b/src/generic/splitter.cpp
@@ -312,7 +312,7 @@ void wxSplitterWindow::OnMouseEvent(wxMouseEvent& event)
                 OnUnsplit(removedWindow);
                 wxSplitterEvent eventUnsplit(wxEVT_SPLITTER_UNSPLIT, this);
                 eventUnsplit.m_data.win = removedWindow;
-                (void)DoSendEvent(eventUnsplit);
+                (void)ProcessWindowEvent(eventUnsplit);
                 SetSashPositionAndNotify(0);
             }
             else if ( posSashNew == GetWindowSize() )
@@ -323,7 +323,7 @@ void wxSplitterWindow::OnMouseEvent(wxMouseEvent& event)
                 OnUnsplit(removedWindow);
                 wxSplitterEvent eventUnsplit(wxEVT_SPLITTER_UNSPLIT, this);
                 eventUnsplit.m_data.win = removedWindow;
-                (void)DoSendEvent(eventUnsplit);
+                (void)ProcessWindowEvent(eventUnsplit);
                 SetSashPositionAndNotify(0);
             }
             else
@@ -488,7 +488,7 @@ void wxSplitterWindow::OnSize(wxSizeEvent& event)
             update.m_data.resize.oldSize = old_size;
             update.m_data.resize.newSize = size;
 
-            if (DoSendEvent(update))
+            if ( ProcessWindowEvent(update) )
             {
                 if (update.IsAllowed())
                 {
@@ -699,7 +699,7 @@ void wxSplitterWindow::SetSashPositionAndNotify(int sashPos)
     wxSplitterEvent event(wxEVT_SPLITTER_SASH_POS_CHANGED, this);
     event.m_data.resize.pos = m_sashPosition;
 
-    (void)DoSendEvent(event);
+    (void)ProcessWindowEvent(event);
 }
 
 // Position and size subwindows.
@@ -926,11 +926,6 @@ void wxSplitterWindow::UpdateSize()
     SizeWindows();
 }
 
-bool wxSplitterWindow::DoSendEvent(wxSplitterEvent& event)
-{
-    return GetEventHandler()->ProcessEvent(event);
-}
-
 wxSize wxSplitterWindow::DoGetBestSize() const
 {
     // get best sizes of subwindows
@@ -1035,7 +1030,7 @@ int wxSplitterWindow::OnSashPositionChanging(int newSashPosition)
     wxSplitterEvent event(wxEVT_SPLITTER_SASH_POS_CHANGING, this);
     event.m_data.resize.pos = newSashPosition;
 
-    if (DoSendEvent(event))
+    if ( ProcessWindowEvent(event) )
     {
         if (event.IsAllowed())
         {
@@ -1062,7 +1057,7 @@ void wxSplitterWindow::OnDoubleClickSash(int x, int y)
     wxSplitterEvent event(wxEVT_SPLITTER_DOUBLECLICKED, this);
     event.m_data.pt.x = x;
     event.m_data.pt.y = y;
-    if ( DoSendEvent(event) )
+    if ( !ProcessWindowEvent(event) || event.IsAllowed() )
     {
         if ( GetMinimumPaneSize() == 0 || m_permitUnsplitAlways )
         {
@@ -1071,7 +1066,7 @@ void wxSplitterWindow::OnDoubleClickSash(int x, int y)
             {
                 wxSplitterEvent unsplitEvent(wxEVT_SPLITTER_UNSPLIT, this);
                 unsplitEvent.m_data.win = win;
-                (void)DoSendEvent(unsplitEvent);
+                (void)ProcessWindowEvent(unsplitEvent);
             }
         }
     }

--- a/src/generic/splitter.cpp
+++ b/src/generic/splitter.cpp
@@ -493,8 +493,8 @@ void wxSplitterWindow::OnSize(wxSizeEvent& event)
                 if (update.IsAllowed())
                 {
                     // If the user set the sashposition to -1
-                    // we keep the already calculated value, otherwise
-                    // the user provided the new position.
+                    // we keep the already calculated value,
+                    // otherwise the user provided the new position.
                     int userPos = update.GetSashPosition();
                     if (userPos != -1)
                         newPosition = userPos;

--- a/src/generic/splitter.cpp
+++ b/src/generic/splitter.cpp
@@ -488,19 +488,22 @@ void wxSplitterWindow::OnSize(wxSizeEvent& event)
             update.m_data.resize.oldSize = old_size;
             update.m_data.resize.newSize = size;
 
-            if (!DoSendEvent(update))
+            if (DoSendEvent(update))
             {
-                // the event handler vetoed the change
-                newPosition = -1;
-            }
-            else
-            {
-                // If the user set the sashposition to -1
-                // we keep the already calculated value,
-                // otherwise the user provided the new position.
-                int userPos = update.GetSashPosition();
-                if (userPos != -1)
-                    newPosition = userPos;
+                if (update.IsAllowed())
+                {
+                    // If the user set the sashposition to -1
+                    // we keep the already calculated value, otherwise
+                    // the user provided the new position.
+                    int userPos = update.GetSashPosition();
+                    if (userPos != -1)
+                        newPosition = userPos;
+                }
+                else
+                {
+                    // the event handler vetoed the change
+                    newPosition = -1;
+                }
             }
 
             // Also check if the second window became too small.
@@ -925,7 +928,7 @@ void wxSplitterWindow::UpdateSize()
 
 bool wxSplitterWindow::DoSendEvent(wxSplitterEvent& event)
 {
-    return !GetEventHandler()->ProcessEvent(event) || event.IsAllowed();
+    return GetEventHandler()->ProcessEvent(event);
 }
 
 wxSize wxSplitterWindow::DoGetBestSize() const
@@ -1032,15 +1035,18 @@ int wxSplitterWindow::OnSashPositionChanging(int newSashPosition)
     wxSplitterEvent event(wxEVT_SPLITTER_SASH_POS_CHANGING, this);
     event.m_data.resize.pos = newSashPosition;
 
-    if ( !DoSendEvent(event) )
+    if (DoSendEvent(event))
     {
-        // the event handler vetoed the change
-        newSashPosition = -1;
-    }
-    else
-    {
-        // it could have been changed by it
-        newSashPosition = event.GetSashPosition();
+        if (event.IsAllowed())
+        {
+            // it could have been changed by it
+            newSashPosition = event.GetSashPosition();
+        }
+        else
+        {
+            // the event handler vetoed the change
+            newSashPosition = -1;
+        }
     }
 
     return newSashPosition;


### PR DESCRIPTION
I added now an example on how to use the resize event.

I'm terrible sorry, but when I added the example, I noticed that I missed some renaming before. Originally I wanted the event to use UPDATE in the name instead of RESIZE, but when I thought about it's meaning I figured that RESIZE is better. I changed all occurrences, but I missed one file which didn't show up in my own code and only broke the build when I compiled the sample.

I fixed it now along with the sample.