### PR TITLE
Backport wxFileDialog::AddShortcut() changes to 3.2

### DIFF
--- a/build/elfabi/check_all.sh
+++ b/build/elfabi/check_all.sh
@@ -17,12 +17,21 @@ rc=0
 for l in $libraries; do
     name=$(basename $l .so)
     echo -n "Checking ${name}... "
-    if ! abidiff ${thisdir}/${name}.abi $l; then
-        echo "!!! ABI changes detected in ${name} !!!"
-        rc=1
-    else
-        echo 'ok'
-    fi
+    abidiff ${thisdir}/${name}.abi $l
+    case $? in
+        0)
+            echo 'ok'
+            ;;
+
+        4)
+            echo '*** ABI changes detected in ${name} ***'
+            ;;
+
+        *)
+            echo "!!! INCOMPATIBLE ABI changes detected in ${name} !!!"
+            rc=1
+            ;;
+    esac
 done
 
 exit $rc

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -237,6 +237,7 @@ Changes in behaviour which may result in build errors
 
 All (GUI):
 
+- Add wxFileDialog::AddShortcut() (#22543).
 - Fix grid window scrollbars when freezing part of the grid (#22602).
 - Avoid warnings with wxStaticText flags in C++20 (David Connet, #22656).
 - Fix AUI floating pane position when dragging (Konstantin S. Matveyev, #22533).

--- a/include/wx/filedlg.h
+++ b/include/wx/filedlg.h
@@ -56,6 +56,17 @@ enum
 
 #define wxFD_DEFAULT_STYLE      wxFD_OPEN
 
+#if wxABI_VERSION >= 30201
+
+// Flags for wxFileDialog::AddShortcut().
+enum
+{
+    wxFD_SHORTCUT_TOP       = 0x0001,
+    wxFD_SHORTCUT_BOTTOM    = 0x0002
+};
+
+#endif // wxABI_VERSION >= 3.2.1
+
 extern WXDLLIMPEXP_DATA_CORE(const char) wxFileDialogNameStr[];
 extern WXDLLIMPEXP_DATA_CORE(const char) wxFileSelectorPromptStr[];
 extern WXDLLIMPEXP_DATA_CORE(const char) wxFileSelectorDefaultWildcardStr[];
@@ -129,6 +140,14 @@ public:
     virtual int GetCurrentlySelectedFilterIndex () const
         { return m_currentlySelectedFilterIndex; }
 
+
+#if defined(__WXUNIVERSAL__) || !(defined(__WXMSW__) || defined(__WXGTK20__))
+#if wxABI_VERSION >= 30201
+    // Add a shortcut to the given directory in the sidebar containing such
+    // shortcuts if supported.
+    bool AddShortcut(const wxString& directory, int flags = 0);
+#endif // wxABI_VERSION >= 3.2.1
+#endif // Platforms without native implementation.
 
     // A customize hook methods will be called by wxFileDialog later if this
     // function returns true, see its documentation for details.

--- a/include/wx/gtk/filedlg.h
+++ b/include/wx/gtk/filedlg.h
@@ -55,6 +55,9 @@ public:
 
     virtual int ShowModal() wxOVERRIDE;
 
+#if wxABI_VERSION >= 30201
+    bool AddShortcut(const wxString& directory, int flags = 0);
+#endif // wxABI_VERSION >= 3.2.1
     virtual bool SupportsExtraControl() const wxOVERRIDE { return true; }
 
     // Implementation only.

--- a/include/wx/msw/filedlg.h
+++ b/include/wx/msw/filedlg.h
@@ -33,6 +33,9 @@ public:
 
     virtual void GetPaths(wxArrayString& paths) const wxOVERRIDE;
     virtual void GetFilenames(wxArrayString& files) const wxOVERRIDE;
+#if wxABI_VERSION >= 30201
+    bool AddShortcut(const wxString& directory, int flags = 0);
+#endif // wxABI_VERSION >= 3.2.1
     virtual bool SupportsExtraControl() const wxOVERRIDE { return true; }
 
     virtual int ShowModal() wxOVERRIDE;

--- a/include/wx/msw/private/filedialog.h
+++ b/include/wx/msw/private/filedialog.h
@@ -55,6 +55,9 @@ public:
     // Set the initial path to show in the dialog.
     void SetInitialPath(const wxString& path);
 
+    // Add a shortcut.
+    void AddPlace(const wxString& path, FDAP fdap);
+
     // Show the file dialog with the given parent window and options.
     //
     // Returns the selected path, or paths, in the provided output parameters,
@@ -72,6 +75,9 @@ public:
 private:
     wxCOMPtr<IFileDialog> m_fileDialog;
 };
+
+// Initialize an IShellItem object with the given path.
+HRESULT InitShellItemFromPath(wxCOMPtr<IShellItem>& item, const wxString& path);
 
 // Extract the filesystem path corresponding to the given shell item.
 HRESULT GetFSPathFromShellItem(const wxCOMPtr<IShellItem>& item, wxString& path);

--- a/interface/wx/filedlg.h
+++ b/interface/wx/filedlg.h
@@ -233,6 +233,46 @@ public:
     virtual ~wxFileDialog();
 
     /**
+        Add a directory to the list of shortcuts shown in the dialog.
+
+        File dialogs on many platforms display a fixed list of directories
+        which can be easily selected by the user. This function allows to add
+        an application-defined directory to this list, which can be convenient
+        for the programs that use specific directories for their files instead
+        of the default user document directory (see wxStandardPaths).
+
+        Currently this function is only implemented in wxMSW and wxGTK and does
+        nothing under the other platforms. Moreover, in wxMSW this function is
+        incompatible with the use of SetExtraControlCreator(), if you need to
+        use this function and customize the dialog contents, please use the
+        newer SetCustomizeHook() instead.
+
+        The @ref page_samples_dialogs "dialogs sample" shows the use of this
+        function by adding two custom shortcuts corresponding to the
+        subdirectories of @c WXWIN environment variable if it is defined.
+
+        @note In wxMSW, the shortcuts appear in a separate section called
+            "Application Links" by default. To change the title of this
+            section, the application can specify a value of the @c
+            FileDescription field of the version information structure in its
+            resource file -- if present, this string will be used as the
+            section title.
+
+        @param directory The full path to the directory, which should exist.
+        @param flags Can be set to @c wxFD_SHORTCUT_BOTTOM (which is also the
+            default behaviour) to add the shortcut after the existing ones,
+            or @c wxFD_SHORTCUT_TOP to add it before them. Support for the
+            latter flag is only available in wxMSW, in wxGTK the shortcuts are
+            always added to the bottom of the list.
+        @return @true on success or @false if shortcut couldn't be added, e.g.
+            because this functionality is not available on the current
+            platform.
+
+        @since 3.2.1
+     */
+    bool AddShortcut(const wxString& directory, int flags = 0);
+
+    /**
         Returns the path of the file currently selected in dialog.
 
         Notice that this file is not necessarily going to be accepted by the

--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -1824,6 +1824,18 @@ void MyFrame::FileOpen(wxCommandEvent& WXUNUSED(event) )
                     )
                  );
 
+    // For demonstration purposes, add wxWidgets directories to the sidebar.
+    wxString wxdir;
+    if ( wxGetEnv("WXWIN", &wxdir) )
+    {
+        dialog.AddShortcut(wxdir + "/src");
+
+        // By default shortcuts are added at the bottom, but we can override
+        // this in the ports that support it (currently only wxMSW) and add a
+        // shortcut added later at the top instead.
+        dialog.AddShortcut(wxdir + "/include", wxFD_SHORTCUT_TOP);
+    }
+
     // Note: this object must remain alive until ShowModal() returns.
     MyCustomizeHook myCustomizer(dialog);
 

--- a/src/common/fldlgcmn.cpp
+++ b/src/common/fldlgcmn.cpp
@@ -851,6 +851,17 @@ wxString wxFileDialogBase::AppendExtension(const wxString &filePath,
     return filePath + ext;
 }
 
+#if defined(__WXUNIVERSAL__) || !(defined(__WXMSW__) || defined(__WXGTK20__))
+
+bool wxFileDialogBase::AddShortcut(const wxString& WXUNUSED(directory),
+                                   int WXUNUSED(flags))
+{
+    // Not implemented by default.
+    return false;
+}
+
+#endif // Platforms without native implementation.
+
 bool wxFileDialogBase::SetCustomizeHook(wxFileDialogCustomizeHook& customizeHook)
 {
     if ( !SupportsExtraControl() )

--- a/src/gtk/filedlg.cpp
+++ b/src/gtk/filedlg.cpp
@@ -20,6 +20,7 @@
 #endif
 
 #include "wx/gtk/private.h"
+#include "wx/gtk/private/error.h"
 #include "wx/gtk/private/mnemonics.h"
 
 #ifdef __UNIX__
@@ -497,6 +498,23 @@ void wxFileDialog::GTKSelectionChanged(const wxString& filename)
     m_currentlySelectedFilename = filename;
 
     UpdateExtraControlUI();
+}
+
+bool wxFileDialog::AddShortcut(const wxString& directory, int WXUNUSED(flags))
+{
+    wxGtkError error;
+
+    if ( !gtk_file_chooser_add_shortcut_folder(GTK_FILE_CHOOSER(m_widget),
+                                               directory.utf8_str(),
+                                               error.Out()) )
+    {
+        wxLogDebug("Failed to add shortcut \"%s\": %s",
+                   directory, error.GetMessage());
+
+        return false;
+    }
+
+    return true;
 }
 
 #endif // wxUSE_FILEDLG

--- a/version-script.in
+++ b/version-script.in
@@ -12,7 +12,9 @@
 #
 #   # public symbols added in release @WX_VERSION_TAG@.2 (please keep in alphabetical order):
 #   @WX_VERSION_TAG@.2 {
-#           *wxChoice*GetCurrentSelection*;
+#       extern "C++"
+#           "wxChoice::GetCurrentSelection()";
+#       };
 #   };
 #
 # If a symbols should have been added in this way, but is forgotten then it
@@ -20,6 +22,13 @@
 # released with the generic branch version due to the final wildcard below,
 # and once released its version cannot be changed.
 
+
+# public symbols added in 3.2.1 (please keep in alphabetical order):
+@WX_VERSION_TAG@.1 {
+    extern "C++" {
+        "wxFileDialog::AddShortcut(const wxString&, int)";
+    };
+};
 
 # symbols available since the beginning of this branch are only given
 # generic branch tag (don't remove this!):


### PR DESCRIPTION
This is a backport of #22635.

See #22543.
