### PR TITLE
Fix wxGTK build with glib < 2.50

### DIFF
--- a/include/wx/gtk/private/log.h
+++ b/include/wx/gtk/private/log.h
@@ -128,7 +128,17 @@ private:
     wxDECLARE_NO_COPY_CLASS(LogFilterByMessage);
 };
 
-#endif // wxHAS_GLIB_LOG_WRITER
+#else // !wxHAS_GLIB_LOG_WRITER
+
+// Provide stubs to avoid having to use preprocessor checks in the code using
+// these classes.
+class LogFilterByMessage
+{
+public:
+    explicit LogFilterByMessage(const char* WXUNUSED(message)) { }
+};
+
+#endif // wxHAS_GLIB_LOG_WRITER/!wxHAS_GLIB_LOG_WRITER
 
 } // namespace wxGTKImpl
 


### PR DESCRIPTION
This was recently broken by bffcb88266 (Optionally detect not filtered
GTK log messages, 2022-05-12), see #22424.

Fix it by providing a trivial "do nothing" version of LogFilterByMessage
even if we can't implement it -- this seems to be preferable to using
preprocessor checks in the code using it.

Closes #22434.

---

@taler21 I couldn't actually test this with old glib as I don't have any sufficiently old systems at hand any more, please let me know if you can test it and confirm that it works (or if it doesn't, of course). TIA!