### PR TITLE
Use correct wxBitmap size for STC

### DIFF
--- a/src/osx/core/bitmap.cpp
+++ b/src/osx/core/bitmap.cpp
@@ -76,7 +76,7 @@ public:
     bool HasAlpha() const;
     WXImage GetImage() const;
 
-    void SetScaleFactor(double scale) { m_scaleFactor = scale; }
+    void SetScaleFactor(double scale);
     double GetScaleFactor() const { return m_scaleFactor; }
 
     const void *GetRawAccess() const;
@@ -367,6 +367,18 @@ WXImage wxBitmapRefData::GetImage() const
     }
 
     return m_nsImage;
+}
+
+void wxBitmapRefData::SetScaleFactor( double scale )
+{
+    wxCHECK_RET( IsOk() , wxT("invalid bitmap") ) ;
+
+    if ( m_scaleFactor == scale )
+        return ;
+
+    CGContextScaleCTM( m_hBitmap, 1 / GetScaleFactor(), -1 / GetScaleFactor() );
+    m_scaleFactor = scale;
+    CGContextScaleCTM( m_hBitmap, GetScaleFactor(), -GetScaleFactor() );
 }
 
 void wxBitmapRefData::UseAlpha( bool use )

--- a/src/stc/PlatWX.cpp
+++ b/src/stc/PlatWX.cpp
@@ -293,13 +293,12 @@ void SurfaceImpl::InitPixMap(int width, int height, Surface *surface, WindowID w
     wxMemoryDC* mdc = surface
         ? new wxMemoryDC(static_cast<SurfaceImpl*>(surface)->hdc)
         : new wxMemoryDC();
-    mdc->GetImpl()->SetWindow(GETWIN(winid));
     hdc = mdc;
     hdcOwned = true;
     if (width < 1) width = 1;
     if (height < 1) height = 1;
-    bitmap = new wxBitmap();
-    bitmap->CreateWithDIPSize(width, height,(GETWIN(winid))->GetDPIScaleFactor());
+    bitmap = new wxBitmap(GETWIN(winid)->ToPhys(wxSize(width, height)));
+    bitmap->SetScaleFactor(GETWIN(winid)->GetDPIScaleFactor());
     mdc->SelectObject(*bitmap);
 }
 


### PR DESCRIPTION
This fixes rendering artifacts.

On Windows, the bitmap should have the width and height as provided to InitPixMap(), and initialized with the correct scale factor to prevent performance regressions. CreateWithDIPSize() in combination with ToDIP(width, height) cannot be used, because the scaled size will be rounded and can cause the final bitmap to become too large.

On macOS (retina) CreateWithDIPSize has to be used, so the internal bitmap context has the correct size and scale.

Remove obsolete mdc->GetImpl()->SetWindow(), this is not needed anymore because the DPI is now determined from the associated bitmap content scale factor, and not from the wxWindow.

See #22450