### PR TITLE
Update subsurface position when a GL canvas is sized.

### DIFF
--- a/include/wx/unix/glegl.h
+++ b/include/wx/unix/glegl.h
@@ -122,6 +122,7 @@ public:
     wl_subcompositor *m_wlSubcompositor;
     wl_callback *m_wlFrameCallbackHandler;
     wl_egl_window *m_wlEGLWindow;
+    wl_subsurface *m_wlSubsurface;
 
 private:
 
@@ -132,7 +133,6 @@ private:
     unsigned long m_xwindow;
     wl_surface *m_wlSurface;
     wl_region *m_wlRegion;
-    wl_subsurface *m_wlSubsurface;
 
     // the global/default versions of the above
     static EGLConfig *ms_glEGLConfig;

--- a/src/unix/glegl.cpp
+++ b/src/unix/glegl.cpp
@@ -445,6 +445,9 @@ static void gtk_glcanvas_size_callback(GtkWidget *widget,
     int scale = gtk_widget_get_scale_factor(widget);
     wl_egl_window_resize(win->m_wlEGLWindow, win->m_width * scale,
                          win->m_height * scale, 0, 0);
+    int x, y;
+    gdk_window_get_origin(win->GTKGetDrawingWindow(), &x, &y);
+    wl_subsurface_set_position(win->m_wlSubsurface, x, y);
 }
 
 } // extern "C"


### PR DESCRIPTION
I'm using a `wxGLCanvas` which ends up being laid out towards the right-hand-side of the screen and I find that without this change the GL canvas is rendered much too far left on systems that use Wayland.  I could be missing the point entirely but I thought I'd submit it, as it works for me!