### PR TITLE
Always call wxSecureZeroMemory() to wipe memory in wxSecretValue

### DIFF
--- a/include/wx/secretstore.h
+++ b/include/wx/secretstore.h
@@ -170,6 +170,8 @@ private:
 
 #else // !wxUSE_SECRETSTORE
 
+#include "wx/utils.h"
+
 // Provide stand in for wxSecretValue allowing to use it without having #if
 // wxUSE_SECRETSTORE checks everywhere. Unlike the real version, this class
 // doesn't provide any added security.
@@ -211,7 +213,7 @@ public:
         return m_data;
     }
 
-    static void Wipe(size_t size, void *data) { memset(data, 0, size); }
+    static void Wipe(size_t size, void *data) { wxSecureZeroMemory(data, size); }
     static void WipeString(wxString& str)
     {
         str.assign(str.length(), '*');

--- a/src/common/secretstore.cpp
+++ b/src/common/secretstore.cpp
@@ -25,6 +25,7 @@
 
 #include "wx/log.h"
 #include "wx/translation.h"
+#include "wx/utils.h"
 
 #include "wx/private/secretstore.h"
 
@@ -114,18 +115,11 @@ wxString wxSecretValue::GetAsString(const wxMBConv& conv) const
            );
 }
 
-#ifndef __WINDOWS__
-
 /* static */
 void wxSecretValue::Wipe(size_t size, void *data)
 {
-    // memset_s() is not present under non-MSW systems anyhow and there doesn't
-    // seem to be any other way to portably ensure that the memory is really
-    // cleared, so just do it in this obvious way.
-    memset(data, 0, size);
+    wxSecureZeroMemory(data, size);
 }
-
-#endif // __WINDOWS__
 
 /* static */
 void wxSecretValue::WipeString(wxString& str)

--- a/src/msw/secretstore.cpp
+++ b/src/msw/secretstore.cpp
@@ -140,12 +140,6 @@ wxSecretValueImpl* wxSecretValue::NewImpl(size_t size, const void *data)
 }
 
 /* static */
-void wxSecretValue::Wipe(size_t size, void *data)
-{
-    ::SecureZeroMemory(data, size);
-}
-
-/* static */
 wxSecretStore wxSecretStore::GetDefault()
 {
     // There is only a single store under Windows anyhow.


### PR DESCRIPTION
Replaces a call to MSW native ::SecureZeroMemory(), and calls to plain
memset().

A sequel to PR #2582.