### PR TITLE
Fix missing option description, wrong handler name

### DIFF
--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -1155,7 +1155,13 @@ No additional properties.
 
 @subsubsection xrc_wxdatepickerctrl wxDatePickerCtrl
 
-No additional properties.
+@beginTable
+@hdr3col{property, type, description}
+@row3col{null-text, @ref overview_xrcformat_type_string,
+    Set the text to show when there is no valid value (default: empty).
+    Only used if the control has wxDP_ALLOWNONE style.
+    Currently implemented on MSW, ignored elsewhere. @since 3.1.5.}
+@endTable
 
 
 @subsubsection xrc_wxdialog wxDialog
@@ -2215,7 +2221,7 @@ later only and you need to explicitly register its handler using
 @code
     #include <wx/xrc/xh_styledtextctrl.h>
 
-    AddHandler(new wxStyledTextCtrl);
+    AddHandler(new wxStyledTextCtrlXmlHandler);
 @endcode
 to use it.
 


### PR DESCRIPTION
This PR fixes some problems with xrc_format.h

### wxDatePickerCtrl:

Added missing documentation for null-text option.

Note that xrc_schema.rnc already specified this parameter, but it did not exist in xrc_format.h

### wxStyledTextCtrl:

Fixed incorrect handler name
