### PR TITLE
Add digits property to wxSpinCtrlDoubleXmlHandler

### DIFF
--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -2090,6 +2090,8 @@ additional property:
 @beginTable
 @row3col{inc, float,
     The amount by which the number is changed by a single arrow press.}
+@row3col{digits, integer,
+    Sets the precision of the value of the spin control (default: 0). @since 3.1.7.}
 @endTable
 
 @since  3.1.1.

--- a/misc/schema/xrc_schema.rnc
+++ b/misc/schema/xrc_schema.rnc
@@ -1513,7 +1513,8 @@ wxSpinCtrlDouble =
         [xrc:p="o"] element value {_, t_float }* &
         [xrc:p="o"] element min   {_, t_float }* &
         [xrc:p="o"] element max   {_, t_float }* &
-        [xrc:p="o"] element inc   {_, t_float}*
+        [xrc:p="o"] element inc   {_, t_float}* &
+        [xrc:p="o"] element digits {_, t_integer}*
     }
 
 

--- a/src/xrc/xh_spin.cpp
+++ b/src/xrc/xh_spin.cpp
@@ -23,6 +23,7 @@ static const long DEFAULT_VALUE = 0;
 static const long DEFAULT_MIN = 0;
 static const long DEFAULT_MAX = 100;
 static const int DEFAULT_INCREMENT = 1;
+static const int DEFAULT_DIGITS = 0;
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxSpinButtonXmlHandler, wxXmlResourceHandler);
 
@@ -139,6 +140,10 @@ wxObject *wxSpinCtrlDoubleXmlHandler::DoCreateResource()
                     double(GetFloat(wxS("value"), DEFAULT_VALUE)),
                     double(GetFloat(wxS("inc"), DEFAULT_INC)),
                     GetName());
+
+    int digits = GetLong("digits", DEFAULT_DIGITS);
+    if (digits != DEFAULT_DIGITS)
+        control->SetDigits(digits);
 
     SetupWindow(control);
 


### PR DESCRIPTION
This adds the ability to set the precision of the floating point number in a **wxSpinCtrlDoubleXmlHandler**. While it is possible to set the precision by specifying a precision value for the `inc` property, that has the side effect of changing the scroll buttons to use that increment. Note that without setting the precision, a user cannot enter in any non-integer value, as nothing beyond the decimal or comma is accepted (the default precision is zero).
