### PR TITLE
WebView handler improvements for advanced requests and Edge handler implementation

### DIFF
--- a/build/cmake/samples/CMakeLists.txt
+++ b/build/cmake/samples/CMakeLists.txt
@@ -153,7 +153,7 @@ wx_add_sample(uiaction DEPENDS wxUSE_UIACTIONSIMULATOR)
 wx_add_sample(validate validate.cpp validate.h DEPENDS wxUSE_VALIDATORS)
 wx_add_sample(vscroll vstest.cpp)
 wx_add_sample(webview LIBRARIES wxwebview
-    DATA ../help/doc.zip:doc.zip
+    DATA ../help/doc.zip:doc.zip handler_advanced.html
     NAME webviewsample DEPENDS wxUSE_WEBVIEW)
 if(TARGET webviewsample AND wxUSE_STC)
     wx_exe_link_libraries(webviewsample wxstc)

--- a/include/wx/msw/private/comstream.h
+++ b/include/wx/msw/private/comstream.h
@@ -21,7 +21,37 @@ public:
 
     virtual ~wxCOMBaseStreamAdapter() { }
 
-    DECLARE_IUNKNOWN_METHODS;
+    // IUnknown
+    STDMETHODIMP QueryInterface(REFIID riid, void** ppv) wxOVERRIDE
+    {
+        if (riid == IID_IUnknown ||
+            riid == IID_ISequentialStream ||
+            riid == IID_IStream)
+        {
+            *ppv = this;
+            AddRef();
+            return S_OK;
+        }
+
+        *ppv = NULL;
+        return E_NOINTERFACE;
+    }
+
+    STDMETHODIMP_(ULONG) AddRef() wxOVERRIDE
+    {
+        return ++m_cRef;
+    }
+
+    STDMETHODIMP_(ULONG) Release() wxOVERRIDE
+    {
+        if (--m_cRef == wxAutoULong(0))
+        {
+                delete this;
+                return 0;
+        }
+        else
+            return m_cRef;
+    }
 
     // IStream
     virtual HRESULT STDMETHODCALLTYPE Seek(
@@ -110,6 +140,8 @@ protected:
 
         return wxFromStart;
     }
+private:
+    wxAutoULong m_cRef;
 };
 
 class wxCOMInputStreamAdapter : public wxCOMBaseStreamAdapter
@@ -167,13 +199,5 @@ public:
     }
 
 };
-
-BEGIN_IID_TABLE(wxCOMBaseStreamAdapter)
-ADD_IID(Unknown)
-ADD_IID(SequentialStream)
-ADD_IID(Stream)
-END_IID_TABLE;
-
-IMPLEMENT_IUNKNOWN_METHODS(wxCOMBaseStreamAdapter);
 
 #endif // WX_COMSTREAM_H

--- a/include/wx/msw/private/comstream.h
+++ b/include/wx/msw/private/comstream.h
@@ -1,0 +1,179 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/msw/private/comstream.h
+// Purpose:     COM Stream adapter to wxStreamBase based streams
+// Created:     2021-01-15
+// Copyright:   (c) 2021 wxWidgets team
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef WX_COMSTREAM_H
+#define WX_COMSTREAM_H
+
+#include "wx/stream.h"
+#include "wx/msw/ole/comimpl.h"
+
+class wxCOMBaseStreamAdapter : public IStream
+{
+public:
+    wxCOMBaseStreamAdapter(wxStreamBase* stream):
+        m_stream(stream)
+    { }
+
+    virtual ~wxCOMBaseStreamAdapter() { }
+
+    DECLARE_IUNKNOWN_METHODS;
+
+    // IStream
+    virtual HRESULT STDMETHODCALLTYPE Seek(
+        LARGE_INTEGER WXUNUSED(dlibMove), DWORD WXUNUSED(dwOrigin),
+        ULARGE_INTEGER *WXUNUSED(plibNewPosition)) wxOVERRIDE
+    {
+        return E_NOTIMPL;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE SetSize(ULARGE_INTEGER WXUNUSED(libNewSize))
+    {
+        return E_NOTIMPL;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE CopyTo(IStream *WXUNUSED(pstm),
+        ULARGE_INTEGER WXUNUSED(cb), ULARGE_INTEGER *WXUNUSED(pcbRead),
+        ULARGE_INTEGER *WXUNUSED(pcbWritten)) wxOVERRIDE
+    {
+        return E_NOTIMPL;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE Commit(DWORD WXUNUSED(grfCommitFlags)) wxOVERRIDE
+    {
+        return E_NOTIMPL;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE Revert(void) wxOVERRIDE
+    {
+        return E_NOTIMPL;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE LockRegion(ULARGE_INTEGER WXUNUSED(libOffset),
+        ULARGE_INTEGER WXUNUSED(cb), DWORD WXUNUSED(dwLockType)) wxOVERRIDE
+    {
+        return E_NOTIMPL;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE UnlockRegion(ULARGE_INTEGER WXUNUSED(libOffset),
+        ULARGE_INTEGER WXUNUSED(cb), DWORD WXUNUSED(dwLockType)) wxOVERRIDE
+    {
+        return E_NOTIMPL;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE Stat(STATSTG *pstatstg, DWORD WXUNUSED(grfStatFlag)) wxOVERRIDE
+    {
+        pstatstg->type = STGTY_STREAM;
+        pstatstg->cbSize.QuadPart = m_stream->GetSize();
+
+        return S_OK;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE Clone(IStream **WXUNUSED(ppstm)) wxOVERRIDE
+    {
+        return E_NOTIMPL;
+    }
+
+    // ISequentialStream
+
+    virtual HRESULT STDMETHODCALLTYPE Read(void *WXUNUSED(pv),
+        ULONG WXUNUSED(cb), ULONG *WXUNUSED(pcbRead)) wxOVERRIDE
+    {
+        return E_NOTIMPL;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE Write(const void *WXUNUSED(pv),
+        ULONG WXUNUSED(cb), ULONG *WXUNUSED(pcbWritten)) wxOVERRIDE
+    {
+        return E_NOTIMPL;
+    }
+
+
+protected:
+    wxStreamBase* m_stream;
+
+    static wxSeekMode OriginToSeekMode(DWORD origin)
+    {
+        switch (origin)
+        {
+        case STREAM_SEEK_SET:
+            return wxFromStart;
+        case STREAM_SEEK_CUR:
+            return wxFromCurrent;
+        case STREAM_SEEK_END:
+            return wxFromEnd;
+        }
+
+        return wxFromStart;
+    }
+};
+
+class wxCOMInputStreamAdapter : public wxCOMBaseStreamAdapter
+{
+public:
+    wxCOMInputStreamAdapter(wxInputStream* stream):
+        wxCOMBaseStreamAdapter(stream)
+    {
+
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE Seek(
+        LARGE_INTEGER dlibMove, DWORD dwOrigin,
+        ULARGE_INTEGER *plibNewPosition) wxOVERRIDE
+    {
+        wxFileOffset newOffset = reinterpret_cast<wxInputStream*>(m_stream)->SeekI(dlibMove.QuadPart, OriginToSeekMode(dwOrigin));
+        if (plibNewPosition)
+            plibNewPosition->QuadPart = newOffset;
+        return S_OK;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE Read(void *pv, ULONG cb, ULONG *pcbRead) wxOVERRIDE
+    {
+        wxInputStream* inputStr = reinterpret_cast<wxInputStream*>(m_stream);
+        inputStr->Read(pv, cb);
+        *pcbRead = inputStr->LastRead();
+        return S_OK;
+    }
+
+};
+
+class wxCOMOutputStreamAdapter : public wxCOMBaseStreamAdapter
+{
+public:
+    wxCOMOutputStreamAdapter(wxOutputStream* stream) :
+        wxCOMBaseStreamAdapter(stream)
+    { }
+
+    virtual HRESULT STDMETHODCALLTYPE Seek(
+        LARGE_INTEGER dlibMove, DWORD dwOrigin,
+        ULARGE_INTEGER *plibNewPosition) wxOVERRIDE
+    {
+        wxFileOffset newOffset = reinterpret_cast<wxOutputStream*>(m_stream)->SeekO(dlibMove.QuadPart, OriginToSeekMode(dwOrigin));
+        if (plibNewPosition)
+            plibNewPosition->QuadPart = newOffset;
+        return S_OK;
+    }
+
+    virtual HRESULT STDMETHODCALLTYPE Write(const void *pv, ULONG cb, ULONG *pcbWritten) wxOVERRIDE
+    {
+        wxOutputStream* outputStr = reinterpret_cast<wxOutputStream*>(m_stream);
+        outputStr->Write(pv, cb);
+        *pcbWritten = outputStr->LastWrite();
+        return S_OK;
+    }
+
+};
+
+BEGIN_IID_TABLE(wxCOMBaseStreamAdapter)
+ADD_IID(Unknown)
+ADD_IID(SequentialStream)
+ADD_IID(Stream)
+END_IID_TABLE;
+
+IMPLEMENT_IUNKNOWN_METHODS(wxCOMBaseStreamAdapter);
+
+#endif // WX_COMSTREAM_H

--- a/include/wx/msw/private/webview_edge.h
+++ b/include/wx/msw/private/webview_edge.h
@@ -14,6 +14,7 @@
 #include "wx/dynlib.h"
 #endif
 #include "wx/msw/private/comptr.h"
+#include "wx/hashmap.h"
 
 #include <WebView2.h>
 
@@ -40,6 +41,8 @@ __CRT_UUID_DECL(ICoreWebView2SourceChangedEventHandler, 0x3c067f9f, 0x5388, 0x47
 __CRT_UUID_DECL(ICoreWebView2WebMessageReceivedEventHandler, 0x57213f19, 0x00e6, 0x49fa, 0x8e,0x07, 0x89,0x8e,0xa0,0x1e,0xcb,0xd2);
 #endif
 
+WX_DECLARE_STRING_HASH_MAP(wxSharedPtr<wxWebViewHandler>, wxStringToWebHandlerMap);
+
 class wxWebViewEdgeImpl
 {
 public:
@@ -65,6 +68,7 @@ public:
     wxVector<wxString> m_userScriptIds;
     wxString m_scriptMsgHandlerName;
     wxString m_customUserAgent;
+    wxStringToWebHandlerMap m_handlers;
 
     // WebView Events tokens
     EventRegistrationToken m_navigationStartingToken = { };
@@ -75,6 +79,7 @@ public:
     EventRegistrationToken m_DOMContentLoadedToken = { };
     EventRegistrationToken m_containsFullScreenElementChangedToken = { };
     EventRegistrationToken m_webMessageReceivedToken = { };
+    EventRegistrationToken m_webResourceRequestedToken = { };
 
     // WebView Event handlers
     HRESULT OnNavigationStarting(ICoreWebView2* sender, ICoreWebView2NavigationStartingEventArgs* args);
@@ -85,6 +90,7 @@ public:
     HRESULT OnDOMContentLoaded(ICoreWebView2* sender, ICoreWebView2DOMContentLoadedEventArgs* args);
     HRESULT OnContainsFullScreenElementChanged(ICoreWebView2* sender, IUnknown* args);
     HRESULT OnWebMessageReceived(ICoreWebView2* sender, ICoreWebView2WebMessageReceivedEventArgs* args);
+    HRESULT OnWebResourceRequested(ICoreWebView2* sender, ICoreWebView2WebResourceRequestedEventArgs* args);
     HRESULT OnAddScriptToExecuteOnDocumentedCreatedCompleted(HRESULT errorCode, LPCWSTR id);
 
     HRESULT OnEnvironmentCreated(HRESULT result, ICoreWebView2Environment* environment);

--- a/include/wx/webview.h
+++ b/include/wx/webview.h
@@ -92,6 +92,37 @@ enum wxWebViewUserScriptInjectionTime
     wxWEBVIEW_INJECT_AT_DOCUMENT_END
 };
 
+class WXDLLIMPEXP_WEBVIEW wxWebViewHandlerRequest
+{
+public:
+    virtual ~wxWebViewHandlerRequest() { }
+    virtual wxString GetRawURI() const = 0;
+    virtual wxString GetURI() const { return GetRawURI(); }
+    virtual wxInputStream* GetData() const = 0;
+    virtual wxString GetDataString(const wxMBConv& conv = wxConvUTF8) const;
+    virtual wxString GetMethod() const = 0;
+    virtual wxString GetHeader(const wxString& name) const = 0;
+};
+
+class WXDLLIMPEXP_WEBVIEW wxWebViewHandlerResponseData
+{
+public:
+    virtual ~wxWebViewHandlerResponseData() { }
+    virtual wxInputStream* GetStream() = 0;
+};
+
+class WXDLLIMPEXP_WEBVIEW wxWebViewHandlerResponse
+{
+public:
+    virtual ~wxWebViewHandlerResponse() { }
+    virtual void SetStatus(int status) = 0;
+    virtual void SetContentType(const wxString& contentType) = 0;
+    virtual void SetHeader(const wxString& name, const wxString& value) = 0;
+    virtual void Finish(wxSharedPtr<wxWebViewHandlerResponseData> data) = 0;
+    virtual void Finish(const wxString& text, const wxMBConv& conv = wxConvUTF8);
+    virtual void FinishWithError() = 0;
+};
+
 //Base class for custom scheme handlers
 class WXDLLIMPEXP_WEBVIEW wxWebViewHandler
 {
@@ -100,12 +131,17 @@ public:
         : m_scheme(scheme), m_securityURL() {}
     virtual ~wxWebViewHandler() {}
     virtual wxString GetName() const { return m_scheme; }
-    virtual wxFSFile* GetFile(const wxString &uri) = 0;
+    virtual wxFSFile* GetFile(const wxString &uri);
     virtual void SetSecurityURL(const wxString& url) { m_securityURL = url; }
     virtual wxString GetSecurityURL() const { return m_securityURL; }
+    virtual void SetVirtualHost(const wxString& host) { m_virtualHost = host; }
+    virtual wxString GetVirtualHost() const;
+    virtual void StartRequest(const wxWebViewHandlerRequest& request,
+                              wxSharedPtr<wxWebViewHandlerResponse> response);
 private:
     wxString m_scheme;
     wxString m_securityURL;
+    wxString m_virtualHost;
 };
 
 extern WXDLLIMPEXP_DATA_WEBVIEW(const char) wxWebViewNameStr[];

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -192,7 +192,8 @@ public:
     virtual wxInputStream* GetData() const = 0;
 
     /**
-        @return The body data of the request as a string.
+        @return The body data of the request as a string. The returned string
+            is empty if the supplied @c conv doesn't match the encoding.
     */
     virtual wxString GetDataString(const wxMBConv& conv = wxConvUTF8) const;
 
@@ -571,7 +572,8 @@ public:
     It is available for Windows 7 and newer.
 
     This backend does not support custom schemes. When using handlers see
-    wxWebViewHandler::SetVirtualHost() for more details on how to use handlers.
+    wxWebViewHandler::SetVirtualHost() for more details on how to access
+    handler provided URLs.
 
     This backend is not enabled by default, to build it follow these steps:
     - Visual Studio 2015 or newer, or GCC/Clang with c++11 is required

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -278,6 +278,7 @@ public:
             String value of the header
     */
     virtual void SetHeader(const wxString& name, const wxString& value) = 0;
+
     /**
         Finishes the request with binary data.
 
@@ -454,7 +455,7 @@ public:
     /**
         When using the edge backend handler urls are https urls with a
         virtual host. As default @c name.wxsite is used as the virtual hostname.
-        If you customize this host use a non existing site (ideally a reserved
+        If you customize this host, use a non existing site (ideally a reserved
         subdomain of a domain you control). If @c localassests.domain.example is
         used the handlers content will be available under
         %https://localassets.domain.example/

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -162,6 +162,155 @@ enum wxWebViewIE_EmulationLevel
 };
 
 /**
+    @class wxWebViewHandlerRequest
+
+    A class giving access to various parameters of a webview request.
+
+    @since 3.3.0
+    @library{wxwebview}
+    @category{webview}
+
+    @see wxWebViewHandler::StartRequest()
+ */
+class WXDLLIMPEXP_WEBVIEW wxWebViewHandlerRequest
+{
+public:
+    /**
+        @return The unmodified url of the request.
+    */
+    virtual wxString GetRawURI() const = 0;
+
+    /**
+        @return The url of the request. Can be modified by the backend for
+                compatibility.
+    */
+    virtual wxString GetURI() const { return GetRawURI(); }
+
+    /**
+        @return The body data of the request of @c null if nothing was posted.
+    */
+    virtual wxInputStream* GetData() const = 0;
+
+    /**
+        @return The body data of the request as a string.
+    */
+    virtual wxString GetDataString(const wxMBConv& conv = wxConvUTF8) const;
+
+    /**
+        @return The requests HTTP method (e.g. POST, GET, OPTIONS).
+    */
+    virtual wxString GetMethod() const = 0;
+
+    /**
+        Returns a header from the request or an empty string if the header
+        could not be found.
+
+        @param name Name of the header field
+    */
+    virtual wxString GetHeader(const wxString& name) const = 0;
+};
+
+/**
+    @class wxWebViewHandlerResponseData
+
+    A class holding the response data. Stream must be available until
+    this object is destroyed.
+
+    @since 3.3.0
+    @library{wxwebview}
+    @category{webview}
+
+    @see wxWebViewHandlerResponse::Finish(wxSharedPtr<wxWebViewHandlerResponseData>)
+ */
+class WXDLLIMPEXP_WEBVIEW wxWebViewHandlerResponseData
+{
+public:
+    /**
+        @return returns pointer to the stream.
+
+        @see wxWebViewHandlerResponse::Finish()
+    */
+    virtual wxInputStream* GetStream() = 0;
+};
+
+/**
+    @class wxWebViewHandlerResponse
+
+    A class giving access to various webview response parameters.
+
+    Usually a wxWebViewHandler() would set various parameters required
+    for the response like HTTP status, various headers and must then
+    call Finish() to complete the response or call FinishWithError() to
+    abort the request.
+
+    @since 3.3.0
+    @library{wxwebview}
+    @category{webview}
+
+    @see wxWebViewHandler::StartRequest()
+ */
+class WXDLLIMPEXP_WEBVIEW wxWebViewHandlerResponse
+{
+public:
+    /**
+        Sets the status code of the response.
+
+        @param status HTTP status code
+    */
+    virtual void SetStatus(int status) = 0;
+
+    /**
+        Sets the MIME type of the response.
+
+        @param contentType MIME type of the response content
+    */
+    virtual void SetContentType(const wxString& contentType) = 0;
+
+    /**
+        Sets a response header which will be sent to the web view.
+
+        The header will be added if it hasn't been set before or replaced
+        otherwise.
+
+        @param name
+            Name of the header
+        @param value
+            String value of the header
+    */
+    virtual void SetHeader(const wxString& name, const wxString& value) = 0;
+    /**
+        Finishes the request with binary data.
+
+        @param data
+            The data object will be dereferenced when the request is completed
+
+        @see Finish(const wxString&, const wxMBConv&)
+    */
+    virtual void Finish(wxSharedPtr<wxWebViewHandlerResponseData> data) = 0;
+
+    /**
+        Finishes the request with text data.
+
+        @param text
+            Text content of the response (can be empty)
+        @param conv
+            Conversion used when sending the text in the response
+
+        @see Finish(wxSharedPtr<wxWebViewHandlerResponseData>)
+    */
+    virtual void Finish(const wxString& text, const wxMBConv& conv = wxConvUTF8);
+
+    /**
+        Finishes the request as an error.
+
+        This will notify that the request could not produce any data.
+
+        @see Finish()
+    */
+    virtual void FinishWithError() = 0;
+};
+
+/**
     @class wxWebViewHistoryItem
 
     A simple class that contains the URL and title of an element of the history
@@ -259,6 +408,10 @@ public:
     The base class for handling custom schemes in wxWebView, for example to
     allow virtual file system support.
 
+    A new handler should either implement GetFile() or if a more detailed
+    request handling is required (access to headers, post data)
+    StartRequest() has to be implemented.
+
     @since 2.9.3
     @library{wxwebview}
     @category{webview}
@@ -277,7 +430,7 @@ public:
     /**
         @return A pointer to the file represented by @c uri.
     */
-    virtual wxFSFile* GetFile(const wxString &uri) = 0;
+    virtual wxFSFile* GetFile(const wxString &uri);
 
     /**
         @return The name of the scheme, as passed to the constructor.
@@ -297,6 +450,81 @@ public:
         @since 3.1.5
     */
     virtual wxString GetSecurityURL() const;
+
+    /**
+        When using the edge backend handler urls are https urls with a
+        virtual host. As default @c name.wxsite is used as the virtual hostname.
+        If you customize this host use a non existing site (ideally a reserved
+        subdomain of a domain you control). If @c localassests.domain.example is
+        used the handlers content will be available under
+        %https://localassets.domain.example/
+
+        This has to be set @b before registering the handler via
+        wxWebView::RegisterHandler().
+
+        @since 3.3.0
+    */
+    virtual void SetVirtualHost(const wxString& host);
+
+    /**
+        @return The virtual host of this handler
+
+        @see SetVirtualHost()
+        @since 3.3.0
+    */
+    virtual wxString GetVirtualHost() const;
+
+    /**
+        Implementing this method allows for more control over requests from
+        the backend then GetFile(). More details of the request are available
+        from the request object which allows access to URL, method, postdata
+        and headers.
+
+        A response can be send via the response object. The response does not
+        have to be finished from this method and it's possible to be finished
+        asynchronously via wxWebViewHandlerResponse::Finish().
+
+        The following pseudo code demonstrates a typical implementation:
+        @code
+        void StartRequest(const wxWebViewHandlerRequest& request,
+                              wxSharedPtr<wxWebViewHandlerResponse> response) wxOVERRIDE
+        {
+            // Set common headers allowing access from XMLHTTPRequests()
+            response->SetHeader("Access-Control-Allow-Origin", "*");
+            response->SetHeader("Access-Control-Allow-Headers", "*");
+
+            // Handle options request
+            if (request.GetMethod().IsSameAs("options", false))
+            {
+                response->Finish("");
+                return;
+            }
+
+            // Check the post data type
+            if (!request.GetHeader("Content-Type").StartsWith("application/json"))
+            {
+                response->FinishWithError();
+                return;
+            }
+
+            // Process input data
+            wxString postData = request.GetDataString();
+
+            ...
+
+            // Send result
+            response->SetContentType("application/json");
+            response->Finish("{ result: true }");
+        }
+        @endcode
+
+        @note This is only usesd by macOS and the Edge backend.
+
+        @see GetFile()
+        @since 3.3.0
+    */
+    virtual void StartRequest(const wxWebViewHandlerRequest& request,
+                              wxSharedPtr<wxWebViewHandlerResponse> response);
 };
 
 /**
@@ -341,7 +569,8 @@ public:
     <a href="https://docs.microsoft.com/en-us/microsoft-edge/hosting/webview2">Edge WebView2</a>.
     It is available for Windows 7 and newer.
 
-    This backend does not support custom schemes and virtual file systems.
+    This backend does not support custom schemes. When using handlers see
+    wxWebViewHandler::SetVirtualHost() for more details on how to use handlers.
 
     This backend is not enabled by default, to build it follow these steps:
     - Visual Studio 2015 or newer, or GCC/Clang with c++11 is required
@@ -440,7 +669,8 @@ public:
     wxWebView supports the registering of custom scheme handlers, for example
     @c file or @c http. To do this create a new class which inherits from
     wxWebViewHandler, where wxWebHandler::GetFile() returns a pointer to a
-    wxFSFile which represents the given url. You can then register your handler
+    wxFSFile which represents the given url or wxWebHandler::StartRequest() for
+    more complex requests. You can then register your handler
     with RegisterHandler() it will be called for all pages and resources.
 
     wxWebViewFSHandler is provided to access the virtual file system encapsulated by
@@ -708,6 +938,12 @@ public:
         @note On macOS in order to use handlers two-step creation has to be
               used and RegisterHandler() has to be called before Create().
               With the other backends it has to be called after Create().
+
+        @note The Edge backend does not support custom schemes, but the
+              handler is available as a virtual host under
+              %https://scheme.wxsite to customize this virtual host call
+              wxWebViewHandler::SetVirtualHost() before registering the
+              handler.
     */
     virtual void RegisterHandler(wxSharedPtr<wxWebViewHandler> handler) = 0;
 

--- a/samples/webview/handler_advanced.html
+++ b/samples/webview/handler_advanced.html
@@ -1,0 +1,55 @@
+<head>
+    <title>Advanced Handler Sample</title>
+
+    <style>
+        .mono {
+            font-family: monospace;
+        }
+    </style>
+
+    <script>
+        function sendRequest() {
+            let url = document.getElementById("request_url").value;
+            let request_content_type = document.getElementById("request_content_type").value;
+            let request_data = document.getElementById("request_data").value;
+            console.log("clicked");
+
+            const req = new XMLHttpRequest();
+            req.addEventListener("load", (ev) => {
+                document.getElementById("response_response").value = req.responseText;
+            });
+            req.open("POST", url);
+            req.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
+            req.send(request_data);
+        }
+    </script>
+</head>
+
+<body>
+    <p>
+        This sample demonstrates how to use <i>wxWebViewHandler::StartRequest()</i>
+        to enable advanced requests from html and javascript in the web view.
+    </p>
+
+    Request URL<br />
+    <input id="request_url" size="40" value=""><br />
+    Request content type<br />
+    <input id="request_content_type" size="40" value="application/json"><br />
+    Request Data<br />
+    <textarea class="mono" cols="60" rows="8" id="request_data">{ param1: "wxwidgets", param2: "webview" }</textarea>
+    <br />
+    <button onclick="sendRequest()">Start request</button><br />
+    Response Data<br />
+    <textarea class="mono" cols="60" rows="8" id="response_response"></textarea>
+
+    <script>
+        // init request_url
+        let postURL;
+        if (navigator.userAgent.indexOf("Edg") > 0)
+            postURL = "https://wxpost.wxsite//main/test/1";
+        else
+            postURL = "wxpost://main/test/1";
+
+        document.getElementById("request_url").value = postURL;
+    </script>
+</body>

--- a/samples/webview/webview.bkl
+++ b/samples/webview/webview.bkl
@@ -17,4 +17,10 @@
         </if>
     </exe>
 
+    <wx-data id="data">
+        <files>
+            handler_advanced.html
+        </files>
+    </wx-data>
+
 </makefile>

--- a/src/common/webview.cpp
+++ b/src/common/webview.cpp
@@ -64,7 +64,7 @@ wxString wxWebViewHandlerRequest::GetDataString(const wxMBConv& conv) const
     size_t length = data->GetLength();
     wxMemoryBuffer buffer;
     data->ReadAll(buffer.GetWriteBuf(length), length);
-    wxString dataStr((const char*) buffer.GetData(), conv, length);
+    wxString dataStr(static_cast<const char*>(buffer.GetData()), conv, length);
     return dataStr;
 }
 

--- a/src/common/webview.cpp
+++ b/src/common/webview.cpp
@@ -13,6 +13,8 @@
 
 
 #include "wx/webview.h"
+#include "wx/filesys.h"
+#include "wx/mstream.h"
 
 #if defined(__WXOSX__)
 #include "wx/osx/webview_webkit.h"
@@ -51,6 +53,92 @@ wxDEFINE_EVENT( wxEVT_WEBVIEW_TITLE_CHANGED, wxWebViewEvent );
 wxDEFINE_EVENT( wxEVT_WEBVIEW_FULLSCREEN_CHANGED, wxWebViewEvent);
 wxDEFINE_EVENT( wxEVT_WEBVIEW_SCRIPT_MESSAGE_RECEIVED, wxWebViewEvent);
 wxDEFINE_EVENT( wxEVT_WEBVIEW_SCRIPT_RESULT, wxWebViewEvent);
+
+// wxWebViewHandlerRequest
+wxString wxWebViewHandlerRequest::GetDataString(const wxMBConv& conv) const
+{
+    wxInputStream* data = GetData();
+    if (!data)
+        return wxString();
+
+    size_t length = data->GetLength();
+    wxMemoryBuffer buffer;
+    data->ReadAll(buffer.GetWriteBuf(length), length);
+    wxString dataStr((const char*) buffer.GetData(), conv, length);
+    return dataStr;
+}
+
+// wxWebViewHandlerResponseDataStream
+class wxWebViewHandlerResponseDataString : public wxWebViewHandlerResponseData
+{
+public:
+    wxWebViewHandlerResponseDataString(const wxCharBuffer& data): m_data(data)
+    {
+        m_stream = new wxMemoryInputStream(m_data, m_data.length());
+    }
+
+    ~wxWebViewHandlerResponseDataString() { delete m_stream; }
+
+    virtual wxInputStream* GetStream() wxOVERRIDE
+    {
+        return m_stream;
+    }
+
+    wxCharBuffer m_data;
+    wxInputStream* m_stream;
+};
+
+// wxWebViewHandlerResponse
+void wxWebViewHandlerResponse::Finish(const wxString& text,
+    const wxMBConv& conv)
+{
+    Finish(wxSharedPtr<wxWebViewHandlerResponseData>(
+        new wxWebViewHandlerResponseDataString(text.mb_str(conv))));
+}
+
+// wxWebViewHandlerResponseDataFile
+class wxWebViewHandlerResponseDataFile : public wxWebViewHandlerResponseData
+{
+public:
+    wxWebViewHandlerResponseDataFile(wxFSFile* file): m_file(file) { }
+
+    ~wxWebViewHandlerResponseDataFile() { delete m_file; }
+
+    virtual wxInputStream* GetStream() wxOVERRIDE
+    { return m_file->GetStream(); }
+
+    wxFSFile* m_file;
+};
+
+// wxWebViewHandler
+wxString wxWebViewHandler::GetVirtualHost() const
+{
+    if (m_virtualHost.empty())
+        return GetName() + ".wxsite";
+    else
+        return m_virtualHost;
+}
+
+wxFSFile* wxWebViewHandler::GetFile(const wxString& WXUNUSED(uri))
+{
+    return NULL;
+}
+
+void wxWebViewHandler::StartRequest(const wxWebViewHandlerRequest& request,
+                                    wxSharedPtr<wxWebViewHandlerResponse> response)
+{
+    wxFSFile* file = GetFile(request.GetURI());
+    if (file)
+    {
+        response->SetContentType(file->GetMimeType());
+        response->Finish(wxSharedPtr<wxWebViewHandlerResponseData>(
+            new wxWebViewHandlerResponseDataFile(file)));
+    }
+    else
+        response->FinishWithError();
+}
+
+// wxWebView
 
 wxStringWebViewFactoryMap wxWebView::m_factoryMap;
 

--- a/src/osx/webview_webkit.mm
+++ b/src/osx/webview_webkit.mm
@@ -30,6 +30,7 @@
 #include "wx/hashmap.h"
 #include "wx/filesys.h"
 #include "wx/msgdlg.h"
+#include "wx/mstream.h"
 #include "wx/textdlg.h"
 #include "wx/filedlg.h"
 
@@ -847,6 +848,107 @@ wxString nsErrorToWxHtmlError(NSError* error, wxWebViewNavigationError* out)
 @end
 
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_13
+
+class wxWebViewWebKitHandlerRequest: public wxWebViewHandlerRequest
+{
+public:
+    wxWebViewWebKitHandlerRequest(NSURLRequest* request):
+        m_data(NULL),
+        m_request(request)
+    { }
+
+    ~wxWebViewWebKitHandlerRequest()
+    { wxDELETE(m_data); }
+
+    virtual wxString GetRawURI() const wxOVERRIDE
+    { return wxCFStringRef::AsString(m_request.URL.absoluteString); }
+
+    virtual wxInputStream* GetData() const wxOVERRIDE
+    {
+        if (!m_data && m_request.HTTPBody)
+            m_data = new wxMemoryInputStream(m_request.HTTPBody.bytes, m_request.HTTPBody.length);
+
+        return m_data;
+    }
+
+    virtual wxString GetMethod() const wxOVERRIDE
+    { return wxCFStringRef::AsString(m_request.HTTPMethod); }
+
+    virtual wxString GetHeader(const wxString& name) const wxOVERRIDE
+    {
+        return wxCFStringRef::AsString(
+            [m_request valueForHTTPHeaderField:wxCFStringRef(name).AsNSString()]);
+    }
+
+    mutable wxInputStream* m_data;
+    NSURLRequest* m_request;
+};
+
+class API_AVAILABLE(macos(10.13)) wxWebViewWebkitHandlerResponse: public wxWebViewHandlerResponse
+{
+public:
+    wxWebViewWebkitHandlerResponse(id<WKURLSchemeTask> task):
+        m_status(200),
+        m_task([task retain])
+    {
+        m_headers = [[NSMutableDictionary alloc] init];
+    }
+
+    ~wxWebViewWebkitHandlerResponse()
+    {
+        [m_headers release];
+        [m_task release];
+    }
+
+    virtual void SetStatus(int status) wxOVERRIDE
+    { m_status = status; }
+
+    virtual void SetContentType(const wxString& contentType) wxOVERRIDE
+    { SetHeader("Content-Type", contentType); }
+
+    virtual void SetHeader(const wxString& name, const wxString& value) wxOVERRIDE
+    {
+        [m_headers setValue:wxCFStringRef(value).AsNSString()
+                     forKey:wxCFStringRef(name).AsNSString()];
+    }
+
+    virtual void Finish(wxSharedPtr<wxWebViewHandlerResponseData> data) wxOVERRIDE
+    {
+        m_data = data;
+        wxInputStream* stream = data->GetStream();
+        size_t length = stream->GetLength();
+        NSHTTPURLResponse* response = [[NSHTTPURLResponse alloc] initWithURL:m_task.request.URL
+                                                                  statusCode:m_status
+                                                                 HTTPVersion:nil
+                                                                headerFields:m_headers];
+        [m_task didReceiveResponse:response];
+        [response release];
+
+        //Load the data, we malloc it so it is tidied up properly
+        void* buffer = malloc(length);
+        stream->Read(buffer, length);
+        NSData *taskData = [[NSData alloc] initWithBytesNoCopy:buffer length:length];
+        [m_task didReceiveData:taskData];
+        [taskData release];
+
+        [m_task didFinish];
+    }
+
+    virtual void FinishWithError() wxOVERRIDE
+    {
+        NSError *error = [[NSError alloc] initWithDomain:NSURLErrorDomain
+                            code:NSURLErrorFileDoesNotExist
+                            userInfo:nil];
+        [m_task didFailWithError:error];
+        [error release];
+    }
+
+    int m_status;
+    NSMutableDictionary* m_headers;
+    id<WKURLSchemeTask> m_task;
+    wxSharedPtr<wxWebViewHandlerResponseData> m_data;
+};
+
 @implementation WebViewCustomProtocol
 
 - (id)initWithHandler:(wxWebViewHandler *)handler
@@ -858,49 +960,9 @@ wxString nsErrorToWxHtmlError(NSError* error, wxWebViewNavigationError* out)
 - (void)webView:(WKWebView *)webView startURLSchemeTask:(id<WKURLSchemeTask>)urlSchemeTask
 WX_API_AVAILABLE_MACOS(10, 13)
 {
-    NSURLRequest *request = urlSchemeTask.request;
-    NSString* path = [[request URL] absoluteString];
-
-    wxString wxpath = wxCFStringRef::AsString(path);
-
-    wxFSFile* file = m_handler->GetFile(wxpath);
-
-    if (!file)
-    {
-        NSError *error = [[NSError alloc] initWithDomain:NSURLErrorDomain
-                            code:NSURLErrorFileDoesNotExist
-                            userInfo:nil];
-
-        [urlSchemeTask didFailWithError:error];
-
-        [error release];
-
-        return;
-    }
-
-    size_t length = file->GetStream()->GetLength();
-
-
-    NSURLResponse *response =  [[NSURLResponse alloc] initWithURL:[request URL]
-                               MIMEType:wxCFStringRef(file->GetMimeType()).AsNSString()
-                               expectedContentLength:length
-                               textEncodingName:nil];
-
-    //Load the data, we malloc it so it is tidied up properly
-    void* buffer = malloc(length);
-    file->GetStream()->Read(buffer, length);
-    NSData *data = [[NSData alloc] initWithBytesNoCopy:buffer length:length];
-
-    //Set the data
-    [urlSchemeTask didReceiveResponse:response];
-    [urlSchemeTask didReceiveData:data];
-
-    //Notify that we have finished
-    [urlSchemeTask didFinish];
-
-    [data release];
-
-    [response release];
+    wxWebViewWebKitHandlerRequest request(urlSchemeTask.request);
+    wxSharedPtr<wxWebViewHandlerResponse> response(new wxWebViewWebkitHandlerResponse(urlSchemeTask));
+    m_handler->StartRequest(request, response);
 }
 
 - (void)webView:(WKWebView *)webView stopURLSchemeTask:(id<WKURLSchemeTask>)urlSchemeTask


### PR DESCRIPTION
The current `wxWebViewHandler` does only allow simple synchronous GET requests which is fine for many applications. To allow local REST like requests asynchronous POST requests, should be able to be processed.

I've added a new method `wxWebViewHandler::StartRequest()` which allows for more advanced request processing while maintaining backward compatibility through a default implementation that calls `wxWebViewHandler::GetFile()`.

A response can be send via the response object. The response does not have to be finished from this method and it's possible to be finished asynchronously via `wxWebViewHandlerResponse::Finish()`.

The following pseudo code demonstrates a typical implementation:
```C++
void MyAdvancedWebViewHandler::StartRequest(const wxWebViewHandlerRequest& request,
                      wxSharedPtr<wxWebViewHandlerResponse> response) wxOVERRIDE
{
    // Set common headers allowing acces from XMLHTTPRequests()
    response->SetHeader("Access-Control-Allow-Origin", "*");
    response->SetHeader("Access-Control-Allow-Headers", "*");

    // Handle options request
    if (request.GetMethod().IsSameAs("options", false))
    {
        response->Finish("");
        return;
    }

    // Check the post data type
    if (!request.GetHeader("Content-Type").StartsWith("application/json"))
    {
        response->FinishWithError();
        return;
    }

    // Process input data
    wxString postData = request.GetDataString();

    ...

    // Send result
    response->SetContentType("application/json");
    response->Finish("{ result: true }");
}
```

This is currently implemented for **WKWebView** and **Edge** backends. It should be possible for **webkit2** but I will probably not implement this in the first go.

The Edge backend currently does not support custom schemes. The handler implementation relies on "virtual hosts" which make handlers available at something like https://wxfs.wxsite . `LoadURL()` has handling to redirect a call to wxfs:///some.zip#protocol=zip/index.html to https://wxfs.wxsite///some.zip#protocol=zip/index.html . This allows for easy cross platform code in many cases, but obviously doesn't handle cases where the content requests custom schemes. 

In future versions custom schemes will be available via WebView2 but this is an acceptable compromise for now and can be interesting for some cases in the future, where virtual http(s) hosting of local assets might be wished.
The virtual host name defaults to the handlers name + ".wxsite" but can be customized via `wxWebViewHandler::SetVirtualHost()`.

As always any **feedback** is welcome on interface or implementation details. 
The edge backend support can be tested via the _webviewsample_.

ToDo:
- [x] Add macOS implementation
- [x] Add Edge implementation
- [x] Complete documentation
- [x] Integrate advanced webviewhandler into sample
