### PR TITLE
Fix script parsing in wxLocaleIdent

### DIFF
--- a/src/common/uilocale.cpp
+++ b/src/common/uilocale.cpp
@@ -215,7 +215,7 @@ wxLocaleIdent wxLocaleIdent::FromTag(const wxString& tag)
 
         case 4:
             // Must be an ISO 15924 script.
-            locId.m_script = (*it).Left(1).Upper() + (*it).Mid(2).Lower();
+            locId.m_script = (*it).Left(1).Upper() + (*it).Mid(1).Lower();
             break;
 
         default:
@@ -299,7 +299,7 @@ wxLocaleIdent& wxLocaleIdent::Script(const wxString& script)
         script.find_first_not_of(validCharsAlpha) == wxString::npos)
     {
         // Capitalize first character
-        m_script = script.Left(1).Upper() + script.Mid(2).Lower();
+        m_script = script.Left(1).Upper() + script.Mid(1).Lower();
     }
     else if (!script.empty())
     {

--- a/src/common/uilocale.cpp
+++ b/src/common/uilocale.cpp
@@ -215,7 +215,7 @@ wxLocaleIdent wxLocaleIdent::FromTag(const wxString& tag)
 
         case 4:
             // Must be an ISO 15924 script.
-            locId.m_script = (*it).Left(1).Upper() + (*it).Mid(1).Lower();
+            locId.m_script = it->Capitalize();
             break;
 
         default:
@@ -299,7 +299,7 @@ wxLocaleIdent& wxLocaleIdent::Script(const wxString& script)
         script.find_first_not_of(validCharsAlpha) == wxString::npos)
     {
         // Capitalize first character
-        m_script = script.Left(1).Upper() + script.Mid(1).Lower();
+        m_script = script.Capitalize();
     }
     else if (!script.empty())
     {

--- a/tests/intl/intltest.cpp
+++ b/tests/intl/intltest.cpp
@@ -415,6 +415,8 @@ TEST_CASE("wxUILocale::FindLanguageInfo", "[uilocale]")
     CheckFindLanguage("English", "en");
     CheckFindLanguage("English_United States", "en_US");
     CheckFindLanguage("English_United States.utf8", "en_US");
+    // Test tag that includes an explicit script
+    CheckFindLanguage("sr-Latn-RS", "sr_RS@latin");
 }
 
 // Test which can be used to check if the given locale tag is supported.


### PR DESCRIPTION
The script part of a locale tag was incorrectly parsed due to a wrong index in the calls to `wxString::Mid`. This resulted in shortened script tags that couldn't be interpreted anymore.