### PR TITLE
Remove __TDATE__ and __TTIME__ macros in <wx/chartype.h>

### DIFF
--- a/include/wx/chartype.h
+++ b/include/wx/chartype.h
@@ -241,17 +241,9 @@
 /* a helper macro allowing to make another macro Unicode-friendly, see below */
 #define wxAPPLY_T(x) wxT(x)
 
-/* Unicode-friendly __FILE__, __DATE__ and __TIME__ analogs */
+/* Unicode-friendly __FILE__ analog */
 #ifndef __TFILE__
     #define __TFILE__ wxAPPLY_T(__FILE__)
-#endif
-
-#ifndef __TDATE__
-    #define __TDATE__ wxAPPLY_T(__DATE__)
-#endif
-
-#ifndef __TTIME__
-    #define __TTIME__ wxAPPLY_T(__TIME__)
 #endif
 
 #endif /* _WX_WXCHARTYPE_H_ */

--- a/src/common/utilscmn.cpp
+++ b/src/common/utilscmn.cpp
@@ -1405,8 +1405,8 @@ wxVersionInfo wxGetLibraryVersionInfo()
 #endif
                wxDEBUG_LEVEL,
 #if !wxUSE_REPRODUCIBLE_BUILD
-               __TDATE__,
-               __TTIME__,
+               __DATE__,
+               __TIME__,
 #endif
                wxPlatformInfo::Get().GetToolkitMajorVersion(),
                wxPlatformInfo::Get().GetToolkitMinorVersion()


### PR DESCRIPTION
1. The names conflict with rules for reserved identifier names in C.

2. They are not very useful as wxString now accepts regular string
literals.

3. They are (fortunately) undocumented.

4. They are nearly unused in wx's own codebase.

5. Having either `__TIME__` or `__DATE__` mentioned in a header file slows
down ccache builds with ccache's default settings, (and this is unobvious
without enabling ccache's debug log). Anything containing
`__TIME__`/`__DATE__` is considered needing a recompilation. This affects
any code that is using wx and #includes e.g. `<wx/string.h>`.