### PR TITLE
Handle Aero Snapped window position in wxPersistentRegisterAndRestore

### DIFF
--- a/include/wx/msw/private/tlwgeom.h
+++ b/include/wx/msw/private/tlwgeom.h
@@ -119,14 +119,11 @@ public:
             ::GetWindowRect(tlw->GetHWND(), &rect);
             // Height and width should be the same unless the user performed
             // an Aero Snap operation.
-            if ((rect.bottom - rect.top) !=
-                (m_placement.rcNormalPosition.bottom - m_placement.rcNormalPosition.top)
-                ||
-                (rect.right - rect.left) !=
-                (m_placement.rcNormalPosition.right - m_placement.rcNormalPosition.left))
+            const RECT rcNormal = m_placement.rcNormalPosition;
+            if ((rcWindow.bottom - rcWindow.top) != (rcNormal.bottom - rcNormal.top) ||
+                (rcWindow.right - rcWindow.left) != (rcNormal.right - rcNormal.left))
             {
-                MONITORINFO mi;
-                mi.cbSize = sizeof(mi);
+                WinStruct<MONITORINFO> mi;
                 if (!::GetMonitorInfo(::MonitorFromWindow(tlw->GetHWND(),
                     MONITOR_DEFAULTTONEAREST), &mi))
                 {

--- a/include/wx/msw/private/tlwgeom.h
+++ b/include/wx/msw/private/tlwgeom.h
@@ -113,36 +113,39 @@ public:
             return false;
         }
 
-        RECT rect;
-        ::GetWindowRect(tlw->GetHWND(), &rect);
-        // Height and width should be the same unless the user performed
-        // an Aero Snap operation.
-        if ((rect.bottom - rect.top) !=
-            (m_placement.rcNormalPosition.bottom - m_placement.rcNormalPosition.top)
-            ||
-            (rect.right - rect.left) !=
-            (m_placement.rcNormalPosition.right - m_placement.rcNormalPosition.left))
+        if (m_placement.showCmd != SW_SHOWMAXIMIZED && m_placement.showCmd != SW_SHOWMINIMIZED)
         {
-            MONITORINFO mi;
-            mi.cbSize = sizeof(mi);
-            if (!::GetMonitorInfo(::MonitorFromWindow(tlw->GetHWND(), 
-                MONITOR_DEFAULTTONEAREST), &mi))
+            RECT rect;
+            ::GetWindowRect(tlw->GetHWND(), &rect);
+            // Height and width should be the same unless the user performed
+            // an Aero Snap operation.
+            if ((rect.bottom - rect.top) !=
+                (m_placement.rcNormalPosition.bottom - m_placement.rcNormalPosition.top)
+                ||
+                (rect.right - rect.left) !=
+                (m_placement.rcNormalPosition.right - m_placement.rcNormalPosition.left))
             {
-                wxLogLastError("GetMonitorInfo");
-                return false;
-            }
+                MONITORINFO mi;
+                mi.cbSize = sizeof(mi);
+                if (!::GetMonitorInfo(::MonitorFromWindow(tlw->GetHWND(), 
+                    MONITOR_DEFAULTTONEAREST), &mi))
+                {
+                    wxLogLastError("GetMonitorInfo");
+                    return false;
+                }
 
-            // If the tray is on the top or the left, then the rectangle needs to
-            // be adjusted to match what ::SetWindowPlacement expects.
-            if (mi.rcMonitor.top < mi.rcWork.top || 
-                mi.rcMonitor.left < mi.rcWork.left)
-            {
-                // Negative offset to eliminate the tray width/height.
-                OffsetRect(&rect, (mi.rcMonitor.left - mi.rcWork.left),
-                     (mi.rcMonitor.top - mi.rcWork.top));
-            }
+                // If the tray is on the top or the left, then the rectangle needs to
+                // be adjusted to match what ::SetWindowPlacement expects.
+                if (mi.rcMonitor.top < mi.rcWork.top || 
+                    mi.rcMonitor.left < mi.rcWork.left)
+                {
+                    // Negative offset to eliminate the tray width/height.
+                    OffsetRect(&rect, (mi.rcMonitor.left - mi.rcWork.left),
+                         (mi.rcMonitor.top - mi.rcWork.top));
+                }
 
-            ::CopyRect(&m_placement.rcNormalPosition, &rect);
+                ::CopyRect(&m_placement.rcNormalPosition, &rect);
+            }
         }
 
         return true;

--- a/include/wx/msw/private/tlwgeom.h
+++ b/include/wx/msw/private/tlwgeom.h
@@ -115,8 +115,8 @@ public:
 
         if (m_placement.showCmd != SW_SHOWMAXIMIZED && m_placement.showCmd != SW_SHOWMINIMIZED)
         {
-            RECT rect;
-            ::GetWindowRect(tlw->GetHWND(), &rect);
+            RECT rcWindow;
+            ::GetWindowRect(tlw->GetHWND(), &rcWindow);
             // Height and width should be the same unless the user performed
             // an Aero Snap operation.
             const RECT rcNormal = m_placement.rcNormalPosition;
@@ -137,11 +137,11 @@ public:
                     mi.rcMonitor.left < mi.rcWork.left)
                 {
                     // Negative offset to eliminate the tray width/height.
-                    OffsetRect(&rect, (mi.rcMonitor.left - mi.rcWork.left),
+                    OffsetRect(&rcWindow, (mi.rcMonitor.left - mi.rcWork.left),
                          (mi.rcMonitor.top - mi.rcWork.top));
                 }
 
-                ::CopyRect(&m_placement.rcNormalPosition, &rect);
+                ::CopyRect(&m_placement.rcNormalPosition, &rcWindow);
             }
         }
 

--- a/include/wx/msw/private/tlwgeom.h
+++ b/include/wx/msw/private/tlwgeom.h
@@ -127,7 +127,7 @@ public:
             {
                 MONITORINFO mi;
                 mi.cbSize = sizeof(mi);
-                if (!::GetMonitorInfo(::MonitorFromWindow(tlw->GetHWND(), 
+                if (!::GetMonitorInfo(::MonitorFromWindow(tlw->GetHWND(),
                     MONITOR_DEFAULTTONEAREST), &mi))
                 {
                     wxLogLastError("GetMonitorInfo");
@@ -136,7 +136,7 @@ public:
 
                 // If the tray is on the top or the left, then the rectangle needs to
                 // be adjusted to match what ::SetWindowPlacement expects.
-                if (mi.rcMonitor.top < mi.rcWork.top || 
+                if (mi.rcMonitor.top < mi.rcWork.top ||
                     mi.rcMonitor.left < mi.rcWork.left)
                 {
                     // Negative offset to eliminate the tray width/height.


### PR DESCRIPTION
If the app is using wxPersistentRegisterAndRestore, this will correctly save the
current window position if the user closes the top level window after using
an Aero Snap function without restoring the window before closing it.

The wxTLWGeometry class uses ::GetWindowPlacement() and ::SetWindowPlacement() to save/restore a top level window's position. The problem is that ::GetWindowPlacement() returns an incorrect position when the last sizing of the window was an Aero Snap. If the window is not maximized or iconized, then the correct position can be retrieved by a call to ::GetWindowRect(). However this is a different coordinate system (screen coordinates versus work area coordinates), so the rectangle retrieved can _not_ be used directly by ::SetWindowPlacement(). There is no Windows API for converting between the two coordinate systems.

The new code checks to see if the width or height of the rectangle returned by ::GetWindowRect() is the same as that returned by ::GetWindowPlacement(). If it's not the same, then the rectangle retrieved by ::GetWindowPlacement() is updated with the Aero Snapped dimensions.