### PR TITLE
Allow selecting and copying text in wxMessageDialog on GTK

### DIFF
--- a/src/gtk/msgdlg.cpp
+++ b/src/gtk/msgdlg.cpp
@@ -187,10 +187,29 @@ void wxMessageDialog::GTKCreateMsgDialog()
         gtk_window_set_keep_above(GTK_WINDOW(m_widget), TRUE);
     }
 
+    // A GTKMessageDialog usually displays its labels without selection enabled,
+    // so we enable selection to allow the user to select+copy the text out of
+    // the dialog.
+    GtkMessageDialog * const msgdlg = GTK_MESSAGE_DIALOG(m_widget);
+
+    GtkWidget* area = gtk_message_dialog_get_message_area(msgdlg);
+    GList* labels = gtk_container_get_children(GTK_CONTAINER(area));
+
+    for ( GList* elem = labels; elem; elem = elem->next )
+    {
+        GtkWidget* widget = GTK_WIDGET( elem->data );
+
+        if ( GTK_IS_LABEL(widget) )
+        {
+            gtk_label_set_selectable(GTK_LABEL(widget), TRUE);
+        }
+    }
+
+    g_list_free(labels);
+
     // we need to add buttons manually if we use custom labels or always for
     // Yes/No/Cancel dialog as GTK+ doesn't support it natively
     const bool addButtons = buttons == GTK_BUTTONS_NONE;
-
 
     if ( addButtons )
     {


### PR DESCRIPTION
Normally, the GTK message dialogs have non-selectable text, but that also means users can't copy the text. This can be inconvenient if the dialog is used for error messages, since then the error message can't be copied.

Instead, provide a new style that enables selection (and copying) on the text labels used in the GTK message dialog to fix that.

To test this, a simple patch to the dialogs sample can be done:
```
─────────────────────────────────────────────────────────────────────────────────────────────┐
• samples/dialogs/dialogs.cpp:978: void MyFrame::MessageBox(wxCommandEvent& WXUNUSED(event)) │
─────────────────────────────────────────────────────────────────────────────────────────────┘
978|978|                            "Message box text",
979|979|                            wxCENTER |
980|980|                            wxNO_DEFAULT | wxYES_NO | wxCANCEL |
981|   |-                           wxICON_INFORMATION);
   |981|+                           wxICON_INFORMATION | wxMESSAGE_SELECT);
982|982| 
983|983|     wxString extmsg;
984|984|     if ( dialog.SetYesNoCancelLabels
```
Without the patch, the dialog text can't be selected or copied, with the patch it can be.

I think this would also be nice to backport to 3.2, since it doesn't change any ABI (the only user-facing change is the new define for the style), and it doesn't change the default behavior (the new behavior is opt-in by providing the style). If that is the case, the interface comment should be updated to the 3.2 version it is included in.