### PR TITLE
Change wxImage::ResampleBox() to avoid MSVS 2022 optimizer bug

### DIFF
--- a/src/common/image.cpp
+++ b/src/common/image.cpp
@@ -673,7 +673,8 @@ wxImage wxImage::ResampleBox(int width, int height) const
             const BoxPrecalc& hPrecalc = hPrecalcs[x];
 
             // Box of pixels to average
-            averaged_pixels = 0;
+            averaged_pixels = (vPrecalc.boxEnd - vPrecalc.boxStart + 1)
+                                * (hPrecalc.boxEnd - hPrecalc.boxStart + 1);
             sum_r = sum_g = sum_b = sum_a = 0.0;
 
             for ( int j = vPrecalc.boxStart; j <= vPrecalc.boxEnd; ++j )
@@ -696,8 +697,6 @@ wxImage wxImage::ResampleBox(int width, int height) const
                         sum_g += src_data[src_pixel_index * 3 + 1];
                         sum_b += src_data[src_pixel_index * 3 + 2];
                     }
-
-                    averaged_pixels++;
                 }
             }
 


### PR DESCRIPTION
Calculate averaged_pixels directly instead of doing it in a loop as we
somehow end up with a value of 0 for it when using MSVS 2022 optimized
64-bit build.

See #22761.