### PR TITLE
Fix for missing X11 libraries when linking wxGTK2 statically

### DIFF
--- a/build/cmake/toolkit.cmake
+++ b/build/cmake/toolkit.cmake
@@ -116,9 +116,10 @@ if(WXGTK)
 endif()
 
 # We need X11 for non-GTK Unix ports (X11, Motif) and for GTK with X11
-# support, but not for Wayland-only GTK (which is why we have to do this after
-# find_package(GTKx) above, as this is what sets wxHAVE_GDK_X11).
-if(UNIX AND NOT APPLE AND NOT WIN32 AND (WXX11 OR WXMOTIF OR (WXGTK AND wxHAVE_GDK_X11)))
+# support, but not for Wayland-only GTK (necessarily 3 or later), which is why
+# we have to do this after find_package(GTKx) above, as this is what sets
+# wxHAVE_GDK_X11.
+if(UNIX AND NOT APPLE AND NOT WIN32 AND (WXX11 OR WXMOTIF OR WXGTK2 OR (WXGTK AND wxHAVE_GDK_X11)))
     find_package(X11 REQUIRED)
     list(APPEND wxTOOLKIT_INCLUDE_DIRS ${X11_INCLUDE_DIR})
     list(APPEND wxTOOLKIT_LIBRARIES ${X11_LIBRARIES})


### PR DESCRIPTION
We must always use them with wxGTK2, so don't check wxHAVE_GDK_X11 for
it, otherwise we're never going to include X11 libraries when using it,
but they are always required.
