### PR TITLE
Fix initializing wxFont from wxNativeFontInfo in wxQt

### DIFF
--- a/src/qt/font.cpp
+++ b/src/qt/font.cpp
@@ -349,7 +349,7 @@ void wxFont::SetEncoding(wxFontEncoding encoding)
 
 void wxFont::DoSetNativeFontInfo(const wxNativeFontInfo& info)
 {
-    SetFractionalPointSize(info.GetPointSize());
+    SetFractionalPointSize(info.GetFractionalPointSize());
     SetFamily(info.GetFamily());
     SetStyle(info.GetStyle());
     SetNumericWeight(info.GetWeight());


### PR DESCRIPTION
This also makes the font test pass for `wxQt`