### PR TITLE
Do use host-specific pkg-config when cross-compiling

### DIFF
--- a/configure
+++ b/configure
@@ -25052,23 +25052,21 @@ $as_echo "no" >&6; }
 fi
 
 if test "$build" != "$host"; then
-    case "${host}" in
-        *-linux-*)
+    case "$PKG_CONFIG" in
+        */$host-pkg-config )
             ;;
 
-        *)
-            disable_build_system_pkg_config=1
-            ;;
+        * )
+            { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Not using native pkg-config when cross-compiling." >&5
+$as_echo "$as_me: WARNING: Not using native pkg-config when cross-compiling." >&2;}
+
+
+
+                                                if test -z "$PKG_CONFIG_LIBDIR"; then
+                PKG_CONFIG_LIBDIR=/dev/null
+                export PKG_CONFIG_LIBDIR
+            fi
     esac
-fi
-
-if test "$disable_build_system_pkg_config" = 1; then
-
-
-                if test -z "$PKG_CONFIG_LIBDIR"; then
-        PKG_CONFIG_LIBDIR=/dev/null
-        export PKG_CONFIG_LIBDIR
-    fi
 fi
 
 

--- a/configure.in
+++ b/configure.in
@@ -2098,32 +2098,28 @@ dnl the build system, they are at best useless and can be harmful (e.g. they
 dnl may define options inappropriate for the cross-build, resulting in the
 dnl failure of all the subsequent tests).
 dnl
-dnl Note that we only do it in this particular case because in other cases we
-dnl may want to use .pc files on the build system, e.g. it's common to have
-dnl them when cross-compiling from x86_64 Linux to ARM Linux.
+dnl However do use .pc files for the host libraries that can be found by the
+dnl host-specific pkg-config if it was found by PKG_PROG_PKG_CONFIG above.
 if test "$build" != "$host"; then
-    case "${host}" in
-        *-linux-*)
+    case "$PKG_CONFIG" in
+        */$host-pkg-config )
             ;;
 
-        *)
-            disable_build_system_pkg_config=1
-            ;;
+        * )
+            AC_MSG_WARN([Not using native pkg-config when cross-compiling.])
+
+            dnl pkg.m4 forbids the use of PKG_XXX, so undo it here to avoid autoconf
+            dnl errors.
+            m4_pattern_allow([PKG_CONFIG_LIBDIR])
+
+            dnl If pkg-config libdir is already defined, we suppose that they know what
+            dnl they're doing and leave it alone, but if not, set it to a path in which
+            dnl no .pc files will be found.
+            if test -z "$PKG_CONFIG_LIBDIR"; then
+                PKG_CONFIG_LIBDIR=/dev/null
+                export PKG_CONFIG_LIBDIR
+            fi
     esac
-fi
-
-if test "$disable_build_system_pkg_config" = 1; then
-    dnl pkg.m4 forbids the use of PKG_XXX, so undo it here to avoid autoconf
-    dnl errors.
-    m4_pattern_allow([PKG_CONFIG_LIBDIR])
-
-    dnl If pkg-config libdir is already defined, we suppose that they know what
-    dnl they're doing and leave it alone, but if not, set it to a path in which
-    dnl no .pc files will be found.
-    if test -z "$PKG_CONFIG_LIBDIR"; then
-        PKG_CONFIG_LIBDIR=/dev/null
-        export PKG_CONFIG_LIBDIR
-    fi
 fi
 
 dnl ---------------------------------------------------------------------------


### PR DESCRIPTION
This re-enables the use of $host-pkg-config after it was disabled again by d6ddfe87e1 (Disable build system pkg-config when cross-compiling to non-Linux, 2022-11-30).

---

@paulcor Does this address [your concerns](https://github.com/wxWidgets/wxWidgets/commit/d6ddfe87e1e75fc26cb50e2e8be215443460d444#commitcomment-92076182)?