### PR TITLE
grid usability: auto scrolling, cancel drag actions with ESCAPE

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2825,6 +2825,11 @@ protected:
     // setting m_isDragging to true
     wxPoint m_startDragPos;
 
+public:
+    // the position of the last mouse event
+    // used for detection of the movement direction
+    wxPoint m_lastMousePos;
+private:
     bool    m_waitForSlowClick;
 
     wxCursor m_rowResizeCursor;

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2804,9 +2804,16 @@ protected:
     // or -1 if there is no resize operation in progress.
     int     m_dragRowOrCol;
 
+    // Original row or column size when resizing; used when the user cancels
+    int     m_dragRowOrColOldSize;
+
     // true if a drag operation is in progress; when this is true,
     // m_startDragPos is valid, i.e. not wxDefaultPosition
     bool    m_isDragging;
+
+    // true if a drag operation was canceled
+    // (mouse event Dragging() might still be active until LeftUp)
+    bool    m_canceledDragging;
 
     // the position (in physical coordinates) where the user started dragging
     // the mouse or wxDefaultPosition if mouse isn't being dragged
@@ -3029,7 +3036,7 @@ private:
 
     void DoColHeaderClick(int col);
 
-    void DoStartResizeRowOrCol(int col);
+    void DoStartResizeRowOrCol(int col, int size);
     void DoStartMoveRow(int col);
     void DoStartMoveCol(int col);
 

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2813,7 +2813,9 @@ protected:
 
     // true if a drag operation was canceled
     // (mouse event Dragging() might still be active until LeftUp)
-    bool    m_canceledDragging;
+    // m_isDragging can only be set after m_cancelledDragging is cleared.
+    // This is done when a mouse event happens with left button up.
+    bool    m_cancelledDragging;
 
     // the position (in physical coordinates) where the user started dragging
     // the mouse or wxDefaultPosition if mouse isn't being dragged

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -100,6 +100,7 @@ class WXDLLIMPEXP_FWD_CORE wxGridCornerLabelWindow;
 class WXDLLIMPEXP_FWD_CORE wxGridEvent;
 class WXDLLIMPEXP_FWD_CORE wxGridRowLabelWindow;
 class WXDLLIMPEXP_FWD_CORE wxGridWindow;
+class WXDLLIMPEXP_FWD_CORE wxGridSubwindow;
 class WXDLLIMPEXP_FWD_CORE wxGridTypeRegistry;
 class WXDLLIMPEXP_FWD_CORE wxGridSelection;
 
@@ -2825,11 +2826,10 @@ protected:
     // setting m_isDragging to true
     wxPoint m_startDragPos;
 
-public:
     // the position of the last mouse event
     // used for detection of the movement direction
     wxPoint m_lastMousePos;
-private:
+
     bool    m_waitForSlowClick;
 
     wxCursor m_rowResizeCursor;
@@ -2973,6 +2973,13 @@ private:
 
     // release the mouse capture if it's currently captured
     void EndDraggingIfNecessary();
+
+    // helper for Process...MouseEvent to block re-triggering m_isDragging
+    bool CheckIfDragCancelled(wxMouseEvent *event);
+
+    // helper for Process...MouseEvent to scroll
+    void CheckDoDragScroll(wxGridSubwindow *eventGridWindow, wxGridSubwindow *gridWindow,
+                           wxPoint posEvent, int direction);
 
     // return true if the grid should be refreshed right now
     bool ShouldRefresh() const

--- a/include/wx/generic/gridsel.h
+++ b/include/wx/generic/gridsel.h
@@ -112,6 +112,7 @@ public:
     wxVectorGridBlockCoords& GetBlocks() { return m_selection; }
 
     void EndSelecting();
+    void CancelSelecting();
 
 private:
     void SelectBlockNoEvent(const wxGridBlockCoords& block)

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -281,6 +281,8 @@ public:
 
     wxGrid *GetOwner() { return m_owner; }
 
+    virtual bool IsFrozen() const { return false; }
+
 protected:
     void OnMouseCaptureLost(wxMouseCaptureLostEvent& event);
 

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -300,8 +300,6 @@ public:
     {
     }
 
-    virtual bool IsFrozen() const { return false; }
-
 private:
     void OnPaint( wxPaintEvent& event );
     void OnMouseEvent( wxMouseEvent& event );
@@ -331,8 +329,6 @@ public:
         : wxGridSubwindow(parent)
     {
     }
-
-    virtual bool IsFrozen() const { return false; }
 
 private:
     void OnPaint( wxPaintEvent& event );

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -13,7 +13,6 @@
 
     - Make Begin/EndBatch() the same as the generic Freeze/Thaw()
     - Review the column reordering code, it's a mess.
-    - Implement row reordering after dealing with the columns.
  */
 
 // For compilers that support precompilation, includes "wx/wx.h".
@@ -5216,7 +5215,6 @@ void wxGrid::ProcessGridCellMouseEvent(wxMouseEvent& event, wxGridWindow *eventG
     // the window receiving the event might not be the same as the one under
     // the mouse (e.g. in the case of a dragging event started in one window,
     // but continuing over another one)
-
 
     if ( CheckIfDragCancelled(&event) )
         return;

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -3951,7 +3951,6 @@ void wxGrid::ProcessRowLabelMouseEvent( wxMouseEvent& event, wxGridRowLabelWindo
     if ( event.Dragging() && (m_winCapture == rowLabelWin) )
     {
         // scroll when at the edges or outside the window
-        fprintf(stderr, "ProcessRowLabelMouseEvent %d  ", rowLabelWin->IsFrozen());
         CheckDoDragScroll(this, rowLabelWin, m_rowLabelWin, event_pos, false, true);
     }
 
@@ -4427,9 +4426,7 @@ void wxGrid::ProcessColLabelMouseEvent( wxMouseEvent& event, wxGridColLabelWindo
     if ( event.Dragging() && (m_winCapture == colLabelWin) )
     {
         // scroll when at the edges or outside the window
-        //CheckDoDragScroll(this, colLabelWin, m_colLabelWin, event_pos, true, false);
         CheckDoDragScroll(this, colLabelWin, GetColLabelWindow(), event_pos, true, false);
-        
     }
 
     if ( event.Dragging() )

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -3036,7 +3036,7 @@ void wxGrid::Init()
     m_dragRowOrCol = -1;
     m_dragRowOrColOldSize = -1;
     m_isDragging = false;
-    m_canceledDragging = false;
+    m_cancelledDragging = false;
     m_startDragPos = wxDefaultPosition;
 
     m_sortCol = wxNOT_FOUND;
@@ -3866,7 +3866,7 @@ void wxGrid::ProcessRowLabelMouseEvent( wxMouseEvent& event, wxGridRowLabelWindo
     int y;
     wxGridWindow *gridWindow = rowLabelWin->IsFrozen() ? m_frozenRowGridWin : m_gridWin;
 
-    // store position, before its modified in the next step
+    // store position, before it's modified in the next step
     int event_y = event.GetPosition().y;
     static int last_event_y;
 
@@ -3879,17 +3879,17 @@ void wxGrid::ProcessRowLabelMouseEvent( wxMouseEvent& event, wxGridRowLabelWindo
     CalcGridWindowUnscrolledPosition(0, event.GetPosition().y,  NULL, &y, gridWindow);
     int row = YToRow( y );
 
-    if ( m_canceledDragging )
+    if ( m_cancelledDragging )
     {
         if ( event.LeftIsDown() )
             return;
         else
-            m_canceledDragging = false;
+            m_cancelledDragging = false;
     }
 
     if ( event.Dragging() && (m_winCapture == rowLabelWin) )
     {
-        // start auto scrolling at the edges
+        // scroll when at the edges or outside the window
         int sy = GetViewStart().y;
         int h = rowLabelWin->GetSize().y;
 
@@ -3900,8 +3900,10 @@ void wxGrid::ProcessRowLabelMouseEvent( wxMouseEvent& event, wxGridRowLabelWindo
                 Scroll(wxDefaultCoord, sy - 1);
         }
         else if ( rowLabelWin->IsFrozen() && event_y >= h )
+        {
             // frozen window was left, add the height of the non-frozen window
             h += m_rowLabelWin->GetSize().y;
+        }
 
         if ( event_y < 0 && sy > 0 )
             Scroll(wxDefaultCoord, sy - 1);
@@ -4359,7 +4361,7 @@ void wxGrid::ProcessColLabelMouseEvent( wxMouseEvent& event, wxGridColLabelWindo
     int x;
     wxGridWindow *gridWindow = colLabelWin->IsFrozen() ? m_frozenColGridWin : m_gridWin;
 
-    // store position, before its modified in the next step
+    // store position, before it's modified in the next step
     int event_x = event.GetPosition().x;
     static int last_event_x;
 
@@ -4373,17 +4375,17 @@ void wxGrid::ProcessColLabelMouseEvent( wxMouseEvent& event, wxGridColLabelWindo
 
     int col = XToCol(x);
 
-    if ( m_canceledDragging )
+    if ( m_cancelledDragging )
     {
         if ( event.LeftIsDown() )
             return;
         else
-            m_canceledDragging = false;
+            m_cancelledDragging = false;
     }
 
     if ( event.Dragging() && (m_winCapture == colLabelWin) )
     {
-        // start auto scrolling at the edges
+        // scroll when at the edges or outside the window
         int sx = GetViewStart().x;
         int w = colLabelWin->GetSize().x;
 
@@ -4394,8 +4396,10 @@ void wxGrid::ProcessColLabelMouseEvent( wxMouseEvent& event, wxGridColLabelWindo
                 Scroll(wxDefaultCoord, sx - 1);
         }
         else if ( colLabelWin->IsFrozen() && event_x >= w )
+        {
             // frozen window was left, add the height of the non-frozen window
             x += m_colLabelWin->GetSize().x;
+        }
 
         if ( event_x < 0 && sx > 0 )
             Scroll(sx - 1, wxDefaultCoord);
@@ -5188,12 +5192,12 @@ void wxGrid::ProcessGridCellMouseEvent(wxMouseEvent& event, wxGridWindow *eventG
     // the mouse (e.g. in the case of a dragging event started in one window,
     // but continuing over another one)
 
-    if ( m_canceledDragging )
+    if ( m_cancelledDragging )
     {
         if ( event.LeftIsDown() )
             return;
         else
-            m_canceledDragging = false;
+            m_cancelledDragging = false;
     }
 
     wxGridWindow *gridWindow =
@@ -5202,7 +5206,7 @@ void wxGrid::ProcessGridCellMouseEvent(wxMouseEvent& event, wxGridWindow *eventG
     if ( !gridWindow )
         gridWindow = eventGridWindow;
 
-    // store position, before its modified in the next step
+    // store position, before it's modified in the next step
     wxPoint event_pos = event.GetPosition();
     static wxPoint last_event_pos;
 
@@ -5239,7 +5243,7 @@ void wxGrid::ProcessGridCellMouseEvent(wxMouseEvent& event, wxGridWindow *eventG
 
     if ( isDraggingWithLeft && (m_winCapture == eventGridWindow) )
     {
-        // start auto scrolling at the edges
+        // scroll when at the edges or outside the window
         int w, h;
         eventGridWindow->GetSize(&w, &h);
         // ViewStart is scroll position in scroll units
@@ -5254,8 +5258,10 @@ void wxGrid::ProcessGridCellMouseEvent(wxMouseEvent& event, wxGridWindow *eventG
                 sx_new = sxy.x - 1;
         }
         else if ( eventGridWindow->IsFrozen() && event_pos.x >= w )
+        {
             // frozen window was left, add the width of the non-frozen window
             w += m_gridWin->GetSize().x;
+        }
 
         if ( event_pos.x < 0 && sxy.x > 0 )
             sx_new = sxy.x - 1;
@@ -5270,8 +5276,10 @@ void wxGrid::ProcessGridCellMouseEvent(wxMouseEvent& event, wxGridWindow *eventG
                 sy_new = sxy.y - 1;
         }
         else if ( eventGridWindow->IsFrozen() && event_pos.y >= h )
+        {
             // frozen window was left, add the height of the non-frozen window
             h += m_gridWin->GetSize().y;
+        }
 
         if ( event_pos.y < 0 && sxy.y > 0 )
             sy_new = sxy.y - 1;
@@ -6349,7 +6357,7 @@ void wxGrid::OnKeyDown( wxKeyEvent& event )
                     }
                     EndDraggingIfNecessary();
                     // ensure that a new drag operation is only started after a LeftUp
-                    m_canceledDragging = true;
+                    m_cancelledDragging = true;
                 }
                 else
                     ClearSelection();

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -6324,12 +6324,11 @@ void wxGrid::OnKeyDown( wxKeyEvent& event )
                         case WXGRID_CURSOR_RESIZE_ROW:
                         case WXGRID_CURSOR_RESIZE_COL:
                             // reset to size from before dragging
-                            if ( m_cursorMode == WXGRID_CURSOR_RESIZE_ROW )
-                                wxGridRowOperations().SetLineSize(this,
-                                    m_dragRowOrCol, m_dragRowOrColOldSize);
-                            else
-                                wxGridColumnOperations().SetLineSize(this,
-                                    m_dragRowOrCol, m_dragRowOrColOldSize);
+                            (m_cursorMode == WXGRID_CURSOR_RESIZE_ROW
+                                ? static_cast<const wxGridOperations&>(wxGridRowOperations())
+                                : static_cast<const wxGridOperations&>(wxGridColumnOperations())
+                            ).SetLineSize(this, m_dragRowOrCol, m_dragRowOrColOldSize);
+
                             m_dragRowOrCol = -1;
                             break;
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -3953,7 +3953,7 @@ void wxGrid::ProcessRowLabelMouseEvent( wxMouseEvent& event, wxGridRowLabelWindo
     // store position, before it's modified in the next step
     const wxPoint posEvent = event.GetPosition();
 
-    event.SetPosition(event.GetPosition() + GetGridWindowOffset(gridWindow));
+    event.SetPosition(posEvent + GetGridWindowOffset(gridWindow));
 
     // for drag, we could be moving from the window sending the event to the other
     if ( rowLabelWin->IsFrozen() && event.GetPosition().y > rowLabelWin->GetClientSize().y )
@@ -4423,7 +4423,7 @@ void wxGrid::ProcessColLabelMouseEvent( wxMouseEvent& event, wxGridColLabelWindo
     // store position, before it's modified in the next step
     const wxPoint posEvent = event.GetPosition();
 
-    event.SetPosition(event.GetPosition() + GetGridWindowOffset(gridWindow));
+    event.SetPosition(posEvent + GetGridWindowOffset(gridWindow));
 
     // for drag, we could be moving from the window sending the event to the other
     if (colLabelWin->IsFrozen() && event.GetPosition().x > colLabelWin->GetClientSize().x)

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -3880,10 +3880,12 @@ void wxGrid::ProcessRowLabelMouseEvent( wxMouseEvent& event, wxGridRowLabelWindo
     int row = YToRow( y );
 
     if ( m_canceledDragging )
+    {
         if ( event.LeftIsDown() )
             return;
         else
             m_canceledDragging = false;
+    }
 
     if ( event.Dragging() && (m_winCapture == rowLabelWin) )
     {
@@ -4371,11 +4373,13 @@ void wxGrid::ProcessColLabelMouseEvent( wxMouseEvent& event, wxGridColLabelWindo
 
     int col = XToCol(x);
 
-    if (m_canceledDragging)
-        if (event.LeftIsDown())
+    if ( m_canceledDragging )
+    {
+        if ( event.LeftIsDown() )
             return;
         else
             m_canceledDragging = false;
+    }
 
     if ( event.Dragging() && (m_winCapture == colLabelWin) )
     {
@@ -5185,10 +5189,12 @@ void wxGrid::ProcessGridCellMouseEvent(wxMouseEvent& event, wxGridWindow *eventG
     // but continuing over another one)
 
     if ( m_canceledDragging )
+    {
         if ( event.LeftIsDown() )
             return;
         else
             m_canceledDragging = false;
+    }
 
     wxGridWindow *gridWindow =
         DevicePosToGridWindow(event.GetPosition() + eventGridWindow->GetPosition());

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -3866,7 +3866,8 @@ void CheckDoDragScroll(wxGrid *grid, wxGridSubwindow *eventGridWindow,
     wxGridSubwindow *gridWindow, wxPoint event_pos,
     bool horizontal, bool vertical)
 {
-    // scroll when at the edges or outside the window
+    // helper for Process{Row|Col}LabelMouseEvent, ProcessGridCellMouseEvent:
+    //  scroll when at the edges or outside the window
     // eventGridWindow: the window that received the mouse event
     // gridWindow: the same or the corresponding non-frozen window
     int w, h;

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -5265,7 +5265,7 @@ void wxGrid::ProcessGridCellMouseEvent(wxMouseEvent& event, wxGridWindow *eventG
 
         if ( event_pos.x < 0 && sxy.x > 0 )
             sx_new = sxy.x - 1;
-        else if ( event_pos.y >= w )
+        else if ( event_pos.x >= w )
             sx_new = sxy.x + 1;
 
         // check y direction

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -3865,7 +3865,7 @@ void wxGrid::CheckDoDragScroll(wxGridSubwindow *eventGridWindow, wxGridSubwindow
                                wxPoint posEvent, int direction)
 {
     // helper for Process{Row|Col}LabelMouseEvent, ProcessGridCellMouseEvent:
-    //  scroll when at the edges or outside the window
+    //  scroll when at the edges or outside the window w. respect to direction
     // eventGridWindow: the window that received the mouse event
     // gridWindow: the same or the corresponding non-frozen window
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -6341,11 +6341,14 @@ void wxGrid::OnKeyDown( wxKeyEvent& event )
                             break;
                     }
                     EndDraggingIfNecessary();
+
                     // ensure that a new drag operation is only started after a LeftUp
                     m_cancelledDragging = true;
                 }
                 else
+                {
                     ClearSelection();
+                }
                 break;
 
             case WXK_TAB:

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -6338,7 +6338,7 @@ void wxGrid::OnKeyDown( wxKeyEvent& event )
 
                         case WXGRID_CURSOR_RESIZE_ROW:
                         case WXGRID_CURSOR_RESIZE_COL:
-                            // reset to size before dragging
+                            // reset to size from before dragging
                             if ( m_cursorMode == WXGRID_CURSOR_RESIZE_ROW )
                                 wxGridRowOperations().SetLineSize(this,
                                     m_dragRowOrCol, m_dragRowOrColOldSize);

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -3871,6 +3871,7 @@ void wxGrid::CheckDoDragScroll(wxGridSubwindow *eventGridWindow, wxGridSubwindow
 
     if ( !m_isDragging )
     {
+        // drag is just starting
         m_lastMousePos = posEvent;
         return;
     }

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -4398,7 +4398,7 @@ void wxGrid::ProcessColLabelMouseEvent( wxMouseEvent& event, wxGridColLabelWindo
         else if ( colLabelWin->IsFrozen() && event_x >= w )
         {
             // frozen window was left, add the height of the non-frozen window
-            x += m_colLabelWin->GetSize().x;
+            w += m_colLabelWin->GetSize().x;
         }
 
         if ( event_x < 0 && sx > 0 )

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -6319,7 +6319,6 @@ void wxGrid::OnKeyDown( wxKeyEvent& event )
                         case WXGRID_CURSOR_MOVE_ROW:
                             // end row/column moving
                             m_winCapture->Refresh();
-                            EndDraggingIfNecessary();
                             m_dragLastPos = -1;
                             break;
 
@@ -6332,7 +6331,6 @@ void wxGrid::OnKeyDown( wxKeyEvent& event )
                             else
                                 wxGridColumnOperations().SetLineSize(this,
                                     m_dragRowOrCol, m_dragRowOrColOldSize);
-                            EndDraggingIfNecessary();
                             m_dragRowOrCol = -1;
                             break;
 
@@ -6341,9 +6339,9 @@ void wxGrid::OnKeyDown( wxKeyEvent& event )
                         case WXGRID_CURSOR_SELECT_COL:
                             if ( m_selection )
                                 m_selection->CancelSelecting();
-                            EndDraggingIfNecessary();
                             break;
                     }
+                    EndDraggingIfNecessary();
                     // ensure that a new drag operation is only started after a LeftUp
                     m_canceledDragging = true;
                 }

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -3868,6 +3868,13 @@ void wxGrid::CheckDoDragScroll(wxGridSubwindow *eventGridWindow, wxGridSubwindow
     //  scroll when at the edges or outside the window
     // eventGridWindow: the window that received the mouse event
     // gridWindow: the same or the corresponding non-frozen window
+
+    if ( !m_isDragging )
+    {
+        m_lastMousePos = posEvent;
+        return;
+    }
+
     int w, h;
     eventGridWindow->GetSize(&w, &h);
     // ViewStart is scroll position in scroll units
@@ -4242,6 +4249,7 @@ void wxGrid::ProcessRowLabelMouseEvent( wxMouseEvent& event, wxGridRowLabelWindo
 
         ChangeCursorMode(WXGRID_CURSOR_SELECT_CELL, rowLabelWin);
         m_dragLastPos = -1;
+        m_lastMousePos = wxDefaultPosition;
         m_isDragging = false;
     }
 
@@ -4710,6 +4718,7 @@ void wxGrid::ProcessColLabelMouseEvent( wxMouseEvent& event, wxGridColLabelWindo
 
         ChangeCursorMode(WXGRID_CURSOR_SELECT_CELL, GetColLabelWindow());
         m_dragLastPos = -1;
+        m_lastMousePos = wxDefaultPosition;
         m_isDragging = false;
     }
 
@@ -4835,6 +4844,7 @@ void wxGrid::DoAfterDraggingEnd()
 
     m_isDragging = false;
     m_startDragPos = wxDefaultPosition;
+    m_lastMousePos = wxDefaultPosition;
 
     m_cursorMode = WXGRID_CURSOR_SELECT_CELL;
     m_winCapture->SetCursor( *wxSTANDARD_CURSOR );

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -6338,7 +6338,7 @@ void wxGrid::OnKeyDown( wxKeyEvent& event )
 
                         case WXGRID_CURSOR_RESIZE_ROW:
                         case WXGRID_CURSOR_RESIZE_COL:
-                            // how could we reset?
+                            // reset to size before dragging
                             if ( m_cursorMode == WXGRID_CURSOR_RESIZE_ROW )
                                 wxGridRowOperations().SetLineSize(this,
                                     m_dragRowOrCol, m_dragRowOrColOldSize);

--- a/src/generic/gridsel.cpp
+++ b/src/generic/gridsel.cpp
@@ -72,6 +72,20 @@ void wxGridSelection::EndSelecting()
     m_grid->GetEventHandler()->ProcessEvent(gridEvt);
 }
 
+void wxGridSelection::CancelSelecting()
+{
+    // It's possible that nothing was selected finally, e.g. the mouse could
+    // have been dragged around only to return to the starting cell, just don't
+    // do anything in this case.
+    if ( !IsSelection() )
+        return;
+
+    const wxGridBlockCoords& block = m_selection.back();
+    m_grid->RefreshBlock(block.GetTopLeft(), block.GetBottomRight());
+    m_selection.pop_back();
+}
+
+
 bool wxGridSelection::IsInSelection( int row, int col ) const
 {
     // Check whether the given cell is contained in one of the selected blocks.


### PR DESCRIPTION
This is a first attempt.
For drag actions like resizing, selecting and moving, auto scrolling is implemented.
This will scroll by one scroll unit whenever a mouse event occurs and the mouse pointer is at the edge or outside the window.
Frozen rows/columns are handled.
I have seen that there is wxAutoScrollTimer. Maybe this could be used, but this is out of scope for me.
Maybe, the auto scroll code from `ProcessGridCellMouseEvent` could be refactored into a function that could also be used for rows and column. I will consider this, if the auto scroll functionality as such is accepted.

When a drag action is ongoing, the user can now cancel it with ESCAPE. Further dragging will be blocked until a mouse event occurs with left mouse button up. This is tracked by `m_canceledDragging`.

Please try out and provide feedback.

I have only tested on Windows and have not tested what happens if Right-To-Left is active.