### PR TITLE
Add msw.window.no-composited system option

### DIFF
--- a/interface/wx/sysopt.h
+++ b/interface/wx/sysopt.h
@@ -72,6 +72,10 @@
         appearance but not all fonts are available in this quality,
         e.g. the Terminal font in small sizes is not and this option may be
         used if wider fonts selection is more important than higher quality.
+    @flag{msw.window.no-composited}
+        If set to 1, disables the use of composited, i.e. double-buffered,
+        windows by default in wxMSW. This is not recommended, but can be useful
+        for debugging or working around redraw problems in the existing code.
     @endFlagTable
 
 

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -549,7 +549,11 @@ bool wxWindowMSW::CreateUsingMSWClass(const wxChar* classname,
     // checking it it's already set for the parent, even though we could.
     if ( !classname )
     {
-        exstyle |= WS_EX_COMPOSITED;
+        // We also allow disabling the use of this style globally by setting
+        // a system option if nothing else (i.e. turning it off for individual
+        // windows) works.
+        if ( !wxSystemOptions::GetOptionInt("msw.window.no-composited") )
+            exstyle |= WS_EX_COMPOSITED;
     }
 
     if ( IsShown() )


### PR DESCRIPTION
For some applications turning off double buffering for individual windows may be infeasible, so allow doing it globally using this system option.

Note that wxAutoBufferedPaintDC still does no buffering in wxMSW now, even when this option is set, so setting it will result in flickering in any code using it. The solution is to use wxBufferedPaintDC directly in the programs that use this option.

----

I think we might need to add this one, even if I don't like doing it -- what do you think?