### PR TITLE
Scrolling with enabled flag wxDV_VARIABLE_LINE_HEIGHT (#23102)

### DIFF
--- a/samples/dataview/dataview.cpp
+++ b/samples/dataview/dataview.cpp
@@ -755,7 +755,6 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, int x, int y, int w, int
     fifthPanelSz->Add(button_sizer5);
     fifthPanel->SetSizerAndFit(fifthPanelSz);
 
-
     // page showing the indexed list model
     // -----------------------------------
 

--- a/samples/dataview/dataview.cpp
+++ b/samples/dataview/dataview.cpp
@@ -104,6 +104,7 @@ private:
     void OnShowCurrent(wxCommandEvent& event);
     void OnSetNinthCurrent(wxCommandEvent& event);
     void OnChangeNinthTitle(wxCommandEvent& event);
+    void OnEnsureNinthAndSecondColumn(wxCommandEvent& event);
 
     void OnPrependList(wxCommandEvent& event);
     void OnDeleteList(wxCommandEvent& event);
@@ -452,6 +453,7 @@ enum
     ID_SHOW_CURRENT,
     ID_SET_NINTH_CURRENT,
     ID_CHANGE_NINTH_TITLE,
+    ID_ENSURE_NINTH_SECOND_COLUMN,
 
     ID_PREPEND_LIST     = 200,
     ID_DELETE_LIST      = 201,
@@ -506,6 +508,7 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_BUTTON( ID_SHOW_CURRENT, MyFrame::OnShowCurrent )
     EVT_BUTTON( ID_SET_NINTH_CURRENT, MyFrame::OnSetNinthCurrent )
     EVT_BUTTON( ID_CHANGE_NINTH_TITLE, MyFrame::OnChangeNinthTitle )
+    EVT_BUTTON(ID_ENSURE_NINTH_SECOND_COLUMN, MyFrame::OnEnsureNinthAndSecondColumn)
 
     EVT_BUTTON( ID_PREPEND_LIST, MyFrame::OnPrependList )
     EVT_BUTTON( ID_DELETE_LIST, MyFrame::OnDeleteList )
@@ -741,9 +744,17 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, int x, int y, int w, int
 
     BuildDataViewCtrl(fifthPanel, Page_VarHeight);
 
+    wxBoxSizer* button_sizer5 = new wxBoxSizer(wxHORIZONTAL);
+    button_sizer5->Add(
+        new wxButton(fifthPanel, ID_ENSURE_NINTH_SECOND_COLUMN,
+            "Make ninth symphony and second column visible"),
+        wxSizerFlags().DoubleBorder());
+
     wxSizer *fifthPanelSz = new wxBoxSizer(wxVERTICAL);
     fifthPanelSz->Add(m_ctrl[Page_VarHeight], 1, wxGROW | wxALL, 5);
+    fifthPanelSz->Add(button_sizer5);
     fifthPanel->SetSizerAndFit(fifthPanelSz);
+
 
     // page showing the indexed list model
     // -----------------------------------
@@ -1586,6 +1597,14 @@ void MyFrame::OnChangeNinthTitle(wxCommandEvent& WXUNUSED(event))
 
     m_music_model->SetValue("Symphony No. 9", item, 0);
     m_music_model->ItemChanged(item);
+}
+
+void MyFrame::OnEnsureNinthAndSecondColumn(wxCommandEvent& WXUNUSED(event))
+{
+    wxDataViewItem item(m_long_music_model->GetNinthItem());
+    m_ctrl[Page_VarHeight]->Select(item);
+    wxDataViewColumn *col = m_ctrl[Page_VarHeight]->GetColumn(1);
+    m_ctrl[Page_VarHeight]->EnsureVisible(item, col);
 }
 
 void MyFrame::OnValueChanged( wxDataViewEvent &event )

--- a/samples/dataview/dataview.cpp
+++ b/samples/dataview/dataview.cpp
@@ -508,7 +508,7 @@ wxBEGIN_EVENT_TABLE(MyFrame, wxFrame)
     EVT_BUTTON( ID_SHOW_CURRENT, MyFrame::OnShowCurrent )
     EVT_BUTTON( ID_SET_NINTH_CURRENT, MyFrame::OnSetNinthCurrent )
     EVT_BUTTON( ID_CHANGE_NINTH_TITLE, MyFrame::OnChangeNinthTitle )
-    EVT_BUTTON(ID_ENSURE_NINTH_SECOND_COLUMN, MyFrame::OnEnsureNinthAndSecondColumn)
+    EVT_BUTTON( ID_ENSURE_NINTH_SECOND_COLUMN, MyFrame::OnEnsureNinthAndSecondColumn )
 
     EVT_BUTTON( ID_PREPEND_LIST, MyFrame::OnPrependList )
     EVT_BUTTON( ID_DELETE_LIST, MyFrame::OnDeleteList )

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -6450,9 +6450,23 @@ void wxDataViewCtrl::EnsureVisibleRowCol( int row, int column )
     int last = m_clientArea->GetLastFullyVisibleRow();
     if( row < first )
         m_clientArea->ScrollTo( row, column );
-    else if( row > last )
-        m_clientArea->ScrollTo( row - last + first, column );
-    else
+    else if (row > last)
+    {
+        if (!HasFlag(wxDV_VARIABLE_LINE_HEIGHT))
+            m_clientArea->ScrollTo(row - last + first, column);
+        else
+        {
+            // calculate scroll position based on last visible item
+            const int itemStart = m_clientArea->GetLineStart(row);
+            const int itemHeight = m_clientArea->GetLineHeight(row);
+            const int clientHeight = m_clientArea->GetSize().y;
+            int scrollX, scrollY;
+            GetScrollPixelsPerUnit(&scrollX, &scrollY);
+            int scrollPosY = (itemStart + itemHeight - clientHeight) / scrollY;
+            Scroll(-1, scrollPosY + 1); // +1 due to integer division, always show whole item
+        }
+    }
+    else if (row == first)
         m_clientArea->ScrollTo( first, column );
 }
 

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -6448,7 +6448,7 @@ void wxDataViewCtrl::EnsureVisibleRowCol( int row, int column )
 
     int first = m_clientArea->GetFirstVisibleRow();
     int last = m_clientArea->GetLastFullyVisibleRow();
-    if( row < first )
+    if( row <= first )
         m_clientArea->ScrollTo( row, column );
     else if (row > last)
     {
@@ -6466,8 +6466,7 @@ void wxDataViewCtrl::EnsureVisibleRowCol( int row, int column )
             Scroll(-1, scrollPosY);
         }
     }
-    else if (row == first)
-        m_clientArea->ScrollTo( first, column );
+    // #noelse
 }
 
 void wxDataViewCtrl::EnsureVisible( const wxDataViewItem & item, const wxDataViewColumn * column )

--- a/src/generic/datavgen.cpp
+++ b/src/generic/datavgen.cpp
@@ -6462,8 +6462,8 @@ void wxDataViewCtrl::EnsureVisibleRowCol( int row, int column )
             const int clientHeight = m_clientArea->GetSize().y;
             int scrollX, scrollY;
             GetScrollPixelsPerUnit(&scrollX, &scrollY);
-            int scrollPosY = (itemStart + itemHeight - clientHeight) / scrollY;
-            Scroll(-1, scrollPosY + 1); // +1 due to integer division, always show whole item
+            int scrollPosY = (itemStart + itemHeight - clientHeight + scrollY - 1) / scrollY;
+            Scroll(-1, scrollPosY);
         }
     }
     else if (row == first)


### PR DESCRIPTION
scroll to last visible item must be calculated based on item position instead of the first visible row.