### PR TITLE
Fix calculation of spin button size in wxSpinCtrl editor

### DIFF
--- a/src/propgrid/advprops.cpp
+++ b/src/propgrid/advprops.cpp
@@ -251,9 +251,6 @@ wxPGWindowList wxPGSpinCtrlEditor::CreateControls( wxPropertyGrid* propgrid, wxP
                                                    const wxPoint& pos, const wxSize& sz ) const
 {
     const int margin = 1;
-    wxSize butSz(18, sz.y);
-    wxSize tcSz(sz.x - butSz.x - margin, sz.y);
-    wxPoint butPos(pos.x + tcSz.x + margin, pos.y);
 
     wxSpinButton* wnd2;
 
@@ -271,8 +268,18 @@ wxPGWindowList wxPGSpinCtrlEditor::CreateControls( wxPropertyGrid* propgrid, wxP
 #ifdef __WXMSW__
     wnd2->Hide();
 #endif
-    wnd2->Create( propgrid->GetPanel(), wxPG_SUBID2, butPos, butSz, wxSP_VERTICAL );
-
+    wnd2->Create( propgrid->GetPanel(), wxPG_SUBID2, wxDefaultPosition, wxDefaultSize, wxSP_VERTICAL );
+    // Scale spin button to the required height (row height)
+    wxSize butSz = wnd2->GetBestSize();
+#ifdef __WXGTK3__
+    // Under GTK+ 3 spin button is always horizontal and cannot be downscaled
+    int butWidth = butSz.x;
+#else
+    double sc = (double)sz.y / butSz.y;
+    int butWidth = wxMax(18, wxRound(sc*butSz.x));
+#endif
+    wxSize tcSz(sz.x - butWidth - margin, sz.y);
+    wnd2->SetSize(pos.x + tcSz.x + margin, pos.y, butWidth, sz.y);
     wnd2->SetRange( INT_MIN, INT_MAX );
     wnd2->SetValue( 0 );
 


### PR DESCRIPTION
Under GTK+ 3 wxSpinButton (being a part wxSpinCtrl editor) is always
displayed horizontally and its minimal width is greater than 18 pixels
so its best width has to be left unmodified and we can only attempt
to fit its height to the height of the wxSpinCtrl property cell.
For other ports wxSpinButton can be displayed vertically and scaled as
necessary.

Closes #18385.

(cherry picked from commit e6a726781153936bf219bbde5c58d0948a858dcd)