### PR TITLE
Add link to wxUiEditor in list of XRC tools

### DIFF
--- a/docs/doxygen/overviews/xrc.h
+++ b/docs/doxygen/overviews/xrc.h
@@ -57,6 +57,8 @@ specialised tool. Examples of these include:
     can output C++, XRC or python.
 @li wxCrafter (free version) <http://www.codelite.org/wxcrafter/>, a C++-based
     form designer that can output C++ or XRC.
+@li wxUiEditor <https://github.com/KeyWorksRW/wxUiEditor>, a C++-based
+    form designer that can output C++ or XRC.
 
 There's a more complete list at <https://wiki.wxwidgets.org/Tools>
 


### PR DESCRIPTION
This is the most recent form designer, current with the XRC changes added up
through wxWIdgets 3.2.0.