### PR TITLE
Update wxCommandLinkButtonXmlHandler

### DIFF
--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -1052,6 +1052,14 @@ concatenated into a single string using a new line character between them
     Second line of text describing the action performed when the button is pressed (default: none).  }
 @row3col{bitmap, @ref overview_xrcformat_type_bitmap,
     Bitmap to display in the button (optional). @since 3.1.5}
+@row3col{pressed, @ref overview_xrcformat_type_bitmap,
+     Bitmap to show when the button is pressed (default: none, same as @c bitmap). @since 3.1.7}
+@row3col{focus, @ref overview_xrcformat_type_bitmap,
+     Bitmap to show when the button has focus (default: none, same as @c bitmap). @since 3.1.7}
+@row3col{disabled, @ref overview_xrcformat_type_bitmap,
+     Bitmap to show when the button is disabled (default: none, same as @c bitmap). @since 3.1.7}
+@row3col{current, @ref overview_xrcformat_type_bitmap,
+     Bitmap to show when the mouse cursor hovers above the bitmap (default: none, same as @c bitmap). @since 3.1.7}
 @row3col{default, @ref overview_xrcformat_type_bool,
     Should this button be the default button in dialog (default: 0)? @since 3.1.5}
 @endTable

--- a/misc/schema/xrc_schema.rnc
+++ b/misc/schema/xrc_schema.rnc
@@ -826,9 +826,13 @@ wxCommandLinkButton =
         stdObjectNodeAttributes &
         stdWindowProperties &
         [xrc:p="important"] element label {_, t_text }* &
-        [xrc:p="o"] element note {_, t_text }* &
-        [xrc:p="o"] element bitmap {_, t_bitmap }* &
-        [xrc:p="o"] element default {_, t_bool }*
+        [xrc:p="o"] element note          {_, t_text }* &
+        [xrc:p="o"] element bitmap        {_, t_bitmap }* &
+        [xrc:p="o"] element pressed       {_, t_bitmap }* &
+        [xrc:p="o"] element focus         {_, t_bitmap }* &
+        [xrc:p="o"] element disabled      {_, t_bitmap }* &
+        [xrc:p="o"] element current       {_, t_bitmap }* &
+        [xrc:p="o"] element default       {_, t_bool }*
     }
 
 

--- a/src/xrc/xh_cmdlinkbn.cpp
+++ b/src/xrc/xh_cmdlinkbn.cpp
@@ -22,11 +22,6 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxCommandLinkButtonXmlHandler, wxXmlResourceHandler);
 wxCommandLinkButtonXmlHandler::wxCommandLinkButtonXmlHandler()
     : wxXmlResourceHandler()
 {
-    XRC_ADD_STYLE(wxBU_LEFT);
-    XRC_ADD_STYLE(wxBU_RIGHT);
-    XRC_ADD_STYLE(wxBU_TOP);
-    XRC_ADD_STYLE(wxBU_BOTTOM);
-    XRC_ADD_STYLE(wxBU_EXACTFIT);
     AddWindowStyles();
 }
 
@@ -53,6 +48,19 @@ wxObject *wxCommandLinkButtonXmlHandler::DoCreateResource()
     }
 
     SetupWindow(button);
+
+    const wxXmlNode* node = GetParamNode("pressed");
+    if (node)
+        button->SetBitmapPressed(GetBitmapBundle(node));
+    node = GetParamNode("focus");
+    if (node)
+        button->SetBitmapFocus(GetBitmapBundle(node));
+    node = GetParamNode("disabled");
+    if (node)
+        button->SetBitmapDisabled(GetBitmapBundle(node));
+    node = GetParamNode("current");
+    if (node)
+        button->SetBitmapCurrent(GetBitmapBundle(node));
 
     return button;
 }


### PR DESCRIPTION
This PR adds the missing `pressed`, `focus`, `disabled` and `current` bitmaps to **wxCommandLinkButtonXmlHandler**.

This also removes the `wxBU_...` styles from this handler because **wxCommandLinkButton** doesn't support them (per the API documentation).

This is the fourth, and I believe final button type control that supports the 4 additional bitmaps besides the main one. For post 3.2, I'll look into moving all 4 of these into a single function call.