### PR TITLE
Fix memory leak in ListBox destructor

### DIFF
--- a/src/univ/listbox.cpp
+++ b/src/univ/listbox.cpp
@@ -197,7 +197,7 @@ bool wxListBox::Create(wxWindow *parent,
 wxListBox::~wxListBox()
 {
     // call this just to free the client data -- and avoid leaking memory
-    DoClear();
+    Clear();
 
     if ( IsSorted() )
         delete m_strings.sorted;


### PR DESCRIPTION
Memory is allocate in wxGenericFileCtrl::SetWildcard when client data [append](https://github.com/wxWidgets/wxWidgets/blob/master/src/generic/filectrlg.cpp#L1202) to container but the memory is never released because [wxItemContainer::Clear](https://github.com/wxWidgets/wxWidgets/blob/master/src/common/ctrlsub.cpp#L92-L104) isn't called. DoClear() is called from Clear.