### PR TITLE
wxOSX: Extending wxNativeFontInfo

### DIFF
--- a/src/osx/carbon/font.cpp
+++ b/src/osx/carbon/font.cpp
@@ -384,6 +384,9 @@ void wxFontRefData::Alloc()
                 }
             }
 
+            m_info = wxNativeFontInfo();
+            m_info.InitFromFont(m_ctFont);
+
             entryWithSize.font = m_ctFont;
             entryWithSize.cgFont = m_cgFont;
             entryWithSize.fontAttributes = m_ctFontAttributes;
@@ -855,6 +858,12 @@ void wxNativeFontInfo::InitFromFont(CTFontRef font)
 
     wxCFRef<CTFontDescriptorRef> desc(CTFontCopyFontDescriptor(font));
     InitFromFontDescriptor( desc );
+
+    // in case the font itself does not exist as italic it might have
+    // been created with the emulation via a font transform
+    if ( !CGAffineTransformIsIdentity(CTFontGetMatrix(font)) ) {
+        m_style = wxFONTSTYLE_ITALIC;
+    }
 }
 
 void wxNativeFontInfo::InitFromFontDescriptor(CTFontDescriptorRef desc)
@@ -1122,8 +1131,18 @@ bool wxNativeFontInfo::FromString(const wxString& s)
         m_encoding = (wxFontEncoding)l;
         return true;
     }
-    else if ( version == 2 )
+    else if ( version == 2 || version == 3 )
     {
+        wxFontStyle style = wxFONTSTYLE_NORMAL;
+
+        if ( version == 3 )
+        {
+            token = tokenizer.GetNextToken();
+            if ( !token.ToLong(&l) )
+                return false;
+            style = (wxFontStyle)l;
+        }
+
         token = tokenizer.GetNextToken();
         if ( !token.ToLong(&l) )
             return false;
@@ -1154,6 +1173,7 @@ bool wxNativeFontInfo::FromString(const wxString& s)
             m_underlined = underlined;
             m_strikethrough = strikethrough;
             m_encoding = encoding;
+            m_style = style;
             return true;
         }
     }
@@ -1167,6 +1187,9 @@ wxString wxNativeFontInfo::ToString() const
 
     // version 2 is a streamed property list of the font descriptor as recommended by Apple
     // prefixed by the attributes that are non-native to the native font ref like underline, strikethrough etc.
+    // version 3 adds to v2 the style attribute because this cannot always be expressed
+    // in the native font descriptor. In situations where there is no native italic font
+    //  the slant-ness has to be emulated in the font's transform
     wxCFDictionaryRef attributes(CTFontDescriptorCopyAttributes(GetCTFontDescriptor()));
 
     if (attributes != NULL)
@@ -1181,8 +1204,9 @@ wxString wxNativeFontInfo::ToString() const
             xml.Replace("\t",wxEmptyString,true);
             xml = xml.Mid(xml.Find("<plist"));
 
-            s.Printf("%d;%d;%d;%d;%s",
-                 2, // version
+            s.Printf("%d;%d;%d;%d;%d;%s",
+                 3, // version
+                 (int)GetStyle(),
                  GetUnderlined(),
                  GetStrikethrough(),
                  (int)GetEncoding(),


### PR DESCRIPTION
After resolving a font, recreate the native font info from the newly generated font. This persists the font family correctly. Also recognize an emulated slantness from a CTFontRef’s affine transform.