### PR TITLE
Fix typo in event docs

### DIFF
--- a/interface/wx/event.h
+++ b/interface/wx/event.h
@@ -4925,7 +4925,7 @@ public:
 
     The values of this type should only be created using wxNewEventType().
 
-    See the macro wxDEFINE_EVENT_TYPE() for more information.
+    See the macro wxDEFINE_EVENT() for more information.
 
     @see @ref overview_events
 */


### PR DESCRIPTION
Should be wxDEFINE_EVENT, not wxDEFINE_EVENT_TYPE