### PR TITLE
Fix creating wxBitmap of depth 32 but without real alpha in wxMSW

### DIFF
--- a/src/msw/dib.cpp
+++ b/src/msw/dib.cpp
@@ -760,6 +760,13 @@ bool wxDIB::Create(const wxImage& image, PixelFormat pf, int dstDepth)
                     *dst++ = src[2];
                     *dst++ = src[1];
                     *dst++ = src[0];
+
+                    // If source has no alpha, but the DIB does have it, we
+                    // need to still fill it, even if there is no real
+                    // transparency.
+                    if ( dstDepth == 32 )
+                        *dst++ = wxALPHA_OPAQUE;
+
                     src += 3;
                 }
             }


### PR DESCRIPTION
This worked until 7e9afad53a (Add real support for monochrome bitmaps to
wxMSW, 2020-10-19) because we always created the DIB of the depth
matching the alpha presence, i.e. 32bpp only if alpha was used and 24bpp
otherwise, but since this change we can use different depths, and hence
different number of bytes per pixel, for the source and destination
pixel data and so need to account for it.

An alternative fix could be to still create 24bpp DIBs even when depth
of 32 is explicitly requested, as it was done before, but it's probably
better to respect the explicitly specified depth, even if, admittedly,
it's not really clear what, if any, effect does this have in practice.

Closes #22548.