### PR TITLE
Corrected path for x64 wxrc.exe file

### DIFF
--- a/build/tools/msvs/package.bat
+++ b/build/tools/msvs/package.bat
@@ -68,7 +68,7 @@ copy utils\wxrc\%VCver%_mswudll\wxrc.exe lib\%VCver%_dll
 rem Package the 64 bit files
 
 REM Copy wxrc.exe to the dll folder.
-copy utils\wxrc\%VCver%_mswudll_x64\wxrc.exe lib\%VCver%_x64_dll
+copy utils\wxrc\%VCver%_x64_mswudll\wxrc.exe lib\%VCver%_x64_dll
 
 7z a -t7z %packagePath%\%VCver%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_x64_Dev.7z lib\%VCver%_x64_dll\mswud lib\%VCver%_x64_dll\mswu lib\%VCver%_x64_dll\wxMSW%wxDllVers%ud_*.pdb lib\%VCver%_x64_dll\wxbase%wxDllVers%ud_*.pdb lib\%VCver%_x64_dll\wxMSW%wxDllVers%ud_*.dll lib\%VCver%_x64_dll\wxbase%wxDllVers%u*.dll lib\%VCver%_x64_dll\*.lib  lib\%VCver%_x64_dll\wxrc.exe
 7z a -t7z %packagePath%\%VCver%\wxMSW-%wxMAJOR_VERSION%.%wxMINOR_VERSION%.%wxRELEASE_NUMBER%_%VCver%_x64_ReleaseDLL.7z lib\%VCver%_x64_dll\wxMSW%wxDllVers%u_*.dll lib\%VCver%_x64_dll\wxbase%wxDllVers%u_*.dll


### PR DESCRIPTION
Fixes issue #23122. This should be backported to 3.2. I don't know a quick way to do this other than making the change on the 3.2 branch and making another PR, which I am quite willing to do, just let me know.