### PR TITLE
Fix wxDataViewMainWindow::ItemAdded() when used after wxDataViewCtrl::AssociateModel()

### DIFF
--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -3094,6 +3094,12 @@ bool wxDataViewMainWindow::ItemAdded(const wxDataViewItem & parent, const wxData
         if ( !parentNode )
             return false;
 
+        // If the parent has children but child nodes was not initialized then
+        // the node is collapsed so just return as nodes will be initialized in
+        // Expand().
+        if ( parentNode->GetChildNodes().empty() )
+            return true;
+
         parentNode->SetHasChildren(true);
 
         wxDataViewTreeNode *itemNode = new wxDataViewTreeNode(parentNode, item);

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -3094,6 +3094,14 @@ bool wxDataViewMainWindow::ItemAdded(const wxDataViewItem & parent, const wxData
         if ( !parentNode )
             return false;
 
+        // If the parent has not children then just mask it as container and return.
+        // Nodes will be initialized in Expand().
+        if ( !parentNode->HasChildren() )
+        {
+            parentNode->SetHasChildren(true);
+            return true;
+        }
+
         // If the parent has children but child nodes was not initialized then
         // the node is collapsed so just return as nodes will be initialized in
         // Expand().


### PR DESCRIPTION
Note about the test:
Use the own data view model to call `AssociateModel()` with it because with `wxDataViewTreeCtrl` (which uses `wxDataViewListStore` as the model) the problem can't be reproduced.