### PR TITLE
Fix crash on wxBitmapBundleImplRC::AddBitmap

### DIFF
--- a/src/msw/bmpbndl.cpp
+++ b/src/msw/bmpbndl.cpp
@@ -250,7 +250,7 @@ wxBitmapBundleImplRC::AddBitmap(const ResourceInfo& info,
     (
         bitmap.GetSize() == sizeExpected,
         wxString::Format(wxS("Bitmap \"%s\" should have size %d*%d."),
-                         sizeExpected.x, sizeExpected.y)
+                         info.name, sizeExpected.x, sizeExpected.y)
     );
 
     if ( sizeNeeded != sizeExpected )


### PR DESCRIPTION
There has three args, but only give two.