### PR TITLE
[wxUniv] Set tab offset to zero if all tabs are visible

### DIFF
--- a/src/univ/notebook.cpp
+++ b/src/univ/notebook.cpp
@@ -1144,6 +1144,8 @@ void wxNotebook::UpdateSpinBtn()
         {
             m_spinbtn->Hide();
         }
+        // reset offset to zero if all tabs are visible
+        m_offset = 0;
     }
 }
 


### PR DESCRIPTION
In current state the value of m_offset can have negative value after [calculations](https://github.com/wxWidgets/wxWidgets/blob/master/src/univ/notebook.cpp#L1106) but with all visible tabs it leads to incorrect refreshing after changing selection in some case:
![p1](https://user-images.githubusercontent.com/17313967/152656939-cc02dc0a-1c01-4245-85f8-a49946e531b8.jpg)

So reset it to 0 if all tabs are visible