### PR TITLE
Include macOS 12 name in wxGetOsDescription()

### DIFF
--- a/src/osx/cocoa/utils_base.mm
+++ b/src/osx/cocoa/utils_base.mm
@@ -77,17 +77,6 @@ wxString wxGetOsDescription()
     {
         switch (minorVer)
         {
-            case 7:
-                osName = "Lion";
-                // 10.7 was the last version where the "Mac" prefix was used
-                osBrand = "Mac OS X";
-                break;
-            case 8:
-                osName = "Mountain Lion";
-                break;
-            case 9:
-                osName = "Mavericks";
-                break;
             case 10:
                 osName = "Yosemite";
                 break;
@@ -117,6 +106,9 @@ wxString wxGetOsDescription()
                 break;
             case 12:
                 osName = "Monterey";
+                break;
+            case 13:
+                osName = "Ventura";
                 break;
         }
     }


### PR DESCRIPTION
macOS 13 is called _Ventura_
Additionally remove names for unsupported macOS versions

It seems to me Apple is backing up a little from using the code names for marketing materials, but we'll see what the future brings. For now it's unfortunately still useful to include the code name/marketing name in the OS description.