### PR TITLE
grid: fix row/col drag markers

### DIFF
--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -634,6 +634,11 @@ public:
     // call DrawRowLabel or DrawColumnLabel
     virtual void DrawLineLabel(wxGrid *grid, wxDC& dc, int line) const = 0;
 
+    // return the value of GetRowLabelSize/GetColLabelSize
+    virtual int GetLabelSize(const wxGrid *grid) const = 0;
+
+    // helper for Process...MouseEvent for drawing markers on label windows
+    void PrepareDCForLabels(wxGrid *grid, wxDC &dc) const;
 
     // make the specified line visible by doing a minimal amount of scrolling
     virtual void MakeLineVisible(wxGrid *grid, int line) const = 0;
@@ -781,6 +786,8 @@ public:
 
     virtual void DrawLineLabel(wxGrid *grid, wxDC& dc, int line) const wxOVERRIDE
         { grid->DrawRowLabel(dc, line); }
+    virtual int GetLabelSize(const wxGrid *grid) const wxOVERRIDE
+        { return grid->GetRowLabelSize(); }
 
     virtual void MakeLineVisible(wxGrid *grid, int line) const wxOVERRIDE
         { grid->MakeCellVisible(line, -1); }
@@ -923,6 +930,8 @@ public:
 
     virtual void DrawLineLabel(wxGrid *grid, wxDC& dc, int line) const wxOVERRIDE
         { grid->DrawColLabel(dc, line); }
+    virtual int GetLabelSize(const wxGrid *grid) const wxOVERRIDE
+        { return grid->GetRowLabelSize(); }
 
     virtual void MakeLineVisible(wxGrid *grid, int line) const wxOVERRIDE
         { grid->MakeCellVisible(-1, line); }

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -634,9 +634,6 @@ public:
     // call DrawRowLabel or DrawColumnLabel
     virtual void DrawLineLabel(wxGrid *grid, wxDC& dc, int line) const = 0;
 
-    // return the value of GetRowLabelSize/GetColLabelSize
-    virtual int GetLabelSize(const wxGrid *grid) const = 0;
-
     // helper for Process...MouseEvent for drawing markers on label windows
     void PrepareDCForLabels(wxGrid *grid, wxDC &dc) const;
 
@@ -786,8 +783,6 @@ public:
 
     virtual void DrawLineLabel(wxGrid *grid, wxDC& dc, int line) const wxOVERRIDE
         { grid->DrawRowLabel(dc, line); }
-    virtual int GetLabelSize(const wxGrid *grid) const wxOVERRIDE
-        { return grid->GetRowLabelSize(); }
 
     virtual void MakeLineVisible(wxGrid *grid, int line) const wxOVERRIDE
         { grid->MakeCellVisible(line, -1); }
@@ -930,8 +925,6 @@ public:
 
     virtual void DrawLineLabel(wxGrid *grid, wxDC& dc, int line) const wxOVERRIDE
         { grid->DrawColLabel(dc, line); }
-    virtual int GetLabelSize(const wxGrid *grid) const wxOVERRIDE
-        { return grid->GetRowLabelSize(); }
 
     virtual void MakeLineVisible(wxGrid *grid, int line) const wxOVERRIDE
         { grid->MakeCellVisible(-1, line); }

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -4052,27 +4052,25 @@ void wxGrid::ProcessRowColLabelMouseEvent( const wxGridOperations &oper, wxMouse
             else if ( m_cursorMode == oper.GetCursorModeMove() )
             {
                 // determine the y or x position of the drop marker
-                int marker;
+                int markerPos;
                 if ( coord >= oper.GetLineStartPos(this, lineAt) + (oper.GetLineSize(this, lineAt) / 2) )
-                    marker = oper.GetLineEndPos(this, lineAt);
+                    markerPos = oper.GetLineEndPos(this, lineAt);
                 else
-                    marker = oper.GetLineStartPos(this, lineAt);
+                    markerPos = oper.GetLineStartPos(this, lineAt);
 
-                if ( marker != m_dragLastPos )
+                if ( markerPos != m_dragLastPos )
                 {
                     wxClientDC dc( headerWin );
                     oper.PrepareDCForLabels(this, dc);
 
-                    wxSize clientSize = headerWin->GetClientSize();
-
-                    marker++;
+                    int markerLength = oper.Select(headerWin->GetClientSize());
 
                     // Clean up the last indicator
                     if ( m_dragLastPos >= 0 )
                     {
                         wxPen pen(headerWin->GetBackgroundColour(), 2);
                         dc.SetPen(pen);
-                        oper.DrawParallelLine(dc, 0, oper.Select(clientSize), m_dragLastPos + 1);
+                        oper.DrawParallelLine(dc, 0, markerLength, m_dragLastPos + 1);
                         dc.SetPen(wxNullPen);
 
                         int lastLine = oper.PosToLine(this, m_dragLastPos, NULL, false);
@@ -4091,10 +4089,10 @@ void wxGrid::ProcessRowColLabelMouseEvent( const wxGridOperations &oper, wxMouse
                     // Draw the marker
                     wxPen pen(*color, 2);
                     dc.SetPen(pen);
-                    oper.DrawParallelLine(dc, 0, oper.Select(clientSize), marker);
+                    oper.DrawParallelLine(dc, 0, markerLength, markerPos + 1);
                     dc.SetPen(wxNullPen);
 
-                    m_dragLastPos = marker - 1;
+                    m_dragLastPos = markerPos;
                 }
             }
         }
@@ -4131,11 +4129,13 @@ void wxGrid::ProcessRowColLabelMouseEvent( const wxGridOperations &oper, wxMouse
                     // Show button as pressed
                     wxClientDC dc( headerWin );
                     oper.PrepareDCForLabels(this, dc);
-                    int lineTop = oper.GetLineStartPos(this, line);
-                    int lineBottom = oper.GetLineEndPos(this, line) - 1;
                     dc.SetPen( wxPen( headerWin->GetBackgroundColour(), 1 ) );
-                    oper.DrawParallelLine(dc, 0, oper.GetLabelSize(this)-1, lineTop);
-                    dual.DrawParallelLine(dc, lineTop, lineBottom, 1);
+
+                    int lineStart = oper.GetLineStartPos(this, line);
+                    int lineEnd = oper.GetLineEndPos(this, line) - 1;
+                    int lineLength = oper.Select(headerWin->GetClientSize()) - 1;
+                    oper.DrawParallelLine(dc, 0, lineLength, lineStart);
+                    dual.DrawParallelLine(dc, lineStart, lineEnd, 1);
 
                     ChangeCursorMode(oper.GetCursorModeMove(), headerWin);
                 }

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -251,6 +251,10 @@ int wxGridColumnOperations::GetFirstLine(const wxGrid *grid, wxGridWindow *gridW
 
 void wxGridOperations::PrepareDCForLabels(wxGrid *grid, wxDC &dc) const
 {
+    // The grid can be scrolled in both directions and so grid->DoPrepareDC
+    // could offset the device context in both directions.
+    // For row and col labels, we want only one direction and so
+    // we reset the other direction to the original, unscrolled value.
     wxPoint dcOriginBefore = dc.GetDeviceOrigin();
     grid->DoPrepareDC(dc);
     wxPoint dcOrigin = dc.GetDeviceOrigin();

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -249,6 +249,20 @@ int wxGridColumnOperations::GetFirstLine(const wxGrid *grid, wxGridWindow *gridW
     return grid->GetNumberFrozenCols();
 }
 
+void wxGridOperations::PrepareDCForLabels(wxGrid *grid, wxDC &dc) const
+{
+    wxPoint dcOriginBefore = dc.GetDeviceOrigin();
+    grid->DoPrepareDC(dc);
+    wxPoint dcOrigin = dc.GetDeviceOrigin();
+
+    if ( GetOrientation() == wxVERTICAL )
+        dcOrigin.x = dcOriginBefore.x;
+    else if ( GetOrientation() == wxHORIZONTAL )
+        dcOrigin.y = dcOriginBefore.y;
+
+    dc.SetDeviceOrigin(dcOrigin.x, dcOrigin.y);
+}
+
 // ----------------------------------------------------------------------------
 // wxGridCellWorker is an (almost) empty common base class for
 // wxGridCellRenderer and wxGridCellEditor managing ref counting
@@ -4047,7 +4061,7 @@ void wxGrid::ProcessRowColLabelMouseEvent( const wxGridOperations &oper, wxMouse
                 if ( marker != m_dragLastPos )
                 {
                     wxClientDC dc( headerWin );
-                    DoPrepareDC(dc);
+                    oper.PrepareDCForLabels(this, dc);
 
                     wxSize clientSize = headerWin->GetClientSize();
 
@@ -4116,11 +4130,11 @@ void wxGrid::ProcessRowColLabelMouseEvent( const wxGridOperations &oper, wxMouse
                 {
                     // Show button as pressed
                     wxClientDC dc( headerWin );
-                    DoPrepareDC(dc);
+                    oper.PrepareDCForLabels(this, dc);
                     int lineTop = oper.GetLineStartPos(this, line);
                     int lineBottom = oper.GetLineEndPos(this, line) - 1;
                     dc.SetPen( wxPen( headerWin->GetBackgroundColour(), 1 ) );
-                    oper.DrawParallelLine(dc, 0, m_rowLabelWidth-1, lineTop);
+                    oper.DrawParallelLine(dc, 0, oper.GetLabelSize(this)-1, lineTop);
                     dual.DrawParallelLine(dc, lineTop, lineBottom, 1);
 
                     ChangeCursorMode(oper.GetCursorModeMove(), headerWin);


### PR DESCRIPTION
This PR fixes DC preparation and marker size when grid row/col drag markers are drawn.

From unifying row/col mouse handling, `m_rowLabelWidth` was left over.
`wxGridOperations::GetLabelSize` is now implemented/used instead.

When dragging a col/row, a marker is drawn/deleted.
Until now the grid's `DoPrepareDC` was used to scroll the `wxClientDC`. This does inialize both scroll directions, which is not correct. When e.g. dragging a row in a horizontally scrolled grid, there was an offset.
`wxGridOperations::PrepareDCForLabels` is now implemented instead, which resets one direction to the unscrolled value.

The DC handling could probably be unified with `wxGridRowLabelWindow::OnPaint`, but I'm not into this deep enough.


I'm not 100% happy with the names. Maybe, names `GetLineLabelSize` and `PrepareDCForLineLabels` would be better, but I don't like these either as no line numbers arguments are involved here.
