### PR TITLE
Fix two issues with GTK3 at HiDPI

### DIFF
--- a/src/gtk/bitmap.cpp
+++ b/src/gtk/bitmap.cpp
@@ -1053,11 +1053,18 @@ static cairo_surface_t* GetSubSurface(cairo_surface_t* surface, const wxRect& re
 }
 #endif
 
-wxBitmap wxBitmap::GetSubBitmap( const wxRect& rect) const
+wxBitmap wxBitmap::GetSubBitmap( const wxRect& rect_) const
 {
     wxBitmap ret;
 
     wxCHECK_MSG(IsOk(), ret, wxT("invalid bitmap"));
+
+#ifdef __WXGTK3__
+    double scale = M_BMPDATA->m_scaleFactor;
+    wxRect rect(rect_.x*scale, rect_.y*scale, rect_.width*scale, rect_.height*scale);
+#else
+    wxRect rect(rect_);
+#endif
 
     const int w = rect.width;
     const int h = rect.height;

--- a/src/gtk/dc.cpp
+++ b/src/gtk/dc.cpp
@@ -310,7 +310,7 @@ bool wxGTKCairoDCImpl::DoStretchBlit(int xdest, int ydest, int dstWidth, int dst
     const double bmpScale = bitmap.IsOk() ? bitmap.GetScaleFactor() : 1.0;
 
     cairo_scale(cr, dstWidth / (sx * srcWidth * bmpScale), dstHeight / (sy * srcHeight * bmpScale));
-    cairo_set_source_surface(cr, surfaceSrc, -xsrc_dev, -ysrc_dev);
+    cairo_set_source_surface(cr, surfaceSrc, -xsrc_dev * bmpScale, -ysrc_dev * bmpScale);
     const wxRasterOperationMode rop_save = m_logicalFunction;
     SetLogicalFunction(rop);
     cairo_pattern_set_filter(cairo_get_source(cr), CAIRO_FILTER_NEAREST);
@@ -333,7 +333,7 @@ bool wxGTKCairoDCImpl::DoStretchBlit(int xdest, int ydest, int dstWidth, int dst
         if (ysrcMask != -1)
             ysrcMask_dev = source->LogicalToDeviceY(ysrcMask);
         cairo_clip(cr);
-        cairo_mask_surface(cr, maskSurf, -xsrcMask_dev, -ysrcMask_dev);
+        cairo_mask_surface(cr, maskSurf, -xsrcMask_dev * bmpScale, -ysrcMask_dev * bmpScale);
     }
     else
     {


### PR DESCRIPTION
Fix `wxDC::Blit` and `wxBitmap::GetSubBitmap`, both need to scale the coordinates with the scale factor of the bitmap.

See #22512