### PR TITLE
Explain how to best use wxFrame as input form

### DIFF
--- a/interface/wx/frame.h
+++ b/interface/wx/frame.h
@@ -26,6 +26,17 @@
     CreateToolBar() functions, manages these windows and adjusts the value returned
     by GetClientSize() to reflect the remaining size available to application windows.
 
+    If a frame is to be used as an input form, the controls should not be created as
+    its children. Instead, a wxPanel should be created as the sole child of the frame,
+    serving as the parent of the actual controls (the frame will size the panel so it
+    always fills its client area). Doing this will ensure that tabbing between the controls
+    works and the frame background has the expected colour. Moreover, as a frame is by
+    default resizable, it could be better to use wxScrolledWindow instead of wxPanel,
+    to make sure the controls are easily accessible regardless of the frame size. However,
+    please consider whether it would not be better to use wxDialog instead of wxFrame,
+    where using a panel like this is not needed and wxDialog also offers other benefits
+    such as creating specialized sizers (e.g., for buttons, with their platform-correct order).
+
     @remarks An application should normally define a wxCloseEvent handler for the
              frame to respond to system close events, for example so that related
              data and subwindows can be cleaned up.


### PR DESCRIPTION
I think providing this information is useful, I have seen the issue raised on forums many times.

I have no idea why wxScrolledWindow is not hyperlinked.

I was wondering whether it would not be also useful to add two entries to the FAQ:
1. Windows FAQ (I assume this applies only to Windows?): _Why is the frame background colour wrong?_ 
2. Common FAQ: _Why does a control take the whole wxFrame space, ignoring my attempts to size it?_

The second question is answered in several places in the docs already (including wxFrame in the default event processing section); however, it may be a bit difficult to find.