### PR TITLE
Add reserved virtual functions for forward ABI compatibility

### DIFF
--- a/include/wx/app.h
+++ b/include/wx/app.h
@@ -537,6 +537,10 @@ protected:
 
     friend class WXDLLIMPEXP_FWD_BASE wxEvtHandler;
 
+    // Stub virtual functions for forward binary compatibility. DO NOT USE.
+    virtual void* WXReservedApp1(void*);
+    virtual void* WXReservedApp2(void*);
+
     // the application object is a singleton anyhow, there is no sense in
     // copying it
     wxDECLARE_NO_COPY_CLASS(wxAppConsoleBase);

--- a/include/wx/apptrait.h
+++ b/include/wx/apptrait.h
@@ -172,6 +172,11 @@ public:
     virtual wxString GetAssertStackTrace();
 #endif // wxUSE_STACKWALKER
 
+protected:
+    // Stub virtual functions for forward binary compatibility. DO NOT USE.
+    virtual void* WXReservedAppTraits1(void*);
+    virtual void* WXReservedAppTraits2(void*);
+
 private:
     static wxSocketManager *ms_manager;
 };

--- a/include/wx/event.h
+++ b/include/wx/event.h
@@ -4079,6 +4079,10 @@ protected:
     // Search tracker objects for event connection with this sink
     wxEventConnectionRef *FindRefInTrackerList(wxEvtHandler *handler);
 
+    // Stub virtual functions for forward binary compatibility. DO NOT USE.
+    virtual void* WXReservedEvtHandler1(void*);
+    virtual void* WXReservedEvtHandler2(void*);
+
 private:
     // pass the event to wxTheApp instance, called from TryAfter()
     bool DoTryApp(wxEvent& event);

--- a/include/wx/filedlg.h
+++ b/include/wx/filedlg.h
@@ -210,6 +210,10 @@ protected:
     // are used -- must be called if the dialog was accepted.
     void TransferDataFromExtraControl();
 
+    // Stub virtual functions for forward binary compatibility. DO NOT USE.
+    virtual void* WXReservedFileDialog1(void*);
+    virtual void* WXReservedFileDialog2(void*);
+
 private:
     ExtraControlCreatorFunction m_extraControlCreator;
 

--- a/include/wx/textentry.h
+++ b/include/wx/textentry.h
@@ -250,6 +250,12 @@ protected:
     virtual bool DoAutoCompleteCustom(wxTextCompleter *completer);
 
 
+    // Stub virtual functions for forward binary compatibility. DO NOT USE.
+    virtual void* WXReservedTextEntry1(void*);
+    virtual void* WXReservedTextEntry2(void*);
+    virtual void* WXReservedTextEntry3(void*);
+
+
     // class which should be used to temporarily disable text change events
     //
     // if suppress argument in ctor is false, nothing is done

--- a/include/wx/toplevel.h
+++ b/include/wx/toplevel.h
@@ -349,6 +349,11 @@ protected:
     static int WidthDefault(int w) { return w == wxDefaultCoord ? GetDefaultSize().x : w; }
     static int HeightDefault(int h) { return h == wxDefaultCoord ? GetDefaultSize().y : h; }
 
+    // Stub virtual functions for forward binary compatibility. DO NOT USE.
+    virtual void* WXReservedTLW1(void*);
+    virtual void* WXReservedTLW2(void*);
+    virtual void* WXReservedTLW3(void*);
+
 
     // the frame icon
     wxIconBundle m_icons;

--- a/include/wx/window.h
+++ b/include/wx/window.h
@@ -1999,6 +1999,12 @@ protected:
     // wxMouseCaptureLostEvent to windows on capture stack.
     static void NotifyCaptureLost();
 
+
+    // Stub virtual functions for forward binary compatibility. DO NOT USE.
+    virtual void* WXReservedWindow1(void*);
+    virtual void* WXReservedWindow2(void*);
+    virtual void* WXReservedWindow3(void*);
+
 private:
     // recursively call our own and our children DoEnable() when the
     // enabled/disabled status changed because a parent window had been

--- a/src/common/appbase.cpp
+++ b/src/common/appbase.cpp
@@ -897,6 +897,9 @@ void wxAppConsoleBase::SetCLocale()
     wxSetlocale(LC_ALL, "");
 }
 
+void* wxAppConsoleBase::WXReservedApp1(void*) { return NULL; }
+void* wxAppConsoleBase::WXReservedApp2(void*) { return NULL; }
+
 // ============================================================================
 // other classes implementations
 // ============================================================================
@@ -1089,6 +1092,8 @@ wxString wxAppTraitsBase::GetAssertStackTrace()
 }
 #endif // wxUSE_STACKWALKER
 
+void* wxAppTraitsBase::WXReservedAppTraits1(void*) { return NULL; }
+void* wxAppTraitsBase::WXReservedAppTraits2(void*) { return NULL; }
 
 // ============================================================================
 // global functions implementation

--- a/src/common/event.cpp
+++ b/src/common/event.cpp
@@ -2014,6 +2014,9 @@ void wxEvtHandler::OnSinkDestroyed( wxEvtHandler *sink )
     }
 }
 
+void* wxEvtHandler::WXReservedEvtHandler1(void*) { return NULL; }
+void* wxEvtHandler::WXReservedEvtHandler2(void*) { return NULL; }
+
 #endif // wxUSE_BASE
 
 #if wxUSE_GUI

--- a/src/common/fldlgcmn.cpp
+++ b/src/common/fldlgcmn.cpp
@@ -969,6 +969,9 @@ void wxFileDialogBase::SetFilterIndexFromExt(const wxString& ext)
     }
 }
 
+void* wxFileDialogBase::WXReservedFileDialog1(void*) { return NULL; }
+void* wxFileDialogBase::WXReservedFileDialog2(void*) { return NULL; }
+
 //----------------------------------------------------------------------------
 // wxFileDialog convenience functions
 //----------------------------------------------------------------------------

--- a/src/common/textentrycmn.cpp
+++ b/src/common/textentrycmn.cpp
@@ -191,6 +191,10 @@ wxTextEntryBase::~wxTextEntryBase()
     delete m_hintData;
 }
 
+void* wxTextEntryBase::WXReservedTextEntry1(void*) { return NULL; }
+void* wxTextEntryBase::WXReservedTextEntry2(void*) { return NULL; }
+void* wxTextEntryBase::WXReservedTextEntry3(void*) { return NULL; }
+
 // ----------------------------------------------------------------------------
 // text accessors
 // ----------------------------------------------------------------------------

--- a/src/common/toplvcmn.cpp
+++ b/src/common/toplvcmn.cpp
@@ -505,3 +505,7 @@ void wxTopLevelWindowBase::RequestUserAttention(int WXUNUSED(flags))
     // it's probably better than do nothing, isn't it?
     Raise();
 }
+
+void* wxTopLevelWindowBase::WXReservedTLW1(void*) { return NULL; }
+void* wxTopLevelWindowBase::WXReservedTLW2(void*) { return NULL; }
+void* wxTopLevelWindowBase::WXReservedTLW3(void*) { return NULL; }

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -4162,3 +4162,6 @@ wxWindowBase::AdjustForLayoutDirection(wxCoord x,
 }
 
 
+void* wxWindowBase::WXReservedWindow1(void*) { return NULL; }
+void* wxWindowBase::WXReservedWindow2(void*) { return NULL; }
+void* wxWindowBase::WXReservedWindow3(void*) { return NULL; }


### PR DESCRIPTION
These functions can be repurposed to do something useful in 3.2 branch
later without breaking ABI-compatibility, as overriding an existing
virtual function doesn't break it -- unlike adding a new one.

Closes #22555.