### PR TITLE
wxQt: Add wxFrame::GetClientAreaOrigin() override

### DIFF
--- a/include/wx/qt/frame.h
+++ b/include/wx/qt/frame.h
@@ -55,6 +55,7 @@ public:
     virtual QScrollArea *QtGetScrollBarsContainer() const override;
 
 protected:
+    virtual wxPoint GetClientAreaOrigin() const override;
     virtual void DoGetClientSize(int *width, int *height) const override;
     virtual void DoSetClientSize(int width, int height) override;
 

--- a/src/qt/frame.cpp
+++ b/src/qt/frame.cpp
@@ -208,6 +208,45 @@ QScrollArea *wxFrame::QtGetScrollBarsContainer() const
     return dynamic_cast <QScrollArea *> (GetQMainWindow()->centralWidget() );
 }
 
+// get the origin of the client area in the client coordinates
+// excluding any menubar and toolbar if any.
+wxPoint wxFrame::GetClientAreaOrigin() const
+{
+    wxPoint pt = wxTopLevelWindow::GetClientAreaOrigin();
+
+    // It seems that Qt always adds 1px border around QMainWindow,
+    // being resizable or not, so account for it here.
+    pt += wxPoint(1, 1);
+
+#ifndef __WXUNIVERSAL__
+#if wxUSE_MENUBAR
+    wxMenuBar * const menubar = GetMenuBar();
+    if ( menubar && menubar->IsAttached() )
+        pt.y += menubar->GetSize().y;
+#endif // wxUSE_MENUBAR
+
+#if wxUSE_TOOLBAR
+    wxToolBar * const toolbar = GetToolBar();
+    if ( toolbar && toolbar->IsShown() )
+    {
+        const wxSize sizeTB = toolbar->GetSize();
+        const int directionTB = toolbar->GetDirection();
+
+        if ( directionTB == wxTB_TOP )
+        {
+            pt.y += sizeTB.y;
+        }
+        else if ( directionTB == wxTB_LEFT )
+        {
+            pt.x += sizeTB.x;
+        }
+    }
+#endif // wxUSE_TOOLBAR
+#endif // __WXUNIVERSAL__
+
+    return pt;
+}
+
 void wxFrame::DoGetClientSize(int *width, int *height) const
 {
     wxWindow::DoGetClientSize(width, height);


### PR DESCRIPTION
The patch should not assert:
1. It asserts with master
2. It doesn't assert with this PR

```
diff --git a/samples/minimal/minimal.cpp b/samples/minimal/minimal.cpp
index 501caf9096..8937cd2adc 100644
--- a/samples/minimal/minimal.cpp
+++ b/samples/minimal/minimal.cpp
@@ -26,6 +26,7 @@
     #include "wx/wx.h"
 #endif
 
+
 // ----------------------------------------------------------------------------
 // resources
 // ----------------------------------------------------------------------------
@@ -64,6 +65,10 @@ public:
     void OnQuit(wxCommandEvent& event);
     void OnAbout(wxCommandEvent& event);
 
+    wxPanel* m_panel1;
+    wxPanel* m_panel2;
+    wxPanel* m_panel3;
+
 private:
     // any class wishing to process wxWidgets events must use this macro
     wxDECLARE_EVENT_TABLE();
@@ -170,6 +175,14 @@ MyFrame::MyFrame(const wxString& title)
     SetSizer(sizer);
 #endif // wxUSE_MENUBAR/!wxUSE_MENUBAR
 
+    m_panel1 = new wxPanel(this, wxID_ANY);
+    m_panel2 = new wxPanel(m_panel1, wxID_ANY, wxPoint(0, 50), wxSize(200, 100));
+    m_panel3 = new wxPanel(m_panel2, wxID_ANY, wxPoint(50, 50), wxSize(100, 50));
+
+    m_panel1->SetBackgroundColour(*wxGREEN);
+    m_panel2->SetBackgroundColour(*wxBLUE);
+    m_panel3->SetBackgroundColour(*wxRED);
+
 #if wxUSE_STATUSBAR
     // create a status bar just for fun (by default with 1 pane only)
     CreateStatusBar(2);
@@ -188,6 +201,7 @@ void MyFrame::OnQuit(wxCommandEvent& WXUNUSED(event))
 
 void MyFrame::OnAbout(wxCommandEvent& WXUNUSED(event))
 {
+#if 0
     wxMessageBox(wxString::Format
                  (
                     "Welcome to %s!\n"
@@ -200,4 +214,18 @@ void MyFrame::OnAbout(wxCommandEvent& WXUNUSED(event))
                  "About wxWidgets minimal sample",
                  wxOK | wxICON_INFORMATION,
                  this);
+#endif
+    const wxPoint thisOrig = ClientToScreen(wxPoint(0, 0));
+    const wxPoint pnl1Orig = m_panel1->ClientToScreen(wxPoint(0, 0));
+    const wxPoint pnl2Orig = m_panel2->ClientToScreen(wxPoint(0, 0));
+    const wxPoint pnl3Orig = m_panel3->ClientToScreen(wxPoint(0, 0));
+
+    wxLogDebug("thisOrig (%d, %d)", thisOrig.x, thisOrig.y);
+    wxLogDebug("pnl1Orig (%d, %d)", pnl1Orig.x, pnl1Orig.y);
+    wxLogDebug("pnl2Orig (%d, %d)", pnl2Orig.x, pnl2Orig.y);
+    wxLogDebug("pnl3Orig (%d, %d)", pnl3Orig.x, pnl3Orig.y);
+
+    wxASSERT(pnl1Orig == thisOrig);
+    wxASSERT(pnl2Orig == thisOrig + wxPoint(0, 50));
+    wxASSERT(pnl3Orig == thisOrig + wxPoint(50, 100));
 }

```