### PR TITLE
Fix nullptr access when missing menuitem in OSX menu handler

### DIFF
--- a/src/osx/menu_osx.cpp
+++ b/src/osx/menu_osx.cpp
@@ -361,7 +361,7 @@ bool wxMenu::HandleCommandProcess( wxMenuItem* item )
 {
     int menuid = item ? item->GetId() : 0;
     bool processed = false;
-    if (item && item->IsCheckable())
+    if ( item && item->IsCheckable() )
         item->Check( !item->IsChecked() ) ;
 
     if ( SendEvent( menuid , (item && item->IsCheckable()) ? item->IsChecked() : -1 ) )

--- a/src/osx/menu_osx.cpp
+++ b/src/osx/menu_osx.cpp
@@ -361,10 +361,10 @@ bool wxMenu::HandleCommandProcess( wxMenuItem* item )
 {
     int menuid = item ? item->GetId() : 0;
     bool processed = false;
-    if (item->IsCheckable())
+    if (item && item->IsCheckable())
         item->Check( !item->IsChecked() ) ;
 
-    if ( SendEvent( menuid , item->IsCheckable() ? item->IsChecked() : -1 ) )
+    if ( SendEvent( menuid , (item && item->IsCheckable()) ? item->IsChecked() : -1 ) )
         processed = true ;
 
     if(!processed && item)


### PR DESCRIPTION
Sometimes the menu item passed to the command process function might be null, so we can't dereference it to test checkability in that case.

I don't have a clear case from the samples when this happens, but there was already a test for a null menu item when looking for the menu ID, so this guards the rest of the accesses. This was found from a crash we saw in KiCad (https://gitlab.com/kicad/code/kicad/-/issues/13149) which had a stacktrace of
```
hread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   libwx_osx_cocoau-3.2.0.1.0.dylib	       0x107c79b04 wxMenu::HandleCommandProcess(wxMenuItem*) + 188
1   libwx_osx_cocoau-3.2.0.1.0.dylib	       0x107c79adc wxMenu::HandleCommandProcess(wxMenuItem*) + 148
2   AppKit                        	       0x1c004d400 -[NSApplication(NSResponder) sendAction:to:from:] + 456
3   AppKit                        	       0x1c0142f84 -[NSMenuItem _corePerformAction] + 444
4   AppKit                        	       0x1c0142c78 -[NSCarbonMenuImpl performActionWithHighlightingForItemAtIndex:] + 100
5   AppKit                        	       0x1c018b40c -[NSMenu performActionForItemAtIndex:] + 196
6   AppKit                        	       0x1c018b330 -[NSMenu _internalPerformActionForItemAtIndex:] + 100
7   AppKit                        	       0x1c018b13c -[NSCarbonMenuImpl _carbonCommandProcessEvent:handlerCallRef:] + 116
8   AppKit                        	       0x1c0126b70 NSSLMMenuEventHandler + 728
9   HIToolbox                     	       0x1c5e63418 DispatchEventToHandlers(EventTargetRec*, OpaqueEventRef*, HandlerCallRec*) + 1116
10  HIToolbox                     	       0x1c5e62884 SendEventToEventTargetInternal(OpaqueEventRef*, OpaqueEventTargetRef*, HandlerCallRec*) + 356
11  HIToolbox                     	       0x1c5e789c4 SendEventToEventTarget + 40
12  HIToolbox                     	       0x1c5ed8ca0 SendHICommandEvent(unsigned int, HICommand const*, unsigned int, unsigned int, unsigned char, void const*, OpaqueEventTargetRef*, OpaqueEventTargetRef*, OpaqueEventRef**) + 420
13  HIToolbox                     	       0x1c5efd9f8 SendMenuCommandWithContextAndModifiers + 56
14  HIToolbox                     	       0x1c5efd988 SendMenuItemSelectedEvent + 352
15  HIToolbox                     	       0x1c5efd7b4 FinishMenuSelection(SelectionData*, MenuResult*, MenuResult*) + 100
16  HIToolbox                     	       0x1c5efe16c MenuSelectCore(MenuData*, Point, double, unsigned int, OpaqueMenuRef**, unsigned short*) + 564
17  HIToolbox                     	       0x1c5efde88 _HandleMenuSelection2 + 416
18  AppKit                        	       0x1bffe63fc _NSHandleCarbonMenuEvent + 288
19  AppKit                        	       0x1bffe61e8 _DPSEventHandledByCarbon + 68
20  AppKit                        	       0x1bfe480a4 -[NSApplication(NSEvent) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 3380
21  AppKit                        	       0x1bfe399b4 -[NSApplication run] + 596
22  libwx_osx_cocoau-3.2.0.1.0.dylib	       0x107cf5048 wxGUIEventLoop::OSXDoRun() + 196
23  libwx_osx_cocoau-3.2.0.1.0.dylib	       0x107bec368 wxCFEventLoop::DoRun() + 40
24  libwx_osx_cocoau-3.2.0.1.0.dylib	       0x107b43330 wxEventLoopBase::Run() + 192
25  libwx_osx_cocoau-3.2.0.1.0.dylib	       0x107b13d38 wxAppConsoleBase::MainLoop() + 208
26  libwx_osx_cocoau-3.2.0.1.0.dylib	       0x107c931c4 wxApp::OnRun() + 36
27  kicad                         	       0x104dfad48 APP_KICAD::OnRun() + 28
28  libwx_osx_cocoau-3.2.0.1.0.dylib	       0x107b75e54 wxEntry(int&, wchar_t**) + 88
29  kicad                         	       0x104df9444 main + 52
30  dyld                          	       0x1059390f4 start + 520
```