### PR TITLE
Replace raw stat/lstat with wx macros

### DIFF
--- a/src/common/ffile.cpp
+++ b/src/common/ffile.cpp
@@ -336,7 +336,7 @@ bool wxTempFFile::Open(const wxString& strName)
     mode_t mode;
 
     wxStructStat st;
-    if ( stat( (const char*) m_strName.fn_str(), &st) == 0 )
+    if ( wxStat(m_strName, &st) == 0 )
     {
         mode = st.st_mode;
     }

--- a/src/common/file.cpp
+++ b/src/common/file.cpp
@@ -556,7 +556,7 @@ bool wxTempFile::Open(const wxString& strName)
     mode_t mode;
 
     wxStructStat st;
-    if ( stat( (const char*) m_strName.fn_str(), &st) == 0 )
+    if ( wxStat(m_strName, &st) == 0 )
     {
         mode = st.st_mode;
     }

--- a/src/generic/filectrlg.cpp
+++ b/src/generic/filectrlg.cpp
@@ -184,7 +184,7 @@ void wxFileData::ReadData()
     wxStructStat buff;
 
 #if defined(__UNIX__) && !defined(__VMS)
-    const bool hasStat = lstat( m_filePath.fn_str(), &buff ) == 0;
+    const bool hasStat = wxLstat( m_filePath, &buff ) == 0;
     if ( hasStat )
         m_type |= S_ISLNK(buff.st_mode) ? is_link : 0;
 #else // no lstat()


### PR DESCRIPTION
In some places, the wxStat macro is not honoured and the original version is used, even if the wxStructStat is used as a parameter.