### PR TITLE
Mention embedded images in SVG not being supported

### DIFF
--- a/interface/wx/bmpbndl.h
+++ b/interface/wx/bmpbndl.h
@@ -252,6 +252,7 @@ public:
 
         - Text elements are not supported at all (see note for workaround).
         - SVG 1.1 filters are not supported.
+        - Embedded images are not supported.
 
         These limitations will be relaxed in the future wxWidgets versions.
 
@@ -277,7 +278,7 @@ public:
         @note Converting text objects to path objects will allow them to be
             rasterized as expected. This can be done in an SVG editor such as
             Inkscape. (In Inkscape, select a text object and choose
-            *Object to Path* from the *Path* menu.)
+            "Object to Path" from the "Path" menu.)
      */
     static wxBitmapBundle FromSVG(char* data, const wxSize& sizeDef);
 

--- a/interface/wx/bmpbndl.h
+++ b/interface/wx/bmpbndl.h
@@ -252,7 +252,7 @@ public:
 
         - Text elements are not supported at all (see note for workaround).
         - SVG 1.1 filters are not supported.
-        - Embedded images are not supported.
+        - Embedded images are not supported (see note for workaround).
 
         These limitations will be relaxed in the future wxWidgets versions.
 
@@ -278,7 +278,12 @@ public:
         @note Converting text objects to path objects will allow them to be
             rasterized as expected. This can be done in an SVG editor such as
             Inkscape. (In Inkscape, select a text object and choose
-            "Object to Path" from the "Path" menu.)
+            "Object to Path" from the "Path" menu.)\n
+            Converting embedded images to paths from an SVG editor will
+            allow them to be rasterized. For example, selecting "Trace Bitmap"
+            from the "Path" menu in Inkscape can perform this. This is only
+            recommended for simple images, however, as more complex images
+            may not rasterize well.
      */
     static wxBitmapBundle FromSVG(char* data, const wxSize& sizeDef);
 


### PR DESCRIPTION
At least from my experiments, PNG and BMP files embedded in SVGs do not get rasterized at all by nanosvg.  I only have Inkscape to test with, so perhaps it's something with how Inkscape saves SVG, but I more strongly suspect nanosvg just doesn't support this.  Looking at the code, that seems to be the case. However, please let me know if I am mistaken.

Also, fix minor doxygen formatting in note.