### PR TITLE
Fix wx-config and wxrc links when using DESTDIR with CMake

### DIFF
--- a/build/cmake/install.cmake
+++ b/build/cmake/install.cmake
@@ -43,9 +43,10 @@ else()
     install(CODE "execute_process( \
         COMMAND ${CMAKE_COMMAND} -E create_symlink \
         ${CMAKE_INSTALL_PREFIX}/lib/wx/config/${wxBUILD_FILE_ID} \
-        ${CMAKE_INSTALL_PREFIX}/bin/wx-config \
+        ${CMAKE_CURRENT_BINARY_DIR}/bin/wx-config \
         )"
     )
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/wx-config DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 endif()
 
 install(EXPORT wxWidgetsTargets NAMESPACE wx:: DESTINATION "lib/cmake/wxWidgets/${wxPLATFORM_LIB_DIR}")

--- a/build/cmake/install.cmake
+++ b/build/cmake/install.cmake
@@ -43,10 +43,10 @@ else()
     install(CODE "execute_process( \
         COMMAND ${CMAKE_COMMAND} -E create_symlink \
         ${CMAKE_INSTALL_PREFIX}/lib/wx/config/${wxBUILD_FILE_ID} \
-        ${CMAKE_CURRENT_BINARY_DIR}/bin/wx-config \
+        ${CMAKE_CURRENT_BINARY_DIR}/wx-config \
         )"
     )
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/bin/wx-config DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/wx-config DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 endif()
 
 install(EXPORT wxWidgetsTargets NAMESPACE wx:: DESTINATION "lib/cmake/wxWidgets/${wxPLATFORM_LIB_DIR}")

--- a/build/cmake/install.cmake
+++ b/build/cmake/install.cmake
@@ -46,7 +46,7 @@ else()
         ${CMAKE_CURRENT_BINARY_DIR}/bin/wx-config \
         )"
     )
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/wx-config DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/bin/wx-config DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 endif()
 
 install(EXPORT wxWidgetsTargets NAMESPACE wx:: DESTINATION "lib/cmake/wxWidgets/${wxPLATFORM_LIB_DIR}")

--- a/build/cmake/utils/CMakeLists.txt
+++ b/build/cmake/utils/CMakeLists.txt
@@ -40,10 +40,10 @@ if(wxUSE_XRC)
         wx_install(CODE "execute_process( \
             COMMAND ${CMAKE_COMMAND} -E create_symlink \
             ${CMAKE_INSTALL_PREFIX}/bin/${wxrc_output_name}${EXE_SUFFIX} \
-            ${CMAKE_CURRENT_BINARY_DIR}/bin/wxrc${EXE_SUFFIX} \
+            ${CMAKE_CURRENT_BINARY_DIR}/wxrc${EXE_SUFFIX} \
             )"
         )
-        wx_install(FILES ${CMAKE_CURRENT_BINARY_DIR}/bin/wxrc${EXE_SUFFIX} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+        wx_install(FILES ${CMAKE_CURRENT_BINARY_DIR}/wxrc${EXE_SUFFIX} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
     endif()
 endif()
 

--- a/build/cmake/utils/CMakeLists.txt
+++ b/build/cmake/utils/CMakeLists.txt
@@ -43,7 +43,7 @@ if(wxUSE_XRC)
             ${CMAKE_CURRENT_BINARY_DIR}/bin/wxrc${EXE_SUFFIX} \
             )"
         )
-        wx_install(FILES ${CMAKE_CURRENT_BINARY_DIR}/wxrc${EXE_SUFFIX} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+        wx_install(FILES ${CMAKE_CURRENT_BINARY_DIR}/bin/wxrc${EXE_SUFFIX} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
     endif()
 endif()
 

--- a/build/cmake/utils/CMakeLists.txt
+++ b/build/cmake/utils/CMakeLists.txt
@@ -40,9 +40,10 @@ if(wxUSE_XRC)
         wx_install(CODE "execute_process( \
             COMMAND ${CMAKE_COMMAND} -E create_symlink \
             ${CMAKE_INSTALL_PREFIX}/bin/${wxrc_output_name}${EXE_SUFFIX} \
-            ${CMAKE_INSTALL_PREFIX}/bin/wxrc${EXE_SUFFIX} \
+            ${CMAKE_CURRENT_BINARY_DIR}/bin/wxrc${EXE_SUFFIX} \
             )"
         )
+        wx_install(FILES ${CMAKE_CURRENT_BINARY_DIR}/wxrc${EXE_SUFFIX} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
     endif()
 endif()
 


### PR DESCRIPTION
Don't try installing the symlinks under the root directory when DESTDIR
is specified.

Closes #22610.