### PR TITLE
Improve wxBitmapBundle scaling logic and ensure it's consistent for files and MSW resources

### DIFF
--- a/docs/doxygen/overviews/high_dpi.md
+++ b/docs/doxygen/overviews/high_dpi.md
@@ -285,6 +285,24 @@ XRC format has been updated to allow specifying wxBitmapBundle with
 multiple bitmaps or a single SVG image can be used.
 
 
+Adapting Existing Code To High DPI  {#high_dpi_existing_code}
+==================================
+
+Generally speaking, adding support for high DPI to the existing wxWidgets
+programs involves doing at least the following:
+
+1. Not using any hard-coded pixel values outside of `FromDIP()` (note that
+   this does _not_ apply to XRC).
+2. Using wxBitmapBundle containing at least 2 (normal and high DPI) bitmaps
+   instead of wxBitmap and wxImageList when setting bitmaps.
+3. Updating any custom art providers to override
+   wxArtProvider::CreateBitmapBundle() (and, of course, return multiple bitmaps
+   from it) instead of wxArtProvider::CreateBitmap().
+4. Removing any calls to wxToolBar::SetToolBitmapSize() or, equivalently,
+   `<bitmapsize>` attributes from the XRC, as this forces unwanted scaling.
+
+
+
 Platform-Specific Build Issues      {#high_dpi_platform_specific}
 ==============================
 

--- a/include/wx/bmpbndl.h
+++ b/include/wx/bmpbndl.h
@@ -230,10 +230,16 @@ protected:
     // If this function is used, GetNextAvailableScale() must be overridden!
     wxSize DoGetPreferredSize(double scale) const;
 
-    // Override this function if DoGetPreferredSize() is used: it can use the
-    // provided parameter as an internal index, it's guaranteed to be 0 when
-    // calling this function for the first time. When there are no more scales,
-    // return 0.
+    // Helper for implementing GetBitmap(): if we need to upscale a bitmap,
+    // uses GetNextAvailableScale() to find the index of the best bitmap to
+    // use, where "best" is defined as "using scale which is a divisor of the
+    // given one", as upscaling by an integer factor is strongly preferable.
+    size_t GetIndexToUpscale(const wxSize& size) const;
+
+    // Override this function if DoGetPreferredSize() or GetIndexToUpscale() is
+    // used: it can use the provided parameter as an internal index, it's
+    // guaranteed to be 0 when calling this function for the first time. When
+    // there are no more scales, return 0.
     //
     // This function is not pure virtual because it doesn't need to be
     // implemented if DoGetPreferredSize() is never used, but it will assert if

--- a/include/wx/bmpbndl.h
+++ b/include/wx/bmpbndl.h
@@ -224,6 +224,14 @@ wxBitmapBundle wxBitmapBundle::FromImage(const wxImage& image)
 class WXDLLIMPEXP_CORE wxBitmapBundleImpl : public wxRefCounter
 {
 protected:
+    // Standard implementation of GetPreferredBitmapSizeAtScale(): choose the
+    // scale closest to the given one from the available bitmap scales.
+    //
+    // Note that scales *must* be sorted in increasing scale order and there
+    // must be at least 1 of them.
+    wxSize
+    DoGetPreferredSize(double scale, size_t n, const double *availableScales) const;
+
     virtual ~wxBitmapBundleImpl();
 
 public:

--- a/include/wx/bmpbndl.h
+++ b/include/wx/bmpbndl.h
@@ -227,10 +227,19 @@ protected:
     // Standard implementation of GetPreferredBitmapSizeAtScale(): choose the
     // scale closest to the given one from the available bitmap scales.
     //
-    // Note that scales *must* be sorted in increasing scale order and there
-    // must be at least 1 of them.
-    wxSize
-    DoGetPreferredSize(double scale, size_t n, const double *availableScales) const;
+    // If this function is used, GetNextAvailableScale() must be overridden!
+    wxSize DoGetPreferredSize(double scale) const;
+
+    // Override this function if DoGetPreferredSize() is used: it can use the
+    // provided parameter as an internal index, it's guaranteed to be 0 when
+    // calling this function for the first time. When there are no more scales,
+    // return 0.
+    //
+    // This function is not pure virtual because it doesn't need to be
+    // implemented if DoGetPreferredSize() is never used, but it will assert if
+    // it's called.
+    virtual double GetNextAvailableScale(size_t& i) const;
+
 
     virtual ~wxBitmapBundleImpl();
 

--- a/interface/wx/toolbar.h
+++ b/interface/wx/toolbar.h
@@ -882,6 +882,10 @@ public:
 
         It is usually unnecessary to call this function, as the tools will
         always be made big enough to fit the size of the bitmaps used in them.
+        Moreover, calling it may force wxToolBar to scale its images, even
+        using non-integer scaling factor, which will usually look bad, instead
+        of adapting the image size to the current DPI scaling in order to avoid
+        doing this.
 
         If you do call it, it must be done before toolbar is Realize()'d.
 
@@ -893,6 +897,9 @@ public:
             ...
             toolbar->Realize();
         @endcode
+
+        Note that this example would scale bitmaps to 48 pixels when using 150%
+        DPI scaling, which wouldn't happen without calling SetToolBitmapSize().
 
         @param size
             The size of the bitmaps in the toolbar in logical pixels.

--- a/src/common/artprov.cpp
+++ b/src/common/artprov.cpp
@@ -428,8 +428,16 @@ wxBitmapBundle wxArtProvider::GetBitmapBundle(const wxArtID& id,
             const wxBitmap& bitmap = provider->CreateBitmap(id, client, size);
             if ( bitmap.IsOk() )
             {
+                // The returned bitmap bundle must have the requested default
+                // size if it is provided, but if not, use the size of the
+                // bitmap, which may be different from this size.
                 bitmapbundle = wxBitmapBundle::FromImpl(
-                        new wxBitmapBundleImplArt(id, client, bitmap.GetSize())
+                        new wxBitmapBundleImplArt(
+                                id,
+                                client,
+                                size.IsFullySpecified() ? size
+                                                        : bitmap.GetSize()
+                            )
                     );
                 break;
             }

--- a/src/common/artprov.cpp
+++ b/src/common/artprov.cpp
@@ -309,7 +309,7 @@ wxArtProvider::RescaleOrResizeIfNeeded(wxBitmap& bmp, const wxSize& sizeNeeded)
         return;
 
 #if wxUSE_IMAGE
-    if ((bmp_h <= sizeNeeded.x) && (bmp_w <= sizeNeeded.y))
+    if ((bmp_w <= sizeNeeded.x) && (bmp_h <= sizeNeeded.y))
     {
         // the caller wants default size, which is larger than
         // the image we have; to avoid degrading it visually by

--- a/src/common/artprov.cpp
+++ b/src/common/artprov.cpp
@@ -309,7 +309,11 @@ wxArtProvider::RescaleOrResizeIfNeeded(wxBitmap& bmp, const wxSize& sizeNeeded)
         return;
 
 #if wxUSE_IMAGE
-    if ((bmp_w <= sizeNeeded.x) && (bmp_h <= sizeNeeded.y))
+    // Allow upscaling by an integer factor: this looks not too horribly and is
+    // needed to use reasonably-sized bitmaps in the code not yet updated to
+    // use wxBitmapBundle but using custom art providers.
+    if ((bmp_w <= sizeNeeded.x) && (bmp_h <= sizeNeeded.y) &&
+            (sizeNeeded.x % bmp_w || sizeNeeded.y % bmp_h))
     {
         // the caller wants default size, which is larger than
         // the image we have; to avoid degrading it visually by
@@ -319,7 +323,7 @@ wxArtProvider::RescaleOrResizeIfNeeded(wxBitmap& bmp, const wxSize& sizeNeeded)
         img.Resize(sizeNeeded, offset);
         bmp = wxBitmap(img);
     }
-    else // scale (down or mixed, but not up)
+    else // scale (down or mixed, but not up, or at least not by an int factor)
 #endif // wxUSE_IMAGE
     {
         wxBitmap::Rescale(bmp, sizeNeeded);

--- a/src/common/bmpbndl.cpp
+++ b/src/common/bmpbndl.cpp
@@ -240,13 +240,17 @@ wxSize wxBitmapBundleImplSet::GetPreferredBitmapSizeAtScale(double scale) const
     const double baseY = GetDefaultSize().y;
 
     const size_t n = m_entries.size();
-    wxVector<double> scales(n);
+    wxVector<double> scales;
+    scales.reserve(n);
     for ( size_t i = 0; i < n; ++i )
     {
-        scales[i] = m_entries[i].bitmap.GetSize().y / baseY;
+        if ( m_entries[i].generated )
+            continue;
+
+        scales.push_back(m_entries[i].bitmap.GetSize().y / baseY);
     }
 
-    return DoGetPreferredSize(scale, n, &scales[0]);
+    return DoGetPreferredSize(scale, scales.size(), &scales[0]);
 }
 
 wxBitmap wxBitmapBundleImplSet::GetBitmap(const wxSize& size)

--- a/src/common/bmpbndl.cpp
+++ b/src/common/bmpbndl.cpp
@@ -721,10 +721,11 @@ wxBitmapBundleImpl::DoGetPreferredSize(double scaleTarget,
 
         // Decide whether we should use this one or the previous smaller one
         // depending on which of them is closer to the target size, breaking
-        // the tie in favour of the bigger size.
+        // the tie in favour of the smaller size as it's arguably better to use
+        // slightly smaller bitmaps than too big ones.
         const double scaleLast = availableScales[i - 1];
 
-        scaleBest = scaleThis - scaleTarget <= scaleTarget - scaleLast
+        scaleBest = scaleThis - scaleTarget < scaleTarget - scaleLast
                         ? scaleThis
                         : scaleLast;
         break;
@@ -740,7 +741,7 @@ wxBitmapBundleImpl::DoGetPreferredSize(double scaleTarget,
         // But check how far is it from the requested scale: if it's more than
         // 1.5 times larger, we should still scale it, notably to ensure that
         // bitmaps of standard size are scaled when 2x DPI scaling is used.
-        if ( scaleTarget >= 1.5*scaleMax )
+        if ( scaleTarget > 1.5*scaleMax )
         {
             // However scaling by non-integer scales doesn't work well at all, so
             // round it to the closest integer in this case.

--- a/src/common/bmpbndl.cpp
+++ b/src/common/bmpbndl.cpp
@@ -738,9 +738,18 @@ wxBitmapBundleImpl::DoGetPreferredSize(double scaleTarget,
         const double scaleMax = availableScales[n - 1];
 
         // But check how far is it from the requested scale: if it's more than
-        // 1.5 times smaller, we should still scale it, notably to ensure that
+        // 1.5 times larger, we should still scale it, notably to ensure that
         // bitmaps of standard size are scaled when 2x DPI scaling is used.
-        scaleBest = scaleTarget / scaleMax >= 1.5 ? scaleTarget : scaleMax;
+        if ( scaleTarget >= 1.5*scaleMax )
+        {
+            // However scaling by non-integer scales doesn't work well at all, so
+            // round it to the closest integer in this case.
+            scaleBest = wxRound(scaleTarget);
+        }
+        else // Target scale is not much greater than the biggest one we have.
+        {
+            scaleBest = scaleMax;
+        }
     }
 
     return GetDefaultSize()*scaleBest;

--- a/src/common/bmpbndl.cpp
+++ b/src/common/bmpbndl.cpp
@@ -803,11 +803,17 @@ size_t wxBitmapBundleImpl::GetIndexToUpscale(const wxSize& size) const
     size_t indexLast = 0;
 
     const wxSize sizeDef = GetDefaultSize();
-    for ( size_t i = 0;; indexLast = i)
+    for ( size_t i = 0;; )
     {
+        // Save it before it's updated by GetNextAvailableScale().
+        size_t indexPrev = i;
+
         const double scaleThis = GetNextAvailableScale(i);
         if ( scaleThis == 0.0 )
             break;
+
+        // Only update it now, knowing that this index could have been used.
+        indexLast = indexPrev;
 
         const double scale = size.y / (sizeDef.y*scaleThis);
         if (wxRound(scale) == scale)

--- a/src/gtk/artgtk.cpp
+++ b/src/gtk/artgtk.cpp
@@ -306,22 +306,7 @@ wxBitmap wxGTK2ArtProvider::CreateBitmap(const wxArtID& id,
     if (stocksize == GTK_ICON_SIZE_INVALID)
         stocksize = GTK_ICON_SIZE_BUTTON;
 
-    GdkPixbuf *pixbuf = CreateGtkIcon(stockid.utf8_str(), stocksize, size);
-
-    if (pixbuf && size != wxDefaultSize &&
-        (size.x != gdk_pixbuf_get_width(pixbuf) ||
-         size.y != gdk_pixbuf_get_height(pixbuf)))
-    {
-        GdkPixbuf *p2 = gdk_pixbuf_scale_simple(pixbuf, size.x, size.y,
-                                                GDK_INTERP_BILINEAR);
-        if (p2)
-        {
-            g_object_unref (pixbuf);
-            pixbuf = p2;
-        }
-    }
-
-    return wxBitmap(pixbuf);
+    return wxBitmap(CreateGtkIcon(stockid.utf8_str(), stocksize, size));
 }
 
 wxIconBundle

--- a/src/msw/artmsw.cpp
+++ b/src/msw/artmsw.cpp
@@ -210,18 +210,6 @@ static wxBitmap CreateFromStdIcon(const char *iconName,
     wxBitmap bmp;
     bmp.CopyFromIcon(icon);
 
-    // The standard native message box icons are in message box size (32x32).
-    // If they are requested in any size other than the default or message
-    // box size, they must be rescaled first.
-    if ( client != wxART_MESSAGE_BOX && client != wxART_OTHER )
-    {
-        const wxSize size = wxArtProvider::GetNativeSizeHint(client);
-        if ( size != wxDefaultSize )
-        {
-            wxBitmap::Rescale(bmp, size);
-        }
-    }
-
     return bmp;
 }
 
@@ -251,14 +239,7 @@ wxBitmap wxWindowsArtProvider::CreateBitmap(const wxArtID& id,
             bitmap = MSWGetBitmapFromIconLocation(sii.szPath, sii.iIcon,
                                                   sizeNeeded);
             if ( bitmap.IsOk() )
-            {
-                if ( bitmap.GetSize() != sizeNeeded )
-                {
-                    wxBitmap::Rescale(bitmap, sizeNeeded);
-                }
-
                 return bitmap;
-            }
         }
     }
 #endif // wxHAS_SHGetStockIconInfo

--- a/src/msw/artmsw.cpp
+++ b/src/msw/artmsw.cpp
@@ -203,16 +203,6 @@ protected:
                                   const wxSize& size) wxOVERRIDE;
 };
 
-static wxBitmap CreateFromStdIcon(const char *iconName,
-                                  const wxArtClient& client)
-{
-    wxIcon icon(iconName);
-    wxBitmap bmp;
-    bmp.CopyFromIcon(icon);
-
-    return bmp;
-}
-
 wxBitmap wxWindowsArtProvider::CreateBitmap(const wxArtID& id,
                                             const wxArtClient& client,
                                             const wxSize& size)
@@ -284,7 +274,7 @@ wxBitmap wxWindowsArtProvider::CreateBitmap(const wxArtID& id,
             name = "wxICON_QUESTION";
 
         if ( name )
-            return CreateFromStdIcon(name, client);
+            return wxIcon(name);
     }
 
     // for anything else, fall back to generic provider:

--- a/src/msw/bmpbndl.cpp
+++ b/src/msw/bmpbndl.cpp
@@ -144,6 +144,9 @@ public:
     virtual wxSize GetPreferredBitmapSizeAtScale(double scale) const wxOVERRIDE;
     virtual wxBitmap GetBitmap(const wxSize& size) wxOVERRIDE;
 
+protected:
+    virtual double GetNextAvailableScale(size_t& i) const wxOVERRIDE;
+
 private:
     // Load the bitmap from the given resource and add it m_bitmaps, after
     // rescaling it to the given size if necessary, i.e. if the needed size is
@@ -189,6 +192,11 @@ wxSize wxBitmapBundleImplRC::GetDefaultSize() const
     return m_bitmaps[0].GetSize();
 }
 
+double wxBitmapBundleImplRC::GetNextAvailableScale(size_t& i) const
+{
+    return i < m_resourceInfos.size() ? m_resourceInfos[i++].scale : 0.0;
+}
+
 wxSize wxBitmapBundleImplRC::GetPreferredBitmapSizeAtScale(double scale) const
 {
     const size_t n = m_resourceInfos.size();
@@ -198,7 +206,7 @@ wxSize wxBitmapBundleImplRC::GetPreferredBitmapSizeAtScale(double scale) const
         scales[i] = m_resourceInfos[i].scale;
     }
 
-    return DoGetPreferredSize(scale, n, &scales[0]);
+    return DoGetPreferredSize(scale);
 }
 
 wxBitmap

--- a/src/msw/bmpbndl.cpp
+++ b/src/msw/bmpbndl.cpp
@@ -269,17 +269,28 @@ wxBitmap wxBitmapBundleImplRC::GetBitmap(const wxSize& size)
 
         const wxSize sizeThis = sizeDef*info.scale;
 
-        // Use this bitmap if it's the first one bigger than the requested size
-        // or if it's the last item as in this case we're not going to find any
-        // bitmap bigger than the given one anyhow and we don't have any choice
-        // but to upscale the largest one we have.
-        if ( sizeThis.y >= size.y || i + 1 == m_resourceInfos.size() )
+        // Use this bitmap if it's the first one bigger than the requested size.
+        if ( sizeThis.y >= size.y )
             return AddBitmap(info, sizeThis, size);
     }
 
-    wxFAIL_MSG( wxS("unreachable") );
+    // We have to upscale some bitmap because we don't have any bitmaps larger
+    // than the requested size. Try to find one which can be upscaled using an
+    // integer factor.
+    const ResourceInfo* infoToRescale = NULL;
+    for ( size_t i = 0; i < m_resourceInfos.size(); ++i )
+    {
+        const ResourceInfo& info = m_resourceInfos[i];
 
-    return wxBitmap();
+        const double scale = size.y / sizeDef.y*info.scale;
+        if ( scale == wxRound(scale) )
+            infoToRescale = &info;
+    }
+
+    if ( !infoToRescale )
+        infoToRescale = &m_resourceInfos.back();
+
+    return AddBitmap(*infoToRescale, sizeDef*infoToRescale->scale, size);
 }
 
 // ============================================================================

--- a/src/msw/bmpbndl.cpp
+++ b/src/msw/bmpbndl.cpp
@@ -285,20 +285,11 @@ wxBitmap wxBitmapBundleImplRC::GetBitmap(const wxSize& size)
     // We have to upscale some bitmap because we don't have any bitmaps larger
     // than the requested size. Try to find one which can be upscaled using an
     // integer factor.
-    const ResourceInfo* infoToRescale = NULL;
-    for ( size_t i = 0; i < m_resourceInfos.size(); ++i )
-    {
-        const ResourceInfo& info = m_resourceInfos[i];
+    const size_t i = GetIndexToUpscale(size);
 
-        const double scale = size.y / sizeDef.y*info.scale;
-        if ( scale == wxRound(scale) )
-            infoToRescale = &info;
-    }
+    const ResourceInfo& info = m_resourceInfos[i];
 
-    if ( !infoToRescale )
-        infoToRescale = &m_resourceInfos.back();
-
-    return AddBitmap(*infoToRescale, sizeDef*infoToRescale->scale, size);
+    return AddBitmap(info, sizeDef*info.scale, size);
 }
 
 // ============================================================================

--- a/src/msw/bmpbndl.cpp
+++ b/src/msw/bmpbndl.cpp
@@ -191,48 +191,14 @@ wxSize wxBitmapBundleImplRC::GetDefaultSize() const
 
 wxSize wxBitmapBundleImplRC::GetPreferredBitmapSizeAtScale(double scale) const
 {
-    // Optimistically assume we're going to use this exact scale by default.
-    double scalePreferred = scale;
-
-    for ( size_t i = 0; ; ++i )
+    const size_t n = m_resourceInfos.size();
+    wxVector<double> scales(n);
+    for ( size_t i = 0; i < n; ++i )
     {
-        if ( i == m_resourceInfos.size() )
-        {
-            // The requested scale is bigger than anything we have, so use the
-            // biggest available one.
-            scalePreferred = m_resourceInfos[i - 1].scale;
-            break;
-        }
-
-        const double scaleThis = m_resourceInfos[i].scale;
-
-        // Keep looking for the exact match which we still can hope to find
-        // while the current scale is smaller.
-        if ( scaleThis < scale )
-            continue;
-
-        // If we've found the exact match, just use it.
-        if ( scaleThis == scale )
-            break;
-
-        // We've found the closest bigger scale.
-
-        // If there is no smaller one, we have no choice but to use this one.
-        if ( i == 0 )
-            break;
-
-        // Decide whether we should use this one or the previous smaller one
-        // depending on which of them is closer to the target scale, breaking
-        // the tie in favour of the bigger one.
-        const double scaleLast = m_resourceInfos[i - 1].scale;
-
-        scalePreferred = scaleThis - scale <= scale - scaleLast
-                            ? scaleThis
-                            : scaleLast;
-        break;
+        scales[i] = m_resourceInfos[i].scale;
     }
 
-    return GetDefaultSize()*scalePreferred;
+    return DoGetPreferredSize(scale, n, &scales[0]);
 }
 
 wxBitmap

--- a/tests/graphics/bmpbundle.cpp
+++ b/tests/graphics/bmpbundle.cpp
@@ -301,6 +301,7 @@ TEST_CASE("BitmapBundle::GetPreferredSize", "[bmpbundle]")
 
     CHECK_THAT( BitmapAtScale(b, 3.33), SameAs(3.0, 1.5) );
     CHECK_THAT( BitmapAtScale(b, 4.25), SameAs(4.0, 2.0) );
+    CHECK_THAT( BitmapAtScale(b, 4.50), SameAs(4.5, 1.5) );
     CHECK_THAT( BitmapAtScale(b, 5   ), SameAs(5.0, 1.0) );
 }
 

--- a/tests/graphics/bmpbundle.cpp
+++ b/tests/graphics/bmpbundle.cpp
@@ -69,10 +69,10 @@ TEST_CASE("BitmapBundle::GetPreferredSize", "[bmpbundle]")
     CHECK( b.GetPreferredBitmapSizeAtScale(1   ) == normal );
     CHECK( b.GetPreferredBitmapSizeAtScale(1.25) == normal );
     CHECK( b.GetPreferredBitmapSizeAtScale(1.4 ) == normal );
+    CHECK( b.GetPreferredBitmapSizeAtScale(1.5 ) == normal );
 
     // Once it becomes too big, we're going to need to scale, but we should be
     // scaling by an integer factor.
-    CHECK( b.GetPreferredBitmapSizeAtScale(1.5 ) == bigger );
     CHECK( b.GetPreferredBitmapSizeAtScale(1.75) == bigger );
     CHECK( b.GetPreferredBitmapSizeAtScale(2   ) == bigger );
     CHECK( b.GetPreferredBitmapSizeAtScale(2.25) == bigger );
@@ -88,14 +88,14 @@ TEST_CASE("BitmapBundle::GetPreferredSize", "[bmpbundle]")
     CHECK( b.GetPreferredBitmapSizeAtScale(1   ) == normal );
     CHECK( b.GetPreferredBitmapSizeAtScale(1.25) == normal );
     CHECK( b.GetPreferredBitmapSizeAtScale(1.4 ) == normal );
-    CHECK( b.GetPreferredBitmapSizeAtScale(1.5 ) == bigger );
+    CHECK( b.GetPreferredBitmapSizeAtScale(1.5 ) == normal );
     CHECK( b.GetPreferredBitmapSizeAtScale(1.75) == bigger );
     CHECK( b.GetPreferredBitmapSizeAtScale(2   ) == bigger );
     CHECK( b.GetPreferredBitmapSizeAtScale(2.5 ) == bigger );
+    CHECK( b.GetPreferredBitmapSizeAtScale(3   ) == bigger );
 
     // This scale is too big to use any of the existing bitmaps, so they will
     // be scaled, but use integer factors.
-    CHECK( b.GetPreferredBitmapSizeAtScale(3   ) == triple );
     CHECK( b.GetPreferredBitmapSizeAtScale(3.33) == triple );
 }
 

--- a/tests/graphics/bmpbundle.cpp
+++ b/tests/graphics/bmpbundle.cpp
@@ -272,10 +272,14 @@ TEST_CASE("BitmapBundle::GetPreferredSize", "[bmpbundle]")
     CHECK_THAT( BitmapAtScale(b, 3   ), SameAs(2) );
 
     // This scale is too big to use any of the existing bitmaps, so they will
-    // be scaled, but use integer factors.
-    CHECK_THAT( BitmapAtScale(b, 3.33), SameAs(3, 2) );
+    // be scaled, but use integer factors and, importantly, scale the correct
+    // bitmap using them: we need to scale the small bitmap by a factor of 3,
+    // rather than scaling the larger bitmap by a factor of 1.5 here, but we
+    // must also scale the larger one by a factor of 2 rather than scaling the
+    // small one by a factor of 4.
+    CHECK_THAT( BitmapAtScale(b, 3.33), SameAs(3, 1) );
     CHECK_THAT( BitmapAtScale(b, 4   ), SameAs(4, 2) );
-    CHECK_THAT( BitmapAtScale(b, 5   ), SameAs(5, 2) );
+    CHECK_THAT( BitmapAtScale(b, 5   ), SameAs(5, 1) );
 
 
     // Finally check that things work as expected when we have 3 versions.
@@ -294,6 +298,10 @@ TEST_CASE("BitmapBundle::GetPreferredSize", "[bmpbundle]")
     CHECK_THAT( BitmapAtScale(b, 2   ), SameAs(2.0) );
     CHECK_THAT( BitmapAtScale(b, 2.5 ), SameAs(2.0) );
     CHECK_THAT( BitmapAtScale(b, 3   ), SameAs(2.0) );
+
+    CHECK_THAT( BitmapAtScale(b, 3.33), SameAs(3.0, 1.5) );
+    CHECK_THAT( BitmapAtScale(b, 4.25), SameAs(4.0, 2.0) );
+    CHECK_THAT( BitmapAtScale(b, 5   ), SameAs(5.0, 1.0) );
 }
 
 #ifdef wxHAS_DPI_INDEPENDENT_PIXELS

--- a/tests/graphics/bmpbundle.cpp
+++ b/tests/graphics/bmpbundle.cpp
@@ -50,6 +50,15 @@ TEST_CASE("BitmapBundle::FromBitmaps", "[bmpbundle]")
     CHECK( b.GetBitmap(wxSize(24, 24)).GetSize() == wxSize(24, 24) );
 }
 
+TEST_CASE("BitmapBundle::GetBitmap", "[bmpbundle]")
+{
+    const wxBitmapBundle b = wxBitmapBundle::FromBitmap(wxBitmap(16, 16));
+
+    CHECK( b.GetBitmap(wxSize(16, 16)).GetSize() == wxSize(16, 16) );
+    CHECK( b.GetBitmap(wxSize(32, 32)).GetSize() == wxSize(32, 32) );
+    CHECK( b.GetBitmap(wxSize(24, 24)).GetSize() == wxSize(24, 24) );
+}
+
 // Helper functions for the test below.
 namespace
 {

--- a/tests/graphics/bmpbundle.cpp
+++ b/tests/graphics/bmpbundle.cpp
@@ -15,6 +15,7 @@
 #include "wx/bmpbndl.h"
 
 #include "wx/artprov.h"
+#include "wx/dcmemory.h"
 
 #include "asserthelper.h"
 
@@ -49,54 +50,250 @@ TEST_CASE("BitmapBundle::FromBitmaps", "[bmpbundle]")
     CHECK( b.GetBitmap(wxSize(24, 24)).GetSize() == wxSize(24, 24) );
 }
 
+// Helper functions for the test below.
+namespace
+{
+
+// Default size here doesn't really matter.
+const wxSize BITMAP_SIZE(16, 16);
+
+// The choice of colours here is arbitrary too, but they need to be all
+// different to allow identifying which bitmap got scaled.
+struct ColourAtScale
+{
+    double scale;
+    wxUint32 rgb;
+};
+
+const ColourAtScale colours[] =
+{
+    { 1.0, 0x000000ff },
+    { 1.5, 0x0000ff00 },
+    { 2.0, 0x00ff0000 },
+};
+
+// Return the colour used for the (original) bitmap at the given scale.
+wxColour GetColourForScale(double scale)
+{
+    wxColour col;
+    for ( size_t n = 0; n < WXSIZEOF(colours); ++n )
+    {
+        if ( colours[n].scale == scale )
+        {
+            col.SetRGB(colours[n].rgb);
+            return col;
+        }
+    }
+
+    wxFAIL_MSG("no colour for this scale");
+
+    return col;
+}
+
+double GetScaleFromColour(const wxColour& col)
+{
+    const wxUint32 rgb = col.GetRGB();
+    for ( size_t n = 0; n < WXSIZEOF(colours); ++n )
+    {
+        if ( colours[n].rgb == rgb )
+            return colours[n].scale;
+    }
+
+    wxFAIL_MSG(wxString::Format("no scale for colour %s", col.GetAsString()));
+
+    return 0.0;
+}
+
+double SizeToScale(const wxSize& size)
+{
+    return static_cast<double>(size.y) / BITMAP_SIZE.y;
+}
+
+wxBitmap MakeSolidBitmap(double scale)
+{
+    wxBitmap bmp(BITMAP_SIZE*scale);
+
+    wxMemoryDC dc(bmp);
+    dc.SetBackground(GetColourForScale(scale));
+    dc.Clear();
+
+    return bmp;
+}
+
+wxColour GetBitmapColour(const wxBitmap& bmp)
+{
+    const wxImage img = bmp.ConvertToImage();
+
+    // We just assume the bitmap is solid colour, we could check it, but it
+    // doesn't seem really useful to do it.
+    return wxColour(img.GetRed(0, 0), img.GetGreen(0, 0), img.GetBlue(0, 0));
+}
+
+// This struct exists just to allow using it conveniently in CHECK_THAT().
+struct BitmapAtScale
+{
+    BitmapAtScale(const wxBitmapBundle& b, double scale)
+        : size(b.GetPreferredBitmapSizeAtScale(scale)),
+          bitmap(b.GetBitmap(size))
+    {
+    }
+
+    const wxSize size;
+    const wxBitmap bitmap;
+};
+
+class BitmapAtScaleMatcher : public Catch::MatcherBase<BitmapAtScale>
+{
+public:
+    explicit BitmapAtScaleMatcher(double scale, double scaleOrig)
+        : m_scale(scale),
+          m_scaleOrig(scaleOrig)
+    {
+    }
+
+    bool match(const BitmapAtScale& bitmapAtScale) const wxOVERRIDE
+    {
+        const wxBitmap& bmp = bitmapAtScale.bitmap;
+
+        if ( SizeToScale(bitmapAtScale.size) != m_scale ||
+                SizeToScale(bmp.GetSize()) != m_scale )
+        {
+            m_diffDesc.Printf("should have scale %.1f", m_scale);
+        }
+
+        if ( GetBitmapColour(bmp) != GetColourForScale(m_scaleOrig) )
+        {
+            if ( m_diffDesc.empty() )
+                m_diffDesc = "should be ";
+            else
+                m_diffDesc += " and be ";
+
+            m_diffDesc += wxString::Format("created from x%.1f", m_scaleOrig);
+        }
+
+        return m_diffDesc.empty();
+    }
+
+    std::string describe() const wxOVERRIDE
+    {
+        return m_diffDesc.utf8_string();
+    }
+
+private:
+    const double m_scale;
+    const double m_scaleOrig;
+    mutable wxString m_diffDesc;
+};
+
+// The first parameter here determines the size of the expected bitmap and the
+// second one, which defaults to the first one if it's not specified, the size
+// of the bitmap which must have been scaled to create the bitmap of the right
+// size.
+BitmapAtScaleMatcher SameAs(double scale, double scaleOrig = 0.0)
+{
+    if ( scaleOrig == 0.0 )
+        scaleOrig = scale;
+
+    return BitmapAtScaleMatcher(scale, scaleOrig);
+}
+
+} // anonymous namespace
+
+namespace Catch
+{
+    template <>
+    struct StringMaker<BitmapAtScale>
+    {
+        static std::string convert(const BitmapAtScale& bitmapAtScale)
+        {
+            const wxBitmap& bmp = bitmapAtScale.bitmap;
+
+            wxString scaleError;
+            if ( bmp.GetSize() != bitmapAtScale.size )
+            {
+                scaleError.Printf(" (DIFFERENT from expected %.1f)",
+                                  SizeToScale(bitmapAtScale.size));
+            }
+
+            return wxString::Format
+                   (
+                        "x%.1f bitmap%s created from x%.1f",
+                        SizeToScale(bmp.GetSize()),
+                        scaleError,
+                        GetScaleFromColour(GetBitmapColour(bmp))
+                   ).utf8_string();
+        }
+    };
+}
+
 TEST_CASE("BitmapBundle::GetPreferredSize", "[bmpbundle]")
 {
     // Check that empty bundle doesn't have any preferred size.
     wxBitmapBundle b;
     CHECK( b.GetPreferredBitmapSizeAtScale(1) == wxDefaultSize );
 
-    const wxSize normal(32, 32);
-    const wxSize bigger(64, 64);
-    const wxSize triple(96, 96);
+    const wxBitmap normal = MakeSolidBitmap(1.0);
+    const wxBitmap middle = MakeSolidBitmap(1.5);
+    const wxBitmap bigger = MakeSolidBitmap(2.0);
 
 
     // Then check what happens if there is only a single bitmap.
-    b = wxBitmapBundle::FromBitmap(wxBitmap(normal));
+    b = wxBitmapBundle::FromBitmap(normal);
 
     // We should avoid scaling as long as the size is close enough to the
     // actual bitmap size.
-    CHECK( b.GetPreferredBitmapSizeAtScale(0   ) == normal );
-    CHECK( b.GetPreferredBitmapSizeAtScale(1   ) == normal );
-    CHECK( b.GetPreferredBitmapSizeAtScale(1.25) == normal );
-    CHECK( b.GetPreferredBitmapSizeAtScale(1.4 ) == normal );
-    CHECK( b.GetPreferredBitmapSizeAtScale(1.5 ) == normal );
+    CHECK_THAT( BitmapAtScale(b, 0   ), SameAs(1) );
+    CHECK_THAT( BitmapAtScale(b, 1   ), SameAs(1) );
+    CHECK_THAT( BitmapAtScale(b, 1.25), SameAs(1) );
+    CHECK_THAT( BitmapAtScale(b, 1.4 ), SameAs(1) );
+    CHECK_THAT( BitmapAtScale(b, 1.5 ), SameAs(1) );
 
     // Once it becomes too big, we're going to need to scale, but we should be
     // scaling by an integer factor.
-    CHECK( b.GetPreferredBitmapSizeAtScale(1.75) == bigger );
-    CHECK( b.GetPreferredBitmapSizeAtScale(2   ) == bigger );
-    CHECK( b.GetPreferredBitmapSizeAtScale(2.25) == bigger );
-    CHECK( b.GetPreferredBitmapSizeAtScale(2.5 ) == triple );
+    CHECK_THAT( BitmapAtScale(b, 1.75), SameAs(2, 1) );
+    CHECK_THAT( BitmapAtScale(b, 2   ), SameAs(2, 1) );
+    CHECK_THAT( BitmapAtScale(b, 2.25), SameAs(2, 1) );
+    CHECK_THAT( BitmapAtScale(b, 2.5 ), SameAs(3, 1) );
 
 
     // Now check what happens when there is also a double size bitmap.
-    b = wxBitmapBundle::FromBitmaps(wxBitmap(normal), wxBitmap(bigger));
+    b = wxBitmapBundle::FromBitmaps(normal, bigger);
 
     // Check that the existing bitmaps are used without scaling for most of the
     // typical scaling values.
-    CHECK( b.GetPreferredBitmapSizeAtScale(0   ) == normal );
-    CHECK( b.GetPreferredBitmapSizeAtScale(1   ) == normal );
-    CHECK( b.GetPreferredBitmapSizeAtScale(1.25) == normal );
-    CHECK( b.GetPreferredBitmapSizeAtScale(1.4 ) == normal );
-    CHECK( b.GetPreferredBitmapSizeAtScale(1.5 ) == normal );
-    CHECK( b.GetPreferredBitmapSizeAtScale(1.75) == bigger );
-    CHECK( b.GetPreferredBitmapSizeAtScale(2   ) == bigger );
-    CHECK( b.GetPreferredBitmapSizeAtScale(2.5 ) == bigger );
-    CHECK( b.GetPreferredBitmapSizeAtScale(3   ) == bigger );
+    CHECK_THAT( BitmapAtScale(b, 0   ), SameAs(1) );
+    CHECK_THAT( BitmapAtScale(b, 1   ), SameAs(1) );
+    CHECK_THAT( BitmapAtScale(b, 1.25), SameAs(1) );
+    CHECK_THAT( BitmapAtScale(b, 1.4 ), SameAs(1) );
+    CHECK_THAT( BitmapAtScale(b, 1.5 ), SameAs(1) );
+    CHECK_THAT( BitmapAtScale(b, 1.75), SameAs(2) );
+    CHECK_THAT( BitmapAtScale(b, 2   ), SameAs(2) );
+    CHECK_THAT( BitmapAtScale(b, 2.5 ), SameAs(2) );
+    CHECK_THAT( BitmapAtScale(b, 3   ), SameAs(2) );
 
     // This scale is too big to use any of the existing bitmaps, so they will
     // be scaled, but use integer factors.
-    CHECK( b.GetPreferredBitmapSizeAtScale(3.33) == triple );
+    CHECK_THAT( BitmapAtScale(b, 3.33), SameAs(3, 2) );
+    CHECK_THAT( BitmapAtScale(b, 4   ), SameAs(4, 2) );
+    CHECK_THAT( BitmapAtScale(b, 5   ), SameAs(5, 2) );
+
+
+    // Finally check that things work as expected when we have 3 versions.
+    wxVector<wxBitmap> bitmaps;
+    bitmaps.push_back(normal);
+    bitmaps.push_back(middle);
+    bitmaps.push_back(bigger);
+    b = wxBitmapBundle::FromBitmaps(bitmaps);
+
+    CHECK_THAT( BitmapAtScale(b, 0   ), SameAs(1.0) );
+    CHECK_THAT( BitmapAtScale(b, 1   ), SameAs(1.0) );
+    CHECK_THAT( BitmapAtScale(b, 1.25), SameAs(1.0) );
+    CHECK_THAT( BitmapAtScale(b, 1.4 ), SameAs(1.5) );
+    CHECK_THAT( BitmapAtScale(b, 1.5 ), SameAs(1.5) );
+    CHECK_THAT( BitmapAtScale(b, 1.75), SameAs(1.5) );
+    CHECK_THAT( BitmapAtScale(b, 2   ), SameAs(2.0) );
+    CHECK_THAT( BitmapAtScale(b, 2.5 ), SameAs(2.0) );
+    CHECK_THAT( BitmapAtScale(b, 3   ), SameAs(2.0) );
 }
 
 #ifdef wxHAS_DPI_INDEPENDENT_PIXELS


### PR DESCRIPTION
This is related to #22449, please see the discussion there for the full context, but the brief summary is that we now do our utmost to only upscale bitmaps by integer scale factors, as this is the only thing which works reasonably well (i.e. not horribly) in practice.

Please also check the new unit tests that describe in a hopefully relatively clear the expected behaviour (note that many of them would have failed without the rest of the changes here).