### PR TITLE
Improve implementation of WX_ASSERT_FAILS_WITH_ASSERT_MESSAGE

### DIFF
--- a/tests/testprec.h
+++ b/tests/testprec.h
@@ -109,15 +109,15 @@ public:
 
 // macro to use for the functions which are supposed to fail an assertion
 #if wxDEBUG_LEVEL
-    // some old cppunit versions don't define CPPUNIT_ASSERT_THROW so roll our
-    // own
     #define WX_ASSERT_FAILS_WITH_ASSERT_MESSAGE(msg, code) \
         wxSTATEMENT_MACRO_BEGIN \
             bool throwsAssert = false; \
             try { code ; } \
             catch ( const TestAssertFailure& ) { throwsAssert = true; } \
-            if ( !throwsAssert ) \
-                CPPUNIT_FAIL(msg); \
+            if ( throwsAssert ) \
+                SUCCEED("assert triggered"); \
+            else \
+                FAIL_CHECK(msg); \
         wxSTATEMENT_MACRO_END
 
     #define WX_ASSERT_FAILS_WITH_ASSERT(code) \


### PR DESCRIPTION
Use SUCCEED() in it so passing tests are actually counted (before running a test using this macro resulted in misleading output saying that 0 asserts passed) and also use FAIL_CHECK(), instead of FAIL(), to which CPPUNIT_FAIL() expanded before, to allow the rest of the test to run even if this check fails, as missing assertions shouldn't be fatal.

Also remove a very old and outdated comment mentioning CppUnit.