### PR TITLE
Improve fallback logic in wxArtProvider::GetBitmap{,Bundle}()

### DIFF
--- a/include/wx/artprov.h
+++ b/include/wx/artprov.h
@@ -226,9 +226,14 @@ protected:
         return GetSizeHint(client, true);
     }
 
-    // Derived classes must override CreateBitmap or CreateIconBundle
-    // (or both) to create requested art resource. This method is called
-    // only once per instance's lifetime for each requested wxArtID.
+    // Derived classes must override at least one of the CreateXXX() functions
+    // below to create requested art resource. Overriding more than one of them
+    // is also possible but is usually not needed, as both GetBitmap() and
+    // GetBitmapBundle() will try using both CreateBitmap() and
+    // CreateBitmapBundle().
+    //
+    // Note that these methods are called only once per instance's lifetime for
+    // each requested wxArtID as the return value is cached.
     virtual wxBitmap CreateBitmap(const wxArtID& WXUNUSED(id),
                                   const wxArtClient& WXUNUSED(client),
                                   const wxSize& WXUNUSED(size))
@@ -236,11 +241,12 @@ protected:
         return wxNullBitmap;
     }
 
-    // Default implementation creates a wxBitmapBundle which returns the
-    // specified art resource in whichever size it is being asked for.
-    virtual wxBitmapBundle CreateBitmapBundle(const wxArtID& id,
-                                              const wxArtClient& client,
-                                              const wxSize& size);
+    virtual wxBitmapBundle CreateBitmapBundle(const wxArtID& WXUNUSED(id),
+                                              const wxArtClient& WXUNUSED(client),
+                                              const wxSize& WXUNUSED(size))
+    {
+        return wxBitmapBundle();
+    }
 
     virtual wxIconBundle CreateIconBundle(const wxArtID& WXUNUSED(id),
                                           const wxArtClient& WXUNUSED(client))

--- a/tests/graphics/bmpbundle.cpp
+++ b/tests/graphics/bmpbundle.cpp
@@ -14,6 +14,8 @@
 
 #include "wx/bmpbndl.h"
 
+#include "wx/artprov.h"
+
 #include "asserthelper.h"
 
 // ----------------------------------------------------------------------------
@@ -144,3 +146,16 @@ TEST_CASE("BitmapBundle::FromSVGFile", "[bmpbundle][svg][file]")
 }
 
 #endif // wxHAS_SVG
+
+TEST_CASE("BitmapBundle::ArtProvider", "[bmpbundle][art]")
+{
+    // Check that creating a bogus bundle fails as expected.
+    wxBitmapBundle b = wxArtProvider::GetBitmapBundle("bloordyblop");
+    CHECK( !b.IsOk() );
+
+    // And that creating a bundle using a standard icon works.
+    const wxSize size(16, 16);
+    b = wxArtProvider::GetBitmapBundle(wxART_INFORMATION, wxART_MENU, size);
+    CHECK( b.IsOk() );
+    CHECK( b.GetDefaultSize() == size );
+}


### PR DESCRIPTION
This improves the changes of f78db92462 (Avoid bitmap scaling in
wxArtProvider::GetBitmapBundle(), 2021-12-17) and still uses a custom
bundle to avoid scaling the bitmap if possible, but does it in
GetBitmapBundle() itself rather than CreateBitmapBundle().

This allows to also use CreateBitmapBundle() from GetBitmap(), as there
is no possibility of infinite recursion due to calling each of these
functions from the other one any more, and so allows defining art
providers overriding only CreateBitmapBundle() instead of having to
always override both it and CreateBitmap().

Also add a unit test, even if just a trivial one, for these functions,
to at least check that they don't crash.

---

@TcT2k @kosh543 Please let me know if you see anything wrong with this one.