### PR TITLE
Handle Windows CRT locale names

### DIFF
--- a/include/wx/localedefs.h
+++ b/include/wx/localedefs.h
@@ -151,6 +151,9 @@ struct WXDLLIMPEXP_BASE wxLanguageInfo
     // supported
     wxString GetLocaleName() const;
 
+    // returns CanonicalRef if set, otherwise CanonicalName
+    wxString GetCanonicalWithRegion() const;
+
     // Call setlocale() and return non-null value if it works for this language.
     //
     // This function is mostly for internal use, as changing locale involves

--- a/interface/wx/intl.h
+++ b/interface/wx/intl.h
@@ -400,7 +400,7 @@ public:
         This function may be used to find the language description structure for the
         given locale, specified either as a two letter ISO language code (for example,
         "pt"), a language code followed by the country code ("pt_BR") or a full, human
-        readable, language description ("Portuguese-Brazil").
+        readable, language description ("Portuguese_Brazil").
 
         Returns the information for the given language or @NULL if this language
         is unknown. Note that even if the returned pointer is valid, the caller

--- a/interface/wx/intl.h
+++ b/interface/wx/intl.h
@@ -87,6 +87,16 @@ struct wxLanguageInfo
         string is empty.
      */
     wxString GetLocaleName() const;
+
+    /**
+        Return the canonical locale name including the region, if known.
+
+        The value is identical to @c CanonicalRef, if not empty,
+        otherwise it is identical to @c CanonicalName.
+
+        @since 3.1.6
+    */
+    wxString GetCanonicalWithRegion() const;
 };
 
 

--- a/interface/wx/uilocale.h
+++ b/interface/wx/uilocale.h
@@ -225,7 +225,7 @@ public:
         This function may be used to find the language description structure for the
         given locale, specified either as a two letter ISO language code (for example,
         "pt"), a language code followed by the country code ("pt_BR") or a full, human
-        readable, language description ("Portuguese-Brazil").
+        readable, language description ("Portuguese_Brazil").
 
         Returns the information for the given language or @NULL if this language
         is unknown. Note that even if the returned pointer is valid, the caller
@@ -374,10 +374,11 @@ public:
 
         The following tag syntax is accepted:
 
-        - BCP-47:  \<language\>[-\<script\>][-\<region\>][-\<extension\>]
-        - Windows: \<language\>[-\<script\>][-\<region\>][-\<extension\>][_\<sortorder\>]
-        - POSIX:   \<language\>[_\<region\>][.\<charset\>][@@\<modifier\>]
-        - macOS:   \<language\>[-\<script\>][_\<region\>]
+        - BCP-47:      \<language\>[-\<script\>][-\<region\>][-\<extension\>]
+        - Windows:     \<language\>[-\<script\>][-\<region\>][-\<extension\>][_\<sortorder\>]
+        - Windows CRT: \<language\>[_\<region\>][.\<charset\>]
+        - POSIX:       \<language\>[_\<region\>][.\<charset\>][@@\<modifier\>]
+        - macOS:       \<language\>[-\<script\>][_\<region\>]
 
         The string must contain at least the language part (2 or 3 ASCII
         letters) and may contain script and region separated by dashes, i.e.

--- a/interface/wx/uilocale.h
+++ b/interface/wx/uilocale.h
@@ -225,7 +225,9 @@ public:
         This function may be used to find the language description structure for the
         given locale, specified either as a two letter ISO language code (for example,
         "pt"), a language code followed by the country code ("pt_BR") or a full, human
-        readable, language description ("Portuguese_Brazil").
+        readable, language description ("Portuguese_Brazil"). Please note that only
+        the underscore character is supported as the separator between language and
+        region codes.
 
         Returns the information for the given language or @NULL if this language
         is unknown. Note that even if the returned pointer is valid, the caller
@@ -351,8 +353,9 @@ public:
 
         - BCP-47,
         - Windows,
-        - POSIX, and
-        - macOS.
+        - POSIX,
+        - macOS. and
+        - MSVC CRT.
 
         See section 2.01 of https://www.rfc-editor.org/rfc/bcp/bcp47.txt for the
         full BCP-47 syntax. Here we fully support just the subset we're interested in:
@@ -374,11 +377,11 @@ public:
 
         The following tag syntax is accepted:
 
-        - BCP-47:      \<language\>[-\<script\>][-\<region\>][-\<extension\>]
-        - Windows:     \<language\>[-\<script\>][-\<region\>][-\<extension\>][_\<sortorder\>]
-        - Windows CRT: \<language\>[_\<region\>][.\<charset\>]
-        - POSIX:       \<language\>[_\<region\>][.\<charset\>][@@\<modifier\>]
-        - macOS:       \<language\>[-\<script\>][_\<region\>]
+        - BCP-47:   \<language\>[-\<script\>][-\<region\>][-\<extension\>]
+        - Windows:  \<language\>[-\<script\>][-\<region\>][-\<extension\>][_\<sortorder\>]
+        - POSIX:    \<language\>[_\<region\>][.\<charset\>][@@\<modifier\>]
+        - macOS:    \<language\>[-\<script\>][_\<region\>]
+        - MSVC CRT: \<language\>[_\<region\>][.\<charset\>]
 
         The string must contain at least the language part (2 or 3 ASCII
         letters) and may contain script and region separated by dashes, i.e.
@@ -397,6 +400,11 @@ public:
         empty wxLocaleIdent is returned. Of course, even if this function
         returns a non-empty object, the resulting locale may still be invalid
         or unsupported, use wxUILocale::IsSupported() to check for this.
+
+        Note that the format "MSVC CRT" (Microsoft Visual C++ C RunTime) is
+        only supported as an input format, so that locale names as returned
+        by the CRT function setlocale can be handled, mainly for compatibility
+        with wxLocale.
      */
     static wxLocaleIdent FromTag(const wxString& tag);
 

--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -159,17 +159,22 @@ const char* wxLanguageInfo::TrySetLocale() const
 
 const char* wxLanguageInfo::TrySetLocale() const
 {
-    return wxSetlocale(LC_ALL, CanonicalRef.empty() ? CanonicalName : CanonicalRef);
+    return wxSetlocale(LC_ALL, GetCanonicalWithRegion());
 }
 
 #endif // __WINDOWS__/!__WINDOWS__
 
 wxString wxLanguageInfo::GetLocaleName() const
 {
-    wxString localeId = CanonicalRef.empty() ? CanonicalName : CanonicalRef;
+    wxString localeId = GetCanonicalWithRegion();
     wxUILocale uiLocale = wxUILocale::FromTag(localeId);
     wxString localeName = uiLocale.IsSupported() ? uiLocale.GetName() : wxString();
     return localeName;
+}
+
+wxString wxLanguageInfo::GetCanonicalWithRegion() const
+{
+    return CanonicalRef.empty() ? CanonicalName : CanonicalRef;
 }
 
 // ----------------------------------------------------------------------------
@@ -295,7 +300,7 @@ bool wxLocale::Init(const wxString& name,
         else
         {
             strName = langInfo->Description;
-            strShort = langInfo->CanonicalRef.empty() ? langInfo->CanonicalName : langInfo->CanonicalRef;
+            strShort = langInfo->GetCanonicalWithRegion();
             languageId = langInfo->Language;
         }
     }
@@ -442,7 +447,7 @@ bool wxLocale::Init(int lang, int flags)
     else
     {
         name = info->Description;
-        shortName = info->CanonicalRef.empty() ? info->CanonicalName : info->CanonicalRef;
+        shortName = info->GetCanonicalWithRegion();
     }
 
     DoInit(name, shortName, lang);
@@ -750,7 +755,7 @@ bool wxLocale::IsAvailable(int lang)
         return false;
     }
 
-    wxString localeTag = info->CanonicalRef.empty() ? info->LocaleTag : info->CanonicalRef;
+    wxString localeTag = info->GetCanonicalWithRegion();
     wxUILocale uiLocale(wxLocaleIdent::FromTag(localeTag));
 
     return uiLocale.IsSupported();

--- a/src/common/uilocale.cpp
+++ b/src/common/uilocale.cpp
@@ -96,11 +96,11 @@ wxLocaleIdent wxLocaleIdent::FromTag(const wxString& tag)
     // The script tag takes precedence, if a modifier is also specified.
     //
     // The following tag syntax is accepted:
-    //   BCP47:   language[-script][-region][-extension]
-    //   Windows: language[-script][-region][-extension][_sortorder]
-    //   Windows CRT: language[_region][.codepage]
-    //   POSIX:   language[_region][.charset][@modifier]
-    //   macOS:   language[-script][_region]
+    //   BCP47:    language[-script][-region][-extension]
+    //   Windows:  language[-script][-region][-extension][_sortorder]
+    //   POSIX:    language[_region][.charset][@modifier]
+    //   macOS:    language[-script][_region]
+    //   MSVC CRT: language[_region][.codepage]
 
     wxLocaleIdent locId;
 
@@ -731,6 +731,9 @@ wxString wxUILocale::GetLanguageCanonicalName(int lang)
 /* static */
 const wxLanguageInfo* wxUILocale::FindLanguageInfo(const wxString& locale)
 {
+    if (locale.empty())
+        return NULL;
+
     CreateLanguagesDB();
 
     // Determine full language and region names, which will be compared
@@ -782,6 +785,9 @@ const wxLanguageInfo* wxUILocale::FindLanguageInfo(const wxString& locale)
 /* static */
 const wxLanguageInfo* wxUILocale::FindLanguageInfo(const wxLocaleIdent& locId)
 {
+    if (locId.IsEmpty())
+        return NULL;
+
     CreateLanguagesDB();
 
     const wxLanguageInfo* infoRet = NULL;

--- a/src/common/uilocale.cpp
+++ b/src/common/uilocale.cpp
@@ -41,7 +41,6 @@ namespace
 const char* validCharsAlpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 const char* validCharsAlnum = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 const char* validCharsModExt = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-";
-const char* validCharsTag = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.@";
 
 // Handle special case "ca-ES-valencia"
 // Sync attributes modifier and extension
@@ -99,15 +98,9 @@ wxLocaleIdent wxLocaleIdent::FromTag(const wxString& tag)
     // The following tag syntax is accepted:
     //   BCP47:   language[-script][-region][-extension]
     //   Windows: language[-script][-region][-extension][_sortorder]
+    //   Windows CRT: language[_region][.codepage]
     //   POSIX:   language[_region][.charset][@modifier]
     //   macOS:   language[-script][_region]
-
-    // Locale tags must always use alphanumeric characters and certain special characters "-_.@"
-    if (tag.find_first_not_of(validCharsTag) != wxString::npos)
-    {
-        wxFAIL_MSG("tag contains invalid characters (not alphanumeric) or invalid delimiters");
-        return wxLocaleIdent();
-    }
 
     wxLocaleIdent locId;
 
@@ -125,10 +118,6 @@ wxLocaleIdent wxLocaleIdent::FromTag(const wxString& tag)
         else
             locId.Modifier(tagRest);
     }
-    else
-    {
-        wxASSERT_MSG(tag.find('@') == wxString::npos, "modifier delimiter found, but modifier is empty");
-    }
 
     // 1b. Check for charset in POSIX tag
     tagMain = tagMain.BeforeFirst('.', &tagRest);
@@ -137,27 +126,40 @@ wxLocaleIdent wxLocaleIdent::FromTag(const wxString& tag)
         // POSIX charset found
         locId.Charset(tagRest);
     }
-    else
+
+    // 1c. Check for Windows CRT language and region names
     {
-        wxASSERT_MSG(tagMain.find('.') == wxString::npos, "charset delimiter found, but charset is empty");
+        // The tag is potentially a Windows CRT language/region name,
+        // if language and region part both have a length greater 3
+        // (that is, they are not given as ISO codes)
+        wxString tagTemp = tagMain.BeforeFirst('_', &tagRest);
+        if (tagTemp.length() > 3 && (tagRest.empty() || tagRest.length() > 3))
+        {
+            const wxLanguageInfo* const info = wxUILocale::FindLanguageInfo(tagMain);
+            if (info)
+            {
+                tagMain = info->LocaleTag;
+            }
+        }
     }
 
-    // 1c. Check for sort order in Windows tag
+    // 1d. Check for sort order in Windows tag
     //
     // Make sure we don't extract the region identifier erroneously as a sortorder identifier
-    wxString tagTemp = tagMain.BeforeFirst('_', &tagRest);
-    if (tagRest.length() > 4 && locId.m_modifier.empty() && locId.m_charset.empty())
     {
-        // Windows sortorder found
-        locId.SortOrder(tagRest);
-        tagMain = tagTemp;
+        wxString tagTemp = tagMain.BeforeFirst('_', &tagRest);
+        if (tagRest.length() > 4 && locId.m_modifier.empty() && locId.m_charset.empty())
+        {
+            // Windows sortorder found
+            locId.SortOrder(tagRest);
+            tagMain = tagTemp;
+        }
     }
 
     // 2. Handle remaining tag identifier as being BCP47-like
 
     // Now that special POSIX attributes have been handled
     // POSIX specific delimiters must no longer be present
-    wxASSERT_MSG(tagMain.find_first_of(".@") == wxString::npos, "tag contains invalid delimiters");
 
     // Replace '_' separators by '-' to simplify further processing
     tagMain.Replace("_", "-");
@@ -208,13 +210,11 @@ wxLocaleIdent wxLocaleIdent::FromTag(const wxString& tag)
 
         case 4:
             // Must be an ISO 15924 script.
-            wxASSERT_MSG(locId.m_script.empty(), "script already set");
             locId.m_script = (*it).Left(1).Upper() + (*it).Mid(2).Lower();
             break;
 
         default:
             // This looks to be completely invalid.
-            wxFAIL_MSG("invalid code length, script or region code expected");
             return wxLocaleIdent();
     }
 
@@ -733,6 +733,19 @@ const wxLanguageInfo* wxUILocale::FindLanguageInfo(const wxString& locale)
 {
     CreateLanguagesDB();
 
+    // Determine full language and region names, which will be compared
+    // to the entry description in the language database.
+    // The locale string may have the form "language[_region][.codeset]".
+    // We ignore the "codeset" part here.
+    wxString region;
+    wxString languageOnly = locale.BeforeFirst('.').BeforeFirst('_', &region);
+    wxString language= languageOnly;
+    if (!region.empty())
+    {
+        // Construct description consisting of language and region
+        language << " (" << region << ")";
+    }
+
     const wxLanguageInfo* infoRet = NULL;
 
     const wxLanguageInfos& languagesDB = wxGetLanguageInfos();
@@ -742,14 +755,15 @@ const wxLanguageInfo* wxUILocale::FindLanguageInfo(const wxString& locale)
         const wxLanguageInfo* info = &languagesDB[i];
 
         if (wxStricmp(locale, info->CanonicalName) == 0 ||
-            wxStricmp(locale, info->Description) == 0)
+            wxStricmp(language, info->Description) == 0)
         {
             // exact match, stop searching
             infoRet = info;
             break;
         }
 
-        if (wxStricmp(locale, info->CanonicalName.BeforeFirst(wxS('_'))) == 0)
+        if (wxStricmp(locale, info->CanonicalName.BeforeFirst(wxS('_'))) == 0 ||
+            wxStricmp(languageOnly, info->Description) == 0)
         {
             // a match -- but maybe we'll find an exact one later, so continue
             // looking

--- a/src/unix/uilocale.cpp
+++ b/src/unix/uilocale.cpp
@@ -157,7 +157,7 @@ locale_t TryCreateMatchingLocale(wxLocaleIdent& locId)
               it != infos.end();
               ++it )
         {
-            const wxString& fullname = it->CanonicalRef.empty() ? it->CanonicalName : it->CanonicalRef;
+            const wxString& fullname = it->GetCanonicalWithRegion();
             if ( fullname.BeforeFirst('_') == lang )
             {
                 // We never have encoding in our canonical names, but we


### PR DESCRIPTION
This PR fixes issue https://github.com/wxWidgets/wxWidgets/issues/22247 by handling Windows CRT locale names properly.

Additionally, method `FindLanguageInfo` was fixed to support human readable locale strings like "English_United States" as claimed by the documentation. The previous implementation was broken. However, the separator between language and region has to be an underscore (not a hyphen). The interface description was updated to show "Portuguese_Brazil" (instead of "Portuguese-Brazil").

**Note**: The final return call to `DoPostInit` in method `wxLocale::Init((const wxString& name, const wxString& shortName = wxEmptyString, const wxString& locale = wxEmptyString, bool bLoadDefault = true);` now uses the parameter `strShort` (instead of `shortName`). `shortName` can be empty, and using an empty string for the language of the translation catalog doesn't make much sense, does it? The drawback of this is that `strShort` and `shortName` could possibly be different. However, this can only happen, if inconsistent parameters were specified like `locale="fr"` and `shortName="de"`.
