### PR TITLE
Fix ParseDateTime to handle default 'T' separator

### DIFF
--- a/src/common/datetimefmt.cpp
+++ b/src/common/datetimefmt.cpp
@@ -1752,7 +1752,7 @@ wxDateTime::ParseDateTime(const wxString& date, wxString::const_iterator *end)
         // Skip spaces, as the ParseTime() function fails on spaces
         while ( endDate != date.end() && wxIsspace(*endDate) )
             ++endDate;
-        
+
         // Skip possible 'T' separator in front of time component
         if ( endDate != date.end() && *endDate == 'T' )
             ++endDate;

--- a/src/common/datetimefmt.cpp
+++ b/src/common/datetimefmt.cpp
@@ -1752,6 +1752,10 @@ wxDateTime::ParseDateTime(const wxString& date, wxString::const_iterator *end)
         // Skip spaces, as the ParseTime() function fails on spaces
         while ( endDate != date.end() && wxIsspace(*endDate) )
             ++endDate;
+        
+        // Skip possible 'T' separator in front of time component
+        if ( endDate != date.end() && *endDate == 'T' )
+            ++endDate;
 
         const wxString timestr(endDate, date.end());
         if ( !dtTime.ParseTime(timestr, &endTime) )

--- a/tests/datetime/datetimetest.cpp
+++ b/tests/datetime/datetimetest.cpp
@@ -1441,6 +1441,15 @@ void DateTimeTestCase::TestDateTimeParse()
         },
 
         {
+            // with 'T' separator
+            "2010-01-04T14:30",
+            {  4, wxDateTime::Jan, 2010, 14, 30,  0 },
+            true,
+            "",
+            false
+        },
+
+        {
             // date after time
             "14:30:00 2020-01-04",
             {  4, wxDateTime::Jan, 2020, 14, 30,  0 },


### PR DESCRIPTION
`ParseDateTime` currently fails if there is a 'T' separator in front of time component. `FormatISOCombined()` uses this separator as the default, so `wxDateTime` can't parse its own formatted results by default. Example

```cpp
wxDateTime dt;
wxASSERT(dt.ParseDateTime("1979-10-31 13:37:09"));
wxASSERT(dt.IsValid());

wxDateTime otherDt;
// OK
wxASSERT(otherDt.ParseDateTime(dt.FormatISOCombined(' ')));
// Fails using the defaults (and, according to the help, the standard format)
wxASSERT(otherDt.ParseDateTime(dt.FormatISOCombined()));
```