### PR TITLE
wxTaskBarIcon: Prefer GetPopupMenu over CreatePopupMenu

### DIFF
--- a/src/osx/cocoa/taskbar.mm
+++ b/src/osx/cocoa/taskbar.mm
@@ -334,7 +334,12 @@ bool wxTaskBarIconDockImpl::PopupMenu(wxMenu *WXUNUSED(menu))
 - (void) clickedAction: (id) sender
 {
     wxUnusedVar(sender);
-    wxMenu *menu = impl->CreatePopupMenu();
+    wxMenu *menu = impl->GetPopupMenu();
+    if (menu) {
+        impl->PopupMenu(menu);
+        return;
+    }
+    menu = impl->CreatePopupMenu();
     if (menu)
     {
         impl->PopupMenu(menu);


### PR DESCRIPTION
### What has changed
When clicking a `wxTaskBarIcon` subclass constructed with `wxTBI_CUSTOM_STATUSITEM` or `wxTBI_DEFAULT_TYPE` on macOS the `GetPopupMenu()` method is called before `CreatePopupMenu()`.

### Why this was changed
Before this change the `GetPopupMenu()` method was _not_ called before `CreatePopupMenu()`, which is contradictory to the intended behaviour as described in the documentation.

### Links
This resolves https://github.com/wxWidgets/wxWidgets/issues/23008, more details in the issue description.

### How can a reviewer test this change
I have verified locally that the menu provided in `GetPopupMenu()` is displayed. I would appreciate suggestions for how to create a unit test for this change (to prevent regression) as I'm not familiar with C++ unit tests, nor with the wxWidgets tests.