### PR TITLE
XRC: Add support for SetArtProvider in wxAuiNotebook handler

### DIFF
--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -741,6 +741,14 @@ wxAuiPaneInfo objects have the following properties:
 
 @subsubsection xrc_wxauinotebook wxAuiNotebook
 
+@beginTable
+@hdr3col{property, type, description}
+@row3col{art-provider, @ref overview_xrcformat_type_string,
+    One of @c default for wxAuiDefaultTabArt or @c simple for wxAuiSimpleTabArt
+    (default: @c default).
+    @since 3.2.0}
+@endTable
+
 A wxAuiNotebook can have one or more child objects of the @c notebookpage
 pseudo-class.
 @c notebookpage objects have the following properties:

--- a/misc/schema/xrc_schema.rnc
+++ b/misc/schema/xrc_schema.rnc
@@ -580,6 +580,7 @@ wxAuiNotebook =
         attribute class { "wxAuiNotebook" } &
         stdObjectNodeAttributes &
         stdWindowProperties &
+        [xrc:p="o"] element art-provider {_, ("default" | "simple") }* &
         (wxAuiNotebook_notebookpage | objectRef)*
     }
 

--- a/src/xrc/xh_aui.cpp
+++ b/src/xrc/xh_aui.cpp
@@ -275,6 +275,14 @@ wxObject *wxAuiXmlHandler::DoCreateResource()
                     GetSize(),
                     GetStyle(wxS("style")));
 
+        wxString provider = GetText("art-provider", false);
+        if (provider == "default" || provider.IsEmpty())
+            anb->SetArtProvider(new wxAuiDefaultTabArt);
+        else if (provider.CmpNoCase("simple") == 0)
+            anb->SetArtProvider(new wxAuiSimpleTabArt);
+        else
+            ReportError("invalid wxAuiNotebook art provider");
+
         SetupWindow(anb);
 
         wxAuiNotebook *old_par = m_notebook;


### PR DESCRIPTION
This adds the ability to change the art provider for wxAuiNotebook, which changes the appearance of the tabs. I used the same `art-provider` keyword that is used for wxRibbonBar, though the only common value between them is "default".

I only supplied options for "default" and "simple". Technically, there is a generic provider available for GTK and MSW (MAC automatically uses this), however since it is not documented (even though it exists in the tabart.h header file), and presumably breaks from standard UI on GTK/MSW, I did not add it. 

This could have been implemented as a boolean using "simple" but then it would have to be rewritten if other art providers are ever added, hence the if/else if clauses.