### PR TITLE
Re-re-enable using pkg-config when targeting Linux systems

### DIFF
--- a/configure
+++ b/configure
@@ -24989,20 +24989,28 @@ $as_echo "no" >&6; }
 fi
 
 if test "$build" != "$host"; then
-    case "$PKG_CONFIG" in
-        */$host-pkg-config )
+            case "${host}" in
+        *-linux-*)
             ;;
 
         * )
-            { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Not using native pkg-config when cross-compiling." >&5
+                                    case "$PKG_CONFIG" in
+                */$host-pkg-config )
+                    ;;
+
+                * )
+                    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Not using native pkg-config when cross-compiling." >&5
 $as_echo "$as_me: WARNING: Not using native pkg-config when cross-compiling." >&2;}
 
 
 
-                                                if test -z "$PKG_CONFIG_LIBDIR"; then
-                PKG_CONFIG_LIBDIR=/dev/null
-                export PKG_CONFIG_LIBDIR
-            fi
+                                                                                if test -z "$PKG_CONFIG_LIBDIR"; then
+                        PKG_CONFIG_LIBDIR=/dev/null
+                        export PKG_CONFIG_LIBDIR
+                    fi
+                    ;;
+            esac
+            ;;
     esac
 fi
 

--- a/configure.in
+++ b/configure.in
@@ -2095,28 +2095,37 @@ dnl When cross-compiling for another system from Linux, don't use .pc files on
 dnl the build system, they are at best useless and can be harmful (e.g. they
 dnl may define options inappropriate for the cross-build, resulting in the
 dnl failure of all the subsequent tests).
-dnl
-dnl However do use .pc files for the host libraries that can be found by the
-dnl host-specific pkg-config if it was found by PKG_PROG_PKG_CONFIG above.
 if test "$build" != "$host"; then
-    case "$PKG_CONFIG" in
-        */$host-pkg-config )
+    dnl Assume that using pkg-config does work when cross-compiling to another
+    dnl Linux system, e.g. when targeting ARM Linux from x86_64 system.
+    case "${host}" in
+        *-linux-*)
             ;;
 
         * )
-            AC_MSG_WARN([Not using native pkg-config when cross-compiling.])
+            dnl But otherwise only do it if a host-specific pkg-config is
+            dnl available as using the build system one is not going to work.
+            case "$PKG_CONFIG" in
+                */$host-pkg-config )
+                    ;;
 
-            dnl pkg.m4 forbids the use of PKG_XXX, so undo it here to avoid autoconf
-            dnl errors.
-            m4_pattern_allow([PKG_CONFIG_LIBDIR])
+                * )
+                    AC_MSG_WARN([Not using native pkg-config when cross-compiling.])
 
-            dnl If pkg-config libdir is already defined, we suppose that they know what
-            dnl they're doing and leave it alone, but if not, set it to a path in which
-            dnl no .pc files will be found.
-            if test -z "$PKG_CONFIG_LIBDIR"; then
-                PKG_CONFIG_LIBDIR=/dev/null
-                export PKG_CONFIG_LIBDIR
-            fi
+                    dnl pkg.m4 forbids the use of PKG_XXX, so undo it here to avoid autoconf
+                    dnl errors.
+                    m4_pattern_allow([PKG_CONFIG_LIBDIR])
+
+                    dnl If pkg-config libdir is already defined, we suppose that they know what
+                    dnl they're doing and leave it alone, but if not, set it to a path in which
+                    dnl no .pc files will be found.
+                    if test -z "$PKG_CONFIG_LIBDIR"; then
+                        PKG_CONFIG_LIBDIR=/dev/null
+                        export PKG_CONFIG_LIBDIR
+                    fi
+                    ;;
+            esac
+            ;;
     esac
 fi
 


### PR DESCRIPTION
The change of 7899850496 (Do use host-specific pkg-config when cross-compiling, 2022-12-15) should have been done in addition to the previous logic instead of replacing it, as it has resulted in not using pkg-config any more when targeting Linux systems, which wasn't the intention.

So re-apply the changes of d6ddfe87e1 (Disable build system pkg-config when cross-compiling to non-Linux, 2022-11-30) to handle cross-compiling to Linux specially.

This makes the logic even uglier than before, but it still seems like the most pragmatic solution and the original intention was always to do this and not the wrongly simplified version that was actually applied.

See #22886, #23037, #23171.

---

I've somehow managed to do something rather different from what I _wanted_ to do in the last change here, as I've realized while looking at #23171, so here is the hopefully final version.