### PR TITLE
Ensure that wxrc gets added to the change_install_names

### DIFF
--- a/configure
+++ b/configure
@@ -27356,7 +27356,6 @@ $as_echo "$as_me: WARNING: XML library not built, cannot build wxrc" >&2;}
     USE_XML=0
 else
     USE_XML=1
-    echo "${HOST_PREFIX}install_name_tool \${changes} \${2}/wxrc-${WX_RELEASE}" >> change-install-names
 fi
 
 
@@ -33938,6 +33937,10 @@ done
 for i in \${libnames} ; do
     ${HOST_PREFIX}install_name_tool \${changes} -id \${3}/\${i} \${1}/\${i}
 done
+
+if [[ -f "\${2}/wxrc-${WX_RELEASE}" ]]; then
+    ${HOST_PREFIX}install_name_tool \${changes} \${2}/wxrc-${WX_RELEASE}
+fi
 EOF
             chmod +x change-install-names
             DYLIB_RPATH_INSTALL="\$(wx_top_builddir)/change-install-names \${DESTDIR}\${libdir} \${DESTDIR}\${bindir} \${libdir} \$(wx_top_builddir)/lib"

--- a/configure.in
+++ b/configure.in
@@ -2975,7 +2975,6 @@ if test "$wxUSE_XML" != "yes"; then
     USE_XML=0
 else
     USE_XML=1
-    echo "${HOST_PREFIX}install_name_tool \${changes} \${2}/wxrc-${WX_RELEASE}" >> change-install-names
 fi
 
 
@@ -4046,6 +4045,10 @@ done
 for i in \${libnames} ; do
     ${HOST_PREFIX}install_name_tool \${changes} -id \${3}/\${i} \${1}/\${i}
 done
+
+if [[ -f "\${2}/wxrc-${WX_RELEASE}" ]]; then
+    ${HOST_PREFIX}install_name_tool \${changes} \${2}/wxrc-${WX_RELEASE}
+fi
 EOF
             chmod +x change-install-names
             DYLIB_RPATH_INSTALL="\$(wx_top_builddir)/change-install-names \${DESTDIR}\${libdir} \${DESTDIR}\${bindir} \${libdir} \$(wx_top_builddir)/lib"


### PR DESCRIPTION
This is somewhat a WIP since I didn't fully test this but I think it is correct.

In the present order of operations, the file change-install-names gets overwritten when the main portion of it is created in the configure script.

It used to be that the code that tested for XML as "below" the creation of the main script, but it got moved "above" it in https://github.com/wxWidgets/wxWidgets/commit/30915c61631f05a06c0c64503540519ae67a5b3d#diff-bb21aa33a3f69ccb36c68b220f40ad08f29b9cd2c05dfedae7b9e3d5d4d08f6bR2949

it seems like the code move from 7500 to 2500. The file `change-install-names` gets created around line 3000 (in configure.in).

In the proposed implementation, I think that It addresses the issues raised in https://github.com/wxWidgets/wxWidgets/issues/15551

Saw from https://github.com/wxWidgets/wxWidgets/issues/15452#issuecomment-1011007656 that this functionaly came at the request from the MacPorts community. I tried to look through their patches (since it seems they released a 3.2 package as well) but I couldn't find any patch related to the one I am submitting. 

I am not so sure how they get around it. Maybe they simply missed this in their test suite ????