### PR TITLE
Avoid unused variable warnings

### DIFF
--- a/samples/dialogs/dialogs.cpp
+++ b/samples/dialogs/dialogs.cpp
@@ -3855,19 +3855,16 @@ void StdButtonSizerDialog::OnEvent(wxCommandEvent& WXUNUSED(event))
     EnableDisableControls();
 
     long flags = 0;
-    unsigned long numButtons = 0;
 
     if (m_chkboxAffirmativeButton->IsChecked())
     {
         if (m_radiobtnOk->GetValue())
         {
             flags |= wxOK;
-            numButtons ++;
         }
         else if (m_radiobtnYes->GetValue())
         {
             flags |= wxYES;
-            numButtons ++;
         }
     }
 
@@ -3876,13 +3873,11 @@ void StdButtonSizerDialog::OnEvent(wxCommandEvent& WXUNUSED(event))
         if (m_radiobtnCancel->GetValue())
         {
             flags |= wxCANCEL;
-            numButtons ++;
         }
 
         else if (m_radiobtnClose->GetValue())
         {
             flags |= wxCLOSE;
-            numButtons ++;
         }
 
     }
@@ -3890,19 +3885,16 @@ void StdButtonSizerDialog::OnEvent(wxCommandEvent& WXUNUSED(event))
     if (m_chkboxApply->IsChecked())
     {
         flags |= wxAPPLY;
-        numButtons ++;
     }
 
     if (m_chkboxNo->IsChecked())
     {
         flags |= wxNO;
-        numButtons ++;
     }
 
     if (m_chkboxHelp->IsChecked())
     {
         flags |= wxHELP;
-        numButtons ++;
     }
 
     if (m_chkboxNoDefault->IsChecked())

--- a/src/generic/progdlgg.cpp
+++ b/src/generic/progdlgg.cpp
@@ -210,29 +210,20 @@ bool wxGenericProgressDialog::Create( const wxString& title,
     m_estimated =
     m_remaining = nullptr;
 
-    // also count how many labels we really have
-    size_t nTimeLabels = 0;
-
     wxSizer * const sizerLabels = new wxFlexGridSizer(2);
 
     if ( style & wxPD_ELAPSED_TIME )
     {
-        nTimeLabels++;
-
         m_elapsed = CreateLabel(GetElapsedLabel(), sizerLabels);
     }
 
     if ( style & wxPD_ESTIMATED_TIME )
     {
-        nTimeLabels++;
-
         m_estimated = CreateLabel(GetEstimatedLabel(), sizerLabels);
     }
 
     if ( style & wxPD_REMAINING_TIME )
     {
-        nTimeLabels++;
-
         m_remaining = CreateLabel(GetRemainingLabel(), sizerLabels);
     }
     sizerTop->Add(sizerLabels, 0, wxALIGN_CENTER_HORIZONTAL | wxTOP, LAYOUT_MARGIN);

--- a/src/ribbon/toolbar.cpp
+++ b/src/ribbon/toolbar.cpp
@@ -530,7 +530,7 @@ wxRect wxRibbonToolBar::GetToolRect(int tool_id)const
 {
     size_t group_count = m_groups.GetCount();
     size_t g, t;
-    int pos = 0;
+
     for(g = 0; g < group_count; ++g)
     {
         wxRibbonToolBarToolGroup* group = m_groups.Item(g);
@@ -542,9 +542,7 @@ wxRect wxRibbonToolBar::GetToolRect(int tool_id)const
             {
                 return wxRect(group->position + tool->position, tool->size);
             }
-            ++pos;
         }
-        ++pos; // Increment pos for group separator.
     }
     return wxRect();
 }

--- a/src/richtext/richtextbuffer.cpp
+++ b/src/richtext/richtextbuffer.cpp
@@ -4938,7 +4938,9 @@ bool wxRichTextParagraph::Draw(wxDC& dc, wxRichTextDrawingContext& context, cons
                     child->Draw(dc, context, objectRange, selection, childRect, maxDescent, style);
 
                     objectPosition.x += objectSize.x;
+#if wxRICHTEXT_USE_OPTIMIZED_LINE_DRAWING && wxRICHTEXT_USE_PARTIAL_TEXT_EXTENTS
                     i ++;
+#endif
                 }
                 else if (child->GetRange().GetStart() > lineRange.GetEnd())
                     // Can break out of inner loop now since we've passed this line's range

--- a/src/richtext/richtextbuffer.cpp
+++ b/src/richtext/richtextbuffer.cpp
@@ -4899,7 +4899,9 @@ bool wxRichTextParagraph::Draw(wxDC& dc, wxRichTextDrawingContext& context, cons
             // Loop through objects until we get to the one within range
             wxRichTextObjectList::compatibility_iterator node2 = m_children.GetFirst();
 
+#if wxRICHTEXT_USE_OPTIMIZED_LINE_DRAWING && wxRICHTEXT_USE_PARTIAL_TEXT_EXTENTS
             int i = 0;
+#endif
             while (node2)
             {
                 wxRichTextObject* child = node2->GetData();

--- a/src/richtext/richtextbuffer.cpp
+++ b/src/richtext/richtextbuffer.cpp
@@ -3345,7 +3345,6 @@ bool wxRichTextParagraphLayoutBox::DeleteRange(const wxRichTextRange& range)
 /// Get any text in this object for the given range
 wxString wxRichTextParagraphLayoutBox::GetTextForRange(const wxRichTextRange& range) const
 {
-    int lineCount = 0;
     wxString text;
     wxRichTextObjectList::compatibility_iterator node = m_children.GetFirst();
     while (node)
@@ -3365,8 +3364,6 @@ wxString wxRichTextParagraphLayoutBox::GetTextForRange(const wxRichTextRange& ra
 
             if ((childRange.GetEnd() == child->GetRange().GetEnd()) && node->GetNext())
                 text += wxT("\n");
-
-            lineCount ++;
         }
         node = node->GetNext();
     }

--- a/src/richtext/richtextctrl.cpp
+++ b/src/richtext/richtextctrl.cpp
@@ -1347,10 +1347,6 @@ void wxRichTextCtrl::OnChar(wxKeyEvent& event)
 
         bool processed = DeleteSelectedContent(& newPos);
 
-        int deletions = 0;
-        if (processed)
-            deletions ++;
-
         // Submit range in character positions, which are greater than caret positions,
         if (newPos < GetFocusObject()->GetOwnRange().GetEnd()+1)
         {
@@ -1363,7 +1359,6 @@ void wxRichTextCtrl::OnChar(wxKeyEvent& event)
                     if (CanDeleteRange(* GetFocusObject(), range.FromInternal()))
                     {
                         GetFocusObject()->DeleteRangeWithUndo(range, this, & GetBuffer());
-                        deletions ++;
                     }
                     processed = true;
                 }
@@ -1375,7 +1370,6 @@ void wxRichTextCtrl::OnChar(wxKeyEvent& event)
                 if (CanDeleteRange(* GetFocusObject(), range.FromInternal()))
                 {
                     GetFocusObject()->DeleteRangeWithUndo(range, this, & GetBuffer());
-                    deletions ++;
                 }
             }
         }
@@ -1576,10 +1570,6 @@ bool wxRichTextCtrl::ProcessBackKey(wxKeyEvent& event, int flags)
 
         bool processed = DeleteSelectedContent(& newPos);
 
-        int deletions = 0;
-        if (processed)
-            deletions ++;
-
         // Submit range in character positions, which are greater than caret positions,
         // so subtract 1 for deleted character and add 1 for conversion to character position.
         if (newPos > -1)
@@ -1593,7 +1583,6 @@ bool wxRichTextCtrl::ProcessBackKey(wxKeyEvent& event, int flags)
                     if (CanDeleteRange(* GetFocusObject(), range.FromInternal()))
                     {
                         GetFocusObject()->DeleteRangeWithUndo(range, this, & GetBuffer());
-                        deletions ++;
                     }
                     processed = true;
                 }
@@ -1605,7 +1594,6 @@ bool wxRichTextCtrl::ProcessBackKey(wxKeyEvent& event, int flags)
                 if (CanDeleteRange(* GetFocusObject(), range.FromInternal()))
                 {
                     GetFocusObject()->DeleteRangeWithUndo(range, this, & GetBuffer());
-                    deletions ++;
                 }
             }
         }


### PR DESCRIPTION
For some reason there have been a couple of variables declared, written to, but never read from. I have removed them, assuming this is a correct thing to do.

Using CMake 64-bit Debug build with MSVC 2022 v17.4.3, GCC 12.2, and clang 15.0; the only remaining warning in the library is
```
D:\Dev\Desktop\!Lib\wxWidgets-PB\src\richtext\richtextbuffer.cpp:4902:17: warning: variable 'i' set but not used [-Wunused-but-set-variable]
            int i = 0;
```
The variable is used only in a conditionally compiled block
https://github.com/wxWidgets/wxWidgets/blob/1d3d0ae49693d59dc6b86a2128997df211d17675/src/richtext/richtextbuffer.cpp#L4924-L4930
so I don't know what to do, aside from using `wxUnusedVar()` or declaring the variable also in a similar conditionally compiled block. Neither sounds appealing but I guess one has to be picked.

There is also a warning about missing enum switch value in the webview2 SDK but I suppose suppressing warnings in 3rd party code would be too much work.

There is still a bunch of warning in the samples and benchmarks but I think these are much lower priority when in comes to warning-less build. I would still like to address them in the future, if possible.



