### PR TITLE
Document wxBookCtrlBase::GetControlSizer

### DIFF
--- a/interface/wx/bookctrl.h
+++ b/interface/wx/bookctrl.h
@@ -333,6 +333,11 @@ public:
     */
     wxWindow* GetPage(size_t page) const;
 
+    /**
+        Returns the sizer containing the control, if any.
+    */
+    wxSizer* GetControlSizer() const;
+
     ///@}
 
 
@@ -359,9 +364,6 @@ public:
     // set/get option to shrink to fit current page
     void SetFitToCurrentPage(bool fit) { m_fitToCurrentPage = fit; }
     bool GetFitToCurrentPage() const { return m_fitToCurrentPage; }
-
-    // returns the sizer containing the control, if any
-    wxSizer* GetControlSizer() const { return m_controlSizer; }
 
     // we do have multiple pages
     virtual bool HasMultiplePages() const { return true; }


### PR DESCRIPTION
The documentation for wxChoiceBook discusses using this method, but it was not previously documented.