### PR TITLE
Grid: drag move improvements

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2804,8 +2804,11 @@ protected:
     // operation in progress.
     int     m_dragMoveRowOrCol;
 
-    // Last horizontal mouse position while drag-moving a column.
+    // Last drag marker position while drag-moving a column.
     int     m_dragLastPos;
+
+    // Last drag marker colour while drag-moving a column.
+    const wxColour *m_dragLastColour;
 
     // Row or column (depending on m_cursorMode value) currently being resized
     // or -1 if there is no resize operation in progress.
@@ -2987,6 +2990,10 @@ private:
     // helper for Process...MouseEvent to scroll
     void CheckDoDragScroll(wxGridSubwindow *eventGridWindow, wxGridSubwindow *gridWindow,
                            wxPoint posEvent, int direction);
+
+    // helper for Process...LabelMouseEvent to check whether a drag operation
+    // would end at the source line, i.e. have no effect
+    bool CheckIfAtDragSourceLine(const wxGridOperations &oper, int coord);
 
     // return true if the grid should be refreshed right now
     bool ShouldRefresh() const

--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -2804,10 +2804,10 @@ protected:
     // operation in progress.
     int     m_dragMoveRowOrCol;
 
-    // Last drag marker position while drag-moving a column.
+    // Last drag marker position while drag-moving a row or column.
     int     m_dragLastPos;
 
-    // Last drag marker colour while drag-moving a column.
+    // Last drag marker colour while drag-moving a row or column.
     const wxColour *m_dragLastColour;
 
     // Row or column (depending on m_cursorMode value) currently being resized

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -4283,13 +4283,7 @@ void wxGrid::ProcessRowColLabelMouseEvent( const wxGridOperations &oper, wxMouse
         {
             DoColHeaderClick(line);
         }
-
-        ChangeCursorMode(WXGRID_CURSOR_SELECT_CELL, labelWin);
-        m_dragMoveRowOrCol = -1;
-        m_dragLastPos = -1;
-        m_dragLastColour = NULL;
-        m_lastMousePos = wxDefaultPosition;
-        m_isDragging = false;
+        EndDraggingIfNecessary();
     }
 
     // ------------ Right button down
@@ -4535,6 +4529,10 @@ void wxGrid::DoAfterDraggingEnd()
     m_isDragging = false;
     m_startDragPos = wxDefaultPosition;
     m_lastMousePos = wxDefaultPosition;
+    // from drag moving row/col
+    m_dragMoveRowOrCol = -1;
+    m_dragLastPos = -1;
+    m_dragLastColour = NULL;
 
     m_cursorMode = WXGRID_CURSOR_SELECT_CELL;
     m_winCapture->SetCursor( *wxSTANDARD_CURSOR );

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -4515,6 +4515,9 @@ void wxGrid::CancelMouseCapture()
     // cancel operation currently in progress, whatever it is
     if ( m_winCapture )
     {
+        if ( m_cursorMode == WXGRID_CURSOR_MOVE_COL ||
+             m_cursorMode == WXGRID_CURSOR_MOVE_ROW )
+            m_winCapture->Refresh();
         DoAfterDraggingEnd();
     }
 }

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -7112,6 +7112,17 @@ void wxGrid::DrawRowLabel( wxDC& dc, int row )
     // (in that case it's omitted to have a 'pressed' appearance)
     if (m_cursorMode != WXGRID_CURSOR_MOVE_ROW || row != m_dragMoveRowOrCol)
         rend.DrawBorder(*this, dc, rect);
+    else
+    {
+#ifdef __WXGTK__
+        dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT)));
+        dc.DrawRectangle(rect);
+#endif
+        if ( GetBorder() == wxBORDER_NONE )
+            rect.Deflate(2);
+        else
+            rect.Deflate(1);
+    }
 
     int hAlign, vAlign;
     GetRowLabelAlignment(&hAlign, &vAlign);
@@ -7261,6 +7272,17 @@ void wxGrid::DrawColLabel(wxDC& dc, int col)
         // (in that case it's omitted to have a 'pressed' appearance)
         if (m_cursorMode != WXGRID_CURSOR_MOVE_COL || col != m_dragMoveRowOrCol)
             rend.DrawBorder(*this, dc, rect);
+        else
+        {
+#ifdef __WXGTK__
+            dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT)));
+            dc.DrawRectangle(rect);
+#endif
+            if ( GetBorder() == wxBORDER_NONE )
+                rect.Deflate(2);
+            else
+                rect.Deflate(1);
+        }
     }
 
     int hAlign, vAlign;


### PR DESCRIPTION
Some improvements:
 - better visualization of the 'pressed' label of the row/col that will be dragged (see image below)
 - this is done by `DrawLineLabel` omitting the border
 - the 'pressed' state will also be maintained when re-painted, e.g. due to scrolling
 - correctly visualize with grey insertion markers if no move would happen (helper method `CheckIfAtDragSourceLine` checking the coordinate whether it's max. half a line away from the source line)
 - don't call `DoEndMove` in this case
 - correctly update marker color w. hidden cols/rows; e.g. row 2 is hidden and row 3 dragged to row 1 -> change from grey to blue
 - re-paint label window if drag move is canceled by lost mouse capture

I don't like the variable reset code at the end of the `event.LeftUp()` handler around line 4288 as this has grown a lot.
I'm not 100% sure, but I think this block, including the call to `ChangeCursorMode` could be replaced by a call to `EndDraggingIfNecessary` and the reset code for `m_dragMoveRowOrCol, m_dragLastPos,  m_dragLastColour` could then be added to `DoAfterDraggingEnd`.

![grafik](https://user-images.githubusercontent.com/5512021/170471453-47970d46-9aeb-4c7f-b51d-cac3f7bbc536.png)
