### PR TITLE
Fix bitmap returned from wxMSW wxImageList::GetBitmap()

### DIFF
--- a/src/msw/imaglist.cpp
+++ b/src/msw/imaglist.cpp
@@ -448,7 +448,11 @@ wxBitmap wxImageList::GetBitmap(int index) const
     int bmp_width = 0, bmp_height = 0;
     GetSize(index, bmp_width, bmp_height);
 
-    wxBitmap bitmap(bmp_width, bmp_height);
+    // Specify the depth to force using a DIB for this bitmap as drawing on a
+    // DDB, that would be created by default, results in bitmaps that look
+    // correct, but are not drawn correctly by Windows itself, e.g. transparent
+    // areas appear as black in the menus (see #22669).
+    wxBitmap bitmap(bmp_width, bmp_height, 32);
 
 #if wxUSE_WXDIB && wxUSE_IMAGE
     wxMemoryDC dc;


### PR DESCRIPTION
This fixes #22669 (~~in the first commit; the rest are just some cleanup~~), but I still don't fully understand why, i.e. what was wrong with the original code. It used 32bpp DDB, rather than DIB, but it should still have worked, AFAICS -- except it clearly didn't. @a-wi Would you have any idea by chance?

In any case, the fix should do no harm and fixes the menu item appearance, so I'll apply it if no better solution can be found.

Edit: Remove "cleanup" commits that broke unit tests again because in fact we still can have bitmaps without alpha in the image list.