### PR TITLE
Use the appropriate bezel style for wxToggleButton under Mac

### DIFF
--- a/src/osx/cocoa/button.mm
+++ b/src/osx/cocoa/button.mm
@@ -176,9 +176,7 @@ NSButton *wxButtonCocoaImpl::GetNSButton() const
 // Set bezel style depending on the wxBORDER_XXX flags specified by the style
 // and also accounting for the label (bezels are different for multiline
 // buttons and normal ones) and the ID (special bezel is used for help button).
-//
-// This is extern because it's also used in src/osx/cocoa/tglbtn.mm.
-extern "C"
+static
 void
 SetBezelStyleFromBorderFlags(NSButton *v,
                              long style,

--- a/src/osx/cocoa/tglbtn.mm
+++ b/src/osx/cocoa/tglbtn.mm
@@ -27,8 +27,10 @@
 
 static
 void
-SetToggleButtonBezelStyle(NSButton *v, long style)
+SetToggleButtonStyle(NSButton *v, long style)
 {
+    NSButtonType type = NSOnOffButton;
+
     // This is the appropriate default bezel style for the toggle buttons.
     NSBezelStyle bezel = NSShadowlessSquareBezelStyle;
 
@@ -39,6 +41,7 @@ SetToggleButtonBezelStyle(NSButton *v, long style)
 
         case wxBORDER_NONE:
             [v setBordered:NO];
+            type = NSToggleButton;
             break;
 
         case wxBORDER_SIMPLE:
@@ -53,6 +56,7 @@ SetToggleButtonBezelStyle(NSButton *v, long style)
     }
 
     [v setBezelStyle:bezel];
+    [v setButtonType:type];
 }
 
 wxWidgetImplType* wxWidgetImpl::CreateToggleButton( wxWindowMac* wxpeer,
@@ -67,9 +71,8 @@ wxWidgetImplType* wxWidgetImpl::CreateToggleButton( wxWindowMac* wxpeer,
     NSRect r = wxOSXGetFrameForControl( wxpeer, pos , size ) ;
     wxNSButton* v = [[wxNSButton alloc] initWithFrame:r];
 
-    SetToggleButtonBezelStyle(v, style);
+    SetToggleButtonStyle(v, style);
 
-    [v setButtonType:NSOnOffButton];
     wxWidgetCocoaImpl* c = new wxButtonCocoaImpl( wxpeer, v );
     return c;
 }
@@ -86,7 +89,7 @@ wxWidgetImplType* wxWidgetImpl::CreateBitmapToggleButton( wxWindowMac* wxpeer,
     NSRect r = wxOSXGetFrameForControl( wxpeer, pos , size ) ;
     wxNSButton* v = [[wxNSButton alloc] initWithFrame:r];
 
-    SetToggleButtonBezelStyle(v, style);
+    SetToggleButtonStyle(v, style);
     
     if (label.IsOk())
         [v setImage: wxOSXGetImageFromBundle(label) ];

--- a/src/osx/cocoa/tglbtn.mm
+++ b/src/osx/cocoa/tglbtn.mm
@@ -25,13 +25,35 @@
 #include "wx/osx/private.h"
 #include "wx/private/bmpbndl.h"
 
-// from button.mm
+static
+void
+SetToggleButtonBezelStyle(NSButton *v, long style)
+{
+    // This is the appropriate default bezel style for the toggle buttons.
+    NSBezelStyle bezel = NSShadowlessSquareBezelStyle;
 
-extern "C" void SetBezelStyleFromBorderFlags(NSButton *v,
-                                             long style,
-                                             wxWindowID winid = wxID_ANY,
-                                             const wxString& label = wxString(),
-                                             const wxBitmapBundle& bitmap = wxBitmapBundle());
+    switch ( style & wxBORDER_MASK )
+    {
+        case 0:
+            break;
+
+        case wxBORDER_NONE:
+            [v setBordered:NO];
+            break;
+
+        case wxBORDER_SIMPLE:
+            bezel = NSSmallSquareBezelStyle;
+            break;
+
+        case wxBORDER_STATIC:
+        case wxBORDER_RAISED:
+        case wxBORDER_THEME:
+        case wxBORDER_SUNKEN:
+            break;
+    }
+
+    [v setBezelStyle:bezel];
+}
 
 wxWidgetImplType* wxWidgetImpl::CreateToggleButton( wxWindowMac* wxpeer,
                                     wxWindowMac* WXUNUSED(parent),
@@ -45,7 +67,7 @@ wxWidgetImplType* wxWidgetImpl::CreateToggleButton( wxWindowMac* wxpeer,
     NSRect r = wxOSXGetFrameForControl( wxpeer, pos , size ) ;
     wxNSButton* v = [[wxNSButton alloc] initWithFrame:r];
 
-    SetBezelStyleFromBorderFlags(v, style, winid, label);
+    SetToggleButtonBezelStyle(v, style);
 
     [v setButtonType:NSOnOffButton];
     wxWidgetCocoaImpl* c = new wxButtonCocoaImpl( wxpeer, v );
@@ -64,7 +86,7 @@ wxWidgetImplType* wxWidgetImpl::CreateBitmapToggleButton( wxWindowMac* wxpeer,
     NSRect r = wxOSXGetFrameForControl( wxpeer, pos , size ) ;
     wxNSButton* v = [[wxNSButton alloc] initWithFrame:r];
 
-    SetBezelStyleFromBorderFlags(v, style, winid, wxString(), label);
+    SetToggleButtonBezelStyle(v, style);
     
     if (label.IsOk())
         [v setImage: wxOSXGetImageFromBundle(label) ];


### PR DESCRIPTION
It should use NSShadowlessSquareBezelStyle rather than
NSRoundedBezelStyle that it was given by default by the function
SetToggleButtonBezelStyle() used for determining normal push button
bezels.

As a side effect, this function doesn't need to be extern any more and
can be made static.

Closes #22140.

---

I've rebased my old commit on the latest master, as I'd like to either merge it or delete this branch. Stefan, do you think it's an improvement (please see the original issue for the discussion)?