### PR TITLE
Fix determining DPI info for wxDialog creation

### DIFF
--- a/src/msw/nonownedwnd.cpp
+++ b/src/msw/nonownedwnd.cpp
@@ -235,10 +235,14 @@ WXLRESULT wxNonOwnedWindow::MSWWindowProc(WXUINT message, WXWPARAM wParam, WXLPA
 
     switch ( message )
     {
-        case WM_NCCREATE:
-            m_perMonitorDPIaware = IsPerMonitorDPIAware(GetHwnd());
-            if ( m_perMonitorDPIaware )
+        case WM_NCCALCSIZE:
+            // Use this message ID to determine the DPI information on
+            // window creation, since WM_NCCREATE is not generated for dialogs.
+            if ( m_activeDPI == wxDefaultSize )
+            {
+                m_perMonitorDPIaware = IsPerMonitorDPIAware(GetHwnd());
                 m_activeDPI = GetDPI();
+            }
             break;
 
         case WM_DPICHANGED:


### PR DESCRIPTION
WM_NCCREATE is not received for dialogs, so use a different message.
There seem to be no other messages that are always and only send on creation,
so use WM_NCCALCSIZE which seems always generated but not too often.

Use m_activeDPI to determine if the DPI variables have been initialized or not,
instead of adding another variable for this.

See #22116