### PR TITLE
Add wxAUI_TB_DEFAULT_STYLE as valid style

### DIFF
--- a/src/xrc/xh_auitoolb.cpp
+++ b/src/xrc/xh_auitoolb.cpp
@@ -1,5 +1,5 @@
 /////////////////////////////////////////////////////////////////////////////
-// Name:        src/xrc/xh_toolb.cpp
+// Name:        src/xrc/xh_auitoolb.cpp
 // Purpose:     XRC resource for wxAuiToolBar
 // Author:      Vaclav Slavik
 // Created:     2000/08/11
@@ -31,6 +31,7 @@ wxAuiToolBarXmlHandler::wxAuiToolBarXmlHandler()
     , m_isInside(false)
     , m_toolbar(NULL)
 {
+    XRC_ADD_STYLE(wxAUI_TB_DEFAULT_STYLE);
     XRC_ADD_STYLE(wxAUI_TB_TEXT);
     XRC_ADD_STYLE(wxAUI_TB_NO_TOOLTIPS);
     XRC_ADD_STYLE(wxAUI_TB_NO_AUTORESIZE);


### PR DESCRIPTION
wxAUI_TB_DEFAULT_STYLE is defined as zero, so not supplying any style has the same effect, but it's a bit odd for this handler not to allow this value (most/all other handlers support the various ???_DEFAULT_STYLE variations).