### PR TITLE
Improve `wxTLW::GetBestSize()` for windows with the unique child

### DIFF
--- a/include/wx/toplevel.h
+++ b/include/wx/toplevel.h
@@ -325,6 +325,8 @@ protected:
         DoGetPosition(x, y);
     }
 
+    virtual wxSize DoGetBestClientSize() const override;
+
     // test whether this window makes part of the frame
     // (menubar, toolbar and statusbar are excluded from automatic layout)
     virtual bool IsOneOfBars(const wxWindow *WXUNUSED(win)) const

--- a/include/wx/toplevel.h
+++ b/include/wx/toplevel.h
@@ -354,6 +354,14 @@ protected:
 
     bool m_modified;
 
+private:
+    // Return true if this window uses some automatic layout mechanism.
+    bool UsesAutoLayout() const;
+
+    // Return the only child of this window if it has exactly one or null
+    // pointer otherwise.
+    wxWindow* GetUniqueChild() const;
+
     wxDECLARE_NO_COPY_CLASS(wxTopLevelWindowBase);
     wxDECLARE_EVENT_TABLE();
 };

--- a/src/common/toplvcmn.cpp
+++ b/src/common/toplvcmn.cpp
@@ -408,6 +408,49 @@ bool wxTopLevelWindowBase::IsTopNavigationDomain(NavigationKind kind) const
     return true;
 }
 
+wxWindow* wxTopLevelWindowBase::GetUniqueChild() const
+{
+    // do we have _exactly_ one child?
+    wxWindow *child = nullptr;
+    for ( wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
+          node;
+          node = node->GetNext() )
+    {
+        wxWindow *win = node->GetData();
+
+        // exclude top level and managed windows (status bar isn't
+        // currently in the children list except under wxMac anyhow, but
+        // it makes no harm to test for it)
+        if ( !win->IsTopLevel() && !IsOneOfBars(win) )
+        {
+            // We don't take hidden children into account and we also consider
+            // that something more complicated than just the default resizing
+            // behaviour is necessary if there are any hidden windows, so give
+            // up immediately in this case.
+            if ( !win->IsShown() )
+                return nullptr;
+
+            // Also stop if it's not our first child.
+            if ( child )
+                return nullptr;
+
+            child = win;
+        }
+    }
+
+    return child;
+}
+
+bool wxTopLevelWindowBase::UsesAutoLayout() const
+{
+    return GetAutoLayout()
+                || GetSizer()
+#if wxUSE_CONSTRAINTS
+                    || GetConstraints()
+#endif
+        ;
+}
+
 // default resizing behaviour - if only ONE subwindow, resize to fill the
 // whole client area
 bool wxTopLevelWindowBase::Layout()
@@ -421,43 +464,16 @@ bool wxTopLevelWindowBase::Layout()
 
 
     // if we're using sizers or constraints - do use them
-    if ( GetAutoLayout()
-            || GetSizer()
-#if wxUSE_CONSTRAINTS
-                    || GetConstraints()
-#endif
-                                        )
+    if ( UsesAutoLayout() )
     {
         return wxNonOwnedWindow::Layout();
     }
     else
     {
         // do we have _exactly_ one child?
-        wxWindow *child = nullptr;
-        for ( wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
-              node;
-              node = node->GetNext() )
+        if ( wxWindow* const child = GetUniqueChild() )
         {
-            wxWindow *win = node->GetData();
-
-            // exclude top level and managed windows (status bar isn't
-            // currently in the children list except under wxMac anyhow, but
-            // it makes no harm to test for it)
-            if ( !win->IsTopLevel() && !IsOneOfBars(win) )
-            {
-                if ( child )
-                {
-                    return false; // it's our second subwindow - nothing to do
-                }
-
-                child = win;
-            }
-        }
-
-        // do we have any children at all?
-        if ( child && child->IsShown() )
-        {
-            // exactly one child - set it's size to fill the whole frame
+            // yes - set its size to fill the whole frame
             int clientW, clientH;
             DoGetClientSize(&clientW, &clientH);
 

--- a/src/common/toplvcmn.cpp
+++ b/src/common/toplvcmn.cpp
@@ -486,6 +486,18 @@ bool wxTopLevelWindowBase::Layout()
     return false;
 }
 
+wxSize wxTopLevelWindowBase::DoGetBestClientSize() const
+{
+    // The logic here parallels that of Layout() above.
+    if ( !UsesAutoLayout() )
+    {
+        if ( wxWindow* const child = GetUniqueChild() )
+            return child->GetBestSize();
+    }
+
+    return wxNonOwnedWindow::DoGetBestClientSize();
+}
+
 // The default implementation for the close window event.
 void wxTopLevelWindowBase::OnCloseWindow(wxCloseEvent& WXUNUSED(event))
 {


### PR DESCRIPTION
See #22983.
