### PR TITLE
Use variadic templates for vararg funcs

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -90,7 +90,7 @@ jobs:
             if git diff origin/master \
                ':!.github/workflows/code_checks.yml' \
                ':!src/stc/scintilla/' \
-               | grep -E '^\+.*(wxOVERRIDE|wxNOEXCEPT|\WNULL)'; then
+               | grep -E '^\+.*(wxOVERRIDE|wxNOEXCEPT|[^_@]NULL)'; then
               echo "::error ::Please use C++11 equivalents of the deprecated macros in the new code."
               exit 1
             fi

--- a/include/wx/longlong.h
+++ b/include/wx/longlong.h
@@ -1112,6 +1112,12 @@ namespace std
 #include "wx/strvararg.h"
 
 template<>
+struct wxFormatStringSpecifier<wxLongLong>
+{
+    enum { value = wxFormatString::Arg_LongLongInt };
+};
+
+template<>
 struct WXDLLIMPEXP_BASE wxArgNormalizer<wxLongLong>
 {
      wxArgNormalizer(wxLongLong value,

--- a/include/wx/msgout.h
+++ b/include/wx/msgout.h
@@ -16,8 +16,7 @@
 // ----------------------------------------------------------------------------
 
 #include "wx/defs.h"
-#include "wx/chartype.h"
-#include "wx/strvararg.h"
+#include "wx/string.h"
 
 // ----------------------------------------------------------------------------
 // wxMessageOutput is a class abstracting formatted output target, i.e.
@@ -37,21 +36,15 @@ public:
     static wxMessageOutput* Set(wxMessageOutput* msgout);
 
     // show a message to the user
-    // void Printf(const wxString& format, ...) = 0;
-    WX_DEFINE_VARARG_FUNC_VOID(Printf, 1, (const wxFormatString&),
-                               DoPrintfWchar, DoPrintfUtf8)
+    template <typename FormatString, typename... Targs>
+    void Printf(FormatString format, Targs... args)
+    {
+        Output(wxString::Format(format, args...));
+    }
 
     // called by DoPrintf() to output formatted string but can also be called
     // directly if no formatting is needed
     virtual void Output(const wxString& str) = 0;
-
-protected:
-#if !wxUSE_UTF8_LOCALE_ONLY
-    void DoPrintfWchar(const wxChar *format, ...);
-#endif
-#if wxUSE_UNICODE_UTF8
-    void DoPrintfUtf8(const char *format, ...);
-#endif
 
 private:
     static wxMessageOutput* ms_msgOut;

--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -2212,7 +2212,7 @@ public:
 
     // returns the string containing the result of Printf() to it
   template <typename... Targs>
-  static wxString Format(const wxString& format, Targs... args)
+  static wxString Format(const wxFormatString& format, Targs... args)
   {
       wxString s;
       s.Printf(format, args...);
@@ -2241,7 +2241,7 @@ public:
 
   // use Printf()
   template <typename... Targs>
-  int sprintf(const wxString& format, Targs... args)
+  int sprintf(const wxFormatString& format, Targs... args)
   {
       return Printf(format, args...);
   }

--- a/include/wx/strvararg.h
+++ b/include/wx/strvararg.h
@@ -7,6 +7,17 @@
 // Licence:     wxWindows licence
 ///////////////////////////////////////////////////////////////////////////////
 
+/*
+    This header contains helpers for implementing printf-like functions in
+    wxWidgets as well as legacy WX_DEFINE_VARARG_FUNC macros that are not used
+    by wxWidgets itself any more, but are preserved here as they can be used in
+    the application code (even if they had never been part of documented API).
+
+    The only non-deprecated parts of this header are wxFormatString class and
+    wxFormatStringSpecifier and wxArgNormalizer templates, which are used by
+    wxWidgets itself.
+ */
+
 #ifndef _WX_STRVARARG_H_
 #define _WX_STRVARARG_H_
 

--- a/include/wx/strvararg.h
+++ b/include/wx/strvararg.h
@@ -384,6 +384,9 @@ struct wxFormatStringSpecifier<const T*>
     };
 
 wxFORMAT_STRING_SPECIFIER(bool, wxFormatString::Arg_Int)
+wxFORMAT_STRING_SPECIFIER(char, wxFormatString::Arg_Char | wxFormatString::Arg_Int)
+wxFORMAT_STRING_SPECIFIER(signed char, wxFormatString::Arg_Char | wxFormatString::Arg_Int)
+wxFORMAT_STRING_SPECIFIER(unsigned char, wxFormatString::Arg_Char | wxFormatString::Arg_Int)
 wxFORMAT_STRING_SPECIFIER(int, wxFormatString::Arg_Int)
 wxFORMAT_STRING_SPECIFIER(unsigned int, wxFormatString::Arg_Int)
 wxFORMAT_STRING_SPECIFIER(short int, wxFormatString::Arg_Int)
@@ -401,6 +404,8 @@ wxFORMAT_STRING_SPECIFIER(long double, wxFormatString::Arg_LongDouble)
 #if wxWCHAR_T_IS_REAL_TYPE
 wxFORMAT_STRING_SPECIFIER(wchar_t, wxFormatString::Arg_Char | wxFormatString::Arg_Int)
 #endif
+wxFORMAT_STRING_SPECIFIER(wxUniChar, wxFormatString::Arg_Char | wxFormatString::Arg_Int)
+wxFORMAT_STRING_SPECIFIER(wxUniCharRef, wxFormatString::Arg_Char | wxFormatString::Arg_Int)
 
 #ifndef wxNO_IMPLICIT_WXSTRING_ENCODING
 wxFORMAT_STRING_SPECIFIER(char*, wxFormatString::Arg_String)
@@ -409,6 +414,12 @@ wxFORMAT_STRING_SPECIFIER(signed char*, wxFormatString::Arg_String)
 wxFORMAT_STRING_SPECIFIER(const char*, wxFormatString::Arg_String)
 wxFORMAT_STRING_SPECIFIER(const unsigned char*, wxFormatString::Arg_String)
 wxFORMAT_STRING_SPECIFIER(const signed char*, wxFormatString::Arg_String)
+wxFORMAT_STRING_SPECIFIER(wxCharBuffer, wxFormatString::Arg_String)
+wxFORMAT_STRING_SPECIFIER(wxScopedCharBuffer, wxFormatString::Arg_String)
+wxFORMAT_STRING_SPECIFIER(std::string, wxFormatString::Arg_String)
+#ifdef __cpp_lib_string_view
+wxFORMAT_STRING_SPECIFIER(std::string_view, wxFormatString::Arg_String)
+#endif
 #else // wxNO_IMPLICIT_WXSTRING_ENCODING
 wxDISABLED_FORMAT_STRING_SPECIFIER(char*)
 wxDISABLED_FORMAT_STRING_SPECIFIER(unsigned char*)
@@ -419,6 +430,12 @@ wxDISABLED_FORMAT_STRING_SPECIFIER(const signed char*)
 #endif // wxNO_IMPLICIT_WXSTRING_ENCODING
 wxFORMAT_STRING_SPECIFIER(wchar_t*, wxFormatString::Arg_String)
 wxFORMAT_STRING_SPECIFIER(const wchar_t*, wxFormatString::Arg_String)
+
+wxFORMAT_STRING_SPECIFIER(wxWCharBuffer, wxFormatString::Arg_String)
+wxFORMAT_STRING_SPECIFIER(wxScopedWCharBuffer, wxFormatString::Arg_String)
+wxFORMAT_STRING_SPECIFIER(wxString, wxFormatString::Arg_String)
+wxFORMAT_STRING_SPECIFIER(wxCStrData, wxFormatString::Arg_String)
+wxFORMAT_STRING_SPECIFIER(std::wstring, wxFormatString::Arg_String)
 
 wxFORMAT_STRING_SPECIFIER(int*, wxFormatString::Arg_IntPtr | wxFormatString::Arg_Pointer)
 wxFORMAT_STRING_SPECIFIER(short int*, wxFormatString::Arg_ShortIntPtr | wxFormatString::Arg_Pointer)

--- a/include/wx/strvararg.h
+++ b/include/wx/strvararg.h
@@ -467,6 +467,18 @@ struct wxArgNormalizerWchar : public wxArgNormalizer<T>
                          const wxFormatString *fmt, unsigned index)
         : wxArgNormalizer<T>(value, fmt, index) {}
 };
+
+// Helper function for creating a wxArgNormalizerWchar<T> with type deduced
+// from the type of the argument.
+//
+// NB: Unlike the class ctor, which uses 1-based indices, it takes 0-based
+//     index which makes it more convenient to use in pack expansions.
+template<typename T>
+wxArgNormalizerWchar<T>
+wxNormalizeArgWchar(T value, const wxFormatString *fmt, unsigned indexFrom0)
+{
+    return wxArgNormalizerWchar<T>(value, fmt, indexFrom0 + 1);
+}
 #endif // !wxUSE_UTF8_LOCALE_ONLY
 
 // normalizer for passing arguments to functions working with UTF-8 encoded
@@ -479,6 +491,14 @@ struct wxArgNormalizerWchar : public wxArgNormalizer<T>
                             const wxFormatString *fmt, unsigned index)
             : wxArgNormalizer<T>(value, fmt, index) {}
     };
+
+    // Same type-deducing helper as above, but for wxArgNormalizerUtf8<T>
+    template<typename T>
+    wxArgNormalizerUtf8<T>
+    wxNormalizeArgUtf8(T value, const wxFormatString *fmt, unsigned indexFrom0)
+    {
+        return wxArgNormalizerUtf8<T>(value, fmt, indexFrom0 + 1);
+    }
 
     #define wxArgNormalizerNative wxArgNormalizerUtf8
 #else // wxUSE_UNICODE_WCHAR

--- a/include/wx/strvararg.h
+++ b/include/wx/strvararg.h
@@ -871,9 +871,7 @@ struct wxArgNormalizerNarrowChar
         wxASSERT_ARG_TYPE( fmt, index,
                            wxFormatString::Arg_Char | wxFormatString::Arg_Int );
 
-        // We use char if there is no format string at all, i.e. when used like
-        // e.g. Foo("foo", "bar", 'c', nullptr), but is this the bast choice?
-        if ( !fmt || fmt->GetArgumentType(index) == wxFormatString::Arg_Char )
+        if ( fmt && fmt->GetArgumentType(index) == wxFormatString::Arg_Char )
             m_value = wx_truncate_cast(T, wxUniChar(value).GetValue());
         else
             m_value = value;

--- a/include/wx/wxcrtvararg.h
+++ b/include/wx/wxcrtvararg.h
@@ -237,21 +237,43 @@
 // ----------------------------------------------------------------------------
 
 wxGCC_ONLY_WARNING_SUPPRESS(format-nonliteral)
+wxGCC_ONLY_WARNING_SUPPRESS(format-security)
 
-WX_DEFINE_VARARG_FUNC_SANS_N0(int, wxPrintf, 1, (const wxFormatString&),
-                              wxCRT_PrintfW, wxCRT_PrintfA)
-inline int wxPrintf(const wxFormatString& s)
+template <typename... Targs>
+int wxPrintf(const wxFormatString& format, Targs... args)
 {
-    return wxPrintf(wxASCII_STR("%s"), s.InputAsString());
+    format.Validate({wxFormatStringSpecifier<Targs>::value...});
+
+#if wxUSE_UNICODE_UTF8
+    #if !wxUSE_UTF8_LOCALE_ONLY
+        if ( wxLocaleIsUtf8 )
+    #endif
+            return wxCRT_PrintfA(format, wxArgNormalizerUtf8<Targs>{args, nullptr, 0}.get()...);
+#endif // wxUSE_UNICODE_UTF8
+
+#if !wxUSE_UTF8_LOCALE_ONLY
+    return wxCRT_PrintfW(format, wxArgNormalizerWchar<Targs>{args, nullptr, 0}.get()...);
+#endif // !wxUSE_UTF8_LOCALE_ONLY
 }
 
-WX_DEFINE_VARARG_FUNC_SANS_N0(int, wxFprintf, 2, (FILE*, const wxFormatString&),
-                              wxCRT_FprintfW, wxCRT_FprintfA)
-inline int wxFprintf(FILE *f, const wxFormatString& s)
+template <typename... Targs>
+int wxFprintf(FILE* fp, const wxFormatString& format, Targs... args)
 {
-    return wxFprintf(f, wxASCII_STR("%s"), s.InputAsString());
+    format.Validate({wxFormatStringSpecifier<Targs>::value...});
+
+#if wxUSE_UNICODE_UTF8
+    #if !wxUSE_UTF8_LOCALE_ONLY
+        if ( wxLocaleIsUtf8 )
+    #endif
+            return wxCRT_FprintfA(fp, format, wxArgNormalizerUtf8<Targs>{args, nullptr, 0}.get()...);
+#endif // wxUSE_UNICODE_UTF8
+
+#if !wxUSE_UTF8_LOCALE_ONLY
+    return wxCRT_FprintfW(fp, format, wxArgNormalizerWchar<Targs>{args, nullptr, 0}.get()...);
+#endif // !wxUSE_UTF8_LOCALE_ONLY
 }
 
+wxGCC_ONLY_WARNING_RESTORE(format-security)
 wxGCC_ONLY_WARNING_RESTORE(format-nonliteral)
 
 // va_list versions of printf functions simply forward to the respective
@@ -296,48 +318,69 @@ wxVfprintf(FILE *f, const wxString& format, va_list ap)
 
 #if !wxUSE_UTF8_LOCALE_ONLY
 int WXDLLIMPEXP_BASE wxDoSprintfWchar(char *str, const wxChar *format, ...);
+int WXDLLIMPEXP_BASE wxDoSprintfWchar(wchar_t *str, const wxChar *format, ...);
 #endif
 #if wxUSE_UNICODE_UTF8
 int WXDLLIMPEXP_BASE wxDoSprintfUtf8(char *str, const char *format, ...);
+int WXDLLIMPEXP_BASE wxDoSprintfUtf8(wchar_t *str, const char *format, ...);
 #endif
-WX_DEFINE_VARARG_FUNC(int, wxSprintf, 2, (char*, const wxFormatString&),
-                      wxDoSprintfWchar, wxDoSprintfUtf8)
+
+template <typename CharType, typename... Targs>
+int wxSprintf(CharType* str, const wxFormatString& format, Targs... args)
+{
+    format.Validate({wxFormatStringSpecifier<Targs>::value...});
+
+#if wxUSE_UNICODE_UTF8
+    #if !wxUSE_UTF8_LOCALE_ONLY
+        if ( wxLocaleIsUtf8 )
+    #endif
+            return wxDoSprintfUtf8(str, format, wxArgNormalizerUtf8<Targs>{args, nullptr, 0}.get()...);
+#endif // wxUSE_UNICODE_UTF8
+
+#if !wxUSE_UTF8_LOCALE_ONLY
+    return wxDoSprintfWchar(str, format, wxArgNormalizerWchar<Targs>{args, nullptr, 0}.get()...);
+#endif // !wxUSE_UTF8_LOCALE_ONLY
+}
 
 int WXDLLIMPEXP_BASE
 wxVsprintf(char *str, const wxString& format, va_list argptr);
 
 #if !wxUSE_UTF8_LOCALE_ONLY
 int WXDLLIMPEXP_BASE wxDoSnprintfWchar(char *str, size_t size, const wxChar *format, ...);
+int WXDLLIMPEXP_BASE wxDoSnprintfWchar(wchar_t *str, size_t size, const wxChar *format, ...);
 #endif
 #if wxUSE_UNICODE_UTF8
 int WXDLLIMPEXP_BASE wxDoSnprintfUtf8(char *str, size_t size, const char *format, ...);
+int WXDLLIMPEXP_BASE wxDoSnprintfUtf8(wchar_t *str, size_t size, const char *format, ...);
 #endif
-WX_DEFINE_VARARG_FUNC(int, wxSnprintf, 3, (char*, size_t, const wxFormatString&),
-                      wxDoSnprintfWchar, wxDoSnprintfUtf8)
+
+template <typename CharType, typename... Targs>
+int wxSnprintf(CharType* str, size_t size, const wxFormatString& format, Targs... args)
+{
+    format.Validate({wxFormatStringSpecifier<Targs>::value...});
+
+#if wxUSE_UNICODE_UTF8
+    #if !wxUSE_UTF8_LOCALE_ONLY
+        if ( wxLocaleIsUtf8 )
+    #endif
+            return wxDoSnprintfUtf8(str, size, format, wxArgNormalizerUtf8<Targs>{args, nullptr, 0}.get()...);
+#endif // wxUSE_UNICODE_UTF8
+
+#if !wxUSE_UTF8_LOCALE_ONLY
+    return wxDoSnprintfWchar(str, size, format, wxArgNormalizerWchar<Targs>{args, nullptr, 0}.get()...);
+#endif // !wxUSE_UTF8_LOCALE_ONLY
+}
 
 int WXDLLIMPEXP_BASE
 wxVsnprintf(char *str, size_t size, const wxString& format, va_list argptr);
 
 #if !wxUSE_UTF8_LOCALE_ONLY
-int WXDLLIMPEXP_BASE wxDoSprintfWchar(wchar_t *str, const wxChar *format, ...);
 #endif
 #if wxUSE_UNICODE_UTF8
-int WXDLLIMPEXP_BASE wxDoSprintfUtf8(wchar_t *str, const char *format, ...);
 #endif
-WX_DEFINE_VARARG_FUNC(int, wxSprintf, 2, (wchar_t*, const wxFormatString&),
-                      wxDoSprintfWchar, wxDoSprintfUtf8)
 
 int WXDLLIMPEXP_BASE
 wxVsprintf(wchar_t *str, const wxString& format, va_list argptr);
-
-#if !wxUSE_UTF8_LOCALE_ONLY
-int WXDLLIMPEXP_BASE wxDoSnprintfWchar(wchar_t *str, size_t size, const wxChar *format, ...);
-#endif
-#if wxUSE_UNICODE_UTF8
-int WXDLLIMPEXP_BASE wxDoSnprintfUtf8(wchar_t *str, size_t size, const char *format, ...);
-#endif
-WX_DEFINE_VARARG_FUNC(int, wxSnprintf, 3, (wchar_t*, size_t, const wxFormatString&),
-                      wxDoSnprintfWchar, wxDoSnprintfUtf8)
 
 int WXDLLIMPEXP_BASE
 wxVsnprintf(wchar_t *str, size_t size, const wxString& format, va_list argptr);

--- a/interface/wx/mimetype.h
+++ b/interface/wx/mimetype.h
@@ -433,16 +433,19 @@ public:
     /**
         Constructor allowing to specify all the fields at once.
 
-        This is a vararg constructor taking an arbitrary number of extensions
-        after the first four required parameters. The list must be terminated
-        by @NULL.
+        This is a variadic constructor taking an arbitrary number of extensions
+        (which can be strings of any kind) after the four required parameters.
+
+        In wxWidgets versions before 3.3.0 the list of extensions had to be
+        terminated with @NULL, but this is not the case any more, trailing
+        @NULL is still allowed, but will be ignored.
      */
+    template <typename... Targs>
     wxFileTypeInfo(const wxString& mimeType,
                    const wxString& openCmd,
                    const wxString& printCmd,
                    const wxString& description,
-                   const wxString& extension,
-                   ...);
+                   Targs... extensions);
 
     /**
        Constructor using an array of string elements corresponding to the

--- a/src/common/appbase.cpp
+++ b/src/common/appbase.cpp
@@ -972,7 +972,7 @@ wxString wxAppTraitsBase::GetAssertStackTrace()
 #if !defined(__WINDOWS__)
     // on Unix stack frame generation may take some time, depending on the
     // size of the executable mainly... warn the user that we are working
-    wxFprintf(stderr, "Collecting stack trace information, please wait...");
+    wxFputs("Collecting stack trace information, please wait...", stderr);
     fflush(stderr);
 #endif // !__WINDOWS__
 

--- a/src/common/filename.cpp
+++ b/src/common/filename.cpp
@@ -1341,7 +1341,7 @@ bool wxFileName::Rmdir(const wxString& dir, int flags)
         {
             // SHFileOperation may return non-Win32 error codes, so don't use
             // wxLogApiError() as the error message used by it could be wrong.
-            wxLogDebug(wxS("SHFileOperation(FO_DELETE) failed: error 0x%08lx"),
+            wxLogDebug(wxS("SHFileOperation(FO_DELETE) failed: error 0x%08x"),
                        ret);
             return false;
         }

--- a/src/common/mimecmn.cpp
+++ b/src/common/mimecmn.cpp
@@ -103,55 +103,6 @@ wxString wxMimeTypeCommands::GetVerbCmd(size_t n) const
 // wxFileTypeInfo
 // ----------------------------------------------------------------------------
 
-void wxFileTypeInfo::DoVarArgInit(const wxString& mimeType,
-                                  const wxString& openCmd,
-                                  const wxString& printCmd,
-                                  const wxString& desc,
-                                  va_list argptr)
-{
-    m_mimeType = mimeType;
-    m_openCmd = openCmd;
-    m_printCmd = printCmd;
-    m_desc = desc;
-
-    for ( ;; )
-    {
-        // icc gives this warning in its own va_arg() macro, argh
-#ifdef __INTELC__
-    #pragma warning(push)
-    #pragma warning(disable: 1684)
-#endif
-
-        wxArgNormalizedString ext(WX_VA_ARG_STRING(argptr));
-
-#ifdef __INTELC__
-    #pragma warning(pop)
-#endif
-        if ( !ext )
-        {
-            // nullptr terminates the list
-            break;
-        }
-
-        m_exts.Add(ext.GetString());
-    }
-}
-
-void wxFileTypeInfo::VarArgInit(const wxString *mimeType,
-                                const wxString *openCmd,
-                                const wxString *printCmd,
-                                const wxString *desc,
-                                ...)
-{
-    va_list argptr;
-    va_start(argptr, desc);
-
-    DoVarArgInit(*mimeType, *openCmd, *printCmd, *desc, argptr);
-
-    va_end(argptr);
-}
-
-
 wxFileTypeInfo::wxFileTypeInfo(const wxArrayString& sArray)
     : m_mimeType(sArray[0u])
     , m_openCmd( sArray[1u])

--- a/src/common/msgout.cpp
+++ b/src/common/msgout.cpp
@@ -69,34 +69,6 @@ wxMessageOutput* wxMessageOutput::Set(wxMessageOutput* msgout)
     return old;
 }
 
-#if !wxUSE_UTF8_LOCALE_ONLY
-void wxMessageOutput::DoPrintfWchar(const wxChar *format, ...)
-{
-    va_list args;
-    va_start(args, format);
-    wxString out;
-
-    out.PrintfV(format, args);
-    va_end(args);
-
-    Output(out);
-}
-#endif // !wxUSE_UTF8_LOCALE_ONLY
-
-#if wxUSE_UNICODE_UTF8
-void wxMessageOutput::DoPrintfUtf8(const char *format, ...)
-{
-    va_list args;
-    va_start(args, format);
-    wxString out;
-
-    out.PrintfV(format, args);
-    va_end(args);
-
-    Output(out);
-}
-#endif // wxUSE_UNICODE_UTF8
-
 // ----------------------------------------------------------------------------
 // wxMessageOutputBest
 // ----------------------------------------------------------------------------

--- a/src/common/string.cpp
+++ b/src/common/string.cpp
@@ -1679,38 +1679,6 @@ wxString wxString::FromCDouble(double val, int precision)
 // formatted output
 // ---------------------------------------------------------------------------
 
-#if !wxUSE_UTF8_LOCALE_ONLY
-/* static */
-wxString wxString::DoFormatWchar(const wxChar *format, ...)
-{
-    va_list argptr;
-    va_start(argptr, format);
-
-    wxString s;
-    s.PrintfV(format, argptr);
-
-    va_end(argptr);
-
-    return s;
-}
-#endif // !wxUSE_UTF8_LOCALE_ONLY
-
-#if wxUSE_UNICODE_UTF8
-/* static */
-wxString wxString::DoFormatUtf8(const char *format, ...)
-{
-    va_list argptr;
-    va_start(argptr, format);
-
-    wxString s;
-    s.PrintfV(format, argptr);
-
-    va_end(argptr);
-
-    return s;
-}
-#endif // wxUSE_UNICODE_UTF8
-
 /* static */
 wxString wxString::FormatV(const wxString& format, va_list argptr)
 {

--- a/src/common/strvararg.cpp
+++ b/src/common/strvararg.cpp
@@ -653,31 +653,9 @@ wxString wxFormatString::InputAsString() const
 namespace
 {
 
-template<typename CharType>
-wxFormatString::ArgumentType DoGetArgumentType(const CharType *format,
-                                               unsigned n)
+wxFormatString::ArgumentType ArgTypeFromParamType(wxPrintfArgType type)
 {
-    wxCHECK_MSG( format, wxFormatString::Arg_Unknown,
-                 "empty format string not allowed here" );
-
-    wxPrintfConvSpecParser<CharType> parser(format);
-
-    if ( n > parser.nargs )
-    {
-        // The n-th argument doesn't appear in the format string and is unused.
-        // This can happen e.g. if a translation of the format string is used
-        // and the translation language tends to avoid numbers in singular forms.
-        // The translator would then typically replace "%d" with "One" (e.g. in
-        // Hebrew). Passing too many vararg arguments does not harm, so its
-        // better to be more permissive here and allow legitimate uses in favour
-        // of catching harmless errors.
-        return wxFormatString::Arg_Unused;
-    }
-
-    wxCHECK_MSG( parser.pspec[n-1] != nullptr, wxFormatString::Arg_Unknown,
-                 "requested argument not found - invalid format string?" );
-
-    switch ( parser.pspec[n-1]->m_type )
+    switch ( type )
     {
         case wxPAT_CHAR:
         case wxPAT_WCHAR:
@@ -725,6 +703,33 @@ wxFormatString::ArgumentType DoGetArgumentType(const CharType *format,
     // silence warning
     wxFAIL_MSG( "unexpected argument type" );
     return wxFormatString::Arg_Unknown;
+}
+
+template<typename CharType>
+wxFormatString::ArgumentType DoGetArgumentType(const CharType *format,
+                                               unsigned n)
+{
+    wxCHECK_MSG( format, wxFormatString::Arg_Unknown,
+                 "empty format string not allowed here" );
+
+    wxPrintfConvSpecParser<CharType> parser(format);
+
+    if ( n > parser.nargs )
+    {
+        // The n-th argument doesn't appear in the format string and is unused.
+        // This can happen e.g. if a translation of the format string is used
+        // and the translation language tends to avoid numbers in singular forms.
+        // The translator would then typically replace "%d" with "One" (e.g. in
+        // Hebrew). Passing too many vararg arguments does not harm, so its
+        // better to be more permissive here and allow legitimate uses in favour
+        // of catching harmless errors.
+        return wxFormatString::Arg_Unused;
+    }
+
+    wxCHECK_MSG( parser.pspec[n-1] != nullptr, wxFormatString::Arg_Unknown,
+                 "requested argument not found - invalid format string?" );
+
+    return ArgTypeFromParamType(parser.pspec[n-1]->m_type);
 }
 
 } // anonymous namespace

--- a/src/common/strvararg.cpp
+++ b/src/common/strvararg.cpp
@@ -732,6 +732,64 @@ wxFormatString::ArgumentType DoGetArgumentType(const CharType *format,
     return ArgTypeFromParamType(parser.pspec[n-1]->m_type);
 }
 
+#if wxDEBUG_LEVEL
+
+template<typename CharType>
+void DoValidateFormat(const CharType* format, const std::vector<int>& argTypes)
+{
+    wxPrintfConvSpecParser<CharType> parser(format);
+
+    // For the reasons mentioned in the comment in DoGetArgumentType() above,
+    // we ignore any extraneous argument types, so we only check that the
+    // format format specifiers we actually have match the types.
+    for ( unsigned n = 0; n < parser.nargs; ++n )
+    {
+        if ( n == argTypes.size() )
+        {
+            wxFAIL_MSG
+            (
+                wxString::Format
+                (
+                    "Not enough arguments, %zu given but at least %u needed",
+                    argTypes.size(),
+                    parser.nargs
+                )
+            );
+
+            // Useless to continue further.
+            return;
+        }
+
+        auto const pspec = parser.pspec[n];
+        if ( !pspec )
+        {
+            wxFAIL_MSG
+            (
+                wxString::Format
+                (
+                    "Missing format specifier for argument %u in \"%s\"",
+                    n + 1, format
+                )
+            );
+
+            continue;
+        }
+
+        auto const ptype = ArgTypeFromParamType(pspec->m_type);
+        wxASSERT_MSG
+        (
+            (ptype & argTypes[n]) == ptype,
+            wxString::Format
+            (
+                "Format specifier mismatch for argument %u of \"%s\"",
+                n + 1, format
+            )
+        );
+    }
+}
+
+#endif // wxDEBUG_LEVEL
+
 } // anonymous namespace
 
 wxFormatString::ArgumentType wxFormatString::GetArgumentType(unsigned n) const
@@ -748,3 +806,19 @@ wxFormatString::ArgumentType wxFormatString::GetArgumentType(unsigned n) const
     wxFAIL_MSG( "unreachable code" );
     return Arg_Unknown;
 }
+
+#if wxDEBUG_LEVEL
+
+void wxFormatString::Validate(const std::vector<int>& argTypes) const
+{
+    if ( m_char )
+        DoValidateFormat(m_char.data(), argTypes);
+    else if ( m_wchar )
+        DoValidateFormat(m_wchar.data(), argTypes);
+    else if ( m_str )
+        DoValidateFormat(m_str->wx_str(), argTypes);
+    else if ( m_cstr )
+        DoValidateFormat(m_cstr->AsInternal(), argTypes);
+}
+
+#endif // wxDEBUG_LEVEL

--- a/tests/misc/misctests.cpp
+++ b/tests/misc/misctests.cpp
@@ -17,6 +17,7 @@
 #include "wx/defs.h"
 
 #include "wx/math.h"
+#include "wx/mimetype.h"
 
 // just some classes using wxRTTI for wxStaticCast() test
 #include "wx/tarstrm.h"
@@ -213,3 +214,30 @@ TEST_CASE("wxMulDivInt32", "[math]")
     // Check that it doesn't overflow.
     CHECK( wxMulDivInt32((INT_MAX - 1)/2, 200, 100) == INT_MAX - 1 );
 }
+
+#if wxUSE_MIMETYPE
+TEST_CASE("wxFileTypeInfo", "[mime]")
+{
+    SECTION("no extensions")
+    {
+        wxFileTypeInfo fti("binary/*", "", wxString{}, L"plain binary");
+        REQUIRE( fti.GetExtensionsCount() == 0 );
+    }
+
+    SECTION("extension without null at the end")
+    {
+        wxFileTypeInfo fti("image/png", "", wxEmptyString, "PNG image", "png");
+        REQUIRE( fti.GetExtensionsCount() == 1 );
+        CHECK( fti.GetExtensions()[0] == "png" );
+    }
+
+    SECTION("two extensions with null at the end")
+    {
+        wxFileTypeInfo fti("image/jpeg", "", "", "JPEG image",
+                           "jpg", L"jpeg", nullptr);
+        REQUIRE( fti.GetExtensionsCount() == 2 );
+        CHECK( fti.GetExtensions()[0] == "jpg" );
+        CHECK( fti.GetExtensions()[1] == "jpeg" );
+    }
+}
+#endif // wxUSE_MIMETYPE

--- a/tests/strings/vararg.cpp
+++ b/tests/strings/vararg.cpp
@@ -232,6 +232,7 @@ TEST_CASE("ArgsValidation", "[wxString][vararg][error]")
 #endif
 
     // but these are not:
+    WX_ASSERT_FAILS_WITH_ASSERT( wxString::Format("%d + %d = %d", 2, 2) );
     WX_ASSERT_FAILS_WITH_ASSERT( wxString::Format("%i", "foo") );
     WX_ASSERT_FAILS_WITH_ASSERT( wxString::Format("%s", (void*)&written) );
     WX_ASSERT_FAILS_WITH_ASSERT( wxString::Format("%d", ptr) );

--- a/utils/wxrc/wxrc.cpp
+++ b/utils/wxrc/wxrc.cpp
@@ -417,7 +417,7 @@ wxArrayString XmlResApp::PrepareTempFiles()
     for (size_t i = 0; i < parFiles.GetCount(); i++)
     {
         if (flagVerbose)
-            wxPrintf(wxT("processing ") + parFiles[i] +  wxT("...\n"));
+            wxPrintf(wxT("processing %s...\n"), parFiles[i]);
 
         wxXmlDocument doc;
 
@@ -529,7 +529,7 @@ void XmlResApp::FindFilesInXML(wxXmlNode *node, wxArrayString& flist, const wxSt
                 fullname = inputPath + wxFILE_SEP_PATH + n->GetContent();
 
             if (flagVerbose)
-                wxPrintf(wxT("adding     ") + fullname +  wxT("...\n"));
+                wxPrintf(wxT("adding     %s...\n"), fullname);
 
             wxString filename = GetInternalFileName(n->GetContent(), flist);
             n->SetContent(filename);
@@ -569,7 +569,7 @@ void XmlResApp::MakePackageZIP(const wxArrayString& flist)
     files.RemoveLast();
 
     if (flagVerbose)
-        wxPrintf(wxT("compressing ") + parOutput +  wxT("...\n"));
+        wxPrintf(wxT("compressing %s...\n"), parOutput);
 
     wxString cwd = wxGetCwd();
     wxSetWorkingDirectory(parOutputPath);
@@ -639,7 +639,7 @@ void XmlResApp::MakePackageCPP(const wxArrayString& flist)
     unsigned i;
 
     if (flagVerbose)
-        wxPrintf(wxT("creating C++ source file ") + parOutput +  wxT("...\n"));
+        wxPrintf(wxT("creating C++ source file %s...\n"), parOutput);
 
     file.Write(""
 "//\n"
@@ -797,7 +797,7 @@ void XmlResApp::MakePackagePython(const wxArrayString& flist)
     unsigned i;
 
     if (flagVerbose)
-        wxPrintf(wxT("creating Python source file ") + parOutput +  wxT("...\n"));
+        wxPrintf(wxT("creating Python source file %s...\n"), parOutput);
 
     file.Write(
        "#\n"
@@ -881,7 +881,7 @@ ExtractedStrings XmlResApp::FindStrings()
     for (size_t i = 0; i < parFiles.GetCount(); i++)
     {
         if (flagVerbose)
-            wxPrintf(wxT("processing ") + parFiles[i] +  wxT("...\n"));
+            wxPrintf(wxT("processing %s...\n"), parFiles[i]);
 
         wxXmlDocument doc;
         if (!doc.Load(parFiles[i]))


### PR DESCRIPTION
~The last commit here requires C++14 and so can't be merged yet.~

The latest version doesn't require C++14 any more at the price of slightly changing/breaking `%c` handling.