### PR TITLE
Use [[nodiscard]] in places with memory leak risk

### DIFF
--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -249,7 +249,6 @@ typedef short int WXTYPE;
 
 #if wxCHECK_CXX_STD(201703L)
     #define wxFALLTHROUGH [[fallthrough]]
-    #define wxNODISCARD [[nodiscard]]
 #elif defined(__has_warning) && WX_HAS_CLANG_FEATURE(cxx_attributes)
     #define wxFALLTHROUGH [[clang::fallthrough]]
 #elif wxCHECK_GCC_VERSION(7, 0)
@@ -260,9 +259,18 @@ typedef short int WXTYPE;
     #define wxFALLTHROUGH ((void)0)
 #endif
 
-#ifndef wxNODISCARD
+/* wxNODISCARD is used to notate that the function return value should not be ignored */
+
+#if wxCHECK_CXX_STD(201703L)
+    #define wxNODISCARD [[nodiscard]]
+#elif defined(__VISUALC__)
+    #define wxNODISCARD _Check_return_
+#elif defined(__clang__) || defined(__GNUCC__)
+    #define wxNODISCARD __attribute__ ((warn_unused_result))
+#else
     #define wxNODISCARD
 #endif
+
 
 /* these macros are obsolete, use the standard C++ casts directly now */
 #define wx_static_cast(t, x) static_cast<t>(x)

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -259,7 +259,7 @@ typedef short int WXTYPE;
     #define wxFALLTHROUGH ((void)0)
 #endif
 
-/* wxNODISCARD is used to notate that the function return value should not be ignored */
+/* wxNODISCARD is used to indicate that the function return value must not be ignored */
 
 #if wxCHECK_CXX_STD(201703L)
     #define wxNODISCARD [[nodiscard]]

--- a/include/wx/defs.h
+++ b/include/wx/defs.h
@@ -249,6 +249,7 @@ typedef short int WXTYPE;
 
 #if wxCHECK_CXX_STD(201703L)
     #define wxFALLTHROUGH [[fallthrough]]
+    #define wxNODISCARD [[nodiscard]]
 #elif defined(__has_warning) && WX_HAS_CLANG_FEATURE(cxx_attributes)
     #define wxFALLTHROUGH [[clang::fallthrough]]
 #elif wxCHECK_GCC_VERSION(7, 0)
@@ -257,6 +258,10 @@ typedef short int WXTYPE;
 
 #ifndef wxFALLTHROUGH
     #define wxFALLTHROUGH ((void)0)
+#endif
+
+#ifndef wxNODISCARD
+    #define wxNODISCARD
 #endif
 
 /* these macros are obsolete, use the standard C++ casts directly now */

--- a/include/wx/msw/ole/oleutils.h
+++ b/include/wx/msw/ole/oleutils.h
@@ -84,11 +84,11 @@ public:
 
     // Returns the owned BSTR and gives up its ownership,
     // the caller is responsible for freeing it
-    BSTR Detach();
+    wxNODISCARD BSTR Detach();
 
     // Returns a copy of the owned BSTR,
     // the caller is responsible for freeing it
-    BSTR Copy() const { return SysAllocString(m_bstrBuf); }
+    wxNODISCARD BSTR Copy() const { return SysAllocString(m_bstrBuf); }
 
     // Returns the address of the owned BSTR, not to be called
     // when wxBasicString already contains a non-null BSTR
@@ -102,7 +102,7 @@ public:
 
     // retrieve a copy of our string - caller must SysFreeString() it later!
     wxDEPRECATED_MSG("use Copy() instead")
-    BSTR Get() const { return Copy(); }
+    wxNODISCARD BSTR Get() const { return Copy(); }
 private:
     // actual string
     BSTR m_bstrBuf;
@@ -129,7 +129,7 @@ public:
 #endif
     virtual bool Write(wxString& str) const override;
 
-    wxVariantData* Clone() const override { return new wxVariantDataCurrency(m_value); }
+    wxNODISCARD wxVariantData* Clone() const override { return new wxVariantDataCurrency(m_value); }
     virtual wxString GetType() const override { return wxS("currency"); }
 
     DECLARE_WXANY_CONVERSION()
@@ -155,7 +155,7 @@ public:
 #endif
     virtual bool Write(wxString& str) const override;
 
-    wxVariantData* Clone() const override { return new wxVariantDataErrorCode(m_value); }
+    wxNODISCARD wxVariantData* Clone() const override { return new wxVariantDataErrorCode(m_value); }
     virtual wxString GetType() const override { return wxS("errorcode"); }
 
     DECLARE_WXANY_CONVERSION()
@@ -183,7 +183,7 @@ public:
 #endif
     virtual bool Write(wxString& str) const override;
 
-    wxVariantData* Clone() const override { return new wxVariantDataSafeArray(m_value); }
+    wxNODISCARD wxVariantData* Clone() const override { return new wxVariantDataSafeArray(m_value); }
     virtual wxString GetType() const override { return wxS("safearray"); }
 
     DECLARE_WXANY_CONVERSION()
@@ -214,7 +214,7 @@ bool wxConvertOleToVariant(const VARIANTARG& oleVariant, wxVariant& variant,
 #endif // wxUSE_VARIANT
 
 // Convert string to Unicode
-WXDLLIMPEXP_CORE BSTR wxConvertStringToOle(const wxString& str);
+wxNODISCARD WXDLLIMPEXP_CORE BSTR wxConvertStringToOle(const wxString& str);
 
 // Convert string from BSTR to wxString
 WXDLLIMPEXP_CORE wxString wxConvertStringFromOle(BSTR bStr);

--- a/include/wx/msw/ole/safearray.h
+++ b/include/wx/msw/ole/safearray.h
@@ -367,7 +367,7 @@ public:
             result = sa.ConvertToVariant(variant);
 
         if ( sa.HasArray() )
-            static_cast<void*>(sa.Detach()); // we do not own the array, just attached it
+            wxUnusedVar(sa.Detach()); // we do not own the array, just attached it
 
         return result;
     }
@@ -381,7 +381,7 @@ public:
             result = sa.ConvertToArrayString(strings);
 
         if ( sa.HasArray() )
-            static_cast<void*>(sa.Detach()); // we do not own the array, just attached it
+            wxUnusedVar(sa.Detach()); // we do not own the array, just attached it
 
         return result;
     }

--- a/include/wx/msw/ole/safearray.h
+++ b/include/wx/msw/ole/safearray.h
@@ -32,7 +32,7 @@ public:
     void Destroy();
 
     // Unlocks the owned SAFEARRAY, returns it and gives up its ownership.
-    SAFEARRAY* Detach();
+    wxNODISCARD SAFEARRAY* Detach();
 
     // Returns true if has a valid SAFEARRAY.
     bool HasArray() const { return m_array != nullptr; }
@@ -367,7 +367,7 @@ public:
             result = sa.ConvertToVariant(variant);
 
         if ( sa.HasArray() )
-            sa.Detach();
+            static_cast<void*>(sa.Detach()); // we do not own the array, just attached it
 
         return result;
     }
@@ -381,7 +381,7 @@ public:
             result = sa.ConvertToArrayString(strings);
 
         if ( sa.HasArray() )
-            sa.Detach();
+            static_cast<void*>(sa.Detach()); // we do not own the array, just attached it
 
         return result;
     }

--- a/include/wx/msw/private/cotaskmemptr.h
+++ b/include/wx/msw/private/cotaskmemptr.h
@@ -68,7 +68,7 @@ public:
 
     // Gives up the ownership of the pointer,
     // making the caller responsible for freeing it.
-    T* release()
+    wxNODISCARD T* release()
     {
         T* ptr(m_ptr);
 


### PR DESCRIPTION
I understand if this is rejected, considering the attribute not very useful and just adding noise to a declaration.

I believe it could be used at least in places with a memory leak risk as I did here for MSW-specific code. 

Discarding the return value from any `Get*()`, `Is*()`, (let alone `Clone()`) function almost always indicates a bug, but there are so many such functions that it is probably not realistic to add it everywhere needed.

There may be more functions with a memory leak risk but for now, I have just added the few I could think off the top of my head. If this proposal is accepted, I will look for more candidates.

**EDIT**
It seems that the attribute could be used even with many widespread pre-C++17 compilers, see https://stackoverflow.com/a/45191044/7267315.