### PR TITLE
Add MSWHitTestLeftRight

### DIFF
--- a/include/wx/msw/notebook.h
+++ b/include/wx/msw/notebook.h
@@ -192,6 +192,11 @@ protected:
   wxPoint m_bgBrushAdj;
 #endif // wxUSE_UXTHEME
 
+private:
+      // Workaround for Windows bug to detect the correct flags for left/right
+      // tab orientation.
+      // Returns the pageindex or -1 if the point is not on a tab, same as HitTest().
+      int MSWHitTestLeftRight(const wxPoint &pt, long *flags) const;
 
   wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxNotebook);
   wxDECLARE_EVENT_TABLE();


### PR DESCRIPTION
As discussed in my previous PR with GetTabRect, I now created a fix for issue https://github.com/wxWidgets/wxWidgets/issues/4775.

This now fixes the reporting of the tab->HitTest method for left/right orientation in MSW.