### PR TITLE
Fix calling TransferDataFromCustomControls() with common dialogs

### DIFF
--- a/include/wx/filedlg.h
+++ b/include/wx/filedlg.h
@@ -198,6 +198,8 @@ protected:
     wxWindow* CreateExtraControlWithParent(wxWindow* parent) const;
     // returns true if control is created, also sets m_extraControl
     bool CreateExtraControl();
+    // destroy m_extraControl and reset it to NULL
+    void DestroyExtraControl();
     // return true if SetExtraControlCreator() was called
     bool HasExtraControlCreator() const
         { return m_extraControlCreator != NULL; }

--- a/include/wx/msw/filedlg.h
+++ b/include/wx/msw/filedlg.h
@@ -60,6 +60,9 @@ private:
     // called when the currently selected type of files changes in the dialog
     void MSWOnTypeChange(int nFilterIndex);
 
+    // called when the dialog is accepted, i.e. a file is chosen in it
+    void MSWOnFileOK();
+
     // The real implementation of ShowModal() using traditional common dialog
     // functions.
     int ShowCommFileDialog(WXHWND owner);

--- a/interface/wx/filedlgcustomize.h
+++ b/interface/wx/filedlgcustomize.h
@@ -331,6 +331,7 @@ public:
         // This object may be destroyed before the dialog, but must remain
         // alive until ShowModal() returns.
         EncryptHook customizeHook;
+        dialog.SetCustomizeHook(customHook);
 
         if ( dialog.ShowModal() == wxID_OK )
         {

--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -2009,10 +2009,42 @@ void MyFrame::FileSave(wxCommandEvent& WXUNUSED(event) )
 
     dialog.SetFilterIndex(1);
 
+    // This tests the (even more simplified) example from the docs.
+    class EncryptHook : public wxFileDialogCustomizeHook
+    {
+    public:
+        EncryptHook()
+            : m_encrypt(false)
+        {
+        }
+
+        void AddCustomControls(wxFileDialogCustomize& customizer) wxOVERRIDE
+        {
+            m_checkbox = customizer.AddCheckBox("Encrypt");
+        }
+
+        void TransferDataFromCustomControls() wxOVERRIDE
+        {
+            m_encrypt = m_checkbox->GetValue();
+        }
+
+        bool Encrypt() const { return m_encrypt; }
+
+    private:
+        wxFileDialogCheckBox* m_checkbox;
+
+        bool m_encrypt;
+    };
+
+    EncryptHook customHook;
+    dialog.SetCustomizeHook(customHook);
+
     if (dialog.ShowModal() == wxID_OK)
     {
-        wxLogMessage("%s, filter %d",
-                     dialog.GetPath(), dialog.GetFilterIndex());
+        wxLogMessage("%s, filter %d%s",
+                     dialog.GetPath(),
+                     dialog.GetFilterIndex(),
+                     customHook.Encrypt() ? ", encrypt" : "");
     }
 }
 

--- a/src/common/fldlgcmn.cpp
+++ b/src/common/fldlgcmn.cpp
@@ -903,6 +903,15 @@ bool wxFileDialogBase::CreateExtraControl()
     return m_extraControl != NULL;
 }
 
+void wxFileDialogBase::DestroyExtraControl()
+{
+    if ( m_extraControl )
+    {
+        m_extraControl->Destroy();
+        m_extraControl = NULL;
+    }
+}
+
 void wxFileDialogBase::UpdateExtraControlUI()
 {
     if ( m_customizeHook )

--- a/src/msw/dirdlg.cpp
+++ b/src/msw/dirdlg.cpp
@@ -281,7 +281,7 @@ wxIFileDialog::wxIFileDialog(const CLSID& clsid)
                     clsid,
                     NULL, // no outer IUnknown
                     CLSCTX_INPROC_SERVER,
-                    wxIID_PPV_ARGS(IFileOpenDialog, &m_fileDialog)
+                    wxIID_PPV_ARGS(IFileDialog, &m_fileDialog)
                  );
     if ( FAILED(hr) )
     {
@@ -300,7 +300,7 @@ int wxIFileDialog::Show(HWND owner, int options,
     hr = m_fileDialog->SetOptions(options | FOS_FORCEFILESYSTEM);
     if ( FAILED(hr) )
     {
-        wxLogApiError(wxS("IFileOpenDialog::SetOptions"), hr);
+        wxLogApiError(wxS("IFileDialog::SetOptions"), hr);
         return false;
     }
 
@@ -348,7 +348,7 @@ void wxIFileDialog::SetTitle(const wxString& message)
     {
         // This error is not serious, let's just log it and continue even
         // without the title set.
-        wxLogApiError(wxS("IFileOpenDialog::SetTitle"), hr);
+        wxLogApiError(wxS("IFileDialog::SetTitle"), hr);
     }
 }
 
@@ -401,7 +401,7 @@ void wxIFileDialog::SetInitialPath(const wxString& defaultPath)
     {
         hr = m_fileDialog->SetFolder(folder);
         if ( FAILED(hr) )
-            wxLogApiError(wxS("IFileOpenDialog::SetFolder"), hr);
+            wxLogApiError(wxS("IFileDialog::SetFolder"), hr);
     }
 }
 


### PR DESCRIPTION
When using common dialogs, because IFileDialog-based implementation is
not available either at compile- or run-time, this function needs to be
called while the extra controls still exist, i.e. before ShowModal()
returns, so do it from CDN_FILEOK handler.

Move the code that called it previously into the new MSWOnFileOK() for
consistency with the other callbacks.

Closes #22521.