### PR TITLE
Remove leftover blocks that used to be used in ANSI build

### DIFF
--- a/include/wx/buffer.h
+++ b/include/wx/buffer.h
@@ -419,7 +419,7 @@ public:
 #if wxUSE_UNICODE_WCHAR
     #define wxWC2WXbuf wxChar*
     #define wxWX2WCbuf wxChar*
-#elif wxUSE_UNICODE_UTF8
+#else /* wxUSE_UNICODE_UTF8 */
     #define wxWC2WXbuf wxWCharBuffer
     #define wxWX2WCbuf wxWCharBuffer
 #endif

--- a/include/wx/strvararg.h
+++ b/include/wx/strvararg.h
@@ -528,7 +528,7 @@ struct wxArgNormalizerWchar : public wxArgNormalizer<T>
     #define wxArgNormalizerNative wxArgNormalizerUtf8
 #else // wxUSE_UNICODE_WCHAR
     #define wxArgNormalizerNative wxArgNormalizerWchar
-#endif // wxUSE_UNICODE_UTF8 // wxUSE_UNICODE_UTF8
+#endif // wxUSE_UNICODE_UTF8/wxUSE_UNICODE_WCHAR
 
 
 

--- a/include/wx/wxcrtvararg.h
+++ b/include/wx/wxcrtvararg.h
@@ -288,12 +288,9 @@ wxGCC_ONLY_WARNING_RESTORE(format-nonliteral)
             if ( wxLocaleIsUtf8 ) return implA args;                 \
             else return implW args
     #endif
-#elif wxUSE_UNICODE_WCHAR
+#else // wxUSE_UNICODE_WCHAR
     #define WX_VARARG_VFOO_IMPL(args, implW, implA)                  \
         return implW args
-#else // ANSI
-    #define WX_VARARG_VFOO_IMPL(args, implW, implA)                  \
-        return implA args
 #endif
 
 inline int


### PR DESCRIPTION
Update some comments and prefer using #if/#else when testing for wxUSE_UNICODE_UTF8 and wxUSE_UNICODE_WCHAR rather than #if/#elif as exactly one of them is always defined now. Similarly, test for wxUSE_UNICODE_WCHAR directly instead of testing !wxUSE_UNICODE_UTF8 and vice versa.

It could be nice to actually test for just a single one of these symbols everywhere, but this would require a lot of noisy changes, so for now keep the code as is.

No real changes, just simplify.