### PR TITLE
Parse time zone in ParseDateTime() + fixes + tests

### DIFF
--- a/include/wx/datetime.h
+++ b/include/wx/datetime.h
@@ -1150,6 +1150,10 @@ private:
     // assign the preferred first day of a week to flags, if necessary
     void UseEffectiveWeekDayFlags(WeekFlags &flags) const;
 
+    // parse time zone (e.g. "+0100") between [iterator,dateEnd)
+    bool ParseRFC822TimeZone(wxString::const_iterator* iterator,
+                             const wxString::const_iterator& dateEnd);
+
     // the internal representation of the time is the amount of milliseconds
     // elapsed since the origin which is set by convention to the UNIX/C epoch
     // value: the midnight of January 1, 1970 (UTC)

--- a/src/common/datetimefmt.cpp
+++ b/src/common/datetimefmt.cpp
@@ -791,8 +791,13 @@ wxDateTime::ParseRFC822TimeZone(wxString::const_iterator *iterator,
         }
         else
         {
+            // TZ is max 3 characters long; we do not want to consume
+            // characters beyond that.
+            wxString::const_iterator pPlusMax3 = pEnd;
+            if ( p != pEnd && p + 1 != pEnd && p + 2 != pEnd && p + 3 != pEnd )
+                pPlusMax3 = p + 3;
             // abbreviation
-            const wxString tz(p, pEnd);
+            const wxString tz(p, pPlusMax3);
             if ( tz == wxT("UT") || tz == wxT("UTC") || tz == wxT("GMT") )
                 offset = 0;
             else if ( tz == wxT("AST") )
@@ -1774,6 +1779,19 @@ wxDateTime::ParseDateTime(const wxString& date, wxString::const_iterator *end)
     Set(dtDate.GetDay(), dtDate.GetMonth(), dtDate.GetYear(),
         dtTime.GetHour(), dtTime.GetMinute(), dtTime.GetSecond(),
         dtTime.GetMillisecond());
+
+    // let's see if there is a time zone specified
+    // after date and/or time
+    if ( endBoth != date.end() && *endBoth == ' ' )
+    {
+        wxString::const_iterator tz = endBoth + 1;
+        if ( tz != date.end() &&
+             ParseRFC822TimeZone(&tz, date.end())
+           )
+        {
+            endBoth = tz;
+        }
+    }
 
     *end = endBoth;
 

--- a/src/common/datetimefmt.cpp
+++ b/src/common/datetimefmt.cpp
@@ -751,7 +751,7 @@ wxDateTime::ParseRfc822Date(const wxString& originalDate, wxString::const_iterat
     // to the date string (32 being the length of a typical RFC822 timestamp).
     const wxString date(originalDate + wxString(32, '\0'));
 
-    const wxString::const_iterator pEnd = date.end();
+    const wxString::const_iterator pEnd = date.begin() + originalDate.length();
     wxString::const_iterator p = date.begin();
 
     // 1. week day (optional)
@@ -896,7 +896,8 @@ wxDateTime::ParseRfc822Date(const wxString& originalDate, wxString::const_iterat
         // the explicit offset given: it has the form of hhmm
         bool plus = *p++ == '+';
 
-        if ( !wxIsdigit(*p) || !wxIsdigit(*(p + 1)) )
+        if ( p == pEnd || !wxIsdigit(*p) ||
+             p + 1 == pEnd || !wxIsdigit(*(p + 1)) )
             return false;
 
 
@@ -905,7 +906,8 @@ wxDateTime::ParseRfc822Date(const wxString& originalDate, wxString::const_iterat
 
         p += 2;
 
-        if ( !wxIsdigit(*p) || !wxIsdigit(*(p + 1)) )
+        if ( p == pEnd || !wxIsdigit(*p) ||
+             p + 1 == pEnd || !wxIsdigit(*(p + 1)) )
             return false;
 
         // minutes
@@ -920,7 +922,7 @@ wxDateTime::ParseRfc822Date(const wxString& originalDate, wxString::const_iterat
     {
         // the symbolic timezone given: may be either military timezone or one
         // of standard abbreviations
-        if ( !*(p + 1) )
+        if ( p + 1 == pEnd )
         {
             // military: Z = UTC, J unused, A = -1, ..., Y = +12
             static const int offsets[26] =
@@ -939,7 +941,7 @@ wxDateTime::ParseRfc822Date(const wxString& originalDate, wxString::const_iterat
         else
         {
             // abbreviation
-            const wxString tz(p, date.end());
+            const wxString tz(p, pEnd);
             if ( tz == wxT("UT") || tz == wxT("UTC") || tz == wxT("GMT") )
                 offset = 0;
             else if ( tz == wxT("AST") )

--- a/src/common/datetimefmt.cpp
+++ b/src/common/datetimefmt.cpp
@@ -736,6 +736,106 @@ wxString wxDateTime::Format(const wxString& formatp, const TimeZone& tz) const
     return res;
 }
 
+bool
+wxDateTime::ParseRFC822TimeZone(wxString::const_iterator *iterator,
+                                const wxString::const_iterator &pEnd)
+{
+    wxString::const_iterator& p = *iterator;
+    int offset = 0; // just to suppress warnings
+    if ( *p == '-' || *p == '+' )
+    {
+        // the explicit offset given: it has the form of hhmm
+        bool plus = *p++ == '+';
+
+        if ( p == pEnd || !wxIsdigit(*p) ||
+             p + 1 == pEnd || !wxIsdigit(*(p + 1)) )
+            return false;
+
+
+        // hours
+        offset = MIN_PER_HOUR*(10*(*p - '0') + (*(p + 1) - '0'));
+
+        p += 2;
+
+        if ( p == pEnd || !wxIsdigit(*p) ||
+             p + 1 == pEnd || !wxIsdigit(*(p + 1)) )
+            return false;
+
+        // minutes
+        offset += 10*(*p - '0') + (*(p + 1) - '0');
+
+        if ( !plus )
+            offset = -offset;
+
+        p += 2;
+    }
+    else // not numeric
+    {
+        // the symbolic timezone given: may be either military timezone or one
+        // of standard abbreviations
+        if ( p + 1 == pEnd )
+        {
+            // military: Z = UTC, J unused, A = -1, ..., Y = +12
+            static const int offsets[26] =
+            {
+                //A  B   C   D   E   F   G   H   I    J    K    L    M
+                -1, -2, -3, -4, -5, -6, -7, -8, -9,   0, -10, -11, -12,
+                //N  O   P   R   Q   S   T   U   V    W    Z    Y    Z
+                +1, +2, +3, +4, +5, +6, +7, +8, +9, +10, +11, +12, 0
+            };
+
+            if ( *p < wxT('A') || *p > wxT('Z') || *p == wxT('J') )
+                return false;
+
+            offset = offsets[*p++ - 'A'];
+        }
+        else
+        {
+            // abbreviation
+            const wxString tz(p, pEnd);
+            if ( tz == wxT("UT") || tz == wxT("UTC") || tz == wxT("GMT") )
+                offset = 0;
+            else if ( tz == wxT("AST") )
+                offset = AST - GMT0;
+            else if ( tz == wxT("ADT") )
+                offset = ADT - GMT0;
+            else if ( tz == wxT("EST") )
+                offset = EST - GMT0;
+            else if ( tz == wxT("EDT") )
+                offset = EDT - GMT0;
+            else if ( tz == wxT("CST") )
+                offset = CST - GMT0;
+            else if ( tz == wxT("CDT") )
+                offset = CDT - GMT0;
+            else if ( tz == wxT("MST") )
+                offset = MST - GMT0;
+            else if ( tz == wxT("MDT") )
+                offset = MDT - GMT0;
+            else if ( tz == wxT("PST") )
+                offset = PST - GMT0;
+            else if ( tz == wxT("PDT") )
+                offset = PDT - GMT0;
+            else
+                return false;
+
+            p += tz.length();
+        }
+
+        // make it minutes
+        offset *= MIN_PER_HOUR;
+    }
+
+    // As always, dealing with the time zone is the most interesting part: we
+    // can't just use MakeFromTimeZone() here because it wouldn't handle the
+    // DST correctly because the TZ specified in the string is DST-invariant
+    // and so we have to manually shift to the UTC first and then convert to
+    // the local TZ.
+    *this -= wxTimeSpan::Minutes(offset);
+    MakeFromUTC();
+
+    return true;
+}
+
 // this function parses a string in (strict) RFC 822 format: see the section 5
 // of the RFC for the detailed description, but briefly it's something of the
 // form "Sat, 18 Dec 1999 00:48:30 +0100"
@@ -889,102 +989,13 @@ wxDateTime::ParseRfc822Date(const wxString& originalDate, wxString::const_iterat
     if ( *p++ != ' ' )
         return false;
 
-    // 7. now the interesting part: the timezone
-    int offset = 0; // just to suppress warnings
-    if ( *p == '-' || *p == '+' )
-    {
-        // the explicit offset given: it has the form of hhmm
-        bool plus = *p++ == '+';
-
-        if ( p == pEnd || !wxIsdigit(*p) ||
-             p + 1 == pEnd || !wxIsdigit(*(p + 1)) )
-            return false;
-
-
-        // hours
-        offset = MIN_PER_HOUR*(10*(*p - '0') + (*(p + 1) - '0'));
-
-        p += 2;
-
-        if ( p == pEnd || !wxIsdigit(*p) ||
-             p + 1 == pEnd || !wxIsdigit(*(p + 1)) )
-            return false;
-
-        // minutes
-        offset += 10*(*p - '0') + (*(p + 1) - '0');
-
-        if ( !plus )
-            offset = -offset;
-
-        p += 2;
-    }
-    else // not numeric
-    {
-        // the symbolic timezone given: may be either military timezone or one
-        // of standard abbreviations
-        if ( p + 1 == pEnd )
-        {
-            // military: Z = UTC, J unused, A = -1, ..., Y = +12
-            static const int offsets[26] =
-            {
-                //A  B   C   D   E   F   G   H   I    J    K    L    M
-                -1, -2, -3, -4, -5, -6, -7, -8, -9,   0, -10, -11, -12,
-                //N  O   P   R   Q   S   T   U   V    W    Z    Y    Z
-                +1, +2, +3, +4, +5, +6, +7, +8, +9, +10, +11, +12, 0
-            };
-
-            if ( *p < wxT('A') || *p > wxT('Z') || *p == wxT('J') )
-                return false;
-
-            offset = offsets[*p++ - 'A'];
-        }
-        else
-        {
-            // abbreviation
-            const wxString tz(p, pEnd);
-            if ( tz == wxT("UT") || tz == wxT("UTC") || tz == wxT("GMT") )
-                offset = 0;
-            else if ( tz == wxT("AST") )
-                offset = AST - GMT0;
-            else if ( tz == wxT("ADT") )
-                offset = ADT - GMT0;
-            else if ( tz == wxT("EST") )
-                offset = EST - GMT0;
-            else if ( tz == wxT("EDT") )
-                offset = EDT - GMT0;
-            else if ( tz == wxT("CST") )
-                offset = CST - GMT0;
-            else if ( tz == wxT("CDT") )
-                offset = CDT - GMT0;
-            else if ( tz == wxT("MST") )
-                offset = MST - GMT0;
-            else if ( tz == wxT("MDT") )
-                offset = MDT - GMT0;
-            else if ( tz == wxT("PST") )
-                offset = PST - GMT0;
-            else if ( tz == wxT("PDT") )
-                offset = PDT - GMT0;
-            else
-                return false;
-
-            p += tz.length();
-        }
-
-        // make it minutes
-        offset *= MIN_PER_HOUR;
-    }
-
-
     // the spec was correct, construct the date from the values we found
     Set(day, mon, year, hour, min, sec);
 
-    // As always, dealing with the time zone is the most interesting part: we
-    // can't just use MakeFromTimeZone() here because it wouldn't handle the
-    // DST correctly because the TZ specified in the string is DST-invariant
-    // and so we have to manually shift to the UTC first and then convert to
-    // the local TZ.
-    *this -= wxTimeSpan::Minutes(offset);
-    MakeFromUTC();
+    // 7. now the interesting part: the timezone
+
+    if ( !ParseRFC822TimeZone(&p, pEnd) )
+        return false;
 
     if ( end )
         *end = originalDate.begin() + (p - date.begin());

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -1416,23 +1416,26 @@ void DateTimeTestCase::TestDateTimeParse()
     static const struct ParseTestData
     {
         const char *str;
-        Date date;              // NB: this should be in UTC
+        Date date;      // either local time or UTC
         bool good;
         const char *beyondEnd;  // what remains unprocessed of the input
+        bool dateIsUTC; // true when timezone is specified
     } parseTestDates[] =
     {
         {
             "Thu 22 Nov 2007 07:40:00 PM",
             { 22, wxDateTime::Nov, 2007, 19, 40,  0 },
             true,
-            ""
+            "",
+            false
         },
 
         {
             "2010-01-04 14:30",
             {  4, wxDateTime::Jan, 2010, 14, 30,  0 },
             true,
-            ""
+            "",
+            false
         },
 
         {
@@ -1440,36 +1443,116 @@ void DateTimeTestCase::TestDateTimeParse()
             "14:30:00 2020-01-04",
             {  4, wxDateTime::Jan, 2020, 14, 30,  0 },
             true,
+            "",
+            false
         },
 
         {
             "bloordyblop",
             {  1, wxDateTime::Jan, 9999,  0,  0,  0},
             false,
-            "bloordyblop"
+            "bloordyblop",
+            false
         },
 
         {
             "2022-03-09 19:12:05 and some text after space",
             {  9, wxDateTime::Mar, 2022,  19,  12,  5, -1 },
             true,
-            " and some text after space"
+            " and some text after space",
+            false
         },
 
         {
-            // something other than a space right after time
+            "2022-03-09 19:12:05 ", // just a trailing space
+            {  9, wxDateTime::Mar, 2022,  19,  12,  5, -1 },
+            true,
+            " ",
+            false
+        },
+
+        // something other than a space right after time
+        {
             "2022-03-09 19:12:05AAaaaa",
             {  9, wxDateTime::Mar, 2022,  19,  12,  5, -1 },
             true,
-            "AAaaaa"
+            "AAaaaa",
+            false
+        },
+
+        // the rest have a time zone specified, and when the
+        // time zone is valid, the date to compare to is in UTC
+        {
+            "2012-01-01 10:12:05 +0100",
+            {  1, wxDateTime::Jan, 2012,   9,  12,  5, -1 },
+            true,
+            "",
+            true
         },
 
         {
-            "2012-01-01 10:12:05 +0100",
-            {  1, wxDateTime::Jan, 2012,  10,  12,  5, -1 },
-            true, // ParseDateTime does know yet +0100, but
-                  // ignoring that, parsing still succeeds
-            " +0100"
+            "2022-03-09 19:12:05 -0700",
+            { 10, wxDateTime::Mar, 2022,   2,  12,  5, -1 },
+            true,
+            "",
+            true
+        },
+
+        {
+            "2022-03-09 19:12:05 +0615",
+            {  9, wxDateTime::Mar, 2022,  12,  57,  5, -1 },
+            true,
+            "",
+            true
+        },
+
+        {
+            "2022-03-09 19:12:05 +0615 and some text",
+            {  9, wxDateTime::Mar, 2022,  12,  57,  5, -1 },
+            true,
+            " and some text",
+            true
+        },
+
+        {
+            "2022-03-09 15:12:05 UTC",
+            {  9, wxDateTime::Mar, 2022,  15,  12,  5, -1 },
+            true,
+            "",
+            true
+        },
+
+        {
+            "2022-03-09 15:12:05 UTC and some text",
+            {  9, wxDateTime::Mar, 2022,  15,  12,  5, -1 },
+            true,
+            " and some text",
+            true
+        },
+
+        {
+            // date after time
+            "15:12:05 2022-03-09 UTC",
+            {  9, wxDateTime::Mar, 2022,  15,  12,  5, -1 },
+            true,
+            "",
+            true
+        },
+
+        {
+            "2022-03-09 15:12:05 +010", // truncated time zone
+            {  9, wxDateTime::Mar, 2022,  15,  12,  5, -1 },
+            true,
+            " +010",
+            false
+        },
+
+        {
+            "2022-03-09 15:12:05 GM", // truncated time zone
+            {  9, wxDateTime::Mar, 2022,  15,  12,  5, -1 },
+            true,
+            " GM",
+            false
         },
 
     };
@@ -1493,7 +1576,10 @@ void DateTimeTestCase::TestDateTimeParse()
                 parseTestDates[n].good
             );
 
-            CPPUNIT_ASSERT_EQUAL( parseTestDates[n].date.DT(), dt );
+            wxDateTime dtReal = parseTestDates[n].dateIsUTC ?
+                parseTestDates[n].date.DT().FromUTC() :
+                parseTestDates[n].date.DT();
+            CPPUNIT_ASSERT_EQUAL( dtReal, dt );
             CPPUNIT_ASSERT_EQUAL( wxString(parseTestDates[n].beyondEnd), wxString(end) );
         }
         else // failed to parse

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -1106,6 +1106,18 @@ void DateTimeTestCase::TestParseRFC822()
             true
         },
 
+        {
+            "Sat, 18 Dec 1999 10:48:30 G", // military time zone
+            { 18, wxDateTime::Dec, 1999, 17, 48, 30 },
+            true
+        },
+
+        {
+            "Sat, 18 Dec 1999 10:48:30 Q", // military time zone
+            { 18, wxDateTime::Dec, 1999,  6, 48, 30 },
+            true
+        },
+
         // seconds are optional according to the RFC
         {
             "Sun, 01 Jun 2008 16:30 +0200",
@@ -1160,7 +1172,25 @@ void DateTimeTestCase::TestParseRFC822()
         },
 
         {
+            "Sun, 01 Jun 2008 16:39:10 +020", // truncated time zone
+            { 0 },
+            false
+        },
+
+        {
             "Sun, 01 Jun 2008 16:39:10 +02", // truncated time zone
+            { 0 },
+            false
+        },
+
+        {
+            "Sun, 01 Jun 2008 16:39:10 +0", // truncated time zone
+            { 0 },
+            false
+        },
+
+        {
+            "Sun, 01 Jun 2008 16:39:10 +", // truncated time zone
             { 0 },
             false
         },

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -1160,13 +1160,13 @@ void DateTimeTestCase::TestParseRFC822()
         },
 
         {
-            "Sun 01 Jun 2008 16:39:10 +02", // truncated time zone
+            "Sun, 01 Jun 2008 16:39:10 +02", // truncated time zone
             { 0 },
             false
         },
 
         {
-            "Sun 01 Jun 2008 16:39:10 G", // truncated time zone
+            "Sun, 01 Jun 2008 16:39:10 GM", // truncated time zone
             { 0 },
             false
         },


### PR DESCRIPTION
Support for same kind of time zones in `ParseDateTime()` that `ParseRFC822Date()` parses and understands.

Besides that, some fixes, and more tests.

Adding time zone support for `ParseDateTime()` is why I initially started looking at these time parsing functions, and this is the final PR of that sort.