### PR TITLE
Change wxGenericTreeCtrl::OnSysColourChanged to protected

### DIFF
--- a/include/wx/generic/treectlg.h
+++ b/include/wx/generic/treectlg.h
@@ -357,12 +357,12 @@ protected:
 
     virtual wxSize DoGetBestSize() const wxOVERRIDE;
 
-private:
     void OnSysColourChanged(wxSysColourChangedEvent& WXUNUSED(event))
     {
         InitVisualAttributes();
     }
 
+private:
     // (Re)initialize colours, fonts, pens, brushes used by the control using
     // the current system colours and font.
     void InitVisualAttributes();


### PR DESCRIPTION
Advice from the docs is to call the base class OnSysColourChanged when
handling wxEVT_SYS_COLOUR_CHANGED events to not break normal control
behavior and event propagation.

That does not work with a private base class method. Make it accessible
like in other controls.