### PR TITLE
XRC: Support SetEmptyCellSize in wxGridBagSizer

### DIFF
--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -2733,6 +2733,9 @@ support the following properties:
     optionally the proportion can be appended after each number
     separated by a @c :
     (default: none).}
+@row3col{empty_cellsize, @ref overview_xrcformat_type_size,
+    Size used for cells in the grid with no item. (default: @c wxDefaultSize).
+    @since 3.2.0}
 @endTable
 
 @subsection overview_xrcformat_wxwrapsizer wxWrapSizer

--- a/misc/schema/xrc_schema.rnc
+++ b/misc/schema/xrc_schema.rnc
@@ -2043,6 +2043,7 @@ wxGridBagSizer =
                                                      "wxFLEX_GROWMODE_ALL") }* &
         [xrc:p="o"] element growablerows        {_, t_list_of_numbers_with_weights }* &
         [xrc:p="o"] element growablecols        {_, t_list_of_numbers_with_weights }* &
+        [xrc:p="o"] element empty_cellsize      {_, t_size }* &
         (wxSizerGB_item | objectRef)*
     }
 

--- a/src/xrc/xh_sizer.cpp
+++ b/src/xrc/xh_sizer.cpp
@@ -253,6 +253,13 @@ wxObject* wxSizerXmlHandler::Handle_sizer()
     m_isInside = true;
     m_isGBS = (m_class == wxT("wxGridBagSizer"));
 
+    if (m_isGBS)
+    {
+        wxSize cellsize = GetSize(wxT("empty_cellsize"));
+        if (cellsize != wxDefaultSize)
+            wxDynamicCast(sizer, wxGridBagSizer)->SetEmptyCellSize(cellsize);
+    }
+
     wxObject* parent = m_parent;
 #if wxUSE_STATBOX
     // wxStaticBoxSizer's child controls should be parented by the box itself,

--- a/src/xrc/xh_sizer.cpp
+++ b/src/xrc/xh_sizer.cpp
@@ -257,7 +257,7 @@ wxObject* wxSizerXmlHandler::Handle_sizer()
     {
         wxSize cellsize = GetSize(wxT("empty_cellsize"));
         if (cellsize != wxDefaultSize)
-            wxDynamicCast(sizer, wxGridBagSizer)->SetEmptyCellSize(cellsize);
+            static_cast<wxGridBagSizer*>(sizer)->SetEmptyCellSize(cellsize);
     }
 
     wxObject* parent = m_parent;


### PR DESCRIPTION
This PR adds the ability for XRC to call wxGridBagSizer::SetEmptyCellSize() by supporting a `empty_cellsize` property.