### PR TITLE
Use usual half-open interval for wxID_LOWEST..wxID_HIGHEST

### DIFF
--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -1779,10 +1779,10 @@ enum wxStandardID
     wxID_ANY = -1,
 
 
-    /* all predefined ids are between wxID_LOWEST and wxID_HIGHEST */
-    wxID_LOWEST = 4999,
+    /* all predefined ids are between wxID_LOWEST and wxID_HIGHEST (exclusive) */
+    wxID_LOWEST = 5000,
 
-    wxID_OPEN,
+    wxID_OPEN = wxID_LOWEST,
     wxID_CLOSE,
     wxID_NEW,
     wxID_SAVE,
@@ -1935,7 +1935,8 @@ enum wxStandardID
     /*  IDs used by generic file ctrl (4 consecutive starting from this value) */
     wxID_FILECTRL = 5950,
 
-    wxID_HIGHEST = 5999
+    /* Lowest ID not reserved for standard wx IDs greater than wxID_LOWEST */
+    wxID_HIGHEST = 6000
 };
 
 /*  ---------------------------------------------------------------------------- */

--- a/interface/wx/defs.h
+++ b/interface/wx/defs.h
@@ -591,11 +591,12 @@ enum wxStandardID
     /**
         Start of the range reserved for wxWidgets-defined IDs.
 
-        Don't define custom IDs in the range from wxID_LOWEST to wxID_HIGHEST.
+        Don't define custom IDs in the range from wxID_LOWEST to wxID_HIGHEST
+        (exclusive).
      */
-    wxID_LOWEST = 4999,
+    wxID_LOWEST = 5000,
 
-    wxID_OPEN,
+    wxID_OPEN = wxID_LOWEST,
     wxID_CLOSE,
     wxID_NEW,
     wxID_SAVE,
@@ -743,13 +744,14 @@ enum wxStandardID
     /**
         End of the range reserved for wxWidgets-defined IDs.
 
-        Don't define custom IDs in the range from wxID_LOWEST to wxID_HIGHEST.
+        Don't define custom IDs in the range from wxID_LOWEST to wxID_HIGHEST
+        (exclusive).
 
         When using an enum to define a number of custom IDs, assigning the
-        value of @c wxID_HIGHEST+1 to the first element ensures that none of
+        value of @c wxID_HIGHEST to the first element ensures that none of
         the enum elements will conflict with any standard IDs.
      */
-    wxID_HIGHEST = 5999
+    wxID_HIGHEST = 6000
 };
 
 /**


### PR DESCRIPTION
The reserved wx IDs were previously in (wxID_LOWEST, wxID_HIGHEST] range, which was very unusual, as C++ always uses intervals half-open in the other direction, i.e. [begin, end).

It also conflicted (in theory, if not in practice, as wxID_HIGHEST wasn't actually used for anything) with the common practice, used even by wx own samples, of starting the custom IDs at wxID_HIGHEST rather than wxID_HIGHEST+1.

So change this to use the standard convention, retroactively making all the code using wxID_HIGHEST valid -- this seems better than insisting on starting the IDs from wxID_HIGHEST+1.

---

This replaces #22904.