### PR TITLE
Derive generic wxSearchCtrl from wxTextEntry too

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -46,6 +46,9 @@ Changes in behaviour which may result in build errors
 - wxMotif and wxGTK1 ports have been removed, please use wxWidgets 3.2 if you
   still need them.
 
+- Generic wxSearchCtrl doesn't provide methods that make sense only for
+  multiline text controls any longer, for consistency with the other ports.
+
 - wxOnAssert() overload taking wide character file name was removed. If you
   call it for any reason, please use one of the other overloads instead.
 

--- a/include/wx/generic/srchctlg.h
+++ b/include/wx/generic/srchctlg.h
@@ -69,16 +69,7 @@ public:
 
     virtual wxString GetRange(long from, long to) const override;
 
-    virtual int GetLineLength(long lineNo) const override;
-    virtual wxString GetLineText(long lineNo) const override;
-    virtual int GetNumberOfLines() const override;
-
-    virtual bool IsModified() const override;
     virtual bool IsEditable() const override;
-
-    // more readable flag testing methods
-    virtual bool IsSingleLine() const;
-    virtual bool IsMultiLine() const;
 
     // If the return values from and to are the same, there is no selection.
     virtual void GetSelection(long* from, long* to) const override;
@@ -95,14 +86,6 @@ public:
     virtual void Replace(long from, long to, const wxString& value) override;
     virtual void Remove(long from, long to) override;
 
-    // load/save the controls contents from/to the file
-    virtual bool LoadFile(const wxString& file);
-    virtual bool SaveFile(const wxString& file = wxEmptyString);
-
-    // sets/clears the dirty flag
-    virtual void MarkDirty() override;
-    virtual void DiscardEdits() override;
-
     // set the max number of characters which may be entered in a single line
     // text control
     virtual void SetMaxLength(unsigned long WXUNUSED(len)) override;
@@ -115,31 +98,6 @@ public:
     // insert the character which would have resulted from this key event,
     // return true if anything has been inserted
     virtual bool EmulateKeyPress(const wxKeyEvent& event);
-
-    // text control under some platforms supports the text styles: these
-    // methods allow to apply the given text style to the given selection or to
-    // set/get the style which will be used for all appended text
-    virtual bool SetStyle(long start, long end, const wxTextAttr& style) override;
-    virtual bool GetStyle(long position, wxTextAttr& style) override;
-    virtual bool SetDefaultStyle(const wxTextAttr& style) override;
-    virtual const wxTextAttr& GetDefaultStyle() const override;
-
-    // translate between the position (which is just an index in the text ctrl
-    // considering all its contents as a single strings) and (x, y) coordinates
-    // which represent column and line.
-    virtual long XYToPosition(long x, long y) const override;
-    virtual bool PositionToXY(long pos, long *x, long *y) const override;
-
-    virtual void ShowPosition(long pos) override;
-
-    // find the character at position given in pixels
-    //
-    // NB: pt is in device coords (not adjusted for the client area origin nor
-    //     scrolling)
-    virtual wxTextCtrlHitTestResult HitTest(const wxPoint& pt, long *pos) const override;
-    virtual wxTextCtrlHitTestResult HitTest(const wxPoint& pt,
-                                            wxTextCoord *col,
-                                            wxTextCoord *row) const override;
 
     // Clipboard operations
     virtual void Copy() override;
@@ -188,9 +146,6 @@ public:
 protected:
     virtual void DoSetValue(const wxString& value, int flags) override;
     virtual wxString DoGetValue() const override;
-
-    virtual bool DoLoadFile(const wxString& file, int fileType) override;
-    virtual bool DoSaveFile(const wxString& file, int fileType) override;
 
     // override the base class virtuals involved into geometry calculations
     virtual wxSize DoGetBestClientSize() const override;

--- a/include/wx/srchctrl.h
+++ b/include/wx/srchctrl.h
@@ -25,7 +25,7 @@
 
     class WXDLLIMPEXP_CORE wxSearchCtrlBaseBaseClass
         : public wxCompositeWindow< wxNavigationEnabled<wxControl> >,
-          public wxTextCtrlIface
+          public wxTextEntryBase
     {
     };
 #elif defined(__WXMAC__)

--- a/interface/wx/srchctrl.h
+++ b/interface/wx/srchctrl.h
@@ -14,6 +14,11 @@
     This control is implemented natively under macOS and GTK 3.6 or later and
     generically for all the other platforms.
 
+    Please note that this class provides many wxTextCtrl-like methods, but does
+    _not_ necessarily derive from wxTextCtrl in all ports (although it does in
+    the generic version). Only the methods defined in wxTextEntry interface
+    class are guaranteed to be available under all platforms.
+
     @beginStyleTable
     @style{wxTE_PROCESS_TAB}
            The control will receive @c wxEVT_CHAR events for TAB pressed -
@@ -60,7 +65,7 @@
 
     @see wxTextCtrl
 */
-class wxSearchCtrl : public wxTextCtrl
+class wxSearchCtrl : public wxControl, public wxTextEntry
 {
 public:
     /**

--- a/src/generic/srchctlg.cpp
+++ b/src/generic/srchctlg.cpp
@@ -71,16 +71,6 @@ public:
         wxTextCtrl::DoSetValue(value, flags);
     }
 
-    bool DoLoadFile(const wxString& file, int fileType) override
-    {
-        return wxTextCtrl::DoLoadFile(file, fileType);
-    }
-
-    bool DoSaveFile(const wxString& file, int fileType) override
-    {
-        return wxTextCtrl::DoSaveFile(file, fileType);
-    }
-
 protected:
     void OnText(wxCommandEvent& eventText)
     {
@@ -561,36 +551,9 @@ wxString wxSearchCtrl::GetRange(long from, long to) const
     return m_text->GetRange(from, to);
 }
 
-int wxSearchCtrl::GetLineLength(long lineNo) const
-{
-    return m_text->GetLineLength(lineNo);
-}
-wxString wxSearchCtrl::GetLineText(long lineNo) const
-{
-    return m_text->GetLineText(lineNo);
-}
-int wxSearchCtrl::GetNumberOfLines() const
-{
-    return m_text->GetNumberOfLines();
-}
-
-bool wxSearchCtrl::IsModified() const
-{
-    return m_text->IsModified();
-}
 bool wxSearchCtrl::IsEditable() const
 {
     return m_text->IsEditable();
-}
-
-// more readable flag testing methods
-bool wxSearchCtrl::IsSingleLine() const
-{
-    return m_text->IsSingleLine();
-}
-bool wxSearchCtrl::IsMultiLine() const
-{
-    return m_text->IsMultiLine();
 }
 
 // If the return values from and to are the same, there is no selection.
@@ -621,26 +584,6 @@ void wxSearchCtrl::Remove(long from, long to)
     m_text->Remove(from, to);
 }
 
-// load/save the controls contents from/to the file
-bool wxSearchCtrl::LoadFile(const wxString& file)
-{
-    return m_text->LoadFile(file);
-}
-bool wxSearchCtrl::SaveFile(const wxString& file)
-{
-    return m_text->SaveFile(file);
-}
-
-// sets/clears the dirty flag
-void wxSearchCtrl::MarkDirty()
-{
-    m_text->MarkDirty();
-}
-void wxSearchCtrl::DiscardEdits()
-{
-    m_text->DiscardEdits();
-}
-
 // set the max number of characters which may be entered in a single line
 // text control
 void wxSearchCtrl::SetMaxLength(unsigned long len)
@@ -664,58 +607,6 @@ void wxSearchCtrl::AppendText(const wxString& text)
 bool wxSearchCtrl::EmulateKeyPress(const wxKeyEvent& event)
 {
     return m_text->EmulateKeyPress(event);
-}
-
-// text control under some platforms supports the text styles: these
-// methods allow to apply the given text style to the given selection or to
-// set/get the style which will be used for all appended text
-bool wxSearchCtrl::SetStyle(long start, long end, const wxTextAttr& style)
-{
-    return m_text->SetStyle(start, end, style);
-}
-bool wxSearchCtrl::GetStyle(long position, wxTextAttr& style)
-{
-    return m_text->GetStyle(position, style);
-}
-bool wxSearchCtrl::SetDefaultStyle(const wxTextAttr& style)
-{
-    return m_text->SetDefaultStyle(style);
-}
-const wxTextAttr& wxSearchCtrl::GetDefaultStyle() const
-{
-    return m_text->GetDefaultStyle();
-}
-
-// translate between the position (which is just an index in the text ctrl
-// considering all its contents as a single strings) and (x, y) coordinates
-// which represent column and line.
-long wxSearchCtrl::XYToPosition(long x, long y) const
-{
-    return m_text->XYToPosition(x, y);
-}
-bool wxSearchCtrl::PositionToXY(long pos, long *x, long *y) const
-{
-    return m_text->PositionToXY(pos, x, y);
-}
-
-void wxSearchCtrl::ShowPosition(long pos)
-{
-    m_text->ShowPosition(pos);
-}
-
-// find the character at position given in pixels
-//
-// NB: pt is in device coords (not adjusted for the client area origin nor
-//     scrolling)
-wxTextCtrlHitTestResult wxSearchCtrl::HitTest(const wxPoint& pt, long *pos) const
-{
-    return m_text->HitTest(pt, pos);
-}
-wxTextCtrlHitTestResult wxSearchCtrl::HitTest(const wxPoint& pt,
-                                        wxTextCoord *col,
-                                        wxTextCoord *row) const
-{
-    return m_text->HitTest(pt, col, row);
 }
 
 // Clipboard operations
@@ -907,16 +798,6 @@ void wxSearchCtrl::ChangeValue(const wxString& value)
 void wxSearchCtrl::DoSetValue(const wxString& value, int flags)
 {
     m_text->DoSetValue(value, flags);
-}
-
-bool wxSearchCtrl::DoLoadFile(const wxString& file, int fileType)
-{
-    return m_text->DoLoadFile(file, fileType);
-}
-
-bool wxSearchCtrl::DoSaveFile(const wxString& file, int fileType)
-{
-    return m_text->DoSaveFile(file, fileType);
 }
 
 bool wxSearchCtrl::ShouldInheritColours() const


### PR DESCRIPTION
And update the documentation (see #22951).