### PR TITLE
Simplify defining classes inheriting from wxDataViewModel

### DIFF
--- a/include/wx/dataview.h
+++ b/include/wx/dataview.h
@@ -196,11 +196,6 @@ class WXDLLIMPEXP_CORE wxDataViewModel: public wxRefCounter
 public:
     wxDataViewModel();
 
-    virtual unsigned int GetColumnCount() const = 0;
-
-    // return type as reported by wxVariant
-    virtual wxString GetColumnType( unsigned int col ) const = 0;
-
     // get value into a wxVariant
     virtual void GetValue( wxVariant &variant,
                            const wxDataViewItem &item, unsigned int col ) const = 0;
@@ -280,6 +275,16 @@ public:
     // internal
     virtual bool IsListModel() const { return false; }
     virtual bool IsVirtualListModel() const { return false; }
+
+    // deprecated: these methods used to be pure virtual but they're not really
+    // needed by the implementation, and so now overriding them is unnecessary
+    // as they're never called, but they're still preserved to avoid breaking
+    // the existing code using "override" with them in the derived classes.
+    virtual unsigned int GetColumnCount() const { return 0; }
+    virtual wxString GetColumnType( unsigned int WXUNUSED(col) ) const
+    {
+        return wxString();
+    }
 
 protected:
     // Dtor is protected because the objects of this class must not be deleted,
@@ -1112,10 +1117,6 @@ public:
 
     // override base virtuals
 
-    virtual unsigned int GetColumnCount() const wxOVERRIDE;
-
-    virtual wxString GetColumnType( unsigned int col ) const wxOVERRIDE;
-
     virtual void GetValueByRow( wxVariant &value,
                            unsigned int row, unsigned int col ) const wxOVERRIDE;
 
@@ -1384,10 +1385,6 @@ public:
 
     virtual bool HasDefaultCompare() const wxOVERRIDE
         { return true; }
-    virtual unsigned int GetColumnCount() const wxOVERRIDE
-        { return 1; }
-    virtual wxString GetColumnType( unsigned int WXUNUSED(col) ) const wxOVERRIDE
-        { return wxT("wxDataViewIconText"); }
 
     wxDataViewTreeStoreNode *FindNode( const wxDataViewItem &item ) const;
     wxDataViewTreeStoreContainerNode *FindContainerNode( const wxDataViewItem &item ) const;

--- a/include/wx/dataview.h
+++ b/include/wx/dataview.h
@@ -280,7 +280,9 @@ public:
     // needed by the implementation, and so now overriding them is unnecessary
     // as they're never called, but they're still preserved to avoid breaking
     // the existing code using "override" with them in the derived classes.
+    wxDEPRECATED_MSG("Use wxDataViewCtrl::GetColumnCount() and don't override")
     virtual unsigned int GetColumnCount() const { return 0; }
+    wxDEPRECATED_MSG("Don't override this function, is is not needed any more")
     virtual wxString GetColumnType( unsigned int WXUNUSED(col) ) const
     {
         return wxString();

--- a/interface/wx/dataview.h
+++ b/interface/wx/dataview.h
@@ -15,8 +15,7 @@
     All other models derive from it and must implement its pure virtual functions
     in order to define a complete data model. In detail, you need to override
     wxDataViewModel::IsContainer, wxDataViewModel::GetParent, wxDataViewModel::GetChildren,
-    wxDataViewModel::GetColumnCount, wxDataViewModel::GetColumnType and
-    wxDataViewModel::GetValue in order to define the data model which acts as an
+    and wxDataViewModel::GetValue in order to define the data model which acts as an
     interface between your actual data and the wxDataViewCtrl.
 
     Note that wxDataViewModel does not define the position or index of any item
@@ -245,19 +244,6 @@ public:
     */
     virtual unsigned int GetChildren(const wxDataViewItem& item,
                                      wxDataViewItemArray& children) const = 0;
-
-    /**
-        Override this to indicate the number of columns in the model.
-    */
-    virtual unsigned int GetColumnCount() const = 0;
-
-    /**
-        Override this to indicate what type of data is stored in the
-        column specified by @a col.
-
-        This should return a string indicating the type of data as reported by wxVariant.
-    */
-    virtual wxString GetColumnType(unsigned int col) const = 0;
 
     /**
         Override this to indicate which wxDataViewItem representing the parent
@@ -3550,16 +3536,6 @@ public:
         @since 2.9.4
     */
     wxUIntPtr GetItemData(const wxDataViewItem& item) const;
-
-    /**
-        Overridden from wxDataViewModel
-    */
-    virtual unsigned int GetColumnCount() const;
-
-    /**
-        Overridden from wxDataViewModel
-    */
-    virtual wxString GetColumnType( unsigned int col ) const;
 
     /**
         Sets the client data associated with the item.

--- a/samples/dataview/mymodels.cpp
+++ b/samples/dataview/mymodels.cpp
@@ -521,9 +521,6 @@ void MyListModel::GetValueByRow( wxVariant &variant,
                     variant = wxString::Format("%d", row % 100);
             }
             break;
-
-        case Col_Max:
-            wxFAIL_MSG( "invalid column" );
     }
 }
 
@@ -589,9 +586,6 @@ bool MyListModel::GetAttrByRow( unsigned int row, unsigned int col,
                     return false;
             }
             break;
-
-        case Col_Max:
-            wxFAIL_MSG( "invalid column" );
     }
 
     return true;
@@ -635,9 +629,6 @@ bool MyListModel::SetValueByRow( const wxVariant &variant,
         case Col_Custom:
             m_customColValues[row] = variant.GetString();
             break;
-
-        case Col_Max:
-            wxFAIL_MSG( "invalid column" );
     }
 
     return false;

--- a/samples/dataview/mymodels.h
+++ b/samples/dataview/mymodels.h
@@ -150,19 +150,6 @@ public:
 
     // implementation of base class virtuals to define model
 
-    virtual unsigned int GetColumnCount() const wxOVERRIDE
-    {
-        return 6;
-    }
-
-    virtual wxString GetColumnType( unsigned int col ) const wxOVERRIDE
-    {
-        if (col == 2)
-            return "long";
-
-        return "string";
-    }
-
     virtual void GetValue( wxVariant &variant,
                            const wxDataViewItem &item, unsigned int col ) const wxOVERRIDE;
     virtual bool SetValue( const wxVariant &variant,
@@ -213,8 +200,7 @@ public:
         Col_EditableText,
         Col_Date,
         Col_TextWithAttr,
-        Col_Custom,
-        Col_Max
+        Col_Custom
     };
 
     MyListModel(int modelFlags);
@@ -228,19 +214,6 @@ public:
 
 
     // implementation of base class virtuals to define model
-
-    virtual unsigned int GetColumnCount() const wxOVERRIDE
-    {
-        return Col_Max;
-    }
-
-    virtual wxString GetColumnType( unsigned int col ) const wxOVERRIDE
-    {
-        if (col == Col_ToggleIconText)
-            return wxDataViewCheckIconTextRenderer::GetDefaultType();
-
-        return "string";
-    }
 
     virtual void GetValueByRow( wxVariant &variant,
                                 unsigned int row, unsigned int col ) const wxOVERRIDE;
@@ -294,8 +267,6 @@ public:
     }
 
     // Implement base class pure virtual methods.
-    unsigned GetColumnCount() const wxOVERRIDE { return 1; }
-    wxString GetColumnType(unsigned) const wxOVERRIDE { return "string"; }
     unsigned GetCount() const wxOVERRIDE { return m_strings.size(); }
     void GetValueByRow(wxVariant& val, unsigned row, unsigned) const wxOVERRIDE
     {

--- a/src/common/datavcmn.cpp
+++ b/src/common/datavcmn.cpp
@@ -2350,24 +2350,16 @@ void wxDataViewListStore::AppendColumn( const wxString &varianttype )
     m_cols.Add( varianttype );
 }
 
-unsigned int wxDataViewListStore::GetColumnCount() const
-{
-    return m_cols.GetCount();
-}
-
 unsigned int wxDataViewListStore::GetItemCount() const
 {
     return m_data.size();
 }
 
-wxString wxDataViewListStore::GetColumnType( unsigned int pos ) const
-{
-    return m_cols[pos];
-}
-
 void wxDataViewListStore::AppendItem( const wxVector<wxVariant> &values, wxUIntPtr data )
 {
-    wxCHECK_RET( values.size() == GetColumnCount(), "wrong number of values" );
+    wxCHECK_RET( m_data.empty() || values.size() == m_data[0]->m_values.size(),
+                 "wrong number of values" );
+
     wxDataViewListStoreLine *line = new wxDataViewListStoreLine( data );
     line->m_values = values;
     m_data.push_back( line );
@@ -2377,7 +2369,9 @@ void wxDataViewListStore::AppendItem( const wxVector<wxVariant> &values, wxUIntP
 
 void wxDataViewListStore::PrependItem( const wxVector<wxVariant> &values, wxUIntPtr data )
 {
-    wxCHECK_RET( values.size() == GetColumnCount(), "wrong number of values" );
+    wxCHECK_RET( m_data.empty() || values.size() == m_data[0]->m_values.size(),
+                 "wrong number of values" );
+
     wxDataViewListStoreLine *line = new wxDataViewListStoreLine( data );
     line->m_values = values;
     m_data.insert( m_data.begin(), line );
@@ -2388,7 +2382,9 @@ void wxDataViewListStore::PrependItem( const wxVector<wxVariant> &values, wxUInt
 void wxDataViewListStore::InsertItem(  unsigned int row, const wxVector<wxVariant> &values,
                                        wxUIntPtr data )
 {
-    wxCHECK_RET( values.size() == GetColumnCount(), "wrong number of values" );
+    wxCHECK_RET( m_data.empty() || values.size() == m_data[0]->m_values.size(),
+                 "wrong number of values" );
+
     wxDataViewListStoreLine *line = new wxDataViewListStoreLine( data );
     line->m_values = values;
     m_data.insert( m_data.begin()+row, line );
@@ -2536,7 +2532,7 @@ wxDataViewColumn *wxDataViewListCtrl::AppendTextColumn( const wxString &label,
 
     wxDataViewColumn *ret = new wxDataViewColumn( label,
         new wxDataViewTextRenderer( wxT("string"), mode ),
-        GetStore()->GetColumnCount()-1, width, align, flags );
+        GetColumnCount(), width, align, flags );
 
     wxDataViewCtrl::AppendColumn( ret );
 
@@ -2550,7 +2546,7 @@ wxDataViewColumn *wxDataViewListCtrl::AppendToggleColumn( const wxString &label,
 
     wxDataViewColumn *ret = new wxDataViewColumn( label,
         new wxDataViewToggleRenderer( wxT("bool"), mode ),
-        GetStore()->GetColumnCount()-1, width, align, flags );
+        GetColumnCount(), width, align, flags );
 
     return wxDataViewCtrl::AppendColumn( ret ) ? ret : NULL;
 }
@@ -2562,7 +2558,7 @@ wxDataViewColumn *wxDataViewListCtrl::AppendProgressColumn( const wxString &labe
 
     wxDataViewColumn *ret = new wxDataViewColumn( label,
         new wxDataViewProgressRenderer( wxEmptyString, wxT("long"), mode ),
-        GetStore()->GetColumnCount()-1, width, align, flags );
+        GetColumnCount(), width, align, flags );
 
     return wxDataViewCtrl::AppendColumn( ret ) ? ret : NULL;
 }
@@ -2574,7 +2570,7 @@ wxDataViewColumn *wxDataViewListCtrl::AppendIconTextColumn( const wxString &labe
 
     wxDataViewColumn *ret = new wxDataViewColumn( label,
         new wxDataViewIconTextRenderer( wxT("wxDataViewIconText"), mode ),
-        GetStore()->GetColumnCount()-1, width, align, flags );
+        GetColumnCount(), width, align, flags );
 
     return wxDataViewCtrl::AppendColumn( ret ) ? ret : NULL;
 }

--- a/src/generic/treelist.cpp
+++ b/src/generic/treelist.cpp
@@ -364,8 +364,6 @@ public:
 
 
     // Implement the base class pure virtual methods.
-    virtual unsigned GetColumnCount() const wxOVERRIDE;
-    virtual wxString GetColumnType(unsigned col) const wxOVERRIDE;
     virtual void GetValue(wxVariant& variant,
                           const wxDataViewItem& item,
                           unsigned col) const wxOVERRIDE;
@@ -634,25 +632,6 @@ void wxTreeListModel::CheckItem(Node* item, wxCheckBoxState checkedState)
     item->m_checkedState = checkedState;
 
     ItemChanged(ToDVI(item));
-}
-
-unsigned wxTreeListModel::GetColumnCount() const
-{
-    return m_numColumns;
-}
-
-wxString wxTreeListModel::GetColumnType(unsigned col) const
-{
-    if ( col == 0 )
-    {
-        return m_treelist->HasFlag(wxTL_CHECKBOX)
-                    ? wxDataViewCheckIconTextRenderer::GetDefaultType()
-                    : wxDataViewIconTextRenderer::GetDefaultType();
-    }
-    else // All the other columns contain just text.
-    {
-        return wxS("string");
-    }
 }
 
 void
@@ -1086,7 +1065,7 @@ wxTreeListCtrl::GetItemText(wxTreeListItem item, unsigned col) const
     // reference to return so we use a static variable that exists just for the
     // purpose of this check -- and so we put it in its own scope so that it's
     // never even created during normal program execution.
-    if ( !m_model || col >= m_model->GetColumnCount() )
+    if ( !m_model || col >= GetColumnCount() )
     {
         static wxString s_empty;
 
@@ -1094,7 +1073,7 @@ wxTreeListCtrl::GetItemText(wxTreeListItem item, unsigned col) const
         {
             wxFAIL_MSG( "Must create first" );
         }
-        else if ( col >= m_model->GetColumnCount() )
+        else if ( col >= GetColumnCount() )
         {
             wxFAIL_MSG( "Invalid column index" );
         }
@@ -1111,7 +1090,7 @@ wxTreeListCtrl::SetItemText(wxTreeListItem item,
                             const wxString& text)
 {
     wxCHECK_RET( m_model, "Must create first" );
-    wxCHECK_RET( col < m_model->GetColumnCount(), "Invalid column index" );
+    wxCHECK_RET( col < GetColumnCount(), "Invalid column index" );
 
     m_model->SetItemText(item, col, text);
 }

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -752,7 +752,7 @@ wxgtk_tree_model_get_n_columns (GtkTreeModel *tree_model)
     if ( wxtree_model->stamp == 0 )
         return 0;
 
-    return wxtree_model->internal->GetDataViewModel()->GetColumnCount();
+    return wxtree_model->internal->GetOwner()->GetColumnCount();
 }
 
 static GType

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -757,7 +757,7 @@ wxgtk_tree_model_get_n_columns (GtkTreeModel *tree_model)
 
 static GType
 wxgtk_tree_model_get_column_type (GtkTreeModel *tree_model,
-                                  gint          index)
+                                  gint          WXUNUSED(index))
 {
     GtkWxTreeModel *wxtree_model = (GtkWxTreeModel *) tree_model;
     g_return_val_if_fail (GTK_IS_WX_TREE_MODEL (wxtree_model), G_TYPE_INVALID);
@@ -765,19 +765,7 @@ wxgtk_tree_model_get_column_type (GtkTreeModel *tree_model,
     if ( wxtree_model->stamp == 0 )
         return G_TYPE_INVALID;
 
-    GType gtype = G_TYPE_INVALID;
-
-    wxString wxtype = wxtree_model->internal->GetDataViewModel()->GetColumnType( (unsigned int) index );
-
-    if (wxtype == wxT("string"))
-        gtype = G_TYPE_STRING;
-    else
-    {
-        gtype = G_TYPE_POINTER;
-        // wxFAIL_MSG( wxT("non-string columns not supported for searching yet") );
-    }
-
-    return gtype;
+    return G_TYPE_STRING;
 }
 
 static gboolean
@@ -824,20 +812,12 @@ wxgtk_tree_model_get_value (GtkTreeModel *tree_model,
         return;
 
     wxDataViewModel *model = wxtree_model->internal->GetDataViewModel();
-    wxString mtype = model->GetColumnType( (unsigned int) column );
-    if (mtype == wxT("string"))
-    {
-        wxVariant variant;
-        g_value_init( value, G_TYPE_STRING );
-        wxDataViewItem item( (void*) iter->user_data );
-        model->GetValue( variant, item, (unsigned int) column );
+    wxVariant variant;
+    g_value_init( value, G_TYPE_STRING );
+    wxDataViewItem item( (void*) iter->user_data );
+    model->GetValue( variant, item, (unsigned int) column );
 
-        g_value_set_string( value, variant.GetString().utf8_str() );
-    }
-    else
-    {
-        wxFAIL_MSG( wxT("non-string columns not supported yet") );
-    }
+    g_value_set_string( value, variant.GetString().utf8_str() );
 }
 
 static gboolean

--- a/tests/controls/dataviewctrltest.cpp
+++ b/tests/controls/dataviewctrltest.cpp
@@ -161,16 +161,6 @@ public:
 
     // Overridden wxDataViewModel methods.
 
-    unsigned int GetColumnCount() const wxOVERRIDE
-    {
-        return 1;
-    }
-
-    wxString GetColumnType(unsigned int WXUNUSED(col)) const wxOVERRIDE
-    {
-        return "string";
-    }
-
     void GetValue(wxVariant &variant, const wxDataViewItem &item,
                   unsigned int WXUNUSED(col)) const wxOVERRIDE
     {


### PR DESCRIPTION
Don't require overriding `GetColumn{Count,Type}()` that are useless.

This is something I wanted to do since a very long time, and we probably need to do it now or never.

Please let me know if anybody thinks this should not be done.

Closes #17755.