### PR TITLE
wxQt: wxEVT_TEXT_ENTER processing fixup

### DIFF
--- a/include/wx/qt/private/winevent.h
+++ b/include/wx/qt/private/winevent.h
@@ -82,6 +82,11 @@ public:
             return wxQtSignalHandler< Handler >::GetHandler();
     }
 
+    // Hack used by wxTextEntry derived classes (by specializing this function)
+    // to toggle the dialog's default button off and on on focus events.
+    // see src/qt/textentry.cpp for the reason.
+    void ToggleDefaultButtonOnFocusEvent() { }
+
 protected:
     /* Not implemented here: wxHelpEvent, wxIdleEvent wxJoystickEvent,
      * wxMouseCaptureLostEvent, wxMouseCaptureChangedEvent,
@@ -144,6 +149,8 @@ protected:
         if ( !this->GetHandler() )
             return;
 
+        ToggleDefaultButtonOnFocusEvent();
+
         if ( !this->GetHandler()->QtHandleFocusEvent(this, event) )
             Widget::focusInEvent(event);
         else
@@ -155,6 +162,8 @@ protected:
     {
         if ( !this->GetHandler() )
             return;
+
+        ToggleDefaultButtonOnFocusEvent();
 
         if ( !this->GetHandler()->QtHandleFocusEvent(this, event) )
             Widget::focusOutEvent(event);
@@ -457,24 +466,5 @@ protected:
         }
     }
 };
-
-// Used by wxTextEntry derived classes to toggle the dialog's default button
-// off and on. see src/qt/textentry.cpp for the reason.
-#define wxHANDLE_DIALOG_DEFAULT_BUTTON(Widget)              \
-    virtual void focusInEvent(QFocusEvent *e) override      \
-    {                                                       \
-        if ( GetHandler()->HasFlag(wxTE_PROCESS_ENTER) )    \
-            GetHandler()->ToggleDefaultButton();            \
-                                                            \
-        Widget::focusInEvent(e);                            \
-    }                                                       \
-                                                            \
-    virtual void focusOutEvent(QFocusEvent *e) override     \
-    {                                                       \
-        if ( GetHandler()->HasFlag(wxTE_PROCESS_ENTER) )    \
-            GetHandler()->ToggleDefaultButton();            \
-                                                            \
-        Widget::focusOutEvent(e);                           \
-    }
 
 #endif

--- a/include/wx/qt/private/winevent.h
+++ b/include/wx/qt/private/winevent.h
@@ -458,4 +458,23 @@ protected:
     }
 };
 
+// Used by wxTextEntry derived classes to toggle the dialog's default button
+// off and on. see src/qt/textentry.cpp for the reason.
+#define wxHANDLE_DIALOG_DEFAULT_BUTTON(Widget)              \
+    virtual void focusInEvent(QFocusEvent *e) override      \
+    {                                                       \
+        if ( GetHandler()->HasFlag(wxTE_PROCESS_ENTER) )    \
+            GetHandler()->ToggleDefaultButton();            \
+                                                            \
+        Widget::focusInEvent(e);                            \
+    }                                                       \
+                                                            \
+    virtual void focusOutEvent(QFocusEvent *e) override     \
+    {                                                       \
+        if ( GetHandler()->HasFlag(wxTE_PROCESS_ENTER) )    \
+            GetHandler()->ToggleDefaultButton();            \
+                                                            \
+        Widget::focusOutEvent(e);                           \
+    }
+
 #endif

--- a/include/wx/qt/private/winevent.h
+++ b/include/wx/qt/private/winevent.h
@@ -33,11 +33,11 @@ protected:
         m_handler = handler;
     }
 
-    void EmitEvent( wxEvent &event ) const
+    bool EmitEvent( wxEvent &event ) const
     {
         wxWindow *handler = GetHandler();
         event.SetEventObject( handler );
-        handler->HandleWindowEvent( event );
+        return handler->HandleWindowEvent( event );
     }
 
     virtual Handler *GetHandler() const

--- a/include/wx/qt/textctrl.h
+++ b/include/wx/qt/textctrl.h
@@ -71,6 +71,9 @@ protected:
 
     virtual QScrollArea *QtGetScrollBarsContainer() const override;
 
+    // From wxTextEntry:
+    virtual wxWindow *GetEditableWindow() override { return this; }
+
 private:
     wxQtEdit *m_qtEdit;
 

--- a/include/wx/qt/textentry.h
+++ b/include/wx/qt/textentry.h
@@ -38,7 +38,7 @@ public:
 
     // For internal use only, see implementation for explanation.
     // Only controls with wxTE_PROCESS_ENTER flag use this function.
-    void ToggleDefaultButton();
+    void QtToggleDefaultButton();
 
 protected:
     virtual wxString DoGetValue() const override;

--- a/include/wx/qt/textentry.h
+++ b/include/wx/qt/textentry.h
@@ -36,6 +36,10 @@ public:
     virtual bool IsEditable() const override;
     virtual void SetEditable(bool editable) override;
 
+    // For internal use only, see implementation for explanation.
+    // Only controls with wxTE_PROCESS_ENTER flag use this function.
+    void ToggleDefaultButton();
+
 protected:
     virtual wxString DoGetValue() const override;
     virtual void DoSetValue(const wxString& value, int flags=0) override;

--- a/src/qt/combobox.cpp
+++ b/src/qt/combobox.cpp
@@ -26,8 +26,6 @@ public:
     virtual void showPopup() override;
     virtual void hidePopup() override;
 
-    wxHANDLE_DIALOG_DEFAULT_BUTTON(QComboBox)
-
     class IgnoreTextChange
     {
     public:
@@ -55,6 +53,14 @@ private:
 
     bool m_textChangeIgnored;
 };
+
+// specialization
+template<> void
+wxQtEventSignalHandler<QComboBox, wxComboBox>::ToggleDefaultButtonOnFocusEvent()
+{
+    if ( GetHandler()->HasFlag(wxTE_PROCESS_ENTER) )
+        GetHandler()->QtToggleDefaultButton();
+}
 
 wxQtComboBox::wxQtComboBox( wxWindow *parent, wxComboBox *handler )
     : wxQtEventSignalHandler< QComboBox, wxComboBox >( parent, handler ),
@@ -93,7 +99,7 @@ void wxQtComboBox::activated(int WXUNUSED(index))
             {
                 // allow the dialog (if we are child of) to close itself
                 // by forwarding the event to the default button if any.
-                handler->ToggleDefaultButton();
+                handler->QtToggleDefaultButton();
             }
         }
         else

--- a/src/qt/combobox.cpp
+++ b/src/qt/combobox.cpp
@@ -82,7 +82,16 @@ void wxQtComboBox::activated(int WXUNUSED(index))
 {
     wxComboBox *handler = GetHandler();
     if ( handler )
-        handler->SendSelectionChangedEvent(wxEVT_COMBOBOX);
+    {
+        if ( handler->HasFlag(wxTE_PROCESS_ENTER) )
+        {
+            wxCommandEvent event( wxEVT_TEXT_ENTER, handler->GetId() );
+            event.SetString( handler->GetValue() );
+            EmitEvent( event );
+        }
+        else
+            handler->SendSelectionChangedEvent(wxEVT_COMBOBOX);
+    }
 }
 
 void wxQtComboBox::editTextChanged(const QString &text)

--- a/src/qt/combobox.cpp
+++ b/src/qt/combobox.cpp
@@ -26,6 +26,8 @@ public:
     virtual void showPopup() override;
     virtual void hidePopup() override;
 
+    wxHANDLE_DIALOG_DEFAULT_BUTTON(QComboBox)
+
     class IgnoreTextChange
     {
     public:
@@ -87,7 +89,12 @@ void wxQtComboBox::activated(int WXUNUSED(index))
         {
             wxCommandEvent event( wxEVT_TEXT_ENTER, handler->GetId() );
             event.SetString( handler->GetValue() );
-            EmitEvent( event );
+            if ( !EmitEvent( event ) )
+            {
+                // allow the dialog (if we are child of) to close itself
+                // by forwarding the event to the default button if any.
+                handler->ToggleDefaultButton();
+            }
         }
         else
             handler->SendSelectionChangedEvent(wxEVT_COMBOBOX);

--- a/src/qt/textctrl.cpp
+++ b/src/qt/textctrl.cpp
@@ -48,6 +48,14 @@ public:
     virtual void SetStyleFlags(long flags) = 0;
 };
 
+// specialization
+template<> void
+wxQtEventSignalHandler<QLineEdit, wxTextCtrl>::ToggleDefaultButtonOnFocusEvent()
+{
+    if ( GetHandler()->HasFlag(wxTE_PROCESS_ENTER) )
+        GetHandler()->QtToggleDefaultButton();
+}
+
 namespace
 {
 
@@ -82,8 +90,6 @@ class wxQtLineEdit : public wxQtEventSignalHandler< QLineEdit, wxTextCtrl >
 {
 public:
     wxQtLineEdit( wxWindow *parent, wxTextCtrl *handler );
-
-    wxHANDLE_DIALOG_DEFAULT_BUTTON(QLineEdit)
 
 private:
     void textChanged();
@@ -478,7 +484,7 @@ void wxQtLineEdit::returnPressed()
             {
                 // allow the dialog (if we are child of) to close itself
                 // by forwarding the event to the default button if any.
-                handler->ToggleDefaultButton();
+                handler->QtToggleDefaultButton();
             }
         }
     }

--- a/src/qt/textctrl.cpp
+++ b/src/qt/textctrl.cpp
@@ -83,6 +83,8 @@ class wxQtLineEdit : public wxQtEventSignalHandler< QLineEdit, wxTextCtrl >
 public:
     wxQtLineEdit( wxWindow *parent, wxTextCtrl *handler );
 
+    wxHANDLE_DIALOG_DEFAULT_BUTTON(QLineEdit)
+
 private:
     void textChanged();
     void returnPressed();
@@ -472,7 +474,12 @@ void wxQtLineEdit::returnPressed()
         {
             wxCommandEvent event( wxEVT_TEXT_ENTER, handler->GetId() );
             event.SetString( handler->GetValue() );
-            EmitEvent( event );
+            if ( !EmitEvent( event ) )
+            {
+                // allow the dialog (if we are child of) to close itself
+                // by forwarding the event to the default button if any.
+                handler->ToggleDefaultButton();
+            }
         }
     }
 }

--- a/src/qt/textentry.cpp
+++ b/src/qt/textentry.cpp
@@ -12,6 +12,7 @@
 #include "wx/window.h"
 
 #include <QtWidgets/QPushButton>
+#include <QPointer>
 
 namespace
 {
@@ -29,7 +30,7 @@ namespace
 // the button to false. We'll toggle this property off in focusInEvent(), and if the
 // wxEVT_TEXT_ENTER handler decides to Skip() the event, toggle it on again and let
 // the default processing to take place.
-QPushButton* g_defaultButton = nullptr;
+QPointer<QPushButton> g_defaultButton;
 
 }
 
@@ -134,14 +135,9 @@ wxWindow *wxTextEntry::GetEditableWindow()
     return nullptr;
 }
 
-void wxTextEntry::ToggleDefaultButton()
+void wxTextEntry::QtToggleDefaultButton()
 {
-    if ( g_defaultButton )
-    {
-        g_defaultButton->setDefault(true);
-        g_defaultButton = nullptr;
-    }
-    else
+    if ( g_defaultButton.isNull() )
     {
         wxWindow* const wxwin = GetEditableWindow();
         QWidget* const qwin = wxwin->GetHandle()->window();
@@ -156,10 +152,13 @@ void wxTextEntry::ToggleDefaultButton()
                 if ( button->isDefault() )
                 {
                     button->setDefault(false);
-                    g_defaultButton = button;
-                    break;
+                    g_defaultButton = QPointer<QPushButton>(button);
+                    return;
                 }
             }
         }
     }
+
+    if ( g_defaultButton )
+        g_defaultButton->setDefault(!g_defaultButton->isDefault());
 }

--- a/src/qt/textentry.cpp
+++ b/src/qt/textentry.cpp
@@ -9,6 +9,29 @@
 #include "wx/wxprec.h"
 
 #include "wx/textentry.h"
+#include "wx/window.h"
+
+#include <QtWidgets/QPushButton>
+
+namespace
+{
+// From Qt documentation (under default:bool property):
+// -----------------------------------------------------
+// > A button with this property set to true (i.e., the dialog's default button,)
+// > will automatically be pressed when the user presses enter...
+// > In a dialog, only one push button at a time can be the default button.
+// > The default button behavior is provided only in dialogs.
+//
+// At Qt level, there is no way to stop the default button from being pressed when
+// the user presses enter [even though the text entry has wxTE_PROCESS_ENTER flag and
+// the handler doesn't call Skip() which means "don't propagate the event to the parent
+// which will eventually close the window"] other than setting the default property of
+// the button to false. We'll toggle this property off in focusInEvent(), and if the
+// wxEVT_TEXT_ENTER handler decides to Skip() the event, toggle it on again and let
+// the default processing to take place.
+QPushButton* g_defaultButton = nullptr;
+
+}
 
 wxTextEntry::wxTextEntry()
 {
@@ -111,3 +134,32 @@ wxWindow *wxTextEntry::GetEditableWindow()
     return nullptr;
 }
 
+void wxTextEntry::ToggleDefaultButton()
+{
+    if ( g_defaultButton )
+    {
+        g_defaultButton->setDefault(true);
+        g_defaultButton = nullptr;
+    }
+    else
+    {
+        wxWindow* const wxwin = GetEditableWindow();
+        QWidget* const qwin = wxwin->GetHandle()->window();
+
+        if ( qwin && qwin->windowType() == Qt::Dialog )
+        {
+            QList<QPushButton*> childButtons =
+                qwin->findChildren<QPushButton*>(QString(), Qt::FindDirectChildrenOnly);
+
+            for ( auto button : childButtons )
+            {
+                if ( button->isDefault() )
+                {
+                    button->setDefault(false);
+                    g_defaultButton = button;
+                    break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Can be tested with this patch:
```
diff --git a/samples/minimal/minimal.cpp b/samples/minimal/minimal.cpp
index 501caf9096..759b60f3cc 100644
--- a/samples/minimal/minimal.cpp
+++ b/samples/minimal/minimal.cpp
@@ -186,18 +186,80 @@ void MyFrame::OnQuit(wxCommandEvent& WXUNUSED(event))
     Close(true);
 }
 
+namespace
+{
+
+class TestDialog : public wxDialog
+{
+    enum
+    {
+        Control1_ID = wxID_HIGHEST,
+        Control2_ID,
+        Control3_ID
+    };
+
+public:
+    explicit TestDialog(wxWindow* parent)
+        : wxDialog(parent, wxID_ANY, "Test dialog")
+    {
+        const wxString choices[] = { "foo", "bar", "baz" };
+
+        wxControl* const control1 =
+            new wxComboBox(this, Control1_ID, wxString(),
+                           wxDefaultPosition, wxDefaultSize,
+                           WXSIZEOF(choices), choices);
+        control1->SetToolTip("ProcessEnter_No");
+
+        wxControl* const control2 =
+            new wxComboBox(this, Control2_ID, wxString(),
+                           wxDefaultPosition, wxDefaultSize,
+                           WXSIZEOF(choices), choices, wxTE_PROCESS_ENTER);
+        control2->SetToolTip("ProcessEnter_ButSkip");
+
+        wxControl* const control3 =
+            new wxTextCtrl(this, Control3_ID, wxString(),
+                           wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+        control3->SetToolTip("ProcessEnter_WithoutSkipping");
+
+        wxSizer* const sizer = new wxBoxSizer(wxVERTICAL);
+        sizer->Add(control1, wxSizerFlags().Expand().Border());
+        sizer->Add(control2, wxSizerFlags().Expand().Border());
+        sizer->Add(control3, wxSizerFlags().Expand().Border());
+        sizer->Add(CreateStdDialogButtonSizer(wxOK));
+        SetSizerAndFit(sizer);
+    }
+
+private:
+    void OnTextEnter(wxCommandEvent& e)
+    {
+        const int id = e.GetId();
+        switch ( id )
+        {
+            case Control1_ID: // ProcessEnter_No
+                wxFAIL_MSG("Shouldn't be getting wxEVT_TEXT_ENTER at all");
+                break;
+
+            case Control2_ID: // ProcessEnter_ButSkip
+                wxLogStatus("ProcessEnter_ButSkip");
+                e.Skip();
+                break;
+
+            case Control3_ID: // ProcessEnter_WithoutSkipping
+                wxLogStatus("ProcessEnter_WithoutSkipping");
+                break;
+        }
+    }
+
+    wxDECLARE_EVENT_TABLE();
+};
+
+wxBEGIN_EVENT_TABLE(TestDialog, wxDialog)
+    EVT_TEXT_ENTER(wxID_ANY, TestDialog::OnTextEnter)
+wxEND_EVENT_TABLE()
+}
+
 void MyFrame::OnAbout(wxCommandEvent& WXUNUSED(event))
 {
-    wxMessageBox(wxString::Format
-                 (
-                    "Welcome to %s!\n"
-                    "\n"
-                    "This is the minimal wxWidgets sample\n"
-                    "running under %s.",
-                    wxVERSION_STRING,
-                    wxGetOsDescription()
-                 ),
-                 "About wxWidgets minimal sample",
-                 wxOK | wxICON_INFORMATION,
-                 this);
+    TestDialog dlg(this);
+    dlg.ShowModal();
 }
```