### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/include/wx/choicebk.h
+++ b/include/wx/choicebk.h
@@ -86,7 +86,7 @@ protected:
 
     void UpdateSelectedPage(size_t newsel) wxOVERRIDE
     {
-        GetChoiceCtrl()->Select(newsel);
+        GetChoiceCtrl()->Select(static_cast<int>(newsel));
     }
 
     wxBookCtrlEvent* CreatePageChangingEvent() const wxOVERRIDE;

--- a/include/wx/htmllbox.h
+++ b/include/wx/htmllbox.h
@@ -265,7 +265,7 @@ public:
     // -----------------
 
     virtual unsigned int GetCount() const wxOVERRIDE
-        { return m_items.GetCount(); }
+        { return static_cast<unsigned int>(m_items.GetCount()); }
 
     virtual wxString GetString(unsigned int n) const wxOVERRIDE;
 

--- a/include/wx/richtext/richtextbuffer.h
+++ b/include/wx/richtext/richtextbuffer.h
@@ -368,7 +368,8 @@ public:
     /**
         Constructor taking value and units flag.
     */
-    wxTextAttrDimension(int value, wxTextAttrUnits units = wxTEXT_ATTR_UNITS_TENTHS_MM) { m_value = value; m_flags = units|wxTEXT_ATTR_VALUE_VALID; }
+    wxTextAttrDimension(int value, wxTextAttrUnits units = wxTEXT_ATTR_UNITS_TENTHS_MM) { m_value = value;
+        m_flags = static_cast<wxTextAttrDimensionFlags>(units | wxTEXT_ATTR_VALUE_VALID); }
 
     /**
         Resets the dimension value and flags.
@@ -426,7 +427,8 @@ public:
     /**
         Sets the integer value and units.
     */
-    void SetValue(int value, wxTextAttrUnits units) { m_value = value; m_flags = units | wxTEXT_ATTR_VALUE_VALID; }
+    void SetValue(int value, wxTextAttrUnits units) { m_value = value;
+        m_flags = static_cast<wxTextAttrDimensionFlags>(units | wxTEXT_ATTR_VALUE_VALID); }
 
     /**
         Sets the dimension.

--- a/include/wx/richtext/richtextctrl.h
+++ b/include/wx/richtext/richtextctrl.h
@@ -178,7 +178,7 @@ public:
     /**
         Returns the number of items.
     */
-    int GetCount() const { return m_objects.GetCount(); }
+    int GetCount() const { return static_cast<int>(m_objects.GetCount()); }
 
     wxRichTextObjectPtrArray    m_objects;
     wxArrayString               m_labels;


### PR DESCRIPTION
This adds a `static_cast<>` to fix warnings from the MSVC compiler (Version 19.29.30136 for x64) when compiling a 64-bit app.

`warning C4244: '=': conversion from 'int' to 'wxTextAttrDimensionFlags', possible loss of data`

`warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data`

I created a test header file that #includes roughly 700 header files from wxWidgets, and these were the only ones that generated warnings.