### PR TITLE
wxUniv Call base version of HandleMouse to get focus for widget

### DIFF
--- a/src/univ/anybutton.cpp
+++ b/src/univ/anybutton.cpp
@@ -210,8 +210,6 @@ bool wxStdAnyButtonInputHandler::HandleMouse(wxInputConsumer *consumer,
             m_winHasMouse = true;
 
             consumer->PerformAction(wxACTION_BUTTON_PRESS);
-
-            return true;
         }
         else if ( event.LeftUp() )
         {

--- a/src/univ/listbox.cpp
+++ b/src/univ/listbox.cpp
@@ -1439,8 +1439,6 @@ bool wxStdListboxInputHandler::HandleMouse(wxInputConsumer *consumer,
     if ( !action.IsEmpty() )
     {
         lbox->PerformAction(action, item);
-
-        return true;
     }
 
     return wxStdInputHandler::HandleMouse(consumer, event);


### PR DESCRIPTION
Focus is setting in [base theme handler](https://github.com/wxWidgets/wxWidgets/blob/master/src/univ/themes/gtk.cpp#L2572-L2584) so it should be also called on left click on widget.