### PR TITLE
Get rid of symlinks in the distribution archives

### DIFF
--- a/build/tools/release.sh
+++ b/build/tools/release.sh
@@ -47,6 +47,18 @@ tar x -C $destdir -i
 
 cd $destdir
 
+# Check that there are no symlinks because we don't handle them correctly
+# under MSW systems currently.
+if ! find . -type l -exec false {} + -quit; then
+    set +x
+    echo 'There are unexpected symlinks in the source tree:' >&2
+    echo '' >& 2
+    find . -type l -fprint /dev/stderr
+    echo '' >& 2
+    echo 'Please remove them or fix #22271.' >&2
+    exit 2
+fi
+
 # Compile gettext catalogs.
 make -C $prefix/locale -s MSGFMT=msgfmt allmo
 


### PR DESCRIPTION
This seems to work for me, so I'll merge it soon if there are no objections.