### PR TITLE
Demonstrate how to interrupt closing an application

### DIFF
--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -4498,6 +4498,9 @@ public:
         }
     @endcode
 
+    See also @c samples/dialogs for a full example of interrupting closing an
+    application when there are e.g. unsaved files.
+
     The EVT_END_SESSION event is slightly different as it is sent by the system
     when the user session is ending (e.g. because of log out or shutdown) and
     so all windows are being forcefully closed. At least under MSW, after the

--- a/samples/dialogs/dialogs.h
+++ b/samples/dialogs/dialogs.h
@@ -517,8 +517,10 @@ public:
 
     void OnTestDefaultActionDialog(wxCommandEvent& event);
     void OnModalHook(wxCommandEvent& event);
+    void OnSimulatedUnsaved(wxCommandEvent& event);
 
     void OnExit(wxCommandEvent& event);
+    void OnClose(wxCloseEvent& event);
 
 private:
 #if wxUSE_COLOURDLG
@@ -564,6 +566,7 @@ private:
     wxTipWindow *m_tipWindow;
 #endif // wxUSE_TIPWINDOW
 
+    bool m_confirmExit;
     wxDECLARE_EVENT_TABLE();
 };
 
@@ -656,7 +659,8 @@ enum
     DIALOGS_PROPERTY_SHEET_BUTTONTOOLBOOK,
     DIALOGS_STANDARD_BUTTON_SIZER_DIALOG,
     DIALOGS_TEST_DEFAULT_ACTION,
-    DIALOGS_MODAL_HOOK
+    DIALOGS_MODAL_HOOK,
+    DIALOGS_SIMULATE_UNSAVED
 };
 
 #endif


### PR DESCRIPTION
Add a menu item to the dialogs sample for simulating having unsaved
documents in the application. Then demonstrate how to do something
when the user attempts to close the application, e.g. show a dialog,
and possibly cancel closing.

This code was originally written for debugging some issue related to
closing an application, but besides that it serves as an example of a
very common pattern a lot of real world applications need in some form.