### PR TITLE
Update docs [docs] [low priority]

### DIFF
--- a/docs/doxygen/mainpages/platdetails.h
+++ b/docs/doxygen/mainpages/platdetails.h
@@ -84,7 +84,7 @@ In order to configure wxWidgets to compile wxX11 you will need to type:
 wxMSW is a port of wxWidgets for the Windows platforms (Windows XP and later
 are supported). wxMSW provides native look and feel for each Windows version.
 This port can be compiled with several compilers including Microsoft
-VC++ 2005 or later, MinGW, Cygwin as well as cross-compilation with a
+VC++ 2015 or later, MinGW, Cygwin as well as cross-compilation with a
 Linux-hosted MinGW tool chain.
 
 @subpage plat_msw_install "Build and Install Instructions"

--- a/docs/doxygen/overviews/archive.h
+++ b/docs/doxygen/overviews/archive.h
@@ -181,7 +181,7 @@ entries looked up by name can be opened using the
 wxArchiveInputStream::OpenEntry() method.
 
 @code
-using ZipEntryPtr = std::shared_ptr<wxZipEntry>;
+using ZipEntryPtr = std::unique_ptr<wxZipEntry>;
 using ZipCatalog = std::map<wxString, ZipEntryPtr>;
 ZipEntryPtr entry;
 ZipCatalog cat;
@@ -192,7 +192,7 @@ wxZipInputStream zip(in);
 
 // load the zip catalog
 while (entry.reset(zip.GetNextEntry()), entry.get() != nullptr)
-    cat[entry->GetInternalName()] = entry;
+    cat[entry->GetInternalName()] = std::move(entry);
 
 // open an entry by name
 auto it = cat.find(wxZipEntry::GetInternalName(localName));

--- a/docs/doxygen/overviews/archive.h
+++ b/docs/doxygen/overviews/archive.h
@@ -14,7 +14,7 @@
 The archive classes handle archive formats such as zip.
 Currently zip and tar support is bundled with wxWidgets and
 when external liblzma library is available (see @ref page_build_liblzma),
-XZ format using LZMA2 algorithm is supported.
+XZ format using LZMA2 algorithm is supported as well.
 
 For each archive type, there are the following classes (using zip here as an
 example):

--- a/docs/doxygen/overviews/archive.h
+++ b/docs/doxygen/overviews/archive.h
@@ -67,7 +67,7 @@ ownership).
 Reading from the input stream then returns the entry's data. Eof() becomes
 @true after an attempt has been made to read past the end of the entry's data.
 
-When there are no more entries, GetNextEntry() returns @nullptr and sets Eof().
+When there are no more entries, GetNextEntry() returns @NULL and sets Eof().
 
 @code
 std::unique_ptr<wxZipEntry> entry;

--- a/docs/doxygen/overviews/archive.h
+++ b/docs/doxygen/overviews/archive.h
@@ -14,7 +14,7 @@
 The archive classes handle archive formats such as zip.
 Currently zip and tar support is bundled with wxWidgets and
 when external liblzma library is available (see @ref page_build_liblzma),
-XZ format using LZMA2 alghoritm is supported.
+XZ format using LZMA2 algorithm is supported.
 
 For each archive type, there are the following classes (using zip here as an
 example):

--- a/docs/doxygen/overviews/backwardcompatibility.h
+++ b/docs/doxygen/overviews/backwardcompatibility.h
@@ -11,15 +11,9 @@
 
 @tableofcontents
 
-Many of the GUIs and platforms supported by wxWidgets are continuously
-evolving, and some of the new platforms wxWidgets now supports were quite
-unimaginable even a few years ago. In this environment wxWidgets must also
-evolve in order to support these new features and platforms.
-
-However the goal of wxWidgets is not only to provide a consistent programming
+The goal of wxWidgets is not only to provide a consistent programming
 interface across many platforms, but also to provide an interface that is
-reasonably stable over time, to help protect its users from some of the
-uncertainty of the future.
+reasonably stable over time.
 
 
 
@@ -33,20 +27,20 @@ major.minor.release.sub-release
 @endverbatim
 
 A stable release of wxWidgets will have an even number for @e minor, e.g.
-2.6.0. Stable, in this context, means that the API is not changing. In truth,
+3.2.0. Stable, in this context, means that the API is not changing. In truth,
 some changes are permitted, but only those that are backward compatible. For
-example, you can expect later 2.6.x releases, such as 2.6.1 and 2.6.2 to be
+example, you can expect later 3.2.x releases, such as 3.2.1 and 3.2.2 to be
 backward compatible with their predecessor.
 
 When it becomes necessary to make changes which are not wholly backward
 compatible, the stable branch is forked, creating a new development branch of
 wxWidgets. This development branch will have an odd number for @e minor, for
-example 2.7.x. Releases from this branch are known as development snapshots.
+example 3.3.x. Releases from this branch are known as development snapshots.
 
 The stable branch and the development branch will then be developed in parallel
 for some time. When it is no longer useful to continue developing the stable
 branch, the development branch is renamed and becomes a new stable branch, for
-example: 2.8.0. And the process begins again. This is how the tension between
+example: 3.4.0. And the process begins again. This is how the tension between
 keeping the interface stable, and allowing the library to evolve is managed.
 
 You can expect the versions with the same major and even minor version number
@@ -59,43 +53,43 @@ require no changes or only small changes to work with the new version.
 
 Later releases from a stable branch are backward compatible with earlier
 releases from the same branch at the source level. This means that, for
-example, if you develop your application using wxWidgets 2.8.0 then it should
-also compile fine with all later 2.8.x versions.
+example, if you develop your application using wxWidgets 3.2.0 then it should
+also compile fine with all later 3.2.x versions.
 
 The converse is also true providing you avoid any new features not present in
-the earlier version. For example if you develop using 2.6.1 your program will
-compile fine with wxWidgets 2.8.0 providing you don't use any 2.8.1 specific
+the earlier version. For example if you develop using 3.3.1 your program will
+compile fine with wxWidgets 3.2.0 providing you don't use any 3.3.1 specific
 features.
 
 For some platforms binary compatibility is also supported, see
 @ref overview_backwardcompat_libbincompat below.
 
-Between minor versions, for example between 2.4.x, 2.6.x and 2.8.x, there will
+Between minor versions, for example between 2.8.x, 3.0.x and 3.2.x, there will
 be some incompatibilities. Wherever possible the old way of doing something is
 kept alongside the new for a time wrapped inside:
 
 @code
-#if WXWIN_COMPATIBILITY_2_6
+#if WXWIN_COMPATIBILITY_3_0
     // deprecated feature
     ...
 #endif
 @endcode
 
 By default the @c WXWIN_COMPATIBILITY_X_X macro is set to 1 for the previous
-stable branch, for example in 2.8.x, @c WXWIN_COMPATIBILITY_2_6 = 1. For the
-next earlier stable branch the default is 0, so @c WXWIN_COMPATIBILITY_2_4 = 0
-for 2.8.x. Earlier than that, obsolete features are removed.
+stable branch, for example in 3.2.x, @c WXWIN_COMPATIBILITY_3_0 = 1. For the
+next earlier stable branch the default is 0, so @c WXWIN_COMPATIBILITY_2_8 = 0
+for 3.2.x. Earlier than that, obsolete features are removed.
 
 These macros can be changed in @c setup.h. Or on UNIX-like systems you can set
-them using the @c \--disable-compat26 and @c \--enable-compat24 options to
-configure.
+them using the @c \--disable-compat30 and @c \--enable-compat28 options to
+configure. Their values can also be changed with CMake.
 
 They can be useful in two ways:
 
-@li Changing @c WXWIN_COMPATIBILITY_2_6 to 0 can be useful to find uses of
+@li Changing @c WXWIN_COMPATIBILITY_3_0 to 0 can be useful to find uses of
     deprecated features in your program that should eventually be removed.
-@li Changing @c WXWIN_COMPATIBILITY_2_4 to 1 can be useful to compile a program
-    developed using 2.4.x that no longer compiles with 2.8.x.
+@li Changing @c WXWIN_COMPATIBILITY_2_8 to 1 can be useful to compile a program
+    developed using 2.8.x that no longer compiles with 3.2.x.
 
 A program requiring one of these macros to be 1 will become incompatible with
 some future version of wxWidgets, and you should consider updating it.
@@ -111,11 +105,11 @@ shared libraries, also known as dynamic link libraries (DLLs) on Windows or
 dynamic shared libraries on macOS.
 
 For example, suppose several applications are installed on a system requiring
-wxWidgets 2.6.0, 2.6.1 and 2.6.2. Since 2.6.2 is backward compatible with the
-earlier versions, it should be enough to install just wxWidgets 2.6.2 shared
+wxWidgets 3.2.0, 3.2.1 and 3.2.2. Since 3.2.2 is backward compatible with the
+earlier versions, it should be enough to install just wxWidgets 3.2.2 shared
 libraries, and all the applications should be able to use them. If binary
-compatibility is not supported, then all the required versions 2.6.0, 2.6.1 and
-2.6.2 must be installed side by side.
+compatibility is not supported, then all the required versions 3.2.0, 3.2.1 and
+3.2.2 must be installed side by side.
 
 Achieving this, without the user being required to have the source code and
 recompile everything, places many extra constraints on the changes that can be
@@ -134,12 +128,12 @@ of the same compiler are not compatible.
 @section overview_backwardcompat_appbincompat Application Binary Compatibility
 
 The most important aspect of binary compatibility is that applications compiled
-with one version of wxWidgets, e.g. 2.6.1, continue to work with shared
-libraries of a later binary compatible version, for example 2.6.2. The converse
+with one version of wxWidgets, e.g. 3.2.1, continue to work with shared
+libraries of a later binary compatible version, for example 3.2.2. The converse
 can also be useful however. That is, it can be useful for a developer using a
-later version, e.g. 2.6.2 to be able to create binary application packages that
+later version, e.g. 3.2.2 to be able to create binary application packages that
 will work with all binary compatible versions of the shared library starting
-with, for example 2.6.0.
+with, for example 3.2.0.
 
 To do this the developer must, of course, avoid any features not available in
 the earlier versions. However this is not necessarily enough; in some cases an
@@ -150,7 +144,7 @@ To help with this, a preprocessor symbol @c wxABI_VERSION can be defined during
 the compilation of the application (this would usually be done in the
 application's makefile or project settings). It should be set to the lowest
 version that is being targeted, as a number with two decimal digits for each
-component, for example @c wxABI_VERSION=20600 for 2.6.0.
+component, for example @c wxABI_VERSION=30200 for 3.2.0.
 
 Setting @c wxABI_VERSION should prevent the application from implicitly
 depending on a later version of wxWidgets, and also disables any new features
@@ -160,7 +154,7 @@ versions of wxWidgets being targeted.
 Uses of @c wxABI_VERSION are stripped out of the wxWidgets sources when each
 new development branch is created. Therefore it is only useful to help achieve
 compatibility with earlier versions with the same major and even minor version
-numbers. It won't, for example, help you write code compatible with 2.6.x using
-wxWidgets 2.8.x.
+numbers. It won't, for example, help you write code compatible with 3.0.x using
+wxWidgets 3.2.x.
 
 */

--- a/docs/doxygen/overviews/envvars.h
+++ b/docs/doxygen/overviews/envvars.h
@@ -39,3 +39,4 @@ wxWidgets programs.
          be safely ignored if the code works as expected.}
 */
 
+@see wxSystemOptions

--- a/docs/doxygen/overviews/exceptions.h
+++ b/docs/doxygen/overviews/exceptions.h
@@ -12,17 +12,12 @@
 @tableofcontents
 
 wxWidgets had been started long before the exceptions were introduced in C++ so
-it is not very surprising that it is not built around using them as some more
-modern C++ libraries are. For instance, the library doesn't throw exceptions to
-signal about the errors. Moreover, up to (and including) the version 2.4 of
-wxWidgets, even using the exceptions in the user code was dangerous because the
-library code wasn't exception-safe and so an exception propagating through it
-could result in memory and/or resource leaks, and also not very convenient.
+it is not very surprising that it is not built around using them, i.e.
+the library doesn't throw exceptions to signal about the errors.
 
-However the recent wxWidgets versions are exception-friendly. This means that
-while the library still doesn't use the exceptions by itself, it should be now
-safe to use the exceptions in the user code and the library tries to help you
-with this.
+However it is exception-friendly. This means that while the library doesn't
+use the exceptions by itself, it should be now safe to use the exceptions in
+the user code and the library tries to help you with this.
 
 
 
@@ -96,17 +91,6 @@ void TestNewDocument()
     }
 }
 @endcode
-
-Unfortunately, by default this example only works when using a C++11 compiler
-because the exception can't be safely propagated back to the code handling it
-in @c TestNewDocument() through the system event dispatch functions which are
-not compatible with C++ exceptions and needs to be stored by wxWidgets when it
-is first caught and rethrown later, when it is safe to do it. And such storing
-and rethrowing of exceptions is only possible in C++11, so while everything
-just works if you do use C++11, there is an extra step if you are using C++98:
-In this case you need to override wxApp::StoreCurrentException() and
-wxApp::RethrowStoredException() to help wxWidgets to do this, please see the
-documentation of these functions for more details.
 
 
 @section overview_exceptions_tech Technicalities

--- a/docs/doxygen/overviews/thread.h
+++ b/docs/doxygen/overviews/thread.h
@@ -16,26 +16,21 @@
 
 @tableofcontents
 
+@note In the new code, it is highly recommended to use concurrency classes
+      provided in C++11 and newer, instead of their wxWidgets counterparts.
+      The warning about not using GUI classes from non-GUI threads still applies.
+
 wxWidgets provides a complete set of classes encapsulating objects necessary in
 multi-threaded (MT) applications: the wxThread class itself and different
 synchronization objects: mutexes (see wxMutex) and critical sections (see
 wxCriticalSection) with conditions (see wxCondition). The thread API in
-wxWidgets resembles to POSIX1.c threads API (a.k.a. pthreads), although several
+wxWidgets resembles to POSIX thread API (a.k.a. pthreads), although several
 functions have different names and some features inspired by Win32 thread API
 are there as well.
 
 These classes hopefully make writing MT programs easier and they also provide
 some extra error checking (compared to the native - be it Win32 or Posix -
-thread API), however it is still a non-trivial undertaking especially for large
-projects. Before starting an MT application (or starting to add MT features to
-an existing one) it is worth asking oneself if there is no easier and safer way
-to implement the same functionality. Of course, in some situations threads
-really make sense (classical example is a server application which launches a
-new thread for each new client), but in others it might be an overkill. On the
-other hand, the recent evolution of the computer hardware shows an important
-trend towards multi-core systems, which are better exploited using multiple
-threads (e.g. you may want to split a long task among as many threads as many
-CPU (cores) the system reports; see wxThread::GetCPUCount).
+thread API).
 
 To implement non-blocking operations @e without using multiple threads you have
 two possible implementation choices:
@@ -44,8 +39,8 @@ two possible implementation choices:
 - do everything at once but call wxWindow::Update() or wxApp::YieldFor(wxEVT_CATEGORY_UI)
   periodically to update the screen.
 
-If instead you choose to use threads in your application, please read the
-following section of this overview.
+However, it is generally much better to run time-consuming tasks in worker threads instead
+of trying to work around blocked GUI (and risk reentrancy problems).
 
 @see wxThread, wxThreadHelper, wxMutex, wxCriticalSection, wxCondition,
      wxSemaphore
@@ -60,9 +55,11 @@ thread and several worker threads which communicate with the main one using
 @b events is much more robust and will undoubtedly save you countless problems
 (example: under Win32 a thread can only access GDI objects such as pens,
 brushes, device contexts created by itself and not by the other threads).
+The GUI thread is the thread in which wxWidgets was initialized, where
+wxIsMainThread() returns @true.
 
 For communication between secondary threads and the main thread, you may use
-wxEvtHandler::QueueEvent or its short version ::wxQueueEvent. These functions
+wxEvtHandler::QueueEvent() or its short version ::wxQueueEvent(). These functions
 have a thread-safe implementation so that they can be used as they are for
 sending events from one thread to another. However there is no built in method
 to send messages to the worker threads and you will need to use the available

--- a/docs/msw/install.md
+++ b/docs/msw/install.md
@@ -479,7 +479,7 @@ project file from `$WXWIN\samples\minimal` or some other sample and adapt it to
 your application.
 
 If you are not using Visual Studio please see
-@subpage plat_msw_winxp "Windows XP Support" to enable visual styles in your
+@subpage plat_msw_winxp "Theme Support" to enable visual styles in your
 application.
 
 Advanced Library Configurations        {#msw_advanced}

--- a/docs/msw/install.md
+++ b/docs/msw/install.md
@@ -310,11 +310,9 @@ The full list of the build settings follows:
 
 * `MONOLITHIC=1`
 
-  Starting with version 2.5.1, wxWidgets has the ability to be built as
-  several smaller libraries instead of single big one as used to be the case
-  in 2.4 and older versions. This is called "multilib build" and is the
-  default behaviour of makefiles. You can still build single library
-  ("monolithic build") by setting MONOLITHIC variable to 1.
+  wxWidgets is by default built as several smaller libraries ("multilib build")
+  instead of single big one as used to be the case in its much older versions.
+  You can still build single library ("monolithic build") by setting MONOLITHIC variable to 1.
 
 * `USE_GUI=0`
 
@@ -333,7 +331,7 @@ The full list of the build settings follows:
 
   Links static version of C and C++ runtime libraries into the executable, so
   that the program does not depend on DLLs provided with the compiler (e.g.
-  Visual C++'s msvcrt.dll).
+  Visual C++'s msvcrt.dll). Can be used only with MSVC.
   Caution: Do not use static runtime libraries when building DLL (SHARED=1)!
 
 * `DEBUG_FLAG=0`
@@ -396,8 +394,8 @@ The full list of the build settings follows:
 * `COMPILER_PREFIX=<string>`
 
   If you build with multiple versions of the same compiler, you can put
-  their outputs into directories like `vc6_lib`, `vc8_lib` etc. instead of
-  `vc_lib` by setting this variable to e.g. `vc6`. This is merely a
+  their outputs into directories like `vc14_lib`, `vc15_lib` etc. instead of
+  `vc_lib` by setting this variable to e.g. `vc15`. This is merely a
   convenience variable, you can achieve the same effect (but different
   directory names) with the CFG option.
 
@@ -415,7 +413,7 @@ The full list of the build settings follows:
 Building Applications Using wxWidgets  {#msw_build_apps}
 =====================================
 
-If you use MSVS 2010 or later IDE for building your project, simply add
+If you use MSVS for building your project, simply add
 `wxwidgets.props` property sheet to (all) your project(s) using wxWidgets
 by using "View|Property Manager" menu item to open the property manager
 window and then selecting "Add Existing Property Sheet..." from the context

--- a/docs/msw/winxp.md
+++ b/docs/msw/winxp.md
@@ -1,54 +1,25 @@
-Microsoft Windows XP Support from wxWidgets {#plat_msw_winxp}
+Microsoft Windows Theme Support from wxWidgets {#plat_msw_winxp}
 -------------------------------------------
 
-Windows XP introduces the themes (called "visual styles" in the Microsoft
-documentation) in Windows world. As wxWidgets uses the standard Windows
-controls for most of its classes, it can take advantage of it without
-(almost) any effort from your part. The only thing you need to do if you
-want your program to honour the visual style setting of Windows XP is to
+Windows XP introduced the themes (called "visual styles" in the Microsoft
+documentation) which have been used since then for Win32 controls.
+As wxWidgets uses the standard Windows controls for most of its
+classes, it can take advantage of it without (almost) any effort from your part.
+The only thing you need to do if you want your program to honour the visual style is to
 add the manifest file to your program (this is not at all specific to
 wxWidgets programs but is required for all Windows applications).
 
 wxWidgets now includes manifest resources in wx.rc, so it should be enough to
 include "wx/msw/wx.rc" in your application's resource file and you get
-XP look automatically. Notice that MSVC embeds manifest in the
-executables it produces and wxWidgets doesn't use its own manifest when using
-this compiler. And if you don't want to use wxWidgets manifest with another
-compiler you may define wxUSE_NO_MANIFEST as 1 prior to including wx/msw/wx.rc.
+proper look automatically. Notice that MSVS automatically generates the manifest
+and embeds it in the executables it produces. Therefore, wxWidgets by default doesn't
+use its own manifest when using MSVC (i.e., wxUSE_RC_MANIFEST is not defined as 1).
+If you don't want to use wxWidgets manifest with any compiler you may define wxUSE_NO_MANIFEST
+as 1 prior to including wx/msw/wx.rc.
 
+wxWidgets offers three manifests, differing only in which DPI-awareness mode they use.
+Which of the three is used depends on the value of wxUSE_DPI_AWARE_MANIFEST define.
+See more in @ref high_dpi_platform_msw "MSW Platform-Specific Build Issues" the High DPI guide.
 
-Finally, if all else fails you may always use a manifest manually. For this you
-need to create your own manifest file and put it in a file called
-"yourapp.exe.manifest" in the same directory where "yourapp.exe" resides.
-Alternatively, you can include the manifest in your applications resource
-section. Please see the MSDN documentation at
-
-http://msdn.microsoft.com/en-us/library/windows/desktop/bb773175
-
-for more details.
-
-Here is the example manifest which you can put into controls.exe.manifest
-file to test theme support using the controls sample:
-
-    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-    <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-    <assemblyIdentity
-        version="0.64.1.0"
-        processorArchitecture="x86"
-        name="Controls"
-        type="win32"
-    />
-    <description>Controls: wxWidgets sample application</description>
-    <dependency>
-        <dependentAssembly>
-            <assemblyIdentity
-                type="win32"
-                name="Microsoft.Windows.Common-Controls"
-                version="6.0.0.0"
-                processorArchitecture="*"
-                publicKeyToken="6595b64144ccf1df"
-                language="*"
-            />
-        </dependentAssembly>
-    </dependency>
-    </assembly>
+More information about application manifests is available at
+https://learn.microsoft.com/en-us/windows/win32/controls/cookbook-overview#using-manifests-or-directives-to-ensure-that-visual-styles-can-be-applied-to-applications


### PR DESCRIPTION
There may be some issues still left to improve in the updated docs.

~~I left some code examples in the Archive Formats untouched, as I was not sure how to best improve them.~~
I updated the examples but the one using `ZipCatalog` produces an error when used with an empty zip file.

In the Exceptions programming guide, the section about exceptions in GUI tests could be extended, at least `tests/test.cpp` mentioned as an example of wxWidgets GUI test application setup.