### PR TITLE
Fix line numbers in Linux stack walk

### DIFF
--- a/src/unix/stackwalk.cpp
+++ b/src/unix/stackwalk.cpp
@@ -333,9 +333,8 @@ int wxStackWalker::InitFrames(wxStackFrame *arr, size_t n, void **addresses, cha
         }
         else
         {
-            wxLogDebug(wxT("Unexpected addr2line format: \"%s\" - ")
-                       wxT("the semicolon is missing"),
-                       filename.c_str());
+            wxLogDebug("Unexpected addr2line format: \"%s\" - the colon is missing",
+                       filename);
         }
 #endif // __WXOSX__/!__WXOSX__
 

--- a/src/unix/stackwalk.cpp
+++ b/src/unix/stackwalk.cpp
@@ -263,8 +263,15 @@ ReadSingleResult(FILE* fp, unsigned long i,
     const size_t posColon = filename.find(wxT(':'));
     if ( posColon != wxString::npos )
     {
-        // parse line number
-        if ( !wxString(filename, posColon + 1, wxString::npos).ToULong(&line) )
+        // parse line number: note that there can be more stuff following it in
+        // addr2line output, e.g. "(discriminator N)", see
+        // http://wiki.dwarfstd.org/index.php?title=Path_Discriminators
+        wxString afterColon(filename, posColon + 1, wxString::npos);
+        const size_t posSpace = afterColon.find(' ');
+        if ( posSpace != wxString::npos )
+            afterColon.erase(posSpace);
+
+        if ( !afterColon.ToULong(&line) )
             line = 0;
 
         // remove line number from 'filename'

--- a/src/unix/stackwalk.cpp
+++ b/src/unix/stackwalk.cpp
@@ -37,6 +37,9 @@
     #include <cxxabi.h>
 #endif // HAVE_CXA_DEMANGLE
 
+namespace
+{
+
 // ----------------------------------------------------------------------------
 // tiny helper wrapper around popen/pclose()
 // ----------------------------------------------------------------------------
@@ -65,6 +68,8 @@ private:
 
     wxDECLARE_NO_COPY_CLASS(wxStdioPipe);
 };
+
+} // anonymous namespace
 
 // ============================================================================
 // implementation

--- a/src/unix/stackwalk.cpp
+++ b/src/unix/stackwalk.cpp
@@ -225,7 +225,7 @@ bool ReadLine(FILE* fp, unsigned long num, wxString* line)
     }
 
     *line = wxString::FromAscii(g_buf);
-    line->RemoveLast();
+    line->RemoveLast(); // trailing newline
 
     return true;
 }
@@ -311,9 +311,6 @@ int wxStackWalker::InitFrames(wxStackFrame *arr, size_t n, void **addresses, cha
         // 1st line has function name
         if ( !ReadLine(fp, i, &name) )
             return false;
-
-        name = wxString::FromAscii(g_buf);
-        name.RemoveLast(); // trailing newline
 
         if ( name == wxT("??") )
             name.clear();

--- a/src/unix/stackwalk.cpp
+++ b/src/unix/stackwalk.cpp
@@ -322,9 +322,9 @@ int wxStackWalker::InitFrames(wxStackFrame *arr, size_t n, void **addresses, cha
         const size_t posColon = filename.find(wxT(':'));
         if ( posColon != wxString::npos )
         {
-            // parse line number (it's ok if it fails, this will just leave
-            // line at its current, invalid, 0 value)
-            wxString(filename, posColon + 1, wxString::npos).ToULong(&line);
+            // parse line number
+            if ( !wxString(filename, posColon + 1, wxString::npos).ToULong(&line) )
+                line = 0;
 
             // remove line number from 'filename'
             filename.erase(posColon);


### PR DESCRIPTION
The old code didn't work for the symbols not in the executable itself, which wasn't very useful when using shared wx libraries.

Use the correct offset for the shared libraries and run addr2line separately for each module to fix this.

A better solution would be to implement addr2line functionality ourselves, which shouldn't be that difficult if we can use libdw, but this will have to wait.