### PR TITLE
locale: Avoid using glibc specific defines on musl

### DIFF
--- a/src/unix/uilocale.cpp
+++ b/src/unix/uilocale.cpp
@@ -615,7 +615,7 @@ wxString
 wxUILocaleImplUnix::GetLocalizedName(wxLocaleName name, wxLocaleForm form) const
 {
     wxString str;
-#if defined(HAVE_LANGINFO_H) && defined(__LINUX__)
+#if defined(HAVE_LANGINFO_H) && defined(__LINUX__) && defined(__GLIBC__)
     switch (name)
     {
         case wxLOCALE_NAME_LOCALE:


### PR DESCRIPTION
musl does not provide some glibc-only enum members e.g. _NL_ADDRESS_LANG_NAME

Signed-off-by: Khem Raj <raj.khem@gmail.com>