### PR TITLE
Fix writing out corrupted TIFF files due to misusing `TIFFSetField()`

### DIFF
--- a/src/common/imagtiff.cpp
+++ b/src/common/imagtiff.cpp
@@ -611,8 +611,8 @@ bool wxTIFFHandler::SaveFile( wxImage *image, wxOutputStream& stream, bool verbo
     const int imageWidth = image->GetWidth();
     TIFFSetField(tif, TIFFTAG_IMAGEWIDTH,  (wxUint32) imageWidth);
     TIFFSetField(tif, TIFFTAG_IMAGELENGTH, (wxUint32)image->GetHeight());
-    TIFFSetField(tif, TIFFTAG_ORIENTATION, ORIENTATION_TOPLEFT);
-    TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG);
+    TIFFSetField(tif, TIFFTAG_ORIENTATION, (wxUint16)ORIENTATION_TOPLEFT);
+    TIFFSetField(tif, TIFFTAG_PLANARCONFIG, (wxUint16)PLANARCONFIG_CONTIG);
 
     // save the image resolution if we have it
     int xres, yres;
@@ -640,8 +640,8 @@ bool wxTIFFHandler::SaveFile( wxImage *image, wxOutputStream& stream, bool verbo
     if ( tiffRes != RESUNIT_NONE )
     {
         TIFFSetField(tif, TIFFTAG_RESOLUTIONUNIT, tiffRes);
-        TIFFSetField(tif, TIFFTAG_XRESOLUTION, xres);
-        TIFFSetField(tif, TIFFTAG_YRESOLUTION, yres);
+        TIFFSetField(tif, TIFFTAG_XRESOLUTION, static_cast<double>(xres));
+        TIFFSetField(tif, TIFFTAG_YRESOLUTION, static_cast<double>(yres));
     }
 
 
@@ -706,15 +706,15 @@ bool wxTIFFHandler::SaveFile( wxImage *image, wxOutputStream& stream, bool verbo
 
     int extraSamples = hasAlpha ? 1 : 0;
 
-    TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, spp + extraSamples);
-    TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, bps);
-    TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, photometric);
-    TIFFSetField(tif, TIFFTAG_COMPRESSION, compression);
+    TIFFSetField(tif, TIFFTAG_SAMPLESPERPIXEL, (wxUint16)(spp + extraSamples));
+    TIFFSetField(tif, TIFFTAG_BITSPERSAMPLE, (wxUint16)bps);
+    TIFFSetField(tif, TIFFTAG_PHOTOMETRIC, (wxUint16)photometric);
+    TIFFSetField(tif, TIFFTAG_COMPRESSION, (wxUint16)compression);
 
     if (extraSamples)
     {
         wxUint16 extra[] = { EXTRASAMPLE_UNSPECIFIED };
-        TIFFSetField(tif, TIFFTAG_EXTRASAMPLES, (long) 1, &extra);
+        TIFFSetField(tif, TIFFTAG_EXTRASAMPLES, (wxUint16) 1, &extra);
     }
 
     // scanlinesize is determined by spp+extraSamples and bps

--- a/src/common/imagtiff.cpp
+++ b/src/common/imagtiff.cpp
@@ -181,6 +181,12 @@ wxTIFFSeekOProc(thandle_t handle, toff_t off, int whence)
 {
     wxOutputStream *stream = (wxOutputStream*) handle;
 
+    // For weird reasons of compatibility with Solaris libc, libtiff calls
+    // Seek(0, SEEK_END) before every write, but we really don't need to do
+    // anything in this case.
+    if ( off == 0 && whence == SEEK_END )
+        return wxFileOffsetToTIFF( stream->TellO() );
+
     toff_t offset = wxFileOffsetToTIFF(
         stream->SeekO((wxFileOffset)off, wxSeekModeFromTIFF(whence)) );
 

--- a/tests/image/image.cpp
+++ b/tests/image/image.cpp
@@ -1109,6 +1109,8 @@ void ImageTestCase::SavePNG()
 static void TestTIFFImage(const wxString& option, int value,
     const wxImage *compareImage = nullptr)
 {
+    INFO("Using option " << option << "=" << value);
+
     wxImage image;
     if (compareImage)
     {
@@ -1131,13 +1133,9 @@ static void TestTIFFImage(const wxString& option, int value,
     wxImage savedImage(memIn);
     REQUIRE(savedImage.IsOk());
 
-    WX_ASSERT_EQUAL_MESSAGE(("While checking for option %s", option),
-        true, savedImage.HasOption(option));
-
-    WX_ASSERT_EQUAL_MESSAGE(("While testing for %s", option),
-        value, savedImage.GetOptionInt(option));
-
-    WX_ASSERT_EQUAL_MESSAGE(("HasAlpha() not equal"), image.HasAlpha(), savedImage.HasAlpha());
+    CHECK( savedImage.HasOption(option) );
+    CHECK( savedImage.GetOptionInt(option) == value );
+    CHECK( savedImage.HasAlpha() == image.HasAlpha() );
 }
 
 void ImageTestCase::SaveTIFF()


### PR DESCRIPTION
See #23048.