### PR TITLE
Fix images with alpha in wxMSW wxImageList without mask support

### DIFF
--- a/src/msw/imaglist.cpp
+++ b/src/msw/imaglist.cpp
@@ -197,7 +197,7 @@ wxImageList::GetImageListBitmaps(wxMSWBitmaps& bitmaps,
             if ( !bmp.HasAlpha() )
                 bmp.SetMask(new wxMask(bmp, GetDefaultMaskColour()));
         }
-        else
+        else if ( !bmp.HasAlpha() )
         {
             // We actually don't have to do anything at all and can just use
             // the original bitmap as is.


### PR DESCRIPTION
This was broken by the pre-3.2 changes to wxImageList which resulted in
not undoing alpha pre-multiplication when adding such images to the
image list.

In particular, this broke the appearance of disabled button images in
wxToolBar, as it uses wxImageList for storing them.

See #22754.