### PR TITLE
CMake: Support spaces in install path with symlinks

### DIFF
--- a/build/cmake/install.cmake
+++ b/build/cmake/install.cmake
@@ -42,8 +42,8 @@ else()
     install(DIRECTORY DESTINATION "bin")
     install(CODE "execute_process( \
         COMMAND ${CMAKE_COMMAND} -E create_symlink \
-        ${CMAKE_INSTALL_PREFIX}/lib/wx/config/${wxBUILD_FILE_ID} \
-        ${CMAKE_INSTALL_PREFIX}/bin/wx-config \
+        \"${CMAKE_INSTALL_PREFIX}/lib/wx/config/${wxBUILD_FILE_ID}\" \
+        \"${CMAKE_INSTALL_PREFIX}/bin/wx-config\" \
         )"
     )
 endif()

--- a/build/cmake/utils/CMakeLists.txt
+++ b/build/cmake/utils/CMakeLists.txt
@@ -39,8 +39,8 @@ if(wxUSE_XRC)
 
         wx_install(CODE "execute_process( \
             COMMAND ${CMAKE_COMMAND} -E create_symlink \
-            ${CMAKE_INSTALL_PREFIX}/bin/${wxrc_output_name}${EXE_SUFFIX} \
-            ${CMAKE_INSTALL_PREFIX}/bin/wxrc${EXE_SUFFIX} \
+            \"${CMAKE_INSTALL_PREFIX}/bin/${wxrc_output_name}${EXE_SUFFIX}\" \
+            \"${CMAKE_INSTALL_PREFIX}/bin/wxrc${EXE_SUFFIX}\" \
             )"
         )
     endif()


### PR DESCRIPTION
Add quotes around the paths so they are treated as one argument.

When using `CMAKE_INSTALL_PREFIX="/home/maarten/install path/"`, it would interpreted the following as 4 separate arguments for `create_symlink` resulting in a CMake usage error:
```
execute_process(COMMAND /usr/bin/cmake -E create_symlink /home/maarten/install path/bin/wxrc-3.2 /home/maarten/install path/bin/wxrc)
```
Now it are just the two arguments:
```
execute_process(COMMAND /usr/bin/cmake -E create_symlink "/home/maarten/install path/bin/wxrc-3.2" "/home/maarten/install path/bin/wxrc")
```

Also useful for 3.2 branch.