### PR TITLE
Fix wrong conversion of negative 64-bit wxAny to wxVariant

### DIFF
--- a/src/common/any.cpp
+++ b/src/common/any.cpp
@@ -165,7 +165,7 @@ bool wxConvertAnyToVariant(const wxAny& any, wxVariant* variant)
             if ( ll > wxINT32_MAX || ll < wxINT32_MIN )
                 *variant = wxLongLong(ll);
             else
-                *variant = (long) wxLongLong(ll).GetLo();
+                *variant = static_cast<long>(ll);
         }
         else
         {

--- a/tests/any/anytest.cpp
+++ b/tests/any/anytest.cpp
@@ -617,6 +617,12 @@ void wxAnyTestCase::wxVariantConversions()
     CPPUNIT_ASSERT(res);
     CPPUNIT_ASSERT(variant.GetType() == "ulonglong");
     CPPUNIT_ASSERT(variant.GetULongLong() == wxULongLong(wxULL(123456)));
+
+    any = (wxLongLong_t)-1;
+    res = any.GetAs(&variant);
+    CPPUNIT_ASSERT(res);
+    CPPUNIT_ASSERT(variant.GetType() == "long");
+    CPPUNIT_ASSERT(variant.GetLong() == -1);
 #endif
 
     // Cannot test equality for the rest, just test that they convert


### PR DESCRIPTION
Extracting the lower part of a 64-bit value only works when long is
32-bit, but not if it's 64-bit as well as is the case under LP64 Unix
systems.

Just use a normal cast to long instead, as this is simpler and works in
all cases.

Also add a simple unit test for this case, which would have previously
failed, but passes now.

Closes #22592.