### PR TITLE
wxBitmapComboBox: Fix for emitting of  wxEVT_TEXT_ENTER event

### DIFF
--- a/samples/widgets/bmpcombobox.cpp
+++ b/samples/widgets/bmpcombobox.cpp
@@ -425,7 +425,9 @@ void BitmapComboBoxWidgetsPage::CreateCombo()
         flags |= wxCB_SORT;
     if ( m_chkReadonly->GetValue() )
         flags |= wxCB_READONLY;
-
+    else
+        flags |= wxTE_PROCESS_ENTER;
+    
     switch ( m_radioKind->GetSelection() )
     {
         default:

--- a/src/msw/bmpcbox.cpp
+++ b/src/msw/bmpcbox.cpp
@@ -157,11 +157,22 @@ void wxBitmapComboBox::RecreateControl()
     wxComboBox::DoClear();
 
     HWND hwnd = GetHwnd();
+   
+    WNDPROC wndproc_edit = nullptr;
+    WinStruct<COMBOBOXINFO> combobox_info;
+    // Get wndproc_edit before initial control will be destroyed
+    if (::GetComboBoxInfo(hwnd, &combobox_info))
+        wndproc_edit = wxGetWindowProc(combobox_info.hwndItem);
+
     DissociateHandle();
     ::DestroyWindow(hwnd);
 
     if ( !MSWCreateControl(wxT("COMBOBOX"), wxEmptyString, pos, size) )
         return;
+    
+    // Set wndproc_edit for new created contol
+    if (::GetComboBoxInfo(GetHwnd(), &combobox_info))
+        wxSetWindowProc(combobox_info.hwndItem, wndproc_edit);
 
     // initialize the controls contents
     for ( i = 0; i < numItems; i++ )


### PR DESCRIPTION
Alternative solution for #16318

This code was provided by @xarbit for https://github.com/prusa3d/PrusaSlicer with https://github.com/prusa3d/wxWidgets/commit/24d72953141b5f3acb2bd0b750e73efedd8b8b09#diff-86749244e33368aea5650ada6ac71568b356109f0fab7f3645536e75f308c6eb. 

But most of code in this commit doesn't used now. 
And it would be great to have these changes in the upstream wxWidgets.