### PR TITLE
Fix compilation on 64-bit OpenIndiana (SunOS)

### DIFF
--- a/configure
+++ b/configure
@@ -21166,8 +21166,14 @@ fi
         ;;
 
     *-*-solaris2* )
-                if test "$ac_cv_sizeof_void_p" = 8 -a -d "/usr/lib/64"; then
+                                if test "$ac_cv_sizeof_void_p" = 8 -a -d "/usr/lib/64"; then
             wx_cv_std_libpath="lib/64"
+            if test -n "$PKG_CONFIG_PATH"; then
+                PKG_CONFIG_PATH="/usr/$wx_cv_std_libpath/pkgconfig:$PKG_CONFIG_PATH"
+            else
+                PKG_CONFIG_PATH="/usr/$wx_cv_std_libpath/pkgconfig"
+            fi
+            export PKG_CONFIG_PATH
         fi
         ;;
 

--- a/configure.in
+++ b/configure.in
@@ -2212,8 +2212,16 @@ case "${host}" in
 
     *-*-solaris2* )
         dnl use ../lib or ../lib/64 depending on the size of void*
+        dnl The pkg-config path should be adjusted for 64-bit.
+        dnl see https://docs.oracle.com/cd/E37838_01/html/E66175/gplhi.html
         if test "$ac_cv_sizeof_void_p" = 8 -a -d "/usr/lib/64"; then
             wx_cv_std_libpath="lib/64"
+            if test -n "$PKG_CONFIG_PATH"; then
+                PKG_CONFIG_PATH="/usr/$wx_cv_std_libpath/pkgconfig:$PKG_CONFIG_PATH"
+            else
+                PKG_CONFIG_PATH="/usr/$wx_cv_std_libpath/pkgconfig"
+            fi
+            export PKG_CONFIG_PATH
         fi
         ;;
 


### PR DESCRIPTION
Trying again, hopefully the right way.

src/unix/mediactrl.cpp failed to compile due to a precision-losing cast
(from 'gpointer' {aka 'void*'} to 'window_id_type' {aka 'unsigned int'}).

Tell pkg-config to use 64-bit configs if building for 64-bit on SunOS.

PKG_CONFIG_PATH is set to /usr/lib/64/pkgconfig in that case.

Documented at:
https://docs.oracle.com/cd/E37838_01/html/E66175/gplhi.html

This PR doesn't touch CMake; the CMake build on SunOS seems to fail
for various reasons unrelated to this issue.