### PR TITLE
wxQt menu fixes

### DIFF
--- a/include/wx/qt/menuitem.h
+++ b/include/wx/qt/menuitem.h
@@ -40,6 +40,12 @@ public:
     virtual QAction *GetHandle() const;
 
     virtual void SetFont(const wxFont& font);
+
+#if wxUSE_ACCEL
+    virtual void AddExtraAccel(const wxAcceleratorEntry& accel) override;
+    virtual void ClearExtraAccels() override;
+#endif // wxUSE_ACCEL
+
 private:
     // Qt is using an action instead of a menu item.
     wxQtAction *m_qtAction;

--- a/interface/wx/menuitem.h
+++ b/interface/wx/menuitem.h
@@ -439,7 +439,10 @@ public:
         <tt>\\t</tt> followed by a valid key combination (e.g. <tt>CTRL+V</tt>).
         Its general syntax is any combination of @c "CTRL", @c "RAWCTRL",  @c
         "ALT" and @c "SHIFT" strings (case doesn't matter) separated by either
-        @c '-' or @c '+' characters and followed by the accelerator itself.
+        @c '-' or @c '+' characters and followed by the accelerator itself. Note that
+        the displayed accelerator can differ from the string specified here though,
+        e.g. <tt>Ctrl+X</tt> could be actually shown on the screen when <tt>Ctrl-X</tt>
+        is used.
         Notice that @c CTRL corresponds to the "Ctrl" key on most platforms but
         not under macOS where it is mapped to "Cmd" key on Mac keyboard.
         Usually this is exactly what you want in portable code but if you

--- a/src/qt/menuitem.cpp
+++ b/src/qt/menuitem.cpp
@@ -35,6 +35,7 @@ public:
     }
 
 private:
+    void onActionToggled( bool checked );
     void onActionTriggered( bool checked );
 
     const wxWindowID m_mitemId;
@@ -180,6 +181,7 @@ wxQtAction::wxQtAction( wxMenu *handler, int id, const wxString &text, const wxS
             break;
     }
 
+    connect( this, &QAction::toggled, this, &wxQtAction::onActionToggled );
     connect( this, &QAction::triggered, this, &wxQtAction::onActionTriggered );
 
     UpdateShortcutsFromLabel( text );
@@ -196,8 +198,12 @@ void wxQtAction::UpdateShortcutsFromLabel(const wxString& text)
 #endif // wxUSE_ACCEL
 }
 
-void wxQtAction::onActionTriggered( bool checked )
+void wxQtAction::onActionToggled( bool checked )
 {
     GetMenu()->Check(m_mitemId, checked);
+}
+
+void wxQtAction::onActionTriggered( bool checked )
+{
     GetMenu()->SendEvent(m_mitemId, m_isCheckable ? checked : -1 );
 }

--- a/tests/menu/menu.cpp
+++ b/tests/menu/menu.cpp
@@ -444,15 +444,11 @@ void MenuTestCase::RadioItems()
     // Subsequent items in a group are not checked.
     CPPUNIT_ASSERT( !menu->IsChecked(MenuTestCase_First + 1) );
 
-#ifdef __WXQT__
-    WARN("Radio check test does not work under Qt");
-#else
     // Checking the second one make the first one unchecked however.
     menu->Check(MenuTestCase_First + 1, true);
     CPPUNIT_ASSERT( !menu->IsChecked(MenuTestCase_First) );
     CPPUNIT_ASSERT( menu->IsChecked(MenuTestCase_First + 1) );
     menu->Check(MenuTestCase_First, true);
-#endif
 
     // Adding more radio items after a separator creates another radio group...
     menu->AppendSeparator();
@@ -464,30 +460,22 @@ void MenuTestCase::RadioItems()
     CPPUNIT_ASSERT( menu->IsChecked(MenuTestCase_First) );
     CPPUNIT_ASSERT( menu->IsChecked(MenuTestCase_First + 2) );
 
-#ifdef __WXQT__
-    WARN("Radio check test does not work under Qt");
-#else
     menu->Check(MenuTestCase_First + 3, true);
     CPPUNIT_ASSERT( menu->IsChecked(MenuTestCase_First + 3) );
     CPPUNIT_ASSERT( !menu->IsChecked(MenuTestCase_First + 2) );
 
     CPPUNIT_ASSERT( menu->IsChecked(MenuTestCase_First) );
     menu->Check(MenuTestCase_First + 2, true);
-#endif
 
     // Insert an item in the middle of an existing radio group.
     menu->InsertRadioItem(4, MenuTestCase_First + 5, "Radio 5");
     CPPUNIT_ASSERT( menu->IsChecked(MenuTestCase_First + 2) );
     CPPUNIT_ASSERT( !menu->IsChecked(MenuTestCase_First + 5) );
 
-#ifdef __WXQT__
-    WARN("Radio check test does not work under Qt");
-#else
     menu->Check( MenuTestCase_First + 5, true );
     CPPUNIT_ASSERT( !menu->IsChecked(MenuTestCase_First + 3) );
 
     menu->Check( MenuTestCase_First + 3, true );
-#endif
 
     // Prepend a couple of items before the first group.
     menu->PrependRadioItem(MenuTestCase_First + 6, "Radio 6");
@@ -495,9 +483,6 @@ void MenuTestCase::RadioItems()
     CPPUNIT_ASSERT( !menu->IsChecked(MenuTestCase_First + 6) );
     CPPUNIT_ASSERT( !menu->IsChecked(MenuTestCase_First + 7) );
 
-#ifdef __WXQT__
-    WARN("Radio check test does not work under Qt");
-#else
     menu->Check(MenuTestCase_First + 7, true);
     CPPUNIT_ASSERT( !menu->IsChecked(MenuTestCase_First + 1) );
 
@@ -505,7 +490,6 @@ void MenuTestCase::RadioItems()
     // Check that the last radio group still works as expected.
     menu->Check(MenuTestCase_First + 4, true);
     CPPUNIT_ASSERT( !menu->IsChecked(MenuTestCase_First + 5) );
-#endif
 }
 
 void MenuTestCase::RemoveAdd()


### PR DESCRIPTION
**N.B.** There is changes done locally to `wxUIActionSimulator` (not included here)
necessary to make the menu test and the other tests pass. which will be published later.

**About this commit** fd62dad3211ec20f1644dcd0f8dfd802514da31e :

Under my system (Ubuntu 18.04 with Qt 5.9) shortcuts like `Ctrl-V` and `Ctrl-Shift-T`
don't work but the **non hyphenated** ones work correctly, i.e. `Ctrl+V` and `Ctrl+Shift+T`
Does anyone know for sure that hyphenated shortcuts really don't work with `Qt`? because I can't find any official docs about this. moreover, using `QKeySequence::NativeText` or `QKeySequence::PortableText` doesn't make any deference at all!