### PR TITLE
Make wxQt::Refresh() compliant with the documentation

### DIFF
--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -561,11 +561,35 @@ void wxWindowQt::Refresh( bool WXUNUSED( eraseBackground ), const wxRect *rect )
                        GetName(),
                        rect->x, rect->y, rect->width, rect->height);
             widget->update( wxQtConvertRect( *rect ));
+
+            wxWindowList& children = GetChildren();
+            if ( !children.empty() )
+            {
+                wxRect parentRect = *rect;
+                ClientToScreen(&parentRect.x, &parentRect.y);
+
+                for ( auto childWin : children )
+                {
+                    wxRect childRect = childWin->GetScreenRect();
+                    childRect.Intersect(parentRect);
+                    if ( !childRect.IsEmpty() )
+                    {
+                        childWin->ScreenToClient(&childRect.x, &childRect.y);
+                        childWin->RefreshRect(childRect);
+                    }
+                }
+            }
         }
         else
         {
             wxLogTrace(TRACE_QT_WINDOW, wxT("wxWindow::Refresh %s"), GetName());
             widget->update();
+
+            wxWindowList& children = GetChildren();
+            for ( auto childWin : children )
+            {
+                childWin->Refresh();
+            }
         }
     }
 }


### PR DESCRIPTION
`wxWindow::Refresh()` documentation says:
> Causes this window, and all of its children recursively, to be repainted.

This commit add the missing recursion explicitly as there is no way to tell **Qt** to obey to the wx convention of refreshing windows.

see: https://forum.qt.io/topic/7891/how-to-forcibly-update-child-widgets-in-parent