### PR TITLE
Install Python wheel module to fix Windows CI

### DIFF
--- a/build/tools/httpbin.sh
+++ b/build/tools/httpbin.sh
@@ -55,6 +55,7 @@ httpbin_launch() {
     # it may not support Python version that we actually have (this one
     # still works with 3.4, 20.0.1 is the last one to support 3.5).
     python3 -m pip install --user --upgrade pip==19.1.1
+    python3 -m pip install wheel --user
 
     echo "Installing using `python3 -m pip --version`"
 


### PR DESCRIPTION
I suspect this might fix what is happening with the Windows CMake build, but not sure.

(Wonder if GitHub updated the default Python version on the Windows images?)