### PR TITLE
Fix toolbar resizing when moving to a lower DPI screen

### DIFF
--- a/include/wx/msw/toolbar.h
+++ b/include/wx/msw/toolbar.h
@@ -48,7 +48,6 @@ public:
 
     virtual bool Realize() wxOVERRIDE;
 
-    virtual void SetToolBitmapSize(const wxSize& size) wxOVERRIDE;
     virtual wxSize GetToolSize() const wxOVERRIDE;
 
     virtual void SetRows(int nRows) wxOVERRIDE;
@@ -115,6 +114,8 @@ protected:
     virtual void DoEnableTool(wxToolBarToolBase *tool, bool enable) wxOVERRIDE;
     virtual void DoToggleTool(wxToolBarToolBase *tool, bool toggle) wxOVERRIDE;
     virtual void DoSetToggle(wxToolBarToolBase *tool, bool toggle) wxOVERRIDE;
+
+    virtual void DoSetToolBitmapSize(const wxSize& size) wxOVERRIDE;
 
     // return the appropriate size and flags for the toolbar control
     virtual wxSize DoGetBestSize() const wxOVERRIDE;

--- a/include/wx/osx/toolbar.h
+++ b/include/wx/osx/toolbar.h
@@ -53,7 +53,6 @@ public:
 #endif
     virtual bool Realize() wxOVERRIDE;
 
-    virtual void SetToolBitmapSize(const wxSize& size) wxOVERRIDE;
     virtual wxSize GetToolSize() const wxOVERRIDE;
 
     virtual void SetRows(int nRows) wxOVERRIDE;
@@ -114,6 +113,8 @@ protected:
     virtual void DoEnableTool(wxToolBarToolBase *tool, bool enable) wxOVERRIDE;
     virtual void DoToggleTool(wxToolBarToolBase *tool, bool toggle) wxOVERRIDE;
     virtual void DoSetToggle(wxToolBarToolBase *tool, bool toggle) wxOVERRIDE;
+
+    virtual void DoSetToolBitmapSize(const wxSize& size) wxOVERRIDE;
 
     wxDECLARE_EVENT_TABLE();
 #if wxOSX_USE_NATIVE_TOOLBAR

--- a/include/wx/tbarbase.h
+++ b/include/wx/tbarbase.h
@@ -467,10 +467,8 @@ public:
 
     // get/set the size of the bitmaps used by the toolbar: should be called
     // before adding any tools to the toolbar
-    virtual void SetToolBitmapSize(const wxSize& size)
-        { m_defaultWidth = size.x; m_defaultHeight = size.y; }
-    virtual wxSize GetToolBitmapSize() const
-        { return wxSize(m_defaultWidth, m_defaultHeight); }
+    virtual void SetToolBitmapSize(const wxSize& size);
+    virtual wxSize GetToolBitmapSize() const;
 
     // the button size in some implementations is bigger than the bitmap size:
     // get the total button size (by default the same as bitmap size)

--- a/include/wx/tbarbase.h
+++ b/include/wx/tbarbase.h
@@ -685,6 +685,10 @@ protected:
         return tool;
     }
 
+    // set the tool bitmap size without changing m_requestedBitmapSize
+    virtual void DoSetToolBitmapSize(const wxSize& size);
+
+
     // the list of all our tools
     wxToolBarToolsList m_tools;
 
@@ -700,10 +704,15 @@ protected:
     int m_toolPacking,
         m_toolSeparation;
 
-    // the size of the toolbar bitmaps
+    // the currently used size of the toolbar bitmaps: the name is unfortunate
+    // but keep it for compatibility
     wxCoord m_defaultWidth, m_defaultHeight;
 
 private:
+    // the size of the bitmaps requested by the application by calling
+    // SetToolBitmapSize()
+    wxSize m_requestedBitmapSize;
+
     wxDECLARE_EVENT_TABLE();
     wxDECLARE_NO_COPY_CLASS(wxToolBarBase);
 };

--- a/src/common/tbarbase.cpp
+++ b/src/common/tbarbase.cpp
@@ -433,10 +433,17 @@ void wxToolBarBase::ClearTools()
     }
 }
 
-void wxToolBarBase::SetToolBitmapSize(const wxSize& size)
+void wxToolBarBase::DoSetToolBitmapSize(const wxSize& size)
 {
     m_defaultWidth = size.x;
     m_defaultHeight = size.y;
+}
+
+void wxToolBarBase::SetToolBitmapSize(const wxSize& size)
+{
+    m_requestedBitmapSize = size;
+
+    DoSetToolBitmapSize(size);
 }
 
 wxSize wxToolBarBase::GetToolBitmapSize() const
@@ -448,7 +455,7 @@ void wxToolBarBase::AdjustToolBitmapSize()
 {
     if ( HasFlag(wxTB_NOICONS) )
     {
-        SetToolBitmapSize(wxSize(0, 0));
+        DoSetToolBitmapSize(wxSize(0, 0));
         return;
     }
 
@@ -476,6 +483,11 @@ void wxToolBarBase::AdjustToolBitmapSize()
                                 sizeOrig
                                );
 
+        // Don't do anything if it doesn't change, our current size is supposed
+        // to satisfy any constraints we might have anyhow.
+        if ( sizePreferred == sizeOrig )
+            return;
+
         // This size is supposed to be in logical units for the platforms where
         // they differ from physical ones, so convert it.
         //
@@ -486,14 +498,16 @@ void wxToolBarBase::AdjustToolBitmapSize()
         // use the size computed here, this would need to be revisited.
         sizePreferred /= GetContentScaleFactor();
 
-        // Increase the bitmap size to the preferred one, as the default bitmap
-        // size is small and using larger bitmaps shouldn't shrink them to it.
-        // However intentionally setting a size larger than the actual bitmap
-        // size should scale them up, as people sometimes want to use bigger
-        // buttons and this is how it used to behave before wxBitmapBundle
-        // introduction.
-        if ( sizePreferred.x > sizeOrig.x || sizePreferred.y > sizeOrig.y )
-            SetToolBitmapSize(sizePreferred);
+        // Don't decrease the bitmap below the size requested by the application
+        // as using larger bitmaps shouldn't shrink them to the small default
+        // size.
+        sizePreferred.IncTo(m_requestedBitmapSize);
+
+        // Call DoSetToolBitmapSize() and not SetToolBitmapSize() to avoid
+        // changing the requested bitmap size: if we set our own adjusted size
+        // as the preferred one, we wouldn't decrease it later even if we ought
+        // to, as when moving from a monitor with higher DPI to a lower-DPI one.
+        DoSetToolBitmapSize(sizePreferred);
     }
 }
 

--- a/src/common/tbarbase.cpp
+++ b/src/common/tbarbase.cpp
@@ -433,6 +433,17 @@ void wxToolBarBase::ClearTools()
     }
 }
 
+void wxToolBarBase::SetToolBitmapSize(const wxSize& size)
+{
+    m_defaultWidth = size.x;
+    m_defaultHeight = size.y;
+}
+
+wxSize wxToolBarBase::GetToolBitmapSize() const
+{
+    return wxSize(m_defaultWidth, m_defaultHeight);
+}
+
 void wxToolBarBase::AdjustToolBitmapSize()
 {
     if ( HasFlag(wxTB_NOICONS) )

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1669,9 +1669,9 @@ bool wxToolBar::MSWOnNotify(int WXUNUSED(idCtrl),
 // toolbar geometry
 // ----------------------------------------------------------------------------
 
-void wxToolBar::SetToolBitmapSize(const wxSize& size)
+void wxToolBar::DoSetToolBitmapSize(const wxSize& size)
 {
-    wxToolBarBase::SetToolBitmapSize(size);
+    wxToolBarBase::DoSetToolBitmapSize(size);
 
     ::SendMessage(GetHwnd(), TB_SETBITMAPSIZE, 0, MAKELONG(size.x, size.y));
 }

--- a/src/osx/cocoa/toolbar.mm
+++ b/src/osx/cocoa/toolbar.mm
@@ -1332,7 +1332,7 @@ void wxToolBar::DoSetSize(int x, int y, int width, int height, int sizeFlags)
     DoLayout();
 }    
 
-void wxToolBar::SetToolBitmapSize(const wxSize& size)
+void wxToolBar::DoSetToolBitmapSize(const wxSize& size)
 {
     m_defaultWidth = size.x + kwxMacToolBorder;
     m_defaultHeight = size.y + kwxMacToolBorder;

--- a/src/osx/iphone/toolbar.mm
+++ b/src/osx/iphone/toolbar.mm
@@ -280,7 +280,7 @@ void wxToolBar::DoSetSize(int x, int y, int width, int height, int sizeFlags)
     DoLayout();
 } 
 
-void wxToolBar::SetToolBitmapSize(const wxSize& size)
+void wxToolBar::DoSetToolBitmapSize(const wxSize& size)
 {
     m_defaultWidth = size.x;
     m_defaultHeight = size.y;


### PR DESCRIPTION
I hope this doesn't introduce any new problems but at least it does solve #22105 while still allowing toggling buttons size in the sample to keep working.