### PR TITLE
Fix high DPI support for MDI windows

### DIFF
--- a/src/msw/mdi.cpp
+++ b/src/msw/mdi.cpp
@@ -210,6 +210,8 @@ bool wxMDIParentFrame::Create(wxWindow *parent,
 
   SetOwnBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE));
 
+  InheritAttributes();
+
   // unlike (almost?) all other windows, frames are created hidden
   m_isShown = false;
 


### PR DESCRIPTION
High DPI support was disabled for wxMDIParentFrame (and everything
inside them) since the changes of 4700298c26 (Move DPI handling from
wxTopLevelWindow to wxNonOwnedWindow, 2020-06-01).

Add a call to InheritAttributes() to ensure that m_perMonitorDPIaware is
set correctly for them too.

A more robust approach ensuring that it's initialized would be even
better, we probably could initialize this field on demand and not
override InheritAttributes() at all.

---

@MaartenBent I'm pretty sure we need to do this as otherwise the toolbar in the mdi sample doesn't get resized at all, but wanted to ask you if you see a better way to do it and/or any other places where this call might be missing. TIA!