### PR TITLE
Make doc/code changes to wxRichTextCtrlXmlHandler

### DIFF
--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -1935,19 +1935,17 @@ a single wxSizer child with non-ribbon windows in it.
 @hdr3col{property, type, description}
 @row3col{value, @ref overview_xrcformat_type_text,
     Initial value of the control (default: empty).}
-@row3col{maxlength, integer,
-    Maximum length of the text entered (default: unlimited).}
 @endTable
 
-Notice that wxRichTextCtrl support in XRC is available in wxWidgets 2.9.5 and
-later only and you need to explicitly register its handler using
+Notice that you need to explicitly register the handler using
 @code
     #include <wx/xrc/xh_richtext.h>
 
-    AddHandler(new wxRichTextCtrl);
+    AddHandler(new wxRichTextCtrlXmlHandler);
 @endcode
 to use it.
 
+@since 2.9.5
 
 @subsubsection xrc_wxscrollbar wxScrollBar
 

--- a/misc/schema/xrc_schema.rnc
+++ b/misc/schema/xrc_schema.rnc
@@ -1404,8 +1404,7 @@ wxRichTextCtrl =
         attribute class { "wxRichTextCtrl" } &
         stdObjectNodeAttributes &
         stdWindowProperties &
-        [xrc:p="o"] element value     {_, t_text }* &
-        [xrc:p="o"] element maxlength {_, t_integer }*
+        [xrc:p="o"] element value {_, t_text }*
     }
 
 

--- a/src/xrc/xh_richtext.cpp
+++ b/src/xrc/xh_richtext.cpp
@@ -24,7 +24,9 @@ wxRichTextCtrlXmlHandler::wxRichTextCtrlXmlHandler() : wxXmlResourceHandler()
     XRC_ADD_STYLE(wxTE_PROCESS_TAB);
     XRC_ADD_STYLE(wxTE_MULTILINE);
     XRC_ADD_STYLE(wxTE_READONLY);
-    XRC_ADD_STYLE(wxTE_AUTO_URL);
+
+    XRC_ADD_STYLE(wxRE_CENTRE_CARET);
+    XRC_ADD_STYLE(wxRE_READONLY);
 
     AddWindowStyles();
 }
@@ -42,9 +44,6 @@ wxObject *wxRichTextCtrlXmlHandler::DoCreateResource()
                  GetName());
 
     SetupWindow(text);
-
-    if (HasParam(wxT("maxlength")))
-        text->SetMaxLength(GetLong(wxT("maxlength")));
 
     return text;
 }


### PR DESCRIPTION
## Doc fixes (xrc_format.h, xrc_schema.rnc)
Fixed the wrong handler name specified for wxRichTextCtrl.

Changed the wording to make it very clear that the handler must be explicitly loaded, and moved the minimum version requirement after the table.

Removed `maxlength` property. SetMaxLength() is for single-line edit controls, and does nothing on multi-line controls. Since wxRichTextCtrl is always a multi-line control, this parameter will not set the maximum length of the text as it indicated.

## Code changes (xh_richtext.cpp)

Added missing `wxRE_` styles for wxRichTextCtrlXmlHandler. While technically wxRE_READONLY has the same value as wxTE_READONLY, a user should be able to specify the wxRE_READONLY style to match the wxRichTextCtrl documentation.

Removed the wxTE_AUTO_URL style. This style is only supported in wxTextCtrl (MSW and GTK), not wxRichTextCtrl. Changing this will generate an assert about an unknown style in a legacy file that used it. Howevewr, the user may otherwise be confused because URLs still look like regular text, and they are not clickable as they would be with this style set in in a wxTextCtrl.

Removed the `maxlength` processing, since it ended up calling a function that simply returned (see description in doc section above about why it was removed from the docs).
