### PR TITLE
Fix recently broken wxMemoryDC::SetFont(wxNullFont) in wxMSW

### DIFF
--- a/src/msw/dcmemory.cpp
+++ b/src/msw/dcmemory.cpp
@@ -148,7 +148,8 @@ void wxMemoryDCImpl::SetFont(const wxFont& font)
     // We need to adjust the font size by the ratio between the scale factor we
     // use and the default/global scale factor used when creating fonts.
     wxFont scaledFont = font;
-    scaledFont.WXAdjustToPPI(wxDisplay::GetStdPPI()*m_contentScaleFactor);
+    if ( scaledFont.IsOk() )
+        scaledFont.WXAdjustToPPI(wxDisplay::GetStdPPI()*m_contentScaleFactor);
     wxMSWDCImpl::SetFont(scaledFont);
 }
 

--- a/tests/graphics/measuring.cpp
+++ b/tests/graphics/measuring.cpp
@@ -27,6 +27,7 @@
 #endif
 
 #include "wx/dcclient.h"
+#include "wx/dcmemory.h"
 #include "wx/dcps.h"
 #include "wx/metafile.h"
 
@@ -79,6 +80,13 @@ TEST_CASE("wxDC::GetTextExtent", "[dc][text-extent]")
 
     // And even empty strings count like one line.
     CHECK( dc.GetMultiLineTextExtent(wxString()) == wxSize(0, sz.y) );
+}
+
+TEST_CASE("wxMemoryDC::GetTextExtent", "[memdc][text-extent]")
+{
+    wxBitmap bmp(100, 100);
+    wxMemoryDC memdc(bmp);
+    GetTextExtentTester<wxMemoryDC> testMem(memdc);
 }
 
 #if wxUSE_PRINTING_ARCHITECTURE && wxUSE_POSTSCRIPT

--- a/tests/graphics/measuring.cpp
+++ b/tests/graphics/measuring.cpp
@@ -79,9 +79,11 @@ TEST_CASE("wxDC::GetTextExtent", "[dc][text-extent]")
 
     // And even empty strings count like one line.
     CHECK( dc.GetMultiLineTextExtent(wxString()) == wxSize(0, sz.y) );
+}
 
-    // Test the functions with some other DC kinds also.
 #if wxUSE_PRINTING_ARCHITECTURE && wxUSE_POSTSCRIPT
+TEST_CASE("wxPostScriptDC::GetTextExtent", "[psdc][text-extent]")
+{
     wxPostScriptDC psdc;
     // wxPostScriptDC doesn't have any font set by default but its
     // GetTextExtent() requires one to be set. This is probably a bug and we
@@ -89,13 +91,16 @@ TEST_CASE("wxDC::GetTextExtent", "[dc][text-extent]")
     // around it.
     psdc.SetFont(*wxNORMAL_FONT);
     GetTextExtentTester<wxPostScriptDC> testPS(psdc);
-#endif
+}
+#endif // wxUSE_POSTSCRIPT
 
 #if wxUSE_ENH_METAFILE
+TEST_CASE("wxEnhMetaFileDC::GetTextExtent", "[emfdc][text-extent]")
+{
     wxEnhMetaFileDC metadc;
     GetTextExtentTester<wxEnhMetaFileDC> testMF(metadc);
-#endif
 }
+#endif // wxUSE_ENH_METAFILE
 
 TEST_CASE("wxDC::LeadingAndDescent", "[dc][text-extent]")
 {

--- a/tests/graphics/measuring.cpp
+++ b/tests/graphics/measuring.cpp
@@ -37,26 +37,28 @@
 // helper for XXXTextExtent() methods
 // ----------------------------------------------------------------------------
 
-template <typename T>
-struct GetTextExtentTester
+namespace
 {
-    // Constructor runs a couple of simple tests for GetTextExtent().
-    GetTextExtentTester(const T& obj)
-    {
-        // Test that getting the height only doesn't crash.
-        int y;
-        obj.GetTextExtent("H", NULL, &y);
 
-        CHECK( y > 1 );
+// Run a couple of simple tests for GetTextExtent().
+template <typename T>
+void GetTextExtentTester(const T& obj)
+{
+    // Test that getting the height only doesn't crash.
+    int y;
+    obj.GetTextExtent("H", NULL, &y);
 
-        wxSize size = obj.GetTextExtent("Hello");
-        CHECK( size.x > 1 );
-        CHECK( size.y == y );
+    CHECK( y > 1 );
 
-        // Test that getting text extent of an empty string returns (0, 0).
-        CHECK( obj.GetTextExtent(wxString()) == wxSize() );
-    }
-};
+    wxSize size = obj.GetTextExtent("Hello");
+    CHECK( size.x > 1 );
+    CHECK( size.y == y );
+
+    // Test that getting text extent of an empty string returns (0, 0).
+    CHECK( obj.GetTextExtent(wxString()) == wxSize() );
+}
+
+} // anonymous namespace
 
 // ----------------------------------------------------------------------------
 // tests themselves
@@ -66,7 +68,7 @@ TEST_CASE("wxDC::GetTextExtent", "[dc][text-extent]")
 {
     wxClientDC dc(wxTheApp->GetTopWindow());
 
-    GetTextExtentTester<wxClientDC> testDC(dc);
+    GetTextExtentTester(dc);
 
     int w;
     dc.GetMultiLineTextExtent("Good\nbye", &w, NULL);
@@ -86,14 +88,14 @@ TEST_CASE("wxMemoryDC::GetTextExtent", "[memdc][text-extent]")
 {
     wxBitmap bmp(100, 100);
     wxMemoryDC memdc(bmp);
-    GetTextExtentTester<wxMemoryDC> testMem(memdc);
+    GetTextExtentTester(memdc);
 
     // Under MSW, this wxDC should work even without any valid font -- but
     // this is not the case under wxGTK and probably neither elsewhere, so
     // restrict this test to that platform only.
 #ifdef __WXMSW__
     memdc.SetFont(wxNullFont);
-    GetTextExtentTester<wxMemoryDC> testMemNoFont(memdc);
+    GetTextExtentTester(memdc);
 #endif // __WXMSW__
 }
 
@@ -106,7 +108,7 @@ TEST_CASE("wxPostScriptDC::GetTextExtent", "[psdc][text-extent]")
     // should set the default font in it implicitly but for now just work
     // around it.
     psdc.SetFont(*wxNORMAL_FONT);
-    GetTextExtentTester<wxPostScriptDC> testPS(psdc);
+    GetTextExtentTester(psdc);
 }
 #endif // wxUSE_POSTSCRIPT
 
@@ -114,7 +116,7 @@ TEST_CASE("wxPostScriptDC::GetTextExtent", "[psdc][text-extent]")
 TEST_CASE("wxEnhMetaFileDC::GetTextExtent", "[emfdc][text-extent]")
 {
     wxEnhMetaFileDC metadc;
-    GetTextExtentTester<wxEnhMetaFileDC> testMF(metadc);
+    GetTextExtentTester(metadc);
 }
 #endif // wxUSE_ENH_METAFILE
 
@@ -146,7 +148,7 @@ TEST_CASE("wxWindow::GetTextExtent", "[window][text-extent]")
 {
     wxWindow* const win = wxTheApp->GetTopWindow();
 
-    GetTextExtentTester<wxWindow> testWin(*win);
+    GetTextExtentTester(*win);
 }
 
 TEST_CASE("wxDC::GetPartialTextExtent", "[dc][text-extent][partial]")

--- a/tests/graphics/measuring.cpp
+++ b/tests/graphics/measuring.cpp
@@ -87,6 +87,14 @@ TEST_CASE("wxMemoryDC::GetTextExtent", "[memdc][text-extent]")
     wxBitmap bmp(100, 100);
     wxMemoryDC memdc(bmp);
     GetTextExtentTester<wxMemoryDC> testMem(memdc);
+
+    // Under MSW, this wxDC should work even without any valid font -- but
+    // this is not the case under wxGTK and probably neither elsewhere, so
+    // restrict this test to that platform only.
+#ifdef __WXMSW__
+    memdc.SetFont(wxNullFont);
+    GetTextExtentTester<wxMemoryDC> testMemNoFont(memdc);
+#endif // __WXMSW__
 }
 
 #if wxUSE_PRINTING_ARCHITECTURE && wxUSE_POSTSCRIPT


### PR DESCRIPTION
This is mostly to fix #22240, but also some extra cleanup.