### PR TITLE
Fix compilation on recent FreeBSDs by linking against epoll-shim

### DIFF
--- a/configure
+++ b/configure
@@ -2142,7 +2142,7 @@ Optional Features:
   --enable-webrequest     use wxWebRequest
   --enable-ipc            use interprocess communication (wxSocket etc.)
   --enable-baseevtloop    use event loop in console programs too
-  --enable-epollloop      use wxEpollDispatcher class (Linux only)
+  --enable-epollloop      use wxEpollDispatcher class (mostly Linux only)
   --enable-selectloop     use wxSelectDispatcher class
   --enable-any            use wxAny class
   --enable-apple_ieee     use the Apple IEEE codec
@@ -35638,6 +35638,11 @@ done
             if test "$ac_cv_header_sys_epoll_h" = "yes"; then
                 $as_echo "#define wxUSE_EPOLL_DISPATCHER 1" >>confdefs.h
 
+                case "${host}" in
+                *-*-freebsd*)
+                                                            EPOLL_LINK="-lepoll-shim"
+                ;;
+                esac
             else
                 { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: sys/epoll.h not available, wxEpollDispatcher disabled" >&5
 $as_echo "$as_me: WARNING: sys/epoll.h not available, wxEpollDispatcher disabled" >&2;}
@@ -38852,7 +38857,7 @@ if test "$SHARED" = 1; then
 fi
 
 LIBS=`echo $LIBS`
-EXTRALIBS="$LDFLAGS $LDFLAGS_VERSIONING $LIBS $PCRE_LINK $DMALLOC_LIBS"
+EXTRALIBS="$LDFLAGS $LDFLAGS_VERSIONING $LIBS $PCRE_LINK $DMALLOC_LIBS $EPOLL_LINK"
 EXTRALIBS_XML="$EXPAT_LINK"
 EXTRALIBS_HTML="$MSPACK_LINK"
 EXTRALIBS_MEDIA="$GST_LIBS"

--- a/configure
+++ b/configure
@@ -2142,7 +2142,7 @@ Optional Features:
   --enable-webrequest     use wxWebRequest
   --enable-ipc            use interprocess communication (wxSocket etc.)
   --enable-baseevtloop    use event loop in console programs too
-  --enable-epollloop      use wxEpollDispatcher class (mostly Linux only)
+  --enable-epollloop      use wxEpollDispatcher class (Linux only)
   --enable-selectloop     use wxSelectDispatcher class
   --enable-any            use wxAny class
   --enable-apple_ieee     use the Apple IEEE codec
@@ -35636,11 +35636,14 @@ fi
 done
 
             if test "$ac_cv_header_sys_epoll_h" = "yes"; then
-                $as_echo "#define wxUSE_EPOLL_DISPATCHER 1" >>confdefs.h
-
                 case "${host}" in
-                *-*-freebsd*)
-                                                            EPOLL_LINK="-lepoll-shim"
+                *-*-linux*)
+                                                            $as_echo "#define wxUSE_EPOLL_DISPATCHER 1" >>confdefs.h
+
+                ;;
+                *)
+                    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: wxEpollDispatcher disabled, because OS is not Linux" >&5
+$as_echo "$as_me: WARNING: wxEpollDispatcher disabled, because OS is not Linux" >&2;}
                 ;;
                 esac
             else
@@ -38857,7 +38860,7 @@ if test "$SHARED" = 1; then
 fi
 
 LIBS=`echo $LIBS`
-EXTRALIBS="$LDFLAGS $LDFLAGS_VERSIONING $LIBS $PCRE_LINK $DMALLOC_LIBS $EPOLL_LINK"
+EXTRALIBS="$LDFLAGS $LDFLAGS_VERSIONING $LIBS $PCRE_LINK $DMALLOC_LIBS"
 EXTRALIBS_XML="$EXPAT_LINK"
 EXTRALIBS_HTML="$MSPACK_LINK"
 EXTRALIBS_MEDIA="$GST_LIBS"

--- a/configure.in
+++ b/configure.in
@@ -730,7 +730,7 @@ WX_ARG_FEATURE(webrequest,    [  --enable-webrequest     use wxWebRequest], wxUS
 WX_ARG_FEATURE(ipc,           [  --enable-ipc            use interprocess communication (wxSocket etc.)], wxUSE_IPC)
 
 WX_ARG_FEATURE(baseevtloop,   [  --enable-baseevtloop    use event loop in console programs too], wxUSE_CONSOLE_EVENTLOOP)
-WX_ARG_FEATURE(epollloop,     [  --enable-epollloop      use wxEpollDispatcher class (mostly Linux only)], wxUSE_EPOLL_DISPATCHER)
+WX_ARG_FEATURE(epollloop,     [  --enable-epollloop      use wxEpollDispatcher class (Linux only)], wxUSE_EPOLL_DISPATCHER)
 WX_ARG_FEATURE(selectloop,    [  --enable-selectloop     use wxSelectDispatcher class], wxUSE_SELECT_DISPATCHER)
 
 dnl please keep the settings below in alphabetical order
@@ -6246,12 +6246,14 @@ if test "$wxUSE_CONSOLE_EVENTLOOP" = "yes"; then
         if test "$wxUSE_EPOLL_DISPATCHER" = "yes"; then
             AC_CHECK_HEADERS(sys/epoll.h,,, [AC_INCLUDES_DEFAULT()])
             if test "$ac_cv_header_sys_epoll_h" = "yes"; then
-                AC_DEFINE(wxUSE_EPOLL_DISPATCHER)
                 case "${host}" in
-                *-*-freebsd*)
-                    dnl On FreeBSD sys/epoll.h may exist, but using its functions
-                    dnl requires linking against epoll-shim.
-                    EPOLL_LINK="-lepoll-shim"
+                *-*-linux*)
+                    dnl On FreeBSD or other *BSD sys/epoll.h may exist, but
+                    dnl we shall use epoll on Linux only.
+                    AC_DEFINE(wxUSE_EPOLL_DISPATCHER)
+                ;;
+                *)
+                    AC_MSG_WARN([wxEpollDispatcher disabled, because OS is not Linux])
                 ;;
                 esac
             else
@@ -8284,7 +8286,7 @@ if test "$SHARED" = 1; then
 fi
 
 LIBS=`echo $LIBS`
-EXTRALIBS="$LDFLAGS $LDFLAGS_VERSIONING $LIBS $PCRE_LINK $DMALLOC_LIBS $EPOLL_LINK"
+EXTRALIBS="$LDFLAGS $LDFLAGS_VERSIONING $LIBS $PCRE_LINK $DMALLOC_LIBS"
 EXTRALIBS_XML="$EXPAT_LINK"
 EXTRALIBS_HTML="$MSPACK_LINK"
 EXTRALIBS_MEDIA="$GST_LIBS"

--- a/configure.in
+++ b/configure.in
@@ -730,7 +730,7 @@ WX_ARG_FEATURE(webrequest,    [  --enable-webrequest     use wxWebRequest], wxUS
 WX_ARG_FEATURE(ipc,           [  --enable-ipc            use interprocess communication (wxSocket etc.)], wxUSE_IPC)
 
 WX_ARG_FEATURE(baseevtloop,   [  --enable-baseevtloop    use event loop in console programs too], wxUSE_CONSOLE_EVENTLOOP)
-WX_ARG_FEATURE(epollloop,     [  --enable-epollloop      use wxEpollDispatcher class (Linux only)], wxUSE_EPOLL_DISPATCHER)
+WX_ARG_FEATURE(epollloop,     [  --enable-epollloop      use wxEpollDispatcher class (mostly Linux only)], wxUSE_EPOLL_DISPATCHER)
 WX_ARG_FEATURE(selectloop,    [  --enable-selectloop     use wxSelectDispatcher class], wxUSE_SELECT_DISPATCHER)
 
 dnl please keep the settings below in alphabetical order
@@ -6247,6 +6247,13 @@ if test "$wxUSE_CONSOLE_EVENTLOOP" = "yes"; then
             AC_CHECK_HEADERS(sys/epoll.h,,, [AC_INCLUDES_DEFAULT()])
             if test "$ac_cv_header_sys_epoll_h" = "yes"; then
                 AC_DEFINE(wxUSE_EPOLL_DISPATCHER)
+                case "${host}" in
+                *-*-freebsd*)
+                    dnl On FreeBSD sys/epoll.h may exist, but using its functions
+                    dnl requires linking against epoll-shim.
+                    EPOLL_LINK="-lepoll-shim"
+                ;;
+                esac
             else
                 AC_MSG_WARN([sys/epoll.h not available, wxEpollDispatcher disabled])
             fi
@@ -8277,7 +8284,7 @@ if test "$SHARED" = 1; then
 fi
 
 LIBS=`echo $LIBS`
-EXTRALIBS="$LDFLAGS $LDFLAGS_VERSIONING $LIBS $PCRE_LINK $DMALLOC_LIBS"
+EXTRALIBS="$LDFLAGS $LDFLAGS_VERSIONING $LIBS $PCRE_LINK $DMALLOC_LIBS $EPOLL_LINK"
 EXTRALIBS_XML="$EXPAT_LINK"
 EXTRALIBS_HTML="$MSPACK_LINK"
 EXTRALIBS_MEDIA="$GST_LIBS"


### PR DESCRIPTION
On recent FreeBSDs, the "Linux-only" `<sys/epoll.h>` exists in the default
include path, and is thus detected by configure. However, on FreeBSD the
epoll API is implemented in a library, `epoll-shim`, which needs to be
linked along with the wx libraries to anything using wx.

(The epoll-shim library is available for other *BSD too, but at least on OpenBSD
it's not on the default include path, and doesn't get detected by configure
without adjusting `CFLAGS`, and for that reason there is no issue with compilation,
and this PR doesn't need to address other *BSD.)