### PR TITLE
Fix webview edge on Windows 7

### DIFF
--- a/src/msw/webview_edge.cpp
+++ b/src/msw/webview_edge.cpp
@@ -795,6 +795,8 @@ bool wxWebViewEdge::Create(wxWindow* parent,
         return false;
     }
 
+    MSWDisableComposited();
+
     if (!m_impl->Create())
         return false;
     Bind(wxEVT_SIZE, &wxWebViewEdge::OnSize, this);


### PR DESCRIPTION
Disable double buffering on the edge host window. With double buffering enabled rendering fails on Windows 7 (possibly Win8). It shouldn't affect performance as the contents are rendered and hosted by the external edge process anyway.