### PR TITLE
CMake: Fix building with wxUSE_WEBVIEW_EDGE_STATIC

### DIFF
--- a/build/cmake/lib/webview/CMakeLists.txt
+++ b/build/cmake/lib/webview/CMakeLists.txt
@@ -86,7 +86,9 @@ elseif(WXMSW)
         endif()
 
         if (wxUSE_WEBVIEW_EDGE_STATIC)
-            target_link_directories(wxwebview PUBLIC "${WEBVIEW2_PACKAGE_DIR}/build/native/$(LibrariesArchitecture)/")
+            target_link_directories(wxwebview PUBLIC
+                $<BUILD_INTERFACE:${WEBVIEW2_PACKAGE_DIR}/build/native/$(LibrariesArchitecture)/>
+            )
         else()
             wx_webview_copy_webview2_loader(wxwebview)
         endif()


### PR DESCRIPTION
Add the directory only to the build interface, not to the install interface.
INTERFACE_LINK_DIRECTORIES can't use paths that are prefixed in the source (or build) directory.