### PR TITLE
Use DESTDIR when creating symlinks in CMake install

### DIFF
--- a/build/cmake/install.cmake
+++ b/build/cmake/install.cmake
@@ -43,7 +43,7 @@ else()
     install(CODE "execute_process( \
         COMMAND ${CMAKE_COMMAND} -E create_symlink \
         ${CMAKE_INSTALL_PREFIX}/lib/wx/config/${wxBUILD_FILE_ID} \
-        ${CMAKE_INSTALL_PREFIX}/bin/wx-config \
+        \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/wx-config\" \
         )"
     )
 endif()

--- a/build/cmake/utils/CMakeLists.txt
+++ b/build/cmake/utils/CMakeLists.txt
@@ -30,17 +30,18 @@ if(wxUSE_XRC)
         BUNDLE DESTINATION "bin"
         )
 
-    if(NOT WIN32_MSVC_NAMING)
+    if(NOT WIN32_MSVC_NAMING AND wxBUILD_INSTALL)
         if(IPHONE)
             set(EXE_SUFFIX ".app")
         else()
             set(EXE_SUFFIX ${CMAKE_EXECUTABLE_SUFFIX})
         endif()
 
-        wx_install(CODE "execute_process( \
+        # Don't use wx_install() here to preserve quoting.
+        install(CODE "execute_process( \
             COMMAND ${CMAKE_COMMAND} -E create_symlink \
             ${CMAKE_INSTALL_PREFIX}/bin/${wxrc_output_name}${EXE_SUFFIX} \
-            ${CMAKE_INSTALL_PREFIX}/bin/wxrc${EXE_SUFFIX} \
+            \"\$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/bin/wxrc${EXE_SUFFIX}\" \
             )"
         )
     endif()


### PR DESCRIPTION
Prepend $ENV{DESTDIR}, sufficiently quoted to delay its expansion until
the execution of "cmake -E create_symlink" command, to the command
path arguments.

Closes #22610.