### PR TITLE
Fix some wxListCtrl tests

### DIFF
--- a/tests/controls/listbasetest.cpp
+++ b/tests/controls/listbasetest.cpp
@@ -449,18 +449,23 @@ void ListBaseTestCase::Visible()
     wxListCtrl* const list = GetList();
 
     list->InsertColumn(0, "Column 0");
+    list->InsertItem(0, wxString::Format("string 0"));
 
     int count = list->GetCountPerPage();
 
-    for( int i = 0; i < count + 10; i++ )
+    for( int i = 1; i < count + 10; i++ )
     {
         list->InsertItem(i, wxString::Format("string %d", i));
     }
 
     CPPUNIT_ASSERT_EQUAL(count + 10, list->GetItemCount());
     CPPUNIT_ASSERT_EQUAL(0, list->GetTopItem());
+    CPPUNIT_ASSERT(list->IsVisible(0));
+    CPPUNIT_ASSERT(!list->IsVisible(count + 1));
 
-    list->EnsureVisible(count + 9);
+    CPPUNIT_ASSERT(list->EnsureVisible(count + 9));
+    CPPUNIT_ASSERT(list->IsVisible(count + 9));
+    CPPUNIT_ASSERT(!list->IsVisible(9));
 
     CPPUNIT_ASSERT(list->GetTopItem() != 0);
 }

--- a/tests/controls/listctrltest.cpp
+++ b/tests/controls/listctrltest.cpp
@@ -79,7 +79,7 @@ CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( ListCtrlTestCase, "ListCtrlTestCase" );
 void ListCtrlTestCase::setUp()
 {
     m_list = new wxListCtrl(wxTheApp->GetTopWindow());
-    m_list->SetWindowStyle(wxLC_REPORT);
+    m_list->SetWindowStyle(wxLC_REPORT | wxLC_EDIT_LABELS);
     m_list->SetSize(400, 200);
 }
 
@@ -91,9 +91,17 @@ void ListCtrlTestCase::tearDown()
 
 void ListCtrlTestCase::EditLabel()
 {
+    EventCounter editItem(m_list, wxEVT_LIST_BEGIN_LABEL_EDIT);
+    EventCounter endEditItem(m_list, wxEVT_LIST_END_LABEL_EDIT);
+
     m_list->InsertColumn(0, "Column 0");
     m_list->InsertItem(0, "foo");
     m_list->EditLabel(0);
+
+    m_list->EndEditLabel(true);
+
+    CHECK(editItem.GetCount() == 1);
+    CHECK(endEditItem.GetCount() == 1);
 }
 
 void ListCtrlTestCase::SubitemRect()


### PR DESCRIPTION
The use of `CPPUNIT_ASSERT` is for consistency only. and will be replaced with `CHECK` later when the file is updated.