### PR TITLE
Use translation context for more standard OSX menu items

### DIFF
--- a/src/osx/cocoa/menu.mm
+++ b/src/osx/cocoa/menu.mm
@@ -240,7 +240,7 @@ public :
     virtual NSMenu* MacCreateOrFindWindowMenu()
     {
         NSString* nsWindowMenuTitle = wxNSStringWithWxString(wxStripMenuCodes(wxApp::s_macWindowMenuTitleName, wxStrip_Menu));
-        NSString* nsAlternateWindowMenuTitle = wxNSStringWithWxString(wxStripMenuCodes(_("&Window"), wxStrip_Menu));
+        NSString* nsAlternateWindowMenuTitle = wxNSStringWithWxString(wxGETTEXT_IN_CONTEXT("macOS menu name", "Window"));
 
         NSMenu* windowMenu = nil;
 
@@ -257,7 +257,7 @@ public :
         if ( windowMenu == nil )
         {
             NSString* nsHelpMenuTitle = wxNSStringWithWxString(wxStripMenuCodes(wxApp::s_macHelpMenuTitleName, wxStrip_Menu));
-            NSString* nsAlternateHelpTitle = wxNSStringWithWxString(wxStripMenuCodes(_("&Help"), wxStrip_Menu));
+            NSString* nsAlternateHelpTitle = wxNSStringWithWxString(wxGETTEXT_IN_CONTEXT("macOS menu name", "Help"));
 
             NSMenuItem* helpMenu = nil;
             NSInteger numberOfMenus = [m_osxMenu numberOfItems];
@@ -296,18 +296,18 @@ public :
             // already exists or not
             [windowMenu removeAllItems];
 
-            item = [[NSMenuItem alloc] initWithTitle:wxNSStringWithWxString(_("Minimize")) action:@selector(performMiniaturize:) keyEquivalent:@"m"];
+            item = [[NSMenuItem alloc] initWithTitle:wxNSStringWithWxString(wxGETTEXT_IN_CONTEXT("macOS menu item", "Minimize")) action:@selector(performMiniaturize:) keyEquivalent:@"m"];
             [windowMenu insertItem:item atIndex:0];
             [item setEnabled:YES];
             [item release];
 
-            item = [[NSMenuItem alloc] initWithTitle:wxNSStringWithWxString(_("Zoom")) action:@selector(performZoom:) keyEquivalent:@""];
+            item = [[NSMenuItem alloc] initWithTitle:wxNSStringWithWxString(wxGETTEXT_IN_CONTEXT("macOS menu item", "Zoom")) action:@selector(performZoom:) keyEquivalent:@""];
             [windowMenu insertItem:item atIndex:1];
             [item release];
 
             [windowMenu insertItem:[NSMenuItem separatorItem] atIndex:2];
 
-            item = [[NSMenuItem alloc] initWithTitle:wxNSStringWithWxString(_("Bring All to Front")) action:@selector(arrangeInFront:) keyEquivalent:@""];
+            item = [[NSMenuItem alloc] initWithTitle:wxNSStringWithWxString(wxGETTEXT_IN_CONTEXT("macOS menu item", "Bring All to Front")) action:@selector(arrangeInFront:) keyEquivalent:@""];
             [windowMenu insertItem:item atIndex:3];
             [item release];
 


### PR DESCRIPTION
Similar items were added context in d85f0e311d40b56732b52905b7ee7d73b8414494,
but some were missed back then.

The context primarily serves as a translator comment, informing that these
are indeed OSX menu item names, and not something else.

Also to match the established translations of OSX itself, for some
languages these may need to be translated using particular terminology
different than on other platforms.

wxstd.pot should be regenerated; not done by this PR.