### PR TITLE
CMake: Use builtin NanoSVG by default

### DIFF
--- a/build/cmake/options.cmake
+++ b/build/cmake/options.cmake
@@ -114,7 +114,7 @@ wx_add_thirdparty_library(wxUSE_EXPAT EXPAT "use expat for XML parsing" DEFAULT_
 wx_add_thirdparty_library(wxUSE_LIBJPEG JPEG "use libjpeg (JPEG file format)")
 wx_add_thirdparty_library(wxUSE_LIBPNG PNG "use libpng (PNG image format)")
 wx_add_thirdparty_library(wxUSE_LIBTIFF TIFF "use libtiff (TIFF file format)")
-wx_add_thirdparty_library(wxUSE_NANOSVG NanoSVG "use NanoSVG for rasterizing SVG")
+wx_add_thirdparty_library(wxUSE_NANOSVG NanoSVG "use NanoSVG for rasterizing SVG" DEFAULT builtin)
 
 wx_option(wxUSE_LIBLZMA "use LZMA compression" OFF)
 set(wxTHIRD_PARTY_LIBRARIES ${wxTHIRD_PARTY_LIBRARIES} wxUSE_LIBLZMA "use liblzma for LZMA compression")


### PR DESCRIPTION
Since we do not provide a FindNanoSVG module, we should use the builtin by default.
And prevent warnings about not being able to find the package configuration file.

See for example this build log: https://github.com/wxWidgets/wxWidgets/runs/7920178325?check_suite_focus=true#step:6:64

Can be backported to 3.2