### PR TITLE
Fix memory leak of command line arguments in wxMSW

### DIFF
--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -418,7 +418,12 @@ static void DoCommonPostCleanup()
 #endif // wxUSE_LOG
 }
 
-void wxEntryCleanup()
+// for MSW the real wxEntryCleanup() is defined in msw/main.cpp
+#ifndef __WINDOWS__
+    #define wxEntryCleanupReal wxEntryCleanup
+#endif // !__WINDOWS__
+
+void wxEntryCleanupReal()
 {
     DoCommonPreCleanup();
 

--- a/src/msw/main.cpp
+++ b/src/msw/main.cpp
@@ -38,7 +38,7 @@
 
 // defined in common/init.cpp
 extern int wxEntryReal(int& argc, wxChar **argv);
-extern int wxEntryCleanupReal(int& argc, wxChar **argv);
+extern void wxEntryCleanupReal();
 
 // ============================================================================
 // implementation: various entry points
@@ -188,6 +188,18 @@ int wxEntry(int& argc, wxChar **argv)
 // Windows-specific wxEntry
 // ----------------------------------------------------------------------------
 
+// Declare the functions used in wxCore to access the command line arguments
+// data in wxBase.
+WXDLLIMPEXP_BASE void wxMSWCommandLineInit();
+WXDLLIMPEXP_BASE void wxMSWCommandLineCleanup();
+WXDLLIMPEXP_BASE int& wxMSWCommandLineGetArgc();
+WXDLLIMPEXP_BASE wchar_t** wxMSWCommandLineGetArgv();
+
+#if wxUSE_BASE
+
+namespace
+{
+
 struct wxMSWCommandLineArguments
 {
     wxMSWCommandLineArguments() { argc = 0; argv = nullptr; }
@@ -202,17 +214,51 @@ struct wxMSWCommandLineArguments
         argv = ::CommandLineToArgvW(::GetCommandLineW(), &argc);
     }
 
-    ~wxMSWCommandLineArguments()
+    void Cleanup()
     {
         if ( argc )
+        {
             ::LocalFree(argv);
+            argc = 0;
+        }
+    }
+
+    ~wxMSWCommandLineArguments()
+    {
+        Cleanup();
     }
 
     int argc;
     wxChar **argv;
+
+    wxDECLARE_NO_COPY_CLASS(wxMSWCommandLineArguments);
 };
 
 static wxMSWCommandLineArguments wxArgs;
+
+} // anonymous namespace
+
+WXDLLIMPEXP_BASE void wxMSWCommandLineInit()
+{
+    wxArgs.Init();
+}
+
+WXDLLIMPEXP_BASE void wxMSWCommandLineCleanup()
+{
+    wxArgs.Cleanup();
+}
+
+WXDLLIMPEXP_BASE int& wxMSWCommandLineGetArgc()
+{
+    return wxArgs.argc;
+}
+
+WXDLLIMPEXP_BASE wchar_t** wxMSWCommandLineGetArgv()
+{
+    return wxArgs.argv;
+}
+
+#endif // wxUSE_BASE
 
 #if wxUSE_GUI
 
@@ -228,7 +274,7 @@ wxMSWEntryCommon(HINSTANCE hInstance, int nCmdShow)
     wxUnusedVar(nCmdShow);
 #endif
 
-    wxArgs.Init();
+    wxMSWCommandLineInit();
 
     return true;
 }
@@ -241,7 +287,7 @@ WXDLLEXPORT bool wxEntryStart(HINSTANCE hInstance,
     if ( !wxMSWEntryCommon(hInstance, nCmdShow) )
        return false;
 
-    return wxEntryStart(wxArgs.argc, wxArgs.argv);
+    return wxEntryStart(wxMSWCommandLineGetArgc(), wxMSWCommandLineGetArgv());
 }
 
 WXDLLEXPORT int wxEntry(HINSTANCE hInstance,
@@ -252,7 +298,7 @@ WXDLLEXPORT int wxEntry(HINSTANCE hInstance,
     if ( !wxMSWEntryCommon(hInstance, nCmdShow) )
         return -1;
 
-    return wxEntry(wxArgs.argc, wxArgs.argv);
+    return wxEntry(wxMSWCommandLineGetArgc(), wxMSWCommandLineGetArgv());
 }
 
 #endif // wxUSE_GUI
@@ -265,9 +311,16 @@ WXDLLEXPORT int wxEntry(HINSTANCE hInstance,
 
 int wxEntry()
 {
-    wxArgs.Init();
+    wxMSWCommandLineInit();
 
-    return wxEntry(wxArgs.argc, wxArgs.argv);
+    return wxEntry(wxMSWCommandLineGetArgc(), wxMSWCommandLineGetArgv());
+}
+
+void wxEntryCleanup()
+{
+    wxEntryCleanupReal();
+
+    wxMSWCommandLineCleanup();
 }
 
 HINSTANCE wxhInstance = 0;


### PR DESCRIPTION
Use the same hack already used for wxEntryReal() before to define a MSW-specific wxEntryCleanup() which frees the memory allocated by ::CommandLineToArgvW() after performing the common cleanup.

Also refactor the code dealing with them to avoid having different wxArgs variables in wxBase and wxCode, which was almost certainly unintentional and definitely very confusing. Now we keep just a single wxArgs in wxBase and provide access to it from wxCore via the exported functions.

Closes #23081.