### PR TITLE
Fix lack of key events for wxSearchCtrl under Mac

### DIFF
--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -449,6 +449,17 @@ public:
 
     @end
 
+    @interface wxNSSearchField : NSSearchField
+    {
+        wxNSTextFieldEditor* fieldEditor;
+        BOOL m_withinTextDidChange;
+    }
+
+    - (wxNSTextFieldEditor*) fieldEditor;
+    - (void) setFieldEditor:(wxNSTextFieldEditor*) fieldEditor;
+
+    @end
+
     @interface wxNSComboBox : NSComboBox
     {
         wxNSTextFieldEditor* fieldEditor;

--- a/include/wx/osx/cocoa/private.h
+++ b/include/wx/osx/cocoa/private.h
@@ -423,11 +423,12 @@ public:
 
     @interface wxNSTextField : NSTextField <NSTextFieldDelegate>
     {
-        wxNSTextFieldEditor* fieldEditor;
     }
 
-    - (wxNSTextFieldEditor*) fieldEditor;
-    - (void) setFieldEditor:(wxNSTextFieldEditor*) fieldEditor;
+    // Note that the name WXFieldEditor is special and is checked by
+    // windowWillReturnFieldEditor: in wxNonOwnedWindowController
+    // implementation, see there.
+    @property (retain) wxNSTextFieldEditor* WXFieldEditor;
 
     @end
 
@@ -451,22 +452,18 @@ public:
 
     @interface wxNSSearchField : NSSearchField
     {
-        wxNSTextFieldEditor* fieldEditor;
         BOOL m_withinTextDidChange;
     }
 
-    - (wxNSTextFieldEditor*) fieldEditor;
-    - (void) setFieldEditor:(wxNSTextFieldEditor*) fieldEditor;
+    @property (retain) wxNSTextFieldEditor* WXFieldEditor;
 
     @end
 
     @interface wxNSComboBox : NSComboBox
     {
-        wxNSTextFieldEditor* fieldEditor;
     }
 
-    - (wxNSTextFieldEditor*) fieldEditor;
-    - (void) setFieldEditor:(wxNSTextFieldEditor*) fieldEditor;
+    @property (retain) wxNSTextFieldEditor* WXFieldEditor;
 
     @end
 

--- a/src/osx/cocoa/combobox.mm
+++ b/src/osx/cocoa/combobox.mm
@@ -48,33 +48,6 @@
     }
 }
 
-- (void) dealloc
-{
-    [fieldEditor release];
-    [super dealloc];
-}
-
-// Over-riding NSComboBox onKeyDown method doesn't work for key events.
-// Ensure that we can use our own wxNSTextFieldEditor to catch key events.
-// See windowWillReturnFieldEditor in nonownedwnd.mm.
-// Key events will be caught and handled via wxNSTextFieldEditor onkey...
-// methods in textctrl.mm.
-
-- (void) setFieldEditor:(wxNSTextFieldEditor*) editor
-{
-    if ( editor != fieldEditor )
-    {
-        [editor retain];
-        [fieldEditor release];
-        fieldEditor = editor;
-    }
-}
-
-- (wxNSTextFieldEditor*) fieldEditor
-{
-    return fieldEditor;
-}
-
 - (void)controlTextDidChange:(NSNotification *)aNotification
 {
     wxUnusedVar(aNotification);
@@ -99,7 +72,7 @@
     {
         wxNSTextFieldControl* timpl = dynamic_cast<wxNSTextFieldControl*>(impl);
         if ( timpl )
-            timpl->UpdateInternalSelectionFromEditor(fieldEditor);
+            timpl->UpdateInternalSelectionFromEditor(self.WXFieldEditor);
         impl->DoNotifyFocusLost();
     }
 }

--- a/src/osx/cocoa/nonownedwnd.mm
+++ b/src/osx/cocoa/nonownedwnd.mm
@@ -583,49 +583,20 @@ extern int wxOSXGetIdFromSelector(SEL action );
 {
     wxUnusedVar(sender);
 
-    if ([anObject isKindOfClass:[wxNSTextField class]])
+    if ( [anObject respondsToSelector:@selector(WXFieldEditor)] )
     {
-        wxNSTextField* tf = (wxNSTextField*) anObject;
-        wxNSTextFieldEditor* editor = [tf fieldEditor];
+        wxNSTextFieldEditor* editor = [anObject WXFieldEditor];
         if ( editor == nil )
         {
             editor = [[wxNSTextFieldEditor alloc] init];
             [editor setFieldEditor:YES];
-            [editor setTextField:tf];
-            [tf setFieldEditor:editor];
-            [editor release];
-        }
-        return editor;
-    } 
-    else if ([anObject isKindOfClass:[wxNSSearchField class]])
-    {
-        wxNSSearchField* sf = (wxNSSearchField*) anObject;
-        wxNSTextFieldEditor* editor = [sf fieldEditor];
-        if ( editor == nil )
-        {
-            editor = [[wxNSTextFieldEditor alloc] init];
-            [editor setFieldEditor:YES];
-            [editor setTextField:sf];
-            [sf setFieldEditor:editor];
+            [editor setTextField:anObject];
+            [anObject setWXFieldEditor:editor];
             [editor release];
         }
         return editor;
     }
-    else if ([anObject isKindOfClass:[wxNSComboBox class]])
-    {
-        wxNSComboBox * cb = (wxNSComboBox*) anObject;
-        wxNSTextFieldEditor* editor = [cb fieldEditor];
-        if ( editor == nil )
-        {
-            editor = [[wxNSTextFieldEditor alloc] init];
-            [editor setFieldEditor:YES];
-            [editor setTextField:cb];
-            [cb setFieldEditor:editor];
-            [editor release];
-        }
-        return editor;
-    }    
- 
+
     return nil;
 }
 

--- a/src/osx/cocoa/nonownedwnd.mm
+++ b/src/osx/cocoa/nonownedwnd.mm
@@ -597,6 +597,20 @@ extern int wxOSXGetIdFromSelector(SEL action );
         }
         return editor;
     } 
+    else if ([anObject isKindOfClass:[wxNSSearchField class]])
+    {
+        wxNSSearchField* sf = (wxNSSearchField*) anObject;
+        wxNSTextFieldEditor* editor = [sf fieldEditor];
+        if ( editor == nil )
+        {
+            editor = [[wxNSTextFieldEditor alloc] init];
+            [editor setFieldEditor:YES];
+            [editor setTextField:sf];
+            [sf setFieldEditor:editor];
+            [editor release];
+        }
+        return editor;
+    }
     else if ([anObject isKindOfClass:[wxNSComboBox class]])
     {
         wxNSComboBox * cb = (wxNSComboBox*) anObject;

--- a/src/osx/cocoa/srchctrl.mm
+++ b/src/osx/cocoa/srchctrl.mm
@@ -24,14 +24,6 @@
 #include "wx/osx/private.h"
 #include "wx/osx/cocoa/private/textimpl.h"
 
-
-@interface wxNSSearchField : NSSearchField
-{
-    BOOL m_withinTextDidChange;
-}
-
-@end
-
 @implementation wxNSSearchField
 
 + (void)initialize
@@ -42,6 +34,21 @@
         initialized = YES;
         wxOSXCocoaClassAddWXMethods( self );
     }
+}
+
+- (void) setFieldEditor:(wxNSTextFieldEditor*) editor
+{
+    if ( editor != fieldEditor )
+    {
+        [editor retain];
+        [fieldEditor release];
+        fieldEditor = editor;
+    }
+}
+
+- (wxNSTextFieldEditor*) fieldEditor
+{
+    return fieldEditor;
 }
 
 - (id)initWithFrame:(NSRect)frame

--- a/src/osx/cocoa/srchctrl.mm
+++ b/src/osx/cocoa/srchctrl.mm
@@ -36,21 +36,6 @@
     }
 }
 
-- (void) setFieldEditor:(wxNSTextFieldEditor*) editor
-{
-    if ( editor != fieldEditor )
-    {
-        [editor retain];
-        [fieldEditor release];
-        fieldEditor = editor;
-    }
-}
-
-- (wxNSTextFieldEditor*) fieldEditor
-{
-    return fieldEditor;
-}
-
 - (id)initWithFrame:(NSRect)frame
 {
     if ( self = [super initWithFrame:frame] )

--- a/src/osx/cocoa/textctrl.mm
+++ b/src/osx/cocoa/textctrl.mm
@@ -584,36 +584,6 @@ NSView* wxMacEditHelper::ms_viewCurrentlyEdited = nil;
     }
 }
 
-- (id) initWithFrame:(NSRect) frame
-{
-    if ( self = [super initWithFrame:frame] )
-    {
-        fieldEditor = nil;
-    }
-    return self;
-}
-
-- (void) dealloc
-{
-    [fieldEditor release];
-    [super dealloc];
-}
-
-- (void) setFieldEditor:(wxNSTextFieldEditor*) editor
-{
-    if ( editor != fieldEditor )
-    {
-        [editor retain];
-        [fieldEditor release];
-        fieldEditor = editor;
-    }
-}
-
-- (wxNSTextFieldEditor*) fieldEditor
-{
-    return fieldEditor;
-}
-
 - (void) setEnabled:(BOOL) flag
 {
     [super setEnabled: flag];
@@ -736,7 +706,7 @@ NSView* wxMacEditHelper::ms_viewCurrentlyEdited = nil;
     {
         wxNSTextFieldControl* timpl = dynamic_cast<wxNSTextFieldControl*>(impl);
         if ( timpl )
-            timpl->UpdateInternalSelectionFromEditor(fieldEditor);
+            timpl->UpdateInternalSelectionFromEditor(self.WXFieldEditor);
         impl->DoNotifyFocusLost();
     }
 }


### PR DESCRIPTION
The real fix is in the first commit, but the second one makes the code a bit more palatable.

I think both commits should be safe to backport to 3.2, but if there is any doubt about the latter one, we could backport just the first one, as it's enough to fix the user-visible bug.