### PR TITLE
Fix for a check of the combobox enable state, when control is recreating

### DIFF
--- a/src/msw/combobox.cpp
+++ b/src/msw/combobox.cpp
@@ -537,7 +537,7 @@ void wxComboBox::MSWRecreate()
         SetSelection(selection);
 
     // If disabled we'll have to disable it again after re-creating
-    if ( !IsEnabled() )
+    if ( !IsThisEnabled() )
         DoEnable(false);
 }
 


### PR DESCRIPTION
For check of the ComboBox enable state is better to use IsThisEnable() instead of IsEnable(),  IsEnabled() == IsThisEnabled() && parent.IsEnabled(). As a result it is possible, that when TopLevelWindow is disabled at the moment of a control recreation, then ComboBox is recreated with disable state.