### PR TITLE
Fix link when using wxSimplebook both directly and indirectly

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -3827,6 +3827,7 @@ COND_USE_GUI_1_ALL_GUI_HEADERS =  \
 	wx/creddlg.h \
 	wx/bmpbndl.h \
 	wx/filedlgcustomize.h \
+	wx/compositebookctrl.h \
 	$(LOWLEVEL_HDR) \
 	$(GUI_CORE_HEADERS) \
 	wx/mediactrl.h \

--- a/build/bakefiles/files.bkl
+++ b/build/bakefiles/files.bkl
@@ -1317,6 +1317,7 @@ IMPORTANT: please read docs/tech/tn0016.txt before modifying this file!
     wx/creddlg.h
     wx/bmpbndl.h
     wx/filedlgcustomize.h
+    wx/compositebookctrl.h
 </set>
 
 <!-- ====================================================================== -->

--- a/build/cmake/files.cmake
+++ b/build/cmake/files.cmake
@@ -1218,6 +1218,7 @@ set(GUI_CMN_HDR
     wx/generic/animate.h
     wx/bmpbndl.h
     wx/filedlgcustomize.h
+    wx/compositebookctrl.h
 )
 
 set(UNIX_SRC

--- a/build/files
+++ b/build/files
@@ -983,6 +983,7 @@ GUI_CMN_HDR =
     wx/combo.h
     wx/combobox.h
     wx/commandlinkbutton.h
+    wx/compositebookctrl.h
     wx/compositewin.h
     wx/control.h
     wx/creddlg.h

--- a/build/msw/wx_core.vcxproj
+++ b/build/msw/wx_core.vcxproj
@@ -1516,6 +1516,7 @@
     <ClInclude Include="..\..\include\wx\creddlg.h" />
     <ClInclude Include="..\..\include\wx\generic\creddlgg.h" />
     <ClInclude Include="..\..\include\wx\filedlgcustomize.h" />
+    <ClInclude Include="..\..\include\wx\compositebookctrl.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/build/msw/wx_core.vcxproj.filters
+++ b/build/msw/wx_core.vcxproj.filters
@@ -753,6 +753,9 @@
     <ClCompile Include="..\..\src\msw\customdraw.cpp">
       <Filter>MSW Sources</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\msw\darkmode.cpp">
+      <Filter>MSW Sources</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\msw\data.cpp">
       <Filter>MSW Sources</Filter>
     </ClCompile>
@@ -1074,9 +1077,6 @@
     <ClCompile Include="..\..\src\xrc\xmlreshandler.cpp">
       <Filter>Common Sources</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\msw\darkmode.cpp">
-      <Filter>MSW Sources</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\src\msw\version.rc">
@@ -1205,6 +1205,9 @@
       <Filter>Common Headers</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\wx\commandlinkbutton.h">
+      <Filter>Common Headers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\wx\compositebookctrl.h">
       <Filter>Common Headers</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\wx\compositewin.h">

--- a/include/wx/aui/auibook.h
+++ b/include/wx/aui/auibook.h
@@ -23,8 +23,7 @@
 
 #include "wx/aui/tabart.h"
 #include "wx/aui/framemanager.h"
-#include "wx/bookctrl.h"
-#include "wx/containr.h"
+#include "wx/compositebookctrl.h"
 
 
 class wxAuiNotebook;
@@ -244,7 +243,7 @@ protected:
 
 
 
-class WXDLLIMPEXP_AUI wxAuiNotebook : public wxNavigationEnabled<wxBookCtrlBase>
+class WXDLLIMPEXP_AUI wxAuiNotebook : public wxCompositeBookCtrlBase
 {
 
 public:

--- a/include/wx/choicebk.h
+++ b/include/wx/choicebk.h
@@ -15,9 +15,8 @@
 
 #if wxUSE_CHOICEBOOK
 
-#include "wx/bookctrl.h"
+#include "wx/compositebookctrl.h"
 #include "wx/choice.h"
-#include "wx/containr.h"
 
 class WXDLLIMPEXP_FWD_CORE wxChoice;
 
@@ -36,7 +35,7 @@ wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_CHOICEBOOK_PAGE_CHANGING, wxBo
 // wxChoicebook
 // ----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxChoicebook : public wxNavigationEnabled<wxBookCtrlBase>
+class WXDLLIMPEXP_CORE wxChoicebook : public wxCompositeBookCtrlBase
 {
 public:
     wxChoicebook() { }

--- a/include/wx/compositebookctrl.h
+++ b/include/wx/compositebookctrl.h
@@ -1,0 +1,33 @@
+///////////////////////////////////////////////////////////////////////////////
+// Name:        wx/custombookctrl.h
+// Purpose:     Helper for wxBookCtrlBase subclasses composed of several windows
+// Author:      Vadim Zeitlin
+// Created:     2023-01-29
+// Copyright:   (c) 2023 Vadim Zeitlin <vadim@wxwidgets.org>
+// Licence:     wxWindows licence
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef _WX_COMPOSITEBOOKCTRL_H_
+#define _WX_COMPOSITEBOOKCTRL_H_
+
+#include "wx/bookctrl.h"
+
+#if wxUSE_BOOKCTRL
+
+#include "wx/containr.h"
+
+// ----------------------------------------------------------------------------
+// wxCompositeBookCtrlBase
+// ----------------------------------------------------------------------------
+
+// This class is specifically DLL-exported, even though it's trivial, in order
+// to ensure that there is only a single copy of it in the wx DLL.
+class WXDLLIMPEXP_CORE wxCompositeBookCtrlBase : public wxNavigationEnabled<wxBookCtrlBase>
+{
+public:
+    wxCompositeBookCtrlBase();
+};
+
+#endif // wxUSE_BOOKCTRL
+
+#endif // _WX_COMPOSITEBOOKCTRL_H_

--- a/include/wx/listbook.h
+++ b/include/wx/listbook.h
@@ -15,8 +15,7 @@
 
 #if wxUSE_LISTBOOK
 
-#include "wx/bookctrl.h"
-#include "wx/containr.h"
+#include "wx/compositebookctrl.h"
 
 class WXDLLIMPEXP_FWD_CORE wxListView;
 class WXDLLIMPEXP_FWD_CORE wxListEvent;
@@ -36,7 +35,7 @@ wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_LISTBOOK_PAGE_CHANGING, wxBook
 // wxListbook
 // ----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxListbook : public wxNavigationEnabled<wxBookCtrlBase>
+class WXDLLIMPEXP_CORE wxListbook : public wxCompositeBookCtrlBase
 {
 public:
     wxListbook() { }

--- a/include/wx/simplebook.h
+++ b/include/wx/simplebook.h
@@ -10,11 +10,10 @@
 #ifndef _WX_SIMPLEBOOK_H_
 #define _WX_SIMPLEBOOK_H_
 
-#include "wx/bookctrl.h"
+#include "wx/compositebookctrl.h"
 
 #if wxUSE_BOOKCTRL
 
-#include "wx/containr.h"
 #include "wx/vector.h"
 
 // ----------------------------------------------------------------------------
@@ -23,7 +22,7 @@
 
 // NB: This class doesn't use DLL export declaration as it's fully inline.
 
-class wxSimplebook : public wxNavigationEnabled<wxBookCtrlBase>
+class wxSimplebook : public wxCompositeBookCtrlBase
 {
 public:
     wxSimplebook()

--- a/include/wx/toolbook.h
+++ b/include/wx/toolbook.h
@@ -15,8 +15,7 @@
 
 #if wxUSE_TOOLBOOK
 
-#include "wx/bookctrl.h"
-#include "wx/containr.h"
+#include "wx/compositebookctrl.h"
 
 class WXDLLIMPEXP_FWD_CORE wxToolBarBase;
 class WXDLLIMPEXP_FWD_CORE wxCommandEvent;
@@ -35,7 +34,7 @@ wxDECLARE_EXPORTED_EVENT( WXDLLIMPEXP_CORE, wxEVT_TOOLBOOK_PAGE_CHANGING, wxBook
 // wxToolbook
 // ----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxToolbook : public wxNavigationEnabled<wxBookCtrlBase>
+class WXDLLIMPEXP_CORE wxToolbook : public wxCompositeBookCtrlBase
 {
 public:
     wxToolbook()

--- a/include/wx/treebook.h
+++ b/include/wx/treebook.h
@@ -15,8 +15,7 @@
 
 #if wxUSE_TREEBOOK
 
-#include "wx/bookctrl.h"
-#include "wx/containr.h"
+#include "wx/compositebookctrl.h"
 #include "wx/treebase.h"        // for wxTreeItemId
 #include "wx/vector.h"
 
@@ -29,7 +28,7 @@ class WXDLLIMPEXP_FWD_CORE wxTreeEvent;
 // wxTreebook
 // ----------------------------------------------------------------------------
 
-class WXDLLIMPEXP_CORE wxTreebook : public wxNavigationEnabled<wxBookCtrlBase>
+class WXDLLIMPEXP_CORE wxTreebook : public wxCompositeBookCtrlBase
 {
 public:
     // Constructors and such

--- a/src/common/bookctrl.cpp
+++ b/src/common/bookctrl.cpp
@@ -22,9 +22,9 @@
 
 #if wxUSE_BOOKCTRL
 
-#include "wx/imaglist.h"
+#include "wx/compositebookctrl.h"
 
-#include "wx/bookctrl.h"
+#include "wx/imaglist.h"
 
 // ============================================================================
 // implementation
@@ -556,5 +556,11 @@ int wxBookCtrlBase::DoSetSelection(size_t n, int flags)
 }
 
 wxIMPLEMENT_DYNAMIC_CLASS(wxBookCtrlEvent, wxNotifyEvent);
+
+// Implement the trivial ctor here to ensure it's emitted here and exported
+// from the DLL instead of having an inline version of it which may result in
+// link errors if it happens to be instantiated both inside and outside of the
+// DLL, see #22805.
+wxCompositeBookCtrlBase::wxCompositeBookCtrlBase() = default;
 
 #endif // wxUSE_BOOKCTRL


### PR DESCRIPTION
This resulted in its base class wxNavigationEnabled<wxBookCtrlBase> being instantiated both in the application itself (when using it directly) and inside the wx DLLs (when using another class using the same base class, but defined in the DLL, such as wxAuiNotebook) and gave linking errors.

Work around this by explicitly defining wxCompositeBookCtrlBase, corresponding to this base class, ourselves and export it from the DLL so that it's the single instance which is always used.

Closes #22805.