### PR TITLE
Fix compilation on OpenIndiana (SunOS)

### DIFF
--- a/src/unix/mediactrl.cpp
+++ b/src/unix/mediactrl.cpp
@@ -16,6 +16,7 @@
 #include "wx/mediactrl.h"
 
 #include <gst/gst.h>                // main gstreamer header
+#include <stdint.h>
 
 #if GST_CHECK_VERSION(1,0,0)
 #include <gst/video/video.h>
@@ -307,7 +308,7 @@ extern "C" {
 static gint gtk_window_realize_callback(GtkWidget* widget,
                                         wxGStreamerMediaBackend* be)
 {
-    window_id_type window_id = (window_id_type)wxGtkGetIdFromWidget(widget);
+    window_id_type window_id = (window_id_type)(uintptr_t)wxGtkGetIdFromWidget(widget);
 
 #if GST_CHECK_VERSION(1,0,0)
     gst_video_overlay_set_window_handle(be->m_xoverlay, window_id);
@@ -674,7 +675,7 @@ void wxGStreamerMediaBackend::SetupXOverlay()
     }
     else
     {
-        window_id = (window_id_type)wxGtkGetIdFromWidget(m_ctrl->m_wxwindow);
+        window_id = (window_id_type)(uintptr_t)wxGtkGetIdFromWidget(m_ctrl->m_wxwindow);
 #else
         window_id = ctrl->GetHandle();
 #endif


### PR DESCRIPTION
src/unix/mediactrl.cpp failed to compile due to a precision-losing cast:

```
mediactrl.cpp: In function 'gint gtk_window_realize_callback(GtkWidget*, wxGStreamerMediaBackend*)':
mediactrl.cpp:310:32: error: cast from 'gpointer' {aka 'void*'} to 'window_id_type' {aka 'unsigned int'} loses precision [-fpermissive]
mediactrl.cpp: In member function 'void wxGStreamerMediaBackend::SetupXOverlay()':
mediactrl.cpp:677:21: error: cast from 'gpointer' {aka 'void*'} to 'window_id_type' {aka 'unsigned int'} loses precision [-fpermissive]
```

The error can be silenced by casting first to (uintptr_t). Whether this is
the right thing to do is a different matter; the inherent danger of
gpointer's value not fitting in window_id_type remains.

There doesn't appear to be much SunOS-specific about this error, but
it seems that mediactrl.cpp often isn't compiled at all on Linux.