### PR TITLE
Warn about using find_package(wxWidgets) with older CMake

### DIFF
--- a/docs/doxygen/overviews/cmake.md
+++ b/docs/doxygen/overviews/cmake.md
@@ -101,6 +101,14 @@ You can use `find_package(wxWidgets)` to use a compiled version of wxWidgets.
 Have a look at the [CMake Documentation](https://cmake.org/cmake/help/latest/module/FindwxWidgets.html)
 for detailed instructions. wxWidgets also provides an example CMake file in the minimal sample folder.
 
+*WARNING*: Please note that CMake `findwxWidgets` module unfortunately doesn't
+detect wxWidgets 3.2.0 in versions of CMake older than 3.24. You may copy the
+latest version of `FindwxWidgets.cmake` from [CMake sources][1] to your system
+to fix this or, if you build wxWidgets itself using CMake, use `CONFIG` mode of
+`find_package()` which works even with older CMake versions.
+
+[1]: https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/FindwxWidgets.cmake
+
 Your *CMakeLists.txt* would look like this:
 ~~~
 ...


### PR DESCRIPTION
See #22590.

---

I don't really know what to say here, but @PBfordev is probably right and we should at least mention the problem. @MaartenBent could you please check if this is correct and/or fix it if it isn't? TIA!