### PR TITLE
Don't disable deprecation warnings in wxGTK build

### DIFF
--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -129,8 +129,8 @@ function(wx_set_common_target_properties target_name)
             -Woverloaded-virtual
         )
 
-        if(WXOSX_COCOA OR WXGTK3)
-            # when building using GTK+ 3 or Cocoa we currently get tons of deprecation
+        if(WXOSX_COCOA)
+            # when building using Cocoa we currently get tons of deprecation
             # warnings from the standard headers -- disable them as we already know
             # that they're deprecated but we still have to use them to support older
             # toolkit versions and leaving this warning enabled prevents seeing any

--- a/configure
+++ b/configure
@@ -42928,7 +42928,7 @@ esac
         CXXWARNINGS="$CXXWARNINGS -Wno-deprecated-declarations -Wno-narrowing -Wno-write-strings"
     fi
 
-                        if test "$WXGTK4" != 1 -a \( "$WXGTK3" = 1 -o "$wxUSE_MAC" = 1 \) ; then
+                        if test "$wxUSE_MAC" = 1 ; then
         CXXWARNINGS="$CXXWARNINGS -Wno-deprecated-declarations"
 
                         OBJCXXFLAGS="$OBJCXXFLAGS -Wno-deprecated-declarations"

--- a/configure.in
+++ b/configure.in
@@ -8183,12 +8183,12 @@ elif test "$GXX" = yes ; then
         CXXWARNINGS="$CXXWARNINGS -Wno-deprecated-declarations -Wno-narrowing -Wno-write-strings"
     fi
 
-    dnl when building using GTK+ 3 or Cocoa we currently get tons of deprecation
+    dnl when building using Cocoa we currently get tons of deprecation
     dnl warnings from the standard headers -- disable them as we already know
     dnl that they're deprecated but we still have to use them to support older
     dnl toolkit versions and leaving this warning enabled prevents seeing any
     dnl other ones
-    if test "$WXGTK4" != 1 -a \( "$WXGTK3" = 1 -o "$wxUSE_MAC" = 1 \) ; then
+    if test "$wxUSE_MAC" = 1 ; then
         CXXWARNINGS="$CXXWARNINGS -Wno-deprecated-declarations"
 
         dnl CXXWARNINGS is not used for Objective-C++ code compilation, but we

--- a/include/wx/gtk/private/cairo.h
+++ b/include/wx/gtk/private/cairo.h
@@ -11,6 +11,18 @@
 #define _WX_GTK_PRIVATE_CAIRO_H_
 
 // ----------------------------------------------------------------------------
+// Redefine GDK function to avoiding deprecation warnings
+// ----------------------------------------------------------------------------
+
+wxGCC_WARNING_SUPPRESS(deprecated-declarations)
+
+static inline
+cairo_t* wx_gdk_cairo_create(GdkWindow* w) { return gdk_cairo_create(w); }
+#define gdk_cairo_create wx_gdk_cairo_create
+
+wxGCC_WARNING_RESTORE(deprecated-declarations)
+
+// ----------------------------------------------------------------------------
 // RAII helper creating a Cairo context in ctor and destroying it in dtor
 // ----------------------------------------------------------------------------
 

--- a/include/wx/gtk/private/cairo.h
+++ b/include/wx/gtk/private/cairo.h
@@ -1,0 +1,43 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/gtk/private/cairo.h
+// Purpose:     Cairo-related helpers
+// Author:      Vadim Zeitlin
+// Created:     2022-09-23
+// Copyright:   (c) 2022 Vadim Zeitlin <vadim@wxwidgets.org>
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_GTK_PRIVATE_CAIRO_H_
+#define _WX_GTK_PRIVATE_CAIRO_H_
+
+// ----------------------------------------------------------------------------
+// RAII helper creating a Cairo context in ctor and destroying it in dtor
+// ----------------------------------------------------------------------------
+
+namespace wxGTKImpl
+{
+
+class CairoContext
+{
+public:
+    explicit CairoContext(GdkWindow* window)
+        : m_cr(gdk_cairo_create(window))
+    {
+    }
+
+    ~CairoContext()
+    {
+        cairo_destroy(m_cr);
+    }
+
+    operator cairo_t*() const { return m_cr; }
+
+private:
+    cairo_t* const m_cr;
+
+    wxDECLARE_NO_COPY_CLASS(CairoContext);
+};
+
+} // namespace wxGTKImpl
+
+#endif // _WX_GTK_PRIVATE_CAIRO_H_

--- a/include/wx/gtk/private/gtk2-compat.h
+++ b/include/wx/gtk/private/gtk2-compat.h
@@ -554,6 +554,9 @@ static inline void wx_gtk_widget_get_preferred_size(GtkWidget* widget, GtkRequis
 }
 #define gtk_widget_get_preferred_size wx_gtk_widget_get_preferred_size
 
+#define wx_gdk_device_get_window_at_position(unused, win_x, win_y) \
+    gdk_window_at_pointer(win_x, win_y)
+
 #include <gdk/gdkkeysyms.h>
 
 #if defined(GDK_Alt_L) && !defined(GDK_KEY_Alt_L)
@@ -672,6 +675,9 @@ inline bool wx_is_at_least_gtk2(int minor)
 }
 
 #else // __WXGTK3__
+
+#define wx_gdk_device_get_window_at_position(device, win_x, win_y) \
+    gdk_device_get_window_at_position(device, win_x, win_y)
 
 // With GTK+ 3 we don't need to check for GTK+ 2 version and
 // gtk_check_version() would fail due to major version mismatch.

--- a/include/wx/gtk/private/gtk3-compat.h
+++ b/include/wx/gtk/private/gtk3-compat.h
@@ -10,9 +10,17 @@
 #ifndef _WX_GTK_PRIVATE_COMPAT3_H_
 #define _WX_GTK_PRIVATE_COMPAT3_H_
 
-wxGCC_WARNING_SUPPRESS(deprecated-declarations)
+#ifdef __WXGTK4__
 
-#ifndef __WXGTK4__
+inline GdkDevice* wx_get_gdk_device_from_display(GdkDisplay* display)
+{
+    GdkSeat* seat = gdk_display_get_default_seat(display);
+    return gdk_seat_get_pointer(seat);
+}
+
+#else // !__WXGTK4__
+
+wxGCC_WARNING_SUPPRESS(deprecated-declarations)
 
 // ----------------------------------------------------------------------------
 // the following were introduced in GTK+ 3.20
@@ -40,10 +48,17 @@ static inline void wx_gtk_widget_set_margin_end(GtkWidget* widget, gint margin)
 }
 #define gtk_widget_set_margin_end wx_gtk_widget_set_margin_end
 
+inline GdkDevice* wx_get_gdk_device_from_display(GdkDisplay* display)
+{
+    GdkDeviceManager* manager = gdk_display_get_device_manager(display);
+    return gdk_device_manager_get_client_pointer(manager);
+}
+
 #endif // __WXGTK3__
-#endif // !__WXGTK4__
 
 wxGCC_WARNING_RESTORE()
+
+#endif // __WXGTK4__/!__WXGTK4__
 
 #if defined(__WXGTK4__) || !defined(__WXGTK3__)
 static inline bool wx_is_at_least_gtk3(int /* minor */)

--- a/include/wx/gtk/private/mediactrl.h
+++ b/include/wx/gtk/private/mediactrl.h
@@ -28,7 +28,8 @@
 extern "C" {
 inline gpointer wxGtkGetIdFromWidget(GtkWidget* widget)
 {
-    gdk_flush();
+    GdkDisplay* display = gtk_widget_get_display(widget);
+    gdk_display_flush(display);
 
     GdkWindow* window = gtk_widget_get_window(widget);
     wxASSERT(window);

--- a/include/wx/gtk/private/threads.h
+++ b/include/wx/gtk/private/threads.h
@@ -1,0 +1,26 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/gtk/private/threads.h
+// Purpose:     Wrappers for GDK threads support.
+// Author:      Vadim Zeitlin
+// Created:     2022-09-23
+// Copyright:   (c) 2022 Vadim Zeitlin <vadim@wxwidgets.org>
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_GTK_PRIVATE_THREADS_H_
+#define _WX_GTK_PRIVATE_THREADS_H_
+
+// ----------------------------------------------------------------------------
+// RAII wrapper for acquiring/leaving GDK lock in ctor/dtor
+// ----------------------------------------------------------------------------
+
+class wxGDKThreadsLock
+{
+public:
+    wxGDKThreadsLock() { gdk_threads_enter(); }
+   ~wxGDKThreadsLock() { gdk_threads_leave(); }
+
+   wxDECLARE_NO_COPY_CLASS(wxGDKThreadsLock);
+};
+
+#endif // _WX_GTK_PRIVATE_THREADS_H_

--- a/include/wx/gtk/private/threads.h
+++ b/include/wx/gtk/private/threads.h
@@ -11,6 +11,20 @@
 #define _WX_GTK_PRIVATE_THREADS_H_
 
 // ----------------------------------------------------------------------------
+// Redefine GDK functions to avoiding deprecation warnings
+// ----------------------------------------------------------------------------
+
+wxGCC_WARNING_SUPPRESS(deprecated-declarations)
+
+static inline void wx_gdk_threads_enter() { gdk_threads_enter(); }
+#define gdk_threads_enter wx_gdk_threads_enter
+
+static inline void wx_gdk_threads_leave() { gdk_threads_leave(); }
+#define gdk_threads_leave wx_gdk_threads_leave
+
+wxGCC_WARNING_RESTORE(deprecated-declarations)
+
+// ----------------------------------------------------------------------------
 // RAII wrapper for acquiring/leaving GDK lock in ctor/dtor
 // ----------------------------------------------------------------------------
 

--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -84,6 +84,7 @@ using namespace std;
 #ifdef __WXGTK__
 #ifdef __WXGTK20__
 #include "wx/gtk/private/wrapgtk.h"
+#include "wx/gtk/private/cairo.h"
 #else // GTK+ 1.x
 #include <gtk/gtk.h>
 #endif

--- a/src/gtk/app.cpp
+++ b/src/gtk/app.cpp
@@ -31,6 +31,7 @@
 
 #include "wx/gtk/private.h"
 #include "wx/gtk/private/log.h"
+#include "wx/gtk/private/threads.h"
 
 #include "wx/gtk/mimetype.h"
 //-----------------------------------------------------------------------------

--- a/src/gtk/assertdlg_gtk.cpp
+++ b/src/gtk/assertdlg_gtk.cpp
@@ -136,7 +136,7 @@ void gtk_assert_dialog_process_backtrace (GtkAssertDialog *dlg)
     GdkDisplay* display = gdk_window_get_display(parent);
     GdkCursor* cur = gdk_cursor_new_for_display(display, GDK_WATCH);
     gdk_window_set_cursor (parent, cur);
-    gdk_flush ();
+    gdk_display_flush (display);
 
     (*dlg->callback)(dlg->userdata);
 

--- a/src/gtk/dataview.cpp
+++ b/src/gtk/dataview.cpp
@@ -1238,14 +1238,22 @@ extern "C" {
     // are actually macros expanding into function calls, which shouldn't be
     // performed before the library is initialized, so we need to use either an
     // inline function or a define, which is simpler.
-    #define GtkWxCellEditorBinBaseType GTK_TYPE_BIN
+    #define GetGtkWxCellEditorBinBaseType() GTK_TYPE_BIN
 #else // GTK+ < 4
     // GtkHBox is deprecated since 3.2, so avoid warnings about using it.
     wxGCC_WARNING_SUPPRESS(deprecated-declarations)
 
     typedef GtkHBox GtkWxCellEditorBinBase;
     typedef GtkHBoxClass GtkWxCellEditorBinBaseClass;
-    #define GtkWxCellEditorBinBaseType GTK_TYPE_HBOX
+
+    // Here we use an inline function to avoid the deprecation warning about
+    // GTK_TYPE_HBOX.
+    inline GType GetGtkWxCellEditorBinBaseType()
+    {
+        wxGCC_WARNING_SUPPRESS(deprecated-declarations)
+        return GTK_TYPE_HBOX;
+        wxGCC_WARNING_RESTORE(deprecated-declarations)
+    }
 
     wxGCC_WARNING_RESTORE(deprecated-declarations)
 #endif // GTK+ version
@@ -1292,7 +1300,7 @@ gtk_wx_cell_editor_bin_get_type()
         };
 
         cell_editor_bin_type = g_type_register_static(
-            GtkWxCellEditorBinBaseType,
+            GetGtkWxCellEditorBinBaseType(),
             "GtkWxCellEditorBin", &cell_editor_bin_info, (GTypeFlags)0 );
 
 

--- a/src/gtk/dc.cpp
+++ b/src/gtk/dc.cpp
@@ -21,6 +21,7 @@
 #include "wx/gtk/dc.h"
 
 #include "wx/gtk/private/wrapgtk.h"
+#include "wx/gtk/private/cairo.h"
 
 wxGTKCairoDCImpl::wxGTKCairoDCImpl(wxDC* owner)
     : wxGCDCImpl(owner)
@@ -419,11 +420,10 @@ wxWindowDCImpl::wxWindowDCImpl(wxWindowDC* owner, wxWindow* window)
     }
     if (gdkWindow)
     {
-        cairo_t* cr = gdk_cairo_create(gdkWindow);
+        wxGTKImpl::CairoContext cr(gdkWindow);
         SetLayoutDirection(wxLayout_Default);
         AdjustForRTL(cr);
         wxGraphicsContext* gc = wxGraphicsContext::CreateFromNative(cr);
-        cairo_destroy(cr);
         gc->SetContentScaleFactor(m_contentScaleFactor);
         SetGraphicsContext(gc);
         GtkAllocation a;
@@ -468,11 +468,10 @@ wxClientDCImpl::wxClientDCImpl(wxClientDC* owner, wxWindow* window)
     }
     if (gdkWindow)
     {
-        cairo_t* cr = gdk_cairo_create(gdkWindow);
+        wxGTKImpl::CairoContext cr(gdkWindow);
         SetLayoutDirection(wxLayout_Default);
         AdjustForRTL(cr);
         wxGraphicsContext* gc = wxGraphicsContext::CreateFromNative(cr);
-        cairo_destroy(cr);
         gc->SetContentScaleFactor(m_contentScaleFactor);
         SetGraphicsContext(gc);
         if (!gtk_widget_get_has_window(widget))
@@ -524,9 +523,8 @@ wxScreenDCImpl::wxScreenDCImpl(wxScreenDC* owner)
     GdkWindow* window = gdk_get_default_root_window();
     InitSize(window);
 
-    cairo_t* cr = gdk_cairo_create(window);
+    wxGTKImpl::CairoContext cr(window);
     wxGraphicsContext* gc = wxGraphicsContext::CreateFromNative(cr);
-    cairo_destroy(cr);
     gc->SetContentScaleFactor(m_contentScaleFactor);
     SetGraphicsContext(gc);
 }

--- a/src/gtk/fontpicker.cpp
+++ b/src/gtk/fontpicker.cpp
@@ -37,7 +37,10 @@ static void gtk_fontbutton_setfont_callback(GtkFontButton *widget,
 {
     // update the m_selectedFont member of the wxFontButton
     wxASSERT(p);
+
+    wxGCC_WARNING_SUPPRESS(deprecated-declarations)
     p->SetNativeFontInfo(gtk_font_button_get_font_name(widget));
+    wxGCC_WARNING_RESTORE(deprecated-declarations)
 
     // fire the colour-changed event
     wxFontPickerEvent event(p, p->GetId(), p->GetSelectedFont());
@@ -103,7 +106,10 @@ void wxFontButton::UpdateFont()
     wxASSERT_MSG( info, wxT("The fontbutton's internal font is not valid ?") );
 
     const wxString& fontname = info->ToString();
+
+    wxGCC_WARNING_SUPPRESS(deprecated-declarations)
     gtk_font_button_set_font_name(GTK_FONT_BUTTON(m_widget), wxGTK_CONV(fontname));
+    wxGCC_WARNING_RESTORE(deprecated-declarations)
 }
 
 void wxFontButton::SetNativeFontInfo(const char* gtkdescription)

--- a/src/gtk/glcanvas.cpp
+++ b/src/gtk/glcanvas.cpp
@@ -200,7 +200,9 @@ bool wxGLCanvas::Create(wxWindow *parent,
     g_signal_connect(m_wxwindow, "draw", G_CALLBACK(draw), this);
 #endif
 
+    wxGCC_WARNING_SUPPRESS(deprecated-declarations)
     gtk_widget_set_double_buffered(m_wxwindow, false);
+    wxGCC_WARNING_RESTORE(deprecated-declarations)
 
     return true;
 }

--- a/src/gtk/listbox.cpp
+++ b/src/gtk/listbox.cpp
@@ -423,7 +423,11 @@ void wxListBox::Update()
     wxWindow::Update();
 
     if (m_treeview)
+    {
+        wxGCC_WARNING_SUPPRESS(deprecated-declarations)
         gdk_window_process_updates(gtk_widget_get_window(GTK_WIDGET(m_treeview)), true);
+        wxGCC_WARNING_RESTORE(deprecated-declarations)
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/src/gtk/menu.cpp
+++ b/src/gtk/menu.cpp
@@ -754,7 +754,10 @@ void wxMenuItem::SetupBitmaps(wxWindow *win)
         GtkWidget* image = wxGtkImage::New(win);
         WX_GTK_IMAGE(image)->Set(m_bitmap);
         gtk_widget_show(image);
+
+        wxGCC_WARNING_SUPPRESS(deprecated-declarations)
         gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(m_menuItem), image);
+        wxGCC_WARNING_RESTORE(deprecated-declarations)
     }
 #endif
 }

--- a/src/gtk/notebook.cpp
+++ b/src/gtk/notebook.cpp
@@ -352,7 +352,11 @@ wxSize wxNotebook::CalcSizeFromPage(const wxSize& sizePage) const
 
         GtkStyleContext* sc = gtk_widget_get_style_context(m_widget);
         gtk_style_context_save(sc);
+
+        wxGCC_WARNING_SUPPRESS(deprecated-declarations)
         gtk_style_context_add_region(sc, "tab", GtkRegionFlags(0));
+        wxGCC_WARNING_RESTORE(deprecated-declarations)
+
         gtk_style_context_add_class(sc, "top");
         gtk_style_context_get_padding(sc, GTK_STATE_FLAG_NORMAL, &b);
         sizeTabMax.IncBy(b.left + b.right, b.top + b.bottom);

--- a/src/gtk/textctrl.cpp
+++ b/src/gtk/textctrl.cpp
@@ -31,6 +31,7 @@
 
 #include "wx/gtk/private.h"
 #include "wx/gtk/private/gtk3-compat.h"
+#include "wx/gtk/private/threads.h"
 
 #if wxUSE_SPELLCHECK && defined(__WXGTK3__)
 extern "C" {
@@ -1208,12 +1209,11 @@ void wxTextCtrl::GTKAfterLayout()
 extern "C" {
 static gboolean afterLayout(void* data)
 {
-    gdk_threads_enter();
+    wxGDKThreadsLock threadsLock;
 
     wxTextCtrl* win = static_cast<wxTextCtrl*>(data);
     win->GTKAfterLayout();
 
-    gdk_threads_leave();
     return false;
 }
 }

--- a/src/gtk/timer.cpp
+++ b/src/gtk/timer.cpp
@@ -15,6 +15,7 @@
 #include "wx/app.h"
 
 #include "wx/gtk/private/wrapgtk.h"
+#include "wx/gtk/private/threads.h"
 
 // ----------------------------------------------------------------------------
 // wxTimerImpl
@@ -33,12 +34,11 @@ static gboolean timeout_callback(gpointer data)
     // When getting called from GDK's timer handler we
     // are no longer within GDK's grab on the GUI
     // thread so we must lock it here ourselves.
-    gdk_threads_enter();
+    {
+        wxGDKThreadsLock threadsLock;
 
-    timer->Notify();
-
-    // Release lock again.
-    gdk_threads_leave();
+        timer->Notify();
+    } // Release lock again.
 
     wxApp* app = wxTheApp;
     if (app)

--- a/src/gtk/toplevel.cpp
+++ b/src/gtk/toplevel.cpp
@@ -39,6 +39,7 @@
 #include "wx/gtk/private/stylecontext.h"
 #include "wx/gtk/private/win_gtk.h"
 #include "wx/gtk/private/backend.h"
+#include "wx/gtk/private/threads.h"
 
 #ifdef GDK_WINDOWING_X11
     #include <gdk/gdkx.h>
@@ -596,14 +597,14 @@ static gboolean request_frame_extents_timeout(void* data)
 {
     // WM support for _NET_REQUEST_FRAME_EXTENTS is broken
     gs_requestFrameExtentsStatus = RFE_STATUS_BROKEN;
-    gdk_threads_enter();
+
+    wxGDKThreadsLock threadsLock;
     wxTopLevelWindowGTK* win = static_cast<wxTopLevelWindowGTK*>(data);
     win->m_netFrameExtentsTimerId = 0;
     wxTopLevelWindowGTK::DecorSize decorSize = win->m_decorSize;
     wxGetFrameExtents(gtk_widget_get_window(win->m_widget),
         &decorSize.left, &decorSize.right, &decorSize.top, &decorSize.bottom);
     win->GTKUpdateDecorSize(decorSize);
-    gdk_threads_leave();
     return false;
 }
 }

--- a/src/gtk/utilsgtk.cpp
+++ b/src/gtk/utilsgtk.cpp
@@ -67,7 +67,7 @@ GdkWindow* wxGetTopLevelGDK();
 
 void wxBell()
 {
-    gdk_beep();
+    gdk_display_beep(gdk_display_get_default());
 }
 
 // ----------------------------------------------------------------------------

--- a/src/gtk/utilsgtk.cpp
+++ b/src/gtk/utilsgtk.cpp
@@ -42,6 +42,7 @@
     #if wxUSE_STACKWALKER
         #include "wx/stackwalk.h"
     #endif // wxUSE_STACKWALKER
+    #include "wx/gtk/private/gtk3-compat.h"
 #endif // wxDEBUG_LEVEL
 
 #include <stdarg.h>
@@ -368,9 +369,9 @@ bool wxGUIAppTraits::ShowAssertDialog(const wxString& msg)
 #ifdef __WXGTK4__
         gdk_seat_ungrab(gdk_display_get_default_seat(display));
 #elif defined(__WXGTK3__)
+        GdkDevice* const device = wx_get_gdk_device_from_display(display);
+
         wxGCC_WARNING_SUPPRESS(deprecated-declarations)
-        GdkDeviceManager* manager = gdk_display_get_device_manager(display);
-        GdkDevice* device = gdk_device_manager_get_client_pointer(manager);
         gdk_device_ungrab(device, unsigned(GDK_CURRENT_TIME));
         wxGCC_WARNING_RESTORE()
 #else

--- a/src/gtk/webview_webkit2.cpp
+++ b/src/gtk/webview_webkit2.cpp
@@ -34,8 +34,12 @@
 // Helper function to get string from Webkit JS result
 bool wxGetStringFromJSResult(WebKitJavascriptResult* js_result, wxString* output)
 {
+    wxGCC_WARNING_SUPPRESS(deprecated-declarations)
+
     JSGlobalContextRef context = webkit_javascript_result_get_global_context(js_result);
     JSValueRef value = webkit_javascript_result_get_value(js_result);
+
+    wxGCC_WARNING_RESTORE(deprecated-declarations)
 
     JSValueRef exception = NULL;
     wxJSStringRef js_value

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -1858,11 +1858,8 @@ gtk_window_motion_notify_callback( GtkWidget * WXUNUSED(widget),
     {
         // synthesise a mouse enter or leave event if needed
         GdkWindow* winUnderMouse =
-#ifdef __WXGTK3__
-            gdk_device_get_window_at_position(gdk_event->device, NULL, NULL);
-#else
-            gdk_window_at_pointer(NULL, NULL);
-#endif
+            wx_gdk_device_get_window_at_position(gdk_event->device, NULL, NULL);
+
         GdkDisplay* display = winUnderMouse
             ? gdk_window_get_display(winUnderMouse)
             : NULL;
@@ -5101,15 +5098,7 @@ void wxWindowGTK::WarpPointer( int x, int y )
     GdkDisplay* display = gtk_widget_get_display(m_widget);
     GdkScreen* screen = gtk_widget_get_screen(m_widget);
 #ifdef __WXGTK3__
-#ifdef __WXGTK4__
-    GdkSeat* seat = gdk_display_get_default_seat(display);
-    GdkDevice* device = gdk_seat_get_pointer(seat);
-#else
-    wxGCC_WARNING_SUPPRESS(deprecated-declarations)
-    GdkDeviceManager* manager = gdk_display_get_device_manager(display);
-    GdkDevice* device = gdk_device_manager_get_client_pointer(manager);
-    wxGCC_WARNING_RESTORE()
-#endif
+    GdkDevice* const device = wx_get_gdk_device_from_display(display);
     gdk_device_warp(device, screen, x, y);
 #else
 #ifdef GDK_WINDOWING_X11

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -4981,12 +4981,17 @@ void wxWindowGTK::RealizeTabOrder()
 
             chain = g_list_reverse(chain);
 
+            wxGCC_WARNING_SUPPRESS(deprecated-declarations)
             gtk_container_set_focus_chain(GTK_CONTAINER(m_wxwindow), chain);
+            wxGCC_WARNING_RESTORE(deprecated-declarations)
+
             g_list_free(chain);
         }
         else // no children
         {
+            wxGCC_WARNING_SUPPRESS(deprecated-declarations)
             gtk_container_unset_focus_chain(GTK_CONTAINER(m_wxwindow));
+            wxGCC_WARNING_RESTORE(deprecated-declarations)
         }
     }
 }
@@ -5199,7 +5204,10 @@ void wxWindowGTK::Update()
         GdkWindow* window = GTKGetDrawingWindow();
         if (window == NULL)
             window = gtk_widget_get_window(m_widget);
+
+        wxGCC_WARNING_SUPPRESS(deprecated-declarations)
         gdk_window_process_updates(window, true);
+        wxGCC_WARNING_RESTORE(deprecated-declarations)
 
         // Flush again, but no need to wait for it to finish
         gdk_display_flush(display);
@@ -5444,12 +5452,18 @@ void wxWindowGTK::SetDoubleBuffered( bool on )
     wxCHECK_RET( (m_widget != NULL), wxT("invalid window") );
 
     if ( m_wxwindow )
+    {
+        wxGCC_WARNING_SUPPRESS(deprecated-declarations)
         gtk_widget_set_double_buffered( m_wxwindow, on );
+        wxGCC_WARNING_RESTORE(deprecated-declarations)
+    }
 }
 
 bool wxWindowGTK::IsDoubleBuffered() const
 {
+    wxGCC_WARNING_SUPPRESS(deprecated-declarations)
     return gtk_widget_get_double_buffered( m_wxwindow ) != 0;
+    wxGCC_WARNING_RESTORE(deprecated-declarations)
 }
 
 void wxWindowGTK::ClearBackground()
@@ -5970,6 +5984,8 @@ bool wxWindowGTK::DoPopupMenu( wxMenu *menu, int x, int y )
     else
 #endif // GTK_CHECK_VERSION(3,22,0)
     {
+        wxGCC_WARNING_SUPPRESS(deprecated-declarations)
+
         gtk_menu_popup(
                   GTK_MENU(menu->m_menu),
                   NULL,           // parent menu shell
@@ -5979,6 +5995,8 @@ bool wxWindowGTK::DoPopupMenu( wxMenu *menu, int x, int y )
                   0,                            // button used to activate it
                   gtk_get_current_event_time()
                 );
+
+        wxGCC_WARNING_RESTORE(deprecated-declarations)
     }
 
     // it is possible for gtk_menu_popup() to fail

--- a/src/gtk/window.cpp
+++ b/src/gtk/window.cpp
@@ -1863,9 +1863,15 @@ gtk_window_motion_notify_callback( GtkWidget * WXUNUSED(widget),
 #else
             gdk_window_at_pointer(NULL, NULL);
 #endif
+        GdkDisplay* display = winUnderMouse
+            ? gdk_window_get_display(winUnderMouse)
+            : NULL;
+        if ( !display )
+            display = gdk_display_get_default();
+
         // This seems to be necessary and actually been added to
         // GDK itself in version 2.0.X
-        gdk_flush();
+        gdk_display_flush(display);
 
         bool hasMouse = winUnderMouse == gdk_event->window;
         if ( hasMouse != g_captureWindowHasMouse )

--- a/src/unix/mediactrl.cpp
+++ b/src/unix/mediactrl.cpp
@@ -1059,7 +1059,9 @@ bool wxGStreamerMediaBackend::CreateControl(wxControl* ctrl, wxWindow* parent,
     // Turn off double-buffering so that
     // so it doesn't draw over the video and cause sporadic
     // disappearances of the video
+    wxGCC_WARNING_SUPPRESS(deprecated-declarations)
     gtk_widget_set_double_buffered(m_ctrl->m_wxwindow, FALSE);
+    wxGCC_WARNING_RESTORE(deprecated-declarations)
 #endif
 
     // don't erase the background of our control window

--- a/src/unix/mediactrl_gstplayer.cpp
+++ b/src/unix/mediactrl_gstplayer.cpp
@@ -362,7 +362,9 @@ bool wxGStreamerMediaBackend::CreateControl(wxControl* ctrl, wxWindow* parent,
     // Turn off double-buffering so that
     // so it doesn't draw over the video and cause sporadic
     // disappearances of the video
+    wxGCC_WARNING_SUPPRESS(deprecated-declarations)
     gtk_widget_set_double_buffered(m_ctrl->m_wxwindow, FALSE);
+    wxGCC_WARNING_RESTORE(deprecated-declarations)
 #endif
 
     // don't erase the background of our control window

--- a/src/unix/uiactionx11.cpp
+++ b/src/unix/uiactionx11.cpp
@@ -32,6 +32,7 @@
 
 #ifdef __WXGTK20__
 #include "wx/gtk/private/wrapgtk.h"
+#include "wx/gtk/private/gtk3-compat.h"
 #include <gdk/gdkx.h>
 
 GtkWidget* wxGetTopLevelGTK();
@@ -435,9 +436,13 @@ bool wxUIActionSimulatorX11Impl::MouseMove(long x, long y)
         return false;
 
 #ifdef  __WXGTK20__
-    GdkWindow* const gdkwin1 = gdk_window_at_pointer(NULL, NULL);
+#ifdef  __WXGTK3__
+    GdkDisplay* const display = gdk_window_get_display(wxGetTopLevelGDK());
+    GdkDevice* const device = wx_get_gdk_device_from_display(display);
+#endif
+    GdkWindow* const gdkwin1 = wx_gdk_device_get_window_at_position(device, NULL, NULL);
     const bool ret = DoX11MouseMove(x, y);
-    GdkWindow* const gdkwin2 = gdk_window_at_pointer(NULL, NULL);
+    GdkWindow* const gdkwin2 = wx_gdk_device_get_window_at_position(device, NULL, NULL);
 
     if ( gdkwin1 != gdkwin2 )
     {


### PR DESCRIPTION
This finally undoes my own changes in 36d6ddb8de (Disable warnings about deprecated declarations in wxGTK3 build, 2016-02-23) as this turned out to be a bad idea and adds some RAII helpers at the same time.

Please let me know if anybody has any objections to this.