### PR TITLE
Fix wrong links in documentation

### DIFF
--- a/docs/doxygen/overviews/high_dpi.md
+++ b/docs/doxygen/overviews/high_dpi.md
@@ -270,11 +270,11 @@ bitmap will be the default bundle size, which must be provided when creating
 this kind of bitmap bundle, as SVG image itself doesn't necessarily contain
 this information.
 
-Note that wxWidgets currently uses [NanoSVG][1] library for SVG support and so
+Note that wxWidgets currently uses [NanoSVG][2] library for SVG support and so
 doesn't support all SVG standard features and you may need to simplify or
 tweak the SVG files to make them appear correctly.
 
-[1]: https://github.com/memononen/nanosvg
+[2]: https://github.com/memononen/nanosvg
 
 wxBitmapBundle and XRC              {#high_dpi_bundle_xrc}
 ----------------------
@@ -317,22 +317,22 @@ MSW                                 {#high_dpi_platform_msw}
 ---
 
 The behaviour of the application when running on a high-DPI display depends on
-the values in its [manifest][1]. You may either use your own manifest, in which
+the values in its [manifest][3]. You may either use your own manifest, in which
 case you need to define the `dpiAware` (for compatibility with older OS
 versions) and `dpiAwareness` (for proper per-monitor DPI support) in it, or
 simply include `wx/msw/wx.rc` from your resource file to use the manifest
 provided by wxWidgets and predefine `wxUSE_DPI_AWARE_MANIFEST` to opt-in into
-[high DPI support][2]: define it as `1` for minimal DPI awareness and `2` for
+[high DPI support][4]: define it as `1` for minimal DPI awareness and `2` for
 full, per-monitor DPI awareness supported by Windows 10 version 1703 or later.
 
-[1]: https://docs.microsoft.com/en-us/windows/win32/sbscs/application-manifests
-[2]: https://docs.microsoft.com/en-us/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows
+[3]: https://docs.microsoft.com/en-us/windows/win32/sbscs/application-manifests
+[4]: https://docs.microsoft.com/en-us/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows
 
 macOS                               {#high_dpi_platform_mac}
 -----
 
 DPI-aware applications must set their `NSPrincipalClass` to `wxNSApplication`
 (or at least `NSApplication`) in their `Info.plist` file. Also see Apple [high
-resolution guidelines][3] for more information.
+resolution guidelines][5] for more information.
 
-[3]: https://developer.apple.com/library/archive/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Explained/Explained.html
+[5]: https://developer.apple.com/library/archive/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Explained/Explained.html

--- a/docs/doxygen/overviews/install.md
+++ b/docs/doxygen/overviews/install.md
@@ -56,7 +56,7 @@ using the following command:
 
     $ git clone --recurse-submodules https://github.com/wxWidgets/wxWidgets.git
 
-Alternatively, you can download the sources from the [downloads page][1].
+Alternatively, you can download the sources from the [downloads page][5].
 Please note that all the source archives in different formats (ZIP, 7z,
 tar.bz2) contain the same files, but use different line ending formats: Unix
 ("LF") for the latter one and DOS ("CR LF") for the two other ones, and it is
@@ -64,6 +64,7 @@ usually preferable to choose the format corresponding to the current platform.
 When downloading the sources with DOS ends of lines, prefer 7z format for much
 smaller file size.
 
+[5]: https://www.wxwidgets.org/downloads/
 
 ### Selecting the build system
 
@@ -223,11 +224,11 @@ launchctl setenv WXWIN /Users/dconnet/devtools/wx/wxWidgets-3.1.5
 
 ### Other IDEs
 
-If you use an IDE with wxWidgets support, such as [Code::Blocks][1] or
-[CodeLite][2], please use the IDE wizards.
+If you use an IDE with wxWidgets support, such as [Code::Blocks][6] or
+[CodeLite][7], please use the IDE wizards.
 
-[1]: https://www.codeblocks.org/
-[2]: https://codelite.org/
+[6]: https://www.codeblocks.org/
+[7]: https://codelite.org/
 
 If you use another IDE, under Unix you should run `wx-config --cxxflags` and
 `wx-config --libs` commands separately and copy-and-paste their output to the


### PR DESCRIPTION
Using the same link id more than once a page results in all links using the first one.
See e.g. link to NanoSVG here
https://docs.wxwidgets.org/trunk/overview_high_dpi.html

Also add a missing link target