### PR TITLE
Fix implicit declaration configuration errors

### DIFF
--- a/configure
+++ b/configure
@@ -26116,6 +26116,7 @@ else
 
                     #include <zlib.h>
                     #include <stdio.h>
+                    #include <stdlib.h>
 
                     int main()
                     {
@@ -26255,6 +26256,7 @@ else
 
                     #include <png.h>
                     #include <stdio.h>
+                    #include <stdlib.h>
 
                     int main()
                     {
@@ -37928,6 +37930,7 @@ if ${wx_cv_inotify_usable+:} false; then :
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
+#include <sys/inotify.h>
 int main() { return inotify_init(); }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :

--- a/configure.in
+++ b/configure.in
@@ -2513,6 +2513,7 @@ if test "$wxUSE_ZLIB" != "no" ; then
                 [
                     #include <zlib.h>
                     #include <stdio.h>
+                    #include <stdlib.h>
 
                     int main()
                     {
@@ -2598,6 +2599,7 @@ if test "$wxUSE_LIBPNG" != "no" ; then
                 [
                     #include <png.h>
                     #include <stdio.h>
+                    #include <stdlib.h>
 
                     int main()
                     {
@@ -5622,7 +5624,9 @@ if test "$wxUSE_FSWATCHER" = "yes"; then
                 [whether inotify is usable],
                 wx_cv_inotify_usable,
                 AC_LINK_IFELSE(
-                    [AC_LANG_SOURCE([int main() { return inotify_init(); }])],
+                    [AC_LANG_SOURCE([
+                       #include <sys/inotify.h>
+                       int main() { return inotify_init(); }])],
                     [wx_cv_inotify_usable=yes],
                     [wx_cv_inotify_usable=no]
                 )


### PR DESCRIPTION
I'm trying to upstream the patch from https://github.com/macports/macports-ports/commit/2869659a8f5527391be8614a28c9e9a6b6c6d5aa from Xcode 12:
```
conftest.c:56:33: error: implicitly declaring library function 'exit' with type 'void (int) __attribute__((noreturn))' [-Werror,-Wimplicit-function-declaration]
```
https://trac.macports.org/ticket/61672