### PR TITLE
Fix issue #22526

### DIFF
--- a/include/wx/unix/private/uilocale.h
+++ b/include/wx/unix/private/uilocale.h
@@ -33,4 +33,34 @@ const char *wxSetlocaleTryAll(int c, const wxLocaleIdent& lc);
 // Extract date format from D_T_FMT value.
 wxString wxGetDateFormatOnly(const wxString& fmt);
 
+// Helper class changing the global locale to the one specified by the
+// environment variables in its ctor and restoring it in its dtor.
+namespace
+{
+
+class TempDefautLocaleSetter
+{
+public:
+    explicit TempDefautLocaleSetter(int localeCategory)
+        : m_localeCategory(localeCategory),
+          m_localeOrig(strdup(setlocale(localeCategory, NULL)))
+    {
+        setlocale(localeCategory, "");
+    }
+
+    ~TempDefautLocaleSetter()
+    {
+        setlocale(m_localeCategory, m_localeOrig);
+        free(m_localeOrig);
+    }
+
+private:
+    const int m_localeCategory;
+    char* const m_localeOrig;
+
+    wxDECLARE_NO_COPY_CLASS(TempDefautLocaleSetter);
+};
+
+} // anonymous namespace
+
 #endif // _WX_UNIX_PRIVATE_UILOCALE_H_

--- a/include/wx/unix/private/uilocale.h
+++ b/include/wx/unix/private/uilocale.h
@@ -41,11 +41,11 @@ namespace
 class TempDefautLocaleSetter
 {
 public:
-    explicit TempDefautLocaleSetter(int localeCategory)
-        : m_localeCategory(localeCategory),
+    explicit TempDefautLocaleSetter(int localeCategory, const wxString& localeId = "")
+        : m_localeCategory(localeCategory), m_localeId(localeId),
           m_localeOrig(strdup(setlocale(localeCategory, NULL)))
     {
-        setlocale(localeCategory, "");
+        setlocale(localeCategory, m_localeId.mb_str());
     }
 
     ~TempDefautLocaleSetter()
@@ -56,6 +56,7 @@ public:
 
 private:
     const int m_localeCategory;
+    wxString m_localeId;
     char* const m_localeOrig;
 
     wxDECLARE_NO_COPY_CLASS(TempDefautLocaleSetter);

--- a/include/wx/unix/private/uilocale.h
+++ b/include/wx/unix/private/uilocale.h
@@ -41,11 +41,12 @@ namespace
 class TempLocaleSetter
 {
 public:
-    explicit TempLocaleSetter(int localeCategory, const wxString& localeId = "")
-        : m_localeCategory(localeCategory), m_localeId(localeId),
+    explicit TempLocaleSetter(int localeCategory,
+                              const wxString& localeId = wxString())
+        : m_localeCategory(localeCategory),
           m_localeOrig(strdup(setlocale(localeCategory, NULL)))
     {
-        setlocale(localeCategory, m_localeId.mb_str());
+        setlocale(localeCategory, localeId.mb_str());
     }
 
     ~TempLocaleSetter()
@@ -56,7 +57,6 @@ public:
 
 private:
     const int m_localeCategory;
-    wxString m_localeId;
     char* const m_localeOrig;
 
     wxDECLARE_NO_COPY_CLASS(TempLocaleSetter);

--- a/include/wx/unix/private/uilocale.h
+++ b/include/wx/unix/private/uilocale.h
@@ -38,17 +38,17 @@ wxString wxGetDateFormatOnly(const wxString& fmt);
 namespace
 {
 
-class TempDefautLocaleSetter
+class TempLocaleSetter
 {
 public:
-    explicit TempDefautLocaleSetter(int localeCategory, const wxString& localeId = "")
+    explicit TempLocaleSetter(int localeCategory, const wxString& localeId = "")
         : m_localeCategory(localeCategory), m_localeId(localeId),
           m_localeOrig(strdup(setlocale(localeCategory, NULL)))
     {
         setlocale(localeCategory, m_localeId.mb_str());
     }
 
-    ~TempDefautLocaleSetter()
+    ~TempLocaleSetter()
     {
         setlocale(m_localeCategory, m_localeOrig);
         free(m_localeOrig);
@@ -59,7 +59,7 @@ private:
     wxString m_localeId;
     char* const m_localeOrig;
 
-    wxDECLARE_NO_COPY_CLASS(TempDefautLocaleSetter);
+    wxDECLARE_NO_COPY_CLASS(TempLocaleSetter);
 };
 
 } // anonymous namespace

--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -554,7 +554,7 @@ wxString wxLocale::GetSystemEncodingName()
     // GNU libc provides current character set this way (this conforms
     // to Unix98)
     {
-        TempDefautLocaleSetter setDefautLocale(LC_CTYPE);
+        TempLocaleSetter setDefautLocale(LC_CTYPE);
 
         encname = wxString::FromAscii(nl_langinfo(CODESET));
     }

--- a/src/common/intl.cpp
+++ b/src/common/intl.cpp
@@ -553,11 +553,11 @@ wxString wxLocale::GetSystemEncodingName()
 #if defined(HAVE_LANGINFO_H) && defined(CODESET)
     // GNU libc provides current character set this way (this conforms
     // to Unix98)
-    char* oldLocale = strdup(setlocale(LC_CTYPE, NULL));
-    setlocale(LC_CTYPE, "");
-    encname = wxString::FromAscii(nl_langinfo(CODESET));
-    setlocale(LC_CTYPE, oldLocale);
-    free(oldLocale);
+    {
+        TempDefautLocaleSetter setDefautLocale(LC_CTYPE);
+
+        encname = wxString::FromAscii(nl_langinfo(CODESET));
+    }
 
     if (encname.empty())
 #endif // HAVE_LANGINFO_H

--- a/src/common/uilocale.cpp
+++ b/src/common/uilocale.cpp
@@ -56,6 +56,11 @@ inline void CheckLanguageVariant(wxLocaleIdent& locId)
     }
 }
 
+inline bool IsDefaultCLocale(const wxString& locale)
+{
+    return locale.IsSameAs("C", false) || locale.IsSameAs("POSIX", false);
+}
+
 } // anonymous namespace
 
 
@@ -258,7 +263,7 @@ wxLocaleIdent wxLocaleIdent::FromTag(const wxString& tag)
 
 wxLocaleIdent& wxLocaleIdent::Language(const wxString& language)
 {
-    if (language.IsSameAs("C", false) || language.IsSameAs("POSIX", false))
+    if (IsDefaultCLocale(language))
     {
         m_language = language.Upper();
     }
@@ -470,7 +475,7 @@ bool wxUILocale::UseDefault()
 bool wxUILocale::UseLocaleName(const wxString& localeName)
 {
     wxUILocaleImpl* impl = NULL;
-    if (localeName.IsSameAs("C", false) || localeName.IsSameAs("POSIX", false))
+    if (IsDefaultCLocale(localeName))
     {
         impl = wxUILocaleImpl::CreateStdC();
     }
@@ -741,9 +746,9 @@ wxString wxUILocale::GetLanguageCanonicalName(int lang)
 }
 
 /* static */
-const wxLanguageInfo* wxUILocale::FindLanguageInfo(const wxString& locale)
+const wxLanguageInfo* wxUILocale::FindLanguageInfo(const wxString& localeOrig)
 {
-    if (locale.empty())
+    if (localeOrig.empty())
         return NULL;
 
     CreateLanguagesDB();
@@ -752,13 +757,13 @@ const wxLanguageInfo* wxUILocale::FindLanguageInfo(const wxString& locale)
     // to the entry description in the language database.
     // The locale string may have the form "language[_region][.codeset]".
     // We ignore the "codeset" part here.
-    wxString myLocale = locale;
-    if (myLocale.IsSameAs("C", false) || myLocale.IsSameAs("POSIX", false))
+    wxString locale = localeOrig;
+    if (IsDefaultCLocale(locale))
     {
-        myLocale = "en_US";
+        locale = "en_US";
     }
     wxString region;
-    wxString languageOnly = myLocale.BeforeFirst('.').BeforeFirst('_', &region);
+    wxString languageOnly = locale.BeforeFirst('.').BeforeFirst('_', &region);
     wxString language = languageOnly;
     if (!region.empty())
     {
@@ -774,7 +779,7 @@ const wxLanguageInfo* wxUILocale::FindLanguageInfo(const wxString& locale)
     {
         const wxLanguageInfo* info = &languagesDB[i];
 
-        if (wxStricmp(myLocale, info->CanonicalName) == 0 ||
+        if (wxStricmp(locale, info->CanonicalName) == 0 ||
             wxStricmp(language, info->Description) == 0)
         {
             // exact match, stop searching
@@ -782,7 +787,7 @@ const wxLanguageInfo* wxUILocale::FindLanguageInfo(const wxString& locale)
             break;
         }
 
-        if (wxStricmp(myLocale, info->CanonicalName.BeforeFirst(wxS('_'))) == 0 ||
+        if (wxStricmp(locale, info->CanonicalName.BeforeFirst(wxS('_'))) == 0 ||
             wxStricmp(languageOnly, info->Description) == 0)
         {
             // a match -- but maybe we'll find an exact one later, so continue
@@ -809,7 +814,7 @@ const wxLanguageInfo* wxUILocale::FindLanguageInfo(const wxLocaleIdent& locId)
 
     const wxLanguageInfo* infoRet = NULL;
     wxString localeTag = locId.GetTag(wxLOCALE_TAGTYPE_BCP47);
-    if (locId.GetLanguage().IsSameAs("C", false) || locId.GetLanguage().IsSameAs("POSIX", false))
+    if (IsDefaultCLocale(locId.GetLanguage()))
     {
         localeTag = "en-US";
     }

--- a/src/common/uilocale.cpp
+++ b/src/common/uilocale.cpp
@@ -752,9 +752,14 @@ const wxLanguageInfo* wxUILocale::FindLanguageInfo(const wxString& locale)
     // to the entry description in the language database.
     // The locale string may have the form "language[_region][.codeset]".
     // We ignore the "codeset" part here.
+    wxString myLocale = locale;
+    if (myLocale.IsSameAs("C", false) || myLocale.IsSameAs("POSIX", false))
+    {
+        myLocale = "en_US";
+    }
     wxString region;
-    wxString languageOnly = locale.BeforeFirst('.').BeforeFirst('_', &region);
-    wxString language= languageOnly;
+    wxString languageOnly = myLocale.BeforeFirst('.').BeforeFirst('_', &region);
+    wxString language = languageOnly;
     if (!region.empty())
     {
         // Construct description consisting of language and region
@@ -769,7 +774,7 @@ const wxLanguageInfo* wxUILocale::FindLanguageInfo(const wxString& locale)
     {
         const wxLanguageInfo* info = &languagesDB[i];
 
-        if (wxStricmp(locale, info->CanonicalName) == 0 ||
+        if (wxStricmp(myLocale, info->CanonicalName) == 0 ||
             wxStricmp(language, info->Description) == 0)
         {
             // exact match, stop searching
@@ -777,7 +782,7 @@ const wxLanguageInfo* wxUILocale::FindLanguageInfo(const wxString& locale)
             break;
         }
 
-        if (wxStricmp(locale, info->CanonicalName.BeforeFirst(wxS('_'))) == 0 ||
+        if (wxStricmp(myLocale, info->CanonicalName.BeforeFirst(wxS('_'))) == 0 ||
             wxStricmp(languageOnly, info->Description) == 0)
         {
             // a match -- but maybe we'll find an exact one later, so continue
@@ -804,6 +809,10 @@ const wxLanguageInfo* wxUILocale::FindLanguageInfo(const wxLocaleIdent& locId)
 
     const wxLanguageInfo* infoRet = NULL;
     wxString localeTag = locId.GetTag(wxLOCALE_TAGTYPE_BCP47);
+    if (locId.GetLanguage().IsSameAs("C", false) || locId.GetLanguage().IsSameAs("POSIX", false))
+    {
+        localeTag = "en-US";
+    }
 
     const wxLanguageInfos& languagesDB = wxGetLanguageInfos();
     const size_t count = languagesDB.size();

--- a/src/unix/uilocale.cpp
+++ b/src/unix/uilocale.cpp
@@ -338,6 +338,14 @@ wxUILocaleImplUnix::Use()
 
         wxSetlocaleTryAll(LC_ALL, locIdAlt);
     }
+    
+#ifdef HAVE_LANGINFO_H
+    // In case of the system default locale the codeset can not be
+    // determined properly in the constructor, because the default
+    // locale is actually not set yet.
+    // Therefore we have to do it here (again).
+    m_codeset = GetLangInfo(CODESET);
+#endif
 }
 
 wxString

--- a/src/unix/uilocale.cpp
+++ b/src/unix/uilocale.cpp
@@ -99,7 +99,7 @@ private:
     mutable wxString m_name;
 
 #ifdef HAVE_LOCALE_T
-    // Only null for the default locale.
+    // Only null for the default or "C" locale.
     locale_t m_locale;
 #endif // HAVE_LOCALE_T
 

--- a/src/unix/uilocale.cpp
+++ b/src/unix/uilocale.cpp
@@ -20,6 +20,11 @@
 
 #if wxUSE_INTL
 
+#include <locale.h>
+#ifdef HAVE_LANGINFO_H
+    #include <langinfo.h>
+#endif
+
 #include "wx/uilocale.h"
 #include "wx/private/uilocale.h"
 
@@ -29,11 +34,6 @@
 #include "wx/log.h"
 #include "wx/tokenzr.h"
 #include "wx/utils.h"
-
-#include <locale.h>
-#ifdef HAVE_LANGINFO_H
-    #include <langinfo.h>
-#endif
 
 #define TRACE_I18N wxS("i18n")
 

--- a/src/unix/uilocale.cpp
+++ b/src/unix/uilocale.cpp
@@ -352,7 +352,7 @@ wxUILocaleImplUnix::InitLocaleNameAndCodeset() const
     // If extended locale support is not available, we need to temporarily
     // switch the global locale to the one we use.
 #ifndef HAVE_LOCALE_T
-    TempDefautLocaleSetter setDefautLocale(LC_CTYPE);
+    TempDefautLocaleSetter setDefautLocale(LC_CTYPE, m_locId.GetName());
 #endif
 
 #ifdef _NL_LOCALE_NAME
@@ -400,6 +400,8 @@ wxUILocaleImplUnix::GetLangInfo(nl_item item) const
     // We assume that we have nl_langinfo_l() if we have locale_t.
     if ( m_locale )
         return nl_langinfo_l(item, m_locale);
+#else
+    TempDefautLocaleSetter setDefautLocale(LC_CTYPE, m_locId.GetName());
 #endif // HAVE_LOCALE_T
 
     return nl_langinfo(item);

--- a/src/unix/uilocale.cpp
+++ b/src/unix/uilocale.cpp
@@ -338,7 +338,7 @@ wxUILocaleImplUnix::Use()
 
         wxSetlocaleTryAll(LC_ALL, locIdAlt);
     }
-    
+
 #ifdef HAVE_LANGINFO_H
     // In case of the system default locale the codeset can not be
     // determined properly in the constructor, because the default

--- a/src/unix/uilocale.cpp
+++ b/src/unix/uilocale.cpp
@@ -470,9 +470,20 @@ wxUILocaleImplUnix::InitLocaleNameAndCodeset() const
 #ifdef _NL_LOCALE_NAME
     m_name = GetLangInfo(_NL_LOCALE_NAME(LC_CTYPE));
 #else
-    // This won't work for the default or "C" locale, but we can't really get
-    // its name without nl_langinfo() support for this.
     m_name = m_locId.GetName();
+    if ( m_name.empty() )
+    {
+        // This must be the default locale.
+        wxString locName,
+                 modifier;
+        if ( !GetLocaleFromEnvironment(locName, modifier) )
+        {
+            // This is the default locale if nothing is specified.
+            locName = "en_US";
+        }
+
+        m_name = locName + modifier;
+    }
 #endif
 
     m_codeset = GetLangInfo(CODESET);

--- a/src/unix/uilocale.cpp
+++ b/src/unix/uilocale.cpp
@@ -356,7 +356,7 @@ wxUILocaleImplUnix::GetName() const
 wxLocaleIdent
 wxUILocaleImplUnix::GetLocaleId() const
 {
-    return m_locId;
+    return wxLocaleIdent::FromTag(GetName());
 }
 
 #ifdef HAVE_LANGINFO_H

--- a/src/unix/uilocale.cpp
+++ b/src/unix/uilocale.cpp
@@ -349,8 +349,6 @@ wxUILocaleImplUnix::Use()
 void
 wxUILocaleImplUnix::InitLocaleNameAndCodeset() const
 {
-    m_name = m_locId.GetName();
-
     // We need to temporarily switch the locale, do it using extended locale
     // support if available as this doesn't affect any other threads or by
     // changing the global locale otherwise because we don't have any other
@@ -363,7 +361,14 @@ wxUILocaleImplUnix::InitLocaleNameAndCodeset() const
     TempDefautLocaleSetter setDefautLocale(LC_CTYPE);
 #endif
 
+#ifdef _NL_LOCALE_NAME
     m_name = GetLangInfo(_NL_LOCALE_NAME(LC_CTYPE));
+#else
+    // This won't work for the default or "C" locale, but we can't really get
+    // its name without nl_langinfo() support for this.
+    m_name = m_locId.GetName();
+#endif
+
     m_codeset = GetLangInfo(CODESET);
 #endif // HAVE_LANGINFO_H
 }

--- a/src/unix/uilocale.cpp
+++ b/src/unix/uilocale.cpp
@@ -352,7 +352,7 @@ wxUILocaleImplUnix::InitLocaleNameAndCodeset() const
     // If extended locale support is not available, we need to temporarily
     // switch the global locale to the one we use.
 #ifndef HAVE_LOCALE_T
-    TempDefautLocaleSetter setDefautLocale(LC_CTYPE, m_locId.GetName());
+    TempLocaleSetter setThisLocale(LC_CTYPE, m_locId.GetName());
 #endif
 
 #ifdef _NL_LOCALE_NAME
@@ -401,7 +401,7 @@ wxUILocaleImplUnix::GetLangInfo(nl_item item) const
     if ( m_locale )
         return nl_langinfo_l(item, m_locale);
 #else
-    TempDefautLocaleSetter setDefautLocale(LC_CTYPE, m_locId.GetName());
+    TempLocaleSetter setThisLocale(LC_CTYPE, m_locId.GetName());
 #endif // HAVE_LOCALE_T
 
     return nl_langinfo(item);

--- a/tests/intl/intltest.cpp
+++ b/tests/intl/intltest.cpp
@@ -233,6 +233,8 @@ void IntlTestCase::IsAvailable()
 
 TEST_CASE("wxLocale::Default", "[locale]")
 {
+    CHECK( wxLocale::IsAvailable(wxLANGUAGE_DEFAULT) );
+
     wxLocale loc;
 
     REQUIRE( loc.Init(wxLANGUAGE_DEFAULT, wxLOCALE_DONT_LOAD_DEFAULT) );


### PR DESCRIPTION
`GetSystemLocale()` creates internally a default locale instance that is then queried for its identifier. Under Unix this fails, because `GetLocaleId()` returns any empty `wxLocaleIdent`. With this change the method will determine the identifier correctly for the default locale.