### PR TITLE
Minimizing grid lines redraw when custom draw function is used

### DIFF
--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -2625,6 +2625,9 @@ void wxGridWindow::OnMouseWheel( wxMouseEvent& event )
 {
     if (!m_owner->ProcessWindowEvent( event ))
         event.Skip();
+
+    // To redraw grid after scroll. If not called - some lines are not updated in grids where cell is combined from multiple items.
+    m_owner->Refresh();
 }
 
 // This seems to be required for wxX11/wxGTK otherwise the mouse
@@ -2839,6 +2842,9 @@ void wxGrid::InitPixelFields()
 #else
     m_defaultRowHeight += 4;
 #endif
+
+    // To make full row scroll. In other case rows are scrolled partialy.
+    m_yScrollPixelsPerLine = m_defaultRowHeight;
 
     // Don't change the value when called from OnDPIChanged() later if the
     // corresponding label window is hidden, these values should remain zeroes
@@ -6791,6 +6797,11 @@ void wxGrid::DrawAllGridWindowLines(wxDC& dc, const wxRegion & WXUNUSED(reg), wx
 {
     if ( !m_gridLinesEnabled || !gridWindow )
          return;
+
+    wxObjectRefData *pRefData = this->GetRefData();
+    if (pRefData) {
+        return;
+    }
 
     int top, bottom, left, right;
 

--- a/src/generic/grid.cpp
+++ b/src/generic/grid.cpp
@@ -6790,6 +6790,8 @@ wxGrid::DrawRangeGridLines(wxDC& dc,
     dc.DestroyClippingRegion();
 }
 
+extern wxWindow *wxTheWindowBeingScrolled;
+
 // This is used to redraw all grid lines e.g. when the grid line colour
 // has been changed
 //
@@ -6798,8 +6800,8 @@ void wxGrid::DrawAllGridWindowLines(wxDC& dc, const wxRegion & WXUNUSED(reg), wx
     if ( !m_gridLinesEnabled || !gridWindow )
          return;
 
-    wxObjectRefData *pRefData = this->GetRefData();
-    if (pRefData) {
+    // Minimizing grid lines redraw count.
+    if (this == wxTheWindowBeingScrolled) {
         return;
     }
 

--- a/src/generic/scrlwing.cpp
+++ b/src/generic/scrlwing.cpp
@@ -474,6 +474,8 @@ void wxScrollHelperBase::SetTargetWindow(wxWindow *target)
 // scrolling implementation itself
 // ----------------------------------------------------------------------------
 
+wxWindow *wxTheWindowBeingScrolled;
+
 void wxScrollHelperBase::HandleOnScroll(wxScrollWinEvent& event)
 {
     int nScrollInc = CalcScrollInc(event);
@@ -485,10 +487,7 @@ void wxScrollHelperBase::HandleOnScroll(wxScrollWinEvent& event)
         return;
     }
 
-    if (m_win) {
-        wxObjectRefData *pRefObjData = new wxObjectRefData;
-        m_win->SetRefData(pRefObjData);
-    }
+    wxTheWindowBeingScrolled = m_win;
 
     bool needsRefresh = false;
     int dx = 0,
@@ -555,10 +554,6 @@ void wxScrollHelperBase::HandleOnScroll(wxScrollWinEvent& event)
         m_win->Refresh(true, GetScrollRect());
     }
 #endif // __WXUNIVERSAL__
-
-    if (m_win) {
-        m_win->UnRef();
-    }
 }
 
 int wxScrollHelperBase::CalcScrollInc(wxScrollWinEvent& event)

--- a/src/generic/scrlwing.cpp
+++ b/src/generic/scrlwing.cpp
@@ -476,6 +476,17 @@ void wxScrollHelperBase::SetTargetWindow(wxWindow *target)
 
 wxWindow *wxTheWindowBeingScrolled;
 
+class CScrolledWindowHolder final
+{
+public:
+    CScrolledWindowHolder(wxWindow *window) {
+        wxTheWindowBeingScrolled = window;
+    }
+    ~CScrolledWindowHolder() {
+        wxTheWindowBeingScrolled = nullptr;
+    }
+};
+
 void wxScrollHelperBase::HandleOnScroll(wxScrollWinEvent& event)
 {
     int nScrollInc = CalcScrollInc(event);
@@ -487,7 +498,7 @@ void wxScrollHelperBase::HandleOnScroll(wxScrollWinEvent& event)
         return;
     }
 
-    wxTheWindowBeingScrolled = m_win;
+    CScrolledWindowHolder scrolledWindow(m_win);
 
     bool needsRefresh = false;
     int dx = 0,

--- a/src/generic/scrlwing.cpp
+++ b/src/generic/scrlwing.cpp
@@ -485,6 +485,11 @@ void wxScrollHelperBase::HandleOnScroll(wxScrollWinEvent& event)
         return;
     }
 
+    if (m_win) {
+        wxObjectRefData *pRefObjData = new wxObjectRefData;
+        m_win->SetRefData(pRefObjData);
+    }
+
     bool needsRefresh = false;
     int dx = 0,
         dy = 0;
@@ -550,6 +555,10 @@ void wxScrollHelperBase::HandleOnScroll(wxScrollWinEvent& event)
         m_win->Refresh(true, GetScrollRect());
     }
 #endif // __WXUNIVERSAL__
+
+    if (m_win) {
+        m_win->UnRef();
+    }
 }
 
 int wxScrollHelperBase::CalcScrollInc(wxScrollWinEvent& event)


### PR DESCRIPTION
Related to  issue "wxGrid mouse scroll is slow #23007"

This commit makes the following changes:

1. Default scroll Y value is changed to the row height. That will result in full row scroll instead of partial scroll.
2. Grid lines redraw is disabled when mouse scroll is detected. That is achieved by using `m_win->SetRefData(pRefObjData);`

Grid scroll with mouse is much faster after those changes. 