### PR TITLE
Proper icon rendering for different DPIs using wxGenericTreeCtrl

### DIFF
--- a/samples/treectrl/treetest.cpp
+++ b/samples/treectrl/treetest.cpp
@@ -955,7 +955,7 @@ MyTreeCtrl::MyTreeCtrl(wxWindow *parent, const wxWindowID id,
 {
     m_reverseSort = false;
 
-    CreateImages(16);
+    CreateImages(32);
     CreateStateImageList();
 
     // Add some items to the tree
@@ -979,8 +979,6 @@ void MyTreeCtrl::CreateImages(int size)
     // should correspond to TreeCtrlIcon_xxx enum
     wxIcon icons[5];
 
-    const auto scaleFac = this->GetDPIScaleFactor();
-
     if (m_alternateImages)
     {
         icons[TreeCtrlIcon_File] = wxIcon(icon1_xpm);
@@ -992,10 +990,10 @@ void MyTreeCtrl::CreateImages(int size)
     else
     {
         icons[TreeCtrlIcon_File] =
-        icons[TreeCtrlIcon_FileSelected] = wxArtProvider::GetIcon(wxART_NORMAL_FILE, wxART_LIST, iconSize*scaleFac);
+        icons[TreeCtrlIcon_FileSelected] = wxArtProvider::GetIcon(wxART_NORMAL_FILE, wxART_LIST, iconSize);
         icons[TreeCtrlIcon_Folder] =
         icons[TreeCtrlIcon_FolderSelected] =
-        icons[TreeCtrlIcon_FolderOpened] = wxArtProvider::GetIcon(wxART_FOLDER, wxART_LIST, iconSize*scaleFac);
+        icons[TreeCtrlIcon_FolderOpened] = wxArtProvider::GetIcon(wxART_FOLDER, wxART_LIST, iconSize);
     }
 
     // Make a vector of bundles corresponding to the icons. We use a custom

--- a/samples/treectrl/treetest.cpp
+++ b/samples/treectrl/treetest.cpp
@@ -979,6 +979,8 @@ void MyTreeCtrl::CreateImages(int size)
     // should correspond to TreeCtrlIcon_xxx enum
     wxIcon icons[5];
 
+    const auto scaleFac = this->GetDPIScaleFactor();
+
     if (m_alternateImages)
     {
         icons[TreeCtrlIcon_File] = wxIcon(icon1_xpm);
@@ -990,10 +992,10 @@ void MyTreeCtrl::CreateImages(int size)
     else
     {
         icons[TreeCtrlIcon_File] =
-        icons[TreeCtrlIcon_FileSelected] = wxArtProvider::GetIcon(wxART_NORMAL_FILE, wxART_LIST, iconSize);
+        icons[TreeCtrlIcon_FileSelected] = wxArtProvider::GetIcon(wxART_NORMAL_FILE, wxART_LIST, iconSize*scaleFac);
         icons[TreeCtrlIcon_Folder] =
         icons[TreeCtrlIcon_FolderSelected] =
-        icons[TreeCtrlIcon_FolderOpened] = wxArtProvider::GetIcon(wxART_FOLDER, wxART_LIST, iconSize);
+        icons[TreeCtrlIcon_FolderOpened] = wxArtProvider::GetIcon(wxART_FOLDER, wxART_LIST, iconSize*scaleFac);
     }
 
     // Make a vector of bundles corresponding to the icons. We use a custom

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -2385,7 +2385,7 @@ void wxGenericTreeCtrl::CalculateLineHeight()
         for (int i = 0; i < n ; i++)
         {
             int width = 0, height = 0;
-            GetImawxSize size = GetImages().at(i).GetDefaultSize();geList()->GetSize(i, width, height);
+            GetImageList()->GetSize(i, width, height);
 
             if (height > m_lineHeight) m_lineHeight = height;
         }

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -2381,11 +2381,11 @@ void wxGenericTreeCtrl::CalculateLineHeight()
         // Calculate a m_lineHeight value from the normal Image sizes.
         // May be toggle off. Then wxGenericTreeCtrl will spread when
         // necessary (which might look ugly).
-        int n = GetImageCount();
-        for (int i = 0; i < n ; i++)
+        auto &imgs = GetImages();
+        for ( auto &img : imgs )
         {
             int height = 0;
-            wxSize size = GetImages().at(i).GetDefaultSize();
+            wxSize size = img.GetDefaultSize();
             height = size.GetHeight();
 
             if (height > m_lineHeight) m_lineHeight = height;

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -2662,12 +2662,15 @@ void wxGenericTreeCtrl::PaintItem(wxGenericTreeItem *item, wxDC& dc)
     {
         dc.SetClippingRegion(item->GetX() + state_w, item->GetY(),
                              image_w, total_h);
-        GetImageList()->Draw( image, dc,
-                                 item->GetX() + state_w,
-                                 item->GetY() +
-                                    (total_h > image_h ? (total_h-image_h)/2
-                                                       : 0),
-                                 wxIMAGELIST_DRAW_TRANSPARENT );
+
+        const wxCoord x = item->GetX() + state_w;
+        const wxCoord y = item->GetY() + (total_h > image_h ? (total_h-image_h)/2 : 0);
+        const auto scale = this->GetDPIScaleFactor();
+        const auto imgSize = wxSize(image_h*scale,image_h*scale);
+
+        auto &img = GetImages().at(image);
+        dc.DrawBitmap(img.GetBitmap(imgSize), x, y, true);
+
         dc.DestroyClippingRegion();
     }
 

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -2384,8 +2384,10 @@ void wxGenericTreeCtrl::CalculateLineHeight()
         int n = GetImageCount();
         for (int i = 0; i < n ; i++)
         {
-            int width = 0, height = 0;
-            GetImageList()->GetSize(i, width, height);
+            int height = 0;
+            wxSize size = GetImages().at(i).GetDefaultSize();
+            height = size.GetHeight();
+
             if (height > m_lineHeight) m_lineHeight = height;
         }
     }
@@ -2666,7 +2668,7 @@ void wxGenericTreeCtrl::PaintItem(wxGenericTreeItem *item, wxDC& dc)
         const wxCoord x = item->GetX() + state_w;
         const wxCoord y = item->GetY() + (total_h > image_h ? (total_h-image_h)/2 : 0);
 
-        auto &img = GetImages().at(image);
+        auto img = GetBitmapBundle(image);
         dc.DrawBitmap(img.GetBitmapFor(this), x, y, true);
 
         dc.DestroyClippingRegion();
@@ -3007,10 +3009,6 @@ void wxGenericTreeCtrl::OnPaint( wxPaintEvent &WXUNUSED(event) )
 
     dc.SetFont( m_normalFont );
     dc.SetPen( m_dottedPen );
-
-    // this is now done dynamically
-    //if(GetImageList() == NULL)
-    // m_lineHeight = (int)(dc.GetCharHeight() + 4);
 
     int y = 2;
     PaintLevel( m_anchor, dc, 0, y );

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -2665,11 +2665,9 @@ void wxGenericTreeCtrl::PaintItem(wxGenericTreeItem *item, wxDC& dc)
 
         const wxCoord x = item->GetX() + state_w;
         const wxCoord y = item->GetY() + (total_h > image_h ? (total_h-image_h)/2 : 0);
-        const auto scale = this->GetDPIScaleFactor();
-        const auto imgSize = wxSize(image_h*scale,image_h*scale);
 
         auto &img = GetImages().at(image);
-        dc.DrawBitmap(img.GetBitmap(imgSize), x, y, true);
+        dc.DrawBitmap(img.GetBitmapFor(this), x, y, true);
 
         dc.DestroyClippingRegion();
     }

--- a/src/generic/treectlg.cpp
+++ b/src/generic/treectlg.cpp
@@ -2381,12 +2381,11 @@ void wxGenericTreeCtrl::CalculateLineHeight()
         // Calculate a m_lineHeight value from the normal Image sizes.
         // May be toggle off. Then wxGenericTreeCtrl will spread when
         // necessary (which might look ugly).
-        auto &imgs = GetImages();
-        for ( auto &img : imgs )
+        int n = GetImageCount();
+        for (int i = 0; i < n ; i++)
         {
-            int height = 0;
-            wxSize size = img.GetDefaultSize();
-            height = size.GetHeight();
+            int width = 0, height = 0;
+            GetImawxSize size = GetImages().at(i).GetDefaultSize();geList()->GetSize(i, width, height);
 
             if (height > m_lineHeight) m_lineHeight = height;
         }


### PR DESCRIPTION
Fixes blurry rendering of icons in TreeCtrl on GTK using Wayland