### PR TITLE
Fix wxFontList::FindOrCreateFont() for pixel and fractional point sizes

### DIFF
--- a/include/wx/font.h
+++ b/include/wx/font.h
@@ -640,7 +640,12 @@ public:
                              wxFontWeight weight,
                              bool underline = false,
                              const wxString& face = wxEmptyString,
-                             wxFontEncoding encoding = wxFONTENCODING_DEFAULT);
+                             wxFontEncoding encoding = wxFONTENCODING_DEFAULT)
+        {   return FindOrCreateFont(wxFontInfo(pointSize)
+                                    .Family(family)
+                                    .Style(style).Weight(weight).Underlined(underline)
+                                    .FaceName(face).Encoding(encoding));
+        }
 
     wxDEPRECATED_MSG("use wxFONT{FAMILY,STYLE,WEIGHT}_XXX constants")
     wxFont *FindOrCreateFont(int pointSize, int family, int style, int weight,
@@ -650,11 +655,7 @@ public:
         { return FindOrCreateFont(pointSize, (wxFontFamily)family, (wxFontStyle)style,
                                   (wxFontWeight)weight, underline, face, encoding); }
 
-    wxFont *FindOrCreateFont(const wxFontInfo& fontInfo)
-        { return FindOrCreateFont(fontInfo.GetPointSize(), fontInfo.GetFamily(),
-                                  fontInfo.GetStyle(), fontInfo.GetWeight(),
-                                  fontInfo.IsUnderlined(), fontInfo.GetFaceName(),
-                                  fontInfo.GetEncoding()); }
+    wxFont *FindOrCreateFont(const wxFontInfo& fontInfo);
 };
 
 extern WXDLLIMPEXP_DATA_CORE(wxFontList*)    wxTheFontList;

--- a/include/wx/font.h
+++ b/include/wx/font.h
@@ -634,6 +634,11 @@ WXDLLIMPEXP_CORE bool wxFromString(const wxString& str, wxFontBase* font);
 class WXDLLIMPEXP_CORE wxFontList: public wxGDIObjListBase
 {
 public:
+    // Preferred function that works for any kind of fonts.
+    wxFont *FindOrCreateFont(const wxFontInfo& fontInfo);
+
+    // Non-deprecated but limited older function only working for the fonts
+    // with the integer sizes.
     wxFont *FindOrCreateFont(int pointSize,
                              wxFontFamily family,
                              wxFontStyle style,
@@ -641,7 +646,8 @@ public:
                              bool underline = false,
                              const wxString& face = wxEmptyString,
                              wxFontEncoding encoding = wxFONTENCODING_DEFAULT)
-        {   return FindOrCreateFont(wxFontInfo(pointSize)
+        {
+            return FindOrCreateFont(wxFontInfo(pointSize)
                                     .Family(family)
                                     .Style(style).Weight(weight).Underlined(underline)
                                     .FaceName(face).Encoding(encoding));
@@ -654,8 +660,6 @@ public:
                               wxFontEncoding encoding = wxFONTENCODING_DEFAULT)
         { return FindOrCreateFont(pointSize, (wxFontFamily)family, (wxFontStyle)style,
                                   (wxFontWeight)weight, underline, face, encoding); }
-
-    wxFont *FindOrCreateFont(const wxFontInfo& fontInfo);
 };
 
 extern WXDLLIMPEXP_DATA_CORE(wxFontList*)    wxTheFontList;

--- a/interface/wx/font.h
+++ b/interface/wx/font.h
@@ -1387,6 +1387,12 @@ public:
     /**
         Finds a font of the given specification, or creates one and adds it to the
         list. See the @ref wxFont "wxFont constructor" for details of the arguments.
+
+        Note that in the new code it's preferable to use FindOrCreateFont()
+        overload taking wxFontInfo, as it can be used for the fonts with
+        fractional point sizes or fonts with sizes specified in pixels, unlike
+        this overload which can only be used with the fonts using integer size
+        in points.
     */
     wxFont* FindOrCreateFont(int point_size, wxFontFamily family, wxFontStyle style,
                              wxFontWeight weight, bool underline = false,
@@ -1396,6 +1402,16 @@ public:
     /**
         Finds a font of the given specification, or creates one and adds it to the
         list. See the @ref wxFont "wxFont constructor" for details of the arguments.
+
+        Example of using this function to retrieve (creating it if necessary) a
+        bold font of size 20:
+
+        @code
+            wxFont* font = wxTheFontList->FindOrCreateFont(wxFontInfo(20).Bold());
+        @endcode
+
+        @return Font pointer which must @e not be deleted by the caller. The
+            pointer is normally always valid, i.e. non-null.
 
         @since 3.1.1
     */

--- a/src/common/gdicmn.cpp
+++ b/src/common/gdicmn.cpp
@@ -815,9 +815,17 @@ wxFont *wxFontList::FindOrCreateFont(const wxFontInfo& fontInfo)
         font = (wxFont *)node->GetData();
 
         if ( info.IsUsingSizeInPixels() )
-            same = font->GetPixelSize() == info.GetPixelSize();
+        {
+            // When the width is 0, it means that we don't care about it.
+            if ( info.GetPixelSize().x == 0 )
+                same = font->GetPixelSize().y == info.GetPixelSize().y;
+            else
+                same = font->GetPixelSize() == info.GetPixelSize();
+        }
         else
+        {
             same = font->GetFractionalPointSize() == info.GetFractionalPointSize();
+        }
 
         if ( same &&
              font->GetStyle () == info.GetStyle() &&

--- a/src/common/gdicmn.cpp
+++ b/src/common/gdicmn.cpp
@@ -872,12 +872,15 @@ wxFont *wxFontList::FindOrCreateFont(const wxFontInfo& fontInfo)
     }
 
     // font not found, create the new one
-    font = nullptr;
-    wxFont fontTmp(info);
-    if (fontTmp.IsOk())
+    font = new wxFont(info);
+    if (font->IsOk())
     {
-        font = new wxFont(fontTmp);
         list.Append(font);
+    }
+    else
+    {
+        delete font;
+        font = nullptr;
     }
 
     return font;

--- a/src/osx/carbon/font.cpp
+++ b/src/osx/carbon/font.cpp
@@ -718,7 +718,7 @@ wxSize wxFont::GetPixelSize() const
     wxDouble width, height = 0;
     dc->GetTextExtent(wxT("g"), &width, &height, nullptr, nullptr);
     delete dc;
-    return wxSize((int)width, (int)height);
+    return wxSize(wxRound(width), wxRound(height));
 #else
     return wxFontBase::GetPixelSize();
 #endif

--- a/tests/font/fonttest.cpp
+++ b/tests/font/fonttest.cpp
@@ -478,33 +478,23 @@ TEST_CASE("wxFont::NativeFontInfoUserDesc", "[font][fontinfo]")
 
 TEST_CASE("wxFontList::FindOrCreate", "[font][fontinfo][fontlist]")
 {
-    wxFont* font1{nullptr};
-    wxFont* font2{nullptr};
-
-    // test retrieving fonts with fractional point size
     const double pointSize = 10.5;
-    const wxFontInfo pointSizeInfo(pointSize);
-
-    font1 = wxTheFontList->FindOrCreateFont(pointSizeInfo);
-    REQUIRE(font1);
-    REQUIRE(font1->IsOk());
-    REQUIRE(font1->GetFractionalPointSize() == pointSize);
-
-    // font 2 should be font1 from the font list "cache"
-    font2 = wxTheFontList->FindOrCreateFont(pointSizeInfo);
-    REQUIRE(font2 == font1);
-
-
-    // test retrieving fonts with pixel size
     const wxSize pixelSize(0, 32);
-    const wxFontInfo pixelSizeInfo(pixelSize);
 
-    font1 = wxTheFontList->FindOrCreateFont(pixelSizeInfo);
+    wxFontInfo info;
+    SECTION("From point size") { info = wxFontInfo{pointSize}; }
+    SECTION("From pixel size") { info = wxFontInfo{pixelSize}; }
+
+    wxFont* const font1 = wxTheFontList->FindOrCreateFont(info);
     REQUIRE(font1);
     REQUIRE(font1->IsOk());
-    REQUIRE(font1->GetPixelSize() == pixelSize);
+
+    if ( info.IsUsingSizeInPixels() )
+        CHECK(font1->GetPixelSize() == pixelSize);
+    else
+        CHECK(font1->GetFractionalPointSize() == pointSize);
 
     // font 2 should be font1 from the font list "cache"
-    font2 = wxTheFontList->FindOrCreateFont(pixelSizeInfo);
-    REQUIRE(font2 == font1);
+    wxFont* const font2 = wxTheFontList->FindOrCreateFont(info);
+    CHECK(font2 == font1);
 }

--- a/tests/font/fonttest.cpp
+++ b/tests/font/fonttest.cpp
@@ -488,7 +488,7 @@ TEST_CASE("wxFontList::FindOrCreate", "[font][fontinfo][fontlist]")
     font1 = wxTheFontList->FindOrCreateFont(pointSizeInfo);
     REQUIRE(font1);
     REQUIRE(font1->IsOk());
-    REQUIRE(font1->GetPointSize() == pointSize);
+    REQUIRE(font1->GetFractionalPointSize() == pointSize);
 
     // font 2 should be font1 from the font list "cache"
     font2 = wxTheFontList->FindOrCreateFont(pointSizeInfo);

--- a/tests/font/fonttest.cpp
+++ b/tests/font/fonttest.cpp
@@ -489,7 +489,12 @@ TEST_CASE("wxFontList::FindOrCreate", "[font][fontinfo][fontlist]")
     REQUIRE(font1);
     REQUIRE(font1->IsOk());
 
+    // There is a bug in wxOSX which results in the font size in points being
+    // changed (rounded) by the call to GetPixelSize() inside DumpFont(), so we
+    // can't use it there until #23144 is fixed.
+#ifndef __WXMAC__
     INFO("Font from font list:" << DumpFont(font1));
+#endif
 
     if ( info.IsUsingSizeInPixels() )
         CHECK(font1->GetPixelSize().y == pixelSize.y);

--- a/tests/font/fonttest.cpp
+++ b/tests/font/fonttest.cpp
@@ -492,7 +492,7 @@ TEST_CASE("wxFontList::FindOrCreate", "[font][fontinfo][fontlist]")
     INFO("Font from font list:" << DumpFont(font1));
 
     if ( info.IsUsingSizeInPixels() )
-        CHECK(font1->GetPixelSize() == pixelSize);
+        CHECK(font1->GetPixelSize().y == pixelSize.y);
     else
         CHECK(font1->GetFractionalPointSize() == pointSize);
 

--- a/tests/font/fonttest.cpp
+++ b/tests/font/fonttest.cpp
@@ -475,3 +475,36 @@ TEST_CASE("wxFont::NativeFontInfoUserDesc", "[font][fontinfo]")
         CHECK( font.GetFractionalPointSize() == sizeUsed );
     }
 }
+
+TEST_CASE("wxFontList::FindOrCreate", "[font][fontinfo][fontlist]")
+{
+    wxFont* font1{nullptr};
+    wxFont* font2{nullptr};
+
+    // test retrieving fonts with fractional point size
+    const double pointSize = 10.5;
+    const wxFontInfo pointSizeInfo(pointSize);
+
+    font1 = wxTheFontList->FindOrCreateFont(pointSizeInfo);
+    REQUIRE(font1);
+    REQUIRE(font1->IsOk());
+    REQUIRE(font1->GetPointSize() == pointSize);
+
+    // font 2 should be font1 from the font list "cache"
+    font2 = wxTheFontList->FindOrCreateFont(pointSizeInfo);
+    REQUIRE(font2 == font1);
+
+
+    // test retrieving fonts with pixel size
+    const wxSize pixelSize(0, 32);
+    const wxFontInfo pixelSizeInfo(pixelSize);
+
+    font1 = wxTheFontList->FindOrCreateFont(pixelSizeInfo);
+    REQUIRE(font1);
+    REQUIRE(font1->IsOk());
+    REQUIRE(font1->GetPixelSize() == pixelSize);
+
+    // font 2 should be font1 from the font list "cache"
+    font2 = wxTheFontList->FindOrCreateFont(pixelSizeInfo);
+    REQUIRE(font2 == font1);
+}

--- a/tests/font/fonttest.cpp
+++ b/tests/font/fonttest.cpp
@@ -489,6 +489,8 @@ TEST_CASE("wxFontList::FindOrCreate", "[font][fontinfo][fontlist]")
     REQUIRE(font1);
     REQUIRE(font1->IsOk());
 
+    INFO("Font from font list:" << DumpFont(font1));
+
     if ( info.IsUsingSizeInPixels() )
         CHECK(font1->GetPixelSize() == pixelSize);
     else


### PR DESCRIPTION
This is an attempt to fix #23139. From the two approaches suggested by vadz in the referenced issue, I have chosen "just make it work" one instead of "make it work and pretty". The upside is that it can be easily backported. Yes that was the reason for my choice. ;P

Regarding the added tests. Instead of adding a new test file for `wxFontList` (which would require rebaking), I added one `TEST_CASE` to existing `fonttest.cpp`.

The new tests are very simple (but IMO sufficient); however, I am not sure if any tests in `fonttest.cpp` are actually run and from which test executable (gui or drawing?). I am also not sure about comparing doubles with `==`  and `Approx()` should probably have been used there.