### PR TITLE
Fix building benchmarks

### DIFF
--- a/tests/benchmarks/bench.cpp
+++ b/tests/benchmarks/bench.cpp
@@ -15,6 +15,8 @@
 // headers
 // ----------------------------------------------------------------------------
 
+#include <float.h>
+
 #include "wx/app.h"
 #include "wx/cmdline.h"
 #include "wx/stopwatch.h"


### PR DESCRIPTION
GCC failed to compile `bench.cpp` due to `DBL_MAX` not being declared:
```
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\benchmarks\bench.cpp: In member function 'bool BenchApp::RunSingleBenchmark(Bench::Function*)':
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\benchmarks\bench.cpp:303:22: error: 'DBL_MAX' was not declared in this scope
  303 |     double timeMin = DBL_MAX,
      |                      ^~~~~~~
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\benchmarks\bench.cpp:27:1: note: 'DBL_MAX' is defined in header '<cfloat>'; did you forget to '#include <cfloat>'?
   26 | #include "bench.h"
  +++ |+#include <cfloat>
   27 |
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\benchmarks\bench.cpp:327:18: error: 'timeMax' was not declared in this scope; did you mean 'timeval'?
  327 |         if ( t > timeMax )
      |                  ^~~~~~~
      |                  timeval
[ 97%] Built target test_gui
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\benchmarks\bench.cpp:355:31: error: 'timeMax' was not declared in this scope; did you mean 'timeval'?
  355 |             n, m, s, timeMin, timeMax
      |                               ^~~~~~~
      |                               timeval
mingw32-make[2]: *** [benchmarks\bench_gui\CMakeFiles\bench_gui.dir\build.make:91: benchmarks/bench_gui/CMakeFiles/bench_gui.dir/__/__/__/__/tests/benchmarks/bench.cpp.obj] Error 1

```
Fix this by including `float.h` (GCC suggested including `<cfloat>` but it seems wxWidgets does not use that header).