### PR TITLE
Fix the name of EVT_WEBVIEW_FULLSCREEN_CHANGED event in the docs

### DIFF
--- a/interface/wx/webview.h
+++ b/interface/wx/webview.h
@@ -711,8 +711,8 @@ public:
     @event{EVT_WEBVIEW_TITLE_CHANGED(id, func)}
        Process a @c wxEVT_WEBVIEW_TITLE_CHANGED event, generated when
        the page title changes. Use GetString to get the title.
-    @event{EVT_WEBVIEW_FULL_SCREEN_CHANGED(id, func)}
-       Process a @c EVT_WEBVIEW_FULL_SCREEN_CHANGED event, generated when
+    @event{EVT_WEBVIEW_FULLSCREEN_CHANGED(id, func)}
+       Process a @c wxEVT_WEBVIEW_FULLSCREEN_CHANGED event, generated when
        the page wants to enter or leave fullscreen. Use GetInt to get the status.
        Not implemented for the IE backend
        and is only available in wxWidgets 3.1.5 or later.
@@ -1584,8 +1584,8 @@ public:
     @event{EVT_WEBVIEW_TITLE_CHANGED(id, func)}
        Process a @c wxEVT_WEBVIEW_TITLE_CHANGED event, generated when
        the page title changes. Use GetString to get the title.
-    @event{EVT_WEBVIEW_FULL_SCREEN_CHANGED(id, func)}
-       Process a @c EVT_WEBVIEW_FULL_SCREEN_CHANGED event, generated when
+    @event{EVT_WEBVIEW_FULLSCREEN_CHANGED(id, func)}
+       Process a @c wxEVT_WEBVIEW_FULLSCREEN_CHANGED event, generated when
        the page wants to enter or leave fullscreen. Use GetInt to get the status.
        Not implemented for the IE backend
        and is only available in wxWidgets 3.1.5 or later.


### PR DESCRIPTION
The name had an extra underscore in it (EVT_WEBVIEW_FULL_SCREEN_CHANGED).

Closes #22947.

Should be backported.