### PR TITLE
Fix an integer promotion caused test build error

### DIFF
--- a/include/wx/rawbmp.h
+++ b/include/wx/rawbmp.h
@@ -717,7 +717,10 @@ struct wxPixelDataOut<wxBitmap>
                 {
                     wxByte mask = static_cast<wxByte>(1 << m_bit);
                     wxByte value = static_cast<wxByte>(b << m_bit);
-                    (*m_ptr &= ~mask) |= value;
+                    auto& val_m_ptr = *m_ptr;
+                    val_m_ptr = static_cast<wxByte>(val_m_ptr & ~mask);
+                    val_m_ptr |= value;
+
                     return *this;
                 }
                 operator bool() const

--- a/include/wx/rawbmp.h
+++ b/include/wx/rawbmp.h
@@ -717,7 +717,8 @@ struct wxPixelDataOut<wxBitmap>
                 {
                     wxByte mask = static_cast<wxByte>(1 << m_bit);
                     wxByte value = static_cast<wxByte>(b << m_bit);
-                    auto& val_m_ptr = *m_ptr;
+                    wxByte& val_m_ptr = *m_ptr;
+
                     val_m_ptr = static_cast<wxByte>(val_m_ptr & ~mask);
                     val_m_ptr |= value;
 


### PR DESCRIPTION
[ 89%] Building CXX object tests/headers/CMakeFiles/test_headers.dir/__/__/__/__/tests/allheaders.cpp.obj
In file included from C:\data\wxWidgets\wxWidgets-src\tests\allheaders.h:283,
                 from C:\data\wxWidgets\wxWidgets-src\tests\allheaders.cpp:412:
C:/data/wxWidgets/wxWidgets-src/include/wx/rawbmp.h: In member function 'wxPixelDataOut<wxBitmap>::wxPixelDataIn<wxPixelFormat<void, 1, -1, -1, -1, -1, bool> >::Reference& wxPixelDataOut<wxBitmap>::wxPixelDataIn<wxPixelFormat<void, 1, -1, -1, -1, -1, bool> >::Reference::operator=(bool)':
C:/data/wxWidgets/wxWidgets-src/include/wx/rawbmp.h:720:29: error: conversion from 'int' to 'wxByte' {aka 'unsigned char'} may change value [-Werror=arith-conversion]
  720 |                     (*m_ptr &= ~mask) |= value;
      |                      ~~~~~~~^~~~~~~~
cc1plus.exe: some warnings being treated as errors