### PR TITLE
Remove useless check for grid size in wxGrid::FreezeTo()

### DIFF
--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -5643,7 +5643,8 @@ public:
 
         Note that this method doesn't do anything, and returns @false, if any
         of the following conditions are true:
-        - Either @a row or @a col are out of range
+        - Either @a row or @a col are out of range, i.e. negative or strictly
+          greater than the total number of grid rows or columns.
         - There are any merged cells in the area to be frozen
         - Grid uses a native header control (see UseNativeColHeader())
 
@@ -5651,7 +5652,7 @@ public:
 
         @since 3.1.3
      */
-    bool FreezeTo(unsigned row, unsigned col);
+    bool FreezeTo(int row, int col);
 
     /// @overload
     bool FreezeTo(const wxGridCellCoords& coords);

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -5644,7 +5644,6 @@ public:
         Note that this method doesn't do anything, and returns @false, if any
         of the following conditions are true:
         - Either @a row or @a col are out of range
-        - Size of the frozen area would be bigger than the current viewing area
         - There are any merged cells in the area to be frozen
         - Grid uses a native header control (see UseNativeColHeader())
 

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -5643,12 +5643,16 @@ public:
 
         Note that this method doesn't do anything, and returns @false, if any
         of the following conditions are true:
-        - Either @a row or @a col are out of range, i.e. negative or strictly
-          greater than the total number of grid rows or columns.
         - There are any merged cells in the area to be frozen
         - Grid uses a native header control (see UseNativeColHeader())
 
         (some of these limitations could be lifted in the future).
+
+        Additionally, the function also returns false if either @a row or @a
+        col are out of range, i.e. negative or strictly greater than the total
+        number of grid rows or columns and also generates an assert failure in
+        this case, as this indicates a programming error and not a limitation
+        of the current implementation, unlike the conditions above.
 
         @since 3.1.3
      */

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -5459,17 +5459,6 @@ bool wxGrid::FreezeTo(int row, int col)
     // freeze
     if ( row > m_numFrozenRows || col > m_numFrozenCols )
     {
-        // check that it fits in client size
-        int cw, ch;
-        GetClientSize( &cw, &ch );
-
-        cw -= m_rowLabelWidth;
-        ch -= m_colLabelHeight;
-
-        if ((row > 0 && GetRowBottom(row - 1) >= ch) ||
-            (col > 0 && GetColRight(col - 1) >= cw))
-            return false;
-
         // check all involved cells for merged ones
         int cell_rows, cell_cols;
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -5451,7 +5451,7 @@ bool wxGrid::FreezeTo(int row, int col)
     wxCHECK_MSG( row >= 0 && col >= 0, false,
                 "Number of rows or cols can't be negative!");
 
-    if ( row >= m_numRows || col >= m_numCols ||
+    if ( row > m_numRows || col > m_numCols ||
         !m_rowAt.empty() || m_canDragRowMove ||
         !m_colAt.empty() || m_canDragColMove || m_useNativeHeader )
         return false;

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -5448,12 +5448,14 @@ void wxGrid::InitializeFrozenWindows()
 
 bool wxGrid::FreezeTo(int row, int col)
 {
-    wxCHECK_MSG( row >= 0 && col >= 0, false,
-                "Number of rows or cols can't be negative!");
+    wxCHECK_MSG( row >= 0 && row <= m_numRows, false,
+                 "Invalid number of rows to freeze" );
 
-    if ( row > m_numRows || col > m_numCols ||
-        !m_rowAt.empty() || m_canDragRowMove ||
-        !m_colAt.empty() || m_canDragColMove || m_useNativeHeader )
+    wxCHECK_MSG( col >= 0 && col <= m_numCols, false,
+                 "Invalid number of columns to freeze" );
+
+    if ( !m_rowAt.empty() || m_canDragRowMove ||
+         !m_colAt.empty() || m_canDragColMove || m_useNativeHeader )
         return false;
 
     // freeze


### PR DESCRIPTION
This resulted in silently doing nothing when calling FreezeTo() on a
grid which hadn't been resized to its full size yet, which seems wrong
and not useful at all, so simply remove this check and freeze the
requested rows/columns in any case -- it's the user responsibility to
make the grid sufficiently big to allow the user to see the non-frozen
parts.

---

I'd like to make this change (at least in master, it might be too incompatible to backport to 3.2) because the current behaviour doesn't seem useful at all to me because it results in all calls to `FreezeTo()` done before the first layout to just do nothing at all.

Ideal would arguably be to freeze/thaw the grid automatically as it becomes big enough/too small, but this is more difficult and I think this is more useful than the current behaviour.

Any objections?