### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ on:
       - '*.yml'
       - 'wxwidgets.props'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/ci_mac.yml
+++ b/.github/workflows/ci_mac.yml
@@ -63,6 +63,9 @@ on:
     - '*.yml'
     - 'wxwidgets.props'
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     defaults:

--- a/.github/workflows/ci_mac_xcode.yml
+++ b/.github/workflows/ci_mac_xcode.yml
@@ -63,6 +63,9 @@ on:
     - '*.yml'
     - 'wxwidgets.props'
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     defaults:

--- a/.github/workflows/ci_msw.yml
+++ b/.github/workflows/ci_msw.yml
@@ -45,6 +45,9 @@ on:
       - '*.md'
       - '*.yml'
 
+permissions:
+  contents: read
+
 jobs:
   msw-msvs:
     runs-on: windows-${{ matrix.vsversion }}

--- a/.github/workflows/ci_msw_cross.yml
+++ b/.github/workflows/ci_msw_cross.yml
@@ -49,6 +49,9 @@ on:
       - '*.yml'
       - 'wxwidgets.props'
 
+permissions:
+  contents: read
+
 jobs:
   msw-cross-build:
     # Set up this job to run in a Debian Sid container because it has recent

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   check-unix:
     runs-on: ubuntu-20.04

--- a/.github/workflows/docs_update.yml
+++ b/.github/workflows/docs_update.yml
@@ -18,6 +18,9 @@ on:
   workflow_dispatch:
 
 
+permissions:
+  contents: read
+
 jobs:
   update:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
