### PR TITLE
cmake: Fix statvfs support

### DIFF
--- a/build/cmake/setup.cmake
+++ b/build/cmake/setup.cmake
@@ -320,9 +320,11 @@ if(UNIX)
         l += fs.f_blocks;
         l += fs.f_bavail;"
         HAVE_STATVFS)
-    if(HAVE_STATFS)
-        set(WX_STATFS_T "struct statfs")
-        wx_check_cxx_source_compiles("
+    if(HAVE_STATVFS)
+      set(WX_STATFS_T "struct statvfs")
+    elseif(HAVE_STATFS)
+      set(WX_STATFS_T "struct statfs")
+      wx_check_cxx_source_compiles("
             return 0; }
             #if defined(__BSD__)
             #include <sys/param.h>
@@ -334,11 +336,7 @@ if(UNIX)
             int foo() {
             struct statfs fs;
             statfs(\"/\", &fs);"
-            HAVE_STATFS_DECL)
-    else()
-        if(HAVE_STATVFS)
-            set(WX_STATFS_T "struct statvfs")
-        endif()
+        HAVE_STATFS_DECL)
     endif()
 
     if(NOT HAVE_STATFS AND NOT HAVE_STATVFS)

--- a/build/cmake/setup.cmake
+++ b/build/cmake/setup.cmake
@@ -290,7 +290,7 @@ if(UNIX)
     wx_check_funcs(mkstemp mktemp)
 
     # get the library function to use for wxGetDiskSpace(): it is statfs() under
-    # Linux and *BSD and statvfs() under Solaris
+    # Linux and *BSD and statvfs() under Solaris and NetBSD
     wx_check_c_source_compiles("
         return 0; }
         #if defined(__BSD__)
@@ -308,6 +308,18 @@ if(UNIX)
         l += fs.f_blocks;
         l += fs.f_bavail;"
         HAVE_STATFS)
+    wx_check_c_source_compiles("
+        return 0; }
+        #include <sys/statvfs.h>
+
+        int foo() {
+        long l;
+        struct statvfs fs;
+        statvfs(\"/\", &fs);
+        l = fs.f_bsize;
+        l += fs.f_blocks;
+        l += fs.f_bavail;"
+        HAVE_STATVFS)
     if(HAVE_STATFS)
         set(WX_STATFS_T "struct statfs")
         wx_check_cxx_source_compiles("
@@ -324,9 +336,8 @@ if(UNIX)
             statfs(\"/\", &fs);"
             HAVE_STATFS_DECL)
     else()
-        # TODO: implement statvfs checks
         if(HAVE_STATVFS)
-            set(WX_STATFS_T statvfs_t)
+            set(WX_STATFS_T "struct statvfs")
         endif()
     endif()
 

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -85,7 +85,11 @@
 // different platforms and even different versions of the same system (Solaris
 // 7 and 8): if you want to test for this, don't forget that the problems only
 // appear if the large files support is enabled
-#ifdef HAVE_STATFS
+#if defined(HAVE_STATVFS)
+    #include <sys/statvfs.h>
+
+    #define wxStatfs statvfs
+#elif defined(HAVE_STATFS)
     #ifdef __BSD__
         #include <sys/param.h>
         #include <sys/mount.h>
@@ -99,13 +103,9 @@
         // some systems lack statfs() prototype in the system headers (AIX 4)
         extern "C" int statfs(const char *path, struct statfs *buf);
     #endif
-#elif defined(HAVE_STATVFS)
-    #include <sys/statvfs.h>
+#endif // HAVE_STATVFS/HAVE_STATFS
 
-    #define wxStatfs statvfs
-#endif // HAVE_STATFS/HAVE_STATVFS
-
-#if defined(HAVE_STATFS) || defined(HAVE_STATVFS)
+#if defined(HAVE_STATVFS) || defined(HAVE_STATFS)
     // WX_STATFS_T is detected by configure
     #define wxStatfs_t WX_STATFS_T
 #endif
@@ -1342,11 +1342,11 @@ bool wxGetDiskSpace(const wxString& path, wxDiskspaceSize_t *pTotal, wxDiskspace
 
     // under Solaris we also have to use f_frsize field instead of f_bsize
     // which is in general a multiple of f_frsize
-#ifdef HAVE_STATFS
-    wxDiskspaceSize_t blockSize = fs.f_bsize;
-#else // HAVE_STATVFS
+#ifdef HAVE_STATVFS
     wxDiskspaceSize_t blockSize = fs.f_frsize;
-#endif // HAVE_STATFS/HAVE_STATVFS
+#else // HAVE_STATFS
+    wxDiskspaceSize_t blockSize = fs.f_bsize;
+#endif // HAVE_STATVFS/HAVE_STATFS
 
     if ( pTotal )
     {

--- a/src/unix/utilsunx.cpp
+++ b/src/unix/utilsunx.cpp
@@ -99,13 +99,11 @@
         // some systems lack statfs() prototype in the system headers (AIX 4)
         extern "C" int statfs(const char *path, struct statfs *buf);
     #endif
-#endif // HAVE_STATFS
-
-#ifdef HAVE_STATVFS
+#elif defined(HAVE_STATVFS)
     #include <sys/statvfs.h>
 
     #define wxStatfs statvfs
-#endif // HAVE_STATVFS
+#endif // HAVE_STATFS/HAVE_STATVFS
 
 #if defined(HAVE_STATFS) || defined(HAVE_STATVFS)
     // WX_STATFS_T is detected by configure
@@ -1344,11 +1342,11 @@ bool wxGetDiskSpace(const wxString& path, wxDiskspaceSize_t *pTotal, wxDiskspace
 
     // under Solaris we also have to use f_frsize field instead of f_bsize
     // which is in general a multiple of f_frsize
-#ifdef HAVE_STATVFS
-    wxDiskspaceSize_t blockSize = fs.f_frsize;
-#else // HAVE_STATFS
+#ifdef HAVE_STATFS
     wxDiskspaceSize_t blockSize = fs.f_bsize;
-#endif // HAVE_STATVFS/HAVE_STATFS
+#else // HAVE_STATVFS
+    wxDiskspaceSize_t blockSize = fs.f_frsize;
+#endif // HAVE_STATFS/HAVE_STATVFS
 
     if ( pTotal )
     {


### PR DESCRIPTION
NetBSD provides statvfs, but no statfs. Tested on NetBSD.