### PR TITLE
Enable double buffering by default in wxMSW

### DIFF
--- a/include/wx/dcbuffer.h
+++ b/include/wx/dcbuffer.h
@@ -15,12 +15,11 @@
 #include "wx/dcclient.h"
 #include "wx/window.h"
 
-// Split platforms into two groups - those which have well-working
-// double-buffering by default, and those which do not.
-#if defined(__WXMAC__) || defined(__WXGTK20__) || defined(__WXDFB__) || defined(__WXQT__)
-    #define wxALWAYS_NATIVE_DOUBLE_BUFFER       1
-#else
+// Only deprecated wxGTK1 and wxMotif platforms don't use double buffering.
+#if defined(__WXMOTIF__) || (defined(__WXGTK__) && !defined(__WXGTK20__))
     #define wxALWAYS_NATIVE_DOUBLE_BUFFER       0
+#else
+    #define wxALWAYS_NATIVE_DOUBLE_BUFFER       1
 #endif
 
 

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -54,8 +54,7 @@ public:
                 long style = 0,
                 const wxString& name = wxASCII_STR(wxPanelNameStr))
     {
-        return CreateUsingMSWClass(GetMSWClassName(style),
-                                   parent, id, pos, size, style, name);
+        return CreateUsingMSWClass(NULL, parent, id, pos, size, style, name);
     }
 
     // Non-portable, MSW-specific Create() variant allowing to create the

--- a/src/msw/combo.cpp
+++ b/src/msw/combo.cpp
@@ -111,12 +111,6 @@ bool wxComboCtrl::Create(wxWindow *parent,
     if ( style & wxCC_STD_BUTTON )
         m_iFlags |= wxCC_POPUP_ON_MOUSE_UP;
 
-    // Prepare background for double-buffering or better background theme
-    // support, whichever is possible.
-    SetDoubleBuffered(true);
-    if ( !IsDoubleBuffered() )
-        SetBackgroundStyle( wxBG_STYLE_PAINT );
-
     // Create textctrl, if necessary
     CreateTextCtrl( wxNO_BORDER );
 

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -539,6 +539,19 @@ bool wxWindowMSW::CreateUsingMSWClass(const wxChar* classname,
     msflags &= ~WS_BORDER;
 #endif // wxUniversal
 
+    // Enable double buffering by default for all our own, i.e. not the ones
+    // using native controls, classes.
+    //
+    // Note that this function is not used for top-level windows, so we don't
+    // set this style for them, and also that setting it for children of
+    // windows that already have WS_EX_COMPOSITED set doesn't seem to have any
+    // bad effect as the style is just ignored in this case, so we don't bother
+    // checking it it's already set for the parent, even though we could.
+    if ( !classname )
+    {
+        exstyle |= WS_EX_COMPOSITED;
+    }
+
     if ( IsShown() )
     {
         msflags |= WS_VISIBLE;

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -544,6 +544,10 @@ bool wxWindowMSW::CreateUsingMSWClass(const wxChar* classname,
         msflags |= WS_VISIBLE;
     }
 
+    // If the class name is not specified, use the one for generic wxWindow.
+    if ( !classname )
+        classname = GetMSWClassName(style);
+
     if ( !MSWCreate(classname, NULL, pos, size, msflags, exstyle) )
         return false;
 


### PR DESCRIPTION
I've simply turned on `WS_EX_COMPOSITED` for all our windows and so far I haven't seen anything bad happening in the few samples I've tried (drawing, grid, notebook, toolbar, widgets). This doesn't mean there are no problems at all, of course, so it would be great if people could please test their applications with this PR _before_ it gets merged.

Please report any problems you see with it!

See #22846.