### PR TITLE
GTK: wxGetKeyState to support WXK_CAPITAL WXK_NUMLOCK WXK_SCROLL

### DIFF
--- a/src/unix/utilsx11.cpp
+++ b/src/unix/utilsx11.cpp
@@ -2608,34 +2608,46 @@ static bool wxGetKeyStateGTK(wxKeyCode key)
     GdkDisplay* display = gdk_window_get_display(wxGetTopLevelGDK());
     GdkKeymap* keymap = gdk_keymap_get_for_display(display);
 
-    if (key == WXK_ALT)
-        return (gdk_keymap_get_modifier_state(keymap) & GDK_MOD1_MASK) != 0;
+    guint mask = 0;
+    switch (key)
+    {
+        case WXK_ALT:
+            mask = GDK_MOD1_MASK;
+            break;
 
-    if (key == WXK_CONTROL)
-        return (gdk_keymap_get_modifier_state(keymap) & GDK_CONTROL_MASK) != 0;
+        case WXK_CONTROL:
+            mask = GDK_CONTROL_MASK;
+            break;
 
-    if (key == WXK_SHIFT)
-        return (gdk_keymap_get_modifier_state(keymap) & GDK_SHIFT_MASK) != 0;
+        case WXK_SHIFT:
+            mask = GDK_SHIFT_MASK;
+            break;
 
-    if (key == WXK_CAPITAL)
-        return gdk_keymap_get_caps_lock_state(keymap) != FALSE;
+        case WXK_CAPITAL:
+            return gdk_keymap_get_caps_lock_state(keymap) != FALSE;
 
-    if (key == WXK_NUMLOCK)
-        return gdk_keymap_get_num_lock_state(keymap) != FALSE;
+        case WXK_NUMLOCK:
+            return gdk_keymap_get_num_lock_state(keymap) != FALSE;
 
-# if GTK_CHECK_VERSION(3,18,0)
-    if (key == WXK_SCROLL && gtk_check_version(3,18,0) == nullptr)
-        return gdk_keymap_get_scroll_lock_state(keymap) != FALSE;
-# endif
+#if GTK_CHECK_VERSION(3,18,0)
+        case WXK_SCROLL:
+            if (gtk_check_version(3,18,0) == nullptr)
+                return gdk_keymap_get_scroll_lock_state(keymap) != FALSE;
+            wxFALLTHROUGH;
+#endif // GTK 3.18+
 
-    wxString err_msg;
-    err_msg.Printf("Unsupported key %u, only supported are: Ctrl Alt Shift Caps Num", (unsigned int)key);
-# if GTK_CHECK_VERSION(3,18,0)
-    if (gtk_check_version(3,18,0) == nullptr)
-        err_msg += " Scroll";
-# endif
-    wxFAIL_MSG(err_msg);
-    return false;
+        default:
+            wxFAIL_MSG(wxString::Format(
+                "Unsupported key %u, the only supported ones are: Ctrl, Alt, "
+                "Shift, Caps Lock, Num Lock and Scroll Lock for GTK 3.18+",
+                key));
+
+            return false;
+    }
+
+    // Mask is set if we get here, so it must be one of the modifier keys.
+    return (gdk_keymap_get_modifier_state(keymap) & mask) != 0;
+
 }
 #endif // wxHAS_GETKEYSTATE_GTK
 

--- a/src/unix/utilsx11.cpp
+++ b/src/unix/utilsx11.cpp
@@ -2607,27 +2607,35 @@ static bool wxGetKeyStateGTK(wxKeyCode key)
 
     GdkDisplay* display = gdk_window_get_display(wxGetTopLevelGDK());
     GdkKeymap* keymap = gdk_keymap_get_for_display(display);
-    guint state = gdk_keymap_get_modifier_state(keymap);
-    guint mask = 0;
-    switch (key)
-    {
-        case WXK_ALT:
-            mask = GDK_MOD1_MASK;
-            break;
 
-        case WXK_CONTROL:
-            mask = GDK_CONTROL_MASK;
-            break;
+    if (key == WXK_ALT)
+        return (gdk_keymap_get_modifier_state(keymap) & GDK_MOD1_MASK) != 0;
 
-        case WXK_SHIFT:
-            mask = GDK_SHIFT_MASK;
-            break;
+    if (key == WXK_CONTROL)
+        return (gdk_keymap_get_modifier_state(keymap) & GDK_CONTROL_MASK) != 0;
 
-        default:
-            wxFAIL_MSG(wxS("Unsupported key, only modifiers can be used"));
-            return false;
-    }
-    return (state & mask) != 0;
+    if (key == WXK_SHIFT)
+        return (gdk_keymap_get_modifier_state(keymap) & GDK_SHIFT_MASK) != 0;
+
+    if (key == WXK_CAPITAL)
+        return gdk_keymap_get_caps_lock_state(keymap) != FALSE;
+
+    if (key == WXK_NUMLOCK)
+        return gdk_keymap_get_num_lock_state(keymap) != FALSE;
+
+# if GTK_CHECK_VERSION(3,18,0)
+    if (key == WXK_SCROLL && gtk_check_version(3,18,0) == nullptr)
+        return gdk_keymap_get_scroll_lock_state(keymap) != FALSE;
+# endif
+
+    wxString err_msg;
+    err_msg.Printf("Unsupported key %u, only supported are: Ctrl Alt Shift Caps Num", (unsigned int)key);
+# if GTK_CHECK_VERSION(3,18,0)
+    if (gtk_check_version(3,18,0) == nullptr)
+        err_msg += " Scroll";
+# endif
+    wxFAIL_MSG(err_msg);
+    return false;
 }
 #endif // wxHAS_GETKEYSTATE_GTK
 


### PR DESCRIPTION
Fixed #23195
Note that its actually possible to make wxGetKeyStateGTK to support some of modifiers under GTK earlier than 3.4 as gdk_keymap_get_caps_lock_state supported by GTK 2.16 and gdk_keymap_get_num_lock_state supported by GTK 3.0 but i intentionally left check for 3.4 as it was to keep 'silent fail' behavior under older versions and to simplify things...