### PR TITLE
3.2: Queue wxWebViewEdge events to avoid difficult to debug bugs

### DIFF
--- a/include/wx/msw/private/webview_edge.h
+++ b/include/wx/msw/private/webview_edge.h
@@ -56,6 +56,7 @@ public:
 
     bool m_initialized;
     bool m_isBusy;
+    bool m_inEventCallback;
     wxString m_pendingURL;
     wxString m_pendingPage;
     int m_pendingContextMenuEnabled;

--- a/include/wx/msw/webview_edge.h
+++ b/include/wx/msw/webview_edge.h
@@ -88,6 +88,7 @@ public:
 
     virtual bool SetUserAgent(const wxString& userAgent) wxOVERRIDE;
 
+    virtual bool RunScript(const wxString& javascript, wxString* output = NULL) const wxOVERRIDE;
     virtual void RunScriptAsync(const wxString& javascript, void* clientData = NULL) const wxOVERRIDE;
     virtual bool AddScriptMessageHandler(const wxString& name) wxOVERRIDE;
     virtual bool RemoveScriptMessageHandler(const wxString& name) wxOVERRIDE;


### PR DESCRIPTION
Using HandleWindowEvent() from the WebView2 event callbacks is a common error source when user code does something blocking like RunScript() or ShowModal().
Queue the events to prevent this where possible, in wxEVT_WEBVIEW_NAVIGATING at least warn the developer instead of hanging silently.

Closes #22834, #22744, #19075

(cherry picked from commit 0ace9894c787f7ace607bfe2f4c2ae0f9f5708d2)