### PR TITLE
Add GetTabRect() and GetTabOrientation() to wxNotebook.

### DIFF
--- a/include/wx/msw/notebook.h
+++ b/include/wx/msw/notebook.h
@@ -93,6 +93,9 @@ public:
     // style.
   void SetTabSize(const wxSize& sz) override;
 
+  // Return the position and size of the tab for the given page
+  wxRect GetTabRect(size_t page) const override;
+
     // hit test
   virtual int HitTest(const wxPoint& pt, long *flags = nullptr) const override;
 

--- a/include/wx/notebook.h
+++ b/include/wx/notebook.h
@@ -139,6 +139,13 @@ public:
     // new is wxNOT_FOUND)
     void SendPageChangedEvent(int nPageOld, int nPageNew = wxNOT_FOUND);
 
+    // return wxTOP/wxBOTTOM/wxRIGHT/wxLEFT
+    wxDirection GetTabOrientation() const;
+
+    // return the rectangle in window coordinates of the page selector.
+    // For example, for a wxNotebook this would be its tab.
+    virtual wxRect GetTabRect(size_t page) const;
+
 #if wxUSE_EXTENDED_RTTI
     // XTI accessors
     virtual void AddPageInfo( wxNotebookPageInfo* info );

--- a/include/wx/univ/notebook.h
+++ b/include/wx/univ/notebook.h
@@ -93,9 +93,6 @@ public:
     // return true if all tabs have the same width
     bool FixedSizeTabs() const { return HasFlag(wxNB_FIXEDWIDTH); }
 
-    // return wxTOP/wxBOTTOM/wxRIGHT/wxLEFT
-    wxDirection GetTabOrientation() const;
-
     // return true if the notebook has tabs at the sidesand not at the top (or
     // bottom) as usual
     bool IsVertical() const;
@@ -120,6 +117,9 @@ public:
 
     // refresh the currently selected tab
     void RefreshCurrent();
+
+    // get the tab rect
+    wxRect GetTabRect(size_t page) const override;
 
 protected:
     virtual wxNotebookPage *DoRemovePage(size_t nPage) override;
@@ -163,9 +163,6 @@ protected:
 
     // refresh all tabs
     void RefreshAllTabs();
-
-    // get the tab rect (inefficient, don't use this in a loop)
-    wxRect GetTabRect(int page) const;
 
     // get the rectangle containing all tabs
     wxRect GetAllTabsRect() const;

--- a/interface/wx/notebook.h
+++ b/interface/wx/notebook.h
@@ -191,6 +191,26 @@ public:
     */
     virtual void SetPadding(const wxSize& padding);
 
+    /**
+        This is a convenience function mapping wxBK_TOP etc styles to one of the
+        wxDirection enum elements.
+
+        @since 3.3.0
+    */
+    wxDirection GetTabOrientation() const;
+
+    /**
+        Return the rectangle of the given page tab in window coordinates.
+        This function will always return the rectangle for the specified tab, even
+        if the tab is currently not visible. If the page is invalid the returned
+        rectangle is empty.
+
+        @note Currently only available in Univ and MSW
+
+        @since 3.3.0
+    */
+    virtual wxRect GetTabRect(size_t page) const;
+
     // implementations of pure virtuals
     virtual int GetPageImage(size_t nPage) const;
     virtual bool SetPageImage(size_t page, int image);
@@ -201,6 +221,5 @@ public:
     virtual int ChangeSelection(size_t page);
     virtual bool InsertPage(size_t index, wxWindow * page, const wxString & text,
                             bool select = false, int imageId = NO_IMAGE);
-
 };
 

--- a/src/common/nbkbase.cpp
+++ b/src/common/nbkbase.cpp
@@ -33,6 +33,8 @@
 
 extern WXDLLEXPORT_DATA(const char) wxNotebookNameStr[] = "notebook";
 
+#define IS_VALID_PAGE(nPage) ((nPage) < GetPageCount())
+
 wxDEFINE_EVENT( wxEVT_NOTEBOOK_PAGE_CHANGED, wxBookCtrlEvent );
 wxDEFINE_EVENT( wxEVT_NOTEBOOK_PAGE_CHANGING, wxBookCtrlEvent );
 
@@ -195,6 +197,29 @@ void wxNotebookBase::SendPageChangedEvent(int nPageOld, int nPageNew)
     event.SetOldSelection(nPageOld);
     event.SetEventObject(this);
     GetEventHandler()->ProcessEvent(event);
+}
+
+wxDirection wxNotebookBase::GetTabOrientation() const
+{
+    long style = GetWindowStyle();
+    if (style & wxBK_BOTTOM)
+        return wxBOTTOM;
+    else if (style & wxBK_RIGHT)
+        return wxRIGHT;
+    else if (style & wxBK_LEFT)
+        return wxLEFT;
+
+    // wxBK_TOP == 0 so we don't have to test for it
+    return wxTOP;
+}
+
+wxRect wxNotebookBase::GetTabRect(size_t page) const
+{
+    wxRect r;
+    wxCHECK_MSG(IS_VALID_PAGE(page), r, wxT("invalid notebook page"));
+    wxFAIL_MSG("Not implemented");
+
+    return r;
 }
 
 #endif // wxUSE_NOTEBOOK

--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -499,6 +499,21 @@ void wxNotebook::SetTabSize(const wxSize& sz)
     ::SendMessage(GetHwnd(), TCM_SETITEMSIZE, 0, MAKELPARAM(sz.x, sz.y));
 }
 
+wxRect wxNotebook::GetTabRect(size_t page) const
+{
+    wxRect r;
+    wxCHECK_MSG(IS_VALID_PAGE(page), r, wxT("invalid notebook page"));
+
+    if (GetPageCount() > 0)
+    {
+        RECT rect;
+        if (TabCtrl_GetItemRect(GetHwnd(), page, &rect))
+            r = wxRectFromRECT(rect);
+    }
+
+    return r;
+}
+
 wxSize wxNotebook::CalcSizeFromPage(const wxSize& sizePage) const
 {
     // we can't use TabCtrl_AdjustRect here because it only works for wxNB_TOP

--- a/src/univ/notebook.cpp
+++ b/src/univ/notebook.cpp
@@ -659,21 +659,7 @@ bool wxNotebook::IsVertical() const
     return dir == wxLEFT || dir == wxRIGHT;
 }
 
-wxDirection wxNotebook::GetTabOrientation() const
-{
-    long style = GetWindowStyle();
-    if ( style & wxBK_BOTTOM )
-        return wxBOTTOM;
-    else if ( style & wxBK_RIGHT )
-        return wxRIGHT;
-    else if ( style & wxBK_LEFT )
-        return wxLEFT;
-
-    // wxBK_TOP == 0 so we don't have to test for it
-    return wxTOP;
-}
-
-wxRect wxNotebook::GetTabRect(int page) const
+wxRect wxNotebook::GetTabRect(size_t page) const
 {
     wxRect rect;
     wxCHECK_MSG( IS_VALID_PAGE(page), rect, wxT("invalid notebook page") );
@@ -688,7 +674,7 @@ wxRect wxNotebook::GetTabRect(int page) const
     else
     {
         widthBefore = 0;
-        for ( int n = 0; n < page; n++ )
+        for (size_t n = 0; n < page; n++)
         {
             widthBefore += m_widths[n];
         }

--- a/tests/controls/notebooktest.cpp
+++ b/tests/controls/notebooktest.cpp
@@ -10,7 +10,6 @@
 
 #if wxUSE_NOTEBOOK
 
-
 #ifndef WX_PRECOMP
     #include "wx/app.h"
     #include "wx/panel.h"
@@ -45,10 +44,12 @@ private:
         CPPUNIT_TEST( Image );
         CPPUNIT_TEST( RowCount );
         CPPUNIT_TEST( NoEventsOnDestruction );
+        CPPUNIT_TEST( GetTabRect );
     CPPUNIT_TEST_SUITE_END();
 
     void RowCount();
     void NoEventsOnDestruction();
+    void GetTabRect();
 
     void OnPageChanged(wxNotebookEvent&) { m_numPageChanges++; }
 
@@ -161,6 +162,38 @@ TEST_CASE("wxNotebook::AddPageEvents", "[wxNotebook][AddPage][event]")
     // And events for the selection change should have been generated.
     CHECK( countPageChanging.GetCount() == 1 );
     CHECK( countPageChanged.GetCount() == 1 );
+}
+
+void NotebookTestCase::GetTabRect()
+{
+    // Not yet implemented for GTK or OSX, and possibly other platforms.
+#if defined(__WXMSW__) || defined(__WXUNIVERSAL__)
+
+    if (wxIsRunningUnderWine())
+    {
+        // Wine behaves different than Windows. Windows reports the size of a tab even if it is not visible
+        // while Wine returns an empty rectangle.
+        WARN("Skipping test known to fail under Wine.");
+        return;
+    }
+
+    wxNotebook *notebook = new wxNotebook(wxTheApp->GetTopWindow(), wxID_ANY, wxDefaultPosition, wxSize(400, 200));
+    wxScopedPtr<wxNotebook> cleanup(notebook);
+
+    // Create many pages, so at least some of the are not visible.
+    for (size_t i = 0; i < 30; i++)
+        notebook->AddPage(new wxPanel(notebook), "Page");
+
+    for (size_t i = 0; i < notebook->GetPageCount(); i++)
+    {
+        wxRect r = notebook->GetTabRect(i);
+        CHECK(r.width != 0);
+        CHECK(r.height != 0);
+    }
+
+#else
+    WARN("Skipping test because notebook->GetTabRect() is not supported on this platform");
+#endif // defined(__WXMSW__) || defined(__WXUNIVERSAL__)
 }
 
 #endif //wxUSE_NOTEBOOK


### PR DESCRIPTION
Add GetTabOrientation() to return the orientation of the tabs on a wxNotebook.
Add GetTabRect() to return the window coordinates of a tab from a wxNotebook.