### PR TITLE
Fix for scaling of the bitmap size for wxBitmapComboBox

### DIFF
--- a/src/common/bmpcboxcmn.cpp
+++ b/src/common/bmpcboxcmn.cpp
@@ -116,7 +116,7 @@ bool wxBitmapComboBoxBase::OnAddBitmap(const wxBitmapBundle& bitmap)
 {
     if ( bitmap.IsOk() )
     {
-        wxSize bmpDefaultSize = bitmap.GetPreferredLogicalSizeFor(GetControl());
+        wxSize bmpDefaultSize = bitmap.GetPreferredBitmapSizeAtScale(1.0);
         int width = bmpDefaultSize.GetWidth();
         int height = bmpDefaultSize.GetHeight();
 
@@ -219,7 +219,7 @@ void wxBitmapComboBoxBase::DrawItem(wxDC& dc,
 
         // Draw the image centered
         dc.DrawBitmap(bmp,
-                      rect.x + (m_usedImgSize.x-w)/2 + imgSpacingLeft,
+                      rect.x + (win->FromDIP(m_usedImgSize.x)-w)/2 + imgSpacingLeft,
                       rect.y + (rect.height-h)/2,
                       true);
     }
@@ -234,7 +234,8 @@ wxCoord wxBitmapComboBoxBase::MeasureItem(size_t WXUNUSED(item)) const
 {
     if ( m_usedImgSize.y >= 0 )
     {
-        int imgHeightArea = m_usedImgSize.y + 2;
+        const wxWindow* win = const_cast<wxBitmapComboBoxBase*>(this)->GetControl();
+        int imgHeightArea = win->FromDIP(m_usedImgSize.y) + 2;
         return imgHeightArea > m_fontHeight ? imgHeightArea : m_fontHeight;
     }
 


### PR DESCRIPTION
Calculate m_usedImgSize from unscaled bitmap size instead of calculation from scaled control.

You can use **samples/widgets** > **BitmapCombobox** > **"Add widget icons"** for reproducing the issue.

If use this combobox on scaled Display, then space between bitmap and text increases.
![bmpcb_bug](https://user-images.githubusercontent.com/19184891/169046340-4f234184-783a-4771-bf1d-81c1e34b7179.jpg)

After fix bitmapcombobox works as expected
![bmpcb_fix](https://user-images.githubusercontent.com/19184891/169046983-7cf7af88-4985-47a4-b6fb-88696ca029f0.jpg)

