### PR TITLE
Recognize current GNOME versions in GetDesktopEnvironment()

### DIFF
--- a/src/gtk/utilsgtk.cpp
+++ b/src/gtk/utilsgtk.cpp
@@ -434,11 +434,11 @@ wxString wxGUIAppTraits::GetDesktopEnvironment() const
 #if wxUSE_DETECT_SM
     if ( de.empty() )
     {
-        static const wxString s_SM = GetSM();
+        static const wxString s_SM = GetSM().Upper();
 
-        if (s_SM == wxT("GnomeSM"))
+        if (s_SM.Contains(wxT("GNOME")))
             de = wxT("GNOME");
-        else if (s_SM == wxT("KDE"))
+        else if (s_SM.Contains(wxT("KDE")))
             de = wxT("KDE");
     }
 #endif // wxUSE_DETECT_SM


### PR DESCRIPTION
GNOME session manager currently returns "gnome-session", but we only
checked for "GnomeSM" value, which was apparently used in GNOME 2 or
maybe even earlier.

Check for the presence of "GNOME" substring anywhere in the session
manager name (ignoring case) to cover both values and also do the same
for KDE for consistency.