### PR TITLE
Add support for wxUSE_TASKBARBUTTON option to configure

### DIFF
--- a/configure
+++ b/configure
@@ -1365,6 +1365,7 @@ enable_ico_cur
 enable_dccache
 enable_ps_in_msw
 enable_ownerdrawn
+enable_taskbarbutton
 enable_uxtheme
 enable_wxdib
 enable_webviewie
@@ -2334,6 +2335,7 @@ Optional Features:
   --enable-dccache        cache temporary wxDC objects (Win32 only)
   --enable-ps-in-msw      use PS printing in wxMSW (Win32 only)
   --enable-ownerdrawn     use owner drawn controls (Win32 and OS/2 only)
+  --enable-taskbarbutton  enable wxTaskBarButton (Win32 only)
   --enable-uxtheme        enable support for Windows XP themed look (Win32 only)
   --enable-wxdib          use wxDIB class (Win32 only)
   --enable-webviewie      use wxWebView IE backend (Win32 only)
@@ -12734,6 +12736,35 @@ fi
 
 
           eval "$wx_cv_use_ownerdrawn"
+
+
+          enablestring=
+          defaultval=$wxUSE_ALL_FEATURES
+          if test -z "$defaultval"; then
+              if test x"$enablestring" = xdisable; then
+                  defaultval=yes
+              else
+                  defaultval=no
+              fi
+          fi
+
+          # Check whether --enable-taskbarbutton was given.
+if test "${enable_taskbarbutton+set}" = set; then :
+  enableval=$enable_taskbarbutton;
+                          if test "$enableval" = yes; then
+                            wx_cv_use_taskbarbutton='wxUSE_TASKBARBUTTON=yes'
+                          else
+                            wx_cv_use_taskbarbutton='wxUSE_TASKBARBUTTON=no'
+                          fi
+
+else
+
+                          wx_cv_use_taskbarbutton='wxUSE_TASKBARBUTTON=${'DEFAULT_wxUSE_TASKBARBUTTON":-$defaultval}"
+
+fi
+
+
+          eval "$wx_cv_use_taskbarbutton"
 
 
           enablestring=
@@ -40335,6 +40366,11 @@ if test "$wxUSE_MSW" = 1 ; then
 
     if test "$wxUSE_POSTSCRIPT_ARCHITECTURE_IN_MSW" = "yes"; then
         $as_echo "#define wxUSE_POSTSCRIPT_ARCHITECTURE_IN_MSW 1" >>confdefs.h
+
+    fi
+
+    if test "$wxUSE_TASKBARBUTTON" = "yes"; then
+        $as_echo "#define wxUSE_TASKBARBUTTON 1" >>confdefs.h
 
     fi
 

--- a/configure.in
+++ b/configure.in
@@ -1059,6 +1059,7 @@ dnl ---------------------------------------------------------------------------
 WX_ARG_FEATURE(dccache,     [  --enable-dccache        cache temporary wxDC objects (Win32 only)], wxUSE_DC_CACHEING)
 WX_ARG_FEATURE(ps-in-msw,   [  --enable-ps-in-msw      use PS printing in wxMSW (Win32 only)], wxUSE_POSTSCRIPT_ARCHITECTURE_IN_MSW)
 WX_ARG_FEATURE(ownerdrawn,  [  --enable-ownerdrawn     use owner drawn controls (Win32 and OS/2 only)], wxUSE_OWNER_DRAWN)
+WX_ARG_FEATURE(taskbarbutton,[  --enable-taskbarbutton  enable wxTaskBarButton (Win32 only)], wxUSE_TASKBARBUTTON)
 WX_ARG_FEATURE(uxtheme,     [  --enable-uxtheme        enable support for Windows XP themed look (Win32 only)], wxUSE_UXTHEME)
 WX_ARG_FEATURE(wxdib,       [  --enable-wxdib          use wxDIB class (Win32 only)], wxUSE_DIB)
 WX_ARG_FEATURE(webviewie,   [  --enable-webviewie      use wxWebView IE backend (Win32 only)], wxUSE_WEBVIEW_IE)
@@ -7163,6 +7164,10 @@ if test "$wxUSE_MSW" = 1 ; then
 
     if test "$wxUSE_POSTSCRIPT_ARCHITECTURE_IN_MSW" = "yes"; then
         AC_DEFINE(wxUSE_POSTSCRIPT_ARCHITECTURE_IN_MSW)
+    fi
+
+    if test "$wxUSE_TASKBARBUTTON" = "yes"; then
+        AC_DEFINE(wxUSE_TASKBARBUTTON)
     fi
 
     if test "$wxUSE_UXTHEME" = "yes"; then


### PR DESCRIPTION
Add new --enable-taskbarbutton option and define wxUSE_TASKBARBUTTON as 1 by default instead of always defining it as 0, as was the case before.

Closes #22900.