### PR TITLE
Use window scale factor for all MSW wxDCs associated with windows

### DIFF
--- a/include/wx/msw/dc.h
+++ b/include/wx/msw/dc.h
@@ -171,6 +171,9 @@ protected:
         m_isClipBoxValid = false;
     }
 
+    // Unlike the public SetWindow(), this one doesn't call InitializePalette().
+    void InitWindow(wxWindow* window);
+
     // create an uninitialized DC: this should be only used by the derived
     // classes
     wxMSWDCImpl( wxDC *owner ) : wxDCImpl( owner ) { Init(); }

--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -470,6 +470,13 @@ WXHDC wxDC::GetHDC() const
 // wxMSWDCImpl
 // ---------------------------------------------------------------------------
 
+void wxMSWDCImpl::InitWindow(wxWindow* window)
+{
+    m_window = window;
+    if ( m_window )
+        m_contentScaleFactor = m_window->GetDPIScaleFactor();
+}
+
 wxMSWDCImpl::wxMSWDCImpl( wxDC *owner, WXHDC hDC ) :
     wxDCImpl( owner )
 {

--- a/src/msw/dcclient.cpp
+++ b/src/msw/dcclient.cpp
@@ -156,7 +156,7 @@ wxWindowDCImpl::wxWindowDCImpl( wxDC *owner, wxWindow *window ) :
 {
     wxCHECK_RET( window, wxT("invalid window in wxWindowDCImpl") );
 
-    m_window = window;
+    InitWindow(window);
     m_hDC = (WXHDC) ::GetWindowDC(GetHwndOf(m_window));
 
     // m_bOwnsDC was already set to false in the base class ctor, so the DC
@@ -199,7 +199,7 @@ wxClientDCImpl::wxClientDCImpl( wxDC *owner, wxWindow *window ) :
 {
     wxCHECK_RET( window, wxT("invalid window in wxClientDCImpl") );
 
-    m_window = window;
+    InitWindow(window);
     m_hDC = (WXHDC)::GetDC(GetHwndOf(window));
 
     // m_bOwnsDC was already set to false in the base class ctor, so the DC
@@ -263,7 +263,7 @@ wxPaintDCImpl::wxPaintDCImpl( wxDC *owner, wxWindow *window ) :
 
     paintStack.top().createdPaintDC = true;
 
-    m_window = window;
+    InitWindow(window);
 
     // do we have a DC for this window in the cache?
     m_hDC = FindDCInCache(m_window);
@@ -352,7 +352,7 @@ wxPaintDCExImpl::wxPaintDCExImpl(wxDC *owner, wxWindow *window, WXHDC dc)
 {
     wxCHECK_RET( dc, wxT("wxPaintDCEx requires an existing device context") );
 
-    m_window = window;
+    InitWindow(window);
     m_hDC = dc;
 }
 


### PR DESCRIPTION
This ensures that we use correct font sizes with the DCs and, in
particular, fixes the font size in wxAutoBufferedPaintDC when using DPI
scaling different from 100% after the changes of e3557b8c0a (Respect
bitmap content scale factor in wxMSW wxMemoryDC, 2022-03-26).

See #22234.

---

@MaartenBent this fixes the size of the text in the dataview sample for me and I've also tested that the drawing sample still works as expected/as before. Please let me know if you see anything wrong. TIA!