### PR TITLE
fix column insertion w. native header and non-default column widths

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -3473,9 +3473,6 @@ bool wxGrid::Redimension( wxGridTableMessage& msg )
             int numCols = msg.GetCommandInt2();
             m_numCols += numCols;
 
-            if ( m_useNativeHeader )
-                GetGridColHeader()->SetColumnCount(m_numCols);
-
             if ( !m_colAt.IsEmpty() )
             {
                 //Shift the column IDs
@@ -3512,6 +3509,9 @@ bool wxGrid::Redimension( wxGridTableMessage& msg )
                     m_colRights[i] = right;
                 }
             }
+
+            if (m_useNativeHeader)
+                GetGridColHeader()->SetColumnCount(m_numCols);
 
             UpdateCurrentCellOnRedim();
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -3586,8 +3586,6 @@ bool wxGrid::Redimension( wxGridTableMessage& msg )
             size_t pos = msg.GetCommandInt();
             int numCols = msg.GetCommandInt2();
             m_numCols -= numCols;
-            if ( m_useNativeHeader )
-                GetGridColHeader()->SetColumnCount(m_numCols);
 
             if ( !m_colAt.IsEmpty() )
             {
@@ -3619,6 +3617,9 @@ bool wxGrid::Redimension( wxGridTableMessage& msg )
                     m_colRights[i] = w;
                 }
             }
+
+            if (m_useNativeHeader)
+                GetGridColHeader()->SetColumnCount(m_numCols);
 
             UpdateCurrentCellOnRedim();
 


### PR DESCRIPTION
This fixes wxPython issue https://github.com/wxWidgets/Phoenix/issues/1777

The problem was that native header `SetColumnCount` was called before `m_colAt` and `m_colWidths` were updated.
`SetColumnCount` in turn checks whether columns are visible and `col.IsVisible()` will look at the widths.

For `wxGRIDTABLE_NOTIFY_COLS_APPENDED` it was done in the right order already and commented accordingly...