### PR TITLE
Fix title bar miss height of floating pane

### DIFF
--- a/src/gtk/minifram.cpp
+++ b/src/gtk/minifram.cpp
@@ -91,7 +91,8 @@ static gboolean expose_event(GtkWidget* widget, GdkEventExpose* gdk_event, wxMin
 
     if (win->m_miniTitle && !win->GetTitle().empty())
     {
-        dc.SetFont( *wxSMALL_FONT );
+        const wxFont* smallFont = wxSMALL_FONT;
+        dc.SetFont( *smallFont );
 
         wxBrush brush(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT));
         dc.SetBrush( brush );
@@ -99,7 +100,7 @@ static gboolean expose_event(GtkWidget* widget, GdkEventExpose* gdk_event, wxMin
         dc.DrawRectangle( win->m_miniEdge-1,
                           win->m_miniEdge-1,
                           win->m_width - (2*(win->m_miniEdge-1)),
-                          15  );
+                          wxWindow::FromDIP(smallFont->GetPixelSize().y, win) );
 
         const wxColour textColor = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT);
         dc.SetTextForeground(textColor);
@@ -323,10 +324,12 @@ bool wxMiniFrame::Create( wxWindow *parent, wxWindowID id, const wxString &title
       const wxPoint &pos, const wxSize &size,
       long style, const wxString &name )
 {
+    wxFrame::Create( parent, id, title, pos, size, style, name );
+
     m_isDragMove = false;
     m_miniTitle = 0;
     if (style & wxCAPTION)
-        m_miniTitle = 16;
+        m_miniTitle = wxWindow::FromDIP(wxSMALL_FONT->GetPixelSize().y, this);
 
     if (style & wxRESIZE_BORDER)
         m_miniEdge = 4;
@@ -340,8 +343,6 @@ bool wxMiniFrame::Create( wxWindow *parent, wxWindowID id, const wxString &title
         m_minWidth = minWidth;
     if (m_minHeight < minHeight)
         m_minHeight = minHeight;
-
-    wxFrame::Create( parent, id, title, pos, size, style, name );
 
     // Use a GtkEventBox for the title and borders. Using m_widget for this
     // almost works, except that setting the resize cursor has no effect.

--- a/src/gtk/minifram.cpp
+++ b/src/gtk/minifram.cpp
@@ -91,9 +91,8 @@ static gboolean expose_event(GtkWidget* widget, GdkEventExpose* gdk_event, wxMin
 
     if (win->m_miniTitle && !win->GetTitle().empty())
     {
-        const wxFont* smallFont = wxSMALL_FONT;
-        int height = wxWindow::FromDIP(smallFont->GetPixelSize().y, win) + 4;
-        dc.SetFont( *smallFont );
+        dc.SetFont( *wxSMALL_FONT );
+        int height = wxMax(dc.GetTextExtent("X").y, 16);
 
         wxBrush brush(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT));
         dc.SetBrush( brush );
@@ -333,8 +332,11 @@ bool wxMiniFrame::Create( wxWindow *parent, wxWindowID id, const wxString &title
 
     m_isDragMove = false;
     m_miniTitle = 0;
-    if (style & wxCAPTION)
-        m_miniTitle = wxWindow::FromDIP(wxSMALL_FONT->GetPixelSize().y, this) + 4;
+    if (style & wxCAPTION) {
+        wxClientDC dc(this);
+        dc.SetFont(*wxSMALL_FONT);
+        m_miniTitle = wxMax(dc.GetTextExtent("X").y, 16);
+    }
 
     if (style & wxRESIZE_BORDER)
         m_miniEdge = 4;

--- a/src/gtk/minifram.cpp
+++ b/src/gtk/minifram.cpp
@@ -92,6 +92,7 @@ static gboolean expose_event(GtkWidget* widget, GdkEventExpose* gdk_event, wxMin
     if (win->m_miniTitle && !win->GetTitle().empty())
     {
         const wxFont* smallFont = wxSMALL_FONT;
+        int height = wxWindow::FromDIP(smallFont->GetPixelSize().y, win) + 4;
         dc.SetFont( *smallFont );
 
         wxBrush brush(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT));
@@ -100,16 +101,20 @@ static gboolean expose_event(GtkWidget* widget, GdkEventExpose* gdk_event, wxMin
         dc.DrawRectangle( win->m_miniEdge-1,
                           win->m_miniEdge-1,
                           win->m_width - (2*(win->m_miniEdge-1)),
-                          wxWindow::FromDIP(smallFont->GetPixelSize().y, win) );
+                          height );
 
         const wxColour textColor = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT);
         dc.SetTextForeground(textColor);
-        dc.DrawText( win->GetTitle(), 6, 4 );
+        dc.DrawText( win->GetTitle(), 6, 2 );
 
         if (style & wxCLOSE_BOX)
         {
             dc.SetTextBackground(textColor);
-            dc.DrawBitmap( win->m_closeButton, win->m_width-18, 3, true );
+            dc.DrawBitmap(
+                    win->m_closeButton,
+                    win->m_width-18,
+                    win->m_miniEdge - 1 + (height - 16) / 2,
+                    true );
         }
     }
 
@@ -329,7 +334,7 @@ bool wxMiniFrame::Create( wxWindow *parent, wxWindowID id, const wxString &title
     m_isDragMove = false;
     m_miniTitle = 0;
     if (style & wxCAPTION)
-        m_miniTitle = wxWindow::FromDIP(wxSMALL_FONT->GetPixelSize().y, this);
+        m_miniTitle = wxWindow::FromDIP(wxSMALL_FONT->GetPixelSize().y, this) + 4;
 
     if (style & wxRESIZE_BORDER)
         m_miniEdge = 4;


### PR DESCRIPTION
![compare](https://user-images.githubusercontent.com/12020335/173877884-8aaf56c3-043b-4167-86c6-fd86db761493.png)
it change fixed size as wxMiniFrame's title bar height to small font's pixel height. 
Right auidemo is before patch, left is after patch