### PR TITLE
Add undetermined state to wxCheckBoxXmlHandler

### DIFF
--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -937,6 +937,8 @@ No additional properties.
      Label to use for the checkbox (default: empty).}
 @row3col{checked, @ref overview_xrcformat_type_bool,
      Should the checkbox be checked initially (default: 0)?}
+@row3col{undetermined, @ref overview_xrcformat_type_bool,
+     Should a 3-state checkbox be initialized as undetermined (default: 0)?}
 @endTable
 
 

--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -946,10 +946,10 @@ No additional properties.
 @hdr3col{property, type, description}
 @row3col{label, @ref overview_xrcformat_type_text,
      Label to use for the checkbox (default: empty).}
-@row3col{checked, @ref overview_xrcformat_type_bool,
-     Should the checkbox be checked initially (default: 0)?}
-@row3col{undetermined, @ref overview_xrcformat_type_bool,
-     Should a 3-state checkbox be initialized as undetermined (default: 0)?}
+@row3col{checked, integer,
+    Sets the initial state of the checkbox. 0 is unchecked (default),
+    1 is checked, and since wxWidgets 3.1.7, 2 sets the undetermined
+    state of a 3-state checkbox.}
 @endTable
 
 

--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -948,6 +948,8 @@ No additional properties.
      Label to use for the checkbox (default: empty).}
 @row3col{checked, @ref overview_xrcformat_type_bool,
      Should the checkbox be checked initially (default: 0)?}
+@row3col{undetermined, @ref overview_xrcformat_type_bool,
+     Should a 3-state checkbox be initialized as undetermined (default: 0)?}
 @endTable
 
 

--- a/misc/schema/xrc_schema.rnc
+++ b/misc/schema/xrc_schema.rnc
@@ -765,7 +765,8 @@ wxCheckBox =
         stdObjectNodeAttributes &
         stdWindowProperties &
         [xrc:p="important"] element label {_, t_text }* &
-        [xrc:p="o"] element checked {_, t_bool }*
+        [xrc:p="o"] element checked {_, t_bool }* &
+        [xrc:p="o"] element undetermined {_, t_bool }*
     }
 
 

--- a/misc/schema/xrc_schema.rnc
+++ b/misc/schema/xrc_schema.rnc
@@ -765,8 +765,7 @@ wxCheckBox =
         stdObjectNodeAttributes &
         stdWindowProperties &
         [xrc:p="important"] element label {_, t_text }* &
-        [xrc:p="o"] element checked {_, t_bool }* &
-        [xrc:p="o"] element undetermined {_, t_bool }*
+        [xrc:p="o"] element checked       {_, t_integer }*
     }
 
 

--- a/misc/schema/xrc_schema.rnc
+++ b/misc/schema/xrc_schema.rnc
@@ -760,7 +760,8 @@ wxCheckBox =
         stdObjectNodeAttributes &
         stdWindowProperties &
         [xrc:p="important"] element label {_, t_text }* &
-        [xrc:p="o"] element checked {_, t_bool }*
+        [xrc:p="o"] element checked {_, t_bool }* &
+        [xrc:p="o"] element undetermined {_, t_bool }*
     }
 
 

--- a/src/xrc/xh_chckb.cpp
+++ b/src/xrc/xh_chckb.cpp
@@ -49,7 +49,7 @@ wxObject *wxCheckBoxXmlHandler::DoCreateResource()
     else if (state == wxCHK_UNDETERMINED)
         // will generate a warning if wxCHK_3STATE is not set
         control->Set3StateValue(wxCHK_UNDETERMINED);
-        
+
     SetupWindow(control);
 
     return control;

--- a/src/xrc/xh_chckb.cpp
+++ b/src/xrc/xh_chckb.cpp
@@ -43,7 +43,11 @@ wxObject *wxCheckBoxXmlHandler::DoCreateResource()
                     wxDefaultValidator,
                     GetName());
 
-    control->SetValue(GetBool( wxT("checked")));
+    if (GetBool("checked"))
+        control->SetValue(true);
+    else if (GetBool("undetermined") && (GetStyle() & wxCHK_3STATE))
+        control->Set3StateValue(wxCHK_UNDETERMINED);
+
     SetupWindow(control);
 
     return control;

--- a/src/xrc/xh_chckb.cpp
+++ b/src/xrc/xh_chckb.cpp
@@ -43,11 +43,13 @@ wxObject *wxCheckBoxXmlHandler::DoCreateResource()
                     wxDefaultValidator,
                     GetName());
 
-    if (GetBool("checked"))
+    int state = GetLong("checked", wxCHK_UNCHECKED);
+    if (state == wxCHK_CHECKED)
         control->SetValue(true);
-    else if (GetBool("undetermined") && (GetStyle() & wxCHK_3STATE))
+    else if (state == wxCHK_UNDETERMINED)
+        // will generate a warning if wxCHK_3STATE is not set
         control->Set3StateValue(wxCHK_UNDETERMINED);
-
+        
     SetupWindow(control);
 
     return control;


### PR DESCRIPTION
A 3-state checkbox can be initialized as `checked` or `undetermined` -- this adds support for the `undetermined` initial state, but only if the checkbox style is set to wxCHK_3STATE.
