### PR TITLE
Update wxToggleButtonXmlHandler

### DIFF
--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -893,6 +893,17 @@ Example:
 @hdr3col{property, type, description}
 @row3col{bitmap, @ref overview_xrcformat_type_bitmap,
      Label to display on the button (default: none).}
+@row3col{pressed, @ref overview_xrcformat_type_bitmap,
+     Bitmap to show when the button is pressed (default: none, same as @c bitmap). @since 3.1.7}
+@row3col{focus, @ref overview_xrcformat_type_bitmap,
+     Bitmap to show when the button has focus (default: none, same as @c bitmap). @since 3.1.7}
+@row3col{disabled, @ref overview_xrcformat_type_bitmap,
+     Bitmap to show when the button is disabled (default: none, same as @c bitmap). @since 3.1.7}
+@row3col{current, @ref overview_xrcformat_type_bitmap,
+     Bitmap to show when the mouse cursor hovers above the bitmap (default: none, same as @c bitmap). @since 3.1.7}
+@row3col{margins, @ref overview_xrcformat_type_size,
+    Set the margins between the bitmap and the text of the button.
+    This method is currently only implemented under MSW. If it is not called, a default margin is used around the bitmap. @since 3.1.7}
 @row3col{checked, @ref overview_xrcformat_type_bool,
      Should the button be checked/pressed initially (default: 0)?}
 @endTable
@@ -2229,6 +2240,17 @@ No additional properties.
      Should the button be checked/pressed initially (default: 0)?}
 @row3col{bitmap, @ref overview_xrcformat_type_bitmap,
     Bitmap to display in the button (optional). @since 3.1.1}
+@row3col{pressed, @ref overview_xrcformat_type_bitmap,
+     Bitmap to show when the button is pressed (default: none, same as @c bitmap). @since 3.1.7}
+@row3col{focus, @ref overview_xrcformat_type_bitmap,
+     Bitmap to show when the button has focus (default: none, same as @c bitmap). @since 3.1.7}
+@row3col{disabled, @ref overview_xrcformat_type_bitmap,
+     Bitmap to show when the button is disabled (default: none, same as @c bitmap). @since 3.1.7}
+@row3col{current, @ref overview_xrcformat_type_bitmap,
+     Bitmap to show when the mouse cursor hovers above the bitmap (default: none, same as @c bitmap). @since 3.1.7}
+@row3col{margins, @ref overview_xrcformat_type_size,
+    Set the margins between the bitmap and the text of the button.
+    This method is currently only implemented under MSW. If it is not called, a default margin is used around the bitmap. @since 3.1.7}
 @row3col{bitmapposition, @c wxLEFT|wxRIGHT|wxTOP|wxBOTTOM,
     Position of the bitmap in the button, see wxButton::SetBitmapPosition() (default: wxLEFT). @since 3.1.1}
 @endTable

--- a/misc/schema/xrc_schema.rnc
+++ b/misc/schema/xrc_schema.rnc
@@ -725,6 +725,11 @@ wxBitmapToggleButton =
         stdObjectNodeAttributes &
         stdWindowProperties &
         [xrc:p="important"] element bitmap {_, t_bitmap }* &
+        [xrc:p="o"] element pressed        {_, t_bitmap }* &
+        [xrc:p="o"] element focus          {_, t_bitmap }* &
+        [xrc:p="o"] element disabled       {_, t_bitmap }* &
+        [xrc:p="o"] element current        {_, t_bitmap }* &
+        [xrc:p="o"] element margins        {_, t_size }* &
         [xrc:p="o"] element checked {_, t_bool }*
     }
 
@@ -1615,6 +1620,11 @@ wxToggleButton =
         [xrc:p="important"] element label {_, t_text }* &
         [xrc:p="o"] element checked {_, t_bool }* &
         [xrc:p="o"] element bitmap         {_, t_bitmap }* &
+        [xrc:p="o"] element pressed        {_, t_bitmap }* &
+        [xrc:p="o"] element focus          {_, t_bitmap }* &
+        [xrc:p="o"] element disabled       {_, t_bitmap }* &
+        [xrc:p="o"] element current        {_, t_bitmap }* &
+        [xrc:p="o"] element margins        {_, t_size }* &
         [xrc:p="o"] element bitmapposition {_, t_direction }*
     }
 

--- a/src/xrc/xh_tglbtn.cpp
+++ b/src/xrc/xh_tglbtn.cpp
@@ -26,7 +26,12 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxToggleButtonXmlHandler, wxXmlResourceHandler);
 wxToggleButtonXmlHandler::wxToggleButtonXmlHandler()
     : wxXmlResourceHandler()
 {
+    XRC_ADD_STYLE(wxBU_LEFT);
+    XRC_ADD_STYLE(wxBU_RIGHT);
+    XRC_ADD_STYLE(wxBU_TOP);
+    XRC_ADD_STYLE(wxBU_BOTTOM);
     XRC_ADD_STYLE(wxBU_EXACTFIT);
+    XRC_ADD_STYLE(wxBU_NOTEXT);
 
     AddWindowStyles();
 }
@@ -85,6 +90,23 @@ void wxToggleButtonXmlHandler::DoCreateToggleButton(wxObject *control)
         button->SetBitmap(GetBitmapBundle("bitmap", wxART_BUTTON),
                           GetDirection("bitmapposition"));
     }
+
+    const wxXmlNode* node = GetParamNode("pressed");
+    if (node)
+        button->SetBitmapPressed(GetBitmapBundle(node));
+    node = GetParamNode("focus");
+    if (node)
+        button->SetBitmapFocus(GetBitmapBundle(node));
+    node = GetParamNode("disabled");
+    if (node)
+        button->SetBitmapDisabled(GetBitmapBundle(node));
+    node = GetParamNode("current");
+    if (node)
+        button->SetBitmapCurrent(GetBitmapBundle(node));
+
+    const wxSize margins = GetSize("margins");
+    if (margins != wxDefaultSize)
+        button->SetBitmapMargins(margins);
 #endif
 
     button->SetValue(GetBool( wxT("checked")));
@@ -102,6 +124,23 @@ void wxToggleButtonXmlHandler::DoCreateBitmapToggleButton(wxObject *control)
                    GetStyle(),
                    wxDefaultValidator,
                    GetName());
+
+    const wxXmlNode* node = GetParamNode("pressed");
+    if (node)
+        button->SetBitmapPressed(GetBitmapBundle(node));
+    node = GetParamNode("focus");
+    if (node)
+        button->SetBitmapFocus(GetBitmapBundle(node));
+    node = GetParamNode("disabled");
+    if (node)
+        button->SetBitmapDisabled(GetBitmapBundle(node));
+    node = GetParamNode("current");
+    if (node)
+        button->SetBitmapCurrent(GetBitmapBundle(node));
+
+    const wxSize margins = GetSize("margins");
+    if (margins != wxDefaultSize)
+        button->SetBitmapMargins(margins);
 
     button->SetValue(GetBool( wxT("checked")));
 }


### PR DESCRIPTION
This PR adds the missing `pressed`, `focus`, `disabled` and `current` bitmaps to **wxToggleButtonXmlHandler**. It also adds the missing `wxBU_...` styles. Note that this handler will create either `wxToggleButton` or `wxBitmapToggleButton`, so it's necessary to support the styles that affect button text, even though only the `wxToggleButton` control can use them.

I also added the missing "margins" property, matching the wxButtonXmlHandler handler.

