### PR TITLE
Add GetDPIScaleFactor to wxDC and wxGraphicsContext

### DIFF
--- a/include/wx/dc.h
+++ b/include/wx/dc.h
@@ -539,6 +539,8 @@ public:
 
     virtual double GetContentScaleFactor() const { return m_contentScaleFactor; }
 
+    virtual double GetDPIScaleFactor() const { return 1.0; }
+
 #ifdef __WXMSW__
     // Native Windows functions using the underlying HDC don't honour GDI+
     // transformations which may be applied to it. Using this function we can
@@ -826,6 +828,9 @@ public:
 
     double GetContentScaleFactor() const
         { return m_pimpl->GetContentScaleFactor(); }
+
+    double GetDPIScaleFactor() const
+        { return m_pimpl->GetDPIScaleFactor(); }
 
     // Right-To-Left (RTL) modes
 

--- a/include/wx/dcgraph.h
+++ b/include/wx/dcgraph.h
@@ -101,6 +101,7 @@ public:
     virtual bool CanGetTextExtent() const wxOVERRIDE;
     virtual int GetDepth() const wxOVERRIDE;
     virtual wxSize GetPPI() const wxOVERRIDE;
+    virtual double GetDPIScaleFactor() const wxOVERRIDE;
 
     virtual void SetLogicalFunction(wxRasterOperationMode function) wxOVERRIDE;
 

--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -880,6 +880,7 @@ public:
 
     void SetContentScaleFactor(double contentScaleFactor);
     double GetContentScaleFactor() const { return m_contentScaleFactor; }
+    double GetDPIScaleFactor() const;
 
 #ifdef __WXMSW__
     virtual WXHDC GetNativeHDC() = 0;

--- a/include/wx/msw/dc.h
+++ b/include/wx/msw/dc.h
@@ -77,7 +77,7 @@ public:
     virtual bool CanGetTextExtent() const wxOVERRIDE;
     virtual int GetDepth() const wxOVERRIDE;
     virtual wxSize GetPPI() const wxOVERRIDE;
-
+    virtual double GetDPIScaleFactor() const wxOVERRIDE;
 
     virtual void SetMapMode(wxMappingMode mode) wxOVERRIDE;
     virtual void SetUserScale(double x, double y) wxOVERRIDE;

--- a/include/wx/msw/dcmemory.h
+++ b/include/wx/msw/dcmemory.h
@@ -27,6 +27,7 @@ public:
     virtual void DoDrawRectangle(wxCoord x, wxCoord y, wxCoord width, wxCoord height) wxOVERRIDE;
     virtual void DoGetSize(int* width, int* height) const wxOVERRIDE;
     virtual void DoSelect(const wxBitmap& bitmap) wxOVERRIDE;
+    virtual double GetDPIScaleFactor() const wxOVERRIDE;
 
     virtual wxBitmap DoGetAsBitmap(const wxRect* subrect) const wxOVERRIDE
     { return subrect == NULL ? GetSelectedBitmap() : GetSelectedBitmap().GetSubBitmapOfHDC(*subrect, GetHDC() );}

--- a/interface/wx/dc.h
+++ b/interface/wx/dc.h
@@ -1551,6 +1551,14 @@ public:
     wxSize GetPPI() const;
 
     /**
+       Get the DPI scale factor. Can be used to scale coordinates and sizes
+       appropriate to the DPI of the associated wxWindow or wxDC.
+
+        @since 3.1.7
+    */
+    double GetDPIScaleFactor() const;
+
+    /**
         Gets the horizontal and vertical extent of this device context in @e device units.
         It can be used to scale graphics to fit the page.
 

--- a/interface/wx/graphics.h
+++ b/interface/wx/graphics.h
@@ -1156,6 +1156,14 @@ public:
     void DisableOffset();
     bool OffsetEnabled() const;
 
+    /**
+       Get the DPI scale factor. Can be used to scale coordinates and sizes
+       appropriate to the DPI of the associated wxWindow or wxDC.
+
+        @since 3.1.7
+    */
+    double GetDPIScaleFactor() const;
+
     /** @}
     */
 };

--- a/samples/drawing/drawing.cpp
+++ b/samples/drawing/drawing.cpp
@@ -574,38 +574,40 @@ void MyCanvas::DrawTestPoly(wxDC& dc)
     wxBrush brushHatch(*wxRED, wxBRUSHSTYLE_FDIAGONAL_HATCH);
     dc.SetBrush(brushHatch);
 
+    double scale = dc.GetDPIScaleFactor();
+
     wxPoint star[5];
-    star[0] = wxPoint(100, 60);
-    star[1] = wxPoint(60, 150);
-    star[2] = wxPoint(160, 100);
-    star[3] = wxPoint(40, 100);
-    star[4] = wxPoint(140, 150);
+    star[0] = scale * wxPoint(100, 60);
+    star[1] = scale * wxPoint(60, 150);
+    star[2] = scale * wxPoint(160, 100);
+    star[3] = scale * wxPoint(40, 100);
+    star[4] = scale * wxPoint(140, 150);
 
     dc.DrawText("You should see two (irregular) stars below, the left one "
-                "hatched", 10, 10);
+                "hatched", scale * 10, scale * 10);
     dc.DrawText("except for the central region and the right "
-                "one entirely hatched", 10, 30);
-    dc.DrawText("The third star only has a hatched outline", 10, 50);
+                "one entirely hatched", scale * 10, scale * 30);
+    dc.DrawText("The third star only has a hatched outline", scale * 10, scale* 50);
 
-    dc.DrawPolygon(WXSIZEOF(star), star, 0, 30);
-    dc.DrawPolygon(WXSIZEOF(star), star, 160, 30, wxWINDING_RULE);
+    dc.DrawPolygon(WXSIZEOF(star), star, scale * 0, scale * 30);
+    dc.DrawPolygon(WXSIZEOF(star), star, scale * 160, scale * 30, wxWINDING_RULE);
 
     wxBrush brushHatchGreen(*wxGREEN, wxBRUSHSTYLE_FDIAGONAL_HATCH);
     dc.SetBrush(brushHatchGreen);
     wxPoint star2[10];
-    star2[0] = wxPoint(0, 100);
-    star2[1] = wxPoint(-59, -81);
-    star2[2] = wxPoint(95, 31);
-    star2[3] = wxPoint(-95, 31);
-    star2[4] = wxPoint(59, -81);
-    star2[5] = wxPoint(0, 80);
-    star2[6] = wxPoint(-47, -64);
-    star2[7] = wxPoint(76, 24);
-    star2[8] = wxPoint(-76, 24);
-    star2[9] = wxPoint(47, -64);
+    star2[0] = scale * wxPoint(0, 100);
+    star2[1] = scale * wxPoint(-59, -81);
+    star2[2] = scale * wxPoint(95, 31);
+    star2[3] = scale * wxPoint(-95, 31);
+    star2[4] = scale * wxPoint(59, -81);
+    star2[5] = scale * wxPoint(0, 80);
+    star2[6] = scale * wxPoint(-47, -64);
+    star2[7] = scale * wxPoint(76, 24);
+    star2[8] = scale * wxPoint(-76, 24);
+    star2[9] = scale * wxPoint(47, -64);
     int count[2] = {5, 5};
 
-    dc.DrawPolyPolygon(WXSIZEOF(count), count, star2, 450, 150);
+    dc.DrawPolyPolygon(WXSIZEOF(count), count, star2, scale * 450, scale * 150);
 }
 
 void MyCanvas::DrawTestLines( int x, int y, int width, wxDC &dc )
@@ -1655,7 +1657,7 @@ void MyCanvas::DrawGradients(wxDC& dc)
 
         wxGraphicsPen pen = gc->CreatePen(
             wxGraphicsPenInfo(wxColour(0,0,0)).Width(6).Join(wxJOIN_BEVEL).LinearGradient(
-                gfr.x + gfr.width/2, gfr.y, 
+                gfr.x + gfr.width/2, gfr.y,
                 gfr.x + gfr.width/2, gfr.y + gfr.height,
                 stops));
         gc->SetPen(pen);
@@ -1834,7 +1836,7 @@ void MyCanvas::OnPaint(wxPaintEvent &WXUNUSED(event))
 void MyCanvas::Draw(wxDC& pdc)
 {
 #if wxUSE_GRAPHICS_CONTEXT
-    wxGCDC gdc;
+    wxGCDC gdc(this);
 
     if ( m_renderer )
     {

--- a/src/common/dcgraph.cpp
+++ b/src/common/dcgraph.cpp
@@ -24,6 +24,8 @@
     #include "wx/geometry.h"
 #endif
 
+#include "wx/display.h"
+
 //-----------------------------------------------------------------------------
 // Local functions
 //-----------------------------------------------------------------------------
@@ -485,7 +487,12 @@ wxSize wxGCDCImpl::GetPPI() const
 
     // This is the same value that wxGraphicsContext::GetDPI() returns by
     // default.
-    return wxSize(72, 72);
+    return wxDisplay::GetStdPPI();
+}
+
+double wxGCDCImpl::GetDPIScaleFactor() const
+{
+    return m_graphicContext ? m_graphicContext->GetDPIScaleFactor() : 1.0;
 }
 
 int wxGCDCImpl::GetDepth() const

--- a/src/common/graphcmn.cpp
+++ b/src/common/graphcmn.cpp
@@ -34,6 +34,7 @@
 #endif
 
 #include "wx/private/graphics.h"
+#include "wx/display.h"
 
 //-----------------------------------------------------------------------------
 
@@ -612,6 +613,13 @@ void wxGraphicsContext::SetContentScaleFactor(double contentScaleFactor)
     m_contentScaleFactor = contentScaleFactor;
 }
 
+ double wxGraphicsContext::GetDPIScaleFactor() const
+{
+     wxDouble x, y;
+     GetDPI(&x, &y);
+     return x / (double)wxDisplay::GetStdPPIValue();
+}
+
 #if 0
 void wxGraphicsContext::SetAlpha( wxDouble WXUNUSED(alpha) )
 {
@@ -635,8 +643,8 @@ void wxGraphicsContext::GetDPI( wxDouble* dpiX, wxDouble* dpiY) const
     {
         // Use some standard DPI value, it doesn't make much sense for the
         // contexts not using any pixels anyhow.
-        *dpiX = 72.0;
-        *dpiY = 72.0;
+        *dpiX = wxDisplay::GetStdPPIValue();
+        *dpiY = wxDisplay::GetStdPPIValue();
     }
 }
 
@@ -908,8 +916,8 @@ wxGraphicsContext::CreateLinearGradientBrush(
     return GetRenderer()->CreateLinearGradientBrush
                           (
                             x1, y1,
-                            x2, y2, 
-                            gradientStops, 
+                            x2, y2,
+                            gradientStops,
                             matrix
                           );
 }

--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -2661,6 +2661,11 @@ wxSize wxMSWDCImpl::GetPPI() const
     return ppi;
 }
 
+double wxMSWDCImpl::GetDPIScaleFactor() const
+{
+    return GetPPI().x / 96.0;
+}
+
 // ----------------------------------------------------------------------------
 // DC caching
 // ----------------------------------------------------------------------------

--- a/src/msw/dcmemory.cpp
+++ b/src/msw/dcmemory.cpp
@@ -143,6 +143,11 @@ void wxMemoryDCImpl::DoSelect( const wxBitmap& bitmap )
     SetFont(GetFont());
 }
 
+double wxMemoryDCImpl::GetDPIScaleFactor() const
+{
+    return m_contentScaleFactor;
+}
+
 void wxMemoryDCImpl::SetFont(const wxFont& font)
 {
     // We need to adjust the font size by the ratio between the scale factor we


### PR DESCRIPTION
It can be used to scale coordinates and sizes to the DPI of the DC.

The patch proposed in #22310 (using `GetContentScaleFactor`) does not work on macOS retina, since it uses logical pixels (and doesn't need scaling). Resulting in everything double the size.
So add `GetDPIScaleFactor` , just like `wxWindow` already has.





