### PR TITLE
Fixes for using mask and alpha in wxMSW wxImageList

### DIFF
--- a/include/wx/msw/imaglist.h
+++ b/include/wx/msw/imaglist.h
@@ -24,7 +24,7 @@ public:
    * Public interface
    */
 
-  wxImageList();
+  wxImageList() { Init(); }
 
   // Creates an image list.
   // Specify the width and height of the images in the list,
@@ -32,7 +32,7 @@ public:
   // from icons), and the initial size of the list.
   wxImageList(int width, int height, bool mask = true, int initialCount = 1)
   {
-    m_hImageList = NULL;
+    Init();
     Create(width, height, mask, initialCount);
   }
   virtual ~wxImageList();
@@ -198,7 +198,15 @@ public:
 protected:
   WXHIMAGELIST m_hImageList;
   wxSize m_size;
+
+private:
   bool m_useMask;
+
+  void Init()
+  {
+    m_hImageList = NULL;
+    m_useMask = false;
+  }
 
   wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxImageList);
 };

--- a/src/msw/imaglist.cpp
+++ b/src/msw/imaglist.cpp
@@ -64,12 +64,6 @@ static HBITMAP GetMaskForImage(const wxBitmap& bitmap, const wxBitmap& mask);
 // wxImageList creation/destruction
 // ----------------------------------------------------------------------------
 
-wxImageList::wxImageList()
-    : m_hImageList(NULL)
-    , m_useMask(false)
-{
-}
-
 // Creates an image list
 bool wxImageList::Create(int width, int height, bool mask, int initial)
 {

--- a/src/msw/imaglist.cpp
+++ b/src/msw/imaglist.cpp
@@ -458,10 +458,6 @@ wxIcon wxImageList::GetIcon(int index) const
 
 static HBITMAP GetMaskForImage(const wxBitmap& bitmap, const wxBitmap& mask)
 {
-#if wxUSE_IMAGE
-    wxBitmap bitmapWithMask;
-#endif // wxUSE_IMAGE
-
     HBITMAP hbmpMask;
     wxMask *pMask;
     bool deleteMask = false;
@@ -474,23 +470,6 @@ static HBITMAP GetMaskForImage(const wxBitmap& bitmap, const wxBitmap& mask)
     else
     {
         pMask = bitmap.GetMask();
-
-#if wxUSE_IMAGE
-        // check if we don't have alpha in this bitmap -- we can create a mask
-        // from it (and we need to do it for the older systems which don't
-        // support 32bpp bitmaps natively)
-        if ( !pMask )
-        {
-            wxImage img(bitmap.ConvertToImage());
-            if ( img.HasAlpha() )
-            {
-                img.ConvertAlphaToMask();
-                bitmapWithMask = wxBitmap(img);
-                pMask = bitmapWithMask.GetMask();
-            }
-        }
-#endif // wxUSE_IMAGE
-
         if ( !pMask )
         {
             // use the light grey count as transparent: the trouble here is

--- a/src/msw/imaglist.cpp
+++ b/src/msw/imaglist.cpp
@@ -209,7 +209,7 @@ void GetImageListBitmaps(const wxBitmap& bitmap, const wxBitmap& mask, bool useM
     hbmp = GetHbitmapOf(bitmap);
 #endif // wxUSE_WXDIB && wxUSE_IMAGE
 }
-};
+} // anonymous namespace
 
 // Adds a bitmap, and optionally a mask bitmap.
 // Note that wxImageList creates new bitmaps, so you may delete

--- a/src/msw/imaglist.cpp
+++ b/src/msw/imaglist.cpp
@@ -82,7 +82,10 @@ bool wxImageList::Create(int width, int height, bool mask, int initial)
 
     // For comctl32.dll < 6 always use masks as it doesn't support alpha.
     if ( mask || wxApp::GetComCtl32Version() < 600 )
+    {
+        m_useMask = true;
         flags |= ILC_MASK;
+    }
 
     // Grow by 1, I guess this is reasonable behaviour most of the time
     m_hImageList = (WXHIMAGELIST) ImageList_Create(width, height, flags,
@@ -92,7 +95,6 @@ bool wxImageList::Create(int width, int height, bool mask, int initial)
         wxLogLastError(wxT("ImageList_Create()"));
     }
 
-    m_useMask = (flags & ILC_MASK) != 0;
     return m_hImageList != 0;
 }
 


### PR DESCRIPTION
This fixes #22021 without rebreaking #19036 (I've tested both).

Also some cleanup.