### PR TITLE
Fix GetColumnCount for wxLC_LIST style

### DIFF
--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -566,6 +566,11 @@ public:
 
     /**
         Returns the number of columns.
+
+        The control can have multiple columns only in wxLC_REPORT mode. In
+        wxLC_LIST mode this function returns 1, as a list is still considered
+        to have a (single) column. In wxLC_SMALL_ICON and wxLC_ICON modes, it
+        returns 0 as there are no columns at all.
     */
     int GetColumnCount() const;
 

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -2349,7 +2349,7 @@ void wxListMainWindow::SendNotify( size_t line,
 
     // provide information about the (first column of the) item in the event if
     // we have a valid item and any columns at all
-    if ( line != (size_t)-1 && GetColumnCount() )
+    if ( line != (size_t)-1 && GetListCtrl()->GetColumnCount() )
     {
         GetLine(line)->GetItem( 0, le.m_item );
     }
@@ -5353,7 +5353,9 @@ int wxGenericListCtrl::GetItemCount() const
 
 int wxGenericListCtrl::GetColumnCount() const
 {
-    return m_mainWin->GetColumnCount();
+    if ( !HasFlag(wxLC_LIST) )
+        return m_mainWin->GetColumnCount();
+    return 1;
 }
 
 void wxGenericListCtrl::SetItemSpacing( int spacing, bool isSmall )

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -2331,8 +2331,10 @@ void wxListMainWindow::SendNotify( size_t line,
                                    wxEventType command,
                                    const wxPoint& point )
 {
-    wxListEvent le( command, GetParent()->GetId() );
-    le.SetEventObject( GetParent() );
+    wxGenericListCtrl* const listctrl = GetListCtrl();
+
+    wxListEvent le( command, listctrl->GetId() );
+    le.SetEventObject( listctrl );
 
     le.m_item.m_itemId =
     le.m_itemIndex = line;
@@ -2349,12 +2351,12 @@ void wxListMainWindow::SendNotify( size_t line,
 
     // provide information about the (first column of the) item in the event if
     // we have a valid item and any columns at all
-    if ( line != (size_t)-1 && GetListCtrl()->GetColumnCount() )
+    if ( line != (size_t)-1 && listctrl->GetColumnCount() )
     {
         GetLine(line)->GetItem( 0, le.m_item );
     }
 
-    GetParent()->GetEventHandler()->ProcessEvent( le );
+    listctrl->GetEventHandler()->ProcessEvent( le );
 }
 
 bool wxListMainWindow::ChangeCurrentWithoutEvent(size_t current)

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -4908,6 +4908,10 @@ void wxGenericListCtrl::Init()
 
 wxGenericListCtrl::~wxGenericListCtrl()
 {
+    // Don't wait until the base class does it because our subwindows expect
+    // their parent window to be a wxListCtrl, but this won't be the case any
+    // more when we get to the base class dtor (it will be only a wxWindow).
+    DestroyChildren();
 }
 
 void wxGenericListCtrl::CreateOrDestroyHeaderWindowAsNeeded()

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -5355,9 +5355,11 @@ int wxGenericListCtrl::GetItemCount() const
 
 int wxGenericListCtrl::GetColumnCount() const
 {
-    if ( !HasFlag(wxLC_LIST) )
-        return m_mainWin->GetColumnCount();
-    return 1;
+    // wxLC_LIST is special as we want to return 1 for it, for compatibility
+    // with the native wxMSW version and not the real number of columns, which
+    // is 0. For the other non-wxLC_REPORT modes returning 0 is fine, however,
+    // as wxMSW does it too.
+    return HasFlag(wxLC_LIST) ? 1 : m_mainWin->GetColumnCount();
 }
 
 void wxGenericListCtrl::SetItemSpacing( int spacing, bool isSmall )

--- a/tests/controls/listctrltest.cpp
+++ b/tests/controls/listctrltest.cpp
@@ -148,9 +148,11 @@ void ListCtrlTestCase::ColumnCount()
     m_list->InsertColumn(1, "Column 1");
     CHECK(m_list->GetColumnCount() == 2);
 
-    // wxLC_LIST mode
-    tearDown();
-    m_list = new wxListCtrl(wxTheApp->GetTopWindow(), wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLC_LIST);
+    // Recreate the control in wxLC_LIST mode to check the count there as well.
+    delete m_list;
+    m_list = new wxListCtrl(wxTheApp->GetTopWindow(), wxID_ANY,
+                            wxDefaultPosition, wxDefaultSize,
+                            wxLC_LIST);
     CHECK(m_list->GetColumnCount() == 1);
 }
 

--- a/tests/controls/listctrltest.cpp
+++ b/tests/controls/listctrltest.cpp
@@ -148,12 +148,24 @@ void ListCtrlTestCase::ColumnCount()
     m_list->InsertColumn(1, "Column 1");
     CHECK(m_list->GetColumnCount() == 2);
 
-    // Recreate the control in wxLC_LIST mode to check the count there as well.
+    // Recreate the control in other modes to check the count there as well.
     delete m_list;
     m_list = new wxListCtrl(wxTheApp->GetTopWindow(), wxID_ANY,
                             wxDefaultPosition, wxDefaultSize,
                             wxLC_LIST);
     CHECK(m_list->GetColumnCount() == 1);
+
+    delete m_list;
+    m_list = new wxListCtrl(wxTheApp->GetTopWindow(), wxID_ANY,
+                            wxDefaultPosition, wxDefaultSize,
+                            wxLC_ICON);
+    CHECK(m_list->GetColumnCount() == 0);
+
+    delete m_list;
+    m_list = new wxListCtrl(wxTheApp->GetTopWindow(), wxID_ANY,
+                            wxDefaultPosition, wxDefaultSize,
+                            wxLC_SMALL_ICON);
+    CHECK(m_list->GetColumnCount() == 0);
 }
 
 #if wxUSE_UIACTIONSIMULATOR

--- a/tests/controls/listctrltest.cpp
+++ b/tests/controls/listctrltest.cpp
@@ -48,10 +48,12 @@ private:
         WXUISIM_TEST( ColumnClick );
         WXUISIM_TEST( ColumnDrag );
         CPPUNIT_TEST( SubitemRect );
+        CPPUNIT_TEST( ColumnCount );
     CPPUNIT_TEST_SUITE_END();
 
     void EditLabel();
     void SubitemRect();
+    void ColumnCount();
 #if wxUSE_UIACTIONSIMULATOR
     // Column events are only supported in wxListCtrl currently so we test them
     // here rather than in ListBaseTest
@@ -137,6 +139,19 @@ void ListCtrlTestCase::SubitemRect()
     // Here we can't check for exact equality neither as there can be a margin.
     CHECK(rectLabel.GetLeft() >= rectItem.GetLeft());
     CHECK(rectLabel.GetRight() == rectItem.GetRight());
+}
+
+void ListCtrlTestCase::ColumnCount()
+{
+    CHECK(m_list->GetColumnCount() == 0);
+    m_list->InsertColumn(0, "Column 0");
+    m_list->InsertColumn(1, "Column 1");
+    CHECK(m_list->GetColumnCount() == 2);
+
+    // wxLC_LIST mode
+    tearDown();
+    m_list = new wxListCtrl(wxTheApp->GetTopWindow(), wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLC_LIST);
+    CHECK(m_list->GetColumnCount() == 1);
 }
 
 #if wxUSE_UIACTIONSIMULATOR


### PR DESCRIPTION
Fix: #22482 

Unlike wxMSW the generic version of GetColumnCount returns 0 for wxLC_LIST style that prevent correct handling SendNotify at least under wxUniv. 

I can't test other ports that use generic version so don't know does the bug exist there. If not and such changes may break something I'll update GetColumnCount in PR only for wxUniv with this:

```
int wxGenericListCtrl::GetColumnCount() const
{
#ifdef __WXUNIVERSAL__
    if ( HasFlag(wxLC_LIST) )
        return 1;
#endif
    return m_mainWin->GetColumnCount();
}
```