### PR TITLE
Allow WebView2 Edge updates without restart

### DIFF
--- a/include/wx/msw/private/webview_edge.h
+++ b/include/wx/msw/private/webview_edge.h
@@ -100,7 +100,6 @@ public:
 
     static wxDynamicLibrary ms_loaderDll;
     static wxString ms_browserExecutableDir;
-    static wxString ms_version;
 
     static bool Initialize();
 


### PR DESCRIPTION
The previous implementation initialized the version number only once. This caused subsequent calls to `wxWebView::GetBackendVersionInfo()` to return the same version number even if the runtime has been updated or a fixed version runtime had been activated via `wxWebViewEdge::MSWSetBrowserExecutableDir()`.

This change allows to require a minimum runtime version and allow a runtime update without requiring a restart of the application.