### PR TITLE
Fix wxNotebook::HitTest() for horizontal orientation in wxMSW

### DIFF
--- a/include/wx/msw/notebook.h
+++ b/include/wx/msw/notebook.h
@@ -192,6 +192,12 @@ protected:
   wxPoint m_bgBrushAdj;
 #endif // wxUSE_UXTHEME
 
+private:
+  // This function is used instead of TCM_HITTEST for implementing HitTest()
+  // for the notebooks with horizontal orientation.
+  //
+  // It has the same semantics as HitTest().
+  int MSWHitTestLeftRight(const wxPoint& pt, long *flags) const;
 
   wxDECLARE_DYNAMIC_CLASS_NO_COPY(wxNotebook);
   wxDECLARE_EVENT_TABLE();


### PR DESCRIPTION
Native control doesn't seem to implement TCM_HITTEST correctly for the tabs on the left or right side, so provide our own implementation of HitTest() in this case.

Also add a unit test checking that HitTest() does something reasonable.

Closes #4775.

cc @skeetor