### PR TITLE
Don't use system libcurl under Mac with --disable-sys-libs

### DIFF
--- a/configure
+++ b/configure
@@ -27421,7 +27421,14 @@ if test "$wxUSE_LIBMSPACK" != "no"; then
 fi
 
 
-if test "$wxUSE_WEBREQUEST" = "yes" -a "$wxUSE_LIBCURL" != "no"; then
+if test "$wxUSE_WEBREQUEST" = "yes"; then
+    if test "$wxUSE_LIBCURL" = "builtin"; then
+                                                if test "$USE_DARWIN" = 1; then
+            wxUSE_LIBCURL=no
+        fi
+    fi
+
+    if test "$wxUSE_LIBCURL" != "no"; then
 
 pkg_failed=no
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for LIBCURL" >&5
@@ -27482,15 +27489,15 @@ fi
 	echo "$LIBCURL_PKG_ERRORS" >&5
 
 
-            wxUSE_LIBCURL=no
-            { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
+                wxUSE_LIBCURL=no
+                { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
 $as_echo "not found" >&6; }
 
 
 elif test $pkg_failed = untried; then
 
-            wxUSE_LIBCURL=no
-            { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
+                wxUSE_LIBCURL=no
+                { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
 $as_echo "not found" >&6; }
 
 
@@ -27500,11 +27507,12 @@ else
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 
-            wxUSE_LIBCURL=yes
-            CXXFLAGS="$LIBCURL_CFLAGS $CXXFLAGS"
-            LIBS="$LIBCURL_LIBS $LIBS"
+                wxUSE_LIBCURL=yes
+                CXXFLAGS="$LIBCURL_CFLAGS $CXXFLAGS"
+                LIBS="$LIBCURL_LIBS $LIBS"
 
 fi
+    fi
 fi
 
 

--- a/configure.in
+++ b/configure.in
@@ -3001,18 +3001,31 @@ dnl ------------------------------------------------------------------------
 dnl Check for libcurl
 dnl ------------------------------------------------------------------------
 
-if test "$wxUSE_WEBREQUEST" = "yes" -a "$wxUSE_LIBCURL" != "no"; then
-    PKG_CHECK_MODULES(LIBCURL, [libcurl],
-        [
-            wxUSE_LIBCURL=yes
-            CXXFLAGS="$LIBCURL_CFLAGS $CXXFLAGS"
-            LIBS="$LIBCURL_LIBS $LIBS"
-        ],
-        [
+if test "$wxUSE_WEBREQUEST" = "yes"; then
+    if test "$wxUSE_LIBCURL" = "builtin"; then
+        dnl When using --disable-sys-libs, we typically want to disable
+        dnl dependencies on the libraries that are not part of "the
+        dnl platform" and under macOS libcurl is definitely not part of the
+        dnl system -- but under Linux it arguably is, so handle this case
+        dnl appropriately.
+        if test "$USE_DARWIN" = 1; then
             wxUSE_LIBCURL=no
-            AC_MSG_RESULT([not found])
-        ]
-    )
+        fi
+    fi
+
+    if test "$wxUSE_LIBCURL" != "no"; then
+        PKG_CHECK_MODULES(LIBCURL, [libcurl],
+            [
+                wxUSE_LIBCURL=yes
+                CXXFLAGS="$LIBCURL_CFLAGS $CXXFLAGS"
+                LIBS="$LIBCURL_LIBS $LIBS"
+            ],
+            [
+                wxUSE_LIBCURL=no
+                AC_MSG_RESULT([not found])
+            ]
+        )
+    fi
 fi
 
 dnl ----------------------------------------------------------------


### PR DESCRIPTION
It doesn't seem right that the system zlib (installed by e.g. MacPorts)
can be picked up by configure even when --disable-sys-libs is specified,
so disable its use under Mac, as libcurl is optional there.

Still use the system libcurl under Linux in the same case, however, as
it's required to have wxWebRequest at all there and dependency on it is
not really a problem in practice.

This commit is best viewed with Git --color-moved
--color-moved-ws=ignore-all-space -w options.

----

Any comments are welcome, as usual. I realize that it's weird to handle the same option differently under different platforms, but it really seems to make sense in this case.