### PR TITLE
wxGrid: minor fixups and cleanups 

### DIFF
--- a/include/wx/generic/gridsel.h
+++ b/include/wx/generic/gridsel.h
@@ -119,7 +119,7 @@ private:
     {
         SelectBlock(block.GetTopRow(), block.GetLeftCol(),
                     block.GetBottomRow(), block.GetRightCol(),
-                    wxKeyboardState(), false);
+                    wxKeyboardState(), wxEVT_NULL);
     }
 
     // Really select the block and don't check for the current selection mode.

--- a/include/wx/generic/gridsel.h
+++ b/include/wx/generic/gridsel.h
@@ -108,7 +108,7 @@ public:
     wxArrayInt GetRowSelection() const;
     wxArrayInt GetColSelection() const;
 
-    wxGridBlockCoordsVector& GetBlocks() { return m_selection; }
+    const wxGridBlockCoordsVector& GetBlocks() const { return m_selection; }
 
     void EndSelecting();
     void CancelSelecting();

--- a/include/wx/generic/gridsel.h
+++ b/include/wx/generic/gridsel.h
@@ -19,6 +19,8 @@
 
 #include "wx/vector.h"
 
+wxDEPRECATED_MSG("use wxGridBlockCoordsVector instead")
+typedef wxVector<wxGridBlockCoords> wxVectorGridBlockCoords;
 
 // Note: for all eventType arguments of the methods of this class wxEVT_NULL
 //       may be passed to forbid events generation completely.

--- a/include/wx/generic/gridsel.h
+++ b/include/wx/generic/gridsel.h
@@ -19,7 +19,6 @@
 
 #include "wx/vector.h"
 
-typedef wxVector<wxGridBlockCoords> wxVectorGridBlockCoords;
 
 // Note: for all eventType arguments of the methods of this class wxEVT_NULL
 //       may be passed to forbid events generation completely.
@@ -109,7 +108,7 @@ public:
     wxArrayInt GetRowSelection() const;
     wxArrayInt GetColSelection() const;
 
-    wxVectorGridBlockCoords& GetBlocks() { return m_selection; }
+    wxGridBlockCoordsVector& GetBlocks() { return m_selection; }
 
     void EndSelecting();
     void CancelSelecting();
@@ -136,7 +135,7 @@ private:
     // We don't currently check if the new block is contained by several
     // existing blocks, as this would be more difficult and doesn't seem to be
     // really needed in practice.
-    void MergeOrAddBlock(wxVectorGridBlockCoords& blocks,
+    void MergeOrAddBlock(wxGridBlockCoordsVector& blocks,
                          const wxGridBlockCoords& block);
 
     // All currently selected blocks. We expect there to be a relatively small
@@ -146,7 +145,7 @@ private:
     // Selection may be empty, but if it isn't, the last block is special, as
     // it is the current block, which is affected by operations such as
     // extending the current selection from keyboard.
-    wxVectorGridBlockCoords             m_selection;
+    wxGridBlockCoordsVector             m_selection;
 
     wxGrid                              *m_grid;
     wxGrid::wxGridSelectionModes        m_selectionMode;

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -11144,7 +11144,7 @@ wxArrayInt wxGrid::GetSelectedCols() const
 
 void wxGrid::ClearSelection()
 {
-    if ( m_selection )
+    if ( IsSelection() )
         m_selection->ClearSelection();
 }
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -10948,7 +10948,7 @@ wxGridBlocks wxGrid::GetSelectedBlocks() const
     if ( !m_selection )
         return wxGridBlocks();
 
-    const wxVectorGridBlockCoords& blocks = m_selection->GetBlocks();
+    const wxGridBlockCoordsVector& blocks = m_selection->GetBlocks();
     return wxGridBlocks(blocks.begin(), blocks.end());
 }
 

--- a/src/generic/gridsel.cpp
+++ b/src/generic/gridsel.cpp
@@ -312,7 +312,7 @@ wxGridSelection::DeselectBlock(const wxGridBlockCoords& block,
     // Note: in row/column selection mode, we only need part1 and part2
 
     // Blocks to refresh.
-    wxVectorGridBlockCoords refreshBlocks;
+    wxGridBlockCoordsVector refreshBlocks;
     // Add the deselected block.
     refreshBlocks.push_back(canonicalizedBlock);
 
@@ -882,7 +882,7 @@ wxGridSelection::Select(const wxGridBlockCoords& block,
     }
 }
 
-void wxGridSelection::MergeOrAddBlock(wxVectorGridBlockCoords& blocks,
+void wxGridSelection::MergeOrAddBlock(wxGridBlockCoordsVector& blocks,
                                       const wxGridBlockCoords& newBlock)
 {
     size_t count = blocks.size();

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -659,6 +659,12 @@ TEST_CASE_METHOD(GridTestCase, "Grid::RangeSelect", "[grid]")
     if ( !EnableUITests() )
         return;
 
+#ifdef __WXGTK20__
+    // Works locally, but not when run on Travis CI.
+    if ( IsAutomaticTest() )
+        return;
+#endif
+
     EventCounter select(m_grid, wxEVT_GRID_RANGE_SELECTED);
 
     wxUIActionSimulator sim;

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -665,6 +665,19 @@ TEST_CASE_METHOD(GridTestCase, "Grid::RangeSelect", "[grid]")
 
     wxSKIP_AUTOMATIC_TEST_IF_GTK2();
 
+#ifdef __WXGTK3__
+    // works locally, but not when run on GitHub CI.
+    if ( IsAutomaticTest() )
+    {
+        wxString useASAN;
+        if ( wxGetEnv("wxUSE_ASAN", &useASAN) && useASAN == "1" )
+        {
+            WARN("Skipping test failing for unknown reason");
+            return;
+        }
+    }
+#endif // __WXGTK3__
+
     EventCounter select(m_grid, wxEVT_GRID_RANGE_SELECTED);
 
     wxUIActionSimulator sim;

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -28,6 +28,14 @@
 
 #include "waitforpaint.h"
 
+// To disable tests which work locally, but not when run on GitHub CI.
+#if defined(__WXGTK__) && !defined(__WXGTK3__)
+    #define wxSKIP_AUTOMATIC_TEST_IF_GTK2() \
+        if ( IsAutomaticTest() ) return
+#else
+    #define wxSKIP_AUTOMATIC_TEST_IF_GTK2()
+#endif
+
 namespace
 {
 
@@ -609,17 +617,13 @@ TEST_CASE_METHOD(GridTestCase, "Grid::SortClick", "[grid]")
 TEST_CASE_METHOD(GridTestCase, "Grid::Size", "[grid]")
 {
     // TODO on OSX resizing interactively works, but not automated
-    // Grid could not pass the test under GTK, OSX, and Universal.
+    // Grid could not pass the test under OSX and Universal.
     // So there may has bug in Grid implementation
 #if wxUSE_UIACTIONSIMULATOR && !defined(__WXOSX__) && !defined(__WXUNIVERSAL__)
     if ( !EnableUITests() )
         return;
 
-#ifdef __WXGTK20__
-    // Works locally, but not when run on Travis CI.
-    if ( IsAutomaticTest() )
-        return;
-#endif
+    wxSKIP_AUTOMATIC_TEST_IF_GTK2();
 
     EventCounter colsize(m_grid, wxEVT_GRID_COL_SIZE);
     EventCounter rowsize(m_grid, wxEVT_GRID_ROW_SIZE);
@@ -659,11 +663,7 @@ TEST_CASE_METHOD(GridTestCase, "Grid::RangeSelect", "[grid]")
     if ( !EnableUITests() )
         return;
 
-#ifdef __WXGTK20__
-    // Works locally, but not when run on Travis CI.
-    if ( IsAutomaticTest() )
-        return;
-#endif
+    wxSKIP_AUTOMATIC_TEST_IF_GTK2();
 
     EventCounter select(m_grid, wxEVT_GRID_RANGE_SELECTED);
 
@@ -1456,16 +1456,12 @@ TEST_CASE_METHOD(GridTestCase, "Grid::WindowAsEditorControl", "[grid]")
 
 TEST_CASE_METHOD(GridTestCase, "Grid::ResizeScrolledHeader", "[grid]")
 {
-    // TODO this test currently works only under Windows unfortunately
+    // TODO this test currently works only under Windows and GTK unfortunately
 #if wxUSE_UIACTIONSIMULATOR && (defined(__WXMSW__) || defined(__WXGTK__))
     if ( !EnableUITests() )
         return;
 
-#ifdef __WXGTK20__
-    // Works locally, but not when run on Travis CI.
-    if ( IsAutomaticTest() )
-        return;
-#endif
+    wxSKIP_AUTOMATIC_TEST_IF_GTK2();
 
     SECTION("Default") {}
     SECTION("Native header") { m_grid->UseNativeColHeader(); }
@@ -1507,16 +1503,12 @@ TEST_CASE_METHOD(GridTestCase, "Grid::ResizeScrolledHeader", "[grid]")
 
 TEST_CASE_METHOD(GridTestCase, "Grid::ColumnMinWidth", "[grid]")
 {
-    // TODO this test currently works only under Windows unfortunately
+    // TODO this test currently works only under Windows and GTK unfortunately
 #if wxUSE_UIACTIONSIMULATOR && (defined(__WXMSW__) || defined(__WXGTK__))
     if ( !EnableUITests() )
         return;
 
-#ifdef __WXGTK20__
-    // Works locally, but not when run on Travis CI.
-    if ( IsAutomaticTest() )
-        return;
-#endif
+    wxSKIP_AUTOMATIC_TEST_IF_GTK2();
 
     SECTION("Default") {}
     SECTION("Native header")

--- a/tests/controls/gridtest.cpp
+++ b/tests/controls/gridtest.cpp
@@ -674,6 +674,11 @@ TEST_CASE_METHOD(GridTestCase, "Grid::RangeSelect", "[grid]")
     sim.MouseDown();
     wxYield();
 
+    // Move the mouse a bit while staying inside the first cell of the range
+    // so that the range selection really starts off by the next move.
+    sim.MouseMove(pt.x + 5, pt.y + 5);
+    wxYield();
+
     sim.MouseMove(pt.x + 50, pt.y + 50);
     wxYield();
 


### PR DESCRIPTION
This is the first PR in an attempt to implement this feature request (#22694)

In other words, i want to add transparent selection to `wxGrid` , keeping the old mechanism
in place as alternative/user preference (or as a fallback where transparency is not supported by the target system)

**Old:**
![Screenshot_2022-09-12_14-42-56](https://user-images.githubusercontent.com/7704771/189698497-e5a24cea-d8ab-4437-9467-c8a6bf2feb07.png)

**New:**
![Screenshot_2022-09-12_14-43-19](https://user-images.githubusercontent.com/7704771/189698719-e1bffc13-4080-4de4-abdc-64139ca3da76.png)

