### PR TITLE
Fix incorrect coding of "\"

### DIFF
--- a/docs/doxygen/overviews/resyntax.h
+++ b/docs/doxygen/overviews/resyntax.h
@@ -125,7 +125,7 @@ follows; some more constraints are described later, under
 
 The lookahead constraints may not contain back references (see later), and all
 parentheses within them are considered non-capturing. A RE may not end with
-"\".
+\"\\\".
 
 
 @section overview_resyntax_bracket Bracket Expressions

--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -298,7 +298,7 @@ the following table:
 @itemdef{ "\n", line break }
 @itemdef{ "\r", carriage return }
 @itemdef{ "\t", tab }
-@itemdef{ "\\", "\" }
+@itemdef{ \"\\\", backslash }
 @endDefList
 
 By default, the text is translated using wxLocale::GetTranslation() before
@@ -2957,10 +2957,10 @@ files with older values of @c version attribute of @c \<resource\>).
 
 @subsection overview_xrcformat_pre_v2530 Versions Before 2.5.3.0
 
-Version 2.5.3.0 introduced C-like handling of "\\" in text. In older versions,
+Version 2.5.3.0 introduced C-like handling of \"\\\\\" in text. In older versions,
 "\n", "\t" and "\r" escape sequences were replaced with respective characters
-in the same matter it's done in C, but "\\" was left intact instead of being
-replaced with single "\", as one would expect. Starting with 2.5.3.0, all of
+in the same matter as it's done in C, but \"\\\\\" was left intact instead of being
+replaced with a single \"\\\", as one would expect. Starting with 2.5.3.0, all of
 them are handled in C-like manner.
 
 


### PR DESCRIPTION
This commit fixes a formatting problem with these two files
when built with Doxygen version 1.9.3.

The correct encoding is to escape the quotes and the backslash.
While the older style encoding used to work, it is no longer
supported due to a fix with how a single quote gets handled
by Doxygen. The escaped version works with Doxygen 1.8.17
so this will work fine with the current build version as well as
in more recent versions (tested with 1.9.3).