### PR TITLE
NetBSD support for ping command

### DIFF
--- a/src/unix/dialup.cpp
+++ b/src/unix/dialup.cpp
@@ -795,6 +795,7 @@ wxDialUpManagerImpl::NetConnection wxDialUpManagerImpl::CheckPing()
     // nothing to add to ping command
 #elif defined(__AIX__) || \
       defined (__BSD__) || \
+      defined (__NetBSD__) || \
       defined(__LINUX__) || \
       defined(__OSF__) || \
       defined(__SGI__) || \


### PR DESCRIPTION
Handle NetBSD like other BSDs for ping.

NetBSD does not define __BSD__, use __NetBSD__.