### PR TITLE
Update contributors list for 3.2.0

### DIFF
--- a/docs/doxygen/mainpages/copyright.h
+++ b/docs/doxygen/mainpages/copyright.h
@@ -29,17 +29,118 @@ recognition of the new name by OSI.
 
 @section section_acknowledgements Acknowledgements
 
-The following is the list of the core, active developers of wxWidgets which keep
-it running and have provided an invaluable, extensive and high-quality amount of
-changes over the many of years of wxWidgets' life:
+The following is the list of the current core, active developers of wxWidgets:
+
+@li Vadim Zeitlin
+@li Stefan Csomor
+@li Paul Cornett
+@li Maarten Bent
+@li Artur Wieczorek
+@li Robin Dunn
+@li Vaclav Slavik
+@li Tobias Taschner
+@li Bryan Petty
+
+We would also like to thank the following people for multiple significant
+contributions to wxWidgets 3.2.0 release:
+
+@li Cătălin Răceanu
+@li Dimitri Schoolwerth
+@li Ulrich Telle
+@li Lauri Nurmi
+@li PB
+@li Scott Talbert
+@li New Pagodi
+@li AliKet
+@li Ian McInerney
+
+And, finally, here is the list, in alphabetical order, of all contributors to
+wxWidgets 3.2.0 -- thank you for making this project possible!
+
+Adolfo Jayme Barrientos, Adrian DC, Adrian Lopez, adrian5, Adrien Tétar,
+Alexander Bisono, Alexander Koshelev, Alexander Kovalenko, Alexey Rassikhin,
+Ali Asady, alilie, Andrea Zanellato, Andreas Falkenhahn, Andrew Radke, Andrius
+Balsevičius, Andriy Byelikov, Andy Robinson, Anil Kumar, Anton Triest, Antti
+Nietosvaara, approach, ARATA Mizuki, Armel Asselin, ArnaudD-FR, Arrigo
+Marchiori, Arthur Norman, Artur Sochirca, ashishmore, atbara46, atobi,
+bakcsizs, Bartek Warzocha, basos, Be, Ben Bronk, Benjamin Drung, Besnik Bleta,
+Bill Forster, Bill Su, Biswapriyo Nath, Blake Eryx, Blake Madden, Blake-Madden,
+Bogdan Iordanescu, brawer, Brian Clark, Bronek Kozicki, Bryan Petty, Burak
+Koray, Carl Godkin, Carlos Azevedo, Catalin Raceanu, Chaobin, Zhang, Chilau He,
+Chris Lemin, chris2oph, Christian, cnbatch, Corey Daley, cosminp, CPUBug,
+Damien Ruscoe, Dan Gudmundsson, Dan Korn, Dan-Korn, Danail Stoychev, Daniel
+Collins, Daniel Kulp, Danny Scott, dasimx, David Connet, David Costanzo, David
+Hart, David Howland, David Roberts, David Vanderson, Deamhan, dghart, Dietmar
+Schwertberger, DINAKAR T.D, Dominic Letz, Dominique Martinet, donovan6000, dsr,
+Dummy, dvertx, Dévai Tamás, Eduard Ereza Martínez, Eran Ifrah, Eric Jensen,
+Eric Raijmakers, Erik Sperling Johansen, Evileye, ExplorerLog, exprosic, Fabian
+Cenedese, Felipe, ffa-benarmstrong, flederwiesel, followait, frederick-vs-ja,
+Frode Roxrud Gill, Frédéric Bron, Fulvio Senore, fuscated, fx, gafatoa, Gary
+Allen, Gavin Kinsey, Gavs64, georgp24, Ger Hobbelt, Gerhard Gruber, GH Cao,
+Gian-Carlo Pascutto, Gideon van Melle, Gilbert Pelletier, Glen Fletcher, Graham
+Dawes, Gunter Königsmann, Gustavo Grieco, Gérard Durand, Hallgeir Holien, Hans
+Mackowiak, Hartwig Wiesmann, Hashir Ahmad, Hertatijanto Hartono, Him Prasad
+Gautam, Hiroshi Takey F. (hiro2233), Hubert Talbot, Hugo Elias, hwiesmann, Ian
+Langworth, Igor Ivanov, Igor Korot, IhateTrains, ikamakj, Ilya Bizyaev, Ilya
+Ivanov, Ilya Sinitsin, Ilya Sinitsyn, imReker, Iwbnwif Yiw, JackBoosY, Jake
+Nelson, James Pan, Jan Knepper, Jan Niklas Hasse, Jan van Dijk, Jay Nabonne,
+jbbbms, Jeff Bland, Jeff Davidson, Jeff Hostetler, Jeinzi, Jens Göpfert,
+jensgoe, Jevgenijs Protopopovs, jgehw, Jiawei Huang, Joao Matos, Johannes
+Maibaum, John Gehrig, John Roberts, JohnKnow, jolz, Jonathan Dagresta, Jonathan
+Li, jonkraber, Joonas Kuusela, Joost Nieuwenhuijse, Jorge Moraleda, Jose
+Lorenzo, Josue Andrade Gomes, Jouk Jansen, jozef m, jtbattle, Juha Sointusalo,
+jwiesemann, Karl Waclawek, Kasper, kathoum, Kaya Zeren, Kelvin Lee, Kenneth
+Porter, Kevin B. McCarty, Kevin Ollivier, Kinaou Hervé, kkocdko, kkrev, Knut
+Petter Lehre, Kolya Kosenko, Konstantin S. Matveyev, KT, Kumazuma, Kvaz1r,
+laptabrok, Laurent Poujoulat, Leland Lucius, Liam Treacy, lucian-rotariu, Lynn
+C. Rees, Manuel Garcia, Manuel Martin, Marc Jessome, Marc-Philip, Marco
+DeFreitas, Marcos, Marek Roszko, Marek Temnyak, Mariano Reingart, marius,
+Markus Juergens, Markus Pingel, Mart Raudsepp, Martin Ettl, Martin Koegler,
+Martin Srebotnjak, Mathew Maidment, Matthew Griffin, Matthew Heinsen Egan, Max
+Maisel, Mehmet Soyturk, mehmets, Metallicow, mgimenez, Micha Ahrweiler,
+michael, Mick Phillips, Mick Waites, Miguel Gimenez, Mike Capone, mikek, Mikko
+P, mill-j, milotype, mimi89999, mirh, Mitrik Sicilian, mj_smoker, mrX,
+NancyLi1013, Naser Buhamad, Nathan Ridge, naveen, Nick Matthews, nick863,
+nicolas-f, NikitaFeodonit, Nineis K, nns52k, novak, nowhere, Nusi,
+oleksii.vorobiov, Oliver Kiddle, Oliver Smith, Olly Betts, ousnius, Owen
+Wengerd, pan93412, Pascal Cuoq, Patriccollu, Paul Kulchenko, Pavel Kalugin,
+Pavel Maryanov, Pavel O., Pavel Pimenov, Pavel Tyunin, Pedro Vicente, Pete
+Bannister, Pete Stieber, Peter Most, Peter Tissen, PeterO, phallobst, Phil
+Rosenberg, phowstan, Pierluigi Passaro, pk, PKEuS, Prashant Kumar Nirmal, Priit
+Laes, Prince David, QuentinC, R.J.V. Bertin, Rafael Kitover, Randalphwa, Raul
+Tambre, Razvan Macovei, Rebel_X, redtide, René J.V. Bertin, René Kijewski,
+Richard Broker, Richard Fath, Richard Gibson, Richard Powell, Richard Reznicek,
+Richard Smith, Rick Nelson, Rick S, rk, rlbxku1r, Rob Krakora, Rob McKay,
+Roberto Boriotti, Roberto Perpuly, Roger Sanders, rom, Ronny Krüger, Rutger van
+Eerd, Ryan Norton, Samuel Dunn, samurajj, Satya Das, sbesombes, scootergrisen,
+Scott Furry, Scott Mansell, Sean D'Epagnier, Sebastian Dröge, Sebastian
+Pipping, Sebastian Walderich, Serghei Amelian, Silent, Simon Richter, Simon
+Rozman, Simon Stone, skruse, Stefan Brüns, Stefan Neis, Stefan Ziegler, Stefano
+D. Mtangoo, Steffen Olszewski, Stepan Hrbek, Stephen Smith, Steve Browne,
+Steven Lamerton, Suzumizaki-Kimitaka, Takeshi Abe, taler21, tamasmeszaros,
+tellowkrinkle, Teodor Petrov, Thierry Bultel, Thomas Khyn, Thomas Klausner,
+Thomas Krebs, Thomas Pointhuber, Tijs Vermeulen, Tim Kosse, Tim Roberts, Tim
+Stahlhut, tm, TMTisFree, Tobias Fleischer, Tobias Hammer, Tobias Schlager,
+Tomas Rapkauskas, Tomasz Słodkowicz, Tomay, tommash, Tristan, trivia21, Troels
+Knakkergaard, Trylz, Umberto Carletti, utelle, Uwe Runtemund, Vitaly
+Stakhovsky, Vojtech Kral, Vsevolod V Gromov, Wacek Gocki, Walter Cheuk,
+wangpengli.qwerty, wangqr, wanup, wiz, Wolfgang Stöggl, wxBen, Xaviou, Xiaofeng
+Wang, Xlord2, yenwu, Yuri Chornoivan, Yuri D'Elia, YuSanka, Zane U. Ji, zhivko,
+zonkx, İsmail Dönmez.
+
+Please contact us if your name was accidentally omitted from this list and
+sorry in advance in this case.
+
+
+@subsection subsection_acknowledgements_past Historic Contributors
+
+The following people have kept the project going and provided an invaluable,
+extensive and high-quality amount of changes over the many of years of
+wxWidgets' life but are not actively involved in wxWidgets development any
+longer:
 
 @li Julian Smart
-@li Vadim Zeitlin
 @li Robert Roebling
-@li Robin Dunn
-@li Stefan Csomor
-@li Vaclav Slavik
-@li Paul Cornett
 @li Wlodzimierz `ABX' Skiba
 @li Chris Elliott
 @li David Elliott

--- a/misc/scripts/spellcheck
+++ b/misc/scripts/spellcheck
@@ -12,7 +12,7 @@ fi
 $CODESPELL \
   -I misc/suppressions/codespell-words \
   -x misc/suppressions/codespell-lines \
-  -S 'build/cmake/modules/cotire.cmake,docs/changes.txt,docs/changes_30.txt,*.png,*.ico,*.bmp,*.cur,docs/doxygen/images,docs/doxygen/doxygen-awesome-css' \
+  -S 'build/cmake/modules/cotire.cmake,docs/changes.txt,docs/changes_30.txt,*.png,*.ico,*.bmp,*.cur,docs/doxygen/images,docs/doxygen/mainpages/copyright.h,docs/doxygen/doxygen-awesome-css' \
   README.md docs include interface
 
 rc=$?


### PR DESCRIPTION
Also move some historical contributors to a separate section.

---

I am not very comfortable splitting some contributors into a special group, but OTOH there is no denying that there is some difference between people having contributed more than 100 changes to 3.2.0 from those contributing just one or two, so it seems like we should separate them somehow. But please let me know what do you think.

Also, I'm not sure if I was right to move @JulianSmart to historical contributors -- maybe you're just on a hiatus and plan returning to wx development one of these days? Please let me know if I jumped the gun here.