### PR TITLE
fix griddemo issue introduced w. PR22260

### DIFF
--- a/samples/grid/griddemo.cpp
+++ b/samples/grid/griddemo.cpp
@@ -2698,12 +2698,12 @@ TabularGridFrame::TabularGridFrame()
                                         "Allow row reordering");
     m_chkEnableRowMove->SetValue(true);
     sizerStyles->Add(m_chkEnableRowMove, wxSizerFlags().Border());
-    sizerControls->Add(sizerStyles);
 
     m_chkEnableColMove = new wxCheckBox(panel, Id_Check_EnableColMove,
                                         "Allow column re&ordering");
     m_chkEnableColMove->SetValue(true);
     sizerStyles->Add(m_chkEnableColMove, wxSizerFlags().Border());
+
     sizerControls->Add(sizerStyles);
 
     sizerControls->AddSpacer(FromDIP(10));


### PR DESCRIPTION
Copied too many lines: sizerStyles was added twice and so crashed when the tabular demo window was closed.