### PR TITLE
wxBitmapBundle-related regressions

### DIFF
--- a/src/common/artprov.cpp
+++ b/src/common/artprov.cpp
@@ -149,12 +149,13 @@ namespace
 class wxBitmapBundleImplArt : public wxBitmapBundleImpl
 {
 public:
-    wxBitmapBundleImplArt(const wxArtID& id,
+    wxBitmapBundleImplArt(const wxBitmap& bitmap,
+                          const wxArtID& id,
                           const wxArtClient& client,
                           const wxSize& size)
         : m_artId(id),
           m_artClient(client),
-          m_sizeDefault(GetValidSize(id, client, size))
+          m_sizeDefault(GetValidSize(bitmap, size))
     {
     }
 
@@ -176,24 +177,14 @@ public:
     }
 
 private:
-    static wxSize GetValidSize(const wxArtID& id,
-                               const wxArtClient& client,
-                               const wxSize& size)
+    static wxSize GetValidSize(const wxBitmap& bitmap, const wxSize& size)
     {
         // If valid size is provided, just use it.
         if ( size != wxDefaultSize )
             return size;
 
-        // Otherwise, try to get the size we'd use without creating a bitmap
-        // immediately.
-        const wxSize sizeHint = wxArtProvider::GetSizeHint(client);
-        if ( sizeHint != wxDefaultSize )
-            return sizeHint;
-
-        // If we really have to, do create a bitmap just to get its size. Note
-        // we need the size in logical pixels here, it will be scaled later if
-        // necessary, so use GetDIPSize() and not GetSize().
-        const wxBitmap bitmap = wxArtProvider::GetBitmap(id, client);
+        // Note we need the size in logical pixels here, it will be scaled
+        // later if necessary, so use GetDIPSize() and not GetSize().
         if ( bitmap.IsOk() )
             return bitmap.GetDIPSize();
 
@@ -439,9 +430,10 @@ wxBitmapBundle wxArtProvider::GetBitmapBundle(const wxArtID& id,
             // lower priority one: even if this means that the bitmap will be
             // scaled, at least we'll be using the expected bitmap rather than
             // potentially using a bitmap of a different style.
-            if ( provider->CreateBitmap(id, client, size).IsOk() )
+            const wxBitmap bitmap = provider->CreateBitmap(id, client, size);
+            if ( bitmap.IsOk() )
             {
-                bitmapbundle = wxBitmapBundle::FromImpl(new wxBitmapBundleImplArt(id, client, size));
+                bitmapbundle = wxBitmapBundle::FromImpl(new wxBitmapBundleImplArt(bitmap, id, client, size));
                 break;
             }
         }

--- a/src/common/artprov.cpp
+++ b/src/common/artprov.cpp
@@ -165,8 +165,9 @@ public:
 
     virtual wxSize GetPreferredBitmapSizeAtScale(double scale) const wxOVERRIDE
     {
-        // We have no preferred sizes.
-        return m_sizeDefault*scale;
+        // Any non-integer scaling or any downscaling will look ugly,
+        // only allow upscaling by a factor of 2.
+        return scale > 1.5 ? 2 * m_sizeDefault : m_sizeDefault;
     }
 
     virtual wxBitmap GetBitmap(const wxSize& size) wxOVERRIDE

--- a/src/osx/core/bmpbndl.mm
+++ b/src/osx/core/bmpbndl.mm
@@ -148,7 +148,7 @@ wxSize wxOSXImageBundleImpl::GetPreferredBitmapSizeAtScale(double scale) const
 
 wxBitmap wxOSXImageBundleImpl::GetBitmap(const wxSize& WXUNUSED(size))
 {
-    return wxBitmap();
+    return wxBitmap(wxOSXGetImageFromBundleImpl(this));
 }
 
 wxBitmapBundle wxOSXMakeBundleFromImage( WXImage img)


### PR DESCRIPTION
I'm creating this as draft PR because I realized I'm really not sure how to address some regressions in Poedit. I see two kind of issues so far:

- [x] Not showing bitmaps at all on macOS. I'm reasonably sure that 33db99a62f6941319e9d60e1f9e34889d37123c4 is the correct fix. For bitmaps loaded via `[NSImage imageNamed]`, they already supported multiple resolutions in `wxBitmap` and wxBitmap == wxBitmapBundle  for them. So just returning the NSImage regardless of expected size seems correct to me. Notice that this affects *all* bitmaps loaded via `wxArtProvider` with resources stored in app bundle on macOS.

- [ ] I'm seeing unexpected scaling of bitmaps with [now-horrible](https://github.com/wxWidgets/wxWidgets/commit/84cb293e712ba2db7a946a166a83e1d0fdec3297) (and previously ugly blurred, but recognizable) results in e.g. toolbar icons. I'm unsure how to best fix this and feel like I'm missing something important.

Generally speaking, resizing bitmaps or icons is *always* bad, regardless of whether it's e.g. bicubic (and so blurred) or nearest-neigbour (and so quite possibly outright damaged, e.g. removed vertical or horizontal edges in icons, sometimes making them unrecognizable). In sizes as small as this, the only safe resizing is scaling up by integer multiples. Even SVG rendering at different scale factors is going to produce questionable results.

Arguably, the entire point of `wxBitmapBundle`-like APIs is to avoid inevitably-ugly scaling of small bitmaps and it needs to take great care to avoid rescaling anything.

So if I look at the current code:

1. [Carefully picking the best size](https://github.com/wxWidgets/wxWidgets/blob/d90cb7511b07249d0cdd34278a2ab46e084817ab/src/msw/bmpbndl.cpp#L295) is great (this was the first thing I checked - this is pretty much how Poedit picks from its 1x, 2x and 1.5x manually-drawn icons on Windows). 

2. But that's not actually used if the bitmap was created through `wxArtProvider` (with a provider not overriding `CreateBitmapBundle()`).  And [this is not good](https://github.com/wxWidgets/wxWidgets/blob/d90cb7511b07249d0cdd34278a2ab46e084817ab/src/common/artprov.cpp#L169), see above. And it is coupled with [GetBitmap implementation](https://github.com/wxWidgets/wxWidgets/blob/d90cb7511b07249d0cdd34278a2ab46e084817ab/src/common/artprov.cpp#L174) which will happily resize to any size. 

3. Point 2 has consequences: bitmaps loaded this way (now represented as `wxBitmapBundle` internally) loose their intrinsic size. They become sponges willing to resize to any size. They don't signal their best size at all.

4. I think 84cb293e712ba2db7a946a166a83e1d0fdec3297 makes this worse, but don't care too deeply, because both situations were bad (and the commit's argument about consistency with other functions makes sense).

Here's a specific stacktrace showing where this goes wrong. I'm pretty sure it's not going to be the only one:

```
 	Poedit.exe!wxBitmapHelpers::Rescale(wxBitmap & bmp, const wxSize & sizeNeeded) Line 77	C++
>	Poedit.exe!wxArtProvider::RescaleOrResizeIfNeeded(wxBitmap & bmp, const wxSize & sizeNeeded) Line 338	C++
 	Poedit.exe!wxArtProvider::GetBitmap(const wxString & id, const wxString & client, const wxSize & size) Line 396	C++
 	Poedit.exe!`anonymous namespace'::wxBitmapBundleImplArt::GetBitmap(const wxSize & size) Line 174	C++
 	Poedit.exe!wxBitmapBundle::GetBitmap(const wxSize & size) Line 493	C++
 	Poedit.exe!wxToolBarToolBase::GetNormalBitmap(const wxSize & size) Line 153	C++
 	Poedit.exe!wxToolBar::Realize() Line 873	C++
 	Poedit.exe!wxToolBarXmlHandler::DoCreateResource() Line 246	C++
 	Poedit.exe!wxXmlResourceHandlerImpl::CreateResource(wxXmlNode * node, wxObject * parent, wxObject * instance) Line 1528	C++
 	Poedit.exe!wxXmlResourceHandler::CreateResource(wxXmlNode * node, wxObject * parent, wxObject * instance) Line 181	C++
 	Poedit.exe!wxXmlResource::DoCreateResFromNode(wxXmlNode & node, wxObject * parent, wxObject * instance, wxXmlResourceHandler * handlerToUse) Line 1095	C++
 	Poedit.exe!wxXmlResource::CreateResFromNode(wxXmlNode * node, wxObject * parent, wxObject * instance, wxXmlResourceHandler * handlerToUse) Line 372	C++
 	Poedit.exe!wxXmlResource::LoadToolBar(wxWindow * parent, const wxString & name) Line 511	C++
```

`wxToolBar::Realize()` asked for 24x24px bitmap, but mine was 34x34px or 26x26px (atypical, but who cares - some extra padding on top of 24/32 px icon).

I don't particularly care for Poedit, because I'll migrate it to `wxBitmapBundle` and sidestep this issue — at least I *think* that if `wxBitmapBundle` refuses to provide 24px version, `wxToolBar` will use what is given to it, as it used to do. But it's likely to affect at least some other code…

