### PR TITLE
Create bigger windows on high DPI screens in wxMSW by default

### DIFF
--- a/src/common/toplvcmn.cpp
+++ b/src/common/toplvcmn.cpp
@@ -214,16 +214,18 @@ wxSize wxTopLevelWindowBase::GetDefaultSize()
 {
     wxSize size = wxGetClientDisplayRect().GetSize();
 #ifndef __WXOSX_IPHONE__
-    // create proportionally bigger windows on small screens
+    // create proportionally bigger windows on small screens but also scale the
+    // size with DPI on the large screens to avoid creating windows too small
+    // to fit anything at all when using high DPI
     if ( size.x >= 1024 )
-        size.x = 400;
+        size.x = FromDIP(400, NULL /* no window */);
     else if ( size.x >= 800 )
         size.x = 300;
     else if ( size.x >= 320 )
         size.x = 240;
 
     if ( size.y >= 768 )
-        size.y = 250;
+        size.y = FromDIP(250, NULL /* no window */);
     else if ( size.y > 200 )
     {
         size.y *= 2;


### PR DESCRIPTION
When using 200% DPI scaling, 400*250 windows are too small as almost
nothing fits into them, so use 800*500 size for them instead.

This is still completely arbitrary, but clearly better.

---

This is a trivial change, but I think worth making. Unless somebody has any better ideas?