### PR TITLE
Informally deprecate wxDynamicLibrary::GetSymbolAorW()

### DIFF
--- a/include/wx/dynlib.h
+++ b/include/wx/dynlib.h
@@ -111,8 +111,10 @@ enum wxPluginCategory
 
 #ifdef __WINDOWS__
 
-// same as wxDL_INIT_FUNC() but appends 'A' or 'W' to the function name, see
-// wxDynamicLibrary::GetSymbolAorW()
+// same as wxDL_INIT_FUNC() but appends 'W' (never 'A' any more) to the
+// function name, see wxDynamicLibrary::GetSymbolAorW()
+//
+// shouldn't be used any longer, just use wxDL_INIT_FUNC() instead
 #define wxDL_INIT_FUNC_AW(pfx, name, dynlib) \
     pfx ## name = (name ## _t)(dynlib).GetSymbolAorW(#name)
 
@@ -292,6 +294,8 @@ public:
 #ifdef __WINDOWS__
     // This function is misnamed now as it always loads "W" symbol because we
     // always use Unicode now, but keeps its old name for compatibility.
+    //
+    // Use RawGetSymbol() directly with the name containing "W" in the new code.
     static void *RawGetSymbolAorW(wxDllType handle, const wxString& name)
     {
         return RawGetSymbol

--- a/interface/wx/dynlib.h
+++ b/interface/wx/dynlib.h
@@ -182,13 +182,14 @@ public:
     void* GetSymbol(const wxString& name, bool* success = 0) const;
 
     /**
-        This function is available only under Windows as it is only useful when
-        dynamically loading symbols from standard Windows DLLs. Such functions
-        have either @c 'A' (in ANSI build) or @c 'W' (in Unicode, or wide
-        character build) suffix if they take string parameters. Using this
-        function, you can use just the base name of the function and the
-        correct suffix is appended automatically depending on the current
-        build. Otherwise, this method is identical to GetSymbol().
+        @deprecated
+
+        Returns the symbol with the given name with "W" appended to it.
+
+        This function was useful to hide the differences between ANSI and
+        Unicode builds but shouldn't be used in the new code, as ANSI build is
+        not supported any longer. Just call GetSymbol() directly instead and
+        pass the name ending with `W` to it.
 
         @onlyfor{wxmsw}
     */

--- a/src/msw/app.cpp
+++ b/src/msw/app.cpp
@@ -402,13 +402,13 @@ private:
     int m_dataLen;              // length data buffer
     int m_dataLine;             // line offset
 
-    typedef DWORD (WINAPI *GetConsoleCommandHistory_t)(LPTSTR sCommands,
-                                                       DWORD nBufferLength,
-                                                       LPCTSTR sExeName);
-    typedef DWORD (WINAPI *GetConsoleCommandHistoryLength_t)(LPCTSTR sExeName);
+    typedef DWORD (WINAPI *GetConsoleCommandHistoryW_t)(LPWSTR sCommands,
+                                                        DWORD nBufferLength,
+                                                        LPCWSTR sExeName);
+    typedef DWORD (WINAPI *GetConsoleCommandHistoryLengthW_t)(LPCWSTR sExeName);
 
-    GetConsoleCommandHistory_t m_pfnGetConsoleCommandHistory;
-    GetConsoleCommandHistoryLength_t m_pfnGetConsoleCommandHistoryLength;
+    GetConsoleCommandHistoryW_t m_pfnGetConsoleCommandHistoryW;
+    GetConsoleCommandHistoryLengthW_t m_pfnGetConsoleCommandHistoryLengthW;
 
     wxDECLARE_NO_COPY_CLASS(wxConsoleStderr);
 };
@@ -430,12 +430,12 @@ bool wxConsoleStderr::DoInit()
     // dtor
     m_hStderr = hStderr;
 
-    wxDL_INIT_FUNC_AW(m_pfn, GetConsoleCommandHistory, m_dllKernel32);
-    if ( !m_pfnGetConsoleCommandHistory )
+    wxDL_INIT_FUNC(m_pfn, GetConsoleCommandHistoryW, m_dllKernel32);
+    if ( !m_pfnGetConsoleCommandHistoryW )
         return false;
 
-    wxDL_INIT_FUNC_AW(m_pfn, GetConsoleCommandHistoryLength, m_dllKernel32);
-    if ( !m_pfnGetConsoleCommandHistoryLength )
+    wxDL_INIT_FUNC(m_pfn, GetConsoleCommandHistoryLengthW, m_dllKernel32);
+    if ( !m_pfnGetConsoleCommandHistoryLengthW )
         return false;
 
     // remember the current command history to be able to compare with it later
@@ -495,12 +495,12 @@ int wxConsoleStderr::GetCommandHistory(wxWCharBuffer& buf) const
     // these functions are internal and may only be called by cmd.exe
     static const wxChar *CMD_EXE = wxT("cmd.exe");
 
-    const int len = m_pfnGetConsoleCommandHistoryLength(CMD_EXE);
+    const int len = m_pfnGetConsoleCommandHistoryLengthW(CMD_EXE);
     if ( len )
     {
         buf.extend(len);
 
-        int len2 = m_pfnGetConsoleCommandHistory(buf.data(), len, CMD_EXE);
+        int len2 = m_pfnGetConsoleCommandHistoryW(buf.data(), len, CMD_EXE);
 
         if ( len2 != len )
         {

--- a/src/msw/artmsw.cpp
+++ b/src/msw/artmsw.cpp
@@ -49,13 +49,13 @@ MSW_SHDefExtractIcon(LPCTSTR pszIconFile, int iIndex, UINT uFlags,
     typedef HRESULT
     (WINAPI *SHDefExtractIcon_t)(LPCTSTR, int, UINT, HICON*, HICON*, UINT);
 
-    static SHDefExtractIcon_t s_SHDefExtractIcon = nullptr;
-    if ( !s_SHDefExtractIcon )
+    static SHDefExtractIcon_t s_SHDefExtractIconW = nullptr;
+    if ( !s_SHDefExtractIconW )
     {
         wxDynamicLibrary shell32(wxT("shell32.dll"));
-        wxDL_INIT_FUNC_AW(s_, SHDefExtractIcon, shell32);
+        wxDL_INIT_FUNC(s_, SHDefExtractIconW, shell32);
 
-        if ( !s_SHDefExtractIcon )
+        if ( !s_SHDefExtractIconW )
             return E_FAIL;
 
         // Prevent the DLL from being unloaded while we use its function.
@@ -63,8 +63,8 @@ MSW_SHDefExtractIcon(LPCTSTR pszIconFile, int iIndex, UINT uFlags,
         shell32.Detach();
     }
 
-    return (*s_SHDefExtractIcon)(pszIconFile, iIndex, uFlags,
-                                 phiconLarge, phiconSmall, nIconSize);
+    return (*s_SHDefExtractIconW)(pszIconFile, iIndex, uFlags,
+                                  phiconLarge, phiconSmall, nIconSize);
 }
 
 #endif // !defined(SHDefExtractIcon)

--- a/src/msw/mediactrl_am.cpp
+++ b/src/msw/mediactrl_am.cpp
@@ -807,7 +807,7 @@ struct IBaseFilter : public IMediaFilter
 //
 //---------------------------------------------------------------------------
 
-typedef BOOL (WINAPI* LPAMGETERRORTEXT)(HRESULT, wxChar *, DWORD);
+typedef BOOL (WINAPI* AMGetErrorTextW_t)(HRESULT, wxChar *, DWORD);
 
 class WXDLLIMPEXP_MEDIA wxAMMediaBackend : public wxMediaBackendCommonBase
 {
@@ -876,7 +876,7 @@ public:
     // Stuff for getting useful debugging strings
 #if wxDEBUG_LEVEL
     wxDynamicLibrary m_dllQuartz;
-    LPAMGETERRORTEXT m_lpAMGetErrorText;
+    AMGetErrorTextW_t m_lpAMGetErrorTextW;
     wxString GetErrorString(HRESULT hrdsv);
 #endif // wxDEBUG_LEVEL
     wxEvtHandler* m_evthandler;
@@ -930,8 +930,8 @@ wxIMPLEMENT_DYNAMIC_CLASS(wxAMMediaBackend, wxMediaBackend);
 wxString wxAMMediaBackend::GetErrorString(HRESULT hrdsv)
 {
     wxChar szError[MAX_ERROR_TEXT_LEN];
-    if( m_lpAMGetErrorText != nullptr &&
-       (*m_lpAMGetErrorText)(hrdsv, szError, MAX_ERROR_TEXT_LEN) == 0)
+    if( m_lpAMGetErrorTextW != nullptr &&
+       (*m_lpAMGetErrorTextW)(hrdsv, szError, MAX_ERROR_TEXT_LEN) == 0)
     {
         return wxString::Format(wxT("DirectShow error \"%s\" \n")
                                      wxT("(numeric %X)\n")
@@ -1007,8 +1007,7 @@ bool wxAMMediaBackend::CreateControl(wxControl* ctrl, wxWindow* parent,
 #if wxDEBUG_LEVEL
     if ( m_dllQuartz.Load(wxT("quartz.dll"), wxDL_VERBATIM) )
     {
-        m_lpAMGetErrorText = (LPAMGETERRORTEXT)
-                                m_dllQuartz.GetSymbolAorW(wxT("AMGetErrorText"));
+        wxDL_INIT_FUNC(m_lp, AMGetErrorTextW, m_dllQuartz);
     }
 #endif // wxDEBUG_LEVEL
 


### PR DESCRIPTION
This function is useless now, so don't use it nor the related wxDL_INIT_FUNC_AW() macro in wxWidgets own code any more and document it as being deprecated -- even though the function is not really deprecated at the code level because it doesn't cost much to continue to provide it and it's not worth forcing people to change their code, if they happen to use it, when updating wxWidgets.

Closes #22930.