### PR TITLE
Fix more double negatives used with 'neither' in mainly non-API docs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ task:
 
   # We need to pass flags so that libraries under /usr/local are found, because
   # configure doesn't look for them there by default (it ought to always use
-  # pkg-config instead, but it currently doesn't do this neither).
+  # pkg-config instead, but it currently doesn't do this either).
   configure_script: |
     ./configure --disable-optimise --disable-debug_info CXXFLAGS=-Werror CPPFLAGS=-I/usr/local/include LDFLAGS=-L/usr/local/lib
 

--- a/configure.in
+++ b/configure.in
@@ -4883,7 +4883,7 @@ if test "$TOOLKIT" != "MSW"; then
 
           *-*-irix* )
                 dnl gcc under IRIX doesn't seem to like -pthread, but it
-                dnl doesn't give an error for it neither, just a warning
+                dnl doesn't give an error for it either, just a warning
                 dnl message -- but this is still very annoying
                 if test "x$GCC" = "xyes"; then
                     THREAD_OPTS=""

--- a/docs/changes_30.txt
+++ b/docs/changes_30.txt
@@ -528,7 +528,7 @@ Build system changes
   it's not the default "x86". E.g. a library built with MSVC 10 for amd64 is
   called "wxbase294ud_vc110_amd64.dll" now.
 
-- MSVC projects don't include neither wxUniversal nor ANSI (non-Unicode)
+- MSVC projects don't include the wxUniversal or ANSI (non-Unicode)
   configurations any more. The simplest way to build wxWidgets in these
   configurations if you need them is to use nmake from the command line with
   WXUNIV=1 or UNICODE=0 command line parameter respectively.

--- a/docs/contributing/how-to-add-new-font-encoding.md
+++ b/docs/contributing/how-to-add-new-font-encoding.md
@@ -45,7 +45,7 @@ have to do:
    "iconv -l" on your favourite Unix system. For the list of charsets
    supported under Win32, look under HKEY_CLASSES_ROOT\MIME\Database\Charset
    in regedit. Of course, being consistent with the existing encoding names
-   wouldn't hurt neither.
+   wouldn't hurt either.
 
 3. Normally you don't have to do anything else if you've got support for this
    encoding under both Win32 and Unix. If you haven't, you should modify

--- a/docs/contributing/how-to-write-unit-tests.md
+++ b/docs/contributing/how-to-write-unit-tests.md
@@ -74,7 +74,7 @@ Tests physical structure
 All (i.e. both GUI and non-GUI) unit tests are under `tests` subdirectory. When
 adding a new test, try to find an existing file to add it to. If there are no
 applicable files, try to add a new file to an existing directory. If there is
-no applicable directory neither, create a new one and put the new file there
+no applicable directory either, create a new one and put the new file there
 (i.e. do _not_ put new files directly under `tests`). If your test is small,
 consider adding it to `tests/misc/misctests.cpp`.
 

--- a/docs/doxygen/overviews/unicode.h
+++ b/docs/doxygen/overviews/unicode.h
@@ -234,10 +234,10 @@ The problems can be separated into three broad classes:
 Because of the need to support implicit conversions to both @c char and
 @c wchar_t, wxString implementation is rather involved and many of its operators
 don't return the types which they could be naively expected to return.
-For example, the @c operator[] doesn't return neither a @c char nor a @c wchar_t
-but an object of a helper class wxUniChar or wxUniCharRef which is implicitly
-convertible to either. Usually you don't need to worry about this as the
-conversions do their work behind the scenes however in some cases it doesn't
+For example, the @c operator[] doesn't return either a @c char or a @c wchar_t
+and instead returns an object of a helper class wxUniChar or wxUniCharRef that is
+implicitly convertible to either. Usually you don't need to worry about this as
+the conversions do their work behind the scenes however in some cases it doesn't
 work. Here are some examples, using a wxString object @c s and some integer @c
 n:
 

--- a/docs/gtk/install.md
+++ b/docs/gtk/install.md
@@ -150,7 +150,7 @@ used to override this.
    typically will, still be used if found.
 
  * `--without-libpng` \n
-   Disables PNG image format code. Don't use neither the system nor the builtin
+   Disables PNG image format code. Use neither the system nor the builtin
    libpng (although GTK itself still uses it).
 
  * `--without-libjpeg` \n


### PR DESCRIPTION
In many cases it should be 'either'.

No changes to actual code.

Complements #22723, which focused on API docs and comments in C++ code.