### PR TITLE
Menu bitmaps fixes

### DIFF
--- a/docs/doxygen/mainpages/introduction.h
+++ b/docs/doxygen/mainpages/introduction.h
@@ -91,8 +91,8 @@ NetBSD, Solaris, AIX, ...) and require GTK+ 2.6 or later or GTK+ 3.x. The
 primary supported compiler is GNU g++.
 
 @li wxOSX/Cocoa: This is the native port for Apple computers. wxOSX/Cocoa
-supports 32 or 64 bit Intel Macs running macOS 10.10 or later. The port can be
-built either with g++ or clang.
+supports 32 or 64 bit Intel Macs running macOS 10.10 or later. The port can
+currently be only built using Apple clang.
 
 Other platforms (e.g. iOS - with a minimum requirement of iOS 13), compilers
 (Sun CC, HP-UX aCC, IBM xlC or SGI mipsPro under Unix) and ports (wxQT, wxGTK1,

--- a/docs/doxygen/mainpages/platdetails.h
+++ b/docs/doxygen/mainpages/platdetails.h
@@ -54,6 +54,10 @@ wxOSX/Cocoa is the port of wxWidgets for the macOS platform. It requires
 a minimum SDK 10.11, Xcode 7.2.1 or greater (runs under 10.10.5 and higher),
 and supports x86_64 (but not i386) and ARM builds and deploying under 10.10.
 
+Note that Apple clang must be used to build wxOSX, due to the use of
+Apple-specific extensions ("blocks") in the macOS SDK headers, and hence the
+applications using it must be built using clang as well.
+
 @subpage plat_osx_install "Build and Install Instructions"
 
 

--- a/include/wx/gtk/menuitem.h
+++ b/include/wx/gtk/menuitem.h
@@ -29,8 +29,6 @@ public:
     virtual void Enable( bool enable = true ) wxOVERRIDE;
     virtual void Check( bool check = true ) wxOVERRIDE;
     virtual bool IsChecked() const wxOVERRIDE;
-    virtual void SetBitmap(const wxBitmapBundle& bitmap);
-    virtual wxBitmap GetBitmap() const;
     void SetupBitmaps(wxWindow *win);
 
 #if wxUSE_ACCEL
@@ -60,7 +58,6 @@ public:
 #endif
 
 private:
-    wxBitmapBundle m_bitmap; // Bitmap for menuitem, if any
     GtkWidget *m_menuItem;  // GtkMenuItem
 
     wxDECLARE_DYNAMIC_CLASS(wxMenuItem);

--- a/include/wx/gtk1/menuitem.h
+++ b/include/wx/gtk1/menuitem.h
@@ -32,8 +32,6 @@ public:
     virtual void Enable( bool enable = TRUE );
     virtual void Check( bool check = TRUE );
     virtual bool IsChecked() const;
-    virtual void SetBitmap(const wxBitmapBundle& bitmap) { m_bitmap = bitmap; }
-    virtual wxBitmap GetBitmap() const;
 
 #if wxUSE_ACCEL
     virtual wxAcceleratorEntry *GetAccel() const;
@@ -65,7 +63,6 @@ private:
     void DoSetText(const wxString& text);
 
     wxString  m_hotKey;
-    wxBitmapBundle  m_bitmap; // Bitmap for menuitem, if any
 
     GtkWidget *m_menuItem;  // GtkMenuItem
     GtkWidget* m_labelWidget; // Label widget

--- a/include/wx/menuitem.h
+++ b/include/wx/menuitem.h
@@ -115,6 +115,11 @@ public:
     void SetHelp(const wxString& str);
     const wxString& GetHelp() const { return m_help; }
 
+    // bitmap-related functions
+
+    virtual void SetBitmap(const wxBitmapBundle& bmp);
+    virtual wxBitmap GetBitmap() const;
+
 #if wxUSE_ACCEL
     // extract the accelerator from the given menu string, return NULL if none
     // found
@@ -175,6 +180,7 @@ protected:
                  *m_subMenu;        // our sub menu or NULL
     wxString      m_text,           // label of the item
                   m_help;           // the help string for the item
+    wxBitmapBundle m_bitmap;        // item bitmap, may be invalid
     wxItemKind    m_kind;           // separator/normal/check/radio item?
     bool          m_isChecked;      // is checked?
     bool          m_isEnabled;      // is enabled?

--- a/include/wx/menuitem.h
+++ b/include/wx/menuitem.h
@@ -118,6 +118,10 @@ public:
     // bitmap-related functions
 
     virtual void SetBitmap(const wxBitmapBundle& bmp);
+    wxBitmapBundle GetBitmapBundle() const { return m_bitmap; }
+
+    // This method only exists for compatibility, prefer using
+    // GetBitmapBundle() in the new code.
     virtual wxBitmap GetBitmap() const;
 
 #if wxUSE_ACCEL

--- a/include/wx/motif/menuitem.h
+++ b/include/wx/motif/menuitem.h
@@ -35,12 +35,6 @@ public:
     virtual void SetItemLabel(const wxString& label);
     virtual void Enable(bool enable = true);
     virtual void Check(bool check = true);
-    // included SetBitmap and GetBitmap as copied from the GTK include file
-    // I'm not sure if this works but it silences the linker in the
-    // menu sample.
-    //     JJ
-    virtual void SetBitmap(const wxBitmapBundle& bitmap) { m_bitmap = bitmap; }
-    virtual wxBitmap GetBitmap() const { return GetBitmapFromBundle(m_bitmap); }
 
     // implementation from now on
     void CreateItem (WXWidget menu, wxMenuBar * menuBar, wxMenu * topMenu,
@@ -59,7 +53,6 @@ private:
     WXWidget    m_buttonWidget;
     wxMenuBar*  m_menuBar;
     wxMenu*     m_topMenu;        // Top-level menu e.g. popup-menu
-    wxBitmapBundle  m_bitmap; // Bitmap for menuitem, if any
 
     wxDECLARE_DYNAMIC_CLASS(wxMenuItem);
 };

--- a/include/wx/msw/menu.h
+++ b/include/wx/msw/menu.h
@@ -69,10 +69,6 @@ public:
     // containing this position.
     bool MSWGetRadioGroupRange(int pos, int *start, int *end) const;
 
-#if wxUSE_MENUBAR
-    virtual void Attach(wxMenuBarBase *menubar) wxOVERRIDE;
-#endif
-
     void SetupBitmaps();
 
 #if wxUSE_ACCEL
@@ -225,16 +221,6 @@ public:
 protected:
     // common part of all ctors
     void Init();
-
-    void SetupBitmaps();
-
-    void OnDPIChanged(wxDPIChangedEvent& event)
-    {
-        // need to reset bitmaps
-        SetupBitmaps();
-
-        event.Skip();
-    }
 
     WXHMENU       m_hMenu;
 

--- a/include/wx/msw/menuitem.h
+++ b/include/wx/msw/menuitem.h
@@ -139,7 +139,7 @@ private:
     int MSGetMenuItemPos() const;
 
     // item bitmaps
-    wxBitmapBundle m_bmpChecked,     // bitmap to put near the item
+    wxBitmapBundle m_bitmap,     // bitmap to put near the item
                    m_bmpUnchecked;   // (checked is used also for 'uncheckable' items)
 #if wxUSE_OWNER_DRAWN
     wxBitmapBundle m_bmpDisabled;

--- a/include/wx/msw/menuitem.h
+++ b/include/wx/msw/menuitem.h
@@ -78,14 +78,25 @@ public:
         DoSetBitmap(bmpUnchecked, false);
     }
 
-    void SetBitmap(const wxBitmapBundle& bmp, bool bChecked = true)
+    virtual void SetBitmap(const wxBitmapBundle& bmp) wxOVERRIDE
     {
-        DoSetBitmap(bmp, bChecked);
+        DoSetBitmap(bmp, true);
+    }
+
+    virtual wxBitmap GetBitmap() const wxOVERRIDE
+    {
+        return GetBitmap(true);
     }
 
     void SetupBitmaps();
 
-    wxBitmap GetBitmap(bool bChecked = true) const;
+    // The functions taking bChecked are wxMSW-specific.
+    void SetBitmap(const wxBitmapBundle& bmp, bool bChecked)
+    {
+        DoSetBitmap(bmp, bChecked);
+    }
+
+    wxBitmap GetBitmap(bool bChecked) const;
 
 #if wxUSE_OWNER_DRAWN
     void SetDisabledBitmap(const wxBitmapBundle& bmpDisabled)
@@ -139,8 +150,7 @@ private:
     int MSGetMenuItemPos() const;
 
     // item bitmaps
-    wxBitmapBundle m_bitmap,     // bitmap to put near the item
-                   m_bmpUnchecked;   // (checked is used also for 'uncheckable' items)
+    wxBitmapBundle m_bmpUnchecked;   // (used only for checkable items)
 #if wxUSE_OWNER_DRAWN
     wxBitmapBundle m_bmpDisabled;
 #endif // wxUSE_OWNER_DRAWN

--- a/include/wx/osx/menuitem.h
+++ b/include/wx/osx/menuitem.h
@@ -48,9 +48,6 @@ public:
     void RemoveHiddenItems();
 #endif // wxUSE_ACCEL
 
-    virtual void SetBitmap(const wxBitmapBundle& bitmap) ;
-    virtual wxBitmap GetBitmap() const;
-
 
     // Implementation only from now on.
 
@@ -62,8 +59,6 @@ public:
     wxMenuItemImpl* GetPeer() { return m_peer; }
 private:
     void UncheckRadio() ;
-
-    wxBitmapBundle m_bitmap; // Bitmap for menuitem, if any
 
     wxMenuItemImpl* m_peer;
 

--- a/include/wx/qt/menuitem.h
+++ b/include/wx/qt/menuitem.h
@@ -35,8 +35,7 @@ public:
     virtual void Check(bool check = true) wxOVERRIDE;
     virtual bool IsChecked() const wxOVERRIDE;
 
-    virtual void SetBitmap(const wxBitmapBundle& bitmap);
-    virtual wxBitmap GetBitmap() const { return GetBitmapFromBundle(m_bitmap); }
+    virtual void SetBitmap(const wxBitmapBundle& bitmap) wxOVERRIDE;
 
     virtual QAction *GetHandle() const;
 
@@ -44,7 +43,6 @@ public:
 private:
     // Qt is using an action instead of a menu item.
     wxQtAction *m_qtAction;
-    wxBitmapBundle m_bitmap;
 
     wxDECLARE_DYNAMIC_CLASS( wxMenuItem );
 };

--- a/include/wx/univ/menuitem.h
+++ b/include/wx/univ/menuitem.h
@@ -39,9 +39,11 @@ public:
     // hopefully
     void SetBitmaps(const wxBitmapBundle& bmpChecked,
                     const wxBitmapBundle& bmpUnchecked = wxBitmapBundle());
-    void SetBitmap(const wxBitmapBundle& bmp) { SetBitmaps(bmp); }
-    wxBitmap GetBitmap(bool checked = true) const
+    virtual void SetBitmap(const wxBitmapBundle& bmp) wxOVERRIDE { SetBitmaps(bmp); }
+    wxBitmap GetBitmap(bool checked) const
       { return GetBitmapFromBundle(checked ? m_bitmap : m_bmpUnchecked); }
+    virtual wxBitmap GetBitmap() const wxOVERRIDE
+      { return GetBitmap(true); }
 
     void SetDisabledBitmap( const wxBitmapBundle& bmpDisabled )
       { m_bmpDisabled = bmpDisabled; }
@@ -93,8 +95,7 @@ protected:
     void UpdateAccelInfo();
 
     // the bitmaps (may be invalid, then they're not used)
-    wxBitmapBundle m_bitmap,
-                   m_bmpUnchecked,
+    wxBitmapBundle m_bmpUnchecked,
                    m_bmpDisabled;
 
     // the positions of the first and last items of the radio group this item

--- a/include/wx/univ/menuitem.h
+++ b/include/wx/univ/menuitem.h
@@ -41,7 +41,7 @@ public:
                     const wxBitmapBundle& bmpUnchecked = wxBitmapBundle());
     void SetBitmap(const wxBitmapBundle& bmp) { SetBitmaps(bmp); }
     wxBitmap GetBitmap(bool checked = true) const
-      { return GetBitmapFromBundle(checked ? m_bmpChecked : m_bmpUnchecked); }
+      { return GetBitmapFromBundle(checked ? m_bitmap : m_bmpUnchecked); }
 
     void SetDisabledBitmap( const wxBitmapBundle& bmpDisabled )
       { m_bmpDisabled = bmpDisabled; }
@@ -93,7 +93,7 @@ protected:
     void UpdateAccelInfo();
 
     // the bitmaps (may be invalid, then they're not used)
-    wxBitmapBundle m_bmpChecked,
+    wxBitmapBundle m_bitmap,
                    m_bmpUnchecked,
                    m_bmpDisabled;
 

--- a/interface/wx/menuitem.h
+++ b/interface/wx/menuitem.h
@@ -161,11 +161,16 @@ public:
     wxColour& GetBackgroundColour() const;
 
     /**
+        Returns the item bitmap.
+    */
+    wxBitmap GetBitmap() const;
+
+    /**
         Returns the checked or unchecked bitmap.
 
-        The @c checked parameter is only available in wxMSW.
+        This overload only exists in wxMSW, avoid using it in portable code.
     */
-    virtual wxBitmap GetBitmap(bool checked = true) const;
+    wxBitmap GetBitmap(bool checked) const;
 
     /**
         Returns the bitmap used for disabled items.
@@ -351,23 +356,26 @@ public:
     /**
         Sets the bitmap for the menu item.
 
-        It is equivalent to wxMenuItem::SetBitmaps(bmp, wxNullBitmap) if
-        @a checked is @true (default value) or SetBitmaps(wxNullBitmap, bmp)
-        otherwise.
-
-        SetBitmap() must be called before the item is appended to the menu,
-        i.e. appending the item without a bitmap and setting one later is not
-        guaranteed to work. But the bitmap can be changed or reset later if it
-        had been set up initially.
-
         Notice that GTK+ uses a global setting called @c gtk-menu-images to
         determine if the images should be shown in the menus at all. If it is
         off (which is the case in e.g. Gnome 2.28 by default), no images will
         be shown, consistently with the native behaviour.
-
-        @onlyfor{wxmsw,wxosx,wxgtk}
     */
-    virtual void SetBitmap(const wxBitmapBundle& bmp, bool checked = true);
+    void SetBitmap(const wxBitmapBundle& bmp);
+
+    /**
+        Sets the checked or unchecked bitmap for the menu item.
+
+        It is equivalent to wxMenuItem::SetBitmaps(bmp, wxNullBitmap) if
+        @a checked is @true or SetBitmaps(wxNullBitmap, bmp) otherwise.
+
+        Note that different bitmaps for checked and unchecked item states are
+        not supported in most ports, while setting just a single bitmap using
+        the overload above is supported in all of them.
+
+        @onlyfor{wxmsw}
+    */
+    void SetBitmap(const wxBitmapBundle& bmp, bool checked);
 
     /**
         Sets the checked/unchecked bitmaps for the menu item.

--- a/interface/wx/menuitem.h
+++ b/interface/wx/menuitem.h
@@ -162,6 +162,9 @@ public:
 
     /**
         Returns the item bitmap.
+
+        This method exists only for compatibility, please use GetBitmapBundle()
+        in the new code.
     */
     wxBitmap GetBitmap() const;
 
@@ -171,6 +174,18 @@ public:
         This overload only exists in wxMSW, avoid using it in portable code.
     */
     wxBitmap GetBitmap(bool checked) const;
+
+    /**
+        Returns the bitmap bundle containing the bitmap used for this item.
+
+        The returned bundle is invalid, i.e. empty, if no bitmap is associated
+        with the item.
+
+        @see SetBitmap()
+
+        @since 3.2.0
+    */
+    wxBitmapBundle GetBitmapBundle() const;
 
     /**
         Returns the bitmap used for disabled items.

--- a/src/common/menucmn.cpp
+++ b/src/common/menucmn.cpp
@@ -344,6 +344,16 @@ wxString wxMenuItemBase::GetLabelFromText(const wxString& text)
 }
 #endif
 
+void wxMenuItemBase::SetBitmap(const wxBitmapBundle& bmp)
+{
+    m_bitmap = bmp;
+}
+
+wxBitmap wxMenuItemBase::GetBitmap() const
+{
+    return GetBitmapFromBundle(m_bitmap);
+}
+
 wxBitmap wxMenuItemBase::GetBitmapFromBundle(const wxBitmapBundle& bundle) const
 {
     wxBitmap bmp;

--- a/src/gtk/menu.cpp
+++ b/src/gtk/menu.cpp
@@ -756,21 +756,6 @@ void wxMenuItem::ClearExtraAccels()
 
 #endif // wxUSE_ACCEL
 
-void wxMenuItem::SetBitmap(const wxBitmapBundle& bitmap)
-{
-    if (m_kind == wxITEM_NORMAL)
-        m_bitmap = bitmap;
-    else
-    {
-        wxFAIL_MSG("only normal menu items can have bitmaps");
-    }
-}
-
-wxBitmap wxMenuItem::GetBitmap() const
-{
-    return GetBitmapFromBundle(m_bitmap);
-}
-
 void wxMenuItem::SetupBitmaps(wxWindow *win)
 {
 #ifndef __WXGTK4__

--- a/src/gtk1/menu.cpp
+++ b/src/gtk1/menu.cpp
@@ -870,11 +870,6 @@ wxAcceleratorEntry *wxMenuItem::GetAccel() const
 
 #endif // wxUSE_ACCEL
 
-wxBitmap wxMenuItem::GetBitmap() const
-{
-   return GetBitmapFromBundle(m_bitmap);
-}
-
 void wxMenuItem::Check( bool check )
 {
     wxCHECK_RET( m_menuItem, wxT("invalid menu item") );

--- a/src/msw/menu.cpp
+++ b/src/msw/menu.cpp
@@ -305,19 +305,6 @@ bool wxMenu::MSWGetRadioGroupRange(int pos, int *start, int *end) const
     return m_radioData && m_radioData->GetGroupRange(pos, start, end);
 }
 
-#if wxUSE_MENUBAR
-void wxMenu::Attach(wxMenuBarBase* menubar)
-{
-    wxMenuBase::Attach(menubar);
-
-    if (menubar->IsAttached())
-    {
-        // menubar is already attached, we need to call SetupBitmaps
-        SetupBitmaps();
-    }
-}
-#endif
-
 void wxMenu::SetupBitmaps()
 {
     for ( wxMenuItemList::compatibility_iterator node = m_items.GetFirst();
@@ -611,14 +598,6 @@ bool wxMenu::DoInsertOrAppend(wxMenuItem *pItem, size_t pos)
     // if we're already attached to the menubar, we must update it
     if ( IsAttached() && GetMenuBar()->IsAttached() )
     {
-        if ( pItem->IsSubMenu() )
-        {
-            pItem->GetSubMenu()->SetupBitmaps();
-        }
-        if ( !pItem->IsSeparator() )
-        {
-            pItem->SetupBitmaps();
-        }
         GetMenuBar()->Refresh();
     }
 
@@ -1259,14 +1238,6 @@ void wxMenuBar::RebuildAccelTable()
 
 #endif // wxUSE_ACCEL
 
-void wxMenuBar::SetupBitmaps()
-{
-    for ( wxMenuList::const_iterator it = m_menus.begin(); it != m_menus.end(); ++it )
-    {
-        (*it)->SetupBitmaps();
-    }
-}
-
 void wxMenuBar::Attach(wxFrame *frame)
 {
     wxMenuBarBase::Attach(frame);
@@ -1274,10 +1245,6 @@ void wxMenuBar::Attach(wxFrame *frame)
 #if wxUSE_ACCEL
     RebuildAccelTable();
 #endif // wxUSE_ACCEL
-
-    SetupBitmaps();
-
-    frame->Bind(wxEVT_DPI_CHANGED, &wxMenuBar::OnDPIChanged, this);
 }
 
 void wxMenuBar::Detach()

--- a/src/msw/menuitem.cpp
+++ b/src/msw/menuitem.cpp
@@ -690,7 +690,7 @@ void wxMenuItem::SetItemLabel(const wxString& txt)
 
 wxBitmap wxMenuItem::GetBitmap(bool bChecked) const
 {
-    wxBitmap bmp = GetBitmapFromBundle(bChecked ? m_bmpChecked : m_bmpUnchecked);
+    wxBitmap bmp = GetBitmapFromBundle(bChecked ? m_bitmap : m_bmpUnchecked);
 #if wxUSE_IMAGE
     if ( bmp.IsOk() && !bmp.HasAlpha() && wxGetWinVersion() >= wxWinVersion_Vista)
     {
@@ -712,7 +712,7 @@ wxBitmap wxMenuItem::GetDisabledBitmap() const
 
 void wxMenuItem::DoSetBitmap(const wxBitmapBundle& bmpNew, bool bChecked)
 {
-    wxBitmapBundle& bmp = bChecked ? m_bmpChecked : m_bmpUnchecked;
+    wxBitmapBundle& bmp = bChecked ? m_bitmap : m_bmpUnchecked;
     if ( bmp.IsSameAs(bmpNew) )
         return;
     bmp = bmpNew;
@@ -863,7 +863,7 @@ bool wxMenuItem::OnMeasureItem(size_t *width, size_t *height)
         *width += imgWidth + data->CheckBgMargin.GetTotalX();
     }
 
-    if ( m_bmpChecked.IsOk() || m_bmpUnchecked.IsOk() )
+    if ( m_bitmap.IsOk() || m_bmpUnchecked.IsOk() )
     {
         // get size of bitmap always return valid value (0 for invalid bitmap),
         // so we don't needed check if bitmap is valid ;)
@@ -1087,7 +1087,7 @@ bool wxMenuItem::OnDrawItem(wxDC& dc, const wxRect& rc,
                         - data->CheckBgMargin.cyBottomHeight
                         - data->CheckMargin.cyBottomHeight);
 
-    if ( IsCheckable() && !m_bmpChecked.IsOk() )
+    if ( IsCheckable() && !m_bitmap.IsOk() )
     {
         if ( stat & wxODChecked )
         {

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -2368,8 +2368,6 @@ static void wxYieldForCommandsOnly()
 
 bool wxWindowMSW::DoPopupMenu(wxMenu *menu, int x, int y)
 {
-    menu->SetupBitmaps();
-
     wxPoint pt;
     if ( x == wxDefaultCoord && y == wxDefaultCoord )
     {
@@ -2450,7 +2448,16 @@ wxWindowMSW::DoSendMenuOpenCloseEvent(wxEventType evtType, wxMenu* menu)
 {
     wxMenuEvent event(evtType, menu && !menu->IsAttached() ? wxID_ANY : 0, menu);
 
-    return wxMenu::ProcessMenuEvent(menu, event, this);
+    const bool processed = wxMenu::ProcessMenuEvent(menu, event, this);
+
+    if ( menu && evtType == wxEVT_MENU_OPEN )
+    {
+        // Do this after possibly executing the user-defined wxEVT_MENU_OPEN
+        // handler which could have modified the bitmaps.
+        menu->SetupBitmaps();
+    }
+
+    return processed;
 }
 
 bool wxWindowMSW::HandleMenuPopup(wxEventType evtType, WXHMENU hMenu)

--- a/src/osx/menuitem_osx.cpp
+++ b/src/osx/menuitem_osx.cpp
@@ -70,16 +70,6 @@ wxMenuItem::~wxMenuItem()
 // change item state
 // -----------------
 
-void wxMenuItem::SetBitmap(const wxBitmapBundle& bitmap)
-{
-      m_bitmap = bitmap;
-}
-
-wxBitmap wxMenuItem::GetBitmap() const
-{
-    return GetBitmapFromBundle(m_bitmap);
-}
-
 void wxMenuItem::Enable(bool bDoEnable)
 {
     if (( m_isEnabled != bDoEnable

--- a/src/univ/menu.cpp
+++ b/src/univ/menu.cpp
@@ -1616,7 +1616,7 @@ void wxMenuItem::SetCheckable(bool checkable)
 void wxMenuItem::SetBitmaps(const wxBitmapBundle& bmpChecked,
                             const wxBitmapBundle& bmpUnchecked)
 {
-    m_bmpChecked = bmpChecked;
+    m_bitmap = bmpChecked;
     m_bmpUnchecked = bmpUnchecked;
 
     NotifyMenu();


### PR DESCRIPTION
Make updating bitmaps from `wxEVT_MENU_OPEN` handler work again and also refactor the code to reduce duplication and allow adding `GetBitmapBundle()` easily -- and do this.

The switch to only calling `SetupBitmaps()` when opening the menu is a non-trivial change, but I don't see how to fix #22530 otherwise.

Any reviews and testing would be very welcome!