### PR TITLE
Actually return English with wxLOCALE_FORM_ENGLISH in GetLocalizedName

### DIFF
--- a/src/osx/core/uilocale.mm
+++ b/src/osx/core/uilocale.mm
@@ -150,6 +150,8 @@ wxString
 wxUILocaleImplCF::GetLocalizedName(wxLocaleName name, wxLocaleForm form) const
 {
     NSString* str = nullptr;
+    NSLocale *enLocale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
+    [enLocale autorelease];
     switch (name)
     {
         case wxLOCALE_NAME_LOCALE:
@@ -159,7 +161,7 @@ wxUILocaleImplCF::GetLocalizedName(wxLocaleName name, wxLocaleForm form) const
                     str = [m_nsloc localizedStringForLocaleIdentifier:[m_nsloc localeIdentifier]];
                     break;
                 case wxLOCALE_FORM_ENGLISH:
-                    str = [m_nsloc displayNameForKey:NSLocaleIdentifier value:[m_nsloc localeIdentifier]];
+                    str = [enLocale displayNameForKey:NSLocaleIdentifier value:[m_nsloc localeIdentifier]];
                     break;
                 default:
                     wxFAIL_MSG("unknown wxLocaleForm");
@@ -172,7 +174,7 @@ wxUILocaleImplCF::GetLocalizedName(wxLocaleName name, wxLocaleForm form) const
                     str = [m_nsloc localizedStringForLanguageCode:[m_nsloc languageCode]];
                     break;
                 case wxLOCALE_FORM_ENGLISH:
-                    str = [m_nsloc displayNameForKey:NSLocaleIdentifier value:[m_nsloc localeIdentifier]];
+                    str = [enLocale displayNameForKey:NSLocaleIdentifier value:[m_nsloc localeIdentifier]];
                     break;
                 default:
                      wxFAIL_MSG("unknown wxLocaleForm");
@@ -185,7 +187,7 @@ wxUILocaleImplCF::GetLocalizedName(wxLocaleName name, wxLocaleForm form) const
                     str = [m_nsloc localizedStringForCountryCode:[m_nsloc countryCode]];
                     break;
                 case wxLOCALE_FORM_ENGLISH:
-                    str = [m_nsloc displayNameForKey:NSLocaleIdentifier value:[m_nsloc localeIdentifier]];
+                    str = [enLocale displayNameForKey:NSLocaleIdentifier value:[m_nsloc localeIdentifier]];
                     break;
                 default:
                     wxFAIL_MSG("unknown wxLocaleForm");


### PR DESCRIPTION
`GetLocalizedName` on macOS would return the name localized with the current locale instead of English, when English was specifically requested.

Steps to reproduce:
1. Set system language/country to German/Germany.
2. Start the `internat` sample.
3. Observe that UI locale name in English is shown as `Deutsch (Deutschland)`, which is not widely considered to be English.

![Bildschirmfoto 2023-01-29 um 23 39 37](https://user-images.githubusercontent.com/5632407/215357224-a2481aa0-2bb7-45c5-b0cd-44a537bd5349.png)

If I'm reading [Apple's documentation](https://developer.apple.com/documentation/foundation/nslocale/1642864-localizedstringforlocaleidentifi) correctly, it explicitly states that the code in `case wxLOCALE_FORM_NATIVE` is equivalent to the code in `case wxLOCALE_FORM_ENGLISH`, so it makes sense the output is identical too.

This PR changes the code to create an `en_US`-`NSLocale` object for acquiring the name in English.