### PR TITLE
Add a missing xpm to the xrc sample

### DIFF
--- a/build/cmake/samples/CMakeLists.txt
+++ b/build/cmake/samples/CMakeLists.txt
@@ -233,7 +233,7 @@ wx_list_add_prefix(XRC_RC_FILES rc/
     variable.xpm variable.xrc
     variants.xpm variants.xrc
     throbber.gif stop.xpm
-    wxbanner.gif
+    stop_2x.xpm wxbanner.gif
     )
 wx_add_sample(xrc
     xrcdemo.cpp

--- a/samples/xrc/xrcdemo.bkl
+++ b/samples/xrc/xrcdemo.bkl
@@ -42,7 +42,7 @@
             variable.xpm variable.xrc
             variants.xpm variants.xrc
             throbber.gif stop.xpm
-            wxbanner.gif
+            stop_2x.xpm wxbanner.gif
         </files>
     </wx-data>
 


### PR DESCRIPTION
Testing a the xrc sample in a GTK+3 wx3.1.6 build today (I'd not realised the release was so imminent; sorry) I get an assert:
`Cannot open bitmap resource "stop_2x.xpm"`.

That bitmap is indeed missing from the created sample/xrc dir, though it exists in wx/samples. It was added in #49fd3a22,  but that didn't add it to samples/xrc/xrcdemo.bkl (or build/cmake/samples/CMakeLists.txt).