### PR TITLE
Fix scaling of standard MSW platform icons in high DPI

### DIFF
--- a/src/msw/artmsw.cpp
+++ b/src/msw/artmsw.cpp
@@ -23,6 +23,7 @@
 #endif
 
 #include "wx/image.h"
+#include "wx/display.h"
 #include "wx/dynlib.h"
 #include "wx/volume.h"
 #include "wx/msw/private.h"
@@ -109,8 +110,12 @@ MSWGetBitmapFromIconLocation(const TCHAR* path, int index, const wxSize& size)
     // the same anyhow, of course, but if it isn't, the actual icon size would
     // be size.x in both directions as we only pass "x" to SHDefExtractIcon()
     // above.
+    //
+    // Also always use the primary display scale factor here because this is
+    // what SHDefExtractIcon() uses.
     wxIcon icon;
-    if ( !icon.InitFromHICON((WXHICON)hIcon, size.x, size.x) )
+    if ( !icon.InitFromHICON((WXHICON)hIcon, size.x, size.x,
+                             wxDisplay().GetScaleFactor()) )
         return wxNullBitmap;
 
     return wxBitmap(icon);
@@ -171,6 +176,9 @@ wxBitmap wxWindowsArtProvider::CreateBitmap(const wxArtID& id,
 {
     wxBitmap bitmap;
 
+    // We don't have any window here, so if we call GetNativeSizeHint(), it
+    // will use the primary monitor DPI scale factor, which is consistent with
+    // what MSWGetBitmapFromIconLocation() does.
     const wxSize
         sizeNeeded = size.IsFullySpecified()
                         ? size


### PR DESCRIPTION
Use the correct scaling factor when creating the bitmap in wxWindowsArtProvider, otherwise the bitmap was wrongly rescaled again when actually using it.

It still seems wrong to always use the primary display scaling here, but we just don't have any window to use in this code and at least it is consistent and works when primary display scaling is not 100% now.

Closes #23031.

----

@MaartenBent Please let me know if you see anything wrong with this.