### PR TITLE
Fix wxWebResponse::GetHeader() and GetURL() in wxMSW

### DIFF
--- a/tests/net/webrequest.cpp
+++ b/tests/net/webrequest.cpp
@@ -230,6 +230,17 @@ TEST_CASE_METHOD(RequestFixture,
 }
 
 TEST_CASE_METHOD(RequestFixture,
+                 "WebRequest::Get::Header", "[net][webrequest][get]")
+{
+    if ( !InitBaseURL() )
+        return;
+
+    Create("/response-headers?freeform=wxWidgets%20works!");
+    Run();
+    CHECK( request.GetResponse().GetHeader("freeform") == "wxWidgets works!" );
+}
+
+TEST_CASE_METHOD(RequestFixture,
                  "WebRequest::Get::Param", "[net][webrequest][get]")
 {
     if ( !InitBaseURL() )
@@ -510,13 +521,21 @@ TEST_CASE_METHOD(RequestFixture,
     request.Start();
     RunLoopWithTimeout();
 
-    WARN("Request state " << request.GetState());
+    CHECK( request.GetState() == wxWebRequest::State_Completed );
     wxWebResponse response = request.GetResponse();
     REQUIRE( response.IsOk() );
-    WARN("Status: " << response.GetStatus()
+    WARN("URL: " << response.GetURL() << "\n" <<
+         "Status: " << response.GetStatus()
                     << " (" << response.GetStatusText() << ")\n" <<
          "Body length: " << response.GetContentLength() << "\n" <<
          "Body: " << response.AsString() << "\n");
+
+    // Also show the value of the given header if requested.
+    wxString header;
+    if ( wxGetEnv("WX_TEST_WEBREQUEST_HEADER", &header) )
+    {
+        WARN("Header " << header << ": " << response.GetHeader(header));
+    }
 }
 
 WX_DECLARE_STRING_HASH_MAP(wxString, wxWebRequestHeaderMap);


### PR DESCRIPTION
These functions returned strings of wrong size, with some junk after the
end of the actual string, due to a confusion between the size of the
buffer in bytes used by the WinHTTP functions and the length of the
buffer in (wide) characters used by wxWCharBuffer.

Fix this and add a unit test checking that the expected header is
returned.

Closes #22181.