### PR TITLE
Improve wxBitmapBundle documentation

### DIFF
--- a/interface/wx/bmpbndl.h
+++ b/interface/wx/bmpbndl.h
@@ -22,9 +22,9 @@
     Currently bitmap bundles can be created from:
 
         - A vector of bitmaps, of any provenance.
+        - An SVG (as memory block, file, or resource) which will be rasterized at required resolutions.
+        - A custom bitmap source using wxBitmapBundleImpl.
         - A single wxBitmap or wxImage for backwards compatibility.
-
-    More functions for creating bitmap bundles will be added in the future.
 
     Objects of wxBitmapBundle class have value-like semantics, i.e. they can be
     copied around freely (and cheaply) and don't need to be allocated on the


### PR DESCRIPTION
I believe that using an SVG or a custom bitmap source should be mentioned in the class description, SVG in particular. Currently, this can only be deduced from the method list.

Removing that sentence may seem overly aggressive, but IMO there are no plans for this, such promises are often not fulfilled, and thus sentences like this are not useful. In fact I was itching to remove "These limitations will be relaxed in the future wxWidgets versions." from the `FromSVG()` description for the very same reason.