### PR TITLE
Fix depth buffer for the OpenGL samples under Linux

### DIFF
--- a/samples/opengl/cube/cube.cpp
+++ b/samples/opengl/cube/cube.cpp
@@ -458,9 +458,10 @@ wxEND_EVENT_TABLE()
 MyFrame::MyFrame( bool stereoWindow )
        : wxFrame(NULL, wxID_ANY, "wxWidgets OpenGL Cube Sample")
 {
-    int stereoAttribList[] = { WX_GL_RGBA, WX_GL_DOUBLEBUFFER, WX_GL_STEREO, 0 };
+    int attribList[] = { WX_GL_RGBA, WX_GL_DOUBLEBUFFER, WX_GL_DEPTH_SIZE, 16, 0 };
+    int stereoAttribList[] = { WX_GL_RGBA, WX_GL_DOUBLEBUFFER, WX_GL_DEPTH_SIZE, 16, WX_GL_STEREO, 0 };
 
-    new TestGLCanvas(this, stereoWindow ? stereoAttribList : NULL);
+    new TestGLCanvas(this, stereoWindow ? stereoAttribList : attribList);
 
     SetIcon(wxICON(sample));
 
@@ -481,7 +482,7 @@ MyFrame::MyFrame( bool stereoWindow )
     Show();
 
     // test IsDisplaySupported() function:
-    static const int attribs[] = { WX_GL_RGBA, WX_GL_DOUBLEBUFFER, 0 };
+    static const int attribs[] = { WX_GL_RGBA, WX_GL_DEPTH_SIZE, 16, WX_GL_DOUBLEBUFFER, 0 };
     wxLogStatus("Double-buffered display %s supported",
                 wxGLCanvas::IsDisplaySupported(attribs) ? "is" : "not");
 

--- a/samples/opengl/cube/cube.cpp
+++ b/samples/opengl/cube/cube.cpp
@@ -34,6 +34,10 @@
     #include "../../sample.xpm"
 #endif
 
+#ifndef WGL_STEREO_ARB
+    #define WGL_STEREO_ARB  0x2012
+#endif
+
 // ----------------------------------------------------------------------------
 // constants
 // ----------------------------------------------------------------------------
@@ -309,12 +313,12 @@ wxBEGIN_EVENT_TABLE(TestGLCanvas, wxGLCanvas)
     EVT_TIMER(SpinTimer, TestGLCanvas::OnSpinTimer)
 wxEND_EVENT_TABLE()
 
-TestGLCanvas::TestGLCanvas(wxWindow *parent, int *attribList)
+TestGLCanvas::TestGLCanvas(wxWindow *parent, const wxGLAttributes& attribList)
     // With perspective OpenGL graphics, the wxFULL_REPAINT_ON_RESIZE style
     // flag should always be set, because even making the canvas smaller should
     // be followed by a paint event that updates the entire canvas with new
     // viewport settings.
-    : wxGLCanvas(parent, wxID_ANY, attribList,
+    : wxGLCanvas(parent, attribList, wxID_ANY,
                  wxDefaultPosition, wxDefaultSize,
                  wxFULL_REPAINT_ON_RESIZE),
       m_xangle(30.0),
@@ -323,15 +327,13 @@ TestGLCanvas::TestGLCanvas(wxWindow *parent, int *attribList)
       m_useStereo(false),
       m_stereoWarningAlreadyDisplayed(false)
 {
-    if ( attribList )
+    int i = 0;
+    const int* attributes = attribList.GetGLAttrs();
+    while ( attributes[i] != 0 )
     {
-        int i = 0;
-        while ( attribList[i] != 0 )
-        {
-            if ( attribList[i] == WX_GL_STEREO )
-                m_useStereo = true;
-            ++i;
-        }
+        if ( attributes[i] == WGL_STEREO_ARB )
+            m_useStereo = true;
+        ++i;
     }
 }
 
@@ -458,8 +460,10 @@ wxEND_EVENT_TABLE()
 MyFrame::MyFrame( bool stereoWindow )
        : wxFrame(NULL, wxID_ANY, "wxWidgets OpenGL Cube Sample")
 {
-    int attribList[] = { WX_GL_RGBA, WX_GL_DOUBLEBUFFER, WX_GL_DEPTH_SIZE, 16, 0 };
-    int stereoAttribList[] = { WX_GL_RGBA, WX_GL_DOUBLEBUFFER, WX_GL_DEPTH_SIZE, 16, WX_GL_STEREO, 0 };
+    wxGLAttributes attribList;
+    wxGLAttributes stereoAttribList;
+    attribList.Defaults().PlatformDefaults().EndList();
+    stereoAttribList.Defaults().PlatformDefaults().Stereo().EndList();
 
     new TestGLCanvas(this, stereoWindow ? stereoAttribList : attribList);
 

--- a/samples/opengl/cube/cube.h
+++ b/samples/opengl/cube/cube.h
@@ -65,7 +65,7 @@ private:
 class TestGLCanvas : public wxGLCanvas
 {
 public:
-    TestGLCanvas(wxWindow *parent, int *attribList = NULL);
+    TestGLCanvas(wxWindow *parent, const wxGLAttributes& attribList);
 
 private:
     void OnPaint(wxPaintEvent& event);

--- a/samples/opengl/penguin/penguin.cpp
+++ b/samples/opengl/penguin/penguin.cpp
@@ -92,7 +92,10 @@ MyFrame::MyFrame(wxFrame *frame, const wxString& title, const wxPoint& pos,
 
     Show(true);
 
-    m_canvas = new TestGLCanvas(this, wxID_ANY, wxDefaultPosition,
+    // Create the OpenGL Canvas with default attributes
+    wxGLAttributes attribList;
+    attribList.Defaults().PlatformDefaults().EndList();
+    m_canvas = new TestGLCanvas(this, attribList, wxID_ANY, wxDefaultPosition,
         GetClientSize(), wxSUNKEN_BORDER);
 }
 
@@ -138,12 +141,13 @@ wxBEGIN_EVENT_TABLE(TestGLCanvas, wxGLCanvas)
 wxEND_EVENT_TABLE()
 
 TestGLCanvas::TestGLCanvas(wxWindow *parent,
+                           const wxGLAttributes& attribList,
                            wxWindowID id,
                            const wxPoint& pos,
                            const wxSize& size,
                            long style,
                            const wxString& name)
-    : wxGLCanvas(parent, id, NULL, pos, size,
+    : wxGLCanvas(parent, attribList, id, pos, size,
                  style | wxFULL_REPAINT_ON_RESIZE, name)
 {
     // Explicitly create a new rendering context instance for this canvas.

--- a/samples/opengl/penguin/penguin.h
+++ b/samples/opengl/penguin/penguin.h
@@ -76,7 +76,8 @@ private:
 class TestGLCanvas : public wxGLCanvas
 {
 public:
-    TestGLCanvas(wxWindow *parent, wxWindowID id = wxID_ANY,
+    TestGLCanvas(wxWindow *parent, const wxGLAttributes& attribList,
+        wxWindowID id = wxID_ANY,
         const wxPoint& pos = wxDefaultPosition,
         const wxSize& size = wxDefaultSize, long style = 0,
         const wxString& name = "TestGLCanvas");


### PR DESCRIPTION
This PR is being created as a result of the conversation [here](https://forums.wxwidgets.org/viewtopic.php?f=23&t=49603).

Two of the OpenGL samples, specifically the Cube and Penguin sample, did not have a working depth buffer when compiled under Linux. While the cube sample wasn't visually affected by this (only being visible if backface culling was disabled), the visual issues could be visible in the penguin sample under specific rotations.

The issue was caused by mistakenly assuming the depth buffer was enabled by default on Linux, which is not the case. This PR contains two commits, one which adds the depth buffer size to the attribute list in the cube sample (which uses the old integer array method already), and which adds a `wxGLAttributes` object as an argument to the Canvas implementation (which is the preferred method as of wx 3.2).

---
As an aside, the [documentation](https://docs.wxwidgets.org/trunk/classwx_g_l_attributes.html#a547c600aa202a3fdee88ac9c3594c819) of the depth value for `wxGLAttributes` claims that valid values are 0, 16, and 32. However, when I attempt to use the value of 32, it causes the following assertions on the application start:
```
../src/unix/glegl.cpp(372): assert ""Assert failure"" failed in InitVisual(): Failed to get an EGLConfig for the requested attributes.
../src/unix/glegl.cpp(311): assert ""fbc"" failed in wxGLContext(): Invalid EGLConfig for OpenGL
```
Interestingly, a value of 24 works fine. Is this a mistake in the documentation? If so, I can add an extra commit to this PR to correct that.