### PR TITLE
Fix (not) showing values for empty cells in wxDVC using wxDataViewVirtualListModel in wxGTK

### DIFF
--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -3199,14 +3199,6 @@ gtk_dataview_header_button_press_callback( GtkWidget *WXUNUSED(widget),
     return FALSE;
 }
 
-// Helper for wxGtkTreeCellDataFunc() below.
-static void wxGtkTreeSetVisibleProp(GtkCellRenderer *renderer, gboolean visible)
-{
-    wxGtkValue gvalue( G_TYPE_BOOLEAN );
-    g_value_set_boolean( gvalue, visible );
-    g_object_set_property( G_OBJECT(renderer), "visible", gvalue );
-}
-
 extern "C"
 {
 
@@ -3241,7 +3233,9 @@ static void wxGtkTreeCellDataFunc( GtkTreeViewColumn *WXUNUSED(column),
         visible = cell->PrepareForItem(wx_model, item, column);
     }
 
-    wxGtkTreeSetVisibleProp(renderer, visible);
+    wxGtkValue gvalue( G_TYPE_BOOLEAN );
+    g_value_set_boolean( gvalue, visible );
+    g_object_set_property( G_OBJECT(renderer), "visible", gvalue );
 }
 
 } // extern "C"

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -3233,25 +3233,15 @@ static void wxGtkTreeCellDataFunc( GtkTreeViewColumn *WXUNUSED(column),
 
     wxDataViewModel *wx_model = tree_model->internal->GetDataViewModel();
 
-    if (!wx_model->IsVirtualListModel())
+    gboolean visible = wx_model->HasValue(item, column);
+    if ( visible )
     {
-        gboolean visible = wx_model->HasValue(item, column);
-        wxGtkTreeSetVisibleProp(renderer, visible);
+        cell->GtkSetCurrentItem(item);
 
-        if ( !visible )
-            return;
+        visible = cell->PrepareForItem(wx_model, item, column);
     }
 
-    cell->GtkSetCurrentItem(item);
-
-    if (!cell->PrepareForItem(wx_model, item, column))
-    {
-        // We don't have any value in this cell, after all, so hide it.
-        if (!wx_model->IsVirtualListModel())
-        {
-            wxGtkTreeSetVisibleProp(renderer, FALSE);
-        }
-    }
+    wxGtkTreeSetVisibleProp(renderer, visible);
 }
 
 } // extern "C"

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -3225,13 +3225,10 @@ static void wxGtkTreeCellDataFunc( GtkTreeViewColumn *WXUNUSED(column),
 
     wxDataViewModel *wx_model = tree_model->internal->GetDataViewModel();
 
-    gboolean visible = wx_model->HasValue(item, column);
-    if ( visible )
-    {
-        cell->GtkSetCurrentItem(item);
+    cell->GtkSetCurrentItem(item);
 
-        visible = cell->PrepareForItem(wx_model, item, column);
-    }
+    // Cells without values shouldn't be rendered at all.
+    const bool visible = cell->PrepareForItem(wx_model, item, column);
 
     wxGtkValue gvalue( G_TYPE_BOOLEAN );
     g_value_set_boolean( gvalue, visible );


### PR DESCRIPTION
This should fix #22359 and, AFAICS, doesn't have any negative effects.

I couldn't find any real explanation about why was this check added in the first place, but there doesn't seem to be any performance reason to not make it even for the virtual list models: it is called for every item in the model, which makes it totally unsuitable for big numbers of items, but this was already the case before anyhow and the extra overhead of calling `HasValue()` for it shouldn't be noticeable compared to calling `GetValue()`. But please let me know if I'm missing anything here or, also, if there are any other situations in which this still doesn't fix the original problem.