### PR TITLE
Remove "98" from the supported C++ standards list in CMake

### DIFF
--- a/build/cmake/options.cmake
+++ b/build/cmake/options.cmake
@@ -53,7 +53,7 @@ if(NOT MSVC OR MSVC_VERSION GREATER 1800)
         set(wxCXX_STANDARD_DEFAULT COMPILER_DEFAULT)
     endif()
     wx_option(wxBUILD_CXX_STANDARD "C++ standard used to build wxWidgets targets"
-              ${wxCXX_STANDARD_DEFAULT} STRINGS COMPILER_DEFAULT 98 11 14 17 20)
+              ${wxCXX_STANDARD_DEFAULT} STRINGS COMPILER_DEFAULT 11 14 17 20)
 endif()
 
 if(WIN32)


### PR DESCRIPTION
wxWidgets now requires at least C++11.