### PR TITLE
Show debug log messages on the console in the test when enabled

### DIFF
--- a/src/common/markupparser.cpp
+++ b/src/common/markupparser.cpp
@@ -294,7 +294,7 @@ bool wxMarkupParser::Parse(const wxString& text)
                     const wxString tag = ExtractUntil('>', it, end);
                     if ( tag.empty() )
                     {
-                        wxLogDebug("%s at %lu.",
+                        wxLogDebug("%s at %zu.",
                                    it == end ? "Unclosed tag starting"
                                              : "Empty tag",
                                    pos);
@@ -311,7 +311,7 @@ bool wxMarkupParser::Parse(const wxString& text)
                         if ( !err.empty() )
                         {
                             wxLogDebug("Bad attributes for \"%s\" "
-                                       "at %lu: %s.",
+                                       "at %zu: %s.",
                                        name, pos, err);
                             return false;
                         }
@@ -322,7 +322,7 @@ bool wxMarkupParser::Parse(const wxString& text)
                     {
                         if ( tags.empty() || tags.top().name != tag )
                         {
-                            wxLogDebug("Unmatched closing tag \"%s\" at %lu.",
+                            wxLogDebug("Unmatched closing tag \"%s\" at %zu.",
                                        tag, pos);
                             return false;
                         }
@@ -330,7 +330,7 @@ bool wxMarkupParser::Parse(const wxString& text)
 
                     if ( !OutputTag(tags.top(), start) )
                     {
-                        wxLogDebug("Unknown tag at %lu.", pos);
+                        wxLogDebug("Unknown tag at %zu.", pos);
                         return false;
                     }
 
@@ -340,7 +340,7 @@ bool wxMarkupParser::Parse(const wxString& text)
                 break;
 
             case '>':
-                wxLogDebug("'>' should be escaped as \"&gt\"; at %lu.",
+                wxLogDebug("'>' should be escaped as \"&gt\"; at %zu.",
                            it - text.begin());
                 break;
 

--- a/tests/fswatcher/fswatchertest.cpp
+++ b/tests/fswatcher/fswatchertest.cpp
@@ -34,27 +34,6 @@
 // local functions
 // ----------------------------------------------------------------------------
 
-#if wxUSE_LOG
-// Logging is disabled by default when running the tests, but sometimes it can
-// be helpful to see the errors in case of unexpected failure, so this class
-// re-enables logs in its scope.
-//
-// It's a counterpart to wxLogNull.
-class LogEnabler
-{
-public:
-    LogEnabler() : m_wasEnabled(wxLog::EnableLogging(true)) { }
-    ~LogEnabler() { wxLog::EnableLogging(m_wasEnabled); }
-
-private:
-    const bool m_wasEnabled;
-
-    wxDECLARE_NO_COPY_CLASS(LogEnabler);
-};
-#else // !wxUSE_LOG
-class LogEnabler { };
-#endif // wxUSE_LOG/!wxUSE_LOG
-
 // class generating file system events
 class EventGenerator
 {
@@ -161,7 +140,7 @@ public:
         ms_watchDir.AppendDir("fswatcher_test");
         REQUIRE(!ms_watchDir.DirExists());
 
-        LogEnabler enableLogs;
+        TestLogEnabler enableLogs;
         REQUIRE(ms_watchDir.Mkdir());
 
         REQUIRE(ms_watchDir.DirExists());
@@ -176,7 +155,7 @@ public:
         // just to be really sure we know what we remove
         REQUIRE( ms_watchDir.GetDirs().Last() == "fswatcher_test" );
 
-        LogEnabler enableLogs;
+        TestLogEnabler enableLogs;
         CHECK( ms_watchDir.Rmdir(wxPATH_RMDIR_RECURSIVE) );
 
         ms_watchDir = wxFileName();

--- a/tests/testprec.h
+++ b/tests/testprec.h
@@ -148,6 +148,25 @@ extern bool IsAutomaticTest();
 
 extern bool IsRunningUnderXVFB();
 
+#if wxUSE_LOG
+// Logging is disabled by default when running the tests, but sometimes it can
+// be helpful to see the errors in case of unexpected failure, so this class
+// re-enables logs in its scope.
+//
+// It's a counterpart to wxLogNull.
+class TestLogEnabler
+{
+public:
+    TestLogEnabler();
+    ~TestLogEnabler();
+
+private:
+    wxDECLARE_NO_COPY_CLASS(TestLogEnabler);
+};
+#else // !wxUSE_LOG
+class TestLogEnabler { };
+#endif // wxUSE_LOG/!wxUSE_LOG
+
 #if wxUSE_GUI
 
 // Return true if the UI tests are enabled, used by WXUISIM_TEST().


### PR DESCRIPTION
Using LogEnabler in wxFileSystemWatcher test case still didn't show
anything even in case of unexpected failures because debug messages
didn't appear in the test output.

Fix this by using a custom log target which shows the debug (and trace)
messages on stderr, instead of using the debug output for them, even
under MSW.

Also make LogEnabler public, and rename it to a more unique name, as it
could be useful in the other tests too.