### PR TITLE
editors.h: Fix missing include

### DIFF
--- a/include/wx/propgrid/editors.h
+++ b/include/wx/propgrid/editors.h
@@ -13,6 +13,10 @@
 
 #include "wx/defs.h"
 
+#if wxUSE_BMPBUTTON
+#include "wx/bmpbndl.h"
+#endif
+
 #if wxUSE_PROPGRID
 
 #include "wx/window.h"

--- a/include/wx/propgrid/editors.h
+++ b/include/wx/propgrid/editors.h
@@ -13,14 +13,11 @@
 
 #include "wx/defs.h"
 
-#if wxUSE_BMPBUTTON
-#include "wx/bmpbndl.h"
-#endif
-
 #if wxUSE_PROPGRID
 
 #include "wx/window.h"
 
+class WXDLLIMPEXP_FWD_CORE wxBitmapBundle;
 class WXDLLIMPEXP_FWD_PROPGRID wxPGCell;
 class WXDLLIMPEXP_FWD_PROPGRID wxPGProperty;
 class WXDLLIMPEXP_FWD_PROPGRID wxPropertyGrid;


### PR DESCRIPTION
At line https://github.com/wxWidgets/wxWidgets/blob/88d526660f2e7d3038fd0ff6eb0ae9b4c6e96656/include/wx/propgrid/editors.h#L473-L475 the statement will use `wxBitmapBundle` however  `wx/bmpbndl.h` is not included.