### PR TITLE
[wxTaskBarIcon][macOS] Fix scaling bug of icon on external screen

### DIFF
--- a/src/osx/cocoa/taskbar.mm
+++ b/src/osx/cocoa/taskbar.mm
@@ -391,7 +391,14 @@ bool wxTaskBarIconCustomStatusItemImpl::SetIcon(const wxBitmapBundle& icon, cons
     m_icon = IconFromBundle(icon);
     NSImage* nsimage = m_icon.GetNSImage();
     [[m_statusItem button] setImageScaling: NSImageScaleProportionallyUpOrDown];
-    [[m_statusItem button] setImage: nsimage];
+
+    CGFloat statusBarThickness = [[NSStatusBar systemStatusBar] thickness];
+    NSSize statusBarSize = NSMakeSize(statusBarThickness, statusBarThickness);
+    NSImage* statusBarScaledImage = [NSImage imageWithSize:statusBarSize flipped:NO drawingHandler:^BOOL(NSRect dstRect) {
+        [nsimage drawInRect:dstRect fromRect:NSZeroRect operation:NSCompositingOperationSourceOver fraction:1];
+        return YES;
+    }];
+    [[m_statusItem button] setImage:statusBarScaledImage];
     
     wxCFStringRef cfTooltip(tooltip);
     [[m_statusItem button] setToolTip:cfTooltip.AsNSString()];


### PR DESCRIPTION
### What has changed?
When an image is set as icon on the wxTaskBarIcon it's now wrapped before it's applied to the status bar, in order to draw correct scale on all screens

### Why was this changed?
When using the wxTaskBarIcon on multiple screens the screen without focus draws the image with an invalid scale, making it appear compressed. In pictures:

Inactive screen before
<img width="324" alt="Before" src="https://user-images.githubusercontent.com/13438123/208126991-d8de7922-ca8d-4b35-9e13-6b5b64f5ab37.png">

Inactive screen after
<img width="290" alt="After" src="https://user-images.githubusercontent.com/13438123/208127039-99aab96f-5ebe-42db-bb8a-774541277f29.png">

### Links and documentation
From AppKit release notes:

> 10.9 introduces multiple menu bars, each of which draws the status items. If your status item has a custom view, this view is positioned in one menu bar, and other menu bars get a “clone”, which looks identical. The clones are not exposed in the API.

> The clones are drawn by redirecting your custom view’s drawing into another window. This means that your status item should not make assumptions about the drawing destination. For example, it should not assume that a call to -drawRect: is destined for the view’s window, or that the resolution of the drawing destination matches the resolution of the status item’s screen. You must also not assume that the status item is on any particular display...

I could not find any references to this in Apple documentation, only in a copy of old release notes here: https://gist.github.com/zwaldowski/8710fddc8b0b39d2c152

It appears that contrary to the above notes about how to draw the status bar item image the standard status item created by AppKit _does_ make assumptions on where it's drawn and so messes up how the image is drawn in these hidden "clones". The fix makes sure the image is always drawn in the current context with no assumption on what screen the destination is on.

I based this fix on a workaround I found here: https://bugreports.qt.io/browse/QTBUG-88600

### How can a reviewer test this?
I have not tested any of the samples myself but any use of the wxTaskBarIcon on macOS (when extra screen is plugged in) should show the issue clearly (perhaps the effect isn't as visible when the scale varies less between the screens though). When using this fix the icon appears correctly for me in my project.

If this needs to be unit tested I'm open to suggestions on how to implement that.