### PR TITLE
Fix XRC environment variable expansion for bitmap bundles

### DIFF
--- a/src/xrc/xmlres.cpp
+++ b/src/xrc/xmlres.cpp
@@ -1967,7 +1967,7 @@ wxBitmapBundle wxXmlResourceHandlerImpl::GetBitmapBundle(const wxString& param,
     }
 
     wxBitmapBundle bitmapBundle;
-    wxString paramValue = GetParamValue(node);
+    wxString paramValue = GetFilePath(node);
     if ( paramValue.EndsWith(".svg") )
     {
         if ( paramValue.Contains(";") )


### PR DESCRIPTION
Fixes the expansion of environment variables in XRC bitmap paths not working anymore after merging #22040, which changed the call of ``GetBitmap`` to ``GetBitmapBundle``.

Use ``GetFilePath`` instead of ``GetParamValue``.