### PR TITLE
wxListCtrl fixes for wxQt

### DIFF
--- a/include/wx/qt/listctrl.h
+++ b/include/wx/qt/listctrl.h
@@ -264,6 +264,11 @@ public:
     // data is arbitrary data to be passed to the sort function.
     bool SortItems(wxListCtrlCompare fn, wxIntPtr data);
 
+    // Sort indicator in header.
+    virtual void ShowSortIndicator(int col, bool ascending = true) override;
+    virtual int GetSortIndicator() const override;
+    virtual bool IsAscendingSortIndicator() const override;
+
     virtual QWidget *GetHandle() const override;
 
 protected:

--- a/include/wx/qt/listctrl.h
+++ b/include/wx/qt/listctrl.h
@@ -209,6 +209,8 @@ public:
     // Ensures this item is visible
     bool EnsureVisible(long item);
 
+    bool IsVisible(long item) const override;
+
     // Find an item whose label matches this string, starting from the item after 'start'
     // or the beginning if 'start' is -1.
     long FindItem(long start, const wxString& str, bool partial = false);

--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -632,6 +632,10 @@ public:
         Gets the number of items that can fit vertically in the visible area of
         the list control (list or report view) or the total number of items in
         the list control (icon or small icon view).
+
+        @note The caller must ensure that there is at least one item in the control
+              to be able to calculate the count per page under wxQt, otherwise 0 will
+              be returned.
     */
     int GetCountPerPage() const;
 

--- a/interface/wx/listctrl.h
+++ b/interface/wx/listctrl.h
@@ -1077,7 +1077,7 @@ public:
         @c wxLIST_AUTOSIZE will resize the column to the length of its longest item.
 
         @c wxLIST_AUTOSIZE_USEHEADER will resize the column to the length of the
-        header (Win32) or 80 pixels (other platforms).
+        header (wxMSW and wxQt) or 80 pixels (other platforms).
 
         In small or normal icon view, @a col must be -1, and the column width is set
         for all columns.

--- a/samples/listctrl/listtest.cpp
+++ b/samples/listctrl/listtest.cpp
@@ -151,6 +151,8 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_MENU(LIST_TOGGLE_HEADER, MyFrame::OnToggleHeader)
     EVT_MENU(LIST_TOGGLE_BELL, MyFrame::OnToggleBell)
     EVT_MENU(LIST_CHECKVISIBILITY, MyFrame::OnCheckVisibility)
+    EVT_MENU(LIST_AUTOSIZE, MyFrame::OnAutoResize)
+    EVT_MENU(LIST_AUTOSIZE_USEHEADER, MyFrame::OnAutoResize)
     EVT_MENU(LIST_FIND, MyFrame::OnFind)
     EVT_MENU(LIST_TOGGLE_CHECKBOX, MyFrame::OnToggleItemCheckBox)
     EVT_MENU(LIST_GET_CHECKBOX, MyFrame::OnGetItemCheckBox)
@@ -259,6 +261,9 @@ MyFrame::MyFrame(const wxString& title)
     menuList->Check(LIST_TOGGLE_HEADER, true);
     menuList->AppendCheckItem(LIST_TOGGLE_BELL, "Toggle &bell on no match");
     menuList->Append( LIST_CHECKVISIBILITY, "Check if lines 2 and 9 are visible" );
+    menuList->AppendSeparator();
+    menuList->Append( LIST_AUTOSIZE, "Auto resize column 2\tCtrl-R" );
+    menuList->Append( LIST_AUTOSIZE_USEHEADER, "Auto resize column 2 (use header)\tCtrl-Shift-R" );
     menuList->AppendSeparator();
     menuList->AppendCheckItem(LIST_TOGGLE_CHECKBOXES,
                               "&Enable Checkboxes");
@@ -377,6 +382,20 @@ void MyFrame::OnCheckVisibility(wxCommandEvent& WXUNUSED(event))
         wxLogMessage( "Line 9 is visible" );
     else
         wxLogMessage( "Line 9 is not visible" );
+}
+
+void MyFrame::OnAutoResize(wxCommandEvent& event)
+{
+    if ( event.GetId() == LIST_AUTOSIZE )
+    {
+        wxLogMessage( "Column 2 resized to content" );
+        m_listCtrl->SetColumnWidth(1, wxLIST_AUTOSIZE);
+    }
+    else
+    {
+        wxLogMessage( "Column 2 resized to header" );
+        m_listCtrl->SetColumnWidth(1, wxLIST_AUTOSIZE_USEHEADER);
+    }
 }
 
 void MyFrame::OnGoTo(wxCommandEvent& WXUNUSED(event))

--- a/samples/listctrl/listtest.h
+++ b/samples/listctrl/listtest.h
@@ -117,6 +117,7 @@ protected:
     void OnVirtualView(wxCommandEvent& event);
     void OnSmallVirtualView(wxCommandEvent& event);
     void OnCheckVisibility(wxCommandEvent& event);
+    void OnAutoResize(wxCommandEvent& event);
     void OnSetItemsCount(wxCommandEvent& event);
 
 
@@ -243,5 +244,7 @@ enum
     LIST_THAW,
     LIST_TOGGLE_LINES,
     LIST_CHECKVISIBILITY,
+    LIST_AUTOSIZE,
+    LIST_AUTOSIZE_USEHEADER,
     LIST_CTRL                   = 1000
 };

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -1376,7 +1376,7 @@ bool wxListCtrl::SetItemData(long item, long data)
 bool wxListCtrl::GetItemRect(long item, wxRect& rect, int WXUNUSED(code)) const
 {
     wxCHECK_MSG(item >= 0 && (item < GetItemCount()), false,
-                 "invalid item in GetSubItemRect");
+                 "invalid item in GetItemRect");
 
     const int columnCount = m_model->columnCount(QModelIndex());
     if ( columnCount == 0 )
@@ -1395,7 +1395,7 @@ bool wxListCtrl::GetItemRect(long item, wxRect& rect, int WXUNUSED(code)) const
 bool wxListCtrl::GetSubItemRect(long item,
                                 long subItem,
                                 wxRect& rect,
-                                int WXUNUSED(code)) const
+                                int code) const
 {
     wxCHECK_MSG(item >= 0 && item < GetItemCount(),
         false, "invalid row index in GetSubItemRect");
@@ -1406,6 +1406,45 @@ bool wxListCtrl::GetSubItemRect(long item,
     const QModelIndex index = m_qtTreeWidget->model()->index(item, subItem);
     rect = wxQtConvertRect(m_qtTreeWidget->visualRect(index));
     rect.Offset(0, m_qtTreeWidget->GetHeaderHeight());
+
+    switch ( code )
+    {
+        case wxLIST_RECT_BOUNDS:
+            // Nothing to do.
+            break;
+
+        case wxLIST_RECT_ICON:
+        case wxLIST_RECT_LABEL:
+            {
+                QVariant var = index.data(Qt::DecorationRole);
+                if ( var.isValid() )
+                {
+                    const int iconWidth = m_qtTreeWidget->iconSize().width();
+
+                    if ( code == wxLIST_RECT_ICON )
+                    {
+                        rect.width = iconWidth;
+                    }
+                    else // wxLIST_RECT_LABEL
+                    {
+                        rect.x += iconWidth;
+                        rect.width -= iconWidth;
+                    }
+                }
+                else // No icon
+                {
+                    if ( code == wxLIST_RECT_ICON )
+                        rect = wxRect();
+                    //else: label rect is the same as the full one
+                }
+            }
+            break;
+
+        default:
+            wxFAIL_MSG(wxS("Unknown rectangle requested"));
+            return false;
+        }
+
     return true;
 }
 

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -955,8 +955,8 @@ class wxQtListTreeWidget : public wxQtEventSignalHandler< QTreeView, wxListCtrl 
     // Data type passed to EmitListEvent() as extra data
     struct ListEventData
     {
-        int m_colOrFirstRow = -1; // column index or first (de)selected row
-        int m_colWidthOrLastRow = -1; // column width or last (de)selected row
+        int m_colOrFirstRow; // column index or first (de)selected row
+        int m_colWidthOrLastRow; // column width or last (de)selected row
     };
 
 public:

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -1138,6 +1138,7 @@ bool wxListCtrl::Create(wxWindow *parent,
 
     m_qtTreeWidget->setRootIsDecorated(false);
     m_qtTreeWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_qtTreeWidget->setTabKeyNavigation(true);
 
     if ( !QtCreateControl(parent, id, pos, size, style, validator, name) )
         return false;

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -299,6 +299,25 @@ public:
 
             case Qt::TextAlignmentRole:
                 return header.m_align;
+
+            case Qt::DecorationRole:
+            {
+                wxImageList *imageList = GetImageList();
+                if ( imageList == nullptr )
+                    return QVariant();
+
+                int imageIndex = -1;
+
+                if ( imageIndex == -1 )
+                    imageIndex = header.m_image;
+
+                if ( imageIndex == -1 )
+                    return QVariant();
+
+                wxBitmap image = imageList->GetBitmap(imageIndex);
+                wxCHECK_MSG(image.IsOk(), QVariant(), "Invalid image");
+                return QVariant::fromValue(*image.GetHandle());
+            }
         }
         return QVariant();
     }
@@ -714,7 +733,7 @@ public:
 protected:
     wxImageList *GetImageList() const
     {
-        const int requiredList = m_listCtrl->HasFlag(wxLC_SMALL_ICON)
+        const int requiredList = m_listCtrl->HasFlag(wxLC_SMALL_ICON | wxLC_LIST | wxLC_REPORT)
             ? wxIMAGE_LIST_SMALL
             : wxIMAGE_LIST_NORMAL;
         return m_listCtrl->GetImageList(requiredList);
@@ -1597,9 +1616,17 @@ long wxListCtrl::GetNextItem(long item, int WXUNUSED(geometry), int state) const
     return -1;
 }
 
-void wxListCtrl::DoUpdateImages(int WXUNUSED(which))
+void wxListCtrl::DoUpdateImages(int which)
 {
-    // TODO: Ensure the icons are actually updated.
+    wxImageList* const imageList = GetUpdatedImageList(which);
+
+    if ( imageList )
+    {
+        int width, height;
+        imageList->GetSize(0, width, height);
+        m_qtTreeWidget->setIconSize(QSize(width, height));
+        m_qtTreeWidget->update();
+    }
 }
 
 void wxListCtrl::RefreshItem(long item)

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -153,12 +153,18 @@ public:
     {
     }
 
-    int rowCount(const QModelIndex& WXUNUSED(parent) = QModelIndex()) const override
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override
     {
+        if ( parent.isValid() )
+            return 0;
+
         return static_cast<int>(m_rows.size());
     }
-    int columnCount(const QModelIndex& WXUNUSED(parent) = QModelIndex()) const override
+    int columnCount(const QModelIndex& parent = QModelIndex()) const override
     {
+        if ( parent.isValid() )
+            return 0;
+
         return static_cast<int>(m_headers.size());
     }
 
@@ -884,8 +890,11 @@ public:
     {
     }
 
-    int rowCount(const QModelIndex& WXUNUSED(parent) = QModelIndex()) const override
+    int rowCount(const QModelIndex& parent = QModelIndex()) const override
     {
+        if ( parent.isValid() )
+            return 0;
+
         return m_rowCount;
     }
 

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -1128,9 +1128,6 @@ bool wxListCtrl::Create(wxWindow *parent,
     m_qtTreeWidget->setModel(m_model);
     m_model->SetView(m_qtTreeWidget);
 
-    if (style & wxLC_NO_HEADER)
-        m_qtTreeWidget->setHeaderHidden(true);
-
     m_qtTreeWidget->setRootIsDecorated(false);
     m_qtTreeWidget->setSelectionBehavior(QAbstractItemView::SelectRows);
 

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -226,7 +226,7 @@ public:
 
             case Qt::CheckStateRole:
                 return col == 0 && m_listCtrl->HasCheckBoxes()
-                    ? rowItem.m_checked
+                    ? rowItem.CheckState()
                     : QVariant();
 
             default:
@@ -802,6 +802,11 @@ private:
         ColumnItem &operator[](int index)
         {
             return m_columns[index];
+        }
+
+        Qt::CheckState CheckState() const
+        {
+            return m_checked ? Qt::Checked : Qt::Unchecked;
         }
 
         std::vector<ColumnItem> m_columns;

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -1005,6 +1005,17 @@ public:
         return m_itemDelegate.GetEditControl();
     }
 
+    void EnableEditLabel(bool enable)
+    {
+        if ( enable )
+        {
+            setItemDelegate(&m_itemDelegate);
+            setEditTriggers(SelectedClicked | EditKeyPressed);
+        }
+        else
+            setEditTriggers(NoEditTriggers);
+    }
+
     virtual void paintEvent(QPaintEvent *event) override
     {
         QTreeView::paintEvent(event);
@@ -1050,9 +1061,6 @@ wxQtListTreeWidget::wxQtListTreeWidget( wxWindow *parent, wxListCtrl *handler )
     connect(this, &QTreeView::clicked, this, &wxQtListTreeWidget::itemClicked);
     connect(this, &QTreeView::pressed, this, &wxQtListTreeWidget::itemPressed);
     connect(this, &QTreeView::activated, this, &wxQtListTreeWidget::itemActivated);
-
-    setItemDelegate(&m_itemDelegate);
-    setEditTriggers(NoEditTriggers);
 }
 
 void wxQtListTreeWidget::EmitListEvent(wxEventType typ,
@@ -1614,6 +1622,7 @@ void wxListCtrl::SetWindowStyleFlag(long style)
 {
     m_windowStyle = style;
     m_qtTreeWidget->setHeaderHidden((style & wxLC_NO_HEADER) != 0);
+    m_qtTreeWidget->EnableEditLabel((style & wxLC_EDIT_LABELS) != 0);
     m_qtTreeWidget->setSelectionMode((style & wxLC_SINGLE_SEL) != 0
         ? QAbstractItemView::SingleSelection
         : QAbstractItemView::ExtendedSelection
@@ -1758,6 +1767,7 @@ wxTextCtrl* wxListCtrl::EditLabel(long item,
     // Open the editor first so that it's available when handling events as per
     // wx standard.
     const QModelIndex index = m_model->index(item, 0);
+    m_qtTreeWidget->selectionModel()->setCurrentIndex(index, QItemSelectionModel::Select);
     m_qtTreeWidget->openPersistentEditor(index);
 
     wxListEvent event;

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -985,6 +985,24 @@ public:
         return header() != nullptr ? header()->height() : 0;
     }
 
+    int GetRowCount() const
+    {
+        if ( model() )
+            return model()->rowCount();
+
+        return 0;
+    }
+
+    int GetCountPerPage() const
+    {
+        // this may not be exact but should be a good approximation:
+        const int h = rowHeight(model()->index(0, 0));
+        if ( h )
+            return viewport()->height() / h;
+        else
+            return 0;
+    }
+
 private:
     void itemClicked(const QModelIndex &index);
     void itemActivated(const QModelIndex &index);
@@ -1170,12 +1188,9 @@ bool wxListCtrl::SetColumnsOrder(const wxArrayInt& WXUNUSED(orders))
 
 int wxListCtrl::GetCountPerPage() const
 {
-    // this may not be exact but should be a good approximation:
-    const int h = m_qtTreeWidget->visualRect(m_model->index(0, 0)).height();
-    if ( h )
-        return m_qtTreeWidget->height() / h;
-    else
-        return 0;
+    wxCHECK_MSG(m_qtTreeWidget->GetRowCount() > 0, 0,
+        "wxListCtrl needs at least one item to calculate the count per page");
+    return m_qtTreeWidget->GetCountPerPage();
 }
 
 wxRect wxListCtrl::GetViewRect() const

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -386,8 +386,13 @@ public:
             false, "Invalid column");
 
         ColumnItem &column = m_headers[index];
-        column.m_label = wxQtConvertString(info.GetText());
-        column.m_align = wxQtConvertTextAlign(info.GetAlign());
+
+        if ( info.m_mask & wxLIST_MASK_TEXT )
+            column.m_label = wxQtConvertString(info.GetText());
+        if ( info.m_mask & wxLIST_MASK_FORMAT )
+            column.m_align = wxQtConvertTextAlign(info.GetAlign());
+        if ( info.m_mask & wxLIST_MASK_IMAGE )
+            column.m_image = info.m_image;
 
         headerDataChanged(Qt::Horizontal, index, index);
         return true;

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -1364,7 +1364,11 @@ int wxListCtrl::GetItemCount() const
 
 int wxListCtrl::GetColumnCount() const
 {
-    return m_model->columnCount(QModelIndex());
+    // wxLC_LIST is special as we want to return 1 for it, for compatibility
+    // with the native wxMSW version and not the real number of columns, which
+    // is 0. For the other non-wxLC_REPORT modes returning 0 is fine, however,
+    // as wxMSW does it too.
+    return HasFlag(wxLC_LIST) ? 1 : m_model->columnCount(QModelIndex());
 }
 
 wxSize wxListCtrl::GetItemSpacing() const

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -1671,6 +1671,17 @@ bool wxListCtrl::EnsureVisible(long item)
     return true;
 }
 
+bool wxListCtrl::IsVisible(long item) const
+{
+    wxRect itemRect;
+    if ( !GetItemRect(item, itemRect) )
+        return false;
+
+    wxRect viewportRect = wxQtConvertRect( m_qtTreeWidget->viewport()->rect() );
+    viewportRect.y += m_qtTreeWidget->GetHeaderHeight();
+    return !viewportRect.Intersect(itemRect).IsEmpty();
+}
+
 long wxListCtrl::FindItem(long start, const wxString& str, bool partial)
 {
     return m_model->FindItem(start, wxQtConvertString(str), partial);

--- a/src/qt/listctrl.cpp
+++ b/src/qt/listctrl.cpp
@@ -706,7 +706,9 @@ public:
     void SortItems(wxListCtrlCompare fn, wxIntPtr data)
     {
         CompareAdapter compare(fn, data);
+        beginResetModel();
         std::sort(m_rows.begin(), m_rows.end(), compare);
+        endResetModel();
     }
 
     bool IsItemChecked(long item) const
@@ -1092,6 +1094,7 @@ protected:
         {
             setSectionsClickable(true);
             setContextMenuPolicy(Qt::CustomContextMenu);
+            setSortIndicatorShown(true);
 
             connect(this, &QHeaderView::sectionClicked,
                     this, &wxQtHeaderView::sectionClicked);
@@ -1188,6 +1191,8 @@ wxQtListTreeWidget::wxQtListTreeWidget( wxWindow *parent, wxListCtrl *handler )
     m_closingEditor(0)
 {
     setHeader(new wxQtHeaderView(this));
+
+    setSortingEnabled(true);
 
     connect(this, &QTreeView::pressed, this, &wxQtListTreeWidget::itemPressed);
     connect(this, &QTreeView::activated, this, &wxQtListTreeWidget::itemActivated);
@@ -2105,6 +2110,36 @@ bool wxListCtrl::ScrollList(int dx, int dy)
 bool wxListCtrl::SortItems(wxListCtrlCompare fn, wxIntPtr data)
 {
     m_model->SortItems(fn, data);
+    return true;
+}
+
+void wxListCtrl::ShowSortIndicator(int col, bool ascending)
+{
+    const auto header = m_qtTreeWidget->header();
+    if ( header )
+        header->setSortIndicator(col, ascending ? Qt::DescendingOrder
+                                                : Qt::AscendingOrder);
+}
+
+int wxListCtrl::GetSortIndicator() const
+{
+    const auto header = m_qtTreeWidget->header();
+    if ( header && header->isSortIndicatorShown() )
+    {
+        // If no section has a sort indicator, sortIndicatorSection()
+        // returns section 0 by default.
+        return header->sortIndicatorSection();
+    }
+
+    return -1;
+}
+
+bool wxListCtrl::IsAscendingSortIndicator() const
+{
+    const auto header = m_qtTreeWidget->header();
+    if ( header )
+        return header->sortIndicatorOrder() == Qt::AscendingOrder;
+
     return true;
 }
 


### PR DESCRIPTION
The following events are still not implemented by this PR:
```
wxEVT_LIST_BEGIN_DRAG
wxEVT_LIST_BEGIN_RDRAG
wxEVT_LIST_COL_BEGIN_DRAG
wxEVT_LIST_CACHE_HINT
```
other than that, this PR makes `[ListCtrlTestCase]` and `[VirtListCtrlTestCase]` tests pass for me.