### PR TITLE
Refactor issue templates using HTML comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -60,7 +60,7 @@ For example:
 - wxWidgets version <!-- [e.g. 3.2.1] --> you use:
 - wxWidgets port <!-- [e.g. wxMSW, wxGTK, wxOSX] --> you use:
 - OS <!-- [e.g. Windows 10, Ubuntu 22.10, macOS 15] --> and its version:
- 
+
 <!-- For wxGTK only (**remove** this section if not using wxGTK) -->
 + GTK version: <!-- [e.g. 3.24.5] -->
 + Which GDK <!-- [X11 or Wayland] --> backend is used:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,41 +6,62 @@ labels: ''
 assignees: ''
 
 ---
+<!--
 
 IMPORTANT NOTE
 --------------
 
-This is a _template_, please **REMOVE** all the placeholders after filling in all the applicable sections as indicated, including this note.
+Please note that this entry field uses [Markdown][1], which means that you
+need to escape any code snippets pasted here using fenced code blocks,
+i.e. by putting ``` before and after it. Also escape, using
+backslash, i.e. `\<` any angle brackets to prevent them from being
+interpreted as HTML tags.
 
-Please also note that this entry field uses [Markdown][1], which means that you need to escape any code snippets pasted here using the fenced code blocks, i.e. by putting <tt>```</tt> before and after it. Also escape, using backslash, i.e. `\<` any angle brackets to prevent them from being interpreted as HTML tags.
+Use the Preview tab to review your issue before submitting it to verify that
+your formatting is correct.
 
 [1]: https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax
 
 ---
 
-**Describe the bug**
+Describe the bug:
 A clear and concise description of what the bug is.
 
-**Expected vs observed behaviour**
-Please describe what you expected to happen and what actually happens. Make sure to explain what exactly is the problem, just attaching a screenshot is not always sufficient. When in doubt, please provide more details rather than too few.
+Expected vs observed behaviour:
+Please describe what you expected to happen and what actually happens. Make
+sure to explain what exactly is the problem, just attaching a screenshot is
+not always sufficient. When in doubt, please provide more details rather
+than too few.
 
-**Patch or snippet allowing to reproduce the problem**
-Please attach the smallest possible patch allowing to reproduce the problem in a sample. If there is absolutely no appropriate sample, please attach a minimal self-contained example in a single file.
+Patch or snippet allowing to reproduce the problem:
+Please attach the smallest possible patch allowing to reproduce the problem
+in a sample. If there is absolutely no appropriate sample, please attach a
+minimal self-contained example in a single file.
 
-Skip this step if the problem can be reproduced in one of the samples without any changes.
+Skip this step if the problem can be reproduced in one of the samples
+without any changes.
 
-**To Reproduce**
-Steps to reproduce the behaviour, please make them as detailed as possible, e.g.
+To Reproduce:
+Steps to reproduce the behaviour, please make them as detailed as possible.
+For example:
+
 1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
+2. Click on '...'
+3. Scroll down to '...'
 4. See error
+-->
 
-**Platform and version information**
- - wxWidgets version you use: [e.g. 3.1.6]
- - wxWidgets port you use: [e.g. wxMSW, wxGTK, wxOSX]
- - OS and its version: [e.g. Windows 10.0.19042.867, Ubuntu 22.10, macOS 15]
- - For wxGTK only (**remove** this if not using wxGTK)
-   + GTK version: [e.g. 3.24.5]
-   + Which GDK backend is used: [X11 or Wayland]
-   + If relevant, i.e. for appearance-related problems: [current theme]
+### Description
+<!-- Describe the bug here -->
+
+
+### Platform and version information
+
+- wxWidgets version <!-- [e.g. 3.2.1] --> you use:
+- wxWidgets port <!-- [e.g. wxMSW, wxGTK, wxOSX] --> you use:
+- OS <!-- [e.g. Windows 10, Ubuntu 22.10, macOS 15] --> and its version:
+ 
+<!-- For wxGTK only (**remove** this section if not using wxGTK) -->
++ GTK version: <!-- [e.g. 3.24.5] -->
++ Which GDK <!-- [X11 or Wayland] --> backend is used:
++ Current theme: <!-- (If relevant, i.e. for appearance-related problems) -->

--- a/.github/ISSUE_TEMPLATE/build_problem.md
+++ b/.github/ISSUE_TEMPLATE/build_problem.md
@@ -6,9 +6,9 @@ labels: 'build'
 assignees: ''
 
 ---
+<!--
 
-**Describe the problem**
-Describe how exactly do you build wxWidgets, including the full `configure`
+Please describe exactly how you build wxWidgets, including the full `configure`
 command line and/or `make` command line if relevant.
 
 Please attach the full build log, but feel free to quote the relevant parts of
@@ -16,9 +16,15 @@ it here.
 
 When using `configure`, please also attach `config.log` file.
 
+-->
 
-**Platform and version information**
- - wxWidgets version you use: [e.g. 3.1.6]
- - wxWidgets port you use: [e.g. wxMSW, wxGTK, wxOSX]
- - OS and its version: [e.g. Windows 10.0.19042.867, Ubuntu 22.10, macOS 15]
- - Compiler being used: [e.g. MSVS 2022, gcc 12.1]
+### Description
+<!-- Describe the problem here -->
+
+
+### Platform and version information
+
+- wxWidgets version <!-- [e.g. 3.2.1] --> you are building:
+- wxWidgets port <!-- [e.g. wxMSW, wxGTK, wxOSX] --> you are building:
+- OS <!-- [e.g. Windows 10, Ubuntu 22.10, macOS 15] --> and its version:
+- Compiler <!-- [e.g. MSVS 2022, gcc 12.1] --> being used:

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -7,9 +7,14 @@ assignees: ''
 
 ---
 
-**Describe the proposed addition**
+<!--
 
 Implementation ideas and helpful links, e.g. to platform-specific API that can
 be used, are welcome.
 
 Please mention if you propose to submit pull requests implementing this.
+
+-->
+
+### Description
+<!-- Describe the proposed addition here -->


### PR DESCRIPTION
This PR places the explanatory information in an HTML comment so that the user does not need to manually delete it.

Please note that I did change a bit of the wording in some of these. For example, in the bug_report.md file, I added the suggestion to use the Preview tab to check formatting (it will also show that the comments are automatically removed). I also made some more subtle changes -- I removed the suggested \<t>\</t> around the \`\`\` block since github will display the code section in an indented block without it. Most of the other changes are formatting to force wrap the commented descriptions.