### PR TITLE
Don't use token-pasting with non-identifiers in msvc/wx/setup.h

### DIFF
--- a/include/msvc/wx/setup.h
+++ b/include/msvc/wx/setup.h
@@ -127,15 +127,15 @@
     #endif
 #endif // wxTOOLKIT_PREFIX
 
+#ifdef wxSUFFIX
+    #define wxTOOLKIT_FULL wxCONCAT(wxTOOLKIT_PREFIX, wxSUFFIX)
+#else // suffix is empty
+    #define wxTOOLKIT_FULL wxTOOLKIT_PREFIX
+#endif
+
 // the real setup.h header file we need is in the build-specific directory,
 // construct the path to it
-#ifdef wxSUFFIX
-    #define wxSETUPH_PATH \
-        wxCONCAT6(../../../lib/, wxLIB_SUBDIR, /, wxTOOLKIT_PREFIX, wxSUFFIX, /wx/setup.h)
-#else // suffix is empty
-    #define wxSETUPH_PATH \
-        wxCONCAT5(../../../lib/, wxLIB_SUBDIR, /, wxTOOLKIT_PREFIX, /wx/setup.h)
-#endif
+#define wxSETUPH_PATH ../../../lib/wxLIB_SUBDIR/wxTOOLKIT_FULL/wx/setup.h
 
 #define wxSETUPH_PATH_STR wxSTRINGIZE(wxSETUPH_PATH)
 


### PR DESCRIPTION
This used to work with the non-standard preprocessor in the older MSVC
versions, but doesn't work with the new standard-compliant one in MSVS
2022 (enabled by /Zc:preprocessor).

Luckily, it seems that we don't really need it neither, as simply
expanding the macros in a /-separated strings work with both the new and
the old preprocessors and has the same effect, so just do this instead.

Also simplify the code a little by defining wxTOOLKIT_FULL and
constructing wxSETUPH_PATH once instead of twice.

See #22654.

Co-Authored-By: Vadim Zeitlin <vadim@wxwidgets.org>