### PR TITLE
MSW: Fix multi monitor and dpi wxTLW::RestoreToGeometry()

### DIFF
--- a/include/wx/msw/private/tlwgeom.h
+++ b/include/wx/msw/private/tlwgeom.h
@@ -130,10 +130,23 @@ public:
             m_placement.showCmd = SW_HIDE;
         }
 
+        wxSize oldDPI = tlw->GetDPI();
         if ( !::SetWindowPlacement(GetHwndOf(tlw), &m_placement) )
         {
             wxLogLastError(wxS("SetWindowPlacement"));
             return false;
+        }
+        wxSize newDPI = tlw->GetDPI();
+        // If a window was placed on a monitor with a different DPI than the
+        // main display call SetWindowPlacement() a second time to apply
+        // the window size correctly.
+        if (oldDPI != newDPI)
+        {
+            if (!::SetWindowPlacement(GetHwndOf(tlw), &m_placement))
+            {
+                wxLogLastError(wxS("SetWindowPlacement"));
+                return false;
+            }
         }
 
         return true;


### PR DESCRIPTION
When using `wxPersistAndRestore()` (or `wxTopLevelWindow::RestoreToGeometry()` directly) with multiple monitors and different scaling settings only the position would be restored correctly. The window size would be wrong.

If a window was placed on a monitor with a different DPI than the main display call `SetWindowPlacement()` a second time to apply the window size correctly.