### PR TITLE
Use output directory under wx directory in the build tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include(build/cmake/policies.cmake NO_POLICY_SCOPE)
 
 # Initialize variables for quick access to wx root dir in sub dirs
 set(wxSOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-set(wxBINARY_DIR ${CMAKE_BINARY_DIR})
+set(wxBINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 set(wxOUTPUT_DIR ${wxBINARY_DIR}/lib)
 
 # parse the version number from wx/version.h and include in wxMAJOR_VERSION and wxMINOR_VERSION

--- a/build/cmake/config.cmake
+++ b/build/cmake/config.cmake
@@ -13,15 +13,15 @@ set(TOOLCHAIN_FULLNAME ${wxBUILD_FILE_ID})
 
 macro(wx_configure_script input output)
     # variables used in wx-config-inplace.in
-    set(abs_top_srcdir ${CMAKE_CURRENT_SOURCE_DIR})
-    set(abs_top_builddir ${CMAKE_CURRENT_BINARY_DIR})
+    set(abs_top_srcdir ${wxSOURCE_DIR})
+    set(abs_top_builddir ${wxBINARY_DIR})
 
     configure_file(
-        ${CMAKE_CURRENT_SOURCE_DIR}/${input}
-        ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${output}
+        ${wxSOURCE_DIR}/${input}
+        ${wxBINARY_DIR}${CMAKE_FILES_DIRECTORY}/${output}
         ESCAPE_QUOTES @ONLY NEWLINE_STYLE UNIX)
     file(COPY
-        ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${output}
+        ${wxBINARY_DIR}${CMAKE_FILES_DIRECTORY}/${output}
         DESTINATION ${wxCONFIG_DIR}
         FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ
             GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
@@ -80,8 +80,8 @@ function(wx_write_config_inplace)
     execute_process(
         COMMAND
         "${CMAKE_COMMAND}" -E ${COPY_CMD}
-        "${CMAKE_CURRENT_BINARY_DIR}/lib/wx/config/inplace-${TOOLCHAIN_FULLNAME}"
-        "${CMAKE_CURRENT_BINARY_DIR}/wx-config"
+        "${wxBINARY_DIR}/lib/wx/config/inplace-${TOOLCHAIN_FULLNAME}"
+        "${wxBINARY_DIR}/wx-config"
         )
 endfunction()
 

--- a/build/cmake/lib/webview/CMakeLists.txt
+++ b/build/cmake/lib/webview/CMakeLists.txt
@@ -50,7 +50,7 @@ elseif(WXMSW)
         set(WEBVIEW2_URL "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/${WEBVIEW2_VERSION}")
         set(WEBVIEW2_SHA256 "6a34bb553e18cfac7297b4031f3eac2558e439f8d16a45945c22945ac404105d")
 
-        set(WEBVIEW2_DEFAULT_PACKAGE_DIR "${CMAKE_BINARY_DIR}/packages/Microsoft.Web.WebView2.${WEBVIEW2_VERSION}")
+        set(WEBVIEW2_DEFAULT_PACKAGE_DIR "${CMAKE_CURRENT_BINARY_DIR}/packages/Microsoft.Web.WebView2.${WEBVIEW2_VERSION}")
 
         if(NOT EXISTS ${WEBVIEW2_PACKAGE_DIR})
             unset(WEBVIEW2_PACKAGE_DIR CACHE)
@@ -67,11 +67,11 @@ elseif(WXMSW)
             set(WEBVIEW2_PACKAGE_DIR ${WEBVIEW2_DEFAULT_PACKAGE_DIR} CACHE PATH "WebView2 SDK PATH" FORCE)
             file(DOWNLOAD
                 ${WEBVIEW2_URL}
-                ${CMAKE_BINARY_DIR}/webview2.nuget
+                ${CMAKE_CURRENT_BINARY_DIR}/webview2.nuget
                 EXPECTED_HASH SHA256=${WEBVIEW2_SHA256})
             file(MAKE_DIRECTORY ${WEBVIEW2_PACKAGE_DIR})
             execute_process(COMMAND
-                "${CMAKE_COMMAND}" -E tar x "${CMAKE_BINARY_DIR}/webview2.nuget"
+                "${CMAKE_COMMAND}" -E tar x "${CMAKE_CURRENT_BINARY_DIR}/webview2.nuget"
                 WORKING_DIRECTORY "${WEBVIEW2_PACKAGE_DIR}"
             )
         endif()


### PR DESCRIPTION
CMAKE_CURRENT_BINARY_DIR is the same as CMAKE_BINARY_DIR when building wx directly, but they can be different when including this makefile from a super-project using add_subdirectory() and it makes more sense to use the former.

This also fixes wx-config symlink created in such build, as it the link was broken before because it was created under CMAKE_CURRENT_BINARY_DIR but pointed to a file in a different CMAKE_BINARY_DIR.

---

This is another CMake fix that I'm relatively confident in, for the reasons described above, but a confirmation from @TcT2k and/or @MaartenBent would still be welcome. TIA!