### PR TITLE
Use wxChoice for month selection in wxGenericCalendarCtrl

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -250,6 +250,7 @@ All (GUI):
 - Fix compilation problem in wx/propgrid/editors.h (Loïc Bartoletti, #22875).
 - Fix wxGenericTreeCtrl icons rendering in high DPI (Gerhard Stein, #22887).
 - Add macros for event tables for missing wxWebView events (PB, #22949).
+- Improve month selection in wxGenericCalendarCtrl (Lauri Nurmi, #22853).
 
 wxGTK:
 

--- a/include/wx/generic/calctrlg.h
+++ b/include/wx/generic/calctrlg.h
@@ -14,6 +14,8 @@
 #include "wx/control.h"         // the base class
 #include "wx/dcclient.h"        // for wxPaintDC
 
+class WXDLLIMPEXP_FWD_CORE wxChoice;
+// Not used here any more, but still declared for backwards compatibility.
 class WXDLLIMPEXP_FWD_CORE wxComboBox;
 class WXDLLIMPEXP_FWD_CORE wxStaticText;
 class WXDLLIMPEXP_FWD_CORE wxSpinCtrl;
@@ -238,7 +240,8 @@ private:
     // show the correct controls
     void ShowCurrentControls();
 
-    // create the month combo and year spin controls
+    // create the month choice and year spin controls: the name is misleading
+    // (it should be called CreateMonthChoice()) but preserved for compatibility
     void CreateMonthComboBox();
     void CreateYearSpinCtrl();
 
@@ -268,7 +271,7 @@ private:
 
     // the subcontrols
     wxStaticText *m_staticMonth;
-    wxComboBox *m_comboMonth;
+    wxChoice *m_choiceMonth;
 
     wxStaticText *m_staticYear;
     wxSpinCtrl *m_spinYear;

--- a/src/generic/calctrlg.cpp
+++ b/src/generic/calctrlg.cpp
@@ -24,7 +24,7 @@
     #include "wx/dcclient.h"
     #include "wx/settings.h"
     #include "wx/brush.h"
-    #include "wx/combobox.h"
+    #include "wx/choice.h"
     #include "wx/listbox.h"
     #include "wx/stattext.h"
     #include "wx/textctrl.h"
@@ -127,7 +127,7 @@ wxGenericCalendarCtrl::wxGenericCalendarCtrl(wxWindow *parent,
 
 void wxGenericCalendarCtrl::Init()
 {
-    m_comboMonth = NULL;
+    m_choiceMonth = NULL;
     m_spinYear = NULL;
     m_staticYear = NULL;
     m_staticMonth = NULL;
@@ -227,7 +227,7 @@ wxGenericCalendarCtrl::~wxGenericCalendarCtrl()
 
     if ( !HasFlag(wxCAL_SEQUENTIAL_MONTH_SELECTION) )
     {
-        delete m_comboMonth;
+        delete m_choiceMonth;
         delete m_staticMonth;
         delete m_spinYear;
         delete m_staticYear;
@@ -250,32 +250,30 @@ void wxGenericCalendarCtrl::SetWindowStyleFlag(long style)
 }
 
 // ----------------------------------------------------------------------------
-// Create the wxComboBox and wxSpinCtrl
+// Create the wxChoice and wxSpinCtrl
 // ----------------------------------------------------------------------------
 
 void wxGenericCalendarCtrl::CreateMonthComboBox()
 {
-    m_comboMonth = new wxComboBox(GetParent(), wxID_ANY,
-                                  wxEmptyString,
+    m_choiceMonth = new wxChoice(GetParent(), wxID_ANY,
                                   wxDefaultPosition,
                                   wxDefaultSize,
-                                  0, NULL,
-                                  wxCB_READONLY | wxCLIP_SIBLINGS);
+                                  0, NULL);
 
     wxDateTime::Month m;
     for ( m = wxDateTime::Jan; m < wxDateTime::Inv_Month; wxNextMonth(m) )
     {
-        m_comboMonth->Append(wxDateTime::GetMonthName(m));
+        m_choiceMonth->Append(wxDateTime::GetMonthName(m));
     }
 
-    m_comboMonth->SetSelection(GetDate().GetMonth());
-    m_comboMonth->SetSize(wxDefaultCoord,
+    m_choiceMonth->SetSelection(GetDate().GetMonth());
+    m_choiceMonth->SetSize(wxDefaultCoord,
                           wxDefaultCoord,
                           wxDefaultCoord,
                           wxDefaultCoord,
                           wxSIZE_AUTO_WIDTH|wxSIZE_AUTO_HEIGHT);
 
-    m_comboMonth->Bind(wxEVT_COMBOBOX, &wxGenericCalendarCtrl::OnMonthChange, this);
+    m_choiceMonth->Bind(wxEVT_CHOICE, &wxGenericCalendarCtrl::OnMonthChange, this);
 }
 
 void wxGenericCalendarCtrl::CreateYearSpinCtrl()
@@ -301,14 +299,14 @@ bool wxGenericCalendarCtrl::Destroy()
         m_staticYear->Destroy();
     if ( m_spinYear )
         m_spinYear->Destroy();
-    if ( m_comboMonth )
-        m_comboMonth->Destroy();
+    if ( m_choiceMonth )
+        m_choiceMonth->Destroy();
     if ( m_staticMonth )
         m_staticMonth->Destroy();
 
     m_staticYear = NULL;
     m_spinYear = NULL;
-    m_comboMonth = NULL;
+    m_choiceMonth = NULL;
     m_staticMonth = NULL;
 
     return wxControl::Destroy();
@@ -359,7 +357,7 @@ void wxGenericCalendarCtrl::ShowCurrentControls()
     {
         if ( AllowMonthChange() )
         {
-            m_comboMonth->Show();
+            m_choiceMonth->Show();
             m_staticMonth->Hide();
 
             if ( AllowYearChange() )
@@ -373,7 +371,7 @@ void wxGenericCalendarCtrl::ShowCurrentControls()
         }
         else
         {
-            m_comboMonth->Hide();
+            m_choiceMonth->Hide();
             m_staticMonth->Show();
         }
 
@@ -386,7 +384,7 @@ void wxGenericCalendarCtrl::ShowCurrentControls()
 
 wxControl *wxGenericCalendarCtrl::GetMonthControl() const
 {
-    return AllowMonthChange() ? (wxControl *)m_comboMonth : (wxControl *)m_staticMonth;
+    return AllowMonthChange() ? (wxControl *)m_choiceMonth : (wxControl *)m_staticMonth;
 }
 
 wxControl *wxGenericCalendarCtrl::GetYearControl() const
@@ -455,7 +453,7 @@ bool wxGenericCalendarCtrl::SetDate(const wxDateTime& date)
                 if ( !(GetWindowStyle() & wxCAL_SEQUENTIAL_MONTH_SELECTION) )
                 {
                     // update the controls
-                    m_comboMonth->SetSelection(m_date.GetMonth());
+                    m_choiceMonth->SetSelection(m_date.GetMonth());
 
                     if ( AllowYearChange() )
                     {
@@ -668,15 +666,15 @@ size_t wxGenericCalendarCtrl::GetWeek(const wxDateTime& date) const
 // ----------------------------------------------------------------------------
 
 // this is a composite control and it must arrange its parts each time its
-// size or position changes: the combobox and spinctrl are along the top of
+// size or position changes: the choice and spinctrl are along the top of
 // the available area and the calendar takes up the rest of the space
 
-// the static controls are supposed to be always smaller than combo/spin so we
+// the static controls are supposed to be always smaller than choice/spin so we
 // always use the latter for size calculations and position the static to take
 // the same space
 
 // the constants used for the layout
-#define VERT_MARGIN    5           // distance between combo and calendar
+#define VERT_MARGIN    5           // distance between choice and calendar
 #define HORZ_MARGIN    5           //                            spin
 
 wxSize wxGenericCalendarCtrl::DoGetBestSize() const
@@ -689,13 +687,13 @@ wxSize wxGenericCalendarCtrl::DoGetBestSize() const
 
     if ( !HasFlag(wxCAL_SEQUENTIAL_MONTH_SELECTION) )
     {
-        const wxSize bestSizeCombo = m_comboMonth->GetBestSize();
+        const wxSize bestSizeChoice = m_choiceMonth->GetBestSize();
         const wxSize bestSizeSpin = m_spinYear->GetBestSize();
 
-        height += wxMax(bestSizeCombo.y, bestSizeSpin.y)
+        height += wxMax(bestSizeChoice.y, bestSizeSpin.y)
                     + VERT_MARGIN;
 
-        wxCoord w2 = bestSizeCombo.x + HORZ_MARGIN + bestSizeSpin.x;
+        wxCoord w2 = bestSizeChoice.x + HORZ_MARGIN + bestSizeSpin.x;
         if ( width < w2 )
             width = w2;
     }
@@ -715,16 +713,16 @@ void wxGenericCalendarCtrl::DoMoveWindow(int x, int y, int width, int height)
 
     if ( !HasFlag(wxCAL_SEQUENTIAL_MONTH_SELECTION) && m_staticMonth )
     {
-        wxSize sizeCombo = m_comboMonth->GetEffectiveMinSize();
+        wxSize sizeChoice = m_choiceMonth->GetEffectiveMinSize();
         wxSize sizeStatic = m_staticMonth->GetSize();
         wxSize sizeSpin = m_spinYear->GetSize();
 
-        int maxHeight = wxMax(sizeSpin.y, sizeCombo.y);
+        int maxHeight = wxMax(sizeSpin.y, sizeChoice.y);
         int dy = (maxHeight - sizeStatic.y) / 2;
-        m_comboMonth->Move(x, y + (maxHeight - sizeCombo.y)/2);
-        m_staticMonth->SetSize(x, y + dy, sizeCombo.x, -1);
+        m_choiceMonth->Move(x, y + (maxHeight - sizeChoice.y)/2);
+        m_staticMonth->SetSize(x, y + dy, sizeChoice.x, -1);
 
-        int xDiff = sizeCombo.x + HORZ_MARGIN;
+        int xDiff = sizeChoice.x + HORZ_MARGIN;
 
         m_spinYear->SetSize(x + xDiff, y + (maxHeight - sizeSpin.y)/2, width - xDiff, maxHeight);
         m_staticYear->SetSize(x + xDiff, y + dy, width - xDiff, sizeStatic.y);
@@ -1567,7 +1565,7 @@ void wxGenericCalendarCtrl::OnMonthChange(wxCommandEvent& event)
     {
         // The date must have been changed to ensure it's in valid range,
         // reflect this in the month choice control.
-        m_comboMonth->SetSelection(dt.GetMonth());
+        m_choiceMonth->SetSelection(dt.GetMonth());
     }
 
     SetDateAndNotify(dt);


### PR DESCRIPTION
For no obvious reason the generic calendar control used a read-only wxComboBox until now.

While this is more or less identical to a wxChoice on MSW, it is somewhat different on OSX and Gtk: Whereas a wxChoice can be opened by clicking anywhere on it, a wxComboBox requires clicking on the arrows on the right edge. A wxComboBox allows selecting and copying the current value, but this is probably not terribly useful in a calendar.

See #22853.

(cherry picked from commit fc499810cebc54f0e4bf369054879fbe3e4dee3c)