### PR TITLE
Improvements to closing wxDocument

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -11,6 +11,12 @@ INCOMPATIBLE CHANGES SINCE 3.2.x:
 Changes in behaviour not resulting in compilation errors
 --------------------------------------------------------
 
+- wxDocument::OnCloseDocument() was called twice in previous versions when
+  closing the document from the menu. Now it is only called once and after
+  destroying all the existing document views. If you overrode this function,
+  please check that you don't rely on any views existing when it's called.
+
+
 Changes in behaviour which may result in build errors
 -----------------------------------------------------
 

--- a/include/wx/docview.h
+++ b/include/wx/docview.h
@@ -188,6 +188,12 @@ public:
     // part of the parent document and not a disk file as usual.
     bool IsChildDocument() const { return m_documentParent != NULL; }
 
+    // Ask the user if the document should be saved if it's modified and save
+    // it if necessary.
+    //
+    // Returns false if the user cancelled closing or if saving failed.
+    bool CanClose();
+
 protected:
     wxList                m_documentViews;
     wxString              m_documentFile;

--- a/include/wx/docview.h
+++ b/include/wx/docview.h
@@ -117,6 +117,10 @@ public:
     // modified to false)
     virtual bool OnSaveModified();
 
+    // Similar to OnSaveModified() but doesn't allow the user to prevent the
+    // document from closing as it will be closed unconditionally.
+    virtual void OnSaveBeforeForceClose();
+
     // if you override, remember to call the default
     // implementation (wxDocument::OnChangeFilename)
     virtual void OnChangeFilename(bool notifyViews);

--- a/interface/wx/docview.h
+++ b/interface/wx/docview.h
@@ -1472,10 +1472,12 @@ public:
         case since wxWidgets 2.9.0.
 
         Returning @false from this function prevents the document from closing.
-        The default implementation does this if the document is modified and
-        the user didn't confirm discarding the modifications to it.
-
-        Return @true to allow the document to be closed.
+        Note that there is no need to ask the user if the changes to the
+        document should be saved, as this was already checked by
+        OnSaveModified() by the time this function is called, if necessary, and
+        so, typically, this function should always return @true to allow the
+        document to be closed, as leaving it open after asking the user about
+        saving the changes would be confusing.
     */
     virtual bool OnCloseDocument();
 

--- a/interface/wx/docview.h
+++ b/interface/wx/docview.h
@@ -1545,6 +1545,19 @@ public:
     virtual bool OnSaveModified();
 
     /**
+        This function is called when a document is forced to close.
+
+        The default implementation asks the user whether to save the changes
+        but, unlike OnSaveModified(), does not allow to cancel closing.
+
+        The document is force closed when wxDocManager::CloseDocument() is
+        called with its @c force argument set to @true.
+
+        @since 3.3.0
+     */
+    virtual void OnSaveBeforeForceClose();
+
+    /**
         Removes the view from the document's list of views.
 
         If the view was really removed, also calls OnChangedViewList().

--- a/samples/docview/docview.cpp
+++ b/samples/docview/docview.cpp
@@ -75,6 +75,7 @@ wxIMPLEMENT_APP(MyApp);
 
 wxBEGIN_EVENT_TABLE(MyApp, wxApp)
     EVT_MENU(wxID_ABOUT, MyApp::OnAbout)
+    EVT_MENU(wxID_CLEAR, MyApp::OnForceCloseAll)
 wxEND_EVENT_TABLE()
 
 MyApp::MyApp()
@@ -315,6 +316,7 @@ void MyApp::AppendDocumentFileCommands(wxMenu *menu, bool supportsPrinting)
     menu->Append(wxID_SAVE);
     menu->Append(wxID_SAVEAS);
     menu->Append(wxID_REVERT, _("Re&vert..."));
+    menu->Append(wxID_CLEAR, "&Force close all");
 
     if ( supportsPrinting )
     {
@@ -435,6 +437,13 @@ wxFrame *MyApp::CreateChildFrame(wxView *view, bool isCanvas)
     subframe->SetIcon(isCanvas ? wxICON(chrt) : wxICON(notepad));
 
     return subframe;
+}
+
+void MyApp::OnForceCloseAll(wxCommandEvent& WXUNUSED(event))
+{
+    // Pass "true" here to force closing just for testing this functionality,
+    // there is no real reason to force the issue here.
+    wxDocManager::GetDocumentManager()->CloseDocuments(true);
 }
 
 void MyApp::OnAbout(wxCommandEvent& WXUNUSED(event))

--- a/samples/docview/docview.h
+++ b/samples/docview/docview.h
@@ -71,6 +71,9 @@ private:
     void CreateMenuBarForFrame(wxFrame *frame, wxMenu *file, wxMenu *edit);
 
 
+    // force close all windows
+    void OnForceCloseAll(wxCommandEvent& event);
+
     // show the about box: as we can have different frames it's more
     // convenient, even if somewhat less usual, to handle this in the
     // application object itself

--- a/src/common/docview.cpp
+++ b/src/common/docview.cpp
@@ -527,26 +527,34 @@ bool wxDocument::OnSaveModified()
 {
     if ( IsModified() )
     {
-        switch ( wxMessageBox
-                 (
-                    wxString::Format
-                    (
-                     _("Do you want to save changes to %s?"),
-                     GetUserReadableName()
-                    ),
-                    wxTheApp->GetAppDisplayName(),
-                    wxYES_NO | wxCANCEL | wxICON_QUESTION | wxCENTRE,
-                    GetDocumentWindow()
-                 ) )
+        wxMessageDialog dialogSave
+            (
+                GetDocumentWindow(),
+                wxString::Format
+                (
+                    _("Do you want to save changes to %s?"),
+                    GetUserReadableName()
+                ),
+                wxTheApp->GetAppDisplayName(),
+                wxYES_NO | wxCANCEL | wxICON_QUESTION | wxCENTRE
+            );
+        dialogSave.SetYesNoCancelLabels
+            (
+                _("&Save"),
+                _("&Discard changes"),
+                _("Do&n't close")
+            );
+
+        switch ( dialogSave.ShowModal() )
         {
-            case wxNO:
+            case wxID_NO:
                 Modify(false);
                 break;
 
-            case wxYES:
+            case wxID_YES:
                 return Save();
 
-            case wxCANCEL:
+            case wxID_CANCEL:
                 return false;
         }
     }


### PR DESCRIPTION
This started as a bug fix for the [problem with calling `OnCloseDocument()` twice](https://groups.google.com/g/wx-users/c/RxaqAIS1R1c/m/PcrEdg7QAQAJ), but also includes some related, even though independent, improvements.