### PR TITLE
Add wxNODISCARD to wxBitmapBundle functions

### DIFF
--- a/include/wx/bmpbndl.h
+++ b/include/wx/bmpbndl.h
@@ -62,17 +62,17 @@ public:
 
     // Create from the given collection of bitmaps (all of which must be valid,
     // but if the vector itself is empty, empty bundle is returned).
-    static wxNODISCARD wxBitmapBundle FromBitmaps(const wxVector<wxBitmap>& bitmaps);
-    static wxNODISCARD wxBitmapBundle FromBitmaps(const wxBitmap& bitmap1,
+    wxNODISCARD static wxBitmapBundle FromBitmaps(const wxVector<wxBitmap>& bitmaps);
+    wxNODISCARD static wxBitmapBundle FromBitmaps(const wxBitmap& bitmap1,
                                       const wxBitmap& bitmap2);
 
     // Create from a single bitmap (this is only useful for compatibility
     // with the existing code). Returns empty bundle if bitmap is invalid.
-    static wxNODISCARD wxBitmapBundle FromBitmap(const wxBitmap& bitmap);
-    static wxNODISCARD wxBitmapBundle FromImage(const wxImage& image);
+    wxNODISCARD static wxBitmapBundle FromBitmap(const wxBitmap& bitmap);
+    wxNODISCARD static wxBitmapBundle FromImage(const wxImage& image);
 
     // Create from icon bundle.
-    static wxNODISCARD wxBitmapBundle FromIconBundle(const wxIconBundle& iconBundle);
+    wxNODISCARD static wxBitmapBundle FromIconBundle(const wxIconBundle& iconBundle);
 
     // It should be possible to implement SVG rasterizing without raw bitmap
     // support using wxDC::DrawSpline(), but currently we don't do it and so
@@ -81,16 +81,16 @@ public:
     // Create from the SVG data (data is supposed to be in UTF-8 encoding).
     // Notice that the data here is non-const because it can be temporarily
     // modified while parsing it.
-    static wxNODISCARD wxBitmapBundle FromSVG(char* data, const wxSize& sizeDef);
+    wxNODISCARD static wxBitmapBundle FromSVG(char* data, const wxSize& sizeDef);
 
     // This overload currently makes a copy of the data.
-    static wxNODISCARD wxBitmapBundle FromSVG(const char* data, const wxSize& sizeDef);
+    wxNODISCARD static wxBitmapBundle FromSVG(const char* data, const wxSize& sizeDef);
 
     // This overload works for data not terminated with 0
-    static wxNODISCARD wxBitmapBundle FromSVG(const wxByte* data, size_t len, const wxSize& sizeDef);
+    wxNODISCARD static wxBitmapBundle FromSVG(const wxByte* data, size_t len, const wxSize& sizeDef);
 
     // Load SVG image from the given file (must be a local file, not an URL).
-    static wxNODISCARD wxBitmapBundle FromSVGFile(const wxString& path, const wxSize& sizeDef);
+    wxNODISCARD static wxBitmapBundle FromSVGFile(const wxString& path, const wxSize& sizeDef);
 
     // Create from SVG image stored as an application resource.
     // On Windows, name must be a resource with RT_RCDATA type.
@@ -101,15 +101,15 @@ public:
 
     // Create from the resources: all existing versions of the bitmap of the
     // form name_2x or name@2x (and also using other factors) will be used.
-    static wxNODISCARD wxBitmapBundle FromResources(const wxString& name);
+    wxNODISCARD static wxBitmapBundle FromResources(const wxString& name);
 
     // Create from files: all existing versions of the bitmap of the
     // form filename_2x or name@2x (and also using other factors) will be used.
-    static wxNODISCARD wxBitmapBundle FromFiles(const wxString& fullpathname);
-    static wxNODISCARD wxBitmapBundle FromFiles(const wxString& path, const wxString& filename, const wxString& extension = wxASCII_STR("png"));
+    wxNODISCARD static wxBitmapBundle FromFiles(const wxString& fullpathname);
+    wxNODISCARD static wxBitmapBundle FromFiles(const wxString& path, const wxString& filename, const wxString& extension = wxASCII_STR("png"));
 
     // Create from existing implementation
-    static wxNODISCARD wxBitmapBundle FromImpl(wxBitmapBundleImpl* impl);
+    wxNODISCARD static wxBitmapBundle FromImpl(wxBitmapBundleImpl* impl);
 
     // Check if bitmap bundle is non-empty.
     wxNODISCARD bool IsOk() const { return m_impl.get() != nullptr; }
@@ -159,14 +159,14 @@ public:
 
     // Get the bitmap size preferred by the majority of the elements of the
     // bundles at the given scale or the scale appropriate for the given window.
-    static wxNODISCARD wxSize
+    wxNODISCARD static wxSize
     GetConsensusSizeFor(double scale, const wxVector<wxBitmapBundle>& bundles);
-    static wxNODISCARD wxSize
+    wxNODISCARD static wxSize
     GetConsensusSizeFor(wxWindow* win, const wxVector<wxBitmapBundle>& bundles);
 
     // Create wxImageList and fill it with the images from the given bundles in
     // the sizes appropriate for the DPI scaling used for the specified window.
-    static wxNODISCARD wxImageList*
+    wxNODISCARD static wxImageList*
     CreateImageList(wxWindow* win, const wxVector<wxBitmapBundle>& bundles);
 
 private:

--- a/include/wx/bmpbndl.h
+++ b/include/wx/bmpbndl.h
@@ -62,17 +62,17 @@ public:
 
     // Create from the given collection of bitmaps (all of which must be valid,
     // but if the vector itself is empty, empty bundle is returned).
-    static wxBitmapBundle FromBitmaps(const wxVector<wxBitmap>& bitmaps);
-    static wxBitmapBundle FromBitmaps(const wxBitmap& bitmap1,
+    static wxNODISCARD wxBitmapBundle FromBitmaps(const wxVector<wxBitmap>& bitmaps);
+    static wxNODISCARD wxBitmapBundle FromBitmaps(const wxBitmap& bitmap1,
                                       const wxBitmap& bitmap2);
 
     // Create from a single bitmap (this is only useful for compatibility
     // with the existing code). Returns empty bundle if bitmap is invalid.
-    static wxBitmapBundle FromBitmap(const wxBitmap& bitmap);
-    static wxBitmapBundle FromImage(const wxImage& image);
+    static wxNODISCARD wxBitmapBundle FromBitmap(const wxBitmap& bitmap);
+    static wxNODISCARD wxBitmapBundle FromImage(const wxImage& image);
 
     // Create from icon bundle.
-    static wxBitmapBundle FromIconBundle(const wxIconBundle& iconBundle);
+    static wxNODISCARD wxBitmapBundle FromIconBundle(const wxIconBundle& iconBundle);
 
     // It should be possible to implement SVG rasterizing without raw bitmap
     // support using wxDC::DrawSpline(), but currently we don't do it and so
@@ -81,76 +81,76 @@ public:
     // Create from the SVG data (data is supposed to be in UTF-8 encoding).
     // Notice that the data here is non-const because it can be temporarily
     // modified while parsing it.
-    static wxBitmapBundle FromSVG(char* data, const wxSize& sizeDef);
+    static wxNODISCARD wxBitmapBundle FromSVG(char* data, const wxSize& sizeDef);
 
     // This overload currently makes a copy of the data.
-    static wxBitmapBundle FromSVG(const char* data, const wxSize& sizeDef);
+    static wxNODISCARD wxBitmapBundle FromSVG(const char* data, const wxSize& sizeDef);
 
     // This overload works for data not terminated with 0
-    static wxBitmapBundle FromSVG(const wxByte* data, size_t len, const wxSize& sizeDef);
+    static wxNODISCARD wxBitmapBundle FromSVG(const wxByte* data, size_t len, const wxSize& sizeDef);
 
     // Load SVG image from the given file (must be a local file, not an URL).
-    static wxBitmapBundle FromSVGFile(const wxString& path, const wxSize& sizeDef);
+    static wxNODISCARD wxBitmapBundle FromSVGFile(const wxString& path, const wxSize& sizeDef);
 
     // Create from SVG image stored as an application resource.
     // On Windows, name must be a resource with RT_RCDATA type.
     // On MacOS, name must be a file with an extension "svg" placed in the
     // "Resources" subdirectory of the application bundle.
-    static wxBitmapBundle FromSVGResource(const wxString& name, const wxSize& sizeDef);
+    static wxNODISCARD wxBitmapBundle FromSVGResource(const wxString& name, const wxSize& sizeDef);
 #endif // wxHAS_SVG
 
     // Create from the resources: all existing versions of the bitmap of the
     // form name_2x or name@2x (and also using other factors) will be used.
-    static wxBitmapBundle FromResources(const wxString& name);
+    static wxNODISCARD wxBitmapBundle FromResources(const wxString& name);
 
     // Create from files: all existing versions of the bitmap of the
     // form filename_2x or name@2x (and also using other factors) will be used.
-    static wxBitmapBundle FromFiles(const wxString& fullpathname);
-    static wxBitmapBundle FromFiles(const wxString& path, const wxString& filename, const wxString& extension = wxASCII_STR("png"));
+    static wxNODISCARD wxBitmapBundle FromFiles(const wxString& fullpathname);
+    static wxNODISCARD wxBitmapBundle FromFiles(const wxString& path, const wxString& filename, const wxString& extension = wxASCII_STR("png"));
 
     // Create from existing implementation
-    static wxBitmapBundle FromImpl(wxBitmapBundleImpl* impl);
+    static wxNODISCARD wxBitmapBundle FromImpl(wxBitmapBundleImpl* impl);
 
     // Check if bitmap bundle is non-empty.
-    bool IsOk() const { return m_impl.get() != nullptr; }
+    wxNODISCARD bool IsOk() const { return m_impl.get() != nullptr; }
 
     // Clear the bundle contents, IsOk() will return false after doing this.
     void Clear();
 
     // Get the size of the bitmap represented by this bundle when using the
     // default DPI, i.e. 100% scaling. Returns invalid size for empty bundle.
-    wxSize GetDefaultSize() const;
+    wxNODISCARD wxSize GetDefaultSize() const;
 
     // Get the physical size of the preferred bitmap at the given scale.
-    wxSize GetPreferredBitmapSizeAtScale(double scale) const;
+    wxNODISCARD wxSize GetPreferredBitmapSizeAtScale(double scale) const;
 
     // Get preferred size, i.e. usually the closest size in which a bitmap is
     // available to the ideal size determined from the default size and the DPI
     // scaling, for the given window, in physical/logical pixels respectively.
-    wxSize GetPreferredBitmapSizeFor(const wxWindow* window) const;
-    wxSize GetPreferredLogicalSizeFor(const wxWindow* window) const;
+    wxNODISCARD wxSize GetPreferredBitmapSizeFor(const wxWindow* window) const;
+    wxNODISCARD wxSize GetPreferredLogicalSizeFor(const wxWindow* window) const;
 
     // Get bitmap of the specified size, creating a new bitmap from the closest
     // available size by rescaling it if necessary.
     //
     // If size == wxDefaultSize, GetDefaultSize() is used for it instead.
-    wxBitmap GetBitmap(const wxSize& size) const;
+    wxNODISCARD wxBitmap GetBitmap(const wxSize& size) const;
 
     // Get icon of the specified size, this is just a convenient wrapper for
     // GetBitmap() converting the returned bitmap to the icon.
-    wxIcon GetIcon(const wxSize& size) const;
+    wxNODISCARD wxIcon GetIcon(const wxSize& size) const;
 
     // Helpers combining GetPreferredBitmapSizeFor() and GetBitmap() or
     // GetIcon(): return the bitmap or icon of the size appropriate for the
     // current DPI scaling of the given window.
-    wxBitmap GetBitmapFor(const wxWindow* window) const;
-    wxIcon GetIconFor(const wxWindow* window) const;
+    wxNODISCARD wxBitmap GetBitmapFor(const wxWindow* window) const;
+    wxNODISCARD wxIcon GetIconFor(const wxWindow* window) const;
 
     // Access implementation
-    wxBitmapBundleImpl* GetImpl() const { return m_impl.get(); }
+    wxNODISCARD wxBitmapBundleImpl* GetImpl() const { return m_impl.get(); }
 
     // Check if two objects refer to the same bundle.
-    bool IsSameAs(const wxBitmapBundle& other) const
+    wxNODISCARD bool IsSameAs(const wxBitmapBundle& other) const
     {
         return GetImpl() == other.GetImpl();
     }
@@ -159,14 +159,14 @@ public:
 
     // Get the bitmap size preferred by the majority of the elements of the
     // bundles at the given scale or the scale appropriate for the given window.
-    static wxSize
+    static wxNODISCARD wxSize
     GetConsensusSizeFor(double scale, const wxVector<wxBitmapBundle>& bundles);
-    static wxSize
+    static wxNODISCARD wxSize
     GetConsensusSizeFor(wxWindow* win, const wxVector<wxBitmapBundle>& bundles);
 
     // Create wxImageList and fill it with the images from the given bundles in
     // the sizes appropriate for the DPI scaling used for the specified window.
-    static wxImageList*
+    static wxNODISCARD wxImageList*
     CreateImageList(wxWindow* win, const wxVector<wxBitmapBundle>& bundles);
 
 private:

--- a/include/wx/bmpbndl.h
+++ b/include/wx/bmpbndl.h
@@ -96,7 +96,7 @@ public:
     // On Windows, name must be a resource with RT_RCDATA type.
     // On MacOS, name must be a file with an extension "svg" placed in the
     // "Resources" subdirectory of the application bundle.
-    static wxNODISCARD wxBitmapBundle FromSVGResource(const wxString& name, const wxSize& sizeDef);
+    wxNODISCARD static wxBitmapBundle FromSVGResource(const wxString& name, const wxSize& sizeDef);
 #endif // wxHAS_SVG
 
     // Create from the resources: all existing versions of the bitmap of the


### PR DESCRIPTION
I'm embarrassed to admit that I was trying to do this:

```
wxBitmapBundle bb;
bb.FromBitmaps(...)
```

and it took me a little while to figure out why it wasn't working until I finally read the help.  Adding `wxNODISCARD` would help others from making the same mistake.