### PR TITLE
Fix compile error for missing _NL_ constants

### DIFF
--- a/src/unix/uilocale.cpp
+++ b/src/unix/uilocale.cpp
@@ -614,6 +614,8 @@ wxUILocaleImplUnix::GetLocalizedName(wxLocaleName name, wxLocaleForm form) const
     switch (name)
     {
         case wxLOCALE_NAME_LOCALE:
+#if defined(_NL_ADDRESS_LANG_NAME) && defined(_NL_IDENTIFICATION_LANGUAGE) && \
+    defined(_NL_ADDRESS_COUNTRY_NAME) && defined(_NL_IDENTIFICATION_TERRITORY)
             {
                 str = GetFormOfLangInfo(form,
                                         _NL_ADDRESS_LANG_NAME,
@@ -627,18 +629,23 @@ wxUILocaleImplUnix::GetLocalizedName(wxLocaleName name, wxLocaleForm form) const
                     str << " (" << strCtry << ")";
                 }
             }
+#endif
             break;
 
         case wxLOCALE_NAME_LANGUAGE:
+#if defined(_NL_ADDRESS_LANG_NAME) && defined(_NL_IDENTIFICATION_LANGUAGE)
             str = GetFormOfLangInfo(form,
                                     _NL_ADDRESS_LANG_NAME,
                                     _NL_IDENTIFICATION_LANGUAGE);
+#endif
             break;
 
         case wxLOCALE_NAME_COUNTRY:
+#if defined(_NL_ADDRESS_COUNTRY_NAME) && defined(_NL_IDENTIFICATION_TERRITORY)
             str = GetFormOfLangInfo(form,
                                     _NL_ADDRESS_COUNTRY_NAME,
                                     _NL_IDENTIFICATION_TERRITORY);
+#endif
             break;
 
         default:

--- a/src/unix/uilocale.cpp
+++ b/src/unix/uilocale.cpp
@@ -629,6 +629,8 @@ wxUILocaleImplUnix::GetLocalizedName(wxLocaleName name, wxLocaleForm form) const
                     str << " (" << strCtry << ")";
                 }
             }
+#else
+            wxUnusedVar(form);
 #endif
             break;
 
@@ -645,6 +647,8 @@ wxUILocaleImplUnix::GetLocalizedName(wxLocaleName name, wxLocaleForm form) const
             str = GetFormOfLangInfo(form,
                                     _NL_ADDRESS_COUNTRY_NAME,
                                     _NL_IDENTIFICATION_TERRITORY);
+#else
+            wxUnusedVar(form);
 #endif
             break;
 
@@ -653,6 +657,8 @@ wxUILocaleImplUnix::GetLocalizedName(wxLocaleName name, wxLocaleForm form) const
     }
     return str;
 #else // !HAVE_LANGINFO_H
+    wxUnusedVar(name);
+    wxUnusedVar(form);
     // If HAVE_LANGINFO_H is not available, we could use our own language database
     // to retrieve the requested information.
     // For now, just return an empty string.


### PR DESCRIPTION
On Solaris (and potentially other Unix systems) some or all `_NL_*` preprocessor symbols for retrieving certain locale information may be missing, causing compile errors (see https://github.com/wxWidgets/wxWidgets/pull/22538#issuecomment-1160124060).

For now, return empty strings in such cases.