### PR TITLE
Remove assert checking bitmap sizes in MSW wxHeaderCtrl

### DIFF
--- a/src/msw/headerctrl.cpp
+++ b/src/msw/headerctrl.cpp
@@ -460,35 +460,29 @@ void wxMSWHeaderCtrl::DoInsertItem(const wxHeaderColumn& col, unsigned int idx)
     hdi.pszText = buf.data();
     hdi.cchTextMax = wxStrlen(buf);
 
-    wxBitmap bmp = col.GetBitmapBundle().GetBitmapFor(this);
-    if ( bmp.IsOk() )
+    const wxBitmapBundle& bb = col.GetBitmapBundle();
+    if ( bb.IsOk() )
     {
         hdi.mask |= HDI_IMAGE;
 
         if ( HasFlag(wxHD_BITMAP_ON_RIGHT) )
             hdi.fmt |= HDF_BITMAP_ON_RIGHT;
 
-        const int bmpWidth = bmp.GetLogicalWidth(),
-                  bmpHeight = bmp.GetLogicalHeight();
-
+        wxSize bmpSize;
         if ( !m_imageList )
         {
-            m_imageList = new wxImageList(bmpWidth, bmpHeight);
+            bmpSize = bb.GetPreferredBitmapSizeFor(this);
+            m_imageList = new wxImageList(bmpSize.x, bmpSize.y);
             (void) // suppress mingw32 warning about unused computed value
             Header_SetImageList(GetHwnd(), GetHimagelistOf(m_imageList));
         }
         else // already have an image list
         {
-            // check that all bitmaps we use have the same size
-            int imageWidth,
-                imageHeight;
-            m_imageList->GetSize(0, imageWidth, imageHeight);
-
-            wxASSERT_MSG( imageWidth == bmpWidth && imageHeight == bmpHeight,
-                          "all column bitmaps must have the same size" );
+            // use the same size for all bitmaps
+            bmpSize = m_imageList->GetSize();
         }
 
-        m_imageList->Add(bmp);
+        m_imageList->Add(bb.GetBitmap(bmpSize));
         hdi.iImage = m_imageList->GetImageCount() - 1;
     }
 


### PR DESCRIPTION
This assert could trigger when the window DPI was changed (e.g. due to
moving it to another display using different DPI scaling factor) and
doesn't seem very useful.

Just ensure that we always use the same size for all bitmaps in the
image list.

Closes #22267.

---

I didn't see the assert failure even before, but it definitely can't happen any more.

@MaartenBent Please let me know if you see anything wrong with this. TIA!