### PR TITLE
Add GetErrorStr() for obtaining descriptions for wxDynamicLibrary errors

### DIFF
--- a/include/wx/dynlib.h
+++ b/include/wx/dynlib.h
@@ -251,10 +251,10 @@ public:
     wxDllType Detach() { wxDllType h = m_handle; m_handle = NULL; return h; }
 
     // unload the given library handle (presumably returned by Detach() before)
-    static void Unload(wxDllType handle, wxString* errorDest = NULL);
+    static bool Unload(wxDllType handle, wxString* errorDest = NULL);
 
     // unload the library, also done automatically in dtor
-    void Unload();
+    bool Unload();
 
     // return error message related to the latest failure
     wxString GetErrorStr() const { return m_lastError; }

--- a/include/wx/dynlib.h
+++ b/include/wx/dynlib.h
@@ -251,10 +251,13 @@ public:
     wxDllType Detach() { wxDllType h = m_handle; m_handle = NULL; return h; }
 
     // unload the given library handle (presumably returned by Detach() before)
-    static void Unload(wxDllType handle);
+    static void Unload(wxDllType handle, wxString* errorDest = NULL);
 
     // unload the library, also done automatically in dtor
     void Unload();
+
+    // return error message related to the latest failure
+    wxString GetErrorStr() const { return m_lastError; }
 
     // Return the raw handle from dlopen and friends.
     wxDllType GetLibHandle() const { return m_handle; }
@@ -358,11 +361,21 @@ protected:
     void* DoGetSymbol(const wxString& name, bool* success = NULL) const;
 
     // log the error after an OS dynamic library function failure
-    static void ReportError(const wxString& msg,
+    // also updates GetErrorStr()
+    void ReportError(const wxString& msg,
+                     const wxString& name = wxString()) const;
+
+    // log the error after an OS dynamic library function failure
+    // the error message is written to errorDest
+    static void ReportError(wxString* errorDest,
+                            const wxString& msg,
                             const wxString& name = wxString());
 
     // the handle to DLL or NULL
     wxDllType m_handle;
+
+    // system error after failing to (un)load a library or a symbol
+    mutable wxString m_lastError;
 
     // no copy ctor/assignment operators (or we'd try to unload the library
     // twice)

--- a/include/wx/dynlib.h
+++ b/include/wx/dynlib.h
@@ -254,7 +254,7 @@ public:
     static void Unload(wxDllType handle);
 
     // unload the library, also done automatically in dtor
-    void Unload() { if ( IsLoaded() ) { Unload(m_handle); m_handle = NULL; } }
+    void Unload();
 
     // Return the raw handle from dlopen and friends.
     wxDllType GetLibHandle() const { return m_handle; }

--- a/interface/wx/dynlib.h
+++ b/interface/wx/dynlib.h
@@ -246,8 +246,11 @@ public:
         Unloads the library from memory. wxDynamicLibrary object automatically
         calls this method from its destructor if it had been successfully
         loaded.
+
+        Returns @true on success or if there was no library loaded; @false
+        otherwise.
     */
-    void Unload();
+    bool Unload();
     /**
         Unloads the library from memory. wxDynamicLibrary object automatically
         calls this method from its destructor if it had been successfully
@@ -258,10 +261,13 @@ public:
         wxDynamicLibrary object. In this case you may call Detach() and store
         the handle somewhere and call this static method later to unload it.
 
+        Returns @true on success, or if there was no library loaded; @false
+        otherwise.
+
         @param errorDest In case of an error, the error message is optionally
                written to @c errorDest.
     */
-    static void Unload(wxDllType handle, wxString *errorDest = NULL);
+    static bool Unload(wxDllType handle, wxString *errorDest = NULL);
     /**
         Returns an error string describing the latest error that occurred.
 

--- a/interface/wx/dynlib.h
+++ b/interface/wx/dynlib.h
@@ -257,8 +257,21 @@ public:
         in memory during a longer period of time than the scope of the
         wxDynamicLibrary object. In this case you may call Detach() and store
         the handle somewhere and call this static method later to unload it.
+
+        @param errorDest In case of an error, the error message is optionally
+               written to @c errorDest.
     */
-    static void Unload(wxDllType handle);
+    static void Unload(wxDllType handle, wxString *errorDest = NULL);
+    /**
+        Returns an error string describing the latest error that occurred.
+
+        The purpose of this function is similar to that of wxSysErrorMsg(), but
+        on most platforms errors related to dynamic library loading are not
+        available as system errors.
+
+        @since 3.1.6
+    */
+    wxString GetErrorStr() const;
 };
 
 

--- a/src/common/dynlib.cpp
+++ b/src/common/dynlib.cpp
@@ -85,6 +85,7 @@ bool wxDynamicLibrary::Load(const wxString& libnameOrig, int flags)
     {
         ReportError(_("Failed to load shared library '%s'"), libname);
     }
+    // TODO: GetErrorStr() is not updated if wxDL_QUIET was given
 
     return IsLoaded();
 }
@@ -93,7 +94,7 @@ void wxDynamicLibrary::Unload()
 {
     if ( IsLoaded() )
     {
-        Unload(m_handle);
+        Unload(m_handle, &m_lastError);
         m_handle = NULL;
     }
 }
@@ -252,5 +253,14 @@ wxString wxDynamicLibrary::GetPluginsDirectory()
 #endif
 }
 
+// ----------------------------------------------------------------------------
+// error handling
+// ----------------------------------------------------------------------------
+
+void wxDynamicLibrary::ReportError(const wxString& message,
+                                   const wxString& name) const
+{
+    ReportError(&m_lastError, message, name);
+}
 
 #endif // wxUSE_DYNLIB_CLASS

--- a/src/common/dynlib.cpp
+++ b/src/common/dynlib.cpp
@@ -89,6 +89,15 @@ bool wxDynamicLibrary::Load(const wxString& libnameOrig, int flags)
     return IsLoaded();
 }
 
+void wxDynamicLibrary::Unload()
+{
+    if ( IsLoaded() )
+    {
+        Unload(m_handle);
+        m_handle = NULL;
+    }
+}
+
 void *wxDynamicLibrary::DoGetSymbol(const wxString &name, bool *success) const
 {
     wxCHECK_MSG( IsLoaded(), NULL,

--- a/src/common/dynlib.cpp
+++ b/src/common/dynlib.cpp
@@ -90,12 +90,19 @@ bool wxDynamicLibrary::Load(const wxString& libnameOrig, int flags)
     return IsLoaded();
 }
 
-void wxDynamicLibrary::Unload()
+bool wxDynamicLibrary::Unload()
 {
     if ( IsLoaded() )
     {
-        Unload(m_handle, &m_lastError);
+        wxDllType h = m_handle;
         m_handle = NULL;
+        return Unload(h, &m_lastError);
+    }
+    else
+    {
+        // we didn't do anything, but there was no
+        // error either, so return true.
+        return true;
     }
 }
 

--- a/src/msw/dlmsw.cpp
+++ b/src/msw/dlmsw.cpp
@@ -191,12 +191,17 @@ wxDynamicLibrary::RawLoad(const wxString& libname, int flags)
 }
 
 /* static */
-void wxDynamicLibrary::Unload(wxDllType handle, wxString *errorDest)
+bool wxDynamicLibrary::Unload(wxDllType handle, wxString *errorDest)
 {
     if ( !::FreeLibrary(handle) )
     {
         wxLogLastError(wxT("FreeLibrary"));
         ReportError(errorDest, _("Failed to unload shared library"));
+        return false;
+    }
+    else
+    {
+        return true;
     }
 }
 

--- a/src/msw/dlmsw.cpp
+++ b/src/msw/dlmsw.cpp
@@ -147,7 +147,9 @@ wxDllType wxDynamicLibrary::GetProgramHandle()
 // ----------------------------------------------------------------------------
 
 /* static */
-void wxDynamicLibrary::ReportError(const wxString& message, const wxString& name)
+void wxDynamicLibrary::ReportError(wxString* errorDest,
+                                   const wxString& message,
+                                   const wxString& name)
 {
     wxString msg(message);
     if ( name.IsEmpty() && msg.Find("%s") == wxNOT_FOUND )
@@ -165,6 +167,9 @@ void wxDynamicLibrary::ReportError(const wxString& message, const wxString& name
     // Mimic the output of wxLogSysError(), but use our pre-processed
     // errMsg.
     wxLogError(msg + " " + _("(error %d: %s)"), name, code, errMsg);
+
+    if ( errorDest )
+        *errorDest = errMsg;
 }
 
 // ----------------------------------------------------------------------------
@@ -186,11 +191,12 @@ wxDynamicLibrary::RawLoad(const wxString& libname, int flags)
 }
 
 /* static */
-void wxDynamicLibrary::Unload(wxDllType handle)
+void wxDynamicLibrary::Unload(wxDllType handle, wxString *errorDest)
 {
     if ( !::FreeLibrary(handle) )
     {
         wxLogLastError(wxT("FreeLibrary"));
+        ReportError(errorDest, _("Failed to unload shared library"));
     }
 }
 

--- a/src/unix/dlunix.cpp
+++ b/src/unix/dlunix.cpp
@@ -82,12 +82,12 @@ wxDllType wxDynamicLibrary::RawLoad(const wxString& libname, int flags)
 }
 
 /* static */
-void wxDynamicLibrary::Unload(wxDllType handle)
+void wxDynamicLibrary::Unload(wxDllType handle, wxString* errorDest)
 {
     int rc = dlclose(handle);
 
     if ( rc != 0 )
-        ReportError(_("Failed to unload shared library"));
+        ReportError(errorDest, _("Failed to unload shared library"));
 }
 
 /* static */
@@ -103,7 +103,8 @@ void *wxDynamicLibrary::RawGetSymbol(wxDllType handle, const wxString& name)
 // ----------------------------------------------------------------------------
 
 /* static */
-void wxDynamicLibrary::ReportError(const wxString& message,
+void wxDynamicLibrary::ReportError(wxString* errorDest,
+                                   const wxString& message,
                                    const wxString& name)
 {
     wxString msg(message);
@@ -119,6 +120,9 @@ void wxDynamicLibrary::ReportError(const wxString& message,
         err = _("Unknown dynamic library error");
 
     wxLogError(msg + wxT(": %s"), name, err);
+
+    if ( errorDest )
+        *errorDest = err;
 }
 
 

--- a/src/unix/dlunix.cpp
+++ b/src/unix/dlunix.cpp
@@ -82,12 +82,19 @@ wxDllType wxDynamicLibrary::RawLoad(const wxString& libname, int flags)
 }
 
 /* static */
-void wxDynamicLibrary::Unload(wxDllType handle, wxString* errorDest)
+bool wxDynamicLibrary::Unload(wxDllType handle, wxString* errorDest)
 {
     int rc = dlclose(handle);
 
     if ( rc != 0 )
+    {
         ReportError(errorDest, _("Failed to unload shared library"));
+        return false;
+    }
+    else
+    {
+        return true;
+    }
 }
 
 /* static */

--- a/src/unix/dlunix.cpp
+++ b/src/unix/dlunix.cpp
@@ -112,7 +112,8 @@ void wxDynamicLibrary::ReportError(const wxString& message,
     // msg needs a %s for the name
     wxASSERT(msg.Find("%s") != wxNOT_FOUND);
 
-    wxString err(dlerror());
+    const char* de = dlerror();
+    wxString err(de ? de : "");
 
     if ( err.empty() )
         err = _("Unknown dynamic library error");


### PR DESCRIPTION
Until now, such error strings were logged, but there was no way to obtain
the string and do something else with it instead of logging.

The purpose of GetErrorStr() this function is similar to that of
wxSysErrorMsg(), but on most platforms dynamic library loading errors
are not available as system errors.

This is a simplified version of the previously rejected PR #1462,
with fewer changes to behavior.