### PR TITLE
Allow creating wxBitmapBundle from XPM and switch wxRichToolTip to use it

### DIFF
--- a/include/wx/bmpbndl.h
+++ b/include/wx/bmpbndl.h
@@ -45,6 +45,12 @@ public:
     // wxBitmapBundle.
     wxBitmapBundle(const wxImage& image);
 
+    // And another one from XPM data, as it's relatively common to pass it to
+    // various functions that take wxBitmapBundle in the existing code. It is
+    // not formally deprecated, but should be avoided in any new code and can
+    // become deprecated in the future.
+    wxBitmapBundle(const char* const* xpm);
+
     // Default copy ctor and assignment operator and dtor would be ok, but need
     // to be defined out of line, where wxBitmapBundleImpl is fully declared.
 

--- a/include/wx/generic/private/richtooltip.h
+++ b/include/wx/generic/private/richtooltip.h
@@ -10,7 +10,7 @@
 #ifndef _WX_GENERIC_PRIVATE_RICHTOOLTIP_H_
 #define _WX_GENERIC_PRIVATE_RICHTOOLTIP_H_
 
-#include "wx/icon.h"
+#include "wx/bmpbndl.h"
 #include "wx/colour.h"
 
 // ----------------------------------------------------------------------------
@@ -34,7 +34,7 @@ public:
 
     virtual void SetBackgroundColour(const wxColour& col,
                                      const wxColour& colEnd) wxOVERRIDE;
-    virtual void SetCustomIcon(const wxIcon& icon) wxOVERRIDE;
+    virtual void SetCustomIcon(const wxBitmapBundle& icon) wxOVERRIDE;
     virtual void SetStandardIcon(int icon) wxOVERRIDE;
     virtual void SetTimeout(unsigned milliseconds,
                             unsigned millisecondsDelay = 0) wxOVERRIDE;
@@ -48,7 +48,7 @@ protected:
              m_message;
 
 private:
-    wxIcon m_icon;
+    wxBitmapBundle m_icon;
 
     wxColour m_colStart,
              m_colEnd;

--- a/include/wx/private/richtooltip.h
+++ b/include/wx/private/richtooltip.h
@@ -26,7 +26,7 @@ public:
     // These methods simply mirror the public wxRichToolTip ones.
     virtual void SetBackgroundColour(const wxColour& col,
                                      const wxColour& colEnd) = 0;
-    virtual void SetCustomIcon(const wxIcon& icon) = 0;
+    virtual void SetCustomIcon(const wxBitmapBundle& icon) = 0;
     virtual void SetStandardIcon(int icon) = 0;
     virtual void SetTimeout(unsigned milliseconds,
                             unsigned millisecondsShowdelay = 0) = 0;

--- a/include/wx/richtooltip.h
+++ b/include/wx/richtooltip.h
@@ -16,8 +16,8 @@
 
 #include "wx/colour.h"
 
+class WXDLLIMPEXP_FWD_CORE wxBitmapBundle;
 class WXDLLIMPEXP_FWD_CORE wxFont;
-class WXDLLIMPEXP_FWD_CORE wxIcon;
 class WXDLLIMPEXP_FWD_CORE wxWindow;
 
 class wxRichToolTipImpl;
@@ -68,7 +68,7 @@ public:
     // warning/error ones (the question icon doesn't make sense for a tooltip)
     // or a custom icon.
     void SetIcon(int icon = wxICON_INFORMATION);
-    void SetIcon(const wxIcon& icon);
+    void SetIcon(const wxBitmapBundle& icon);
 
     // Set timeout after which the tooltip should disappear, in milliseconds.
     // By default the tooltip is hidden after system-dependent interval of time

--- a/interface/wx/bmpbndl.h
+++ b/interface/wx/bmpbndl.h
@@ -127,6 +127,18 @@ public:
     wxBitmapBundle(const wxImage& image);
 
     /**
+        Conversion constructor from XPM data.
+
+        This constructor overload exists only for compatibility with the
+        existing code passing XPM data (e.g. @c foo_xpm after including @c
+        foo.xpm) directly to the functions expecting a bitmap. Don't use it in
+        the new code, as it is likely to be deprecated in the future.
+
+        @since 3.2.0
+     */
+    wxBitmapBundle(const char* const* xpm);
+
+    /**
         Copy constructor creates a copy of another bundle.
      */
     wxBitmapBundle(const wxBitmapBundle& other);

--- a/interface/wx/richtooltip.h
+++ b/interface/wx/richtooltip.h
@@ -128,7 +128,7 @@ public:
      */
     //@{
     void SetIcon(int icon = wxICON_INFORMATION);
-    void SetIcon(const wxIcon& icon);
+    void SetIcon(const wxBitmapBundle& icon);
     //@}
 
     /**

--- a/src/common/bmpbndl.cpp
+++ b/src/common/bmpbndl.cpp
@@ -358,6 +358,11 @@ wxBitmapBundle::wxBitmapBundle(const wxImage& image)
 {
 }
 
+wxBitmapBundle::wxBitmapBundle(const char* const* xpm)
+    : m_impl(new wxBitmapBundleImplSet(wxBitmap(xpm)))
+{
+}
+
 wxBitmapBundle::wxBitmapBundle(const wxBitmapBundle& other)
     : m_impl(other.m_impl)
 {

--- a/src/common/richtooltipcmn.cpp
+++ b/src/common/richtooltipcmn.cpp
@@ -48,7 +48,7 @@ void wxRichToolTip::SetIcon(int icon)
     m_impl->SetStandardIcon(icon);
 }
 
-void wxRichToolTip::SetIcon(const wxIcon& icon)
+void wxRichToolTip::SetIcon(const wxBitmapBundle& icon)
 {
     m_impl->SetCustomIcon(icon);
 }

--- a/src/generic/richtooltipg.cpp
+++ b/src/generic/richtooltipg.cpp
@@ -61,7 +61,7 @@ public:
     wxRichToolTipPopup(wxWindow* parent,
                        const wxString& title,
                        const wxString& message,
-                       const wxIcon& icon,
+                       const wxBitmapBundle& icon,
                        wxTipKind tipKind,
                        const wxFont& titleFont_) :
         m_timer(this)
@@ -141,7 +141,7 @@ public:
             // Themed tooltips under MSW align the text with the title, not
             // with the icon, so use a helper horizontal sizer in this case.
             wxBoxSizer* const sizerTextIndent = new wxBoxSizer(wxHORIZONTAL);
-            sizerTextIndent->AddSpacer(icon.GetWidth());
+            sizerTextIndent->AddSpacer(icon.GetPreferredLogicalSizeFor(this).x);
             sizerTextIndent->Add(sizerText,
                                     wxSizerFlags().Border(wxLEFT).Centre());
 
@@ -616,7 +616,7 @@ wxRichToolTipGenericImpl::SetBackgroundColour(const wxColour& col,
     m_colEnd = colEnd;
 }
 
-void wxRichToolTipGenericImpl::SetCustomIcon(const wxIcon& icon)
+void wxRichToolTipGenericImpl::SetCustomIcon(const wxBitmapBundle& icon)
 {
     m_icon = icon;
 }
@@ -631,7 +631,7 @@ void wxRichToolTipGenericImpl::SetStandardIcon(int icon)
             // Although we don't use this icon in a list, we need a smallish
             // icon here and not an icon of a typical message box size so use
             // wxART_LIST to get it.
-            m_icon = wxArtProvider::GetIcon
+            m_icon = wxArtProvider::GetBitmapBundle
                      (
                         wxArtProvider::GetMessageBoxIconId(icon),
                         wxART_LIST
@@ -643,7 +643,7 @@ void wxRichToolTipGenericImpl::SetStandardIcon(int icon)
             break;
 
         case wxICON_NONE:
-            m_icon = wxNullIcon;
+            m_icon = wxBitmapBundle();
             break;
     }
 }

--- a/src/msw/richtooltip.cpp
+++ b/src/msw/richtooltip.cpp
@@ -81,7 +81,7 @@ public:
         wxRichToolTipGenericImpl::SetBackgroundColour(col, colEnd);
     }
 
-    virtual void SetCustomIcon(const wxIcon& icon) wxOVERRIDE
+    virtual void SetCustomIcon(const wxBitmapBundle& icon) wxOVERRIDE
     {
         // Custom icons are not supported by EM_SHOWBALLOONTIP.
         m_canUseNative = false;


### PR DESCRIPTION
Without the first commit, the second one would have broken dialogs sample compilation, as it uses `SetIcon(tip_xpm)`.