### PR TITLE
Fix ambiguous overload error on GetPathSeparator()

### DIFF
--- a/include/wx/filename.h
+++ b/include/wx/filename.h
@@ -490,7 +490,7 @@ public:
 
     // get the canonical path separator for this format
     static wxUniChar GetPathSeparator(wxPathFormat format = wxPATH_NATIVE)
-        { return GetPathSeparators(format)[0u]; }
+        { return GetPathSeparators(format)[0]; }
 
     // is the char a path separator for this format?
     static bool IsPathSeparator(wxChar ch, wxPathFormat format = wxPATH_NATIVE);


### PR DESCRIPTION
When using `wx/filename.h`, I'm constantly getting this error:

```
/usr/i686-w64-mingw32/sys-root/mingw/include/wx-3.2/wx/filename.h: In static member function 'static wxUniChar wxFileName::GetPathSeparator(wxPathFormat)':
/usr/i686-w64-mingw32/sys-root/mingw/include/wx-3.2/wx/filename.h:493:43: error: ambiguous overload for 'operator[]' (operand types are 'wxString' and 'unsigned int')
  493 |         { return GetPathSeparators(format)[0u]; }
      |                                           ^
```

The error seems to be related to the missing definition of `wxSIZE_T_IS_UINT` inside `platform.h`, which causes this function:

https://github.com/wxWidgets/wxWidgets/blob/58f5a885ec20ea518f94e16d2fcff6d0b8decd17/include/wx/string.h#L213

to be not declared.
Without worrying about the absence of `wxSIZE_T_IS_UINT` or if it would be better to always declare the above function, in my opinion the easiest way to fix this issue is to replace the literal `0u` with `0` into `GetPathSeparator()`. I think that there is no need to force a sign in this case and, hopefully, the right candidate always exists here:

https://github.com/wxWidgets/wxWidgets/blob/58f5a885ec20ea518f94e16d2fcff6d0b8decd17/include/wx/string.h#L210

This solution always worked fine on my side, with both CYGWIN 64bit native compiler and i686/x86_64-w64 cross compilers.
Tested with wxWidgets 3.2.1.