### PR TITLE
Fix ParseDateTime() to also accept time + date, in that order

### DIFF
--- a/src/common/datetimefmt.cpp
+++ b/src/common/datetimefmt.cpp
@@ -2050,6 +2050,11 @@ wxDateTime::ParseDate(const wxString& date, wxString::const_iterator *end)
     if ( !haveDay && !haveWDay )
         return false;
 
+    // even if haveDay == true, we cannot construct a date from a day number
+    // alone, without at least a weekday or month
+    if ( !haveWDay && !haveMon )
+        return false;
+
     if ( haveWDay && (haveMon || haveYear || haveDay) &&
          !(haveDay && haveMon && haveYear) )
     {

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -1206,6 +1206,7 @@ void DateTimeTestCase::TestDateParse()
         { "31/04/06" },
         { "bloordyblop" },
         { "2 .  .    " },
+        { "14:30:15" },
     };
 
     wxGCC_WARNING_RESTORE(missing-field-initializers)
@@ -1220,7 +1221,7 @@ void DateTimeTestCase::TestDateParse()
         const wxString datestr = TranslateDate(parseTestDates[n].str);
 
         const char * const end = dt.ParseDate(datestr);
-        if ( end && !*end )
+        if ( end )
         {
             WX_ASSERT_MESSAGE(
                 ("Erroneously parsed \"%s\"", datestr),
@@ -1345,6 +1346,13 @@ void DateTimeTestCase::TestDateTimeParse()
         },
 
         {
+            // date after time
+            "14:30:00 2020-01-04",
+            {  4, wxDateTime::Jan, 2020, 14, 30,  0 },
+            true,
+        },
+
+        {
             "bloordyblop",
             {  1, wxDateTime::Jan, 9999,  0,  0,  0},
             false
@@ -1353,7 +1361,8 @@ void DateTimeTestCase::TestDateTimeParse()
         {
             "2012-01-01 10:12:05 +0100",
             {  1, wxDateTime::Jan, 2012,  10,  12,  5, -1 },
-            false // ParseDateTime does know yet +0100
+            true // ParseDateTime does know yet +0100, but
+                 // ignoring that, parsing still succeeds
         },
     };
 
@@ -1369,7 +1378,7 @@ void DateTimeTestCase::TestDateTimeParse()
         const wxString datestr = TranslateDate(parseTestDates[n].str);
 
         const char * const end = dt.ParseDateTime(datestr);
-        if ( end && !*end )
+        if ( end )
         {
             WX_ASSERT_MESSAGE(
                 ("Erroneously parsed \"%s\"", datestr),


### PR DESCRIPTION
The intent of the implementation clearly is to allow parsing time first,
date second. But this failed, because a time such as "14:30:15" would
successfully parse as a date (as 14th of current month, current year).

Consequently an attempt is made to parse the actual date as time, which
fails, and therefore the whole ParseDateTime() fails.

Adding a failing test case for ensuring times cannot be parsed as dates
does not cause a failure, because partially yet successfully parsed inputs
get silently ignored (in both ParseDate and ParseDateTime tests). Fixing
both of these, too.