### PR TITLE
Prevent memory bloat when creating new wxThreads.

### DIFF
--- a/include/wx/thread.h
+++ b/include/wx/thread.h
@@ -602,9 +602,6 @@ protected:
     // of this thread.
     virtual void *Entry() = 0;
 
-    // use this to call the Entry() virtual method
-    void *CallEntry();
-
     // Callbacks which may be overridden by the derived class to perform some
     // specific actions when the thread is deleted or killed. By default they
     // do nothing.

--- a/include/wx/thrimpl.cpp
+++ b/include/wx/thrimpl.cpp
@@ -342,16 +342,8 @@ wxSemaError wxSemaphore::Post()
 // ----------------------------------------------------------------------------
 
 #include "wx/utils.h"
-#include "wx/private/threadinfo.h"
-#include "wx/scopeguard.h"
 
 void wxThread::Sleep(unsigned long milliseconds)
 {
     wxMilliSleep(milliseconds);
-}
-
-void *wxThread::CallEntry()
-{
-    wxON_BLOCK_EXIT0(wxThreadSpecificInfo::ThreadCleanUp);
-    return Entry();
 }

--- a/src/gtk1/threadsgi.cpp
+++ b/src/gtk1/threadsgi.cpp
@@ -125,7 +125,7 @@ void wxThreadPrivate::SprocStart(void *ptr)
 
   thr->p_internal->thread_id = getpid();
   thr->p_internal->exit_status = 0;
-  status = thr->CallEntry();
+  status = thr->Entry();
   thr->Exit(status);
 }
 

--- a/src/unix/threadpsx.cpp
+++ b/src/unix/threadpsx.cpp
@@ -27,6 +27,8 @@
 
 #include "wx/thread.h"
 #include "wx/except.h"
+#include "wx/private/threadinfo.h"
+#include "wx/scopeguard.h"
 
 #ifndef WX_PRECOMP
     #include "wx/app.h"
@@ -868,6 +870,11 @@ void *wxThreadInternal::PthreadStart(wxThread *thread)
 
         return (void *)-1;
     }
+
+    // ThreadCleanUp() will be called in thread->CallEntry(),
+    // but there might be wxLog calls after that recreating the thread info.
+    // Make sure they get recleaned when leaving this function.
+    wxON_BLOCK_EXIT0(wxThreadSpecificInfo::ThreadCleanUp);
 
     // have to declare this before pthread_cleanup_push() which defines a
     // block!


### PR DESCRIPTION
The log functions in PthreadStart cause a new wxThreadSpecificInfo object to be created after the original one has already been discarded by CallEntry. Perform the wxThreadSpecificInfo::ThreadCleanUp again at the end of PthreadStart, so that it will not needlessly remain there consuming memory till the end of program.