### PR TITLE
wxArtProvider::GetSizeHints() improvements: DIPs and get rid of `bool platform_dependent = false`

### DIFF
--- a/include/wx/artprov.h
+++ b/include/wx/artprov.h
@@ -224,10 +224,7 @@ protected:
     static void CleanUpProviders();
 
     // Get the default size of an icon for a specific client
-    virtual wxSize DoGetSizeHint(const wxArtClient& client)
-    {
-        return GetSizeHint(client, true);
-    }
+    virtual wxSize DoGetSizeHint(const wxArtClient& client);
 
     // Derived classes must override at least one of the CreateXXX() functions
     // below to create requested art resource. Overriding more than one of them

--- a/include/wx/artprov.h
+++ b/include/wx/artprov.h
@@ -199,11 +199,14 @@ public:
     // have native equivalent
     static wxSize GetNativeSizeHint(const wxArtClient& client);
 
-    // Get the size hint of an icon from a specific wxArtClient, queries
-    // the topmost provider if platform_dependent = false
-    static wxSize GetSizeHint(const wxArtClient& client, bool platform_dependent = false);
+    // Get the size hint of an icon from a specific wxArtClient from the
+    // topmost (i.e. first used) provider.
+    static wxSize GetSizeHint(const wxArtClient& client);
 
 #if WXWIN_COMPATIBILITY_3_0
+    wxDEPRECATED_MSG("use GetSizeHint() without bool argument or GetNativeSizeHint()")
+    static wxSize GetSizeHint(const wxArtClient& client, bool platform_dependent);
+
     wxDEPRECATED_MSG("use wxBitmap::Rescale() instead.")
     static void RescaleBitmap(wxBitmap& bmp, const wxSize& sizeNeeded);
 #endif // WXWIN_COMPATIBILITY_3_0

--- a/include/wx/artprov.h
+++ b/include/wx/artprov.h
@@ -19,6 +19,8 @@
 
 class WXDLLIMPEXP_FWD_CORE wxArtProvidersList;
 class WXDLLIMPEXP_FWD_CORE wxArtProviderCache;
+class WXDLLIMPEXP_FWD_CORE wxWindow;
+
 class wxArtProviderModule;
 
 // ----------------------------------------------------------------------------
@@ -196,12 +198,15 @@ public:
                                       const wxArtClient& client = wxASCII_STR(wxART_OTHER));
 
     // Gets native size for given 'client' or wxDefaultSize if it doesn't
-    // have native equivalent
-    static wxSize GetNativeSizeHint(const wxArtClient& client);
+    // have native equivalent. The first version returns the size in logical
+    // pixels while the second one returns it in DIPs.
+    static wxSize GetNativeSizeHint(const wxArtClient& client, wxWindow* win = NULL);
+    static wxSize GetNativeDIPSizeHint(const wxArtClient& client);
 
     // Get the size hint of an icon from a specific wxArtClient from the
     // topmost (i.e. first used) provider.
-    static wxSize GetSizeHint(const wxArtClient& client);
+    static wxSize GetSizeHint(const wxArtClient& client, wxWindow* win = NULL);
+    static wxSize GetDIPSizeHint(const wxArtClient& client);
 
 #if WXWIN_COMPATIBILITY_3_0
     wxDEPRECATED_MSG("use GetSizeHint() without bool argument or GetNativeSizeHint()")
@@ -226,7 +231,10 @@ protected:
     // Destroy caches & all providers
     static void CleanUpProviders();
 
-    // Get the default size of an icon for a specific client
+    // Get the default size of an icon for a specific client.
+    //
+    // Although this function doesn't have "DIP" in its name, it should return
+    // the size in DIPs.
     virtual wxSize DoGetSizeHint(const wxArtClient& client);
 
     // Derived classes must override at least one of the CreateXXX() functions

--- a/interface/wx/artprov.h
+++ b/interface/wx/artprov.h
@@ -440,6 +440,13 @@ public:
 
 
 protected:
+    /**
+        Derived art provider classes may override this method to return the
+        size of the images used by this provider.
+
+        The default implementation returns the result of GetNativeSizeHint().
+     */
+    virtual wxSize DoGetSizeHint(const wxArtClient& client);
 
     /**
         Derived art provider classes may override this method to create requested art

--- a/interface/wx/artprov.h
+++ b/interface/wx/artprov.h
@@ -333,7 +333,7 @@ public:
                           const wxSize& size = wxDefaultSize);
 
     /**
-        Returns native icon size for use specified by @a client hint.
+        Returns native icon size for use specified by @a client hint in DIPs.
 
         If the platform has no commonly used default for this use or if
         @a client is not recognized, returns wxDefaultSize.
@@ -343,20 +343,42 @@ public:
               In that case, this method returns only one of them, picked
               reasonably.
 
-        @since 2.9.0
+        @since 3.1.6
      */
-    static wxSize GetNativeSizeHint(const wxArtClient& client);
+    static wxSize GetNativeDIPSizeHint(const wxArtClient& client);
 
     /**
-        Returns a suitable size hint for the given @e wxArtClient.
+        Returns native icon size for use specified by @a client hint.
+
+        This function does the same thing as GetNativeDIPSizeHint(), but uses
+        @a win to convert the returned value to logical pixels. If @a win is
+        @NULL, default DPI scaling (i.e. that of the primary display) is used.
+
+        @since 2.9.0 (@a win parameter is available only since 3.1.6)
+     */
+    static wxSize GetNativeSizeHint(const wxArtClient& client, wxWindow* win = NULL);
+
+    /**
+        Returns a suitable size hint for the given @e wxArtClient in DIPs.
 
         Return the size used by the topmost wxArtProvider for the given @a
         client. @e wxDefaultSize may be returned if the client doesn't have a
         specified size, like wxART_OTHER for example.
 
-        @see GetNativeSizeHint()
+        @see GetNativeDIPSizeHint()
     */
-    static wxSize GetSizeHint(const wxArtClient& client);
+    static wxSize GetDIPSizeHint(const wxArtClient& client);
+
+    /**
+        Returns a suitable size hint for the given @e wxArtClient.
+
+        This function does the same thing as GetDIPSizeHint(), but uses @a win
+        to convert the returned value to logical pixels. If @a win is @NULL,
+        default DPI scaling (i.e. that of the primary display) is used.
+
+        Note that @a win parameter is only available since wxWidgets 3.1.6.
+     */
+    static wxSize GetSizeHint(const wxArtClient& client, wxWindow* win = NULL);
 
     /**
         Query registered providers for icon bundle with given ID.
@@ -442,7 +464,9 @@ protected:
         Derived art provider classes may override this method to return the
         size of the images used by this provider.
 
-        The default implementation returns the result of GetNativeSizeHint().
+        Note that the returned size should be in DPI-independent pixels, i.e.
+        DIPs. The default implementation returns the result of
+        GetNativeDIPSizeHint().
      */
     virtual wxSize DoGetSizeHint(const wxArtClient& client);
 

--- a/interface/wx/artprov.h
+++ b/interface/wx/artprov.h
@@ -350,15 +350,13 @@ public:
     /**
         Returns a suitable size hint for the given @e wxArtClient.
 
-        If @a platform_default is @true, return a size based on the current
-        platform using GetNativeSizeHint(), otherwise return the size from the
-        topmost wxArtProvider. @e wxDefaultSize may be returned if the client
-        doesn't have a specified size, like wxART_OTHER for example.
+        Return the size used by the topmost wxArtProvider for the given @a
+        client. @e wxDefaultSize may be returned if the client doesn't have a
+        specified size, like wxART_OTHER for example.
 
         @see GetNativeSizeHint()
     */
-    static wxSize GetSizeHint(const wxArtClient& client,
-                              bool platform_default = false);
+    static wxSize GetSizeHint(const wxArtClient& client);
 
     /**
         Query registered providers for icon bundle with given ID.

--- a/samples/treelist/treelist.cpp
+++ b/samples/treelist/treelist.cpp
@@ -363,9 +363,9 @@ MyFrame::~MyFrame()
 
 void MyFrame::InitImageList()
 {
-    wxSize iconSize = wxArtProvider::GetSizeHint(wxART_LIST);
+    wxSize iconSize = wxArtProvider::GetSizeHint(wxART_LIST, this);
     if ( iconSize == wxDefaultSize )
-        iconSize = wxSize(16, 16);
+        iconSize = FromDIP(wxSize(16, 16));
 
     m_imageList = new wxImageList(iconSize.x, iconSize.y);
 

--- a/src/common/artprov.cpp
+++ b/src/common/artprov.cpp
@@ -24,6 +24,7 @@
     #include "wx/hashmap.h"
     #include "wx/image.h"
     #include "wx/module.h"
+    #include "wx/window.h"
 #endif
 
 // ===========================================================================

--- a/src/common/artprov.cpp
+++ b/src/common/artprov.cpp
@@ -543,6 +543,11 @@ wxArtID wxArtProvider::GetMessageBoxIconId(int flags)
     return GetNativeSizeHint(client);
 }
 
+wxSize wxArtProvider::DoGetSizeHint(const wxArtClient& client)
+{
+    return GetNativeSizeHint(client);
+}
+
 #ifndef wxHAS_NATIVE_ART_PROVIDER_IMPL
 /*static*/
 wxSize wxArtProvider::GetNativeSizeHint(const wxArtClient& WXUNUSED(client))

--- a/src/common/artprov.cpp
+++ b/src/common/artprov.cpp
@@ -567,7 +567,7 @@ wxSize wxArtProvider::GetNativeSizeHint(const wxArtClient& client, wxWindow* win
 
 #ifndef wxHAS_NATIVE_ART_PROVIDER_IMPL
 /*static*/
-wxSize wxArtProvider::GetNativeSizeHint(const wxArtClient& WXUNUSED(client))
+wxSize wxArtProvider::GetNativeDIPSizeHint(const wxArtClient& WXUNUSED(client))
 {
     // rather than returning some arbitrary value that doesn't make much
     // sense (as 2.8 used to do), tell the caller that we don't have a clue:

--- a/src/common/artprov.cpp
+++ b/src/common/artprov.cpp
@@ -530,15 +530,19 @@ wxArtID wxArtProvider::GetMessageBoxIconId(int flags)
     }
 }
 
+#if WXWIN_COMPATIBILITY_3_0
 /*static*/ wxSize wxArtProvider::GetSizeHint(const wxArtClient& client,
                                          bool platform_dependent)
 {
-    if (!platform_dependent)
-    {
-        wxArtProvidersList::compatibility_iterator node = sm_providers->GetFirst();
-        if (node)
-            return node->GetData()->DoGetSizeHint(client);
-    }
+    return platform_dependent ? GetNativeSizeHint(client) : GetSizeHint(client);
+}
+#endif // WXWIN_COMPATIBILITY_3_0
+
+/*static*/ wxSize wxArtProvider::GetSizeHint(const wxArtClient& client)
+{
+    wxArtProvidersList::compatibility_iterator node = sm_providers->GetFirst();
+    if (node)
+        return node->GetData()->DoGetSizeHint(client);
 
     return GetNativeSizeHint(client);
 }

--- a/src/common/artprov.cpp
+++ b/src/common/artprov.cpp
@@ -538,18 +538,30 @@ wxArtID wxArtProvider::GetMessageBoxIconId(int flags)
 }
 #endif // WXWIN_COMPATIBILITY_3_0
 
-/*static*/ wxSize wxArtProvider::GetSizeHint(const wxArtClient& client)
+/*static*/ wxSize wxArtProvider::GetDIPSizeHint(const wxArtClient& client)
 {
     wxArtProvidersList::compatibility_iterator node = sm_providers->GetFirst();
     if (node)
         return node->GetData()->DoGetSizeHint(client);
 
-    return GetNativeSizeHint(client);
+    return GetNativeDIPSizeHint(client);
+}
+
+/*static*/
+wxSize wxArtProvider::GetSizeHint(const wxArtClient& client, wxWindow* win)
+{
+    return wxWindow::FromDIP(GetDIPSizeHint(client), win);
 }
 
 wxSize wxArtProvider::DoGetSizeHint(const wxArtClient& client)
 {
-    return GetNativeSizeHint(client);
+    return GetNativeDIPSizeHint(client);
+}
+
+/*static*/
+wxSize wxArtProvider::GetNativeSizeHint(const wxArtClient& client, wxWindow* win)
+{
+    return wxWindow::FromDIP(GetNativeDIPSizeHint(client), win);
 }
 
 #ifndef wxHAS_NATIVE_ART_PROVIDER_IMPL

--- a/src/gtk/artgtk.cpp
+++ b/src/gtk/artgtk.cpp
@@ -388,7 +388,7 @@ wxGTK2ArtProvider::CreateIconBundle(const wxArtID& id,
 // ----------------------------------------------------------------------------
 
 /*static*/
-wxSize wxArtProvider::GetNativeSizeHint(const wxArtClient& client)
+wxSize wxArtProvider::GetNativeDIPSizeHint(const wxArtClient& client)
 {
     // Gtk has specific sizes for each client, see artgtk.cpp
     GtkIconSize gtk_size = ArtClientToIconSize(client);

--- a/src/msw/artmsw.cpp
+++ b/src/msw/artmsw.cpp
@@ -324,35 +324,34 @@ wxBitmap wxWindowsArtProvider::CreateBitmap(const wxArtID& id,
 // ----------------------------------------------------------------------------
 
 /*static*/
-wxSize wxArtProvider::GetNativeSizeHint(const wxArtClient& client)
+wxSize wxArtProvider::GetNativeDIPSizeHint(const wxArtClient& client)
 {
-    const wxWindow* win = wxApp::GetMainTopWindow();
     if ( client == wxART_TOOLBAR )
     {
-        return wxWindow::FromDIP(wxSize(24, 24), win);
+        return wxSize(24, 24);
     }
     else if ( client == wxART_MENU )
     {
-        return wxWindow::FromDIP(wxSize(16, 16), win);
+        return wxSize(16, 16);
     }
     else if ( client == wxART_FRAME_ICON )
     {
-        return wxSize(wxGetSystemMetrics(SM_CXSMICON, win),
-                      wxGetSystemMetrics(SM_CYSMICON, win));
+        return wxSize(::GetSystemMetrics(SM_CXSMICON),
+                      ::GetSystemMetrics(SM_CYSMICON));
     }
     else if ( client == wxART_CMN_DIALOG ||
               client == wxART_MESSAGE_BOX )
     {
-        return wxSize(wxGetSystemMetrics(SM_CXICON, win),
-                      wxGetSystemMetrics(SM_CYICON, win));
+        return wxSize(::GetSystemMetrics(SM_CXICON),
+                      ::GetSystemMetrics(SM_CYICON));
     }
     else if (client == wxART_BUTTON)
     {
-        return wxWindow::FromDIP(wxSize(16, 16), win);
+        return wxSize(16, 16);
     }
     else if (client == wxART_LIST)
     {
-        return wxWindow::FromDIP(wxSize(16, 16), win);
+        return wxSize(16, 16);
     }
 
     return wxDefaultSize;

--- a/src/osx/artmac.cpp
+++ b/src/osx/artmac.cpp
@@ -116,11 +116,11 @@ wxIconBundle wxMacArtProvider::CreateIconBundle(const wxArtID& id, const wxArtCl
 #endif
 
 // ----------------------------------------------------------------------------
-// wxArtProvider::GetNativeSizeHint()
+// wxArtProvider::GetNativeDIPSizeHint()
 // ----------------------------------------------------------------------------
 
 /*static*/
-wxSize wxArtProvider::GetNativeSizeHint(const wxArtClient& client)
+wxSize wxArtProvider::GetNativeDIPSizeHint(const wxArtClient& client)
 {
     if ( client == wxART_TOOLBAR )
     {


### PR DESCRIPTION
The main goal here was the last commit, but I've decided to simplify things a bit first as I really don't see why would we want to have this `bool platform_dependent` argument. @vslavik Please let me know if I'm missing anything.

@MaartenBent Your review would also be appreciated, TIA!