### PR TITLE
Fix return value of wxToolBar::GetToolBitmapSize() under GTK/Mac

### DIFF
--- a/interface/wx/toolbar.h
+++ b/interface/wx/toolbar.h
@@ -594,6 +594,11 @@ public:
         usually unnecessary to call either this function or
         SetToolBitmapSize() at all.
 
+        This function returns the size in logical pixels, for consistency with
+        SetToolBitmapSize() which takes size in logical pixels. See @ref
+        overview_high_dpi for more information about the different pixel types
+        and how to convert between them.
+
         @remarks Note that this is the size of the bitmap you pass to AddTool(),
             and not the eventual size of the tool button.
 

--- a/src/common/tbarbase.cpp
+++ b/src/common/tbarbase.cpp
@@ -486,7 +486,7 @@ void wxToolBarBase::AdjustToolBitmapSize()
         // We want to round 1.5 down to 1, but 1.75 up to 2.
         int scaleFactorRoundedDown =
             static_cast<int>(ceil(2*GetDPIScaleFactor())) / 2;
-        sizeNeeded = m_requestedBitmapSize*scaleFactorRoundedDown;
+        sizeNeeded = FromPhys(m_requestedBitmapSize*scaleFactorRoundedDown);
     }
     else // Determine the best size to use from the bitmaps we have.
     {


### PR DESCRIPTION
Fix another pixel units confusion in wxToolBar code and ensure that "sizeNeeded" is expressed in logical units when a fixed bitmap size is set, to make it consistent with the case when it is not set, and also because bitmap size is supposed to be expressed in logical pixels, in both SetToolBitmapSize() and, for consistency, GetToolBitmapSize() too.

Also explicitly mention the latter in the documentation.

Closes #23222.

@a-wi @MaartenBent Please let me know if you see anything wrong with this. TIA!