### PR TITLE
AUI Floating Pane position fix

### DIFF
--- a/src/aui/floatpane.cpp
+++ b/src/aui/floatpane.cpp
@@ -203,6 +203,10 @@ void wxAuiFloatingFrame::OnClose(wxCloseEvent& evt)
 
 void wxAuiFloatingFrame::OnMoveEvent(wxMoveEvent& event)
 {
+    // Always sync pane's floating_pos with frame's position
+    if (m_ownerMgr)
+        m_ownerMgr->GetPane(m_paneWindow).floating_pos = event.GetPosition();
+
     if (!m_solidDrag)
     {
         // systems without solid window dragging need to be
@@ -215,7 +219,6 @@ void wxAuiFloatingFrame::OnMoveEvent(wxMoveEvent& event)
         m_moving = true;
         return;
     }
-
 
     wxRect winRect = GetRect();
 
@@ -241,14 +244,6 @@ void wxAuiFloatingFrame::OnMoveEvent(wxMoveEvent& event)
         m_last3Rect = m_last2Rect;
         m_last2Rect = m_lastRect;
         m_lastRect = winRect;
-
-        // However still update the internally stored position to avoid
-        // snapping back to the old one later.
-        if (m_ownerMgr)
-        {
-            m_ownerMgr->GetPane(m_paneWindow).
-                floating_pos = winRect.GetPosition();
-        }
 
         return;
     }


### PR DESCRIPTION
Sometimes pane's floating position is out of sync with it's owner (frame).
This PR solves this issue.

Example of the issue:
When you open some floating pane for the first time and i'ts floating_position is wxDefaultPosition, it's frame position will be in the center of managed window. After you close if and open it again, it's position will be in (0, 0) because OnMove event has been ignored.
NOTE: (0, 0) comes from OnSize event.
