### PR TITLE
Keep ClientData when Clone() classes that inherit from wxClientDataContainer

### DIFF
--- a/include/wx/clntdata.h
+++ b/include/wx/clntdata.h
@@ -161,7 +161,7 @@ protected:
 
 // This class is a replacement for wxClientDataContainer, and unlike
 // wxClientDataContainer the wxSharedClientDataContainer client data is
-// copyable, so it can be copied when objects containing it are cloned.
+// copiable, so it can be copied when objects containing it are cloned.
 // Like wxClientDataContainer, wxSharedClientDataContainer is a mixin
 // that provides storage and management of "client data.". The client data
 // is reference counted and managed by the container.

--- a/include/wx/clntdata.h
+++ b/include/wx/clntdata.h
@@ -161,7 +161,7 @@ protected:
 
 // This class is a replacement for wxClientDataContainer, and unlike
 // wxClientDataContainer the wxSharedClientDataContainer client data is
-// possible to copy (as a shared ptr) when instances of it are cloned.
+// copyable, so it can be copied when objects containing it are cloned.
 // Like wxClientDataContainer, wxSharedClientDataContainer is a mixin
 // that provides storage and management of "client data.". The client data
 // is reference counted and managed by the container.
@@ -172,15 +172,17 @@ protected:
 class WXDLLIMPEXP_BASE wxSharedClientDataContainer
 {
 public:
+    // Provide the same functions as in wxClientDataContainer, so that objects
+    // using it and this class could be used in exactly the same way.
     void SetClientObject(wxClientData *data);
     wxClientData *GetClientObject() const;
     void SetClientData(void *data);
     void *GetClientData() const;
 
 protected:
-    bool HasClientDataContainer() const {return NULL != m_data.get();}
-    wxSharedPtr<wxClientDataContainer> GetClientDataContainer() const {return m_data;}
-    void SetClientDataContainer(wxSharedPtr<wxClientDataContainer> data) {m_data = data;}
+    bool HasClientDataContainer() const { return m_data.get() != NULL; }
+    wxSharedPtr<wxClientDataContainer> GetClientDataContainer() const { return m_data; }
+    void SetClientDataContainer(wxSharedPtr<wxClientDataContainer> data) { m_data = data; }
 
 private:
     //Helper function that will create m_data if it is currently NULL

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -137,7 +137,7 @@ class wxGridDirectionOperations;
 //     class is not documented and is not public at all
 // ----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxGridCellWorker : public wxClientDataContainer, public wxRefCounter
+class WXDLLIMPEXP_CORE wxGridCellWorker : public wxSharedClientDataContainer, public wxRefCounter
 {
 public:
     wxGridCellWorker() { }
@@ -704,7 +704,7 @@ private:
 // class may be returned by wxGridTable::GetAttr().
 // ----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxGridCellAttr : public wxClientDataContainer, public wxRefCounter
+class WXDLLIMPEXP_CORE wxGridCellAttr : public wxSharedClientDataContainer, public wxRefCounter
 {
 public:
     enum wxAttrKind

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -140,10 +140,8 @@ class wxGridDirectionOperations;
 class WXDLLIMPEXP_CORE wxGridCellWorker : public wxSharedClientDataContainer, public wxRefCounter
 {
 public:
-    // default ctor
     wxGridCellWorker() {}
 
-    // copy ctor
     wxGridCellWorker(const wxGridCellWorker& other);
 
     // interpret renderer parameters: arbitrary string whose interpretation is
@@ -172,13 +170,11 @@ private:
 class WXDLLIMPEXP_CORE wxGridCellRenderer : public wxGridCellWorker
 {
 public:
-    // default ctor
     wxGridCellRenderer()
         : wxGridCellWorker()
     {
     }
 
-    // copy ctor
     wxGridCellRenderer(const wxGridCellRenderer& other)
         : wxGridCellWorker(other)
     {
@@ -391,7 +387,6 @@ private:
 class WXDLLIMPEXP_CORE wxGridCellEditor : public wxGridCellWorker
 {
 public:
-    // default ctor
     wxGridCellEditor()
         : wxGridCellWorker(),
           m_control(NULL),
@@ -399,7 +394,6 @@ public:
     {
     }
 
-    // copy ctor
     wxGridCellEditor(const wxGridCellEditor& other);
 
     bool IsCreated() const { return m_control != NULL; }
@@ -557,13 +551,11 @@ typedef wxObjectDataPtr<wxGridCellEditor> wxGridCellEditorPtr;
 class wxGridCellActivatableEditor : public wxGridCellEditor
 {
 public:
-    // default ctor
     wxGridCellActivatableEditor()
         : wxGridCellEditor()
     {
     }
 
-    // copy ctor
     wxGridCellActivatableEditor(const wxGridCellActivatableEditor& other)
         : wxGridCellEditor(other)
     {

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -140,7 +140,11 @@ class wxGridDirectionOperations;
 class WXDLLIMPEXP_CORE wxGridCellWorker : public wxSharedClientDataContainer, public wxRefCounter
 {
 public:
-    wxGridCellWorker() { }
+    // default ctor
+    wxGridCellWorker() {}
+
+    // copy ctor
+    wxGridCellWorker(const wxGridCellWorker& other);
 
     // interpret renderer parameters: arbitrary string whose interpretation is
     // left to the derived classes
@@ -168,6 +172,18 @@ private:
 class WXDLLIMPEXP_CORE wxGridCellRenderer : public wxGridCellWorker
 {
 public:
+    // default ctor
+    wxGridCellRenderer()
+        : wxGridCellWorker()
+    {
+    }
+
+    // copy ctor
+    wxGridCellRenderer(const wxGridCellRenderer& other)
+        : wxGridCellWorker(other)
+    {
+    }
+
     // draw the given cell on the provided DC inside the given rectangle
     // using the style specified by the attribute and the default or selected
     // state corresponding to the isSelected value.
@@ -375,7 +391,24 @@ private:
 class WXDLLIMPEXP_CORE wxGridCellEditor : public wxGridCellWorker
 {
 public:
-    wxGridCellEditor();
+    // default ctor
+    wxGridCellEditor()
+        : wxGridCellWorker(),
+          m_control(NULL),
+          m_attr(NULL)
+    {
+    }
+
+    // copy ctor
+    wxGridCellEditor(const wxGridCellEditor& other)
+        : wxGridCellWorker(other),
+          m_control(other.m_control),
+          m_attr(other.m_attr),
+          m_colFgOld(other.m_colFgOld),
+          m_colBgOld(other.m_colBgOld),
+          m_fontOld(other.m_fontOld)
+    {
+    }
 
     bool IsCreated() const { return m_control != NULL; }
 
@@ -523,8 +556,6 @@ protected:
     // suppress the stupid gcc warning about the class having private dtor and
     // no friends
     friend class wxGridCellEditorDummyFriend;
-
-    wxDECLARE_NO_COPY_CLASS(wxGridCellEditor);
 };
 
 // Smart pointer to wxGridCellEditor, calling DecRef() on it automatically.
@@ -534,6 +565,18 @@ typedef wxObjectDataPtr<wxGridCellEditor> wxGridCellEditorPtr;
 class wxGridCellActivatableEditor : public wxGridCellEditor
 {
 public:
+    // default ctor
+    wxGridCellActivatableEditor()
+        : wxGridCellEditor()
+    {
+    }
+
+    // copy ctor
+    wxGridCellActivatableEditor(const wxGridCellActivatableEditor& other)
+        : wxGridCellEditor(other)
+    {
+    }
+
     // In this class these methods must be overridden.
     virtual wxGridActivationResult
     TryActivate(int row, int col, wxGrid* grid,

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -400,15 +400,7 @@ public:
     }
 
     // copy ctor
-    wxGridCellEditor(const wxGridCellEditor& other)
-        : wxGridCellWorker(other),
-          m_control(other.m_control),
-          m_attr(other.m_attr),
-          m_colFgOld(other.m_colFgOld),
-          m_colBgOld(other.m_colBgOld),
-          m_fontOld(other.m_fontOld)
-    {
-    }
+    wxGridCellEditor(const wxGridCellEditor& other);
 
     bool IsCreated() const { return m_control != NULL; }
 

--- a/include/wx/generic/gridctrl.h
+++ b/include/wx/generic/gridctrl.h
@@ -23,13 +23,11 @@
 class WXDLLIMPEXP_ADV wxGridCellStringRenderer : public wxGridCellRenderer
 {
 public:
-    // default ctor
     wxGridCellStringRenderer()
         : wxGridCellRenderer()
     {
     }
 
-    // copy ctor
     wxGridCellStringRenderer(const wxGridCellStringRenderer& other)
         : wxGridCellRenderer(other)
     {
@@ -71,7 +69,6 @@ public:
     {
     }
 
-    // copy ctor
     wxGridCellNumberRenderer(const wxGridCellNumberRenderer& other)
         : wxGridCellStringRenderer(other),
           m_minValue(other.m_minValue),
@@ -116,7 +113,6 @@ public:
                             int precision = -1,
                             int format = wxGRID_FLOAT_FORMAT_DEFAULT);
 
-    // copy ctor
     wxGridCellFloatRenderer(const wxGridCellFloatRenderer& other)
         : wxGridCellStringRenderer(other),
           m_width(other.m_width),
@@ -170,13 +166,11 @@ private:
 class WXDLLIMPEXP_ADV wxGridCellBoolRenderer : public wxGridCellRenderer
 {
 public:
-    // default ctor
     wxGridCellBoolRenderer()
         : wxGridCellRenderer()
     {
     }
 
-    // copy ctor
     wxGridCellBoolRenderer(const wxGridCellBoolRenderer& other)
         : wxGridCellRenderer(other)
     {
@@ -217,7 +211,6 @@ class WXDLLIMPEXP_ADV wxGridCellDateRenderer : public wxGridCellStringRenderer
 public:
     explicit wxGridCellDateRenderer(const wxString& outformat = wxString());
 
-    // copy ctor
     wxGridCellDateRenderer(const wxGridCellDateRenderer& other)
         : wxGridCellStringRenderer(other),
           m_oformat(other.m_oformat),
@@ -271,7 +264,6 @@ public:
     {
     }
 
-    // copy ctor
     wxGridCellDateTimeRenderer(const wxGridCellDateTimeRenderer& other)
         : wxGridCellDateRenderer(other),
           m_iformat(other.m_iformat)
@@ -297,7 +289,6 @@ class WXDLLIMPEXP_ADV wxGridCellChoiceRenderer : public wxGridCellStringRenderer
 public:
     wxGridCellChoiceRenderer( const wxString& choices = wxEmptyString );
 
-    // copy ctor
     wxGridCellChoiceRenderer(const wxGridCellChoiceRenderer& other);
 
     virtual wxSize GetMaxBestSize(wxGrid& grid,
@@ -320,13 +311,11 @@ protected:
 class WXDLLIMPEXP_ADV wxGridCellEnumRenderer : public wxGridCellChoiceRenderer
 {
 public:
-    // default ctor
     wxGridCellEnumRenderer( const wxString& choices = wxEmptyString )
         : wxGridCellChoiceRenderer(choices)
     {
     }
 
-    // copy ctor
     wxGridCellEnumRenderer(const wxGridCellEnumRenderer& other)
         : wxGridCellChoiceRenderer(other)
     {
@@ -356,13 +345,11 @@ protected:
 class WXDLLIMPEXP_ADV wxGridCellAutoWrapStringRenderer : public wxGridCellStringRenderer
 {
 public:
-    // default ctor
     wxGridCellAutoWrapStringRenderer()
         : wxGridCellStringRenderer()
     {
     }
 
-    // copy ctor
     wxGridCellAutoWrapStringRenderer(const wxGridCellAutoWrapStringRenderer& other)
         : wxGridCellStringRenderer(other)
     {

--- a/include/wx/generic/gridctrl.h
+++ b/include/wx/generic/gridctrl.h
@@ -63,8 +63,8 @@ protected:
 class WXDLLIMPEXP_ADV wxGridCellNumberRenderer : public wxGridCellStringRenderer
 {
 public:
-    wxGridCellNumberRenderer(long minValue = LONG_MIN,
-                             long maxValue = LONG_MAX)
+    explicit wxGridCellNumberRenderer(long minValue = LONG_MIN,
+                                      long maxValue = LONG_MAX)
         : wxGridCellStringRenderer(),
           m_minValue(minValue),
           m_maxValue(maxValue)

--- a/include/wx/generic/gridctrl.h
+++ b/include/wx/generic/gridctrl.h
@@ -23,6 +23,18 @@
 class WXDLLIMPEXP_ADV wxGridCellStringRenderer : public wxGridCellRenderer
 {
 public:
+    // default ctor
+    wxGridCellStringRenderer()
+        : wxGridCellRenderer()
+    {
+    }
+
+    // copy ctor
+    wxGridCellStringRenderer(const wxGridCellStringRenderer& other)
+        : wxGridCellRenderer(other)
+    {
+    }
+
     // draw the string
     virtual void Draw(wxGrid& grid,
                       wxGridCellAttr& attr,
@@ -37,7 +49,8 @@ public:
                                wxDC& dc,
                                int row, int col) wxOVERRIDE;
 
-    virtual wxGridCellRenderer *Clone() const wxOVERRIDE;
+    virtual wxGridCellRenderer *Clone() const wxOVERRIDE
+        { return new wxGridCellStringRenderer(*this); }
 
 protected:
     // calc the string extent for given string/font
@@ -50,10 +63,19 @@ protected:
 class WXDLLIMPEXP_ADV wxGridCellNumberRenderer : public wxGridCellStringRenderer
 {
 public:
-    explicit wxGridCellNumberRenderer(long minValue = LONG_MIN,
-                                      long maxValue = LONG_MAX)
-        : m_minValue(minValue),
+    wxGridCellNumberRenderer(long minValue = LONG_MIN,
+                             long maxValue = LONG_MAX)
+        : wxGridCellStringRenderer(),
+          m_minValue(minValue),
           m_maxValue(maxValue)
+    {
+    }
+
+    // copy ctor
+    wxGridCellNumberRenderer(const wxGridCellNumberRenderer& other)
+        : wxGridCellStringRenderer(other),
+          m_minValue(other.m_minValue),
+          m_maxValue(other.m_maxValue)
     {
     }
 
@@ -77,7 +99,8 @@ public:
     // Optional parameters for this renderer are "<min>,<max>".
     virtual void SetParameters(const wxString& params) wxOVERRIDE;
 
-    virtual wxGridCellRenderer *Clone() const wxOVERRIDE;
+    virtual wxGridCellRenderer *Clone() const wxOVERRIDE
+        { return new wxGridCellNumberRenderer(*this); }
 
 protected:
     wxString GetString(const wxGrid& grid, int row, int col);
@@ -92,6 +115,16 @@ public:
     wxGridCellFloatRenderer(int width = -1,
                             int precision = -1,
                             int format = wxGRID_FLOAT_FORMAT_DEFAULT);
+
+    // copy ctor
+    wxGridCellFloatRenderer(const wxGridCellFloatRenderer& other)
+        : wxGridCellStringRenderer(other),
+          m_width(other.m_width),
+          m_precision(other.m_precision),
+          m_style(other.m_style),
+          m_format(other.m_format)
+    {
+    }
 
     // get/change formatting parameters
     int GetWidth() const { return m_width; }
@@ -118,7 +151,8 @@ public:
     // with format being one of f|e|g|E|F|G
     virtual void SetParameters(const wxString& params) wxOVERRIDE;
 
-    virtual wxGridCellRenderer *Clone() const wxOVERRIDE;
+    virtual wxGridCellRenderer *Clone() const wxOVERRIDE
+        { return new wxGridCellFloatRenderer(*this); }
 
 protected:
     wxString GetString(const wxGrid& grid, int row, int col);
@@ -136,6 +170,18 @@ private:
 class WXDLLIMPEXP_ADV wxGridCellBoolRenderer : public wxGridCellRenderer
 {
 public:
+    // default ctor
+    wxGridCellBoolRenderer()
+        : wxGridCellRenderer()
+    {
+    }
+
+    // copy ctor
+    wxGridCellBoolRenderer(const wxGridCellBoolRenderer& other)
+        : wxGridCellRenderer(other)
+    {
+    }
+
     // draw a check mark or nothing
     virtual void Draw(wxGrid& grid,
                       wxGridCellAttr& attr,
@@ -154,7 +200,8 @@ public:
                                   wxGridCellAttr& attr,
                                   wxDC& dc) wxOVERRIDE;
 
-    virtual wxGridCellRenderer *Clone() const wxOVERRIDE;
+    virtual wxGridCellRenderer *Clone() const wxOVERRIDE
+        { return new wxGridCellBoolRenderer(*this); }
 };
 
 
@@ -170,7 +217,13 @@ class WXDLLIMPEXP_ADV wxGridCellDateRenderer : public wxGridCellStringRenderer
 public:
     explicit wxGridCellDateRenderer(const wxString& outformat = wxString());
 
-    wxGridCellDateRenderer(const wxGridCellDateRenderer& other);
+    // copy ctor
+    wxGridCellDateRenderer(const wxGridCellDateRenderer& other)
+        : wxGridCellStringRenderer(other),
+          m_oformat(other.m_oformat),
+          m_tz(other.m_tz)
+    {
+    }
 
     // draw the string right aligned
     virtual void Draw(wxGrid& grid,
@@ -189,7 +242,8 @@ public:
                                   wxGridCellAttr& attr,
                                   wxDC& dc) wxOVERRIDE;
 
-    virtual wxGridCellRenderer *Clone() const wxOVERRIDE;
+    virtual wxGridCellRenderer *Clone() const wxOVERRIDE
+        { return new wxGridCellDateRenderer(*this); }
 
     // output strptime()-like format string
     virtual void SetParameters(const wxString& params) wxOVERRIDE;
@@ -211,11 +265,21 @@ class WXDLLIMPEXP_ADV wxGridCellDateTimeRenderer : public wxGridCellDateRenderer
 {
 public:
     wxGridCellDateTimeRenderer(const wxString& outformat = wxASCII_STR(wxDefaultDateTimeFormat),
-                               const wxString& informat = wxASCII_STR(wxDefaultDateTimeFormat));
+                               const wxString& informat = wxASCII_STR(wxDefaultDateTimeFormat))
+        : wxGridCellDateRenderer(outformat),
+          m_iformat(informat)
+    {
+    }
 
-    wxGridCellDateTimeRenderer(const wxGridCellDateTimeRenderer& other);
+    // copy ctor
+    wxGridCellDateTimeRenderer(const wxGridCellDateTimeRenderer& other)
+        : wxGridCellDateRenderer(other),
+          m_iformat(other.m_iformat)
+    {
+    }
 
-    virtual wxGridCellRenderer *Clone() const wxOVERRIDE;
+    virtual wxGridCellRenderer *Clone() const wxOVERRIDE
+        { return new wxGridCellDateTimeRenderer(*this); }
 
 protected:
     virtual void
@@ -231,7 +295,10 @@ protected:
 class WXDLLIMPEXP_ADV wxGridCellChoiceRenderer : public wxGridCellStringRenderer
 {
 public:
-    wxGridCellChoiceRenderer() { }
+    wxGridCellChoiceRenderer( const wxString& choices = wxEmptyString );
+
+    // copy ctor
+    wxGridCellChoiceRenderer(const wxGridCellChoiceRenderer& other);
 
     virtual wxSize GetMaxBestSize(wxGrid& grid,
                                   wxGridCellAttr& attr,
@@ -241,12 +308,10 @@ public:
     virtual void SetParameters(const wxString& params) wxOVERRIDE;
 
     virtual wxGridCellRenderer *Clone() const wxOVERRIDE
-    {
-        return new wxGridCellChoiceRenderer(*this);
-    }
+        { return new wxGridCellChoiceRenderer(*this); }
 
 protected:
-    wxGridCellChoiceRenderer(const wxGridCellChoiceRenderer& other);
+    wxString GetString(const wxGrid& grid, int row, int col);
 
     wxArrayString m_choices;
 };
@@ -256,7 +321,17 @@ protected:
 class WXDLLIMPEXP_ADV wxGridCellEnumRenderer : public wxGridCellChoiceRenderer
 {
 public:
-    wxGridCellEnumRenderer( const wxString& choices = wxEmptyString );
+    // default ctor
+    wxGridCellEnumRenderer( const wxString& choices = wxEmptyString )
+        : wxGridCellChoiceRenderer(choices)
+    {
+    }
+
+    // copy ctor
+    wxGridCellEnumRenderer(const wxGridCellEnumRenderer& other)
+        : wxGridCellChoiceRenderer(other)
+    {
+    }
 
     // draw the string right aligned
     virtual void Draw(wxGrid& grid,
@@ -271,17 +346,25 @@ public:
                                wxDC& dc,
                                int row, int col) wxOVERRIDE;
 
-    virtual wxGridCellRenderer *Clone() const wxOVERRIDE;
-
-protected:
-    wxString GetString(const wxGrid& grid, int row, int col);
+    virtual wxGridCellRenderer *Clone() const wxOVERRIDE
+        { return new wxGridCellEnumRenderer(*this); }
 };
 
 
 class WXDLLIMPEXP_ADV wxGridCellAutoWrapStringRenderer : public wxGridCellStringRenderer
 {
 public:
-    wxGridCellAutoWrapStringRenderer() : wxGridCellStringRenderer() { }
+    // default ctor
+    wxGridCellAutoWrapStringRenderer()
+        : wxGridCellStringRenderer()
+    {
+    }
+
+    // copy ctor
+    wxGridCellAutoWrapStringRenderer(const wxGridCellAutoWrapStringRenderer& other)
+        : wxGridCellStringRenderer(other)
+    {
+    }
 
     virtual void Draw(wxGrid& grid,
                       wxGridCellAttr& attr,
@@ -307,7 +390,8 @@ public:
                               int row, int col,
                               int height) wxOVERRIDE;
 
-    virtual wxGridCellRenderer *Clone() const wxOVERRIDE;
+    virtual wxGridCellRenderer *Clone() const wxOVERRIDE
+        { return new wxGridCellAutoWrapStringRenderer(*this); }
 
 private:
     wxArrayString GetTextLines( wxGrid& grid,

--- a/include/wx/generic/gridctrl.h
+++ b/include/wx/generic/gridctrl.h
@@ -311,7 +311,6 @@ public:
         { return new wxGridCellChoiceRenderer(*this); }
 
 protected:
-    wxString GetString(const wxGrid& grid, int row, int col);
 
     wxArrayString m_choices;
 };
@@ -348,6 +347,9 @@ public:
 
     virtual wxGridCellRenderer *Clone() const wxOVERRIDE
         { return new wxGridCellEnumRenderer(*this); }
+
+protected:
+    wxString GetString(const wxGrid& grid, int row, int col);
 };
 
 

--- a/include/wx/generic/gridctrl.h
+++ b/include/wx/generic/gridctrl.h
@@ -37,8 +37,7 @@ public:
                                wxDC& dc,
                                int row, int col) wxOVERRIDE;
 
-    virtual wxGridCellRenderer *Clone() const wxOVERRIDE
-        { return new wxGridCellStringRenderer; }
+    virtual wxGridCellRenderer *Clone() const wxOVERRIDE;
 
 protected:
     // calc the string extent for given string/font
@@ -78,8 +77,7 @@ public:
     // Optional parameters for this renderer are "<min>,<max>".
     virtual void SetParameters(const wxString& params) wxOVERRIDE;
 
-    virtual wxGridCellRenderer *Clone() const wxOVERRIDE
-        { return new wxGridCellNumberRenderer(m_minValue, m_maxValue); }
+    virtual wxGridCellRenderer *Clone() const wxOVERRIDE;
 
 protected:
     wxString GetString(const wxGrid& grid, int row, int col);
@@ -156,8 +154,7 @@ public:
                                   wxGridCellAttr& attr,
                                   wxDC& dc) wxOVERRIDE;
 
-    virtual wxGridCellRenderer *Clone() const wxOVERRIDE
-        { return new wxGridCellBoolRenderer; }
+    virtual wxGridCellRenderer *Clone() const wxOVERRIDE;
 };
 
 
@@ -173,11 +170,7 @@ class WXDLLIMPEXP_ADV wxGridCellDateRenderer : public wxGridCellStringRenderer
 public:
     explicit wxGridCellDateRenderer(const wxString& outformat = wxString());
 
-    wxGridCellDateRenderer(const wxGridCellDateRenderer& other)
-        : m_oformat(other.m_oformat),
-          m_tz(other.m_tz)
-    {
-    }
+    wxGridCellDateRenderer(const wxGridCellDateRenderer& other);
 
     // draw the string right aligned
     virtual void Draw(wxGrid& grid,
@@ -220,11 +213,7 @@ public:
     wxGridCellDateTimeRenderer(const wxString& outformat = wxASCII_STR(wxDefaultDateTimeFormat),
                                const wxString& informat = wxASCII_STR(wxDefaultDateTimeFormat));
 
-    wxGridCellDateTimeRenderer(const wxGridCellDateTimeRenderer& other)
-        : wxGridCellDateRenderer(other),
-          m_iformat(other.m_iformat)
-    {
-    }
+    wxGridCellDateTimeRenderer(const wxGridCellDateTimeRenderer& other);
 
     virtual wxGridCellRenderer *Clone() const wxOVERRIDE;
 
@@ -257,10 +246,7 @@ public:
     }
 
 protected:
-    wxGridCellChoiceRenderer(const wxGridCellChoiceRenderer& other)
-        : m_choices(other.m_choices)
-    {
-    }
+    wxGridCellChoiceRenderer(const wxGridCellChoiceRenderer& other);
 
     wxArrayString m_choices;
 };
@@ -321,8 +307,7 @@ public:
                               int row, int col,
                               int height) wxOVERRIDE;
 
-    virtual wxGridCellRenderer *Clone() const wxOVERRIDE
-        { return new wxGridCellAutoWrapStringRenderer; }
+    virtual wxGridCellRenderer *Clone() const wxOVERRIDE;
 
 private:
     wxArrayString GetTextLines( wxGrid& grid,

--- a/include/wx/generic/grideditors.h
+++ b/include/wx/generic/grideditors.h
@@ -128,8 +128,7 @@ public:
     // parameters string format is "min,max"
     virtual void SetParameters(const wxString& params) wxOVERRIDE;
 
-    virtual wxGridCellEditor *Clone() const wxOVERRIDE
-        { return new wxGridCellNumberEditor(m_min, m_max); }
+    virtual wxGridCellEditor *Clone() const wxOVERRIDE;
 
     // added GetValue so we can get the value which is in the control
     virtual wxString GetValue() const wxOVERRIDE;
@@ -208,8 +207,7 @@ public:
     virtual void Reset() wxOVERRIDE;
     virtual void StartingKey(wxKeyEvent& event) wxOVERRIDE;
 
-    virtual wxGridCellEditor *Clone() const wxOVERRIDE
-        { return new wxGridCellFloatEditor(m_width, m_precision); }
+    virtual wxGridCellEditor *Clone() const wxOVERRIDE;
 
     // parameters string format is "width[,precision[,format]]"
     // format to choose between f|e|g|E|G (f is used by default)
@@ -262,8 +260,7 @@ public:
     virtual void StartingClick() wxOVERRIDE;
     virtual void StartingKey(wxKeyEvent& event) wxOVERRIDE;
 
-    virtual wxGridCellEditor *Clone() const wxOVERRIDE
-        { return new wxGridCellBoolEditor; }
+    virtual wxGridCellEditor *Clone() const wxOVERRIDE;
 
     // added GetValue so we can get the value which is in the control, see
     // also UseStringValues()
@@ -379,8 +376,7 @@ public:
                         wxWindowID id,
                         wxEvtHandler* evtHandler) wxOVERRIDE;
 
-    virtual wxGridCellEditor *Clone() const wxOVERRIDE
-        { return new wxGridCellAutoWrapStringEditor; }
+    virtual wxGridCellEditor *Clone() const wxOVERRIDE;
 
     wxDECLARE_NO_COPY_CLASS(wxGridCellAutoWrapStringEditor);
 };

--- a/include/wx/generic/grideditors.h
+++ b/include/wx/generic/grideditors.h
@@ -55,7 +55,14 @@ private:
 class WXDLLIMPEXP_ADV wxGridCellTextEditor : public wxGridCellEditor
 {
 public:
-    explicit wxGridCellTextEditor(size_t maxChars = 0);
+    wxGridCellTextEditor(size_t maxChars = 0)
+        : wxGridCellEditor(),
+          m_maxChars(maxChars)
+    {
+    }
+
+    // copy ctor
+    wxGridCellTextEditor(const wxGridCellTextEditor& other);
 
     virtual void Create(wxWindow* parent,
                         wxWindowID id,
@@ -78,7 +85,8 @@ public:
     virtual void SetValidator(const wxValidator& validator);
 #endif
 
-    virtual wxGridCellEditor *Clone() const wxOVERRIDE;
+    virtual wxGridCellEditor *Clone() const wxOVERRIDE
+        { return new wxGridCellTextEditor(*this); }
 
     // added GetValue so we can get the value which is in the control
     virtual wxString GetValue() const wxOVERRIDE;
@@ -98,8 +106,6 @@ private:
     wxScopedPtr<wxValidator> m_validator;
 #endif
     wxString                 m_value;
-
-    wxDECLARE_NO_COPY_CLASS(wxGridCellTextEditor);
 };
 
 // the editor for numeric (long) data
@@ -108,7 +114,21 @@ class WXDLLIMPEXP_ADV wxGridCellNumberEditor : public wxGridCellTextEditor
 public:
     // allows to specify the range - if min == max == -1, no range checking is
     // done
-    wxGridCellNumberEditor(int min = -1, int max = -1);
+    wxGridCellNumberEditor(int min = -1, int max = -1)
+        : wxGridCellTextEditor(),
+          m_min(min),
+          m_max(max)
+    {
+    }
+
+    // copy ctor
+    wxGridCellNumberEditor(const wxGridCellNumberEditor& other)
+        : wxGridCellTextEditor(other),
+          m_min(other.m_min),
+          m_max(other.m_max),
+          m_value(other.m_value)
+    {
+    }
 
     virtual void Create(wxWindow* parent,
                         wxWindowID id,
@@ -128,7 +148,8 @@ public:
     // parameters string format is "min,max"
     virtual void SetParameters(const wxString& params) wxOVERRIDE;
 
-    virtual wxGridCellEditor *Clone() const wxOVERRIDE;
+    virtual wxGridCellEditor *Clone() const wxOVERRIDE
+        { return new wxGridCellNumberEditor(*this); }
 
     // added GetValue so we can get the value which is in the control
     virtual wxString GetValue() const wxOVERRIDE;
@@ -157,8 +178,6 @@ private:
         m_max;
 
     long m_value;
-
-    wxDECLARE_NO_COPY_CLASS(wxGridCellNumberEditor);
 };
 
 
@@ -192,7 +211,24 @@ class WXDLLIMPEXP_ADV wxGridCellFloatEditor : public wxGridCellTextEditor
 public:
     wxGridCellFloatEditor(int width = -1,
                           int precision = -1,
-                          int format = wxGRID_FLOAT_FORMAT_DEFAULT);
+                          int format = wxGRID_FLOAT_FORMAT_DEFAULT)
+        : wxGridCellTextEditor(),
+          m_width(width),
+          m_precision(precision),
+          m_style(format)
+    {
+    }
+
+    // copy ctor
+    wxGridCellFloatEditor(const wxGridCellFloatEditor& other)
+        : wxGridCellTextEditor(other),
+          m_width(other.m_width),
+          m_precision(other.m_precision),
+          m_value(other.m_value),
+          m_style(other.m_style),
+          m_format(other.m_format)
+    {
+    }
 
     virtual void Create(wxWindow* parent,
                         wxWindowID id,
@@ -207,7 +243,8 @@ public:
     virtual void Reset() wxOVERRIDE;
     virtual void StartingKey(wxKeyEvent& event) wxOVERRIDE;
 
-    virtual wxGridCellEditor *Clone() const wxOVERRIDE;
+    virtual wxGridCellEditor *Clone() const wxOVERRIDE
+        { return new wxGridCellFloatEditor(*this); }
 
     // parameters string format is "width[,precision[,format]]"
     // format to choose between f|e|g|E|G (f is used by default)
@@ -224,8 +261,6 @@ private:
 
     int m_style;
     wxString m_format;
-
-    wxDECLARE_NO_COPY_CLASS(wxGridCellFloatEditor);
 };
 
 #endif // wxUSE_TEXTCTRL
@@ -236,7 +271,18 @@ private:
 class WXDLLIMPEXP_ADV wxGridCellBoolEditor : public wxGridCellEditor
 {
 public:
-    wxGridCellBoolEditor() { }
+    // default ctor
+    wxGridCellBoolEditor()
+        : wxGridCellEditor()
+    {
+    }
+
+    // copy ctor
+    wxGridCellBoolEditor(const wxGridCellBoolEditor& other)
+        : wxGridCellEditor(other),
+          m_value(other.m_value)
+    {
+    }
 
     virtual wxGridActivationResult
     TryActivate(int row, int col, wxGrid* grid,
@@ -260,7 +306,8 @@ public:
     virtual void StartingClick() wxOVERRIDE;
     virtual void StartingKey(wxKeyEvent& event) wxOVERRIDE;
 
-    virtual wxGridCellEditor *Clone() const wxOVERRIDE;
+    virtual wxGridCellEditor *Clone() const wxOVERRIDE
+        { return new wxGridCellBoolEditor(*this); }
 
     // added GetValue so we can get the value which is in the control, see
     // also UseStringValues()
@@ -291,8 +338,6 @@ private:
     bool m_value;
 
     static wxString ms_stringValues[2];
-
-    wxDECLARE_NO_COPY_CLASS(wxGridCellBoolEditor);
 };
 
 #endif // wxUSE_CHECKBOX
@@ -307,8 +352,23 @@ public:
     wxGridCellChoiceEditor(size_t count = 0,
                            const wxString choices[] = NULL,
                            bool allowOthers = false);
+
     wxGridCellChoiceEditor(const wxArrayString& choices,
-                           bool allowOthers = false);
+                           bool allowOthers = false)
+        : wxGridCellEditor(),
+          m_choices(choices),
+          m_allowOthers(allowOthers)
+    {
+    }
+
+    // copy ctor
+    wxGridCellChoiceEditor(const wxGridCellChoiceEditor& other)
+        : wxGridCellEditor(other),
+          m_value(other.m_value),
+          m_choices(other.m_choices),
+          m_allowOthers(other.m_allowOthers)
+    {
+    }
 
     virtual void Create(wxWindow* parent,
                         wxWindowID id,
@@ -326,7 +386,8 @@ public:
     // parameters string format is "item1[,item2[...,itemN]]"
     virtual void SetParameters(const wxString& params) wxOVERRIDE;
 
-    virtual wxGridCellEditor *Clone() const wxOVERRIDE;
+    virtual wxGridCellEditor *Clone() const wxOVERRIDE
+        { return new wxGridCellChoiceEditor(*this); }
 
     // added GetValue so we can get the value which is in the control
     virtual wxString GetValue() const wxOVERRIDE;
@@ -339,8 +400,6 @@ protected:
     wxString        m_value;
     wxArrayString   m_choices;
     bool            m_allowOthers;
-
-    wxDECLARE_NO_COPY_CLASS(wxGridCellChoiceEditor);
 };
 
 #endif // wxUSE_COMBOBOX
@@ -351,9 +410,18 @@ class WXDLLIMPEXP_ADV wxGridCellEnumEditor : public wxGridCellChoiceEditor
 {
 public:
     wxGridCellEnumEditor( const wxString& choices = wxEmptyString );
+
+    // copy ctor
+    wxGridCellEnumEditor(const wxGridCellEnumEditor& other)
+        : wxGridCellChoiceEditor(other),
+          m_index(other.m_index)
+    {
+    }
+
     virtual ~wxGridCellEnumEditor() {}
 
-    virtual wxGridCellEditor*  Clone() const wxOVERRIDE;
+    virtual wxGridCellEditor* Clone() const wxOVERRIDE
+        { return new wxGridCellEnumEditor(*this); }
 
     virtual void BeginEdit(int row, int col, wxGrid* grid) wxOVERRIDE;
     virtual bool EndEdit(int row, int col, const wxGrid* grid,
@@ -362,8 +430,6 @@ public:
 
 private:
     long m_index;
-
-    wxDECLARE_NO_COPY_CLASS(wxGridCellEnumEditor);
 };
 
 #endif // wxUSE_COMBOBOX
@@ -371,14 +437,24 @@ private:
 class WXDLLIMPEXP_ADV wxGridCellAutoWrapStringEditor : public wxGridCellTextEditor
 {
 public:
-    wxGridCellAutoWrapStringEditor() : wxGridCellTextEditor() { }
+    // default ctor
+    wxGridCellAutoWrapStringEditor()
+        : wxGridCellTextEditor()
+    {
+    }
+
+    // copy ctor
+    wxGridCellAutoWrapStringEditor(const wxGridCellAutoWrapStringEditor& other)
+        : wxGridCellTextEditor(other)
+    {
+    }
+
     virtual void Create(wxWindow* parent,
                         wxWindowID id,
                         wxEvtHandler* evtHandler) wxOVERRIDE;
 
-    virtual wxGridCellEditor *Clone() const wxOVERRIDE;
-
-    wxDECLARE_NO_COPY_CLASS(wxGridCellAutoWrapStringEditor);
+    virtual wxGridCellEditor *Clone() const wxOVERRIDE
+        { return new wxGridCellAutoWrapStringEditor(*this); }
 };
 
 #if wxUSE_DATEPICKCTRL
@@ -386,7 +462,15 @@ public:
 class WXDLLIMPEXP_ADV wxGridCellDateEditor : public wxGridCellEditor
 {
 public:
-    explicit wxGridCellDateEditor(const wxString& format = wxString());
+    wxGridCellDateEditor(const wxString& format = wxString());
+
+    // copy ctor
+    wxGridCellDateEditor(const wxGridCellDateEditor& other)
+        : wxGridCellEditor(other),
+          m_value(other.m_value),
+          m_format(other.m_format)
+    {
+    }
 
     virtual void SetParameters(const wxString& params) wxOVERRIDE;
 
@@ -403,7 +487,8 @@ public:
 
     virtual void Reset() wxOVERRIDE;
 
-    virtual wxGridCellEditor *Clone() const wxOVERRIDE;
+    virtual wxGridCellEditor *Clone() const wxOVERRIDE
+        { return new wxGridCellDateEditor(*this); }
 
     virtual wxString GetValue() const wxOVERRIDE;
 
@@ -413,8 +498,6 @@ protected:
 private:
     wxDateTime m_value;
     wxString m_format;
-
-    wxDECLARE_NO_COPY_CLASS(wxGridCellDateEditor);
 };
 
 #endif // wxUSE_DATEPICKCTRL

--- a/include/wx/generic/grideditors.h
+++ b/include/wx/generic/grideditors.h
@@ -351,17 +351,17 @@ public:
     wxGridCellChoiceEditor(const wxArrayString& choices,
                            bool allowOthers = false)
         : wxGridCellEditor(),
+          m_choices(choices),
           m_allowOthers(allowOthers)
     {
-        m_choices = wxArrayString(choices);
     }
 
     wxGridCellChoiceEditor(const wxGridCellChoiceEditor& other)
         : wxGridCellEditor(other),
           m_value(other.m_value),
+          m_choices(other.m_choices),
           m_allowOthers(other.m_allowOthers)
     {
-        m_choices = wxArrayString(other.m_choices);
     }
 
     virtual void Create(wxWindow* parent,

--- a/include/wx/generic/grideditors.h
+++ b/include/wx/generic/grideditors.h
@@ -61,7 +61,6 @@ public:
     {
     }
 
-    // copy ctor
     wxGridCellTextEditor(const wxGridCellTextEditor& other);
 
     virtual void Create(wxWindow* parent,
@@ -121,7 +120,6 @@ public:
     {
     }
 
-    // copy ctor
     wxGridCellNumberEditor(const wxGridCellNumberEditor& other)
         : wxGridCellTextEditor(other),
           m_min(other.m_min),
@@ -219,7 +217,6 @@ public:
     {
     }
 
-    // copy ctor
     wxGridCellFloatEditor(const wxGridCellFloatEditor& other)
         : wxGridCellTextEditor(other),
           m_width(other.m_width),
@@ -271,13 +268,11 @@ private:
 class WXDLLIMPEXP_ADV wxGridCellBoolEditor : public wxGridCellEditor
 {
 public:
-    // default ctor
     wxGridCellBoolEditor()
         : wxGridCellEditor()
     {
     }
 
-    // copy ctor
     wxGridCellBoolEditor(const wxGridCellBoolEditor& other)
         : wxGridCellEditor(other),
           m_value(other.m_value)
@@ -361,7 +356,6 @@ public:
         m_choices = wxArrayString(choices);
     }
 
-    // copy ctor
     wxGridCellChoiceEditor(const wxGridCellChoiceEditor& other)
         : wxGridCellEditor(other),
           m_value(other.m_value),
@@ -411,7 +405,6 @@ class WXDLLIMPEXP_ADV wxGridCellEnumEditor : public wxGridCellChoiceEditor
 public:
     wxGridCellEnumEditor( const wxString& choices = wxEmptyString );
 
-    // copy ctor
     wxGridCellEnumEditor(const wxGridCellEnumEditor& other)
         : wxGridCellChoiceEditor(other),
           m_index(other.m_index)
@@ -437,13 +430,11 @@ private:
 class WXDLLIMPEXP_ADV wxGridCellAutoWrapStringEditor : public wxGridCellTextEditor
 {
 public:
-    // default ctor
     wxGridCellAutoWrapStringEditor()
         : wxGridCellTextEditor()
     {
     }
 
-    // copy ctor
     wxGridCellAutoWrapStringEditor(const wxGridCellAutoWrapStringEditor& other)
         : wxGridCellTextEditor(other)
     {
@@ -464,7 +455,6 @@ class WXDLLIMPEXP_ADV wxGridCellDateEditor : public wxGridCellEditor
 public:
     explicit wxGridCellDateEditor(const wxString& format = wxString());
 
-    // copy ctor
     wxGridCellDateEditor(const wxGridCellDateEditor& other)
         : wxGridCellEditor(other),
           m_value(other.m_value),

--- a/include/wx/generic/grideditors.h
+++ b/include/wx/generic/grideditors.h
@@ -55,7 +55,7 @@ private:
 class WXDLLIMPEXP_ADV wxGridCellTextEditor : public wxGridCellEditor
 {
 public:
-    wxGridCellTextEditor(size_t maxChars = 0)
+    explicit wxGridCellTextEditor(size_t maxChars = 0)
         : wxGridCellEditor(),
           m_maxChars(maxChars)
     {
@@ -356,18 +356,18 @@ public:
     wxGridCellChoiceEditor(const wxArrayString& choices,
                            bool allowOthers = false)
         : wxGridCellEditor(),
-          m_choices(choices),
           m_allowOthers(allowOthers)
     {
+        m_choices = wxArrayString(choices);
     }
 
     // copy ctor
     wxGridCellChoiceEditor(const wxGridCellChoiceEditor& other)
         : wxGridCellEditor(other),
           m_value(other.m_value),
-          m_choices(other.m_choices),
           m_allowOthers(other.m_allowOthers)
     {
+        m_choices = wxArrayString(other.m_choices);
     }
 
     virtual void Create(wxWindow* parent,
@@ -462,7 +462,7 @@ public:
 class WXDLLIMPEXP_ADV wxGridCellDateEditor : public wxGridCellEditor
 {
 public:
-    wxGridCellDateEditor(const wxString& format = wxString());
+    explicit wxGridCellDateEditor(const wxString& format = wxString());
 
     // copy ctor
     wxGridCellDateEditor(const wxGridCellDateEditor& other)

--- a/interface/wx/clntdata.h
+++ b/interface/wx/clntdata.h
@@ -64,10 +64,12 @@ public:
 
     This class is a replacement for @ref wxClientDataContainer, and unlike
     wxClientDataContainer the wxSharedClientDataContainer client data is
-    possible to copy (as a shared ptr) when instances of it are cloned.
+    copyable, so it can be copied when objects containing it are cloned.
     Like wxClientDataContainer, wxSharedClientDataContainer is a mixin
     that provides storage and management of "client data.". The client data
-    is reference counted and managed by the container.
+    is reference counted and managed by the container. As the client data
+    is a shared object, changing the client data used by any object changes
+    it for all other objects, too.
 
     @note If your class has a Clone function and needs to store client data,
           use wxSharedClientDataContainer and not wxClientDataContainer!
@@ -76,10 +78,14 @@ public:
     @category{containers}
 
     @see wxClientDataContainer, wxClientData
+    @since 3.1.7
 */
 class wxSharedClientDataContainer
 {
 public:
+    // Provide the same functions as in wxClientDataContainer, so that objects
+    // using it and this class could be used in exactly the same way.
+
     /**
         Get the untyped client data.
     */

--- a/interface/wx/clntdata.h
+++ b/interface/wx/clntdata.h
@@ -21,7 +21,7 @@
     @library{wxbase}
     @category{containers}
 
-    @see wxEvtHandler, wxClientData
+    @see wxSharedClientDataContainer, wxEvtHandler, wxClientData
 */
 class wxClientDataContainer
 {
@@ -36,6 +36,50 @@ public:
     */
     virtual ~wxClientDataContainer();
 
+    /**
+        Get the untyped client data.
+    */
+    void* GetClientData() const;
+
+    /**
+        Get a pointer to the client data object.
+    */
+    wxClientData* GetClientObject() const;
+
+    /**
+        Set the untyped client data.
+    */
+    void SetClientData(void* data);
+
+    /**
+        Set the client data object. Any previous object will be deleted.
+    */
+    void SetClientObject(wxClientData* data);
+};
+
+
+
+/**
+    @class wxSharedClientDataContainer
+
+    This class is a replacement for @ref wxClientDataContainer, and unlike
+    wxClientDataContainer the wxSharedClientDataContainer client data is
+    possible to copy (as a shared ptr) when instances of it are cloned.
+    Like wxClientDataContainer, wxSharedClientDataContainer is a mixin
+    that provides storage and management of "client data.". The client data
+    is reference counted and managed by the container.
+
+    @note If your class has a Clone function and needs to store client data,
+          use wxSharedClientDataContainer and not wxClientDataContainer!
+
+    @library{wxbase}
+    @category{containers}
+
+    @see wxClientDataContainer, wxClientData
+*/
+class wxSharedClientDataContainer
+{
+public:
     /**
         Get the untyped client data.
     */

--- a/interface/wx/clntdata.h
+++ b/interface/wx/clntdata.h
@@ -64,7 +64,7 @@ public:
 
     This class is a replacement for @ref wxClientDataContainer, and unlike
     wxClientDataContainer the wxSharedClientDataContainer client data is
-    copyable, so it can be copied when objects containing it are cloned.
+    copiable, so it can be copied when objects containing it are cloned.
     Like wxClientDataContainer, wxSharedClientDataContainer is a mixin
     that provides storage and management of "client data.". The client data
     is reference counted and managed by the container. As the client data

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -28,7 +28,7 @@
          wxGridCellFloatRenderer, wxGridCellNumberRenderer,
          wxGridCellStringRenderer
 */
-class wxGridCellRenderer : public wxClientDataContainer, public wxRefCounter
+class wxGridCellRenderer : public wxSharedClientDataContainer, public wxRefCounter
 {
 public:
     wxGridCellRenderer();
@@ -571,7 +571,7 @@ public:
          wxGridCellFloatEditor, wxGridCellNumberEditor,
          wxGridCellTextEditor, wxGridCellDateEditor
 */
-class wxGridCellEditor : public wxClientDataContainer, public wxRefCounter
+class wxGridCellEditor : public wxSharedClientDataContainer, public wxRefCounter
 {
 public:
     /**
@@ -1217,7 +1217,7 @@ public:
     @library{wxcore}
     @category{grid}
 */
-class wxGridCellAttr : public wxClientDataContainer, public wxRefCounter
+class wxGridCellAttr : public wxSharedClientDataContainer, public wxRefCounter
 {
 public:
     /**

--- a/src/common/clntdata.cpp
+++ b/src/common/clntdata.cpp
@@ -72,6 +72,35 @@ void *wxClientDataContainer::DoGetClientData() const
 }
 
 
+void wxSharedClientDataContainer::SetClientObject(wxClientData *data)
+{
+    GetValidClientData()->SetClientObject(data);
+}
+
+wxClientData *wxSharedClientDataContainer::GetClientObject() const
+{
+    return HasClientDataContainer() ? GetClientDataContainer()->GetClientObject() : NULL;
+}
+
+void wxSharedClientDataContainer::SetClientData(void *data)
+{
+    GetValidClientData()->SetClientData(data);
+}
+
+void *wxSharedClientDataContainer::GetClientData() const
+{
+    return HasClientDataContainer() ? GetClientDataContainer()->GetClientData() : NULL;
+}
+
+wxClientDataContainer *wxSharedClientDataContainer::GetValidClientData()
+{
+    if ( !HasClientDataContainer() )
+    {
+        m_data = new wxClientDataContainer;
+    }
+    return m_data.get();
+}
+
 // ----------------------------------------------------------------------------
 
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -445,8 +445,8 @@ wxGridCellAttr *wxGridCellAttr::Clone() const
         m_editor->IncRef();
     }
 
-    attr->SetClientDataContainer( GetClientDataContainer() );
- 
+    attr->SetClientDataContainer(GetClientDataContainer());
+
     if ( IsReadOnly() )
         attr->SetReadOnly();
 
@@ -489,7 +489,7 @@ void wxGridCellAttr::MergeWith(wxGridCellAttr *mergefrom)
     }
     if ( !HasClientDataContainer() && mergefrom->HasClientDataContainer() )
     {
-        SetClientDataContainer( mergefrom->GetClientDataContainer() );
+        SetClientDataContainer(mergefrom->GetClientDataContainer());
     }
     if ( !HasReadWriteMode() && mergefrom->HasReadWriteMode() )
         SetReadOnly(mergefrom->IsReadOnly());

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -253,6 +253,11 @@ int wxGridColumnOperations::GetFirstLine(const wxGrid *grid, wxGridWindow *gridW
 // wxGridCellRenderer and wxGridCellEditor managing ref counting
 // ----------------------------------------------------------------------------
 
+wxGridCellWorker::wxGridCellWorker(const wxGridCellWorker& other)
+{
+    SetClientDataContainer(other.GetClientDataContainer());
+}
+
 void wxGridCellWorker::SetParameters(const wxString& WXUNUSED(params))
 {
     // nothing to do

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -445,6 +445,8 @@ wxGridCellAttr *wxGridCellAttr::Clone() const
         m_editor->IncRef();
     }
 
+    attr->SetClientDataContainer( GetClientDataContainer() );
+ 
     if ( IsReadOnly() )
         attr->SetReadOnly();
 
@@ -484,6 +486,10 @@ void wxGridCellAttr::MergeWith(wxGridCellAttr *mergefrom)
     {
         m_editor =  mergefrom->m_editor;
         m_editor->IncRef();
+    }
+    if ( !HasClientDataContainer() && mergefrom->HasClientDataContainer() )
+    {
+        SetClientDataContainer( mergefrom->GetClientDataContainer() );
     }
     if ( !HasReadWriteMode() && mergefrom->HasReadWriteMode() )
         SetReadOnly(mergefrom->IsReadOnly());

--- a/src/generic/gridctrl.cpp
+++ b/src/generic/gridctrl.cpp
@@ -157,14 +157,8 @@ using namespace wxGridPrivate;
 
 // Enables a grid cell to display a formatted date
 
-wxGridCellDateRenderer::wxGridCellDateRenderer(const wxGridCellDateRenderer& other)
-    : m_oformat(other.m_oformat)
-    , m_tz(other.m_tz)
-{
-    SetClientDataContainer(other.GetClientDataContainer());
-}
-
 wxGridCellDateRenderer::wxGridCellDateRenderer(const wxString& outformat)
+    : wxGridCellStringRenderer()
 {
     if ( outformat.empty() )
     {
@@ -175,11 +169,6 @@ wxGridCellDateRenderer::wxGridCellDateRenderer(const wxString& outformat)
         m_oformat = outformat;
     }
     m_tz = wxDateTime::Local;
-}
-
-wxGridCellRenderer *wxGridCellDateRenderer::Clone() const
-{
-    return new wxGridCellDateRenderer(*this);
 }
 
 wxString wxGridCellDateRenderer::GetString(const wxGrid& grid, int row, int col)
@@ -254,26 +243,7 @@ void wxGridCellDateRenderer::SetParameters(const wxString& params)
         m_oformat=params;
 }
 
-
 // Enables a grid cell to display a formatted date and or time
-
-wxGridCellDateTimeRenderer::wxGridCellDateTimeRenderer(const wxString& outformat, const wxString& informat)
-    : wxGridCellDateRenderer(outformat)
-    , m_iformat(informat)
-{
-}
-
-wxGridCellDateTimeRenderer::wxGridCellDateTimeRenderer(const wxGridCellDateTimeRenderer& other)
-    : wxGridCellDateRenderer(other)
-    , m_iformat(other.m_iformat)
-{
-    //SetClientDataContainer(other.GetClientDataContainer()); //Not needed here, as it is also done in wxGridCellDateRenderer ctor
-}
-
-wxGridCellRenderer *wxGridCellDateTimeRenderer::Clone() const
-{
-    return new wxGridCellDateTimeRenderer(*this);
-}
 
 void
 wxGridCellDateTimeRenderer::GetDateParseParams(DateParseParams& params) const
@@ -287,10 +257,11 @@ wxGridCellDateTimeRenderer::GetDateParseParams(DateParseParams& params) const
 // wxGridCellChoiceRenderer
 // ----------------------------------------------------------------------------
 
-wxGridCellChoiceRenderer::wxGridCellChoiceRenderer(const wxGridCellChoiceRenderer& other)
-    : m_choices(other.m_choices)
+wxGridCellChoiceRenderer::wxGridCellChoiceRenderer(const wxString& choices)
+    : wxGridCellStringRenderer()
 {
-    SetClientDataContainer(other.GetClientDataContainer());
+    if (!choices.empty())
+        SetParameters(choices);
 }
 
 wxSize wxGridCellChoiceRenderer::GetMaxBestSize(wxGrid& WXUNUSED(grid),
@@ -321,30 +292,7 @@ void wxGridCellChoiceRenderer::SetParameters(const wxString& params)
     }
 }
 
-// ----------------------------------------------------------------------------
-// wxGridCellEnumRenderer
-// ----------------------------------------------------------------------------
-// Renders a number as a textual equivalent.
-// eg data in cell is 0,1,2 ... n the cell could be rendered as "John","Fred"..."Bob"
-
-
-wxGridCellEnumRenderer::wxGridCellEnumRenderer(const wxString& choices)
-{
-    if (!choices.empty())
-        SetParameters(choices);
-}
-
-wxGridCellRenderer *wxGridCellEnumRenderer::Clone() const
-{
-    wxGridCellEnumRenderer *renderer = new wxGridCellEnumRenderer;
-    renderer->m_choices = m_choices;
-
-    renderer->SetClientDataContainer(GetClientDataContainer());
-
-    return renderer;
-}
-
-wxString wxGridCellEnumRenderer::GetString(const wxGrid& grid, int row, int col)
+wxString wxGridCellChoiceRenderer::GetString(const wxGrid& grid, int row, int col)
 {
     wxGridTableBase *table = grid.GetTable();
     wxString text;
@@ -362,6 +310,13 @@ wxString wxGridCellEnumRenderer::GetString(const wxGrid& grid, int row, int col)
     //If we faild to parse string just show what we where given?
     return text;
 }
+
+// ----------------------------------------------------------------------------
+// wxGridCellEnumRenderer
+// ----------------------------------------------------------------------------
+// Renders a number as a textual equivalent.
+// eg data in cell is 0,1,2 ... n the cell could be rendered as "John","Fred"..."Bob"
+
 
 void wxGridCellEnumRenderer::Draw(wxGrid& grid,
                                    wxGridCellAttr& attr,
@@ -630,13 +585,6 @@ wxGridCellAutoWrapStringRenderer::GetBestWidth(wxGrid& grid,
     return width;
 }
 
-wxGridCellRenderer *wxGridCellAutoWrapStringRenderer::Clone() const
-{
-    wxGridCellAutoWrapStringRenderer *renderer = new wxGridCellAutoWrapStringRenderer;
-    renderer->SetClientDataContainer(GetClientDataContainer());
-    return renderer;
-}
-
 // ----------------------------------------------------------------------------
 // wxGridCellStringRenderer
 // ----------------------------------------------------------------------------
@@ -757,13 +705,6 @@ void wxGridCellStringRenderer::Draw(wxGrid& grid,
                            rect, attr);
 }
 
-wxGridCellRenderer *wxGridCellStringRenderer::Clone() const
-{
-    wxGridCellStringRenderer *renderer = new wxGridCellStringRenderer;
-    renderer->SetClientDataContainer(GetClientDataContainer());
-    return renderer;
-}
-
 // ----------------------------------------------------------------------------
 // wxGridCellNumberRenderer
 // ----------------------------------------------------------------------------
@@ -839,13 +780,6 @@ void wxGridCellNumberRenderer::SetParameters(const wxString& params)
     }
 }
 
-wxGridCellRenderer *wxGridCellNumberRenderer::Clone() const
-{
-    wxGridCellNumberRenderer *renderer = new wxGridCellNumberRenderer(m_minValue, m_maxValue);
-    renderer->SetClientDataContainer(GetClientDataContainer());
-    return renderer;
-}
-
 // ----------------------------------------------------------------------------
 // wxGridCellFloatRenderer
 // ----------------------------------------------------------------------------
@@ -853,23 +787,11 @@ wxGridCellRenderer *wxGridCellNumberRenderer::Clone() const
 wxGridCellFloatRenderer::wxGridCellFloatRenderer(int width,
                                                  int precision,
                                                  int format)
+    : wxGridCellStringRenderer()
 {
     SetWidth(width);
     SetPrecision(precision);
     SetFormat(format);
-}
-
-wxGridCellRenderer *wxGridCellFloatRenderer::Clone() const
-{
-    wxGridCellFloatRenderer *renderer = new wxGridCellFloatRenderer;
-    renderer->m_width = m_width;
-    renderer->m_precision = m_precision;
-    renderer->m_style = m_style;
-    renderer->m_format = m_format;
-
-    renderer->SetClientDataContainer(GetClientDataContainer());
-
-    return renderer;
 }
 
 wxString wxGridCellFloatRenderer::GetString(const wxGrid& grid, int row, int col)
@@ -1103,13 +1025,6 @@ void wxGridCellBoolRenderer::Draw(wxGrid& grid,
         flags |= wxCONTROL_CHECKED;
 
     wxRendererNative::Get().DrawCheckBox( &grid, dc, checkBoxRect, flags );
-}
-
-wxGridCellRenderer *wxGridCellBoolRenderer::Clone() const
-{
-    wxGridCellBoolRenderer *renderer = new wxGridCellBoolRenderer;
-    renderer->SetClientDataContainer(GetClientDataContainer());
-    return renderer;
 }
 
 #endif // wxUSE_GRID

--- a/src/generic/gridctrl.cpp
+++ b/src/generic/gridctrl.cpp
@@ -161,7 +161,7 @@ wxGridCellDateRenderer::wxGridCellDateRenderer(const wxGridCellDateRenderer& oth
     : m_oformat(other.m_oformat)
     , m_tz(other.m_tz)
 {
-    SetClientDataContainer( other.GetClientDataContainer() );
+    SetClientDataContainer(other.GetClientDataContainer());
 }
 
 wxGridCellDateRenderer::wxGridCellDateRenderer(const wxString& outformat)
@@ -267,7 +267,7 @@ wxGridCellDateTimeRenderer::wxGridCellDateTimeRenderer(const wxGridCellDateTimeR
     : wxGridCellDateRenderer(other)
     , m_iformat(other.m_iformat)
 {
-    //SetClientDataContainer( other.GetClientDataContainer() ); //Not needed here, as it is also done in wxGridCellDateRenderer ctor
+    //SetClientDataContainer(other.GetClientDataContainer()); //Not needed here, as it is also done in wxGridCellDateRenderer ctor
 }
 
 wxGridCellRenderer *wxGridCellDateTimeRenderer::Clone() const
@@ -290,7 +290,7 @@ wxGridCellDateTimeRenderer::GetDateParseParams(DateParseParams& params) const
 wxGridCellChoiceRenderer::wxGridCellChoiceRenderer(const wxGridCellChoiceRenderer& other)
     : m_choices(other.m_choices)
 {
-    SetClientDataContainer( other.GetClientDataContainer() );
+    SetClientDataContainer(other.GetClientDataContainer());
 }
 
 wxSize wxGridCellChoiceRenderer::GetMaxBestSize(wxGrid& WXUNUSED(grid),
@@ -339,7 +339,7 @@ wxGridCellRenderer *wxGridCellEnumRenderer::Clone() const
     wxGridCellEnumRenderer *renderer = new wxGridCellEnumRenderer;
     renderer->m_choices = m_choices;
 
-    renderer->SetClientDataContainer( GetClientDataContainer() );
+    renderer->SetClientDataContainer(GetClientDataContainer());
 
     return renderer;
 }
@@ -633,7 +633,7 @@ wxGridCellAutoWrapStringRenderer::GetBestWidth(wxGrid& grid,
 wxGridCellRenderer *wxGridCellAutoWrapStringRenderer::Clone() const
 {
     wxGridCellAutoWrapStringRenderer *renderer = new wxGridCellAutoWrapStringRenderer;
-    renderer->SetClientDataContainer( GetClientDataContainer() );
+    renderer->SetClientDataContainer(GetClientDataContainer());
     return renderer;
 }
 
@@ -760,7 +760,7 @@ void wxGridCellStringRenderer::Draw(wxGrid& grid,
 wxGridCellRenderer *wxGridCellStringRenderer::Clone() const
 {
     wxGridCellStringRenderer *renderer = new wxGridCellStringRenderer;
-    renderer->SetClientDataContainer( GetClientDataContainer() );
+    renderer->SetClientDataContainer(GetClientDataContainer());
     return renderer;
 }
 
@@ -842,7 +842,7 @@ void wxGridCellNumberRenderer::SetParameters(const wxString& params)
 wxGridCellRenderer *wxGridCellNumberRenderer::Clone() const
 {
     wxGridCellNumberRenderer *renderer = new wxGridCellNumberRenderer(m_minValue, m_maxValue);
-    renderer->SetClientDataContainer( GetClientDataContainer() );
+    renderer->SetClientDataContainer(GetClientDataContainer());
     return renderer;
 }
 
@@ -867,7 +867,7 @@ wxGridCellRenderer *wxGridCellFloatRenderer::Clone() const
     renderer->m_style = m_style;
     renderer->m_format = m_format;
 
-    renderer->SetClientDataContainer( GetClientDataContainer() );
+    renderer->SetClientDataContainer(GetClientDataContainer());
 
     return renderer;
 }
@@ -1108,7 +1108,7 @@ void wxGridCellBoolRenderer::Draw(wxGrid& grid,
 wxGridCellRenderer *wxGridCellBoolRenderer::Clone() const
 {
     wxGridCellBoolRenderer *renderer = new wxGridCellBoolRenderer;
-    renderer->SetClientDataContainer( GetClientDataContainer() );
+    renderer->SetClientDataContainer(GetClientDataContainer());
     return renderer;
 }
 

--- a/src/generic/gridctrl.cpp
+++ b/src/generic/gridctrl.cpp
@@ -157,6 +157,13 @@ using namespace wxGridPrivate;
 
 // Enables a grid cell to display a formatted date
 
+wxGridCellDateRenderer::wxGridCellDateRenderer(const wxGridCellDateRenderer& other)
+    : m_oformat(other.m_oformat)
+    , m_tz(other.m_tz)
+{
+    SetClientDataContainer( other.GetClientDataContainer() );
+}
+
 wxGridCellDateRenderer::wxGridCellDateRenderer(const wxString& outformat)
 {
     if ( outformat.empty() )
@@ -256,6 +263,13 @@ wxGridCellDateTimeRenderer::wxGridCellDateTimeRenderer(const wxString& outformat
 {
 }
 
+wxGridCellDateTimeRenderer::wxGridCellDateTimeRenderer(const wxGridCellDateTimeRenderer& other)
+    : wxGridCellDateRenderer(other)
+    , m_iformat(other.m_iformat)
+{
+    //SetClientDataContainer( other.GetClientDataContainer() ); //Not needed here, as it is also done in wxGridCellDateRenderer ctor
+}
+
 wxGridCellRenderer *wxGridCellDateTimeRenderer::Clone() const
 {
     return new wxGridCellDateTimeRenderer(*this);
@@ -272,6 +286,12 @@ wxGridCellDateTimeRenderer::GetDateParseParams(DateParseParams& params) const
 // ----------------------------------------------------------------------------
 // wxGridCellChoiceRenderer
 // ----------------------------------------------------------------------------
+
+wxGridCellChoiceRenderer::wxGridCellChoiceRenderer(const wxGridCellChoiceRenderer& other)
+    : m_choices(other.m_choices)
+{
+    SetClientDataContainer( other.GetClientDataContainer() );
+}
 
 wxSize wxGridCellChoiceRenderer::GetMaxBestSize(wxGrid& WXUNUSED(grid),
                                                 wxGridCellAttr& attr,
@@ -318,6 +338,9 @@ wxGridCellRenderer *wxGridCellEnumRenderer::Clone() const
 {
     wxGridCellEnumRenderer *renderer = new wxGridCellEnumRenderer;
     renderer->m_choices = m_choices;
+
+    renderer->SetClientDataContainer( GetClientDataContainer() );
+
     return renderer;
 }
 
@@ -607,6 +630,13 @@ wxGridCellAutoWrapStringRenderer::GetBestWidth(wxGrid& grid,
     return width;
 }
 
+wxGridCellRenderer *wxGridCellAutoWrapStringRenderer::Clone() const
+{
+    wxGridCellAutoWrapStringRenderer *renderer = new wxGridCellAutoWrapStringRenderer;
+    renderer->SetClientDataContainer( GetClientDataContainer() );
+    return renderer;
+}
+
 // ----------------------------------------------------------------------------
 // wxGridCellStringRenderer
 // ----------------------------------------------------------------------------
@@ -727,6 +757,13 @@ void wxGridCellStringRenderer::Draw(wxGrid& grid,
                            rect, attr);
 }
 
+wxGridCellRenderer *wxGridCellStringRenderer::Clone() const
+{
+    wxGridCellStringRenderer *renderer = new wxGridCellStringRenderer;
+    renderer->SetClientDataContainer( GetClientDataContainer() );
+    return renderer;
+}
+
 // ----------------------------------------------------------------------------
 // wxGridCellNumberRenderer
 // ----------------------------------------------------------------------------
@@ -802,6 +839,13 @@ void wxGridCellNumberRenderer::SetParameters(const wxString& params)
     }
 }
 
+wxGridCellRenderer *wxGridCellNumberRenderer::Clone() const
+{
+    wxGridCellNumberRenderer *renderer = new wxGridCellNumberRenderer(m_minValue, m_maxValue);
+    renderer->SetClientDataContainer( GetClientDataContainer() );
+    return renderer;
+}
+
 // ----------------------------------------------------------------------------
 // wxGridCellFloatRenderer
 // ----------------------------------------------------------------------------
@@ -822,6 +866,8 @@ wxGridCellRenderer *wxGridCellFloatRenderer::Clone() const
     renderer->m_precision = m_precision;
     renderer->m_style = m_style;
     renderer->m_format = m_format;
+
+    renderer->SetClientDataContainer( GetClientDataContainer() );
 
     return renderer;
 }
@@ -1057,6 +1103,13 @@ void wxGridCellBoolRenderer::Draw(wxGrid& grid,
         flags |= wxCONTROL_CHECKED;
 
     wxRendererNative::Get().DrawCheckBox( &grid, dc, checkBoxRect, flags );
+}
+
+wxGridCellRenderer *wxGridCellBoolRenderer::Clone() const
+{
+    wxGridCellBoolRenderer *renderer = new wxGridCellBoolRenderer;
+    renderer->SetClientDataContainer( GetClientDataContainer() );
+    return renderer;
 }
 
 #endif // wxUSE_GRID

--- a/src/generic/gridctrl.cpp
+++ b/src/generic/gridctrl.cpp
@@ -265,9 +265,9 @@ wxGridCellChoiceRenderer::wxGridCellChoiceRenderer(const wxString& choices)
 }
 
 wxGridCellChoiceRenderer::wxGridCellChoiceRenderer(const wxGridCellChoiceRenderer& other)
-    : wxGridCellStringRenderer(other)
+    : wxGridCellStringRenderer(other),
+      m_choices(other.m_choices)
 {
-    m_choices = wxArrayString(other.m_choices);
 }
 
 wxSize wxGridCellChoiceRenderer::GetMaxBestSize(wxGrid& WXUNUSED(grid),
@@ -297,7 +297,6 @@ void wxGridCellChoiceRenderer::SetParameters(const wxString& params)
         m_choices.Add(tk.GetNextToken());
     }
 }
-
 
 // ----------------------------------------------------------------------------
 // wxGridCellEnumRenderer

--- a/src/generic/gridctrl.cpp
+++ b/src/generic/gridctrl.cpp
@@ -264,6 +264,12 @@ wxGridCellChoiceRenderer::wxGridCellChoiceRenderer(const wxString& choices)
         SetParameters(choices);
 }
 
+wxGridCellChoiceRenderer::wxGridCellChoiceRenderer(const wxGridCellChoiceRenderer& other)
+    : wxGridCellStringRenderer(other)
+{
+    m_choices = wxArrayString(other.m_choices);
+}
+
 wxSize wxGridCellChoiceRenderer::GetMaxBestSize(wxGrid& WXUNUSED(grid),
                                                 wxGridCellAttr& attr,
                                                 wxDC& dc)

--- a/src/generic/gridctrl.cpp
+++ b/src/generic/gridctrl.cpp
@@ -298,7 +298,15 @@ void wxGridCellChoiceRenderer::SetParameters(const wxString& params)
     }
 }
 
-wxString wxGridCellChoiceRenderer::GetString(const wxGrid& grid, int row, int col)
+
+// ----------------------------------------------------------------------------
+// wxGridCellEnumRenderer
+// ----------------------------------------------------------------------------
+// Renders a number as a textual equivalent.
+// eg data in cell is 0,1,2 ... n the cell could be rendered as "John","Fred"..."Bob"
+
+
+wxString wxGridCellEnumRenderer::GetString(const wxGrid& grid, int row, int col)
 {
     wxGridTableBase *table = grid.GetTable();
     wxString text;
@@ -316,13 +324,6 @@ wxString wxGridCellChoiceRenderer::GetString(const wxGrid& grid, int row, int co
     //If we faild to parse string just show what we where given?
     return text;
 }
-
-// ----------------------------------------------------------------------------
-// wxGridCellEnumRenderer
-// ----------------------------------------------------------------------------
-// Renders a number as a textual equivalent.
-// eg data in cell is 0,1,2 ... n the cell could be rendered as "John","Fred"..."Bob"
-
 
 void wxGridCellEnumRenderer::Draw(wxGrid& grid,
                                    wxGridCellAttr& attr,

--- a/src/generic/grideditors.cpp
+++ b/src/generic/grideditors.cpp
@@ -672,6 +672,9 @@ void wxGridCellTextEditor::SetValidator(const wxValidator& validator)
 wxGridCellEditor *wxGridCellTextEditor::Clone() const
 {
     wxGridCellTextEditor* editor = new wxGridCellTextEditor(m_maxChars);
+
+    editor->SetClientDataContainer( GetClientDataContainer() );
+
 #if wxUSE_VALIDATORS
     if ( m_validator )
     {
@@ -960,6 +963,13 @@ wxString wxGridCellNumberEditor::GetValue() const
     return s;
 }
 
+wxGridCellEditor *wxGridCellNumberEditor::Clone() const
+{
+    wxGridCellNumberEditor* editor = new wxGridCellNumberEditor;
+    editor->SetClientDataContainer( GetClientDataContainer() );
+    return editor;
+}
+
 // ----------------------------------------------------------------------------
 // wxGridCellFloatEditor
 // ----------------------------------------------------------------------------
@@ -1211,6 +1221,13 @@ bool wxGridCellFloatEditor::IsAcceptedKey(wxKeyEvent& event)
     }
 
     return false;
+}
+
+wxGridCellEditor *wxGridCellFloatEditor::Clone() const
+{
+    wxGridCellFloatEditor* editor = new wxGridCellFloatEditor;
+    editor->SetClientDataContainer( GetClientDataContainer() );
+    return editor;
 }
 
 #endif // wxUSE_TEXTCTRL
@@ -1478,6 +1495,13 @@ void wxGridCellBoolEditor::SetGridFromValue(int row, int col, wxGrid* grid) cons
         table->SetValue(row, col, GetStringValue());
 }
 
+wxGridCellEditor *wxGridCellBoolEditor::Clone() const
+{
+    wxGridCellBoolEditor* editor = new wxGridCellBoolEditor;
+    editor->SetClientDataContainer( GetClientDataContainer() );
+    return editor;
+}
+
 #endif // wxUSE_CHECKBOX
 
 #if wxUSE_COMBOBOX
@@ -1511,6 +1535,7 @@ wxGridCellEditor *wxGridCellChoiceEditor::Clone() const
     wxGridCellChoiceEditor *editor = new wxGridCellChoiceEditor;
     editor->m_allowOthers = m_allowOthers;
     editor->m_choices = m_choices;
+    editor->SetClientDataContainer( GetClientDataContainer() );
 
     return editor;
 }
@@ -1696,6 +1721,7 @@ wxGridCellEditor *wxGridCellEnumEditor::Clone() const
 {
     wxGridCellEnumEditor *editor = new wxGridCellEnumEditor();
     editor->m_index = m_index;
+    editor->SetClientDataContainer( GetClientDataContainer() );
     return editor;
 }
 
@@ -1792,6 +1818,13 @@ wxGridCellAutoWrapStringEditor::Create(wxWindow* parent,
 {
     wxGridCellTextEditor::DoCreate(parent, id, evtHandler,
                                     wxTE_MULTILINE | wxTE_RICH);
+}
+
+wxGridCellEditor *wxGridCellAutoWrapStringEditor::Clone() const
+{
+    wxGridCellAutoWrapStringEditor* editor = new wxGridCellAutoWrapStringEditor;
+    editor->SetClientDataContainer( GetClientDataContainer() );
+    return editor;
 }
 
 #if wxUSE_DATEPICKCTRL
@@ -1959,7 +1992,9 @@ void wxGridCellDateEditor::Reset()
 
 wxGridCellEditor *wxGridCellDateEditor::Clone() const
 {
-    return new wxGridCellDateEditor(m_format);
+    wxGridCellDateEditor* editor = new wxGridCellDateEditor(m_format);
+    editor->SetClientDataContainer( GetClientDataContainer() );
+    return editor;
 }
 
 wxString wxGridCellDateEditor::GetValue() const

--- a/src/generic/grideditors.cpp
+++ b/src/generic/grideditors.cpp
@@ -230,15 +230,12 @@ void wxGridCellEditorEvtHandler::OnChar(wxKeyEvent& event)
 
 wxGridCellEditor::wxGridCellEditor(const wxGridCellEditor& other)
     : wxGridCellWorker(other),
-      m_control(other.m_control)
+      m_control(other.m_control),
+      m_colFgOld(other.m_colFgOld),
+      m_colBgOld(other.m_colBgOld),
+      m_fontOld(other.m_fontOld)
 {
-    if ( other.m_attr != NULL )
-    {
-        m_attr = other.m_attr->Clone();
-    }
-    m_colFgOld = wxColour(other.m_colFgOld);
-    m_colBgOld = wxColour(other.m_colBgOld);
-    m_fontOld = wxFont(other.m_fontOld);
+    m_attr = other.m_attr ? other.m_attr->Clone() : NULL;
 }
 
 wxGridCellEditor::~wxGridCellEditor()

--- a/src/generic/grideditors.cpp
+++ b/src/generic/grideditors.cpp
@@ -673,7 +673,7 @@ wxGridCellEditor *wxGridCellTextEditor::Clone() const
 {
     wxGridCellTextEditor* editor = new wxGridCellTextEditor(m_maxChars);
 
-    editor->SetClientDataContainer( GetClientDataContainer() );
+    editor->SetClientDataContainer(GetClientDataContainer());
 
 #if wxUSE_VALIDATORS
     if ( m_validator )
@@ -966,7 +966,7 @@ wxString wxGridCellNumberEditor::GetValue() const
 wxGridCellEditor *wxGridCellNumberEditor::Clone() const
 {
     wxGridCellNumberEditor* editor = new wxGridCellNumberEditor;
-    editor->SetClientDataContainer( GetClientDataContainer() );
+    editor->SetClientDataContainer(GetClientDataContainer());
     return editor;
 }
 
@@ -1226,7 +1226,7 @@ bool wxGridCellFloatEditor::IsAcceptedKey(wxKeyEvent& event)
 wxGridCellEditor *wxGridCellFloatEditor::Clone() const
 {
     wxGridCellFloatEditor* editor = new wxGridCellFloatEditor;
-    editor->SetClientDataContainer( GetClientDataContainer() );
+    editor->SetClientDataContainer(GetClientDataContainer());
     return editor;
 }
 
@@ -1498,7 +1498,7 @@ void wxGridCellBoolEditor::SetGridFromValue(int row, int col, wxGrid* grid) cons
 wxGridCellEditor *wxGridCellBoolEditor::Clone() const
 {
     wxGridCellBoolEditor* editor = new wxGridCellBoolEditor;
-    editor->SetClientDataContainer( GetClientDataContainer() );
+    editor->SetClientDataContainer(GetClientDataContainer());
     return editor;
 }
 
@@ -1535,7 +1535,7 @@ wxGridCellEditor *wxGridCellChoiceEditor::Clone() const
     wxGridCellChoiceEditor *editor = new wxGridCellChoiceEditor;
     editor->m_allowOthers = m_allowOthers;
     editor->m_choices = m_choices;
-    editor->SetClientDataContainer( GetClientDataContainer() );
+    editor->SetClientDataContainer(GetClientDataContainer());
 
     return editor;
 }
@@ -1721,7 +1721,7 @@ wxGridCellEditor *wxGridCellEnumEditor::Clone() const
 {
     wxGridCellEnumEditor *editor = new wxGridCellEnumEditor();
     editor->m_index = m_index;
-    editor->SetClientDataContainer( GetClientDataContainer() );
+    editor->SetClientDataContainer(GetClientDataContainer());
     return editor;
 }
 
@@ -1823,7 +1823,7 @@ wxGridCellAutoWrapStringEditor::Create(wxWindow* parent,
 wxGridCellEditor *wxGridCellAutoWrapStringEditor::Clone() const
 {
     wxGridCellAutoWrapStringEditor* editor = new wxGridCellAutoWrapStringEditor;
-    editor->SetClientDataContainer( GetClientDataContainer() );
+    editor->SetClientDataContainer(GetClientDataContainer());
     return editor;
 }
 
@@ -1993,7 +1993,7 @@ void wxGridCellDateEditor::Reset()
 wxGridCellEditor *wxGridCellDateEditor::Clone() const
 {
     wxGridCellDateEditor* editor = new wxGridCellDateEditor(m_format);
-    editor->SetClientDataContainer( GetClientDataContainer() );
+    editor->SetClientDataContainer(GetClientDataContainer());
     return editor;
 }
 

--- a/src/generic/grideditors.cpp
+++ b/src/generic/grideditors.cpp
@@ -228,12 +228,6 @@ void wxGridCellEditorEvtHandler::OnChar(wxKeyEvent& event)
 // wxGridCellEditor
 // ----------------------------------------------------------------------------
 
-wxGridCellEditor::wxGridCellEditor()
-{
-    m_control = NULL;
-    m_attr = NULL;
-}
-
 wxGridCellEditor::~wxGridCellEditor()
 {
     Destroy();
@@ -434,9 +428,17 @@ void wxGridCellEditor::StartingClick()
 // wxGridCellTextEditor
 // ----------------------------------------------------------------------------
 
-wxGridCellTextEditor::wxGridCellTextEditor(size_t maxChars)
+wxGridCellTextEditor::wxGridCellTextEditor(const wxGridCellTextEditor& other)
+    : wxGridCellEditor(other),
+        m_maxChars(other.m_maxChars),
+        m_value(other.m_value)
 {
-    m_maxChars = maxChars;
+#if wxUSE_VALIDATORS
+    if ( other.m_validator )
+    {
+        SetValidator(*other.m_validator);
+    }
+#endif
 }
 
 void wxGridCellTextEditor::Create(wxWindow* parent,
@@ -669,21 +671,6 @@ void wxGridCellTextEditor::SetValidator(const wxValidator& validator)
 }
 #endif
 
-wxGridCellEditor *wxGridCellTextEditor::Clone() const
-{
-    wxGridCellTextEditor* editor = new wxGridCellTextEditor(m_maxChars);
-
-    editor->SetClientDataContainer(GetClientDataContainer());
-
-#if wxUSE_VALIDATORS
-    if ( m_validator )
-    {
-        editor->SetValidator(*m_validator);
-    }
-#endif
-    return editor;
-}
-
 // return the value in the text control
 wxString wxGridCellTextEditor::GetValue() const
 {
@@ -693,12 +680,6 @@ wxString wxGridCellTextEditor::GetValue() const
 // ----------------------------------------------------------------------------
 // wxGridCellNumberEditor
 // ----------------------------------------------------------------------------
-
-wxGridCellNumberEditor::wxGridCellNumberEditor(int min, int max)
-{
-    m_min = min;
-    m_max = max;
-}
 
 void wxGridCellNumberEditor::Create(wxWindow* parent,
                                     wxWindowID id,
@@ -963,25 +944,9 @@ wxString wxGridCellNumberEditor::GetValue() const
     return s;
 }
 
-wxGridCellEditor *wxGridCellNumberEditor::Clone() const
-{
-    wxGridCellNumberEditor* editor = new wxGridCellNumberEditor;
-    editor->SetClientDataContainer(GetClientDataContainer());
-    return editor;
-}
-
 // ----------------------------------------------------------------------------
 // wxGridCellFloatEditor
 // ----------------------------------------------------------------------------
-
-wxGridCellFloatEditor::wxGridCellFloatEditor(int width,
-                                             int precision,
-                                             int format)
-{
-    m_width = width;
-    m_precision = precision;
-    m_style = format;
-}
 
 void wxGridCellFloatEditor::Create(wxWindow* parent,
                                    wxWindowID id,
@@ -1221,13 +1186,6 @@ bool wxGridCellFloatEditor::IsAcceptedKey(wxKeyEvent& event)
     }
 
     return false;
-}
-
-wxGridCellEditor *wxGridCellFloatEditor::Clone() const
-{
-    wxGridCellFloatEditor* editor = new wxGridCellFloatEditor;
-    editor->SetClientDataContainer(GetClientDataContainer());
-    return editor;
 }
 
 #endif // wxUSE_TEXTCTRL
@@ -1495,13 +1453,6 @@ void wxGridCellBoolEditor::SetGridFromValue(int row, int col, wxGrid* grid) cons
         table->SetValue(row, col, GetStringValue());
 }
 
-wxGridCellEditor *wxGridCellBoolEditor::Clone() const
-{
-    wxGridCellBoolEditor* editor = new wxGridCellBoolEditor;
-    editor->SetClientDataContainer(GetClientDataContainer());
-    return editor;
-}
-
 #endif // wxUSE_CHECKBOX
 
 #if wxUSE_COMBOBOX
@@ -1510,15 +1461,11 @@ wxGridCellEditor *wxGridCellBoolEditor::Clone() const
 // wxGridCellChoiceEditor
 // ----------------------------------------------------------------------------
 
-wxGridCellChoiceEditor::wxGridCellChoiceEditor(const wxArrayString& choices,
-                                               bool allowOthers)
-    : m_choices(choices),
-      m_allowOthers(allowOthers) { }
-
 wxGridCellChoiceEditor::wxGridCellChoiceEditor(size_t count,
                                                const wxString choices[],
                                                bool allowOthers)
-                      : m_allowOthers(allowOthers)
+                      : wxGridCellEditor(),
+                        m_allowOthers(allowOthers)
 {
     if ( count )
     {
@@ -1528,16 +1475,6 @@ wxGridCellChoiceEditor::wxGridCellChoiceEditor(size_t count,
             m_choices.Add(choices[n]);
         }
     }
-}
-
-wxGridCellEditor *wxGridCellChoiceEditor::Clone() const
-{
-    wxGridCellChoiceEditor *editor = new wxGridCellChoiceEditor;
-    editor->m_allowOthers = m_allowOthers;
-    editor->m_choices = m_choices;
-    editor->SetClientDataContainer(GetClientDataContainer());
-
-    return editor;
 }
 
 void wxGridCellChoiceEditor::Create(wxWindow* parent,
@@ -1709,20 +1646,11 @@ void wxGridCellChoiceEditor::OnComboCloseUp(wxCommandEvent& WXUNUSED(evt))
 // "John","Fred"..."Bob" in the combo choice box
 
 wxGridCellEnumEditor::wxGridCellEnumEditor(const wxString& choices)
-                     :wxGridCellChoiceEditor()
+    : wxGridCellChoiceEditor(),
+      m_index(-1)
 {
-    m_index = -1;
-
     if (!choices.empty())
         SetParameters(choices);
-}
-
-wxGridCellEditor *wxGridCellEnumEditor::Clone() const
-{
-    wxGridCellEnumEditor *editor = new wxGridCellEnumEditor();
-    editor->m_index = m_index;
-    editor->SetClientDataContainer(GetClientDataContainer());
-    return editor;
 }
 
 void wxGridCellEnumEditor::BeginEdit(int row, int col, wxGrid* grid)
@@ -1820,13 +1748,6 @@ wxGridCellAutoWrapStringEditor::Create(wxWindow* parent,
                                     wxTE_MULTILINE | wxTE_RICH);
 }
 
-wxGridCellEditor *wxGridCellAutoWrapStringEditor::Clone() const
-{
-    wxGridCellAutoWrapStringEditor* editor = new wxGridCellAutoWrapStringEditor;
-    editor->SetClientDataContainer(GetClientDataContainer());
-    return editor;
-}
-
 #if wxUSE_DATEPICKCTRL
 
 // ----------------------------------------------------------------------------
@@ -1879,6 +1800,7 @@ struct wxGridCellDateEditorKeyHandler
 #endif // __WXGTK__
 
 wxGridCellDateEditor::wxGridCellDateEditor(const wxString& format)
+    : wxGridCellEditor()
 {
     SetParameters(format);
 }
@@ -1988,13 +1910,6 @@ void wxGridCellDateEditor::Reset()
     wxASSERT_MSG(m_control, "The wxGridCellDateEditor must be created first!");
 
     m_value = DatePicker()->GetValue();
-}
-
-wxGridCellEditor *wxGridCellDateEditor::Clone() const
-{
-    wxGridCellDateEditor* editor = new wxGridCellDateEditor(m_format);
-    editor->SetClientDataContainer(GetClientDataContainer());
-    return editor;
 }
 
 wxString wxGridCellDateEditor::GetValue() const

--- a/src/generic/grideditors.cpp
+++ b/src/generic/grideditors.cpp
@@ -228,6 +228,19 @@ void wxGridCellEditorEvtHandler::OnChar(wxKeyEvent& event)
 // wxGridCellEditor
 // ----------------------------------------------------------------------------
 
+wxGridCellEditor::wxGridCellEditor(const wxGridCellEditor& other)
+    : wxGridCellWorker(other),
+      m_control(other.m_control)
+{
+    if ( other.m_attr != NULL )
+    {
+        m_attr = other.m_attr->Clone();
+    }
+    m_colFgOld = wxColour(other.m_colFgOld);
+    m_colBgOld = wxColour(other.m_colBgOld);
+    m_fontOld = wxFont(other.m_fontOld);
+}
+
 wxGridCellEditor::~wxGridCellEditor()
 {
     Destroy();

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -145,7 +145,6 @@ public:
     wxString m_beforeGridAnnotated;
 };
 
-
 // Compares two grids, checking for differences with attribute presence and
 // cell sizes.
 class GridAttrMatcher : public Catch::MatcherBase<TestableGrid>

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -145,6 +145,7 @@ public:
     wxString m_beforeGridAnnotated;
 };
 
+
 // Compares two grids, checking for differences with attribute presence and
 // cell sizes.
 class GridAttrMatcher : public Catch::MatcherBase<TestableGrid>
@@ -1729,6 +1730,18 @@ TEST_CASE_METHOD(GridTestCase, "Grid::CellAttribute", "[attr][cell][grid]")
         CHECK_ATTR_COUNT( 0 );
     }
 
+    SECTION("Cloning")
+    {
+        CHECK_ATTR_COUNT( 0 );
+
+        m_grid->GetOrCreateCellAttrPtr(0, 0)->SetClientObject(new wxStringClientData("test"));
+        CHECK_ATTR_COUNT( 1 );
+
+        m_grid->SetAttr(0, 1, m_grid->GetOrCreateCellAttrPtr(0, 0)->Clone());
+        CHECK_ATTR_COUNT( 2 );
+
+        CHECK( static_cast<wxStringClientData *>(m_grid->GetOrCreateCellAttrPtr(0, 1)->GetClientObject())->GetData() == "test" );
+    }
 
     // Fill the grid with attributes for next sections.
 


### PR DESCRIPTION
PR includes a test added to gridtest.cpp. Just copy those lines to your codebase and see it fail miserably.

This is my first wxWidgets PR, so any comment is welcome.