### PR TITLE
Add move operations and rvalue support to wxString

### DIFF
--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -2991,6 +2991,12 @@ public:
       m_impl.swap(str.m_impl);
   }
 
+  // non-member swap for ADL
+  friend void swap(wxString& s1, wxString& s2) noexcept
+  {
+      s1.swap(s2);
+  }
+
     // find a substring
   size_t find(const wxString& str, size_t nStart = 0) const
     { return PosFromImpl(m_impl.find(str.m_impl, PosToImpl(nStart))); }

--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -1090,6 +1090,14 @@ public:
     // copy ctor
   wxString(const wxString& stringSrc) : m_impl(stringSrc.m_impl) { }
 
+    // move ctor
+  wxString(wxString&& stringSrc) noexcept : m_impl(std::move(stringSrc.m_impl))
+  {
+#if wxUSE_STRING_POS_CACHE
+    stringSrc.InvalidateCache();
+#endif // wxUSE_STRING_POS_CACHE
+  }
+
     // string containing nRepeat copies of ch
   wxString(wxUniChar ch, size_t nRepeat = 1 )
     { assign(nRepeat, ch); }
@@ -1714,6 +1722,18 @@ public:
 
         m_impl = stringSrc.m_impl;
     }
+
+    return *this;
+  }
+
+    // move from another wxString
+  wxString& operator=(wxString&& stringSrc) noexcept
+  {
+    m_impl = std::move(stringSrc.m_impl);
+#if wxUSE_STRING_POS_CACHE
+    InvalidateCache();
+    stringSrc.InvalidateCache();
+#endif // wxUSE_STRING_POS_CACHE
 
     return *this;
   }

--- a/include/wx/string.h
+++ b/include/wx/string.h
@@ -2978,7 +2978,7 @@ public:
     { replace(first, last, first1, last1 - first1); return *this; }
 
   // swap two strings
-  void swap(wxString& str)
+  void swap(wxString& str) noexcept
   {
 #if wxUSE_STRING_POS_CACHE
       // we modify not only this string but also the other one directly so we

--- a/src/common/string.cpp
+++ b/src/common/string.cpp
@@ -1418,6 +1418,7 @@ wxString& wxString::Truncate(size_t uiLen)
     if ( uiLen < length() )
     {
         erase(begin() + uiLen, end());
+        wxSTRING_SET_CACHED_LENGTH(uiLen);
     }
     //else: nothing to do, string is already short enough
 

--- a/tests/benchmarks/strings.cpp
+++ b/tests/benchmarks/strings.cpp
@@ -9,6 +9,7 @@
 
 #include "wx/string.h"
 #include "wx/ffile.h"
+#include "wx/arrstr.h"
 
 #include "bench.h"
 #include "htmlparser/htmlpars.h"
@@ -290,6 +291,74 @@ BENCHMARK_FUNC(ReplaceShorter)
 {
     wxString str('x', ASCIISTR_LEN);
     return str.Replace("xx", "y") != 0;
+}
+
+// ----------------------------------------------------------------------------
+// string arrays
+// ----------------------------------------------------------------------------
+
+BENCHMARK_FUNC(ArrStrPushBack)
+{
+    wxArrayString a;
+    for (int i = 0; i < 100; ++i)
+    {
+        a.push_back(wxString(asciistr));
+        a.push_back(wxString(utf8str));
+    }
+    return !a.empty();
+}
+
+BENCHMARK_FUNC(ArrStrInsert)
+{
+    wxArrayString a;
+    for (int i = 0; i < 100; ++i)
+    {
+        a.insert(a.begin(), wxString(asciistr));
+        a.insert(a.begin(), wxString(utf8str));
+    }
+    return !a.empty();
+}
+
+BENCHMARK_FUNC(ArrStrSort)
+{
+    wxArrayString a;
+    a.reserve(100);
+    for (int i = 0; i < 100; ++i)
+        a.push_back(wxString(asciistr + i));
+    a.Sort();
+    return !a.empty();
+}
+
+BENCHMARK_FUNC(VectorStrPushBack)
+{
+    std::vector<wxString> v;
+    for (int i = 0; i < 100; ++i)
+    {
+        v.push_back(wxString(asciistr));
+        v.push_back(wxString(utf8str));
+    }
+    return !v.empty();
+}
+
+BENCHMARK_FUNC(VectorStrInsert)
+{
+    std::vector<wxString> v;
+    for (int i = 0; i < 100; ++i)
+    {
+        v.insert(v.begin(), wxString(asciistr));
+        v.insert(v.begin(), wxString(utf8str));
+    }
+    return !v.empty();
+}
+
+BENCHMARK_FUNC(VectorStrSort)
+{
+    std::vector<wxString> v;
+    v.reserve(100);
+    for (int i = 0; i < 100; ++i)
+        v.push_back(wxString(asciistr + i));
+    std::sort(v.begin(), v.end());
+    return !v.empty();
 }
 
 // ----------------------------------------------------------------------------

--- a/tests/strings/stdstrings.cpp
+++ b/tests/strings/stdstrings.cpp
@@ -151,6 +151,86 @@ TEST_CASE("StdString::Assign", "[stdstring]")
     CHECK( s1 == "e" );
 }
 
+TEST_CASE("StdString::AssignOp", "[stdstring]")
+{
+    wxString s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13;
+    s1 = s2 = s3 = s4 = s5 = s6 = s7 = s8 = s9 = s10 = s11 = s12 = s13 = wxT("abc");
+
+    // operator=
+    s1 = wxT("def");
+    CHECK(s1 == wxT("def"));
+
+    s2 = s1;
+    CHECK(s2 == wxT("def"));
+
+    const char* pc = s1.c_str();
+    s3 = pc;
+    CHECK(s3 == wxT("def"));
+
+    const wchar_t* pw = s1.c_str();
+    s4 = pw;
+    CHECK(s4 == wxT("def"));
+
+    s5 = std::move(s1);
+    CHECK(s5 == wxT("def"));
+    s1 = wxT("qwerty");
+    CHECK(s1 == wxT("qwerty"));
+
+    // assign()
+    s6.assign(wxT("def"));
+    CHECK(s6 == wxT("def"));
+
+    s7.assign(s6);
+    CHECK(s7 == wxT("def"));
+
+    pc = s6.c_str();
+    s8.assign(pc);
+    CHECK(s8 == wxT("def"));
+
+    pw = s6.c_str();
+    s9.assign(pw);
+    CHECK(s9 == wxT("def"));
+
+    s10.assign(std::move(s6));
+    CHECK(s10 == wxT("def"));
+    s6 = wxT("qwerty");
+    CHECK(s6 == wxT("qwerty"));
+
+    // swap
+    s11 = wxT("def");
+    std::swap(s11, s12);
+    CHECK(s11 == wxT("abc"));
+    CHECK(s12 == wxT("def"));
+    swap(s11, s12);
+    CHECK(s11 == wxT("def"));
+    CHECK(s12 == wxT("abc"));
+    s11.swap(s12);
+    CHECK(s11 == wxT("abc"));
+    CHECK(s12 == wxT("def"));
+
+    // Self-assignment
+    wxString& s13ref = s13;
+    s13ref = s13;
+    CHECK(s13 == wxT("abc"));
+    s13ref.assign(s13);
+    CHECK(s13 == wxT("abc"));
+    // Self-move may change the value, but shouldn't crash
+    // and reassignment should work
+    s13ref = std::move(s13);
+    s13 = "def";
+    CHECK(s13 == wxT("def"));
+    s13ref.assign(std::move(s13));
+    s13 = "qwerty";
+    CHECK(s13 == wxT("qwerty"));
+    // Self-swap
+    std::swap(s13, s13ref);
+    CHECK(s13 == wxT("qwerty"));
+    swap(s13, s13ref);
+    CHECK(s13 == wxT("qwerty"));
+    s13.swap(s13ref);
+    CHECK(s13 == wxT("qwerty"));
+}
+
 TEST_CASE("StdString::Compare", "[stdstring]")
 {
     wxString s1, s2, s3, s4, s5, s6, s7, s8;

--- a/tests/strings/stdstrings.cpp
+++ b/tests/strings/stdstrings.cpp
@@ -29,6 +29,8 @@ TEST_CASE("StdString::Constructors", "[stdstring]")
              s6(s3, 0, 8),
              s7(s3.begin(), s3.begin() + 8);
     wxString s8(s1, 4, 8);
+    wxString s9(wxString(s1, 8)),
+             s10(wxString(s3), 8);
 
     CHECK( s1 == wxT("abcdefgh") );
     CHECK( s2 == s1 );
@@ -37,6 +39,8 @@ TEST_CASE("StdString::Constructors", "[stdstring]")
     CHECK( s6 == s1 );
     CHECK( s7 == s1 );
     CHECK( s8 == wxT("efgh") );
+    CHECK( s9 == wxT("abcdefgh"));
+    CHECK( s10 == s1 );
 
     const char *pc = s1.c_str();
     CHECK( wxString(pc + 1, pc + 4) == "bcd" );


### PR DESCRIPTION
Ran benchmarks on msvc 2022 and mingw-w64 12 x64 builds, got 55-130% speedup in insert depending on build, 15-44% in sorting, 1-24% in push_back. wxArrayString insert/push_back benchmarks are only affected in STL builds.