### PR TITLE
Show images added to its wxImageList later in wxListbook again

### DIFF
--- a/include/wx/withimages.h
+++ b/include/wx/withimages.h
@@ -55,10 +55,17 @@ public:
         return m_imageList ? m_imageList->GetImageCount() : 0;
     }
 
-    // Return true if we have any images at all.
+    // Return true if we are using any images.
     bool HasImages() const
     {
-        return GetImageCount() != 0;
+        // Note that the sole presence of the image list indicates that we're
+        // using images, even if it is currently empty, because images can be
+        // added to it at any moment (it's common and valid to create an image
+        // list and associate it with the control first and fill it later) and
+        // it's better to err on the side of having the images and not showing
+        // anything if there are really none than decide that we don't have any
+        // and not show those that we do have.
+        return !m_images.empty() || m_imageList;
     }
 
     // Sets the images to use.

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -1611,10 +1611,16 @@ wxSize wxListCtrl::MSWGetBestViewRect(int x, int y) const
     if ( mswStyle & WS_VSCROLL )
         size.x += wxSystemSettings::GetMetric(wxSYS_VSCROLL_X, m_parent);
 
-    // OTOH we have to subtract the size of our borders because the base class
-    // public method already adds them, but ListView_ApproximateViewRect()
-    // already takes the borders into account, so this would be superfluous.
-    return size - GetWindowBorderSize();
+    // This is a dirty hack, but while the size returned by the control does
+    // fit its contents, it results in asymmetric horizontal margins around it,
+    // with 3px on one side and just 1px on the other one. Adding these 2px
+    // makes it looks nicely symmetrical, at least under Windows 7 and 10.
+    // Vertical margins are even more asymmetric, but they're too big and not
+    // too small and it might be a bad idea to allocate size smaller than what
+    // the control thinks it needs, so leave them be.
+    size.IncBy(2, 0);
+
+    return size;
 }
 
 // ----------------------------------------------------------------------------

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -1601,13 +1601,16 @@ wxSize wxListCtrl::MSWGetBestViewRect(int x, int y) const
 
     wxSize size(LOWORD(rc), HIWORD(rc));
 
-    // We have to add space for the scrollbars ourselves, they're not taken
-    // into account by ListView_ApproximateViewRect(), at least not with
-    // commctrl32.dll v6.
+    // We have to account for the scrollbars ourselves, as the control itself
+    // seems to always reserve space for the horizontal scrollbar, even when it
+    // is not needed, but does not reserve space for the vertical scrollbar,
+    // even when it is used. This doesn't make any sense, but using this logic
+    // results in correct result, i.e. just enough space, in all cases.
     const DWORD mswStyle = ::GetWindowLong(GetHwnd(), GWL_STYLE);
 
-    if ( mswStyle & WS_HSCROLL )
-        size.y += wxSystemSettings::GetMetric(wxSYS_HSCROLL_Y, m_parent);
+    if ( !(mswStyle & WS_HSCROLL) )
+        size.y -= wxSystemSettings::GetMetric(wxSYS_HSCROLL_Y, m_parent);
+
     if ( mswStyle & WS_VSCROLL )
         size.x += wxSystemSettings::GetMetric(wxSYS_VSCROLL_X, m_parent);
 


### PR DESCRIPTION
Fix a regression in 3.1.6 which resulted in not showing any images if
the associated image list was empty when it was associated with the
control, as HasImages() returned false in this case and so wxLC_ICON
style was not set.

The fix is to return true from HasImages() if we have image list even if
it is currently empty, as we can't know when (or if) it will become
non-empty and it's better to assume that it will be used (as nothing
really catastrophic should happen if it is not used, finally) rather
than not taking into account the images added to it later.

Closes #22364.