### PR TITLE
macOS: Allow setting some fullscreen style options

### DIFF
--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -314,7 +314,7 @@ public :
 
     virtual bool IsFullScreen() const wxOVERRIDE;
 
-    bool EnableFullScreenView(bool enable) wxOVERRIDE;
+    bool EnableFullScreenView(bool enable, long style) wxOVERRIDE;
 
     virtual bool ShowFullScreen(bool show, long style) wxOVERRIDE;
 
@@ -341,6 +341,7 @@ public :
     void            RestoreWindowLevel() wxOVERRIDE;
 
     bool m_macIgnoreNextFullscreenChange = false;
+    long m_macFullscreenStyle = wxFULLSCREEN_ALL;
 
     static WX_NSResponder GetNextFirstResponder() ;
     static WX_NSResponder GetFormerFirstResponder() ;

--- a/include/wx/osx/core/private.h
+++ b/include/wx/osx/core/private.h
@@ -962,7 +962,7 @@ public :
 
     virtual void ShowWithoutActivating() { Show(true); }
 
-    virtual bool EnableFullScreenView(bool enable) = 0;
+    virtual bool EnableFullScreenView(bool enable, long style) = 0;
 
     virtual bool ShowFullScreen(bool show, long style)= 0;
 

--- a/include/wx/osx/iphone/private.h
+++ b/include/wx/osx/iphone/private.h
@@ -180,7 +180,7 @@ public :
 
     virtual bool IsFullScreen() const;
 
-    virtual bool EnableFullScreenView(bool enable);
+    virtual bool EnableFullScreenView(bool enable, long style);
 
     virtual bool ShowFullScreen(bool show, long style);
 

--- a/include/wx/osx/toplevel.h
+++ b/include/wx/osx/toplevel.h
@@ -64,7 +64,7 @@ public:
     virtual bool IsActive() wxOVERRIDE;
 
     virtual void ShowWithoutActivating() wxOVERRIDE;
-    bool EnableFullScreenView(bool enable = true) wxOVERRIDE;
+    bool EnableFullScreenView(bool enable = true, long style = wxFULLSCREEN_ALL) wxOVERRIDE;
     virtual bool ShowFullScreen(bool show, long style = wxFULLSCREEN_ALL) wxOVERRIDE;
     virtual bool IsFullScreen() const wxOVERRIDE;
 

--- a/include/wx/toplevel.h
+++ b/include/wx/toplevel.h
@@ -171,7 +171,8 @@ public:
     // set the frame icons
     virtual void SetIcons(const wxIconBundle& icons) { m_icons = icons; }
 
-    virtual bool EnableFullScreenView(bool WXUNUSED(enable) = true)
+    virtual bool EnableFullScreenView(bool WXUNUSED(enable) = true,
+                                      long WXUNUSED(style) = wxFULLSCREEN_ALL)
     {
         return false;
     }

--- a/interface/wx/toplevel.h
+++ b/interface/wx/toplevel.h
@@ -649,6 +649,10 @@ public:
         @param enable
             If @true (default) make the zoom button toggle full screen;
             if @false the button does only toggle zoom.
+        @param style
+            This parameter sets which elements will be hidden when the
+            user presses the full screen button. See ShowFullScreen()
+            for possible values. It is available since wxWidgets 3.1.6.
 
         @return @true if the button behaviour has been changed, @false if running
         under another OS.
@@ -658,6 +662,8 @@ public:
         and entering and exiting the mode is animated.
         If the button is not present the old way of switching to full screen
         is used.
+        Only @c ::wxFULLSCREEN_NOTOOLBAR and @c ::wxFULLSCREEN_NOMENUBAR will be
+        used when using the fullscreen API (other values are ignored).
 
         @onlyfor{wxosx}
 
@@ -665,7 +671,7 @@ public:
 
         @since 3.1.0
     */
-    virtual bool EnableFullScreenView(bool enable = true);
+    virtual bool EnableFullScreenView(bool enable = true, long style = wxFULLSCREEN_ALL);
 
     /**
         Depending on the value of @a show parameter the window is either shown

--- a/src/osx/iphone/nonownedwnd.mm
+++ b/src/osx/iphone/nonownedwnd.mm
@@ -284,7 +284,7 @@ bool wxNonOwnedWindowIPhoneImpl::IsFullScreen() const
     return m_macFullScreenData != NULL ;
 }
 
-bool wxNonOwnedWindowIPhoneImpl::EnableFullScreenView(bool WXUNUSED(enable))
+bool wxNonOwnedWindowIPhoneImpl::EnableFullScreenView(bool WXUNUSED(enable), long WXUNUSED(style))
 {
     return true;
 }

--- a/src/osx/toplevel_osx.cpp
+++ b/src/osx/toplevel_osx.cpp
@@ -181,9 +181,9 @@ void wxTopLevelWindowMac::ShowWithoutActivating()
     SendSizeEvent();
 }
 
-bool wxTopLevelWindowMac::EnableFullScreenView(bool enable)
+bool wxTopLevelWindowMac::EnableFullScreenView(bool enable, long style)
 {
-    return m_nowpeer->EnableFullScreenView(enable);
+    return m_nowpeer->EnableFullScreenView(enable, style);
 }
 
 bool wxTopLevelWindowMac::ShowFullScreen(bool show, long style)


### PR DESCRIPTION
When using the native fullscreen API by enabling `EnableFullScrenView()`
allow using hiding (or showing) menu and/or toolbar. An additional style
parameter has been added to `EnableFullScrenView()` to allow customizing
which style is applied when the user presses the fullscreen button
instead of a call to `ShowFullScreen()`.

As an example the webview sample previously would still have the toolbar visible in fullscreen. It now auto hides which is the common behaviour for macOS apps (yet it isn't the system default API behavior).