### PR TITLE
Use wxChoice for month selection in wxGenericCalendarCtrl

### DIFF
--- a/include/wx/generic/calctrlg.h
+++ b/include/wx/generic/calctrlg.h
@@ -14,7 +14,7 @@
 #include "wx/control.h"         // the base class
 #include "wx/dcclient.h"        // for wxPaintDC
 
-class WXDLLIMPEXP_FWD_CORE wxComboBox;
+class WXDLLIMPEXP_FWD_CORE wxChoice;
 class WXDLLIMPEXP_FWD_CORE wxStaticText;
 class WXDLLIMPEXP_FWD_CORE wxSpinCtrl;
 class WXDLLIMPEXP_FWD_CORE wxSpinEvent;
@@ -238,8 +238,8 @@ private:
     // show the correct controls
     void ShowCurrentControls();
 
-    // create the month combo and year spin controls
-    void CreateMonthComboBox();
+    // create the month choice and year spin controls
+    void CreateMonthChoice();
     void CreateYearSpinCtrl();
 
 public:
@@ -268,7 +268,7 @@ private:
 
     // the subcontrols
     wxStaticText *m_staticMonth;
-    wxComboBox *m_comboMonth;
+    wxChoice *m_choiceMonth;
 
     wxStaticText *m_staticYear;
     wxSpinCtrl *m_spinYear;


### PR DESCRIPTION
For no obvious reason the generic calendar control used a read-only wxComboBox until now.

While this is more or less identical to a wxChoice on MSW, it is somewhat different on OSX and Gtk: Whereas a wxChoice can be opened by clicking anywhere on it, a wxComboBox requires clicking on the arrows on the right edge. A wxComboBox allows selecting and copying the current value, but this is probably not terribly useful in a calendar.