### PR TITLE
Make handling of masks wxImageList much simpler and more useful

### DIFF
--- a/include/wx/generic/imaglist.h
+++ b/include/wx/generic/imaglist.h
@@ -58,6 +58,8 @@ public:
 private:
     const wxBitmap *DoGetPtr(int index) const;
 
+    wxBitmap GetImageListBitmap(const wxBitmap& bitmap) const;
+
     wxVector<wxBitmap> m_images;
     bool m_useMask;
 

--- a/include/wx/msw/bitmap.h
+++ b/include/wx/msw/bitmap.h
@@ -276,6 +276,10 @@ public:
     WXHBITMAP GetMaskBitmap() const { return m_maskBitmap; }
     void SetMaskBitmap(WXHBITMAP bmp) { m_maskBitmap = bmp; }
 
+#if wxUSE_IMAGE
+    bool MSWCreateFromImageMask(const wxImage& image);
+#endif // wxUSE_IMAGE
+
 protected:
     WXHBITMAP m_maskBitmap;
 

--- a/include/wx/msw/imaglist.h
+++ b/include/wx/msw/imaglist.h
@@ -200,6 +200,14 @@ protected:
   wxSize m_size;
 
 private:
+  // Private helper used by GetImageListBitmaps().
+  class wxMSWBitmaps;
+
+  // Fills the provided output "bitmaps" object with the actual bitmaps we need
+  // to use with the native control.
+  void GetImageListBitmaps(wxMSWBitmaps& bitmaps,
+                           const wxBitmap& bitmap, const wxBitmap& mask);
+
   bool m_useMask;
 
   void Init()

--- a/interface/wx/imaglist.h
+++ b/interface/wx/imaglist.h
@@ -28,8 +28,8 @@ enum
     @class wxImageList
 
     A wxImageList contains a list of images, which are stored in an unspecified
-    form. Images can have masks for transparent drawing, and can be made from a
-    variety of sources including bitmaps and icons.
+    form. Images can use alpha channel or masks for transparent drawing, and
+    can be made from a variety of sources including bitmaps and icons.
 
     wxImageList is used principally in conjunction with wxTreeCtrl and
     wxListCtrl classes.
@@ -62,7 +62,12 @@ public:
         @param height
             Height of the images in the list.
         @param mask
-            @true if masks should be created for all images.
+            If @true, all images will have masks, with the mask being created
+            from the light grey pixels if not specified otherwise, i.e. if the
+            image doesn't have neither alpha channel nor mask and no mask is
+            explicitly specified when adding it. Note that if an image does
+            have alpha channel or mask, it will always be used, whether this
+            parameter is @true or @false.
         @param initialCount
             The initial size of the list.
 

--- a/src/generic/imaglist.cpp
+++ b/src/generic/imaglist.cpp
@@ -71,62 +71,14 @@ bool wxGenericImageList::Create( int width, int height, bool mask, int WXUNUSED(
 wxBitmap wxGenericImageList::GetImageListBitmap(const wxBitmap& bitmap) const
 {
     wxBitmap bmp(bitmap);
-    if ( m_useMask )
+
+    // If we don't have neither mask nor alpha and were asked to use a mask,
+    // create a default one.
+    if ( m_useMask && !bmp.GetMask() && !bmp.HasAlpha() )
     {
-        if ( bmp.GetMask() )
-        {
-            if ( bmp.HasAlpha() )
-            {
-                // We need to remove alpha channel for compatibility with
-                // native-based wxMSW wxImageList where stored images are not allowed
-                // to have both mask and alpha channel.
-#if wxUSE_IMAGE
-                wxImage img = bmp.ConvertToImage();
-                img.ClearAlpha();
-                bmp = wxBitmap(img, -1, bmp.GetScaleFactor());
-#endif // wxUSE_IMAGE
-            }
-        }
-        else
-        {
-            if ( bmp.HasAlpha() )
-            {
-                // Convert alpha channel to mask.
-#if wxUSE_IMAGE
-                wxImage img = bmp.ConvertToImage();
-                img.ConvertAlphaToMask();
-                bmp = wxBitmap(img, -1, bmp.GetScaleFactor());
-#endif // wxUSE_IMAGE
-            }
-            else
-            {
-                // Like for wxMSW, use the light grey from standard colour map as transparent colour.
-                wxColour col = wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE);
-                bmp.SetMask(new wxMask(bmp, col));
-            }
-        }
-    }
-    else
-    {
-        if ( bmp.GetMask() )
-        {
-            if ( bmp.HasAlpha() )
-            {
-                // TODO: It would be better to blend a mask with existing alpha values.
-                bmp.SetMask(NULL);
-            }
-            else
-            {
-                // Convert a mask to alpha values.
-#if wxUSE_IMAGE
-                wxImage img = bmp.ConvertToImage();
-                img.InitAlpha();
-                bmp = wxBitmap(img, -1, bmp.GetScaleFactor());
-#else
-                bmp.SetMask(NULL);
-#endif // wxUSE_IMAGE
-            }
-        }
+        // Like for wxMSW, use the light grey from standard colour map as transparent colour.
+        wxColour col = wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE);
+        bmp.SetMask(new wxMask(bmp, col));
     }
 
     // Ensure image size is the same as the size of the images on the image list.

--- a/src/generic/imaglist.cpp
+++ b/src/generic/imaglist.cpp
@@ -68,12 +68,10 @@ bool wxGenericImageList::Create( int width, int height, bool mask, int WXUNUSED(
     return m_size != wxSize(0, 0);
 }
 
-namespace
-{
-wxBitmap GetImageListBitmap(const wxBitmap& bitmap, bool useMask, const wxSize& imgSize)
+wxBitmap wxGenericImageList::GetImageListBitmap(const wxBitmap& bitmap) const
 {
     wxBitmap bmp(bitmap);
-    if ( useMask )
+    if ( m_useMask )
     {
         if ( bmp.GetMask() )
         {
@@ -134,13 +132,13 @@ wxBitmap GetImageListBitmap(const wxBitmap& bitmap, bool useMask, const wxSize& 
     // Ensure image size is the same as the size of the images on the image list.
     wxBitmap bmpResized;
     const wxSize sz = bmp.GetLogicalSize();
-    if ( sz.x == imgSize.x && sz.y == imgSize.y )
+    if ( sz.x == m_size.x && sz.y == m_size.y )
     {
         bmpResized = bmp;
     }
-    else if ( sz.x > imgSize.x && sz.y > imgSize.y )
+    else if ( sz.x > m_size.x && sz.y > m_size.y )
     {
-        wxRect r(0, 0, imgSize.x, imgSize.y);
+        wxRect r(0, 0, m_size.x, m_size.y);
         bmpResized = bmp.GetSubBitmap(r);
     }
     else
@@ -149,7 +147,7 @@ wxBitmap GetImageListBitmap(const wxBitmap& bitmap, bool useMask, const wxSize& 
         wxImage img = bmp.ConvertToImage();
         // We need image with new physical size
         const double scaleFactor = bmp.GetScaleFactor();
-        wxImage imgResized = img.Size(scaleFactor * imgSize, wxPoint(0, 0), 0, 0, 0);
+        wxImage imgResized = img.Size(scaleFactor * m_size, wxPoint(0, 0), 0, 0, 0);
         bmpResized = wxBitmap(imgResized, -1, scaleFactor);
 #else
         bmpResized = bmp;
@@ -158,7 +156,6 @@ wxBitmap GetImageListBitmap(const wxBitmap& bitmap, bool useMask, const wxSize& 
 
     return bmpResized;
 }
-};
 
 int wxGenericImageList::Add( const wxBitmap &bitmap )
 {
@@ -175,7 +172,7 @@ int wxGenericImageList::Add( const wxBitmap &bitmap )
     // ImageList_Add() does.
     if ( bitmapSize.x == m_size.x )
     {
-        m_images.push_back(GetImageListBitmap(bitmap, m_useMask, m_size));
+        m_images.push_back(GetImageListBitmap(bitmap));
     }
     else if ( bitmapSize.x > m_size.x )
     {
@@ -183,7 +180,7 @@ int wxGenericImageList::Add( const wxBitmap &bitmap )
         for (int subIndex = 0; subIndex < numImages; subIndex++)
         {
             wxRect rect(m_size.x * subIndex, 0, m_size.x, m_size.y);
-            m_images.push_back(GetImageListBitmap(bitmap.GetSubBitmap(rect), m_useMask, m_size));
+            m_images.push_back(GetImageListBitmap(bitmap.GetSubBitmap(rect)));
         }
     }
     else
@@ -252,7 +249,7 @@ wxGenericImageList::Replace(int index,
     if ( mask.IsOk() )
         bmp.SetMask(new wxMask(mask));
 
-    m_images[index] = GetImageListBitmap(bmp, m_useMask, m_size);
+    m_images[index] = GetImageListBitmap(bmp);
 
     return true;
 }

--- a/src/msw/bitmap.cpp
+++ b/src/msw/bitmap.cpp
@@ -35,6 +35,7 @@
     #include "wx/image.h"
 #endif
 
+#include "wx/scopedarray.h"
 #include "wx/scopedptr.h"
 #include "wx/msw/private.h"
 #include "wx/msw/dc.h"
@@ -935,12 +936,12 @@ bool wxBitmap::CreateFromImage(const wxImage& image, int depth, WXHDC hdc)
     {
         const size_t len  = 2*((w+15)/16);
         BYTE *src  = image.GetData();
-        BYTE *data = new BYTE[h*len];
-        memset(data, 0, h*len);
+        wxScopedArray<BYTE> data(h*len);
+        memset(data.get(), 0, h*len);
         BYTE r = image.GetMaskRed(),
              g = image.GetMaskGreen(),
              b = image.GetMaskBlue();
-        BYTE *dst = data;
+        BYTE *dst = data.get();
         for ( int y = 0; y < h; y++, dst += len )
         {
             BYTE *dstLine = dst;
@@ -958,7 +959,7 @@ bool wxBitmap::CreateFromImage(const wxImage& image, int depth, WXHDC hdc)
             }
         }
 
-        hbitmap = ::CreateBitmap(w, h, 1, 1, data);
+        hbitmap = ::CreateBitmap(w, h, 1, 1, data.get());
         if ( !hbitmap )
         {
             wxLogLastError(wxT("CreateBitmap(mask)"));
@@ -967,8 +968,6 @@ bool wxBitmap::CreateFromImage(const wxImage& image, int depth, WXHDC hdc)
         {
             SetMask(new wxMask((WXHBITMAP)hbitmap));
         }
-
-        delete[] data;
     }
 
     return true;

--- a/src/msw/imaglist.cpp
+++ b/src/msw/imaglist.cpp
@@ -36,7 +36,6 @@
 
 #include "wx/imaglist.h"
 #include "wx/dc.h"
-#include "wx/scopedptr.h"
 #include "wx/msw/dc.h"
 #include "wx/msw/dib.h"
 #include "wx/msw/private.h"
@@ -53,9 +52,8 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxImageList, wxObject);
 // private functions
 // ----------------------------------------------------------------------------
 
-// returns the mask if it's valid, otherwise the bitmap mask and, if it's not
-// valid neither, a "solid" mask (no transparent zones at all)
-static HBITMAP GetMaskForImage(const wxBitmap& bitmap, const wxBitmap& mask);
+// returns the default transparent colour to use for creating the mask
+static wxColour GetDefaultMaskColour();
 
 // ============================================================================
 // implementation
@@ -81,12 +79,16 @@ bool wxImageList::Create(int width, int height, bool mask, int initial)
     // (e.g. ILC_COLOR16) shows completely broken bitmaps
     flags |= ILC_COLOR32;
 
+    m_useMask = mask;
+
     // For comctl32.dll < 6 always use masks as it doesn't support alpha.
-    if ( mask || wxApp::GetComCtl32Version() < 600 )
-    {
-        m_useMask = true;
+    //
+    // We also have to use masks when we don't have wxImage and wxDIB that are
+    // needed to handle alpha.
+#if wxUSE_WXDIB && wxUSE_IMAGE
+    if ( wxApp::GetComCtl32Version() < 600 )
+#endif
         flags |= ILC_MASK;
-    }
 
     // Grow by 1, I guess this is reasonable behaviour most of the time
     m_hImageList = (WXHIMAGELIST) ImageList_Create(width, height, flags,
@@ -142,6 +144,14 @@ class wxImageList::wxMSWBitmaps
 public:
     wxMSWBitmaps() : hbmp(NULL) { }
 
+#if wxUSE_WXDIB && wxUSE_IMAGE
+    void InitFromImageWithAlpha(const wxImage& img)
+    {
+        hbmp = wxDIB(img, wxDIB::PixelFormat_NotPreMultiplied).Detach();
+        hbmpRelease.Init(hbmp);
+    }
+#endif // wxUSE_WXDIB && wxUSE_IMAGE
+
     // These fields are filled by GetImageListBitmaps().
     HBITMAP hbmp;
     AutoHBITMAP hbmpMask;
@@ -151,10 +161,6 @@ private:
     // shouldn't be used otherwise, so it's private.
     AutoHBITMAP hbmpRelease;
 
-    friend void wxImageList::GetImageListBitmaps(wxMSWBitmaps&,
-                                                 const wxBitmap&,
-                                                 const wxBitmap&);
-
     wxDECLARE_NO_COPY_CLASS(wxMSWBitmaps);
 };
 
@@ -162,24 +168,40 @@ void
 wxImageList::GetImageListBitmaps(wxMSWBitmaps& bitmaps,
                                  const wxBitmap& bitmap, const wxBitmap& mask)
 {
+    // This can be overwritten below if we need to modify the bitmap, but it
+    // doesn't cost anything to initialize the bitmap with this HBITMAP.
+    bitmaps.hbmp = GetHbitmapOf(bitmap);
+
 #if wxUSE_WXDIB && wxUSE_IMAGE
-    // We can only use directly bitmaps without alpha and without mask unless
-    // the image list uses masks and need to modify bitmap in all the other
-    // cases, so check if this is necessary.
-    if ( bitmap.HasAlpha() || (!m_useMask && (mask.IsOk() || bitmap.GetMask())) )
+    if ( wxApp::GetComCtl32Version() >= 600 )
     {
         wxBitmap bmp(bitmap);
 
-        if ( mask.IsOk() || bmp.GetMask() )
+        if ( mask.IsOk() )
         {
             // Explicitly specified mask overrides the mask associated with the
             // bitmap, if any.
-            if ( mask.IsOk() )
-                bmp.SetMask(new wxMask(mask));
+            bmp.SetMask(new wxMask(mask));
+        }
 
+        if ( bmp.GetMask() )
+        {
             // Get rid of the mask by converting it to alpha.
             if ( bmp.HasAlpha() )
                 bmp.MSWBlendMaskWithAlpha();
+        }
+        else if ( m_useMask )
+        {
+            // Create the mask from the default transparent colour if we have
+            // nothing else.
+            if ( !bmp.HasAlpha() )
+                bmp.SetMask(new wxMask(bmp, GetDefaultMaskColour()));
+        }
+        else
+        {
+            // We actually don't have to do anything at all and can just use
+            // the original bitmap as is.
+            return;
         }
 
         // wxBitmap normally stores alpha in pre-multiplied format but
@@ -190,8 +212,8 @@ wxImageList::GetImageListBitmaps(wxMSWBitmaps& bitmaps,
         wxImage img = bmp.ConvertToImage();
         if ( !img.HasAlpha() )
             img.InitAlpha();
-        bitmaps.hbmp = wxDIB(img, wxDIB::PixelFormat_NotPreMultiplied).Detach();
-        bitmaps.hbmpRelease.Init(bitmaps.hbmp);
+
+        bitmaps.InitFromImageWithAlpha(img);
 
         // In any case we'll never use mask at the native image list level as
         // it's incompatible with alpha and we need to use alpha.
@@ -199,9 +221,46 @@ wxImageList::GetImageListBitmaps(wxMSWBitmaps& bitmaps,
     else
 #endif // wxUSE_WXDIB && wxUSE_IMAGE
     {
-        bitmaps.hbmp = GetHbitmapOf(bitmap);
-        if ( m_useMask )
-            bitmaps.hbmpMask.Init(GetMaskForImage(bitmap, mask));
+        wxMask maskToUse;
+
+        HBITMAP hbmpMask = NULL;
+
+        // Always use mask if it is specified.
+        if ( mask.IsOk() )
+        {
+            hbmpMask = GetHbitmapOf(mask);
+        }
+        else if ( bitmap.GetMask() )
+        {
+            hbmpMask = bitmap.GetMask()->GetMaskBitmap();
+        }
+#if wxUSE_WXDIB && wxUSE_IMAGE
+        // We can also use alpha, but we have to convert it to a mask as it is
+        // not supported by this comctl32.dll version.
+        else if ( bitmap.HasAlpha() )
+        {
+            wxImage img = bitmap.ConvertToImage();
+            img.ConvertAlphaToMask();
+            bitmaps.InitFromImageWithAlpha(img);
+
+            maskToUse.MSWCreateFromImageMask(img);
+        }
+#endif // wxUSE_WXDIB && wxUSE_IMAGE
+        // We don't have neither mask nor alpha, only force creating the
+        // mask from colour if requested to do it.
+        else if ( m_useMask )
+        {
+            maskToUse.Create(bitmap, GetDefaultMaskColour());
+        }
+
+        if ( !hbmpMask )
+            hbmpMask = maskToUse.GetMaskBitmap();
+
+        if ( hbmpMask )
+        {
+            // windows mask convention is opposite to the wxWidgets one
+            bitmaps.hbmpMask.Init(wxInvertMask(hbmpMask));
+        }
     }
 }
 
@@ -470,35 +529,14 @@ wxIcon wxImageList::GetIcon(int index) const
 // helpers
 // ----------------------------------------------------------------------------
 
-static HBITMAP GetMaskForImage(const wxBitmap& bitmap, const wxBitmap& mask)
+static wxColour GetDefaultMaskColour()
 {
-    HBITMAP hbmpMask;
-    wxScopedPtr<wxMask> maskDeleter;
+    // use the light grey count as transparent: the trouble here is
+    // that the light grey might have been changed by Windows behind
+    // our back, so use the standard colour map to get its real value
+    wxCOLORMAP *cmap = wxGetStdColourMap();
+    wxColour col;
+    wxRGBToColour(col, cmap[wxSTD_COL_BTNFACE].from);
 
-    if ( mask.IsOk() )
-    {
-        hbmpMask = GetHbitmapOf(mask);
-    }
-    else
-    {
-        wxMask* pMask = bitmap.GetMask();
-        if ( !pMask )
-        {
-            // use the light grey count as transparent: the trouble here is
-            // that the light grey might have been changed by Windows behind
-            // our back, so use the standard colour map to get its real value
-            wxCOLORMAP *cmap = wxGetStdColourMap();
-            wxColour col;
-            wxRGBToColour(col, cmap[wxSTD_COL_BTNFACE].from);
-
-            pMask = new wxMask(bitmap, col);
-
-            maskDeleter.reset(pMask);
-        }
-
-        hbmpMask = (HBITMAP)pMask->GetMaskBitmap();
-    }
-
-    // windows mask convention is opposite to the wxWidgets one
-    return wxInvertMask(hbmpMask);
+    return col;
 }


### PR DESCRIPTION
After looking at this code in my attempts to solve #22349 I came to the conclusion that we actually don't need to do anything half as complicated as what we're doing here and can drastically simplify the code while making it more useful.

Useful for me means "do the expected thing" and the expected thing here is clearly use whatever transparency is there in the images, be it alpha or mask. Using `mask == false` shouldn't prevent us from doing it but should only disable creating the default mask based on grey pixels, as this is the only thing which can be possibly unexpected (and hence harmful) here.

@a-wi I'm sorry to undo parts of your changes, but I really don't think that we should stick to the formal interpretation of the `mask` parameter here as, I believe, you tried to do. As I've tried to explain in the commit message, it was never supposed to mean "don't use alpha", for the simple reason that it predates alpha support in wxWidgets.