### PR TITLE
Revert "Disable use of build system pkg-config files when cross-compiling"

### DIFF
--- a/.github/workflows/ci_mac.yml
+++ b/.github/workflows/ci_mac.yml
@@ -93,6 +93,7 @@ jobs:
           runner: macos-11
           arch: x86_64
           configure_flags: --with-osx_iphone --enable-monolithic  --disable-sys-libs --host=i686-apple-darwin_sim --build=x86_64-apple-darwin17.7.0
+          configure_env: PKG_CONFIG_LIBDIR=/dev/null
           xcode_sdk: iphonesimulator
           skip_samples: true
           skip_testing: true
@@ -171,9 +172,9 @@ jobs:
           wxASAN_CXXFLAGS=$wxASAN_CFLAGS
           wxASAN_LDFLAGS="-fsanitize=address"
 
-          ./configure $wxCONFIGURE_OPTIONS --enable-debug "CFLAGS=$wxASAN_CFLAGS" "CXXFLAGS=$wxASAN_CXXFLAGS" "LDFLAGS=$wxASAN_LDFLAGS" || rc=$?
+          ${{ matrix.configure_env }} ./configure $wxCONFIGURE_OPTIONS --enable-debug "CFLAGS=$wxASAN_CFLAGS" "CXXFLAGS=$wxASAN_CXXFLAGS" "LDFLAGS=$wxASAN_LDFLAGS" || rc=$?
         else
-          ./configure $wxCONFIGURE_OPTIONS --disable-debug_info || rc=$?
+          ${{ matrix.configure_env }} ./configure $wxCONFIGURE_OPTIONS --disable-debug_info || rc=$?
         fi
         if [ -n "$rc" ]; then
           echo '*** Configuring failed, contents of config.log follows: ***'

--- a/.github/workflows/ci_mac.yml
+++ b/.github/workflows/ci_mac.yml
@@ -99,7 +99,6 @@ jobs:
           allow_warnings: true
 
     env:
-      wxCONFIGURE_FLAGS: --disable-sys-libs --without-liblzma ${{ matrix.configure_flags }} --prefix=${{ github.workspace }}/localbin_${{ matrix.arch }}
       wxUSE_ASAN: ${{ matrix.use_asan && 1 || 0 }}
       DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
       NSUnbufferedIO: YES
@@ -160,7 +159,7 @@ jobs:
 
     - name: Configuring
       run: |
-        wxCONFIGURE_OPTIONS="--disable-optimise $wxCONFIGURE_FLAGS"
+        wxCONFIGURE_OPTIONS="--disable-optimise --disable-sys-libs --without-liblzma ${{ matrix.configure_flags }} --prefix=${{ github.workspace }}/localbin_${{ matrix.arch }}"
 
         if [ -n "${{ matrix.xcode_sdk }}" ]; then
           sdk_path=`xcrun --sdk ${{ matrix.xcode_sdk }} --show-sdk-path`

--- a/configure
+++ b/configure
@@ -25188,15 +25188,6 @@ $as_echo "no" >&6; }
 
 fi
 
-if test "$build" != "$host"; then
-
-
-                if test -z "$PKG_CONFIG_LIBDIR"; then
-        PKG_CONFIG_LIBDIR=/dev/null
-        export PKG_CONFIG_LIBDIR
-    fi
-fi
-
 
 
 if test "$wxUSE_REGEX" != "no"; then

--- a/configure.in
+++ b/configure.in
@@ -2106,23 +2106,6 @@ fi
 dnl Find pkg-config outside of any conditional.  Done before any PKG_* call.
 PKG_PROG_PKG_CONFIG
 
-dnl When cross-compiling, don't use .pc files on the build system, they are at
-dnl best useless and can be harmful (e.g. they may define options inappropriate
-dnl for the cross-build, resulting in the failure of all the subsequent tests).
-if test "$build" != "$host"; then
-    dnl pkg.m4 forbids the use of PKG_XXX, so undo it here to avoid autoconf
-    dnl errors.
-    m4_pattern_allow([PKG_CONFIG_LIBDIR])
-
-    dnl If pkg-config libdir is already defined, we suppose that they know what
-    dnl they're doing and leave it alone, but if not, set it to a path in which
-    dnl no .pc files will be found.
-    if test -z "$PKG_CONFIG_LIBDIR"; then
-        PKG_CONFIG_LIBDIR=/dev/null
-        export PKG_CONFIG_LIBDIR
-    fi
-fi
-
 dnl ---------------------------------------------------------------------------
 dnl Optional libraries
 dnl


### PR DESCRIPTION
This reverts commit 893ebbab0c5c569e68c0e8c8337e7b79cbc302eb because it breaks cross-compiling using target-specific pkg-config installed on the main system, which is a perfectly legitimate use case.

To avoid the original problem fixed by that commit, PKG_CONFIG_LIBDIR needs to be set manually before running configure when using host pkg-config -- but not when using target pkg-config.

Closes #22886.