### PR TITLE
wxGrid refresh logic revisited

### DIFF
--- a/include/wx/generic/grid.h
+++ b/include/wx/generic/grid.h
@@ -1693,6 +1693,10 @@ public:
     void RefreshBlock(int topRow, int leftCol,
                       int bottomRow, int rightCol);
 
+    // Refresh one or more areas (a combination of wxGridArea enums) entirely.
+    void RefreshArea(int areas);
+
+
     // ------
     // Code that does a lot of grid modification can be enclosed
     // between BeginBatch() and EndBatch() calls to avoid screen

--- a/include/wx/generic/private/grid.h
+++ b/include/wx/generic/private/grid.h
@@ -31,6 +31,23 @@ WX_DECLARE_HASH_MAP_WITH_DECL(wxLongLong_t, wxGridCellAttr*,
                               wxIntegerHash, wxIntegerEqual,
                               wxGridCoordsToAttrMap, class WXDLLIMPEXP_CORE);
 
+// ----------------------------------------------------------------------------
+// enumerations
+// ----------------------------------------------------------------------------
+
+// Flags to pass to wxGrid::RefreshArea()
+enum wxGridArea
+{
+    wxGA_Corner      = 0x001, // m_cornerLabelWin
+    wxGA_RowLabels   = 0x002, // m_rowLabelWin, [m_rowFrozenLabelWin]
+    wxGA_ColLabels   = 0x004, // m_colLabelWin, [m_colFrozenLabelWin]
+    wxGA_Cells       = 0x008, // m_gridwin, [m_frozenCornerGridWin,
+                              // m_frozenColGridWin, m_frozenRowGridWin]
+
+    wxGA_Heading     = wxGA_ColLabels | wxGA_Corner,
+    wxGA_Labels      = wxGA_RowLabels | wxGA_Heading,
+    wxGA_All         = wxGA_Cells | wxGA_Labels
+};
 
 // ----------------------------------------------------------------------------
 // private classes

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -9122,8 +9122,7 @@ void wxGrid::SetCornerLabelValue( const wxString& s )
         m_table->SetCornerLabelValue( s );
         if ( ShouldRefresh() )
         {
-            wxRect rect = m_cornerLabelWin->GetRect();
-            m_cornerLabelWin->Refresh(true, &rect);
+            m_cornerLabelWin->Refresh();
         }
     }
 }

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -5658,101 +5658,20 @@ void wxGrid::Refresh(bool eraseb, const wxRect* rect)
 {
     // Don't do anything if between Begin/EndBatch...
     // EndBatch() will do all this on the last nested one anyway.
-    if ( m_created && ShouldRefresh() )
+    if ( ShouldRefresh() )
     {
-        // Refresh to get correct scrolled position:
         wxScrolledCanvas::Refresh(eraseb, rect);
 
-        if (rect)
-        {
-            int rect_x, rect_y, rectWidth, rectHeight;
-            int width_label, width_cell, height_label, height_cell;
-            int x, y;
-
-            // Copy rectangle can get scroll offsets..
-            rect_x = rect->GetX();
-            rect_y = rect->GetY();
-            rectWidth = rect->GetWidth();
-            rectHeight = rect->GetHeight();
-
-            width_label = m_rowLabelWidth - rect_x;
-            if (width_label > rectWidth)
-                width_label = rectWidth;
-
-            height_label = m_colLabelHeight - rect_y;
-            if (height_label > rectHeight)
-                height_label = rectHeight;
-
-            if (rect_x > m_rowLabelWidth)
-            {
-                x = rect_x - m_rowLabelWidth;
-                width_cell = rectWidth;
-            }
-            else
-            {
-                x = 0;
-                width_cell = rectWidth - (m_rowLabelWidth - rect_x);
-            }
-
-            if (rect_y > m_colLabelHeight)
-            {
-                y = rect_y - m_colLabelHeight;
-                height_cell = rectHeight;
-            }
-            else
-            {
-                y = 0;
-                height_cell = rectHeight - (m_colLabelHeight - rect_y);
-            }
-
-            // Paint corner label part intersecting rect.
-            if ( width_label > 0 && height_label > 0 )
-            {
-                wxRect anotherrect(rect_x, rect_y, width_label, height_label);
-                m_cornerLabelWin->Refresh(eraseb, &anotherrect);
-            }
-
-            // Paint col labels part intersecting rect.
-            if ( width_cell > 0 && height_label > 0 )
-            {
-                wxRect anotherrect(x, rect_y, width_cell, height_label);
-                m_colLabelWin->Refresh(eraseb, &anotherrect);
-            }
-
-            // Paint row labels part intersecting rect.
-            if ( width_label > 0 && height_cell > 0 )
-            {
-                wxRect anotherrect(rect_x, y, width_label, height_cell);
-                m_rowLabelWin->Refresh(eraseb, &anotherrect);
-            }
-
-            // Paint cell area part intersecting rect.
-            if ( width_cell > 0 && height_cell > 0 )
-            {
-                wxRect anotherrect(x, y, width_cell, height_cell);
-                m_gridWin->Refresh(eraseb, &anotherrect);
-            }
-        }
-        else
-        {
-            m_cornerLabelWin->Refresh(eraseb, nullptr);
-            m_colLabelWin->Refresh(eraseb, nullptr);
-            m_rowLabelWin->Refresh(eraseb, nullptr);
-            m_gridWin->Refresh(eraseb, nullptr);
-
-            if ( m_frozenColGridWin )
-            {
-                m_frozenColGridWin->Refresh(eraseb, nullptr);
-                m_colFrozenLabelWin->Refresh(eraseb, nullptr);
-            }
-            if ( m_frozenRowGridWin )
-            {
-                m_frozenRowGridWin->Refresh(eraseb, nullptr);
-                m_rowFrozenLabelWin->Refresh(eraseb, nullptr);
-            }
-            if ( m_frozenCornerGridWin )
-                m_frozenCornerGridWin->Refresh(eraseb, nullptr);
-        }
+        // Notice that this function expects the rectangle to be relative
+        // to the wxGrid window itself, i.e. the origin (0, 0) at the top
+        // left corner of the window. and will correctly refresh the sub-
+        // windows for us, including the frozen ones, but only the parts
+        // intersecting with rect will be refreshed of course. So if we
+        // want to refresh a rectangle in a grid area, we should pass that
+        // rectangle shifted by the position of the area in the grid. e.g.:
+        // wxRect rect = ... // rect calculated relative to cells area
+        // rect.Offset(GetRowLabelSize(), GetColLabelSize());
+        // Refresh(true, &rect);
     }
 }
 
@@ -8854,7 +8773,7 @@ void wxGrid::SetRowLabelSize( int width )
         m_rowLabelWidth = width;
         InvalidateBestSize();
         CalcWindowSizes();
-        wxScrolledCanvas::Refresh( true );
+        Refresh();
     }
 }
 
@@ -8884,7 +8803,7 @@ void wxGrid::SetColLabelSize( int height )
         m_colLabelHeight = height;
         InvalidateBestSize();
         CalcWindowSizes();
-        wxScrolledCanvas::Refresh( true );
+        Refresh();
     }
 }
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -3732,9 +3732,8 @@ wxArrayInt wxGrid::CalcRowLabelsExposed( const wxRegion& reg, wxGridWindow *grid
 
         // logical bounds of update region
         //
-        int dummy;
-        CalcGridWindowUnscrolledPosition( 0, r.GetTop(), &dummy, &top, gridWindow );
-        CalcGridWindowUnscrolledPosition( 0, r.GetBottom(), &dummy, &bottom, gridWindow );
+        CalcGridWindowUnscrolledPosition( 0, r.GetTop(), nullptr, &top, gridWindow );
+        CalcGridWindowUnscrolledPosition( 0, r.GetBottom(), nullptr, &bottom, gridWindow );
 
         // find the row labels within these bounds
         const int rowFirst = internalYToRow(top, gridWindow);
@@ -3773,9 +3772,8 @@ wxArrayInt wxGrid::CalcColLabelsExposed( const wxRegion& reg, wxGridWindow *grid
 
         // logical bounds of update region
         //
-        int dummy;
-        CalcGridWindowUnscrolledPosition( r.GetLeft(), 0, &left, &dummy, gridWindow );
-        CalcGridWindowUnscrolledPosition( r.GetRight(), 0, &right, &dummy, gridWindow );
+        CalcGridWindowUnscrolledPosition( r.GetLeft(), 0, &left, nullptr, gridWindow );
+        CalcGridWindowUnscrolledPosition( r.GetRight(), 0, &right, nullptr, gridWindow );
 
         // find the cells within these bounds
         //
@@ -10551,11 +10549,11 @@ wxGrid::AutoSizeColOrRow(int colOrRow, bool setAsMin, wxGridDirection direction)
             }
             else
             {
-                int cw, ch, dummy;
+                int cw, ch;
                 m_gridWin->GetClientSize( &cw, &ch );
                 wxRect rect ( CellToRect( 0, colOrRow ) );
                 rect.y = 0;
-                CalcScrolledPosition(rect.x, 0, &rect.x, &dummy);
+                CalcScrolledPosition(rect.x, 0, &rect.x, nullptr);
                 rect.width = cw - rect.x;
                 rect.height = m_colLabelHeight;
                 GetColLabelWindow()->Refresh( true, &rect );
@@ -10573,11 +10571,11 @@ wxGrid::AutoSizeColOrRow(int colOrRow, bool setAsMin, wxGridDirection direction)
         SetRowSize(colOrRow, extentMax);
         if ( ShouldRefresh() )
         {
-            int cw, ch, dummy;
+            int cw, ch;
             m_gridWin->GetClientSize( &cw, &ch );
             wxRect rect( CellToRect( colOrRow, 0 ) );
             rect.x = 0;
-            CalcScrolledPosition(0, rect.y, &dummy, &rect.y);
+            CalcScrolledPosition(0, rect.y, nullptr, &rect.y);
             rect.width = m_rowLabelWidth;
             rect.height = ch - rect.y;
             m_rowLabelWin->Refresh( true, &rect );
@@ -10757,11 +10755,10 @@ void wxGrid::SetCellValue( int row, int col, const wxString& s )
         m_table->SetValue( row, col, s );
         if ( ShouldRefresh() )
         {
-            int dummy;
             wxRect rect( CellToRect( row, col ) );
             rect.x = 0;
             rect.width = m_gridWin->GetClientSize().GetWidth();
-            CalcScrolledPosition(0, rect.y, &dummy, &rect.y);
+            CalcScrolledPosition(0, rect.y, nullptr, &rect.y);
             m_gridWin->Refresh( false, &rect );
         }
 


### PR DESCRIPTION
Replaces #22826 

**Not tested under MacOS!**

By the way, there are two commits not included here (because I need
to double check them before inclusion) which are:

1. This patch:
```
diff --git a/src/generic/grid.cpp b/src/generic/grid.cpp
index bca2f1899e..eba6c4b0ab 100644
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -9941,42 +9941,7 @@ void wxGrid::DoSetRowSize( int row, int height )
 
     if ( ShouldRefresh() )
     {
-        // We need to check the size of all the currently visible cells and
-        // decrease the row to cover the start of the multirow cells, if any,
-        // because we need to refresh such cells entirely when resizing.
-        int topRow = row;
-
-        // Note that we don't care about the cells in frozen windows here as
-        // they can't have multiple rows currently.
-        const wxRect rect = m_gridWin->GetRect();
-        int left, right;
-        CalcUnscrolledPosition(rect.GetLeft(), 0, &left, NULL);
-        CalcUnscrolledPosition(rect.GetRight(), 0, &right, NULL);
-
-        const int posLeft = XToPos(left, m_gridWin);
-        const int posRight = XToPos(right, m_gridWin);
-        for ( int pos = posLeft; pos <= posRight; ++pos )
-        {
-            int col = GetColAt(pos);
-
-            int numRows, numCols;
-            if ( GetCellSize(row, col, &numRows, &numCols) == CellSpan_Inside )
-            {
-                // Notice that numRows here is negative.
-                if ( row + numRows < topRow )
-                    topRow = row + numRows;
-            }
-        }
-
-        int y;
-        CalcScrolledPosition(0, GetRowTop(topRow), NULL, &y);
-
-        // Refresh the lower part of the window below the y position
-        int cw, ch;
-        GetClientSize(&cw, &ch);
-
-        const wxRect updateRect(0, y, cw, ch - y);
-        Refresh(true, &updateRect);
+        RefreshArea(wxGA_RowLabels | wxGA_Cells);
     }
 }
 
@@ -10084,40 +10049,7 @@ void wxGrid::DoSetColSize( int col, int width )
 
     if ( ShouldRefresh() )
     {
-        // This code is symmetric with DoSetRowSize(), see there for more
-        // comments.
-
-        int leftCol = col;
-
-        const wxRect rect = m_gridWin->GetRect();
-        int top, bottom;
-        CalcUnscrolledPosition(0, rect.GetTop(), NULL, &top);
-        CalcUnscrolledPosition(0, rect.GetBottom(), NULL, &bottom);
-
-        const int posTop = YToPos(top, m_gridWin);
-        const int posBottom = YToPos(bottom, m_gridWin);
-        for ( int pos = posTop; pos <= posBottom; ++pos )
-        {
-            int row = GetRowAt(pos);
-
-            int numRows, numCols;
-            if ( GetCellSize(row, col, &numRows, &numCols) == CellSpan_Inside )
-            {
-                if ( col + numCols < leftCol )
-                    leftCol = col + numCols;
-            }
-        }
-
-        int x;
-        CalcScrolledPosition(GetColLeft(leftCol), 0, &x, NULL);
-
-        // Refresh the further part of the window to the right (LTR)
-        // or to the left (RTL) of the x position
-        int cw, ch;
-        GetClientSize(&cw, &ch);
-
-        const wxRect updateRect(x, 0, cw - x, ch);
-        Refresh(true, &updateRect);
+        RefreshArea(wxGA_ColLabels | wxGA_Cells);
     }
 }

```
My measurements revealed no difference between the two versions at all (optimized vs non-optimized refresh logic) and I'll leave it to someone else to decide which is better here.

2. The refresh performed in `wxGrid::AutoSizeColOrRow()` looks redundant to me, because it is already
done inside `DoSet{Row,Col}Size()` when `Set{Row,Col}Size()` is called! and I will not touch it for the moment for fear of breaking something inadvertently!!

**TODO:** consider using `RefreshRect()` instead.
 
