### PR TITLE
Allow RFC822 timestamps without a week day

### DIFF
--- a/src/common/datetimefmt.cpp
+++ b/src/common/datetimefmt.cpp
@@ -754,17 +754,22 @@ wxDateTime::ParseRfc822Date(const wxString& originalDate, wxString::const_iterat
     const wxString::const_iterator pEnd = date.end();
     wxString::const_iterator p = date.begin();
 
-    // 1. week day
-    const wxDateTime::WeekDay
-        wd = GetWeekDayFromName(p, pEnd, Name_Abbr, DateLang_English);
-    if ( wd == Inv_WeekDay )
-        return false;
-    //else: ignore week day for now, we could also check that it really
-    //      corresponds to the specified date
+    // 1. week day (optional)
+    // if there is a week day present, it must be separated
+    // by a comma at position [3].
+    if ( date.Length() > 3 && date[3] == ',' )
+    {
+        const wxDateTime::WeekDay
+            wd = GetWeekDayFromName(p, pEnd, Name_Abbr, DateLang_English);
+        if ( wd == Inv_WeekDay )
+            return false;
+        //else: ignore week day for now, we could also check that it really
+        //      corresponds to the specified date
 
-    // 2. separating comma
-    if ( *p++ != ',' || *p++ != ' ' )
-        return false;
+        // 2. separating comma
+        if ( *p++ != ',' || *p++ != ' ' )
+            return false;
+    }
 
     // 3. day number
     if ( !wxIsdigit(*p) )

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -1093,6 +1093,13 @@ void DateTimeTestCase::TestParseRFC822()
             true
         },
 
+        // day of week is optional according to the RFC
+        {
+            "18 Dec 1999 10:48:30 -0500",
+            { 18, wxDateTime::Dec, 1999, 15, 48, 30 },
+            true
+        },
+
         // try some bogus ones too
         {
             "Sun, 01 Jun 2008 16:30: +0200",


### PR DESCRIPTION
RFC 822 specifies the week day is optional.