### PR TITLE
Fix size of the requested bitmap bundle in wxToolBar XRC handler

### DIFF
--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -2283,8 +2283,11 @@ No additional properties.
 
 @beginTable
 @hdr3col{property, type, description}
-@row3col{bitmapsize, @ref overview_xrcformat_type_size,
-    Size of toolbar bitmaps (default: not set).}
+@row3col{bitmapsize, @ref overview_xrcformat_type_pair_ints,
+    Size of toolbar bitmaps in pixels. Note that these are physical pixels, as
+    they typically correspond to the size of available bitmaps, and @e not
+    DIPs, i.e. not depending on the current DPI value. In particular, "d" suffix
+    is invalid and cannot be used here (default: not set).}
 @row3col{margins, @ref overview_xrcformat_type_size,
     Margins (default: platform default).}
 @row3col{packing, integer,

--- a/src/xrc/xh_auitoolb.cpp
+++ b/src/xrc/xh_auitoolb.cpp
@@ -202,9 +202,10 @@ wxObject *wxAuiToolBarXmlHandler::DoCreateResource()
         toolbar->SetName(GetName());
         SetupWindow(toolbar);
 
-        m_toolSize = GetSize(wxS("bitmapsize"));
+        // See comment for the same code in the wxToolBar XRC handler.
+        m_toolSize = GetPairInts(wxS("bitmapsize"));
         if (!(m_toolSize == wxDefaultSize))
-            toolbar->SetToolBitmapSize(m_toolSize);
+            toolbar->SetToolBitmapSize(toolbar->FromDIP(m_toolSize));
         wxSize margins = GetSize(wxS("margins"));
         if (!(margins == wxDefaultSize))
             toolbar->SetMargins(margins.x, margins.y);

--- a/src/xrc/xh_toolb.cpp
+++ b/src/xrc/xh_toolb.cpp
@@ -193,9 +193,13 @@ wxObject *wxToolBarXmlHandler::DoCreateResource()
                          GetName());
         SetupWindow(toolbar);
 
-        m_toolSize = GetSize(wxT("bitmapsize"));
+        // This will be used as GetBitmapBundle() parameter, which should be in
+        // physical pixels, independent of the DPI, so don't use GetSize() here
+        // which would scale it by the current DPI and, instead, just use
+        // FromDIP() ourselves manually when passing it to SetToolBitmapSize().
+        m_toolSize = GetPairInts(wxT("bitmapsize"));
         if (!(m_toolSize == wxDefaultSize))
-            toolbar->SetToolBitmapSize(m_toolSize);
+            toolbar->SetToolBitmapSize(toolbar->FromDIP(m_toolSize));
         wxSize margins = GetSize(wxT("margins"));
         if (!(margins == wxDefaultSize))
             toolbar->SetMargins(margins.x, margins.y);


### PR DESCRIPTION
We need to pass the physical size, not scaled by DPI, as the "size"
parameter of GetBitmapBundle(), so that a user-defined art provider
could use it to select one of the available bitmap sizes (which will
then be scaled, if necessary, by wxBitmapBundle itself).

This change is not 100% backwards-compatible because, in theory, bitmap
sizes could be specified using dialog units previously, but this is not
supported any more. However in practice this never happened because it
simply doesn't make sense to use dialog units for the bitmap sizes and
it doesn't seem worth complicating the code by adding another XRC type
of "DPI-independent pixels that can be expressed in dialog units",
especially considering that DUs are DPI-dependent by definition.

---

I _still_ hadn't got this toolbar bitmap size right, even after struggling with it for so long. But hopefully this is the really last tweak to it.

@kosh543 Could you please check this?