### PR TITLE
Fix compilation of wxGTK 3 with 3.22.z and z < 25

### DIFF
--- a/src/gtk/toplevel.cpp
+++ b/src/gtk/toplevel.cpp
@@ -83,9 +83,16 @@ static bool HasClientDecor(GtkWidget* widget)
     if (wxGTKImpl::IsX11(display))
         return false;
 
-#if defined(GDK_WINDOWING_WAYLAND) && GTK_CHECK_VERSION(3,22,0)
-    if (wxGTKImpl::IsWayland(display) && wx_is_at_least_gtk3(22))
-        return !gdk_wayland_display_prefers_ssd(display);
+    // Contrary to the annotation in the header, this function has become
+    // available only in 3.22.25 and not 3.22.0.
+#if defined(GDK_WINDOWING_WAYLAND) && GTK_CHECK_VERSION(3,22,25)
+    if (wxGTKImpl::IsWayland(display))
+    {
+#ifndef __WXGTK4__
+        if (gtk_check_version(3, 22, 25) == NULL)
+#endif
+            return !gdk_wayland_display_prefers_ssd(display);
+    }
 #endif
     return true;
 }


### PR DESCRIPTION
The function gdk_wayland_display_prefers_ssd() is only effectively
available since 3.22.25, see f2adaba237 (Wayland: Implement KDE's SSD
protocol, 2017-04-28) in GTK repository, so attempting to use it with
earlier GTK 3.22 versions results in a compilation failure.
