### PR TITLE
Update wxButtonXmlHandler

### DIFF
--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -907,6 +907,21 @@ Example:
     Label to display on the button (may be omitted if only the bitmap or stock ID is used).}
 @row3col{bitmap, @ref overview_xrcformat_type_bitmap,
     Bitmap to display in the button (optional).}
+@row3col{pressed, @ref overview_xrcformat_type_bitmap,
+     Bitmap to show when the button is pressed (default: none, same as @c bitmap).
+     This property exists since wxWidgets 3.1.6, but the equivalent (and still
+     supported) "selected" property can be used in the older versions.}
+@row3col{focus, @ref overview_xrcformat_type_bitmap,
+     Bitmap to show when the button has focus (default: none, same as @c bitmap).}
+@row3col{disabled, @ref overview_xrcformat_type_bitmap,
+     Bitmap to show when the button is disabled (default: none, same as @c bitmap).}
+@row3col{current, @ref overview_xrcformat_type_bitmap,
+     Bitmap to show when the mouse cursor hovers above the bitmap (default: none, same as @c bitmap).
+     This property exists since wxWidgets 3.1.6, but the equivalent (and still
+     supported) "hover" property can be used in the older versions.}
+@row3col{margins, @ref overview_xrcformat_type_size,
+    Set the margins between the bitmap and the text of the button.
+    This method is currently only implemented under MSW. If it is not called, a default margin is used around the bitmap.}
 @row3col{bitmapposition, @c wxLEFT|wxRIGHT|wxTOP|wxBOTTOM,
     Position of the bitmap in the button, see wxButton::SetBitmapPosition() (default: wxLEFT).}
 @row3col{default, @ref overview_xrcformat_type_bool,

--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -908,20 +908,16 @@ Example:
 @row3col{bitmap, @ref overview_xrcformat_type_bitmap,
     Bitmap to display in the button (optional).}
 @row3col{pressed, @ref overview_xrcformat_type_bitmap,
-     Bitmap to show when the button is pressed (default: none, same as @c bitmap).
-     This property exists since wxWidgets 3.1.6, but the equivalent (and still
-     supported) "selected" property can be used in the older versions.}
+     Bitmap to show when the button is pressed (default: none, same as @c bitmap). @since 3.1.7}
 @row3col{focus, @ref overview_xrcformat_type_bitmap,
-     Bitmap to show when the button has focus (default: none, same as @c bitmap).}
+     Bitmap to show when the button has focus (default: none, same as @c bitmap). @since 3.1.7}
 @row3col{disabled, @ref overview_xrcformat_type_bitmap,
-     Bitmap to show when the button is disabled (default: none, same as @c bitmap).}
+     Bitmap to show when the button is disabled (default: none, same as @c bitmap). @since 3.1.7}
 @row3col{current, @ref overview_xrcformat_type_bitmap,
-     Bitmap to show when the mouse cursor hovers above the bitmap (default: none, same as @c bitmap).
-     This property exists since wxWidgets 3.1.6, but the equivalent (and still
-     supported) "hover" property can be used in the older versions.}
+     Bitmap to show when the mouse cursor hovers above the bitmap (default: none, same as @c bitmap). @since 3.1.7}
 @row3col{margins, @ref overview_xrcformat_type_size,
     Set the margins between the bitmap and the text of the button.
-    This method is currently only implemented under MSW. If it is not called, a default margin is used around the bitmap.}
+    This method is currently only implemented under MSW. If it is not called, a default margin is used around the bitmap. @since 3.1.7}
 @row3col{bitmapposition, @c wxLEFT|wxRIGHT|wxTOP|wxBOTTOM,
     Position of the bitmap in the button, see wxButton::SetBitmapPosition() (default: wxLEFT).}
 @row3col{default, @ref overview_xrcformat_type_bool,

--- a/include/wx/xrc/xh_bttn.h
+++ b/include/wx/xrc/xh_bttn.h
@@ -22,6 +22,13 @@ public:
     wxButtonXmlHandler();
     virtual wxObject *DoCreateResource() wxOVERRIDE;
     virtual bool CanHandle(wxXmlNode *node) wxOVERRIDE;
+
+    typedef void (wxButton::*BitmapSetter)(const wxBitmapBundle&);
+
+    void SetBitmapIfSpecified(wxButton* button,
+                              BitmapSetter setter,
+                              const char* paramName,
+                              const char* paramNameAlt = NULL);
 };
 
 #endif // wxUSE_XRC && wxUSE_BUTTON

--- a/include/wx/xrc/xh_bttn.h
+++ b/include/wx/xrc/xh_bttn.h
@@ -22,13 +22,6 @@ public:
     wxButtonXmlHandler();
     virtual wxObject *DoCreateResource() wxOVERRIDE;
     virtual bool CanHandle(wxXmlNode *node) wxOVERRIDE;
-
-    typedef void (wxButton::*BitmapSetter)(const wxBitmapBundle&);
-
-    void SetBitmapIfSpecified(wxButton* button,
-                              BitmapSetter setter,
-                              const char* paramName,
-                              const char* paramNameAlt = NULL);
 };
 
 #endif // wxUSE_XRC && wxUSE_BUTTON

--- a/misc/schema/xrc_schema.rnc
+++ b/misc/schema/xrc_schema.rnc
@@ -473,8 +473,8 @@ t_bitmap     = t_url?,
 t_font       = (
                    [xrc:p="o"] element size         {_, t_float }* &
                    [xrc:p="o"] element style        {_, ("normal" | "italic" | "slant") }* &
-                   [xrc:p="o"] element weight       {_, ("normal" | "thin" | "extralight" | "light" | 
-                                                         "medium" | "semibold" | "bold" | "extrabold" | 
+                   [xrc:p="o"] element weight       {_, ("normal" | "thin" | "extralight" | "light" |
+                                                         "medium" | "semibold" | "bold" | "extrabold" |
                                                          "heavy" | "extraheavy" | t_integer) }* &
                    [xrc:p="o"] element family       {_, ("roman" | "script" | "decorative" | "swiss" |
                                                          "modern" | "teletype") }* &
@@ -736,6 +736,11 @@ wxButton =
         stdWindowProperties &
         [xrc:p="o"] element label          {_, t_text }* &
         [xrc:p="o"] element bitmap         {_, t_bitmap }* &
+        [xrc:p="o"] element pressed        {_, t_bitmap }* &
+        [xrc:p="o"] element focus          {_, t_bitmap }* &
+        [xrc:p="o"] element disabled       {_, t_bitmap }* &
+        [xrc:p="o"] element current        {_, t_bitmap }* &
+        [xrc:p="o"] element margins        {_, t_size }* &
         [xrc:p="o"] element bitmapposition {_, t_direction }* &
         [xrc:p="o"] element default        {_, t_bool }*
     }

--- a/src/xrc/xh_bttn.cpp
+++ b/src/xrc/xh_bttn.cpp
@@ -29,7 +29,29 @@ wxButtonXmlHandler::wxButtonXmlHandler()
     XRC_ADD_STYLE(wxBU_TOP);
     XRC_ADD_STYLE(wxBU_BOTTOM);
     XRC_ADD_STYLE(wxBU_EXACTFIT);
+    XRC_ADD_STYLE(wxBU_NOTEXT);
     AddWindowStyles();
+}
+
+// Function calls the given setter with the contents of the node with the given
+// name, if present.
+//
+// If alternative parameter name is specified, it is used too.
+void
+wxButtonXmlHandler::SetBitmapIfSpecified(wxButton* button,
+                                               BitmapSetter setter,
+                                               const char* paramName,
+                                               const char* paramNameAlt)
+{
+    if ( wxXmlNode* const node = GetParamNode(paramName) )
+    {
+        (button->*setter)(GetBitmapBundle(node));
+    }
+    else if ( paramNameAlt )
+    {
+        if ( wxXmlNode* const nodeAlt = GetParamNode(paramNameAlt) )
+            (button->*setter)(GetBitmap(nodeAlt));
+    }
 }
 
 wxObject *wxButtonXmlHandler::DoCreateResource()
@@ -54,6 +76,17 @@ wxObject *wxButtonXmlHandler::DoCreateResource()
     }
 
     SetupWindow(button);
+
+    SetBitmapIfSpecified(button, &wxBitmapButton::SetBitmapPressed,
+                         "pressed", "selected");
+    SetBitmapIfSpecified(button, &wxBitmapButton::SetBitmapFocus, "focus");
+    SetBitmapIfSpecified(button, &wxBitmapButton::SetBitmapDisabled, "disabled");
+    SetBitmapIfSpecified(button, &wxBitmapButton::SetBitmapCurrent,
+                         "current", "hover");
+
+    auto margins = GetSize("margins");
+    if (margins != wxDefaultSize)
+        button->SetBitmapMargins(margins.x, margins.y);
 
     return button;
 }

--- a/src/xrc/xh_bttn.cpp
+++ b/src/xrc/xh_bttn.cpp
@@ -33,27 +33,6 @@ wxButtonXmlHandler::wxButtonXmlHandler()
     AddWindowStyles();
 }
 
-// Function calls the given setter with the contents of the node with the given
-// name, if present.
-//
-// If alternative parameter name is specified, it is used too.
-void
-wxButtonXmlHandler::SetBitmapIfSpecified(wxButton* button,
-                                               BitmapSetter setter,
-                                               const char* paramName,
-                                               const char* paramNameAlt)
-{
-    if ( wxXmlNode* const node = GetParamNode(paramName) )
-    {
-        (button->*setter)(GetBitmapBundle(node));
-    }
-    else if ( paramNameAlt )
-    {
-        if ( wxXmlNode* const nodeAlt = GetParamNode(paramNameAlt) )
-            (button->*setter)(GetBitmap(nodeAlt));
-    }
-}
-
 wxObject *wxButtonXmlHandler::DoCreateResource()
 {
    XRC_MAKE_INSTANCE(button, wxButton)
@@ -77,16 +56,22 @@ wxObject *wxButtonXmlHandler::DoCreateResource()
 
     SetupWindow(button);
 
-    SetBitmapIfSpecified(button, &wxBitmapButton::SetBitmapPressed,
-                         "pressed", "selected");
-    SetBitmapIfSpecified(button, &wxBitmapButton::SetBitmapFocus, "focus");
-    SetBitmapIfSpecified(button, &wxBitmapButton::SetBitmapDisabled, "disabled");
-    SetBitmapIfSpecified(button, &wxBitmapButton::SetBitmapCurrent,
-                         "current", "hover");
+    const wxXmlNode* node = GetParamNode("pressed");
+    if (node)
+        button->SetBitmapPressed(GetBitmapBundle(node));
+    node = GetParamNode("focus");
+    if (node)
+        button->SetBitmapFocus(GetBitmapBundle(node));
+    node = GetParamNode("disabled");
+    if (node)
+        button->SetBitmapDisabled(GetBitmapBundle(node));
+    node = GetParamNode("current");
+    if (node)
+        button->SetBitmapCurrent(GetBitmapBundle(node));
 
-    auto margins = GetSize("margins");
+    const wxSize margins = GetSize("margins");
     if (margins != wxDefaultSize)
-        button->SetBitmapMargins(margins.x, margins.y);
+        button->SetBitmapMargins(margins);
 
     return button;
 }


### PR DESCRIPTION
This updates the XRC **wxButtonXmlHandler**. It adds the same support for additional bitmaps that is in the **wxBitmapButtonXmlHandler**. It adds the missing wxBU_NOTEXT style. It adds a `margins` property that if specified will call `button->SetBitmapMargins()`.

No existing functionality was changed, so this should have zero impact on any existing XRC files.

For the schema, I used the newer names for the additional bitmaps -- there isn't any legacy XRC files to support in this case. However in the actual code, I do still check for the older names just in case a user simply changes the name of the class from wxBitmapButton to wxButton.

I compared using a C++ generated dialog versus loading the dialog from XRC and verified that they visually looked the same. I tested the `pressed` bitmap to verify the bitmap changed when clicked.
