### PR TITLE
Extend API of wxRibbonButtonBar and wxRibbonToolBar to improve positioning of windows relative to tools

### DIFF
--- a/include/wx/ribbon/buttonbar.h
+++ b/include/wx/ribbon/buttonbar.h
@@ -132,6 +132,7 @@ public:
     virtual wxRibbonButtonBarButtonBase *GetItem(size_t n) const;
     virtual wxRibbonButtonBarButtonBase *GetItemById(int id) const;
     virtual int GetItemId(wxRibbonButtonBarButtonBase *button) const;
+    virtual wxRect GetItemRect(int button_id)const;
 
 
     virtual bool Realize() wxOVERRIDE;

--- a/include/wx/ribbon/toolbar.h
+++ b/include/wx/ribbon/toolbar.h
@@ -134,6 +134,8 @@ public:
     virtual wxRibbonToolBarToolBase* GetToolByPos(wxCoord x, wxCoord y)const;
     virtual size_t GetToolCount() const;
     virtual int GetToolId(const wxRibbonToolBarToolBase* tool)const;
+    virtual wxRibbonToolBarToolBase* GetActiveTool() const;
+
 
     virtual wxObject* GetToolClientData(int tool_id)const;
     virtual bool GetToolEnabled(int tool_id)const;

--- a/interface/wx/ribbon/buttonbar.h
+++ b/interface/wx/ribbon/buttonbar.h
@@ -430,6 +430,17 @@ public:
     virtual int GetItemId(wxRibbonButtonBarButtonBase *item) const;
 
     /**
+        Returns the items's rect with coordinates relative to the button bar's
+        parent, or a default-constructed rect if the tool is not found.
+
+        @param button_id
+            ID of the button in question.
+
+        @since 3.2.0
+    */
+    virtual wxRect GetItemRect(int button_id)const;
+
+    /**
         Calculate button layouts and positions.
 
         Must be called after buttons are added to the button bar, as otherwise

--- a/interface/wx/ribbon/toolbar.h
+++ b/interface/wx/ribbon/toolbar.h
@@ -335,6 +335,15 @@ public:
     virtual int GetToolId(const wxRibbonToolBarToolBase* tool)const;
 
     /**
+        Returns the active item of the tool bar or NULL if there is none.
+        The active tool is the one being clicked.
+
+
+        @since 3.2.0
+    */
+    virtual wxRibbonToolBarToolBase* GetActiveTool() const;
+
+    /**
         Get any client data associated with the tool.
 
         @param tool_id

--- a/src/ribbon/buttonbar.cpp
+++ b/src/ribbon/buttonbar.cpp
@@ -1508,6 +1508,29 @@ int wxRibbonButtonBar::GetItemId(wxRibbonButtonBarButtonBase *item) const
     return item->id;
 }
 
+wxRect wxRibbonButtonBar::GetItemRect(int button_id)const
+{
+    wxRibbonButtonBarLayout* layout = m_layouts.Item(m_current_layout);
+    size_t btn_count = layout->buttons.Count();
+    size_t btn_i;
+
+    for (btn_i = 0; btn_i < btn_count; ++btn_i)
+    {
+        wxRibbonButtonBarButtonInstance& instance = layout->buttons.Item(btn_i);
+        wxRibbonButtonBarButtonBase* button = instance.base;
+
+        if (button->id == button_id)
+        {
+            wxRibbonButtonBarButtonSizeInfo& size = button->sizes[instance.size];
+            wxRect btn_rect;
+            btn_rect.SetTopLeft(m_layout_offset + instance.position);
+            btn_rect.SetSize(size.size);
+
+            return btn_rect;
+        }
+    }
+    return wxRect();
+}
 
 bool wxRibbonButtonBarEvent::PopupMenu(wxMenu* menu)
 {

--- a/src/ribbon/toolbar.cpp
+++ b/src/ribbon/toolbar.cpp
@@ -470,6 +470,11 @@ int wxRibbonToolBar::GetToolId(const wxRibbonToolBarToolBase* tool)const
     return tool->id;
 }
 
+wxRibbonToolBarToolBase* wxRibbonToolBar::GetActiveTool() const
+{
+    return m_active_tool == NULL ? NULL : m_active_tool;
+}
+
 wxObject* wxRibbonToolBar::GetToolClientData(int tool_id)const
 {
     wxRibbonToolBarToolBase* tool = FindById(tool_id);


### PR DESCRIPTION
Added `wxRibbonButtonBar::GetItemRect()` and `wxRibbonToolBar::GetActiveTool()` to improve possibility to positioning windows aligned to tools and buttons in the ribbon bar.

Solution of issue #22265 