### PR TITLE
Fix a possible crash in Mac menu item event handling

### DIFF
--- a/src/osx/cocoa/menuitem.mm
+++ b/src/osx/cocoa/menuitem.mm
@@ -86,9 +86,11 @@ SEL wxOSXGetSelectorFromID(int menuId )
     wxUnusedVar(sender);
     if ( impl )
     {
-        wxMenuItem* menuitem = impl->GetWXPeer();
-        if ( menuitem->GetMenu()->HandleCommandProcess(menuitem) == false )
+        if ( wxMenuItem* menuitem = impl->GetWXPeer() )
         {
+            // Ignore the return value as there doesn't seem anything to do
+            // with it here.
+            menuitem->GetMenu()->HandleCommandProcess(menuitem);
         }
      }
 }

--- a/src/osx/cocoa/nonownedwnd.mm
+++ b/src/osx/cocoa/nonownedwnd.mm
@@ -367,8 +367,8 @@ extern int wxOSXGetIdFromSelector(SEL action );
         wxMenuItemImpl* impl = [nsMenuItem implementation];
         if ( impl )
         {
-            wxMenuItem* menuitem = impl->GetWXPeer();
-            return menuitem->GetMenu()->HandleCommandProcess(menuitem);
+            if ( wxMenuItem* menuitem = impl->GetWXPeer() )
+                return menuitem->GetMenu()->HandleCommandProcess(menuitem);
         }
     }
     // otherwise feed back command into common menubar

--- a/src/osx/menu_osx.cpp
+++ b/src/osx/menu_osx.cpp
@@ -366,18 +366,21 @@ bool wxMenu::HandleCommandProcess( wxMenuItem* item )
     if (item->IsCheckable())
         item->Check( !item->IsChecked() ) ;
 
+    // A bit counterintuitively, we call OSXAfterMenuEvent() _before_ calling
+    // the user defined handler. This is done to account for the case when this
+    // handler deletes the window, as it can possibly do.
+    if (wxWindow* const w = GetInvokingWindow())
+    {
+        // Let the invoking window update itself if necessary.
+        w->OSXAfterMenuEvent();
+    }
+
     if ( SendEvent( menuid , item->IsCheckable() ? item->IsChecked() : -1 ) )
         processed = true ;
 
     if(!processed)
     {
         processed = item->GetPeer()->DoDefault();  
-    }
-    
-    if (wxWindow* const w = GetInvokingWindow())
-    {
-        // Let the invoking window update itself if necessary.
-        w->OSXAfterMenuEvent();
     }
 
     return processed;

--- a/src/osx/menu_osx.cpp
+++ b/src/osx/menu_osx.cpp
@@ -359,7 +359,9 @@ bool wxMenu::HandleCommandUpdateStatus( wxMenuItem* item )
 
 bool wxMenu::HandleCommandProcess( wxMenuItem* item )
 {
-    int menuid = item ? item->GetId() : 0;
+    wxCHECK_MSG( item, false, "must have a valid item" );
+
+    int menuid = item->GetId();
     bool processed = false;
     if (item->IsCheckable())
         item->Check( !item->IsChecked() ) ;
@@ -367,7 +369,7 @@ bool wxMenu::HandleCommandProcess( wxMenuItem* item )
     if ( SendEvent( menuid , item->IsCheckable() ? item->IsChecked() : -1 ) )
         processed = true ;
 
-    if(!processed && item)
+    if(!processed)
     {
         processed = item->GetPeer()->DoDefault();  
     }


### PR DESCRIPTION
This replaces #23040 with a better/simpler fix and also cleans things up a little as described there.

AFAICS this could be backported to 3.2 too.