### PR TITLE
Fix XRC environment variable expansion for bitmap bundles

### DIFF
--- a/src/xrc/xmlres.cpp
+++ b/src/xrc/xmlres.cpp
@@ -1967,7 +1967,7 @@ wxBitmapBundle wxXmlResourceHandlerImpl::GetBitmapBundle(const wxString& param,
     }
 
     wxBitmapBundle bitmapBundle;
-    wxString paramValue = GetParamValue(node);
+    wxString paramValue = GetFilePath(node);
     if ( paramValue.EndsWith(".svg") )
     {
         if ( paramValue.Contains(";") )


### PR DESCRIPTION
Thanks to @ousnius for noticing and fixing (#22071) the issue. 
I added a unit test. 