### PR TITLE
wxQt: wxEVT_TEXT_ENTER processing revisited

### DIFF
--- a/include/wx/qt/private/winevent.h
+++ b/include/wx/qt/private/winevent.h
@@ -82,11 +82,6 @@ public:
             return wxQtSignalHandler< Handler >::GetHandler();
     }
 
-    // Hack used by wxTextEntry derived classes (by specializing this function)
-    // to toggle the dialog's default button off and on on focus events.
-    // see src/qt/textentry.cpp for the reason.
-    void ToggleDefaultButtonOnFocusEvent() { }
-
 protected:
     /* Not implemented here: wxHelpEvent, wxIdleEvent wxJoystickEvent,
      * wxMouseCaptureLostEvent, wxMouseCaptureChangedEvent,
@@ -149,8 +144,6 @@ protected:
         if ( !this->GetHandler() )
             return;
 
-        ToggleDefaultButtonOnFocusEvent();
-
         if ( !this->GetHandler()->QtHandleFocusEvent(this, event) )
             Widget::focusInEvent(event);
         else
@@ -162,8 +155,6 @@ protected:
     {
         if ( !this->GetHandler() )
             return;
-
-        ToggleDefaultButtonOnFocusEvent();
 
         if ( !this->GetHandler()->QtHandleFocusEvent(this, event) )
             Widget::focusOutEvent(event);

--- a/include/wx/qt/private/winevent.h
+++ b/include/wx/qt/private/winevent.h
@@ -51,10 +51,10 @@ protected:
 
     // A hack for wxQtEventSignalHandler<>::keyPressEvent() handler for the
     // convenience of wxTextCtrl-like controls to emit the wxEVT_TEXT_ENTER
-    // event. i.e: if the control has wxTE_PROCESS_ENTER flag.
-    bool ProcessTextEnter(QKeyEvent* e)
+    // event if the control has wxTE_PROCESS_ENTER flag.
+    bool HandleKeyPressEvent(QWidget* widget, QKeyEvent* e)
     {
-        Handler* const handler = GetHandler();
+        Handler* const handler = this->GetHandler();
 
         if ( handler->HasFlag(wxTE_PROCESS_ENTER) )
         {
@@ -67,7 +67,7 @@ protected:
             }
         }
 
-        return false;
+        return this->GetHandler()->QtHandleKeyEvent(widget, e);
     }
 
     // Controls supporting wxTE_PROCESS_ENTER flag (e.g. wxTextCtrl, wxComboBox and wxSpinCtrl)
@@ -209,8 +209,7 @@ protected:
         if ( !this->GetHandler() )
             return;
 
-        if ( !this->ProcessTextEnter(event) &&
-             !this->GetHandler()->QtHandleKeyEvent(this, event) )
+        if ( !this->HandleKeyPressEvent(this, event) )
             Widget::keyPressEvent(event);
         else
             event->accept();

--- a/include/wx/qt/textentry.h
+++ b/include/wx/qt/textentry.h
@@ -36,10 +36,6 @@ public:
     virtual bool IsEditable() const override;
     virtual void SetEditable(bool editable) override;
 
-    // For internal use only, see implementation for explanation.
-    // Only controls with wxTE_PROCESS_ENTER flag use this function.
-    void QtToggleDefaultButton();
-
 protected:
     virtual wxString DoGetValue() const override;
     virtual void DoSetValue(const wxString& value, int flags=0) override;

--- a/src/qt/combobox.cpp
+++ b/src/qt/combobox.cpp
@@ -54,14 +54,6 @@ private:
     bool m_textChangeIgnored;
 };
 
-// specialization
-template<> void
-wxQtEventSignalHandler<QComboBox, wxComboBox>::ToggleDefaultButtonOnFocusEvent()
-{
-    if ( GetHandler()->HasFlag(wxTE_PROCESS_ENTER) )
-        GetHandler()->QtToggleDefaultButton();
-}
-
 wxQtComboBox::wxQtComboBox( wxWindow *parent, wxComboBox *handler )
     : wxQtEventSignalHandler< QComboBox, wxComboBox >( parent, handler ),
       m_textChangeIgnored( false )
@@ -91,19 +83,7 @@ void wxQtComboBox::activated(int WXUNUSED(index))
     wxComboBox *handler = GetHandler();
     if ( handler )
     {
-        if ( handler->HasFlag(wxTE_PROCESS_ENTER) )
-        {
-            wxCommandEvent event( wxEVT_TEXT_ENTER, handler->GetId() );
-            event.SetString( handler->GetValue() );
-            if ( !EmitEvent( event ) )
-            {
-                // allow the dialog (if we are child of) to close itself
-                // by forwarding the event to the default button if any.
-                handler->QtToggleDefaultButton();
-            }
-        }
-        else
-            handler->SendSelectionChangedEvent(wxEVT_COMBOBOX);
+        handler->SendSelectionChangedEvent(wxEVT_COMBOBOX);
     }
 }
 

--- a/src/qt/combobox.cpp
+++ b/src/qt/combobox.cpp
@@ -47,6 +47,11 @@ public:
         wxQtComboBox* m_combo;
     };
 
+    virtual wxString GetValueForProcessEnter() override
+    {
+        return GetHandler()->GetValue();
+    }
+
 private:
     void activated(int index);
     void editTextChanged(const QString &text);

--- a/src/qt/radiobox.cpp
+++ b/src/qt/radiobox.cpp
@@ -26,23 +26,30 @@ public:
 };
 
 
-class wxQtButtonGroup : public wxQtSignalHandler< wxRadioBox >, public QButtonGroup
+class wxQtButtonGroup : public QButtonGroup, public wxQtSignalHandler
 {
 public:
-    wxQtButtonGroup( QGroupBox *parent, wxRadioBox *handler ):
-        wxQtSignalHandler< wxRadioBox >(handler ),
-        QButtonGroup(parent)
+    wxQtButtonGroup( QGroupBox *parent, wxRadioBox *handler )
+        : QButtonGroup(parent),
+          wxQtSignalHandler(handler)
     {
         connect(this,
                 static_cast<void (QButtonGroup::*)(int index)>(&QButtonGroup::buttonClicked),
                 this, &wxQtButtonGroup::buttonClicked);
     }
+
+    wxRadioBox* GetRadioBox() const
+    {
+        return static_cast<wxRadioBox*>(wxQtSignalHandler::GetHandler());
+    }
+
 private:
     void buttonClicked(int index);
 };
 
-void wxQtButtonGroup::buttonClicked(int index) {
-    wxRadioBox *handler = GetHandler();
+void wxQtButtonGroup::buttonClicked(int index)
+{
+    wxRadioBox *handler = GetRadioBox();
     if ( handler )
     {
         wxCommandEvent event( wxEVT_RADIOBOX, handler->GetId() );

--- a/src/qt/spinctrl.cpp
+++ b/src/qt/spinctrl.cpp
@@ -138,11 +138,11 @@ QWidget *wxSpinCtrlQt< T, Widget >::GetHandle() const
 // Define a derived helper class to get access to valueFromText:
 
 template < typename Widget >
-class wxQtSpinBoxBase : public wxQtEventSignalHandler< Widget, wxControl >
+class wxQtSpinBoxBase : public wxQtEventSignalHandler< Widget, wxSpinCtrlBase >
 {
 public:
-    wxQtSpinBoxBase( wxWindow *parent, wxControl *handler )
-        : wxQtEventSignalHandler< Widget, wxControl >( parent, handler )
+    wxQtSpinBoxBase( wxWindow *parent, wxSpinCtrlBase *handler )
+        : wxQtEventSignalHandler< Widget, wxSpinCtrlBase >( parent, handler )
     { }
 
     virtual wxString GetValueForProcessEnter() override
@@ -156,7 +156,7 @@ public:
 class wxQtSpinBox : public wxQtSpinBoxBase< QSpinBox >
 {
 public:
-    wxQtSpinBox( wxWindow *parent, wxControl *handler )
+    wxQtSpinBox( wxWindow *parent, wxSpinCtrlBase *handler )
         : wxQtSpinBoxBase< QSpinBox >( parent, handler )
     {
         connect(this, static_cast<void (QSpinBox::*)(int index)>(&QSpinBox::valueChanged),
@@ -165,7 +165,7 @@ public:
 private:
     void valueChanged(int value)
     {
-        if ( wxControl *handler = GetHandler() )
+        if ( wxSpinCtrlBase *handler = GetHandler() )
         {
             wxSpinEvent event( wxEVT_SPINCTRL, handler->GetId() );
             event.SetInt( value );
@@ -177,7 +177,7 @@ private:
 class wxQtDoubleSpinBox : public wxQtSpinBoxBase< QDoubleSpinBox >
 {
 public:
-    wxQtDoubleSpinBox( wxWindow *parent, wxControl *handler )
+    wxQtDoubleSpinBox( wxWindow *parent, wxSpinCtrlBase *handler )
         : wxQtSpinBoxBase< QDoubleSpinBox >( parent, handler )
     {
         connect(this, static_cast<void (QDoubleSpinBox::*)(double value)>(&QDoubleSpinBox::valueChanged),
@@ -186,7 +186,7 @@ public:
 private:
     void valueChanged(double value)
     {
-        if ( wxControl *handler = GetHandler() )
+        if ( wxSpinCtrlBase *handler = GetHandler() )
         {
             wxSpinDoubleEvent event( wxEVT_SPINCTRLDOUBLE, handler->GetId() );
             event.SetValue(value);

--- a/src/qt/spinctrl.cpp
+++ b/src/qt/spinctrl.cpp
@@ -145,6 +145,11 @@ public:
         : wxQtEventSignalHandler< Widget, wxControl >( parent, handler )
     { }
 
+    virtual wxString GetValueForProcessEnter() override
+    {
+        return this->GetHandler()->GetTextValue();
+    }
+
     using Widget::valueFromText;
 };
 

--- a/src/qt/textctrl.cpp
+++ b/src/qt/textctrl.cpp
@@ -459,8 +459,6 @@ wxQtLineEdit::wxQtLineEdit( wxWindow *parent, wxTextCtrl *handler )
 {
     connect(this, &QLineEdit::textChanged,
             this, &wxQtLineEdit::textChanged);
-    connect(this, &QLineEdit::returnPressed,
-            this, &wxQtLineEdit::returnPressed);
 }
 
 void wxQtLineEdit::textChanged()

--- a/src/qt/textctrl.cpp
+++ b/src/qt/textctrl.cpp
@@ -48,14 +48,6 @@ public:
     virtual void SetStyleFlags(long flags) = 0;
 };
 
-// specialization
-template<> void
-wxQtEventSignalHandler<QLineEdit, wxTextCtrl>::ToggleDefaultButtonOnFocusEvent()
-{
-    if ( GetHandler()->HasFlag(wxTE_PROCESS_ENTER) )
-        GetHandler()->QtToggleDefaultButton();
-}
-
 namespace
 {
 
@@ -93,7 +85,6 @@ public:
 
 private:
     void textChanged();
-    void returnPressed();
 };
 
 class wxQtTextEdit : public wxQtEventSignalHandler< QTextEdit, wxTextCtrl >
@@ -468,25 +459,6 @@ void wxQtLineEdit::textChanged()
     if ( handler )
     {
         handler->SendTextUpdatedEventIfAllowed();
-    }
-}
-
-void wxQtLineEdit::returnPressed()
-{
-    wxTextCtrl *handler = GetHandler();
-    if ( handler )
-    {
-        if ( handler->HasFlag(wxTE_PROCESS_ENTER) )
-        {
-            wxCommandEvent event( wxEVT_TEXT_ENTER, handler->GetId() );
-            event.SetString( handler->GetValue() );
-            if ( !EmitEvent( event ) )
-            {
-                // allow the dialog (if we are child of) to close itself
-                // by forwarding the event to the default button if any.
-                handler->QtToggleDefaultButton();
-            }
-        }
     }
 }
 

--- a/src/qt/textctrl.cpp
+++ b/src/qt/textctrl.cpp
@@ -83,6 +83,11 @@ class wxQtLineEdit : public wxQtEventSignalHandler< QLineEdit, wxTextCtrl >
 public:
     wxQtLineEdit( wxWindow *parent, wxTextCtrl *handler );
 
+    virtual wxString GetValueForProcessEnter() override
+    {
+        return GetHandler()->GetValue();
+    }
+
 private:
     void textChanged();
 };
@@ -91,6 +96,11 @@ class wxQtTextEdit : public wxQtEventSignalHandler< QTextEdit, wxTextCtrl >
 {
 public:
     wxQtTextEdit( wxWindow *parent, wxTextCtrl *handler );
+
+    virtual wxString GetValueForProcessEnter() override
+    {
+        return GetHandler()->GetValue();
+    }
 
 private:
     void textChanged();

--- a/src/qt/textentry.cpp
+++ b/src/qt/textentry.cpp
@@ -11,28 +11,6 @@
 #include "wx/textentry.h"
 #include "wx/window.h"
 
-#include <QtWidgets/QPushButton>
-#include <QPointer>
-
-namespace
-{
-// From Qt documentation (under default:bool property):
-// -----------------------------------------------------
-// > A button with this property set to true (i.e., the dialog's default button,)
-// > will automatically be pressed when the user presses enter...
-// > In a dialog, only one push button at a time can be the default button.
-// > The default button behavior is provided only in dialogs.
-//
-// At Qt level, there is no way to stop the default button from being pressed when
-// the user presses enter [even though the text entry has wxTE_PROCESS_ENTER flag and
-// the handler doesn't call Skip() which means "don't propagate the event to the parent
-// which will eventually close the window"] other than setting the default property of
-// the button to false. We'll toggle this property off in focusInEvent(), and if the
-// wxEVT_TEXT_ENTER handler decides to Skip() the event, toggle it on again and let
-// the default processing to take place.
-QPointer<QPushButton> g_defaultButton;
-
-}
 
 wxTextEntry::wxTextEntry()
 {
@@ -133,32 +111,4 @@ void wxTextEntry::DoSetValue(const wxString &WXUNUSED(value), int WXUNUSED(flags
 wxWindow *wxTextEntry::GetEditableWindow()
 {
     return nullptr;
-}
-
-void wxTextEntry::QtToggleDefaultButton()
-{
-    if ( g_defaultButton.isNull() )
-    {
-        wxWindow* const wxwin = GetEditableWindow();
-        QWidget* const qwin = wxwin->GetHandle()->window();
-
-        if ( qwin && qwin->windowType() == Qt::Dialog )
-        {
-            QList<QPushButton*> childButtons =
-                qwin->findChildren<QPushButton*>(QString(), Qt::FindDirectChildrenOnly);
-
-            for ( auto button : childButtons )
-            {
-                if ( button->isDefault() )
-                {
-                    button->setDefault(false);
-                    g_defaultButton = QPointer<QPushButton>(button);
-                    return;
-                }
-            }
-        }
-    }
-
-    if ( g_defaultButton )
-        g_defaultButton->setDefault(!g_defaultButton->isDefault());
 }

--- a/src/qt/toolbar.cpp
+++ b/src/qt/toolbar.cpp
@@ -53,47 +53,51 @@ public:
     wxQtToolButton* m_qtToolButton;
 };
 
-class wxQtToolButton : public QToolButton, public wxQtSignalHandler< wxToolBarTool >
+class wxQtToolButton : public QToolButton, public wxQtSignalHandler
 {
 
 public:
-    wxQtToolButton(wxToolBar *parent, wxToolBarTool *handler)
-        : QToolButton(parent->GetHandle()),
-          wxQtSignalHandler< wxToolBarTool >( handler ) {
+    wxQtToolButton(wxToolBar *handler, wxToolBarTool *tool)
+        : QToolButton(handler->GetHandle()),
+          wxQtSignalHandler( handler ), m_toolId(tool->GetId())
+    {
         setContextMenuPolicy(Qt::PreventContextMenu);
+    }
+
+    wxToolBarBase* GetToolBar() const
+    {
+        return static_cast<wxToolBarBase*>(wxQtSignalHandler::GetHandler());
     }
 
 private:
     void mouseReleaseEvent( QMouseEvent *event ) override;
     void mousePressEvent( QMouseEvent *event ) override;
     void enterEvent( QEvent *event ) override;
+
+    const wxWindowID m_toolId;
 };
 
 void wxQtToolButton::mouseReleaseEvent( QMouseEvent *event )
 {
     QToolButton::mouseReleaseEvent(event);
-    if (event->button() == Qt::LeftButton) {
-        wxToolBarTool *handler = GetHandler();
-        wxToolBarBase *toolbar = handler->GetToolBar();
-        toolbar->OnLeftClick( handler->GetId(), isCheckable() ? 1 : 0 );
+    if (event->button() == Qt::LeftButton)
+    {
+        GetToolBar()->OnLeftClick( m_toolId, isCheckable() ? 1 : 0 );
     }
 }
 
 void wxQtToolButton::mousePressEvent( QMouseEvent *event )
 {
     QToolButton::mousePressEvent(event);
-    if (event->button() == Qt::RightButton) {
-        wxToolBarTool *handler = GetHandler();
-        wxToolBarBase *toolbar = handler->GetToolBar();
-        toolbar->OnRightClick( handler->GetId(), event->x(), event->y() );
+    if (event->button() == Qt::RightButton)
+    {
+        GetToolBar()->OnRightClick( m_toolId, event->x(), event->y() );
     }
 }
 
 void wxQtToolButton::enterEvent( QEvent *WXUNUSED(event) )
 {
-    wxToolBarTool *handler = GetHandler();
-    wxToolBarBase *toolbar = handler->GetToolBar();
-    toolbar->OnMouseEnter( handler->GetId() );
+    GetToolBar()->OnMouseEnter( m_toolId );
 }
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxToolBar, wxControl);

--- a/src/qt/window.cpp
+++ b/src/qt/window.cpp
@@ -180,7 +180,7 @@ void wxQtInternalScrollBar::sliderReleased()
 }
 
 #if wxUSE_ACCEL || defined( Q_MOC_RUN )
-class wxQtShortcutHandler : public QObject, public wxQtSignalHandler< wxWindowQt >
+class wxQtShortcutHandler : public QObject, public wxQtSignalHandler
 {
 
 public:
@@ -191,7 +191,7 @@ public:
 };
 
 wxQtShortcutHandler::wxQtShortcutHandler( wxWindowQt *window )
-    : wxQtSignalHandler< wxWindowQt >( window )
+    : wxQtSignalHandler( window )
 {
 }
 
@@ -199,7 +199,7 @@ void wxQtShortcutHandler::activated()
 {
     int command = sender()->property("wxQt_Command").toInt();
 
-    GetHandler()->QtHandleShortcut( command );
+    static_cast<wxWindowQt*>(GetHandler())->QtHandleShortcut( command );
 }
 #endif // wxUSE_ACCEL
 


### PR DESCRIPTION
@vadz sorry for the noise but I think this one is better than the previous
(now merged!) one.

I really want `wxSpinCtrl` to take advantage of this, but unfortunately it doesn't derive from `wxTextEntry`.