### PR TITLE
Improve handling toolbar tools bitmap size

### DIFF
--- a/docs/doxygen/overviews/high_dpi.md
+++ b/docs/doxygen/overviews/high_dpi.md
@@ -299,7 +299,8 @@ programs involves doing at least the following:
    wxArtProvider::CreateBitmapBundle() (and, of course, return multiple bitmaps
    from it) instead of wxArtProvider::CreateBitmap().
 4. Removing any calls to wxToolBar::SetToolBitmapSize() or, equivalently,
-   `<bitmapsize>` attributes from the XRC, as this forces unwanted scaling.
+   `<bitmapsize>` attributes from the XRC, as this overrides the best size
+   determination and may result in suboptimal appearance.
 
 
 

--- a/include/wx/bmpbndl.h
+++ b/include/wx/bmpbndl.h
@@ -154,13 +154,9 @@ public:
     // Get the bitmap size preferred by the majority of the elements of the
     // bundles at the given scale or the scale appropriate for the given window.
     static wxSize
-    GetConsensusSizeFor(double scale,
-                        const wxVector<wxBitmapBundle>& bundles,
-                        const wxSize& sizeDefault);
+    GetConsensusSizeFor(double scale, const wxVector<wxBitmapBundle>& bundles);
     static wxSize
-    GetConsensusSizeFor(wxWindow* win,
-                        const wxVector<wxBitmapBundle>& bundles,
-                        const wxSize& sizeDefault);
+    GetConsensusSizeFor(wxWindow* win, const wxVector<wxBitmapBundle>& bundles);
 
     // Create wxImageList and fill it with the images from the given bundles in
     // the sizes appropriate for the DPI scaling used for the specified window.

--- a/include/wx/bmpbndl.h
+++ b/include/wx/bmpbndl.h
@@ -152,7 +152,11 @@ public:
     // Implementation only from now on.
 
     // Get the bitmap size preferred by the majority of the elements of the
-    // bundles at the scale appropriate for the given scale.
+    // bundles at the given scale or the scale appropriate for the given window.
+    static wxSize
+    GetConsensusSizeFor(double scale,
+                        const wxVector<wxBitmapBundle>& bundles,
+                        const wxSize& sizeDefault);
     static wxSize
     GetConsensusSizeFor(wxWindow* win,
                         const wxVector<wxBitmapBundle>& bundles,

--- a/interface/wx/toolbar.h
+++ b/interface/wx/toolbar.h
@@ -882,24 +882,21 @@ public:
 
         It is usually unnecessary to call this function, as the tools will
         always be made big enough to fit the size of the bitmaps used in them.
-        Moreover, calling it may force wxToolBar to scale its images, even
-        using non-integer scaling factor, which will usually look bad, instead
-        of adapting the image size to the current DPI scaling in order to avoid
-        doing this.
+        Moreover, calling it forces wxToolBar to scale its images in high DPI
+        using the provided size, instead of letting wxBitmapBundle used for the
+        tool bitmaps determine the best suitable bitmap size, which may result
+        in suboptimal appearance.
 
         If you do call it, it must be done before toolbar is Realize()'d.
 
         Example of using this function to force the bitmaps to be at least
-        32 pixels wide and tall:
+        32 pixels wide and tall (at normal DPI):
         @code
             toolbar->SetToolBitmapSize(FromDIP(wxSize(32, 32)));
             toolbar->AddTool(wxID_NEW, "New", wxBitmapBundle::FromXXX(...));
             ...
             toolbar->Realize();
         @endcode
-
-        Note that this example would scale bitmaps to 48 pixels when using 150%
-        DPI scaling, which wouldn't happen without calling SetToolBitmapSize().
 
         @param size
             The size of the bitmaps in the toolbar in logical pixels.

--- a/src/common/bmpbndl.cpp
+++ b/src/common/bmpbndl.cpp
@@ -596,7 +596,15 @@ wxBitmapBundle::GetConsensusSizeFor(wxWindow* win,
                                     const wxVector<wxBitmapBundle>& bundles,
                                     const wxSize& sizeDefault)
 {
-    const double scale = win->GetDPIScaleFactor();
+    return GetConsensusSizeFor(win->GetDPIScaleFactor(), bundles, sizeDefault);
+}
+
+/* static */
+wxSize
+wxBitmapBundle::GetConsensusSizeFor(double scale,
+                                    const wxVector<wxBitmapBundle>& bundles,
+                                    const wxSize& sizeDefault)
+{
     const wxSize sizeIdeal = sizeDefault*scale;
 
     // We want to use preferred bitmap size, but the preferred sizes can be

--- a/src/common/bmpbndl.cpp
+++ b/src/common/bmpbndl.cpp
@@ -593,20 +593,16 @@ void RecordSizePref(SizePrefs& prefs, const wxSize& size)
 /* static */
 wxSize
 wxBitmapBundle::GetConsensusSizeFor(wxWindow* win,
-                                    const wxVector<wxBitmapBundle>& bundles,
-                                    const wxSize& sizeDefault)
+                                    const wxVector<wxBitmapBundle>& bundles)
 {
-    return GetConsensusSizeFor(win->GetDPIScaleFactor(), bundles, sizeDefault);
+    return GetConsensusSizeFor(win->GetDPIScaleFactor(), bundles);
 }
 
 /* static */
 wxSize
 wxBitmapBundle::GetConsensusSizeFor(double scale,
-                                    const wxVector<wxBitmapBundle>& bundles,
-                                    const wxSize& sizeDefault)
+                                    const wxVector<wxBitmapBundle>& bundles)
 {
-    const wxSize sizeIdeal = sizeDefault*scale;
-
     // We want to use preferred bitmap size, but the preferred sizes can be
     // different for different bitmap bundles, so record all their preferences
     // first.
@@ -631,25 +627,13 @@ wxBitmapBundle::GetConsensusSizeFor(double scale,
         }
         else if ( countThis == countMax )
         {
-            // We have a tie between different sizes, choose the one
-            // corresponding to the current scale factor, if possible, as this
-            // is the ideal bitmap size that should be consistent with all the
-            // other bitmaps.
-            if ( sizePreferred != sizeIdeal )
-            {
-                if ( sizeThis == sizeIdeal )
-                {
-                    sizePreferred = sizeThis;
-                }
-                else // Neither of the sizes is the ideal one.
-                {
-                    // Choose the larger one as like this some bitmaps will be
-                    // downscaled, which should look better than upscaling some
-                    // (other) ones.
-                    if ( sizeThis.y > sizePreferred.y )
-                        sizePreferred = sizeThis;
-                }
-            }
+            // We have a tie between different sizes.
+
+            // Choose the larger one as like this some bitmaps will be
+            // downscaled, which should look better than upscaling some
+            // (other) ones.
+            if ( sizeThis.y > sizePreferred.y )
+                sizePreferred = sizeThis;
         }
     }
 
@@ -664,12 +648,7 @@ wxBitmapBundle::CreateImageList(wxWindow* win,
     wxCHECK_MSG( win, NULL, "must have a valid window" );
     wxCHECK_MSG( !bundles.empty(), NULL, "should have some images" );
 
-    // We arbitrarily choose the default size of the first bundle as the
-    // default size for the image list too, as it's not clear what else could
-    // we do here. Note that this size is only used to break the tie in case
-    // the same number of bundles prefer two different sizes, so it's not going
-    // to matter at all in most cases.
-    wxSize size = GetConsensusSizeFor(win, bundles, bundles[0].GetDefaultSize());
+    wxSize size = GetConsensusSizeFor(win, bundles);
 
     // wxImageList wants the logical size for the platforms where logical and
     // physical pixels are different.

--- a/src/common/bmpcboxcmn.cpp
+++ b/src/common/bmpcboxcmn.cpp
@@ -72,8 +72,7 @@ void wxBitmapComboBoxBase::UpdateInternals()
         m_usedImgSize = wxBitmapBundle::GetConsensusSizeFor
                         (
                             GetControl(),
-                            m_bitmapbundles,
-                            wxSize(0, 0)
+                            m_bitmapbundles
                         );
     }
 }

--- a/src/common/tbarbase.cpp
+++ b/src/common/tbarbase.cpp
@@ -475,7 +475,23 @@ void wxToolBarBase::AdjustToolBitmapSize()
             bundles.push_back(bmp);
     }
 
-    if ( !bundles.empty() )
+    if ( bundles.empty() )
+        return;
+
+    wxSize sizeNeeded;
+
+    if ( m_requestedBitmapSize != wxSize(0, 0) )
+    {
+        // If we have a fixed requested bitmap size, use it, but scale it by
+        // integer factor only, as otherwise we'd force fractional (and hence
+        // ugly looking) scaling here whenever fractional DPI scaling is used.
+
+        // We want to round 1.5 down to 1, but 1.75 up to 2.
+        int scaleFactorRoundedDown =
+            static_cast<int>(ceil(2*GetDPIScaleFactor())) / 2;
+        sizeNeeded = m_requestedBitmapSize*scaleFactorRoundedDown;
+    }
+    else // Determine the best size to use from the bitmaps we have.
     {
         wxSize sizePreferred = wxBitmapBundle::GetConsensusSizeFor
                                (
@@ -492,22 +508,17 @@ void wxToolBarBase::AdjustToolBitmapSize()
         // scale factor may be different from 1) use this size at all
         // currently, so it shouldn't matter. But if/when they are modified to
         // use the size computed here, this would need to be revisited.
-        sizePreferred = FromPhys(sizePreferred);
+        sizeNeeded = FromPhys(sizePreferred);
+    }
 
-        // Don't decrease the bitmap below the size requested by the application
-        // as using larger bitmaps shouldn't shrink them to the small default
-        // size.
-        sizePreferred.IncTo(FromDIP(m_requestedBitmapSize));
-
-        // No need to change the bitmaps size if it doesn't really change.
-        if ( sizePreferred == sizeOrig )
-            return;
-
+    // No need to change the bitmaps size if it doesn't really change.
+    if ( sizeNeeded != sizeOrig )
+    {
         // Call DoSetToolBitmapSize() and not SetToolBitmapSize() to avoid
         // changing the requested bitmap size: if we set our own adjusted size
         // as the preferred one, we wouldn't decrease it later even if we ought
         // to, as when moving from a monitor with higher DPI to a lower-DPI one.
-        DoSetToolBitmapSize(sizePreferred);
+        DoSetToolBitmapSize(sizeNeeded);
     }
 }
 

--- a/src/common/tbarbase.cpp
+++ b/src/common/tbarbase.cpp
@@ -493,12 +493,8 @@ void wxToolBarBase::AdjustToolBitmapSize()
     }
     else // Determine the best size to use from the bitmaps we have.
     {
-        wxSize sizePreferred = wxBitmapBundle::GetConsensusSizeFor
-                               (
-                                this,
-                                bundles,
-                                ToDIP(sizeOrig)
-                               );
+        const wxSize
+            sizePreferred = wxBitmapBundle::GetConsensusSizeFor(this, bundles);
 
         // GetConsensusSizeFor() returns physical size, but we want to operate
         // with logical pixels as everything else is expressed in them.

--- a/tests/graphics/bmpbundle.cpp
+++ b/tests/graphics/bmpbundle.cpp
@@ -460,3 +460,34 @@ TEST_CASE("BitmapBundle::Scale", "[bmpbundle][scale]")
 }
 
 #endif // ports with scaled bitmaps support
+
+TEST_CASE("BitmapBundle::GetConsensusSize", "[bmpbundle]")
+{
+    // Just a trivial helper to make writing the tests below simpler.
+    struct Bundles
+    {
+        wxVector<wxBitmapBundle> vec;
+
+        void Add(int size)
+        {
+            vec.push_back(wxBitmapBundle::FromBitmap(wxSize(size, size)));
+        }
+
+        int GetConsensusSize(double scale) const
+        {
+            return wxBitmapBundle::GetConsensusSizeFor(scale, vec, wxSize()).y;
+        }
+    } bundles;
+
+    // When there is a tie, a larger size is chosen by default.
+    bundles.Add(16);
+    bundles.Add(24);
+    CHECK( bundles.GetConsensusSize(2) == 48 );
+
+    // Breaking the tie results in the smaller size winning now.
+    bundles.Add(16);
+    CHECK( bundles.GetConsensusSize(2) == 32 );
+
+    // Integer scaling factors should be preferred.
+    CHECK( bundles.GetConsensusSize(1.5) == 16 );
+}

--- a/tests/graphics/bmpbundle.cpp
+++ b/tests/graphics/bmpbundle.cpp
@@ -475,7 +475,7 @@ TEST_CASE("BitmapBundle::GetConsensusSize", "[bmpbundle]")
 
         int GetConsensusSize(double scale) const
         {
-            return wxBitmapBundle::GetConsensusSizeFor(scale, vec, wxSize()).y;
+            return wxBitmapBundle::GetConsensusSizeFor(scale, vec).y;
         }
     } bundles;
 


### PR DESCRIPTION
To continue the discussion from [your comment in the other PR](https://github.com/wxWidgets/wxWidgets/pull/22481#issuecomment-1146644195):

> > i.e. sizeOrig*int(scale) instead of using ToDIP(). Do you see any reason not to do this?
> 
> I'm more than a little confused by the code involved:

After thinking about this all again, I've realized that I couldn't really explain what was this code doing myself neither, which seems like a good reason not to keep it -- so I didn't. As you can see, I've changed it significantly now and so none of these points:
 
>     1. ~The default size is 16x15 — how is that not causing problems, but other sizes are?~ (because default size is minimum)
> 
>     2. Why is the code explicitly allowing downscaling only in the very edge case of a) different tool sizes, b) with equal count of both, c) that doesn't happen to match the ideal size https://github.com/wxWidgets/wxWidgets/blob/731d29baceda04c5781c6e204cec3d9df8fe9d53/src/common/bmpbndl.cpp#L670-L677
>         I mean, why even bother?
> 
>     3. Why is it feeding the determined size back as the ideal size next time this function runs? Should the input to GetConsensusSizeFor be `m_requestedBitmapSize` only?

should be relevant any longer.

> I would make a different choice in the snippet above - in a tie, I would pick the size closer to `sizeIdeal`, instead of the larger one.

I couldn't even decide what `sizeIdeal` was supposed to be, so I've just dropped it, making this one moot as well.

More generally speaking, I've made `GetConsensusSizeFor()` testable now and while the existing tests are pretty trivial, it should be easy enough to add more test cases, in particular if we find any cases where it doesn't return the expected result. And if we restore `sizeIdeal` parameter in the future, we'd definitely need to add tests verifying that it works as expected (which would at least force us to define what is the expected behaviour).

> As for using `sizeOrig*int(scale)` instead of `ToDIP()`, unless I'm missing something it would be incorrect:
> 
>     1. `sizeOrig` (aka m_defaultWidth/m_defaultHeight) is expressed in physical pixels

Just to clarify a possible misconception: no, it's expressed in logical pixels. I've agonized a long time over this, but I'm relatively confident that this was the best choice and, at the very least, it's documented as being in LPs:

https://github.com/wxWidgets/wxWidgets/blob/34fa234f48f30bd8fef0f442f55debceafa501bf/interface/wx/toolbar.h#L904-L905

>     2. `ToDIP(sizeOrig)` converts it to DIP
> 
>     3. In `GetConsensusSizeFor` it is immediately converted back by multiplying it by `win->GetDPIScaleFactor()`
> 
>     4. (…and isn't actually used for much)

(and now not at all)

> You're right that calling `SetToolBitmapSize()` may be common.

Yes, see also [this post](https://groups.google.com/g/wx-dev/c/rPPODkXKv2k/m/Ii2gU48FBgAJ).

> Unless I misunderstand the problem, I would:
> 
>     1. Outright deprecate `SetToolBitmapSize()`

We could do this, but it would be better not to and I think we may keep it with this PR.
 
>     2. Either ignore the value provided or only use it as hint for `GetConsensusSizeFor`, but don't `IncTo` to it (possibly only if scaling factor > 1.0)

None of this would help with actually selecting the correct bitmap size. E.g. doing this would mean that toggling the bitmap size in the toolbar sample doesn't work at all.
 
>     3. When adjusting the size, use resize, not rescale — I'm not sure if it is feasible, if this is done in win32, probably not

It would be feasible, but I don't see what's the point of having big toolbar buttons with small bitmaps in the middle of them? The current behaviour seems better to me and more consistent with the other controls.

I know I'm asking for a lot, but it would be great if you could please check how does it affect Poedit. Thanks again!