### PR TITLE
Work around MSVS 2022 optimizer bug in wxImage::ShrinkBy()

### DIFF
--- a/src/common/image.cpp
+++ b/src/common/image.cpp
@@ -390,11 +390,11 @@ wxImage wxImage::ShrinkBy( int xFactor , int yFactor ) const
                     unsigned char red = pixel[0] ;
                     unsigned char green = pixel[1] ;
                     unsigned char blue = pixel[2] ;
-                    unsigned char alpha = 255  ;
-                    if ( source_alpha )
-                        alpha = *(source_alpha + y_offset + x * xFactor + x1) ;
                     if ( !hasMask || red != maskRed || green != maskGreen || blue != maskBlue )
                     {
+                        unsigned char alpha = 255  ;
+                        if ( source_alpha )
+                            alpha = *(source_alpha + y_offset + x * xFactor + x1) ;
                         if ( alpha > 0 )
                         {
                             avgRed += red ;


### PR DESCRIPTION
Move "alpha" initialization inside the conditional to ensure that it's calculated correctly, as it was apparently hoisted out of the loop due to an optimizer bug otherwise.

This commit is best viewed with Git --color-moved option.

Closes #23164.