### PR TITLE
Include wx/defs.h in tipwin.h

### DIFF
--- a/include/wx/tipwin.h
+++ b/include/wx/tipwin.h
@@ -12,6 +12,8 @@
 #ifndef _WX_TIPWIN_H_
 #define _WX_TIPWIN_H_
 
+#include "wx/defs.h"
+
 #if wxUSE_TIPWINDOW
 
 #include "wx/popupwin.h"


### PR DESCRIPTION
tipwin.h does not include wx/defs.h. Because of this wxUSE_TIPWINDOW is not defined.

This pull requests adds #include "wx/defs.h" before wxUSE_TIPWINDOW check.