### PR TITLE
XRC: Support additional wxWizard properties

### DIFF
--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -2517,6 +2517,22 @@ corresponds to the following tree of labels:
 @hdr3col{property, type, description}
 @row3col{bitmap, @ref overview_xrcformat_type_bitmap,
     Bitmap to display on the left side of the wizard (default: none).}
+@row3col{border, integer, Sets width of border around page area. (default: 0).
+    @since 3.2.0}
+@row3col{bmp_placement, @ref overview_xrcformat_type_style,
+    Sets the flags indicating how the wizard or page bitmap should be expanded
+    and positioned to fit the page height. By default, placement is 0
+    (no expansion is done). See wxWizard::SetBitmapPlacement()
+    @since 3.2.0}
+@row3col{bmp_minwidth, integer,
+    Sets the minimum width for the bitmap that will be constructed to contain
+    the actual wizard or page bitmap if a non-zero bitmap placement flag has
+    been set.
+    @since 3.2.0}
+@row3col{bmp_bg_clr, @ref overview_xrcformat_type_colour,
+    Sets the colour that should be used to fill the area not taken up by the
+    wizard or page bitmap, if a non-zero bitmap placement flag has been set.
+    @since 3.2.0}
 @endTable
 
 A wizard object can have one or more child objects of the wxWizardPage or

--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -2519,17 +2519,17 @@ corresponds to the following tree of labels:
     Bitmap to display on the left side of the wizard (default: none).}
 @row3col{border, integer, Sets width of border around page area. (default: 0).
     @since 3.2.0}
-@row3col{bmp_placement, @ref overview_xrcformat_type_style,
+@row3col{bitmap-placement, @ref overview_xrcformat_type_style,
     Sets the flags indicating how the wizard or page bitmap should be expanded
     and positioned to fit the page height. By default, placement is 0
     (no expansion is done). See wxWizard::SetBitmapPlacement()
     @since 3.2.0}
-@row3col{bmp_minwidth, integer,
+@row3col{bitmap-minwidth, integer,
     Sets the minimum width for the bitmap that will be constructed to contain
     the actual wizard or page bitmap if a non-zero bitmap placement flag has
     been set.
     @since 3.2.0}
-@row3col{bmp_bg_clr, @ref overview_xrcformat_type_colour,
+@row3col{bitmap-bg, @ref overview_xrcformat_type_colour,
     Sets the colour that should be used to fill the area not taken up by the
     wizard or page bitmap, if a non-zero bitmap placement flag has been set.
     @since 3.2.0}

--- a/misc/schema/xrc_schema.rnc
+++ b/misc/schema/xrc_schema.rnc
@@ -1734,7 +1734,18 @@ wxWizard =
         stdObjectNodeAttributes &
         stdWindowProperties &
         [xrc:p="o"] element title  {_, t_text }* &
+        [xrc:p="o"] element border   {_, t_integer }* &
         [xrc:p="o"] element bitmap {_, t_bitmap }* &
+        [xrc:p="o"] element bmp_placement {_, ("wxWIZARD_VALIGN_TOP" |
+                                                "wxWIZARD_VALIGN_CENTRE" |
+                                                "wxWIZARD_VALIGN_BOTTOM" |
+                                                "wxWIZARD_VALIGN_CENTRE" |
+                                                "wxWIZARD_HALIGN_LEFT" |
+                                                "wxWIZARD_HALIGN_CENTRE" |
+                                                "wxWIZARD_HALIGN_RIGHT" |
+                                                "wxWIZARD_TILE") }* &
+        [xrc:p="o"] element bmp_minwidth {_, t_integer }* &
+        [xrc:p="o"] element bmp_bg_clr   {_, t_colour }* &
         (wxWizardPage_any | objectRef)*
     }
 

--- a/misc/schema/xrc_schema.rnc
+++ b/misc/schema/xrc_schema.rnc
@@ -1736,16 +1736,16 @@ wxWizard =
         [xrc:p="o"] element title  {_, t_text }* &
         [xrc:p="o"] element border   {_, t_integer }* &
         [xrc:p="o"] element bitmap {_, t_bitmap }* &
-        [xrc:p="o"] element bmp_placement {_, ("wxWIZARD_VALIGN_TOP" |
-                                                "wxWIZARD_VALIGN_CENTRE" |
-                                                "wxWIZARD_VALIGN_BOTTOM" |
-                                                "wxWIZARD_VALIGN_CENTRE" |
-                                                "wxWIZARD_HALIGN_LEFT" |
-                                                "wxWIZARD_HALIGN_CENTRE" |
-                                                "wxWIZARD_HALIGN_RIGHT" |
-                                                "wxWIZARD_TILE") }* &
-        [xrc:p="o"] element bmp_minwidth {_, t_integer }* &
-        [xrc:p="o"] element bmp_bg_clr   {_, t_colour }* &
+        [xrc:p="o"] element bitmap-placement {_, ("wxWIZARD_VALIGN_TOP" |
+                                                  "wxWIZARD_VALIGN_CENTRE" |
+                                                  "wxWIZARD_VALIGN_BOTTOM" |
+                                                  "wxWIZARD_VALIGN_CENTRE" |
+                                                  "wxWIZARD_HALIGN_LEFT" |
+                                                  "wxWIZARD_HALIGN_CENTRE" |
+                                                  "wxWIZARD_HALIGN_RIGHT" |
+                                                  "wxWIZARD_TILE") }* &
+        [xrc:p="o"] element bitmap-minwidth {_, t_integer }* &
+        [xrc:p="o"] element bitmap-bg   {_, t_colour }* &
         (wxWizardPage_any | objectRef)*
     }
 

--- a/src/xrc/xh_wizrd.cpp
+++ b/src/xrc/xh_wizrd.cpp
@@ -46,6 +46,15 @@ wxWizardXmlHandler::wxWizardXmlHandler() : wxXmlResourceHandler()
 
     XRC_ADD_STYLE(wxWIZARD_EX_HELPBUTTON);
     AddWindowStyles();
+
+    // bitmap placement flags
+    XRC_ADD_STYLE(wxWIZARD_VALIGN_TOP);
+    XRC_ADD_STYLE(wxWIZARD_VALIGN_CENTRE);
+    XRC_ADD_STYLE(wxWIZARD_VALIGN_BOTTOM);
+    XRC_ADD_STYLE(wxWIZARD_HALIGN_LEFT);
+    XRC_ADD_STYLE(wxWIZARD_HALIGN_CENTRE);
+    XRC_ADD_STYLE(wxWIZARD_HALIGN_RIGHT);
+    XRC_ADD_STYLE(wxWIZARD_TILE);
 }
 
 wxObject *wxWizardXmlHandler::DoCreateResource()
@@ -63,6 +72,27 @@ wxObject *wxWizardXmlHandler::DoCreateResource()
                     GetBitmapBundle(),
                     GetPosition(),
                     GetStyle(wxT("style"), wxDEFAULT_DIALOG_STYLE));
+
+        int border = GetLong("border", -1);
+        if (border > 0)
+            wiz->SetBorder(border);
+
+        int placement = GetStyle("bmp_placement", 0);
+        if (placement > 0)
+        {
+            wiz->SetBitmapPlacement(placement);
+
+            // The following two options are only valid if "bmp_placement" has been set
+
+            int min_width = GetLong("bmp_minwidth", -1);
+            if (min_width > 0)
+                wiz->SetMinimumBitmapWidth(min_width);
+
+            wxColor clr = GetColour("bmp_bg_clr");
+            if (clr.IsOk())
+                wiz->SetBitmapBackgroundColour(clr);
+        }
+
         SetupWindow(wiz);
 
         wxWizard *old = m_wizard;

--- a/src/xrc/xh_wizrd.cpp
+++ b/src/xrc/xh_wizrd.cpp
@@ -77,18 +77,18 @@ wxObject *wxWizardXmlHandler::DoCreateResource()
         if (border > 0)
             wiz->SetBorder(border);
 
-        int placement = GetStyle("bmp_placement", 0);
+        int placement = GetStyle("bitmap-placement", 0);
         if (placement > 0)
         {
             wiz->SetBitmapPlacement(placement);
 
             // The following two options are only valid if "bmp_placement" has been set
 
-            int min_width = GetLong("bmp_minwidth", -1);
+            int min_width = GetLong("bitmap-minwidth", -1);
             if (min_width > 0)
                 wiz->SetMinimumBitmapWidth(min_width);
 
-            wxColor clr = GetColour("bmp_bg_clr");
+            wxColor clr = GetColour("bitmap-bg");
             if (clr.IsOk())
                 wiz->SetBitmapBackgroundColour(clr);
         }


### PR DESCRIPTION
This PR adds additional properties to wxWizard. The user can now specify a border to place around the page area, a reserved space for a bitmap, as well as placement flags and background color for the bitmap. All of these use existing wxWizard API.

Example usage:

```xml
	<bitmap-placement>wxWIZARD_VALIGN_CENTRE|wxWIZARD_HALIGN_RIGHT</bitmap-placement>
	<bitmap-minwidth>150</bitmap-minwidth>
	<bitmap-bg>#F0F0F0</bitmap-bg>
```

This sets aside 150 pixels for the bitmap, and if the bitmap isn't large enough, it is aligned on the right side of the reserved area, and the background for the area not containing a bitmap is set to light grey. 
