### PR TITLE
Fix warnings in MinGW build

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -273,6 +273,7 @@ void wxGridOperations::PrepareDCForLabels(wxGrid *grid, wxDC &dc) const
 // ----------------------------------------------------------------------------
 
 wxGridCellWorker::wxGridCellWorker(const wxGridCellWorker& other)
+    : wxRefCounter()
 {
     CopyClientDataContainer(other);
 }

--- a/src/msw/artmsw.cpp
+++ b/src/msw/artmsw.cpp
@@ -209,6 +209,11 @@ wxBitmap wxWindowsArtProvider::CreateBitmap(const wxArtID& id,
 {
     wxBitmap bitmap;
 
+    const wxSize
+        sizeNeeded = size.IsFullySpecified()
+                        ? size
+                        : wxArtProvider::GetNativeSizeHint(client);
+
 #ifdef wxHAS_SHGetStockIconInfo
     // first try to use SHGetStockIconInfo, available only on Vista and higher
     SHSTOCKICONID stockIconId = MSWGetStockIconIdForArtProviderId( id );
@@ -221,11 +226,6 @@ wxBitmap wxWindowsArtProvider::CreateBitmap(const wxArtID& id,
         HRESULT res = MSW_SHGetStockIconInfo(stockIconId, uFlags, &sii);
         if ( res == S_OK )
         {
-            const wxSize
-                sizeNeeded = size.IsFullySpecified()
-                                ? size
-                                : wxArtProvider::GetNativeSizeHint(client);
-
             bitmap = MSWGetBitmapFromIconLocation(sii.szPath, sii.iIcon,
                                                   sizeNeeded);
             if ( bitmap.IsOk() )
@@ -247,7 +247,7 @@ wxBitmap wxWindowsArtProvider::CreateBitmap(const wxArtID& id,
 
     if ( volKind != wxFS_VOL_OTHER )
     {
-        bitmap = GetDriveBitmapForVolumeType(volKind, size);
+        bitmap = GetDriveBitmapForVolumeType(volKind, sizeNeeded);
         if ( bitmap.IsOk() )
             return bitmap;
     }
@@ -255,9 +255,9 @@ wxBitmap wxWindowsArtProvider::CreateBitmap(const wxArtID& id,
 
     // notice that the directory used here doesn't need to exist
     if ( id == wxART_FOLDER )
-        bitmap = MSWGetBitmapForPath("C:\\wxdummydir\\", size );
+        bitmap = MSWGetBitmapForPath("C:\\wxdummydir\\", sizeNeeded);
     else if ( id == wxART_FOLDER_OPEN )
-        bitmap = MSWGetBitmapForPath("C:\\wxdummydir\\", size, SHGFI_OPENICON );
+        bitmap = MSWGetBitmapForPath("C:\\wxdummydir\\", sizeNeeded, SHGFI_OPENICON );
 
     if ( !bitmap.IsOk() )
     {

--- a/src/msw/filedlg.cpp
+++ b/src/msw/filedlg.cpp
@@ -692,6 +692,8 @@ public:
           m_typeAlreadyChanged(false)
 #endif // wxUSE_IFILEOPENDIALOG
     {
+        wxUnusedVar(fileDialog);
+
         m_bMovedWindow = false;
         m_centreDir = 0;
     }


### PR DESCRIPTION
You can see them in for example https://ci.appveyor.com/project/wxWidgets/wxwidgets/builds/43893995/job/8yyt4tge7m8vqf56

```
g++ -c -o gcc_mswud\corelib_artmsw.o -I..\..\src\tiff\libtiff -I..\..\src\jpeg -I..\..\src\png -I..\..\src\zlib -I..\..\3rdparty\pcre\src\wx -I..\..\src\expat\expat\lib -g -O0 -mthreads -D__WXMSW__       -D_UNICODE -I..\..\lib\gcc_lib\mswud -I..\..\include  -W -Wall -DWXBUILDING -DwxUSE_BASE=0   -Wno-ctor-dtor-privacy   -MTgcc_mswud\corelib_artmsw.o -MFgcc_mswud\corelib_artmsw.o.d -MD -MP ../../src/msw/artmsw.cpp
../../src/msw/artmsw.cpp:207:64: warning: unused parameter 'client' [-Wunused-parameter]
                                             const wxArtClient& client,
                                                                ^

g++ -c -o gcc_mswud\corelib_filedlg.o -I..\..\src\tiff\libtiff -I..\..\src\jpeg -I..\..\src\png -I..\..\src\zlib -I..\..\3rdparty\pcre\src\wx -I..\..\src\expat\expat\lib -g -O0 -mthreads -D__WXMSW__       -D_UNICODE -I..\..\lib\gcc_lib\mswud -I..\..\include  -W -Wall -DWXBUILDING -DwxUSE_BASE=0   -Wno-ctor-dtor-privacy   -MTgcc_mswud\corelib_filedlg.o -MFgcc_mswud\corelib_filedlg.o.d -MD -MP ../../src/msw/filedlg.cpp
../../src/msw/filedlg.cpp:689:48: warning: unused parameter 'fileDialog' [-Wunused-parameter]
     explicit wxFileDialogMSWData(wxFileDialog* fileDialog)
                                                ^

g++ -c -o gcc_mswud\corelib_grid.o -I..\..\src\tiff\libtiff -I..\..\src\jpeg -I..\..\src\png -I..\..\src\zlib -I..\..\3rdparty\pcre\src\wx -I..\..\src\expat\expat\lib -g -O0 -mthreads -D__WXMSW__       -D_UNICODE -I..\..\lib\gcc_lib\mswud -I..\..\include  -W -Wall -DWXBUILDING -DwxUSE_BASE=0   -Wno-ctor-dtor-privacy   -MTgcc_mswud\corelib_grid.o -MFgcc_mswud\corelib_grid.o.d -MD -MP ../../src/generic/grid.cpp../../src/generic/grid.cpp: In copy constructor 'wxGridCellWorker::wxGridCellWorker(const wxGridCellWorker&)':
../../src/generic/grid.cpp:275:1: warning: base class 'class wxRefCounter' should be explicitly initialized in the copy constructor [-Wextra]
 wxGridCellWorker::wxGridCellWorker(const wxGridCellWorker& other)
 ^
```