### PR TITLE
Make splitter sash visible in non-live resize mode with wxGTK3 and X11

### DIFF
--- a/include/wx/graphics.h
+++ b/include/wx/graphics.h
@@ -68,7 +68,8 @@ enum wxCompositionMode
     wxCOMPOSITION_XOR, /* R = S*(1 - Da) + D*(1 - Sa) */
 
     // mathematical compositions
-    wxCOMPOSITION_ADD /* R = S + D */
+    wxCOMPOSITION_ADD, /* R = S + D */
+    wxCOMPOSITION_DIFF /* R = abs(S - D) */
 };
 
 enum wxGradientType

--- a/interface/wx/dc.h
+++ b/interface/wx/dc.h
@@ -22,7 +22,8 @@
     - wxNO_OP
     - wxCLEAR
     - wxXOR
-    and, in particular, do @em not support the commonly used @c wxINVERT.
+    and only support the commonly used @c wxINVERT when the source colour is
+    white (as it is implemented using wxCOMPOSITION_DIFF composition mode).
 */
 enum wxRasterOperationMode
 {

--- a/interface/wx/graphics.h
+++ b/interface/wx/graphics.h
@@ -302,7 +302,23 @@ enum wxCompositionMode
     wxCOMPOSITION_DEST_OUT, /**< @e R = @e D*(1 - @e Sa) */
     wxCOMPOSITION_DEST_ATOP, /**< @e R = @e S*(1 - @e Da) + @e D*@e Sa */
     wxCOMPOSITION_XOR, /**< @e R = @e S*(1 - @e Da) + @e D*(1 - @e Sa) */
-    wxCOMPOSITION_ADD  /**< @e R = @e S + @e D */
+    wxCOMPOSITION_ADD, /**< @e R = @e S + @e D */
+
+    /**
+        Result is the absolute value of the difference between the source and
+        the destination.
+
+        This composition mode is only supported by Cairo and CoreGraphics-based
+        implementations, i.e. in wxGTK and wxOSX only (unless Cairo-based
+        renderer is explicitly under the other platforms).
+
+        When the source colour is white, this mode can be used to emulate
+        wxINVERT logical function of wxDC, i.e. drawing using this mode twice
+        restores the original contents.
+
+        @since 3.2.0
+     */
+    wxCOMPOSITION_DIFF
 };
 
 /**

--- a/src/common/dcgraph.cpp
+++ b/src/common/dcgraph.cpp
@@ -52,11 +52,13 @@ static wxCompositionMode TranslateRasterOp(wxRasterOperationMode function)
         case wxXOR:        // src XOR dst
             return wxCOMPOSITION_XOR;
 
+        case wxINVERT:     // NOT dst
+            return wxCOMPOSITION_DIFF;
+
         case wxAND:        // src AND dst
         case wxAND_INVERT: // (NOT src) AND dst
         case wxAND_REVERSE:// src AND (NOT dst)
         case wxEQUIV:      // (NOT src) XOR dst
-        case wxINVERT:     // NOT dst
         case wxNAND:       // (NOT src) OR (NOT dst)
         case wxNOR:        // (NOT src) AND (NOT dst)
         case wxOR_INVERT:  // (NOT src) OR dst

--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -3086,6 +3086,9 @@ bool wxCairoContext::SetCompositionMode(wxCompositionMode op)
         case wxCOMPOSITION_ADD:
             cop = CAIRO_OPERATOR_ADD;
             break;
+        case wxCOMPOSITION_DIFF:
+            cop = CAIRO_OPERATOR_DIFFERENCE;
+            break;
         default:
             return false;
     }

--- a/src/generic/sashwin.cpp
+++ b/src/generic/sashwin.cpp
@@ -545,7 +545,6 @@ void wxSashWindow::DrawSashTracker(wxSashEdgePosition edge, int x, int y)
     int w, h;
     GetClientSize(&w, &h);
 
-    wxScreenDC screenDC;
     int x1, y1;
     int x2, y2;
 
@@ -583,18 +582,34 @@ void wxSashWindow::DrawSashTracker(wxSashEdgePosition edge, int x, int y)
     ClientToScreen(&x1, &y1);
     ClientToScreen(&x2, &y2);
 
+#ifdef __WXGTK3__
+    // We need to draw over the parent window, not this one, as we want to
+    // allow the sash go outside of this window.
+    wxWindow* const parent = wxGetTopLevelParent(this);
+    if ( !parent )
+        return;
+
+    wxClientDC dc(parent);
+    parent->ScreenToClient(&x1, &y1);
+    parent->ScreenToClient(&x2, &y2);
+
+    // In the ports with wxGraphicsContext-based wxDC, wxINVERT only works for
+    // inverting the background when using white foreground (note that this
+    // code is not going to work anyhow with wxOSX nor with wxGTK when using
+    // Wayland, as drawing using wxClientDC doesn't work at all there), but
+    // this at least makes it work with wxGTK with X11.
+    wxPen sashTrackerPen(*wxWHITE, 2, wxPENSTYLE_SOLID);
+#else
+    wxScreenDC dc;
+
     wxPen sashTrackerPen(*wxBLACK, 2, wxPENSTYLE_SOLID);
+#endif
 
-    screenDC.SetLogicalFunction(wxINVERT);
-    screenDC.SetPen(sashTrackerPen);
-    screenDC.SetBrush(*wxTRANSPARENT_BRUSH);
+    dc.SetLogicalFunction(wxINVERT);
+    dc.SetPen(sashTrackerPen);
+    dc.SetBrush(*wxTRANSPARENT_BRUSH);
 
-    screenDC.DrawLine(x1, y1, x2, y2);
-
-    screenDC.SetLogicalFunction(wxCOPY);
-
-    screenDC.SetPen(wxNullPen);
-    screenDC.SetBrush(wxNullBrush);
+    dc.DrawLine(x1, y1, x2, y2);
 }
 
 // Position and size subwindows.

--- a/src/generic/splitter.cpp
+++ b/src/generic/splitter.cpp
@@ -79,6 +79,19 @@ static bool IsLive(wxSplitterWindow* wnd)
 #if defined( __WXMAC__ ) && defined(TARGET_API_MAC_OSX) && TARGET_API_MAC_OSX == 1
     return true; // Mac can't paint outside paint event - always need live mode
 #else
+    // wxClientDC doesn't work with Wayland neither, so check if we're using it.
+    #if defined(__WXGTK3__)
+        switch ( wxGetDisplayInfo().type )
+        {
+            case wxDisplayNone:
+            case wxDisplayX11:
+                break;
+
+            case wxDisplayWayland:
+                return true;
+        }
+    #endif // wxGTK3
+
     return wnd->HasFlag(wxSP_LIVE_UPDATE);
 #endif
 }

--- a/src/generic/splitter.cpp
+++ b/src/generic/splitter.cpp
@@ -607,7 +607,6 @@ void wxSplitterWindow::DrawSashTracker(int x, int y)
     int w, h;
     GetClientSize(&w, &h);
 
-    wxScreenDC dc;
     int x1, y1;
     int x2, y2;
 
@@ -624,8 +623,16 @@ void wxSplitterWindow::DrawSashTracker(int x, int y)
         x2 = w-2;
     }
 
+#if defined(__WXGTK3__)
+    wxClientDC dc(this);
+#else
+    // We need to use wxScreenDC and not wxClientDC at least for wxMSW where
+    // drawing in this window itself would be hidden by its children windows,
+    // that cover it almost entirely.
+    wxScreenDC dc;
     ClientToScreen(&x1, &y1);
     ClientToScreen(&x2, &y2);
+#endif
 
     dc.SetLogicalFunction(wxINVERT);
     dc.SetPen(*m_sashTrackerPen);

--- a/src/generic/splitter.cpp
+++ b/src/generic/splitter.cpp
@@ -607,7 +607,7 @@ void wxSplitterWindow::DrawSashTracker(int x, int y)
     int w, h;
     GetClientSize(&w, &h);
 
-    wxScreenDC screenDC;
+    wxScreenDC dc;
     int x1, y1;
     int x2, y2;
 
@@ -627,13 +627,11 @@ void wxSplitterWindow::DrawSashTracker(int x, int y)
     ClientToScreen(&x1, &y1);
     ClientToScreen(&x2, &y2);
 
-    screenDC.SetLogicalFunction(wxINVERT);
-    screenDC.SetPen(*m_sashTrackerPen);
-    screenDC.SetBrush(*wxTRANSPARENT_BRUSH);
+    dc.SetLogicalFunction(wxINVERT);
+    dc.SetPen(*m_sashTrackerPen);
+    dc.SetBrush(*wxTRANSPARENT_BRUSH);
 
-    screenDC.DrawLine(x1, y1, x2, y2);
-
-    screenDC.SetLogicalFunction(wxCOPY);
+    dc.DrawLine(x1, y1, x2, y2);
 }
 
 int wxSplitterWindow::GetWindowSize() const

--- a/src/generic/splitter.cpp
+++ b/src/generic/splitter.cpp
@@ -625,6 +625,12 @@ void wxSplitterWindow::DrawSashTracker(int x, int y)
 
 #if defined(__WXGTK3__)
     wxClientDC dc(this);
+
+    // In the ports with wxGraphicsContext-based wxDC, such as wxGTK3 or wxOSX,
+    // wxINVERT only works for inverting the background when using white
+    // foreground (note that this code is not used anyhow for __WXMAC__ due to
+    // always using live-resizing there, see IsLive()).
+    dc.SetPen(*wxWHITE_PEN);
 #else
     // We need to use wxScreenDC and not wxClientDC at least for wxMSW where
     // drawing in this window itself would be hidden by its children windows,
@@ -632,10 +638,12 @@ void wxSplitterWindow::DrawSashTracker(int x, int y)
     wxScreenDC dc;
     ClientToScreen(&x1, &y1);
     ClientToScreen(&x2, &y2);
+
+    dc.SetPen(*m_sashTrackerPen);
 #endif
 
     dc.SetLogicalFunction(wxINVERT);
-    dc.SetPen(*m_sashTrackerPen);
+
     dc.SetBrush(*wxTRANSPARENT_BRUSH);
 
     dc.DrawLine(x1, y1, x2, y2);

--- a/src/osx/carbon/graphics.cpp
+++ b/src/osx/carbon/graphics.cpp
@@ -2056,6 +2056,9 @@ bool wxMacCoreGraphicsContext::DoSetCompositionMode(wxCompositionMode op)
             case wxCOMPOSITION_ADD:
                 mode = kCGBlendModePlusLighter ;
                 break;
+            case wxCOMPOSITION_DIFF:
+                mode = kCGBlendModeDifference ;
+                break;
             default:
                 return false;
         }


### PR DESCRIPTION
This "fixes", as much as it can be fixed, #16890 by making the sash visible when possible and forcing the use of live-resizing otherwise.