### PR TITLE
Draft with questions: Add/extend editor folders/files to git ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -421,3 +421,26 @@
 /utils/wxrc/wxrc_vc[789].sln
 
 /3rdparty/webview2
+
+# Eclipse project files
+.project
+.cproject
+
+# SublimeText project files
+*.sublime-project
+*.sublime-workspace
+
+# VSCode files
+.vscode/
+*.code-workspace
+*.code-search
+
+# Visual Studio User-specific files
+*.rsuser
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Visual Studio cache/options directory
+.vs/


### PR DESCRIPTION
If a user clones or forks the wxWidgets repository, and wants to use a popular editor like Visual Studio Code, they will need to know enough about git to add the editor's required folder name and/or extensions to the repositories `.git/info/exclude` file. While it's unreasonable to add every editor out there to the ignore list, this PR adds support for Eclipse, Sublime, and VSCode.

Microsoft maintains a template for Visual Studio ignores. A lot of these don't apply, and some of them already exist in the various build directories. However, those don't necessarily cover firing up Visual Studio directly in a Sample directory or some of the other directories. I added the standard user-specific file extensions to ignore that Microsoft recommends as well as the .vs/ cache/options directory. These are at the root, so they apply to any directory. If that seems a reasonable approach, then I can remove the duplicates in some of the individual build paths (e.g., remove `/build/msw/*.suo` and `/tests/test.suo`).

While not as popular as VSCode, two other IDEs that might be useful to add are CodeBlock and CodeLite -- this would entail adding:

```
    # CodeBlock files
    *.cbp
    *.depend
    *.layout

    # CodeLite files
    .codelite/
    *.project
    *.workspace
```
