### PR TITLE
Update TLW icon when the DPI changes in wxMSW

### DIFF
--- a/include/wx/msw/toplevel.h
+++ b/include/wx/msw/toplevel.h
@@ -169,6 +169,11 @@ protected:
                                           int& x, int& y,
                                           int& w, int& h) const wxOVERRIDE;
 
+    // override this one to update our icon on DPI change (not quite the same
+    // thing as font, but close enough...)
+    virtual void MSWUpdateFontOnDPIChange(const wxSize& newDPI) wxOVERRIDE;
+
+
     // This field contains the show command to use when showing the window the
     // next time and also indicates whether the window should be considered
     // being iconized or maximized (which may be different from whether it's
@@ -195,6 +200,10 @@ protected:
     wxWindowRef m_winLastFocused;
 
 private:
+    // Part of SetIcons() actually updating the window icons.
+    void DoSetIcons();
+
+
     // The system menu: initially NULL but can be set (once) by
     // MSWGetSystemMenu(). Owned by this window.
     wxMenu *m_menuSystem;

--- a/src/msw/toplevel.cpp
+++ b/src/msw/toplevel.cpp
@@ -327,6 +327,13 @@ WXLRESULT wxTopLevelWindowMSW::MSWWindowProc(WXUINT message, WXWPARAM wParam, WX
     return rc;
 }
 
+void
+wxTopLevelWindowMSW::MSWUpdateFontOnDPIChange(const wxSize& WXUNUSED(newDPI))
+{
+    if ( !m_icons.IsEmpty() )
+        DoSetIcons();
+}
+
 bool wxTopLevelWindowMSW::CreateDialog(const void *dlgTemplate,
                                        const wxString& title,
                                        const wxPoint& pos,
@@ -1043,8 +1050,13 @@ void wxTopLevelWindowMSW::SetIcons(const wxIconBundle& icons)
         return;
     }
 
-    DoSelectAndSetIcon(icons, SM_CXSMICON, SM_CYSMICON, ICON_SMALL);
-    DoSelectAndSetIcon(icons, SM_CXICON, SM_CYICON, ICON_BIG);
+    DoSetIcons();
+}
+
+void wxTopLevelWindowMSW::DoSetIcons()
+{
+    DoSelectAndSetIcon(m_icons, SM_CXSMICON, SM_CYSMICON, ICON_SMALL);
+    DoSelectAndSetIcon(m_icons, SM_CXICON, SM_CYICON, ICON_BIG);
 }
 
 wxContentProtection wxTopLevelWindowMSW::GetContentProtection() const


### PR DESCRIPTION
While we selected the icon of the size most appropriate for the current
DPI when the window was created, we didn't update the icon later if the
DPI changed as we should, so do it now.

Note that we abuse the existing MSWUpdateFontOnDPIChange() to make it
simple to backport this fix to 3.2 without breaking the ABI.

See #22807.
