### PR TITLE
Fix transferring data from custom wxFileDialog controls

### DIFF
--- a/include/wx/filedlg.h
+++ b/include/wx/filedlg.h
@@ -206,6 +206,9 @@ protected:
     // Helper function for native file dialog usage where no wx events
     // are processed.
     void UpdateExtraControlUI();
+    // Helper function simply transferring data from custom controls if they
+    // are used -- must be called if the dialog was accepted.
+    void TransferDataFromExtraControl();
 
 private:
     ExtraControlCreatorFunction m_extraControlCreator;

--- a/src/common/fldlgcmn.cpp
+++ b/src/common/fldlgcmn.cpp
@@ -617,7 +617,6 @@ public:
     Panel(wxWindow* parent, wxFileDialogCustomizeHook& customizeHook)
         : wxPanel(parent),
           wxFileDialogCustomize(this),
-          m_customizeHook(customizeHook),
           m_lastWasRadio(false)
     {
         // Use a simple horizontal sizer to layout all the controls for now.
@@ -628,16 +627,11 @@ public:
         sizer->AddSpacer(wxSizerFlags::GetDefaultBorder());
 
         // This will call our own AddXXX().
-        m_customizeHook.AddCustomControls(*this);
+        customizeHook.AddCustomControls(*this);
 
         // Now that everything was created, resize and layout.
         SetClientSize(sizer->ComputeFittingClientSize(this));
         sizer->Layout();
-    }
-
-    virtual ~Panel()
-    {
-        m_customizeHook.TransferDataFromCustomControls();
     }
 
 
@@ -719,8 +713,6 @@ private:
         return controlImpl;
     }
 
-
-    wxFileDialogCustomizeHook& m_customizeHook;
 
     bool m_lastWasRadio;
 
@@ -919,6 +911,12 @@ void wxFileDialogBase::UpdateExtraControlUI()
 
     if ( m_extraControl )
         m_extraControl->UpdateWindowUI(wxUPDATE_UI_RECURSE);
+}
+
+void wxFileDialogBase::TransferDataFromExtraControl()
+{
+    if ( m_customizeHook )
+        m_customizeHook->TransferDataFromCustomControls();
 }
 
 void wxFileDialogBase::SetPath(const wxString& path)

--- a/src/generic/filedlgg.cpp
+++ b/src/generic/filedlgg.cpp
@@ -366,6 +366,8 @@ void wxGenericFileDialog::OnOk( wxCommandEvent &WXUNUSED(event) )
         return;
     }
 
+    TransferDataFromExtraControl();
+
     EndModal(wxID_OK);
 }
 

--- a/src/gtk/filedlg.cpp
+++ b/src/gtk/filedlg.cpp
@@ -370,6 +370,8 @@ void wxFileDialog::OnFakeOk(wxCommandEvent& WXUNUSED(event))
         str(gtk_file_chooser_get_current_folder(GTK_FILE_CHOOSER(m_widget)));
     m_dir = wxString::FromUTF8(str);
 
+    TransferDataFromExtraControl();
+
     EndDialog(wxID_OK);
 }
 

--- a/src/motif/filedlg.cpp
+++ b/src/motif/filedlg.cpp
@@ -333,6 +333,8 @@ int wxFileDialog::ShowModal()
 
     if (m_fileName.empty())
         return wxID_CANCEL;
-    else
-        return wxID_OK;
+
+    TransferDataFromExtraControl();
+
+    return wxID_OK;
 }

--- a/src/msw/filedlg.cpp
+++ b/src/msw/filedlg.cpp
@@ -1144,24 +1144,7 @@ void wxFileDialog::MSWOnTypeChange(int nFilterIndex)
 
 void wxFileDialog::MSWOnFileOK()
 {
-    if ( m_customizeHook )
-    {
-        if ( m_extraControl )
-        {
-            // If we've created the old style extra controls even though we're
-            // using the customize hook, we must delete them now, to ensure
-            // that TransferDataFromCustomControls() called from the extra
-            // controls panel destructor is called while the controls still
-            // exist.
-            DestroyExtraControl();
-        }
-        else // This is the normal case, when using IFileDialog.
-        {
-            // Just call TransferDataFromCustomControls() directly, it won't be
-            // called from anywhere else.
-            m_customizeHook->TransferDataFromCustomControls();
-        }
-    }
+    TransferDataFromExtraControl();
 }
 
 // helper used below in ShowCommFileDialog(): style is used to determine

--- a/src/osx/cocoa/filedlg.mm
+++ b/src/osx/cocoa/filedlg.mm
@@ -627,13 +627,13 @@ int wxFileDialog::ShowModal()
 
 void wxFileDialog::ModalFinishedCallback(void* panel, int returnCode)
 {
+    NSSavePanel* const sPanel = static_cast<NSSavePanel*>(panel);
+
     const bool wasAccepted = returnCode == NSModalResponseOK;
     if (HasFlag(wxFD_SAVE))
     {
         if (wasAccepted)
         {
-            NSSavePanel* sPanel = (NSSavePanel*)panel;
-
             NSString* unsafePath = [NSString stringWithUTF8String:[[sPanel URL] fileSystemRepresentation]];
             m_path = wxCFStringRef([[unsafePath precomposedStringWithCanonicalMapping] retain]).AsString();
             m_fileName = wxFileNameFromPath(m_path);
@@ -646,7 +646,7 @@ void wxFileDialog::ModalFinishedCallback(void* panel, int returnCode)
     }
     else
     {
-        NSOpenPanel* oPanel = (NSOpenPanel*)panel;
+        NSOpenPanel* const oPanel = static_cast<NSOpenPanel*>(sPanel);
         if (wasAccepted)
         {
             bool isFirst = true;
@@ -687,7 +687,7 @@ void wxFileDialog::ModalFinishedCallback(void* panel, int returnCode)
     if (GetModality() == wxDIALOG_MODALITY_WINDOW_MODAL)
         SendWindowModalDialogEvent ( wxEVT_WINDOW_MODAL_DIALOG_CLOSED  );
     
-    [(NSSavePanel*) panel setAccessoryView:nil];
+    [sPanel setAccessoryView:nil];
 }
 
 #endif // wxUSE_FILEDLG

--- a/src/osx/cocoa/filedlg.mm
+++ b/src/osx/cocoa/filedlg.mm
@@ -675,6 +675,8 @@ void wxFileDialog::ModalFinishedCallback(void* panel, int returnCode)
             m_filterIndex = m_filterChoice->GetSelection();
         else
             m_filterIndex = GetMatchingFilterExtension(m_fileName);
+
+        TransferDataFromExtraControl();
     }
 
     SetReturnCode(wasAccepted ? wxID_OK : wxID_CANCEL);

--- a/src/osx/cocoa/filedlg.mm
+++ b/src/osx/cocoa/filedlg.mm
@@ -650,7 +650,6 @@ void wxFileDialog::ModalFinishedCallback(void* panel, int returnCode)
         NSOpenPanel* oPanel = (NSOpenPanel*)panel;
         if (returnCode == NSModalResponseOK )
         {
-            panel = oPanel;
             result = wxID_OK;
 
             bool isFirst = true;

--- a/src/osx/cocoa/filedlg.mm
+++ b/src/osx/cocoa/filedlg.mm
@@ -638,10 +638,6 @@ void wxFileDialog::ModalFinishedCallback(void* panel, int returnCode)
             m_path = wxCFStringRef([[unsafePath precomposedStringWithCanonicalMapping] retain]).AsString();
             m_fileName = wxFileNameFromPath(m_path);
             m_dir = wxPathOnly( m_path );
-            if (m_filterChoice)
-                m_filterIndex = m_filterChoice->GetSelection();
-            else
-                m_filterIndex = GetMatchingFilterExtension(m_fileName);
         }
     }
     else
@@ -664,11 +660,6 @@ void wxFileDialog::ModalFinishedCallback(void* panel, int returnCode)
                     isFirst = false;
                 }
             }
-
-            if (m_filterChoice)
-                 m_filterIndex = m_filterChoice->GetSelection();
-            else
-                m_filterIndex = GetMatchingFilterExtension(m_fileName);
         }
         if ( m_delegate )
         {
@@ -677,6 +668,15 @@ void wxFileDialog::ModalFinishedCallback(void* panel, int returnCode)
             m_delegate = nil;
         }
     }
+
+    if (wasAccepted)
+    {
+        if (m_filterChoice)
+            m_filterIndex = m_filterChoice->GetSelection();
+        else
+            m_filterIndex = GetMatchingFilterExtension(m_fileName);
+    }
+
     SetReturnCode(wasAccepted ? wxID_OK : wxID_CANCEL);
     
     // workaround for sandboxed app, see above, must be executed before window modal handler

--- a/src/osx/cocoa/filedlg.mm
+++ b/src/osx/cocoa/filedlg.mm
@@ -627,13 +627,12 @@ int wxFileDialog::ShowModal()
 
 void wxFileDialog::ModalFinishedCallback(void* panel, int returnCode)
 {
-    int result = wxID_CANCEL;
+    const bool wasAccepted = returnCode == NSModalResponseOK;
     if (HasFlag(wxFD_SAVE))
     {
-        if (returnCode == NSModalResponseOK )
+        if (wasAccepted)
         {
             NSSavePanel* sPanel = (NSSavePanel*)panel;
-            result = wxID_OK;
 
             NSString* unsafePath = [NSString stringWithUTF8String:[[sPanel URL] fileSystemRepresentation]];
             m_path = wxCFStringRef([[unsafePath precomposedStringWithCanonicalMapping] retain]).AsString();
@@ -648,10 +647,8 @@ void wxFileDialog::ModalFinishedCallback(void* panel, int returnCode)
     else
     {
         NSOpenPanel* oPanel = (NSOpenPanel*)panel;
-        if (returnCode == NSModalResponseOK )
+        if (wasAccepted)
         {
-            result = wxID_OK;
-
             bool isFirst = true;
             for (NSURL* filename in [oPanel URLs])
             {
@@ -680,7 +677,7 @@ void wxFileDialog::ModalFinishedCallback(void* panel, int returnCode)
             m_delegate = nil;
         }
     }
-    SetReturnCode(result);
+    SetReturnCode(wasAccepted ? wxID_OK : wxID_CANCEL);
     
     // workaround for sandboxed app, see above, must be executed before window modal handler
     // because there this instance will be deleted


### PR DESCRIPTION
Also simplify the dialog code in wxOSX a bit.

@marekr While testing this under macOS in an ASAN-build, I've realized that there was another bad bug here, and this PR fixes it.