### PR TITLE
Gtk diagnostics

### DIFF
--- a/include/wx/gtk1/app.h
+++ b/include/wx/gtk1/app.h
@@ -67,7 +67,19 @@ public:
     // or the XVisualInfo* for SGI.
     GdkVisual      *GetGdkVisual();
 
-private:
+    // Provide the ability to suppress GTK output. By default, all output
+    // will be suppressed, but the user can pass in a mask specifying the
+    // types of messages to suppress. Flags are defined by glib with the
+    // GLogLevelFlags enum.
+    static void GTKSuppressDiagnostics(int flags = -1);
+
+    // Allow wxWidgets to control GTK diagnostics. This is recommended because
+    // it prevents spurious GTK messages from appearing, but can't be done by
+    // default because it would result in a fatal error if the application
+    // calls g_log_set_writer_func() itself.
+    static void GTKAllowDiagnosticsControl();
+
+ private:
     // true if we're inside an assert modal dialog
     bool m_isInAssert;
 

--- a/src/gtk1/app.cpp
+++ b/src/gtk1/app.cpp
@@ -648,3 +648,17 @@ void wxApp::RemoveIdleTag()
         g_isIdle = true;
     }
 }
+
+/* To implement GTKSuppressDiagnostics & GTKAllowDiagnosticsControl
+ * ../gtk/app.cpp uses wxHAS_GLIB_LOG_WRITER */
+/* static */
+void wxApp::GTKSuppressDiagnostics(int WXUNUSED(flags))
+{
+    // We can't do anything here.
+}
+
+/* static */
+void wxApp::GTKAllowDiagnosticsControl()
+{
+    // And don't need to do anything here.
+}


### PR DESCRIPTION
Added in wxgtk1 GTKSupressDiagnostics & GTKAllowDiagnosticsControl. 
I added the dummy routines (as in wxgtk without wxHAS_GLIB_LOG_WRITER), since OpenVMS (probably the only port still using wxgtk1) does not have this log-writer.

The reason for adding is that some sample rograms (i.e. notebook) need the routines.