### PR TITLE
Improve shaped sample and its documentation

### DIFF
--- a/docs/doxygen/mainpages/samples.h
+++ b/docs/doxygen/mainpages/samples.h
@@ -690,10 +690,14 @@ utility under macOS).
 
 @section page_samples_shaped Shaped Window Sample
 
-@sampleabout{how to implement a shaped or transparent window\, and a window showing/hiding with effect}
+@sampleabout{Showing unusual, e.g. shaped or semi-transparent windows}
+
+This sample shows windows with non-rectangular shapes and non-opaque windows as
+well as how the windows can be shown with a special effect.
 
 @see wxTopLevelWindow::SetShape(), wxTopLevelWindow::SetTransparent(),
-wxWindow::ShowWithEffect(), wxWindow::HideWithEffect()
+wxWindow::ShowWithEffect(), wxWindow::HideWithEffect(),
+wxWindow::SetBackgroundStyle()
 
 @sampledir{shaped}
 

--- a/interface/wx/toplevel.h
+++ b/interface/wx/toplevel.h
@@ -585,6 +585,10 @@ public:
     /**
         If the platform supports it will set the window to be translucent.
 
+        Note that in wxGTK this function must be called before the window is
+        shown the first time it's called (but it can be called again after
+        showing the window too).
+
         @param alpha
             Determines how opaque or transparent the window will be, if the
             platform supports the operation. A value of 0 sets the window to be

--- a/interface/wx/toplevel.h
+++ b/interface/wx/toplevel.h
@@ -589,6 +589,9 @@ public:
         shown the first time it's called (but it can be called again after
         showing the window too).
 
+        See @ref page_samples_shaped "the shaped sample" for an example of
+        using this function.
+
         @param alpha
             Determines how opaque or transparent the window will be, if the
             platform supports the operation. A value of 0 sets the window to be

--- a/interface/wx/window.h
+++ b/interface/wx/window.h
@@ -2395,7 +2395,9 @@ public:
         Under wxGTK and wxOSX, you can use ::wxBG_STYLE_TRANSPARENT to obtain
         full transparency of the window background. Note that wxGTK supports
         this only since GTK 2.12 with a compositing manager enabled, call
-        IsTransparentBackgroundSupported() to check whether this is the case.
+        IsTransparentBackgroundSupported() to check whether this is the case,
+        see the example of doing it in @ref page_samples_shaped "the shaped
+        sample".
 
         Also, in order for @c SetBackgroundStyle(wxBG_STYLE_TRANSPARENT) to
         work, it must be called before Create(). If you're using your own


### PR DESCRIPTION
This seems to work as expected for me under all platforms.

The sample is not as colourful as before, but IMO more clear and useful. What do you think?

See #18592.