### PR TITLE
MSW SpinCtrl: handle special keys (e.g. Ctrl+C)

### DIFF
--- a/include/wx/msw/spinctrl.h
+++ b/include/wx/msw/spinctrl.h
@@ -140,6 +140,10 @@ protected:
     void OnSetFocus(wxFocusEvent& event);
     void OnKillFocus(wxFocusEvent& event);
 
+    // returns true for special keys like "Ctrl+C" that should be handled
+    // by the text control
+    virtual bool MSWShouldPreProcessMessage(WXMSG* msg) wxOVERRIDE;
+
     // generate spin control update event with the given value
     void SendSpinUpdate(int value);
 

--- a/include/wx/msw/textentry.h
+++ b/include/wx/msw/textentry.h
@@ -12,6 +12,9 @@
 
 class wxTextAutoCompleteData; // private class used only by wxTextEntry itself
 
+// this one is also used by wxSpinCtrl
+extern bool TextEntryMSWShouldPreProcessMessage(WXMSG* msg);
+
 // ----------------------------------------------------------------------------
 // wxTextEntry: common part of wxComboBox and (single line) wxTextCtrl
 // ----------------------------------------------------------------------------
@@ -86,7 +89,8 @@ protected:
 
     // Returns false if this message shouldn't be preprocessed, but is always
     // handled by the EDIT control represented by this object itself.
-    bool MSWShouldPreProcessMessage(WXMSG* msg) const;
+    bool MSWShouldPreProcessMessage(WXMSG* msg) const
+        { return TextEntryMSWShouldPreProcessMessage(msg); }
 
     // Helper for wxTE_PROCESS_ENTER handling: activates the default button in
     // the dialog containing this control if any.

--- a/src/msw/spinctrl.cpp
+++ b/src/msw/spinctrl.cpp
@@ -734,6 +734,10 @@ bool wxSpinCtrl::MSWOnNotify(int WXUNUSED(idCtrl), WXLPARAM lParam, WXLPARAM *re
     return TRUE;
 }
 
+bool wxSpinCtrl::MSWShouldPreProcessMessage(WXMSG* msg)
+{
+    return TextEntryMSWShouldPreProcessMessage(msg);
+}
 
 // ----------------------------------------------------------------------------
 // size calculations

--- a/src/msw/textentry.cpp
+++ b/src/msw/textentry.cpp
@@ -1072,7 +1072,8 @@ bool wxTextEntry::ClickDefaultButtonIfPossible()
                     wxWindow::MSWGetDefaultButtonFor(GetEditableWindow()));
 }
 
-bool wxTextEntry::MSWShouldPreProcessMessage(WXMSG* msg) const
+// this one is also used by wxSpinCtrl
+extern bool TextEntryMSWShouldPreProcessMessage(WXMSG* msg)
 {
     // check for our special keys here: if we don't do it and the parent frame
     // uses them as accelerators, they wouldn't work at all, so we disable


### PR DESCRIPTION
Sorry, this is the same as PR22397, which was closed when I was re-creating my fork.

There is a wxPython bug report about menu entries like "Copy\tCtrl+C" having precedence over special character handling in the text control of SpinCtrl:
https://github.com/wxWidgets/Phoenix/issues/2148


The reason is that SpinCtrl does not have an implementation of `MSWShouldPreProcessMessage`.

This modification uses `MSWShouldPreProcessMessage(WXMSG* msg);` from `src/msw/textentry.c` also for `src/msw/spinctrl.cpp`.
