### PR TITLE
Work around link errors when using wxSimplebook in DLL wx build

### DIFF
--- a/docs/changes.txt
+++ b/docs/changes.txt
@@ -297,6 +297,7 @@ wxMSW:
 - Don't disable wxComboBox after recreating it (Oleksandra Yushchenko, #23132).
 - Fix wxJoystick::GetProductName() returning nothing (Maarten Bent, #23172).
 - Work around MSVS 2022 optimizer bug in wxImage::ShrinkBy() (#23164).
+- Fix link error with wxSimplebook in DLL builds (Mark Roszko, #22805).
 
 wxOSX:
 

--- a/include/wx/simplebook.h
+++ b/include/wx/simplebook.h
@@ -17,6 +17,25 @@
 #include "wx/containr.h"
 #include "wx/vector.h"
 
+// Hack to work around problems with wxNavigationEnabled<wxBookCtrlBase> when
+// using wx as DLL: we want the compiler to see that it's already available in
+// the DLL by including some other DLL exported class using it as the base in
+// order to prevent it from generating a non-DLL-exported instantiation which
+// will conflict with the one in the DLL at the link-time.
+//
+// Find the first available class using wxNavigationEnabled<wxBookCtrlBase> as
+// base, any will do (except for wxAUI one, as this would create a dependency
+// on the AUI library that we can't have here).
+#if wxUSE_CHOICEBOOK
+    #include "wx/choicebk.h"
+#elif wxUSE_LISTBOOK
+    #include "wx/listbook.h"
+#elif wxUSE_TOOLBOOK
+    #include "wx/toolbook.h"
+#elif wxUSE_TREEBOOK
+    #include "wx/treebook.h"
+#endif
+
 // ----------------------------------------------------------------------------
 // wxSimplebook: a book control without any user-actionable controller.
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
This is an uglier workaround than the one applied in dbbf509e18 (Fix link when using wxSimplebook both directly and indirectly, 2023-01-29) to master but has the advantage of preserving ABI-compatibility.

See #22805.