### PR TITLE
Fix memory leaks in artprov sample

### DIFF
--- a/samples/artprov/artbrows.cpp
+++ b/samples/artprov/artbrows.cpp
@@ -192,6 +192,14 @@ wxArtBrowserDialog::wxArtBrowserDialog(wxWindow *parent)
     SetArtClient(wxART_MESSAGE_BOX);
 }
 
+wxArtBrowserDialog::~wxArtBrowserDialog()
+{
+    const int itemCount = m_list->GetItemCount();
+
+    // item data are set by the ART_ICON macro
+    for ( int i = 0; i < itemCount; ++i )
+        delete reinterpret_cast<wxString*>(m_list->GetItemData(i));
+}
 
 wxSize wxArtBrowserDialog::GetSelectedBitmapSize() const
 {

--- a/samples/artprov/artbrows.h
+++ b/samples/artprov/artbrows.h
@@ -22,6 +22,7 @@ class wxArtBrowserDialog : public wxDialog
 {
 public:
     wxArtBrowserDialog(wxWindow *parent);
+    ~wxArtBrowserDialog();
 
     void SetArtClient(const wxArtClient& client);
     void SetArtBitmap(const wxArtID& id, const wxArtClient& client, const wxSize& size = wxDefaultSize);


### PR DESCRIPTION
The list control used in the Resources Browser dialog had
dynamically allocated wxStrings assigned as item data that
were never freed.