### PR TITLE
wxOSX Translate Courier and Times font names

### DIFF
--- a/src/osx/carbon/font.cpp
+++ b/src/osx/carbon/font.cpp
@@ -927,6 +927,10 @@ void wxNativeFontInfo::CreateCTFontDescriptor()
         if ( fontname.empty() )
             fontname = FamilyToFaceName(m_family);
 
+        // Courier and Times fonts used to be available everywhere and so are commonly
+        // hard-coded in the applications (even though they shouldn't be, and "teletype"
+        // or "roman" font family should be used instead), so make sure we still support
+        // them even if macOS > 12 doesn't have any fonts with these names any more.
         if ( fontname == "Courier")
             fontname = "Courier New";
         else if ( fontname == "Times" )


### PR DESCRIPTION
under macOS 12 Monterey Courier and Times are no more, now always use the new versions (existing since macOS 10.7). and fix native font info toString roundtrip problems