### PR TITLE
Issue 22656: Allow wxStaticText creation to work in C++20

### DIFF
--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -1468,6 +1468,7 @@ enum wxBorder
 wxALLOW_COMBINING_ENUMS(wxAlignment, wxDirection)
 wxALLOW_COMBINING_ENUMS(wxAlignment, wxGeometryCentre)
 wxALLOW_COMBINING_ENUMS(wxAlignment, wxStretch)
+wxALLOW_COMBINING_ENUMS(wxAlignment, wxBorder)
 wxALLOW_COMBINING_ENUMS(wxDirection, wxStretch)
 wxALLOW_COMBINING_ENUMS(wxDirection, wxGeometryCentre)
 


### PR DESCRIPTION
(Issue with mixing enums/ints)