### PR TITLE
Generate wxEVT_KILL_FOCUS for wxSearchCtrl under Mac

### DIFF
--- a/src/osx/cocoa/srchctrl.mm
+++ b/src/osx/cocoa/srchctrl.mm
@@ -68,6 +68,14 @@
         impl->controlTextDidChange();
 }
 
+- (void)controlTextDidEndEditing:(NSNotification *) aNotification
+{
+    wxUnusedVar(aNotification);
+    wxWidgetCocoaImpl* impl = (wxWidgetCocoaImpl* ) wxWidgetImpl::FindFromWXWidget( self );
+    if ( impl )
+        impl->DoNotifyFocusLost();
+}
+
 - (NSArray *)control:(NSControl *)control textView:(NSTextView *)textView completions:(NSArray *)words
  forPartialWordRange:(NSRange)charRange indexOfSelectedItem:(int*)index
 {


### PR DESCRIPTION
Do it using controlTextDidChange: notification as it's already done for
wxTextCtrl and wxComboBox.

See #22702.

---

It seems like there should be some way to avoid duplicating this code in several places too, but I'm not sure how exactly to do it, so for now let's at least fix the bug.