### PR TITLE
Replace references to wxLocale by wxUILocale

### DIFF
--- a/src/common/appcmn.cpp
+++ b/src/common/appcmn.cpp
@@ -39,6 +39,7 @@
 #include "wx/thread.h"
 #include "wx/vidmode.h"
 #include "wx/evtloop.h"
+#include "wx/uilocale.h"
 
 #if wxUSE_FONTMAP
     #include "wx/fontmap.h"
@@ -206,19 +207,11 @@ wxVideoMode wxAppBase::GetDisplayMode() const
 wxLayoutDirection wxAppBase::GetLayoutDirection() const
 {
 #if wxUSE_INTL
-    const wxLocale *const locale = wxGetLocale();
-    if ( locale )
-    {
-        const wxLanguageInfo *const
-            info = wxLocale::GetLanguageInfo(locale->GetLanguage());
-
-        if ( info )
-            return info->LayoutDirection;
-    }
-#endif // wxUSE_INTL
-
+    return wxUILocale::GetCurrent().GetLayoutDirection();
+#else
     // we don't know
     return wxLayout_Default;
+#endif // wxUSE_INTL
 }
 
 #if wxUSE_CMDLINE_PARSER

--- a/src/common/datetimefmt.cpp
+++ b/src/common/datetimefmt.cpp
@@ -52,6 +52,7 @@
 
 #include "wx/datetime.h"
 #include "wx/time.h"
+#include "wx/uilocale.h"
 
 // ============================================================================
 // implementation of wxDateTime
@@ -320,11 +321,11 @@ wxString wxDateTime::Format(const wxString& formatp, const TimeZone& tz) const
     wxString format = formatp;
 #ifdef __WXOSX__
     if ( format.Contains("%c") )
-        format.Replace("%c", wxLocale::GetInfo(wxLOCALE_DATE_TIME_FMT));
+        format.Replace("%c", wxUILocale::GetCurrent().GetInfo(wxLOCALE_DATE_TIME_FMT));
     if ( format.Contains("%x") )
-        format.Replace("%x", wxLocale::GetInfo(wxLOCALE_SHORT_DATE_FMT));
+        format.Replace("%x", wxUILocale::GetCurrent().GetInfo(wxLOCALE_SHORT_DATE_FMT));
     if ( format.Contains("%X") )
-        format.Replace("%X", wxLocale::GetInfo(wxLOCALE_TIME_FMT));
+        format.Replace("%X", wxUILocale::GetCurrent().GetInfo(wxLOCALE_TIME_FMT));
 #endif
     // we have to use our own implementation if the date is out of range of
     // strftime()
@@ -1177,7 +1178,7 @@ wxDateTime::ParseFormat(const wxString& date,
 
 #if wxUSE_INTL
                     const wxString
-                        fmtDateTime = wxLocale::GetInfo(wxLOCALE_DATE_TIME_FMT);
+                        fmtDateTime = wxUILocale::GetCurrent().GetInfo(wxLOCALE_DATE_TIME_FMT);
                     if ( !fmtDateTime.empty() )
                         dt = ParseFormatAt(input, end, fmtDateTime);
 #endif // wxUSE_INTL
@@ -1399,8 +1400,8 @@ wxDateTime::ParseFormat(const wxString& date,
                 {
 #if wxUSE_INTL
                     wxString
-                        fmtDate = wxLocale::GetInfo(wxLOCALE_SHORT_DATE_FMT),
-                        fmtDateAlt = wxLocale::GetInfo(wxLOCALE_LONG_DATE_FMT);
+                        fmtDate = wxUILocale::GetCurrent().GetInfo(wxLOCALE_SHORT_DATE_FMT),
+                        fmtDateAlt = wxUILocale::GetCurrent().GetInfo(wxLOCALE_LONG_DATE_FMT);
 #else // !wxUSE_INTL
                     wxString fmtDate, fmtDateAlt;
 #endif // wxUSE_INTL/!wxUSE_INTL
@@ -1449,7 +1450,7 @@ wxDateTime::ParseFormat(const wxString& date,
             case wxT('X'):       // locale default time representation
                 {
 #if wxUSE_INTL
-                    wxString fmtTime = wxLocale::GetInfo(wxLOCALE_TIME_FMT),
+                    wxString fmtTime = wxUILocale::GetCurrent().GetInfo(wxLOCALE_TIME_FMT),
                              fmtTimeAlt;
 #else // !wxUSE_INTL
                     wxString fmtTime, fmtTimeAlt;

--- a/src/common/string.cpp
+++ b/src/common/string.cpp
@@ -32,6 +32,7 @@
 #include <stdlib.h>
 
 #include "wx/hashmap.h"
+#include "wx/uilocale.h"
 #include "wx/vector.h"
 #include "wx/xlocale.h"
 
@@ -1811,8 +1812,8 @@ bool wxString::ToCDouble(double *pVal) const
     // Create a copy of this string using the decimal point instead of whatever
     // separator the current locale uses.
 #if wxUSE_INTL
-    wxString sep = wxLocale::GetInfo(wxLOCALE_DECIMAL_POINT,
-                                     wxLOCALE_CAT_NUMBER);
+    wxString sep = wxUILocale::GetCurrent().GetInfo(wxLOCALE_DECIMAL_POINT,
+                                                    wxLOCALE_CAT_NUMBER);
     if ( sep == "." )
     {
         // We can avoid an unnecessary string copy in this case.
@@ -1880,8 +1881,8 @@ wxString wxString::FromCDouble(double val, int precision)
 
     wxString s = FromDouble(val, precision);
 #if wxUSE_INTL
-    wxString sep = wxLocale::GetInfo(wxLOCALE_DECIMAL_POINT,
-                                     wxLOCALE_CAT_NUMBER);
+    wxString sep = wxUILocale::GetCurrent().GetInfo(wxLOCALE_DECIMAL_POINT,
+                                                    wxLOCALE_CAT_NUMBER);
 #else // !wxUSE_INTL
     // As above, this is the most common alternative value. Notice that here it
     // doesn't matter if we guess wrongly and the current separator is already

--- a/src/common/xlocale.cpp
+++ b/src/common/xlocale.cpp
@@ -25,6 +25,7 @@
     #include "wx/module.h"
 #endif
 
+#include "wx/uilocale.h"
 #include "wx/xlocale.h"
 
 #include <errno.h>
@@ -89,7 +90,7 @@ wxXLocale::wxXLocale(wxLanguage lang)
 {
     m_locale = NULL;
 
-    const wxLanguageInfo * const info = wxLocale::GetLanguageInfo(lang);
+    const wxLanguageInfo * const info = wxUILocale::GetLanguageInfo(lang);
     if ( info )
     {
         Init(info->GetLocaleName().c_str());

--- a/src/generic/datectlg.cpp
+++ b/src/generic/datectlg.cpp
@@ -35,6 +35,7 @@
 
 #include "wx/datectrl.h"
 #include "wx/generic/datectrl.h"
+#include "wx/uilocale.h"
 
 // ----------------------------------------------------------------------------
 // constants
@@ -243,7 +244,7 @@ private:
     wxString GetLocaleDateFormat() const
     {
 #if wxUSE_INTL
-        wxString fmt = wxLocale::GetInfo(wxLOCALE_SHORT_DATE_FMT);
+        wxString fmt = wxUILocale::GetCurrent().GetInfo(wxLOCALE_SHORT_DATE_FMT);
         if ( HasDPFlag(wxDP_SHOWCENTURY) )
             fmt.Replace("%y", "%Y");
 

--- a/src/generic/helpext.cpp
+++ b/src/generic/helpext.cpp
@@ -26,6 +26,7 @@
 #include "wx/filename.h"
 #include "wx/textfile.h"
 #include "wx/generic/helpext.h"
+#include "wx/uilocale.h"
 
 #include <stdio.h>
 #include <ctype.h>
@@ -220,10 +221,10 @@ bool wxExtHelpController::LoadFile(const wxString& file)
     // "/usr/local/myapp/help" and the current wxLocale is set to be "de", then
     // look in "/usr/local/myapp/help/de/" first and fall back to
     // "/usr/local/myapp/help" if that doesn't exist.
-    const wxLocale * const loc = wxGetLocale();
-    if ( loc )
+    wxLocaleIdent locId = wxUILocale::GetCurrent().GetLocaleId();
+    if ( !locId.IsEmpty() )
     {
-        wxString locName = loc->GetName();
+        wxString locName = locId.GetTag(wxLOCALE_TAGTYPE_POSIX);
 
         // the locale is in general of the form xx_YY.zzzz, try the full firm
         // first and then also more general ones

--- a/src/generic/timectrlg.cpp
+++ b/src/generic/timectrlg.cpp
@@ -27,6 +27,7 @@
 #endif // WX_PRECOMP
 
 #include "wx/timectrl.h"
+#include "wx/uilocale.h"
 
 // This class is only compiled if there is no native version or if we
 // explicitly want to use both the native and generic one (this is useful for
@@ -85,7 +86,7 @@ public:
         // instead of zeros) too as this is the most common unsupported case in
         // practice.
 #if wxUSE_INTL
-        m_useAMPM = wxLocale::GetInfo(wxLOCALE_TIME_FMT).Contains("%p");
+        m_useAMPM = wxUILocale::GetCurrent().GetInfo(wxLOCALE_TIME_FMT).Contains("%p");
 #else
         m_useAMPM = false;
 #endif

--- a/src/msw/datetimectrl.cpp
+++ b/src/msw/datetimectrl.cpp
@@ -20,6 +20,7 @@
 
 
 #include "wx/datetimectrl.h"
+#include "wx/uilocale.h"
 
 #ifdef wxNEEDS_DATETIMEPICKCTRL
 
@@ -231,7 +232,7 @@ wxSize wxDateTimePickerCtrl::DoGetBestSize() const
     {
         // Use the same native format as the underlying native control.
 #if wxUSE_INTL
-        wxString s = wxDateTime::Now().Format(wxLocale::GetOSInfo(MSWGetFormat()));
+        wxString s = wxDateTime::Now().Format(wxUILocale::GetCurrent().GetInfo(MSWGetFormat()));
 #else // !wxUSE_INTL
         wxString s("XXX-YYY-ZZZZ");
 #endif // wxUSE_INTL/!wxUSE_INTL

--- a/src/propgrid/advprops.cpp
+++ b/src/propgrid/advprops.cpp
@@ -31,6 +31,8 @@
 
 #include "wx/odcombo.h"
 
+#include "wx/uilocale.h"
+
 // Drawing ARGB on standard DC is supported by OSX and GTK3
 #if defined(__WXOSX__) || defined(__WXGTK3__)
 #define wxPG_DC_SUPPORTS_ALPHA 1
@@ -2220,7 +2222,7 @@ wxString wxDateProperty::DetermineDefaultDateFormat( bool showCentury )
 {
     // This code is based on datectlg.cpp's GetLocaleDateFormat()
 #if wxUSE_INTL
-    wxString format = wxLocale::GetOSInfo(wxLOCALE_SHORT_DATE_FMT);
+    wxString format = wxUILocale::GetCurrent().GetInfo(wxLOCALE_SHORT_DATE_FMT);
     if ( showCentury )
         format.Replace(wxS("%y"), wxS("%Y"));
     else

--- a/src/unix/mimetype.cpp
+++ b/src/unix/mimetype.cpp
@@ -168,8 +168,8 @@ void wxMimeTypesManagerImpl::LoadXDGApp(const wxString& filename)
     wxString nameicon, namemini;
     nIndex = wxNOT_FOUND;
 #if wxUSE_INTL // try "Icon[locale name]" first
-    if ( locale )
-        nIndex = file.pIndexOf(wxT("Icon[")+locale->GetName()+wxT("]="));
+    if ( wxUILocale::GetCurrent().IsSupported() )
+        nIndex = file.pIndexOf(wxT("Icon[")+wxUILocale::GetCurrent().GetName()+wxT("]="));
 #endif // wxUSE_INTL
     if(nIndex == wxNOT_FOUND)
         nIndex = file.pIndexOf( wxT("Icon=") );

--- a/src/unix/mimetype.cpp
+++ b/src/unix/mimetype.cpp
@@ -34,6 +34,7 @@
 #include "wx/filename.h"
 #include "wx/app.h"
 #include "wx/apptrait.h"
+#include "wx/uilocale.h"
 
 // other standard headers
 #include <ctype.h>
@@ -155,9 +156,8 @@ void wxMimeTypesManagerImpl::LoadXDGApp(const wxString& filename)
     wxString nameapp;
     nIndex = wxNOT_FOUND;
 #if wxUSE_INTL // try "Name[locale name]" first
-    wxLocale *locale = wxGetLocale();
-    if ( locale )
-        nIndex = file.pIndexOf(wxT("Name[")+locale->GetName()+wxT("]="));
+    if ( wxUILocale::GetCurrent().IsSupported() )
+        nIndex = file.pIndexOf(wxT("Name[")+wxUILocale::GetCurrent().GetName()+wxT("]="));
 #endif // wxUSE_INTL
     if(nIndex == wxNOT_FOUND)
         nIndex = file.pIndexOf( wxT("Name=") );


### PR DESCRIPTION
Where possible, references to `wxLocale` were replaced by `wxUILocale`throughout the wxWidgets codebase.

Exceptions are the calls to the static methods `wxLocale::GetSystemEncoding()` and `wxLocale::GetSystemEncodingName()`, for which no corresponding method exist in `wxUILocale`. This affects the following source files:

-  common/strconv.cpp
-  common/translation.cpp
-  gtk/app.cpp
-  gtk1/app.cpp
-  html/winpars.cpp
-  motif/app.cpp
-  msw/textctrl.cpp
-  osx/carbon/app.cpp
-  osx/carbon/graphics.cpp
-  osx/carbon/sound.cpp
-  osx/core/fontenum.cpp
-  richtext/richtextxml.cpp
-  x11/app.cpp
-  xrc/xmlres.cpp
-  osx/carbon/fontdlgosx.mm
-  osx/cocoa/utils.mm

Not yet handled is the use of `wxLocale` in the file [msw/msgdlg.cpp](https://github.com/utelle/wxWidgets/blob/6077c80ec9f044753e8408bb7f36531a223c0a1c/src/msw/msgdlg.cpp#L426):

```C++
    wxLocale * const loc = wxGetLocale();
    if ( loc && loc->GetLanguage() != wxLocale::GetSystemLanguage() )
    {
        if ( m_dialogStyle & wxYES_NO &&
                (GetCustomYesLabel().empty() && GetCustomNoLabel().empty()) )

        {
            // use the strings with mnemonics here as the native message box
            // does
            SetYesNoLabels(_("&Yes"), _("&No"));
        }

        // we may or not have the Ok/Cancel buttons but either we do have them
        // or we already made the labels custom because we called
        // SetYesNoLabels() above so doing this does no harm -- and is
        // necessary in wxYES_NO | wxCANCEL case
        //
        // note that we don't use mnemonics here for consistency with the
        // native message box (which probably doesn't use them because
        // Enter/Esc keys can be already used to dismiss the message box
        // using keyboard)
        if ( GetCustomOKLabel().empty() && GetCustomCancelLabel().empty() )
            SetOKCancelLabels(_("OK"), _("Cancel"));
    }
```

The method corresponding to ` wxLocale::GetSystemLanguage()` is actually ` wxUILocale::GetSystemLocale()`. This could be used here, but I'm not sure whether this would be the right thing to do in the long run, because its use here affects the UI _**language**_ (and not the locale).