### PR TITLE
Experimental support for dark mode for wxMSW

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -5291,6 +5291,7 @@ COND_TOOLKIT_MSW___GUI_SRC_OBJECTS =  \
 	monodll_timectrl.o \
 	monodll_datecontrols.o \
 	monodll_generic_activityindicator.o \
+	monodll_darkmode.o \
 	monodll_msw_checklst.o \
 	monodll_msw_fdrepdlg.o \
 	monodll_msw_fontdlg.o
@@ -7046,6 +7047,7 @@ COND_TOOLKIT_MSW___GUI_SRC_OBJECTS_1 =  \
 	monolib_timectrl.o \
 	monolib_datecontrols.o \
 	monolib_generic_activityindicator.o \
+	monolib_darkmode.o \
 	monolib_msw_checklst.o \
 	monolib_msw_fdrepdlg.o \
 	monolib_msw_fontdlg.o
@@ -8955,6 +8957,7 @@ COND_TOOLKIT_MSW___GUI_SRC_OBJECTS_2 =  \
 	coredll_timectrl.o \
 	coredll_datecontrols.o \
 	coredll_generic_activityindicator.o \
+	coredll_darkmode.o \
 	coredll_msw_checklst.o \
 	coredll_msw_fdrepdlg.o \
 	coredll_msw_fontdlg.o
@@ -10440,6 +10443,7 @@ COND_TOOLKIT_MSW___GUI_SRC_OBJECTS_3 =  \
 	corelib_timectrl.o \
 	corelib_datecontrols.o \
 	corelib_generic_activityindicator.o \
+	corelib_darkmode.o \
 	corelib_msw_checklst.o \
 	corelib_msw_fdrepdlg.o \
 	corelib_msw_fontdlg.o
@@ -15253,6 +15257,9 @@ monodll_timectrl.o: $(srcdir)/src/msw/timectrl.cpp $(MONODLL_ODEP)
 monodll_datecontrols.o: $(srcdir)/src/msw/datecontrols.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/msw/datecontrols.cpp
 
+monodll_darkmode.o: $(srcdir)/src/msw/darkmode.cpp $(MONODLL_ODEP)
+	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/msw/darkmode.cpp
+
 monodll_msw_checklst.o: $(srcdir)/src/msw/checklst.cpp $(MONODLL_ODEP)
 	$(CXXC) -c -o $@ $(MONODLL_CXXFLAGS) $(srcdir)/src/msw/checklst.cpp
 
@@ -20016,6 +20023,9 @@ monolib_timectrl.o: $(srcdir)/src/msw/timectrl.cpp $(MONOLIB_ODEP)
 
 monolib_datecontrols.o: $(srcdir)/src/msw/datecontrols.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/msw/datecontrols.cpp
+
+monolib_darkmode.o: $(srcdir)/src/msw/darkmode.cpp $(MONOLIB_ODEP)
+	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/msw/darkmode.cpp
 
 monolib_msw_checklst.o: $(srcdir)/src/msw/checklst.cpp $(MONOLIB_ODEP)
 	$(CXXC) -c -o $@ $(MONOLIB_CXXFLAGS) $(srcdir)/src/msw/checklst.cpp
@@ -25465,6 +25475,9 @@ coredll_timectrl.o: $(srcdir)/src/msw/timectrl.cpp $(COREDLL_ODEP)
 coredll_datecontrols.o: $(srcdir)/src/msw/datecontrols.cpp $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/msw/datecontrols.cpp
 
+coredll_darkmode.o: $(srcdir)/src/msw/darkmode.cpp $(COREDLL_ODEP)
+	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/msw/darkmode.cpp
+
 coredll_msw_checklst.o: $(srcdir)/src/msw/checklst.cpp $(COREDLL_ODEP)
 	$(CXXC) -c -o $@ $(COREDLL_CXXFLAGS) $(srcdir)/src/msw/checklst.cpp
 
@@ -29196,6 +29209,9 @@ corelib_timectrl.o: $(srcdir)/src/msw/timectrl.cpp $(CORELIB_ODEP)
 
 corelib_datecontrols.o: $(srcdir)/src/msw/datecontrols.cpp $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/msw/datecontrols.cpp
+
+corelib_darkmode.o: $(srcdir)/src/msw/darkmode.cpp $(CORELIB_ODEP)
+	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/msw/darkmode.cpp
 
 corelib_msw_checklst.o: $(srcdir)/src/msw/checklst.cpp $(CORELIB_ODEP)
 	$(CXXC) -c -o $@ $(CORELIB_CXXFLAGS) $(srcdir)/src/msw/checklst.cpp

--- a/build/bakefiles/files.bkl
+++ b/build/bakefiles/files.bkl
@@ -1847,6 +1847,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     src/msw/timectrl.cpp
     src/msw/datecontrols.cpp
     src/generic/activityindicator.cpp
+    src/msw/darkmode.cpp
 </set>
 <set var="MSW_HDR" hints="files">
     wx/generic/clrpickerg.h

--- a/build/cmake/files.cmake
+++ b/build/cmake/files.cmake
@@ -1736,6 +1736,7 @@ set(MSW_SRC
     src/msw/datetimectrl.cpp
     src/msw/hyperlink.cpp
     src/generic/activityindicator.cpp
+    src/msw/darkmode.cpp
 )
 
 set(MSW_HDR

--- a/build/files
+++ b/build/files
@@ -1685,6 +1685,7 @@ MSW_SRC =
     src/msw/commandlinkbutton.cpp
     src/msw/control.cpp
     src/msw/customdraw.cpp
+    src/msw/darkmode.cpp
     src/msw/datecontrols.cpp
     src/msw/datectrl.cpp
     src/msw/datetimectrl.cpp

--- a/build/msw/makefile.gcc
+++ b/build/msw/makefile.gcc
@@ -1997,6 +1997,7 @@ ____CORE_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_timectrl.o \
 	$(OBJS)\monodll_datecontrols.o \
 	$(OBJS)\monodll_activityindicator.o \
+	$(OBJS)\monodll_darkmode.o \
 	$(OBJS)\monodll_msw_checklst.o \
 	$(OBJS)\monodll_msw_fdrepdlg.o \
 	$(OBJS)\monodll_fontdlg.o \
@@ -2845,6 +2846,7 @@ ____CORE_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_timectrl.o \
 	$(OBJS)\monolib_datecontrols.o \
 	$(OBJS)\monolib_activityindicator.o \
+	$(OBJS)\monolib_darkmode.o \
 	$(OBJS)\monolib_msw_checklst.o \
 	$(OBJS)\monolib_msw_fdrepdlg.o \
 	$(OBJS)\monolib_fontdlg.o \
@@ -3575,6 +3577,7 @@ ____CORE_SRC_FILENAMES_2_OBJECTS =  \
 	$(OBJS)\coredll_timectrl.o \
 	$(OBJS)\coredll_datecontrols.o \
 	$(OBJS)\coredll_activityindicator.o \
+	$(OBJS)\coredll_darkmode.o \
 	$(OBJS)\coredll_msw_checklst.o \
 	$(OBJS)\coredll_msw_fdrepdlg.o \
 	$(OBJS)\coredll_fontdlg.o \
@@ -4262,6 +4265,7 @@ ____CORE_SRC_FILENAMES_3_OBJECTS =  \
 	$(OBJS)\corelib_timectrl.o \
 	$(OBJS)\corelib_datecontrols.o \
 	$(OBJS)\corelib_activityindicator.o \
+	$(OBJS)\corelib_darkmode.o \
 	$(OBJS)\corelib_msw_checklst.o \
 	$(OBJS)\corelib_msw_fdrepdlg.o \
 	$(OBJS)\corelib_fontdlg.o \
@@ -7507,6 +7511,9 @@ $(OBJS)\monodll_timectrl.o: ../../src/msw/timectrl.cpp
 $(OBJS)\monodll_datecontrols.o: ../../src/msw/datecontrols.cpp
 	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
 
+$(OBJS)\monodll_darkmode.o: ../../src/msw/darkmode.cpp
+	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
+
 $(OBJS)\monodll_msw_checklst.o: ../../src/msw/checklst.cpp
 	$(CXX) -c -o $@ $(MONODLL_CXXFLAGS) $(CPPDEPS) $<
 
@@ -10092,6 +10099,9 @@ $(OBJS)\monolib_timectrl.o: ../../src/msw/timectrl.cpp
 	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\monolib_datecontrols.o: ../../src/msw/datecontrols.cpp
+	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
+
+$(OBJS)\monolib_darkmode.o: ../../src/msw/darkmode.cpp
 	$(CXX) -c -o $@ $(MONOLIB_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\monolib_msw_checklst.o: ../../src/msw/checklst.cpp
@@ -13107,6 +13117,9 @@ $(OBJS)\coredll_timectrl.o: ../../src/msw/timectrl.cpp
 $(OBJS)\coredll_datecontrols.o: ../../src/msw/datecontrols.cpp
 	$(CXX) -c -o $@ $(COREDLL_CXXFLAGS) $(CPPDEPS) $<
 
+$(OBJS)\coredll_darkmode.o: ../../src/msw/darkmode.cpp
+	$(CXX) -c -o $@ $(COREDLL_CXXFLAGS) $(CPPDEPS) $<
+
 $(OBJS)\coredll_msw_checklst.o: ../../src/msw/checklst.cpp
 	$(CXX) -c -o $@ $(COREDLL_CXXFLAGS) $(CPPDEPS) $<
 
@@ -14855,6 +14868,9 @@ $(OBJS)\corelib_timectrl.o: ../../src/msw/timectrl.cpp
 	$(CXX) -c -o $@ $(CORELIB_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\corelib_datecontrols.o: ../../src/msw/datecontrols.cpp
+	$(CXX) -c -o $@ $(CORELIB_CXXFLAGS) $(CPPDEPS) $<
+
+$(OBJS)\corelib_darkmode.o: ../../src/msw/darkmode.cpp
 	$(CXX) -c -o $@ $(CORELIB_CXXFLAGS) $(CPPDEPS) $<
 
 $(OBJS)\corelib_msw_checklst.o: ../../src/msw/checklst.cpp

--- a/build/msw/makefile.vc
+++ b/build/msw/makefile.vc
@@ -2314,6 +2314,7 @@ ____CORE_SRC_FILENAMES_OBJECTS =  \
 	$(OBJS)\monodll_timectrl.obj \
 	$(OBJS)\monodll_datecontrols.obj \
 	$(OBJS)\monodll_activityindicator.obj \
+	$(OBJS)\monodll_darkmode.obj \
 	$(OBJS)\monodll_msw_checklst.obj \
 	$(OBJS)\monodll_msw_fdrepdlg.obj \
 	$(OBJS)\monodll_fontdlg.obj \
@@ -3162,6 +3163,7 @@ ____CORE_SRC_FILENAMES_1_OBJECTS =  \
 	$(OBJS)\monolib_timectrl.obj \
 	$(OBJS)\monolib_datecontrols.obj \
 	$(OBJS)\monolib_activityindicator.obj \
+	$(OBJS)\monolib_darkmode.obj \
 	$(OBJS)\monolib_msw_checklst.obj \
 	$(OBJS)\monolib_msw_fdrepdlg.obj \
 	$(OBJS)\monolib_fontdlg.obj \
@@ -3942,6 +3944,7 @@ ____CORE_SRC_FILENAMES_2_OBJECTS =  \
 	$(OBJS)\coredll_timectrl.obj \
 	$(OBJS)\coredll_datecontrols.obj \
 	$(OBJS)\coredll_activityindicator.obj \
+	$(OBJS)\coredll_darkmode.obj \
 	$(OBJS)\coredll_msw_checklst.obj \
 	$(OBJS)\coredll_msw_fdrepdlg.obj \
 	$(OBJS)\coredll_fontdlg.obj \
@@ -4627,6 +4630,7 @@ ____CORE_SRC_FILENAMES_3_OBJECTS =  \
 	$(OBJS)\corelib_timectrl.obj \
 	$(OBJS)\corelib_datecontrols.obj \
 	$(OBJS)\corelib_activityindicator.obj \
+	$(OBJS)\corelib_darkmode.obj \
 	$(OBJS)\corelib_msw_checklst.obj \
 	$(OBJS)\corelib_msw_fdrepdlg.obj \
 	$(OBJS)\corelib_fontdlg.obj \
@@ -7952,6 +7956,9 @@ $(OBJS)\monodll_timectrl.obj: ..\..\src\msw\timectrl.cpp
 $(OBJS)\monodll_datecontrols.obj: ..\..\src\msw\datecontrols.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\msw\datecontrols.cpp
 
+$(OBJS)\monodll_darkmode.obj: ..\..\src\msw\darkmode.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\msw\darkmode.cpp
+
 $(OBJS)\monodll_msw_checklst.obj: ..\..\src\msw\checklst.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONODLL_CXXFLAGS) ..\..\src\msw\checklst.cpp
 
@@ -10538,6 +10545,9 @@ $(OBJS)\monolib_timectrl.obj: ..\..\src\msw\timectrl.cpp
 
 $(OBJS)\monolib_datecontrols.obj: ..\..\src\msw\datecontrols.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\msw\datecontrols.cpp
+
+$(OBJS)\monolib_darkmode.obj: ..\..\src\msw\darkmode.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\msw\darkmode.cpp
 
 $(OBJS)\monolib_msw_checklst.obj: ..\..\src\msw\checklst.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(MONOLIB_CXXFLAGS) ..\..\src\msw\checklst.cpp
@@ -13552,6 +13562,9 @@ $(OBJS)\coredll_timectrl.obj: ..\..\src\msw\timectrl.cpp
 $(OBJS)\coredll_datecontrols.obj: ..\..\src\msw\datecontrols.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(COREDLL_CXXFLAGS) ..\..\src\msw\datecontrols.cpp
 
+$(OBJS)\coredll_darkmode.obj: ..\..\src\msw\darkmode.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(COREDLL_CXXFLAGS) ..\..\src\msw\darkmode.cpp
+
 $(OBJS)\coredll_msw_checklst.obj: ..\..\src\msw\checklst.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(COREDLL_CXXFLAGS) ..\..\src\msw\checklst.cpp
 
@@ -15301,6 +15314,9 @@ $(OBJS)\corelib_timectrl.obj: ..\..\src\msw\timectrl.cpp
 
 $(OBJS)\corelib_datecontrols.obj: ..\..\src\msw\datecontrols.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(CORELIB_CXXFLAGS) ..\..\src\msw\datecontrols.cpp
+
+$(OBJS)\corelib_darkmode.obj: ..\..\src\msw\darkmode.cpp
+	$(CXX) /c /nologo /TP /Fo$@ $(CORELIB_CXXFLAGS) ..\..\src\msw\darkmode.cpp
 
 $(OBJS)\corelib_msw_checklst.obj: ..\..\src\msw\checklst.cpp
 	$(CXX) /c /nologo /TP /Fo$@ $(CORELIB_CXXFLAGS) ..\..\src\msw\checklst.cpp

--- a/build/msw/wx_core.vcxproj
+++ b/build/msw/wx_core.vcxproj
@@ -613,6 +613,7 @@
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)msw_%(Filename).obj</ObjectFileName>
       <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='DLL Release|x64'">$(IntDir)msw_%(Filename).obj</ObjectFileName>
     </ClCompile>
+    <ClCompile Include="..\..\src\msw\darkmode.cpp" />
     <ClCompile Include="..\..\src\msw\graphicsd2d.cpp" />
     <ClCompile Include="..\..\src\msw\ole\access.cpp" />
     <ClCompile Include="..\..\src\msw\ole\activex.cpp" />

--- a/build/msw/wx_core.vcxproj.filters
+++ b/build/msw/wx_core.vcxproj.filters
@@ -1074,6 +1074,9 @@
     <ClCompile Include="..\..\src\xrc\xmlreshandler.cpp">
       <Filter>Common Sources</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\msw\darkmode.cpp">
+      <Filter>MSW Sources</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\src\msw\version.rc">

--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -50,6 +50,10 @@ Changes in behaviour not resulting in compilation errors
   you ever used it under MSW (it never did anything in the other ports), you
   can turn on the native WS_EX_TRANSPARENT extended style if really needed.
 
+- wxSystemAppearance::IsDark() now returns whether this application uses dark
+  mode under MSW, use the new AreAppsDark() or IsSystemDark() to check if the
+  other applications or the system are using dark mode.
+
 
 Changes in behaviour which may result in build errors
 -----------------------------------------------------

--- a/include/wx/msw/app.h
+++ b/include/wx/msw/app.h
@@ -37,6 +37,14 @@ public:
     virtual void SetPrintMode(int mode) override { m_printMode = mode; }
     virtual int GetPrintMode() const { return m_printMode; }
 
+    // MSW-specific function to enable experimental dark mode support.
+    enum
+    {
+        DarkMode_Auto   = 0,  // Use dark mode if the system is using it.
+        DarkMode_Always = 1   // Force using dark mode.
+    };
+    bool MSWEnableDarkMode(int flags = 0);
+
     // implementation only
     void OnIdle(wxIdleEvent& event);
     void OnEndSession(wxCloseEvent& event);

--- a/include/wx/msw/checkbox.h
+++ b/include/wx/msw/checkbox.h
@@ -62,6 +62,8 @@ public:
 protected:
     virtual wxSize DoGetBestClientSize() const override;
 
+    virtual bool MSWGetDarkModeSupport(MSWDarkModeSupport& support) const override;
+
     virtual void DoSet3StateValue(wxCheckBoxState value) override;
     virtual wxCheckBoxState DoGet3StateValue() const override;
 

--- a/include/wx/msw/choice.h
+++ b/include/wx/msw/choice.h
@@ -129,6 +129,8 @@ protected:
                            int sizeFlags = wxSIZE_AUTO) override;
     virtual wxSize DoGetSizeFromTextSize(int xlen, int ylen = -1) const override;
 
+    virtual bool MSWGetDarkModeSupport(MSWDarkModeSupport& support) const override;
+
     // Show or hide the popup part of the control.
     void MSWDoPopupOrDismiss(bool show);
 

--- a/include/wx/msw/control.h
+++ b/include/wx/msw/control.h
@@ -124,15 +124,24 @@ protected:
     // Look in our GetSubcontrols() for the windows with the given ID.
     virtual wxWindow *MSWFindItem(long id, WXHWND hWnd) const override;
 
-    // Return the theme to use for this control in dark mode. Default is to use
-    // "Explorer", as this works for several controls, but not all of them and
-    // the others must override either this function or the one below.
-    virtual const wchar_t* MSWGetDarkThemeName() const { return nullptr; }
 
-    // This one can be overridden to use a specific "ID list" when setting the
-    // theme in the dark mode. Note that returning a non-null value from here
-    // disables the use of "Explorer" theme by default.
-    virtual const wchar_t* MSWGetDarkThemeId() const { return nullptr; }
+    // Struct used for MSWGetDarkModeSupport() below.
+    struct MSWDarkModeSupport
+    {
+        // The name of the theme to use (also called "app name").
+        const wchar_t* themeName = nullptr;
+
+        // The theme IDs to use. If neither this field nor the theme name is
+        // set, no theme is applied to the window.
+        const wchar_t* themeId = nullptr;
+    };
+
+    // Called after creating the control to enable dark mode support if needed.
+    //
+    // If this function returns true, wxControl allows using dark mode for the
+    // window and set its theme to the one specified by MSWDarkModeSupport
+    // fields.
+    virtual bool MSWGetDarkModeSupport(MSWDarkModeSupport& support) const;
 
     // Return the message that can be used to retrieve the tooltip window used
     // by a native control. If this message is non-zero and sending it returns

--- a/include/wx/msw/control.h
+++ b/include/wx/msw/control.h
@@ -134,6 +134,10 @@ protected:
         // The theme IDs to use. If neither this field nor the theme name is
         // set, no theme is applied to the window.
         const wchar_t* themeId = nullptr;
+
+        // For some controls we need to set the foreground explicitly, even if
+        // they have some support for the dark theme.
+        bool setForeground = false;
     };
 
     // Called after creating the control to enable dark mode support if needed.

--- a/include/wx/msw/control.h
+++ b/include/wx/msw/control.h
@@ -134,6 +134,11 @@ protected:
     // disables the use of "Explorer" theme by default.
     virtual const wchar_t* MSWGetDarkThemeId() const { return nullptr; }
 
+    // Return the message that can be used to retrieve the tooltip window used
+    // by a native control. If this message is non-zero and sending it returns
+    // a valid HWND, the dark theme is also applied to it, if appropriate.
+    virtual int MSWGetToolTipMessage() const { return 0; }
+
 
     // for controls like radiobuttons which are really composite this array
     // holds the ids (not HWNDs!) of the sub controls

--- a/include/wx/msw/control.h
+++ b/include/wx/msw/control.h
@@ -124,6 +124,12 @@ protected:
     // Look in our GetSubcontrols() for the windows with the given ID.
     virtual wxWindow *MSWFindItem(long id, WXHWND hWnd) const override;
 
+    // Return the theme class to use for this control in dark mode. Default is
+    // not to use any special class, but use "Explorer" as app name, as this
+    // works for several controls, but not all of them and the other must
+    // override this function.
+    virtual const wchar_t* MSWGetDarkThemeClass() const { return nullptr; }
+
 
     // for controls like radiobuttons which are really composite this array
     // holds the ids (not HWNDs!) of the sub controls

--- a/include/wx/msw/control.h
+++ b/include/wx/msw/control.h
@@ -124,11 +124,15 @@ protected:
     // Look in our GetSubcontrols() for the windows with the given ID.
     virtual wxWindow *MSWFindItem(long id, WXHWND hWnd) const override;
 
-    // Return the theme class to use for this control in dark mode. Default is
-    // not to use any special class, but use "Explorer" as app name, as this
-    // works for several controls, but not all of them and the other must
-    // override this function.
-    virtual const wchar_t* MSWGetDarkThemeClass() const { return nullptr; }
+    // Return the theme to use for this control in dark mode. Default is to use
+    // "Explorer", as this works for several controls, but not all of them and
+    // the others must override either this function or the one below.
+    virtual const wchar_t* MSWGetDarkThemeName() const { return nullptr; }
+
+    // This one can be overridden to use a specific "ID list" when setting the
+    // theme in the dark mode. Note that returning a non-null value from here
+    // disables the use of "Explorer" theme by default.
+    virtual const wchar_t* MSWGetDarkThemeId() const { return nullptr; }
 
 
     // for controls like radiobuttons which are really composite this array

--- a/include/wx/msw/listctrl.h
+++ b/include/wx/msw/listctrl.h
@@ -400,6 +400,8 @@ protected:
 
     virtual const wchar_t* MSWGetDarkThemeName() const override;
 
+    virtual int MSWGetToolTipMessage() const override;
+
     void OnDPIChanged(wxDPIChangedEvent& event);
 
     wxSize MSWGetBestViewRect(int x, int y) const;

--- a/include/wx/msw/listctrl.h
+++ b/include/wx/msw/listctrl.h
@@ -16,7 +16,7 @@
 #include "wx/vector.h"
 
 class wxMSWListItemData;
-class wxMSWListHeaderCustomDraw;
+class wxMSWHeaderCtrlCustomDraw;
 
 // define this symbol to indicate the availability of SetColumnsOrder() and
 // related functions
@@ -464,7 +464,7 @@ private:
     void DrawSortArrow();
 
     // Object using for header custom drawing if necessary, may be null.
-    wxMSWListHeaderCustomDraw* m_headerCustomDraw;
+    wxMSWHeaderCtrlCustomDraw* m_headerCustomDraw;
 
 
     wxDECLARE_DYNAMIC_CLASS(wxListCtrl);

--- a/include/wx/msw/listctrl.h
+++ b/include/wx/msw/listctrl.h
@@ -398,7 +398,7 @@ protected:
 
     virtual void MSWAfterReparent() override;
 
-    virtual const wchar_t* MSWGetDarkThemeName() const override;
+    virtual bool MSWGetDarkModeSupport(MSWDarkModeSupport& support) const override;
 
     virtual int MSWGetToolTipMessage() const override;
 

--- a/include/wx/msw/listctrl.h
+++ b/include/wx/msw/listctrl.h
@@ -366,10 +366,7 @@ public:
 
     virtual bool ShouldInheritColours() const override { return false; }
 
-    virtual wxVisualAttributes GetDefaultAttributes() const override
-    {
-        return GetClassDefaultAttributes(GetWindowVariant());
-    }
+    virtual wxVisualAttributes GetDefaultAttributes() const override;
 
     static wxVisualAttributes
     GetClassDefaultAttributes(wxWindowVariant variant = wxWINDOW_VARIANT_NORMAL);
@@ -400,6 +397,8 @@ protected:
     virtual void MSWUpdateFontOnDPIChange(const wxSize& newDPI) override;
 
     virtual void MSWAfterReparent() override;
+
+    virtual const wchar_t* MSWGetDarkThemeName() const override;
 
     void OnDPIChanged(wxDPIChangedEvent& event);
 
@@ -442,6 +441,9 @@ private:
     // set the extended styles for the control (used by Create() and
     // UpdateStyle()), only should be called if InReportView()
     void MSWSetExListStyles();
+
+    // Initialize the header control if it exists.
+    void MSWInitHeader();
 
     // initialize the (already created) m_textCtrl with the associated HWND
     void InitEditControl(WXHWND hWnd);

--- a/include/wx/msw/notebook.h
+++ b/include/wx/msw/notebook.h
@@ -141,6 +141,8 @@ protected:
   // common part of all ctors
   void Init();
 
+  virtual int MSWGetToolTipMessage() const override;
+
   // hides the currently shown page and shows the given one (if not -1) and
   // updates m_selection accordingly
   void UpdateSelection(int selNew);

--- a/include/wx/msw/notebook.h
+++ b/include/wx/msw/notebook.h
@@ -183,6 +183,10 @@ protected:
   void OnEraseBackground(wxEraseEvent& event);
   void OnPaint(wxPaintEvent& event);
 
+  // Paint the notebook ourselves on the provided DC.
+  void MSWNotebookPaint(wxDC& dc);
+
+
   // true if we have already subclassed our updown control
   bool m_hasSubclassedUpdown;
 

--- a/include/wx/msw/private.h
+++ b/include/wx/msw/private.h
@@ -386,6 +386,21 @@ inline RECT wxGetClientRect(HWND hwnd)
     return rect;
 }
 
+// Call MapWindowPoints() on a RECT: because a RECT is (intentionally) laid out
+// as 2 consecutive POINTs, the cast below is valid but we still prefer to hide
+// it in this function instead of writing it out in the rest of the code.
+inline void wxMapWindowPoints(HWND hwndFrom, HWND hwndTo, RECT* rc)
+{
+    ::MapWindowPoints(hwndFrom, hwndTo, reinterpret_cast<POINT *>(rc), 2);
+}
+
+// For consistency also provide an overload taking a POINT, even if this one is
+// even more trivial.
+inline void wxMapWindowPoints(HWND hwndFrom, HWND hwndTo, POINT* pt)
+{
+    ::MapWindowPoints(hwndFrom, hwndTo, pt, 1);
+}
+
 // ---------------------------------------------------------------------------
 // small helper classes
 // ---------------------------------------------------------------------------

--- a/include/wx/msw/private.h
+++ b/include/wx/msw/private.h
@@ -456,6 +456,13 @@ public:
     explicit ClientHDC(HWND hwnd) : AutoHDC(hwnd, ::GetDC(hwnd)) { }
 };
 
+// same as ClientHDC but includes the non-client part of the window
+class WindowHDC : public AutoHDC
+{
+public:
+    explicit WindowHDC(HWND hwnd) : AutoHDC(hwnd, ::GetWindowDC(hwnd)) { }
+};
+
 // the same as ScreenHDC but for memory DCs: creates the HDC compatible with
 // the given one (screen by default) in ctor and destroys it in dtor
 class MemoryHDC

--- a/include/wx/msw/private/customdraw.h
+++ b/include/wx/msw/private/customdraw.h
@@ -12,6 +12,7 @@
 
 #include "wx/itemattr.h"
 
+#include "wx/msw/uxtheme.h"
 #include "wx/msw/wrapcctl.h"
 
 namespace wxMSWImpl
@@ -65,6 +66,25 @@ class wxMSWHeaderCtrlCustomDraw : public wxMSWImpl::CustomDraw
 public:
     wxMSWHeaderCtrlCustomDraw()
     {
+    }
+
+    // Set the colours to the ones used by "Header" theme.
+    //
+    // This is required, for unknown reasons, when using dark mode, because
+    // enabling it for the header control changes the background, but not the
+    // foreground, making the text completely unreadable.
+    //
+    // If this is ever fixed in later Windows versions, this function wouldn't
+    // need to be called any more.
+    void UseHeaderThemeColors(HWND hwndHdr)
+    {
+        wxUxThemeHandle theme{hwndHdr, L"Header"};
+
+        m_attr.SetTextColour(theme.GetColour(HP_HEADERITEM, TMT_TEXTCOLOR));
+
+        // Note that TMT_FILLCOLOR doesn't seem to exist in this theme but the
+        // correct background colour is already used in "ItemsView" theme by
+        // default anyhow.
     }
 
     // Make this field public to let the control update it directly when its

--- a/include/wx/msw/private/customdraw.h
+++ b/include/wx/msw/private/customdraw.h
@@ -56,4 +56,34 @@ private:
 
 } // namespace wxMSWImpl
 
+// ----------------------------------------------------------------------------
+// wxMSWHeaderCtrlCustomDraw: custom draw helper for header control
+// ----------------------------------------------------------------------------
+
+class wxMSWHeaderCtrlCustomDraw : public wxMSWImpl::CustomDraw
+{
+public:
+    wxMSWHeaderCtrlCustomDraw()
+    {
+    }
+
+    // Make this field public to let the control update it directly when its
+    // attributes change.
+    wxItemAttr m_attr;
+
+private:
+    virtual bool HasCustomDrawnItems() const override
+    {
+        // We only exist if the header does need to be custom drawn.
+        return true;
+    }
+
+    virtual const wxItemAttr*
+    GetItemAttr(DWORD_PTR WXUNUSED(dwItemSpec)) const override
+    {
+        // We use the same attribute for all items for now.
+        return &m_attr;
+    }
+};
+
 #endif // _WX_MSW_CUSTOMDRAW_H_

--- a/include/wx/msw/private/darkmode.h
+++ b/include/wx/msw/private/darkmode.h
@@ -45,6 +45,16 @@ HBRUSH GetBackgroundBrush();
 // paint on.
 bool PaintIfNecessary(wxWindow* w);
 
+// If dark mode is active and if the message is one of those used for menu
+// drawing, process it and return true, otherwise just return false without
+// doing anything.
+bool
+HandleMenuMessage(WXLRESULT* result,
+                  wxWindow* w,
+                  WXUINT nMsg,
+                  WXWPARAM wParam,
+                  WXLPARAM lParam);
+
 } // namespace wxMSWDarkMode
 
 #endif // _WX_MSW_PRIVATE_DARKMODE_H_

--- a/include/wx/msw/private/darkmode.h
+++ b/include/wx/msw/private/darkmode.h
@@ -21,7 +21,10 @@ bool IsActive();
 void EnableForTLW(HWND hwnd);
 
 // Set dark theme for the given (child) window if appropriate.
-void AllowForWindow(HWND hwnd);
+//
+// Optional theme class can be specified if a particular class must be used,
+// otherwise the default one is used for it.
+void AllowForWindow(HWND hwnd, const wchar_t* themeClass = nullptr);
 
 } // namespace wxMSWDarkMode
 

--- a/include/wx/msw/private/darkmode.h
+++ b/include/wx/msw/private/darkmode.h
@@ -35,6 +35,14 @@ wxColour GetColour(wxSystemColour index);
 // Return the background brush to be used by default in dark mode.
 HBRUSH GetBackgroundBrush();
 
+// If dark mode is active, paint the given window using inverted colours.
+// Otherwise just return false without doing anything.
+//
+// This can only be called from WM_PAINT handler for a native control and
+// assumes that this control handles WPARAM argument of WM_PAINT as HDC to
+// paint on.
+bool PaintIfNecessary(wxWindow* w);
+
 } // namespace wxMSWDarkMode
 
 #endif // _WX_MSW_PRIVATE_DARKMODE_H_

--- a/include/wx/msw/private/darkmode.h
+++ b/include/wx/msw/private/darkmode.h
@@ -44,7 +44,7 @@ HBRUSH GetBackgroundBrush();
 // This can only be called from WM_PAINT handler for a native control and
 // assumes that this control handles WPARAM argument of WM_PAINT as HDC to
 // paint on.
-bool PaintIfNecessary(wxWindow* w);
+bool PaintIfNecessary(HWND hwnd, WXWNDPROC defWndProc);
 
 // If dark mode is active and if the message is one of those used for menu
 // drawing, process it and return true, otherwise just return false without

--- a/include/wx/msw/private/darkmode.h
+++ b/include/wx/msw/private/darkmode.h
@@ -13,6 +13,10 @@
 namespace wxMSWDarkMode
 {
 
+// Return true if the application is using dark mode: note that this will only
+// be the case if wxApp::MSWEnableDarkMode() was called.
+bool IsActive();
+
 // Enable dark mode for the given TLW if appropriate.
 void EnableForTLW(HWND hwnd);
 

--- a/include/wx/msw/private/darkmode.h
+++ b/include/wx/msw/private/darkmode.h
@@ -10,6 +10,8 @@
 #ifndef _WX_MSW_PRIVATE_DARKMODE_H_
 #define _WX_MSW_PRIVATE_DARKMODE_H_
 
+#include "wx/settings.h"
+
 namespace wxMSWDarkMode
 {
 
@@ -25,6 +27,13 @@ void EnableForTLW(HWND hwnd);
 // Optional theme class can be specified if a particular class must be used,
 // otherwise the default one is used for it.
 void AllowForWindow(HWND hwnd, const wchar_t* themeClass = nullptr);
+
+// Return the colour value appropriate for dark mode if it's used or an invalid
+// colour if it isn't.
+wxColour GetColour(wxSystemColour index);
+
+// Return the background brush to be used by default in dark mode.
+HBRUSH GetBackgroundBrush();
 
 } // namespace wxMSWDarkMode
 

--- a/include/wx/msw/private/darkmode.h
+++ b/include/wx/msw/private/darkmode.h
@@ -25,9 +25,10 @@ void EnableForTLW(HWND hwnd);
 // Set dark theme for the given (child) window if appropriate.
 //
 // Optional theme name and ID can be specified if something other than the
-// default "Explorer" should be used.
+// default "Explorer" should be used. If both theme name and theme ID are null,
+// no theme is set.
 void AllowForWindow(HWND hwnd,
-                    const wchar_t* themeName = nullptr,
+                    const wchar_t* themeName = L"Explorer",
                     const wchar_t* themeId = nullptr);
 
 // Return the colour value appropriate for dark mode if it's used or an invalid

--- a/include/wx/msw/private/darkmode.h
+++ b/include/wx/msw/private/darkmode.h
@@ -16,6 +16,9 @@ namespace wxMSWDarkMode
 // Enable dark mode for the given TLW if appropriate.
 void EnableForTLW(HWND hwnd);
 
+// Set dark theme for the given (child) window if appropriate.
+void AllowForWindow(HWND hwnd);
+
 } // namespace wxMSWDarkMode
 
 #endif // _WX_MSW_PRIVATE_DARKMODE_H_

--- a/include/wx/msw/private/darkmode.h
+++ b/include/wx/msw/private/darkmode.h
@@ -1,0 +1,21 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/msw/private/darkmode.h
+// Purpose:     Dark mode support in wxMSW
+// Author:      Vadim Zeitlin
+// Created:     2022-06-25
+// Copyright:   (c) 2022 Vadim Zeitlin <vadim@wxwidgets.org>
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_MSW_PRIVATE_DARKMODE_H_
+#define _WX_MSW_PRIVATE_DARKMODE_H_
+
+namespace wxMSWDarkMode
+{
+
+// Enable dark mode for the given TLW if appropriate.
+void EnableForTLW(HWND hwnd);
+
+} // namespace wxMSWDarkMode
+
+#endif // _WX_MSW_PRIVATE_DARKMODE_H_

--- a/include/wx/msw/private/darkmode.h
+++ b/include/wx/msw/private/darkmode.h
@@ -24,9 +24,11 @@ void EnableForTLW(HWND hwnd);
 
 // Set dark theme for the given (child) window if appropriate.
 //
-// Optional theme class can be specified if a particular class must be used,
-// otherwise the default one is used for it.
-void AllowForWindow(HWND hwnd, const wchar_t* themeClass = nullptr);
+// Optional theme name and ID can be specified if something other than the
+// default "Explorer" should be used.
+void AllowForWindow(HWND hwnd,
+                    const wchar_t* themeName = nullptr,
+                    const wchar_t* themeId = nullptr);
 
 // Return the colour value appropriate for dark mode if it's used or an invalid
 // colour if it isn't.

--- a/include/wx/msw/radiobut.h
+++ b/include/wx/msw/radiobut.h
@@ -58,6 +58,8 @@ protected:
     virtual wxBorder GetDefaultBorder() const override { return wxBORDER_NONE; }
     virtual wxSize DoGetBestSize() const override;
 
+    virtual bool MSWGetDarkModeSupport(MSWDarkModeSupport& support) const override;
+
     // Implement wxMSWOwnerDrawnButtonBase methods.
     virtual int MSWGetButtonStyle() const override;
     virtual void MSWOnButtonResetOwnerDrawn() override;

--- a/include/wx/msw/spinbutt.h
+++ b/include/wx/msw/spinbutt.h
@@ -61,6 +61,8 @@ public:
     virtual void SetIncrement(int value) override;
     virtual int  GetIncrement() const override;
 
+    virtual bool MSWShouldUseAutoDarkMode() const override;
+
 protected:
    virtual wxSize DoGetBestSize() const override;
 

--- a/include/wx/msw/statbox.h
+++ b/include/wx/msw/statbox.h
@@ -79,6 +79,8 @@ public:
 protected:
     virtual wxWindowList GetCompositeWindowParts() const override;
 
+    virtual bool MSWGetDarkModeSupport(MSWDarkModeSupport& support) const override;
+
     // return the region with all the windows inside this static box excluded
     virtual WXHRGN MSWGetRegionWithoutChildren();
 

--- a/include/wx/msw/statusbar.h
+++ b/include/wx/msw/statusbar.h
@@ -69,7 +69,7 @@ protected:
     virtual bool MSWOnNotify(int idCtrl, WXLPARAM lParam, WXLPARAM* result) override;
 #endif
 
-    virtual const wchar_t* MSWGetDarkThemeId() const override;
+    virtual bool MSWGetDarkModeSupport(MSWDarkModeSupport& support) const override;
 
     // implementation of the public SetStatusWidths()
     void MSWUpdateFieldsWidths();

--- a/include/wx/msw/statusbar.h
+++ b/include/wx/msw/statusbar.h
@@ -69,7 +69,7 @@ protected:
     virtual bool MSWOnNotify(int idCtrl, WXLPARAM lParam, WXLPARAM* result) override;
 #endif
 
-    virtual const wchar_t* MSWGetDarkThemeClass() const override;
+    virtual const wchar_t* MSWGetDarkThemeId() const override;
 
     // implementation of the public SetStatusWidths()
     void MSWUpdateFieldsWidths();

--- a/include/wx/msw/statusbar.h
+++ b/include/wx/msw/statusbar.h
@@ -69,6 +69,8 @@ protected:
     virtual bool MSWOnNotify(int idCtrl, WXLPARAM lParam, WXLPARAM* result) override;
 #endif
 
+    virtual const wchar_t* MSWGetDarkThemeClass() const override;
+
     // implementation of the public SetStatusWidths()
     void MSWUpdateFieldsWidths();
 

--- a/include/wx/msw/toolbar.h
+++ b/include/wx/msw/toolbar.h
@@ -101,6 +101,8 @@ protected:
     // common part of all ctors
     void Init();
 
+    virtual int MSWGetToolTipMessage() const override;
+
     // create the native toolbar control
     bool MSWCreateToolbar(const wxPoint& pos, const wxSize& size);
 

--- a/include/wx/msw/toolbar.h
+++ b/include/wx/msw/toolbar.h
@@ -101,6 +101,7 @@ protected:
     // common part of all ctors
     void Init();
 
+    virtual bool MSWGetDarkModeSupport(MSWDarkModeSupport& support) const override;
     virtual int MSWGetToolTipMessage() const override;
 
     // create the native toolbar control

--- a/include/wx/msw/treectrl.h
+++ b/include/wx/msw/treectrl.h
@@ -212,6 +212,8 @@ protected:
 
     virtual bool MSWShouldSetDefaultFont() const override { return false; }
 
+    virtual int MSWGetToolTipMessage() const override;
+
     virtual void OnImagesChanged() override;
 
     // SetImageList helper

--- a/include/wx/msw/uxtheme.h
+++ b/include/wx/msw/uxtheme.h
@@ -169,9 +169,14 @@ WXDLLIMPEXP_CORE bool wxUxThemeIsActive();
 class wxUxThemeHandle
 {
 public:
-    wxUxThemeHandle(const wxWindow *win, const wchar_t *classes)
+    wxUxThemeHandle(HWND hwnd, const wchar_t *classes) :
+        m_hTheme{::OpenThemeData(hwnd, classes)}
     {
-        m_hTheme = (HTHEME)::OpenThemeData(GetHwndOf(win), classes);
+    }
+
+    wxUxThemeHandle(const wxWindow *win, const wchar_t *classes) :
+        wxUxThemeHandle(GetHwndOf(win), classes)
+    {
     }
 
     operator HTHEME() const { return m_hTheme; }

--- a/include/wx/msw/uxtheme.h
+++ b/include/wx/msw/uxtheme.h
@@ -185,7 +185,7 @@ public:
     }
 
 private:
-    HTHEME m_hTheme;
+    const HTHEME m_hTheme;
 
     wxDECLARE_NO_COPY_CLASS(wxUxThemeHandle);
 };

--- a/include/wx/msw/uxtheme.h
+++ b/include/wx/msw/uxtheme.h
@@ -189,6 +189,12 @@ public:
         }
     }
 
+    // Return the colour for the given part, property and state.
+    //
+    // Note that the order of arguments here is _not_ the same as for
+    // GetThemeColor() because we want to default the state.
+    wxColour GetColour(int part, int prop, int state = 0) const;
+
 private:
     const HTHEME m_hTheme;
 

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -482,21 +482,6 @@ public:
     // querying the parent windows via MSWGetBgBrushForChild() recursively
     WXHBRUSH MSWGetBgBrush(WXHDC hDC);
 
-    enum MSWThemeColour
-    {
-        ThemeColourText = 0,
-        ThemeColourBackground,
-        ThemeColourBorder
-    };
-
-    // returns a specific theme colour, or if that is not possible then
-    // wxSystemSettings::GetColour(fallback)
-    wxColour MSWGetThemeColour(const wchar_t *themeName,
-                               int themePart,
-                               int themeState,
-                               MSWThemeColour themeColour,
-                               wxSystemColour fallback) const;
-
     // gives the parent the possibility to draw its children background, e.g.
     // this is used by wxNotebook to do it using DrawThemeBackground()
     //

--- a/include/wx/msw/window.h
+++ b/include/wx/msw/window.h
@@ -211,6 +211,13 @@ public:
 
     void OnPaint(wxPaintEvent& event);
 
+    // Override this to return true to automatically invert the window colours
+    // in dark mode.
+    //
+    // This doesn't result in visually great results, but may still be better
+    // than using light background.
+    virtual bool MSWShouldUseAutoDarkMode() const { return false; }
+
 public:
     // Windows subclassing
     void SubclassWin(WXHWND hWnd);

--- a/include/wx/settings.h
+++ b/include/wx/settings.h
@@ -172,8 +172,15 @@ public:
     // Return the name if available or empty string otherwise.
     wxString GetName() const;
 
-    // Return true if the current system there is explicitly recognized as
-    // being a dark theme or if the default window background is dark.
+    // Return true if the applications on this system use dark theme by default.
+    bool AreAppsDark() const;
+
+    // Return true if the system elements use dark theme: this can only differ
+    // from AreAppsDark() under MSW where it's possible to configure the system
+    // (taskbar etc) to use a different theme.
+    bool IsSystemDark() const;
+
+    // Return true if this application itself uses a dark theme.
     bool IsDark() const;
 
     // Return true if the background is darker than foreground. This is used by

--- a/include/wx/settings.h
+++ b/include/wx/settings.h
@@ -221,6 +221,12 @@ public:
     // get the object describing the current system appearance
     static wxSystemAppearance GetAppearance();
 
+    // get the first colour for light appearance and the second one for the dark
+    static wxColour SelectLightDark(wxColour colForLight, wxColour colForDark)
+    {
+        return GetAppearance().IsDark() ? colForDark : colForLight;
+    }
+
     // return true if the port has certain feature
     static bool HasFeature(wxSystemFeature index);
 };

--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -1204,6 +1204,9 @@ public:
               than using the native dialog.
             - wxDatePickerCtrl and wxTimePickerCtrl don't support dark mode and
               use the same (light) background as by default in it.
+            - Toolbar items for which wxToolBar::SetDropdownMenu() was called
+              don't draw the menu drop-down correctly, making it almost
+              invisible.
 
         @param flags Can include @c wxApp::DarkMode_Always to force enabling
             dark mode for the application, even if the system doesn't use the

--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -1202,6 +1202,8 @@ public:
             - wxMessageBox() contents doesn't use dark mode. Consider using
               wxGenericMessageDialog if dark mode support is more important
               than using the native dialog.
+            - wxDatePickerCtrl and wxTimePickerCtrl don't support dark mode and
+              use the same (light) background as by default in it.
 
         @param flags Can include @c wxApp::DarkMode_Always to force enabling
             dark mode for the application, even if the system doesn't use the

--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -1181,6 +1181,33 @@ public:
 
     ///@}
 
+    /**
+        @name MSW-specific functions
+    */
+    //@{
+
+    /**
+        Enable experimental dark mode support for MSW applications.
+
+        This function uses @e undocumented, and unsupported by Microsoft,
+        functions to enable dark mode support for the desktop applications
+        under Windows 10 20H1 or later (including all Windows 11 versions).
+
+        @param flags Can include @c wxApp::DarkMode_Always to force enabling
+            dark mode for the application, even if the system doesn't use the
+            dark mode by default. Otherwise dark mode is only used if it is the
+            default mode for the applications on the current system.
+
+        @return @true if dark mode support was enabled, @false if it couldn't
+            be done, most likely because the system doesn't support dark mode.
+
+        @onlyfor{wxmsw}
+
+        @since 3.3.0
+     */
+    bool MSWEnableDarkMode(int flags = 0);
+
+    //@}
 };
 
 

--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -1193,6 +1193,10 @@ public:
         functions to enable dark mode support for the desktop applications
         under Windows 10 20H1 or later (including all Windows 11 versions).
 
+        Note that dark mode can also be enabled by setting the "msw.dark-mode"
+        @ref wxSystemOptions "system option" via an environment variable from
+        outside the application.
+
         @param flags Can include @c wxApp::DarkMode_Always to force enabling
             dark mode for the application, even if the system doesn't use the
             dark mode by default. Otherwise dark mode is only used if it is the

--- a/interface/wx/app.h
+++ b/interface/wx/app.h
@@ -1197,6 +1197,12 @@ public:
         @ref wxSystemOptions "system option" via an environment variable from
         outside the application.
 
+        Known limitations of dark mode support include:
+
+            - wxMessageBox() contents doesn't use dark mode. Consider using
+              wxGenericMessageDialog if dark mode support is more important
+              than using the native dialog.
+
         @param flags Can include @c wxApp::DarkMode_Always to force enabling
             dark mode for the application, even if the system doesn't use the
             dark mode by default. Otherwise dark mode is only used if it is the

--- a/interface/wx/settings.h
+++ b/interface/wx/settings.h
@@ -286,6 +286,11 @@ public:
 
         This method should be used to check whether custom colours more
         appropriate for the default (light) or dark appearance should be used.
+
+        Note that this checks the appearance of the current application and not
+        the other applications on the system, so under MSW, for example, it
+        will return @false even if dark mode is used system-wide unless the
+        application opted in using dark mode using wxApp::MSWEnableDarkMode().
      */
     bool IsDark() const;
 

--- a/interface/wx/settings.h
+++ b/interface/wx/settings.h
@@ -388,5 +388,20 @@ public:
         See the ::wxSystemFeature enum values.
     */
     static bool HasFeature(wxSystemFeature index);
+
+    /**
+        Select one of the two colours depending on whether light or dark mode
+        is used.
+
+        This is just a convenient helper using wxSystemAppearance::IsDark() to
+        select between the two colours.
+
+        @param colForLight Colour returned when using light appearance.
+        @param colForDark Colour returned when using dark appearance, as
+            detected by wxSystemAppearance::IsDark().
+
+        @since 3.3.0
+     */
+    static wxColour SelectLightDark(wxColour colForLight, wxColour colForDark);
 };
 

--- a/interface/wx/settings.h
+++ b/interface/wx/settings.h
@@ -272,6 +272,22 @@ class wxSystemAppearance
 {
 public:
     /**
+        Return true if the applications on this system use dark theme by
+        default.
+
+        This function returns @true if dark mode is enabled for the
+        applications system-wide, even if it's not enabled for this particular
+        application.
+
+        Note that for non-MSW platforms this is currently the same as IsDark(),
+        but under MSW these two functions can return different values as dark
+        mode requires to opt-in into it specifically.
+
+        @since 3.3.0
+     */
+    bool AreAppsDark() const;
+
+    /**
         Return the name if available or empty string otherwise.
 
         This is currently only implemented for macOS and returns
@@ -291,8 +307,22 @@ public:
         the other applications on the system, so under MSW, for example, it
         will return @false even if dark mode is used system-wide unless the
         application opted in using dark mode using wxApp::MSWEnableDarkMode().
+        You can use IsSystemDark() or AreAppsDark() to check if the system is
+        using dark mode by default.
      */
     bool IsDark() const;
+
+    /**
+        Return true if the system UI uses dark theme.
+
+        This is the same as AreAppsDark() on the non-MSW platforms, but can be
+        different from the other function under MSW as it is possible to
+        configure default "Windows mode" and "app mode" to use different colour
+        schemes under Windows.
+
+        @since 3.3.0
+     */
+    bool IsSystemDark() const;
 
     /**
         Return true if the default window background is significantly darker

--- a/interface/wx/sysopt.h
+++ b/interface/wx/sysopt.h
@@ -76,6 +76,11 @@
         If set to 1, disables the use of composited, i.e. double-buffered,
         windows by default in wxMSW. This is not recommended, but can be useful
         for debugging or working around redraw problems in the existing code.
+    @flag{msw.dark-mode}
+        If set to 1, enable experimental support of dark mode if the system is
+        using it, i.e. this has the same effect as calling
+        wxApp::MSWEnableDarkMode(). If set to 2, use dark mode unconditionally,
+        as if this function were called with wxApp::DarkMode_Always argument.
     @endFlagTable
 
 

--- a/samples/drawing/drawing.cpp
+++ b/samples/drawing/drawing.cpp
@@ -524,6 +524,13 @@ MyCanvas::MyCanvas(MyFrame *parent)
     m_useBuffer = false;
     m_showBBox = false;
     m_sizeDIP = wxSize(0, 0);
+
+    Bind(wxEVT_SYS_COLOUR_CHANGED, [this](wxSysColourChangedEvent& event) {
+        event.Skip();
+
+        if ( m_show == File_ShowSystemColours )
+            Refresh();
+    });
 }
 
 void MyCanvas::DrawTestBrushes(wxDC& dc)

--- a/samples/drawing/drawing.cpp
+++ b/samples/drawing/drawing.cpp
@@ -1676,21 +1676,31 @@ void MyCanvas::DrawSystemColours(wxDC& dc)
     wxCoord x(FromDIP(10));
     wxRect r(textSize.GetWidth() + x, x, dc.FromDIP(100), lineHeight);
 
-    wxString title = "System colours";
+    dc.DrawText("System colours", x, r.y);
+    r.y += 2*lineHeight;
 
     const wxSystemAppearance appearance = wxSystemSettings::GetAppearance();
     const wxString appearanceName = appearance.GetName();
     if ( !appearanceName.empty() )
-        title += wxString::Format(" for \"%s\"", appearanceName);
-    if ( appearance.IsDark() )
-        title += " (using dark system theme)";
-    dc.DrawText(title, x, r.y);
-    r.y += 2*lineHeight;
-    dc.DrawText(wxString::Format("Window background is %s",
-                                 appearance.IsUsingDarkBackground() ? "dark"
-                                                                    : "light"),
-                x, r.y);
-    r.y += 3*lineHeight;
+    {
+        dc.DrawText(wxString::Format("System appearance: %s", appearanceName),
+                    x, r.y);
+        r.y += lineHeight;
+    }
+
+    auto const showDarkOrLight = [&](const char* what, bool dark)
+    {
+        dc.DrawText(wxString::Format("%s: %s", what, dark ? "dark" : "light"),
+                    x, r.y);
+        r.y += 1.5*lineHeight;
+    };
+
+    showDarkOrLight("System", appearance.IsSystemDark());
+    showDarkOrLight("App default", appearance.AreAppsDark());
+    showDarkOrLight("Current app", appearance.IsDark());
+    showDarkOrLight("Background", appearance.IsUsingDarkBackground());
+
+    r.y += lineHeight;
 
     dc.SetPen(*wxTRANSPARENT_PEN);
 

--- a/src/common/settcmn.cpp
+++ b/src/common/settcmn.cpp
@@ -68,6 +68,21 @@ void wxSystemSettings::SetScreenType( wxSystemScreenType screen )
 // Trivial wxSystemAppearance implementation
 // ----------------------------------------------------------------------------
 
+// wxMSW has its own implementation of these functions.
+#if !defined(__WXMSW__)
+
+bool wxSystemAppearance::AreAppsDark() const
+{
+    return IsDark();
+}
+
+bool wxSystemAppearance::IsSystemDark() const
+{
+    return IsDark();
+}
+
+#endif // !__WXMSW__
+
 #if !defined(__WXOSX__)
 
 wxString wxSystemAppearance::GetName() const

--- a/src/generic/activityindicator.cpp
+++ b/src/generic/activityindicator.cpp
@@ -149,9 +149,7 @@ private:
         gc->Rotate(m_frame*angle);
 
         // Choose a contrasting background colour.
-        wxColour colBg = wxSystemSettings::GetAppearance().IsDark()
-            ? *wxWHITE
-            : *wxBLACK;
+        wxColour colBg = wxSystemSettings::SelectLightDark(*wxBLACK, *wxWHITE);
 
         const bool isEnabled = m_win->IsThisEnabled();
         for ( int n = 0; n < NUM_DOTS; n++ )

--- a/src/generic/activityindicator.cpp
+++ b/src/generic/activityindicator.cpp
@@ -25,6 +25,7 @@
 
 #ifndef WX_PRECOMP
     #include "wx/dcclient.h"
+    #include "wx/settings.h"
     #include "wx/timer.h"
 #endif // WX_PRECOMP
 
@@ -147,6 +148,11 @@ private:
         // the next position every time.
         gc->Rotate(m_frame*angle);
 
+        // Choose a contrasting background colour.
+        wxColour colBg = wxSystemSettings::GetAppearance().IsDark()
+            ? *wxWHITE
+            : *wxBLACK;
+
         const bool isEnabled = m_win->IsThisEnabled();
         for ( int n = 0; n < NUM_DOTS; n++ )
         {
@@ -159,7 +165,8 @@ private:
             // it in 0..wxALPHA_OPAQUE range.
             const int opacity = opacityIndex*(wxALPHA_OPAQUE + 1)/NUM_DOTS - 1;
 
-            gc->SetBrush(wxBrush(wxColour(0, 0, 0, opacity)));
+            colBg.Set(colBg.Red(), colBg.Green(), colBg.Blue(), opacity);
+            gc->SetBrush(colBg);
 
             gc->FillPath(path);
             gc->Rotate(angle);

--- a/src/generic/fontpickerg.cpp
+++ b/src/generic/fontpickerg.cpp
@@ -22,6 +22,10 @@
 
 #if wxUSE_FONTPICKERCTRL
 
+#ifndef WX_PRECOMP
+    #include "wx/settings.h"
+#endif // WX_PRECOMP
+
 #include "wx/fontpicker.h"
 
 #include "wx/fontdlg.h"
@@ -68,7 +72,7 @@ bool wxGenericFontButton::Create( wxWindow *parent, wxWindowID id,
 void wxGenericFontButton::InitFontData()
 {
     m_data.SetAllowSymbols(true);
-    m_data.SetColour(*wxBLACK);
+    m_data.SetColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNTEXT));
     m_data.EnableEffects(true);
 }
 

--- a/src/generic/graphicc.cpp
+++ b/src/generic/graphicc.cpp
@@ -541,7 +541,7 @@ protected:
 #endif
 #ifdef __WXMSW__
     cairo_surface_t* m_mswSurface;
-    WindowHDC m_mswWindowHDC;
+    ClientHDC m_mswWindowHDC;
     int m_mswStateSavedDC;
 #endif
 #ifdef __WXGTK__

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -3031,11 +3031,7 @@ void wxGrid::Init()
     m_cellHighlightColour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
     m_cellHighlightPenWidth = 2;
     m_cellHighlightROPenWidth = 1;
-    if ( wxSystemSettings::GetAppearance().IsDark() )
-        m_gridFrozenBorderColour = *wxWHITE;
-    else
-        m_gridFrozenBorderColour = *wxBLACK;
-
+    m_gridFrozenBorderColour = wxSystemSettings::SelectLightDark(*wxBLACK, *wxWHITE);
     m_gridFrozenBorderPenWidth = 2;
 
     m_canDragRowMove = false;

--- a/src/generic/richtooltipg.cpp
+++ b/src/generic/richtooltipg.cpp
@@ -171,11 +171,12 @@ public:
 
                 colStart = hTheme.GetColour(TTP_BALLOONTITLE, TMT_GRADIENTCOLOR1);
                 if ( !colStart.IsOk() )
-                    colStart = *wxWHITE;
+                    colStart = wxSystemSettings::SelectLightDark(*wxWHITE, *wxBLACK);
 
                 colEnd = hTheme.GetColour(TTP_BALLOONTITLE, TMT_GRADIENTCOLOR2);
                 if ( !colEnd.IsOk() )
-                    colEnd.Set(0xe4, 0xe5, 0xf0);
+                    colEnd = wxSystemSettings::SelectLightDark({0xe4, 0xe5, 0xf0},
+                                                               {0x40, 0x40, 0x20});
             }
             else
 #endif // HAVE_MSW_THEME

--- a/src/generic/richtooltipg.cpp
+++ b/src/generic/richtooltipg.cpp
@@ -96,21 +96,15 @@ public:
             {
                 titleFont.MakeLarger();
 
-                COLORREF c;
-                if ( FAILED(::GetThemeColor
-                                   (
-                                        wxUxThemeHandle(parent, L"TOOLTIP"),
-                                        TTP_BALLOONTITLE,
-                                        0,
-                                        TMT_TEXTCOLOR,
-                                        &c
-                                    )) )
+                wxUxThemeHandle theme(parent, L"TOOLTIP");
+                wxColour c = theme.GetColour(TTP_BALLOONTITLE, TMT_TEXTCOLOR);
+                if ( !c.IsOk() )
                 {
                     // Use the standard value of this colour as fallback.
-                    c = 0x993300;
+                    c.Set(0x00, 0x33, 0x99);
                 }
 
-                labelTitle->SetForegroundColour(wxRGBToColour(c));
+                labelTitle->SetForegroundColour(c);
             }
             else
 #endif // HAVE_MSW_THEME
@@ -175,30 +169,13 @@ public:
             {
                 wxUxThemeHandle hTheme(GetParent(), L"TOOLTIP");
 
-                COLORREF c1, c2;
-                if ( FAILED(::GetThemeColor
-                                   (
-                                        hTheme,
-                                        TTP_BALLOONTITLE,
-                                        0,
-                                        TMT_GRADIENTCOLOR1,
-                                        &c1
-                                    )) ||
-                    FAILED(::GetThemeColor
-                                  (
-                                        hTheme,
-                                        TTP_BALLOONTITLE,
-                                        0,
-                                        TMT_GRADIENTCOLOR2,
-                                        &c2
-                                  )) )
-                {
-                    c1 = 0xffffff;
-                    c2 = 0xf0e5e4;
-                }
+                colStart = hTheme.GetColour(TTP_BALLOONTITLE, TMT_GRADIENTCOLOR1);
+                if ( !colStart.IsOk() )
+                    colStart = *wxWHITE;
 
-                colStart = wxRGBToColour(c1);
-                colEnd = wxRGBToColour(c2);
+                colEnd = hTheme.GetColour(TTP_BALLOONTITLE, TMT_GRADIENTCOLOR2);
+                if ( !colEnd.IsOk() )
+                    colEnd.Set(0xe4, 0xe5, 0xf0);
             }
             else
 #endif // HAVE_MSW_THEME

--- a/src/msw/app.cpp
+++ b/src/msw/app.cpp
@@ -55,6 +55,7 @@
 #include "wx/msw/private.h"
 #include "wx/msw/dc.h"
 #include "wx/msw/ole/oleutils.h"
+#include "wx/msw/private/darkmode.h"
 #include "wx/msw/private/timer.h"
 
 #if wxUSE_TOOLTIPS
@@ -663,6 +664,15 @@ const wxChar *wxApp::GetRegisteredClassName(const wxChar *name,
             return gs_regClassesInfo[n].GetRequestedName(flags);
     }
 
+    // In dark mode, use the dark background brush instead of specified colour
+    // which would result in light background.
+    HBRUSH hbrBackground;
+    if ( wxMSWDarkMode::IsActive() )
+        hbrBackground = wxMSWDarkMode::GetBackgroundBrush();
+    else
+        hbrBackground = (HBRUSH)wxUIntToPtr(bgBrushCol + 1);
+
+
     // we need to register this class
     WNDCLASS wndclass;
     wxZeroMemory(wndclass);
@@ -670,7 +680,7 @@ const wxChar *wxApp::GetRegisteredClassName(const wxChar *name,
     wndclass.lpfnWndProc   = (WNDPROC)wxWndProc;
     wndclass.hInstance     = wxGetInstance();
     wndclass.hCursor       = ::LoadCursor(nullptr, IDC_ARROW);
-    wndclass.hbrBackground = (HBRUSH)wxUIntToPtr(bgBrushCol + 1);
+    wndclass.hbrBackground = hbrBackground;
     wndclass.style         = CS_HREDRAW | CS_VREDRAW | CS_DBLCLKS | extraStyles;
 
 

--- a/src/msw/app.cpp
+++ b/src/msw/app.cpp
@@ -48,6 +48,7 @@
 #include "wx/thread.h"
 #include "wx/platinfo.h"
 #include "wx/scopeguard.h"
+#include "wx/sysopt.h"
 #include "wx/vector.h"
 #include "wx/weakref.h"
 
@@ -630,6 +631,14 @@ bool wxApp::Initialize(int& argc_, wxChar **argv_)
     InitCommonControls();
 
     wxSetKeyboardHook(true);
+
+    // this is useful to allow users to enable dark mode for the applications
+    // not enabling it themselves by setting the corresponding environment
+    // variable
+    if ( const int darkMode = wxSystemOptions::GetOptionInt("msw.dark-mode") )
+    {
+        MSWEnableDarkMode(darkMode > 1 ? DarkMode_Always : DarkMode_Auto);
+    }
 
     callBaseCleanup.Dismiss();
 

--- a/src/msw/checkbox.cpp
+++ b/src/msw/checkbox.cpp
@@ -88,6 +88,18 @@ WXDWORD wxCheckBox::MSWGetStyle(long style, WXDWORD *exstyle) const
     return msStyle;
 }
 
+bool wxCheckBox::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
+{
+    // Just as radio buttons, check boxes have some dark theme support, but we
+    // still need to change their foreground manually to make it readable in
+    // dark mode.
+    wxCheckBoxBase::MSWGetDarkModeSupport(support);
+
+    support.setForeground = true;
+
+    return true;
+}
+
 // ----------------------------------------------------------------------------
 // wxCheckBox geometry
 // ----------------------------------------------------------------------------

--- a/src/msw/choice.cpp
+++ b/src/msw/choice.cpp
@@ -35,6 +35,7 @@
 #include "wx/dynlib.h"
 
 #include "wx/msw/private.h"
+#include "wx/msw/uxtheme.h"
 
 // ============================================================================
 // implementation
@@ -193,11 +194,10 @@ wxChoice::GetClassDefaultAttributes(wxWindowVariant WXUNUSED(variant))
     attrs.colFg = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
 
     // NB: use EDIT, not COMBOBOX (the latter works in XP but not Vista)
-    attrs.colBg = wnd->MSWGetThemeColour(L"EDIT",
-                                         EP_EDITTEXT,
-                                         ETS_NORMAL,
-                                         ThemeColourBackground,
-                                         wxSYS_COLOUR_WINDOW);
+    wxUxThemeHandle hTheme(wnd, L"EDIT");
+    attrs.colBg = hTheme.GetColour(EP_EDITTEXT, TMT_FILLCOLOR, ETS_NORMAL);
+    if ( !attrs.colBg.IsOk() )
+        attrs.colBg = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
 
     return attrs;
 }

--- a/src/msw/choice.cpp
+++ b/src/msw/choice.cpp
@@ -37,6 +37,8 @@
 #include "wx/msw/private.h"
 #include "wx/msw/uxtheme.h"
 
+#include "wx/msw/private/darkmode.h"
+
 // ============================================================================
 // implementation
 // ============================================================================
@@ -205,6 +207,16 @@ wxChoice::GetClassDefaultAttributes(wxWindowVariant WXUNUSED(variant))
 bool wxChoice::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
 {
     support.themeName = L"CFD";
+
+    // It is slightly improper to do this in a const function, but as we know
+    // that this will only be called when we're using the dark mode, we also
+    // use it to enable it for the drop down list, if any, to ensure that it
+    // uses dark scrollbars.
+    WinStruct<COMBOBOXINFO> info;
+    if ( ::GetComboBoxInfo(GetHwnd(), &info) && info.hwndList )
+    {
+        wxMSWDarkMode::AllowForWindow(info.hwndList);
+    }
 
     return true;
 }

--- a/src/msw/choice.cpp
+++ b/src/msw/choice.cpp
@@ -202,6 +202,13 @@ wxChoice::GetClassDefaultAttributes(wxWindowVariant WXUNUSED(variant))
     return attrs;
 }
 
+bool wxChoice::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
+{
+    support.themeName = L"CFD";
+
+    return true;
+}
+
 wxChoice::~wxChoice()
 {
     Clear();

--- a/src/msw/control.cpp
+++ b/src/msw/control.cpp
@@ -138,11 +138,10 @@ bool wxControl::MSWCreateControl(const wxChar *classname,
         return false;
     }
 
-    if ( wxMSWDarkMode::IsActive() )
+    MSWDarkModeSupport support;
+    if ( wxMSWDarkMode::IsActive() && MSWGetDarkModeSupport(support) )
     {
-        wxMSWDarkMode::AllowForWindow(m_hWnd,
-                                      MSWGetDarkThemeName(),
-                                      MSWGetDarkThemeId());
+        wxMSWDarkMode::AllowForWindow(m_hWnd, support.themeName, support.themeId);
 
         if ( const int msgTT = MSWGetToolTipMessage() )
         {
@@ -194,6 +193,16 @@ bool wxControl::MSWCreateControl(const wxChar *classname,
                        SWP_NOOWNERZORDER |
                        SWP_NOSENDCHANGING);
     }
+
+    return true;
+}
+
+bool wxControl::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
+{
+    // This theme works for a few controls (buttons, texts, comboboxes) and
+    // doesn't seem to do any harm for those that don't support it, so use it
+    // by default.
+    support.themeName = L"Explorer";
 
     return true;
 }

--- a/src/msw/control.cpp
+++ b/src/msw/control.cpp
@@ -294,6 +294,8 @@ WXHBRUSH wxControl::DoMSWControlColor(WXHDC pDC, wxColour colBg, WXHWND hWnd)
 {
     HDC hdc = (HDC)pDC;
 
+    wxColour colFg;
+
     WXHBRUSH hbr = 0;
     if ( !colBg.IsOk() )
     {
@@ -328,11 +330,22 @@ WXHBRUSH wxControl::DoMSWControlColor(WXHDC pDC, wxColour colBg, WXHWND hWnd)
         if ( win )
             hbr = win->MSWGetBgBrush(pDC);
 
-        // if the control doesn't have any bg colour, foreground colour will be
-        // ignored as the return value would be 0 -- so forcefully give it a
-        // non default background brush in this case
-        if ( !hbr && m_hasFgCol )
-            colBg = GetBackgroundColour();
+        if ( !hbr )
+        {
+            if ( wxMSWDarkMode::IsActive() )
+            {
+                colBg = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX);
+                if ( !m_hasFgCol )
+                    colFg = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT);
+            }
+            // if the control doesn't have any bg colour, foreground colour will be
+            // ignored as the return value would be 0 -- so forcefully give it a
+            // non default background brush in this case
+            else if ( m_hasFgCol )
+            {
+                colBg = GetBackgroundColour();
+            }
+        }
     }
 
     // use the background colour override if a valid colour is given: this is
@@ -350,7 +363,9 @@ WXHBRUSH wxControl::DoMSWControlColor(WXHDC pDC, wxColour colBg, WXHWND hWnd)
     // default just the simple black is used
     if ( hbr )
     {
-        ::SetTextColor(hdc, wxColourToRGB(GetForegroundColour()));
+        if ( !colFg.IsOk() )
+            colFg = GetForegroundColour();
+        ::SetTextColor(hdc, wxColourToRGB(colFg));
     }
 
     // finally also set the background colour for text drawing: without this,

--- a/src/msw/control.cpp
+++ b/src/msw/control.cpp
@@ -138,9 +138,19 @@ bool wxControl::MSWCreateControl(const wxChar *classname,
         return false;
     }
 
-    wxMSWDarkMode::AllowForWindow(m_hWnd,
-                                  MSWGetDarkThemeName(),
-                                  MSWGetDarkThemeId());
+    if ( wxMSWDarkMode::IsActive() )
+    {
+        wxMSWDarkMode::AllowForWindow(m_hWnd,
+                                      MSWGetDarkThemeName(),
+                                      MSWGetDarkThemeId());
+
+        if ( const int msgTT = MSWGetToolTipMessage() )
+        {
+            const HWND hwndTT = (HWND)::SendMessage(GetHwnd(), msgTT, 0, 0);
+            if ( ::IsWindow(hwndTT) )
+                wxMSWDarkMode::AllowForWindow(hwndTT);
+        }
+    }
 
     // saving the label in m_labelOrig to return it verbatim
     // later in GetLabel()

--- a/src/msw/control.cpp
+++ b/src/msw/control.cpp
@@ -40,6 +40,7 @@
 #include "wx/msw/uxtheme.h"
 #include "wx/msw/dc.h"          // for wxDCTemp
 #include "wx/msw/ownerdrawnbutton.h"
+#include "wx/msw/private/darkmode.h"
 #include "wx/msw/private/winstyle.h"
 
 // ----------------------------------------------------------------------------
@@ -136,6 +137,8 @@ bool wxControl::MSWCreateControl(const wxChar *classname,
     {
         return false;
     }
+
+    wxMSWDarkMode::AllowForWindow(m_hWnd);
 
     // saving the label in m_labelOrig to return it verbatim
     // later in GetLabel()

--- a/src/msw/control.cpp
+++ b/src/msw/control.cpp
@@ -138,7 +138,9 @@ bool wxControl::MSWCreateControl(const wxChar *classname,
         return false;
     }
 
-    wxMSWDarkMode::AllowForWindow(m_hWnd, MSWGetDarkThemeClass());
+    wxMSWDarkMode::AllowForWindow(m_hWnd,
+                                  MSWGetDarkThemeName(),
+                                  MSWGetDarkThemeId());
 
     // saving the label in m_labelOrig to return it verbatim
     // later in GetLabel()

--- a/src/msw/control.cpp
+++ b/src/msw/control.cpp
@@ -138,7 +138,7 @@ bool wxControl::MSWCreateControl(const wxChar *classname,
         return false;
     }
 
-    wxMSWDarkMode::AllowForWindow(m_hWnd);
+    wxMSWDarkMode::AllowForWindow(m_hWnd, MSWGetDarkThemeClass());
 
     // saving the label in m_labelOrig to return it verbatim
     // later in GetLabel()

--- a/src/msw/control.cpp
+++ b/src/msw/control.cpp
@@ -143,6 +143,9 @@ bool wxControl::MSWCreateControl(const wxChar *classname,
     {
         wxMSWDarkMode::AllowForWindow(m_hWnd, support.themeName, support.themeId);
 
+        if ( support.setForeground )
+            SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT));
+
         if ( const int msgTT = MSWGetToolTipMessage() )
         {
             const HWND hwndTT = (HWND)::SendMessage(GetHwnd(), msgTT, 0, 0);

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -1,0 +1,146 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        src/msw/darkmode.cpp
+// Purpose:     Support for dark mode in wxMSW
+// Author:      Vadim Zeitlin
+// Created:     2022-06-24
+// Copyright:   (c) 2022 Vadim Zeitlin <vadim@wxwidgets.org>
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+/*
+    The code in this file is based on the following sources:
+
+    - win32-darkmode by Richard Yu (https://github.com/ysc3839/win32-darkmode)
+ */
+
+// ============================================================================
+// declarations
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// headers
+// ----------------------------------------------------------------------------
+
+// for compilers that support precompilation, includes "wx.h".
+#include "wx/wxprec.h"
+
+// Allow predefining this as 0 to disable dark mode support completely.
+#ifndef wxUSE_DARK_MODE
+    // Otherwise enable it by default.
+    #define wxUSE_DARK_MODE 1
+#endif
+
+#if wxUSE_DARK_MODE
+
+#ifndef WX_PRECOMP
+    #include "wx/app.h"
+    #include "wx/log.h"
+#endif // WX_PRECOMP
+
+#include "wx/dynlib.h"
+
+static const char* TRACE_DARKMODE = "msw-darkmode";
+
+namespace
+{
+
+// Constants for use with SetPreferredAppMode().
+enum PreferredAppMode
+{
+    AppMode_Default,
+    AppMode_AllowDark,
+    AppMode_ForceDark,
+    AppMode_ForceLight
+};
+
+PreferredAppMode gs_appMode = AppMode_Default;
+
+template <typename T>
+bool TryLoadByOrd(T& func, const wxDynamicLibrary& lib, int ordinal)
+{
+    func = (T)::GetProcAddress(lib.GetLibHandle(), MAKEINTRESOURCEA(ordinal));
+    if ( !func )
+    {
+        wxLogTrace(TRACE_DARKMODE,
+                   "Required function with ordinal %d not found", ordinal);
+        return false;
+    }
+
+    return true;
+}
+
+} // anonymous namespace
+
+// ============================================================================
+// implementation
+// ============================================================================
+
+namespace wxMSWImpl
+{
+
+// Global pointers of the functions we use: they're not only undocumented, but
+// don't appear in the SDK headers at all.
+BOOL (WINAPI *ShouldAppsUseDarkMode)() = nullptr;
+DWORD (WINAPI *SetPreferredAppMode)(DWORD) = nullptr;
+
+bool InitDarkMode()
+{
+    // Note: for simplicity, we support dark mode only in Windows 10 v2004
+    // ("20H1", build number 19041) and later, even if, in principle, it could
+    // be supported as far back as v1809 (build 17763) -- but very few people
+    // must still use it by now and so it just doesn't seem to be worth it.
+    if ( !wxCheckOsVersion(10, 0, 19041) )
+    {
+        wxLogTrace(TRACE_DARKMODE, "Unsupported due to OS version");
+        return false;
+    }
+
+    wxLoadedDLL dllUxTheme(wxS("uxtheme.dll"));
+
+    // These functions are not only undocumented but are not even exported by
+    // name, and have to be resolved using their ordinals.
+    if ( !TryLoadByOrd(ShouldAppsUseDarkMode, dllUxTheme, 132) )
+        return false;
+
+    if ( !TryLoadByOrd(SetPreferredAppMode, dllUxTheme, 135) )
+        return false;
+
+    return true;
+}
+
+} // namespace wxMSWImpl
+
+// ----------------------------------------------------------------------------
+// Public API
+// ----------------------------------------------------------------------------
+
+bool wxApp::MSWEnableDarkMode(int flags)
+{
+    if ( !wxMSWImpl::InitDarkMode() )
+        return false;
+
+    const PreferredAppMode mode = flags & DarkMode_Always ? AppMode_ForceDark
+                                                          : AppMode_AllowDark;
+    const DWORD rc = wxMSWImpl::SetPreferredAppMode(mode);
+
+    // It's supposed to return the old mode normally.
+    if ( rc != static_cast<DWORD>(gs_appMode) )
+    {
+        wxLogTrace(TRACE_DARKMODE,
+                   "SetPreferredAppMode(%d) unexpectedly returned %d",
+                   mode, rc);
+    }
+
+    gs_appMode = mode;
+
+    return true;
+}
+
+#else // !wxUSE_DARK_MODE
+
+bool wxApp::MSWEnableDarkMode(int WXUNUSED(flags))
+{
+    return false;
+}
+
+#endif // wxUSE_DARK_MODE/!wxUSE_DARK_MODE

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -110,6 +110,33 @@ bool InitDarkMode()
            TryLoadByOrd(SetPreferredAppMode, dllUxTheme, 135);
 }
 
+// This function is only used in this file as it's more clear than using
+// IsActive() without the namespace name -- but in the rest of our code, it's
+// IsActive() which is more clear.
+bool ShouldUseDarkMode()
+{
+    switch ( gs_appMode )
+    {
+        case AppMode_Default:
+            // Dark mode support not enabled, don't try using dark mode.
+            return false;
+
+        case AppMode_AllowDark:
+            // Follow the global setting.
+            return wxMSWImpl::ShouldAppsUseDarkMode();
+
+        case AppMode_ForceDark:
+            return true;
+
+        case AppMode_ForceLight:
+            return false;
+    }
+
+    wxFAIL_MSG( "unreachable" );
+
+    return false;
+}
+
 } // namespace wxMSWImpl
 
 // ----------------------------------------------------------------------------
@@ -194,34 +221,15 @@ bool wxApp::MSWEnableDarkMode(int flags)
 namespace wxMSWDarkMode
 {
 
-bool ShouldUseDarkMode()
+bool IsActive()
 {
-    switch ( gs_appMode )
-    {
-        case AppMode_Default:
-            // Dark mode support not enabled, don't try using dark mode.
-            return false;
-
-        case AppMode_AllowDark:
-            // Follow the global setting.
-            return wxMSWImpl::ShouldAppsUseDarkMode();
-
-        case AppMode_ForceDark:
-            return true;
-
-        case AppMode_ForceLight:
-            return false;
-    }
-
-    wxFAIL_MSG( "unreachable" );
-
-    return false;
+    return wxMSWImpl::ShouldUseDarkMode();
 }
 
 void EnableForTLW(HWND hwnd)
 {
     // Nothing to do, dark mode support not enabled or dark mode is not used.
-    if ( !ShouldUseDarkMode() )
+    if ( !wxMSWImpl::ShouldUseDarkMode() )
         return;
 
     BOOL useDarkMode = TRUE;
@@ -240,7 +248,7 @@ void EnableForTLW(HWND hwnd)
 
 void AllowForWindow(HWND hwnd)
 {
-    if ( ShouldUseDarkMode() )
+    if ( wxMSWImpl::ShouldUseDarkMode() )
     {
         // Using "DARK_EXPLORER" theme works as well, but is subtly different
         // and it seems better to use the explicit (even if undocumented) API
@@ -261,6 +269,11 @@ bool wxApp::MSWEnableDarkMode(int WXUNUSED(flags))
 
 namespace wxMSWDarkMode
 {
+
+bool IsActive()
+{
+    return false;
+}
 
 void EnableForTLW(HWND WXUNUSED(hwnd))
 {

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -285,6 +285,7 @@ wxColour GetColour(wxSystemColour index)
         case wxSYS_COLOUR_INFOBK:
         case wxSYS_COLOUR_LISTBOX:
         case wxSYS_COLOUR_WINDOW:
+        case wxSYS_COLOUR_BTNFACE:
             return wxColour(0x202020);
 
         case wxSYS_COLOUR_BTNTEXT:
@@ -303,9 +304,6 @@ wxColour GetColour(wxSystemColour index)
         case wxSYS_COLOUR_INACTIVECAPTION:
         case wxSYS_COLOUR_MENU:
             return wxColour(0x2b2b2b);
-
-        case wxSYS_COLOUR_BTNFACE:
-            return wxColour(0x333333);
 
         case wxSYS_COLOUR_MENUBAR:
             return wxColour(0x626262);

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -260,6 +260,81 @@ void AllowForWindow(HWND hwnd, const wchar_t* themeClass)
     }
 }
 
+wxColour GetColour(wxSystemColour index)
+{
+    // This is not great at all, but better than using light mode colours that
+    // are not appropriate for the dark mode.
+    switch ( index )
+    {
+        case wxSYS_COLOUR_ACTIVECAPTION:
+        case wxSYS_COLOUR_APPWORKSPACE:
+        case wxSYS_COLOUR_INFOBK:
+        case wxSYS_COLOUR_LISTBOX:
+        case wxSYS_COLOUR_WINDOW:
+            return wxColour(0x202020);
+
+        case wxSYS_COLOUR_BTNTEXT:
+        case wxSYS_COLOUR_CAPTIONTEXT:
+        case wxSYS_COLOUR_HIGHLIGHTTEXT:
+        case wxSYS_COLOUR_INFOTEXT:
+        case wxSYS_COLOUR_LISTBOXHIGHLIGHTTEXT:
+        case wxSYS_COLOUR_LISTBOXTEXT:
+        case wxSYS_COLOUR_MENUTEXT:
+        case wxSYS_COLOUR_WINDOWTEXT:
+            return wxColour(0xe0e0e0);
+
+        case wxSYS_COLOUR_SCROLLBAR:
+            return wxColour(0x4d4d4d);
+
+        case wxSYS_COLOUR_INACTIVECAPTION:
+        case wxSYS_COLOUR_MENU:
+            return wxColour(0x2b2b2b);
+
+        case wxSYS_COLOUR_BTNFACE:
+            return wxColour(0x333333);
+
+        case wxSYS_COLOUR_MENUBAR:
+            return wxColour(0x626262);
+
+        case wxSYS_COLOUR_MENUHILIGHT:
+            return wxColour(0x353535);
+
+        case wxSYS_COLOUR_HIGHLIGHT:
+            return wxColour(0x777777);
+
+        case wxSYS_COLOUR_INACTIVECAPTIONTEXT:
+            return wxColour(0xaaaaaa);
+
+        case wxSYS_COLOUR_3DDKSHADOW:
+        case wxSYS_COLOUR_3DLIGHT:
+        case wxSYS_COLOUR_ACTIVEBORDER:
+        case wxSYS_COLOUR_BTNHIGHLIGHT:
+        case wxSYS_COLOUR_BTNSHADOW:
+        case wxSYS_COLOUR_DESKTOP:
+        case wxSYS_COLOUR_GRADIENTACTIVECAPTION:
+        case wxSYS_COLOUR_GRADIENTINACTIVECAPTION:
+        case wxSYS_COLOUR_GRAYTEXT:
+        case wxSYS_COLOUR_HOTLIGHT:
+        case wxSYS_COLOUR_INACTIVEBORDER:
+        case wxSYS_COLOUR_WINDOWFRAME:
+            return wxColour();
+
+        case wxSYS_COLOUR_MAX:
+            break;
+    }
+
+    wxFAIL_MSG( "unreachable" );
+    return wxColour();
+}
+
+HBRUSH GetBackgroundBrush()
+{
+    wxBrush* const brush =
+        wxTheBrushList->FindOrCreateBrush(GetColour(wxSYS_COLOUR_WINDOW));
+
+    return brush ? GetHbrushOf(*brush) : 0;
+}
+
 } // namespace wxMSWDarkMode
 
 #else // !wxUSE_DARK_MODE
@@ -283,6 +358,16 @@ void EnableForTLW(HWND WXUNUSED(hwnd))
 
 void AllowForWindow(HWND WXUNUSED(hwnd), const wchar_t* WXUNUSED(themeClass))
 {
+}
+
+wxColour GetColour(wxSystemColour WXUNUSED(index))
+{
+    return wxColour();
+}
+
+HBRUSH GetBackgroundBrush()
+{
+    return 0;
 }
 
 } // namespace wxMSWDarkMode

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -246,15 +246,17 @@ void EnableForTLW(HWND hwnd)
     wxMSWImpl::AllowDarkModeForWindow(hwnd, TRUE);
 }
 
-void AllowForWindow(HWND hwnd)
+void AllowForWindow(HWND hwnd, const wchar_t* themeClass)
 {
     if ( wxMSWImpl::ShouldUseDarkMode() )
     {
-        // Using "DARK_EXPLORER" theme works as well, but is subtly different
-        // and it seems better to use the explicit (even if undocumented) API
-        // provided for this instead of relying on this special theme name.
         wxMSWImpl::AllowDarkModeForWindow(hwnd, TRUE);
-        ::SetWindowTheme(hwnd, L"EXPLORER", nullptr);
+
+        // For some reason using a theme class is incompatible with using
+        // "Explorer" as the app name, even though it looks like it ought to
+        // be, but passing ("Explorer", "ExplorerStatusBar") here, for example,
+        // does _not_ work, while omitting the app name in this case does work.
+        ::SetWindowTheme(hwnd, themeClass ? nullptr : L"Explorer", themeClass);
     }
 }
 
@@ -279,7 +281,7 @@ void EnableForTLW(HWND WXUNUSED(hwnd))
 {
 }
 
-void AllowForWindow(HWND WXUNUSED(hwnd))
+void AllowForWindow(HWND WXUNUSED(hwnd), const wchar_t* WXUNUSED(themeClass))
 {
 }
 

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -253,18 +253,14 @@ void EnableForTLW(HWND hwnd)
 
 void AllowForWindow(HWND hwnd, const wchar_t* themeName, const wchar_t* themeId)
 {
-    if ( wxMSWImpl::ShouldUseDarkMode() )
+    if ( !wxMSWImpl::ShouldUseDarkMode() )
+        return;
+
+    if ( wxMSWImpl::AllowDarkModeForWindow(hwnd, TRUE) )
+        wxLogTrace(TRACE_DARKMODE, "Allow dark mode for %p failed", hwnd);
+
+    if ( themeName || themeId )
     {
-        if ( wxMSWImpl::AllowDarkModeForWindow(hwnd, TRUE) )
-            wxLogTrace(TRACE_DARKMODE, "Allow dark mode for %p failed", hwnd);
-
-        // Default is to just use "Explorer" theme as it works for several
-        // controls, but we do _not_ use it if the theme ID is specified, as
-        // using it can be incompatible with the "Explorer" theme, e.g.
-        // "ExplorerStatusBar" only works _without_ specifying the theme name.
-        if ( !themeName && !themeId )
-            themeName = L"Explorer";
-
         HRESULT hr = ::SetWindowTheme(hwnd, themeName, themeId);
         if ( FAILED(hr) )
         {

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -195,30 +195,35 @@ bool wxApp::MSWEnableDarkMode(int flags)
 namespace wxMSWDarkMode
 {
 
-void EnableForTLW(HWND hwnd)
+bool ShouldUseDarkMode()
 {
     switch ( gs_appMode )
     {
         case AppMode_Default:
-            // Nothing to do, dark mode support not enabled.
-            return;
+            // Dark mode support not enabled, don't try using dark mode.
+            return false;
 
         case AppMode_AllowDark:
-            if ( !wxMSWImpl::ShouldAppsUseDarkMode() )
-            {
-                // Dark mode is not enabled globally.
-                return;
-            }
-            break;
+            // Follow the global setting.
+            return wxMSWImpl::ShouldAppsUseDarkMode();
 
         case AppMode_ForceDark:
-            // Enable dark mode below.
-            break;
+            return true;
 
         case AppMode_ForceLight:
-            // Nothing to do, dark mode is off by default anyhow.
-            return;
+            return false;
     }
+
+    wxFAIL_MSG( "unreachable" );
+
+    return false;
+}
+
+void EnableForTLW(HWND hwnd)
+{
+    // Nothing to do, dark mode support not enabled or dark mode is not used.
+    if ( !ShouldUseDarkMode() )
+        return;
 
     BOOL useDarkMode = TRUE;
     HRESULT hr = wxDarkModeModule::GetDwmSetWindowAttribute()

--- a/src/msw/darkmode.cpp
+++ b/src/msw/darkmode.cpp
@@ -276,6 +276,9 @@ wxColour GetColour(wxSystemColour index)
     // are not appropriate for the dark mode.
     switch ( index )
     {
+        case wxSYS_COLOUR_BTNSHADOW:
+            return *wxBLACK;
+
         case wxSYS_COLOUR_ACTIVECAPTION:
         case wxSYS_COLOUR_APPWORKSPACE:
         case wxSYS_COLOUR_INFOBK:
@@ -293,6 +296,9 @@ wxColour GetColour(wxSystemColour index)
         case wxSYS_COLOUR_MENUTEXT:
         case wxSYS_COLOUR_WINDOWTEXT:
             return wxColour(0xe0e0e0);
+
+        case wxSYS_COLOUR_HOTLIGHT:
+            return wxColour(0x474747);
 
         case wxSYS_COLOUR_SCROLLBAR:
             return wxColour(0x4d4d4d);
@@ -317,12 +323,10 @@ wxColour GetColour(wxSystemColour index)
         case wxSYS_COLOUR_3DLIGHT:
         case wxSYS_COLOUR_ACTIVEBORDER:
         case wxSYS_COLOUR_BTNHIGHLIGHT:
-        case wxSYS_COLOUR_BTNSHADOW:
         case wxSYS_COLOUR_DESKTOP:
         case wxSYS_COLOUR_GRADIENTACTIVECAPTION:
         case wxSYS_COLOUR_GRADIENTINACTIVECAPTION:
         case wxSYS_COLOUR_GRAYTEXT:
-        case wxSYS_COLOUR_HOTLIGHT:
         case wxSYS_COLOUR_INACTIVEBORDER:
         case wxSYS_COLOUR_WINDOWFRAME:
             return wxColour();

--- a/src/msw/dialog.cpp
+++ b/src/msw/dialog.cpp
@@ -36,6 +36,8 @@
 #endif
 
 #include "wx/msw/private.h"
+#include "wx/msw/private/darkmode.h"
+
 #include "wx/evtloop.h"
 #include "wx/scopedptr.h"
 
@@ -235,6 +237,8 @@ void wxDialog::CreateGripper()
                                     wxGetInstance(),
                                     nullptr
                                );
+
+        wxMSWDarkMode::AllowForWindow((HWND)m_hGripper);
     }
 }
 

--- a/src/msw/dialog.cpp
+++ b/src/msw/dialog.cpp
@@ -352,6 +352,13 @@ WXLRESULT wxDialog::MSWWindowProc(WXUINT message, WXWPARAM wParam, WXLPARAM lPar
                 ::InvalidateRect(GetHwnd(), nullptr, false /* erase bg */);
             }
             break;
+
+        case WM_CTLCOLORDLG:
+            // We need to explicitly set the dark background colour when using
+            // dark mode, otherwise we'd be using the default light background.
+            if ( wxMSWDarkMode::IsActive() )
+                return (WXLRESULT)wxMSWDarkMode::GetBackgroundBrush();
+            break;
     }
 
     if ( !processed )

--- a/src/msw/dialog.cpp
+++ b/src/msw/dialog.cpp
@@ -211,6 +211,10 @@ void wxDialog::SetWindowStyleFlag(long style)
 {
     wxDialogBase::SetWindowStyleFlag(style);
 
+    // Don't do anything if we're setting the style before creating the dialog.
+    if ( !GetHwnd() )
+        return;
+
     if ( HasFlag(wxRESIZE_BORDER) )
         CreateGripper();
     else

--- a/src/msw/frame.cpp
+++ b/src/msw/frame.cpp
@@ -39,6 +39,7 @@
 #endif // WX_PRECOMP
 
 #include "wx/msw/private.h"
+#include "wx/msw/private/darkmode.h"
 
 #include "wx/generic/statusbr.h"
 
@@ -836,6 +837,12 @@ WXLRESULT wxFrame::MSWWindowProc(WXUINT message, WXWPARAM wParam, WXLPARAM lPara
 {
     WXLRESULT rc = 0;
     bool processed = false;
+
+    if ( GetMenuBar() &&
+          wxMSWDarkMode::HandleMenuMessage(&rc, this, message, wParam, lParam) )
+    {
+        return rc;
+    }
 
     switch ( message )
     {

--- a/src/msw/headerctrl.cpp
+++ b/src/msw/headerctrl.cpp
@@ -35,6 +35,7 @@
 #include "wx/msw/wrapcctl.h"
 #include "wx/msw/private.h"
 #include "wx/msw/private/customdraw.h"
+#include "wx/msw/private/darkmode.h"
 #include "wx/msw/private/winstyle.h"
 
 #ifndef HDM_SETBITMAPMARGIN
@@ -92,6 +93,8 @@ protected:
                            int width, int height,
                            int sizeFlags = wxSIZE_AUTO) override;
     virtual void MSWUpdateFontOnDPIChange(const wxSize& newDPI) override;
+
+    virtual const wchar_t* MSWGetDarkThemeName() const override;
 
     // This function can be used as event handle for wxEVT_DPI_CHANGED event.
     void WXHandleDPIChanged(wxDPIChangedEvent& event);
@@ -216,6 +219,12 @@ bool wxMSWHeaderCtrl::Create(wxWindow *parent,
     if ( !MSWCreateControl(WC_HEADER, wxT(""), pos, size) )
         return false;
 
+    if ( wxMSWDarkMode::IsActive() )
+    {
+        m_customDraw = new wxMSWHeaderCtrlCustomDraw();
+        m_customDraw->UseHeaderThemeColors(GetHwnd());
+    }
+
     // special hack for margins when using comctl32.dll v6 or later: the
     // default margin is too big and results in label truncation when the
     // column width is just about right to show it together with the sort
@@ -244,6 +253,11 @@ WXDWORD wxMSWHeaderCtrl::MSWGetStyle(long style, WXDWORD *exstyle) const
     msStyle |= HDS_HORZ | HDS_BUTTONS | HDS_FULLDRAG | HDS_HOTTRACK;
 
     return msStyle;
+}
+
+const wchar_t* wxMSWHeaderCtrl::MSWGetDarkThemeName() const
+{
+    return L"ItemsView";
 }
 
 wxMSWHeaderCtrl::~wxMSWHeaderCtrl()

--- a/src/msw/headerctrl.cpp
+++ b/src/msw/headerctrl.cpp
@@ -94,7 +94,7 @@ protected:
                            int sizeFlags = wxSIZE_AUTO) override;
     virtual void MSWUpdateFontOnDPIChange(const wxSize& newDPI) override;
 
-    virtual const wchar_t* MSWGetDarkThemeName() const override;
+    virtual bool MSWGetDarkModeSupport(MSWDarkModeSupport& support) const override;
 
     // This function can be used as event handle for wxEVT_DPI_CHANGED event.
     void WXHandleDPIChanged(wxDPIChangedEvent& event);
@@ -255,9 +255,11 @@ WXDWORD wxMSWHeaderCtrl::MSWGetStyle(long style, WXDWORD *exstyle) const
     return msStyle;
 }
 
-const wchar_t* wxMSWHeaderCtrl::MSWGetDarkThemeName() const
+bool wxMSWHeaderCtrl::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
 {
-    return L"ItemsView";
+    support.themeName = L"ItemsView";
+
+    return true;
 }
 
 wxMSWHeaderCtrl::~wxMSWHeaderCtrl()

--- a/src/msw/headerctrl.cpp
+++ b/src/msw/headerctrl.cpp
@@ -50,36 +50,6 @@
 extern int WXDLLIMPEXP_CORE wxMSWGetColumnClicked(NMHDR *nmhdr, POINT *ptClick);
 
 // ----------------------------------------------------------------------------
-// wxMSWHeaderCtrlCustomDraw: our custom draw helper
-// ----------------------------------------------------------------------------
-
-class wxMSWHeaderCtrlCustomDraw : public wxMSWImpl::CustomDraw
-{
-public:
-    wxMSWHeaderCtrlCustomDraw()
-    {
-    }
-
-    // Make this field public to let wxHeaderCtrl update it directly when its
-    // attributes change.
-    wxItemAttr m_attr;
-
-private:
-    virtual bool HasCustomDrawnItems() const override
-    {
-        // We only exist if the header does need to be custom drawn.
-        return true;
-    }
-
-    virtual const wxItemAttr*
-    GetItemAttr(DWORD_PTR WXUNUSED(dwItemSpec)) const override
-    {
-        // We use the same attribute for all items for now.
-        return &m_attr;
-    }
-};
-
-// ----------------------------------------------------------------------------
 // wxMSWHeaderCtrl: the native header control
 // ----------------------------------------------------------------------------
 class wxMSWHeaderCtrl : public wxControl

--- a/src/msw/listbox.cpp
+++ b/src/msw/listbox.cpp
@@ -569,7 +569,7 @@ void wxListBox::SetHorizontalExtent(const wxString& s)
         return;
 
 
-    WindowHDC dc(GetHwnd());
+    ClientHDC dc(GetHwnd());
     SelectInHDC selFont(dc, GetHfontOf(GetFont()));
 
     TEXTMETRIC lpTextMetric;

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -3132,7 +3132,7 @@ static void HandleItemPostpaint(NMCUSTOMDRAW nmcd)
         RECT rc = GetCustomDrawnItemRect(nmcd);
 
         // don't use the provided HDC, it's in some strange state by now
-        ::DrawFocusRect(WindowHDC(nmcd.hdr.hwndFrom), &rc);
+        ::DrawFocusRect(ClientHDC(nmcd.hdr.hwndFrom), &rc);
     }
 }
 

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -368,14 +368,7 @@ void wxListCtrl::MSWInitHeader()
     if ( !m_headerCustomDraw )
         m_headerCustomDraw = new wxMSWHeaderCtrlCustomDraw();
 
-    wxUxThemeHandle theme{hwndHdr, L"Header"};
-
-    m_headerCustomDraw->m_attr.SetTextColour(
-        theme.GetColour(HP_HEADERITEM, TMT_TEXTCOLOR)
-    );
-    m_headerCustomDraw->m_attr.SetBackgroundColour(
-        theme.GetColour(HP_HEADERITEM, TMT_FILLCOLOR)
-    );
+    m_headerCustomDraw->UseHeaderThemeColors(hwndHdr);
 }
 
 void wxListCtrl::MSWAfterReparent()

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -244,34 +244,6 @@ public:
     wxDECLARE_NO_COPY_CLASS(wxMSWListItemData);
 };
 
-// wxMSWListHeaderCustomDraw: custom draw helper for the header
-class wxMSWListHeaderCustomDraw : public wxMSWImpl::CustomDraw
-{
-public:
-    wxMSWListHeaderCustomDraw()
-    {
-    }
-
-    // Make this field public to let wxListCtrl update it directly when its
-    // header attributes change.
-    wxItemAttr m_attr;
-
-private:
-    virtual bool HasCustomDrawnItems() const override
-    {
-        // We only exist if the header does need to be custom drawn.
-        return true;
-    }
-
-    virtual const wxItemAttr*
-    GetItemAttr(DWORD_PTR WXUNUSED(dwItemSpec)) const override
-    {
-        // We use the same attribute for all items for now.
-        return &m_attr;
-    }
-};
-
-
 wxBEGIN_EVENT_TABLE(wxListCtrl, wxListCtrlBase)
     EVT_PAINT(wxListCtrl::OnPaint)
     EVT_CHAR_HOOK(wxListCtrl::OnCharHook)
@@ -422,7 +394,7 @@ void wxListCtrl::MSWInitHeader()
     // It's not clear why do we have to do it, but without using custom drawing
     // the header text is drawn in black, making it unreadable, so do use it.
     if ( !m_headerCustomDraw )
-        m_headerCustomDraw = new wxMSWListHeaderCustomDraw();
+        m_headerCustomDraw = new wxMSWHeaderCtrlCustomDraw();
 
     const auto attrs = GetThemeColors(hwndHdr, L"Header", HP_HEADERITEM);
 
@@ -782,7 +754,7 @@ bool wxListCtrl::SetHeaderAttr(const wxItemAttr& attr)
     else // We do have custom attributes.
     {
         if ( !m_headerCustomDraw )
-            m_headerCustomDraw = new wxMSWListHeaderCustomDraw();
+            m_headerCustomDraw = new wxMSWHeaderCtrlCustomDraw();
 
         if ( m_headerCustomDraw->m_attr == attr )
         {

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -694,6 +694,11 @@ const wchar_t* wxListCtrl::MSWGetDarkThemeName() const
     return L"ItemsView";
 }
 
+int wxListCtrl::MSWGetToolTipMessage() const
+{
+    return LVM_GETTOOLTIPS;
+}
+
 wxVisualAttributes wxListCtrl::GetDefaultAttributes() const
 {
     wxVisualAttributes attrs = GetClassDefaultAttributes(GetWindowVariant());

--- a/src/msw/listctrl.cpp
+++ b/src/msw/listctrl.cpp
@@ -620,7 +620,7 @@ void wxListCtrl::SetWindowStyleFlag(long flag)
 // accessors
 // ----------------------------------------------------------------------------
 
-const wchar_t* wxListCtrl::MSWGetDarkThemeName() const
+bool wxListCtrl::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
 {
     // There doesn't seem to be any theme that works well here:
     //  - "Explorer" draws bluish hover highlight rectangle which is not at
@@ -629,7 +629,9 @@ const wchar_t* wxListCtrl::MSWGetDarkThemeName() const
     //    and doesn't draw hover rectangle at all.
     //  - "ItemsView", which we use currently, draws the selection and hover as
     //    expected, but uses light mode scrollbars.
-    return L"ItemsView";
+    support.themeName = L"ItemsView";
+
+    return true;
 }
 
 int wxListCtrl::MSWGetToolTipMessage() const
@@ -646,7 +648,7 @@ wxVisualAttributes wxListCtrl::GetDefaultAttributes() const
         // Note that we intentionally do not use this window HWND for the
         // theme, as it doesn't have dark values for it -- but does have them
         // when we use null window.
-        wxUxThemeHandle theme{HWND(0), MSWGetDarkThemeName()};
+        wxUxThemeHandle theme{HWND(0), L"ItemsView"};
 
         wxColour col = theme.GetColour(0, TMT_TEXTCOLOR);
         if ( col.IsOk() )

--- a/src/msw/msgdlg.cpp
+++ b/src/msw/msgdlg.cpp
@@ -87,10 +87,7 @@ wxMessageDialogMap& HookMap()
 void ScreenRectToClient(HWND hwnd, RECT& rc)
 {
     // map from desktop (i.e. screen) coordinates to ones of this window
-    //
-    // notice that a RECT is laid out as 2 consecutive POINTs so the cast is
-    // valid
-    ::MapWindowPoints(HWND_DESKTOP, hwnd, reinterpret_cast<POINT *>(&rc), 2);
+    wxMapWindowPoints(HWND_DESKTOP, hwnd, &rc);
 }
 
 // set window position to the given rect

--- a/src/msw/msgdlg.cpp
+++ b/src/msw/msgdlg.cpp
@@ -26,6 +26,7 @@
 #include "wx/ptr_scpd.h"
 #include "wx/dynlib.h"
 #include "wx/msw/private/button.h"
+#include "wx/msw/private/darkmode.h"
 #include "wx/msw/private/metrics.h"
 #include "wx/msw/private/msgdlg.h"
 #include "wx/modalhook.h"
@@ -599,6 +600,24 @@ void wxMessageDialog::DoCentre(int dir)
 // Helpers of the wxMSWMessageDialog namespace
 // ----------------------------------------------------------------------------
 
+namespace
+{
+
+HRESULT CALLBACK
+wxTaskDialogCallback(HWND hwnd, UINT msg, WPARAM, LPARAM, LONG_PTR)
+{
+    switch ( msg )
+    {
+        case TDN_DIALOG_CONSTRUCTED:
+            wxMSWDarkMode::EnableForTLW(hwnd);
+            break;
+    }
+
+    return S_OK;
+}
+
+} // anonymous namespace
+
 wxMSWTaskDialogConfig::wxMSWTaskDialogConfig(const wxMessageDialogBase& dlg)
                      : buttons(new TASKDIALOG_BUTTON[MAX_BUTTONS])
 {
@@ -747,6 +766,8 @@ void wxMSWTaskDialogConfig::MSWCommonTaskDialogInit(TASKDIALOGCONFIG &tdc)
 
         AddTaskDialogButton(tdc, IDHELP, 0 /* not used */, btnHelpLabel);
     }
+
+    tdc.pfCallback = wxTaskDialogCallback;
 }
 
 void wxMSWTaskDialogConfig::AddTaskDialogButton(TASKDIALOGCONFIG &tdc,

--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -797,8 +797,16 @@ int wxNotebook::HitTest(const wxPoint& pt, long *flags) const
 LRESULT APIENTRY
 wxNotebookSpinBtnWndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
-    if ( message == WM_ERASEBKGND )
-        return 0;
+    switch ( message )
+    {
+        case WM_ERASEBKGND:
+            return 0;
+
+        case WM_PAINT:
+            if ( wxMSWDarkMode::PaintIfNecessary(hwnd, gs_wndprocNotebookSpinBtn) )
+                return 0;
+            break;
+    }
 
     return ::CallWindowProc(CASTWNDPROC gs_wndprocNotebookSpinBtn,
                             hwnd, message, wParam, lParam);

--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -281,6 +281,11 @@ WXDWORD wxNotebook::MSWGetStyle(long style, WXDWORD *exstyle) const
     return tabStyle;
 }
 
+int wxNotebook::MSWGetToolTipMessage() const
+{
+    return TCM_GETTOOLTIPS;
+}
+
 wxNotebook::~wxNotebook()
 {
 #if wxUSE_UXTHEME

--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -1254,14 +1254,8 @@ wxColour wxNotebook::GetThemeBackgroundColour() const
             // This is total guesswork.
             // See PlatformSDK\Include\Tmschema.h for values.
             // JACS: can also use 9 (TABP_PANE)
-            COLORREF themeColor;
-            bool success = (S_OK == ::GetThemeColor(
-                                        hTheme,
-                                        10 /* TABP_BODY */,
-                                        1 /* NORMAL */,
-                                        3821 /* FILLCOLORHINT */,
-                                        &themeColor));
-            if (!success)
+            wxColour colour = hTheme.GetColour(TABP_BODY, TMT_FILLCOLORHINT, TIS_NORMAL);
+            if ( !colour.IsOk() )
                 return GetBackgroundColour();
 
             /*
@@ -1273,17 +1267,8 @@ wxColour wxNotebook::GetThemeBackgroundColour() const
             This workaround potentially breaks appearance of some themes,
             but in practice it already fixes some themes.
             */
-            if (themeColor == 1)
-            {
-                ::GetThemeColor(
-                                            hTheme,
-                                            10 /* TABP_BODY */,
-                                            1 /* NORMAL */,
-                                            3802 /* FILLCOLOR */,
-                                            &themeColor);
-            }
-
-            wxColour colour = wxRGBToColour(themeColor);
+            if ( colour.GetRGB() == 1 )
+                colour = hTheme.GetColour(TABP_BODY, TMT_FILLCOLOR, TIS_NORMAL);
 
             // Under Vista, the tab background colour is reported incorrectly.
             // So for the default theme at least, hard-code the colour to something

--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -25,8 +25,6 @@
     #include "wx/app.h"
     #include "wx/dcclient.h"
     #include "wx/dcmemory.h"
-    #include "wx/control.h"
-    #include "wx/panel.h"
 #endif  // WX_PRECOMP
 
 #include "wx/imaglist.h"

--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -1127,7 +1127,7 @@ WXHBRUSH wxNotebook::QueryBgBitmap()
     if ( !theme )
         return 0;
 
-    WindowHDC hDC(GetHwnd());
+    ClientHDC hDC(GetHwnd());
 
     RECT rcBg;
     ::GetThemeBackgroundContentRect(theme,

--- a/src/msw/notebook.cpp
+++ b/src/msw/notebook.cpp
@@ -1195,7 +1195,7 @@ bool wxNotebook::MSWPrintChild(WXHDC hDC, wxWindow *child)
 
     // map rect to the coords of the window we're drawing in
     if ( child )
-        ::MapWindowPoints(GetHwnd(), GetHwndOf(child), (POINT *)&rc, 2);
+        wxMapWindowPoints(GetHwnd(), GetHwndOf(child), &rc);
 
     // If we're using a solid colour (for example if we've switched off
     // theming for this notebook), paint it

--- a/src/msw/radiobut.cpp
+++ b/src/msw/radiobut.cpp
@@ -75,6 +75,19 @@ bool wxRadioButton::Create(wxWindow *parent,
     return true;
 }
 
+bool wxRadioButton::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
+{
+    // Weirdly enough, even though radio buttons support dark theme (they
+    // notably change the way they draw the focus rectangle if we set it), they
+    // still use the default black foreground colour in it, making their text
+    // unreadable, so we need to change it manually.
+    wxRadioButtonBase::MSWGetDarkModeSupport(support);
+
+    support.setForeground = true;
+
+    return true;
+}
+
 // ----------------------------------------------------------------------------
 // wxRadioButton functions
 // ----------------------------------------------------------------------------

--- a/src/msw/renderer.cpp
+++ b/src/msw/renderer.cpp
@@ -1223,23 +1223,11 @@ void wxRendererXP::DrawTextCtrl(wxWindow* win,
         return;
     }
 
-    wxColour fill;
-    wxColour bdr;
-    COLORREF cref;
-
-    ::GetThemeColor(hTheme, EP_EDITTEXT,
-                                          ETS_NORMAL, TMT_FILLCOLOR, &cref);
-    fill = wxRGBToColour(cref);
-
-    int etsState;
-    if ( flags & wxCONTROL_DISABLED )
-        etsState = ETS_DISABLED;
-    else
-        etsState = ETS_NORMAL;
-
-    ::GetThemeColor(hTheme, EP_EDITTEXT,
-                                              etsState, TMT_BORDERCOLOR, &cref);
-    bdr = wxRGBToColour(cref);
+    wxColour fill = hTheme.GetColour(EP_EDITTEXT, TMT_FILLCOLOR, ETS_NORMAL);
+    wxColour bdr = hTheme.GetColour(EP_EDITTEXT, TMT_BORDERCOLOR,
+                                    flags & wxCONTROL_DISABLED
+                                        ? ETS_DISABLED
+                                        : ETS_NORMAL);
 
     wxDCPenChanger setPen(dc, bdr);
     wxDCBrushChanger setBrush(dc, fill);

--- a/src/msw/settings.cpp
+++ b/src/msw/settings.cpp
@@ -33,6 +33,7 @@
 #include "wx/msw/missing.h" // for SM_CXCURSOR, SM_CYCURSOR, SM_TABLETPC
 #include "wx/msw/private/darkmode.h"
 #include "wx/msw/private/metrics.h"
+#include "wx/msw/registry.h"
 
 #include "wx/fontutil.h"
 #include "wx/fontenum.h"
@@ -369,6 +370,32 @@ extern wxFont wxGetCCDefaultFont()
 
 #endif // wxUSE_LISTCTRL || wxUSE_TREECTRL
 
+// There is no official API for determining whether dark mode is being used,
+// but HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize
+// contains AppsUseLightTheme and SystemUsesLightTheme values determining
+// whether the applications/system use light or dark mode, so use them.
+//
+// Adapted from https://stackoverflow.com/a/51336913/15275 ("How to detect
+// Windows 10 light/dark mode in Win32 application?").
+namespace
+{
+
+// Return false unless we are sure we're using the dark mode.
+bool IsUsingDarkTheme(const wxString& forWhat)
+{
+    wxRegKey rk(wxRegKey::HKCU, "Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize");
+    if ( rk.Exists() && rk.HasValue(forWhat) )
+    {
+        long value = -1;
+        if ( rk.QueryValue(forWhat, &value) )
+            return value <= 0;
+    }
+
+    return false;
+}
+
+} // anonymous namespace
+
 bool wxSystemAppearance::IsDark() const
 {
     // If the application opted in using dark mode, use the undocumented API
@@ -380,4 +407,14 @@ bool wxSystemAppearance::IsDark() const
     // dark mode for the other applications here, what matters is whether this
     // application itself uses dark colour schema or not.
     return IsUsingDarkBackground();
+}
+
+bool wxSystemAppearance::AreAppsDark() const
+{
+    return IsUsingDarkTheme("AppsUseLightTheme");
+}
+
+bool wxSystemAppearance::IsSystemDark() const
+{
+    return IsUsingDarkTheme("SystemUsesLightTheme");
 }

--- a/src/msw/settings.cpp
+++ b/src/msw/settings.cpp
@@ -33,7 +33,6 @@
 #include "wx/msw/missing.h" // for SM_CXCURSOR, SM_CYCURSOR, SM_TABLETPC
 #include "wx/msw/private/darkmode.h"
 #include "wx/msw/private/metrics.h"
-#include "wx/msw/registry.h"
 
 #include "wx/fontutil.h"
 #include "wx/fontenum.h"
@@ -370,14 +369,6 @@ extern wxFont wxGetCCDefaultFont()
 
 #endif // wxUSE_LISTCTRL || wxUSE_TREECTRL
 
-// There is no official API for determining whether dark mode is being used,
-// but // HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize has
-// a value AppsUseLightTheme = 0 for dark mode and 1 for normal mode, so use it
-// and fall back to the generic algorithm in IsUsingDarkBackground() if it's
-// absent.
-//
-// Adapted from https://stackoverflow.com/a/51336913/15275 ("How to detect
-// Windows 10 light/dark mode in Win32 application?").
 bool wxSystemAppearance::IsDark() const
 {
     // If the application opted in using dark mode, use the undocumented API
@@ -385,13 +376,8 @@ bool wxSystemAppearance::IsDark() const
     if ( wxMSWDarkMode::IsActive() )
         return true;
 
-    wxRegKey rk(wxRegKey::HKCU, "Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize");
-    if ( rk.Exists() && rk.HasValue("AppsUseLightTheme") )
-    {
-        long value = -1;
-        if ( rk.QueryValue("AppsUseLightTheme", &value) )
-            return value <= 0;
-    }
-
+    // Note that we should _not_ check if the system is configured to use the
+    // dark mode for the other applications here, what matters is whether this
+    // application itself uses dark colour schema or not.
     return IsUsingDarkBackground();
 }

--- a/src/msw/spinbutt.cpp
+++ b/src/msw/spinbutt.cpp
@@ -139,6 +139,13 @@ wxSpinButton::~wxSpinButton()
 {
 }
 
+bool wxSpinButton::MSWShouldUseAutoDarkMode() const
+{
+    // Native control doesn't seem to have any support for dark theme, so
+    // invert it in dark mode -- this is not great, but better than nothing.
+    return true;
+}
+
 // ----------------------------------------------------------------------------
 // size calculation
 // ----------------------------------------------------------------------------

--- a/src/msw/statbox.cpp
+++ b/src/msw/statbox.cpp
@@ -95,6 +95,15 @@ bool wxStaticBox::Create(wxWindow *parent,
     return true;
 }
 
+bool wxStaticBox::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
+{
+    // Static boxes don't seem to have any dark mode support, so just set the
+    // foreground colour contrasting with the dark background for them.
+    support.setForeground = true;
+
+    return true;
+}
+
 bool wxStaticBox::ShouldUseCustomPaint() const
 {
     // When not using double buffering, we paint the box ourselves by default

--- a/src/msw/statusbar.cpp
+++ b/src/msw/statusbar.cpp
@@ -679,10 +679,15 @@ bool wxStatusBar::MSWOnNotify(int WXUNUSED(idCtrl), WXLPARAM lParam, WXLPARAM* W
 }
 #endif // wxUSE_TOOLTIPS
 
-const wchar_t* wxStatusBar::MSWGetDarkThemeId() const
+bool wxStatusBar::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
 {
     // This is not documented anywhere but seems to work.
-    return L"ExplorerStatusBar";
+    //
+    // Note that we should _not_ set the theme name to "Explorer", this ID only
+    // works if we do _not_ do it.
+    support.themeId = L"ExplorerStatusBar";
+
+    return true;
 }
 
 #endif // wxUSE_STATUSBAR && wxUSE_NATIVE_STATUSBAR

--- a/src/msw/statusbar.cpp
+++ b/src/msw/statusbar.cpp
@@ -679,7 +679,7 @@ bool wxStatusBar::MSWOnNotify(int WXUNUSED(idCtrl), WXLPARAM lParam, WXLPARAM* W
 }
 #endif // wxUSE_TOOLTIPS
 
-const wchar_t* wxStatusBar::MSWGetDarkThemeClass() const
+const wchar_t* wxStatusBar::MSWGetDarkThemeId() const
 {
     // This is not documented anywhere but seems to work.
     return L"ExplorerStatusBar";

--- a/src/msw/statusbar.cpp
+++ b/src/msw/statusbar.cpp
@@ -679,4 +679,10 @@ bool wxStatusBar::MSWOnNotify(int WXUNUSED(idCtrl), WXLPARAM lParam, WXLPARAM* W
 }
 #endif // wxUSE_TOOLTIPS
 
+const wchar_t* wxStatusBar::MSWGetDarkThemeClass() const
+{
+    // This is not documented anywhere but seems to work.
+    return L"ExplorerStatusBar";
+}
+
 #endif // wxUSE_STATUSBAR && wxUSE_NATIVE_STATUSBAR

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -2108,7 +2108,7 @@ bool wxToolBar::HandlePaint(WXWPARAM wParam, WXLPARAM lParam)
     {
         // erase the dummy separators region ourselves now as nobody painted
         // over them
-        WindowHDC hdc(GetHwnd());
+        ClientHDC hdc(GetHwnd());
         ::SelectClipRgn(hdc, GetHrgnOf(rgnDummySeps));
         MSWDoEraseBackground(hdc);
     }

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -60,6 +60,8 @@
 #include "wx/msw/uxtheme.h"
 #endif
 
+#include "wx/msw/private/darkmode.h"
+
 // ----------------------------------------------------------------------------
 // constants
 // ----------------------------------------------------------------------------
@@ -334,6 +336,11 @@ static bool MSWShouldBeChecked(const wxToolBarToolBase *tool)
     return tool->IsToggled();
 }
 
+static COLORREF wxSysColourToRGB(wxSystemColour syscol)
+{
+    return wxColourToRGB(wxSystemSettings::GetColour(syscol));
+}
+
 // ============================================================================
 // implementation
 // ============================================================================
@@ -462,6 +469,18 @@ bool wxToolBar::MSWCreateToolbar(const wxPoint& pos, const wxSize& size)
         ::SetWindowLong(hwndTTip, GWL_STYLE, styleTTip);
     }
 #endif // wxUSE_TOOLTIPS
+
+    // Change the color scheme when using the dark mode even though MSDN says
+    // that it's not used with comctl32 v6, it actually still is for "3D"
+    // separator above the toolbar, which is drawn partially in white by
+    // default and so looks very ugly in dark mode.
+    if ( wxMSWDarkMode::IsActive() )
+    {
+        COLORSCHEME colScheme{sizeof(COLORSCHEME)};
+        colScheme.clrBtnHighlight =
+        colScheme.clrBtnShadow = wxSysColourToRGB(wxSYS_COLOUR_WINDOW);
+        ::SendMessage(GetHwnd(), TB_SETCOLORSCHEME, 0, (LPARAM)&colScheme);
+    }
 
     return true;
 }
@@ -712,6 +731,17 @@ WXDWORD wxToolBar::MSWGetStyle(long style, WXDWORD *exstyle) const
     msStyle |= TBSTYLE_TRANSPARENT;
 
     return msStyle;
+}
+
+bool wxToolBar::MSWGetDarkModeSupport(MSWDarkModeSupport& support) const
+{
+    wxToolBarBase::MSWGetDarkModeSupport(support);
+
+    // This ensures GetForegroundColour(), used in our custom draw code,
+    // returns the correct colour.
+    support.setForeground = true;
+
+    return true;
 }
 
 int wxToolBar::MSWGetToolTipMessage() const
@@ -1616,7 +1646,7 @@ bool wxToolBar::MSWCommand(WXUINT WXUNUSED(cmd), WXWORD id_)
 
 bool wxToolBar::MSWOnNotify(int WXUNUSED(idCtrl),
                             WXLPARAM lParam,
-                            WXLPARAM *WXUNUSED(result))
+                            WXLPARAM *result)
 {
     LPNMHDR hdr = (LPNMHDR)lParam;
     if ( hdr->code == TBN_DROPDOWN )
@@ -1645,6 +1675,32 @@ bool wxToolBar::MSWOnNotify(int WXUNUSED(idCtrl),
         return true;
     }
 
+    if ( hdr->code == NM_CUSTOMDRAW )
+    {
+        NMTBCUSTOMDRAW* const nmtbcd = (NMTBCUSTOMDRAW*)lParam;
+        switch ( nmtbcd->nmcd.dwDrawStage )
+        {
+            case CDDS_PREPAINT:
+                if ( !wxMSWDarkMode::IsActive() )
+                    break;
+
+                *result = CDRF_NOTIFYITEMDRAW;
+                return true;
+
+            case CDDS_ITEMPREPAINT:
+                // If we get here, we must have returned CDRF_NOTIFYITEMDRAW
+                // from above, so we're using the dark mode and need to
+                // customize the colours for it.
+                nmtbcd->clrText =
+                nmtbcd->clrTextHighlight = wxColourToRGB(GetForegroundColour());
+                nmtbcd->clrHighlightHotTrack = wxSysColourToRGB(wxSYS_COLOUR_HOTLIGHT);
+
+                *result = CDRF_DODEFAULT | TBCDRF_USECDCOLORS | TBCDRF_HILITEHOTTRACK;
+                return true;
+        }
+
+        return false;
+    }
 
     if( !HasFlag(wxTB_NO_TOOLTIPS) )
     {

--- a/src/msw/toolbar.cpp
+++ b/src/msw/toolbar.cpp
@@ -714,6 +714,11 @@ WXDWORD wxToolBar::MSWGetStyle(long style, WXDWORD *exstyle) const
     return msStyle;
 }
 
+int wxToolBar::MSWGetToolTipMessage() const
+{
+    return TB_GETTOOLTIPS;
+}
+
 // ----------------------------------------------------------------------------
 // adding/removing tools
 // ----------------------------------------------------------------------------

--- a/src/msw/tooltip.cpp
+++ b/src/msw/tooltip.cpp
@@ -34,6 +34,7 @@
 #include "wx/tokenzr.h"
 #include "wx/vector.h"
 #include "wx/msw/private.h"
+#include "wx/msw/private/darkmode.h"
 
 #ifndef TTTOOLINFO_V1_SIZE
     #define TTTOOLINFO_V1_SIZE 0x28
@@ -314,6 +315,7 @@ WXHWND wxToolTip::GetToolTipCtrl()
        if ( ms_hwndTT )
        {
            HWND hwnd = (HWND)ms_hwndTT;
+           wxMSWDarkMode::AllowForWindow(hwnd);
            SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0,
                         SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
 

--- a/src/msw/toplevel.cpp
+++ b/src/msw/toplevel.cpp
@@ -39,6 +39,7 @@
 #include "wx/tooltip.h"
 
 #include "wx/msw/private.h"
+#include "wx/msw/private/darkmode.h"
 #include "wx/msw/private/winstyle.h"
 
 #include "wx/msw/winundef.h"
@@ -509,6 +510,8 @@ bool wxTopLevelWindowMSW::Create(wxWindow *parent,
     // make the keyboard indicators (such as underlines for accelerators and
     // focus rectangles) work under Win2k+
     MSWUpdateUIState(UIS_INITIALIZE);
+
+    wxMSWDarkMode::EnableForTLW(GetHwnd());
 
     return true;
 }

--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -2208,6 +2208,11 @@ void wxTreeCtrl::SortChildren(const wxTreeItemId& item)
 // implementation
 // ----------------------------------------------------------------------------
 
+int wxTreeCtrl::MSWGetToolTipMessage() const
+{
+    return TVM_GETTOOLTIPS;
+}
+
 bool wxTreeCtrl::MSWShouldPreProcessMessage(WXMSG* msg)
 {
     if ( msg->message == WM_KEYDOWN )

--- a/src/msw/treectrl.cpp
+++ b/src/msw/treectrl.cpp
@@ -3660,7 +3660,7 @@ bool wxTreeCtrl::MSWOnNotify(int idCtrl, WXLPARAM lParam, WXLPARAM *result)
                 POINT point;
                 point.x = GET_X_LPARAM(pos);
                 point.y = GET_Y_LPARAM(pos);
-                ::MapWindowPoints(HWND_DESKTOP, GetHwnd(), &point, 1);
+                wxMapWindowPoints(HWND_DESKTOP, GetHwnd(), &point);
                 int htFlags = 0;
                 wxTreeItemId item = HitTest(wxPoint(point.x, point.y), htFlags);
 

--- a/src/msw/uxtheme.cpp
+++ b/src/msw/uxtheme.cpp
@@ -36,6 +36,23 @@ bool wxUxThemeIsActive()
 {
     return ::IsAppThemed() && ::IsThemeActive();
 }
+
+wxColour wxUxThemeHandle::GetColour(int part, int prop, int state) const
+{
+    COLORREF col;
+
+    HRESULT hr = ::GetThemeColor(m_hTheme, part, state, prop, &col);
+    if ( FAILED(hr) )
+    {
+        wxLogApiError(
+            wxString::Format("GetThemeColor(%i, %i, %i)", part, state, prop),
+            hr
+        );
+        return wxColour{};
+    }
+
+    return wxRGBToColour(col);
+}
 #else
 bool wxUxThemeIsActive()
 {

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -5106,6 +5106,13 @@ bool wxWindowMSW::HandleCaptureChanged(WXHWND hWndGainedCapture)
 
 bool wxWindowMSW::HandleSettingChange(WXWPARAM wParam, WXLPARAM lParam)
 {
+    // Check for the special case of changing the system light/dark mode.
+    if ( lParam && wxStrcmp((TCHAR*)lParam, wxT("ImmersiveColorSet")) == 0 )
+    {
+        // Forward to the existing function generating an event for this.
+        HandleSysColorChange();
+    }
+
     // despite MSDN saying "(This message cannot be sent directly to a window.)"
     // we need to send this to child windows (it is only sent to top-level
     // windows) so {list,tree}ctrls can adjust their font size if necessary

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -1950,8 +1950,9 @@ void wxWindowMSW::DoGetPosition(int *x, int *y) const
         {
             // In RTL mode, we want the logical left x-coordinate,
             // which would be the physical right x-coordinate.
-            ::MapWindowPoints(nullptr, parent ? GetHwndOf(parent) : HWND_DESKTOP,
-                              (LPPOINT)&rect, 2);
+            wxMapWindowPoints(HWND_DESKTOP,
+                              parent ? GetHwndOf(parent) : HWND_DESKTOP,
+                              &rect);
         }
 
         pos.x = rect.left;
@@ -5456,7 +5457,7 @@ wxWindowMSW::MSWGetBgBrushForChild(WXHDC hDC, wxWindowMSW *child)
         // uses RTL layout, which is exactly what we need here as the child
         // window origin is its _right_ top corner in this case and not the
         // left one.
-        ::MapWindowPoints(nullptr, GetHwnd(), (POINT *)&rc, 2);
+        wxMapWindowPoints(HWND_DESKTOP, GetHwnd(), &rc);
 
         int x = rc.left,
             y = rc.top;

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -5244,68 +5244,6 @@ extern wxCOLORMAP *wxGetStdColourMap()
     return s_cmap;
 }
 
-#if wxUSE_UXTHEME && !defined(TMT_FILLCOLOR)
-    #define TMT_FILLCOLOR       3802
-    #define TMT_TEXTCOLOR       3803
-    #define TMT_BORDERCOLOR     3801
-#endif
-
-wxColour wxWindowMSW::MSWGetThemeColour(const wchar_t *themeName,
-                                        int themePart,
-                                        int themeState,
-                                        MSWThemeColour themeColour,
-                                        wxSystemColour fallback) const
-{
-#if wxUSE_UXTHEME
-    if ( wxUxThemeIsActive() )
-    {
-        int themeProperty = 0;
-
-        // TODO: Convert this into a table? Sure would be faster.
-        switch ( themeColour )
-        {
-            case ThemeColourBackground:
-                themeProperty = TMT_FILLCOLOR;
-                break;
-            case ThemeColourText:
-                themeProperty = TMT_TEXTCOLOR;
-                break;
-            case ThemeColourBorder:
-                themeProperty = TMT_BORDERCOLOR;
-                break;
-            default:
-                wxFAIL_MSG(wxT("unsupported theme colour"));
-        }
-
-        wxUxThemeHandle hTheme((const wxWindow *)this, themeName);
-        COLORREF col;
-        HRESULT hr = ::GetThemeColor
-                            (
-                                hTheme,
-                                themePart,
-                                themeState,
-                                themeProperty,
-                                &col
-                            );
-
-        if ( SUCCEEDED(hr) )
-            return wxRGBToColour(col);
-
-        wxLogApiError(
-            wxString::Format(
-                "GetThemeColor(%s, %i, %i, %i)",
-                themeName, themePart, themeState, themeProperty),
-            hr);
-    }
-#else
-    wxUnusedVar(themeName);
-    wxUnusedVar(themePart);
-    wxUnusedVar(themeState);
-    wxUnusedVar(themeColour);
-#endif
-    return wxSystemSettings::GetColour(fallback);
-}
-
 // ---------------------------------------------------------------------------
 // painting
 // ---------------------------------------------------------------------------

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3135,7 +3135,7 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
             else // no DC given
             {
                 if ( MSWShouldUseAutoDarkMode() &&
-                        wxMSWDarkMode::PaintIfNecessary(this) )
+                        wxMSWDarkMode::PaintIfNecessary(GetHwnd(), m_oldWndProc) )
                     processed = true;
                 else
                     processed = HandlePaint();

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -76,6 +76,7 @@
 #endif
 
 #include "wx/msw/private.h"
+#include "wx/msw/private/darkmode.h"
 #include "wx/msw/private/dpiaware.h"
 #include "wx/msw/private/keyboard.h"
 #include "wx/msw/private/paint.h"
@@ -3132,7 +3133,11 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
             }
             else // no DC given
             {
-                processed = HandlePaint();
+                if ( MSWShouldUseAutoDarkMode() &&
+                        wxMSWDarkMode::PaintIfNecessary(this) )
+                    processed = true;
+                else
+                    processed = HandlePaint();
             }
             break;
 

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -3816,7 +3816,7 @@ wxWindowMSW::MSWHandleMessage(WXLRESULT *result,
                     // it below if it fails.
                     RECT rcClient;
 
-                    WindowHDC hdc(GetHwnd());
+                    ClientHDC hdc(GetHwnd());
 
                     if ( ::GetThemeBackgroundContentRect
                                 (
@@ -4878,7 +4878,7 @@ wxSize wxWindowMSW::GetDPI() const
 
     if ( !dpi.x || !dpi.y )
     {
-        dpi = wxGetDPIofHDC(WindowHDC(hwnd));
+        dpi = wxGetDPIofHDC(ClientHDC(hwnd));
     }
 
     return dpi;

--- a/src/msw/window.cpp
+++ b/src/msw/window.cpp
@@ -4075,6 +4075,16 @@ bool wxWindowMSW::MSWCreate(const wxChar *wclass,
         return false;
     }
 
+    if ( wxMSWDarkMode::IsActive() )
+    {
+        // We currently allow customizing the theme at wxControl level as some
+        // native controls require using a different theme, but for plain
+        // windows it looks like the default ("Explorer") should always be used
+        // and its only (but important) effect is to make their scrollbars
+        // dark, if they're used.
+        wxMSWDarkMode::AllowForWindow(m_hWnd);
+    }
+
     SubclassWin(m_hWnd);
 
     return true;

--- a/tests/controls/pickertest.cpp
+++ b/tests/controls/pickertest.cpp
@@ -208,8 +208,7 @@ void FontPickerCtrlTestCase::ColourSelection()
 {
     wxColour selectedColour(0xFF4269UL);
 
-    CPPUNIT_ASSERT_EQUAL_MESSAGE("Default font picker color must be black",
-        m_font->GetSelectedColour(), wxColour(*wxBLACK));
+    CHECK( m_font->GetSelectedColour() != selectedColour );
 
     m_font->SetSelectedColour(selectedColour);
 


### PR DESCRIPTION
This is not complete yet, but it's already doing something (note that you need to enable it explicitly to test, the simplest way to do it is by setting `WX_MSW_DARK_MODE=2` in the environment).

The most glaring missing piece (at least among those that I've seen, maybe there is something even worse) is support for dark scrollbars. Support for this in some other projects is achieved by hooking `OpenNcThemeData()` function and forcing it to use `Explorer::ScrollBar` instead of `ScrollBar`, but doing this requires mucking with IAT and doesn't seem very robust, so I'm not really sure what to do about it yet. We could add an option to opt-in into doing this, but this looks like a cop out rather than a real solution.

Anyhow, testing this is already welcome, even if, to return to the beginning, many things don't work yet.

Things known not to work and already in my pipeline:

- [x] Radio box buttons are unreadable (I'd like to rewrite `wxRadioBox` to use `wxRadioButton` to fix this, no idea why hadn't it been done like this 30 years ago already...).
- [x] Toolbar problems.
- [x] `wxFontPickerCtrl` initial colour.
- [x] Non-top notebook tabs.
- [ ] Light scrollbars: see above.
- [ ] wxSTC.
- [ ] wxAUI.