### PR TITLE
Fix double negatives used with the word 'neither' in docs and comments

### DIFF
--- a/docs/doxygen/mainpages/const_cpp.h
+++ b/docs/doxygen/mainpages/const_cpp.h
@@ -381,7 +381,7 @@ more details.
         if this macro is defined, the compilation options
         don't include compiler flags needed for multithreaded code generation. This
         implies that wxUSE_THREADS is 0 and also that other (non-wx-based) threading
-        packages cannot be used neither.}
+        packages cannot be used either.}
 @itemdef{wxNO_UNSAFE_WXSTRING_CONV,
         this symbol is not defined by wxWidgets itself, but can be defined by
         the applications using the library to disable unsafe implicit

--- a/docs/doxygen/overviews/changes_since28.h
+++ b/docs/doxygen/overviews/changes_since28.h
@@ -35,7 +35,7 @@ of the information which was correct before doesn't apply any longer.
 For example, the notorious (due to the confusion they created) macros @c wxT()
 and @c _T() are not needed at all any longer. Basically, you can remove them
 from any code which used them. On the other hand, there is no particular harm
-in leaving them neither as the code will still compile and work correctly --
+in leaving them either as the code will still compile and work correctly --
 you only need to remove them if you think that your code looks tidier without
 them. You also don't need to use @c wxChar any longer but can directly use the
 standard @c wchar_t type even if, again, @c wxChar continues to work.

--- a/docs/doxygen/overviews/xrc_format.h
+++ b/docs/doxygen/overviews/xrc_format.h
@@ -2038,9 +2038,9 @@ HTML markup. Note that the markup has to be escaped:
 @subsubsection xrc_wxsimplebook wxSimplebook
 
 wxSimplebook is similar to @ref xrc_wxnotebook "wxNotebook" but simpler: as it
-doesn't show any page headers, it doesn't use neither image list nor individual
+doesn't show any page headers, it uses neither image list nor individual
 page bitmaps and while it still accepts page labels, they are optional as they
-are not shown to the user neither.
+are not shown to the user either.
 
 So @c simplebookpage child elements, that must occur inside this object, only
 have the following properties:

--- a/include/wx/android/setup.h
+++ b/include/wx/android/setup.h
@@ -1664,7 +1664,7 @@
 // Set this to 1 to enable wxDIB class used internally for manipulating
 // wxBitmap data.
 //
-// Default is 1, set it to 0 only if you don't use wxImage neither
+// Default is 1, set it to 0 only if you don't use wxImage either
 //
 // Recommended setting: 1 (without it conversion to/from wxImage won't work)
 #define wxUSE_WXDIB 1

--- a/include/wx/app.h
+++ b/include/wx/app.h
@@ -153,7 +153,7 @@ public:
         // used for paths, config, and other places the user doesn't see
         //
         // by default the display name is the same as app name or a capitalized
-        // version of the program if app name was not set neither but it's
+        // version of the program if app name was not set either but it's
         // usually better to set it explicitly to something nicer
     wxString GetAppDisplayName() const;
 

--- a/include/wx/bmpbuttn.h
+++ b/include/wx/bmpbuttn.h
@@ -18,7 +18,7 @@
 #include "wx/button.h"
 
 // FIXME: right now only wxMSW, wxGTK and wxOSX implement bitmap support in wxButton
-//        itself, this shouldn't be used for the other platforms neither
+//        itself, this shouldn't be used for the other platforms either
 //        when all of them do it
 #if (defined(__WXMSW__) || defined(__WXGTK20__) || defined(__WXOSX__) || defined(__WXQT__)) && !defined(__WXUNIVERSAL__)
     #define wxHAS_BUTTON_BITMAP

--- a/include/wx/calctrl.h
+++ b/include/wx/calctrl.h
@@ -39,7 +39,7 @@ enum
     // deprecated
     wxCAL_NO_YEAR_CHANGE             = 0x0004,
 
-    // don't allow changing neither month nor year (implies
+    // don't allow changing either month or year (implies
     // wxCAL_NO_YEAR_CHANGE)
     wxCAL_NO_MONTH_CHANGE            = 0x000c,
 

--- a/include/wx/checkbox.h
+++ b/include/wx/checkbox.h
@@ -137,7 +137,7 @@ protected:
             // For compatibility we use absence of style flags as wxCHK_2STATE
             // because wxCHK_2STATE used to have the value of 0 and some
             // existing code uses 0 instead of it. Moreover, some code even
-            // uses some non-0 style, e.g. wxBORDER_XXX, but doesn't specify
+            // uses some non-0 style, e.g. wxBORDER_XXX, but specifies
             // neither wxCHK_2STATE nor wxCHK_3STATE -- to avoid breaking it,
             // assume (much more common) 2 state checkbox by default.
             style |= wxCHK_2STATE;

--- a/include/wx/compositewin.h
+++ b/include/wx/compositewin.h
@@ -101,7 +101,7 @@ public:
         // wxGTK as the derived window is not fully created yet and calling its
         // SetSize() may be unexpected. This does mean that any future calls to
         // SetLayoutDirection(wxLayout_Default) wouldn't result in a re-layout
-        // neither, but then we're not supposed to be called with it at all.
+        // either, but then we're not supposed to be called with it at all.
         if ( dir != wxLayout_Default )
             this->SetSize(-1, -1, -1, -1, wxSIZE_FORCE);
     }

--- a/include/wx/convauto.h
+++ b/include/wx/convauto.h
@@ -40,7 +40,7 @@ public:
         m_encDefault = enc;
     }
 
-    // copy ctor doesn't initialize anything neither as conversion can only be
+    // copy ctor doesn't initialize anything either as conversion can only be
     // deduced on first use
     wxConvAuto(const wxConvAuto& other) : wxMBConv()
     {

--- a/include/wx/dataview.h
+++ b/include/wx/dataview.h
@@ -952,7 +952,7 @@ public:
     virtual wxEvent *Clone() const wxOVERRIDE { return new wxDataViewEvent(*this); }
 
     // These methods shouldn't be used outside of wxWidgets and wxWidgets
-    // itself doesn't use them any longer neither as it constructs the events
+    // itself doesn't use them any longer either as it constructs the events
     // with the appropriate ctors directly.
 #if WXWIN_COMPATIBILITY_3_0
     wxDEPRECATED_MSG("Pass the argument to the ctor instead")

--- a/include/wx/dialup.h
+++ b/include/wx/dialup.h
@@ -51,7 +51,7 @@ public:
     static wxDialUpManager *Create();
 
     // could the dialup manager be initialized correctly? If this function
-    // returns false, no other functions will work neither, so it's a good idea
+    // returns false, no other functions will work either, so it's a good idea
     // to call this function and check its result before calling any other
     // wxDialUpManager methods
     virtual bool IsOk() const = 0;
@@ -128,7 +128,7 @@ public:
     virtual bool EnableAutoCheckOnlineStatus(size_t nSeconds = 60) = 0;
 
     // disable automatic check for connection status change - notice that the
-    // wxEVT_DIALUP_XXX events won't be sent any more neither.
+    // wxEVT_DIALUP_XXX events won't be sent any more either.
     virtual void DisableAutoCheckOnlineStatus() = 0;
 
     // additional Unix-only configuration

--- a/include/wx/fontutil.h
+++ b/include/wx/fontutil.h
@@ -329,7 +329,7 @@ public:
     wxString ToString() const;
 
     // we also want to present the native font descriptions to the user in some
-    // human-readable form (it is not platform independent neither, but can
+    // human-readable form (it is not platform independent either, but can
     // hopefully be understood by the user)
     bool FromUserString(const wxString& s);
     wxString ToUserString() const;

--- a/include/wx/generic/ctrlsub.h
+++ b/include/wx/generic/ctrlsub.h
@@ -102,7 +102,7 @@ private:
             if ( type == wxClientData_None )
             {
                 // we didn't have the client data before and are not asked to
-                // store it now neither
+                // store it now either
                 return false;
             }
 

--- a/include/wx/gtk/setup.h
+++ b/include/wx/gtk/setup.h
@@ -1717,7 +1717,7 @@
 // Set this to 1 to enable wxDIB class used internally for manipulating
 // wxBitmap data.
 //
-// Default is 1, set it to 0 only if you don't use wxImage neither
+// Default is 1, set it to 0 only if you don't use wxImage either
 //
 // Recommended setting: 1 (without it conversion to/from wxImage won't work)
 #define wxUSE_WXDIB 1

--- a/include/wx/iconbndl.h
+++ b/include/wx/iconbndl.h
@@ -34,7 +34,7 @@ public:
 
         // Return the icon of the system icon size if exact size is not found.
         // May be combined with other non-NONE enum elements to determine what
-        // happens if the system icon size is not found neither.
+        // happens if the system icon size is not found either.
         FALLBACK_SYSTEM = 1,
 
         // Return the icon of closest larger size or, if there is no icon of

--- a/include/wx/msw/chkconf.h
+++ b/include/wx/msw/chkconf.h
@@ -430,7 +430,7 @@
         and explicitly disabling wxUSE_DBGHELP (which would ideally result in
         an error if wxUSE_STACKWALKER is not disabled too), but it's better to
         avoid giving a compiler error in the former case even if it means not
-        giving it neither in the latter one.
+        giving it either in the latter one.
      */
     #undef wxUSE_STACKWALKER
     #define wxUSE_STACKWALKER 0

--- a/include/wx/msw/dib.h
+++ b/include/wx/msw/dib.h
@@ -225,7 +225,7 @@ private:
         m_depth;
 
     // in some cases we could be using a handle which we didn't create and in
-    // this case we shouldn't free it neither -- this flag tell us if this is
+    // this case we shouldn't free it either -- this flag tell us if this is
     // the case
     bool m_ownsHandle;
 

--- a/include/wx/msw/setup.h
+++ b/include/wx/msw/setup.h
@@ -1717,7 +1717,7 @@
 // Set this to 1 to enable wxDIB class used internally for manipulating
 // wxBitmap data.
 //
-// Default is 1, set it to 0 only if you don't use wxImage neither
+// Default is 1, set it to 0 only if you don't use wxImage either
 //
 // Recommended setting: 1 (without it conversion to/from wxImage won't work)
 #define wxUSE_WXDIB 1

--- a/include/wx/msw/setup_inc.h
+++ b/include/wx/msw/setup_inc.h
@@ -94,7 +94,7 @@
 // Set this to 1 to enable wxDIB class used internally for manipulating
 // wxBitmap data.
 //
-// Default is 1, set it to 0 only if you don't use wxImage neither
+// Default is 1, set it to 0 only if you don't use wxImage either
 //
 // Recommended setting: 1 (without it conversion to/from wxImage won't work)
 #define wxUSE_WXDIB 1

--- a/include/wx/nonownedwnd.h
+++ b/include/wx/nonownedwnd.h
@@ -72,7 +72,7 @@ public:
     {
         // Non owned windows don't inherit attributes from their parent window
         // (if the parent frame is red, it doesn't mean that all dialogs shown
-        // by it should be red as well), so don't do anything here neither.
+        // by it should be red as well), so don't do anything here either.
     }
 
 protected:

--- a/include/wx/private/socket.h
+++ b/include/wx/private/socket.h
@@ -48,7 +48,7 @@
 /*
    Including sys/types.h under Cygwin results in the warnings about "fd_set
    having been defined in sys/types.h" when winsock.h is included later and
-   doesn't seem to be necessary anyhow. It's not needed under Mac neither.
+   doesn't seem to be necessary anyhow. It's not needed under Mac either.
  */
 #if !defined(__WXMAC__) && !defined(__WXMSW__)
 #include <sys/types.h>

--- a/include/wx/stackwalk.h
+++ b/include/wx/stackwalk.h
@@ -126,7 +126,7 @@ public:
     // ctor does nothing, use Walk() to walk the stack
     wxStackWalkerBase() { }
 
-    // dtor does nothing neither but should be virtual
+    // dtor does nothing either but should be virtual
     virtual ~wxStackWalkerBase() { }
 
     // enumerate stack frames from the current location, skipping the initial

--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -455,7 +455,7 @@ private:
   // however notice that this approach does not work when compiler TLS is used,
   // at least not with g++ 4.1.2 under amd64 as it apparently compiles code
   // using this accessor incorrectly when optimizations are enabled (-O2 is
-  // enough) -- luckily we don't need it then neither as static __thread
+  // enough) -- luckily we don't need it then either as static __thread
   // variables are initialized by 0 anyhow then and so we can use the variable
   // directly
   WXEXPORT static Cache& GetCache()
@@ -4275,7 +4275,7 @@ inline const wchar_t* wxCStrData::AsWChar() const
         // if conversion fails, return empty string and not NULL to avoid
         // crashes in code written with either wxWidgets 2 wxString or
         // std::string behaviour in mind: neither of them ever returns NULL
-        // from its c_str() and so we shouldn't neither
+        // from its c_str() and so we shouldn't either
         //
         // notice that the same is done in AsChar() below and
         // wxString::wc_str() and mb_str() for the same reasons

--- a/include/wx/testing.h
+++ b/include/wx/testing.h
@@ -111,7 +111,7 @@ template<class T> class wxExpectModal;
     T must be a class derived from wxDialog and E is the derived class type,
     i.e. this is an example of using CRTP. The default value of E is fine in
     case you're using this class as a base for your wxExpectModal<>
-    specialization anyhow but also if you don't use neither Optional() nor
+    specialization anyhow but also if you don't use either Optional() or
     Describe() methods, as the derived class type is only needed for them.
  */
 template<class T, class E = wxExpectModal<T> >

--- a/include/wx/txtstrm.h
+++ b/include/wx/txtstrm.h
@@ -107,7 +107,7 @@ protected:
     // The second half of a surrogate character when using UTF-16 for wchar_t:
     // we can't return it immediately from GetChar() when we read a Unicode
     // code point outside of the BMP, but we can't keep it in m_lastBytes
-    // neither because it can't separately decoded, so we have a separate 1
+    // either because it can't separately decoded, so we have a separate 1
     // wchar_t buffer just for this case.
 #if SIZEOF_WCHAR_T == 2
     wchar_t m_lastWChar;

--- a/include/wx/univ/setup.h
+++ b/include/wx/univ/setup.h
@@ -1695,7 +1695,7 @@
 // Set this to 1 to enable wxDIB class used internally for manipulating
 // wxBitmap data.
 //
-// Default is 1, set it to 0 only if you don't use wxImage neither
+// Default is 1, set it to 0 only if you don't use wxImage either
 //
 // Recommended setting: 1 (without it conversion to/from wxImage won't work)
 #define wxUSE_WXDIB 1

--- a/include/wx/univ/theme.h
+++ b/include/wx/univ/theme.h
@@ -177,7 +177,7 @@ struct WXDLLIMPEXP_CORE wxThemeInfo
     #define wxUNIV_DEFAULT_THEME gtk
 #elif defined(__WXDFB__) && wxUSE_THEME_MONO
     // use mono theme for DirectFB port because it cannot correctly
-    // render neither win32 nor gtk themes yet:
+    // render either win32 or gtk themes yet:
     #define wxUNIV_DEFAULT_THEME mono
 #endif
 

--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -1337,7 +1337,7 @@ bool wxHandleFatalExceptions(bool doIt = true);
 
     If the function returns @false the initialization could not be performed,
     in this case the library cannot be used and wxUninitialize() shouldn't be
-    called neither.
+    called either.
 
     This function may be called several times but wxUninitialize() must be
     called for each successful call to this function.

--- a/interface/wx/calctrl.h
+++ b/interface/wx/calctrl.h
@@ -20,7 +20,7 @@ enum
     // deprecated
     wxCAL_NO_YEAR_CHANGE             = 0x0004,
 
-    // don't allow changing neither month nor year (implies
+    // don't allow changing either month or year (implies
     // wxCAL_NO_YEAR_CHANGE)
     wxCAL_NO_MONTH_CHANGE            = 0x000c,
 
@@ -350,7 +350,7 @@ public:
         This function should be used instead of changing
         @c wxCAL_NO_MONTH_CHANGE style bit. It allows or disallows the user to
         change the month interactively. Note that if the month cannot be
-        changed, the year cannot be changed neither.
+        changed, the year cannot be changed either.
 
         @return @true if the value of this option really changed or @false if
                 it was already set to the requested value.

--- a/interface/wx/cmdline.h
+++ b/interface/wx/cmdline.h
@@ -580,7 +580,7 @@ public:
 
         By default, this function uses Windows-like word splitting algorithm,
         i.e. single quotes have no special meaning and backslash can't be used
-        to escape spaces neither. With @c wxCMD_LINE_SPLIT_UNIX flag Unix
+        to escape spaces either. With @c wxCMD_LINE_SPLIT_UNIX flag Unix
         semantics is used, i.e. both single and double quotes can be used and
         backslash can be used to escape all the other special characters.
     */

--- a/interface/wx/dialup.h
+++ b/interface/wx/dialup.h
@@ -86,7 +86,7 @@ public:
 
     /**
         Disable automatic check for connection status change - notice that the
-        @c wxEVT_DIALUP_XXX events won't be sent any more neither.
+        @c wxEVT_DIALUP_XXX events won't be sent any more either.
     */
     virtual void DisableAutoCheckOnlineStatus() = 0;
 
@@ -137,7 +137,7 @@ public:
 
     /**
         Returns @true if the dialup manager was initialized correctly. If this
-        function returns @false, no other functions will work neither, so it is
+        function returns @false, no other functions will work either, so it is
         a good idea to call this function and check its result before calling
         any other wxDialUpManager methods.
     */

--- a/interface/wx/eventfilter.h
+++ b/interface/wx/eventfilter.h
@@ -131,7 +131,7 @@ public:
             to suppress some events).
             - Event_Processed to not process this event normally but indicate
             that it was already processed by the event filter and so no default
-            processing should take place neither (this should only be used if
+            processing should take place either (this should only be used if
             the filter really did process the event).
      */
     virtual int FilterEvent(wxEvent& event) = 0;

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -2645,7 +2645,7 @@ public:
         Returns the attribute provider currently being used.
 
         This function may return @NULL if the attribute provider hasn't been
-        neither associated with this table by SetAttrProvider() nor created on
+        either associated with this table by SetAttrProvider() nor created on
         demand by any other methods.
      */
     wxGridCellAttrProvider *GetAttrProvider() const;

--- a/interface/wx/iconbndl.h
+++ b/interface/wx/iconbndl.h
@@ -33,7 +33,7 @@ public:
 
         /// Return the icon of the system icon size if exact size is not found.
         /// May be combined with other non-NONE enum elements to determine what
-        /// happens if the system icon size is not found neither.
+        /// happens if the system icon size is not found either.
         FALLBACK_SYSTEM = 1,
 
         /// Return the icon of closest larger size or, if there is no icon of
@@ -141,7 +141,7 @@ public:
         wxIconBundle::FALLBACK_NONE is given, the function returns an invalid
         icon. If wxIconBundle::FALLBACK_SYSTEM is given, it tries to find the
         icon of standard system size, regardless of the size passed as
-        parameter. Otherwise, or if the icon system size is not found neither,
+        parameter. Otherwise, or if the icon system size is not found either,
         but wxIconBundle::FALLBACK_NEAREST_LARGER flag is specified, the
         function returns the smallest icon of the size larger than the
         requested one or, if this fails too, just the icon closest to the

--- a/interface/wx/modalhook.h
+++ b/interface/wx/modalhook.h
@@ -126,7 +126,7 @@ protected:
         as usual and Exit() will be called when it is dismissed. If the return
         value is anything else, the dialog is not shown at all and its
         wxDialog::ShowModal() simply returns with the given result. In this
-        case, Exit() won't be called neither.
+        case, Exit() won't be called either.
 
         @param dialog The dialog about to be shown, never @NULL.
         @return wxID_NONE to continue with showing the dialog or anything else

--- a/interface/wx/process.h
+++ b/interface/wx/process.h
@@ -66,7 +66,7 @@ public:
     wxProcess(wxEvtHandler* parent = NULL, int id = -1);
 
     /**
-        Creates an object without any associated parent (and hence no id neither)
+        Creates an object without any associated parent (and hence no id either)
         but allows specifying the @a flags which can have the value of
         @c wxPROCESS_DEFAULT or @c wxPROCESS_REDIRECT.
 

--- a/interface/wx/stackwalk.h
+++ b/interface/wx/stackwalk.h
@@ -59,7 +59,7 @@ public:
     wxStackWalker(const char* argv0 = NULL);
 
     /**
-        Destructor does nothing neither but should be virtual as this class is used as
+        Destructor does nothing either but should be virtual as this class is used as
         a base one.
     */
     virtual ~wxStackWalker();

--- a/interface/wx/stdpaths.h
+++ b/interface/wx/stdpaths.h
@@ -496,7 +496,7 @@ public:
         plugins directory on Unix, etc.
 
         Valid values for @a info are:
-            - @c AppInfo_None: don't use neither application nor vendor name in
+            - @c AppInfo_None: use neither application nor vendor name in
             the paths.
             - @c AppInfo_AppName: use the application name in the paths.
             - @c AppInfo_VendorName: use the vendor name in the paths, usually

--- a/interface/wx/strconv.h
+++ b/interface/wx/strconv.h
@@ -115,7 +115,7 @@ public:
         which it output to @e dst. If the length of the resulting wide
         string is greater than @e dstLen, an error is returned. Note that if
         @a srcLen bytes don't include @c NUL characters, the resulting wide
-        string is not @c NUL-terminated neither.
+        string is not @c NUL-terminated either.
 
         If @a srcLen is @c wxNO_LEN, the function supposes that the string is
         properly (i.e. as necessary for the encoding handled by this

--- a/interface/wx/string.h
+++ b/interface/wx/string.h
@@ -163,7 +163,7 @@
     or explicitly convert the return value:
         @code
             auto c = s[0].GetValue();
-            c = 'x';            // Doesn't modify the string neither.
+            c = 'x';            // Doesn't modify the string either.
             wxASSERT( s == "abc" );
         @endcode
 

--- a/interface/wx/textctrl.h
+++ b/interface/wx/textctrl.h
@@ -1694,7 +1694,7 @@ public:
 
         If either of the font, foreground, or background colour is not set in
         @a style, the values of the previous default style are used for them.
-        If the previous default style didn't set them neither, the global font
+        If the previous default style didn't set them either, the global font
         or colours of the text control itself are used as fall back.
 
         However if the @a style parameter is the default wxTextAttr, then the default

--- a/interface/wx/toolbar.h
+++ b/interface/wx/toolbar.h
@@ -591,7 +591,7 @@ public:
         you should use @c wxArtProvider::GetNativeSizeHint(wxART_TOOLBAR) but
         in any case, as the bitmap size is deduced automatically from the size
         of the bitmaps associated with the tools added to the toolbar, it is
-        usually unnecessary to call neither this function nor
+        usually unnecessary to call either this function or
         SetToolBitmapSize() at all.
 
         @remarks Note that this is the size of the bitmap you pass to AddTool(),

--- a/interface/wx/toplevel.h
+++ b/interface/wx/toplevel.h
@@ -304,7 +304,7 @@ public:
         Note that if you associate a sizer with this window, the sizer takes
         precedence and the only-child-resizing is only used as fallback.
 
-        @returns @false if nothing was done because the window doesn't have
+        @returns @false if nothing was done because the window has
                  neither a sizer nor a single child, @true otherwise.
     */
     virtual bool Layout();

--- a/samples/splitter/splitter.cpp
+++ b/samples/splitter/splitter.cpp
@@ -311,7 +311,7 @@ MyFrame::MyFrame()
     // correct initial size, otherwise it will change the sash position by a
     // huge amount when it's resized from its initial default size to its real
     // size when the frame lays it out. This wouldn't be necessary if default
-    // zero gravity were used (although it would do no harm neither).
+    // zero gravity were used (although it would do no harm either).
     m_splitter->SetSize(GetClientSize());
     m_splitter->SetSashGravity(1.0);
 

--- a/src/aui/auibar.cpp
+++ b/src/aui/auibar.cpp
@@ -115,7 +115,7 @@ private:
 wxBitmap wxAuiToolBarItem::GetCurrentBitmapFor(wxWindow* wnd) const
 {
     // We suppose that we don't have disabled bitmap if we don't have the
-    // normal one neither.
+    // normal one either.
     if ( !m_bitmap.IsOk() )
         return wxNullBitmap;
 

--- a/src/aui/framemanager.cpp
+++ b/src/aui/framemanager.cpp
@@ -4851,7 +4851,7 @@ void wxAuiManager::OnPaneButton(wxAuiManagerEvent& evt)
 
             if (e.GetVeto())
             {
-                // If it can't be restored, it can't be floated neither.
+                // If it can't be restored, it can't be floated either.
                 return;
             }
 

--- a/src/aui/tabmdi.cpp
+++ b/src/aui/tabmdi.cpp
@@ -254,7 +254,7 @@ bool wxAuiMDIParentFrame::CloseAll()
     {
         if (!pActiveChild->Close())
         {
-            // it refused to close, don't close the remaining ones neither
+            // it refused to close, don't close the remaining ones either
             return false;
         }
     }

--- a/src/common/arttango.cpp
+++ b/src/common/arttango.cpp
@@ -131,7 +131,7 @@ wxTangoArtProvider::CreateBitmapBundle(const wxArtID& id,
     {
         // Tango does have bookmark-new but no matching bookmark-delete and
         // using mismatching icons would be ugly so we don't provide this one
-        // neither, we should add both of them if Tango ever adds the other one.
+        // either, we should add both of them if Tango ever adds the other one.
         //{ wxART_ADD_BOOKMARK,       BITMAP_DATA(bookmark_new)},
         //{ wxART_DEL_BOOKMARK,       BITMAP_DATA() },
 

--- a/src/common/cmdline.cpp
+++ b/src/common/cmdline.cpp
@@ -1364,7 +1364,7 @@ wxString wxCmdLineParser::GetUsageString() const
                 }
                 else
                 {
-                    wxFAIL_MSG( wxT("option without neither short nor long name") );
+                    wxFAIL_MSG( wxT("option without either short or long name") );
                 }
             }
 

--- a/src/common/containr.cpp
+++ b/src/common/containr.cpp
@@ -358,7 +358,7 @@ void wxControlContainer::HandleOnNavigationKey( wxNavigationKeyEvent& event )
     if ( goingDown )
     {
         // just to be sure it's not used (normally this is not necessary, but
-        // doesn't hurt neither)
+        // doesn't hurt either)
         m_winLastFocused = NULL;
 
         // start from first or last depending on where we're going

--- a/src/common/ctrlcmn.cpp
+++ b/src/common/ctrlcmn.cpp
@@ -326,8 +326,8 @@ struct EllipsizeCalculator
                     {
                         // This ampersand is removed by RemoveMnemonics() and
                         // won't be displayed when this string is drawn
-                        // neither, so we intentionally don't use it for our
-                        // calculations neither -- just account for this in the
+                        // either, so we intentionally don't use it for our
+                        // calculations either -- just account for this in the
                         // assert below.
                         expectedOffsetsCount--;
                     }

--- a/src/common/datetime.cpp
+++ b/src/common/datetime.cpp
@@ -2051,7 +2051,7 @@ wxDateTime& wxDateTime::SetToYearDay(wxDateTime::wxDateTime_t yday)
     for ( Month mon = Jan; mon < Inv_Month; wxNextMonth(mon) )
     {
         // for Dec, we can't compare with gs_cumulatedDays[mon + 1], but we
-        // don't need it neither - because of the CHECK above we know that
+        // don't need it either - because of the CHECK above we know that
         // yday lies in December then
         if ( (mon == Dec) || (yday <= gs_cumulatedDays[isLeap][mon + 1]) )
         {

--- a/src/common/dlgcmn.cpp
+++ b/src/common/dlgcmn.cpp
@@ -161,7 +161,7 @@ wxDialogBase::CheckIfCanBeUsedAsParent(wxDialogModality modality,
         case wxDIALOG_MODALITY_WINDOW_MODAL:
             if ( !parent->IsShownOnScreen() )
             {
-                // using hidden parent won't work correctly neither
+                // using hidden parent won't work correctly either
                 return NULL;
             }
             break;

--- a/src/common/docview.cpp
+++ b/src/common/docview.cpp
@@ -280,7 +280,7 @@ wxDocManager *wxDocument::GetDocumentManager() const
 
 bool wxDocument::OnNewDocument()
 {
-    // notice that there is no need to neither reset nor even check the
+    // notice that there is no need to either reset nor even check the
     // modified flag here as the document itself is a new object (this is only
     // called from CreateDocument()) and so it shouldn't be saved anyhow even
     // if it is modified -- this could happen if the user code creates

--- a/src/common/filename.cpp
+++ b/src/common/filename.cpp
@@ -954,7 +954,7 @@ static wxString wxCreateTempImpl(
     if ( fdTemp == -1 )
     {
         // this might be not necessary as mkstemp() on most systems should have
-        // already done it but it doesn't hurt neither...
+        // already done it but it doesn't hurt either...
         path.clear();
     }
     else // mkstemp() succeeded

--- a/src/common/fontmap.cpp
+++ b/src/common/fontmap.cpp
@@ -343,7 +343,7 @@ bool wxFontMapper::GetAltForEncoding(wxFontEncoding encoding,
 
     // this special value means that we don't know of fonts for this
     // encoding but, moreover, have already asked the user as well and he
-    // didn't specify any font neither
+    // didn't specify any font either
     if ( fontinfo == FONTMAPPER_FONT_DONT_ASK )
     {
         interactive = false;

--- a/src/common/lzmastream.cpp
+++ b/src/common/lzmastream.cpp
@@ -137,7 +137,7 @@ size_t wxLZMAInputStream::OnSysRead(void* outbuf, size_t size)
     m_stream->avail_out = size;
 
     // Decompress input as long as we don't have any errors (including EOF, as
-    // it doesn't make sense to continue after it neither) and have space to
+    // it doesn't make sense to continue after it either) and have space to
     // decompress it to.
     while ( m_lasterror == wxSTREAM_NO_ERROR && m_stream->avail_out > 0 )
     {

--- a/src/common/numformatter.cpp
+++ b/src/common/numformatter.cpp
@@ -194,7 +194,7 @@ void wxNumberFormatter::RemoveTrailingZeroes(wxString& s)
     // Find the last character to keep.
     size_t posLastNonZero = s.find_last_not_of("0");
 
-    // If it's the decimal separator itself, don't keep it neither.
+    // If it's the decimal separator itself, don't keep it either.
     if ( posLastNonZero == posDecSep )
         posLastNonZero--;
 

--- a/src/common/popupcmn.cpp
+++ b/src/common/popupcmn.cpp
@@ -200,7 +200,7 @@ void wxPopupWindowBase::Position(const wxPoint& ptOrigin,
             // do position the control to the left
             x -= size.x + sizeSelf.x;
         }
-        //else: not enough space there neither, leave in default position
+        //else: not enough space there either, leave in default position
     }
 
     Move(x, y, wxSIZE_NO_ADJUSTMENTS);
@@ -296,7 +296,7 @@ void wxPopupTransientWindow::Popup(wxWindow *winFocus)
     // Notice that this works best for combobox-like popups which have a single
     // control inside them and not so well for popups containing a single
     // wxPanel with multiple children inside it but OTOH it does no harm in
-    // this case neither and we can't reliably distinguish between them.
+    // this case either and we can't reliably distinguish between them.
     const wxWindowList& children = GetChildren();
     if ( children.GetCount() == 1 )
     {

--- a/src/common/socket.cpp
+++ b/src/common/socket.cpp
@@ -62,7 +62,7 @@
     #define wxSOCKET_MSG_NOSIGNAL MSG_NOSIGNAL
 #else // MSG_NOSIGNAL not available (BSD including OS X)
     // next best possibility is to use SO_NOSIGPIPE socket option, this covers
-    // BSD systems (including OS X) -- but if we don't have it neither (AIX and
+    // BSD systems (including OS X) -- but if we don't have it either (AIX and
     // old HP-UX do not), we have to fall back to the old way of simply
     // disabling SIGPIPE temporarily, so define a class to do it in a safe way
     #if defined(__UNIX__) && !defined(SO_NOSIGPIPE)

--- a/src/common/stattextcmn.cpp
+++ b/src/common/stattextcmn.cpp
@@ -208,7 +208,7 @@ void wxStaticTextBase::AutoResizeIfNecessary()
         return;
 
     // This method is only called if either the label or the font changed, i.e.
-    // if the label extent changed, so the best size is not the same neither
+    // if the label extent changed, so the best size is not the same either
     // any more.
     //
     // Note that we don't invalidate it when wxST_NO_AUTORESIZE is on because

--- a/src/common/strconv.cpp
+++ b/src/common/strconv.cpp
@@ -2822,7 +2822,7 @@ void wxCSConv::SetEncoding(wxFontEncoding encoding)
                 // It's ok to not have encoding value if we have a name for it.
                 m_encoding = wxFONTENCODING_SYSTEM;
             }
-            else // No name neither.
+            else // No name either.
             {
                 // Fall back to the system default encoding in this case (not
                 // sure how much sense does this make but this is how the old

--- a/src/common/string.cpp
+++ b/src/common/string.cpp
@@ -1858,7 +1858,7 @@ wxString wxString::FromCDouble(double val, int precision)
     // imbue() stream method is called (for the record, the latest libstdc++
     // version included in OS X does it and so seem to do the versions
     // currently included in Android NDK and both FreeBSD and OpenBSD), so we
-    // can't do this neither and are reduced to this hack.
+    // can't do this either and are reduced to this hack.
 
     wxString s = FromDouble(val, precision);
 #if wxUSE_INTL

--- a/src/common/textmeasurecmn.cpp
+++ b/src/common/textmeasurecmn.cpp
@@ -159,7 +159,7 @@ void wxTextMeasureBase::GetMultiLineTextExtent(const wxString& text,
                 if ( !heightLineDefault )
                     heightLineDefault = heightLine;
 
-                // and if we hadn't had any previous one neither, compute it now
+                // and if we hadn't had any previous one either, compute it now
                 if ( !heightLineDefault )
                     heightLineDefault = GetEmptyLineHeight();
 

--- a/src/common/utilscmn.cpp
+++ b/src/common/utilscmn.cpp
@@ -1575,7 +1575,7 @@ wxWindowDisabler::~wxWindowDisabler()
         {
             winTop->Enable();
         }
-        //else: we didn't disable this window, so don't reenable it neither
+        //else: we didn't disable this window, so don't reenable it either
     }
 }
 

--- a/src/common/valnum.cpp
+++ b/src/common/valnum.cpp
@@ -162,7 +162,7 @@ void wxNumValidatorBase::OnChar(wxKeyEvent& event)
     const int ch = event.GetKeyCode();
     if ( ch > WXK_DELETE )
     {
-        // Not a character neither.
+        // Not a character either.
         return;
     }
 #endif // wxUSE_UNICODE/!wxUSE_UNICODE

--- a/src/common/wincmn.cpp
+++ b/src/common/wincmn.cpp
@@ -565,7 +565,7 @@ bool wxWindowBase::Destroy()
     // this wxWindow object was default-constructed and its Create() method had
     // never been called. As we didn't send wxWindowCreateEvent in this case
     // (which is sent after successful creation), don't send the matching
-    // wxWindowDestroyEvent neither.
+    // wxWindowDestroyEvent either.
     if ( GetHandle() )
         SendDestroyEvent();
 

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -2073,7 +2073,7 @@ wxDataViewMainWindow::wxDataViewMainWindow( wxDataViewCtrl *parent, wxWindowID i
              (
                   wxT("wxDataView"),
                   -1, // no specific background brush
-                  0, // no special styles neither
+                  0, // no special styles either
                   wxApp::RegClass_OnlyNR
              ),
       parent, id, pos, size, wxWANTS_CHARS|wxBORDER_NONE, name
@@ -4548,7 +4548,7 @@ void wxDataViewMainWindow::OnCharHook(wxKeyEvent& event)
                 return;
 
             case WXK_RETURN:
-                // Shift-Enter is not special neither.
+                // Shift-Enter is not special either.
                 if ( event.ShiftDown() )
                     break;
                 wxFALLTHROUGH;

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -725,7 +725,7 @@ wxGridCellRenderer* wxGridCellAttr::GetRenderer(const wxGrid* grid, int row, int
             if ( (m_defGridAttr != NULL) && (m_defGridAttr != this) )
             {
                 // if we still don't have one then use the grid default
-                // (no need for IncRef() here neither)
+                // (no need for IncRef() here either)
                 renderer = m_defGridAttr->GetRenderer(NULL, 0, 0);
             }
             else // default grid attr
@@ -769,7 +769,7 @@ wxGridCellEditor* wxGridCellAttr::GetEditor(const wxGrid* grid, int row, int col
             if ( (m_defGridAttr != NULL) && (m_defGridAttr != this) )
             {
                 // if we still don't have one then use the grid default
-                // (no need for IncRef() here neither)
+                // (no need for IncRef() here either)
                 editor = m_defGridAttr->GetEditor(NULL, 0, 0);
             }
             else // default grid attr
@@ -3094,7 +3094,7 @@ void wxGrid::Init()
     m_extraHeight = 0;
 
     // we can't call SetScrollRate() as the window isn't created yet but OTOH
-    // we don't need to call it neither as the scroll position is (0, 0) right
+    // we don't need to call it either as the scroll position is (0, 0) right
     // now anyhow, so just set the parameters directly
     m_xScrollPixelsPerLine = GRID_SCROLL_LINE_X;
     m_yScrollPixelsPerLine = GRID_SCROLL_LINE_Y;
@@ -5837,7 +5837,7 @@ void wxGrid::RefreshBlock(int topRow, int leftCol,
         wxASSERT( topRow == -1 && leftCol == -1 );
 
         // And specifying bottom right corner when the top left one is not
-        // specified doesn't make sense neither.
+        // specified doesn't make sense either.
         wxASSERT( noBottomRight );
 
         return;
@@ -10998,7 +10998,7 @@ DoGetRowOrColBlocks(wxGridBlocks blocks, const wxGridOperations& oper)
             if ( lastNew < firstThis )
             {
                 // Not only it doesn't overlap this block, but it won't overlap
-                // any subsequent ones neither, so insert it here and stop.
+                // any subsequent ones either, so insert it here and stop.
                 res.insert(res.begin() + n, *it);
                 break;
             }

--- a/src/generic/imaglist.cpp
+++ b/src/generic/imaglist.cpp
@@ -72,7 +72,7 @@ wxBitmap wxGenericImageList::GetImageListBitmap(const wxBitmap& bitmap) const
 {
     wxBitmap bmp(bitmap);
 
-    // If we don't have neither mask nor alpha and were asked to use a mask,
+    // If we have neither mask nor alpha and were asked to use a mask,
     // create a default one.
     if ( m_useMask && !bmp.GetMask() && !bmp.HasAlpha() )
     {

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -1467,7 +1467,7 @@ void wxListTextCtrlWrapper::EndEdit(EndReason reason)
 
         case End_Destroy:
             // Don't generate any notifications for the control being destroyed
-            // and don't set focus to it neither.
+            // and don't set focus to it either.
             Finish(false);
             break;
     }

--- a/src/generic/markuptext.cpp
+++ b/src/generic/markuptext.cpp
@@ -211,7 +211,7 @@ public:
         // Adjust the position (unfortunately we need to do this manually as
         // there is no notion of current text position in wx API) rectangle to
         // ensure that all text segments use the same baseline (as there is
-        // nothing equivalent to Windows SetTextAlign(TA_BASELINE) neither).
+        // nothing equivalent to Windows SetTextAlign(TA_BASELINE) either).
         wxRect rect(m_rect);
         rect.x = m_pos;
 

--- a/src/generic/mdig.cpp
+++ b/src/generic/mdig.cpp
@@ -99,7 +99,7 @@ bool wxGenericMDIParentFrame::Create(wxWindow *parent,
 #endif // wxUSE_MENUS
     }
 
-    // the scrolling styles don't make sense neither for us nor for our client
+    // the scrolling styles don't make sense either for us nor for our client
     // window (to which they're supposed to apply)
     style &= ~(wxHSCROLL | wxVSCROLL);
 
@@ -132,7 +132,7 @@ bool wxGenericMDIParentFrame::CloseAll()
         wxGenericMDIChildFrame * const child = client->GetChild(0);
         if ( !child->Close() )
         {
-            // it refused to close, don't close the remaining ones neither
+            // it refused to close, don't close the remaining ones either
             return false;
         }
     }
@@ -402,7 +402,7 @@ wxGenericMDIChildFrame::~wxGenericMDIChildFrame()
     wxGenericMDIParentFrame * const parent = GetGenericMDIParent();
 
     // it could happen that we don't have a valid parent if we hadn't been ever
-    // really created -- but in this case there is nothing else to do neither
+    // really created -- but in this case there is nothing else to do either
     if ( parent )
         parent->WXRemoveChild(this);
 

--- a/src/generic/splitter.cpp
+++ b/src/generic/splitter.cpp
@@ -79,7 +79,7 @@ static bool IsLive(wxSplitterWindow* wnd)
 #if defined( __WXMAC__ ) && defined(TARGET_API_MAC_OSX) && TARGET_API_MAC_OSX == 1
     return true; // Mac can't paint outside paint event - always need live mode
 #else
-    // wxClientDC doesn't work with Wayland neither, so check if we're using it.
+    // wxClientDC doesn't work with Wayland either, so check if we're using it.
     #if defined(__WXGTK3__) && defined(__UNIX__)
         switch ( wxGetDisplayInfo().type )
         {

--- a/src/generic/textdlgg.cpp
+++ b/src/generic/textdlgg.cpp
@@ -71,7 +71,7 @@ bool wxTextEntryDialog::Create(wxWindow *parent,
     // has the same numeric value as wxTE_MULTILINE and so attempting to create
     // a dialog for editing multiline text would also prevent it from having a
     // parent which is undesirable. As it is, we can't create a text entry
-    // dialog without a parent which is not ideal neither but is a much less
+    // dialog without a parent which is not ideal either but is a much less
     // important problem.
     if ( !wxDialog::Create(GetParentForModalDialog(parent, 0),
                            wxID_ANY, caption,

--- a/src/gtk/choice.cpp
+++ b/src/gtk/choice.cpp
@@ -117,7 +117,7 @@ wxChoice::~wxChoice()
     // a Gtk-CRITICAL debug message when the assertion fails inside a signal
     // handler called from gtk_widget_unrealize(), which is annoying, so avoid
     // it by hiding the widget before destroying it -- this doesn't look right,
-    // but shouldn't do any harm neither.
+    // but shouldn't do any harm either.
     Hide();
  #endif // __WXGTK3__
 }

--- a/src/gtk/listbox.cpp
+++ b/src/gtk/listbox.cpp
@@ -929,7 +929,7 @@ wxSize wxListBox::DoGetBestSize() const
     // Add room for the scrollbar
     lbWidth += wxSystemSettings::GetMetric(wxSYS_VSCROLL_X);
 
-    // Don't make the listbox too tall but don't make it too small neither
+    // Don't make the listbox too tall but don't make it too small either
     lbHeight = (cy+4) * wxMin(wxMax(count, 3), 10);
 
     return wxSize(lbWidth, lbHeight);

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -829,7 +829,7 @@ bool wxTextCtrl::Create( wxWindow *parent,
 
         // The call to SetInitialSize() from inside PostCreation() didn't take
         // the value into account because it hadn't been set yet when it was
-        // called (and setting it earlier wouldn't have been correct neither,
+        // called (and setting it earlier wouldn't have been correct either,
         // as the appropriate size depends on the presence of the borders,
         // which are configured in PostCreation()), so recompute the initial
         // size again now that we have set it.

--- a/src/gtk/utilsgtk.cpp
+++ b/src/gtk/utilsgtk.cpp
@@ -314,7 +314,7 @@ protected:
             return;
         }
 
-        // Also ignore frames which don't have neither the function name nor
+        // Also ignore frames which have neither the function name nor
         // the file name, showing them in the dialog wouldn't provide any
         // useful information.
         if ( name.empty() && frame.GetFileName().empty() )

--- a/src/gtk1/app.cpp
+++ b/src/gtk1/app.cpp
@@ -49,7 +49,7 @@
         #include <poll.h>
     #else
         // bug in the OpenBSD headers: at least in 3.1 there is no extern "C"
-        // in neither poll.h nor sys/poll.h which results in link errors later
+        // in either poll.h or sys/poll.h which results in link errors later
         #ifdef __OPENBSD__
             extern "C"
             {

--- a/src/gtk1/combobox.cpp
+++ b/src/gtk1/combobox.cpp
@@ -156,7 +156,7 @@ gtk_combo_select_child_callback( GtkList *WXUNUSED(list), GtkWidget *WXUNUSED(wi
         combo->HandleWindowEvent( event );
 
         // for consistency with the other ports, don't generate text update
-        // events while the user is browsing the combobox neither
+        // events while the user is browsing the combobox either
         wxCommandEvent event2( wxEVT_TEXT, combo->GetId() );
         event2.SetString( combo->GetValue() );
         event2.SetEventObject( combo );

--- a/src/gtk1/listbox.cpp
+++ b/src/gtk1/listbox.cpp
@@ -1099,7 +1099,7 @@ wxSize wxListBox::DoGetBestSize() const
     lbWidth += 3 * cx;
 
     // don't make the listbox too tall (limit height to around 10 items) but don't
-    // make it too small neither
+    // make it too small either
     lbHeight = (cy+4) * wxMin(wxMax(GetCount(), 3), 10);
 
     return wxSize(lbWidth, lbHeight);

--- a/src/msw/anybutton.cpp
+++ b/src/msw/anybutton.cpp
@@ -1574,7 +1574,7 @@ bool wxAnyButton::MSWOnDraw(WXDRAWITEMSTRUCT *wxdis)
         {
             // notice that DT_HIDEPREFIX doesn't work on old (pre-Windows 2000)
             // systems but by happy coincidence ODS_NOACCEL is not used under
-            // them neither so DT_HIDEPREFIX should never be used there
+            // them either so DT_HIDEPREFIX should never be used there
             DrawButtonText(hdc, &rectBtn, this,
                            state & ODS_NOACCEL ? DT_HIDEPREFIX : 0);
         }

--- a/src/msw/choice.cpp
+++ b/src/msw/choice.cpp
@@ -189,7 +189,7 @@ wxChoice::GetClassDefaultAttributes(wxWindowVariant WXUNUSED(variant))
     attrs.font = wxSystemSettings::GetFont(wxSYS_DEFAULT_GUI_FONT);
 
     // there doesn't seem to be any way to get the text colour using themes
-    // API: TMT_TEXTCOLOR doesn't work neither for EDIT nor COMBOBOX
+    // API: TMT_TEXTCOLOR doesn't work either for EDIT nor COMBOBOX
     attrs.colFg = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
 
     // NB: use EDIT, not COMBOBOX (the latter works in XP but not Vista)

--- a/src/msw/datetimectrl.cpp
+++ b/src/msw/datetimectrl.cpp
@@ -185,7 +185,7 @@ wxSize wxDateTimePickerCtrl::DoGetBestSize() const
         // DPI change, so we never use the vertical component of the value
         // returned by it.
         //
-        // Unfortunately, resetting this style doesn't work neither, so we have
+        // Unfortunately, resetting this style doesn't work either, so we have
         // to create a whole new window just for this, which is pretty wasteful
         // but seems unavoidable.
         HWND hwnd;

--- a/src/msw/dc.cpp
+++ b/src/msw/dc.cpp
@@ -337,7 +337,7 @@ BOOL GradientFill(HDC hdc, PTRIVERTEX pVert, ULONG numVert,
     return ::GradientFill(hdc, pVert, numVert, pMesh, numMesh, mode);
 }
 
-#else // Can't use the functions neither statically nor dynamically.
+#else // Can't use the functions either statically or dynamically.
 
 inline
 DWORD GetLayout(HDC WXUNUSED(hdc))

--- a/src/msw/filedlg.cpp
+++ b/src/msw/filedlg.cpp
@@ -1344,7 +1344,7 @@ int wxFileDialog::ShowCommFileDialog(WXHWND hWndParent)
 
     // Convert forward slashes to backslashes (file selector doesn't like
     // forward slashes) and also squeeze multiple consecutive slashes into one
-    // as it doesn't like two backslashes in a row neither
+    // as it doesn't like two backslashes in a row either
 
     wxString  dir;
     size_t    i, len = m_dir.length();

--- a/src/msw/font.cpp
+++ b/src/msw/font.cpp
@@ -543,7 +543,7 @@ void wxNativeFontInfo::SetPixelSize(const wxSize& pixelSize)
     lf.lfHeight = -abs(pixelSize.GetHeight());
     lf.lfWidth = pixelSize.GetWidth();
 
-    // We don't have the right DPI to use here neither, but we need to update
+    // We don't have the right DPI to use here either, but we need to update
     // the point size too, so fall back to the default.
     pointSize = GetPointSizeAtPPI(lf.lfHeight);
 }

--- a/src/msw/fontdlg.cpp
+++ b/src/msw/fontdlg.cpp
@@ -136,7 +136,7 @@ int wxFontDialog::ShowModal()
         // converting LOGFONT height to the value in points shown in the
         // dialog (and this happens even when not using AutoSystemDpiAware),
         // so we need to convert it to standard (not even system, because the
-        // dialog doesn't take it into account neither) DPI.
+        // dialog doesn't take it into account either) DPI.
         logFont.lfHeight = wxNativeFontInfo::GetLogFontHeightAtPPI
                            (
                                 m_fontData.m_initialFont.GetFractionalPointSize(),

--- a/src/msw/frame.cpp
+++ b/src/msw/frame.cpp
@@ -707,7 +707,7 @@ void wxFrame::IconizeChildFrames(bool bIconize)
                 frame->m_wasMinimized = frame->IsIconized();
             }
 
-            // note that we shouldn't touch the hidden frames neither because
+            // note that we shouldn't touch the hidden frames either because
             // iconizing/restoring them would show them as a side effect
             if ( !frame->m_wasMinimized && frame->IsShown() )
                 frame->Iconize(bIconize);

--- a/src/msw/gdiplus.cpp
+++ b/src/msw/gdiplus.cpp
@@ -741,7 +741,7 @@ wxFOR_ALL_GDIPLUS_STATUS_FUNCS(wxDECL_GDIPLUS_FUNC_TYPE)
 // and load gdiplus.dll dynamically, it's not defined in our case resulting in
 // linking errors -- so just provide it ourselves, it doesn't matter where it
 // is and if Cygwin headers are modified to not use it in the future, it's not
-// a big deal neither, we'll just have an unused pointer.
+// a big deal either, we'll just have an unused pointer.
 #if defined(__CYGWIN__) || defined(__MINGW32__)
 void *_GdipStringFormatCachedGenericTypographic = NULL;
 #endif // __CYGWIN__ || __MINGW32__

--- a/src/msw/icon.cpp
+++ b/src/msw/icon.cpp
@@ -102,7 +102,7 @@ wxObjectRefData *wxIcon::CloneRefData(const wxObjectRefData *dataOrig) const
     // which overwrites m_hIcon anyhow currently
     //
     // and if we're called from SetWidth/Height/Depth(), it doesn't make sense
-    // to copy it neither as the handle would be inconsistent with the new size
+    // to copy it either as the handle would be inconsistent with the new size
     return new wxIconRefData(*data);
 }
 

--- a/src/msw/imaglist.cpp
+++ b/src/msw/imaglist.cpp
@@ -270,7 +270,7 @@ wxImageList::GetImageListBitmaps(wxMSWBitmaps& bitmaps,
             maskToUse.MSWCreateFromImageMask(img);
         }
 #endif // wxUSE_WXDIB && wxUSE_IMAGE
-        // We don't have neither mask nor alpha, only force creating the
+        // We don't have either mask nor alpha, only force creating the
         // mask from colour if requested to do it.
         else if ( m_useMask )
         {

--- a/src/msw/listbox.cpp
+++ b/src/msw/listbox.cpp
@@ -642,7 +642,7 @@ wxSize wxListBox::DoGetBestClientSize() const
     wListbox += wxSystemSettings::GetMetric(wxSYS_VSCROLL_X, m_parent);
 
     // don't make the listbox too tall (limit height to 10 items) but don't
-    // make it too small neither
+    // make it too small either
     int hListbox = SendMessage(GetHwnd(), LB_GETITEMHEIGHT, 0, 0)*
                     wxMin(wxMax(m_noItems, 3), 10);
 

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -2050,7 +2050,7 @@ long wxListCtrl::DoInsertColumn(long col, const wxListItem& item)
 
     // LVSCW_AUTOSIZE_USEHEADER is not supported when inserting new column,
     // we'll deal with it below instead. Plain LVSCW_AUTOSIZE is not supported
-    // neither but it doesn't need any special handling as we use fixed value
+    // either but it doesn't need any special handling as we use fixed value
     // for it here, both because we can't do anything else (there are no items
     // with values in this column to compute the size from yet) and for
     // compatibility as wxLIST_AUTOSIZE == -1 and -1 as InsertColumn() width
@@ -3144,7 +3144,7 @@ static void HandleItemPaint(LPNMLVCUSTOMDRAW pLVCD, HFONT hfont)
             syscolFg = COLOR_WINDOWTEXT;
             syscolBg = COLOR_BTNFACE;
 
-            // don't grey out the icon in this case neither
+            // don't grey out the icon in this case either
             nmcd.uItemState &= ~CDIS_SELECTED;
         }
 

--- a/src/msw/richtooltip.cpp
+++ b/src/msw/richtooltip.cpp
@@ -75,7 +75,7 @@ public:
     virtual void SetBackgroundColour(const wxColour& col,
                                      const wxColour& colEnd) wxOVERRIDE
     {
-        // Setting background colour is not supported neither.
+        // Setting background colour is not supported either.
         m_canUseNative = false;
 
         wxRichToolTipGenericImpl::SetBackgroundColour(col, colEnd);

--- a/src/msw/spinctrl.cpp
+++ b/src/msw/spinctrl.cpp
@@ -581,7 +581,7 @@ void wxSpinCtrl::UpdateBuddyStyle()
     // keys only -- but only if we don't need to be able to enter "-" in it as
     // otherwise this would become impossible and also if we don't use
     // hexadecimal as entering "x" of the "0x" prefix wouldn't be allowed
-    // neither then
+    // either then
     wxMSWWinStyleUpdater(GetBuddyHwnd())
         .TurnOnOrOff(m_min >= 0 && GetBase() == 10, ES_NUMBER);
 }

--- a/src/msw/statbox.cpp
+++ b/src/msw/statbox.cpp
@@ -498,7 +498,7 @@ void wxStaticBox::PaintForeground(wxDC& dc, const RECT&)
 
 #if wxUSE_UXTHEME
     // when using XP themes, neither setting the text colour nor transparent
-    // background mode doesn't change anything: the static box def window proc
+    // background mode changes anything: the static box def window proc
     // still draws the label in its own colours, so we need to redraw the text
     // ourselves if we have a non default fg colour
     if ( m_hasFgCol && wxUxThemeIsActive() && !m_labelWin )

--- a/src/msw/textctrl.cpp
+++ b/src/msw/textctrl.cpp
@@ -3244,7 +3244,7 @@ bool wxTextCtrl::MSWSetCharFormat(const wxTextAttr& style, long start, long end)
     if ( style.HasFont() )
     {
         // VZ: CFM_CHARSET doesn't seem to do anything at all in RichEdit 2.0
-        //     but using it doesn't seem to hurt neither so leaving it for now
+        //     but using it doesn't seem to hurt either so leaving it for now
 
         cf.dwMask |= CFM_FACE | CFM_SIZE | CFM_CHARSET |
                      CFM_ITALIC | CFM_BOLD | CFM_UNDERLINE | CFM_STRIKEOUT;

--- a/src/msw/textentry.cpp
+++ b/src/msw/textentry.cpp
@@ -505,7 +505,7 @@ public:
                 // defined at wx level run first).
                 //
                 // Notice that we can't use wxEVT_TEXT here
-                // neither as, due to our use of ACO_AUTOAPPEND, we get
+                // either as, due to our use of ACO_AUTOAPPEND, we get
                 // EN_CHANGE notifications from the control every time
                 // IAutoComplete auto-appends something to it.
                 m_win->Bind(wxEVT_AFTER_CHAR,

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -1305,7 +1305,7 @@ bool wxToolBar::Realize()
         if ( IsVertical() )
         {
             // don't embed controls in the vertical toolbar, this doesn't look
-            // good and wxGTK doesn't do it neither (and the code below can't
+            // good and wxGTK doesn't do it either (and the code below can't
             // deal with this case)
             control->Hide();
             if ( wxStaticText * const staticText = tool->GetStaticText() )

--- a/src/msw/toplevel.cpp
+++ b/src/msw/toplevel.cpp
@@ -765,9 +765,9 @@ bool wxTopLevelWindowMSW::Destroy()
     // Under Windows 10 iconized windows don't get any messages, so delayed
     // destruction doesn't work for them if we don't force a message dispatch
     // here (and it doesn't seem useful to test for MSWIsIconized() as doing
-    // this doesn't do any harm for non-iconized windows neither). For that
+    // this doesn't do any harm for non-iconized windows either). For that
     // matter, doing this shouldn't do any harm under previous OS versions
-    // neither, so checking for the OS version doesn't seem useful too.
+    // either, so checking for the OS version doesn't seem useful too.
     wxWakeUpIdle();
 
     return true;
@@ -867,7 +867,7 @@ wxTopLevelWindowMSW::MSWGetCreateWindowCoords(const wxPoint& pos,
     else
     {
         // OTOH, if x is not set to CW_USEDEFAULT, y shouldn't be set to it
-        // neither because it is not handled as a special value by Windows then
+        // either because it is not handled as a special value by Windows then
         // and so we have to choose some default value for it, even if a
         // completely arbitrary one
         static const int DEFAULT_Y = 200;

--- a/src/msw/uilocale.cpp
+++ b/src/msw/uilocale.cpp
@@ -842,7 +842,7 @@ wxUILocaleImpl* wxUILocaleImpl::CreateForLocale(const wxLocaleIdent& locId)
     {
         // We could try finding the LCID matching the name, but support for XP
         // will be dropped soon, so it just doesn't seem worth to do it (note
-        // that LocaleNameToLCID() itself is not available in XP neither, so we
+        // that LocaleNameToLCID() itself is not available in XP either, so we
         // can't just use it here).
         return NULL;
     }

--- a/src/msw/utils.cpp
+++ b/src/msw/utils.cpp
@@ -995,7 +995,7 @@ wxLoadUserResource(const void **outData,
 
     *outLen = ::SizeofResource(instance, hResource);
 
-    // Notice that we do not need to call neither UnlockResource() (which is
+    // Notice that we need to call neither UnlockResource() (which is
     // obsolete in Win32) nor GlobalFree() (resources are freed on process
     // termination only)
 

--- a/src/msw/utilsexc.cpp
+++ b/src/msw/utilsexc.cpp
@@ -485,7 +485,7 @@ wxPipeOutputStream::wxPipeOutputStream(HANDLE hOutput)
                 m_hOutput,
                 &mode,
                 NULL,       // collection count (we don't set it)
-                NULL        // timeout (we don't set it neither)
+                NULL        // timeout (we don't set it either)
             ) )
     {
         wxLogLastError(wxT("SetNamedPipeHandleState(PIPE_NOWAIT)"));
@@ -584,7 +584,7 @@ long wxExecute(const wxString& cmd, int flags, wxProcess *handler,
 #if wxUSE_THREADS
     // for many reasons, the code below breaks down if it's called from another
     // thread -- this could be fixed, but as Unix versions don't support this
-    // neither I don't want to waste time on this now
+    // either I don't want to waste time on this now
     wxASSERT_MSG( wxThread::IsMain(),
                     wxT("wxExecute() can be called only from the main thread") );
 #endif // wxUSE_THREADS

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -1874,7 +1874,7 @@ void wxWindowMSW::DoGetClientSize(int *x, int *y) const
         //        client size of such window is 1538*1182). No idea how to fix
         //        it though, setting WS_MAXIMIZE in GWL_STYLE before calling
         //        WM_NCCALCSIZE doesn't help and AdjustWindowRectEx() doesn't
-        //        work in this direction neither. So we just have to live with
+        //        work in this direction either. So we just have to live with
         //        the slightly wrong results and relayout the window when it
         //        gets finally shown in its maximized state (see #11762).
         RECT rect;
@@ -2196,7 +2196,7 @@ void wxWindowMSW::DoSetClientSize(int width, int height)
     // setting the client size is less obvious than it could have been
     // because in the result of changing the total size the window scrollbar
     // may [dis]appear and/or its menubar may [un]wrap (and AdjustWindowRect()
-    // doesn't take neither into account) and so the client size will not be
+    // doesn't take either into account) and so the client size will not be
     // correct as the difference between the total and client size changes --
     // so we keep changing it until we get it right
     //
@@ -3981,7 +3981,7 @@ void wxWindowMSW::MSWGetCreateWindowCoords(const wxPoint& pos,
 
     AdjustForParentClientOrigin(x, y);
 
-    // We don't have any clearly good choice for the size by default neither
+    // We don't have any clearly good choice for the size by default either
     // but we must use something non-zero.
     w = WidthDefault(size.x);
     h = HeightDefault(size.y);

--- a/src/osx/artmac.cpp
+++ b/src/osx/artmac.cpp
@@ -130,7 +130,7 @@ wxSize wxArtProvider::GetNativeDIPSizeHint(const wxArtClient& client)
     }
     else if ( client == wxART_BUTTON || client == wxART_MENU )
     {
-        // Mac UI doesn't use any images in neither buttons nor menus in
+        // Mac UI doesn't use any images in either buttons or menus in
         // general but the code using wxArtProvider can use wxART_BUTTON to
         // find the icons of a roughly appropriate size for the buttons and
         // 16x16 seems to be the best choice for this kind of use

--- a/src/osx/cocoa/button.mm
+++ b/src/osx/cocoa/button.mm
@@ -194,7 +194,7 @@ SetBezelStyleFromBorderFlags(NSButton *v,
     }
     else
     {
-        // We can't use rounded bezel styles neither for multiline buttons nor
+        // We can't use rounded bezel styles either for multiline buttons or
         // for buttons containing (big) icons as they are only meant to be used
         // at certain sizes, so the style used depends on whether the label is
         // single or multi line.

--- a/src/osx/listbox_osx.cpp
+++ b/src/osx/listbox_osx.cpp
@@ -280,7 +280,7 @@ wxSize wxListBox::DoGetBestSize() const
         lbWidth += cx;
 
         // don't make the listbox too tall (limit height to around 10 items)
-        // but don't make it too small neither
+        // but don't make it too small either
         lbHeight = wxMax( (cy + 4) * wxMin( wxMax( GetCount(), 3 ), 10 ), 70 );
     }
 

--- a/src/propgrid/propgrid.cpp
+++ b/src/propgrid/propgrid.cpp
@@ -1144,7 +1144,7 @@ wxSize wxPropertyGrid::DoGetBestSize() const
     int lineHeight = wxMax(FromDIP(15), m_lineHeight);
 
     // don't make the grid too tall (limit height to 10 items) but don't
-    // make it too small neither
+    // make it too small either
     int numLines = wxMin
                    (
                     wxMax(m_pState->DoGetRoot()->GetChildCount(), 3),

--- a/src/univ/listbox.cpp
+++ b/src/univ/listbox.cpp
@@ -165,7 +165,7 @@ bool wxListBox::Create(wxWindow *parent,
     if ( style & wxLB_ALWAYS_SB )
         style |= wxALWAYS_SHOW_SB;
 
-    // if we don't have neither multiple nor extended flag, we must have the
+    // if we have neither multiple nor extended flag, we must have the
     // single selection listbox
     if ( !(style & (wxLB_MULTIPLE | wxLB_EXTENDED)) )
         style |= wxLB_SINGLE;

--- a/src/univ/themes/win32.cpp
+++ b/src/univ/themes/win32.cpp
@@ -1581,7 +1581,7 @@ void wxWin32Renderer::DrawLabel(wxDC& dc,
     {
         // the combination of wxCONTROL_SELECTED and wxCONTROL_DISABLED
         // currently only can happen for a menu item and it seems that Windows
-        // doesn't draw the shadow in this case, so we don't do it neither
+        // doesn't draw the shadow in this case, so we don't do it either
         if ( flags & wxCONTROL_SELECTED )
         {
             // just make the label text greyed out

--- a/src/univ/winuniv.cpp
+++ b/src/univ/winuniv.cpp
@@ -504,7 +504,7 @@ void wxWindow::Refresh(bool eraseBackground, const wxRect *rect)
         childrect.Offset(-child->GetPosition());
         // NB: We must call wxWindowNative version because we need to refresh
         //     the entire control, not just its client area, and this is why we
-        //     don't account for child client area origin here neither. Also
+        //     don't account for child client area origin here either. Also
         //     note that we don't pass eraseBackground to the child, but use
         //     true instead: this is because we can't be sure that
         //     eraseBackground=false is safe for children as well and not only

--- a/src/unix/dialup.cpp
+++ b/src/unix/dialup.cpp
@@ -74,7 +74,7 @@ public:
    virtual ~wxDialUpManagerImpl();
 
    /** Could the dialup manager be initialized correctly? If this function
-       returns false, no other functions will work neither, so it's a good idea
+       returns false, no other functions will work either, so it's a good idea
        to call this function and check its result before calling any other
        wxDialUpManager methods.
    */
@@ -140,7 +140,7 @@ public:
    virtual bool EnableAutoCheckOnlineStatus(size_t nSeconds) wxOVERRIDE;
 
    // disable automatic check for connection status change - notice that the
-   // wxEVT_DIALUP_XXX events won't be sent any more neither.
+   // wxEVT_DIALUP_XXX events won't be sent any more either.
    virtual void DisableAutoCheckOnlineStatus() wxOVERRIDE;
 
    // under Unix, the value of well-known host is used to check whether we're

--- a/src/unix/fontutil.cpp
+++ b/src/unix/fontutil.cpp
@@ -880,7 +880,7 @@ void wxNativeFontInfo::SetUnderlined(bool WXUNUSED(underlined))
 
 void wxNativeFontInfo::SetStrikethrough(bool WXUNUSED(strikethrough))
 {
-    // this is not supported by Pango fonts neither
+    // this is not supported by Pango fonts either
 }
 
 bool wxNativeFontInfo::SetFaceName(const wxString& facename)

--- a/src/unix/net.cpp
+++ b/src/unix/net.cpp
@@ -73,7 +73,7 @@ public:
       }
 
    /** Could the dialup manager be initialized correctly? If this function
-       returns FALSE, no other functions will work neither, so it's a good idea
+       returns FALSE, no other functions will work either, so it's a good idea
        to call this function and check its result before calling any other
        wxDialUpManager methods.
    */
@@ -127,7 +127,7 @@ public:
    virtual bool EnableAutoCheckOnlineStatus(size_t nSeconds);
 
    // disable automatic check for connection status change - notice that the
-   // wxEVT_DIALUP_XXX events won't be sent any more neither.
+   // wxEVT_DIALUP_XXX events won't be sent any more either.
    virtual void DisableAutoCheckOnlineStatus();
 
    // under Unix, the value of well-known host is used to check whether we're

--- a/tests/controls/listctrltest.cpp
+++ b/tests/controls/listctrltest.cpp
@@ -136,7 +136,7 @@ void ListCtrlTestCase::SubitemRect()
     m_list->GetSubItemRect(1, 1, rectLabel, wxLIST_RECT_LABEL);
 
     CHECK(rectIcon.IsEmpty());
-    // Here we can't check for exact equality neither as there can be a margin.
+    // Here we can't check for exact equality either as there can be a margin.
     CHECK(rectLabel.GetLeft() >= rectItem.GetLeft());
     CHECK(rectLabel.GetRight() == rectItem.GetRight());
 }

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -605,7 +605,7 @@ void TextCtrlTestCase::Lines()
     // Verify that wrapped lines count as (at least) lines (but it can be more
     // if it's wrapped more than once).
     //
-    // This currently doesn't work neither in wxGTK, wxUniv, or wxOSX/Cocoa, see
+    // This currently works neither in wxGTK, wxUniv, nor wxOSX/Cocoa, see
     // #12366, where GetNumberOfLines() always returns the number of logical,
     // not physical, lines.
     m_text->AppendText("\n" + wxString(50, '1') + ' ' + wxString(50, '2'));

--- a/tests/controls/textentrytest.cpp
+++ b/tests/controls/textentrytest.cpp
@@ -475,7 +475,7 @@ private:
         wxYield();
 
         // Note that clicking it is still not enough to give it focus with
-        // wxGTK neither, so we still need to call SetFocus() nevertheless: but
+        // wxGTK either, so we still need to call SetFocus() nevertheless: but
         // now it works.
         m_control->SetFocus();
 

--- a/tests/filename/filenametest.cpp
+++ b/tests/filename/filenametest.cpp
@@ -792,7 +792,7 @@ TEST_CASE("wxFileName::SameAs", "[filename]")
 
 #if defined(__UNIX__)
     // We need to create a temporary directory and a temporary link.
-    // Unfortunately we can't use wxFileName::CreateTempFileName() for neither
+    // Unfortunately we can't use wxFileName::CreateTempFileName() for either
     // as it creates plain files, so use tempnam() explicitly instead.
     char* tn = tempnam(NULL, "wxfn1");
     const wxString tempdir1 = wxString::From8BitData(tn);

--- a/tests/fswatcher/fswatchertest.cpp
+++ b/tests/fswatcher/fswatchertest.cpp
@@ -441,7 +441,7 @@ TEST_CASE_METHOD(FileSystemWatcherTestCase,
 }
 
 // kqueue-based implementation doesn't collapse create/delete pairs in
-// renames and doesn't detect neither modifications nor access to the
+// renames and detects neither modifications nor access to the
 // files reliably currently so disable these tests
 //
 // FIXME: fix the code and reenable them

--- a/tests/regex/regextest.cpp
+++ b/tests/regex/regextest.cpp
@@ -168,7 +168,7 @@ bool RegExTestCase::parseFlags(const wxString& flags)
             // Also skip the (there is only one) test using POSIX-specified
             // handling of unmatched ')' as a non-special character -- PCRE
             // doesn't support this and it doesn't seem worth implementing
-            // support for this ourselves neither.
+            // support for this ourselves either.
             case 'U':
                 return false;
 

--- a/tests/sizers/boxsizer.cpp
+++ b/tests/sizers/boxsizer.cpp
@@ -397,7 +397,7 @@ TEST_CASE_METHOD(BoxSizerTestCase, "BoxSizer::IncompatibleFlags", "[sizer]")
     // Combining two vertical alignment flags doesn't make sense.
     ASSERT_SIZER_INCOMPATIBLE_FLAGS(wxALIGN_BOTTOM, wxALIGN_CENTRE_VERTICAL);
 
-    // Combining wxEXPAND with vertical alignment doesn't make sense neither.
+    // Combining wxEXPAND with vertical alignment doesn't make sense either.
     ASSERT_SIZER_INCOMPATIBLE_FLAGS(wxEXPAND, wxALIGN_CENTRE_VERTICAL);
     ASSERT_SIZER_INCOMPATIBLE_FLAGS(wxEXPAND, wxALIGN_BOTTOM);
 


### PR DESCRIPTION
In many cases it should be 'either', and 'nor' should be 'or' accordingly.

No changes to actual code.