### PR TITLE
Fix wxRichToolTipPopup size at non-system DPI displays

### DIFF
--- a/src/generic/richtooltipg.cpp
+++ b/src/generic/richtooltipg.cpp
@@ -68,6 +68,9 @@ public:
     {
         Create(parent, wxFRAME_SHAPED);
 
+        // Move to the display where it will be shown,
+        // so below calculations are based on the correct DPI.
+        Move(GetTipPoint(), wxSIZE_ALLOW_MINUS_ONE);
 
         wxBoxSizer* const sizerTitle = new wxBoxSizer(wxHORIZONTAL);
         if ( icon.IsOk() )
@@ -343,7 +346,7 @@ private:
         // The size is the vertical size and the offset is the distance from
         // edge for asymmetric tips, currently hard-coded to be the same as the
         // size.
-        const int tipSize = GetTipHeight();
+        const int tipSize = FromDIP(GetTipHeight());
         const int tipOffset = tipSize;
 
         // The horizontal position of the tip.


### PR DESCRIPTION
Move the popup to the display where it will be shown, so the size calculations are based on the correct DPI.
Also use the correct tipsize for the DPI.

See https://groups.google.com/g/wx-users/c/XO6A2n5VP7c/m/aievWW1YBAAJ
CC @YuSanka 

I did not change `wxPopupWindow` constructor and `wxPopupWindow::Create()` to accept a position (and size) since it would require changing `wxPopupWindow` implementation of all 8 platforms. If you prefer that solution, I can still do that.