### PR TITLE
Fix warnings in gcc 12 optimized build

### DIFF
--- a/include/wx/vector.h
+++ b/include/wx/vector.h
@@ -519,6 +519,13 @@ public:
         const size_t idx = it - begin();
         const size_t after = end() - it;
 
+        // Unfortunately gcc 12 still complains about use-after-free even if
+        // our code is corrects because it actually optimizes it to be wrong,
+        // with -O2 or higher, so use this hack to avoid the warning with it.
+#if wxCHECK_GCC_VERSION(12, 1)
+        __asm__ __volatile__("":::"memory");
+#endif
+
         reserve(size() + count);
 
         // the place where the new element is going to be inserted

--- a/src/stc/scintilla/lexers/LexDMIS.cxx
+++ b/src/stc/scintilla/lexers/LexDMIS.cxx
@@ -244,10 +244,10 @@ void SCI_METHOD LexerDMIS::Lex(Sci_PositionU startPos, Sci_Position lengthDoc, i
 
 			case SCE_DMIS_KEYWORD:
 				if (!setDMISWord.Contains(scCTX.ch)) {
-					char tmpStr[MAX_STR_LEN];
-					memset(tmpStr, 0, MAX_STR_LEN*sizeof(char));
-					scCTX.GetCurrent(tmpStr, (MAX_STR_LEN-1));
-					strncpy(tmpStr, this->UpperCase(tmpStr), (MAX_STR_LEN-1));
+					char tmpBuf[MAX_STR_LEN];
+					memset(tmpBuf, 0, MAX_STR_LEN*sizeof(char));
+					scCTX.GetCurrent(tmpBuf, (MAX_STR_LEN-1));
+					char* const tmpStr = this->UpperCase(tmpBuf);
 
 					if (this->m_minorWords.InList(tmpStr)) {
 						scCTX.ChangeState(SCE_DMIS_MINORWORD);


### PR DESCRIPTION
This should be backported to 3.2 too.