### PR TITLE
Night_Wisp bombs demo patch

### DIFF
--- a/demos/bombs/bombs.cpp
+++ b/demos/bombs/bombs.cpp
@@ -3,7 +3,6 @@
 // Purpose:     Bombs game
 // Author:      P. Foggia 1996
 // Modified by: Wlodzimierz Skiba (ABX) since 2003
-// Modified by: Night_Wisp in 2022
 // Created:     1996
 // Copyright:   (c) 1996 P. Foggia
 // Licence:     wxWindows licence
@@ -197,11 +196,14 @@ void BombsFrame::OnEasyCorner(wxCommandEvent& WXUNUSED(event))
                this
              );
 
-    if(ok!=wxYES)return GetMenuBar()->Check(bombsID_EASYCORNER, m_easyCorner);
+    if(ok!=wxYES)
+    {
+        // Undo the automatic change to the menu bar, to keep it in sync with the actual option value.
+        GetMenuBar()->Check(bombsID_EASYCORNER, m_easyCorner);
+        return;
+    }
 
     m_easyCorner = !m_easyCorner;
-    
-    GetMenuBar()->Check(bombsID_EASYCORNER, m_easyCorner);
 
     NewGame(m_lastLevel, true);
 }

--- a/demos/bombs/bombs.cpp
+++ b/demos/bombs/bombs.cpp
@@ -198,7 +198,7 @@ void BombsFrame::OnEasyCorner(wxCommandEvent& WXUNUSED(event))
 
     if(ok!=wxYES)
     {
-        // Undo the automatic change to the menu bar, to keep it in sync with the actual option value.
+        // Undo the automatic change to the menu bar, keeping it in sync with the actual option value.
         GetMenuBar()->Check(bombsID_EASYCORNER, m_easyCorner);
         return;
     }

--- a/demos/bombs/bombs.cpp
+++ b/demos/bombs/bombs.cpp
@@ -3,6 +3,7 @@
 // Purpose:     Bombs game
 // Author:      P. Foggia 1996
 // Modified by: Wlodzimierz Skiba (ABX) since 2003
+// Modified by: Night_Wisp in 2022
 // Created:     1996
 // Copyright:   (c) 1996 P. Foggia
 // Licence:     wxWindows licence
@@ -183,9 +184,9 @@ void BombsFrame::OnEasyCorner(wxCommandEvent& WXUNUSED(event))
 {
     wxString msg;
     if(m_easyCorner)
-        msg = wxT("enable");
-    else
         msg = wxT("disable");
+    else
+        msg = wxT("enable");
 
     msg = wxT("Do you really want to ") + msg + wxT(" having\ntop left corner always empty for easier start?");
 
@@ -196,9 +197,11 @@ void BombsFrame::OnEasyCorner(wxCommandEvent& WXUNUSED(event))
                this
              );
 
-    if(ok!=wxYES)return;
+    if(ok!=wxYES)return GetMenuBar()->Check(bombsID_EASYCORNER, m_easyCorner);
 
     m_easyCorner = !m_easyCorner;
+    
+    GetMenuBar()->Check(bombsID_EASYCORNER, m_easyCorner);
 
     NewGame(m_lastLevel, true);
 }


### PR DESCRIPTION
* Fix two minor errors in the Bombs demo.

Fix two minor errors in the Bombs demo.

Error 1: When enabling/disabling easy corner, the enable/disable text was mixed up. This resulted in being asked to confirm disabling easy corner, when it was being enabled, and vice versa.
Error 2: When choosing not to switch easy corner, the checkmark in the menu showing it's state still swapped.

Fix 1: Swap the text for enable/disable in the confirm easy mode toggle dialog box.
Fix 2: Call GetMenuBar()->Check(bombsID_EASYCORNER, m_easyCorner); (Check always returns void, and GetMenuBar is only called from the MenuBar, after it's been set up) to set the checkmark's state, when needed.

Added myself in a Modified By section

This fixes issue #22763 