### PR TITLE
Don't expand slider over best size in wxUniv

### DIFF
--- a/src/univ/slider.cpp
+++ b/src/univ/slider.cpp
@@ -487,6 +487,15 @@ void wxSlider::CalcGeometry()
 
     // initialize to the full client rect
     wxRect rectTotal = GetClientRect();
+    wxSize bestClientSize = DoGetBestClientSize();
+    if ( !IsVert() && rectTotal.height > bestClientSize.y )
+    {
+        rectTotal.height = bestClientSize.y;
+    }
+    else if ( IsVert() && rectTotal.width > bestClientSize.x )
+    {
+        rectTotal.width = bestClientSize.x;
+    }
     m_rectSlider = rectTotal;
     wxSize sizeThumb = GetThumbSize();
 


### PR DESCRIPTION
Before/after:

![un2](https://user-images.githubusercontent.com/17313967/173304345-442494b3-5285-4ecd-ac11-a3a9df196382.jpg)

mcve:

```
#include <wx/wx.h>

class MyFrame : public wxFrame
{
public:
    MyFrame(const wxString& title) : wxFrame(NULL, wxID_ANY, title)
    {
        wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
        m_slider = new wxSlider(this, wxID_ANY, 50, 0, 100, wxDefaultPosition, wxDefaultSize, wxSL_VERTICAL);
        mainSizer->Add( m_slider, 1, wxALL|wxEXPAND, 5 );
        this->SetSizer(mainSizer);
        this->Layout();
        this->Centre(wxBOTH);
    }
    wxSlider* m_slider;
};

class MyApp : public wxApp
{
public:
    virtual bool OnInit()
    {
        if (!wxApp::OnInit())
            return false;

        MyFrame* frame = new MyFrame("MCVE");
        frame->Show(true);
        return true;
    }
};

wxIMPLEMENT_APP(MyApp);
```