### PR TITLE
macOS: Fix wxWebViewHandlerRequest::GetDataString

### DIFF
--- a/src/osx/webview_webkit.mm
+++ b/src/osx/webview_webkit.mm
@@ -868,6 +868,8 @@ public:
         if (!m_data && m_request.HTTPBody)
             m_data = new wxMemoryInputStream(m_request.HTTPBody.bytes, m_request.HTTPBody.length);
 
+        if (m_data)
+            m_data->SeekI(0);
         return m_data;
     }
 


### PR DESCRIPTION
An additional call to `wxWebViewHandlerRequest::GetDataString()` would return an empty string because the underlying memory stream wasn't reset.

(Not applicable to 3.2)