### PR TITLE
Fix for GetPrinter logic bug in WinPrinter class

### DIFF
--- a/src/msw/printdlg.cpp
+++ b/src/msw/printdlg.cpp
@@ -87,7 +87,8 @@ public:
             return false;
 
         DWORD bufSize = 0;
-        if ( !::GetPrinter(m_hPrinter, level, nullptr, 0, &bufSize) || !bufSize )
+        ::GetPrinter(m_hPrinter, level, nullptr, 0, &bufSize);
+        if (!bufSize )
             return false;
 
         if ( !::GetPrinter(m_hPrinter,


### PR DESCRIPTION
According to the documentation of GetPrinter, GetPrinter returns false if bufSize is 0 on input. Therefore we can not check for FALSE on the first call. The following if statement always evaluates to true and then false is returned:

```
if ( !::GetPrinter(m_hPrinter, level, nullptr, 0, &bufSize) || !bufSize )
   return false;
```

If bufSize is 0 in the input, we cannot test the return value of GetPrinter for FALSE.