### PR TITLE
Always use vendor in CMake-built DLLs regardless of version

### DIFF
--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -212,7 +212,7 @@ function(wx_set_target_properties target_name)
     if(wxCOMPILER_PREFIX)
         wx_string_append(dll_suffix "_${wxCOMPILER_PREFIX}")
     endif()
-    if(wxBUILD_VENDOR AND wxVERSION_IS_DEV)
+    if(wxBUILD_VENDOR)
         wx_string_append(dll_suffix "_${wxBUILD_VENDOR}")
     endif()
 


### PR DESCRIPTION
The vendor string was ignored for the stable wxWidgets versions (e.g., 3.2). However, vendor should be always used when available, regardless of wxWidgets version. The only case when vendor should not be used is when creating official builds (currently not done with CMake).

This should be back-ported to 3.2, as that version is currently affected (but it will produce different DLL names than 3.2.0 and 3.2.1...).