### PR TITLE
Fix clang 13 warnings about unused err and other minor cleanup

### DIFF
--- a/src/osx/core/display.cpp
+++ b/src/osx/core/display.cpp
@@ -151,8 +151,8 @@ static CGDisplayErr wxOSXGetDisplayList(CGDisplayCount maxDisplays,
         *displayCount = 0;
         if ( onlineCount > 0 )
         {
-            CGDirectDisplayID *onlineDisplays = new CGDirectDisplayID[onlineCount];
-            error = CGGetOnlineDisplayList(onlineCount,onlineDisplays,&onlineCount);
+            wxScopedArray<CGDirectDisplayID> onlineDisplays(onlineCount);
+            error = CGGetOnlineDisplayList(onlineCount,onlineDisplays.get(),&onlineCount);
             if ( error == kCGErrorSuccess )
             {
                 for ( CGDisplayCount i = 0; i < onlineCount; ++i )
@@ -172,7 +172,6 @@ static CGDisplayErr wxOSXGetDisplayList(CGDisplayCount maxDisplays,
                     }
                 }
             }
-            delete[] onlineDisplays;
         }
 
     }
@@ -187,8 +186,8 @@ static int wxOSXGetDisplayFromID( CGDirectDisplayID theID )
 
     if (err == CGDisplayNoErr && theCount > 0 )
     {
-        CGDirectDisplayID* theIDs = new CGDirectDisplayID[theCount];
-        err = wxOSXGetDisplayList(theCount, theIDs, &theCount);
+        wxScopedArray<CGDirectDisplayID> theIDs(theCount);
+        err = wxOSXGetDisplayList(theCount, theIDs.get(), &theCount);
         wxASSERT(err == CGDisplayNoErr);
 
         for (nWhich = 0; nWhich < (int) theCount; ++nWhich)
@@ -196,8 +195,6 @@ static int wxOSXGetDisplayFromID( CGDirectDisplayID theID )
             if (theIDs[nWhich] == theID)
                 break;
         }
-
-        delete [] theIDs;
 
         if (nWhich == (int) theCount)
         {

--- a/src/osx/core/display.cpp
+++ b/src/osx/core/display.cpp
@@ -188,7 +188,8 @@ static int wxOSXGetDisplayFromID( CGDirectDisplayID theID )
     {
         wxScopedArray<CGDirectDisplayID> theIDs(theCount);
         err = wxOSXGetDisplayList(theCount, theIDs.get(), &theCount);
-        wxASSERT(err == CGDisplayNoErr);
+        wxCHECK_MSG( err == CGDisplayNoErr,
+                     wxNOT_FOUND, "wxOSXGetDisplayList() failed" );
 
         for (nWhich = 0; nWhich < (int) theCount; ++nWhich)
         {
@@ -196,11 +197,8 @@ static int wxOSXGetDisplayFromID( CGDirectDisplayID theID )
                 break;
         }
 
-        if (nWhich == (int) theCount)
-        {
-            wxFAIL_MSG(wxT("Failed to find display in display list"));
-            nWhich = wxNOT_FOUND;
-        }
+        wxCHECK_MSG( nWhich != (int) theCount,
+                     wxNOT_FOUND, "Failed to find display in display list" );
     }
 
     return nWhich;
@@ -222,8 +220,8 @@ int wxDisplayFactoryMacOSX::GetFromPoint(const wxPoint& p)
     CGDirectDisplayID theID;
     CGDisplayCount theCount;
     CGDisplayErr err = CGGetDisplaysWithPoint(thePoint, 1, &theID, &theCount);
-    wxASSERT(err == CGDisplayNoErr);
-    wxUnusedVar(err); // suppress "unused" warning in non-debug builds
+    wxCHECK_MSG( err == CGDisplayNoErr,
+                 wxNOT_FOUND, "CGGetDisplaysWithPoint() failed" );
 
     if (theCount)
         return wxOSXGetDisplayFromID(theID);
@@ -248,11 +246,13 @@ int wxDisplayFactoryMacOSX::GetFromWindow(const wxWindow *window)
     CGRect r = CGRectMake(x, y, w, h);
     CGDisplayCount theCount;
     CGDisplayErr err = CGGetDisplaysWithRect(r, 0, NULL, &theCount);
-    wxASSERT(err == CGDisplayNoErr);
+    wxCHECK_MSG( err == CGDisplayNoErr,
+                 wxNOT_FOUND, "CGGetDisplaysWithRect(NULL) failed" );
 
     wxScopedArray<CGDirectDisplayID> theIDs(theCount);
     err = CGGetDisplaysWithRect(r, theCount, theIDs.get(), &theCount);
-    wxASSERT(err == CGDisplayNoErr);
+    wxCHECK_MSG( err == CGDisplayNoErr,
+                 wxNOT_FOUND, "CGGetDisplaysWithRect() failed" );
 
     const double scaleWindow = tlw->GetContentScaleFactor();
     for ( unsigned i = 0; i < theCount; ++i )


### PR DESCRIPTION
This fix the second problem described in [this post](https://groups.google.com/g/wx-dev/c/8Dy_dJZSUZs/m/O8VEYpdVAAAJ)