### PR TITLE
Fix a wxFlexGridSizer layout issue with wxWrapSizers

### DIFF
--- a/src/common/sizer.cpp
+++ b/src/common/sizer.cpp
@@ -2077,8 +2077,9 @@ DoAdjustForGrowables(int delta,
     }
 }
 
-void wxFlexGridSizer::AdjustForGrowables(const wxSize& sz, const wxSize& minSize)
+void wxFlexGridSizer::AdjustForGrowables(const wxSize& sz, const wxSize& originalMinSize)
 {
+    wxSize minSize = originalMinSize;
 #if wxDEBUG_LEVEL
     // by the time this function is called, the sizer should be already fully
     // initialized and hence the number of its columns and rows is known and we
@@ -2141,6 +2142,7 @@ void wxFlexGridSizer::AdjustForGrowables(const wxSize& sz, const wxSize& minSize
         // Only redo if info was actually used
         if( didAdjustMinSize )
         {
+            minSize = CalcMin();
             DoAdjustForGrowables
             (
                 sz.x - minSize.x,


### PR DESCRIPTION
If didAdjustMinSize == true, the minimum width has probably changed, and we should recalculate it. Otherwise we end up using incorrect delta in DoAdjustForGrowables, which might push items too far to the right.

The problem can be replicated by modifying the wrapsizer sample a bit:
```diff
diff --git a/samples/wrapsizer/wrapsizer.cpp b/samples/wrapsizer/wrapsizer.cpp
index 4d0c6d6505..987ee694ab 100644
--- a/samples/wrapsizer/wrapsizer.cpp
+++ b/samples/wrapsizer/wrapsizer.cpp
@@ -91,8 +91,13 @@ WrapSizerFrame::WrapSizerFrame()
 
     m_panel = new wxPanel(this);
 
+    auto gridSizer = new wxFlexGridSizer(2);
+    gridSizer->AddGrowableCol(0, 1);
+    gridSizer->AddSpacer(0);
+
     // Root sizer, vertical
     wxSizer * const sizerRoot = new wxBoxSizer(wxVERTICAL);
+    gridSizer->Add(sizerRoot);
 
     // Some toolbars in a wrap sizer
     wxSizer * const sizerTop = new wxWrapSizer( wxHORIZONTAL );
@@ -144,7 +149,7 @@ WrapSizerFrame::WrapSizerFrame()
     Bind(wxEVT_BUTTON, &WrapSizerFrame::OnButton, this, wxID_OK);
 
     // Set sizer for the panel
-    m_panel->SetSizer(sizerRoot);
+    m_panel->SetSizer(gridSizer);
 
     Show();
 }
```
