### PR TITLE
Add missing fonctionality to wxTextCtrl for wxQt 

### DIFF
--- a/include/wx/qt/textctrl.h
+++ b/include/wx/qt/textctrl.h
@@ -57,6 +57,17 @@ public:
     virtual void SetSelection( long from, long to ) override;
     virtual void GetSelection(long *from, long *to) const override;
 
+    virtual void Copy() override;
+    virtual void Cut() override;
+    virtual void Paste() override;
+
+    virtual void Undo() override;
+    virtual void Redo() override;
+    virtual bool CanUndo() const override;
+    virtual bool CanRedo() const override;
+
+    virtual void EmptyUndoBuffer() override;
+
     virtual wxString DoGetValue() const override;
     virtual void DoSetValue(const wxString &text, int flags = 0) override;
     virtual void WriteText(const wxString& text) override;

--- a/src/qt/textctrl.cpp
+++ b/src/qt/textctrl.cpp
@@ -115,11 +115,8 @@ public:
 private:
     void textChanged();
 
-    void undoAvailable(bool available);
-    void redoAvailable(bool available);
-
-    bool m_undoAvailable,
-         m_redoAvailable;
+    bool m_undoAvailable = false,
+         m_redoAvailable = false;
 };
 
 class wxQtMultiLineEdit : public wxQtEdit
@@ -551,15 +548,16 @@ void wxQtLineEdit::returnPressed()
 
 wxQtTextEdit::wxQtTextEdit( wxWindow *parent, wxTextCtrl *handler )
     : wxQtEventSignalHandler< QTextEdit, wxTextCtrl >( parent, handler )
-    , m_undoAvailable(false), m_redoAvailable(false)
 {
     connect(this, &QTextEdit::textChanged,
             this, &wxQtTextEdit::textChanged);
 
-    connect(this, &QTextEdit::undoAvailable,
-            this, &wxQtTextEdit::undoAvailable);
-    connect(this, &QTextEdit::redoAvailable,
-            this, &wxQtTextEdit::redoAvailable);
+    connect(this, &QTextEdit::undoAvailable, [this](bool available) {
+                m_undoAvailable = available;
+            });
+    connect(this, &QTextEdit::redoAvailable, [this](bool available) {
+                m_redoAvailable = available;
+            });
 }
 
 void wxQtTextEdit::textChanged()
@@ -572,16 +570,6 @@ void wxQtTextEdit::textChanged()
 
     if ( !isUndoRedoEnabled() )
         setUndoRedoEnabled(true);
-}
-
-void wxQtTextEdit::undoAvailable(bool available)
-{
-    m_undoAvailable = available;
-}
-
-void wxQtTextEdit::redoAvailable(bool available)
-{
-    m_redoAvailable = available;
 }
 
 } // anonymous namespace

--- a/tests/controls/textctrltest.cpp
+++ b/tests/controls/textctrltest.cpp
@@ -1445,33 +1445,38 @@ TEST_CASE("wxTextCtrl::EventsOnCreate", "[wxTextCtrl][event]")
 
 TEST_CASE("wxTextCtrl::InitialCanUndo", "[wxTextCtrl][undo]")
 {
-    wxWindow* const parent = wxTheApp->GetTopWindow();
+    long style = 0;
 
-    const long styles[] = { 0, wxTE_RICH, wxTE_RICH2 };
+    SECTION("Plain") { }
+    SECTION("With wxTE_MULTILINE") { style = wxTE_MULTILINE; }
 
-    for ( size_t n = 0; n < WXSIZEOF(styles); n++ )
-    {
-        const long style = styles[n];
+    SECTION("Rich") { style = wxTE_RICH; }
+    SECTION("Rich with wxTE_MULTILINE") { style = wxTE_RICH | wxTE_MULTILINE; }
 
-#ifdef __MINGW32_TOOLCHAIN__
-        if ( style == wxTE_RICH2 )
-        {
-            // We can't call ITextDocument::Undo() in wxMSW code when using
-            // MinGW32, so this test would always fail with it.
-            WARN("Skipping test known to fail with MinGW-32.");
-        }
-        continue;
+#ifndef __MINGW32_TOOLCHAIN__
+    // We can't call ITextDocument::Undo() in wxMSW code when using
+    // MinGW32, so this test would always fail with it.
+    SECTION("Rich v2") { style = wxTE_RICH2; }
+    SECTION("Rich v2 with wxTE_MULTILINE") { style = wxTE_RICH2 | wxTE_MULTILINE; }
 #endif // __MINGW32_TOOLCHAIN__
 
-        INFO("wxTextCtrl with style " << style);
-
-        wxScopedPtr<wxTextCtrl> text(new wxTextCtrl(parent, wxID_ANY, "",
-                                                    wxDefaultPosition,
-                                                    wxDefaultSize,
-                                                    style));
-
-        CHECK( !text->CanUndo() );
+    if ( !style )
+    {
+        // This can happen when explicitly selecting just a single section to
+        // execute -- this code still runs even if the corresponding section is
+        // skipped, so we have to explicitly skip it too in this case.
+        return;
     }
+
+    INFO("wxTextCtrl with style " << style);
+
+    wxWindow* const parent = wxTheApp->GetTopWindow();
+    wxScopedPtr<wxTextCtrl> text(new wxTextCtrl(parent, wxID_ANY, "",
+                                                wxDefaultPosition,
+                                                wxDefaultSize,
+                                                style));
+
+    CHECK( !text->CanUndo() );
 }
 
 // This test would always fail with MinGW-32 for the same reason as described


### PR DESCRIPTION
Which are:
- Copy()
- Cut()
- Paste()
- Undo()
- Redo()
- CanUndo()
- CanRedo()
- EmptyUndoBuffer()

