### PR TITLE
Add a Docker container for regenerating wx configure

### DIFF
--- a/build/tools/autoconf/Dockerfile
+++ b/build/tools/autoconf/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine:3.13
+
+RUN apk add autoconf
+
+# wxWidgets sources must be mounted here.
+VOLUME /wx
+
+WORKDIR /wx
+
+CMD ["autoconf", "-B", "build/autoconf_prepend-include"]

--- a/build/tools/autoconf/README.md
+++ b/build/tools/autoconf/README.md
@@ -1,0 +1,44 @@
+# Docker container for running autoconf
+
+## Rationale
+
+We store generated `configure` in Git to make it simpler for people to build
+wxWidgets without having to run autoconf themselves first, but this means that
+generating it on another system often results in insignificant changes just due
+to a different version of autoconf being used. By using this container, we can
+use the same version everywhere.
+
+To use it, first build the container, then run it, see below.
+
+
+## Build
+
+Just run
+
+```shell
+$ docker build -t autoconf-for-wx build/tools/autoconf
+```
+
+This should (quickly) finish with
+```
+Successfully tagged autoconf-for-wx:latest
+```
+
+
+## Run
+
+Use the following command to update `configure` from `configure.in`:
+
+```shell
+$ docker run -v `pwd`:/wx --rm autoconf-for-wx
+```
+
+It should be run from the top-level wx directory.
+
+
+## Updating autoconf version
+
+When we decide to switch to a newer autoconf version, we should update the
+`Dockerfile` here to use a later version of Alpine Linux: the currently used
+version is specifically chosen because it has the package with the latest
+version of autoconf 2.69.


### PR DESCRIPTION
This allows doing it on any system with Docker instead of having to do it only under Debian stable that was traditionally used for this.

---

I thought this could be useful to others, so I've created this docker file which seems to work well, i.e. regenerating configure using it doesn't result in any unwanted differences.

Would this actually be useful to have? If so, any comments about better Docker practices or whatever would be welcome, I don't know much about it.