### PR TITLE
Use [[fallthrough]] if VC++ accepts it, regardless of __cplusplus value

### DIFF
--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -302,7 +302,7 @@ typedef short int WXTYPE;
 
 /* wxFALLTHROUGH is used to notate explicit fallthroughs in switch statements */
 
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
     #define wxFALLTHROUGH [[fallthrough]]
 #elif __cplusplus >= 201103L && defined(__has_warning) && WX_HAS_CLANG_FEATURE(cxx_attributes)
     #define wxFALLTHROUGH [[clang::fallthrough]]


### PR DESCRIPTION
Since VS 2015 Update 3, the C++ standard targeted by the compiler can be
detected through _MSVC_LANG. This macro is like __cplusplus, but reflects the
actual standard understood by the compiler, unlike __cplusplus which by default
is left to an ancient value for compatibility.