### PR TITLE
Revert "Use new CoreGraphics API to reset clipping region"

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -301,6 +301,7 @@ wxMSW:
 wxOSX:
 
 - Fix possible crash in menu item event handling (#23040).
+- Fix regression in text drawing when using clipping (#22629).
 - Generate wxEVT_DATAVIEW_COLUMN_HEADER_RIGHT_CLICK (#22833).
 - Fix wxDataViewCtrl::HitTest() (Vojtěch Bubník, #22789).
 - Fix position of the controls in wxStaticBox after resizing it (#22837).

--- a/src/osx/carbon/graphics.cpp
+++ b/src/osx/carbon/graphics.cpp
@@ -31,7 +31,6 @@
     #include "wx/osx/dcmemory.h"
     #include "wx/osx/private.h"
     #include "wx/osx/core/cfdictionary.h"
-    #include "wx/osx/private/available.h"
 #else
     #include "CoreServices/CoreServices.h"
     #include "ApplicationServices/ApplicationServices.h"
@@ -2150,36 +2149,27 @@ void wxMacCoreGraphicsContext::ResetClip()
 {
     if ( m_cgContext )
     {
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_13
-        if ( WX_IS_MACOS_OR_IOS_AVAILABLE(10, 13, 11, 0) )
-        {
-            CGContextResetClip(m_cgContext);
-        }
-        else
-#endif
-        {
-            // there is no way for clearing the clip, we can only revert to the stored
-            // state, but then we have to make sure everything else is NOT restored
-            // Note: This trick works as expected only if a state with no clipping
-            // path is stored on the top of the stack. It's guaranteed to work only
-            // when no PushState() was called before because in this case a reference
-            // state (initial state without clipping region) is on the top of the stack.
-            wxASSERT_MSG(m_stateStackLevel == 0,
-                         "Resetting the clip may not work when PushState() was called before");
-            CGAffineTransform transform = CGContextGetCTM( m_cgContext );
-            CGContextRestoreGState( m_cgContext );
-            CGContextSaveGState( m_cgContext );
-            CGAffineTransform transformNew = CGContextGetCTM( m_cgContext );
-            transformNew = CGAffineTransformInvert( transformNew ) ;
-            CGContextConcatCTM( m_cgContext, transformNew);
-            CGContextConcatCTM( m_cgContext, transform);
-            // Retain antialiasing mode
-            DoSetAntialiasMode(m_antialias);
-            // Retain interpolation quality
-            DoSetInterpolationQuality(m_interpolation);
-            // Retain composition mode
-            DoSetCompositionMode(m_composition);
-        }
+        // there is no way for clearing the clip, we can only revert to the stored
+        // state, but then we have to make sure everything else is NOT restored
+        // Note: This trick works as expected only if a state with no clipping
+        // path is stored on the top of the stack. It's guaranteed to work only
+        // when no PushState() was called before because in this case a reference
+        // state (initial state without clipping region) is on the top of the stack.
+        wxASSERT_MSG(m_stateStackLevel == 0,
+                     "Resetting the clip may not work when PushState() was called before");
+        CGAffineTransform transform = CGContextGetCTM( m_cgContext );
+        CGContextRestoreGState( m_cgContext );
+        CGContextSaveGState( m_cgContext );
+        CGAffineTransform transformNew = CGContextGetCTM( m_cgContext );
+        transformNew = CGAffineTransformInvert( transformNew ) ;
+        CGContextConcatCTM( m_cgContext, transformNew);
+        CGContextConcatCTM( m_cgContext, transform);
+        // Retain antialiasing mode
+        DoSetAntialiasMode(m_antialias);
+        // Retain interpolation quality
+        DoSetInterpolationQuality(m_interpolation);
+        // Retain composition mode
+        DoSetCompositionMode(m_composition);
     }
     else
     {


### PR DESCRIPTION
This reverts commit dc11bb18cf2ebc3f36a6d5b083a95b5639149c4f as it results in visual artifacts due to CGContextResetClip() apparently not fully resetting everything.

See #22629.