### PR TITLE
Fix for #22751: Crash in radio box_osx when initialized with null list of str…

### DIFF
--- a/src/osx/radiobox_osx.cpp
+++ b/src/osx/radiobox_osx.cpp
@@ -57,6 +57,10 @@ wxRadioBox::~wxRadioBox()
 {
     SendDestroyEvent();
 
+    // if we don't have a button cycle, we're done.
+    if (m_radioButtonCycle == nullptr) {
+        return;
+    }
     wxRadioButton *next, *current;
 
     current = m_radioButtonCycle->NextInCycle();


### PR DESCRIPTION
…ings #22751

Do not attempt to dereference m_radioButtonCycle