### PR TITLE
Make wxBitmap::HasAlpha() and UseAlpha() available in all ports

### DIFF
--- a/include/wx/bitmap.h
+++ b/include/wx/bitmap.h
@@ -250,6 +250,12 @@ public:
     virtual void SetPalette(const wxPalette& palette) = 0;
 #endif // wxUSE_PALETTE
 
+    // Alpha support for 32bpp bitmaps: check if it's used, request that it be
+    // used or not.
+    virtual bool HasAlpha() const;
+    virtual bool UseAlpha(bool use = true);
+    void ResetAlpha() { UseAlpha(false); }
+
     // copies the contents and mask of the given (colour) icon to the bitmap
     bool CopyFromIcon(const wxIcon& icon);
 

--- a/include/wx/gtk/bitmap.h
+++ b/include/wx/gtk/bitmap.h
@@ -145,7 +145,7 @@ public:
     void *GetRawData(wxPixelDataBase& data, int bpp);
     void UngetRawData(wxPixelDataBase& data);
 
-    bool HasAlpha() const;
+    bool HasAlpha() const wxOVERRIDE;
 
 protected:
 #if wxUSE_IMAGE

--- a/include/wx/msw/bitmap.h
+++ b/include/wx/msw/bitmap.h
@@ -176,8 +176,6 @@ public:
     wxMask *GetMask() const;
     void SetMask(wxMask *mask);
 
-    // these functions are internal and shouldn't be used, they risk to
-    // disappear in the future
     bool HasAlpha() const;
     void UseAlpha(bool use = true);
     void ResetAlpha() { UseAlpha(false); }

--- a/include/wx/osx/bitmap.h
+++ b/include/wx/osx/bitmap.h
@@ -180,10 +180,8 @@ public:
     void *GetRawData(wxPixelDataBase& data, int bpp);
     void UngetRawData(wxPixelDataBase& data);
 
-    // these functions are internal and shouldn't be used, they risk to
-    // disappear in the future
-    bool HasAlpha() const;
-    void UseAlpha(bool use = true);
+    bool HasAlpha() const wxOVERRIDE;
+    bool UseAlpha(bool use = true) wxOVERRIDE;
 
     // returns the 'native' implementation, a GWorldPtr for the content and one for the mask
     WXHBITMAP GetHBITMAP( WXHBITMAP * mask = NULL ) const;

--- a/include/wx/qt/bitmap.h
+++ b/include/wx/qt/bitmap.h
@@ -70,7 +70,7 @@ public:
 
     // these functions are internal and shouldn't be used, they risk to
     // disappear in the future
-    bool HasAlpha() const;
+    bool HasAlpha() const wxOVERRIDE;
 
     QPixmap *GetHandle() const;
 

--- a/interface/wx/bitmap.h
+++ b/interface/wx/bitmap.h
@@ -774,6 +774,16 @@ public:
     virtual int GetWidth() const;
 
     /**
+        Returns true if the bitmap has an alpha channel.
+
+        Note that the fact that a bitmap has an alpha channel doesn't
+        necessarily mean that it has any transparency, as all of its pixels
+        could be using wxALPHA_OPAQUE value. To actually examine the alpha
+        values, the bitmap can be converted to wxImage.
+     */
+    bool HasAlpha() const;
+
+    /**
         Adds the standard bitmap format handlers, which, depending on wxWidgets
         configuration, can be handlers for Windows bitmap, Windows bitmap resource,
         and XPM.
@@ -878,6 +888,13 @@ public:
     static void Rescale(wxBitmap& bmp, const wxSize& sizeNeeded);
 
     /**
+        Remove alpha channel from the bitmap.
+
+        This is the same as calling UseAlpha() with @false argument.
+     */
+    void ResetAlpha();
+
+    /**
         Saves a bitmap in the named file.
 
         @param name
@@ -971,6 +988,24 @@ public:
             Bitmap width in pixels.
     */
     virtual void SetWidth(int width);
+
+    /**
+        Enable or disable use of alpha channel in this bitmap.
+
+        This function is only useful for 32bpp bitmaps and changes their format
+        to use, or not use, the fourth byte of the pixel data for the alpha
+        channel.
+
+        It currently is only implemented in wxMSW and wxOSX and simply always
+        returns @false under the other platforms.
+
+        @return @true if the operation succeeded, @false otherwise, e.g. when
+            trying to enable alpha channel support for a non-32bpp bitmap or if
+            this operation is simply not supported by the current platform.
+
+        @see HasAlpha(), ResetAlpha()
+     */
+    bool UseAlpha(bool use = true);
 };
 
 /**

--- a/src/common/bmpbase.cpp
+++ b/src/common/bmpbase.cpp
@@ -264,6 +264,26 @@ wxSize wxBitmapBase::GetLogicalSize() const
 
 #endif // wxHAS_DPI_INDEPENDENT_PIXELS/!wxHAS_DPI_INDEPENDENT_PIXELS
 
+// ----------------------------------------------------------------------------
+// Alpha support
+// ----------------------------------------------------------------------------
+
+bool wxBitmapBase::HasAlpha() const
+{
+    // We assume that only 32bpp bitmaps use alpha (which is always true) and
+    // that all 32bpp bitmaps do use it (which is not necessarily always the
+    // case, but the ports where it isn't need to override this function to
+    // deal with it as we can't do it here).
+    return GetDepth() == 32;
+}
+
+bool wxBitmapBase::UseAlpha(bool WXUNUSED(use))
+{
+    // This function is not implemented in the case class, we don't have any
+    // generic way to make a bitmap use, or prevent it from using, alpha.
+    return false;
+}
+
 #endif // wxUSE_BITMAP_BASE
 
 // ----------------------------------------------------------------------------

--- a/src/osx/core/bitmap.cpp
+++ b/src/osx/core/bitmap.cpp
@@ -2069,11 +2069,13 @@ void wxBitmap::UngetRawData(wxPixelDataBase& WXUNUSED(dataBase))
     GetBitmapData()->EndRawAccess() ;
 }
 
-void wxBitmap::UseAlpha(bool use )
+bool wxBitmap::UseAlpha(bool use)
 {
     // remember that we are using alpha channel:
     // we'll need to create a proper mask in UngetRawData()
     GetBitmapData()->UseAlpha( use );
+
+    return true;
 }
 
 void wxBitmap::SetSelectedInto(wxDC *dc)


### PR DESCRIPTION
HasAlpha() was already available in most of them, now ensure that it's
present in all of them, especially as it has a reasonable default
implementation.

UseAlpha() was only present in wxMSW and wxOSX and still remains only
implemented there, but provide at least a stub for it elsewhere as well
to avoid problems such as that of #17393.

Closes #17397.