### PR TITLE
Replace "’s" with "'s" in interface headers

### DIFF
--- a/interface/wx/clrpicker.h
+++ b/interface/wx/clrpicker.h
@@ -45,7 +45,7 @@ wxEventType wxEVT_COLOURPICKER_DIALOG_CANCELLED;
     @event{EVT_COLOURPICKER_CHANGED(id, func)}
            The user changed the colour selected in the control either using the
            button or using text control (see @c wxCLRP_USE_TEXTCTRL; note that
-           in this case the event is fired only if the user’s input is valid,
+           in this case the event is fired only if the user's input is valid,
            i.e. recognizable). When using a popup dialog for changing the
            colour, this event is sent only when the changes in the dialog are
            accepted by the user, unlike @c EVT_COLOURPICKER_CURRENT_CHANGED.

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -851,7 +851,7 @@ public:
     virtual bool RemoveScriptMessageHandler(const wxString& name);
 
     /**
-        Injects the specified script into the webpage’s content.
+        Injects the specified script into the webpage's content.
 
         @param javascript The javascript code to add.
         @param injectionTime Specifies when the script will be executed.


### PR DESCRIPTION
I am trying to build wxPython using SIP version 6.6.2 under win10 using MinGW64 GCC and this is one of two place with SIP problems.
wxPython build stopped the second time on "interface/wx/webview.h".
I found what I am guessing was a "smart" single quote; replacing it with a normal quote helped.

Edit: The other sip problem, that happened first, was caused by wxPython code issue.

Tim S.