### PR TITLE
Replace macOS 10.15 runners with macOS 11 ones

### DIFF
--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -57,12 +57,12 @@ jobs:
             runner: ubuntu-18.04
             cmake_generator: Unix Makefiles
             cmake_samples: ALL
-          - name: macOS 10.15 wxOSX
-            runner: macos-10.15
+          - name: macOS 11 wxOSX
+            runner: macos-11
             cmake_generator: Xcode
             cmake_defines: -DCMAKE_CXX_STANDARD=11
-          - name: macOS 10.15 wxIOS
-            runner: macos-10.15
+          - name: macOS 11 wxIOS
+            runner: macos-11
             cmake_generator: Xcode
             cmake_defines: -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_FIND_ROOT_PATH=/usr/local -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=NO
             cmake_samples: OFF

--- a/.github/workflows/ci_mac.yml
+++ b/.github/workflows/ci_mac.yml
@@ -93,12 +93,12 @@ jobs:
           runner: self-hosted
           arch: arm64
           configure_flags: --with-cxx=14 --enable-universal_binary=arm64,x86_64 --disable-shared --disable-debug --enable-optimise
-        - name: wxMac macOS 10.15
-          runner: macos-10.15
+        - name: wxMac macOS 11
+          runner: macos-11
           arch: x86_64
           configure_flags: --disable-sys-libs
         - name: wxiOS
-          runner: macos-10.15
+          runner: macos-11
           arch: x86_64
           configure_flags: --with-osx_iphone --enable-monolithic  --disable-sys-libs --host=i686-apple-darwin_sim --build=x86_64-apple-darwin17.7.0
           xcode_sdk: iphonesimulator


### PR DESCRIPTION
10.15 is being phased out by GitHub, so switch to the still supported
runner platform version.