### PR TITLE
BUG FIX - Comparison with wrong type string leads to a crash in wxDataViewBitmapRenderer::MacRender

### DIFF
--- a/src/osx/cocoa/dataview.mm
+++ b/src/osx/cocoa/dataview.mm
@@ -2985,7 +2985,7 @@ wxDataViewBitmapRenderer::wxDataViewBitmapRenderer(const wxString& varianttype,
 // In all other cases the method returns 'false'.
 bool wxDataViewBitmapRenderer::MacRender()
 {
-    if (GetValue().GetType() == wxS("wxBitmap"))
+    if (GetValue().GetType() == wxS("wxBitmapBundle"))
     {
         wxBitmapBundle bundle;
         bundle << GetValue();


### PR DESCRIPTION
A bitmap bundle type has to be compared with "wxBitmapBundle" and not "wxBitmap".