### PR TITLE
Remove wxGLAttributes::AddDefaultsForWXBefore31()

### DIFF
--- a/include/wx/glcanvas.h
+++ b/include/wx/glcanvas.h
@@ -162,11 +162,7 @@ public:
     wxGLAttributes& FrameBuffersRGB();
     void EndList(); // No more values can be chained
 
-    // This function is undocumented and cannot be chained on purpose!
-    // To keep backwards compatibility with versions before wx3.1 we add here
-    // the default values used in those versions for the case of NULL list.
-    void AddDefaultsForWXBefore31();
-};
+ };
 
 // ----------------------------------------------------------------------------
 // wxGLContextBase: OpenGL rendering context

--- a/src/common/glcmn.cpp
+++ b/src/common/glcmn.cpp
@@ -158,8 +158,7 @@ bool wxGLCanvasBase::ParseAttribList(const int *attribList,
 
     if ( !attribList )
     {
-        // Default visual attributes used in wx versions before wx3.1
-        dispAttrs.AddDefaultsForWXBefore31();
+        dispAttrs.Defaults();
         dispAttrs.EndList();
         if ( ctxAttrs )
             ctxAttrs->EndList();

--- a/src/msw/glcanvas.cpp
+++ b/src/msw/glcanvas.cpp
@@ -537,11 +537,6 @@ wxGLAttributes& wxGLAttributes::Defaults()
     return *this;
 }
 
-void wxGLAttributes::AddDefaultsForWXBefore31()
-{
-    // ParseAttribList() will add EndList(), don't do it now
-    RGBA().DoubleBuffer().Depth(16);
-}
 
 // ----------------------------------------------------------------------------
 // wxGLContext

--- a/src/osx/glcanvas_osx.cpp
+++ b/src/osx/glcanvas_osx.cpp
@@ -356,13 +356,6 @@ wxGLAttributes& wxGLAttributes::Defaults()
     return *this;
 }
 
-void wxGLAttributes::AddDefaultsForWXBefore31()
-{
-    // ParseAttribList() will add EndList(), don't do it now
-    DoubleBuffer();
-    // Negative value will keep its buffer untouched
-    BufferSize(8).Depth(8).MinRGBA(-1, -1, -1, 0);
-}
 
 
 // ----------------------------------------------------------------------------

--- a/src/qt/glcanvas.cpp
+++ b/src/qt/glcanvas.cpp
@@ -327,10 +327,7 @@ wxGLAttributes& wxGLAttributes::Defaults()
     return *this;
 }
 
-void wxGLAttributes::AddDefaultsForWXBefore31()
-{
-    Defaults();
-}
+
 
 //---------------------------------------------------------------------------
 // wxGlContext

--- a/src/unix/glegl.cpp
+++ b/src/unix/glegl.cpp
@@ -275,11 +275,7 @@ wxGLAttributes& wxGLAttributes::Defaults()
     return *this;
 }
 
-void wxGLAttributes::AddDefaultsForWXBefore31()
-{
-    // ParseAttribList() will add EndList(), don't do it now
-    DoubleBuffer();
-}
+
 
 
 // ============================================================================

--- a/src/unix/glx11.cpp
+++ b/src/unix/glx11.cpp
@@ -433,14 +433,6 @@ wxGLAttributes& wxGLAttributes::Defaults()
     return *this;
 }
 
-void wxGLAttributes::AddDefaultsForWXBefore31()
-{
-    // ParseAttribList() will add EndList(), don't do it now
-    DoubleBuffer();
-    if ( wxGLCanvasX11::GetGLXVersion() < 13 )
-        RGBA().Depth(1).MinRGBA(1, 1, 1, 0);
-    // For GLX >= 1.3 its defaults (GLX_RGBA_BIT and GLX_WINDOW_BIT) are OK
-}
 
 
 // ============================================================================


### PR DESCRIPTION
OpenGL visual attributes can be passed by wxGLAttibutes or by a list of integers. In the second case a NULL pointer can be passed, which makes wx to ask for some common defaults. These defaults were not exactly the same in each platform, because it was expected that the OGL driver provides such same defaults.
This is proving not true in some modern hardware.
This patch removes wxGLAttributes::AddDefaultsForWXBefore31() and replace its only call at wxGLCanvasBase::ParseAttribList() with a call to wxGLAttibutes::Defaults(), which does ask for those common OGL visual settings.

This PR is a fix for issue PR #22787
