### PR TITLE
Remove mentions of C++11 in docs

### DIFF
--- a/interface/wx/atomic.h
+++ b/interface/wx/atomic.h
@@ -16,8 +16,8 @@
 /**
     This function increments @a value in an atomic manner.
 
-    @note It is recommended to use @c std::atomic available in C++11 and later
-    instead of this function in any new code.
+    @note It is recommended to use @c std::atomic instead of this function in
+    any new code.
 
     Whenever possible wxWidgets provides an efficient, CPU-specific,
     implementation of this function. If such implementation is available, the

--- a/interface/wx/cmdline.h
+++ b/interface/wx/cmdline.h
@@ -212,7 +212,7 @@ struct wxCmdLineEntryDesc
     }
     @endcode
 
-    With C++11, the for loop could be written:
+    The for loop could be written:
     @code
     for (const auto &arg : parser.GetArguments()) {
         // working on arg as with *itarg above

--- a/interface/wx/dialog.h
+++ b/interface/wx/dialog.h
@@ -630,7 +630,7 @@ public:
         passed as the argument upon completion, instead of generating the
         wxEVT_WINDOW_MODAL_DIALOG_CLOSED event.
 
-        This form is particularly useful in combination with C++11 lambdas,
+        This form is particularly useful in combination with lambdas,
         when it allows writing window-modal very similarly to how ShowModal()
         is used (with the notable exception of not being able to create
         the dialog on stack):

--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -550,7 +550,7 @@ public:
          threads, but that the method will be always called in the main, GUI,
          thread context.
 
-         This overload is particularly useful in combination with C++11 lambdas:
+         This overload is particularly useful in combination with lambdas:
          @code
          wxGetApp().CallAfter([]{
              wxBell();

--- a/interface/wx/grid.h
+++ b/interface/wx/grid.h
@@ -684,13 +684,13 @@ public:
 
     /**
        Return @true to allow the given key to start editing: the base class
-       version only checks that the event has no modifiers. 
+       version only checks that the event has no modifiers.
 
        If the key is F2 (special), editing will always start and this
        method will not be called at all (but StartingKey() will)
     */
     virtual bool IsAcceptedKey(wxKeyEvent& event);
-    
+
 
     /**
        Returns the value currently in the editor control.
@@ -2212,19 +2212,10 @@ struct wxGridBlockDiffResult
     Note that objects of this class can only be returned by wxGrid, but not
     constructed in the application code.
 
-    The preferable way to iterate over it is using C++11 range-for loop:
+    The preferable way to iterate over it is using range-for loop:
     @code
         for ( const auto& block: grid->GetSelectedBlocks() ) {
             ... do something with block ...
-        }
-    @endcode
-    When not using C++11, iteration has to be done manually:
-    @code
-        wxGridBlocks range = grid->GetSelectedBlocks();
-        for ( wxGridBlocks::iterator it = range.begin();
-              it != range.end();
-              ++it ) {
-            ... do something with *it ...
         }
     @endcode
 
@@ -5024,7 +5015,7 @@ public:
     /**
         Returns a range of grid selection blocks.
 
-        The returned range can be iterated over, e.g. with C++11 range-for loop:
+        The returned range can be iterated over, e.g. with range-for loop:
         @code
             for ( const auto block: grid->GetSelectedBlocks() ) {
                 if ( block.Intersects(myBlock) )

--- a/interface/wx/statbox.h
+++ b/interface/wx/statbox.h
@@ -167,8 +167,7 @@ public:
         checkbox stays enabled even if @c box->Enable(false) is called.
 
         However with the actual behaviour, implemented in this overridden
-        method, the following code (shown using C++11 only for convenience,
-        this behaviour is not C++11-specific):
+        method, the following code:
         @code
             auto check = new wxCheckBox(parent, wxID_ANY, "Use the box");
             auto box = new wxStaticBox(parent, wxID_ANY, check);

--- a/interface/wx/thread.h
+++ b/interface/wx/thread.h
@@ -188,7 +188,7 @@ public:
         return wxCOND_NO_ERROR;
         @endcode
 
-        The predicate would typically be a C++11 lambda:
+        The predicate would typically be a lambda:
         @code
         condvar.Wait([]{return value == 1;});
         @endcode

--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -576,7 +576,6 @@ public:
     handler provided URLs.
 
     This backend is not enabled by default, to build it follow these steps:
-    - Visual Studio 2015 or newer, or GCC/Clang with c++11 is required
     - With CMake just enable @c wxUSE_WEBVIEW_EDGE
     - When not using CMake:
         - Download the <a href="https://aka.ms/webviewnuget">WebView2 SDK</a>


### PR DESCRIPTION
Since wxWidgets now requires C++11 it's not necessary to point out C++11 features as such explicitly.

BTW maybe it would make sense to deprecate `wxThread`, `wxCondition` and `wxMutex` as the docs now pretty much only recommend not to use them.