### PR TITLE
Increase margin of listctrl items on mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -402,3 +402,6 @@
 /utils/wxrc/wxrc_vc[789].sln
 
 /3rdparty/webview2
+
+# mac os
+.DS_Store/

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -84,6 +84,8 @@ static const int EXTRA_BORDER_Y = 2;
     // on all platforms as the icons
     // otherwise nearly touch the border
     static const int ICON_OFFSET_X = 2;
+#elif __WXMAC__
+    static const int ICON_OFFSET_X = 4;
 #else
     static const int ICON_OFFSET_X = 0;
 #endif

--- a/src/generic/listctrl.cpp
+++ b/src/generic/listctrl.cpp
@@ -84,7 +84,7 @@ static const int EXTRA_BORDER_Y = 2;
     // on all platforms as the icons
     // otherwise nearly touch the border
     static const int ICON_OFFSET_X = 2;
-#elif __WXMAC__
+#elif defined(__WXMAC__)
     static const int ICON_OFFSET_X = 4;
 #else
     static const int ICON_OFFSET_X = 0;


### PR DESCRIPTION
Change listctrl to apply an icon offset on mac. The 4px offset looks good on my test app on mac. The offset was already fine on Windows and Linux.