### PR TITLE
Create wxPGGlobalVars on demand and not on startup

### DIFF
--- a/include/wx/propgrid/propgrid.h
+++ b/include/wx/propgrid/propgrid.h
@@ -113,7 +113,14 @@ public:
     int HasExtraStyle( int style ) const { return (m_extraStyle & style); }
 };
 
-extern WXDLLIMPEXP_DATA_PROPGRID(wxPGGlobalVarsClass*) wxPGGlobalVars;
+// Internal class providing access to the global wxPGGlobalVars instance.
+class WXDLLIMPEXP_PROPGRID wxPGGlobalVarsPtr
+{
+public:
+    wxPGGlobalVarsClass* operator->() const;
+};
+
+extern WXDLLIMPEXP_DATA_PROPGRID(wxPGGlobalVarsPtr) wxPGGlobalVars;
 
 #define wxPGVariant_EmptyString     (wxPGGlobalVars->m_vEmptyString)
 #define wxPGVariant_Zero            (wxPGGlobalVars->m_vZero)


### PR DESCRIPTION
This is slightly more efficient as it avoids allocating an object which is possibly not ever going to be used on startup of any application linking with the propgrid library (at the price of slower access to this object, but this should never be done in performance-critical parts of the code, hopefully) and avoids a problem with losing the previously registered editors when re-initializing wx modules, as wxPython does.

Closes #23165.