### PR TITLE
Allow using wxBitmapBundle with wxDataViewBitmapRenderer

### DIFF
--- a/include/wx/bmpbndl.h
+++ b/include/wx/bmpbndl.h
@@ -108,6 +108,9 @@ public:
     // Check if bitmap bundle is non-empty.
     bool IsOk() const { return m_impl.get() != NULL; }
 
+    // Clear the bundle contents, IsOk() will return false after doing this.
+    void Clear() { m_impl.reset(NULL); }
+
     // Get the size of the bitmap represented by this bundle when using the
     // default DPI, i.e. 100% scaling. Returns invalid size for empty bundle.
     wxSize GetDefaultSize() const;

--- a/include/wx/bmpbndl.h
+++ b/include/wx/bmpbndl.h
@@ -245,4 +245,19 @@ public:
     virtual wxBitmap GetBitmap(const wxSize& size) = 0;
 };
 
+// ----------------------------------------------------------------------------
+// Allow using wxBitmapBundle in wxVariant
+// ----------------------------------------------------------------------------
+
+#if wxUSE_VARIANT
+
+class WXDLLIMPEXP_FWD_BASE wxVariant;
+
+WXDLLIMPEXP_CORE
+wxBitmapBundle& operator<<(wxBitmapBundle& value, const wxVariant& variant);
+WXDLLIMPEXP_CORE
+wxVariant& operator<<(wxVariant& variant, const wxBitmapBundle& value);
+
+#endif // wxUSE_VARIANT
+
 #endif // _WX_BMPBNDL_H_

--- a/include/wx/dvrenderers.h
+++ b/include/wx/dvrenderers.h
@@ -155,6 +155,15 @@ public:
 
     wxString GetVariantType() const             { return m_variantType; }
 
+    // Check if the given variant type is compatible with the type expected by
+    // this renderer: by default, just compare it with GetVariantType(), but
+    // can be overridden to accept other types that can be converted to the
+    // type needed by the renderer.
+    virtual bool IsCompatibleVariantType(const wxString& variantType) const
+    {
+        return variantType == GetVariantType();
+    }
+
     // Prepare for rendering the value of the corresponding item in the given
     // column taken from the provided non-null model.
     //
@@ -163,8 +172,9 @@ public:
     // it and should probably be removed in the future.
     //
     // Return true if this cell is non-empty or false otherwise (and also if
-    // the model returned a value of the wrong, i.e. different from our
-    // GetVariantType(), type, in which case a debug error is also logged).
+    // the model returned a value of the wrong type, i.e. such that our
+    // IsCompatibleVariantType() returned false for it, in which case a debug
+    // error is also logged).
     bool PrepareForItem(const wxDataViewModel *model,
                         const wxDataViewItem& item,
                         unsigned column);

--- a/include/wx/generic/dvrenderers.h
+++ b/include/wx/generic/dvrenderers.h
@@ -104,6 +104,10 @@ public:
 
     virtual bool SetValue( const wxVariant &value ) wxOVERRIDE;
     virtual bool GetValue( wxVariant &value ) const wxOVERRIDE;
+
+    virtual
+    bool IsCompatibleVariantType(const wxString& variantType) const wxOVERRIDE;
+
 #if wxUSE_ACCESSIBILITY
     virtual wxString GetAccessibleDescription() const wxOVERRIDE;
 #endif // wxUSE_ACCESSIBILITY

--- a/include/wx/generic/dvrenderers.h
+++ b/include/wx/generic/dvrenderers.h
@@ -112,8 +112,7 @@ public:
     virtual wxSize GetSize() const wxOVERRIDE;
 
 private:
-    wxIcon m_icon;
-    wxBitmap m_bitmap;
+    wxBitmapBundle m_bitmapBundle;
 
 protected:
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxDataViewBitmapRenderer);

--- a/include/wx/generic/dvrenderers.h
+++ b/include/wx/generic/dvrenderers.h
@@ -96,7 +96,7 @@ private:
 class WXDLLIMPEXP_ADV wxDataViewBitmapRenderer: public wxDataViewRenderer
 {
 public:
-    static wxString GetDefaultType() { return wxS("wxBitmap"); }
+    static wxString GetDefaultType() { return wxS("wxBitmapBundle"); }
 
     wxDataViewBitmapRenderer( const wxString &varianttype = GetDefaultType(),
                               wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,

--- a/include/wx/gtk/dvrenderers.h
+++ b/include/wx/gtk/dvrenderers.h
@@ -81,7 +81,7 @@ protected:
 class WXDLLIMPEXP_ADV wxDataViewBitmapRenderer: public wxDataViewRenderer
 {
 public:
-    static wxString GetDefaultType() { return wxS("wxBitmap"); }
+    static wxString GetDefaultType() { return wxS("wxBitmapBundle"); }
 
     wxDataViewBitmapRenderer( const wxString &varianttype = GetDefaultType(),
                               wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,

--- a/include/wx/gtk/dvrenderers.h
+++ b/include/wx/gtk/dvrenderers.h
@@ -90,6 +90,9 @@ public:
     bool SetValue( const wxVariant &value ) wxOVERRIDE;
     bool GetValue( wxVariant &value ) const wxOVERRIDE;
 
+    virtual
+    bool IsCompatibleVariantType(const wxString& variantType) const wxOVERRIDE;
+
 protected:
     wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxDataViewBitmapRenderer);
 };

--- a/include/wx/osx/dvrenderers.h
+++ b/include/wx/osx/dvrenderers.h
@@ -104,7 +104,7 @@ private:
 class WXDLLIMPEXP_ADV wxDataViewBitmapRenderer: public wxDataViewRenderer
 {
 public:
-    static wxString GetDefaultType() { return wxS("wxBitmap"); }
+    static wxString GetDefaultType() { return wxS("wxBitmapBundle"); }
 
     wxDataViewBitmapRenderer(const wxString& varianttype = GetDefaultType(),
                              wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,

--- a/include/wx/osx/dvrenderers.h
+++ b/include/wx/osx/dvrenderers.h
@@ -110,6 +110,9 @@ public:
                              wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
                              int align = wxDVR_DEFAULT_ALIGNMENT);
 
+    virtual
+    bool IsCompatibleVariantType(const wxString& variantType) const wxOVERRIDE;
+
     virtual bool MacRender() wxOVERRIDE;
 
 private:

--- a/include/wx/qt/dvrenderers.h
+++ b/include/wx/qt/dvrenderers.h
@@ -34,7 +34,7 @@ public:
 class WXDLLIMPEXP_ADV wxDataViewBitmapRenderer: public wxDataViewRenderer
 {
 public:
-    static wxString GetDefaultType() { return wxS("wxBitmap"); }
+    static wxString GetDefaultType() { return wxS("wxBitmapBundle"); }
 
     wxDataViewBitmapRenderer( const wxString &varianttype = GetDefaultType(),
                               wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,

--- a/include/wx/qt/dvrenderers.h
+++ b/include/wx/qt/dvrenderers.h
@@ -42,6 +42,8 @@ public:
 
     bool SetValue( const wxVariant &value );
     bool GetValue( wxVariant &value ) const;
+
+    bool IsCompatibleVariantType(const wxString& variantType) const;
 };
 
 // ---------------------------------------------------------

--- a/interface/wx/bmpbndl.h
+++ b/interface/wx/bmpbndl.h
@@ -289,6 +289,18 @@ public:
     static wxBitmapBundle FromSVGResource(const wxString& name, const wxSize& sizeDef);
 
     /**
+        Clear the existing bundle contents.
+
+        After calling this function IsOk() returns @false.
+
+        This is the same as assigning a default-constructed bitmap bundle to
+        this object but slightly more explicit.
+
+        @since 3.1.7
+     */
+    void Clear();
+
+    /**
         Check if bitmap bundle is non-empty.
 
         Return @true if the bundle contains any bitmaps or @false if it is

--- a/interface/wx/dataview.h
+++ b/interface/wx/dataview.h
@@ -1981,6 +1981,15 @@ class wxDataViewRenderer : public wxObject
 public:
     /**
         Constructor.
+
+        The @a varianttype parameter is the main type of wxVariant objects
+        supported by this renderer, i.e. those that can be passed to its
+        SetValue(), e.g. "string" for wxDataViewTextRenderer. The value of this
+        parameter is returned by GetVariantType().
+
+        When deriving a custom renderer, either an existing variant type or a
+        new custom one can be used, see wxVariant documentation for more
+        details.
     */
     wxDataViewRenderer(const wxString& varianttype,
                        wxDataViewCellMode mode = wxDATAVIEW_CELL_INERT,
@@ -2061,6 +2070,11 @@ public:
 
     /**
         Returns a string with the type of the wxVariant supported by this renderer.
+
+        Note that a renderer may support more than one variant type, in which
+        case it needs to override IsCompatibleVariantType() to return @a true
+        for all types it supports. But by default only the type returned by
+        this function is supported.
     */
     wxString GetVariantType() const;
 

--- a/interface/wx/dataview.h
+++ b/interface/wx/dataview.h
@@ -2065,6 +2065,19 @@ public:
     wxString GetVariantType() const;
 
     /**
+        Check if the given variant type is compatible with the type expected by
+        this renderer.
+
+        The base class implementation just compares @a variantType with the
+        value returned by GetVariantType(), but this function can be overridden
+        to accept other types that can be converted to the type needed by the
+        renderer.
+
+        @since 3.1.7
+     */
+    virtual bool IsCompatibleVariantType(const wxString& variantType) const;
+
+    /**
         Sets the alignment of the renderer's content.
         The default value of @c wxDVR_DEFAULT_ALIGNMENT indicates that the content
         should have the same alignment as the column header.

--- a/interface/wx/dataview.h
+++ b/interface/wx/dataview.h
@@ -2730,7 +2730,12 @@ protected:
 /**
     @class wxDataViewBitmapRenderer
 
-    This class is used by wxDataViewCtrl to render bitmap controls.
+    This class is used by wxDataViewCtrl to render bitmaps.
+
+    This renderer accepts wxVariant objects storing wxBitmap, wxIcon or
+    wxBitmapBundle inside them, with the latter being preferred as it allows
+    the renderer to automatically select the bitmap of the best matching size
+    depending on the current DPI.
 
     @library{wxcore}
     @category{dvc}
@@ -2740,6 +2745,11 @@ class wxDataViewBitmapRenderer : public wxDataViewRenderer
 public:
     /**
         Returns the wxVariant type used with this renderer.
+
+        Note that the value returned by this function has changed from
+        "wxBitmap" to "wxBitmapBundle" in wxWidgets 3.1.7, however the exact
+        value shouldn't matter, as it is only supposed to be used as the value
+        for the first constructor argument.
 
         @since 3.1.0
      */

--- a/src/common/bmpbndl.cpp
+++ b/src/common/bmpbndl.cpp
@@ -36,6 +36,71 @@
 #include "wx/osx/private.h"
 #endif
 
+#if wxUSE_VARIANT
+
+#include "wx/variant.h"
+
+// We can't use the macros from wx/variant.h because they only work for
+// wxObject-derived classes, so define our own wxVariantData.
+
+class wxBitmapBundleVariantData: public wxVariantData
+{
+public:
+    explicit wxBitmapBundleVariantData(const wxBitmapBundle& value)
+        : m_value(value)
+    {
+    }
+
+    virtual bool Eq(wxVariantData& data) const wxOVERRIDE
+    {
+        // We're only called with the objects of the same type, so the cast is
+        // safe.
+        return static_cast<wxBitmapBundleVariantData&>(data).m_value.IsSameAs(m_value);
+    }
+
+    virtual wxString GetType() const wxOVERRIDE
+    {
+        return wxASCII_STR("wxBitmapBundle");
+    }
+
+    virtual wxClassInfo* GetValueClassInfo() wxOVERRIDE
+    {
+        return NULL;
+    }
+
+    virtual wxVariantData* Clone() const wxOVERRIDE
+    {
+        return new wxBitmapBundleVariantData(m_value);
+    }
+
+    wxBitmapBundle m_value;
+
+    DECLARE_WXANY_CONVERSION()
+};
+
+IMPLEMENT_TRIVIAL_WXANY_CONVERSION(wxBitmapBundle, wxBitmapBundleVariantData)
+
+WXDLLIMPEXP_CORE
+wxBitmapBundle& operator<<(wxBitmapBundle& value, const wxVariant& variant)
+{
+    wxASSERT( variant.GetType() == wxASCII_STR("wxBitmapBundle") );
+
+    wxBitmapBundleVariantData* const
+        data = static_cast<wxBitmapBundleVariantData*>(variant.GetData());
+
+    value = data->m_value;
+    return value;
+}
+
+WXDLLIMPEXP_CORE
+wxVariant& operator<<(wxVariant& variant, const wxBitmapBundle& value)
+{
+    variant.SetData(new wxBitmapBundleVariantData(value));
+    return variant;
+}
+
+#endif // wxUSE_VARIANT
+
 // ----------------------------------------------------------------------------
 // private helpers
 // ----------------------------------------------------------------------------

--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -861,7 +861,7 @@ wxDataViewRendererBase::CheckedGetValue(const wxDataViewModel* model,
     // We always allow the cell to be null, regardless of the renderer type.
     if ( !value.IsNull() )
     {
-        if ( value.GetType() != GetVariantType() )
+        if ( !IsCompatibleVariantType(value.GetType()) )
         {
             // If you're seeing this message, this indicates that either your
             // renderer is using the wrong type, or your model returns values

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -1342,6 +1342,14 @@ bool wxDataViewBitmapRenderer::GetValue( wxVariant& WXUNUSED(value) ) const
     return false;
 }
 
+bool
+wxDataViewBitmapRenderer::IsCompatibleVariantType(const wxString& variantType) const
+{
+    // We can accept values of any types checked by SetValue().
+    return variantType == wxS("wxBitmap")
+            || variantType == wxS("wxIcon");
+}
+
 #if wxUSE_ACCESSIBILITY
 wxString wxDataViewBitmapRenderer::GetAccessibleDescription() const
 {

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -1319,16 +1319,19 @@ bool wxDataViewBitmapRenderer::SetValue( const wxVariant &value )
 {
     if (value.GetType() == wxT("wxBitmap"))
     {
-        m_bitmap << value;
+        wxBitmap bitmap;
+        bitmap << value;
+        m_bitmapBundle = wxBitmapBundle(bitmap);
     }
     else if (value.GetType() == wxT("wxIcon"))
     {
-        m_icon << value;
+        wxIcon icon;
+        icon << value;
+        m_bitmapBundle = wxBitmapBundle(icon);
     }
     else
     {
-        m_icon = wxNullIcon;
-        m_bitmap = wxNullBitmap;
+        m_bitmapBundle.Clear();
     }
 
     return true;
@@ -1348,20 +1351,20 @@ wxString wxDataViewBitmapRenderer::GetAccessibleDescription() const
 
 bool wxDataViewBitmapRenderer::Render( wxRect cell, wxDC *dc, int WXUNUSED(state) )
 {
-    if (m_bitmap.IsOk())
-        dc->DrawBitmap( m_bitmap, cell.x, cell.y, true /* use mask */ );
-    else if (m_icon.IsOk())
-        dc->DrawIcon( m_icon, cell.x, cell.y );
+    if (m_bitmapBundle.IsOk())
+    {
+        dc->DrawBitmap( m_bitmapBundle.GetBitmapFor(GetView()),
+                        cell.x, cell.y,
+                        true /* use mask */ );
+    }
 
     return true;
 }
 
 wxSize wxDataViewBitmapRenderer::GetSize() const
 {
-    if (m_bitmap.IsOk())
-        return wxSize( m_bitmap.GetWidth(), m_bitmap.GetHeight() );
-    else if (m_icon.IsOk())
-        return wxSize( m_icon.GetWidth(), m_icon.GetHeight() );
+    if (m_bitmapBundle.IsOk())
+        return m_bitmapBundle.GetPreferredBitmapSizeFor(GetView());
 
     return GetView()->FromDIP(wxSize(wxDVC_DEFAULT_RENDERER_SIZE,
                                      wxDVC_DEFAULT_RENDERER_SIZE));

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -1317,7 +1317,11 @@ wxDataViewBitmapRenderer::wxDataViewBitmapRenderer( const wxString &varianttype,
 
 bool wxDataViewBitmapRenderer::SetValue( const wxVariant &value )
 {
-    if (value.GetType() == wxT("wxBitmap"))
+    if (value.GetType() == wxT("wxBitmapBundle"))
+    {
+        m_bitmapBundle << value;
+    }
+    else if (value.GetType() == wxT("wxBitmap"))
     {
         wxBitmap bitmap;
         bitmap << value;
@@ -1346,7 +1350,8 @@ bool
 wxDataViewBitmapRenderer::IsCompatibleVariantType(const wxString& variantType) const
 {
     // We can accept values of any types checked by SetValue().
-    return variantType == wxS("wxBitmap")
+    return variantType == wxS("wxBitmapBundle")
+            || variantType == wxS("wxBitmap")
             || variantType == wxS("wxIcon");
 }
 

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -2569,22 +2569,32 @@ wxDataViewBitmapRenderer::wxDataViewBitmapRenderer( const wxString &varianttype,
 
 bool wxDataViewBitmapRenderer::SetValue( const wxVariant &value )
 {
-    wxBitmap bitmap;
-    if (value.GetType() == wxS("wxBitmap"))
+    wxBitmapBundle bitmapBundle;
+    if (value.GetType() == wxS("wxBitmapBundle"))
     {
+        bitmapBundle << value;
+    }
+    else if (value.GetType() == wxS("wxBitmap"))
+    {
+        wxBitmap bitmap;
         bitmap << value;
+        bitmapBundle = wxBitmapBundle(bitmap);
     }
     else if (value.GetType() == wxS("wxIcon"))
     {
         wxIcon icon;
         icon << value;
-        bitmap.CopyFromIcon(icon);
+        bitmapBundle = wxBitmapBundle(icon);
     }
 
 #ifdef __WXGTK3__
-    WX_CELL_RENDERER_PIXBUF(m_renderer)->Set(bitmap);
+    WX_CELL_RENDERER_PIXBUF(m_renderer)->Set(bitmapBundle);
 #else
-    g_object_set(G_OBJECT(m_renderer), "pixbuf", bitmap.IsOk() ? bitmap.GetPixbuf() : NULL, NULL);
+    g_object_set(G_OBJECT(m_renderer),
+        "pixbuf",
+        bitmapBundle.IsOk() ? bitmapBundle.GetBitmap(wxDefaultSize).GetPixbuf()
+                            : NULL,
+        NULL);
 #endif
 
     return true;
@@ -2599,7 +2609,8 @@ bool
 wxDataViewBitmapRenderer::IsCompatibleVariantType(const wxString& variantType) const
 {
     // We can accept values of any types checked by SetValue().
-    return variantType == wxS("wxBitmap")
+    return variantType == wxS("wxBitmapBundle")
+            || variantType == wxS("wxBitmap")
             || variantType == wxS("wxIcon");
 }
 

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -2595,6 +2595,14 @@ bool wxDataViewBitmapRenderer::GetValue( wxVariant &WXUNUSED(value) ) const
     return false;
 }
 
+bool
+wxDataViewBitmapRenderer::IsCompatibleVariantType(const wxString& variantType) const
+{
+    // We can accept values of any types checked by SetValue().
+    return variantType == wxS("wxBitmap")
+            || variantType == wxS("wxIcon");
+}
+
 // ---------------------------------------------------------
 // wxDataViewToggleRenderer
 // ---------------------------------------------------------

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -28,6 +28,9 @@
 #include "wx/osx/private/available.h"
 #include "wx/osx/private/datatransfer.h"
 #include "wx/osx/cocoa/dataview.h"
+
+#include "wx/private/bmpbndl.h"
+
 #include "wx/renderer.h"
 #include "wx/stopwatch.h"
 #include "wx/dcgraph.h"
@@ -2984,6 +2987,13 @@ bool wxDataViewBitmapRenderer::MacRender()
 {
     if (GetValue().GetType() == wxS("wxBitmap"))
     {
+        wxBitmapBundle bundle;
+        bundle << GetValue();
+        if (bundle.IsOk())
+            [GetNativeData()->GetItemCell() setObjectValue:wxOSXGetImageFromBundle(bundle)];
+    }
+    else if (GetValue().GetType() == wxS("wxBitmap"))
+    {
         wxBitmap bitmap;
         bitmap << GetValue();
         if (bitmap.IsOk())
@@ -3003,7 +3013,8 @@ bool
 wxDataViewBitmapRenderer::IsCompatibleVariantType(const wxString& variantType) const
 {
     // We can accept values of any types checked by SetValue().
-    return variantType == wxS("wxBitmap")
+    return variantType == wxS("wxBitmapBundle")
+            || variantType == wxS("wxBitmap")
             || variantType == wxS("wxIcon");
 }
 

--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2999,6 +2999,14 @@ bool wxDataViewBitmapRenderer::MacRender()
     return true;
 }
 
+bool
+wxDataViewBitmapRenderer::IsCompatibleVariantType(const wxString& variantType) const
+{
+    // We can accept values of any types checked by SetValue().
+    return variantType == wxS("wxBitmap")
+            || variantType == wxS("wxIcon");
+}
+
 wxIMPLEMENT_CLASS(wxDataViewBitmapRenderer, wxDataViewRenderer);
 
 // -------------------------------------

--- a/src/qt/dvrenderers.cpp
+++ b/src/qt/dvrenderers.cpp
@@ -54,6 +54,13 @@ bool wxDataViewBitmapRenderer::GetValue( wxVariant &value ) const
     return false;
 }
 
+bool
+wxDataViewBitmapRenderer::IsCompatibleVariantType(const wxString& variantType) const
+{
+    return variantType == wxS("wxBitmap")
+            || variantType == wxS("wxIcon");
+}
+
 //==============================================================================
 
 wxDataViewCustomRenderer::wxDataViewCustomRenderer( const wxString &variantType, wxDataViewCellMode mode,


### PR DESCRIPTION
While looking at #22359, I've realized that we couldn't use `wxBitmapBundle` to show images in wxDVC, so I've fixed this and now the following diff
```diff
diff --git a/samples/dataview/dataview.cpp b/samples/dataview/dataview.cpp
index 4b2f1d933e..4057a43959 100644
--- a/samples/dataview/dataview.cpp
+++ b/samples/dataview/dataview.cpp
@@ -904,7 +904,7 @@ void MyFrame::BuildDataViewCtrl(wxPanel* parent, unsigned int nPanel,
             wxDataViewColumn* const colCheckIconText = new wxDataViewColumn
                 (
                      L"\u2714 + icon + text",
-                     new wxDataViewCheckIconTextRenderer(),
+                     new wxDataViewBitmapRenderer(), // also works with explicit "wxBitmap"
                      MyListModel::Col_ToggleIconText,
                      wxCOL_WIDTH_AUTOSIZE
                 );
diff --git a/samples/dataview/mymodels.cpp b/samples/dataview/mymodels.cpp
index d6d76c2414..5aa6f20388 100644
--- a/samples/dataview/mymodels.cpp
+++ b/samples/dataview/mymodels.cpp
@@ -472,6 +472,11 @@ void MyListModel::GetValueByRow( wxVariant &variant,
             break;

         case Col_ToggleIconText:
+            if ( row % 2 )
+                variant << m_icon[row % 2]; // .GetBitmap(wxSize(16, 16)); -- not needed any longer, but still works too
+            else
+                variant = wxNullVariant;
+            break;
             {
                 wxString text;
                 wxCheckBoxState state;
```
compiles and works, i.e. shows crisp and not scaled bitmaps in high DPI.

@vslavik If you could please test this with Poedit, it would be great.

@MaartenBent @csomor Your review would be welcome as always, TIA!