### PR TITLE
Optimize MSW wxNotebook background painting

### DIFF
--- a/include/wx/msw/notebook.h
+++ b/include/wx/msw/notebook.h
@@ -122,17 +122,9 @@ public:
   // implementation only
   // -------------------
 
+  virtual bool SetBackgroundColour(const wxColour& colour) wxOVERRIDE;
+
 #if wxUSE_UXTHEME
-  virtual bool SetBackgroundColour(const wxColour& colour) wxOVERRIDE
-  {
-      if ( !wxNotebookBase::SetBackgroundColour(colour) )
-          return false;
-
-      UpdateBgBrush();
-
-      return true;
-  }
-
   // draw child background
   virtual bool MSWPrintChild(WXHDC hDC, wxWindow *win) wxOVERRIDE;
 

--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -109,11 +109,6 @@ static bool HasTroubleWithNonTopTabs()
 wxBEGIN_EVENT_TABLE(wxNotebook, wxBookCtrlBase)
     EVT_SIZE(wxNotebook::OnSize)
     EVT_NAVIGATION_KEY(wxNotebook::OnNavigationKey)
-
-#if USE_NOTEBOOK_ANTIFLICKER
-    EVT_ERASE_BACKGROUND(wxNotebook::OnEraseBackground)
-    EVT_PAINT(wxNotebook::OnPaint)
-#endif // USE_NOTEBOOK_ANTIFLICKER
 wxEND_EVENT_TABLE()
 
 // ============================================================================
@@ -1079,6 +1074,28 @@ void wxNotebook::OnNavigationKey(wxNavigationKeyEvent& event)
             }
         }
     }
+}
+
+bool wxNotebook::SetBackgroundColour(const wxColour& colour)
+{
+    if ( !wxNotebookBase::SetBackgroundColour(colour) )
+        return false;
+
+#if wxUSE_UXTHEME
+    UpdateBgBrush();
+#endif // wxUSE_UXTHEME
+
+#if USE_NOTEBOOK_ANTIFLICKER
+    Unbind(wxEVT_ERASE_BACKGROUND, &wxNotebook::OnEraseBackground, this);
+    Unbind(wxEVT_PAINT, &wxNotebook::OnPaint, this);
+    if ( m_hasBgCol || !wxUxThemeIsActive() )
+    {
+        Bind(wxEVT_ERASE_BACKGROUND, &wxNotebook::OnEraseBackground, this);
+        Bind(wxEVT_PAINT, &wxNotebook::OnPaint, this);
+    }
+#endif // USE_NOTEBOOK_ANTIFLICKER
+
+    return true;
 }
 
 #if wxUSE_UXTHEME


### PR DESCRIPTION
MSWDefWindowProc(WM_PAINT, ...) in OnPaint causes performance issues on large
screens so only use it when an actual custom background colour is set.

See #22308