### PR TITLE
Remove errant null check in WindowHDC destructor

### DIFF
--- a/include/wx/msw/private.h
+++ b/include/wx/msw/private.h
@@ -443,7 +443,7 @@ class WindowHDC
 public:
     WindowHDC() : m_hwnd(NULL), m_hdc(NULL) { }
     WindowHDC(HWND hwnd) { m_hdc = ::GetDC(m_hwnd = hwnd); }
-   ~WindowHDC() { if ( m_hwnd && m_hdc ) { ::ReleaseDC(m_hwnd, m_hdc); } }
+   ~WindowHDC() { if ( m_hdc ) { ::ReleaseDC(m_hwnd, m_hdc); } }
 
     operator HDC() const { return m_hdc; }
 


### PR DESCRIPTION
null handles passed to GetDC are completely valid and a GDI DC pointing to the screen is returned that still needs cleanup by ReleaseDC

Fixes #22193 https://github.com/wxWidgets/wxWidgets/issues/22193