### PR TITLE
Document installing vcpkg packages for x64, too

### DIFF
--- a/docs/doxygen/mainpages/liblzma.h
+++ b/docs/doxygen/mainpages/liblzma.h
@@ -76,6 +76,7 @@ as simple as executing the following commands:
     > .\bootstrap-vcpkg.bat
     > .\vcpkg integrate install
     > .\vcpkg install liblzma
+    > .\vcpkg install liblzma:x64-windows
 @endcode
 
 Afterwards, liblzma headers and libraries (in DLL form) will be available to

--- a/docs/msw/install.md
+++ b/docs/msw/install.md
@@ -108,6 +108,7 @@ dependency manager:
     > bootstrap-vcpkg.bat
     > vcpkg integrate install
     > vcpkg install wxwidgets
+    > vcpkg install wxwidgets:x64-windows
 
 The wxWidgets port in vcpkg is kept up to date by Microsoft team members and community
 contributors. If the version is out of date, please [create an issue or pull request]


### PR DESCRIPTION
Vcpkg defaults to installing packages for x86-windows, and from the
perspective of x64 builds, the packages installed just cannot be
found -- and the reason is not very obvious.

Having an example with commands that will install both x86 and x64 is
probably the right thing to do in this day and age -- and if somebody
only wants one and not the other, seeing a package name with architecture
specified helps with guessing how to achieve that.