### PR TITLE
Fix an annoying (even if mostly harmless) TSAN warning

### DIFF
--- a/build/aclocal/atomic_builtins.m4
+++ b/build/aclocal/atomic_builtins.m4
@@ -6,16 +6,13 @@ AC_DEFUN([WX_ATOMIC_BUILTINS],
 [
   AC_REQUIRE([AC_PROG_CC])
   if test -n "$GCC"; then
-    AC_MSG_CHECKING([for __sync_fetch_and_add and __sync_sub_and_fetch builtins])
+    AC_MSG_CHECKING([for __sync_xxx_and_fetch builtins])
     AC_CACHE_VAL(wx_cv_cc_gcc_atomic_builtins, [
       AC_TRY_LINK(
         [],
         [
           unsigned int value=0;
-          /* wxAtomicInc doesn't use return value here */
-          __sync_fetch_and_add(&value, 2);
-          __sync_sub_and_fetch(&value, 1);
-          /* but wxAtomicDec does, so mimic that: */
+          volatile unsigned int r1 = __sync_add_and_fetch(&value, 2);
           volatile unsigned int r2 = __sync_sub_and_fetch(&value, 1);
         ],
         wx_cv_cc_gcc_atomic_builtins=yes,

--- a/configure
+++ b/configure
@@ -25145,8 +25145,8 @@ fi
 
 
   if test -n "$GCC"; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for __sync_fetch_and_add and __sync_sub_and_fetch builtins" >&5
-$as_echo_n "checking for __sync_fetch_and_add and __sync_sub_and_fetch builtins... " >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for __sync_xxx_and_fetch builtins" >&5
+$as_echo_n "checking for __sync_xxx_and_fetch builtins... " >&6; }
     if ${wx_cv_cc_gcc_atomic_builtins+:} false; then :
   $as_echo_n "(cached) " >&6
 else
@@ -25159,10 +25159,7 @@ main ()
 {
 
           unsigned int value=0;
-          /* wxAtomicInc doesn't use return value here */
-          __sync_fetch_and_add(&value, 2);
-          __sync_sub_and_fetch(&value, 1);
-          /* but wxAtomicDec does, so mimic that: */
+          volatile unsigned int r1 = __sync_add_and_fetch(&value, 2);
           volatile unsigned int r2 = __sync_sub_and_fetch(&value, 1);
 
   ;

--- a/interface/wx/atomic.h
+++ b/interface/wx/atomic.h
@@ -16,6 +16,9 @@
 /**
     This function increments @a value in an atomic manner.
 
+    @note It is recommended to use @c std::atomic available in C++11 and later
+    instead of this function in any new code.
+
     Whenever possible wxWidgets provides an efficient, CPU-specific,
     implementation of this function. If such implementation is available, the
     symbol wxHAS_ATOMIC_OPS is defined. Otherwise this function still exists

--- a/interface/wx/atomic.h
+++ b/interface/wx/atomic.h
@@ -22,15 +22,18 @@
     but is implemented in a generic way using a critical section which can be
     prohibitively expensive for use in performance-sensitive code.
 
+    Returns the new value after the increment (the return value is only
+    available since wxWidgets 3.1.7, this function doesn't return anything in
+    previous versions of the library).
+
     @header{wx/atomic.h}
 */
-void wxAtomicInc(wxAtomicInt& value);
+wxInt32 wxAtomicInc(wxAtomicInt& value);
 
 /**
     This function decrements value in an atomic manner.
 
-    Returns 0 if value is 0 after decrement or any non-zero value (not
-    necessarily equal to the value of the variable) otherwise.
+    Returns the new value after decrementing it.
 
     @see wxAtomicInc
 

--- a/tests/thread/atomic.cpp
+++ b/tests/thread/atomic.cpp
@@ -77,15 +77,14 @@ TEST_CASE("Atomic::NoThread", "[atomic]")
     CHECK( int2 == -ITERATIONS_NUM );
 }
 
-TEST_CASE("Atomic::DecReturn", "[atomic]")
+TEST_CASE("Atomic::ReturnValue", "[atomic]")
 {
     wxAtomicInt i(0);
-    wxAtomicInc(i);
-    wxAtomicInc(i);
-    CHECK( i == 2 );
+    REQUIRE( wxAtomicInc(i) == 1 );
+    REQUIRE( wxAtomicInc(i) == 2 );
 
-    CHECK( wxAtomicDec(i) > 0 );
-    CHECK( wxAtomicDec(i) == 0 );
+    REQUIRE( wxAtomicDec(i) == 1 );
+    REQUIRE( wxAtomicDec(i) == 0 );
 }
 
 TEST_CASE("Atomic::WithThreads", "[atomic]")

--- a/tests/thread/atomic.cpp
+++ b/tests/thread/atomic.cpp
@@ -27,13 +27,7 @@ WX_DEFINE_ARRAY_PTR(wxThread *, wxArrayThread);
 // constants
 // ----------------------------------------------------------------------------
 
-// number of times to run the loops: the code takes too long to run if we use
-// the bigger value with generic atomic operations implementation
-#ifdef wxHAS_ATOMIC_OPS
-    static const wxInt32 ITERATIONS_NUM = 10000000;
-#else
-    static const wxInt32 ITERATIONS_NUM = 1000;
-#endif
+static const wxInt32 ITERATIONS_NUM = 10000;
 
 // ----------------------------------------------------------------------------
 // test class

--- a/tests/thread/atomic.cpp
+++ b/tests/thread/atomic.cpp
@@ -171,9 +171,7 @@ void *AtomicTestCase::MyThread::Entry()
         {
             case AtomicTestCase::IncAndDecMixed:
                 wxAtomicInc(m_operateOn);
-                wxAtomicDec(m_operateOn);
-
-                if (m_operateOn < 0)
+                if ( wxAtomicDec(m_operateOn) < 0 )
                     ++negativeValuesSeen;
                 break;
 

--- a/tests/thread/atomic.cpp
+++ b/tests/thread/atomic.cpp
@@ -20,8 +20,9 @@
 #include "wx/thread.h"
 #include "wx/dynarray.h"
 #include "wx/log.h"
+#include "wx/vector.h"
 
-WX_DEFINE_ARRAY_PTR(wxThread *, wxArrayThread);
+typedef wxVector<wxThread*> wxArrayThread;
 
 // ----------------------------------------------------------------------------
 // constants
@@ -123,7 +124,7 @@ TEST_CASE("Atomic::WithThreads", "[atomic]")
             delete thread;
         }
         else
-            threads.Add(thread);
+            threads.push_back(thread);
     }
 
     for ( i = 0; i < count; ++i )

--- a/tests/thread/atomic.cpp
+++ b/tests/thread/atomic.cpp
@@ -30,14 +30,11 @@ WX_DEFINE_ARRAY_PTR(wxThread *, wxArrayThread);
 static const wxInt32 ITERATIONS_NUM = 10000;
 
 // ----------------------------------------------------------------------------
-// test class
+// test helper thread
 // ----------------------------------------------------------------------------
 
-class AtomicTestCase : public CppUnit::TestCase
+namespace
 {
-public:
-    AtomicTestCase() { }
-
     enum ETestType
     {
         IncAndDecMixed,
@@ -45,7 +42,6 @@ public:
         DecOnly
     };
 
-private:
     class MyThread : public wxThread
     {
     public:
@@ -59,34 +55,13 @@ private:
         wxAtomicInt &m_operateOn;
         ETestType m_testType;
     };
+} // anonymous namespace
 
-    CPPUNIT_TEST_SUITE( AtomicTestCase );
-        CPPUNIT_TEST( TestNoThread );
-        CPPUNIT_TEST( TestDecReturn );
-        CPPUNIT_TEST( TestTwoThreadsMix );
-        CPPUNIT_TEST( TestTenThreadsMix );
-        CPPUNIT_TEST( TestTwoThreadsSeparate );
-        CPPUNIT_TEST( TestTenThreadsSeparate );
-    CPPUNIT_TEST_SUITE_END();
+// ----------------------------------------------------------------------------
+// the tests themselves
+// ----------------------------------------------------------------------------
 
-    void TestNoThread();
-    void TestDecReturn();
-    void TestTenThreadsMix() { TestWithThreads(10, IncAndDecMixed); }
-    void TestTwoThreadsMix() { TestWithThreads(2, IncAndDecMixed); }
-    void TestTenThreadsSeparate() { TestWithThreads(10, IncOnly); }
-    void TestTwoThreadsSeparate() { TestWithThreads(2, IncOnly); }
-    void TestWithThreads(int count, ETestType testtype);
-
-    wxDECLARE_NO_COPY_CLASS(AtomicTestCase);
-};
-
-// register in the unnamed registry so that these tests are run by default
-CPPUNIT_TEST_SUITE_REGISTRATION( AtomicTestCase );
-
-// also include in its own registry so that these tests can be run alone
-CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( AtomicTestCase, "AtomicTestCase" );
-
-void AtomicTestCase::TestNoThread()
+TEST_CASE("Atomic::NoThread", "[atomic]")
 {
     wxAtomicInt int1 = 0,
                 int2 = 0;
@@ -97,23 +72,31 @@ void AtomicTestCase::TestNoThread()
         wxAtomicDec(int2);
     }
 
-    CPPUNIT_ASSERT( int1 == ITERATIONS_NUM );
-    CPPUNIT_ASSERT( int2 == -ITERATIONS_NUM );
+    CHECK( int1 == ITERATIONS_NUM );
+    CHECK( int2 == -ITERATIONS_NUM );
 }
 
-void AtomicTestCase::TestDecReturn()
+TEST_CASE("Atomic::DecReturn", "[atomic]")
 {
     wxAtomicInt i(0);
     wxAtomicInc(i);
     wxAtomicInc(i);
-    CPPUNIT_ASSERT( i == 2 );
+    CHECK( i == 2 );
 
-    CPPUNIT_ASSERT( wxAtomicDec(i) > 0 );
-    CPPUNIT_ASSERT( wxAtomicDec(i) == 0 );
+    CHECK( wxAtomicDec(i) > 0 );
+    CHECK( wxAtomicDec(i) == 0 );
 }
 
-void AtomicTestCase::TestWithThreads(int count, ETestType testType)
+TEST_CASE("Atomic::WithThreads", "[atomic]")
 {
+    int count;
+    ETestType testType;
+
+    SECTION( "2 threads using inc and dec") { count =  2; testType = IncAndDecMixed; }
+    SECTION("10 threads using inc and dec") { count = 10; testType = IncAndDecMixed; }
+    SECTION( "2 threads using inc or dec" ) { count =  2; testType = IncOnly; }
+    SECTION("10 threads using inc or dec" ) { count = 10; testType = IncOnly; }
+
     wxAtomicInt    int1=0;
 
     wxArrayThread  threads;
@@ -152,16 +135,16 @@ void AtomicTestCase::TestWithThreads(int count, ETestType testType)
     for ( i = 0; i < count; ++i )
     {
         // each thread should return 0, else it detected some problem
-        CPPUNIT_ASSERT (threads[i]->Wait() == (wxThread::ExitCode)0);
+        CHECK (threads[i]->Wait() == (wxThread::ExitCode)0);
         delete threads[i];
     }
 
-    CPPUNIT_ASSERT( int1 == 0 );
+    CHECK( int1 == 0 );
 }
 
 // ----------------------------------------------------------------------------
 
-void *AtomicTestCase::MyThread::Entry()
+void *MyThread::Entry()
 {
     wxInt32 negativeValuesSeen = 0;
 
@@ -169,17 +152,17 @@ void *AtomicTestCase::MyThread::Entry()
     {
         switch ( m_testType )
         {
-            case AtomicTestCase::IncAndDecMixed:
+            case IncAndDecMixed:
                 wxAtomicInc(m_operateOn);
                 if ( wxAtomicDec(m_operateOn) < 0 )
                     ++negativeValuesSeen;
                 break;
 
-            case AtomicTestCase::IncOnly:
+            case IncOnly:
                 wxAtomicInc(m_operateOn);
                 break;
 
-            case AtomicTestCase::DecOnly:
+            case DecOnly:
                 wxAtomicDec(m_operateOn);
                 break;
         }


### PR DESCRIPTION
And also make `wxAtomicInt` slightly more useful and use it instead of CS + plain int combination for the global initialization counter.