### PR TITLE
Normalize displayed accelerators in wxMSW too

### DIFF
--- a/src/msw/menu.cpp
+++ b/src/msw/menu.cpp
@@ -365,6 +365,18 @@ bool wxMenu::DoInsertOrAppend(wxMenuItem *pItem, size_t pos)
 
     // prepare to insert the item in the menu
     wxString itemText = pItem->GetItemLabel();
+#if wxUSE_ACCEL
+    const int n = FindAccel(pItem->GetId());
+    if ( n != wxNOT_FOUND )
+    {
+        // We need to normalize the accelerator if only to account for RawCtrl
+        // modifier used: we want to show just "Ctrl" for it in the menu.
+        itemText = wxString::Format("%s\t%s",
+                                    itemText.BeforeFirst('\t'),
+                                    m_accels[n]->ToString());
+    }
+#endif // wxUSE_ACCEL
+
     LPCTSTR pData = nullptr;
     if ( pos == (size_t)-1 )
     {


### PR DESCRIPTION
Show the standard accelerator representation instead of the original string specified in the menu item label, as is already done in the other ports.

This fixes the problem with showing "RawCtrl" in the menu for the accelerators using it, as now "Ctrl" is displayed, as expected.

It also changes the display of the existing accelerators using "-", as they're now displayed with "+" in wxMSW too, but this is already the documented behaviour since the recent c4940c0838 (Update wxMenuItem::SetItemLabel() documentation, 2022-11-24) and better conforms to the platform standards -- and could also be (optionally?) disabled later if it turns out to be really undesirable.

Closes #22892.