### PR TITLE
wxQt: wxAnyButton should override GetLabel() too

### DIFF
--- a/include/wx/qt/anybutton.h
+++ b/include/wx/qt/anybutton.h
@@ -24,6 +24,7 @@ public:
     // --------------
 
     virtual void SetLabel( const wxString &label ) override;
+    virtual wxString GetLabel() const override;
 
     virtual QWidget *GetHandle() const override;
 

--- a/src/qt/anybutton.cpp
+++ b/src/qt/anybutton.cpp
@@ -115,6 +115,11 @@ void wxAnyButton::SetLabel( const wxString &label )
     m_qtPushButton->setText( wxQtConvertString( label ));
 }
 
+wxString wxAnyButton::GetLabel() const
+{
+    return wxQtConvertString( m_qtPushButton->text() );
+}
+
 QWidget *wxAnyButton::GetHandle() const
 {
     return m_qtPushButton;


### PR DESCRIPTION
`wxAnyButton` already overrides `SetLabel()`, but not `GetLabel()` in which case an empty string will be returned if we try to call it because the base class version is trying to return the window title instead of the window text/label and this is obviously wrong.