### PR TITLE
Fix Extended RTTI static build

### DIFF
--- a/include/wx/object.h
+++ b/include/wx/object.h
@@ -372,6 +372,10 @@ private:
 
 class WXDLLIMPEXP_BASE wxObject
 {
+#if wxUSE_EXTENDED_RTTI
+    wxDECLARE_DYNAMIC_CLASS(wxObject);
+#endif
+
 public:
     wxObject() { m_refData = NULL; }
     virtual ~wxObject() { UnRef(); }
@@ -393,8 +397,6 @@ public:
     }
 
     bool IsKindOf(const wxClassInfo *info) const;
-
-    virtual wxClassInfo *GetClassInfo() const;
 
     // Turn on the correct set of new and delete operators
 
@@ -440,10 +442,14 @@ public:
     // check if this object references the same data as the other one
     bool IsSameAs(const wxObject& o) const { return m_refData == o.m_refData; }
 
+#if !wxUSE_EXTENDED_RTTI
+    virtual wxClassInfo* GetClassInfo() const;
+
     // RTTI information, usually declared by wxDECLARE_DYNAMIC_CLASS() or
     // similar, but done manually for the hierarchy root. Note that it's public
     // for compatibility reasons, but shouldn't be accessed directly.
     static wxClassInfo ms_classInfo;
+#endif
 
 protected:
     // ensure that our data is not shared with anybody else: if we have no

--- a/include/wx/xti.h
+++ b/include/wx/xti.h
@@ -446,13 +446,17 @@ private:
             { return &name::ms_classInfo; }
 
 #define wxDECLARE_DYNAMIC_CLASS(name)                       \
-    static wxObjectAllocatorAndCreator* ms_constructor;           \
+    static wxObjectAllocatorAndCreator* ms_constructor;     \
     static const wxChar * ms_constructorProperties[];       \
     static const int ms_constructorPropertiesCount;         \
     _DECLARE_DYNAMIC_CLASS(name)
 
 #define wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN(name)             \
     wxDECLARE_NO_ASSIGN_CLASS(name);                        \
+    wxDECLARE_DYNAMIC_CLASS(name)
+
+#define wxDECLARE_DYNAMIC_CLASS_NO_ASSIGN_DEF_COPY(name)    \
+    wxDECLARE_NO_ASSIGN_DEF_COPY(name);                     \
     wxDECLARE_DYNAMIC_CLASS(name)
 
 #define wxDECLARE_DYNAMIC_CLASS_NO_COPY(name)               \

--- a/samples/xti/classlist.cpp
+++ b/samples/xti/classlist.cpp
@@ -440,7 +440,7 @@ wxString DumpHandlerInfo(const wxHandlerInfo *phdlr, int indent)
         return ind + "none";
 
     infostr << ind << "event class: " <<
-        (phdlr->GetEventClassInfo() ? phdlr->GetEventClassInfo()->GetClassName() : "none");
+        (phdlr->GetEventClassInfo() ? wxString(phdlr->GetEventClassInfo()->GetClassName()) : "none");
 
     return infostr;
 }

--- a/samples/xti/xti.cpp
+++ b/samples/xti/xti.cpp
@@ -277,13 +277,13 @@ public:
         // this approach would be used if the handler would not
         // be connected really in the designer, so we have to supply
         // the information
-        const wxObject* but = wxAnyGetAsObjectPtr( m_frame->GetProperty("Button") );
+        const wxObject* but = wxAnyGetAsObjectPtr( m_frame->GetProperty(wxT("Button")) );
         if ( object == but &&
-             propInfo == wxCLASSINFO( wxButton )->FindPropertyInfo("OnClick") )
+             propInfo == wxCLASSINFO( wxButton )->FindPropertyInfo(wxT("OnClick")) )
         {
             eventSink = m_frame;
             handlerInfo = m_frame->GetClassInfo()->
-                FindHandlerInfo("ButtonClickHandler");
+                FindHandlerInfo(wxT("ButtonClickHandler"));
             return true;
         }
         return false;
@@ -315,13 +315,13 @@ void RegisterFrameRTTI()
         wx_dynamic_cast( wxDynamicClassInfo *, wxClassInfo::FindClass("MyXTIFrame"));
     if ( dyninfo == NULL )
     {
-        dyninfo = new wxDynamicClassInfo("myxtiframe.h",
-                            "MyXTIFrame",
+        dyninfo = new wxDynamicClassInfo(wxT("myxtiframe.h"),
+                            wxT("MyXTIFrame"),
                             CLASSINFO(wxFrame) );
 
         // this class has a property named "Button" and the relative handler:
-        dyninfo->AddProperty("Button", wxGetTypeInfo((wxButton**) NULL));
-        dyninfo->AddHandler("ButtonClickHandler",
+        dyninfo->AddProperty(wxT("Button"), wxGetTypeInfo((wxButton**) NULL));
+        dyninfo->AddHandler(wxT("ButtonClickHandler"),
             NULL /* no instance of the handler method */, CLASSINFO( wxEvent ) );
     }
 }
@@ -386,7 +386,7 @@ wxDynamicObject* CreateFrameRTTI()
     Params[4] = wxAny(wxSize(-1,-1));
     Params[5] = wxAny((long)0);
     wxASSERT( info->Create(button, 6, Params ));
-    frameWrapper->SetProperty( "Button", wxAny( button ) );
+    frameWrapper->SetProperty( wxT("Button"), wxAny( button ) );
 
     // other controls page
 
@@ -701,10 +701,10 @@ void MyFrame::OnGenerateCode(wxCommandEvent& WXUNUSED(event))
         wxStringOutputStream str;
         f.Read(str);
 
-        wxDialog dlg(this, wxID_ANY, "Generated code",
+        wxDialog dlg3(this, wxID_ANY, "Generated code",
                      wxDefaultPosition, wxDefaultSize,
                      wxRESIZE_BORDER|wxDEFAULT_DIALOG_STYLE);
-        wxPanel *panel = new wxPanel(&dlg);
+        wxPanel *panel = new wxPanel(&dlg3);
         wxSizer *sz = new wxBoxSizer(wxVERTICAL);
         sz->Add(new wxTextCtrl(panel, wxID_ANY, str.GetString(),
                                wxDefaultPosition, wxDefaultSize,
@@ -712,7 +712,7 @@ void MyFrame::OnGenerateCode(wxCommandEvent& WXUNUSED(event))
                 1, wxGROW|wxALL, 5);
         sz->Add(new wxButton(panel, wxID_OK), 0, wxALIGN_RIGHT|wxALL, 5);
         panel->SetSizerAndFit(sz);
-        dlg.ShowModal();
+        dlg3.ShowModal();
     }
 }
 

--- a/src/common/bmpbtncmn.cpp
+++ b/src/common/bmpbtncmn.cpp
@@ -77,7 +77,7 @@ wxEND_PROPERTIES_TABLE()
 wxEMPTY_HANDLERS_TABLE(wxBitmapButton)
 
 wxCONSTRUCTOR_5( wxBitmapButton, wxWindow*, Parent, wxWindowID, Id, \
-                 wxBitmap, Bitmap, wxPoint, Position, wxSize, Size )
+                 wxBitmapBundle, BitmapBundle, wxPoint, Position, wxSize, Size )
 
 /*
 TODO PROPERTIES :

--- a/src/common/statbmpcmn.cpp
+++ b/src/common/statbmpcmn.cpp
@@ -73,7 +73,7 @@ wxEND_PROPERTIES_TABLE()
 wxEMPTY_HANDLERS_TABLE(wxStaticBitmap)
 
 wxCONSTRUCTOR_5( wxStaticBitmap, wxWindow*, Parent, wxWindowID, Id, \
-                 wxBitmap, Bitmap, wxPoint, Position, wxSize, Size )
+                 wxBitmapBundle, BitmapBundle, wxPoint, Position, wxSize, Size )
 
 /*
     TODO PROPERTIES :

--- a/src/common/xtistrm.cpp
+++ b/src/common/xtistrm.cpp
@@ -504,25 +504,25 @@ void wxObjectRuntimeReaderCallback::CreateObject(int objectID,
                                         const wxClassInfo **objectClassInfos,
                                         wxStringToAnyHashMap &WXUNUSED(metadata))
 {
-    wxObject *o;
-    o = m_data->GetObject(objectID);
+    wxObject *o1;
+    o1 = m_data->GetObject(objectID);
     for ( int i = 0; i < paramCount; ++i )
     {
         if ( objectIdValues[i] != wxInvalidObjectID )
         {
-            wxObject *o;
-            o = m_data->GetObject(objectIdValues[i]);
+            wxObject *o2;
+            o2 = m_data->GetObject(objectIdValues[i]);
             // if this is a dynamic object and we are asked for another class
             // than wxDynamicObject we cast it down manually.
-            wxDynamicObject *dyno = wx_dynamic_cast( wxDynamicObject *, o);
+            wxDynamicObject *dyno = wx_dynamic_cast( wxDynamicObject *, o2);
             if ( dyno!=NULL && (objectClassInfos[i] != dyno->GetClassInfo()) )
             {
-                o = dyno->GetSuperClassInstance();
+                o2 = dyno->GetSuperClassInstance();
             }
-            params[i] = objectClassInfos[i]->ObjectPtrToAny(o);
+            params[i] = objectClassInfos[i]->ObjectPtrToAny(o2);
         }
     }
-    classInfo->Create(o, paramCount, params);
+    classInfo->Create(o1, paramCount, params);
 }
 
 void wxObjectRuntimeReaderCallback::ConstructObject(int objectID,
@@ -533,25 +533,25 @@ void wxObjectRuntimeReaderCallback::ConstructObject(int objectID,
                                         const wxClassInfo **objectClassInfos,
                                         wxStringToAnyHashMap &WXUNUSED(metadata))
 {
-    wxObject *o;
+    wxObject *o1;
     for ( int i = 0; i < paramCount; ++i )
     {
         if ( objectIdValues[i] != wxInvalidObjectID )
         {
-            wxObject *o;
-            o = m_data->GetObject(objectIdValues[i]);
+            wxObject *o2;
+            o2 = m_data->GetObject(objectIdValues[i]);
             // if this is a dynamic object and we are asked for another class
             // than wxDynamicObject we cast it down manually.
-            wxDynamicObject *dyno = wx_dynamic_cast( wxDynamicObject *, o);
+            wxDynamicObject *dyno = wx_dynamic_cast( wxDynamicObject *, o2);
             if ( dyno!=NULL && (objectClassInfos[i] != dyno->GetClassInfo()) )
             {
-                o = dyno->GetSuperClassInstance();
+                o2 = dyno->GetSuperClassInstance();
             }
-            params[i] = objectClassInfos[i]->ObjectPtrToAny(o);
+            params[i] = objectClassInfos[i]->ObjectPtrToAny(o2);
         }
     }
-    o = classInfo->ConstructObject(paramCount, params);
-    m_data->SetObject(objectID, o);
+    o1 = classInfo->ConstructObject(paramCount, params);
+    m_data->SetObject(objectID, o1);
 }
 
 

--- a/src/generic/calctrlg.cpp
+++ b/src/generic/calctrlg.cpp
@@ -45,7 +45,7 @@
 
 #ifdef wxHAS_NATIVE_CALENDARCTRL
 
-wxIMPLEMENT_DYNAMIC_CLASS_XTI(wxGenericCalendarCtrl, wxControl, "wx/calctrl.h");
+wxIMPLEMENT_DYNAMIC_CLASS(wxGenericCalendarCtrl, wxControl);
 
 #endif
 


### PR DESCRIPTION
Fix declaration of 'o' hides previous local declaration warnings.
Change two wxCONSTRUCTOR_5 definitions using wxBitmapBundle instead of wxBitmap (this does not give build errors).
wxGenericCalendarCtrl is missing all XTI implementations, so just use RTTI.
And fix building the xti sample.

Note the shared build still fails due to WXDLLIMPEXP related issues.

Closes #22300