### PR TITLE
CMake: Restore wx-config variables

### DIFF
--- a/build/cmake/config.cmake
+++ b/build/cmake/config.cmake
@@ -12,6 +12,10 @@ file(MAKE_DIRECTORY ${wxCONFIG_DIR})
 set(TOOLCHAIN_FULLNAME ${wxBUILD_FILE_ID})
 
 macro(wx_configure_script input output)
+    # variables used in wx-config-inplace.in
+    set(abs_top_srcdir ${CMAKE_CURRENT_SOURCE_DIR})
+    set(abs_top_builddir ${CMAKE_CURRENT_BINARY_DIR})
+
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/${input}
         ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${output}


### PR DESCRIPTION
This was erroneously removed in ad75a77bc6 (CMake: Cleanup the wx_configure_script macro, 2021-10-27).

Fixes #22806

This should also be backported to 3.2.