### PR TITLE
Fix build when wxUSE_BASE64=0

### DIFF
--- a/include/wx/msw/iniconf.h
+++ b/include/wx/msw/iniconf.h
@@ -81,11 +81,15 @@ protected:
   // read/write
   bool DoReadString(const wxString& key, wxString *pStr) const wxOVERRIDE;
   bool DoReadLong(const wxString& key, long *plResult) const wxOVERRIDE;
+#if wxUSE_BASE64
   bool DoReadBinary(const wxString& key, wxMemoryBuffer *buf) const wxOVERRIDE;
+#endif // wxUSE_BASE64
 
   bool DoWriteString(const wxString& key, const wxString& szValue) wxOVERRIDE;
   bool DoWriteLong(const wxString& key, long lValue) wxOVERRIDE;
+#if wxUSE_BASE64
   bool DoWriteBinary(const wxString& key, const wxMemoryBuffer& buf) wxOVERRIDE;
+#endif // wxUSE_BASE64
 
 private:
   // helpers

--- a/src/common/dcsvg.cpp
+++ b/src/common/dcsvg.cpp
@@ -438,8 +438,14 @@ wxSVGBitmapEmbedHandler::ProcessBitmap(const wxBitmap& bmp,
     wxUnusedVar(x); wxUnusedVar(y);
     wxUnusedVar(stream);
 
+    wxFAIL_MSG
+    (
+        "Embedding bitmaps in SVG is not available because "
+        "wxWidgets was built with wxUSE_BASE64 set to 0."
+    );
+
     return false;
-#endif //wxUSE_BASE64
+#endif // wxUSE_BASE64
 }
 
 // ----------------------------------------------------------

--- a/src/common/dcsvg.cpp
+++ b/src/common/dcsvg.cpp
@@ -397,6 +397,7 @@ wxSVGBitmapEmbedHandler::ProcessBitmap(const wxBitmap& bmp,
                                        wxCoord x, wxCoord y,
                                        wxOutputStream& stream) const
 {
+#if wxUSE_BASE64
     static int sub_images = 0;
 
     if ( wxImage::FindHandler(wxBITMAP_TYPE_PNG) == NULL )
@@ -431,6 +432,14 @@ wxSVGBitmapEmbedHandler::ProcessBitmap(const wxBitmap& bmp,
     stream.Write(buf, strlen((const char*)buf));
 
     return stream.IsOk();
+#else
+    // to avoid compiler warnings about unused variables
+    wxUnusedVar(bmp);
+    wxUnusedVar(x); wxUnusedVar(y);
+    wxUnusedVar(stream);
+
+    return false;
+#endif //wxUSE_BASE64
 }
 
 // ----------------------------------------------------------

--- a/src/msw/iniconf.cpp
+++ b/src/msw/iniconf.cpp
@@ -358,6 +358,8 @@ bool wxIniConfig::DoWriteLong(const wxString& szKey, long lValue)
   return Write(szKey, wxString::Format(wxT("%ld"), lValue));
 }
 
+#if wxUSE_BASE64
+
 bool wxIniConfig::DoReadBinary(const wxString& WXUNUSED(key),
                                wxMemoryBuffer * WXUNUSED(buf)) const
 {
@@ -373,6 +375,8 @@ bool wxIniConfig::DoWriteBinary(const wxString& WXUNUSED(key),
 
     return false;
 }
+
+#endif // wxUSE_BASE64
 
 bool wxIniConfig::Flush(bool /* bCurrentOnly */)
 {


### PR DESCRIPTION
Building wxWidgets with without base64 support is probably quite uncommon (I did it on accident), so feel free to reject.

Also, I am not sure whether just returning `false` from `wxSVGBitmapEmbedHandler::ProcessBitmap()` without any error message is the best thing to do. Perhaps using `wxFAIL_MSG()` as it is done in `wxBitmapBundle::FromResources()` on platforms without resource support would be a bit better.

**EDIT**
The CI log did not help me to figure out which test failed. When running test_gui locally I get a bunch of failures
<details>
<summary>Test log</summary>

```
Test program for wxWidgets GUI features
build: 3.1.7 (wchar_t,Visual C++ 1900,wx containers,compatible with 3.0)
compiled using msvc 1931 (full: 193131106)
running under Windows 10 (build 19044), 64-bit edition as petr

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test_gui.exe is a Catch v1.12.2 host application.
Run with -? for options

-------------------------------------------------------------------------------
ClippingBoxTestCase::wxGCDC
  OneRegionRTL
-------------------------------------------------------------------------------
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(2293)
...............................................................................

D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(847):
warning:
  Skipping test because RTL layout direction is not supported on this platform

-------------------------------------------------------------------------------
ClippingBoxTestCase::wxGCDC
  OneDevRegionRTL
-------------------------------------------------------------------------------
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(2333)
...............................................................................

D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(1028):
warning:
  Skipping test because RTL layout direction is not supported on this platform

-------------------------------------------------------------------------------
ClippingBoxTestCase::wxGCDC
  OneDevRegionRTL TransformMatrix
-------------------------------------------------------------------------------
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(2338)
...............................................................................

D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(1028):
warning:
  Skipping test because RTL layout direction is not supported on this platform

-------------------------------------------------------------------------------
ClippingBoxTestCase::wxGCDC(GDI+)
  OneRegionRTL
-------------------------------------------------------------------------------
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(2621)
...............................................................................

D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(847):
warning:
  Skipping test because RTL layout direction is not supported on this platform

-------------------------------------------------------------------------------
ClippingBoxTestCase::wxGCDC(GDI+)
  OneDevRegionRTL
-------------------------------------------------------------------------------
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(2661)
...............................................................................

D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(1028):
warning:
  Skipping test because RTL layout direction is not supported on this platform

-------------------------------------------------------------------------------
ClippingBoxTestCase::wxGCDC(GDI+)
  OneDevRegionRTL TransformMatrix
-------------------------------------------------------------------------------
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(2666)
...............................................................................

D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(1028):
warning:
  Skipping test because RTL layout direction is not supported on this platform

-------------------------------------------------------------------------------
ClippingBoxTestCase::wxGCDC(Direct2D)
  OneRegionRTL
-------------------------------------------------------------------------------
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(2950)
...............................................................................

D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(847):
warning:
  Skipping test because RTL layout direction is not supported on this platform

-------------------------------------------------------------------------------
ClippingBoxTestCase::wxGCDC(Direct2D)
  OneDevRegionRTL
-------------------------------------------------------------------------------
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(2990)
...............................................................................

D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(1028):
warning:
  Skipping test because RTL layout direction is not supported on this platform

-------------------------------------------------------------------------------
ClippingBoxTestCase::wxGCDC(Direct2D)
  OneDevRegionRTL TransformMatrix
-------------------------------------------------------------------------------
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(2995)
...............................................................................

D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(1028):
warning:
  Skipping test because RTL layout direction is not supported on this platform

-------------------------------------------------------------------------------
ClippingBoxTestCase::wxSVGFileDC
  OneRegionRTL
-------------------------------------------------------------------------------
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(3606)
...............................................................................

D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(847):
warning:
  Skipping test because RTL layout direction is not supported on this platform

-------------------------------------------------------------------------------
ClippingBoxTestCase::wxSVGFileDC
  OneDevRegionRTL
-------------------------------------------------------------------------------
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(3646)
...............................................................................

D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\graphics\clippingbox.cpp(1028):
warning:
  Skipping test because RTL layout direction is not supported on this platform

-------------------------------------------------------------------------------
Grid::SelectUsingEndKey
-------------------------------------------------------------------------------
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\controls\gridtest.cpp(951)
...............................................................................

D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\controls\gridtest.cpp(982): FAILED:
  CHECK( m_grid->IsVisible(8, 9) )
with expansion:
  false

-------------------------------------------------------------------------------
wxTextCtrl::LongPaste
-------------------------------------------------------------------------------
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\controls\textctrltest.cpp(1360)
...............................................................................

D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\controls\textctrltest.cpp(1422): FAILED:
  CHECK( numLines == NUM_LINES + 2 )
with expansion:
  2 == 10002 (0x2712)

D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\controls\textctrltest.cpp(1423): FAILED:
  CHECK( text->GetLineText(numLines - 1) == "THE END" )
with expansion:
   == "THE END"

-------------------------------------------------------------------------------
ExecTestCase
  TestExecute
-------------------------------------------------------------------------------
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\exec\exec.cpp(72)
...............................................................................

D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\exec\exec.cpp(243): FAILED:
  REQUIRE( stderr_arr[0].Contains("file") )
with expansion:
  false

-------------------------------------------------------------------------------
ExecTestCase
  TestAsyncRedirect
-------------------------------------------------------------------------------
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\exec\exec.cpp(75)
...............................................................................

D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\exec\exec.cpp(381): FAILED:
  REQUIRE( tis.ReadLine().Contains(expectedContaining) )
with expansion:
  false

-------------------------------------------------------------------------------
wxHtmlPrintout::Pagination
-------------------------------------------------------------------------------
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\html\htmprint.cpp(47)
...............................................................................

D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\html\htmprint.cpp(104): FAILED:
  CHECK( CountPages(pr) == 3 )
with expansion:
  4 == 3

-------------------------------------------------------------------------------
SettingsTestCase
  GetFont
-------------------------------------------------------------------------------
D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\misc\settings.cpp(33)
...............................................................................

D:\Dev\Desktop\!Lib\wxWidgets-PB\tests\misc\settings.cpp(33): FAILED:
  {Unknown expression after the reported line}
due to unexpected exception with message:
  failed to get LOGFONT in wxCreateFontFromStockObject() at D:\Dev\Desktop\
  !Lib\wxWidgets-PB\src\msw\settings.cpp:156

===============================================================================
test cases:   368 |   363 passed | 5 failed
assertions: 19828 | 19821 passed | 7 failed
```
</details>

but I cannot figure out which, if any, is related to my commits (which should not affect the default build at all).